### PR TITLE
Mavericks fix to APM_Toolbar

### DIFF
--- a/src/ui/apmtoolbar.cpp
+++ b/src/ui/apmtoolbar.cpp
@@ -10,7 +10,16 @@ APMToolBar::APMToolBar(QWidget *parent):
     QDeclarativeView(parent), m_uas(0)
 {
     // Configure our QML object
+    
+    // Hack to fix QTBUG 34300 on OSX where QDir::currentPath has changed behavior. This causes
+    // relative paths to inside the .app package to fail.
+#ifdef Q_OS_MAC
+    QString qmlFile = QApplication::applicationDirPath();
+    qmlFile.append("/qml/ApmToolBar.qml");
+    setSource(QUrl::fromLocalFile(qmlFile));
+#else
     setSource(QUrl::fromLocalFile("qml/ApmToolBar.qml"));
+#endif
     setResizeMode(QDeclarativeView::SizeRootObjectToView);
     this->rootContext()->setContextProperty("globalObj", this);
     connect(LinkManager::instance(),SIGNAL(newLink(LinkInterface*)),


### PR DESCRIPTION
QTBUG 34300 causes relative path references to qml file loading to fail. Mavericks (OSX 10.9) changed the behavior of current directory with respect to application launch path. It is now somewhat non-deterministic if a set current dir hasn't been done. This causes qml file loading to fail because it can't find the relative path into the app package. I changed the code to fully quality the path. I only changed it for OSX, just to be extra safe, but it should be ok for any os. Your call to keep as is, or remove the #ifdef and make it for all builds.
