### PR TITLE
fix unused-but-set-variable warnings/errors in map3D

### DIFF
--- a/src/ui/map3D/Imagery.cc
+++ b/src/ui/map3D/Imagery.cc
@@ -552,8 +552,7 @@ Imagery::UTMtoLL(double utmNorthing, double utmEasting, const QString& utmZone,
 
     std::istringstream iss(utmZone.toStdString());
     iss >> ZoneNumber >> ZoneLetter;
-    if ((ZoneLetter - 'N') >= 0) {
-    } else {
+    if ((ZoneLetter - 'N') < 0) {
         y -= 10000000.0;//remove 10,000,000 meter offset used for southern hemisphere
     }
 


### PR DESCRIPTION
critical because this fixes a compile error on master
