### PR TITLE
URGENT: Fix broken Windows compilation

### DIFF
--- a/qgroundcontrol.pri
+++ b/qgroundcontrol.pri
@@ -285,6 +285,9 @@ win32-msvc2008|win32-msvc2010 {
 
 	# QWebkit is not needed on MS-Windows compilation environment
 	CONFIG -= webkit
+	
+	# Specify the inclusion of (U)INT*_(MAX/MIN) macros within Visual Studio
+	DEFINES += __STDC_LIMIT_MACROS
 
 	# For release builds remove support for various Qt debugging macros.
 	CONFIG(release, debug|release) {

--- a/src/ui/QGCVehicleConfig.cc
+++ b/src/ui/QGCVehicleConfig.cc
@@ -1,4 +1,11 @@
+// On Windows (for VS2010) stdint.h contains the limits normally contained in limits.h
+// It also needs the __STDC_LIMIT_MACROS macro defined in order to include them (done
+// in qgroundcontrol.pri).
+#ifdef WIN32
+#include <stdint.h>
+#else
 #include <limits.h>
+#endif
 
 #include <QTimer>
 
@@ -228,8 +235,8 @@ void QGCVehicleConfig::resetCalibrationRC()
 {
     for (unsigned int i = 0; i < chanMax; ++i)
     {
-        rcMin[i] = INT_MAX;
-        rcMax[i] = INT_MIN;
+        rcMin[i] = (float)INT_MAX;
+        rcMax[i] = (float)INT_MIN;
     }
 }
 
@@ -318,7 +325,7 @@ void QGCVehicleConfig::remoteControlChannelRawChanged(int chan, float val)
     if (chan < 0 || static_cast<unsigned int>(chan) >= chanMax || val < 500 || val > 2500)
         return;
 
-    if (chan + 1 > chanCount) {
+    if (chan + 1 > (int)chanCount) {
         chanCount = chan+1;
     }
 


### PR DESCRIPTION
And again compilation is broken on Windows. Please make this a priority to check over and commit this fix. Turns out UINT16_MAX and related macros exist in stdint.h (not limits.h) and need a macro defined to enable them.

My only question is, why wasn't this commit found earlier? It's frustrating to update and have this happen routinely. Makes it hard for less-active developers to contribute if trunk is always broken on Windows.
