### PR TITLE
Disable text output from GAudioOutput.

### DIFF
--- a/src/GAudioOutput.cc
+++ b/src/GAudioOutput.cc
@@ -329,9 +329,10 @@ void GAudioOutput::beep()
 {
     if (!muted)
     {
+        // TODO: Re-enable audio beeps
         // Use QFile to transform path for all OS
-        QFile f(QCoreApplication::applicationDirPath() + QString("/files/audio/alert.wav"));
-        qDebug() << "FILE:" << f.fileName();
+        //QFile f(QCoreApplication::applicationDirPath() + QString("/files/audio/alert.wav"));
+        //qDebug() << "FILE:" << f.fileName();
         //m_media->setCurrentSource(Phonon::MediaSource(f.fileName().toStdString().c_str()));
         //m_media->play();
     }


### PR DESCRIPTION
All it does is clutter the terminal and it's not doing anything anyways. I don't know if `beep()` should just be removed all together at this point or what the deal is, but these pointless debug outputs should definitely go.
