### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@ Build QGroundControl
 --------------------
 1) From the terminal go to the `groundcontrol` directory
 
-2) Run `qmake`
+2) Run `qmake -spec macx-g++`
 
 3) Run `make -j8`
 


### PR DESCRIPTION
Changed OS X build instructions to force qmake to generate a Makefile instead of xcodeproj files.
