### PR TITLE
Crosstrack error

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1342,6 +1342,7 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
             setDistToWaypoint(p.wp_dist);
             setBearingToWaypoint(p.nav_bearing);
             emit navigationControllerErrorsChanged(this, p.alt_error, p.aspd_error, p.xtrack_error);
+            emit NavigationControllerDataChanged(this, p.nav_roll, p.nav_pitch, p.nav_bearing, p.target_bearing, p.wp_dist);
         }
             break;
         // Messages to ignore

--- a/src/uas/UASInterface.h
+++ b/src/uas/UASInterface.h
@@ -544,6 +544,7 @@ signals:
     void velocityChanged_NED(UASInterface*, double vx, double vy, double vz, quint64 usec);
 
     void navigationControllerErrorsChanged(UASInterface*, double altitudeError, double speedError, double xtrackError);
+    void NavigationControllerDataChanged(UASInterface *uas, float navRoll, float navPitch, float navBearing, float targetBearing, float targetDist);
 
     void imageStarted(int imgid, int width, int height, int depth, int channels);
     void imageDataReceived(int imgid, const unsigned char* imageData, int length, int startIndex);

--- a/src/ui/HSIDisplay.h
+++ b/src/ui/HSIDisplay.h
@@ -62,6 +62,7 @@ public slots:
     void updateLocalPosition(UASInterface*, double x, double y, double z, quint64 usec);
     void updateGlobalPosition(UASInterface*, double lat, double lon, double altAMSL, double altWGS84, quint64 usec);
     void updateSpeed(UASInterface* uas, double vx, double vy, double vz, quint64 time);
+    void UpdateNavErrors(UASInterface *uas, double altitudeError, double airspeedError, double crosstrackError);
     void updatePositionLock(UASInterface* uas, bool lock);
     void updateAttitudeControllerEnabled(bool enabled);
     void updatePositionXYControllerEnabled(bool enabled);
@@ -340,6 +341,9 @@ protected:
     float uiZSetCoordinate;    ///< Z Setpoint coordinate wanted by the UI
     float uiYawSet;            ///< Yaw Setpoint wanted by the UI
     double metricWidth;        ///< Width the instrument represents in meters (the width of the ground shown by the widget)
+
+    // Navigation parameters
+    double crosstrackError;   ///< The crosstrack error (m) reported by the UAS
 
     //
     float xCenterPos;         ///< X center of instrument in virtual coordinates

--- a/src/ui/PrimaryFlightDisplay.h
+++ b/src/ui/PrimaryFlightDisplay.h
@@ -21,6 +21,7 @@ public slots:
     void updateSpeed(UASInterface* uas, double _groundSpeed, double _airSpeed, quint64 timestamp);
     void updateAltitude(UASInterface* uas, double _altitudeAMSL, double _altitudeWGS84, double _altitudeRelative, double _climbRate, quint64 timestamp);
     void updateNavigationControllerErrors(UASInterface* uas, double altitudeError, double speedError, double xtrackError);
+    void UpdateNavigationControllerData(UASInterface *uas, float navRoll, float navPitch, float navBearing, float targetBearing, float targetDistance);
 
     /** @brief Set the currently monitored UAS */
     void forgetUAS(UASInterface* uas);


### PR DESCRIPTION
Fix some dead code in both the HSI widget and the PFD widget. I think everything's working here, though the CDI is not like the pictures I've seen on the internet. Hopefully someone else has the `NAV_CONTROLLER_DATA` message being broadcast with correct data and can test this out and confirm it's correct.

The `NAV_CONTROLLER_DATA` message is lacking a few descriptions, so I'm just guessing that the `target_bearing` field is the subtraction of the bearing that the current mission segments has from the current bearing (course over ground).

And should the CDI have an arrow? It's not obvious what it's saying when you're angled 90deg to the current mission track.