### PR TITLE
Fix Windows Firmware Update crash

### DIFF
--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -290,7 +290,7 @@ bool UDPLink::disconnect()
 
         if(socket)
 	{
-        // Make sure delete happen on correct thread
+		// Make sure delete happen on correct thread
 		socket->deleteLater();
 		socket = NULL;
 	}


### PR DESCRIPTION
Finally found this (_&^@#)_(&)$*& bug! Been trying to repro for a month. Reason for tricky repo is that you have to have booted QGC with restore previous link on a UDP link. Which happens to be the default if you haven't used QGC prior. Bug was caused by threading model changes. Fix is to delete socket on correct thread (this fix has been used in other places, but I missed this one).
