### PR TITLE
LinkInterface::bytesAvailable api removal

### DIFF
--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -147,13 +147,6 @@ public:
      **/
     virtual bool disconnect() = 0;
 
-    /**
-     * @brief Get the current number of bytes in buffer.
-     *
-     * @return The number of bytes ready to read
-     **/
-    virtual qint64 bytesAvailable() = 0;
-
 public slots:
 
     /**

--- a/src/comm/MAVLinkSimulationLink.cc
+++ b/src/comm/MAVLinkSimulationLink.cc
@@ -632,14 +632,6 @@ void MAVLinkSimulationLink::mainloop()
 }
 
 
-qint64 MAVLinkSimulationLink::bytesAvailable()
-{
-    readyBufferMutex.lock();
-    qint64 size = readyBuffer.size();
-    readyBufferMutex.unlock();
-    return size;
-}
-
 void MAVLinkSimulationLink::writeBytes(const char* data, qint64 size)
 {
     // Parse bytes

--- a/src/comm/MAVLinkSimulationLink.h
+++ b/src/comm/MAVLinkSimulationLink.h
@@ -51,7 +51,6 @@ public:
     MAVLinkSimulationLink(QString readFile="", QString writeFile="", int rate=5);
     ~MAVLinkSimulationLink();
     bool isConnected() const;
-    qint64 bytesAvailable();
 
     void run();
     void requestReset() { }

--- a/src/comm/OpalLink.cc
+++ b/src/comm/OpalLink.cc
@@ -58,18 +58,6 @@ OpalLink::OpalLink() :
     QObject::connect(getSignalsTimer, SIGNAL(timeout()), this, SLOT(getSignals()));
 }
 
-
-/*
- *
-  Communication
- *
- */
-
-qint64 OpalLink::bytesAvailable()
-{
-    return 0;
-}
-
 void OpalLink::writeBytes(const char *bytes, qint64 length)
 {
     /* decode the message */

--- a/src/comm/OpalLink.h
+++ b/src/comm/OpalLink.h
@@ -83,8 +83,6 @@ public:
 
     bool disconnect();
 
-    qint64 bytesAvailable();
-
     void run();
 
     int getOpalInstID() {

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -390,21 +390,6 @@ void SerialLink::readBytes()
     }
 }
 
-
-/**
- * @brief Get the number of bytes to read.
- *
- * @return The number of bytes to read
- **/
-qint64 SerialLink::bytesAvailable()
-{
-    if (m_port) {
-        return m_port->bytesAvailable();
-    } else {
-        return 0;
-    }
-}
-
 /**
  * @brief Disconnect the connection.
  *

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -78,7 +78,6 @@ public:
     void requestReset();
 
     bool isConnected() const;
-    qint64 bytesAvailable();
 
     /**
      * @brief The port handle

--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -177,16 +177,6 @@ void TCPLink::readBytes()
 }
 
 /**
- * @brief Get the number of bytes to read.
- *
- * @return The number of bytes to read
- **/
-qint64 TCPLink::bytesAvailable()
-{
-    return _socket->bytesAvailable();
-}
-
-/**
  * @brief Disconnect the connection.
  *
  * @return True if connection has been disconnected, false if connection couldn't be disconnected.

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -67,7 +67,6 @@ public:
     virtual bool    isConnected(void) const;
     virtual bool    connect(void);
     virtual bool    disconnect(void);
-    virtual qint64  bytesAvailable(void);
     virtual void    requestReset(void) {};
 
     // Extensive statistics for scientific purposes

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -267,17 +267,6 @@ void UDPLink::readBytes()
     }
 }
 
-
-/**
- * @brief Get the number of bytes to read.
- *
- * @return The number of bytes to read
- **/
-qint64 UDPLink::bytesAvailable()
-{
-    return socket->pendingDatagramSize();
-}
-
 /**
  * @brief Disconnect the connection.
  *

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -52,7 +52,6 @@ public:
     void requestReset() { }
 
     bool isConnected() const;
-    qint64 bytesAvailable();
     int getPort() const {
         return port;
     }

--- a/src/comm/XbeeLink.cpp
+++ b/src/comm/XbeeLink.cpp
@@ -189,11 +189,6 @@ bool XbeeLink::disconnect()
 	return true;
 }
 
-qint64 XbeeLink::bytesAvailable()
-{
-	return 0;
-}
-
 void XbeeLink::writeBytes(const char *bytes, qint64 length)  // TO DO: delete the data array
 {
 	char *data;

--- a/src/comm/XbeeLink.h
+++ b/src/comm/XbeeLink.h
@@ -36,7 +36,6 @@ public: // virtual functions from LinkInterface
     bool isConnected() const;
     bool connect();
     bool disconnect();
-    qint64 bytesAvailable();
 
     // Extensive statistics for scientific purposes
     qint64 getConnectionSpeed() const;


### PR DESCRIPTION
This is never called because this api doesn’t make any sense given the fact that LinkInterface signals bytesReceived with the bytes in the signal. If bytes are available, then bytesReceived would have already been singled. The data would be in the signal and bytesAvailable would always return 0.

Cleaning my way through the Link stuff as I work my way to a MockLink LinkInterface implementation which will be a configurable simulation of a Pixhawk board. This will be used for better manual testing as well as deeper automated testing.
