### PR TITLE
Add msvc2013 to build types

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -26,7 +26,7 @@ message(Qt version $$[QT_VERSION])
 linux-g++ | linux-g++-64 {
     message(Linux build)
     CONFIG += LinuxBuild
-} else : win32-msvc2008 | win32-msvc2010 | win32-msvc2012 {
+} else : win32-msvc2008 | win32-msvc2010 | win32-msvc2012 | win32-msvc2013 {
     message(Windows build)
     CONFIG += WindowsBuild
 } else : macx-clang | macx-llvm {


### PR DESCRIPTION
readme.md says "Only compilation using Visual Studio 2010, 2012, and 2013 are supported.", so add this to the supported build types in qgroundcontrol.pro, too.
