### PR TITLE
Support for remaining DO_JUMP repetitions

### DIFF
--- a/src/uas/UASWaypointManager.cc
+++ b/src/uas/UASWaypointManager.cc
@@ -104,8 +104,6 @@ void UASWaypointManager::timeout()
         current_state = WP_IDLE;
         current_count = 0;
         current_wp_id = 0;
-        current_partner_systemid = 0;
-        current_partner_compid = 0;
     }
 }
 
@@ -167,8 +165,6 @@ void UASWaypointManager::handleWaypointCount(quint8 systemId, quint8 compId, qui
             current_state = WP_IDLE;
             current_count = 0;
             current_wp_id = 0;
-            current_partner_systemid = 0;
-            current_partner_compid = 0;
         }
 
 
@@ -208,8 +204,6 @@ void UASWaypointManager::handleWaypoint(quint8 systemId, quint8 compId, mavlink_
                 current_state = WP_IDLE;
                 current_count = 0;
                 current_wp_id = 0;
-                current_partner_systemid = 0;
-                current_partner_compid = 0;
 
                 emit _stopProtocolTimer(); // Stop timer on our thread
                 emit readGlobalWPFromUAS(false);


### PR DESCRIPTION
With this change a waypoint message of a DO_JUMP waypoint is accepted even if not requested. It is a workaround in order to allow QGC to show how many repetitions are left.

According to the [mavlink waypoint protocol](http://qgroundcontrol.org/mavlink/waypoint_protocol#waypoint_protocol) there is no straightforward way on how to do this.

This needs [changes on the firmware side](https://github.com/PX4/Firmware/pull/1518) as well.
