### PR TITLE
Changes to allow msbuild to build installers

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -36,14 +36,6 @@ linux-g++ | linux-g++-64 {
     error(Unsupported build type)
 }
 
-# Installer configuration
-
-installer {
-    CONFIG -= debug
-    CONFIG -= debug_and_release
-    CONFIG += release
-}
-
 # Setup our supported build flavors
 
 CONFIG(debug, debug|release) {


### PR DESCRIPTION
No idea why, but manipulating CONFIG like this inside the build file confuses msbuild command line builds. Work fine if you build from the IDE! So in order to build installers you'll need CONFIG+=installer and CONFIG+=release. Needs this change to finish scheduled installer builds and uploads from TeamCity.
