### PR TITLE
Initial implementation of QML Palette support

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -491,7 +491,8 @@ HEADERS += \
     src/QGCComboBox.h \
     src/QGCTemporaryFile.h \
     src/audio/QGCAudioWorker.h \
-    src/QGCQuickWidget.h
+    src/QGCQuickWidget.h \
+    src/QGCPalette.h \
 
 SOURCES += \
     src/main.cc \
@@ -631,6 +632,7 @@ SOURCES += \
     src/QGCTemporaryFile.cc \
     src/audio/QGCAudioWorker.cpp \
     src/QGCQuickWidget.cc \
+    src/QGCPalette.cc \
 
 #
 # Unit Test specific configuration goes here

--- a/src/FactSystem/FactSystem.cc
+++ b/src/FactSystem/FactSystem.cc
@@ -28,6 +28,7 @@
 #include "UASManager.h"
 #include "QGCApplication.h"
 #include "VehicleComponent.h"
+#include "QGCPalette.h"
 
 #include <QtQml>
 
@@ -41,9 +42,10 @@ FactSystem::FactSystem(QObject* parent) :
     qmlRegisterType<Fact>(_factSystemQmlUri, 1, 0, "Fact");
     qmlRegisterType<FactValidator>(_factSystemQmlUri, 1, 0, "FactValidator");
     
-    // FIXME: Where should this go? Also creation string
+    // FIXME: Where should these go?
     qmlRegisterUncreatableType<VehicleComponent>(_factSystemQmlUri, 1, 0, "VehicleComponent", "Can only reference VehicleComponent");
     qmlRegisterUncreatableType<VehicleComponent>(_factSystemQmlUri, 1, 0, "VehicleComponentSummaryItem", "Can only reference VehicleComponentSummaryItem");
+    qmlRegisterType<QGCPalette>(_factSystemQmlUri, 1, 0, "QGCPalette");
 }
 
 FactSystem::~FactSystem()

--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -1,0 +1,108 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#include "QGCPalette.h"
+
+#include <QApplication>
+#include <QPalette>
+
+bool QGCPalette::_paletteLoaded = false;
+
+QColor QGCPalette::_alternateBase[QGCPalette::_cColorGroups];
+QColor QGCPalette::_base[QGCPalette::_cColorGroups];
+QColor QGCPalette::_button[QGCPalette::_cColorGroups];
+QColor QGCPalette::_buttonText[QGCPalette::_cColorGroups];
+QColor QGCPalette::_dark[QGCPalette::_cColorGroups];
+QColor QGCPalette::_highlight[QGCPalette::_cColorGroups];
+QColor QGCPalette::_highlightedText[QGCPalette::_cColorGroups];
+QColor QGCPalette::_light[QGCPalette::_cColorGroups];
+QColor QGCPalette::_mid[QGCPalette::_cColorGroups];
+QColor QGCPalette::_midlight[QGCPalette::_cColorGroups];
+QColor QGCPalette::_shadow[QGCPalette::_cColorGroups];
+QColor QGCPalette::_text[QGCPalette::_cColorGroups];
+QColor QGCPalette::_window[QGCPalette::_cColorGroups];
+QColor QGCPalette::_windowText[QGCPalette::_cColorGroups];
+
+QGCPalette::QGCPalette(QObject* parent) :
+    QObject(parent)
+{
+    if (!_paletteLoaded) {
+        _paletteLoaded = true;
+        
+        struct Group2Group {
+            ColorGroup              qgcColorGroup;
+            QPalette::ColorGroup    qtColorGroup;
+        };
+        
+        static struct Group2Group rgGroup2Group[] = {
+            { Disabled, QPalette::Disabled },
+            { Active, QPalette::Active },
+            { Inactive, QPalette::Inactive }
+        };
+        static const size_t crgGroup2Group = sizeof(rgGroup2Group) / sizeof(rgGroup2Group[0]);
+        Q_ASSERT(crgGroup2Group == _cColorGroups);
+        
+        for (size_t i=0; i<crgGroup2Group; i++) {
+            ColorGroup colorGroup = rgGroup2Group[i].qgcColorGroup;
+            _window[colorGroup] = QColor(34, 34, 34);
+            _windowText[colorGroup] = QColor(255, 255, 255);
+        }
+        
+        for (size_t i=0; i<crgGroup2Group; i++) {
+            struct Group2Group* prgGroup2Group = &rgGroup2Group[i];
+            
+            QPalette syspal = QApplication::palette();
+            syspal.setCurrentColorGroup(prgGroup2Group->qtColorGroup);
+            
+            ColorGroup qgcColorGroup = prgGroup2Group->qgcColorGroup;
+            
+            _alternateBase[qgcColorGroup] = syspal.color(QPalette::AlternateBase);
+            _base[qgcColorGroup] = syspal.color(QPalette::Base);
+            _button[qgcColorGroup] = syspal.color(QPalette::Button);
+            _buttonText[qgcColorGroup] = syspal.color(QPalette::ButtonText);
+            _text[qgcColorGroup] = syspal.color(QPalette::Text);
+            
+            _shadow[qgcColorGroup] = syspal.shadow().color();
+            _dark[qgcColorGroup] = syspal.dark().color();
+            _highlight[qgcColorGroup] = syspal.highlight().color();
+            _highlightedText[qgcColorGroup] = syspal.highlightedText().color();
+            _light[qgcColorGroup] = syspal.light().color();
+            _mid[qgcColorGroup] = syspal.mid().color();
+            _midlight[qgcColorGroup] = syspal.midlight().color();
+        }
+    }
+}
+
+QGCPalette::~QGCPalette()
+{
+    
+}
+
+void QGCPalette::setColorGroup(ColorGroup colorGroup)
+{
+    _colorGroup = colorGroup;
+    emit paletteChanged();
+}

