### PR TITLE
add option "time serie" option to the XYPlot widget

### DIFF
--- a/src/ui/designer/QGCXYPlot.h
+++ b/src/ui/designer/QGCXYPlot.h
@@ -31,10 +31,11 @@ public slots:
     void styleChanged(MainWindow::QGC_MAINWINDOW_STYLE style);
     void updateMinMaxSettings();
 
+
 private slots:
     void on_maxDataShowSpinBox_valueChanged(int value);
     void on_stopStartButton_toggled(bool checked);
-
+    void setTimeAxis();
     void on_timeScrollBar_valueChanged(int value);
 
 private:
@@ -42,6 +43,7 @@ private:
     QwtPlot *plot;
     XYPlotCurve* xycurve;
 
+    bool autoScaleTime;
     double x; /**< Last unused value for the x-coordinate */
     quint64 x_timestamp_us; /**< Timestamp that we last recieved a value for x */
     bool x_valid; /**< Whether we have recieved an x value but so far no corresponding y value */


### PR DESCRIPTION
the autoscale option will make the graph too small when x axis is a time value.

![2014-04-30-065711_803x434_scrot](https://cloud.githubusercontent.com/assets/1732355/2837942/698aaba6-d027-11e3-8787-50583efcffa2.png)
![2014-04-30-055018_1606x413_scrot](https://cloud.githubusercontent.com/assets/1732355/2837980/248d0264-d028-11e3-9a45-cd3244397c26.png)

Adding an option for time serie axis make the graph conform to autoscale and to m_maxShowPoints :
![2014-04-30-065658_803x434_scrot](https://cloud.githubusercontent.com/assets/1732355/2837935/51d37c36-d027-11e3-90a0-a7e9cc850bd6.png)

![2014-04-30-070746_1608x841_scrot](https://cloud.githubusercontent.com/assets/1732355/2837962/be69a848-d027-11e3-8eb7-8de4aa0e19db.png)
