### PR TITLE
Fix broken Windows build

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -80,15 +80,6 @@ win32 {
     QMAKE_MOC = "$$(QTDIR)/bin/moc.exe"
     QMAKE_RCC = "$$(QTDIR)/bin/rcc.exe"
     QMAKE_QMAKE = "$$(QTDIR)/bin/qmake.exe"
-	
-	# Build QAX for GoogleEarth API access
-	!exists( $(QTDIR)/src/activeqt/Makefile ) {
-		message( Making QAx (ONE TIME) )
-		system( cd $$(QTDIR)\\src\\activeqt && $$(QTDIR)\\bin\\qmake.exe )
-		system( cd $$(QTDIR)\\src\\activeqt\\container && $$(QTDIR)\\bin\\qmake.exe )
-		system( cd $$(QTDIR)\\src\\activeqt\\control && $$(QTDIR)\\bin\\qmake.exe )
-                system( cd $$(QTDIR)\\src\\activeqt && nmake )
-	}
 }
 
 macx {

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -115,8 +115,8 @@ UAS::UAS(MAVLinkProtocol* protocol, int id) : UASInterface(),
     altitudeAMSL(0.0),
     altitudeRelative(0.0),
 
-    airSpeed(NAN),
-    groundSpeed(NAN),
+    airSpeed(std::numeric_limits<double>::quiet_NaN()),
+    groundSpeed(std::numeric_limits<double>::quiet_NaN()),
 
     speedX(0.0),
     speedY(0.0),

--- a/src/ui/DebugConsole.cc
+++ b/src/ui/DebugConsole.cc
@@ -40,6 +40,8 @@ This file is part of the QGROUNDCONTROL project
 #include "protocol.h"
 #include "QGC.h"
 
+const float DebugConsole::inDataRateThreshold = 0.4f;
+
 DebugConsole::DebugConsole(QWidget *parent) :
     QWidget(parent),
     currLink(NULL),

--- a/src/ui/DebugConsole.h
+++ b/src/ui/DebugConsole.h
@@ -139,7 +139,7 @@ protected:
     QTimer snapShotTimer;     ///< Timer for measuring traffic snapshots
     static const int snapShotInterval = 500;     ///< Set the time between UI updates for the data rate (ms)
     float lowpassInDataRate;    ///< Lowpass filtered data rate (kilobytes/s)
-    static const float inDataRateThreshold = 0.4;  ///< Threshold where to enable auto-hold (kilobytes/s)
+    static const float inDataRateThreshold;  ///< Threshold where to enable auto-hold (kilobytes/s)
     float lowpassOutDataRate;   ///< Low-pass filtered outgoing data rate (kilobytes/s)
     QStringList commandHistory;
     QString currCommand;

--- a/src/ui/PrimaryFlightDisplay.cc
+++ b/src/ui/PrimaryFlightDisplay.cc
@@ -125,15 +125,15 @@ PrimaryFlightDisplay::PrimaryFlightDisplay(int width, int height, QWidget *paren
     pitch(0),
     heading(0),
 
-    altitudeAMSL(NAN),
-    altitudeRelative(NAN),
+    altitudeAMSL(std::numeric_limits<double>::quiet_NaN()),
+    altitudeRelative(std::numeric_limits<double>::quiet_NaN()),
 
-    groundSpeed(NAN),
-    airSpeed(NAN),
-    climbRate(NAN),
+    groundSpeed(std::numeric_limits<double>::quiet_NaN()),
+    airSpeed(std::numeric_limits<double>::quiet_NaN()),
+    climbRate(std::numeric_limits<double>::quiet_NaN()),
 
     navigationCrosstrackError(0),
-    navigationTargetBearing(NAN),
+    navigationTargetBearing(std::numeric_limits<double>::quiet_NaN()),
 
     layout(COMPASS_INTEGRATED),
     style(OVERLAY_HSI),
@@ -291,19 +291,19 @@ void PrimaryFlightDisplay::updateAttitude(UASInterface* uas, double roll, double
     Q_UNUSED(timestamp);
         // Called from UAS.cc l. 616
         if (isinf(roll)) {
-            this->roll = NAN;
+            this->roll = std::numeric_limits<double>::quiet_NaN();
         } else {
             this->roll = roll * (180.0 / M_PI);
         }
 
         if (isinf(pitch)) {
-            this->pitch = NAN;
+            this->pitch = std::numeric_limits<double>::quiet_NaN();
         } else {
             this->pitch = pitch * (180.0 / M_PI);
         }
 
         if (isinf(yaw)) {
-            this->heading = NAN;
+            this->heading = std::numeric_limits<double>::quiet_NaN();
         } else {
             yaw = yaw * (180.0 / M_PI);
             if (yaw<0) yaw+=360;


### PR DESCRIPTION
- NAN not available in windows headers, use cross platform friendly version
- VS compiler does not allow initializing non-integral types in header files
- ActiveQt libs are already installed by Win Qt4.8.5, no need to build. Plus this part of the makefile just loops without nmake.exe installed which is not part of a standard windows box

Built/Run on: Windows, Ubuntu, OSX
