### PR TITLE
Don't read out seconds since last connection on connection regain

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -350,7 +350,7 @@ void UAS::updateState()
     // Connection gained
     if (connectionLost && (heartbeatInterval < timeoutIntervalHeartbeat))
     {
-        QString audiostring = QString("Link regained to system %1 after %2 seconds").arg(this->getUASID()).arg((int)(connectionLossTime/1000000));
+        QString audiostring = QString("Link regained to system %1").arg(this->getUASID());
         GAudioOutput::instance()->say(audiostring.toLower());
         connectionLost = false;
         connectionLossTime = 0;


### PR DESCRIPTION
This information is not interesting and is blocking the audio channel for more relevant information.
