### PR TITLE
Added MAV_CMD_START_RX_PAIR to the editCommandComboBox when creating a n...

### DIFF
--- a/src/ui/designer/QGCCommandButton.cc
+++ b/src/ui/designer/QGCCommandButton.cc
@@ -83,7 +83,7 @@ QGCCommandButton::QGCCommandButton(QWidget *parent) :
     ui->editCommandComboBox->addItem("MAV_CMD_OVERRIDE_GOTO", MAV_CMD_OVERRIDE_GOTO);
     ui->editCommandComboBox->addItem("MAV_CMD_MISSION_START", MAV_CMD_MISSION_START);
     ui->editCommandComboBox->addItem("MAV_CMD_COMPONENT_ARM_DISARM", MAV_CMD_COMPONENT_ARM_DISARM);
-	ui->editCommandComboBox->addItem("MAV_CMD_START_RX_PAIR", MAV_CMD_START_RX_PAIR);
+    ui->editCommandComboBox->addItem("MAV_CMD_START_RX_PAIR", MAV_CMD_START_RX_PAIR);
     ui->editCommandComboBox->addItem("MAV_CMD_DO_FLIGHTTERMINATION", MAV_CMD_DO_FLIGHTTERMINATION);
     ui->editCommandComboBox->addItem("MAV_CMD_PAYLOAD_PREPARE_DEPLOY", MAV_CMD_PAYLOAD_PREPARE_DEPLOY);
     ui->editCommandComboBox->addItem("MAV_CMD_PAYLOAD_CONTROL_DEPLOY", MAV_CMD_PAYLOAD_CONTROL_DEPLOY);


### PR DESCRIPTION
Hi,

I added the MAV_CMD_START_RX_PAIR to the editCommandComboBox in the QGCCommandButton widget. 

CHANGED:
Append a possibility to the list of command messages

TESTING:
Tested on:
- Windows 7, 64 bits
- Linux, 14.04, 64 bits
