### PR TITLE
- Use pkgconfig on linux to avoid break build on undefineds

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -366,9 +366,7 @@ MacBuild {
         -F$$BASEDIR/libs/lib/Frameworks \
         -framework SDL
 } else:LinuxBuild {
-	LIBS += \
-		-lSDL \
-		-lSDLmain
+	PKGCONFIG = sdl
 } else:WindowsBuild {
 	INCLUDEPATH += \
         $$BASEDIR/libs/lib/sdl/msvc/include \

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -30,7 +30,7 @@ message(Qt version $$[QT_VERSION])
 linux {
     linux-g++ | linux-g++-64 {
         message("Linux build")
-        CONFIG += LinuxBuild
+        CONFIG += LinuxBuild link_pkgconfig
     } else {
         error("Unsuported Linux toolchain, only GCC 32- or 64-bit is supported")
     }


### PR DESCRIPTION
SDL at least on linux distributions has pkg_config as standard to use it on development. This unbreak my compilation on Fedora 20, 21 and Centos
