### PR TITLE
Make Pixhawk default dialect

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -113,10 +113,10 @@ else:infile(user_config.pri, MAVLINK_CONF) {
 	}
     }
 }
-# If no valid user selection is found, default to the ardupilotmega if it's available.
+# If no valid user selection is found, default to the pixhawk if it's available.
 # Note: This can be a list of several dialects.
 else {
-    DEFAULT_MAVLINK_DIALECTS=ardupilotmega
+    DEFAULT_MAVLINK_DIALECTS=pixhawk
     for(dialect, DEFAULT_MAVLINK_DIALECTS) {
 	exists($$MAVLINKPATH/$$dialect) {
 	    MAVLINK_DIALECTS += $$dialect


### PR DESCRIPTION
I was about to change TeamCity builds to default to Pixhawk dialect since as far as I understand this is the primary dialect. Given that it seams strange that the default dialect is ardupilotmega. If Pixhawk is truly the primary dialect/platform then it seems like it should be the default a well. Hence this PR.
