### PR TITLE
Cleaning dangling links

### DIFF
--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -57,7 +57,8 @@ public:
     LinkInterface() :
         QThread(0),
         _ownedByLinkManager(false),
-        _deletedByLinkManager(false)
+        _deletedByLinkManager(false),
+        _flaggedForDeletion(false)
     {
         // Initialize everything for the data rate calculation buffers.
         inDataIndex  = 0;
@@ -340,6 +341,7 @@ private:
 
     bool _ownedByLinkManager;   ///< true: This link has been added to LinkManager, false: Link not added to LinkManager
     bool _deletedByLinkManager; ///< true: Link being deleted from LinkManager, false: error, Links should only be deleted from LinkManager
+    bool _flaggedForDeletion;   ///< true: Garbage colletion ready
 };
 
 #endif // _LINKINTERFACE_H_

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -141,6 +141,7 @@ signals:
 private slots:
     void _linkConnected(void);
     void _linkDisconnected(void);
+    void _delayedDeleteLink();
 
 private:
     /// All access to LinkManager is through LinkManager::instance


### PR DESCRIPTION
Links were being disconnected but never deleted (and never re-used). These links were just accumulating and bloating resources. I did not have much success trying to simply disconnecting and immediately deleting them because it takes a thread cycle for the link disconnect signal to reach the MAVLinkProtocol instance, which keeps talking to the link. It would be a boatload of work to change that signaling and much more prone to errors.

Instead, I've implemented a simple delayed link delete mechanism to clean up these dangling, unused links.