### PR TITLE
Replaced the autopilot-specific inclusion of MAVLink to be more generic

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -92,57 +92,23 @@ INCLUDEPATH += \
 # If the user config file exists, it will be included.
 # if the variable MAVLINK_CONF contains the name of an
 # additional project, QGroundControl includes the support
-# of custom MAVLink messages of this project
+# of custom MAVLink messages of this project. It will also
+# create a QGC_USE_{AUTOPILOT_NAME}_MESSAGES macro for use
+# within the actual code.
 exists(user_config.pri) { 
     include(user_config.pri)
     message("----- USING CUSTOM USER QGROUNDCONTROL CONFIG FROM user_config.pri -----")
     message("Adding support for additional MAVLink messages for: " $$MAVLINK_CONF)
     message("------------------------------------------------------------------------")
 }
-INCLUDEPATH += $$MAVLINKPATH/common
 INCLUDEPATH += $$MAVLINKPATH
-contains(MAVLINK_CONF, pixhawk) { 
-    # Remove the default set - it is included anyway
-    INCLUDEPATH -= $$MAVLINKPATH/common
-
-    # PIXHAWK SPECIAL MESSAGES
-    INCLUDEPATH += $$MAVLINKPATH/pixhawk
-    DEFINES += QGC_USE_PIXHAWK_MESSAGES
+isEmpty(MAVLINK_CONF) { 
+    INCLUDEPATH += $$MAVLINKPATH/common
+} else {
+    INCLUDEPATH += $$MAVLINKPATH/$$MAVLINK_CONF
+    DEFINES += 'MAVLINK_CONF="$${MAVLINK_CONF}.h"'
+    DEFINES += $$sprintf('QGC_USE_%1_MESSAGES', $$upper($$MAVLINK_CONF))
 }
-contains(MAVLINK_CONF, slugs) { 
-    # Remove the default set - it is included anyway
-    INCLUDEPATH -= $$MAVLINKPATH/common
-    
-    # SLUGS SPECIAL MESSAGES
-    INCLUDEPATH += $$MAVLINKPATH/slugs
-    DEFINES += QGC_USE_SLUGS_MESSAGES
-}
-contains(MAVLINK_CONF, ualberta) { 
-    # Remove the default set - it is included anyway
-    INCLUDEPATH -= $$MAVLINKPATH/common
-    
-    # UALBERTA SPECIAL MESSAGES
-    INCLUDEPATH += $$MAVLINKPATH/ualberta
-    DEFINES += QGC_USE_UALBERTA_MESSAGES
-}
-contains(MAVLINK_CONF, ardupilotmega) { 
-    # Remove the default set - it is included anyway
-    INCLUDEPATH -= $$MAVLINKPATH/common
-    INCLUDEPATH -= $$BASEDIR/mavlink/include/v1.0/common
-    
-    # UALBERTA SPECIAL MESSAGES
-    INCLUDEPATH += $$MAVLINKPATH/ardupilotmega
-    DEFINES += QGC_USE_ARDUPILOTMEGA_MESSAGES
-}
-contains(MAVLINK_CONF, senseSoar) { 
-    # Remove the default set - it is included anyway
-    INCLUDEPATH -= $$MAVLINKPATH/common
-    
-    # SENSESOAR SPECIAL MESSAGES
-    INCLUDEPATH += $$MAVLINKPATH/SenseSoar
-    DEFINES += QGC_USE_SENSESOAR_MESSAGES
-}
-
 
 # Include general settings for QGroundControl
 # necessary as last include to override any non-acceptable settings

--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -33,20 +33,8 @@ This file is part of the QGROUNDCONTROL project
 #include <mavlink_types.h>
 #include <mavlink.h>
 
-#ifdef QGC_USE_PIXHAWK_MESSAGES
-#include <pixhawk.h>
-#endif
-
-#ifdef QGC_USE_SLUGS_MESSAGES
-#include <slugs.h>
-#endif
-
-#ifdef QGC_USE_UALBERTA_MESSAGES
-#include <ualberta.h>
-#endif
-
-#ifdef QGC_USE_ARDUPILOTMEGA_MESSAGES
-#include <ardupilotmega.h>
+#ifdef MAVLINK_CONF
+#include MAVLINK_CONF
 #endif
 
 

--- a/src/ui/MAVLinkDecoder.cc
+++ b/src/ui/MAVLinkDecoder.cc
@@ -14,8 +14,6 @@ MAVLinkDecoder::MAVLinkDecoder(MAVLinkProtocol* protocol, QObject *parent) :
         onboardTimeOffset[i] = 0;
     }
 
-
-
     // Fill filter
     messageFilter.insert(MAVLINK_MSG_ID_HEARTBEAT, false);
     messageFilter.insert(MAVLINK_MSG_ID_SYS_STATUS, false);


### PR DESCRIPTION
Now if you have no actual QGC modifications to make and just want your messages to be available for viewing/logging you can just create the user_config.pri file and override MAVLINK_CONF. This means for me to use QGC I don't have to modify any of the build code or additional header files!

NOTE! This has not been tested on anything besides Windows, though I imagine it will work the same as everything I read about gcc seemed to imply the macro argument syntax (-D) is the same as that used for the VS2010 compiler.
