### PR TITLE
Serial port fix

### DIFF
--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -12,7 +12,7 @@
 
 // If you need to make an incompatible changes to stored settings, bump this version number
 // up by 1. This will caused store settings to be cleared on next boot.
-#define QGC_SETTINGS_VERSION 3
+#define QGC_SETTINGS_VERSION 4
 
 #define QGC_APPLICATION_NAME "QGroundControl"
 #define QGC_ORG_NAME "QGroundControl.org"

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -465,7 +465,7 @@ void LinkManager::_updateConfigurationList(void)
 #endif
         // Is this a PX4?
         if (portInfo.vendorIdentifier() == 9900) {
-            SerialConfiguration* pSerial = _findSerialConfiguration(portInfo.portName());
+            SerialConfiguration* pSerial = _findSerialConfiguration(portInfo.systemLocation());
             if (pSerial) {
                 //-- If this port is configured make sure it has the preferred flag set
                 if(!pSerial->isPreferred()) {
@@ -477,7 +477,7 @@ void LinkManager::_updateConfigurationList(void)
                 pSerial = new SerialConfiguration(QString("Pixhawk on %1").arg(portInfo.portName().trimmed()));
                 pSerial->setPreferred(true);
                 pSerial->setBaud(115200);
-                pSerial->setPortName(portInfo.portName());
+                pSerial->setPortName(portInfo.systemLocation());
                 addLinkConfiguration(pSerial);
                 saveList = true;
             }

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -588,7 +588,7 @@ QList<QString> SerialConfiguration::getCurrentPorts()
     QList<QSerialPortInfo> portList =  QSerialPortInfo::availablePorts();
     foreach (const QSerialPortInfo &info, portList)
     {
-        ports.append(info.portName());
+        ports.append(info.systemLocation());
     }
     return ports;
 }

--- a/src/ui/QGCLinkConfiguration.cc
+++ b/src/ui/QGCLinkConfiguration.cc
@@ -137,10 +137,16 @@ void QGCLinkConfiguration::_fixUnnamed(LinkConfiguration* config)
     //-- Check for "Unnamed"
     if (config->name() == tr("Unnamed")) {
         switch(config->type()) {
-            case LinkConfiguration::TypeSerial:
-                config->setName(
-                    QString("Serial Device on %1").arg(dynamic_cast<SerialConfiguration*>(config)->portName()));
+            case LinkConfiguration::TypeSerial: {
+                QString tname = dynamic_cast<SerialConfiguration*>(config)->portName();
+#ifdef Q_OS_WIN32
+                tname.replace("\\\\.\\", "");
+#else
+                tname.replace("/dev/", "");
+#endif
+                config->setName(QString("Serial Device on %1").arg(tname));
                 break;
+                }
             case LinkConfiguration::TypeUdp:
                 config->setName(
                     QString("UDP Link on Port %1").arg(dynamic_cast<UDPConfiguration*>(config)->localPort()));


### PR DESCRIPTION
For whatever reason, QSerialPort stopped working when you provide the “short” name for the port you want to open. As far as I can tell, this is how it’s always beed done (the short version, I mean). All my 3 platforms, Mac OS, Linux and Windows stopped working. I switched to use the full port name and that fixed the problem.

I do not know the reason for it all to stop working and it is specially weird given that I have not heard of anybody else having issues.

The error I was getting when attempting to open the port was *Not Found*. Opening the port from the command line worked just fine so I knew it had to be QGC (QSerialPort).

When debugging, I switched from *usbserial-AH02QFUO* to */dev/cu.usbserial-AH02QFUO* and it then found the port just fine. From there I switched the port name initialization for using the full name (*SerialConfiguration.systemLocation*) instead of the short version (*SerialConfiguration.portName*).

Because of the port name change, I had to bump the settings version number so it wouldn’t load the old port names.
