### PR TITLE
Cleanup some unitialized variable issues pointed out by Valgrind

### DIFF
--- a/src/comm/MAVLinkSimulationWaypointPlanner.cc
+++ b/src/comm/MAVLinkSimulationWaypointPlanner.cc
@@ -436,6 +436,8 @@ MAVLinkSimulationWaypointPlanner::MAVLinkSimulationWaypointPlanner(MAVLinkSimula
     link(parent),
     idle(false),
     current_active_wp_id(-1),
+    yawReached(false),
+    posReached(false),
     timestamp_lastoutside_orbit(0),
     timestamp_firstinside_orbit(0),
     waypoints(&waypoints1),

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -82,8 +82,8 @@ UAS::UAS(MAVLinkProtocol* protocol, QThread* thread, int id) : UASInterface(),
     lpVoltage(12.0f),
     currentCurrent(0.4f),
     batteryRemainingEstimateEnabled(false),
-    // chargeLevel not initialized
-    // timeRemaining  not initialized
+    chargeLevel(-1),
+    timeRemaining(0),
     lowBattAlarm(false),
 
     startTime(QGC::groundTimeMilliseconds()),

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -72,7 +72,8 @@ LinechartWidget::LinechartWidget(int systemid, QWidget *parent) : QWidget(parent
     logging(false),
     logStartTime(0),
     updateTimer(new QTimer()),
-    selectedMAV(-1)
+    selectedMAV(-1),
+    lastTimestamp(0)
 {
     // Add elements defined in Qt Designer
     ui.setupUi(this);

--- a/src/ui/uas/UASQuickView.cc
+++ b/src/ui/uas/UASQuickView.cc
@@ -5,7 +5,8 @@
 #include "UASQuickViewTextItem.h"
 #include <QSettings>
 #include <QInputDialog>
-UASQuickView::UASQuickView(QWidget *parent) : QWidget(parent)
+UASQuickView::UASQuickView(QWidget *parent) : QWidget(parent),
+    uas(NULL)
 {
     quickViewSelectDialog=0;
     m_columnCount=2;


### PR DESCRIPTION
These were found during valgrind analysis of the demo simulation file. Next test is running while interacting with an actual system.

Again the biggest issue is the memory leak when iterating over QSerialPortInfo::availablePorts() using Qt's foreach loop; should be fixed in 5.2.2/5.3.2.
