### PR TITLE
Simulation button should be checkable

### DIFF
--- a/src/ui/px4_configuration/QGCPX4AirframeConfig.ui
+++ b/src/ui/px4_configuration/QGCPX4AirframeConfig.ui
@@ -358,6 +358,9 @@
            <property name="text">
             <string>Simulation Setup</string>
            </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
           </widget>
          </item>
          <item>


### PR DESCRIPTION
Without this, when you go to airframe config and the current config is
Simulation it will not be selected. Hence you won’t know what the
current config is.
