### PR TITLE
Remove hardwired inclusion of OSG

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -875,8 +875,6 @@ win32-msvc2008|win32-msvc2010|win32-msvc2012 {
     DEFINES += MOUSE_ENABLED_WIN
 }
 
-unix:!macx:!symbian: LIBS += -losg
-
 OTHER_FILES += \
     dongfang_notes.txt \
     src/ui/dongfang-scrapyard.txt \


### PR DESCRIPTION
The remainder of .pro and .pri files have conditional inclusion of OpenSceneGraph based on availability. Removed this line which always includes it and overrides the conditional include which is already in other parts of the make files. This allows you to build on linux vm's running under Parallels. Parallels and OSG don't get along without building your own custom version of OSG. Link will fail, due to undefined references between GL and OSG. Tested on OSX and Ubuntu under Paralells (with and without OSG installed).
