### PR TITLE
Remove link error retry logic and cdc checking

### DIFF
--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -105,8 +105,6 @@ public:
     void loadSettings();
     void writeSettings();
 
-    void checkIfCDC();
-
     void run();
     void run2();
 
@@ -161,7 +159,6 @@ protected:
     QMutex m_dataMutex;       // Mutex for reading data from m_port
     QMutex m_writeMutex;      // Mutex for accessing the m_transmitBuffer.
     QString type;
-    bool m_is_cdc;
     
 private slots:
     void _rerouteDisconnected(void);


### PR DESCRIPTION
- Added retry logic to port open to handle case where Pixhawk is past bootloader but still waiting for USB driver to start

This fixes part of Issue #1214 assuming it is the right thing to do. Tested cdc removal on Pixhawk with USB connection at various baud rates and it still worked fine.