### PR TITLE
Reverting previous Installer commit

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -36,6 +36,15 @@ linux-g++ | linux-g++-64 {
     error(Unsupported build type)
 }
 
+# Installer configuration
+
+installer {
+    CONFIG -= debug
+    CONFIG -= debug_and_release
+    CONFIG += release
+    message(Build Installer)
+}
+
 # Setup our supported build flavors
 
 CONFIG(debug, debug|release) {


### PR DESCRIPTION
Figured out why windows command line builds were not working. Previous change was fine. To build Windows release from command line you need to add /property:Configuration=Release to the msbuild command line.
