### PR TITLE
Fix issue #1173

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -476,10 +476,13 @@ void QGCApplication::criticalMessageBoxOnMainThread(const QString& title, const 
 
 void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
 {
+    QString defaultSuffix = "mavlink";
     QString saveFilename = QGCFileDialog::getSaveFileName(MainWindow::instance(),
                                                           tr("Select file to save Flight Data Log"),
                                                           qgcApp()->mavlinkLogFilesLocation(),
-                                                          tr("Flight Data Log (*.mavlink)"));
+                                                          tr("Flight Data Log (*.mavlink)"),
+                                                          0,0,
+                                                          &defaultSuffix);
     if (!saveFilename.isEmpty()) {
         QFile::copy(tempLogfile, saveFilename);
     }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -476,7 +476,7 @@ void QGCApplication::criticalMessageBoxOnMainThread(const QString& title, const 
 
 void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
 {
-    QString defaultSuffix = "mavlink";
+    QString defaultSuffix("mavlink");
     QString saveFilename = QGCFileDialog::getSaveFileName(MainWindow::instance(),
                                                           tr("Select file to save Flight Data Log"),
                                                           qgcApp()->mavlinkLogFilesLocation(),

--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -101,19 +101,23 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
     {
         QFileDialog dlg(parent, caption, dir, filter);
         dlg.setAcceptMode(QFileDialog::AcceptSave);
-        if (selectedFilter)
+        if (selectedFilter) {
             dlg.selectNameFilter(*selectedFilter);
-        if (options)
+        }
+        if (options) {
             dlg.setOptions(options);
+        }
         if (defaultSuffix) {
             //-- Make sure dot is not present
             if (defaultSuffix->startsWith("."))
                 defaultSuffix->remove(0,1);
             dlg.setDefaultSuffix(*defaultSuffix);
         }
-        if (dlg.exec())
-            if (dlg.selectedFiles().count())
+        if (dlg.exec()) {
+            if (dlg.selectedFiles().count()) {
                 return dlg.selectedFiles().first();
+            }
+        }
         return QString("");
     }
 }

--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -109,8 +109,9 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
         }
         if (defaultSuffix) {
             //-- Make sure dot is not present
-            if (defaultSuffix->startsWith("."))
+            if (defaultSuffix->startsWith(".")) {
                 defaultSuffix->remove(0,1);
+            }
             dlg.setDefaultSuffix(*defaultSuffix);
         }
         if (dlg.exec()) {

--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -100,6 +100,7 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
 #endif
     {
         QFileDialog dlg(parent, caption, dir, filter);
+        dlg.setAcceptMode(QFileDialog::AcceptSave);
         if (selectedFilter)
             dlg.selectNameFilter(*selectedFilter);
         if (options)

--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -92,7 +92,7 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
                                   QString* defaultSuffix)
 {
     _validate(selectedFilter, options);
-    
+
 #ifdef QT_DEBUG
     if (qgcApp()->runningUnitTests()) {
         return UnitTest::_getSaveFileName(parent, caption, dir, filter, selectedFilter, options, defaultSuffix);
@@ -105,8 +105,12 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
             dlg.selectNameFilter(*selectedFilter);
         if (options)
             dlg.setOptions(options);
-        if (defaultSuffix)
+        if (defaultSuffix) {
+            //-- Make sure dot is not present
+            if (defaultSuffix->startsWith("."))
+                defaultSuffix->remove(0,1);
             dlg.setDefaultSuffix(*defaultSuffix);
+        }
         if (dlg.exec())
             if (dlg.selectedFiles().count())
                 return dlg.selectedFiles().first();

--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -95,7 +95,7 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
     
 #ifdef QT_DEBUG
     if (qgcApp()->runningUnitTests()) {
-        return UnitTest::_getSaveFileName(parent, caption, dir, filter, selectedFilter, options);
+        return UnitTest::_getSaveFileName(parent, caption, dir, filter, selectedFilter, options, defaultSuffix);
     } else
 #endif
     {

--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -88,7 +88,8 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
                                   const QString& dir,
                                   const QString& filter,
                                   QString* selectedFilter,
-                                  Options options)
+                                  Options options,
+                                  QString* defaultSuffix)
 {
     _validate(selectedFilter, options);
     
@@ -98,7 +99,17 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
     } else
 #endif
     {
-        return QFileDialog::getSaveFileName(parent, caption, dir, filter, selectedFilter, options);
+        QFileDialog dlg(parent, caption, dir, filter);
+        if (selectedFilter)
+            dlg.selectNameFilter(*selectedFilter);
+        if (options)
+            dlg.setOptions(options);
+        if (defaultSuffix)
+            dlg.setDefaultSuffix(*defaultSuffix);
+        if (dlg.exec())
+            if (dlg.selectedFiles().count())
+                return dlg.selectedFiles().first();
+        return QString("");
     }
 }
 

--- a/src/QGCFileDialog.h
+++ b/src/QGCFileDialog.h
@@ -55,12 +55,16 @@ public:
                                         QString* selectedFilter = 0,
                                         Options options = 0);
     
+    /// @brief getSaveFileName with an extra (optional) argument to define the extension (suffix) to
+    ///        be added if none is given by the user. If set, don't add the preceding period (i.e.
+    ///        use "mavlink" instead of ".mavlink")
     static QString getSaveFileName(QWidget* parent = 0,
                                    const QString& caption = QString(),
                                    const QString& dir = QString(),
                                    const QString& filter = QString(),
                                    QString* selectedFilter = 0,
-                                   Options options = 0);
+                                   Options options = 0,
+                                   QString* defaultSuffix = 0);
     
 private slots:
     /// @brief The exec slot is private becasue when only want QGCFileDialog users to use the static methods. Otherwise it will break

--- a/src/QGCFileDialog.h
+++ b/src/QGCFileDialog.h
@@ -61,7 +61,7 @@ public:
       \param caption The caption displayed at the top of the dialog.
       \param dir The initial directory shown to the user.
       \param filter The filter used for selecting the file type.
-      \param selectedFilter **NOT IMPLEMENTED** Returns the filter that the user selected in the file dialog.
+      \param selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
       \param options Set the various options that affect the look and feel of the dialog.
       \return The full path and filename to be opened or QString("") if none.
       \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getOpenFileName">QFileDialog::getOpenFileName()</a>
@@ -79,7 +79,7 @@ public:
       \param caption The caption displayed at the top of the dialog.
       \param dir The initial directory shown to the user.
       \param filter The filter used for selecting the file type.
-      \param selectedFilter **NOT IMPLEMENTED** Returns the filter that the user selected in the file dialog.
+      \param selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
       \param options Set the various options that affect the look and feel of the dialog.
       \return A QStringList object containing zero or more files to be opened.
       \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getOpenFileNames">QFileDialog::getOpenFileNames()</a>
@@ -97,7 +97,7 @@ public:
       \param caption The caption displayed at the top of the dialog.
       \param dir The initial directory shown to the user.
       \param filter The filter used for selecting the file type.
-      \param selectedFilter **NOT IMPLEMENTED** Returns the filter that the user selected in the file dialog.
+      \param selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
       \param options Set the various options that affect the look and feel of the dialog.
       \param defaultSuffix Specifies a string that will be added to the filename if it has no suffix already. The suffix is typically used to indicate the file type (e.g. "txt" indicates a text file).
       \return The full path and filename to be used to save the file or QString("") if none.

--- a/src/QGCFileDialog.h
+++ b/src/QGCFileDialog.h
@@ -43,12 +43,12 @@ public:
 
     //! Static helper that will return an existing directory selected by the user.
     /*!
-      \param parent The parent QWidget.
-      \param caption The caption displayed at the top of the dialog.
-      \param dir The initial directory shown to the user.
-      \param options Set the various options that affect the look and feel of the dialog.
-      \return The chosen path or QString("") if none.
-      \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getExistingDirectory">QFileDialog::getExistingDirectory()</a>
+      @param[in] parent The parent QWidget.
+      @param[in] caption The caption displayed at the top of the dialog.
+      @param[in] dir The initial directory shown to the user.
+      @param[in] options Set the various options that affect the look and feel of the dialog.
+      @return The chosen path or \c QString("") if none.
+      @sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getExistingDirectory">QFileDialog::getExistingDirectory()</a>
     */
     static QString getExistingDirectory(QWidget* parent = 0,
                                         const QString& caption = QString(),
@@ -57,14 +57,14 @@ public:
     
     //! Static helper that invokes a File Open dialog where the user can select a file to be opened.
     /*!
-      \param parent The parent QWidget.
-      \param caption The caption displayed at the top of the dialog.
-      \param dir The initial directory shown to the user.
-      \param filter The filter used for selecting the file type.
-      \param selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
-      \param options Set the various options that affect the look and feel of the dialog.
-      \return The full path and filename to be opened or QString("") if none.
-      \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getOpenFileName">QFileDialog::getOpenFileName()</a>
+      @param[in] parent The parent QWidget.
+      @param[in] caption The caption displayed at the top of the dialog.
+      @param[in] dir The initial directory shown to the user.
+      @param[in] filter The filter used for selecting the file type.
+      @param[out] selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
+      @param[in] options Set the various options that affect the look and feel of the dialog.
+      @return The full path and filename to be opened or \c QString("") if none.
+      @sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getOpenFileName">QFileDialog::getOpenFileName()</a>
     */
     static QString getOpenFileName(QWidget* parent = 0,
                                    const QString& caption = QString(),
@@ -75,14 +75,14 @@ public:
     
     //! Static helper that invokes a File Open dialog where the user can select one or more files to be opened.
     /*!
-      \param parent The parent QWidget.
-      \param caption The caption displayed at the top of the dialog.
-      \param dir The initial directory shown to the user.
-      \param filter The filter used for selecting the file type.
-      \param selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
-      \param options Set the various options that affect the look and feel of the dialog.
-      \return A QStringList object containing zero or more files to be opened.
-      \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getOpenFileNames">QFileDialog::getOpenFileNames()</a>
+      @param[in] parent The parent QWidget.
+      @param[in] caption The caption displayed at the top of the dialog.
+      @param[in] dir The initial directory shown to the user.
+      @param[in] filter The filter used for selecting the file type.
+      @param[out] selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
+      @param[in] options Set the various options that affect the look and feel of the dialog.
+      @return A <a href="http://qt-project.org/doc/qt-4.8/qstringlist.html">QStringList</a> object containing zero or more files to be opened.
+      @sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getOpenFileNames">QFileDialog::getOpenFileNames()</a>
     */
     static QStringList getOpenFileNames(QWidget* parent = 0,
                                         const QString& caption = QString(),
@@ -93,15 +93,17 @@ public:
     
     //! Static helper that invokes a File Save dialog where the user can select a directory and enter a filename to be saved.
     /*!
-      \param parent The parent QWidget.
-      \param caption The caption displayed at the top of the dialog.
-      \param dir The initial directory shown to the user.
-      \param filter The filter used for selecting the file type.
-      \param selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
-      \param options Set the various options that affect the look and feel of the dialog.
-      \param defaultSuffix Specifies a string that will be added to the filename if it has no suffix already. The suffix is typically used to indicate the file type (e.g. "txt" indicates a text file).
-      \return The full path and filename to be used to save the file or QString("") if none.
-      \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getSaveFileName">QFileDialog::getSaveFileName()</a>
+      @param[in] parent The parent QWidget.
+      @param[in] caption The caption displayed at the top of the dialog.
+      @param[in] dir The initial directory shown to the user.
+      @param[in] filter The filter used for selecting the file type.
+      @param[out] selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
+      @param[in] options Set the various options that affect the look and feel of the dialog.
+      @param[in] defaultSuffix Specifies a string that will be added to the filename if it has no suffix already. The suffix is typically used to indicate the file type (e.g. "txt" indicates a text file).
+      @return The full path and filename to be used to save the file or \c QString("") if none.
+      @sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getSaveFileName">QFileDialog::getSaveFileName()</a>
+      @remark If a default suffix is given, it will be appended to the filename if the user does not enter one themselves. That is, if the user simply enters \e foo and the default suffix is set to \e bar,
+      the returned filename will be \e foo.bar. However, if the user specifies a suffix, none will be added. That is, if the user enters \e foo.txt, that's what you will receive in return.
     */
     static QString getSaveFileName(QWidget* parent = 0,
                                    const QString& caption = QString(),

--- a/src/QGCFileDialog.h
+++ b/src/QGCFileDialog.h
@@ -27,20 +27,45 @@
 #include <QFileDialog>
 
 /// @file
-///     @brief Subclass of QFileDialog which re-implements the static public functions. The reason for this
-///             is that the QFileDialog implementations of these use the native os dialogs. On OSX these
-///             these can intermittently hang. So instead here we use the native dialogs. It also allows
-///             use to catch these dialogs for unit testing.
+///     @brief Subclass of <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html">QFileDialog</a>
 ///     @author Don Gagne <don@thegagnes.com>
+
+/*!
+     Subclass of <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html">QFileDialog</a> which re-implements the static public functions. The reason for this
+     is that the <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html">QFileDialog</a> implementations of these use the native os dialogs. On OSX these
+     these can intermittently hang. So instead here we use the native dialogs. It also allows
+     use to catch these dialogs for unit testing.
+*/
 
 class QGCFileDialog : public QFileDialog {
     
 public:
+
+    //! Static helper that will return an existing directory selected by the user.
+    /*!
+      \param parent The parent QWidget.
+      \param caption The caption displayed at the top of the dialog.
+      \param dir The initial directory shown to the user.
+      \param options Set the various options that affect the look and feel of the dialog.
+      \return The chosen path or QString("") if none.
+      \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getExistingDirectory">QFileDialog::getExistingDirectory()</a>
+    */
     static QString getExistingDirectory(QWidget* parent = 0,
                                         const QString& caption = QString(),
                                         const QString& dir = QString(),
                                         Options options = ShowDirsOnly);
     
+    //! Static helper that invokes a File Open dialog where the user can select a file to be opened.
+    /*!
+      \param parent The parent QWidget.
+      \param caption The caption displayed at the top of the dialog.
+      \param dir The initial directory shown to the user.
+      \param filter The filter used for selecting the file type.
+      \param selectedFilter **NOT IMPLEMENTED** Returns the filter that the user selected in the file dialog.
+      \param options Set the various options that affect the look and feel of the dialog.
+      \return The full path and filename to be opened or QString("") if none.
+      \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getOpenFileName">QFileDialog::getOpenFileName()</a>
+    */
     static QString getOpenFileName(QWidget* parent = 0,
                                    const QString& caption = QString(),
                                    const QString& dir = QString(),
@@ -48,6 +73,17 @@ public:
                                    QString* selectedFilter = 0,
                                    Options options = 0);
     
+    //! Static helper that invokes a File Open dialog where the user can select one or more files to be opened.
+    /*!
+      \param parent The parent QWidget.
+      \param caption The caption displayed at the top of the dialog.
+      \param dir The initial directory shown to the user.
+      \param filter The filter used for selecting the file type.
+      \param selectedFilter **NOT IMPLEMENTED** Returns the filter that the user selected in the file dialog.
+      \param options Set the various options that affect the look and feel of the dialog.
+      \return A QStringList object containing zero or more files to be opened.
+      \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getOpenFileNames">QFileDialog::getOpenFileNames()</a>
+    */
     static QStringList getOpenFileNames(QWidget* parent = 0,
                                         const QString& caption = QString(),
                                         const QString& dir = QString(),
@@ -55,9 +91,18 @@ public:
                                         QString* selectedFilter = 0,
                                         Options options = 0);
     
-    /// @brief getSaveFileName with an extra (optional) argument to define the extension (suffix) to
-    ///        be added if none is given by the user. If set, don't add the preceding period (i.e.
-    ///        use "mavlink" instead of ".mavlink")
+    //! Static helper that invokes a File Save dialog where the user can select a directory and enter a filename to be saved.
+    /*!
+      \param parent The parent QWidget.
+      \param caption The caption displayed at the top of the dialog.
+      \param dir The initial directory shown to the user.
+      \param filter The filter used for selecting the file type.
+      \param selectedFilter **NOT IMPLEMENTED** Returns the filter that the user selected in the file dialog.
+      \param options Set the various options that affect the look and feel of the dialog.
+      \param defaultSuffix Specifies a string that will be added to the filename if it has no suffix already. The suffix is typically used to indicate the file type (e.g. "txt" indicates a text file).
+      \return The full path and filename to be used to save the file or QString("") if none.
+      \sa <a href="http://qt-project.org/doc/qt-4.8/qfiledialog.html#getSaveFileName">QFileDialog::getSaveFileName()</a>
+    */
     static QString getSaveFileName(QWidget* parent = 0,
                                    const QString& caption = QString(),
                                    const QString& dir = QString(),

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -355,5 +355,9 @@ QString UnitTest::_getSaveFileName(QWidget* parent,
     Q_UNUSED(options);
     Q_UNUSED(defaultSuffix);
 
+    // Support for selectedFilter (elsewhere) is not yet implemented. Until it is added for all
+    // file dialogs, this stays here.
+    Q_ASSERT(selectedFilter == NULL);
+
     return _fileDialogResponseSingle(getSaveFileName);
 }

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -353,10 +353,11 @@ QString UnitTest::_getSaveFileName(QWidget* parent,
     Q_UNUSED(dir);
     Q_UNUSED(filter);
     Q_UNUSED(options);
-    Q_UNUSED(defaultSuffix);
 
-    // Support for selectedFilter (elsewhere) is not yet implemented. Until it is added for all
-    // file dialogs, this stays here.
+    if(defaultSuffix)
+        Q_ASSERT(defaultSuffix->startsWith(".") == false);
+
+    // Support for selectedFilter is not yet implemented
     Q_ASSERT(selectedFilter == NULL);
 
     return _fileDialogResponseSingle(getSaveFileName);

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -345,16 +345,15 @@ QString UnitTest::_getSaveFileName(QWidget* parent,
                                    const QString& dir,
                                    const QString& filter,
                                    QString* selectedFilter,
-                                   QFileDialog::Options options)
+                                   QFileDialog::Options options,
+                                   QString* defaultSuffix)
 {
     Q_UNUSED(parent);
     Q_UNUSED(caption);
     Q_UNUSED(dir);
     Q_UNUSED(filter);
     Q_UNUSED(options);
-    
-    // Support for selectedFilter is not yet implemented
-    Q_ASSERT(selectedFilter == NULL);
-    
+    Q_UNUSED(defaultSuffix);
+
     return _fileDialogResponseSingle(getSaveFileName);
 }

--- a/src/qgcunittest/UnitTest.h
+++ b/src/qgcunittest/UnitTest.h
@@ -142,7 +142,8 @@ private:
                                     const QString& dir,
                                     const QString& filter,
                                     QString* selectedFilter,
-                                    QFileDialog::Options options);
+                                    QFileDialog::Options options,
+                                    QString* defaultSuffix);
     
     static QString _fileDialogResponseSingle(enum FileDialogType type);
 

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -836,7 +836,7 @@ void MainWindow::createCustomWidget()
 void MainWindow::loadCustomWidget()
 {
     QString widgetFileExtension(".qgw");
-    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Specify Widget File Name"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("QGroundControl Widget (*%1);;").arg(widgetFileExtension));
+    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Specify Widget File Name"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("QGroundControl Widget (*%1)").arg(widgetFileExtension));
     if (fileName != "") loadCustomWidget(fileName);
 }
 void MainWindow::loadCustomWidget(const QString& fileName, int view)

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -996,14 +996,16 @@ void MainWindow::configureWindowName()
 
 void MainWindow::startVideoCapture()
 {
-    QString format = "bmp";
+    QString format("bmp");
     QString initialPath = QDir::currentPath() + tr("/untitled.") + format;
 
     QString screenFileName = QGCFileDialog::getSaveFileName(this, tr("Save As"),
                                                           initialPath,
                                                           tr("%1 Files (*.%2);;All Files (*)")
                                                           .arg(format.toUpper())
-                                                          .arg(format));
+                                                          .arg(format),
+                                                          0,0,
+                                                          &format);
     delete videoTimer;
     videoTimer = new QTimer(this);
 }

--- a/src/ui/QGCBaseParamWidget.cc
+++ b/src/ui/QGCBaseParamWidget.cc
@@ -105,7 +105,8 @@ void QGCBaseParamWidget::saveParametersToFile()
 {
     if (!mav)
         return;
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), qgcApp()->savedParameterFilesLocation(), tr("Parameter File (*.txt)"));
+    QString defaultSuffix("txt");
+    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), qgcApp()->savedParameterFilesLocation(), tr("Parameter File (*.txt)"), 0, 0, &defaultSuffix);
     QFile file(fileName);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         return;

--- a/src/ui/QGCDataPlot2D.cc
+++ b/src/ui/QGCDataPlot2D.cc
@@ -111,21 +111,27 @@ void QGCDataPlot2D::loadFile(QString file)
 }
 
 /**
- * This function brings up a file name dialog and exports to either PDF or SVG, depending on the filename
+ * This function brings up a file name dialog and asks the user to enter a file to save to
+ */
+QString QGCDataPlot2D::getSavePlotFilename()
+{
+    QString defaultSuffix("pdf");
+    QString fileName = QGCFileDialog::getSaveFileName(
+        this, "Export File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
+        "PDF Documents (*.pdf);;SVG Images (*.svg)",
+        0,0,
+        &defaultSuffix);
+    return fileName;
+}
+
+/**
+ * This function aks the user for a filename and exports to either PDF or SVG, depending on the filename
  */
 void QGCDataPlot2D::savePlot()
 {
-    QString fileName = "plot.svg";
-    fileName = QGCFileDialog::getSaveFileName(
-                   this, "Export File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
-                   "PDF Documents (*.pdf);;SVG Images (*.svg)");
+    QString fileName = getSavePlotFilename();
     if (fileName.isEmpty())
         return;
-
-    if (!fileName.contains(".")) {
-        // .pdf is default extension
-        fileName.append(".pdf");
-    }
 
     while(!(fileName.endsWith(".svg") || fileName.endsWith(".pdf"))) {
         QMessageBox::StandardButton button = QGCMessageBox::critical(tr("Unsuitable file extension for PDF or SVG"),
@@ -136,9 +142,8 @@ void QGCDataPlot2D::savePlot()
         if (button == QMessageBox::Cancel) {
             return;
         }
-        fileName = QGCFileDialog::getSaveFileName(
-                       this, "Export File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
-                       "PDF Documents (*.pdf);;SVG Images (*.svg)");
+
+        fileName = getSavePlotFilename();
         if (fileName.isEmpty())
             return; //Abort if cancelled
     }
@@ -685,21 +690,19 @@ bool QGCDataPlot2D::linearRegression(double *x, double *y, int n, double *a, dou
 
 void QGCDataPlot2D::saveCsvLog()
 {
-    QString fileName = "export.csv";
-    fileName = QGCFileDialog::getSaveFileName(
-                   this, "Export CSV File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
-                   "CSV file (*.csv);;Text file (*.txt)");
+    QString defaultSuffix("csv");
+    QString fileName = QGCFileDialog::getSaveFileName(
+        this, "Export CSV File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
+        "CSV file (*.csv);;Text file (*.txt)",
+        0,0,
+        &defaultSuffix);
+
     if (fileName.isEmpty())
         return; //User cancelled
 
-    if (!fileName.contains(".")) {
-        // .csv is default extension
-        fileName.append(".csv");
-    }
-
     bool success = logFile->copy(fileName);
 
-    qDebug() << "Saved CSV log. Success: " << success;
+    qDebug() << "Saved CSV log (" << fileName << "). Success: " << success;
 
     //qDebug() << "READE TO SAVE CSV LOG TO " << fileName;
 }

--- a/src/ui/QGCDataPlot2D.h
+++ b/src/ui/QGCDataPlot2D.h
@@ -63,6 +63,7 @@ protected:
     }
 
     void changeEvent(QEvent *e);
+    QString getSavePlotFilename();
     IncrementalPlot* plot;
     LogCompressor* compressor;
     QFile* logFile;

--- a/src/ui/WaypointList.cc
+++ b/src/ui/WaypointList.cc
@@ -217,10 +217,9 @@ void WaypointList::setUAS(UASInterface* uas)
 
 void WaypointList::saveWaypoints()
 {
-
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), "./waypoints.txt", tr("Waypoint File (*.txt)"));
+    QString defaultSuffix("txt");
+    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), "./waypoints.txt", tr("Waypoint File (*.txt)"), 0, 0, &defaultSuffix);
     WPM->saveWaypoints(fileName);
