### PR TITLE
Fixed RC calibration trim problem

### DIFF
--- a/src/ui/QGCVehicleConfig.cc
+++ b/src/ui/QGCVehicleConfig.cc
@@ -929,6 +929,8 @@ void QGCVehicleConfig::writeCalibrationRC()
 {
     if (!mav) return;
 
+    setTrimPositions();
+
     QString minTpl("RC%1_MIN");
     QString maxTpl("RC%1_MAX");
     QString trimTpl("RC%1_TRIM");


### PR DESCRIPTION
Trim was not being set because setTrimPositions() was never being called.
