### PR TITLE
Fix for crash involving serial links not being removed from QGCToolBar

### DIFF
--- a/src/ui/QGCToolBar.cc
+++ b/src/ui/QGCToolBar.cc
@@ -177,6 +177,7 @@ void QGCToolBar::createUI()
         addLink(LinkManager::instance()->getLinks().last());
     // XXX implies that connect button is always active for the last used link
     connect(LinkManager::instance(), SIGNAL(newLink(LinkInterface*)), this, SLOT(addLink(LinkInterface*)));
+    connect(LinkManager::instance(), SIGNAL(linkRemoved(LinkInterface*)), this, SLOT(removeLink(LinkInterface*)));
 
     // Update label if required
     if (LinkManager::instance()->getLinks().count() < 3) {


### PR DESCRIPTION
QGCToolBar was not being notified of LinkInterface's being removed, so if you added two serial links, deleted the first one, then connected with the second one, it would result in a segfault as QGCToolBar tried to access the first (now nonexistant) one.
