### PR TITLE
Added a check for a division by zero in AbstractCalibrator::logAverage()

### DIFF
--- a/src/ui/RadioCalibration/AbstractCalibrator.cc
+++ b/src/ui/RadioCalibration/AbstractCalibrator.cc
@@ -14,25 +14,42 @@ AbstractCalibrator::~AbstractCalibrator()
 
 uint16_t AbstractCalibrator::logAverage()
 {
+	// Short-circuit here if the log is empty otherwise we get a div-by-0 error.
+	if (log->empty())
+	{
+		return 0;
+	}
+
     uint16_t total = 0;
     for (int i=0; i<log->size(); ++i)
+	{
         total += log->value(i);
+	}
     return total/log->size();
 }
 
 uint16_t AbstractCalibrator::logExtrema()
 {
     uint16_t extrema = logAverage();
-    if (logAverage() < 1500) {
-        for (int i=0; i<log->size(); ++i) {
+    if (logAverage() < 1500)
+	{
+        for (int i=0; i<log->size(); ++i)
+		{
             if (log->value(i) < extrema)
-                extrema = log->value(i);
+			{
+                extrema = log->value(i); 
+			}
         }
         extrema -= 5; // add 5us to prevent integer overflow
-    } else {
-        for (int i=0; i<log->size(); ++i) {
+    }
+	else
+	{
+        for (int i=0; i<log->size(); ++i)
+		{
             if (log->value(i) > extrema)
+			{
                 extrema = log->value(i);
+			}
         }
         extrema += 5; // subtact 5us to prevent integer overflow
     }
@@ -44,6 +61,8 @@ void AbstractCalibrator::channelChanged(uint16_t raw)
 {
     pulseWidth->setText(QString::number(raw));
     if (log->size() == 5)
+	{
         log->pop_front();
+	}
     log->push_back(raw);
 }


### PR DESCRIPTION
This was causing a crash when attempting a calibration when there's no RC data being received.
