### PR TITLE
Fixed Menubar for Ubuntu Unity.

### DIFF
--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -51,8 +51,11 @@
      <x>0</x>
      <y>0</y>
      <width>1024</width>
-     <height>22</height>
+     <height>25</height>
     </rect>
+   </property>
+   <property name="nativeMenuBar">
+    <bool>false</bool>
    </property>
    <widget class="QMenu" name="menuMGround">
     <property name="title">


### PR DESCRIPTION
Changed nativeMenubar is now false, this fixed the menubar not showing up for Ubuntu unity users. Not sure if this will affect any other enviroments, can you verify.

This is a solution for issue #542
