### PR TITLE
FTP: Better timeout handling

### DIFF
--- a/src/uas/QGCUASFileManager.cc
+++ b/src/uas/QGCUASFileManager.cc
@@ -471,15 +471,19 @@ void QGCUASFileManager::_clearAckTimeout(void)
 /// @brief Called when ack timeout timer fires
 void QGCUASFileManager::_ackTimeout(void)
 {
-    _emitErrorMessage(tr("Timeout waiting for ack"));
+    // Make sure to set _currentOperation state before emitting error message. Code may respond
+    // to error message signal by sending another command, which will fail if state is not back
+    // to idle. FileView UI works this way with the List command.
 
     switch (_currentOperation) {
         case kCORead:
             _currentOperation = kCOAck;
+            _emitErrorMessage(tr("Timeout waiting for ack: Sending Terminate command"));
             _sendTerminateCommand();
             break;
         default:
             _currentOperation = kCOIdle;
+            _emitErrorMessage(tr("Timeout waiting for ack"));
             break;
     }
 }

--- a/src/ui/QGCUASFileView.h
+++ b/src/ui/QGCUASFileView.h
@@ -48,11 +48,19 @@ private slots:
     void _listComplete(void);
     void _downloadStatusMessage(const QString& msg);
     void _currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous);
+    void _listCompleteTimeout(void);
 
 private:
+    void _setupListCompleteTimeout(void);
+    void _clearListCompleteTimeout(void);
+    void _requestDirectoryList(const QString& dir);
+
     static const int        _typeFile = QTreeWidgetItem::UserType + 1;
     static const int        _typeDir = QTreeWidgetItem::UserType + 2;
     static const int        _typeError = QTreeWidgetItem::UserType + 3;
+    
+    QTimer                  _listCompleteTimer;                     ///> Used to signal a timeout waiting for a listComplete signal
+    static const int        _listCompleteTimerTimeoutMsecs = 5000;  ///> Timeout in msecs for listComplete timer
     
     QList<int>              _walkIndexStack;
     QList<QTreeWidgetItem*> _walkItemStack;


### PR DESCRIPTION
Edge cases handled:
- FileManager sending timeout error message before resetting state machine state. Could cause FileView UI code to fail, since it will send next List command which will fail due to unfinished previous command.
- Added listComplete signal timeout to FileView UI. Handles the case where either FileManager or Firmware never responds to List command.
