### PR TITLE
Set home

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1651,9 +1651,13 @@ void UAS::setHomePosition(double lat, double lon, double alt)
     if (blockHomePositionChanges)
         return;
 
+    QString uasName = (getUASName() == "")?
+                tr("UAS") + QString::number(getUASID())
+              : getUASName();
+
     QMessageBox msgBox;
     msgBox.setIcon(QMessageBox::Warning);
-    msgBox.setText(tr("Set a new home position for vehicle %s").arg(getUASName()));
+    msgBox.setText(tr("Set a new home position for vehicle %1").arg(uasName));
     msgBox.setInformativeText("Do you want to set a new origin? Waypoints defined in the local frame will be shifted in their physical location");
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
     msgBox.setDefaultButton(QMessageBox::Cancel);

--- a/src/ui/map/QGCMapWidget.h
+++ b/src/ui/map/QGCMapWidget.h
@@ -138,6 +138,8 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event);
     void mouseDoubleClickEvent(QMouseEvent* event);
 
+    //void contextMenuEvent(QContextMenuEvent *);
+
     UASWaypointManager* currWPManager; ///< The current waypoint manager
     bool offlineMode;
     QMap<Waypoint* , mapcontrol::WayPointItem*> waypointsToIcons;
@@ -162,6 +164,7 @@ protected:
     bool mapInitialized;                ///< Map initialized?
     float homeAltitude;                 ///< Home altitude
     QPoint mousePressPos;               ///< Mouse position when the button is released.
+    QPoint contextMousePressPos;        ///< Mouse position when context menu activated.
     int defaultGuidedAlt;               ///< Default altitude for guided mode
     UASInterface *uas;                  ///< Currently selected UAS.
 


### PR DESCRIPTION
Added a 'Set home' option to QMapWidget action context menu (right-clicking on map). Fixed UAS::setHomePosition message box to correctly show UAS name.
