### PR TITLE
mapripper: autocontinue to next zoom level after 3s

### DIFF
--- a/libs/opmapcontrol/src/mapwidget/mapripper.cpp
+++ b/libs/opmapcontrol/src/mapwidget/mapripper.cpp
@@ -56,7 +56,7 @@ namespace mapcontrol
         {
          ++zoom;
          QMessageBox msgBox;
-         msgBox.setText(QString("Continue Ripping at zoom level %1? (Continuing automatically after 3s)").arg(zoom));
+         msgBox.setText(tr("Continue Ripping at zoom level %1? (Continuing automatically after 3s)").arg(zoom));
         // msgBox.setInformativeText("Do you want to save your changes?");
          msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
          msgBox.setDefaultButton(QMessageBox::Yes);


### PR DESCRIPTION
This adds a timeout to the msgbox which appears between the zoom-levels allowing unattended download of larger map parts.
