### PR TITLE
Repaired feature to save images from video downlink (fixes #1239)

### DIFF
--- a/src/ui/HUD.cc
+++ b/src/ui/HUD.cc
@@ -1361,16 +1361,17 @@ void HUD::copyImage(UASInterface* uas)
     if (u)
     {
         QImage temp_im = u->getImage();
-        if (temp_im.byteCount() > 0) {
+        if (temp_im.byteCount() > 0)
+        {
             this->glImage = temp_im;
-
-			// Save to directory if logging is enabled
-			if (imageLoggingEnabled)
-			{
-				temp_im.save(QString("%1/%2.png").arg(imageLogDirectory).arg(imageLogCounter));
-				imageLogCounter++;
-			}
-		}
+            
+            // Save to directory if logging is enabled
+            if (imageLoggingEnabled)
+            {
+                temp_im.save(QString("%1/%2.png").arg(imageLogDirectory).arg(imageLogCounter));
+                imageLogCounter++;
+            }
+        }
     }
 }
 

--- a/src/ui/HUD.cc
+++ b/src/ui/HUD.cc
@@ -1363,14 +1363,14 @@ void HUD::copyImage(UASInterface* uas)
         QImage temp_im = u->getImage();
         if (temp_im.byteCount() > 0) {
             this->glImage = temp_im;
-        }
 
-        // Save to directory if logging is enabled
-        if (imageLoggingEnabled)
-        {
-            u->getImage().save(QString("%1/%2.png").arg(imageLogDirectory).arg(imageLogCounter));
-            imageLogCounter++;
-        }
+			// Save to directory if logging is enabled
+			if (imageLoggingEnabled)
+			{
+				temp_im.save(QString("%1/%2.png").arg(imageLogDirectory).arg(imageLogCounter));
+				imageLogCounter++;
+			}
+		}
     }
 }
 


### PR DESCRIPTION
problem:
in src/ui/HUD.cc copyImage(UASInterface* u): u->getImage() was called twice. The first called already erased the buffer.

changes:
src/ui/HUD.cc: copyImage(UASInterface* u): instead of getting the image a second time, we take the one we already fetched