### PR TITLE
Temporary libs fix for QWT for Qt 5.4

### DIFF
--- a/libs/qwt/qwt_transform.cpp
+++ b/libs/qwt/qwt_transform.cpp
@@ -15,10 +15,10 @@
 #endif
 
 //! Smallest allowed value for logarithmic scales: 1.0e-150
-QT_STATIC_CONST_IMPL double QwtLogTransform::LogMin = 1.0e-150;
+const double QwtLogTransform::LogMin = 1.0e-150;
 
 //! Largest allowed value for logarithmic scales: 1.0e150
-QT_STATIC_CONST_IMPL double QwtLogTransform::LogMax = 1.0e150;
+const  double QwtLogTransform::LogMax = 1.0e150;
 
 //! Constructor
 QwtTransform::QwtTransform()

--- a/libs/qwt/qwt_transform.h
+++ b/libs/qwt/qwt_transform.h
@@ -107,8 +107,8 @@ public:
 
     virtual QwtTransform *copy() const;
 
-    QT_STATIC_CONST double LogMin;
-    QT_STATIC_CONST double LogMax;
+    static const double LogMin;
+    static const double LogMax;
 };
 
 /*!


### PR DESCRIPTION
@DonLakeFlyer If you like to play with Qt 5.4, this is fixing a few minor compile errors resulting out of the removal of a Qt macro.
