### PR TITLE
Main Menu Reorg

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -1022,28 +1022,6 @@ void MainWindow::showSettings()
     settings.exec();
 }
 
-bool MainWindow::configLink(LinkInterface *link)
-{
-    // Go searching for this link's configuration window
-    QList<QAction*> actions = ui.menuNetwork->actions();
-
-    bool found(false);
-
-    const int32_t& linkIndex(LinkManager::instance()->getLinks().indexOf(link));
-    const int32_t& linkID(LinkManager::instance()->getLinks()[linkIndex]->getId());
-
-    foreach (QAction* action, actions)
-    {
-        if (action->data().toInt() == linkID)
-        {
-            found = true;
-            action->trigger(); // Show the Link Config Dialog
-        }
-    }
-
-    return found;
-}
-
 void MainWindow::simulateLink(bool simulate) {
     if (simulate) {
         if (!simulationLink) {
@@ -1438,11 +1416,6 @@ void MainWindow::loadSimulationView()
         ui.actionSimulationView->setChecked(true);
         _loadCurrentViewState();
     }
-}
-
-QList<QAction*> MainWindow::listLinkMenuActions()
-{
-    return ui.menuNetwork->actions();
 }
 
 /// @brief Hides the spash screen if it is currently being shown

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -116,8 +116,6 @@ public:
         return lowPowerMode;
     }
 
-    QList<QAction*> listLinkMenuActions();
-
     void hideSplashScreen(void);
 
     /// @brief Saves the last used connection
@@ -130,7 +128,6 @@ public:
 public slots:
     /** @brief Show the application settings */
     void showSettings();
-    bool configLink(LinkInterface *link);
     /** @brief Simulate a link */
     void simulateLink(bool simulate);
     /** @brief Set the currently controlled UAS */
@@ -238,8 +235,6 @@ protected:
     void loadSettings();
     void storeSettings();
 
-
-    LinkInterface* udpLink;
 
     QSettings settings;
     QActionGroup* centerStackActionGroup;

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -58,27 +58,12 @@
     <property name="title">
      <string>File</string>
     </property>
-    <addaction name="actionSimulate"/>
     <addaction name="separator"/>
     <addaction name="actionMuteAudioOutput"/>
+    <addaction name="actionAdd_Link"/>
     <addaction name="actionSettings"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
-   </widget>
-   <widget class="QMenu" name="menuNetwork">
-    <property name="title">
-     <string>Communication</string>
-    </property>
-    <addaction name="actionAdd_Link"/>
-    <addaction name="separator"/>
-   </widget>
-   <widget class="QMenu" name="menuTools">
-    <property name="title">
-     <string>Tool Widgets</string>
-    </property>
-    <addaction name="actionNewCustomWidget"/>
-    <addaction name="actionLoadCustomWidgetFile"/>
-    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">
@@ -96,26 +81,38 @@
     <addaction name="actionMissionView"/>
     <addaction name="actionFlightView"/>
     <addaction name="actionEngineersView"/>
+    <addaction name="separator"/>
+    <addaction name="actionFullscreen"/>
+    <addaction name="actionNormal"/>
+   </widget>
+   <widget class="QMenu" name="menuAdvanced">
+    <property name="title">
+     <string>Advanced</string>
+    </property>
+    <widget class="QMenu" name="menuTools">
+     <property name="title">
+      <string>Tool Widgets</string>
+     </property>
+     <addaction name="actionNewCustomWidget"/>
+     <addaction name="actionLoadCustomWidgetFile"/>
+     <addaction name="separator"/>
+    </widget>
     <addaction name="actionGoogleEarthView"/>
     <addaction name="actionLocal3DView"/>
     <addaction name="actionTerminalView"/>
     <addaction name="actionSimulationView"/>
     <addaction name="separator"/>
-    <addaction name="actionFullscreen"/>
-    <addaction name="actionNormal"/>
+    <addaction name="actionSimulate"/>
+    <addaction name="separator"/>
+    <addaction name="menuTools"/>
    </widget>
    <addaction name="menuMGround"/>
-   <addaction name="menuNetwork"/>
    <addaction name="menuPerspectives"/>
-   <addaction name="menuTools"/>
+   <addaction name="menuAdvanced"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionExit">
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/actions/system-log-out.svg</normaloff>:/files/images/actions/system-log-out.svg</iconset>
-   </property>
    <property name="text">
     <string>Exit</string>
    </property>
@@ -171,16 +168,12 @@
   </action>
   <action name="actionAdd_Link">
    <property name="text">
