### PR TITLE
fixed dropRateChanged: it was impossible to represent a drop rate > 1%

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -429,8 +429,7 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
                 }
 
                 // COMMUNICATIONS DROP RATE
-                // FIXME
-                emit dropRateChanged(this->getUASID(), state.drop_rate_comm/10000.0f);
+                emit dropRateChanged(this->getUASID(), 100.0 * state.drop_rate_comm/10000.0f);
             }
             break;
         case MAVLINK_MSG_ID_ATTITUDE:


### PR DESCRIPTION
Hi, just figured this out when sending drop rate to QGC: 10000 (max) was shown as 1% on the drop rate indicator. This fixes the problem.
