### PR TITLE
Be careful with QObject:::destroyed signal

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -3374,8 +3374,8 @@ void UAS::addLink(LinkInterface* link)
 
 void UAS::removeLink(QObject* object)
 {
-    // Be careful of the fact that by the time this signal makes it through the queue
-    // the link object has already been destructed. So no dynamic_cast for example.
+    // Do not dynamic cast or de-reference QObject, since object is either in destructor or may have already
+    // been destroyed.
     
     LinkInterface* link = (LinkInterface*)object;
     

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -1410,6 +1410,9 @@ void MainWindow::simulateLink(bool simulate) {
 
 void MainWindow::commsWidgetDestroyed(QObject *obj)
 {
+    // Do not dynamic cast or de-reference QObject, since object is either in destructor or may have already
+    // been destroyed.
+
     if (commsWidgetList.contains(obj))
     {
         commsWidgetList.removeOne(obj);

--- a/src/ui/QGCUASFileViewMulti.h
+++ b/src/ui/QGCUASFileViewMulti.h
@@ -23,11 +23,11 @@ public:
 public slots:
     void systemDeleted(QObject* uas);
     void systemCreated(UASInterface* uas);
-    void systemSetActive(int uas);
+    void systemSetActive(UASInterface* uas);
 
 protected:
     void changeEvent(QEvent *e);
-    QMap<int, QGCUASFileView*> lists;
+    QMap<UASInterface*, QGCUASFileView*> lists;
 
 private:
     Ui::QGCUASFileViewMulti *ui;

--- a/src/ui/QGCWaypointListMulti.cc
+++ b/src/ui/QGCWaypointListMulti.cc
@@ -25,7 +25,10 @@ QGCWaypointListMulti::QGCWaypointListMulti(QWidget *parent) :
 
 void QGCWaypointListMulti::systemDeleted(QObject* uas)
 {
-    UASInterface* mav = dynamic_cast<UASInterface*>(uas);
+    // Do not dynamic cast or de-reference QObject, since object is either in destructor or may have already
+    // been destroyed.
+
+    UASInterface* mav = static_cast<UASInterface*>(uas);
     if (mav)
     {
         int id = mav->getUASID();

--- a/src/ui/WaypointEditableView.cc
+++ b/src/ui/WaypointEditableView.cc
@@ -302,6 +302,9 @@ void WaypointEditableView::initializeActionView(int actionID)
 
 void WaypointEditableView::deleted(QObject* waypoint)
 {
+    // Do not dynamic cast or de-reference QObject, since object is either in destructor or may have already
+    // been destroyed.
+
     Q_UNUSED(waypoint);
 }
 

--- a/src/ui/designer/QGCToolWidget.cc
+++ b/src/ui/designer/QGCToolWidget.cc
@@ -561,8 +561,9 @@ void QGCToolWidget::addToolWidget(QGCToolWidgetItem* widget)
 
 void QGCToolWidget::widgetRemoved()
 {
-    //Must static cast and not dynamic cast since the object is in the destructor
-    //and we only want to use it as a pointer value
+    // Do not dynamic cast or de-reference QObject, since object is either in destructor or may have already
+    // been destroyed.
+    
     QGCToolWidgetItem *widget = static_cast<QGCToolWidgetItem *>(QObject::sender());
     toolItemList.removeAll(widget);
     storeWidgetsToSettings();

--- a/src/ui/menuactionhelper.cpp
+++ b/src/ui/menuactionhelper.cpp
@@ -25,7 +25,10 @@ QAction *MenuActionHelper::createToolAction(const QString &title, const QString 
 
 void MenuActionHelper::removeDockWidget()
 {
-    QObject *dockWidget = QObject::sender(); //Note that we can't cast to QDockWidget because we are in its destructor
+    // Do not dynamic cast or de-reference QObject, since object is either in destructor or may have already
+    // been destroyed.
+
+    QObject *dockWidget = QObject::sender();
     Q_ASSERT(dockWidget);
 
     qDebug() << "Dockwidget:"  << dockWidget->objectName() << "of type" << dockWidget->metaObject()->className();


### PR DESCRIPTION
Do not dynamic cast or de-reference QObject, since object is either in destructor or may have already been destroyed.

This fixes Issue #990 
