### PR TITLE
Don't use native menu bar on Linux

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -187,6 +187,11 @@ void MainWindow::init()
     ui.setupUi(this);
     hide();
     menuActionHelper->setMenu(ui.menuTools);
+    
+    // Qt 4 on Ubuntu does place the native menubar correctly so on Linux we revert back to in-window menu bar.
+#ifdef Q_OS_LINUX
+    menuBar()->setNativeMenuBar(false);
+#endif
 
     // We only need this menu if we have more than one system
     //    ui.menuConnected_Systems->setEnabled(false);


### PR DESCRIPTION
Fixes Issue #542. Verified in-window menu on Ubuntu, native menu on OSX.
