### PR TITLE
Fix distance to next waypoint widget in QuickView.

### DIFF
--- a/src/ui/uas/UASQuickView.cc
+++ b/src/ui/uas/UASQuickView.cc
@@ -32,7 +32,7 @@ UASQuickView::UASQuickView(QWidget *parent) : QWidget(parent)
         valueEnabled("altitudeAMSL");
         valueEnabled("altitudeRelative");
         valueEnabled("groundSpeed");
-        valueEnabled("distToWP");
+        valueEnabled("distToWaypoint");
     }
 
     QAction *action = new QAction("Add/Remove Items",this);

--- a/src/ui/uas/UASQuickViewTextItem.cc
+++ b/src/ui/uas/UASQuickViewTextItem.cc
@@ -51,7 +51,7 @@ void UASQuickViewTextItem::setValue(double value)
     {
         valueLabel->setText(QString::number(value,'f',1));
     }
-    else if (value >= 100000 || value <= -100000)
+    else 
     {
         valueLabel->setText(QString::number(value,'f',0));
     }


### PR DESCRIPTION
This patch fixes a bug that display 0 for distances to waypoint more
than 10km.

Besides that, it also homogenize the naming of the label to
"distToWaypoint" instead of "distToWP". Old configuration files (in
home directory), should be hacked or removed in order to see this
change.

Signed-off-by: Paul Chavent paul.chavent@onera.fr
