### PR TITLE
Flightgear HIL: remove disable-intro-music argument 

### DIFF
--- a/src/ui/QGCHilFlightGearConfiguration.ui
+++ b/src/ui/QGCHilFlightGearConfiguration.ui
@@ -68,7 +68,7 @@
       </sizepolicy>
      </property>
      <property name="plainText">
-      <string>--roll=0 --pitch=0 --vc=0 --heading=300 --timeofday=noon --disable-hud-3d --disable-fullscreen --geometry=400x300 --disable-anti-alias-hud --wind=0@0 --turbulence=0.0 --prop:/sim/frame-rate-throttle-hz=30 --control=mouse --disable-intro-music --disable-sound --disable-random-objects --disable-ai-models --shading-flat --fog-disable --disable-specular-highlight --disable-random-objects --disable-panel --disable-clouds --fdm=jsb --units-meters --prop:/engines/engine/running=true</string>
+      <string>--roll=0 --pitch=0 --vc=0 --heading=300 --timeofday=noon --disable-hud-3d --disable-fullscreen --geometry=400x300 --disable-anti-alias-hud --wind=0@0 --turbulence=0.0 --prop:/sim/frame-rate-throttle-hz=30 --control=mouse --disable-sound --disable-random-objects --disable-ai-models --shading-flat --fog-disable --disable-specular-highlight --disable-random-objects --disable-panel --disable-clouds --fdm=jsb --units-meters --prop:/engines/engine/running=true</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
The disable-intro-music argument  is not known by Flightgear 3.0
