### PR TITLE
Minor fix to "Connect" button

### DIFF
--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -469,7 +469,7 @@ Rectangle {
 
         QGCButton {
             id: connectButton
-            width: 90
+            width: 100
             height: cellHeight
             visible: (mainToolBar.connectionCount === 0 || mainToolBar.connectionCount === 1)
             text: (mainToolBar.configList.length > 0) ? (mainToolBar.connectionCount === 0) ? qsTr("Connect") : qsTr("Disconnect") : qsTr("Add Link")
@@ -496,7 +496,7 @@ Rectangle {
 
         QGCButton {
             id: multidisconnectButton
-            width: 90
+            width: 100
             height: cellHeight
             text: qsTr("Disconnect")
             visible: (mainToolBar.connectionCount > 1)


### PR DESCRIPTION
The button is too small when it switches to "Disconnect" with multiple connections. That adds a drop down icon to the button and it was overlapping the text.