### PR TITLE
espeak: provide string length including 0 character

### DIFF
--- a/src/GAudioOutput.cc
+++ b/src/GAudioOutput.cc
@@ -212,7 +212,8 @@ bool GAudioOutput::say(QString text, int severity)
 #endif // _MSC_VER
 
 #if defined Q_OS_LINUX
-            unsigned int espeak_size = strlen(text.toStdString().c_str());
+            // Set size of string for espeak: +1 for the null-character
+            unsigned int espeak_size = strlen(text.toStdString().c_str()) + 1;
             espeak_Synth(text.toStdString().c_str(), espeak_size, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL);
 #endif // Q_OS_LINUX
 


### PR DESCRIPTION
fixes problems with qgc reading out strange values/chars at the end of the sentence
