### PR TITLE
Fix for #647

### DIFF
--- a/src/ui/QGCMAVLinkLogPlayer.cc
+++ b/src/ui/QGCMAVLinkLogPlayer.cc
@@ -572,10 +572,18 @@ void QGCMAVLinkLogPlayer::logLoop()
     if (mavlinkLogFormat)
     {
         // Now parse MAVLink messages, grabbing their timestamps as we go. We stop once we
-        // have at least 3ms until the next one.
+        // have at least 3ms until the next one. 
+
+        // We track what the next execution time should be in milliseconds, which we use to set
+        // the next timer interrupt.
         int nextExecutionTime = 0;
+
+        // We use the `findNextMavlinkMessage()` function to scan ahead for MAVLink messages. This
+        // is necessary because we don't know how big each MAVLink message is until we finish parsing
+        // one, and since we only output arrays of bytes, we need to know the size of that array.
         mavlink_message_t msg;
-        msg.len = 0;    // FIXME: Hack, remove once Issue #647 is fixed
+        findNextMavlinkMessage(&msg);
+
         while (nextExecutionTime < 3) {
 
             // Now we're sitting at the start of a MAVLink message, so read it all into a byte array for feeding to our parser.


### PR DESCRIPTION
In the logplayer, the data stream is read ahead for messages, which is used to determine the size of the output bytearrays. Previously, this wasn't done correctly resulting in non-ideal behavior. Now, the next message is scanned properly, so the only bytearrays that are emitted from QGCMAVLinkLogPlayer are MAVLink messages in their entirety. This also has the benefit of skipping invalid/corrupted messages in the log that's being played back.

This does, however, result in double-scanning the log file for every cluster of messages that we process (where one cluster is processed per call to `logLoop()`). Since we are only playing back data, we are likely running this on a fast-enough computer in a safe environment, so performance and power usage should be less than an issue than when actually controlling a UAS.

Fixes #647
