### PR TITLE
Add missing qml module

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Supported builds are 64 bit, built using the clang compiler.
 Supported builds for Linux are 32 or 64-bit, built using gcc.
 
 #### Install Qt5.3+ and SDL1.2 prerequistites
-* For Ubuntu (requires 14.10 for Qt5.3): `sudo apt-get install qtcreator qttools5-dev qtbase5-dev qt5-default qtdeclarative5-dev libqt5serialport5-dev libqt5svg5-dev libqt5webkit5-dev libsdl1.2-dev build-essential libudev-dev`
+* For Ubuntu (requires 14.10 for Qt5.3): `sudo apt-get install qtcreator qttools5-dev qtbase5-dev qt5-default qtdeclarative5-dev libqt5serialport5-dev libqt5svg5-dev libqt5webkit5-dev libsdl1.2-dev build-essential libudev-dev qml-module-qtgraphicaleffects`
 * For Fedora: `sudo yum install qt-creator qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtserialport-devel qt5-qtsvg-devel qt5-qtwebkit-devel SDL-devel SDL-static systemd-devel`
 * For Arch Linux: `pacman -Sy qtcreator qt5-base qt5-declarative qt5-serialport qt5-svg qt5-webkit`
 


### PR DESCRIPTION
Only seems to be missing in some cases but can’t hurt if already
installed.