### PR TITLE
Text to speech tweaks

### DIFF
--- a/src/audio/QGCAudioWorker.cpp
+++ b/src/audio/QGCAudioWorker.cpp
@@ -174,7 +174,7 @@ bool QGCAudioWorker::isMuted()
 }
 
 bool QGCAudioWorker::_getMillisecondString(const QString& string, QString& match, int& number) {
-    QRegularExpression re("([0-9]*ms)");
+    static QRegularExpression re("([0-9]+ms)");
     QRegularExpressionMatchIterator i = re.globalMatch(string);
     while (i.hasNext()) {
         QRegularExpressionMatch qmatch = i.next();


### PR DESCRIPTION
Changes based on suggestion from @Susurrus. The ```([0-9]*ms)``` versus ```([0-9]+ms)``` was a lapse of mine. The use of a non static rule was based on the fact this runs in a separate thread and I didn't know how Qt handled it. It's safe.