### PR TITLE
mapscache moved to user`s home directory to prevent polution of root FS

### DIFF
--- a/libs/opmapcontrol/src/core/cache.cpp
+++ b/libs/opmapcontrol/src/core/cache.cpp
@@ -41,9 +41,9 @@ namespace core {
     void Cache::setCacheLocation(const QString& value)
     {
         cache=value;
-        routeCache = cache + "RouteCache" + QDir::separator();
-        geoCache = cache + "GeocoderCache"+ QDir::separator();
-        placemarkCache = cache + "PlacemarkCache" + QDir::separator();
+        routeCache = cache + "RouteCache/";
+        geoCache = cache + "GeocoderCache/";
+        placemarkCache = cache + "PlacemarkCache/";
         ImageCache.setGtileCache(value);
     }
     QString Cache::CacheLocation()
@@ -54,7 +54,7 @@ namespace core {
     {
         if(cache.isNull()|cache.isEmpty())
         {
-            cache= Utils::PathUtils().GetStoragePath()+"mapscache"+QDir::separator();
+            cache = QDir::homePath() + "/mapscache/";
             setCacheLocation(cache);
         }
     }


### PR DESCRIPTION
1) Now data from google earth cached in user's home directory. This allow QGC to store cached data when running from non root user. 
2) QDir::separator() removed because http://doc.qt.nokia.com/4.7-snapshot/qdir.html#separator says "You do not need to use this function to build file paths. If you always use "/", Qt will translate your paths to conform to the underlying operating system."
