### PR TITLE
Completed Tool Bar settings in Preferences Dialog

### DIFF
--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -126,12 +126,8 @@ public:
     /// @brief Restore (and connects) the last used connection (if any)
     void restoreLastUsedConnection();
     
-#ifdef UNITTEST_BUILD
-    // Returns a pointer to the MainToolBar so that unit tests can change views.
+    /// @brief Gets a pointer to the Main Tool Bar
     MainToolBar* getMainToolBar(void) { return _mainToolBar; }
-#endif
-
-    MainToolBar* getToolBar() { return _mainToolBar; }
 
 public slots:
     /** @brief Show the application settings */

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -131,6 +131,7 @@ public:
     MainToolBar* getMainToolBar(void) { return _mainToolBar; }
 #endif
 
+    MainToolBar* getToolBar() { return _mainToolBar; }
 
 public slots:
     /** @brief Show the application settings */

--- a/src/ui/SettingsDialog.cc
+++ b/src/ui/SettingsDialog.cc
@@ -177,20 +177,20 @@ void SettingsDialog::_selectSavedFilesDirectory(void)
 
 void SettingsDialog::on_showGPS_clicked(bool checked)
 {
-    _mainWindow->getToolBar()->viewStateChanged(TOOL_BAR_SHOW_GPS, checked);
+    _mainWindow->getMainToolBar()->viewStateChanged(TOOL_BAR_SHOW_GPS, checked);
 }
 
 void SettingsDialog::on_showBattery_clicked(bool checked)
 {
-    _mainWindow->getToolBar()->viewStateChanged(TOOL_BAR_SHOW_BATTERY, checked);
+    _mainWindow->getMainToolBar()->viewStateChanged(TOOL_BAR_SHOW_BATTERY, checked);
 }
 
 void SettingsDialog::on_showMessages_clicked(bool checked)
 {
-    _mainWindow->getToolBar()->viewStateChanged(TOOL_BAR_SHOW_MESSAGES, checked);
+    _mainWindow->getMainToolBar()->viewStateChanged(TOOL_BAR_SHOW_MESSAGES, checked);
 }
 
 void SettingsDialog::on_showMav_clicked(bool checked)
 {
-    _mainWindow->getToolBar()->viewStateChanged(TOOL_BAR_SHOW_MAV, checked);
+    _mainWindow->getMainToolBar()->viewStateChanged(TOOL_BAR_SHOW_MAV, checked);
 }

--- a/src/ui/SettingsDialog.cc
+++ b/src/ui/SettingsDialog.cc
@@ -37,6 +37,7 @@
 #include "QGCApplication.h"
 #include "QGCFileDialog.h"
 #include "QGCMessageBox.h"
+#include "MainToolBar.h"
 
 SettingsDialog::SettingsDialog(JoystickInput *joystick, QWidget *parent, int showTab, Qt::WindowFlags flags) :
 QDialog(parent, flags),
@@ -63,6 +64,14 @@ _ui(new Ui::SettingsDialog)
 
     this->window()->setWindowTitle(tr("QGroundControl Settings"));
 
+    // Tool Bar Preferences
+    QSettings settings;
+    settings.beginGroup(TOOL_BAR_SETTINGS_GROUP);
+    _ui->showBattery->setChecked(settings.value( TOOL_BAR_SHOW_BATTERY,  true).toBool());
+    _ui->showGPS->setChecked(settings.value(     TOOL_BAR_SHOW_GPS,      true).toBool());
+    _ui->showMav->setChecked(settings.value(     TOOL_BAR_SHOW_MAV,      true).toBool());
+    _ui->showMessages->setChecked(settings.value(TOOL_BAR_SHOW_MESSAGES, true).toBool());
+    settings.endGroup();
     // Audio preferences
     _ui->audioMuteCheckBox->setChecked(GAudioOutput::instance()->isMuted());
     connect(_ui->audioMuteCheckBox, SIGNAL(toggled(bool)), GAudioOutput::instance(), SLOT(mute(bool)));
