### PR TITLE
Logging: Switched endianness of the timestamp that's logged in MAVLink streams

### DIFF
--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -16,6 +16,7 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QDesktopServices>
+#include <QtEndian>
 
 #include "MAVLinkProtocol.h"
 #include "UASInterface.h"
@@ -359,12 +360,17 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
             if (m_loggingEnabled && m_logfile)
             {
                 uint8_t buf[MAVLINK_MAX_PACKET_LEN+sizeof(quint64)] = {0};
+                
+                // Write the current ground time to the data stream in BigEndian order.
                 quint64 time = QGC::groundTimeUsecs();
-                memcpy(buf, (void*)&time, sizeof(quint64));
-                // Write message to buffer
+                qToBigEndian(time, buf);
+
+                // Now write the message to buffer. This function correctly accounts
+                // for byte ordering already.
                 mavlink_msg_to_send_buffer(buf+sizeof(quint64), &message);
-                //we need to write the maximum package length for having a
-                //consistent file structure and beeing able to parse it again
+
+                // We need to write the maximum package length for having a
+                // consistent file structure and being able to parse it again.
                 int len = MAVLINK_MAX_PACKET_LEN + sizeof(quint64);
                 QByteArray b((const char*)buf, len);
                 if(m_logfile->write(b) != len)


### PR DESCRIPTION
All of MAVLink's scripts assume this timestamp is in BigEndian format, so I think QGC is in the wrong here.
