### PR TITLE
Phonon broken include for Linux

### DIFF
--- a/src/GAudioOutput.h
+++ b/src/GAudioOutput.h
@@ -41,8 +41,8 @@ This file is part of the PIXHAWK project
 #endif
 #ifdef Q_OS_LINUX
 //#include <flite/flite.h>
-#include <Phonon/MediaObject>
-#include <Phonon/AudioOutput>
+#include <phonon/MediaObject>
+#include <phonon/AudioOutput>
 #endif
 #ifdef Q_OS_WIN
 #include <Phonon/MediaObject>


### PR DESCRIPTION
Includes regarding Phonon for Linux platform were broken for last Phonon libraries.

In file GAudioOutput.h, include lines for Phonon libraries where modified, line 44 to 45

From:

```
#include <Phonon/MediaObject>
#include <Phonon/AudioOutput>
```

to:

```
#include <phonon/MediaObject>
#include <phonon/AudioOutput>
```

Hope this helps, even when more errors are present 
