### PR TITLE
Remove TCPLink unit test

### DIFF
--- a/src/qgcunittest/TCPLinkTest.h
+++ b/src/qgcunittest/TCPLinkTest.h
@@ -89,6 +89,8 @@ private:
     const char*         _rgSignals[_cSignals];
 };
 
-DECLARE_TEST(TCPLinkUnitTest)
+// This unit test has gotten too flaky to run reliably under TeamCity. Removing for now till there is
+// time to debug.
+//DECLARE_TEST(TCPLinkUnitTest)
 
 #endif


### PR DESCRIPTION
This test is too flaky to run in TeamCity reliably. I'll add Issue to debug and re-add.
