### PR TITLE
Final Warnings fixed plus Warnings as Errors turned on

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -123,15 +123,13 @@ WindowsBuild {
 #
 
 MacBuild | LinuxBuild {
-	QMAKE_CXXFLAGS_WARN_ON += -Wall
-}
-
-MacBuild {
-	QMAKE_CXXFLAGS_WARN_ON += -Werror
+	QMAKE_CXXFLAGS_WARN_ON += -Wall \
+        -Werror
 }
 
 WindowsBuild {
 	QMAKE_CXXFLAGS_WARN_ON += /W3 \
+        /WX \
         /wd4996 \   # silence warnings about deprecated strcpy and whatnot
         /wd4290     # ignore exception specifications
 }

--- a/src/comm/MAVLinkSimulationLink.cc
+++ b/src/comm/MAVLinkSimulationLink.cc
@@ -483,6 +483,7 @@ void MAVLinkSimulationLink::mainloop()
 #ifdef MAVLINK_ENABLED_PIXHAWK
             mavlink_pattern_detected_t detected;
             detected.confidence = 5.0f;
+            detected.type = 0;  // compiler confused into thinking type is used unitialized, bogus init to silence
 
             if (detectionCounter == 10) {
                 char fileName[] = "patterns/face5.png";

--- a/src/comm/MAVLinkSimulationWaypointPlanner.cc
+++ b/src/comm/MAVLinkSimulationWaypointPlanner.cc
@@ -523,38 +523,29 @@ void MAVLinkSimulationWaypointPlanner::send_setpoint(uint16_t seq)
     if(seq < waypoints->size()) {
         mavlink_mission_item_t *cur = waypoints->at(seq);
 
-        mavlink_message_t msg;
-        mavlink_set_local_position_setpoint_t PControlSetPoint;
-
         // send new set point to local IMU
-        if (cur->frame == 1) {
+        if (cur->frame == MAV_FRAME_LOCAL_NED || cur->frame == MAV_FRAME_LOCAL_ENU) {
+            mavlink_message_t msg;
+            mavlink_set_local_position_setpoint_t PControlSetPoint;
+
             PControlSetPoint.target_system = systemid;
             PControlSetPoint.target_component = MAV_COMP_ID_IMU;
             PControlSetPoint.x = cur->x;
             PControlSetPoint.y = cur->y;
             PControlSetPoint.z = cur->z;
             PControlSetPoint.yaw = cur->param4;
-
-            mavlink_msg_set_local_position_setpoint_encode(systemid, compid, &msg, &PControlSetPoint);
-            link->sendMAVLinkMessage(&msg);
-
-
-        } else {
-            //if (verbose) qDebug("No new set point sent to IMU because the new waypoint %u had no local coordinates\n", cur->seq);
-            PControlSetPoint.target_system = systemid;
-            PControlSetPoint.target_component = MAV_COMP_ID_IMU;
-            PControlSetPoint.x = cur->x;
-            PControlSetPoint.y = cur->y;
-            PControlSetPoint.z = cur->z;
-            PControlSetPoint.yaw = cur->param4;
-
+            PControlSetPoint.coordinate_frame = cur->frame;
+            
             mavlink_msg_set_local_position_setpoint_encode(systemid, compid, &msg, &PControlSetPoint);
             link->sendMAVLinkMessage(&msg);
             emit messageSent(msg);
+
+            uint64_t now = QGC::groundTimeMilliseconds();
+            timestamp_last_send_setpoint = now;
+        } else if (verbose) {
+            qDebug("No new set point sent to IMU because the new waypoint %u had no local coordinates\n", cur->seq);
         }
 
-        uint64_t now = QGC::groundTimeMilliseconds();
-        timestamp_last_send_setpoint = now;
     }
 }
 


### PR DESCRIPTION
No response on Issue #508 so I've tried to fix it myself by just reading up on the mavlink message it is trying to send. The original code seemed very strange in that both sides of the if seem to basically do the same thing. Whereas the debug log message seems to indicate it may be trying to not send message if not in local frame coordinates. The original if, sort of tested for local frame as well, but was missing one of the local frame types. Changed to code to check for local frame correctly and send or not send appropriately. Also set coordinate_frame from the way point frame which silences the error. All of this compiles, but I can't figure out how to test this with the simulator. So other than clean compile some help with making sure this is correct is appreciated.

These last changes complete my wild journey through cleaning up all warnings. Build is now clean on Mac, Ubuntu and Windows both debug and release. I've turned on warnings as errors for all build flavors to prevent it from degrading from fully clean.
