### PR TITLE
Google earth: Corrected #ifdef for Google Earth-specific code.

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -569,7 +569,7 @@ void MainWindow::buildCommonWidgets()
     }
 #endif
 
-#if (defined _MSC_VER) | (defined Q_OS_MAC)
+#if QGC_GOOGLE_EARTH_ENABLED
     if (!googleEarthView)
     {
         googleEarthView = new SubMainWindow(this);


### PR DESCRIPTION
Missed an #ifdef back when fixing the build process for QGC.
