### PR TITLE
Add unistd.h in libs/thirdParty/qserialport/src/posix/qserialportnative_...

### DIFF
--- a/libs/thirdParty/qserialport/src/posix/qserialportnative_posix.cpp
+++ b/libs/thirdParty/qserialport/src/posix/qserialportnative_posix.cpp
@@ -28,6 +28,7 @@
 #include <QSocketNotifier>
 #include "qserialportnative.h"
 #include "termioshelper.h"
+#include <unistd.h>
 
 namespace {
   const int kMinReadTimeout = 100;


### PR DESCRIPTION
...posix.cpp.

Without this change, the program can not be built on Linux.
Before the change It said:
`../qgroundcontrol/libs/thirdParty/qserialport/src/posix/qserialportnative_posix.cpp:105:3: error: '::close' has not been declared
../qgroundcontrol/libs/thirdParty/qserialport/src/posix/qserialportnative_posix.cpp:208:21: error: '::read' has not been declared
../qgroundcontrol/libs/thirdParty/qserialport/src/posix/qserialportnative_posix.cpp:219:21: error: '::write' has not been declared`