-    <string>Manage Links</string>
+    <string>Manage Communication Links</string>
    </property>
   </action>
   <action name="actionSimulate">
    <property name="checkable">
     <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/control/launch.svg</normaloff>:/files/images/control/launch.svg</iconset>
    </property>
    <property name="text">
     <string>Simulate</string>
@@ -190,28 +183,16 @@
    </property>
   </action>
   <action name="actionOnline_Documentation">
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/apps/utilities-system-monitor.svg</normaloff>:/files/images/apps/utilities-system-monitor.svg</iconset>
-   </property>
    <property name="text">
     <string>Online Documentation</string>
    </property>
   </action>
   <action name="actionProject_Roadmap">
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/status/software-update-available.svg</normaloff>:/files/images/status/software-update-available.svg</iconset>
-   </property>
    <property name="text">
     <string>Project Roadmap</string>
    </property>
   </action>
   <action name="actionDeveloper_Credits">
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/categories/preferences-system.svg</normaloff>:/files/images/categories/preferences-system.svg</iconset>
-   </property>
    <property name="text">
     <string>Developer Credits</string>
    </property>
@@ -219,10 +200,6 @@
   <action name="actionMissionView">
    <property name="checkable">
     <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/categories/applications-internet.svg</normaloff>:/files/images/categories/applications-internet.svg</iconset>
    </property>
    <property name="text">
     <string>Plan</string>
@@ -232,10 +209,6 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/apps/utilities-system-monitor.svg</normaloff>:/files/images/apps/utilities-system-monitor.svg</iconset>
-   </property>
    <property name="text">
     <string>Analyze</string>
    </property>
@@ -244,19 +217,11 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/status/network-wireless-encrypted.svg</normaloff>:/files/images/status/network-wireless-encrypted.svg</iconset>
-   </property>
    <property name="text">
     <string>Fly</string>
    </property>
   </action>
   <action name="actionNewCustomWidget">
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/apps/utilities-system-monitor.svg</normaloff>:/files/images/apps/utilities-system-monitor.svg</iconset>
-   </property>
    <property name="text">
     <string>New Custom Widget</string>
    </property>
@@ -264,14 +229,6 @@
   <action name="actionMuteAudioOutput">
    <property name="checkable">
     <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/status/audio-volume-high.svg</normaloff>
-     <normalon>:/files/images/status/audio-volume-muted.svg</normalon>
-     <activeon>:/files/images/status/audio-volume-muted.svg</activeon>
-     <selectedoff>:/files/images/status/audio-volume-high.svg</selectedoff>
-     <selectedon>:/files/images/status/audio-volume-muted.svg</selectedon>:/files/images/status/audio-volume-high.svg</iconset>
    </property>
    <property name="text">
     <string>Mute Audio Output</string>
@@ -329,10 +286,6 @@
    </property>
   </action>
   <action name="actionLoadCustomWidgetFile">
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/status/folder-drag-accept.svg</normaloff>:/files/images/status/folder-drag-accept.svg</iconset>
-   </property>
    <property name="text">
     <string>Load Custom Widget File</string>
    </property>
@@ -340,10 +293,6 @@
   <action name="actionSetup">
    <property name="checkable">
     <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/categories/preferences-system.svg</normaloff>:/files/images/categories/preferences-system.svg</iconset>
    </property>
    <property name="text">
     <string>Setup</string>
@@ -367,10 +316,6 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/apps/accessories-calculator.svg</normaloff>:/files/images/apps/accessories-calculator.svg</iconset>
-   </property>
    <property name="text">
     <string>HIL Simulation</string>
    </property>
@@ -378,10 +323,6 @@
   <action name="actionTerminalView">
    <property name="checkable">
     <bool>true</bool>
-   </property>
-   <property name="icon">
-    <iconset resource="../../qgroundcontrol.qrc">
-     <normaloff>:/files/images/apps/utilities-terminal.svg</normaloff>:/files/images/apps/utilities-terminal.svg</iconset>
    </property>
    <property name="text">
     <string>Terminal</string>


### PR DESCRIPTION
Reorganized the Main Menu a bit into a slightly more logical order. The idea was to move everything a new user would get confused with into a new *Advanced* menu. No functionality was removed or added. Just shuffled around.

I also removed the icons some of the menu entries had. Most entries did not have an icon and those that did would not show at all under Mac OS. They differed wildly in style, none of which matching the new look and feel. We either come up with a new crop of consistently designed icons or leave as is. Clean.


![untitled-1](https://cloud.githubusercontent.com/assets/749243/6477734/040ad98e-c1f5-11e4-9931-507284355f50.png)
