### PR TITLE
Linechart UI improvements

### DIFF
--- a/src/ui/Linechart.ui
+++ b/src/ui/Linechart.ui
@@ -25,8 +25,11 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="5,5,5,5,100">
-   <item row="0" column="0" colspan="4">
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout" columnstretch="5,0,0">
+   <item row="0" column="0" rowspan="3">
     <widget class="QGroupBox" name="curveGroupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
@@ -46,13 +49,16 @@
        <height>16777215</height>
       </size>
      </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="title">
       <string>Curve Selection</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0">
       <property name="spacing">
        <number>2</number>
       </property>
@@ -82,6 +88,9 @@
         <property name="autoFillBackground">
          <bool>false</bool>
         </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
         <property name="frameShape">
          <enum>QFrame::NoFrame</enum>
         </property>
@@ -99,17 +108,103 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>219</width>
-           <height>475</height>
+           <width>368</width>
+           <height>488</height>
           </rect>
          </property>
         </widget>
        </widget>
       </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
+         <number>2</number>
+        </property>
+        <item>
+         <widget class="QComboBox" name="uasSelectionBox">
+          <item>
+           <property name="text">
+            <string>All MAVs</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="shortNameCheckBox">
+              <property name="toolTip">
+               <string>Display only variable names in curve list</string>
+              </property>
+              <property name="text">
+               <string>Short Names</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="showUnitsCheckBox">
+              <property name="toolTip">
+               <string>Display variable units in curve list</string>
+              </property>
+              <property name="whatsThis">
+               <string>Display variable units in curve list</string>
+              </property>
+              <property name="text">
+               <string>Show units</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <item>
+             <widget class="QPushButton" name="recolorButton">
+              <property name="toolTip">
+               <string>Rotate color scheme for all curves</string>
+              </property>
+              <property name="text">
+               <string>Recolor</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Minimum</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="0" column="4" rowspan="4">
+   <item row="0" column="2" rowspan="3">
     <widget class="QGroupBox" name="diagramGroupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -129,45 +224,12 @@
        <height>300</height>
       </size>
      </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="title">
       <string>Diagram</string>
      </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="shortNameCheckBox">
-     <property name="text">
-      <string>Short Names</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2" colspan="2">
-    <widget class="QPushButton" name="recolorButton">
-     <property name="text">
-      <string>Recolor</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0" colspan="4">
-    <widget class="QComboBox" name="uasSelectionBox">
-     <item>
-      <property name="text">
-       <string>All MAVs</string>
-      </property>
-     </item>
     </widget>
    </item>
   </layout>

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -135,8 +135,6 @@ LinechartWidget::LinechartWidget(int systemid, QWidget *parent) : QWidget(parent
     variance->setText("Variance");
     curvesWidgetLayout->addWidget(variance, labelRow, 6);
 
-    // Add and customize plot elements (right side)
-
     // Create the layout
     createLayout();
 
@@ -184,7 +182,7 @@ void LinechartWidget::writeSettings()
     QSettings settings;
     settings.beginGroup("LINECHART");
     if (timeButton) settings.setValue("ENFORCE_GROUNDTIME", timeButton->isChecked());
-    if (unitsCheckBox) settings.setValue("SHOW_UNITS", unitsCheckBox->isChecked());
+    if (ui.showUnitsCheckBox) settings.setValue("SHOW_UNITS", ui.showUnitsCheckBox->isChecked());
     if (ui.shortNameCheckBox) settings.setValue("SHORT_NAMES", ui.shortNameCheckBox->isChecked());
     settings.endGroup();
     settings.sync();
@@ -200,7 +198,7 @@ void LinechartWidget::readSettings()
         activePlot->enforceGroundTime(settings.value("ENFORCE_GROUNDTIME", timeButton->isChecked()).toBool());
         timeButton->setChecked(settings.value("ENFORCE_GROUNDTIME", timeButton->isChecked()).toBool());
     }
