### PR TITLE
Made Q3D emit updateWidget so that local view updates correctly.

### DIFF
--- a/src/ui/map3D/Q3DWidget.cc
+++ b/src/ui/map3D/Q3DWidget.cc
@@ -354,6 +354,7 @@ void
 Q3DWidget::redraw(void)
 {
     emit update();
+    emit updateWidget();
 #if (QGC_EVENTLOOP_DEBUG)
     qDebug() << "EVENTLOOP:" << __FILE__ << __LINE__;
 #endif


### PR DESCRIPTION
Local 3D view was completely unusable because updateWidget was never being called after it was renamed from update. The signal was not being emitted by Q3D.