### PR TITLE
remove unsupported control argument in call to fgfs

### DIFF
--- a/src/ui/QGCHilFlightGearConfiguration.cc
+++ b/src/ui/QGCHilFlightGearConfiguration.cc
@@ -13,7 +13,7 @@ const char* QGCHilFlightGearConfiguration::_sensorHilKey =                  "SEN
 
 // Default set of optional command line parameters. If FlightGear won't run HIL without it it should go into
 // the QGCFlightGearLink code instead.
-const char* QGCHilFlightGearConfiguration::_defaultOptions = "--roll=0 --pitch=0 --vc=0 --heading=300 --timeofday=noon --disable-hud-3d --disable-fullscreen --geometry=400x300 --disable-anti-alias-hud --wind=0@0 --turbulence=0.0 --control=mouse --disable-sound --disable-random-objects --disable-ai-traffic --shading-flat --fog-disable --disable-specular-highlight --disable-panel --disable-clouds --fdm=jsb --units-meters --enable-terrasync";
+const char* QGCHilFlightGearConfiguration::_defaultOptions = "--roll=0 --pitch=0 --vc=0 --heading=300 --timeofday=noon --disable-hud-3d --disable-fullscreen --geometry=400x300 --disable-anti-alias-hud --wind=0@0 --turbulence=0.0 --disable-sound --disable-random-objects --disable-ai-traffic --shading-flat --fog-disable --disable-specular-highlight --disable-panel --disable-clouds --fdm=jsb --units-meters --enable-terrasync";
 
 QGCHilFlightGearConfiguration::QGCHilFlightGearConfiguration(UAS* mav, QWidget *parent) :
     QWidget(parent),


### PR DESCRIPTION
Flightgear 3.2 does not recognize the --control argument and hence does not start when it is provided
