### PR TITLE
MainWindow: set minimum size to 640x400

### DIFF
--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -12,8 +12,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>1024</width>
-    <height>600</height>
+    <width>640</width>
+    <height>400</height>
    </size>
   </property>
   <property name="baseSize">


### PR DESCRIPTION
This makes it fit a lot better on my 800x480 screen. The HUD refuses to the less than ~400 pixels wide, but that's fine since the HUD is the only widget I really need to see.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
