### PR TITLE
Fix Spektrum pair buton such that it works every time.

### DIFF
--- a/qupgrade.pro
+++ b/qupgrade.pro
@@ -223,6 +223,8 @@ win32-msvc2008|win32-msvc2010 {
                 QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtWebKitd4.dll" "$$TARGETDIR_WIN\\debug"$$escape_expand(\\n))
                 QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtXmld4.dll" "$$TARGETDIR_WIN\\debug"$$escape_expand(\\n))
                 QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtXmlPatternsd4.dll" "$$TARGETDIR_WIN\\debug"$$escape_expand(\\n))
+                QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtDeclaratived4.dll" "$$TARGETDIR_WIN\\debug"$$escape_expand(\\n))
+                QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtScriptd4.dll" "$$TARGETDIR_WIN\\debug"$$escape_expand(\\n))
         }
 
         CONFIG(release, debug|release) {
@@ -242,6 +244,8 @@ win32-msvc2008|win32-msvc2010 {
                 QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtWebKit4.dll" "$$TARGETDIR_WIN\\release"$$escape_expand(\\n))
                 QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtXml4.dll" "$$TARGETDIR_WIN\\release"$$escape_expand(\\n))
                 QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtXmlPatterns4.dll" "$$TARGETDIR_WIN\\release"$$escape_expand(\\n))
+                QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtDeclarative4.dll" "$$TARGETDIR_WIN\\debug"$$escape_expand(\\n))
+                QMAKE_POST_LINK += $$quote(xcopy /D /Y "$$(QTDIR)\\bin\\QtScript4.dll" "$$TARGETDIR_WIN\\debug"$$escape_expand(\\n))
                 QMAKE_POST_LINK += $$quote(del /F "$$TARGETDIR_WIN\\release\\qupgrade.exp"$$escape_expand(\\n))
                 QMAKE_POST_LINK += $$quote(del /F "$$TARGETDIR_WIN\\release\\qupgrade.lib"$$escape_expand(\\n))
 

--- a/src/uas/QGCUASParamManager.cc
+++ b/src/uas/QGCUASParamManager.cc
@@ -124,21 +124,21 @@ void QGCUASParamManager::setParameter(int compId, QString paramName, QVariant va
     paramDataModel.updatePendingParamWithValue(compId,paramName,value);
 }
 
-void QGCUASParamManager::sendPendingParameters(bool persistAfterSend)
+void QGCUASParamManager::sendPendingParameters(bool persistAfterSend, bool forceSend)
 {
-    paramCommsMgr->sendPendingParameters(persistAfterSend);
+    paramCommsMgr->sendPendingParameters(persistAfterSend, forceSend);
 }
 
 
 
 
-void QGCUASParamManager::setPendingParam(int compId,  const QString& paramName,  const QVariant& value)
+void QGCUASParamManager::setPendingParam(int compId,  const QString& paramName,  const QVariant& value, bool forceSend)
 {
     if ((0 == compId) || (-1 == compId)) {
         //attempt to get an actual component ID
         compId = paramDataModel.getDefaultComponentId();
     }
-    paramDataModel.updatePendingParamWithValue(compId,paramName,value);
+    paramDataModel.updatePendingParamWithValue(compId,paramName,value, forceSend);
 }
 
 

--- a/src/uas/QGCUASParamManager.h
+++ b/src/uas/QGCUASParamManager.h
@@ -90,7 +90,7 @@ public slots:
     /** @brief Send all pending parameters to the MAV, for storage in transient (RAM) memory
      * @param persistAfterSend  If true, all parameters will be written to persistent storage as well
     */
-    virtual void sendPendingParameters(bool persistAfterSend = false);
+    virtual void sendPendingParameters(bool persistAfterSend = false, bool forceSend = false);
 
 
     /** @brief Request list of parameters from MAV */
@@ -100,7 +100,7 @@ public slots:
     virtual void requestParameterListIfEmpty();
 
     /** @brief queue a pending parameter for sending to the MAV */
-    virtual void setPendingParam(int componentId,  const QString& key,  const QVariant& value);
+    virtual void setPendingParam(int componentId,  const QString& key,  const QVariant& value, bool forceSend = false);
 
     /** @brief remove all params from the pending list */
     virtual void clearAllPendingParams();

--- a/src/uas/UASParameterCommsMgr.cc
+++ b/src/uas/UASParameterCommsMgr.cc
@@ -307,7 +307,7 @@ void UASParameterCommsMgr::requestRcCalibrationParamsUpdate()
  * @param parameterName name of the parameter, as delivered by the system
  * @param value value of the parameter
  */
-void UASParameterCommsMgr::setParameter(int compId, QString paramName, QVariant value)
+void UASParameterCommsMgr::setParameter(int compId, QString paramName, QVariant value, bool forceSend)
 {
     if (paramName.isEmpty()) {
         return;
@@ -328,14 +328,16 @@ void UASParameterCommsMgr::setParameter(int compId, QString paramName, QVariant 
         return;
     }
 
-    QVariant onboardVal;
-    paramDataModel->getOnboardParamValue(compId,paramName,onboardVal);
-    if (onboardVal == value) {
-        setParameterStatusMsg(tr("REJ. %1 already %2").arg(paramName).arg(dblValue),
-                              ParamCommsStatusLevel_Warning
-                              );
-        return;
-    }
+	if (!forceSend) {
+		QVariant onboardVal;
+		paramDataModel->getOnboardParamValue(compId,paramName,onboardVal);
+		if (onboardVal == value) {
+			setParameterStatusMsg(tr("REJ. %1 already %2").arg(paramName).arg(dblValue),
+				ParamCommsStatusLevel_Warning
+				);
+			return;
+		}
+	}
 
     emitPendingParameterCommit(compId, paramName, value);
 
@@ -501,7 +503,7 @@ void UASParameterCommsMgr::writeParamsToPersistentStorage()
 }
 
 
-void UASParameterCommsMgr::sendPendingParameters(bool copyToPersistent)
+void UASParameterCommsMgr::sendPendingParameters(bool copyToPersistent, bool forceSend)
 {
     persistParamsAfterSend |= copyToPersistent;
 
@@ -517,7 +519,7 @@ void UASParameterCommsMgr::sendPendingParameters(bool copyToPersistent)
         setParameterStatusMsg(tr("%1 pending params for component %2").arg(paramList->count()).arg(compId));
 
         for (j = paramList->begin(); j != paramList->end(); ++j) {
-            setParameter(compId, j.key(), j.value());
+            setParameter(compId, j.key(), j.value(), forceSend);
             parametersSent++;
         }
     }

--- a/src/uas/UASParameterCommsMgr.h
+++ b/src/uas/UASParameterCommsMgr.h
@@ -71,13 +71,13 @@ signals:
 
 public slots:
     /** @brief  Iterate through all components, through all pending parameters and send them to UAS */
-    virtual void sendPendingParameters(bool copyToPersistent = false);
+    virtual void sendPendingParameters(bool copyToPersistent = false, bool forceSend = false);
 
     /** @brief  Write the current onboard parameters from transient RAM into persistent storage, e.g. EEPROM or harddisk */
     virtual void writeParamsToPersistentStorage();
 
     /** @brief Write one parameter to the MAV */
-    virtual void setParameter(int component, QString parameterName, QVariant value);
+    virtual void setParameter(int component, QString parameterName, QVariant value, bool forceSend = false);
 
     /** @brief Request list of parameters from MAV */
     virtual void requestParameterList();

--- a/src/uas/UASParameterDataModel.cc
+++ b/src/uas/UASParameterDataModel.cc
@@ -46,19 +46,21 @@ int UASParameterDataModel::countOnboardParams()
 }
 
 
-bool UASParameterDataModel::updatePendingParamWithValue(int compId, const QString& key, const QVariant& value)
+bool UASParameterDataModel::updatePendingParamWithValue(int compId, const QString& key, const QVariant& value, bool forceSend)
 {
     bool pending = true;
     //ensure we have this component in our onboard and pending lists already
     addComponent(compId);
 
-    QMap<QString, QVariant>* existParams = getOnboardParamsForComponent(compId);
-    if (existParams->contains(key)) {
-        QVariant existValue = existParams->value(key);
-        if (existValue == value) {
-            pending = false;
-        }
-    }
+	if (!forceSend) {
+		QMap<QString, QVariant>* existParams = getOnboardParamsForComponent(compId);
+		if (existParams->contains(key)) {
+			QVariant existValue = existParams->value(key);
+			if (existValue == value) {
+				pending = false;
+			}
+		}
+	}
 
     if (pending) {
         setPendingParam(compId,key,value);

--- a/src/uas/UASParameterDataModel.h
+++ b/src/uas/UASParameterDataModel.h
@@ -53,7 +53,7 @@ public:
     /** @brief add this parameter to pending list iff it has changed from onboard value
      * @return true if the parameter is now pending
     */
-    virtual bool updatePendingParamWithValue(int componentId, const QString &key,  const QVariant &value);
+    virtual bool updatePendingParamWithValue(int componentId, const QString &key,  const QVariant &value, bool forceSend = false);
     virtual void handleParamUpdate(int componentId, const QString& key, const QVariant& value);
     virtual bool getOnboardParamValue(int componentId, const QString& key, QVariant& value) const;
 

--- a/src/ui/QGCPX4VehicleConfig.cc
+++ b/src/ui/QGCPX4VehicleConfig.cc
@@ -156,7 +156,7 @@ QGCPX4VehicleConfig::QGCPX4VehicleConfig(QWidget *parent) :
     ui->rcCalibrationButton->setCheckable(true);
     ui->rcCalibrationButton->setEnabled(false);
     connect(ui->rcCalibrationButton, SIGNAL(clicked(bool)), this, SLOT(toggleCalibrationRC(bool)));
-    ui->spektrumPairButton->setCheckable(true);
+    ui->spektrumPairButton->setCheckable(false);
     ui->spektrumPairButton->setEnabled(false);
     connect(ui->spektrumPairButton, SIGNAL(clicked(bool)), this, SLOT(toggleSpektrumPairing(bool)));
 
@@ -345,22 +345,13 @@ void QGCPX4VehicleConfig::toggleSpektrumPairing(bool enabled)
         (void)warnMsgBox.exec();
     }
 
-    if (enabled)
-    {
-        int mode = 1; // DSM2
-        if (ui->dsmxRadioButton->isChecked())
-            mode = 2; // DSMX
+    int mode = 1; // DSM2
+    if (ui->dsmxRadioButton->isChecked())
+        mode = 2; // DSMX
 
-        mav->getParamManager()->setPendingParam(0, "RC_DSM_BIND", mode);
-        // Do not save this parameter, just set in RAM
-        mav->getParamManager()->sendPendingParameters();
-    }
-    else
-    {
-        mav->getParamManager()->setPendingParam(0, "RC_DSM_BIND", (int)0);
-        // Do not save this parameter, just set in RAM
-        mav->getParamManager()->sendPendingParameters();
-    }
+	mav->getParamManager()->setPendingParam(0, "RC_DSM_BIND", mode, true);
+	// Do not save this parameter, just set in RAM
+	mav->getParamManager()->sendPendingParameters(false, true);
 }
 
 void QGCPX4VehicleConfig::setTrimPositions()


### PR DESCRIPTION
- MAV resets the RC_DSM_BIND param back to 0 automatically but QGC
  doesn't know about this and thinks the parameter hasn't changed when the
  pair button is hit a second time. Since it thinks the param has not
  change, it doesn't transmit the update.
- This implements method to allow to optionally force QGC to send the
  update. By default it does not
- Also added copy statements to include the two missing DLLs
  (QtDeclarative and QtScript) automatically as part of Windows build.
