### PR TITLE
Remove erroneous use of QFileDialog::selectNameFilter()

### DIFF
--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -101,9 +101,6 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
     {
         QFileDialog dlg(parent, caption, dir, filter);
         dlg.setAcceptMode(QFileDialog::AcceptSave);
-        if (selectedFilter) {
-            dlg.selectNameFilter(*selectedFilter);
-        }
         if (options) {
             dlg.setOptions(options);
         }


### PR DESCRIPTION
No filters are to be selected. The argument selectedFilter is a pointer to a QString to receive the filter selected/used by the user.