### PR TITLE
Generic mav ui incorrectly hidden

### DIFF
--- a/src/ui/ParameterInterface.cc
+++ b/src/ui/ParameterInterface.cc
@@ -37,7 +37,6 @@ This file is part of the QGROUNDCONTROL project
 
 #include <QDebug>
 #include <QSettings>
-#include "MainWindow.h"
 
 ParameterInterface::ParameterInterface(QWidget *parent) :
     QWidget(parent),
@@ -48,13 +47,6 @@ ParameterInterface::ParameterInterface(QWidget *parent) :
     m_ui->setupUi(this);
 
     QSettings settings;
-    enum MainWindow::CUSTOM_MODE mode = static_cast<enum MainWindow::CUSTOM_MODE>(settings.value("QGC_CUSTOM_MODE", MainWindow::CUSTOM_MODE_NONE).toInt());
-
-    if (mode == MainWindow::CUSTOM_MODE_PX4)
-    {
-        delete m_ui->sensorSettings;
-        m_ui->sensorSettings = NULL;
-    }
 
     // Get current MAV list
     QList<UASInterface*> systems = UASManager::instance()->getUASList();
@@ -79,8 +71,7 @@ ParameterInterface::~ParameterInterface()
 void ParameterInterface::selectUAS(int index)
 {
     m_ui->stackedWidget->setCurrentIndex(index);
-    if (m_ui->sensorSettings)
-        m_ui->sensorSettings->setCurrentIndex(index);
+    m_ui->sensorSettings->setCurrentIndex(index);
     curr = index;
 }
 
@@ -109,11 +100,8 @@ void ParameterInterface::addUAS(UASInterface* uas)
 
     QGCSensorSettingsWidget* sensor = NULL;
 
-    if (m_ui->sensorSettings)
-    {
         sensor = new QGCSensorSettingsWidget(uas, this);
         m_ui->sensorSettings->addWidget(sensor);
-    }
 
     // Set widgets as default
     if (curr == -1) {


### PR DESCRIPTION
This is UI connected to the Onboard Parameters widgets which was incorrectly being hidden due to a bad mode check. This code is generic to any mav so it should always be shown.
