### PR TITLE
Detach the map widget - rebase

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -556,7 +556,7 @@ void MainWindow::buildCommonWidgets()
     {
         pilotView = new SubMainWindow(this);
         pilotView->setObjectName("VIEW_FLIGHT");
-        pilotView->setCentralWidget(new HUD(640,480,this));
+        pilotView->setCentralWidget(new PrimaryFlightDisplay(this));
         addToCentralStackedWidget(pilotView, VIEW_FLIGHT, "Pilot");
     }
 


### PR DESCRIPTION
The changes from #628 rebased onto current HEAD and a fix to avoid having the toggle adding more mapwidgets. The 3rd commit should be squashed into the first, but I've kept them seperate to be as close to the original patches in #628 as possible. I'll happily rebase/squash/etc if needed.
