### PR TITLE
include HIL bit, this makes HIL without RC working again

### DIFF
--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -539,6 +539,8 @@ public:
     bool isAuto();
     /** @brief Check if vehicle is armed */
     bool isArmed() const { return systemIsArmed; }
+    /** @brief Check if vehicle is in HIL mode */
+    bool isHilEnabled() const { return hilEnabled; }
 
     /** @brief Get reference to the waypoint manager **/
     UASWaypointManager* getWaypointManager() {

--- a/src/ui/uas/UASControlWidget.cc
+++ b/src/ui/uas/UASControlWidget.cc
@@ -230,8 +230,8 @@ void UASControlWidget::setMode(int mode)
 
 void UASControlWidget::transmitMode()
 {
-    UASInterface* uas = UASManager::instance()->getUASForId(this->uasID);
-    if (uas) {
+    UASInterface* uas_iface = UASManager::instance()->getUASForId(this->uasID);
+    if (uas_iface) {
         if (modeIdx >= 0 && modeIdx < modesNum) {
             struct full_mode_s mode = modesList[modeIdx];
             // include armed state
@@ -239,6 +239,14 @@ void UASControlWidget::transmitMode()
                 mode.baseMode |= MAV_MODE_FLAG_SAFETY_ARMED;
             } else {
                 mode.baseMode &= ~MAV_MODE_FLAG_SAFETY_ARMED;
+            }
+
+            UAS* uas = dynamic_cast<UAS*>(uas_iface);
+
+            if (uas->isHilEnabled()) {
+                mode.baseMode |= MAV_MODE_FLAG_HIL_ENABLED;
+            } else {
+                mode.baseMode &= ~MAV_MODE_FLAG_HIL_ENABLED;
             }
 
             uas->setMode(mode.baseMode, mode.customMode);


### PR DESCRIPTION
Why was this commented out in the first place?

Now these controls work again in HIL:
![control widget](https://cloud.githubusercontent.com/assets/1419688/2810078/33c3c36c-cd99-11e3-9f9a-5049e0ad1909.png)
