### PR TITLE
Bumped developer version

### DIFF
--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -19,7 +19,7 @@
 #define QGC_ORG_DOMAIN "org.qgroundcontrol"
 
 #define QGC_APPLICATION_VERSION_MAJOR 2
-#define QGC_APPLICATION_VERSION_MINOR 2
+#define QGC_APPLICATION_VERSION_MINOR 3
 
 // The following #definess can be overriden from the command line so that automated build systems can
 // add additional build identification.


### PR DESCRIPTION
I initially change version numbers incorrectly. Should have left stable
at 2.1 and only bumped Developer to 2.2. This leaves Stable at 2.2 and
Developer at 2.3.
