### PR TITLE
Tool bar tweaks

### DIFF
--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -9,10 +9,10 @@ import QGroundControl.MousePosition 1.0
 Button {
     // primary: true - this is the primary button for this group of buttons
     property bool primary: false
-    property bool showHighlight: (pressed | hovered | checked) && !__forceHoverOff
 
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
 
+    property bool __showHighLight: (pressed | hovered | checked) && !__forceHoverOff
 
     // This fixes the issue with button hover where if a Button is near the edge oa QQuickWidget you can
     // move the mouse fast enough such that the MouseArea does not trigger an onExited. This is turn
@@ -70,7 +70,7 @@ Button {
 
                 Rectangle {
                     anchors.fill: parent
-                    color: showHighlight ?
+                    color: __showHighLight ?
                         control.__qgcPal.buttonHighlight :
                         (primary ? control.__qgcPal.primaryButton : control.__qgcPal.button)
                 }
@@ -107,7 +107,7 @@ Button {
                         renderType: Text.NativeRendering
                         anchors.verticalCenter: parent.verticalCenter
                         text: control.text
-                        color: showHighlight ?
+                        color: __showHighLight ?
                             control.__qgcPal.buttonHighlightText :
                             (primary ? control.__qgcPal.primaryButtonText : control.__qgcPal.buttonText)
                     }

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -12,7 +12,7 @@ Button {
 
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
 
-    property bool __showHighLight: (pressed | hovered | checked) && !__forceHoverOff
+    property bool __showHighlight: (pressed | hovered | checked) && !__forceHoverOff
 
     // This fixes the issue with button hover where if a Button is near the edge oa QQuickWidget you can
     // move the mouse fast enough such that the MouseArea does not trigger an onExited. This is turn
@@ -70,7 +70,7 @@ Button {
 
                 Rectangle {
                     anchors.fill: parent
-                    color: __showHighLight ?
+                    color: __showHighlight ?
                         control.__qgcPal.buttonHighlight :
                         (primary ? control.__qgcPal.primaryButton : control.__qgcPal.button)
                 }
@@ -107,7 +107,7 @@ Button {
                         renderType: Text.NativeRendering
                         anchors.verticalCenter: parent.verticalCenter
                         text: control.text
-                        color: __showHighLight ?
+                        color: __showHighlight ?
                             control.__qgcPal.buttonHighlightText :
                             (primary ? control.__qgcPal.primaryButtonText : control.__qgcPal.buttonText)
                     }

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -9,10 +9,10 @@ import QGroundControl.MousePosition 1.0
 Button {
     // primary: true - this is the primary button for this group of buttons
     property bool primary: false
+    property bool showHighlight: (pressed | hovered | checked) && !__forceHoverOff
 
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
 
-    property bool __showHighlight: (pressed | hovered | checked) && !__forceHoverOff
 
     // This fixes the issue with button hover where if a Button is near the edge oa QQuickWidget you can
     // move the mouse fast enough such that the MouseArea does not trigger an onExited. This is turn
@@ -70,7 +70,7 @@ Button {
 
                 Rectangle {
                     anchors.fill: parent
-                    color: __showHighlight ?
+                    color: showHighlight ?
                         control.__qgcPal.buttonHighlight :
                         (primary ? control.__qgcPal.primaryButton : control.__qgcPal.button)
                 }
@@ -107,7 +107,7 @@ Button {
                         renderType: Text.NativeRendering
                         anchors.verticalCenter: parent.verticalCenter
                         text: control.text
-                        color: __showHighlight ?
+                        color: showHighlight ?
                             control.__qgcPal.buttonHighlightText :
                             (primary ? control.__qgcPal.primaryButtonText : control.__qgcPal.buttonText)
                     }

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -3,9 +3,10 @@ import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 import QtQuick.Controls.Private 1.0
 
+import QGroundControl.Controls 1.0
 import QGroundControl.Palette 1.0
 
-Button {
+QGCButton {
     id: button
     property bool repaintChevron: false
     property var  __qgcPal: QGCPalette { colorGroupEnabled: enabled }
@@ -21,6 +22,7 @@ Button {
                     onHoveredChanged: chevron.requestPaint()
                     onPressedChanged: chevron.requestPaint()
                     onCheckedChanged: chevron.requestPaint()
+                    onShowHighlightChanged: chevron.requestPaint()
                     onRepaintChevronChanged: {
                         if(repaintChevron) {
                             chevron.requestPaint()
@@ -42,7 +44,7 @@ Button {
                     context.lineTo(0, height);
                     context.closePath();
                     context.strokeStyle = __qgcPal.windowShade
-                    context.fillStyle = (button.hovered && !button.pressed) ? __qgcPal.buttonHighlight : (button.checked ? __qgcPal.buttonHighlight : __qgcPal.button);
+                    context.fillStyle = showHighlight ? __qgcPal.buttonHighlight : (button.checked ? __qgcPal.buttonHighlight : __qgcPal.button);
                     context.stroke();
                     context.fill();
                 }
@@ -52,7 +54,7 @@ Button {
             text: button.text
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
-            color: (button.hovered && !button.pressed) ? __qgcPal.buttonHighlightText : (button.checked ? __qgcPal.primaryButtonText : __qgcPal.buttonText)
+            color: showHighlight ? __qgcPal.buttonHighlightText : (button.checked ? __qgcPal.primaryButtonText : __qgcPal.buttonText)
         }
     }
 }

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -10,7 +10,7 @@ QGCButton {
     id: button
     property bool repaintChevron: false
     property var  __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-    property bool showHighlight: __showHighLight
+    property bool showHighlight: __showHighlight
     style: ButtonStyle {
         background: Item {
             anchors.margins: 3

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -10,6 +10,7 @@ QGCButton {
     id: button
     property bool repaintChevron: false
     property var  __qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    property bool showHighlight: __showHighLight
     style: ButtonStyle {
         background: Item {
             anchors.margins: 3

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -46,10 +46,14 @@ Rectangle {
 
     property var colorBlue:       "#1a6eaa"
     property var colorGreen:      "#079527"
-    property var colorGreenText:  "#00d930"
     property var colorRed:        "#a81a1b"
     property var colorOrange:     "#a76f26"
     property var colorWhite:      "#f0f0f0"
+
+    property var colorOrangeText: (qgcPal.globalTheme === QGCPalette.Light) ? "#b75711" : "#ea8225"
+    property var colorRedText:    (qgcPal.globalTheme === QGCPalette.Light) ? "#ee1112" : "#ef2526"
+    property var colorGreenText:  (qgcPal.globalTheme === QGCPalette.Light) ? "#046b1b" : "#00d930"
+    property var colorWhiteText:  (qgcPal.globalTheme === QGCPalette.Light) ? "#343333" : "#f0f0f0"
 
     id: toolBarHolder
     color: qgcPal.windowShade
@@ -390,7 +394,7 @@ Rectangle {
                         font.pointSize: 12 * dpiFactor
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
-                        color: (mainToolBar.systemArmed) ? colorRed : colorGreen
+                        color: (mainToolBar.systemArmed) ? colorOrangeText : colorGreenText
                     }
                 }
 
@@ -409,7 +413,7 @@ Rectangle {
                         font.pointSize: 12 * dpiFactor
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
-                        color: (mainToolBar.currentState === "STANDBY") ? colorGreen : colorRed
+                        color: (mainToolBar.currentState === "STANDBY") ? colorGreenText : colorRedText
                     }
                 }
 
@@ -431,7 +435,7 @@ Rectangle {
                     font.weight: Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    color: qgcPal.text
+                    color: colorWhiteText
                 }
             }
 
@@ -452,7 +456,7 @@ Rectangle {
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter
-                    color: colorRed
+                    color: colorRedText
                 }
             }
         }


### PR DESCRIPTION
Tweaked text colors in main tool bar.
Tool bar buttons now use QGCButton as base to inherit hover mode fix.
Made QGCButton.showHightLight into a public property so I could use it as a trigger for repainting the chevron buttons.