### PR TITLE
Added workaround/bugfix for the acceleration calculation in X-Plane-HIL-...

### DIFF
--- a/src/comm/QGCXPlaneLink.h
+++ b/src/comm/QGCXPlaneLink.h
@@ -191,7 +191,7 @@ protected:
     bool attitudeReceived;
 
     float roll, pitch, yaw, rollspeed, pitchspeed, yawspeed;
-    double lat, lon, alt;
+    double lat, lon, alt, alt_agl;
     float vx, vy, vz, xacc, yacc, zacc;
     float ind_airspeed;
     float true_airspeed;


### PR DESCRIPTION
...link. This is clearly considered a workaround, which switches the calculation method (see code) given certain conditions. Those conditions are however set such that the switching between X-Plane accelerations and the re-calculated accelerations has minimal effect.

The code change is necessary because X-Plane (tested up to X-Plane v10.30 64bit) gives wrong accelerations when ground speed is ~zero.