--- a/src/QGCPalette.h
+++ b/src/QGCPalette.h
@@ -1,0 +1,109 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#ifndef QGCPalette_h
+#define QGCPalette_h
+
+#include <QObject>
+#include <QColor>
+
+class QGCPalette : public QObject
+{
+    Q_OBJECT
+    
+    Q_ENUMS(ColorGroup)
+    
+    Q_PROPERTY(ColorGroup colorGroup READ colorGroup WRITE setColorGroup NOTIFY paletteChanged)
+
+    Q_PROPERTY(QColor alternateBase READ alternateBase NOTIFY paletteChanged)
+    Q_PROPERTY(QColor base READ base NOTIFY paletteChanged)
+    Q_PROPERTY(QColor button READ button NOTIFY paletteChanged)
+    Q_PROPERTY(QColor buttonText READ buttonText NOTIFY paletteChanged)
+    Q_PROPERTY(QColor dark READ dark NOTIFY paletteChanged)
+    Q_PROPERTY(QColor highlight READ highlight NOTIFY paletteChanged)
+    Q_PROPERTY(QColor highlightedText READ highlightedText NOTIFY paletteChanged)
+    Q_PROPERTY(QColor light READ light NOTIFY paletteChanged)
+    Q_PROPERTY(QColor mid READ mid NOTIFY paletteChanged)
+    Q_PROPERTY(QColor midlight READ midlight NOTIFY paletteChanged)
+    Q_PROPERTY(QColor shadow READ shadow NOTIFY paletteChanged)
+    Q_PROPERTY(QColor text READ text NOTIFY paletteChanged)
+    Q_PROPERTY(QColor window READ window NOTIFY paletteChanged)
+    Q_PROPERTY(QColor windowText READ windowText NOTIFY paletteChanged)
+
+public:
+    enum ColorGroup {
+        Disabled,
+        Active,
+        Inactive
+    };
+    
+    QGCPalette(QObject* parent = NULL);
+    ~QGCPalette();
+    
+    ColorGroup colorGroup(void) const { return _colorGroup; }
+    void setColorGroup(ColorGroup colorGroup);
+    
+    QColor alternateBase(void) const { return _alternateBase[_colorGroup]; }
+    QColor base(void) const { return _base[_colorGroup]; }
+    QColor button(void) const { return _button[_colorGroup]; }
+    QColor buttonText(void) const { return _buttonText[_colorGroup]; }
+    QColor dark(void) const { return _dark[_colorGroup]; }
+    QColor highlight(void) const { return _highlight[_colorGroup]; }
+    QColor highlightedText(void) const { return _highlightedText[_colorGroup]; }
+    QColor light(void) const { return _light[_colorGroup]; }
+    QColor mid(void) const { return _mid[_colorGroup]; }
+    QColor midlight(void) const { return _midlight[_colorGroup]; }
+    QColor shadow(void) const { return _shadow[_colorGroup]; }
+    QColor text(void) const { return _text[_colorGroup]; }
+    QColor window(void) const { return _window[_colorGroup]; }
+    QColor windowText(void) const { return _windowText[_colorGroup]; }
+    
+signals:
+    void paletteChanged(void);
+    
+private:
+    ColorGroup _colorGroup;
+    
+    static bool _paletteLoaded;
+    
+    static const int _cColorGroups = 3;
+    static QColor _alternateBase[_cColorGroups];
+    static QColor _base[_cColorGroups];
+    static QColor _button[_cColorGroups];
+    static QColor _buttonText[_cColorGroups];
+    static QColor _dark[_cColorGroups];
+    static QColor _highlight[_cColorGroups];
+    static QColor _highlightedText[_cColorGroups];
+    static QColor _light[_cColorGroups];
+    static QColor _mid[_cColorGroups];
+    static QColor _midlight[_cColorGroups];
+    static QColor _shadow[_cColorGroups];
+    static QColor _text[_cColorGroups];
+    static QColor _window[_cColorGroups];
+    static QColor _windowText[_cColorGroups];
+};
+
+#endif

--- a/src/VehicleSetup/SetupViewConnected.qml
+++ b/src/VehicleSetup/SetupViewConnected.qml
@@ -1,13 +1,16 @@
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
+import QGroundControl.FactSystem 1.0
 
 Rectangle {
+    QGCPalette { id: palette; colorGroup: QGCPalette.Active }
+
     id: topLevel
     objectName: "topLevel"
 
     anchors.fill: parent
-    color: "#222"
+    color: palette.window
 
     signal buttonClicked(variant component);
 

--- a/src/VehicleSetup/SetupViewDisconnected.qml
+++ b/src/VehicleSetup/SetupViewDisconnected.qml
@@ -1,10 +1,13 @@
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
+import QGroundControl.FactSystem 1.0
 
 Rectangle {
+    QGCPalette { id: palette; colorGroup: QGCPalette.Active }
+
     anchors.fill: parent
-    color: "#222"
+    color: palette.window
 
     Item {
         anchors.margins: 20
@@ -16,7 +19,7 @@ Rectangle {
 
         Text { width: parent.width; height: parent.height - header.height - footer.height;
             anchors.top: header.bottom
-            color: "white"
+            color: palette.windowText
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             text: "No vehicle currently connected. Vehicle Setup is only available while vehicle is connected." }


### PR DESCRIPTION
Works just like Qt QML SystemPalette. Use as follows:

```
import QGroundControl.FactSystem 1.0
Rectangle {
    QGCPalette { id: palette; colorGroup: QGCPalette::Active }
    color: palette.window
}
```
