### PR TITLE
Firmware Upgrade ui re-work, plus QGCComboBox work

### DIFF
--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -1,10 +1,40 @@
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
+import QtQuick.Controls.Private 1.0
 
 import QGroundControl.Palette 1.0
 
 ComboBox {
-    property var __palette: QGCPalette { colorGroupEnabled: enabled }
+    property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
 
+    property bool __showHighlight: pressed | hovered
+
+    style: ComboBoxStyle {
+        textColor: __showHighlight ?
+                    control.__qgcPal.buttonHighlightText :
+                    control.__qgcPal.buttonText
+
+        background: Item {
+            implicitWidth: Math.round(TextSingleton.implicitHeight * 4.5)
+            implicitHeight: Math.max(25, Math.round(TextSingleton.implicitHeight * 1.2))
+
+            Rectangle {
+                anchors.fill: parent
+                color: __showHighlight ?
+                    control.__qgcPal.buttonHighlight :
+                    control.__qgcPal.button
+            }
+
+            Image {
+                id: imageItem
+                visible: control.menu !== null
+                source: "arrow-down.png"
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.right: parent.right
+                anchors.rightMargin: dropDownButtonWidth / 2
+                opacity: control.enabled ? 0.6 : 0.3
+            }
+        }
+    }
 }

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -36,70 +36,44 @@ Rectangle {
             width: 10
         }
 
-/*
-FIXME: Leaving this in here for now for possible text usage in ui that does better job of describing firmware version
+        Row {
+            spacing: 10
 
-               _ui->statusLog->setText(tr("WARNING: BETA FIRMWARE\n"
--                                           "This firmware version is ONLY intended for beta testers. "
--                                           "Although it has received FLIGHT TESTING, it represents actively changed code. Do NOT use for normal operation.\n\n"
--                                           SELECT_FIRMWARE_LICENSE));
--                break;
--                
--            case 2:
--                _ui->statusLog->setText(tr("WARNING: CONTINUOUS BUILD FIRMWARE\n"
--                                           "This firmware has NOT BEEN FLIGHT TESTED. "
--                                           "It is only intended for DEVELOPERS. Run bench tests without props first. "
--                                           "Do NOT fly this without addional safety precautions. Follow the mailing "
--                                           "list actively when using it.\n\n"
--                                           SELECT_FIRMWARE_LICENSE));
-*/
-
-        ExclusiveGroup { id: firmwareGroup }
-
-        QGCRadioButton {
-            id: stableFirwareRadio
-            exclusiveGroup: firmwareGroup
-            text: qsTr("Standard Version (stable)")
-            checked: true
-            enabled: upgradeButton.enabled
-            onClicked: {
-                if (checked)
-                    controller.firmwareType = FirmwareUpgradeController.StableFirmware
+            ListModel {
+                id: firmwareItems
+                ListElement {
+                    text: qsTr("Standard Version (stable)");
+                    firmwareType: FirmwareUpgradeController.StableFirmware
+                }
+                ListElement {
+                    text: qsTr("Beta Testing (beta)");
+                    firmwareType: FirmwareUpgradeController.BetaFirmware
+                }
+                ListElement {
+                    text: qsTr("Developer Build (master)");
+                    firmwareType: FirmwareUpgradeController.DeveloperFirmware
+                }
+                ListElement {
+                    text: qsTr("Custom firmware file...");
+                    firmwareType: FirmwareUpgradeController.CustomFirmware
+                }
             }
-        }
-        QGCRadioButton {
-            id: betaFirwareRadio
-            exclusiveGroup: firmwareGroup
-            text: qsTr("Beta Testing (beta)")
-            enabled: upgradeButton.enabled
-            onClicked: { if (checked) controller.firmwareType = FirmwareUpgradeController.BetaFirmware }
-        }
-        QGCRadioButton {
-            id: devloperFirwareRadio
-            exclusiveGroup: firmwareGroup
-            text: qsTr("Developer Build (master)")
-            enabled: upgradeButton.enabled
-            onClicked: { if (checked) controller.firmwareType = FirmwareUpgradeController.DeveloperFirmware }
-        }
-        QGCRadioButton {
-            id: customFirwareRadio
-            exclusiveGroup: firmwareGroup
-            text: qsTr("Custom firmware file...")
-            enabled: upgradeButton.enabled
-            onClicked: { if (checked) controller.firmwareType = FirmwareUpgradeController.CustomFirmware }
-        }
 
-        Item {
-            // Just used as a spacer
-            height: 20
-            width: 10
-        }
+            QGCComboBox {
+                id: firmwareCombo
+                width: 200
+                height: upgradeButton.height
+                model: firmwareItems
+            }
 
-        QGCButton {
-            id: upgradeButton
-            text: "UPGRADE"
-            onClicked: {
-                controller.doFirmwareUpgrade();
+            QGCButton {
+                id: upgradeButton
+                text: "UPGRADE"
+                primary: true
+                onClicked: {
+                    controller.firmwareType = firmwareItems.get(firmwareCombo.currentIndex).firmwareType
+                    controller.doFirmwareUpgrade();
+                }
             }
         }
 

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -580,6 +580,27 @@ void FirmwareUpgradeController::_eraseProgressTick(void)
 
 void FirmwareUpgradeController::doFirmwareUpgrade(void)
 {
+    QString warningMsg;
+    
+    if (_firmwareType == BetaFirmware) {
+        warningMsg = tr("WARNING: BETA FIRMWARE\n"
+                        "This firmware version is ONLY intended for beta testers. "
+                        "Although it has received FLIGHT TESTING, it represents actively changed code. Do NOT use for normal operation.\n\n"
+                        "Are you sure you want to continue?");
+    } else if (_firmwareType == DeveloperFirmware) {
+        warningMsg = tr("WARNING: CONTINUOUS BUILD FIRMWARE\n"
+                        "This firmware has NOT BEEN FLIGHT TESTED. "
+                        "It is only intended for DEVELOPERS. Run bench tests without props first. "
+                        "Do NOT fly this without addional safety precautions. Follow the mailing "
+                        "list actively when using it.\n\n"
+                        "Are you sure you want to continue?");
+    }
+    if (!warningMsg.isEmpty()) {
+        if (QGCMessageBox::warning(tr("Firmware Upgrade"), warningMsg, QGCMessageBox::Yes | QGCMessageBox::No, QGCMessageBox::No) == QGCMessageBox::No) {
+            return;
+        }
+    }
+
     Q_ASSERT(_upgradeButton);
     _upgradeButton->setEnabled(false);
     


### PR DESCRIPTION
- QGCComboBox now follows QGCPalette and ui design
- Firmware Upgrade uses combo box for firmware selection
- Firmware Upgrade warns with message box if you select beta or developer firmware versions

![screen shot 2015-02-25 at 12 15 54 pm](https://cloud.githubusercontent.com/assets/5876851/6379595/58e3bbae-bce8-11e4-8338-e83fb2c60a0c.png)
