### PR TITLE
Add SSL check

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -29,6 +29,8 @@ This file is part of the QGROUNDCONTROL project
  */
 
 #include <QApplication>
+#include <QSslSocket>
+
 #include "QGCCore.h"
 #include "MainWindow.h"
 #include "configuration.h"
@@ -148,6 +150,14 @@ int main(int argc, char *argv[])
             firstStart = false;
         }
         core = new QGCCore(firstStart, argc, argv);
+        
+        if (!QSslSocket::supportsSsl()) {
+            QMessageBox::critical(NULL,
+                                  QObject::tr("Missing SSL Support"),
+                                  QObject::tr("QGroundControl requires support for SSL to be installed prior to running. Please see http://www.qgroundcontrol.org/downloads for instructions on installing prerequisites for QGroundControl."));
+            return 1;
+        }
+        
         val = core->exec();
     } while (core->getRestartRequested());
 


### PR DESCRIPTION
This will detect if SSL libraries are missing. This should only happen on Windows OS where a separate install of OpenSLL is required. If missing it points you to the qgroundcontrol.org download page for instructions on fixing the problem.
