### PR TITLE
Fix OS X Installer yet again

### DIFF
--- a/QGCInstaller.pri
+++ b/QGCInstaller.pri
@@ -23,8 +23,9 @@ installer {
         # qgroundcontrol.app file. If you specify a path to the .app file the symbolic
         # links to plugins will not be created correctly.
         QMAKE_POST_LINK += && cd release
-        QMAKE_POST_LINK += && $$dirname(QMAKE_QMAKE)/macdeployqt qgroundcontrol.app -verbose=2 -qmldir=src -dmg
+        QMAKE_POST_LINK += && $$dirname(QMAKE_QMAKE)/macdeployqt qgroundcontrol.app -verbose=2 -qmldir=../src
         QMAKE_POST_LINK += && cd ..
+        QMAKE_POST_LINK += && hdiutil create -layout SPUD -srcfolder $${DESTDIR}/qgroundcontrol.app -volname QGroundControl $${DESTDIR}/qgroundcontrol.dmg
     }
 
     WindowsBuild {


### PR DESCRIPTION
macdeployqt can not be reliably used to create a dmg. Sometimes it just fails silently. Going back to using hdiutil to create the dmg.