### PR TITLE
Fix windows install

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -194,7 +194,9 @@ WindowsBuild {
 	# Copy platform plugins
 	P_DIR = $$[QT_INSTALL_PLUGINS]
 	PLUGINS_DIR_WIN = $$replace(P_DIR, "/", "\\")
-	QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$PLUGINS_DIR_WIN\\platforms\" \"$$DESTDIR_WIN\\platforms\"
+	QMAKE_POST_LINK += $$escape_expand(\\n) mkdir release\\platforms
+	QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY \"$$PLUGINS_DIR_WIN\\platforms\\qwindows$${DLL_QT_DEBUGCHAR}.dll\" \"$$DESTDIR_WIN\\platforms\\qwindows$${DLL_QT_DEBUGCHAR}.dll\"
+	QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$PLUGINS_DIR_WIN\\imageformats\" \"$$DESTDIR_WIN\\imageformats\"
     
 	ReleaseBuild {
 		# Copy Visual Studio DLLs


### PR DESCRIPTION
Copy platforms plugins to install. This is a partial fix to Issue #810. UI images still are not working correctly, but it is at least usable a this point. I'll wait for TeamCity to pass, then Merge and re-test TeamCity Installers.
