### PR TITLE
QGC data logging now records small MAVLink messages.

### DIFF
--- a/src/ui/QGCMAVLinkLogPlayer.ui
+++ b/src/ui/QGCMAVLinkLogPlayer.ui
@@ -29,7 +29,7 @@
    <item>
     <widget class="QLabel" name="logStatsLabel">
      <property name="text">
-      <string>No logfile selected..</string>
+      <string/>
      </property>
     </widget>
    </item>
@@ -53,6 +53,16 @@
      </property>
      <property name="checkable">
       <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="timeLabel">
+     <property name="text">
+      <string>Time</string>
      </property>
     </widget>
    </item>
@@ -119,7 +129,7 @@
    <item>
     <widget class="QLabel" name="logFileNameLabel">
      <property name="text">
-      <string>-</string>
+      <string>No logfile selected..</string>
      </property>
     </widget>
    </item>

--- a/src/ui/QGCStatusBar.cc
+++ b/src/ui/QGCStatusBar.cc
@@ -37,7 +37,7 @@ QGCStatusBar::QGCStatusBar(QWidget *parent) :
 {
     setObjectName("QGC_STATUSBAR");
 
-    toggleLoggingButton = new QPushButton("Logging", this);
+    toggleLoggingButton = new QPushButton(tr("Log to file"), this);
     toggleLoggingButton->setCheckable(true);
 
     addPermanentWidget(toggleLoggingButton);


### PR DESCRIPTION
Previously MAVLink data streams recorded by QGC would use a fixed block size of the maximum MAVLink message length and fill in only the bytes written by the message. This wasted space, make manual parsing difficult, and broke compatibility with scripts provided in the MAVLink project (issue #174).

This patch alters logging to output only a packed data stream (64-bit big endian unix timestamp in microseconds since epoch + MAVLink message) instead of the unpacked data stream previously output. Additionally the previous logging code used the system endianness for packing in the timestamp, this has now been switched to always be big endian regardless of platform. All the documentation specifies big endian, so the code now follows the docs here.

Additionally data playback has been modified to playback both the new packed data streams as well as the old data streams, even those with improper endianness for their timestamps.

Finally, a variety of bugs have been fixed, along with some additional features and user experience changes, hopefully for the better. All existing functionality has been preserved as well.