-
 }
 
 void WaypointList::loadWaypoints()

--- a/src/ui/designer/QGCToolWidget.cc
+++ b/src/ui/designer/QGCToolWidget.cc
@@ -576,7 +576,7 @@ void QGCToolWidget::exportWidget()
     QString fileName = QGCFileDialog::getSaveFileName(
         this, tr("Specify File Name"),
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
-        tr("QGroundControl Widget (*%1);;").arg(widgetFileExtension),
+        tr("QGroundControl Widget (*%1)").arg(widgetFileExtension),
         0,0,
         &defaultSuffix);
     //-- Note that if the user enters foo.bar, this will end up foo.bar.qgw
@@ -591,7 +591,7 @@ void QGCToolWidget::exportWidget()
 void QGCToolWidget::importWidget()
 {
     const QString widgetFileExtension(".qgw");
-    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Specify File Name"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("QGroundControl Widget (*%1);;").arg(widgetFileExtension));
+    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Specify File Name"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("QGroundControl Widget (*%1)").arg(widgetFileExtension));
     loadSettings(fileName);
 }
 

--- a/src/ui/designer/QGCToolWidget.cc
+++ b/src/ui/designer/QGCToolWidget.cc
@@ -571,8 +571,15 @@ void QGCToolWidget::widgetRemoved()
 
 void QGCToolWidget::exportWidget()
 {
+    QString defaultSuffix("qgw");
     const QString widgetFileExtension(".qgw");
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Specify File Name"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("QGroundControl Widget (*%1);;").arg(widgetFileExtension));
+    QString fileName = QGCFileDialog::getSaveFileName(
+        this, tr("Specify File Name"),
+        QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
+        tr("QGroundControl Widget (*%1);;").arg(widgetFileExtension),
+        0,0,
+        &defaultSuffix);
+    //-- Note that if the user enters foo.bar, this will end up foo.bar.qgw
     if (!fileName.endsWith(widgetFileExtension))
     {
         fileName = fileName.append(widgetFileExtension);

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -437,7 +437,7 @@ QString LinechartWidget::getLogSaveFilename()
     QString fileName = QGCFileDialog::getSaveFileName(this,
         tr("Specify log file name"),
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
-        tr("Logfile (*.log);;"),
+        tr("Logfile (*.log)"),
         0,0,
         &defaultSuffix);
     return fileName;

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -431,11 +431,21 @@ void LinechartWidget::refresh()
     setUpdatesEnabled(true);
 }
 
+QString LinechartWidget::getLogSaveFilename()
+{
+    QString defaultSuffix("log");
+    QString fileName = QGCFileDialog::getSaveFileName(this,
+        tr("Specify log file name"),
+        QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
+        tr("Logfile (*.log);;"),
+        0,0,
+        &defaultSuffix);
+    return fileName;
+}
 
 void LinechartWidget::startLogging()
 {
     // Store reference to file
-    // Append correct file ending if needed
     bool abort = false;
 
     // Check if any curve is enabled
@@ -445,9 +455,9 @@ void LinechartWidget::startLogging()
     }
 
     // Let user select the log file name
-    //QDate date(QDate::currentDate());
+    // QDate date(QDate::currentDate());
     // QString("./pixhawk-log-" + date.toString("yyyy-MM-dd") + "-" + QString::number(logindex) + ".log")
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Specify log file name"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("Logfile (*.log);;"));
+    QString fileName = getLogSaveFilename();
 
     while (!(fileName.endsWith(".log")) && !abort && fileName != "") {
         QMessageBox::StandardButton button = QGCMessageBox::critical(tr("Unsuitable file extension for logfile"),
@@ -458,10 +468,10 @@ void LinechartWidget::startLogging()
             abort = true;
             break;
         }
-        fileName = QGCFileDialog::getSaveFileName(this, tr("Specify log file name"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("Logfile (*.log);;"));
+        fileName = getLogSaveFilename();
     }
 
-    qDebug() << "SAVE FILE" << fileName;
+    qDebug() << "SAVE FILE " << fileName;
 
     // Check if the user did not abort the file save dialog
     if (!abort && fileName != "") {

--- a/src/ui/linechart/LinechartWidget.h
+++ b/src/ui/linechart/LinechartWidget.h
@@ -123,6 +123,7 @@ protected:
     QToolButton* createButton(QWidget* parent);
     void createCurveItem(QString curve);
     void createLayout();
+    QString getLogSaveFilename();
     /** @brief Get the name for a curve key */
     QString getCurveName(const QString& key, bool shortEnabled);
 


### PR DESCRIPTION
This is my first contribution and I'm still learning the ropes with GitHub. By now I've learned I should be working on an issue branch off my fork instead of my master branch. For now, this will do. I will get that right in my future PRs.

This fixes issue #1173 and add a few other things asked by @Susurrus:

- [X] Fix issue #1173 by adding a default suffix when none is given by the user
- [x] Properly document the QGCFileDialog class
- [x] Replace and/or update all references to QGCFileDialog::getSaveFileName() to the new format
- [x] Create/Update unit tests for the new default suffix functionality

CHANGED:
- Added (optional) argument to QGCFileDialog::getSaveFileName() allowing you to define a default suffix (extension) to be added if none is given by the user. If the user _does_ provide one, it is not replaced. That is, if the user enters "myflight.log", that's what it will be used. If the user however, enters "myflight" alone and the default suffix is set to "mavlink", the resulting filename will be "myflight.mavlink".
- Note that the default suffix is purposely not setup for localization as I assume it should not be localized.

TESTING:
- Tested (Mac OS X 10.10 only) using an attached Pixhawk (static on the bench, not flying). Unit test completed with no errors.