### PR TITLE
Do not crash in an empty symmetric IncrementalPlot

### DIFF
--- a/src/ui/linechart/IncrementalPlot.cc
+++ b/src/ui/linechart/IncrementalPlot.cc
@@ -214,6 +214,9 @@ void IncrementalPlot::resetScaling()
 void IncrementalPlot::updateScale()
 {
     const double margin = 0.05;
+    if(xmin == DBL_MAX)
+        return;
+
     double xMinRange = xmin-(qAbs(xmin*margin));
     double xMaxRange = xmax+(qAbs(xmax*margin));
     double yMinRange = ymin-(qAbs(ymin*margin));


### PR DESCRIPTION
This crash could be reproduced by starting QGroundControl, switching to
plot, then clicking the "Symmetric" checkbox.
