### PR TITLE
Refactored QGC::groundTime*() functions to be simpler.

### DIFF
--- a/src/QGC.cc
+++ b/src/QGC.cc
@@ -30,29 +30,17 @@ namespace QGC
 
 quint64 groundTimeUsecs()
 {
-    QDateTime time = QDateTime::currentDateTime();
-    time = time.toUTC();
-    /* Return seconds and milliseconds, in milliseconds unit */
-    quint64 microseconds = time.toTime_t() * static_cast<quint64>(1000000);
-    return static_cast<quint64>(microseconds + (time.time().msec()*1000));
+    return groundTimeMilliseconds() * 1000;
 }
 
 quint64 groundTimeMilliseconds()
 {
-    QDateTime time = QDateTime::currentDateTime();
-    time = time.toUTC();
-    /* Return seconds and milliseconds, in milliseconds unit */
-    quint64 seconds = time.toTime_t() * static_cast<quint64>(1000);
-    return static_cast<quint64>(seconds + (time.time().msec()));
+    return static_cast<quint64>(QDateTime::currentMSecsSinceEpoch());
 }
 
 qreal groundTimeSeconds()
 {
-    QDateTime time = QDateTime::currentDateTime();
-    time = time.toUTC();
-    /* Return time in seconds unit */
-    quint64 seconds = time.toTime_t();
-    return static_cast<qreal>(seconds + (time.time().msec() / 1000.0));
+    return static_cast<qreal>(groundTimeMilliseconds()) / 1000.0f;
 }
 
 float limitAngleToPMPIf(float angle)

--- a/src/QGC.h
+++ b/src/QGC.h
@@ -75,11 +75,17 @@ const QColor colorDarkYellow(180, 180, 0);
 const QColor colorBackground("#050508");
 const QColor colorBlack(0, 0, 0);
 
-/** @brief Get the current ground time in microseconds */
+/**
+ * @brief Get the current ground time in microseconds.
+ * @note This does not have microsecond precision, it is limited to millisecond precision.
+ */
 quint64 groundTimeUsecs();
 /** @brief Get the current ground time in milliseconds */
 quint64 groundTimeMilliseconds();
-/** @brief Get the current ground time in seconds */
+/** 
+ * @brief Get the current ground time in fractional seconds
+ * @note Precision is limited to milliseconds.
+ */
 qreal groundTimeSeconds();
 /** @brief Returns the angle limited to -pi - pi */
 float limitAngleToPMPIf(float angle);


### PR DESCRIPTION
I don't see a reason to do all of this DateTime work, when `QDateTime::currentMSecsSinceEpoch()` should do it all for us. Also now documented that `groundTimeUsecs()` only has millisecond precision.
