### PR TITLE
Use regular component ID (0) for PARAM_SET command

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -2417,7 +2417,7 @@ void UAS::setParameter(const int compId, const QString& paramId, const QVariant&
                 p.param_id[i] = 0;
             }
         }
-        mavlink_msg_param_set_encode(mavlink->getSystemId(), compId, &msg, &p);
+        mavlink_msg_param_set_encode(mavlink->getSystemId(), mavlink->getComponentId(), &msg, &p);
         sendMessage(msg);
     }
 }


### PR DESCRIPTION
 I couldn't set parameters over the UDP link because QGC sent PARAM_SET with target component ID as source component ID, MAVCONN serial then filters it (ignore from compId 50).
This fixes it and seems to work.
@LorenzMeier @thomasgubler To set the target component ID as source ID wasn't a hack of any kind that I now reverted?
