### PR TITLE
correction : display duration in hours,minutes,sec

### DIFF
--- a/src/ui/uas/UASView.cc
+++ b/src/ui/uas/UASView.cc
@@ -634,16 +634,26 @@ void UASView::refresh()
         // Thrust
         m_ui->thrustBar->setValue(thrust * 100);
 
+        // Time Elapsed
+        //QDateTime time = MG::TIME::msecToQDateTime(uas->getUptime());
+
+       quint64 filterTime = uas->getUptime() / 1000;
+       int hours = static_cast<int>(filterTime / 3600);
+       int min = static_cast<int>((filterTime - 3600 * hours) / 60);
+       int sec = static_cast<int>(filterTime - 60 * min - 3600 * hours);
+       QString timeText;
+       timeText = timeText.sprintf("%02d:%02d:%02d", hours, min, sec);
+       m_ui->timeElapsedLabel->setText(timeText);
+
         if(this->timeRemaining > 1 && this->timeRemaining < QGC::MAX_FLIGHT_TIME)
         {
             // Filter output to get a higher stability
             filterTime = static_cast<int>(this->timeRemaining);
-            filterTime = 0.8 * filterTime + 0.2 * static_cast<int>(this->timeRemaining);
-            int hours = static_cast<int>(filterTime / 3600);
-            int min = static_cast<int>((filterTime - 3600 * hours) / 60);
-            int sec = static_cast<int>(filterTime - 60 * min - 3600 * hours);
+            // filterTime = 0.8 * filterTime + 0.2 * static_cast<int>(this->timeRemaining);
+            hours = static_cast<int>(filterTime / 3600);
+            min = static_cast<int>((filterTime - 3600 * hours) / 60);
+            sec = static_cast<int>(filterTime - 60 * min - 3600 * hours);
 
-            QString timeText;
             timeText = timeText.sprintf("%02d:%02d:%02d", hours, min, sec);
             m_ui->timeRemainingLabel->setText(timeText);
         }
@@ -652,16 +662,7 @@ void UASView::refresh()
             m_ui->timeRemainingLabel->setText(tr("Calc.."));
         }
 
-        // Time Elapsed
-        //QDateTime time = MG::TIME::msecToQDateTime(uas->getUptime());
 
-        quint64 filterTime = uas->getUptime() / 1000;
-        int hours = static_cast<int>(filterTime / 3600);
-        int min = static_cast<int>((filterTime - 3600 * hours) / 60);
-        int sec = static_cast<int>(filterTime - 60 * min - 3600 * hours);
-        QString timeText;
-        timeText = timeText.sprintf("%02d:%02d:%02d", hours, min, sec);
-        m_ui->timeElapsedLabel->setText(timeText);
     }
     generalUpdateCount++;
 


### PR DESCRIPTION
Correction for flight time hours calculation.

Flight time should display : 36h44m08sec but shows 2204min08sec.

![bug](https://cloud.githubusercontent.com/assets/1732355/2937245/2df2efc2-d892-11e3-9b7e-397dbc247d09.png)

Correction will display hours :

![fix](https://cloud.githubusercontent.com/assets/1732355/2937353/5fb622f0-d89b-11e3-8ce9-1bc766be8044.png)
