### PR TITLE
Default mavlink configuration to pixhawk

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -82,10 +82,10 @@ else:exists(user_config.pri):infile(user_config.pri, MAVLINK_CONF) {
         message($$sprintf("Using MAVLink dialect '%1' specified in user_config.pri", $$MAVLINK_CONF))
     }
 }
-# If no valid user selection is found, default to the ardupilotmega if it's available.
+# If no valid user selection is found, default to the pixhawk if it's available.
 # Note: This can be a list of several dialects.
 else {
-    MAVLINK_CONF=ardupilotmega
+    MAVLINK_CONF=pixhawk
     message($$sprintf("Using default MAVLink dialect '%1'.", $$MAVLINK_CONF))
 }
 


### PR DESCRIPTION
Now that APM is turned off in codebase, makes more sense to default to pixhawk instead of ardupilotmega.
