### PR TITLE
Output audio for NOTICE severity STATUSTEXT messages.

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1253,11 +1253,11 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
             QString text = QString(b);
             int severity = mavlink_msg_statustext_get_severity(&message);
 
-            // Now if the status message starts with "#audio:", or it's at least a
-            // severity level of NOTICE or higher, output it as an audio message.
-            if (text.startsWith("#audio:") || severity <= MAV_SEVERITY_NOTICE)
+	    // If the message is NOTIFY or higher severity, or starts with a '#',
+	    // then read it aloud.
+            if (text.startsWith("#") || severity <= MAV_SEVERITY_NOTICE)
             {
-                text.remove("#audio:");
+                text.remove("#");
                 emit textMessageReceived(uasId, message.compid, severity, text);
                 GAudioOutput::instance()->say(text.toLower(), severity);
             }

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1247,12 +1247,15 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
             QByteArray b;
             b.resize(MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1);
             mavlink_msg_statustext_get_text(&message, b.data());
+ 
             // Ensure NUL-termination
             b[b.length()-1] = '\0';
             QString text = QString(b);
             int severity = mavlink_msg_statustext_get_severity(&message);
 
-            if (text.startsWith("#") || severity <= MAV_SEVERITY_WARNING)
+            // Now if the status message starts with "#audio:", or it's at least a
+            // severity level of NOTICE or higher, output it as an audio message.
+            if (text.startsWith("#audio:") || severity <= MAV_SEVERITY_NOTICE)
             {
                 text.remove("#audio:");
                 emit textMessageReceived(uasId, message.compid, severity, text);


### PR DESCRIPTION
NOTICE messages are "unusual" events that shouldn't be seen during normal operations. In this context I would like to have them output as audio automatically.

Also fixed a bug where setting "#" at the start of the string triggers the audio reading of a message, but what was removed was always exactly "#audio:", which could result in odd behavior. I'd actually propose just using the '#' for indicating that it should be read over audio, but no need to follow through on that here.