### PR TITLE
Added code to handle point size fonts in all QML widgets.

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
@@ -1,3 +1,26 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
@@ -7,11 +30,13 @@ import QGroundControl.FactControls 1.0
 import QGroundControl.Palette 1.0
 import QGroundControl.Controls 1.0
 import QGroundControl.Controllers 1.0
+import QGroundControl.ScreenTools 1.0
 
 Item {
     Loader {
         property FlightModesComponentController controller: FlightModesComponentController { }
         property QGCPalette qgcPal: QGCPalette { colorGroupEnabled: true }
+        property ScreenTools screenTools: ScreenTools { }
         property bool loading: true
 
         anchors.fill: parent
@@ -357,7 +382,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: 20
+                    font.pointSize: 20 * screenTools.dpiFactor;
                 }
 
                 Item { height: 20; width: 10 } // spacer
@@ -848,7 +873,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: 20
+                    font.pointSize: 20 * screenTools.dpiFactor;
                 }
 
                 QGCLabel {

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
@@ -382,7 +382,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: 20 * screenTools.dpiFactor;
+                    font.pointSize: screenTools.dpiAdjustedPointSize(20);
                 }
 
                 Item { height: 20; width: 10 } // spacer
@@ -873,7 +873,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: 20 * screenTools.dpiFactor;
+                    font.pointSize: screenTools.dpiAdjustedPointSize(20);
                 }
 
                 QGCLabel {

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -98,13 +98,13 @@ Rectangle {
 
         QGCLabel {
             text: "POWER CONFIG"
-            font.pointSize: 20 * screenTools.dpiFactor;
+            font.pointSize: screenTools.dpiAdjustedPointSize(20);
         }
 
         QGCLabel {
             text: "Battery"
             color: palette.text
-            font.pointSize: 20 * screenTools.dpiFactor;
+            font.pointSize: screenTools.dpiAdjustedPointSize(20);
         }
 
         Rectangle {
@@ -208,12 +208,12 @@ Rectangle {
                                 text: "Battery Max:"
                                 color: palette.text
                                 width: 80
-                                font.pointSize: 12 * screenTools.dpiFactor;
+                                font.pointSize: screenTools.dpiAdjustedPointSize(12);
                             }
                             QGCLabel {
                                 text: (battNumCells.value * battHighVolt.value).toFixed(1) + ' V'
                                 color: palette.text
-                                font.pointSize: 12 * screenTools.dpiFactor;
+                                font.pointSize: screenTools.dpiAdjustedPointSize(12);
                             }
                         }
                         Row {
@@ -222,12 +222,12 @@ Rectangle {
                                 text: "Battery Min:"
                                 color: palette.text
                                 width: 80
-                                font.pointSize: 12 * screenTools.dpiFactor;
+                                font.pointSize: screenTools.dpiAdjustedPointSize(12);
                             }
                             QGCLabel {
                                 text: (battNumCells.value * battLowVolt.value).toFixed(1) + ' V'
                                 color: palette.text
-                                font.pointSize: 12 * screenTools.dpiFactor;
+                                font.pointSize: screenTools.dpiAdjustedPointSize(12);
                             }
                         }
                     }
@@ -245,7 +245,7 @@ Rectangle {
                 QGCLabel {
                     text: "Propeller Function"
                     color: palette.text
-                    font.pointSize: 20 * screenTools.dpiFactor;
+                    font.pointSize: screenTools.dpiAdjustedPointSize(20);
                 }
                 Rectangle {
                     width: parent.width
@@ -259,7 +259,7 @@ Rectangle {
                 QGCLabel {
                     text: "Magnetometer Distortion"
                     color: palette.text
-                    font.pointSize: 20 * screenTools.dpiFactor;
+                    font.pointSize: screenTools.dpiAdjustedPointSize(20);
                 }
                 Rectangle {
                     width: parent.width

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -1,3 +1,26 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
@@ -6,6 +29,7 @@ import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0
 import QGroundControl.Palette 1.0
 import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     QGCPalette { id: palette; colorGroupEnabled: true }
@@ -14,6 +38,7 @@ Rectangle {
     height: 600
     color: palette.window
 
+    property ScreenTools screenTools: ScreenTools { }
     property int flightLineWidth: 2             // width of lines for flight graphic
     property int loiterAltitudeColumnWidth: 180 // width of loiter altitude column
     property int shadedMargin: 20               // margin inset for shaded areas
@@ -29,7 +54,7 @@ Rectangle {
 
         QGCLabel {
             text: "SAFETY CONFIG"
-            font.pointSize: 20
+            font.pointSize: 20 * screenTools.dpiFactor;
         }
 
         Item { height: 20; width: 10 } // spacer
@@ -37,7 +62,7 @@ Rectangle {
         //-----------------------------------------------------------------
         //-- Return Home Triggers
 
-        QGCLabel { text: "Triggers For Return Home"; color: palette.text; font.pointSize: 20 }
+        QGCLabel { text: "Triggers For Return Home"; color: palette.text; font.pointSize: 20 * screenTools.dpiFactor; }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -96,7 +121,7 @@ Rectangle {
         //-----------------------------------------------------------------
         //-- Return Home Settings
 
-        QGCLabel { text: "Return Home Settings"; font.pointSize: 20 }
+        QGCLabel { text: "Return Home Settings"; font.pointSize: 20 * screenTools.dpiFactor; }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -266,7 +291,7 @@ Rectangle {
         QGCLabel {
             property Fact fact: Fact { name: "NAV_RCL_OBC" }
             width: parent.width
-            font.pointSize: 14
+            font.pointSize: 14 * screenTools.dpiFactor;
             text: "Warning: You have an advanced safety configuration set using the NAV_RCL_OBC parameter. The above settings may not apply.";
             visible: fact.value != 0
             wrapMode: Text.Wrap
@@ -274,7 +299,7 @@ Rectangle {
         QGCLabel {
             property Fact fact: Fact { name: "NAV_DLL_OBC" }
             width: parent.width
-            font.pointSize: 14
+            font.pointSize: 14 * screenTools.dpiFactor;
             text: "Warning: You have an advanced safety configuration set using the NAV_DLL_OBC parameter. The above settings may not apply.";
             visible: fact.value != 0
             wrapMode: Text.Wrap

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -54,7 +54,7 @@ Rectangle {
 
         QGCLabel {
             text: "SAFETY CONFIG"
-            font.pointSize: 20 * screenTools.dpiFactor;
+            font.pointSize: screenTools.dpiAdjustedPointSize(20);
         }
 
         Item { height: 20; width: 10 } // spacer
@@ -62,7 +62,7 @@ Rectangle {
         //-----------------------------------------------------------------
         //-- Return Home Triggers
 
-        QGCLabel { text: "Triggers For Return Home"; color: palette.text; font.pointSize: 20 * screenTools.dpiFactor; }
+        QGCLabel { text: "Triggers For Return Home"; color: palette.text; font.pointSize: screenTools.dpiAdjustedPointSize(20); }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -121,7 +121,7 @@ Rectangle {
         //-----------------------------------------------------------------
         //-- Return Home Settings
 
-        QGCLabel { text: "Return Home Settings"; font.pointSize: 20 * screenTools.dpiFactor; }
+        QGCLabel { text: "Return Home Settings"; font.pointSize: screenTools.dpiAdjustedPointSize(20); }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -273,12 +273,12 @@ Rectangle {
                         QGCLabel {
                             text: "Home loiter altitude";
                             color: palette.text;
-                            enabled: homeLoiterCheckbox.checked == true
+                            enabled: homeLoiterCheckbox.checked === true
                         }
                         FactTextField {
                             id: descendField;
                             fact: Fact { name: "RTL_DESCEND_ALT" }
-                            enabled: homeLoiterCheckbox.checked == true
+                            enabled: homeLoiterCheckbox.checked === true
                             showUnits: true
                         }
                     }
@@ -291,17 +291,17 @@ Rectangle {
         QGCLabel {
             property Fact fact: Fact { name: "NAV_RCL_OBC" }
             width: parent.width
-            font.pointSize: 14 * screenTools.dpiFactor;
+            font.pointSize: screenTools.dpiAdjustedPointSize(14);
             text: "Warning: You have an advanced safety configuration set using the NAV_RCL_OBC parameter. The above settings may not apply.";
-            visible: fact.value != 0
+            visible: fact.value !== 0
             wrapMode: Text.Wrap
         }
         QGCLabel {
             property Fact fact: Fact { name: "NAV_DLL_OBC" }
             width: parent.width
-            font.pointSize: 14 * screenTools.dpiFactor;
+            font.pointSize: screenTools.dpiAdjustedPointSize(14);
             text: "Warning: You have an advanced safety configuration set using the NAV_DLL_OBC parameter. The above settings may not apply.";
-            visible: fact.value != 0
+            visible: fact.value !== 0
             wrapMode: Text.Wrap
         }
     }

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -87,7 +87,7 @@ Rectangle {
 
         QGCLabel {
             text: "SENSORS CONFIG"
-            font.pointSize: 20 * screenTools.dpiFactor;
+            font.pointSize: screenTools.dpiAdjustedPointSize(20);
         }
 
         Item { height: 20; width: 10 } // spacer

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -1,3 +1,26 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
@@ -6,9 +29,11 @@ import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0
 import QGroundControl.Palette 1.0
 import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     property QGCPalette qgcPal: QGCPalette { colorGroupEnabled: true }
+    property ScreenTools screenTools: ScreenTools { }
 
     readonly property int rotationColumnWidth: 200
     readonly property var rotations: [
@@ -62,7 +87,7 @@ Rectangle {
 
         QGCLabel {
             text: "SENSORS CONFIG"
-            font.pointSize: 20
+            font.pointSize: 20 * screenTools.dpiFactor;
         }
 
         Item { height: 20; width: 10 } // spacer

--- a/src/FactSystem/FactSystemTest.qml
+++ b/src/FactSystem/FactSystemTest.qml
@@ -33,7 +33,7 @@ Item {
         Fact { id: fact; name: "RC_MAP_THROTTLE" }
         text: fact.value
         font.family: "Helvetica"
-        font.pointSize: 24 * screenTools.dpiFactor;
+        font.pointSize: screenTools.dpiAdjustedPointSize(24);
         color: "red"
         focus: true
         onAccepted: { fact.value = text; }

--- a/src/FactSystem/FactSystemTest.qml
+++ b/src/FactSystem/FactSystemTest.qml
@@ -24,16 +24,14 @@
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QGroundControl.FactSystem 1.0
-import QGroundControl.ScreenTools 1.0
 
 Item {
-    property ScreenTools screenTools: ScreenTools { }
     TextInput {
         objectName: "testControl"
         Fact { id: fact; name: "RC_MAP_THROTTLE" }
         text: fact.value
         font.family: "Helvetica"
-        font.pointSize: screenTools.dpiAdjustedPointSize(24);
+        font.pointSize: 24;
         color: "red"
         focus: true
         onAccepted: { fact.value = text; }

--- a/src/FactSystem/FactSystemTest.qml
+++ b/src/FactSystem/FactSystemTest.qml
@@ -1,14 +1,39 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QGroundControl.FactSystem 1.0
+import QGroundControl.ScreenTools 1.0
 
 Item {
+    property ScreenTools screenTools: ScreenTools { }
     TextInput {
         objectName: "testControl"
         Fact { id: fact; name: "RC_MAP_THROTTLE" }
         text: fact.value
         font.family: "Helvetica"
-        font.pointSize: 24
+        font.pointSize: 24 * screenTools.dpiFactor;
         color: "red"
         focus: true
         onAccepted: { fact.value = text; }

--- a/src/QmlControls/ScreenTools.cc
+++ b/src/QmlControls/ScreenTools.cc
@@ -32,7 +32,7 @@ ScreenTools::ScreenTools()
     , _dpiFactor( 72.0 / 96.0)
 {
     // Get screen DPI to manage font sizes on different platforms
-    QScreen *srn = QGuiApplication::screens().at(0); // TODO: Find current monitor as opposed to picking first one
+    QScreen *srn = QGuiApplication::primaryScreen();
     if(srn && srn->logicalDotsPerInch() > 50.0) {
         _dotsPerInch = (double)srn->logicalDotsPerInch(); // Font point sizes are based on Mac 72dpi
         _dpiFactor = 72.0 / _dotsPerInch;

--- a/src/QmlControls/ScreenTools.cc
+++ b/src/QmlControls/ScreenTools.cc
@@ -42,6 +42,11 @@ ScreenTools::ScreenTools()
     connect(MainWindow::instance(), &MainWindow::repaintCanvas, this, &ScreenTools::_updateCanvas);
 }
 
+qreal ScreenTools::dpiAdjustedPointSize(qreal pointSize)
+{
+    return pointSize * _dpiFactor;
+}
+
 void ScreenTools::_updateCanvas()
 {
     emit repaintRequestedChanged();

--- a/src/QmlControls/ScreenTools.h
+++ b/src/QmlControls/ScreenTools.h
@@ -85,7 +85,7 @@ public:
       There is a bug as of Qt 5.4 where a Canvas element defined within a QQuickWidget does not receive
       repaint events. QGC's main window will emit these signals when a \c Canvas element needs to be
       repainted.
-      If you use a \c Canvas element inside some QML widget, you can use this cod to handle repaint:
+      If you use a \c Canvas element inside some QML widget, you can use this code to handle repaint:
       @code
       import QGroundControl.ScreenTools 1.0
       ...

--- a/src/QmlControls/ScreenTools.h
+++ b/src/QmlControls/ScreenTools.h
@@ -30,6 +30,19 @@
 #include <QObject>
 #include <QCursor>
 
+/*!
+    @brief Screen helper tools for QML widgets
+    To use its functions, you need to import the module with the following line:
+    @code
+    import QGroundControl.ScreenTools 1.0
+    @endcode
+    @remark As for the screen density functions, QtQuick provides the \c Screen type (defined in QtQuick.Window)
+    but as of Qt 5.4 (QtQuick.Window 2.2), this only works if the main window is QtQuick. As QGC is primarily
+    a Qt application and only some of its UI elements are QLM widgets, this does not work. Hence, these function
+    defined here.
+    @sa <a href="http://doc.qt.io/qt-5/qml-qtquick-window-screen.html">Screen QML Type</a>
+*/
+
 /// This Qml control is used to return screen parameters
 class ScreenTools : public QObject
 {
@@ -37,10 +50,64 @@ class ScreenTools : public QObject
 public:
     ScreenTools();
 
+    //! Returns the screen density in Dots Per Inch
     Q_PROPERTY(double   screenDPI           READ screenDPI CONSTANT)
+    //! Returns a factor used to calculate the font point size to use
+    /*!
+      When defining fonts in point size, as in:
+      @code
+      Text {
+        text: "Foo Bar"
+        font.pointSize: 14
+      }
+      @endcode
+      The size is device dependent. If you define this based on a screen set to 72dpi (Mac OS), once
+      this is displayed on a different screen with a different pixel density, such as 96dpi (Windows),
+      the text will be displayed in the wrong size.
+      Use \c dpiFactor to accomodate for these differences. All font point sizes are given in 72dpi
+      and \c dpiFactor returns a factor to use for adjusting it to the current target screen.
+      @code
+      import QGroundControl.ScreenTools 1.0
+      property ScreenTools screenTools: ScreenTools { }
+      Text {
+        text: "Foo Bar"
+        font.pointSize: 14 * screenTools.dpiFactor
+      }
+      @endcode
+     */
     Q_PROPERTY(double   dpiFactor           READ dpiFactor CONSTANT)
+    //! Returns the global mouse X position
     Q_PROPERTY(int      mouseX              READ mouseX)
+    //! Returns the global mouse Y position
     Q_PROPERTY(int      mouseY              READ mouseY)
+    //! Used to trigger a \c Canvas element repaint.
+    /*!
+      There is a bug as of Qt 5.4 where a Canvas element defined within a QQuickWidget does not receive
+      repaint events. QGC's main window will emit these signals when a \c Canvas element needs to be
+      repainted.
+      If you use a \c Canvas element inside some QML widget, you can use this cod to handle repaint:
+      @code
+      import QGroundControl.ScreenTools 1.0
+      ...
+      property ScreenTools screenTools: ScreenTools { }
+      ...
+        Canvas {
+            id: myCanvas
+            height: 40
+            width:  40
+            Connections {
+                target: screenTools
+                onRepaintRequestedChanged: {
+                    myCanvas.requestPaint();
+                }
+            }
+            onPaint: {
+                var context = getContext("2d");
+                ...
+            }
+        }
+      @endcode
+     */
     Q_PROPERTY(bool     repaintRequested    READ repaintRequested   NOTIFY repaintRequestedChanged)
 
     double  screenDPI           () { return _dotsPerInch; }

--- a/src/QmlControls/ScreenTools.h
+++ b/src/QmlControls/ScreenTools.h
@@ -110,6 +110,12 @@ public:
      */
     Q_PROPERTY(bool     repaintRequested    READ repaintRequested   NOTIFY repaintRequestedChanged)
 
+    //! Utility for adjusting font point size.
+    /*!
+      @sa dpiFactor
+     */
+    Q_INVOKABLE qreal   dpiAdjustedPointSize(qreal pointSize);
+
     double  screenDPI           () { return _dotsPerInch; }
     double  dpiFactor           () { return _dpiFactor; }
     int     mouseX              () { return QCursor::pos().x(); }

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -68,7 +68,7 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         25 * screenTools.dpiFactor;
+            font.pointSize:         screenTools.dpiAdjustedPointSize(25);
             font.bold:              true
             color:                  "black"
 
@@ -79,7 +79,7 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         25 * screenTools.dpiFactor;
+            font.pointSize:         screenTools.dpiAdjustedPointSize(25);
             color:                  calInProgress ? "yellow" : "white"
 
             text: parent.calText

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -1,11 +1,36 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 
 import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    property ScreenTools screenTools: ScreenTools { }
 
     // Indicates whether calibration is valid for this control
     property bool calValid: false
@@ -43,7 +68,7 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         25
+            font.pointSize:         25 * screenTools.dpiFactor;
             font.bold:              true
             color:                  "black"
 
@@ -54,7 +79,7 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         25
+            font.pointSize:         25 * screenTools.dpiFactor;
             color:                  calInProgress ? "yellow" : "white"
 
             text: parent.calText

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -1,3 +1,26 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
 import QtQuick 2.3
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
@@ -6,12 +29,14 @@ import QGroundControl.Controls 1.0
 import QGroundControl.FactControls 1.0
 import QGroundControl.Palette 1.0
 import QGroundControl.FirmwareUpgradeController 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     width: 600
     height: 600
 
     property var qgcPal: QGCPalette { colorGroupEnabled: true }
+    property ScreenTools screenTools: ScreenTools { }
     property FirmwareUpgradeController controller: FirmwareUpgradeController {
         upgradeButton: upgradeButton
         progressBar: progressBar
@@ -26,7 +51,7 @@ Rectangle {
 
         QGCLabel {
             text: "FIRMWARE UPDATE"
-            font.pointSize: 20
+            font.pointSize: 20 * screenTools.dpiFactor;
         }
 
         Item {

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -51,7 +51,7 @@ Rectangle {
 
         QGCLabel {
             text: "FIRMWARE UPDATE"
-            font.pointSize: 20 * screenTools.dpiFactor;
+            font.pointSize: screenTools.dpiAdjustedPointSize(20);
         }
 
         Item {

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -47,7 +47,7 @@ Rectangle {
 
         QGCLabel {
             text: "VEHICLE SUMMARY"
-            font.pointSize: 20 * screenTools.dpiFactor;
+            font.pointSize: screenTools.dpiAdjustedPointSize(20);
         }
 
         Item {

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -1,3 +1,26 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
@@ -5,12 +28,14 @@ import QtQuick.Controls.Styles 1.2
 import QGroundControl.FactSystem 1.0
 import QGroundControl.Palette 1.0
 import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     width: 600
     height: 400
 
     property var qgcPal: QGCPalette { id: palette; colorGroupEnabled: true }
+    property ScreenTools screenTools: ScreenTools { }
 
     id: topLevel
     objectName: "topLevel"
@@ -22,7 +47,7 @@ Rectangle {
 
         QGCLabel {
             text: "VEHICLE SUMMARY"
-            font.pointSize: 20
+            font.pointSize: 20 * screenTools.dpiFactor;
         }
 
         Item {

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -241,7 +241,7 @@ Rectangle {
                     Text {
                         id: messageText
                         text: (mainToolBar.messageCount > 0) ? mainToolBar.messageCount : ''
-                        font.pointSize: 14 * screenTools.dpiFactor
+                        font.pointSize: screenTools.dpiAdjustedPointSize(14);
                         font.weight: Font.DemiBold
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -329,7 +329,7 @@ Rectangle {
                 Text {
                     id: satelitteText
                     text: (mainToolBar.satelliteCount > 0) ? mainToolBar.satelliteCount : ''
-                    font.pointSize: 14 * screenTools.dpiFactor
+                    font.pointSize: screenTools.dpiAdjustedPointSize(14);
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
@@ -364,7 +364,7 @@ Rectangle {
                 Text {
                     id: batteryText
                     text: mainToolBar.batteryVoltage.toFixed(1) + ' V';
-                    font.pointSize: 14 * screenTools.dpiFactor
+                    font.pointSize: screenTools.dpiAdjustedPointSize(14);
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
@@ -392,7 +392,7 @@ Rectangle {
                     Text {
                         id: armedStatusText
                         text: (mainToolBar.systemArmed) ? qsTr("ARMED") :  qsTr("DISARMED")
-                        font.pointSize: 12 * screenTools.dpiFactor
+                        font.pointSize: screenTools.dpiAdjustedPointSize(12);
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
                         color: (mainToolBar.systemArmed) ? colorOrangeText : colorGreenText
@@ -411,7 +411,7 @@ Rectangle {
                     Text {
                         id: stateStatusText
                         text: mainToolBar.currentState
-                        font.pointSize: 12 * screenTools.dpiFactor
+                        font.pointSize: screenTools.dpiAdjustedPointSize(12);
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
                         color: (mainToolBar.currentState === "STANDBY") ? colorGreenText : colorRedText
@@ -432,7 +432,7 @@ Rectangle {
                 Text {
                     id: modeStatusText
                     text: mainToolBar.currentMode
-                    font.pointSize: 12 * screenTools.dpiFactor
+                    font.pointSize: screenTools.dpiAdjustedPointSize(12);
                     font.weight: Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
@@ -453,7 +453,7 @@ Rectangle {
                 Text {
                     id: connectionStatusText
                     text: qsTr("CONNECTION LOST")
-                    font.pointSize: 14 * screenTools.dpiFactor
+                    font.pointSize: screenTools.dpiAdjustedPointSize(14);
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
When defining fonts in point size, you need to take into account the display pixel density. Otherwise you end up with varying font sizes depending on the platform used (i.e. 72dpi for Mac OS, 96dpi for Windows, etc.) When I created the new tool bar (as a QML widget), I added code to handle this. I've now replicated it in all QML widgets.

While at it I've added missing licensing headers to the files I touched and documented *ScreenTools*.
