### PR TITLE
Refactor MAVLink packet loss calculations

### DIFF
--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -503,7 +503,7 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                 lastIndex[message.sysid][message.compid] = expectedSeq;
 
                 // Update on every 32th packet
-                if (totalReceiveCounter[linkId] % 32 == 0)
+                if ((totalReceiveCounter[linkId] & 0x1F) == 0)
                 {
                     // Calculate new loss ratio
                     // Receive loss


### PR DESCRIPTION
Was reading through it and it wasn't very clear, so I refactored it a bit and added comments.
Also replaced an expensive modulus operation with a super-fast bitwise-and.
