### PR TITLE
Fixed Compiler Error C2864 - only static const integral data members can...

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -38,6 +38,11 @@
 * as the previous one created unless one calls deleteSettings in the code after
 * creating the UAS.
 */
+
+const float UAS::lipoFull = 4.2f;  ///< 100% charged voltage
+const float UAS::lipoEmpty = 3.5f; ///< Discharged voltage
+
+
 UAS::UAS(MAVLinkProtocol* protocol, int id) : UASInterface(),
     uasId(id),
     links(new QList<LinkInterface*>()),

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -56,8 +56,8 @@ public:
     UAS(MAVLinkProtocol* protocol, int id = 0);
     ~UAS();
 
-    static const float lipoFull = 4.2f;  ///< 100% charged voltage
-    static const float lipoEmpty = 3.5f; ///< Discharged voltage
+    static const float lipoFull;  ///< 100% charged voltage
+    static const float lipoEmpty; ///< Discharged voltage
 
     /* MANAGEMENT */
 


### PR DESCRIPTION
Changed lipoFull and lipoEmpty initialization to allow correct compilation. This bug was introduced in commit befaccefd92abd839150b6a735f803cf52eb3ad2 (fix bogus type conversion). I'm using windows 7, VS2010 SP1 and QT 4.8.5. 

This is my first pull request, so if I'm doing something wrong please tell me! Thanks.

Pedro 