-    if (unitsCheckBox) unitsCheckBox->setChecked(settings.value("SHOW_UNITS", unitsCheckBox->isChecked()).toBool());
+    if (ui.showUnitsCheckBox) ui.showUnitsCheckBox->setChecked(settings.value("SHOW_UNITS", ui.showUnitsCheckBox->isChecked()).toBool());
     if (ui.shortNameCheckBox) ui.shortNameCheckBox->setChecked(settings.value("SHORT_NAMES", ui.shortNameCheckBox->isChecked()).toBool());
     settings.endGroup();
 }
@@ -278,13 +276,9 @@ void LinechartWidget::createLayout()
     connect(timeButton, SIGNAL(clicked(bool)), activePlot, SLOT(enforceGroundTime(bool)));
     connect(timeButton, SIGNAL(clicked()), this, SLOT(writeSettings()));
 
-    unitsCheckBox = new QCheckBox(this);
-    unitsCheckBox->setText(tr("Show units"));
-    unitsCheckBox->setChecked(true);
-    unitsCheckBox->setToolTip(tr("Enable unit display in curve list"));
-    unitsCheckBox->setWhatsThis(tr("Enable unit display in curve list"));
-    layout->addWidget(unitsCheckBox, 1, 5);
-    connect(unitsCheckBox, SIGNAL(clicked()), this, SLOT(writeSettings()));
+    // Initialize the "Show units" checkbox. This is configured in the .ui file, so all
+    // we do here is attach the clicked() signal.
+    connect(ui.showUnitsCheckBox, SIGNAL(clicked()), this, SLOT(writeSettings()));
 
     ui.diagramGroupBox->setLayout(layout);
 
@@ -671,8 +665,8 @@ void LinechartWidget::addCurve(const QString& curve, const QString& unit)
     unitLabel->setToolTip(tr("Unit of ") + curve);
     unitLabel->setWhatsThis(tr("Unit of ") + curve);
     curvesWidgetLayout->addWidget(unitLabel, labelRow, 4);
-    unitLabel->setVisible(unitsCheckBox->isChecked());
-    connect(unitsCheckBox, SIGNAL(clicked(bool)), unitLabel, SLOT(setVisible(bool)));
+    unitLabel->setVisible(ui.showUnitsCheckBox->isChecked());
+    connect(ui.showUnitsCheckBox, SIGNAL(clicked(bool)), unitLabel, SLOT(setVisible(bool)));
 
     // Mean
     mean = new QLabel(this);

--- a/src/ui/linechart/LinechartWidget.h
+++ b/src/ui/linechart/LinechartWidget.h
@@ -163,7 +163,6 @@ protected:
     QToolButton* scalingLinearButton;
     QToolButton* scalingLogButton;
     QToolButton* logButton;
-    QPointer<QCheckBox> unitsCheckBox;
     QPointer<QCheckBox> timeButton;
 
     QFile* logFile;

--- a/src/ui/linechart/Linecharts.cc
+++ b/src/ui/linechart/Linecharts.cc
@@ -63,6 +63,7 @@ void Linecharts::hideEvent(QHideEvent* event)
 
 void Linecharts::selectSystem(int systemid)
 {
+	Q_UNUSED(systemid);
 //    QWidget* prevWidget = currentWidget();
 //    if (prevWidget)
 //    {


### PR DESCRIPTION
Modified the Linechart widget so that the "Show units" button is under the "Curve Selection" frame, which is what it actually modifies. This also involved me moving it into the Linechart.ui file instead of having it procedurally generated. Is there a reason that the Linechart widget is half described in the .ui file and half generated in `LinechartWidget::createLayout()`?

Also moved all of the UI that was under the "Curve Selection" to inside of it at the bottom so that the grouping of UI elements is more coherent.

I also wanted to add 2px of padding to both of the frames within this widget, but I couldn't figure out how to do it. The UI elements are a bit too cramped without this.

Finally this actually seems to have affected the performance of the initial loading of the UI once a MAVLink input source has been selected. I've been testing it on the demo_log simulated data. Maybe someone can confirm this is occurring and offer insight on how to fix it.
