### PR TITLE
QAx build automated in qgroundcontrol.pro

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -61,6 +61,14 @@ win32 {
     QMAKE_MOC = "$$(QTDIR)/bin/moc.exe"
     QMAKE_RCC = "$$(QTDIR)/bin/rcc.exe"
     QMAKE_QMAKE = "$$(QTDIR)/bin/qmake.exe"
+	
+	# Build QAX for GoogleEarth API access
+	!exists( $(QTDIR)/src/activeqt/Makefile ) {
+		message( Making QAx (ONE TIME) )
+		system( cd $$(QTDIR)\\src\\activeqt && $$(QTDIR)\\bin\\qmake.exe )
+		system( cd $$(QTDIR)\\src\\activeqt\\container && $$(QTDIR)\\bin\\qmake.exe )
+		system( cd $$(QTDIR)\\src\\activeqt\\control && $$(QTDIR)\\bin\\qmake.exe )
+	}
 }
 
 


### PR DESCRIPTION
No longer necessary to qmake activeqt because it has been automated within qgroundcontrol.pro. It will only occur one time if QAx hasn't already been qmade.
