### PR TITLE
Fixed issue #1261

### DIFF
--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -291,7 +291,7 @@ void TCPConfiguration::saveSettings(QSettings& settings, const QString& root)
 void TCPConfiguration::loadSettings(QSettings& settings, const QString& root)
 {
     settings.beginGroup(root);
-    _port = (quint16)settings.value("port", QGC_UDP_PORT).toUInt();
+    _port = (quint16)settings.value("port", QGC_TCP_PORT).toUInt();
     QString address = settings.value("host", _address.toString()).toString();
     _address = address;
     settings.endGroup();

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -267,7 +267,7 @@ qint64 UDPLink::getCurrentOutDataRate() const
 
 UDPConfiguration::UDPConfiguration(const QString& name) : LinkConfiguration(name)
 {
-    _localPort = QGC_UDP_PORT;
+    _localPort = QGC_UDP_LOCAL_PORT;
 }
 
 UDPConfiguration::UDPConfiguration(UDPConfiguration* source) : LinkConfiguration(source)
@@ -404,7 +404,7 @@ void UDPConfiguration::loadSettings(QSettings& settings, const QString& root)
     _confMutex.lock();
     settings.beginGroup(root);
     _hosts.clear();
-    _localPort = (quint16)settings.value("port", QGC_UDP_PORT).toUInt();
+    _localPort = (quint16)settings.value("port", QGC_UDP_LOCAL_PORT).toUInt();
     int hostCount = settings.value("hostCount", 0).toInt();
     for(int i = 0; i < hostCount; i++) {
         QString hkey = QString("host%1").arg(i);

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -40,7 +40,8 @@ This file is part of the QGROUNDCONTROL project
 #include "QGCConfig.h"
 #include "LinkManager.h"
 
-#define QGC_UDP_PORT 14550
+#define QGC_UDP_LOCAL_PORT  14550
+#define QGC_UDP_TARGET_PORT 14555
 
 class UDPConfiguration : public LinkConfiguration
 {

--- a/src/ui/QGCUDPLinkConfiguration.cc
+++ b/src/ui/QGCUDPLinkConfiguration.cc
@@ -108,7 +108,7 @@ void QGCUDPLinkConfiguration::on_addHost_clicked()
     QString hostName = QInputDialog::getText(
         this, tr("Add a host target to MAVLink"),
         tr("Host (hostname:port):                                                     "),
-        QLineEdit::Normal, QString("localhost:%1").arg(QGC_UDP_PORT), &ok);
+        QLineEdit::Normal, QString("localhost:%1").arg(QGC_UDP_TARGET_PORT), &ok);
     if (ok && !hostName.isEmpty()) {
         _config->addHost(hostName);
         _reloadList();


### PR DESCRIPTION
This fixes issue #1261

Fixed logic where target UDP hosts were using the same local, listening port by default.

Also fixed a typo (copy/paste error) in the TCP link settings loading where it was using the UDP port as the default value instead of the TCP port.