### PR TITLE
Fix unit test crash rom Pull 840

### DIFF
--- a/src/qgcunittest/PX4RCCalibrationTest.cc
+++ b/src/qgcunittest/PX4RCCalibrationTest.cc
@@ -711,7 +711,7 @@ void PX4RCCalibrationTest::_validateWidgets(int validateMask, const struct Chann
         }
     }
     
-    for (int chan=_availableChannels; chan<=PX4RCCalibration::_chanMax; chan++) {
+    for (int chan=_availableChannels; chan<PX4RCCalibration::_chanMax; chan++) {
         QCOMPARE(_rgRadioWidget[chan]->isEnabled(), false);
     }
 }


### PR DESCRIPTION
Got lucky on OSX with memory boundary. Only crash on Windows/Linux.
