### PR TITLE
Removed -Werror for Mac since QT wont build otherwise.

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -146,8 +146,9 @@ WindowsBuild {
 
 # Note: -Werror is currently not turned on for Linux due to unfixed problems with release builds. See Issue 535. This will 
 # be removed once the Issue is taken care of.
+# Note: -Werror is also not turned on for Mac because Qt Core throws unused variable warnings for Mac from multiple header files.
 
-LinuxBuild {
+MacBuild | LinuxBuild {
     CONFIG += WarningsAsErrorsOff
 }
 


### PR DESCRIPTION
Disabled warnings as errors on mac to address issue #581, since Qt Core won't build on mac due to unused variable warnings in many header files. Looks like:
/usr/local/Cellar/qt/4.8.4/include/QtGui/qmime.h:119:10: warning: private field 'type' is not used [-Wunused-private-field]
    char type;
         ^
