### PR TITLE
Parameter Types Fix

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -634,7 +634,7 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
                 // Insert with correct type
                 switch (value.param_type)
                 {
-                case MAVLINK_TYPE_FLOAT:
+                case MAV_VAR_FLOAT:
                     {
                     // Variant
                     QVariant param(val.param_float);
@@ -645,7 +645,7 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
                     qDebug() << "RECEIVED PARAM:" << param;
                 }
                     break;
-                case MAVLINK_TYPE_UINT32_T:
+                case MAV_VAR_UINT32:
                     {
                     // Variant
                     QVariant param(val.param_uint32);
@@ -656,7 +656,7 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
                     qDebug() << "RECEIVED PARAM:" << param;
                 }
                     break;
-                case MAVLINK_TYPE_INT32_T:
+                case MAV_VAR_INT32:
                     {
                     // Variant
                     QVariant param(val.param_int32);
@@ -1783,15 +1783,15 @@ void UAS::setParameter(const int component, const QString& id, const QVariant& v
         {
         case QVariant::Int:
             union_value.param_int32 = value.toInt();
-            p.param_type = MAVLINK_TYPE_INT32_T;
+            p.param_type = MAV_VAR_INT32;
             break;
         case QVariant::UInt:
             union_value.param_uint32 = value.toUInt();
-            p.param_type = MAVLINK_TYPE_UINT32_T;
+            p.param_type = MAV_VAR_UINT32;
             break;
         case QMetaType::Float:
             union_value.param_float = value.toFloat();
-            p.param_type = MAVLINK_TYPE_FLOAT;
+            p.param_type = MAV_VAR_FLOAT;
             break;
         default:
             qCritical() << "ABORTED PARAM SEND, NO VALID QVARIANT TYPE";


### PR DESCRIPTION
Hi!

We have tested the parameter interface and ran into the following problem: When a "PARAM_VALUE" message is received in UAS.cc, it checks the parameter type against MAVLINK_TYPE:

```
typedef enum {
..MAVLINK_TYPE_CHAR     = 0,
..MAVLINK_TYPE_UINT8_T  = 1,
..MAVLINK_TYPE_INT8_T   = 2,
..MAVLINK_TYPE_UINT16_T = 3,
..MAVLINK_TYPE_INT16_T  = 4,
..MAVLINK_TYPE_UINT32_T = 5,
..MAVLINK_TYPE_INT32_T  = 6,
..MAVLINK_TYPE_UINT64_T = 7,
..MAVLINK_TYPE_INT64_T  = 8,
..MAVLINK_TYPE_FLOAT    = 9,
..MAVLINK_TYPE_DOUBLE   = 10
} mavlink_message_type_t;
```

but what we send is (motivated by the definition in common.xml: <enum name="MAV_VAR"><description>type of a mavlink parameter</description>):

```
enum MAV_VAR
{
..MAV_VAR_FLOAT=0, /* 32 bit float | */
..MAV_VAR_UINT8=1, /* 8 bit unsigned integer | */
..MAV_VAR_INT8=2, /* 8 bit signed integer | */
..MAV_VAR_UINT16=3, /* 16 bit unsigned integer | */
..MAV_VAR_INT16=4, /* 16 bit signed integer | */
..MAV_VAR_UINT32=5, /* 32 bit unsigned integer | */
..MAV_VAR_INT32=6, /* 32 bit signed integer | */
..MAV_VAR_ENUM_END=7, /*  | */
};
```

One possibility would be to use MAV_VAR_.\* instead of MAVLINK_TYPE_.\* in UAS.cc. Otherwise, the parameter type check fails and the value is not accepted by QGroundControl.

Alternative: Since MAVLINK_TYPE is used already, maybe the MAV_VAR enum should be removed from common.xml. and the XML file documentation should point out that MAVLINK_TYPE should be used (as described on the website)

Regards,
Tobias
