### PR TITLE
Fixed some display of parameters where no vehicle-specific config is specified

### DIFF
--- a/src/ui/designer/QGCParamSlider.cc
+++ b/src/ui/designer/QGCParamSlider.cc
@@ -415,51 +415,51 @@ void QGCParamSlider::setParameterValue(int uas, int component, int paramCount, i
             ui->intValueSpinBox->setEnabled(true);
             ui->doubleValueSpinBox->hide();
             ui->intValueSpinBox->setValue(value.toUInt());
-            ui->intValueSpinBox->setMinimum(-ui->intValueSpinBox->maximum());
-            ui->valueSlider->setValue(floatToScaledInt(value.toUInt()));
+            ui->intValueSpinBox->setRange(0, UINT8_MAX);
             if (parameterMax == 0 && parameterMin == 0)
             {
-                ui->editMaxSpinBox->setValue(255);
+                ui->editMaxSpinBox->setValue(UINT8_MAX);
                 ui->editMinSpinBox->setValue(0);
             }
+            ui->valueSlider->setValue(floatToScaledInt(value.toUInt()));
             break;
         case QVariant::Int:
             ui->intValueSpinBox->show();
             ui->intValueSpinBox->setEnabled(true);
             ui->doubleValueSpinBox->hide();
             ui->intValueSpinBox->setValue(value.toInt());
-            ui->valueSlider->setValue(floatToScaledInt(value.toInt()));
-            ui->intValueSpinBox->setMinimum(-ui->intValueSpinBox->maximum());
+            ui->intValueSpinBox->setRange(INT32_MIN, INT32_MAX);
             if (parameterMax == 0 && parameterMin == 0)
             {
-                ui->editMaxSpinBox->setValue(65535);
-                ui->editMinSpinBox->setValue(0);
+                ui->editMaxSpinBox->setValue(INT32_MAX);
+                ui->editMinSpinBox->setValue(INT32_MIN);
             }
+            ui->valueSlider->setValue(floatToScaledInt(value.toInt()));
             break;
         case QVariant::UInt:
             ui->intValueSpinBox->show();
             ui->intValueSpinBox->setEnabled(true);
             ui->doubleValueSpinBox->hide();
             ui->intValueSpinBox->setValue(value.toUInt());
-            ui->valueSlider->setValue(floatToScaledInt(value.toUInt()));
-            ui->intValueSpinBox->setMinimum(0);
+            ui->intValueSpinBox->setRange(0, UINT32_MAX);
             if (parameterMax == 0 && parameterMin == 0)
             {
-                ui->editMaxSpinBox->setValue(65535);
+                ui->editMaxSpinBox->setValue(UINT32_MAX);
                 ui->editMinSpinBox->setValue(0);
             }
+            ui->valueSlider->setValue(floatToScaledInt(value.toUInt()));
             break;
         case QMetaType::Float:
             ui->doubleValueSpinBox->setValue(value.toFloat());
             ui->doubleValueSpinBox->show();
             ui->doubleValueSpinBox->setEnabled(true);
             ui->intValueSpinBox->hide();
-            ui->valueSlider->setValue(floatToScaledInt(value.toFloat()));
             if (parameterMax == 0 && parameterMin == 0)
             {
                 ui->editMaxSpinBox->setValue(10000);
                 ui->editMinSpinBox->setValue(0);
             }
+            ui->valueSlider->setValue(floatToScaledInt(value.toFloat()));
             break;
         default:
             qCritical() << "ERROR: NO VALID PARAM TYPE";


### PR DESCRIPTION
Makes the sliders range consistent for the specified datatypes. Also sets the sliders value after a default range has been specified so that they actually represent the populated data.
