### PR TITLE
Enlarge the perspective buttons on the toolbar.

### DIFF
--- a/files/styles/style-dark.css
+++ b/files/styles/style-dark.css
@@ -166,12 +166,13 @@ QGCToolBar QProgressBar {
 
 QGCToolBar QToolButton {
     margin: 0;
-    padding: 0;
+    padding: 0 2px;
     border: none;
     border-top: 1px solid #333;
     border-bottom: 1px solid #333;
     border-radius: 0;
     height: 24px;
+    min-width: 30px;
     margin-bottom: 4px;
     text-align: left;
     font-weight: bold;
@@ -191,8 +192,7 @@ QGCToolBar QToolButton:hover {
 QGCToolBar QToolButton#advancedButton {
     margin-left: 0;
     margin-right: 13px;
-    padding: 0 12px 0 4px;
-    padding-right: 8px;
+    padding-right: 10px;
     border-radius: 0;
     border-bottom-right-radius: 6px;
     border-top-right-radius: 6px;
@@ -200,7 +200,7 @@ QGCToolBar QToolButton#advancedButton {
 }
 
 QGCToolBar QToolButton#firstAction {
-    margin-left: 8px;
+    margin-left: 2px;
     border-bottom-left-radius: 6px;
     border-top-left-radius: 6px;
     border-right: none;


### PR DESCRIPTION
Fly was way too small and Plan needed to be a tad bigger as well.

From:
![old](https://cloud.githubusercontent.com/assets/206363/5292428/b5468732-7b16-11e4-8b01-8e98a4e1b3c6.png)

To:
![new](https://cloud.githubusercontent.com/assets/206363/5292429/b66a3852-7b16-11e4-9168-e4272793cb2c.png)
