### PR TITLE
remove sdlmain

### DIFF
--- a/qgroundcontrol.pri
+++ b/qgroundcontrol.pri
@@ -204,7 +204,7 @@ linux-g++|linux-g++-64{
 		-lflite_cmulex \
 		-lflite \
 		-lSDL \
-		-lSDLmain \
+#		-lSDLmain \
 		-lasound
 
 	exists(/usr/include/osg) | exists(/usr/local/include/osg) {


### PR DESCRIPTION
This is needed for successful compilation on archlinux
Needs testing with other operating systems before merging
