### PR TITLE
Correctly initialize floats as NaNs where expected.

### DIFF
--- a/src/ui/PrimaryFlightDisplay.cc
+++ b/src/ui/PrimaryFlightDisplay.cc
@@ -114,6 +114,7 @@ PrimaryFlightDisplay::PrimaryFlightDisplay(QWidget *parent) :
     heading(0),
 
     altitudeAMSL(std::numeric_limits<double>::quiet_NaN()),
+    altitudeWGS84(std::numeric_limits<double>::quiet_NaN()),
     altitudeRelative(std::numeric_limits<double>::quiet_NaN()),
 
     groundSpeed(std::numeric_limits<double>::quiet_NaN()),
@@ -898,7 +899,7 @@ void PrimaryFlightDisplay::drawAltimeter(
     ) {
 
     float primaryAltitude = altitudeWGS84;
-    float secondaryAltitude = 0;
+    float secondaryAltitude = std::numeric_limits<double>::quiet_NaN();
 
     painter.resetTransform();
     fillInstrumentBackground(painter, area);


### PR DESCRIPTION
Fixes #1041.

Initializing secondaryAltitude to NaN also prevents it from being used, which is proper behavior.
