### PR TITLE
Settings versioned independently from app version

### DIFF
--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -10,6 +10,10 @@
 #define MAVLINK_HEARTBEAT_DEFAULT_RATE 1
 #define WITH_TEXT_TO_SPEECH 1
 
+// If you need to make an incompatible changes to stored settings, bump this version number
+// up by 1. This will caused store settings to be cleared on next boot.
+#define QGC_SETTINGS_VERSION 1
+
 #define QGC_APPLICATION_NAME "QGroundControl"
 #define QGC_APPLICATION_VERSION_BASE "v2.0.3"
 

--- a/src/QGCCore.h
+++ b/src/QGCCore.h
@@ -72,7 +72,8 @@ protected:
     void startUASManager();
 
 private:
-    MainWindow*             _mainWindow;
+    MainWindow* _mainWindow;
+    static const char* _settingsVersionKey;
 };
 
 #endif /* _CORE_H_ */


### PR DESCRIPTION
This is the fix for Issue #943. This will causes a settings clear one last time to get the version stamp in there correctly. But then after that we have a real settings versioning scheme in place.
