### PR TITLE
fix qmin/qmax types

### DIFF
--- a/libs/qwt/qwt_math.h
+++ b/libs/qwt/qwt_math.h
@@ -23,8 +23,8 @@
 
 #else // QT_VERSION >= 0x040000
 
-#define qwtMax qMax
-#define qwtMin qMin
+#define qwtMax(x,y) qMax(qreal(x),qreal(y))
+#define qwtMin(x,y) qMin(qreal(x),qreal(y))
 #define qwtAbs qAbs
 
 #endif

--- a/src/ui/designer/QGCXYPlot.cc
+++ b/src/ui/designer/QGCXYPlot.cc
@@ -38,10 +38,10 @@ public:
             ymin = ymax = data.y();
             minMaxSet = true;
         } else if(m_autoScale) {
-            xmin = qMin(xmin, data.x());
-            xmax = qMax(xmax, data.x());
-            ymin = qMin(ymin, data.y());
-            ymax = qMax(ymax, data.y());
+            xmin = qMin(qreal(xmin), data.x());
+            xmax = qMax(qreal(xmax), data.x());
+            ymin = qMin(qreal(ymin), data.y());
+            ymax = qMax(qreal(ymax), data.y());
         }
 
         m_data.append(data);
@@ -73,10 +73,10 @@ public:
             xmax = xmin = m_data.at(0).x();
             ymax = ymin = m_data.at(0).y();
             for(int i = 1; i < m_data.size(); i++) {
-                xmin = qMin(xmin, m_data.at(i).x());
-                xmax = qMax(xmax, m_data.at(i).x());
-                ymin = qMin(ymin, m_data.at(i).y());
-                ymax = qMax(ymax, m_data.at(i).y());
+                xmin = qMin(qreal(xmin), m_data.at(i).x());
+                xmax = qMax(qreal(xmax), m_data.at(i).x());
+                ymin = qMin(qreal(ymin), m_data.at(i).y());
+                ymax = qMax(qreal(ymax), m_data.at(i).y());
             }
         }
     }


### PR DESCRIPTION
qreal is a double on some platforms (x86) and a float on others (e.g. ARM), cast it to fix build errors like these:

src/ui/designer/QGCXYPlot.cc: In member function 'int
XYPlotCurve::appendData(const QPointF&)':
src/ui/designer/QGCXYPlot.cc:41:39: error: no matching function for call
to 'qMin(double&, qreal)'
             xmin = qMin(xmin, data.x());
                                       ^
src/ui/designer/QGCXYPlot.cc:41:39: note: candidate is:
In file included from
/build/v2013.12/build/tmp-angstrom_v2013_12-eglibc/sysroots/sama5d3_xplained/usr/include/qt4/QtCore/qnamespace.h:45:0,
                 from
/build/v2013.12/build/tmp-angstrom_v2013_12-eglibc/sysroots/sama5d3_xplained/usr/include/qt4/QtCore/qobjectdefs.h:45,
                 from
/build/v2013.12/build/tmp-angstrom_v2013_12-eglibc/sysroots/sama5d3_xplained/usr/include/qt4/QtGui/qwindowdefs.h:45,
                 from
/build/v2013.12/build/tmp-angstrom_v2013_12-eglibc/sysroots/sama5d3_xplained/usr/include/qt4/QtGui/qwidget.h:46,
                 from
/build/v2013.12/build/tmp-angstrom_v2013_12-eglibc/sysroots/sama5d3_xplained/usr/include/qt4/QtGui/qdockwidget.h:45,
                 from
/build/v2013.12/build/tmp-angstrom_v2013_12-eglibc/sysroots/sama5d3_xplained/usr/include/qt4/QtGui/QDockWidget:1,
                 from src/ui/designer/QGCXYPlot.cc:1:
/build/v2013.12/build/tmp-angstrom_v2013_12-eglibc/sysroots/sama5d3_xplained/usr/include/qt4/QtCore/qglobal.h:1213:34:
note: template<class T> const T& qMin(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMin(const T &a, const T &b) { return
(a < b) ? a : b; }
                                  ^

See http://www.qtcentre.org/archive/index.php/t-45475.html for some
background.

This fixes #625

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
