### PR TITLE
Repaired overwriting current files for flight data log (fix #1241)

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -498,12 +498,20 @@ void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
             if(QFile::exists(saveFilename) && !QFile::remove(saveFilename)){
                 // if the file cannot be removed, prompt user and ask new path
                 saveError = true;
+<<<<<<< Updated upstream
                 QMessageBox::warning (MainWindow::instance(), "File Error","Could not overwrite existing file.\nPlease provide a different file name to save to.");
                 QFile::copy(tempLogfile, saveFilename);
             } else if(!QFile::copy(tempLogfile, saveFilename)) {
                 // if file could not be copied, prompt user and ask new path
                 saveError = true;
                 QMessageBox::warning (MainWindow::instance(), "File Error","Could not create file.\nPlease provide a different file name to save to.");
+=======
+                QGCApplication::criticalMessageBoxOnMainThread("File Error","Could not overwrite existing file.\nPlease provide a different file name to save to.");
+            } else if(!QFile::copy(tempLogfile, saveFilename)) {
+                // if file could not be copied, prompt user and ask new path
+                saveError = true;
+                QGCApplication::criticalMessageBoxOnMainThread("File Error","Could not create file.\nPlease provide a different file name to save to.");
+>>>>>>> Stashed changes
             }
         }
     } while(saveError); // if the file could not be overwritten, ask for new file

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -496,12 +496,14 @@ void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
         if (!saveFilename.isEmpty()) {
             // if file exsits already, try to remove it first to overwrite it
             if(QFile::exists(saveFilename) && !QFile::remove(saveFilename)){
+                // if the file cannot be removed, prompt user and ask new path
                 saveError = true;
-                QMessageBox::warning (MainWindow::instance(), "File Error","Could not overwrite existing file");
+                QMessageBox::warning (MainWindow::instance(), "File Error","Could not overwrite existing file.\nPlease provide a different file name to save to.");
                 QFile::copy(tempLogfile, saveFilename);
             } else if(!QFile::copy(tempLogfile, saveFilename)) {
+                // if file could not be copied, prompt user and ask new path
                 saveError = true;
-                QMessageBox::warning (MainWindow::instance(), "File Error","Could not create file");
+                QMessageBox::warning (MainWindow::instance(), "File Error","Could not create file.\nPlease provide a different file name to save to.");
             }
         }
     } while(saveError); // if the file could not be overwritten, ask for new file

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -498,11 +498,11 @@ void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
             if(QFile::exists(saveFilename) && !QFile::remove(saveFilename)){
                 // if the file cannot be removed, prompt user and ask new path
                 saveError = true;
-                QGCApplication::criticalMessageBoxOnMainThread("File Error","Could not overwrite existing file.\nPlease provide a different file name to save to.");
+                QGCMessageBox::warning("File Error","Could not overwrite existing file.\nPlease provide a different file name to save to.");
             } else if(!QFile::copy(tempLogfile, saveFilename)) {
                 // if file could not be copied, prompt user and ask new path
                 saveError = true;
-                QGCApplication::criticalMessageBoxOnMainThread("File Error","Could not create file.\nPlease provide a different file name to save to.");
+                QGCMessageBox::warning("File Error","Could not create file.\nPlease provide a different file name to save to.");
             }
         }
     } while(saveError); // if the file could not be overwritten, ask for new file

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -498,20 +498,11 @@ void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
             if(QFile::exists(saveFilename) && !QFile::remove(saveFilename)){
                 // if the file cannot be removed, prompt user and ask new path
                 saveError = true;
-<<<<<<< Updated upstream
-                QMessageBox::warning (MainWindow::instance(), "File Error","Could not overwrite existing file.\nPlease provide a different file name to save to.");
-                QFile::copy(tempLogfile, saveFilename);
-            } else if(!QFile::copy(tempLogfile, saveFilename)) {
-                // if file could not be copied, prompt user and ask new path
-                saveError = true;
-                QMessageBox::warning (MainWindow::instance(), "File Error","Could not create file.\nPlease provide a different file name to save to.");
-=======
                 QGCApplication::criticalMessageBoxOnMainThread("File Error","Could not overwrite existing file.\nPlease provide a different file name to save to.");
             } else if(!QFile::copy(tempLogfile, saveFilename)) {
                 // if file could not be copied, prompt user and ask new path
                 saveError = true;
                 QGCApplication::criticalMessageBoxOnMainThread("File Error","Could not create file.\nPlease provide a different file name to save to.");
->>>>>>> Stashed changes
             }
         }
     } while(saveError); // if the file could not be overwritten, ask for new file


### PR DESCRIPTION
changed QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile) to enable overwriting files
existing file is removed before saving file (QFile::copy cannot overwrite files)