### PR TITLE
Remove disconnect/re-connect on too many link errors

### DIFF
--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -42,12 +42,15 @@ class SerialLink;
 #include <QString>
 #include <QSerialPort>
 #include <QMetaType>
+#include <QLoggingCategory>
 
 // We use QSerialPort::SerialPortError in a signal so we must declare it as a meta type
 Q_DECLARE_METATYPE(QSerialPort::SerialPortError)
 
 #include "QGCConfig.h"
 #include "LinkManager.h"
+
+Q_DECLARE_LOGGING_CATEGORY(SerialLinkLog)
 
 class SerialConfiguration : public LinkConfiguration
 {


### PR DESCRIPTION
Also converted qDebug statements to logging category.

This is the change to remove the disconnect/reconnect code from SerialLink as discussed previously. SerialLink was the only link type that did this. It's hard to say it actually accomplished anything other than adding confusion. Now the user will get true connection lost message due to loss of heartbeat and they can decide what they want to do. It will also now keep the connection open until the user explicitly decides to disconnect. Or if the communication actually does come back things will start working again. 

This will allow us to fix Issue #1219. Also it will stop strange behavior like issue #1214.