### PR TITLE
Run macdeployqt from same dir as qmake

### DIFF
--- a/QGCInstaller.pri
+++ b/QGCInstaller.pri
@@ -19,7 +19,7 @@
 
 installer {
     MacBuild {
-        QMAKE_POST_LINK += && macdeployqt $${DESTDIR}/qgroundcontrol.app -dmg
+        QMAKE_POST_LINK += && $$dirname(QMAKE_QMAKE)/macdeployqt $${DESTDIR}/qgroundcontrol.app -dmg
     }
     
     WindowsBuild {


### PR DESCRIPTION
Handles case where multiple versions of QT are installed on machine. This will allow me to turn the TC installers builds back on.
