### PR TITLE
Better help text for Firmware Upgrade

### DIFF
--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -94,6 +94,7 @@ Rectangle {
             height: 300
             readOnly: true
             frameVisible: false
+            text: qsTr("Please disconnect all connections and unplug board from USB before selecting Upgrade.")
             style: TextAreaStyle {
                 textColor: qgcPal.text
                 backgroundColor: qgcPal.windowShade

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -84,7 +84,8 @@ void FirmwareUpgradeController::_foundBoard(bool firstTry, const QString portNam
 {
     if (firstTry) {
         // Board is still plugged
-        _appendStatusLog(tr("You must unplug your board before beginning the Firmware Upgrade process."));
+        _appendStatusLog(tr("Please unplug your board before beginning the Firmware Upgrade process."));
+        _appendStatusLog(tr("Click Upgrade again once the board is unplugged."));
         _cancel();
     } else {
         _portName = portName;


### PR DESCRIPTION
- Now tells you to disconnect and unplug at the start
- Tells you to click Upgrade again if you didn't unplug 

This is a partial fix to usability issues described in Issue #1272. Better sequence which doesn't require unplug will come later.