### PR TITLE
Set mode compatibility with jMAVSim

### DIFF
--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -569,8 +569,10 @@ public:
     bool isAuto();
     /** @brief Check if vehicle is armed */
     bool isArmed() const { return systemIsArmed; }
-    /** @brief Check if vehicle is in HIL mode */
+    /** @brief Check if vehicle is supposed to be in HIL mode by the GS */
     bool isHilEnabled() const { return hilEnabled; }
+    /** @brief Check if vehicle is in HIL mode */
+    bool isHilActive() const { return base_mode & MAV_MODE_FLAG_HIL_ENABLED; }
 
     /** @brief Get reference to the waypoint manager **/
     UASWaypointManager* getWaypointManager() {

--- a/src/ui/uas/UASControlWidget.cc
+++ b/src/ui/uas/UASControlWidget.cc
@@ -246,7 +246,7 @@ void UASControlWidget::transmitMode()
 
             UAS* uas = dynamic_cast<UAS*>(uas_iface);
 
-            if (uas->isHilEnabled()) {
+            if (uas->isHilEnabled() || uas->isHilActive()) {
                 mode.baseMode |= MAV_MODE_FLAG_HIL_ENABLED;
             } else {
                 mode.baseMode &= ~MAV_MODE_FLAG_HIL_ENABLED;


### PR DESCRIPTION
This allows the mode to be set even though QGC is not in HIL mode and doesn't know that the autopilot is put in HIL mode by jMAVSim.
