### PR TITLE
Changed default MAVLink messages back to nothing from "pixhawk"

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -50,7 +50,7 @@ OBJECTS_DIR = $${BUILDDIR}/obj
 MOC_DIR = $${BUILDDIR}/moc
 UI_DIR = $${BUILDDIR}/ui
 RCC_DIR = $${BUILDDIR}/rcc
-MAVLINK_CONF = "pixhawk"
+MAVLINK_CONF = ""
 MAVLINKPATH = $$BASEDIR/libs/mavlink/include/mavlink/v1.0
 DEFINES += MAVLINK_NO_DATA
 


### PR DESCRIPTION
The default messages should just be the common ones, not any specific project.
