### PR TITLE
Radio Cal no longer selects flight mode switches

### DIFF
--- a/src/AutoPilotPlugins/PX4/RadioComponent.cc
+++ b/src/AutoPilotPlugins/PX4/RadioComponent.cc
@@ -29,7 +29,7 @@
 #include "PX4AutoPilotPlugin.h"
 
 /// @brief Parameters which signal a change in setupComplete state
-static const char* triggerParams[] = { "RC_MAP_MODE_SW", NULL };
+static const char* triggerParams[] = { "RC_MAP_ROLL", "RC_MAP_PITCH", "RC_MAP_YAW", "RC_MAP_THROTTLE", NULL };
 
 RadioComponent::RadioComponent(UASInterface* uas, AutoPilotPlugin* autopilot, QObject* parent) :
     PX4Component(uas, autopilot, parent),
@@ -61,13 +61,19 @@ bool RadioComponent::requiresSetup(void) const
 
 bool RadioComponent::setupComplete(void) const
 {
-    QVariant value;
-    if (_paramMgr->getParameterValue(_paramMgr->getDefaultComponentId(), triggerParams[0], value)) {
-        return value.toInt() != 0;
-    } else {
-        Q_ASSERT(false);
-        return false;
+    for (size_t i=0; triggerParams[i] != NULL; i++) {
+        QVariant value;
+        if (_paramMgr->getParameterValue(_paramMgr->getDefaultComponentId(), triggerParams[0], value)) {
+            if (value.toInt() == 0) {
+                return false;
+            }
+        } else {
+            Q_ASSERT(false);
+            return false;
+        }
     }
+    
+    return true;
 }
 
 QString RadioComponent::setupStateDescription(void) const

--- a/src/qgcunittest/PX4RCCalibrationTest.cc
+++ b/src/qgcunittest/PX4RCCalibrationTest.cc
@@ -68,7 +68,7 @@ const int PX4RCCalibrationTest::_testCenterValue = PX4RCCalibrationTest::_testMi
 
 /// @brief Maps from function index to channel index. -1 signals no mapping. Channel indices are offset 1 from function index
 /// to catch bugs where function index is incorrectly used as channel index.
-const int PX4RCCalibrationTest::_rgFunctionChannelMap[PX4RCCalibration::rcCalFunctionMax]= { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+const int PX4RCCalibrationTest::_rgFunctionChannelMap[PX4RCCalibration::rcCalFunctionMax]= { 1, 2, 3, 4, -1, -1, -1, -1, 9, 10, 11 };
 
 const struct PX4RCCalibrationTest::ChannelSettings PX4RCCalibrationTest::_rgChannelSettings[PX4RCCalibrationTest::_availableChannels] = {
 	// Function										Min                 Max                 #  Reversed
@@ -76,15 +76,20 @@ const struct PX4RCCalibrationTest::ChannelSettings PX4RCCalibrationTest::_rgChan
 	// Channel 0 : Not mapped to function, Simulate invalid Min/Max
 	{ PX4RCCalibration::rcCalFunctionMax,			_testCenterValue,	_testCenterValue,   0, false },
 	
-    // Channels 1-11 are mapped to all available modes
+    // Channels 1-4: Mapped to attitude control function
     { PX4RCCalibration::rcCalFunctionRoll,			_testMinValue,      _testMaxValue,      0, true },
     { PX4RCCalibration::rcCalFunctionPitch,			_testMinValue,      _testMaxValue,      0, false },
     { PX4RCCalibration::rcCalFunctionYaw,			_testMinValue,      _testMaxValue,      0, true },
     { PX4RCCalibration::rcCalFunctionThrottle,		_testMinValue,      _testMaxValue,      0,  false },
-    { PX4RCCalibration::rcCalFunctionModeSwitch,	_testMinValue,      _testMaxValue,      0, false },
-    { PX4RCCalibration::rcCalFunctionPosCtlSwitch,	_testMinValue,      _testMaxValue,      0, false },
-    { PX4RCCalibration::rcCalFunctionLoiterSwitch,	_testMinValue,      _testMaxValue,      0, false },
-    { PX4RCCalibration::rcCalFunctionReturnSwitch,	_testMinValue,      _testMaxValue,      0, false },
+    
+    // Channels 5-8: Not mapped to function, Simulate invalid Min/Max, since available channel Min/Max is still shown.
+    // These are here to skip over the flight mode functions
+    { PX4RCCalibration::rcCalFunctionMax,			_testCenterValue,   _testCenterValue,   0,	false },
+    { PX4RCCalibration::rcCalFunctionMax,			_testCenterValue,   _testCenterValue,   0,	false },
+    { PX4RCCalibration::rcCalFunctionMax,			_testCenterValue,   _testCenterValue,   0,	false },
+    { PX4RCCalibration::rcCalFunctionMax,			_testCenterValue,   _testCenterValue,   0,	false },
+    
+    // Channels 9-11: Remainder of non-flight mode switches
     { PX4RCCalibration::rcCalFunctionFlaps,			_testMinValue,      _testMaxValue,      0, false },
     { PX4RCCalibration::rcCalFunctionAux1,			_testMinValue,      _testMaxValue,      0, false },
     { PX4RCCalibration::rcCalFunctionAux2,			_testMinValue,      _testMaxValue,      0, false },
@@ -105,18 +110,22 @@ const struct PX4RCCalibrationTest::ChannelSettings PX4RCCalibrationTest::_rgChan
 const struct PX4RCCalibrationTest::ChannelSettings PX4RCCalibrationTest::_rgChannelSettingsValidate[PX4RCCalibration::_chanMax] = {
     // Function										Min Value									Max Value									Trim Value										Reversed
 	
-	// Channel 0 is not mapped and should be defaulted
+    // Channels 0: not mapped and should be set to defaults
 	{ PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
 	
-	// Channels 1-11 are mapped to all available modes
+    // Channels 1-4: Mapped to attitude control function
 	{ PX4RCCalibration::rcCalFunctionRoll,			_testMinValue,                              _testMaxValue,                              _testCenterValue,                               true },
     { PX4RCCalibration::rcCalFunctionPitch,			_testMinValue,                              _testMaxValue,                              _testCenterValue,                               false },
     { PX4RCCalibration::rcCalFunctionYaw,			_testMinValue,                              _testMaxValue,                              _testCenterValue,                               true },
     { PX4RCCalibration::rcCalFunctionThrottle,		_testMinValue,                              _testMaxValue,                              _testMinValue,                                  false },
-    { PX4RCCalibration::rcCalFunctionModeSwitch,	_testMinValue,                              _testMaxValue,                              _testCenterValue,                               false },
-    { PX4RCCalibration::rcCalFunctionPosCtlSwitch,	_testMinValue,                              _testMaxValue,                              _testCenterValue,                               false },
-    { PX4RCCalibration::rcCalFunctionLoiterSwitch,	_testMinValue,                              _testMaxValue,                              _testCenterValue,                               false },
-    { PX4RCCalibration::rcCalFunctionReturnSwitch,	_testMinValue,                              _testMaxValue,                              _testCenterValue,                               false },
+    
+    // Channels 5-8: not mapped and should be set to defaults
+    { PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
+    { PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
+    { PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
+    { PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
+    
+    // Channels 9-11: Remainder of non-flight mode switches
     { PX4RCCalibration::rcCalFunctionFlaps,			_testMinValue,                              _testMaxValue,                              _testCenterValue,                               false },
     { PX4RCCalibration::rcCalFunctionAux1,			_testMinValue,                              _testMaxValue,                              _testCenterValue,                               false },
     { PX4RCCalibration::rcCalFunctionAux2,			_testMinValue,                              _testMaxValue,                              _testCenterValue,                               false },
@@ -126,8 +135,8 @@ const struct PX4RCCalibrationTest::ChannelSettings PX4RCCalibrationTest::_rgChan
 	{ PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
 	{ PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
 	{ PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
-	{ PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
-	{ PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
+    { PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
+    { PX4RCCalibration::rcCalFunctionMax,			PX4RCCalibration::_rcCalPWMDefaultMinValue,	PX4RCCalibration::_rcCalPWMDefaultMaxValue,	PX4RCCalibration::_rcCalPWMCenterPoint,         false },
 };
 
 PX4RCCalibrationTest::PX4RCCalibrationTest(void) :
@@ -415,10 +424,6 @@ void PX4RCCalibrationTest::_fullCalibration_test(void)
     _switchMinMaxStep();
     _flapsDetectStep();
     _stickMoveAutoStep("Flaps", PX4RCCalibration::rcCalFunctionFlaps, moveToMin, false /* not identify step */);
-    _switchSelectAutoStep("Mode", PX4RCCalibration::rcCalFunctionModeSwitch);
-    _switchSelectAutoStep("PostCtl", PX4RCCalibration::rcCalFunctionPosCtlSwitch);
-    _switchSelectAutoStep("Loiter", PX4RCCalibration::rcCalFunctionLoiterSwitch);
-    _switchSelectAutoStep("Return", PX4RCCalibration::rcCalFunctionReturnSwitch);
     _switchSelectAutoStep("Aux1", PX4RCCalibration::rcCalFunctionAux1);
     _switchSelectAutoStep("Aux2", PX4RCCalibration::rcCalFunctionAux2);
 

--- a/src/ui/px4_configuration/PX4RCCalibration.cc
+++ b/src/ui/px4_configuration/PX4RCCalibration.cc
@@ -189,13 +189,6 @@ const PX4RCCalibration::stateMachineEntry* PX4RCCalibration::_getStateMachineEnt
     static const char* msgPitchDown = "Move the Pitch stick all the way down and hold it there...";
     static const char* msgPitchUp = "Move the Pitch stick all the way up and hold it there...";
     static const char* msgPitchCenter = "Allow the Pitch stick to move back to center...";
-    static const char* msgModeSwitch = "Next we will assign the channel for the Mode Switch. Move the switch or dial up and down to select the channel.";
-    static const char* msgPosCtlSwitch = "Next we will assign the channel for the PosCtl Switch. Move the switch or dial up and down to select the channel.\n\n"
-                                            "You can click Skip if you don't want to assign this switch.";
-    static const char* msgLoiterSwitch = "Next we will assign the channel for the Loiter Switch. Move the switch or dial up and down to select the channel.\n\n"
-                                            "You can click Skip if you don't want to assign this switch.";
-    static const char* msgReturnSwitch = "Next we will assign the channel for the Return Switch. Move the switch or dial up and down to select the channel.\n\n"
-                                            "You can click Skip if you don't want to assign this switch.";
     static const char* msgAux1Switch = "Move the switch or dial you want to use for Aux1.\n\n"
                                             "You can click Skip if you don't want to assign.";
     static const char* msgAux2Switch = "Move the switch or dial you want to use for Aux2.\n\n"
@@ -223,10 +216,6 @@ const PX4RCCalibration::stateMachineEntry* PX4RCCalibration::_getStateMachineEnt
         { rcCalFunctionMax,                 msgSwitchMinMax,    _imageSwitchMinMax, &PX4RCCalibration::_inputSwitchMinMax,      &PX4RCCalibration::_nextStep,           NULL },
         { rcCalFunctionFlaps,               msgFlapsDetect,     _imageThrottleDown, &PX4RCCalibration::_inputFlapsDetect,       &PX4RCCalibration::_saveFlapsDown,      &PX4RCCalibration::_skipFlaps },
         { rcCalFunctionFlaps,               msgFlapsUp,         _imageThrottleDown, &PX4RCCalibration::_inputFlapsUp,           NULL,                                   NULL },
-        { rcCalFunctionModeSwitch,          msgModeSwitch,      _imageThrottleDown, &PX4RCCalibration::_inputSwitchDetect,      NULL,                                   NULL },
-        { rcCalFunctionPosCtlSwitch,        msgPosCtlSwitch,    _imageThrottleDown, &PX4RCCalibration::_inputSwitchDetect,      NULL,                                   &PX4RCCalibration::_nextStep },
-        { rcCalFunctionLoiterSwitch,        msgLoiterSwitch,    _imageThrottleDown, &PX4RCCalibration::_inputSwitchDetect,      NULL,                                   &PX4RCCalibration::_nextStep },
-        { rcCalFunctionReturnSwitch,        msgReturnSwitch,    _imageThrottleDown, &PX4RCCalibration::_inputSwitchDetect,      NULL,                                   &PX4RCCalibration::_nextStep },
         { rcCalFunctionAux1,                msgAux1Switch,      _imageThrottleDown, &PX4RCCalibration::_inputSwitchDetect,      NULL,                                   &PX4RCCalibration::_nextStep },
         { rcCalFunctionAux2,                msgAux2Switch,      _imageThrottleDown, &PX4RCCalibration::_inputSwitchDetect,      NULL,                                   &PX4RCCalibration::_nextStep },
         { rcCalFunctionMax,                 msgComplete,        _imageThrottleDown, NULL,                                       &PX4RCCalibration::_writeCalibration,   NULL },
@@ -700,6 +689,37 @@ void PX4RCCalibration::_resetInternalCalibrationValues(void)
     
     _showMinMaxOnRadioWidgets(false);
     _showTrimOnRadioWidgets(false);
+    
+    // Reserve the existing Flight Mode switch settings channels so we don't re-use them
+    
+    static const rcCalFunctions rgFlightModeFunctions[] = {
+        rcCalFunctionModeSwitch,
+        rcCalFunctionPosCtlSwitch,
+        rcCalFunctionLoiterSwitch,
+        rcCalFunctionReturnSwitch };
+    static const size_t crgFlightModeFunctions = sizeof(rgFlightModeFunctions) / sizeof(rgFlightModeFunctions[0]);
+
+    int componentId = _paramMgr->getDefaultComponentId();
+    for (size_t i=0; i < crgFlightModeFunctions; i++) {
+        QVariant value;
+        enum rcCalFunctions curFunction = rgFlightModeFunctions[i];
+        
+        bool paramFound = _paramMgr->getParameterValue(componentId, _rgFunctionInfo[curFunction].parameterName, value);
+        Q_ASSERT(paramFound);
+        
+        bool ok;
+        int channel = value.toInt(&ok);
+        Q_ASSERT(ok);
+        Q_UNUSED(ok);
+        
+        // Parameter: 1-based channel, 0=not mapped
+        // _rgFunctionChannelMapping: 0-based channel, _chanMax=not mapped
+        
+        _rgFunctionChannelMapping[curFunction] = (channel == 0) ? _chanMax : channel;
+        if (channel != 0) {
+            _rgChannelInfo[channel - 1].function = curFunction;
+        }
+    }
 }
 
 /// @brief Sets internal calibration values from the stored parameters

--- a/src/ui/px4_configuration/PX4RCCalibration.cc
+++ b/src/ui/px4_configuration/PX4RCCalibration.cc
@@ -706,6 +706,7 @@ void PX4RCCalibration::_resetInternalCalibrationValues(void)
         
         bool paramFound = _paramMgr->getParameterValue(componentId, _rgFunctionInfo[curFunction].parameterName, value);
         Q_ASSERT(paramFound);
+        Q_UNUSED(paramFound);
         
         bool ok;
         int channel = value.toInt(&ok);


### PR DESCRIPTION
You have to do that from Flight Modes config. Changing in prep for new Flight Modes implementation.