### PR TITLE
disable -Werror

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -128,7 +128,6 @@ WindowsBuild {
 MacBuild | LinuxBuild {
 	QMAKE_CXXFLAGS_WARN_ON += \
         -Wall \
-        -Werror \
         -Wno-unused-parameter \
         -Wno-reorder \
         -Wno-unused-variable \


### PR DESCRIPTION
This removes the -Werror compiler option because the current master branch does not compile with this.

If we want to enable this option the correct way is to fix all current warnings and then re-enable -Werror.

From the gcc doc:
-Werror
Make all warnings into errors. 