@@ -115,10 +124,11 @@ void SettingsDialog::styleChanged(int index)
 void SettingsDialog::_deleteSettingsToggled(bool checked)
 {
     if (checked){
-        QGCMessageBox::StandardButton answer = QGCMessageBox::question(tr("Delete Settings"),
-                                                                       tr("All saved settings will be deleted the next time you start QGroundControl. Is this really what you want?"),
-                                                                       QMessageBox::Yes | QMessageBox::No,
-                                                                       QMessageBox::No);
+        QGCMessageBox::StandardButton answer =
+            QGCMessageBox::question(tr("Delete Settings"),
+                tr("All saved settings will be deleted the next time you start QGroundControl. Is this really what you want?"),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::No);
         if (answer == QMessageBox::Yes) {
             qgcApp()->deleteAllSettingsNextBoot();
         } else {
@@ -133,21 +143,17 @@ void SettingsDialog::_deleteSettingsToggled(bool checked)
 void SettingsDialog::_validateBeforeClose(void)
 {
     QGCApplication* app = qgcApp();
-
     // Validate the saved file location
-
     QString saveLocation = _ui->savedFilesLocation->text();
     if (!app->validatePossibleSavedFilesLocation(saveLocation)) {
-        QGCMessageBox::warning(tr("Bad save location"),
-                               tr("The location to save files to is invalid, or cannot be written to. Please provide a valid directory."));
+        QGCMessageBox::warning(
+            tr("Invalid Save Location"),
+            tr("The location to save files is invalid, or cannot be written to. Please provide a valid directory."));
         return;
     }
-
     // Locations is valid, save
     app->setSavedFilesLocation(saveLocation);
-
     qgcApp()->setPromptFlightDataSave(_ui->promptFlightDataSave->checkState() == Qt::Checked);
-
     // Close dialog
     accept();
 }
@@ -155,10 +161,36 @@ void SettingsDialog::_validateBeforeClose(void)
 /// @brief Displays a directory picker dialog to allow the user to select a saved file location
 void SettingsDialog::_selectSavedFilesDirectory(void)
 {
-    QString newLocation = QGCFileDialog::getExistingDirectory(this,
-                                                            tr("Select the directory where you want to save files to."),
-                                                            _ui->savedFilesLocation->text());
+    QString newLocation = QGCFileDialog::getExistingDirectory(
+        this,
+        tr("Select the directory where you want to save files to."),
+        _ui->savedFilesLocation->text());
     if (!newLocation.isEmpty()) {
         _ui->savedFilesLocation->setText(newLocation);
     }
+
+    // TODO:
+    // Once a directory is selected, we need to display the various subdirectories used underneath:
+    // * Flight data logs
+    // * Parameters
+}
+
+void SettingsDialog::on_showGPS_clicked(bool checked)
+{
+    _mainWindow->getToolBar()->viewStateChanged(TOOL_BAR_SHOW_GPS, checked);
+}
+
+void SettingsDialog::on_showBattery_clicked(bool checked)
+{
+    _mainWindow->getToolBar()->viewStateChanged(TOOL_BAR_SHOW_BATTERY, checked);
+}
+
+void SettingsDialog::on_showMessages_clicked(bool checked)
+{
+    _mainWindow->getToolBar()->viewStateChanged(TOOL_BAR_SHOW_MESSAGES, checked);
+}
+
+void SettingsDialog::on_showMav_clicked(bool checked)
+{
+    _mainWindow->getToolBar()->viewStateChanged(TOOL_BAR_SHOW_MAV, checked);
 }

--- a/src/ui/SettingsDialog.h
+++ b/src/ui/SettingsDialog.h
@@ -56,6 +56,11 @@ private slots:
     void _selectSavedFilesDirectory(void);
     void _validateBeforeClose(void);
 
+    void on_showGPS_clicked(bool checked);
+    void on_showBattery_clicked(bool checked);
+    void on_showMessages_clicked(bool checked);
+    void on_showMav_clicked(bool checked);
+
 private:
     MainWindow*         _mainWindow;
     Ui::SettingsDialog* _ui;

--- a/src/ui/SettingsDialog.ui
+++ b/src/ui/SettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>534</width>
-    <height>681</height>
+    <width>500</width>
+    <height>604</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,245 +19,356 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <widget class="QWidget" name="general">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <attribute name="title">
        <string>General</string>
       </attribute>
       <attribute name="toolTip">
        <string>General Settings</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout_8">
        <item>
-        <widget class="QCheckBox" name="audioMuteCheckBox">
-         <property name="text">
-          <string>Mute all audio output</string>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <property name="topMargin">
+          <number>10</number>
          </property>
-         <property name="icon">
-          <iconset resource="../../qgroundcontrol.qrc">
-           <normaloff>:/files/images/status/audio-volume-muted.svg</normaloff>:/files/images/status/audio-volume-muted.svg</iconset>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="reconnectCheckBox">
-         <property name="text">
-          <string>Automatically reconnect last link on application startup</string>
-         </property>
-         <property name="icon">
-          <iconset resource="../../qgroundcontrol.qrc">
-           <normaloff>:/files/images/devices/network-wireless.svg</normaloff>:/files/images/devices/network-wireless.svg</iconset>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="lowPowerCheckBox">
-         <property name="toolTip">
-          <string>Lowers all update rates to save battery power</string>
-         </property>
-         <property name="text">
-          <string>Enable low power mode</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="promptFlightDataSave">
-         <property name="text">
-          <string>Prompt to save Flight Data Log after each flight</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="title">
-          <string>Style</string>
-         </property>
-         <property name="flat">
-          <bool>false</bool>
-         </property>
-         <property name="checkable">
-          <bool>false</bool>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="sizeConstraint">
-             <enum>QLayout::SetMinimumSize</enum>
-            </property>
+         <item>
+          <widget class="QCheckBox" name="audioMuteCheckBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Mute all audio output</string>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="reconnectCheckBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Automatically reconnect last link on application startup</string>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="lowPowerCheckBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Lowers all update rates to save battery power</string>
+           </property>
+           <property name="text">
+            <string>Enable low power mode</string>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="promptFlightDataSave">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Prompt to save Flight Data Log after each flight</string>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Style</string>
+           </property>
+           <property name="flat">
+            <bool>false</bool>
+           </property>
+           <property name="checkable">
+            <bool>false</bool>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_3">
             <item>
-             <widget class="QComboBox" name="styleChooser">
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <property name="sizeConstraint">
+               <enum>QLayout::SetMinimumSize</enum>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>80</number>
+              </property>
               <item>
-               <property name="text">
-                <string>Dark (for indoor use)</string>
-               </property>
+               <widget class="QComboBox" name="styleChooser">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>Dark (for indoor use)</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Light (for outdoor use)</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="fileLocationsLayout">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="title">
+            <string>File Locations</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_7">
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Specify the location you would like to save files:</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <widget class="QLineEdit" name="savedFilesLocation">
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>21</height>
+                 </size>
+                </property>
+                <property name="maxLength">
+                 <number>1024</number>
+                </property>
+               </widget>
               </item>
               <item>
-               <property name="text">
-                <string>Light (for outdoor use)</string>
-               </property>
+               <widget class="QPushButton" name="browseSavedFilesLocation">
+                <property name="text">
+                 <string>Browse</string>
+                </property>
+               </widget>
               </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Tool Bar</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout">
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_3">
+                <item>
+                 <widget class="QCheckBox" name="showGPS">
+                  <property name="minimumSize">
+                   <size>
+                    <width>160</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Show GPS</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="showMessages">
+                  <property name="text">
+                   <string>Show Messages</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <item>
+                 <widget class="QCheckBox" name="showBattery">
+                  <property name="minimumSize">
+                   <size>
+                    <width>160</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Show Battery</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="showMav">
+                  <property name="text">
+                   <string>Show Mav Icon</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_2">
+           <property name="title">
+            <string>Reset All Settings to Default</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <item>
+             <widget class="QCheckBox" name="deleteSettings">
+              <property name="text">
+               <string>Delete all saved settings on next boot</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="font">
+               <font>
+                <pointsize>11</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Note: You can also use --clear-settings as a command line option to accomplish this.</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
            </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="fileLocationsLayout">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>200</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>File Locations</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="font">
-             <font>
-              <pointsize>11</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Parameters will be saved here:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="flightDataLogLocation">
-            <property name="font">
-             <font>
-              <pointsize>11</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>TextLabel</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="browseSavedFilesLocation">
-            <property name="text">
-             <string>Browse</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Specify the location you would like to save files to:</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLineEdit" name="savedFilesLocation">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>21</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="font">
-             <font>
-              <pointsize>11</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Flight Data Logs will be saved here:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="parameterLocation">
-            <property name="font">
-             <font>
-              <pointsize>11</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>TextLabel</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox_2">
-         <property name="title">
-          <string>Danger Zone</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <item>
-           <widget class="QCheckBox" name="deleteSettings">
-            <property name="text">
-             <string>Delete all saved settings on next boot</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_2">
-            <property name="font">
-             <font>
-              <pointsize>11</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Note: You can also use --clear-settings as a command line option to accomplish this.</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </item>
       </layout>
+      <zorder>audioMuteCheckBox</zorder>
+      <zorder>reconnectCheckBox</zorder>
+      <zorder>lowPowerCheckBox</zorder>
+      <zorder>promptFlightDataSave</zorder>
+      <zorder>groupBox</zorder>
+      <zorder>fileLocationsLayout</zorder>
+      <zorder>groupBox_2</zorder>
+      <zorder>groupBox_3</zorder>
      </widget>
     </widget>
    </item>
@@ -276,8 +387,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../../qgroundcontrol.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/ui/toolbar/MainToolBar.cc
+++ b/src/ui/toolbar/MainToolBar.cc
@@ -57,6 +57,10 @@ MainToolBar::MainToolBar(QWidget* parent)
     , _satelliteCount(-1)
     , _dotsPerInch(96.0)    // Default to Windows as it's more likely not to report below
     , _satelliteLock(0)
+    , _showGPS(true)
+    , _showMav(true)
+    , _showMessages(true)
+    , _showBattery(true)
     , _rollDownMessages(0)
 {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -76,7 +80,16 @@ MainToolBar::MainToolBar(QWidget* parent)
     } else {
         qWarning() << "System not reporting logical DPI, which is used to compute the appropriate font size. The default being used is 96dpi. If the text within buttons and UI elements are too big or too small, that's the reason.";
     }
-    // Give the QML code a way to reach us
+
+    // Tool Bar Preferences
+    QSettings settings;
+    settings.beginGroup(TOOL_BAR_SETTINGS_GROUP);
+    _showBattery  = settings.value(TOOL_BAR_SHOW_BATTERY,  true).toBool();
+    _showGPS      = settings.value(TOOL_BAR_SHOW_GPS,      true).toBool();
+    _showMav      = settings.value(TOOL_BAR_SHOW_MAV,      true).toBool();
+    _showMessages = settings.value(TOOL_BAR_SHOW_MESSAGES, true).toBool();
+    settings.endGroup();
+
     setContextPropertyObject("mainToolBar", this);
     setSource(QUrl::fromUserInput("qrc:/qml/MainToolBar.qml"));
     setVisible(true);
@@ -95,6 +108,32 @@ MainToolBar::MainToolBar(QWidget* parent)
 MainToolBar::~MainToolBar()
 {
 
+}
+
+void MainToolBar::_setToolBarState(const QString& key, bool value)
+{
+    QSettings settings;
+    settings.beginGroup(TOOL_BAR_SETTINGS_GROUP);
+    settings.setValue(key, value);
+    settings.endGroup();
+    if(key == TOOL_BAR_SHOW_GPS) {
+        _showGPS = value;
+        emit showGPSChanged(value);
+    } else if(key == TOOL_BAR_SHOW_MAV) {
+        _showMav = value;
+        emit showMavChanged(value);
+    }else if(key == TOOL_BAR_SHOW_BATTERY) {
+        _showBattery = value;
+        emit showBatteryChanged(value);
+    } else if(key == TOOL_BAR_SHOW_MESSAGES) {
+        _showMessages = value;
+        emit showMessagesChanged(value);
+    }
+}
+
+void MainToolBar::viewStateChanged(const QString &key, bool value)
+{
+    _setToolBarState(key, value);
 }
 
 void MainToolBar::onSetupView()

--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -32,6 +32,12 @@ This file is part of the QGROUNDCONTROL project
 
 #include "QGCQmlWidgetHolder.h"
 
+#define TOOL_BAR_SETTINGS_GROUP "TOOLBAR_SETTINGS_GROUP"
+#define TOOL_BAR_SHOW_BATTERY   "ShowBattery"
+#define TOOL_BAR_SHOW_GPS       "ShowGPS"
+#define TOOL_BAR_SHOW_MAV       "ShowMav"
+#define TOOL_BAR_SHOW_MESSAGES  "ShowMessages"
+
 class UASInterface;
 class UASMessage;
 class UASMessageViewRollDown;
@@ -88,6 +94,10 @@ public:
     Q_PROPERTY(QString       currentState       READ currentState       NOTIFY currentStateChanged)
     Q_PROPERTY(double        dotsPerInch        READ dotsPerInch        NOTIFY dotsPerInchChanged)
     Q_PROPERTY(int           satelliteLock      READ satelliteLock      NOTIFY satelliteLockChanged)
+    Q_PROPERTY(bool          showGPS            READ showGPS            NOTIFY showGPSChanged)
+    Q_PROPERTY(bool          showMav            READ showMav            NOTIFY showMavChanged)
+    Q_PROPERTY(bool          showMessages       READ showMessages       NOTIFY showMessagesChanged)
+    Q_PROPERTY(bool          showBattery        READ showBattery        NOTIFY showBatteryChanged)
 
     int           connectionCount        () { return _connectionCount; }
     double        batteryVoltage         () { return _batteryVoltage; }
@@ -108,8 +118,13 @@ public:
     QString       currentState           () { return _currentState; }
     double        dotsPerInch            () { return _dotsPerInch; }
     int           satelliteLock          () { return _satelliteLock; }
+    bool          showGPS                () { return _showGPS; }
+    bool          showMav                () { return _showMav; }
+    bool          showMessages           () { return _showMessages; }
+    bool          showBattery            () { return _showBattery; }
 
     void          setCurrentView         (int currentView);
+    void          viewStateChanged       (const QString& key, bool value);
 
 signals:
     void connectionCountChanged         (int count);
@@ -131,6 +146,10 @@ signals:
     void currentStateChanged            (QString state);
     void dotsPerInchChanged             ();
     void satelliteLockChanged           (int lock);
+    void showGPSChanged                 (bool value);
+    void showMavChanged                 (bool value);
+    void showMessagesChanged            (bool value);
+    void showBatteryChanged             (bool value);
 
 private slots:
     void _setActiveUAS                  (UASInterface* active);
@@ -154,6 +173,7 @@ private slots:
 
 private:
     void _updateConnection              (LinkInterface *disconnectedLink = NULL);
+    void _setToolBarState               (const QString& key, bool value);
 
 private:
     UASInterface*   _mav;
@@ -183,6 +203,10 @@ private:
     QStringList     _connectedList;
     qreal           _dotsPerInch;
     int             _satelliteLock;
+    bool            _showGPS;
+    bool            _showMav;
+    bool            _showMessages;
+    bool            _showBattery;
 
     UASMessageViewRollDown* _rollDownMessages;
 };

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -190,7 +190,7 @@ Rectangle {
             id: messages
             width: (mainToolBar.newMessageCount > 99) ? 70 : 60
             height: cellHeight
-            visible: (mainToolBar.connectionCount > 0)
+            visible: (mainToolBar.connectionCount > 0) && (mainToolBar.showMessages)
             anchors.verticalCenter: parent.verticalCenter
             color:  getMessageColor()
             radius: cellRadius
@@ -266,7 +266,7 @@ Rectangle {
             id: mavIcon
             width: cellHeight
             height: cellHeight
-            visible: showMavStatus()
+            visible: showMavStatus() &&  (mainToolBar.showMav)
             anchors.verticalCenter: parent.verticalCenter
             color: colorBlue
             radius: cellRadius
@@ -285,7 +285,7 @@ Rectangle {
             id: satelitte
             width: 60
             height: cellHeight
-            visible: showMavStatus();
+            visible: showMavStatus()  && (mainToolBar.showGPS)
             anchors.verticalCenter: parent.verticalCenter
             color:  getSatelliteColor();
             radius: cellRadius
@@ -320,7 +320,7 @@ Rectangle {
             id: battery
             width: 80
             height: cellHeight
-            visible: showMavStatus()
+            visible: showMavStatus() && (mainToolBar.showBattery)
             anchors.verticalCenter: parent.verticalCenter
             color:  (mainToolBar.batteryPercent > 40.0 || mainToolBar.batteryPercent < 0.01) ? colorGreen : colorRed
             radius: cellRadius


### PR DESCRIPTION
I've added a Tool Bar section to the general section of the preferences dialog where you can set what to display in the tool bar. For now you can set if these items are shown:

* GPS
* Battery Status
* Messages
* Mav Icon

I've cleaned up a bit the dialog while at it though it seems the preferences dialog is also in need of quite a bit of TLC.

![snap 2015-03-04 at 22 15 24 500x604](https://cloud.githubusercontent.com/assets/749243/6498662/91ae4d6c-c2bc-11e4-9eb0-7dc94d75a808.png)
