### PR TITLE
Removing unused selectedFilter argument from QGXFileDialog methods.

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -476,14 +476,12 @@ void QGCApplication::criticalMessageBoxOnMainThread(const QString& title, const 
 
 void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
 {
-    QString defaultSuffix("mavlink");
     QString saveFilename = QGCFileDialog::getSaveFileName(
         MainWindow::instance(),
         tr("Select file to save Flight Data Log"),
         qgcApp()->mavlinkLogFilesLocation(),
         tr("Flight Data Log (*.mavlink)"),
-        0,
-        &defaultSuffix);
+        "mavlink");
     if (!saveFilename.isEmpty()) {
         QFile::copy(tempLogfile, saveFilename);
     }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -478,7 +478,7 @@ void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
 {
     QString saveFilename = QGCFileDialog::getSaveFileName(
         MainWindow::instance(),
-        tr("Select file to save Flight Data Log"),
+        tr("Save Flight Data Log"),
         qgcApp()->mavlinkLogFilesLocation(),
         tr("Flight Data Log (*.mavlink)"),
         "mavlink");

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -477,12 +477,13 @@ void QGCApplication::criticalMessageBoxOnMainThread(const QString& title, const 
 void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
 {
     QString defaultSuffix("mavlink");
-    QString saveFilename = QGCFileDialog::getSaveFileName(MainWindow::instance(),
-                                                          tr("Select file to save Flight Data Log"),
-                                                          qgcApp()->mavlinkLogFilesLocation(),
-                                                          tr("Flight Data Log (*.mavlink)"),
-                                                          0,0,
-                                                          &defaultSuffix);
+    QString saveFilename = QGCFileDialog::getSaveFileName(
+        MainWindow::instance(),
+        tr("Select file to save Flight Data Log"),
+        qgcApp()->mavlinkLogFilesLocation(),
+        tr("Flight Data Log (*.mavlink)"),
+        0,
+        &defaultSuffix);
     if (!saveFilename.isEmpty()) {
         QFile::copy(tempLogfile, saveFilename);
     }

--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -28,12 +28,13 @@
 #include "UnitTest.h"
 #endif
 
-QString QGCFileDialog::getExistingDirectory(QWidget* parent,
-                                       const QString& caption,
-                                       const QString& dir,
-                                       Options options)
+QString QGCFileDialog::getExistingDirectory(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    Options options)
 {
-    _validate(NULL, options);
+    _validate(options);
     
 #ifdef QT_DEBUG
     if (qgcApp()->runningUnitTests()) {
@@ -45,65 +46,62 @@ QString QGCFileDialog::getExistingDirectory(QWidget* parent,
     }
 }
 
-QString QGCFileDialog::getOpenFileName(QWidget* parent,
-                                  const QString& caption,
-                                  const QString& dir,
-                                  const QString& filter,
-                                  QString* selectedFilter,
-                                  Options options)
+QString QGCFileDialog::getOpenFileName(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QString& filter,
+    Options options)
 {
-    _validate(selectedFilter, options);
+    _validate(options);
     
 #ifdef QT_DEBUG
     if (qgcApp()->runningUnitTests()) {
-        return UnitTest::_getOpenFileName(parent, caption, dir, filter, selectedFilter, options);
+        return UnitTest::_getOpenFileName(parent, caption, dir, filter, options);
     } else
 #endif
     {
-        return QFileDialog::getOpenFileName(parent, caption, dir, filter, selectedFilter, options);
+        return QFileDialog::getOpenFileName(parent, caption, dir, filter, NULL, options);
     }
 }
 
-QStringList QGCFileDialog::getOpenFileNames(QWidget* parent,
-                                       const QString& caption,
-                                       const QString& dir,
-                                       const QString& filter,
-                                       QString* selectedFilter,
-                                       Options options)
+QStringList QGCFileDialog::getOpenFileNames(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QString& filter,
+    Options options)
 {
-    _validate(selectedFilter, options);
+    _validate(options);
     
 #ifdef QT_DEBUG
     if (qgcApp()->runningUnitTests()) {
-        return UnitTest::_getOpenFileNames(parent, caption, dir, filter, selectedFilter, options);
+        return UnitTest::_getOpenFileNames(parent, caption, dir, filter, options);
     } else
 #endif
     {
-        return QFileDialog::getOpenFileNames(parent, caption, dir, filter, selectedFilter, options);
+        return QFileDialog::getOpenFileNames(parent, caption, dir, filter, NULL, options);
     }
 }
 
-QString QGCFileDialog::getSaveFileName(QWidget* parent,
-                                  const QString& caption,
-                                  const QString& dir,
-                                  const QString& filter,
-                                  QString* selectedFilter,
-                                  Options options,
-                                  QString* defaultSuffix)
+QString QGCFileDialog::getSaveFileName(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QString& filter,
+    Options options,
+    QString* defaultSuffix)
 {
-    _validate(selectedFilter, options);
+    _validate(options);
 
 #ifdef QT_DEBUG
     if (qgcApp()->runningUnitTests()) {
-        return UnitTest::_getSaveFileName(parent, caption, dir, filter, selectedFilter, options, defaultSuffix);
+        return UnitTest::_getSaveFileName(parent, caption, dir, filter, options, defaultSuffix);
     } else
 #endif
     {
         QFileDialog dlg(parent, caption, dir, filter);
         dlg.setAcceptMode(QFileDialog::AcceptSave);
-        if (selectedFilter) {
-            dlg.selectNameFilter(*selectedFilter);
-        }
         if (options) {
             dlg.setOptions(options);
         }
@@ -124,16 +122,12 @@ QString QGCFileDialog::getSaveFileName(QWidget* parent,
 }
 
 /// @brief Validates and updates the parameters for the file dialog calls
-void QGCFileDialog::_validate(QString* selectedFilter, Options& options)
+void QGCFileDialog::_validate(Options& options)
 {
     // You can't use QGCFileDialog if QGCApplication is not created yet.
     Q_ASSERT(qgcApp());
     
     Q_ASSERT_X(QThread::currentThread() == qgcApp()->thread(), "Threading issue", "QGCFileDialog can only be called from main thread");
-    
-    // Support for selectedFilter is not yet implemented through the unit test framework
-    Q_UNUSED(selectedFilter);
-    Q_ASSERT(selectedFilter == NULL);
     
     // On OSX native dialog can hang so we always use Qt dialogs
     options |= DontUseNativeDialog;

--- a/src/QGCFileDialog.cc
+++ b/src/QGCFileDialog.cc
@@ -89,14 +89,14 @@ QString QGCFileDialog::getSaveFileName(
     const QString& caption,
     const QString& dir,
     const QString& filter,
-    Options options,
-    QString* defaultSuffix)
+    const QString& defaultSuffix,
+    Options options)
 {
     _validate(options);
 
 #ifdef QT_DEBUG
     if (qgcApp()->runningUnitTests()) {
-        return UnitTest::_getSaveFileName(parent, caption, dir, filter, options, defaultSuffix);
+        return UnitTest::_getSaveFileName(parent, caption, dir, filter, defaultSuffix, options);
     } else
 #endif
     {
@@ -105,12 +105,13 @@ QString QGCFileDialog::getSaveFileName(
         if (options) {
             dlg.setOptions(options);
         }
-        if (defaultSuffix) {
+        if (!defaultSuffix.isEmpty()) {
+            QString suffixCopy(defaultSuffix);
             //-- Make sure dot is not present
-            if (defaultSuffix->startsWith(".")) {
-                defaultSuffix->remove(0,1);
+            if (suffixCopy.startsWith(".")) {
+                suffixCopy.remove(0,1);
             }
-            dlg.setDefaultSuffix(*defaultSuffix);
+            dlg.setDefaultSuffix(suffixCopy);
         }
         if (dlg.exec()) {
             if (dlg.selectedFiles().count()) {

--- a/src/QGCFileDialog.h
+++ b/src/QGCFileDialog.h
@@ -31,10 +31,21 @@
 ///     @author Don Gagne <don@thegagnes.com>
 
 /*!
-     Subclass of <a href="http://qt-project.org/doc/qt-5/qfiledialog.html">QFileDialog</a> which re-implements the static public functions. The reason for this
-     is that the <a href="http://qt-project.org/doc/qt-5/qfiledialog.html">QFileDialog</a> implementations of these use the native os dialogs. On OSX these
-     these can intermittently hang. So instead here we use the native dialogs. It also allows
-     use to catch these dialogs for unit testing.
+    Subclass of <a href="http://qt-project.org/doc/qt-5/qfiledialog.html">QFileDialog</a> which re-implements the static public functions. The reason for this
+    is that the <a href="http://qt-project.org/doc/qt-5/qfiledialog.html">QFileDialog</a> implementations of these use the native os dialogs. On OSX these
+    these can intermittently hang. So instead here we use the native dialogs. It also allows
+    use to catch these dialogs for unit testing.
+    @remark If you need to know what type of file was returned by these functions, you can use something like:
+    @code{.cpp}
+    QString filename = QGCFileDialog::getSaveFileName(this, tr("Save File"), "~/", "Foo files (*.foo);;All Files (*.*)", "foo");
+    if (!filename.isEmpty()) {
+        QFileInfo fi(filename);
+        QString fileExtension(fi.suffix());
+        if (fileExtension == QString("foo")) {
+            // do something
+        }
+    }
+    @endcode
 */
 
 class QGCFileDialog : public QFileDialog {
@@ -96,8 +107,8 @@ public:
       @param[in] caption The caption displayed at the top of the dialog.
       @param[in] dir The initial directory shown to the user.
       @param[in] filter The filter used for selecting the file type.
-      @param[in] options Set the various options that affect the look and feel of the dialog.
       @param[in] defaultSuffix Specifies a string that will be added to the filename if it has no suffix already. The suffix is typically used to indicate the file type (e.g. "txt" indicates a text file).
+      @param[in] options Set the various options that affect the look and feel of the dialog.
       @return The full path and filename to be used to save the file or \c QString("") if none.
       @sa <a href="http://qt-project.org/doc/qt-5/qfiledialog.html#getSaveFileName">QFileDialog::getSaveFileName()</a>
       @remark If a default suffix is given, it will be appended to the filename if the user does not enter one themselves. That is, if the user simply enters \e foo and the default suffix is set to \e bar,
@@ -108,9 +119,9 @@ public:
         const QString& caption = QString(),
         const QString& dir = QString(),
         const QString& filter = QString(),
-        Options options = 0,
-        QString* defaultSuffix = 0);
-    
+        const QString& defaultSuffix = QString(),
+        Options options = 0);
+
 private slots:
     /// @brief The exec slot is private becasue we only want QGCFileDialog users to use the static methods. Otherwise it will break
     ///        unit testing.

--- a/src/QGCFileDialog.h
+++ b/src/QGCFileDialog.h
@@ -123,7 +123,7 @@ public:
         Options options = 0);
 
 private slots:
-    /// @brief The exec slot is private becasue we only want QGCFileDialog users to use the static methods. Otherwise it will break
+    /// @brief The exec slot is private because we only want QGCFileDialog users to use the static methods. Otherwise it will break
     ///        unit testing.
     int exec(void) { return QGCFileDialog::exec(); }
     

--- a/src/QGCFileDialog.h
+++ b/src/QGCFileDialog.h
@@ -50,10 +50,11 @@ public:
       @return The chosen path or \c QString("") if none.
       @sa <a href="http://qt-project.org/doc/qt-5/qfiledialog.html#getExistingDirectory">QFileDialog::getExistingDirectory()</a>
     */
-    static QString getExistingDirectory(QWidget* parent = 0,
-                                        const QString& caption = QString(),
-                                        const QString& dir = QString(),
-                                        Options options = ShowDirsOnly);
+    static QString getExistingDirectory(
+        QWidget* parent = 0,
+        const QString& caption = QString(),
+        const QString& dir = QString(),
+        Options options = ShowDirsOnly);
     
     //! Static helper that invokes a File Open dialog where the user can select a file to be opened.
     /*!
@@ -61,17 +62,16 @@ public:
       @param[in] caption The caption displayed at the top of the dialog.
       @param[in] dir The initial directory shown to the user.
       @param[in] filter The filter used for selecting the file type.
-      @param[out] selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
       @param[in] options Set the various options that affect the look and feel of the dialog.
       @return The full path and filename to be opened or \c QString("") if none.
       @sa <a href="http://qt-project.org/doc/qt-5/qfiledialog.html#getOpenFileName">QFileDialog::getOpenFileName()</a>
     */
-    static QString getOpenFileName(QWidget* parent = 0,
-                                   const QString& caption = QString(),
-                                   const QString& dir = QString(),
-                                   const QString& filter = QString(),
-                                   QString* selectedFilter = 0,
-                                   Options options = 0);
+    static QString getOpenFileName(
+        QWidget* parent = 0,
+        const QString& caption = QString(),
+        const QString& dir = QString(),
+        const QString& filter = QString(),
+        Options options = 0);
     
     //! Static helper that invokes a File Open dialog where the user can select one or more files to be opened.
     /*!
@@ -79,17 +79,16 @@ public:
       @param[in] caption The caption displayed at the top of the dialog.
       @param[in] dir The initial directory shown to the user.
       @param[in] filter The filter used for selecting the file type.
-      @param[out] selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
       @param[in] options Set the various options that affect the look and feel of the dialog.
       @return A <a href="http://qt-project.org/doc/qt-5/qstringlist.html">QStringList</a> object containing zero or more files to be opened.
       @sa <a href="http://qt-project.org/doc/qt-5/qfiledialog.html#getOpenFileNames">QFileDialog::getOpenFileNames()</a>
     */
-    static QStringList getOpenFileNames(QWidget* parent = 0,
-                                        const QString& caption = QString(),
-                                        const QString& dir = QString(),
-                                        const QString& filter = QString(),
-                                        QString* selectedFilter = 0,
-                                        Options options = 0);
+    static QStringList getOpenFileNames(
+        QWidget* parent = 0,
+        const QString& caption = QString(),
+        const QString& dir = QString(),
+        const QString& filter = QString(),
+        Options options = 0);
     
     //! Static helper that invokes a File Save dialog where the user can select a directory and enter a filename to be saved.
     /*!
@@ -97,7 +96,6 @@ public:
       @param[in] caption The caption displayed at the top of the dialog.
       @param[in] dir The initial directory shown to the user.
       @param[in] filter The filter used for selecting the file type.
-      @param[out] selectedFilter **NOT IMPLEMENTED - Set to NULL** Returns the filter that the user selected in the file dialog.
       @param[in] options Set the various options that affect the look and feel of the dialog.
       @param[in] defaultSuffix Specifies a string that will be added to the filename if it has no suffix already. The suffix is typically used to indicate the file type (e.g. "txt" indicates a text file).
       @return The full path and filename to be used to save the file or \c QString("") if none.
@@ -105,21 +103,21 @@ public:
       @remark If a default suffix is given, it will be appended to the filename if the user does not enter one themselves. That is, if the user simply enters \e foo and the default suffix is set to \e bar,
       the returned filename will be \e foo.bar. However, if the user specifies a suffix, none will be added. That is, if the user enters \e foo.txt, that's what you will receive in return.
     */
-    static QString getSaveFileName(QWidget* parent = 0,
-                                   const QString& caption = QString(),
-                                   const QString& dir = QString(),
-                                   const QString& filter = QString(),
-                                   QString* selectedFilter = 0,
-                                   Options options = 0,
-                                   QString* defaultSuffix = 0);
+    static QString getSaveFileName(
+        QWidget* parent = 0,
+        const QString& caption = QString(),
+        const QString& dir = QString(),
+        const QString& filter = QString(),
+        Options options = 0,
+        QString* defaultSuffix = 0);
     
 private slots:
-    /// @brief The exec slot is private becasue when only want QGCFileDialog users to use the static methods. Otherwise it will break
-    ///         unit testing.
+    /// @brief The exec slot is private becasue we only want QGCFileDialog users to use the static methods. Otherwise it will break
+    ///        unit testing.
     int exec(void) { return QGCFileDialog::exec(); }
     
 private:
-    static void _validate(QString* selectedFilter, Options& options);
+    static void _validate(Options& options);
 };
 
 

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -349,8 +349,9 @@ QString UnitTest::_getSaveFileName(
     Q_UNUSED(filter);
     Q_UNUSED(options);
 
-    if(!defaultSuffix.isEmpty())
+    if(!defaultSuffix.isEmpty()) {
         Q_ASSERT(defaultSuffix.startsWith(".") == false);
+    }
 
     return _fileDialogResponseSingle(getSaveFileName);
 }

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -273,10 +273,11 @@ QString UnitTest::_fileDialogResponseSingle(enum FileDialogType type)
     return retFile;
 }
 
-QString UnitTest::_getExistingDirectory(QWidget* parent,
-                                        const QString& caption,
-                                        const QString& dir,
-                                        QFileDialog::Options options)
+QString UnitTest::_getExistingDirectory(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    QFileDialog::Options options)
 {
     Q_UNUSED(parent);
     Q_UNUSED(caption);
@@ -286,12 +287,12 @@ QString UnitTest::_getExistingDirectory(QWidget* parent,
     return _fileDialogResponseSingle(getExistingDirectory);
 }
 
-QString UnitTest::_getOpenFileName(QWidget* parent,
-                                   const QString& caption,
-                                   const QString& dir,
-                                   const QString& filter,
-                                   QString* selectedFilter,
-                                   QFileDialog::Options options)
+QString UnitTest::_getOpenFileName(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QString& filter,
+    QFileDialog::Options options)
 {
     Q_UNUSED(parent);
     Q_UNUSED(caption);
@@ -299,27 +300,21 @@ QString UnitTest::_getOpenFileName(QWidget* parent,
     Q_UNUSED(filter);
     Q_UNUSED(options);
     
-    // Support for selectedFilter is not yet implemented
-    Q_ASSERT(selectedFilter == NULL);
-
     return _fileDialogResponseSingle(getOpenFileName);
 }
 
-QStringList UnitTest::_getOpenFileNames(QWidget* parent,
-                                        const QString& caption,
-                                        const QString& dir,
-                                        const QString& filter,
-                                        QString* selectedFilter,
-                                        QFileDialog::Options options)
+QStringList UnitTest::_getOpenFileNames(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QString& filter,
+    QFileDialog::Options options)
 {
     Q_UNUSED(parent);
     Q_UNUSED(caption);
     Q_UNUSED(dir);
     Q_UNUSED(filter);
     Q_UNUSED(options);
-
-    // Support for selectedFilter is not yet implemented
-    Q_ASSERT(selectedFilter == NULL);
 
     QStringList retFiles;
     
@@ -340,13 +335,13 @@ QStringList UnitTest::_getOpenFileNames(QWidget* parent,
     return retFiles;
 }
 
-QString UnitTest::_getSaveFileName(QWidget* parent,
-                                   const QString& caption,
-                                   const QString& dir,
-                                   const QString& filter,
-                                   QString* selectedFilter,
-                                   QFileDialog::Options options,
-                                   QString* defaultSuffix)
+QString UnitTest::_getSaveFileName(
+    QWidget* parent,
+    const QString& caption,
+    const QString& dir,
+    const QString& filter,
+    QFileDialog::Options options,
+    QString* defaultSuffix)
 {
     Q_UNUSED(parent);
     Q_UNUSED(caption);
@@ -356,9 +351,6 @@ QString UnitTest::_getSaveFileName(QWidget* parent,
 
     if(defaultSuffix)
         Q_ASSERT(defaultSuffix->startsWith(".") == false);
-
-    // Support for selectedFilter is not yet implemented
-    Q_ASSERT(selectedFilter == NULL);
 
     return _fileDialogResponseSingle(getSaveFileName);
 }

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -340,8 +340,8 @@ QString UnitTest::_getSaveFileName(
     const QString& caption,
     const QString& dir,
     const QString& filter,
-    QFileDialog::Options options,
-    QString* defaultSuffix)
+    const QString& defaultSuffix,
+    QFileDialog::Options options)
 {
     Q_UNUSED(parent);
     Q_UNUSED(caption);
@@ -349,8 +349,8 @@ QString UnitTest::_getSaveFileName(
     Q_UNUSED(filter);
     Q_UNUSED(options);
 
-    if(defaultSuffix)
-        Q_ASSERT(defaultSuffix->startsWith(".") == false);
+    if(!defaultSuffix.isEmpty())
+        Q_ASSERT(defaultSuffix.startsWith(".") == false);
 
     return _fileDialogResponseSingle(getSaveFileName);
 }

--- a/src/qgcunittest/UnitTest.h
+++ b/src/qgcunittest/UnitTest.h
@@ -143,9 +143,9 @@ private:
         const QString& caption,
         const QString& dir,
         const QString& filter,
-        QFileDialog::Options options,
-        QString* defaultSuffix);
-    
+        const QString& defaultSuffix,
+        QFileDialog::Options options);
+
     static QString _fileDialogResponseSingle(enum FileDialogType type);
 
     // This allows the private calls to the file dialog methods

--- a/src/qgcunittest/UnitTest.h
+++ b/src/qgcunittest/UnitTest.h
@@ -118,32 +118,33 @@ private:
     
     // When the app is running in unit test mode the QGCFileDialog methods are re-routed here.
     
-    static QString _getExistingDirectory(QWidget* parent,
-                                         const QString& caption,
-                                         const QString& dir,
-                                         QFileDialog::Options options);
+    static QString _getExistingDirectory(
+        QWidget* parent,
+        const QString& caption,
+        const QString& dir,
+        QFileDialog::Options options);
     
-    static QString _getOpenFileName(QWidget* parent,
-                                    const QString& caption,
-                                    const QString& dir,
-                                    const QString& filter,
-                                    QString* selectedFilter,
-                                    QFileDialog::Options options);
+    static QString _getOpenFileName(
+        QWidget* parent,
+        const QString& caption,
+        const QString& dir,
+        const QString& filter,
+        QFileDialog::Options options);
     
-    static QStringList _getOpenFileNames(QWidget* parent,
-                                         const QString& caption,
-                                         const QString& dir,
-                                         const QString& filter,
-                                         QString* selectedFilter,
-                                         QFileDialog::Options options);
+    static QStringList _getOpenFileNames(
+        QWidget* parent,
+        const QString& caption,
+        const QString& dir,
+        const QString& filter,
+        QFileDialog::Options options);
     
-    static QString _getSaveFileName(QWidget* parent,
-                                    const QString& caption,
-                                    const QString& dir,
-                                    const QString& filter,
-                                    QString* selectedFilter,
-                                    QFileDialog::Options options,
-                                    QString* defaultSuffix);
+    static QString _getSaveFileName(
+        QWidget* parent,
+        const QString& caption,
+        const QString& dir,
+        const QString& filter,
+        QFileDialog::Options options,
+        QString* defaultSuffix);
     
     static QString _fileDialogResponseSingle(enum FileDialogType type);
 

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -846,8 +846,7 @@ void MainWindow::startVideoCapture()
         tr("%1 Files (*.%2);;All Files (*)")
         .arg(format.toUpper())
         .arg(format),
-        0,
-        &format);
+        format);
     delete videoTimer;
     videoTimer = new QTimer(this);
 }

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -836,16 +836,18 @@ void MainWindow::configureWindowName()
 
 void MainWindow::startVideoCapture()
 {
+    // TODO: What is this? What kind of "Video" is saved to bmp?
     QString format("bmp");
     QString initialPath = QDir::currentPath() + tr("/untitled.") + format;
 
-    QString screenFileName = QGCFileDialog::getSaveFileName(this, tr("Save As"),
-                                                          initialPath,
-                                                          tr("%1 Files (*.%2);;All Files (*)")
-                                                          .arg(format.toUpper())
-                                                          .arg(format),
-                                                          0,0,
-                                                          &format);
+    QString screenFileName = QGCFileDialog::getSaveFileName(
+        this, tr("Save Video Capture"),
+        initialPath,
+        tr("%1 Files (*.%2);;All Files (*)")
+        .arg(format.toUpper())
+        .arg(format),
+        0,
+        &format);
     delete videoTimer;
     videoTimer = new QTimer(this);
 }

--- a/src/ui/QGCBaseParamWidget.cc
+++ b/src/ui/QGCBaseParamWidget.cc
@@ -105,8 +105,7 @@ void QGCBaseParamWidget::saveParametersToFile()
 {
     if (!mav)
         return;
-    QString defaultSuffix("txt");
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save Parameters"), qgcApp()->savedParameterFilesLocation(), tr("Parameter File (*.txt)"), 0, &defaultSuffix);
+    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save Parameters"), qgcApp()->savedParameterFilesLocation(), tr("Parameter File (*.txt)"), "txt");
     QFile file(fileName);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         return;

--- a/src/ui/QGCBaseParamWidget.cc
+++ b/src/ui/QGCBaseParamWidget.cc
@@ -106,7 +106,7 @@ void QGCBaseParamWidget::saveParametersToFile()
     if (!mav)
         return;
     QString defaultSuffix("txt");
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), qgcApp()->savedParameterFilesLocation(), tr("Parameter File (*.txt)"), 0, 0, &defaultSuffix);
+    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save Parameters"), qgcApp()->savedParameterFilesLocation(), tr("Parameter File (*.txt)"), 0, &defaultSuffix);
     QFile file(fileName);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         return;
@@ -123,7 +123,7 @@ void QGCBaseParamWidget::loadParametersFromFile()
     if (!mav)
         return;
 
-    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Load File"), qgcApp()->savedParameterFilesLocation(), tr("Parameter file (*.txt)"));
+    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Load Parameters"), qgcApp()->savedParameterFilesLocation(), tr("Parameter file (*.txt)"));
     QFile file(fileName);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
         return;

--- a/src/ui/QGCDataPlot2D.cc
+++ b/src/ui/QGCDataPlot2D.cc
@@ -119,7 +119,7 @@ QString QGCDataPlot2D::getSavePlotFilename()
     QString fileName = QGCFileDialog::getSaveFileName(
         this, "Export File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         "PDF Documents (*.pdf);;SVG Images (*.svg)",
-        0,0,
+        0,
         &defaultSuffix);
     return fileName;
 }
@@ -694,7 +694,7 @@ void QGCDataPlot2D::saveCsvLog()
     QString fileName = QGCFileDialog::getSaveFileName(
         this, "Export CSV File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         "CSV file (*.csv);;Text file (*.txt)",
-        0,0,
+        0,
         &defaultSuffix);
 
     if (fileName.isEmpty())

--- a/src/ui/QGCDataPlot2D.cc
+++ b/src/ui/QGCDataPlot2D.cc
@@ -116,7 +116,7 @@ void QGCDataPlot2D::loadFile(QString file)
 QString QGCDataPlot2D::getSavePlotFilename()
 {
     QString fileName = QGCFileDialog::getSaveFileName(
-        this, "Export File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
+        this, "Export Plot File", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         "PDF Documents (*.pdf);;SVG Images (*.svg)",
         "pdf");
     return fileName;
@@ -131,11 +131,13 @@ void QGCDataPlot2D::savePlot()
     if (fileName.isEmpty())
         return;
 
+    // TODO This will change once we add "strict" file types in file selection dialogs
     while(!(fileName.endsWith(".svg") || fileName.endsWith(".pdf"))) {
-        QMessageBox::StandardButton button = QGCMessageBox::critical(tr("Unsuitable file extension for PDF or SVG"),
-                                                                     tr("Please choose .pdf or .svg as file extension. Click OK to change the file extension, cancel to not save the file."),
-                                                                     QMessageBox::Ok | QMessageBox::Cancel,
-                                                                     QMessageBox::Ok);
+        QMessageBox::StandardButton button = QGCMessageBox::warning(
+            tr("Unsuitable file extension for Plot document type."),
+            tr("Please choose .pdf or .svg as file extension. Click OK to change the file extension, cancel to not save the file."),
+            QMessageBox::Ok | QMessageBox::Cancel,
+            QMessageBox::Ok);
         // Abort if cancelled
         if (button == QMessageBox::Cancel) {
             return;

--- a/src/ui/QGCDataPlot2D.cc
+++ b/src/ui/QGCDataPlot2D.cc
@@ -115,12 +115,10 @@ void QGCDataPlot2D::loadFile(QString file)
  */
 QString QGCDataPlot2D::getSavePlotFilename()
 {
-    QString defaultSuffix("pdf");
     QString fileName = QGCFileDialog::getSaveFileName(
         this, "Export File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         "PDF Documents (*.pdf);;SVG Images (*.svg)",
-        0,
-        &defaultSuffix);
+        "pdf");
     return fileName;
 }
 
@@ -690,12 +688,10 @@ bool QGCDataPlot2D::linearRegression(double *x, double *y, int n, double *a, dou
 
 void QGCDataPlot2D::saveCsvLog()
 {
-    QString defaultSuffix("csv");
     QString fileName = QGCFileDialog::getSaveFileName(
         this, "Export CSV File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         "CSV file (*.csv);;Text file (*.txt)",
-        0,
-        &defaultSuffix);
+        "csv");
 
     if (fileName.isEmpty())
         return; //User cancelled

--- a/src/ui/QGCDataPlot2D.cc
+++ b/src/ui/QGCDataPlot2D.cc
@@ -100,13 +100,17 @@ void QGCDataPlot2D::loadFile()
 
 void QGCDataPlot2D::loadFile(QString file)
 {
+    // TODO This "filename" is a private/protected member variable. It should be named in such way
+    // it indicates so. This same name is used in several places within this file in local scopes.
     fileName = file;
-    if (QFileInfo(fileName).isReadable()) {
-        if (fileName.contains(".raw") || fileName.contains(".imu")) {
+    QFileInfo fi(fileName);
+    if (fi.isReadable()) {
+        if (fi.suffix() == QString("raw") || fi.suffix() == QString("imu")) {
             loadRawLog(fileName);
-        } else if (fileName.contains(".txt") || fileName.contains(".csv") || fileName.contains(".csv")) {
+        } else if (fi.suffix() == QString("txt") || fi.suffix() == QString("csv")) {
             loadCsvLog(fileName);
         }
+        // TODO Else, tell the user it doesn't know what to do with the file...
     }
 }
 
@@ -116,7 +120,7 @@ void QGCDataPlot2D::loadFile(QString file)
 QString QGCDataPlot2D::getSavePlotFilename()
 {
     QString fileName = QGCFileDialog::getSaveFileName(
-        this, "Export Plot File", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
+        this, "Save Plot File", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         "PDF Documents (*.pdf);;SVG Images (*.svg)",
         "pdf");
     return fileName;
@@ -691,7 +695,7 @@ bool QGCDataPlot2D::linearRegression(double *x, double *y, int n, double *a, dou
 void QGCDataPlot2D::saveCsvLog()
 {
     QString fileName = QGCFileDialog::getSaveFileName(
-        this, "Export CSV File Name", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
+        this, "Save CSV Log File", QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         "CSV file (*.csv);;Text file (*.txt)",
         "csv");
 

--- a/src/ui/WaypointList.cc
+++ b/src/ui/WaypointList.cc
@@ -217,8 +217,7 @@ void WaypointList::setUAS(UASInterface* uas)
 
 void WaypointList::saveWaypoints()
 {
-    QString defaultSuffix("txt");
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), "./waypoints.txt", tr("Waypoint File (*.txt)"), 0, &defaultSuffix);
+    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), "./waypoints.txt", tr("Waypoint File (*.txt)"), "txt");
     WPM->saveWaypoints(fileName);
 }
 

--- a/src/ui/WaypointList.cc
+++ b/src/ui/WaypointList.cc
@@ -217,13 +217,15 @@ void WaypointList::setUAS(UASInterface* uas)
 
 void WaypointList::saveWaypoints()
 {
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), "./waypoints.txt", tr("Waypoint File (*.txt)"), "txt");
+    // TODO Need better default directory
+    // TODO Need better extension than .txt
+    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save Waypoint File"), "./waypoints.txt", tr("Waypoint File (*.txt)"), "txt");
     WPM->saveWaypoints(fileName);
 }
 
 void WaypointList::loadWaypoints()
 {
-    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Load File"), ".", tr("Waypoint File (*.txt)"));
+    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Load Waypoint File"), ".", tr("Waypoint File (*.txt)"));
     WPM->loadWaypoints(fileName);
 }
 

--- a/src/ui/WaypointList.cc
+++ b/src/ui/WaypointList.cc
@@ -218,7 +218,7 @@ void WaypointList::setUAS(UASInterface* uas)
 void WaypointList::saveWaypoints()
 {
     QString defaultSuffix("txt");
-    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), "./waypoints.txt", tr("Waypoint File (*.txt)"), 0, 0, &defaultSuffix);
+    QString fileName = QGCFileDialog::getSaveFileName(this, tr("Save File"), "./waypoints.txt", tr("Waypoint File (*.txt)"), 0, &defaultSuffix);
     WPM->saveWaypoints(fileName);
 }
 

--- a/src/ui/designer/QGCToolWidget.cc
+++ b/src/ui/designer/QGCToolWidget.cc
@@ -571,14 +571,12 @@ void QGCToolWidget::widgetRemoved()
 
 void QGCToolWidget::exportWidget()
 {
-    QString defaultSuffix("qgw");
     const QString widgetFileExtension(".qgw");
     QString fileName = QGCFileDialog::getSaveFileName(
         this, tr("Specify Widget File Name"),
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         tr("QGroundControl Widget (*%1)").arg(widgetFileExtension),
-        0,
-        &defaultSuffix);
+        "qgw");
     //-- Note that if the user enters foo.bar, this will end up foo.bar.qgw
     if (!fileName.endsWith(widgetFileExtension))
     {

--- a/src/ui/designer/QGCToolWidget.cc
+++ b/src/ui/designer/QGCToolWidget.cc
@@ -573,7 +573,7 @@ void QGCToolWidget::exportWidget()
 {
     const QString widgetFileExtension(".qgw");
     QString fileName = QGCFileDialog::getSaveFileName(
-        this, tr("Specify Widget File Name"),
+        this, tr("Save Widget File"),
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         tr("QGroundControl Widget (*%1)").arg(widgetFileExtension),
         "qgw");
@@ -589,7 +589,7 @@ void QGCToolWidget::exportWidget()
 void QGCToolWidget::importWidget()
 {
     const QString widgetFileExtension(".qgw");
-    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Specify File Name"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("QGroundControl Widget (*%1)").arg(widgetFileExtension));
+    QString fileName = QGCFileDialog::getOpenFileName(this, tr("Load Widget File"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation), tr("QGroundControl Widget (*%1)").arg(widgetFileExtension));
     loadSettings(fileName);
 }
 

--- a/src/ui/designer/QGCToolWidget.cc
+++ b/src/ui/designer/QGCToolWidget.cc
@@ -574,10 +574,10 @@ void QGCToolWidget::exportWidget()
     QString defaultSuffix("qgw");
     const QString widgetFileExtension(".qgw");
     QString fileName = QGCFileDialog::getSaveFileName(
-        this, tr("Specify File Name"),
+        this, tr("Specify Widget File Name"),
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         tr("QGroundControl Widget (*%1)").arg(widgetFileExtension),
-        0,0,
+        0,
         &defaultSuffix);
     //-- Note that if the user enters foo.bar, this will end up foo.bar.qgw
     if (!fileName.endsWith(widgetFileExtension))

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -433,13 +433,11 @@ void LinechartWidget::refresh()
 
 QString LinechartWidget::getLogSaveFilename()
 {
-    QString defaultSuffix("log");
     QString fileName = QGCFileDialog::getSaveFileName(this,
         tr("Specify Log File Name"),
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         tr("Log file (*.log)"),
-        0,
-        &defaultSuffix);
+        "log");
     return fileName;
 }
 

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -434,7 +434,7 @@ void LinechartWidget::refresh()
 QString LinechartWidget::getLogSaveFilename()
 {
     QString fileName = QGCFileDialog::getSaveFileName(this,
-        tr("Specify Log File Name"),
+        tr("Save Log File"),
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
         tr("Log file (*.log)"),
         "log");

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -435,10 +435,10 @@ QString LinechartWidget::getLogSaveFilename()
 {
     QString defaultSuffix("log");
     QString fileName = QGCFileDialog::getSaveFileName(this,
-        tr("Specify log file name"),
+        tr("Specify Log File Name"),
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
-        tr("Logfile (*.log)"),
-        0,0,
+        tr("Log file (*.log)"),
+        0,
         &defaultSuffix);
     return fileName;
 }


### PR DESCRIPTION
Fix issue #1185.

Given that it's not used, I removed the *selectedFilter* argument from the QGXFileDialog file (static) helper methods. If you need to know what file type was selected, you can always do something like:

```c++
QString filename = QGCFileDialog::getSaveFileName(
    this, tr("Save File"), "~/", "Foo files (*.foo);;All Files (*.*)", "foo");
if (!filename.isEmpty()) {
    QFileInfo fi(filename);
    QString fileExtension(fi.suffix());
    if (fileExtension == QString("foo")) {
        // do something
    }
}
```

While at it:

* Added the above example to the Doxygen documentation.
* I've fixed the formatting of the method declarations and prototypes of QGCFileDialog (and other places I happened to be changing) to follow guidelines.
* Changed the caption of a few file save/load operations to something a bit more descriptive (describing what you are saving) and making them consistent.
* Changed the order of the last arguments to some of the QGXFileDialog static helpers. The original idea (from @DonLakeFlyer) was to re-implement the methods found in QFileDialog for adding unit testing to them and forcing the use of Qt's custom dialogs (as opposed to the native ones). At that point, keeping the same parameter order made sense. Once the *selectedFilter* argument was removed, it now made more sense to make the *options* argument last as this is truly optional (and seldom, if ever, used). I also changed the recently added *defaultSuffix* argument from a pointer to a const to be consistent with the other QString arguments.
* Added a few comments on issues that need addressing but I felt it to be out of the scope of this commit.

This is one of many fixes overhauling the file dialog functions throughout QGC.