### PR TITLE
The Fullscreen/Normal menu items in the main window are now checkable.

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -347,6 +347,23 @@ void MainWindow::init()
 
     }
 
+    // Make sure the proper fullscreen/normal menu item is checked properly.
+    if (isFullScreen())
+    {
+        ui.actionFullscreen->setChecked(true);
+        ui.actionNormal->setChecked(false);
+    }
+    else
+    {
+        ui.actionFullscreen->setChecked(false);
+        ui.actionNormal->setChecked(true);
+    }
+
+    // And that they will stay checked properly after user input
+    QObject::connect(ui.actionFullscreen, SIGNAL(triggered()), this, SLOT(fullScreenActionItemCallback()));
+    QObject::connect(ui.actionNormal, SIGNAL(triggered()), this,SLOT(normalActionItemCallback()));
+
+
     // Set OS dependent keyboard shortcuts for the main window, non OS dependent shortcuts are set in MainWindow.ui
 #ifdef Q_OS_MACX
     ui.actionFlightView->setShortcut(QApplication::translate("MainWindow", "Meta+1", 0, QApplication::UnicodeUTF8));
@@ -756,6 +773,16 @@ void MainWindow::showDockWidget(const QString& name, bool show)
         dockWidget->setVisible(show);
     else if (show)
         loadDockWidget(name);
+}
+
+void MainWindow::fullScreenActionItemCallback()
+{
+    ui.actionNormal->setChecked(false);
+}
+
+void MainWindow::normalActionItemCallback()
+{
+    ui.actionFullscreen->setChecked(false);
 }
 
 void MainWindow::loadDockWidget(const QString& name)

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -297,6 +297,18 @@ public slots:
 
 protected slots:
     void showDockWidget(const QString &name, bool show);
+    /**
+     * @brief Unchecks the normalActionItem.
+     * Used as a triggered() callback by the fullScreenAction to make sure only one of it or the
+     * normalAction are checked at a time, as they're mutually exclusive.
+     */
+    void fullScreenActionItemCallback();
+    /**
+     * @brief Unchecks the fullScreenActionItem.
+     * Used as a triggered() callback by the normalAction to make sure only one of it or the
+     * fullScreenAction are checked at a time, as they're mutually exclusive.
+     */
+    void normalActionItemCallback();
 
 signals:
     void styleChanged(MainWindow::QGC_MAINWINDOW_STYLE newTheme);

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -379,11 +379,23 @@
    </property>
   </action>
   <action name="actionFullscreen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Fullscreen</string>
    </property>
   </action>
   <action name="actionNormal">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Normal</string>
    </property>


### PR DESCRIPTION
This further brings sanity to the Perspectives menu, as the Fullscreen and Normal menu items indicate which is selected.

Just thinking about this now, we could've replaced both of these menu items with a single menu item that is either "Enter fullscreen" or "Exit fullscreen", as that would likely take less space, but I guess since this is already done, it's at least a step in the right direction.
