### PR TITLE
qtlogging.ini automatically created at startup, populated with full list of category names

### DIFF
--- a/files/QLoggingCategory/qtlogging.ini
+++ b/files/QLoggingCategory/qtlogging.ini
@@ -1,2 +1,0 @@
-[Rules]
-*Log=false

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -497,7 +497,8 @@ HEADERS += \
     src/ui/QGCUDPLinkConfiguration.h \
     src/uas/UASMessageHandler.h \
     src/ui/toolbar/MainToolBar.h \
-    src/QmlControls/ScreenTools.h
+    src/QmlControls/ScreenTools.h \
+    src/QGCLoggingCategory.h
 
 SOURCES += \
     src/main.cc \
@@ -639,7 +640,8 @@ SOURCES += \
     src/ui/QGCUDPLinkConfiguration.cc \
     src/uas/UASMessageHandler.cc \
     src/ui/toolbar/MainToolBar.cc \
-    src/QmlControls/ScreenTools.cc
+    src/QmlControls/ScreenTools.cc \
+    src/QGCLoggingCategory.cc
 
 #
 # Unit Test specific configuration goes here

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -241,9 +241,6 @@
         <file alias="MockLink.param">src/qgcunittest/MockLink.param</file>
         <file alias="FactSystemTest.qml">src/FactSystem/FactSystemTest.qml</file>
     </qresource>
-    <qresource prefix="/QLoggingCategory">
-        <file alias="qtlogging.ini">files/QLoggingCategory/qtlogging.ini</file>
-    </qresource>
     <qresource prefix="/qml">
         <file alias="test.qml">src/test.qml</file>
         <file alias="QmlTest.qml">src/QmlControls/QmlTest.qml</file>

--- a/src/AutoPilotPlugins/PX4/PX4ParameterFacts.cc
+++ b/src/AutoPilotPlugins/PX4/PX4ParameterFacts.cc
@@ -26,11 +26,12 @@
 
 #include "PX4ParameterFacts.h"
 #include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
 
 #include <QFile>
 #include <QDebug>
 
-Q_LOGGING_CATEGORY(PX4ParameterFactsMetaDataLog, "PX4ParameterFactsMetaDataLog")
+QGC_LOGGING_CATEGORY(PX4ParameterFactsMetaDataLog, "PX4ParameterFactsMetaDataLog")
 
 bool PX4ParameterFacts::_parameterMetaDataLoaded = false;
 QMap<QString, FactMetaData*> PX4ParameterFacts::_mapParameterName2FactMetaData;

--- a/src/FactSystem/FactLoader.cc
+++ b/src/FactSystem/FactLoader.cc
@@ -26,11 +26,12 @@
 
 #include "FactLoader.h"
 #include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
 
 #include <QFile>
 #include <QDebug>
 
-Q_LOGGING_CATEGORY(FactLoaderLog, "FactLoaderLog")
+QGC_LOGGING_CATEGORY(FactLoaderLog, "FactLoaderLog")
 
 FactLoader::FactLoader(UASInterface* uas, QObject* parent) :
     QObject(parent),

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -60,6 +60,7 @@
 #include "QGCFileDialog.h"
 #include "QGCPalette.h"
 #include "ScreenTools.h"
+#include "QGCLoggingCategory.h"
 
 #ifdef QGC_RTLAB_ENABLED
 #include "OpalLink.h"
@@ -128,8 +129,16 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting) :
     if (loggingDirectoryOk) {
         qDebug () << iniFileLocation;
         if (!iniFileLocation.exists(qtLoggingFile)) {
-            if (!QFile::copy(":QLoggingCategory/qtlogging.ini", iniFileLocation.filePath(qtLoggingFile))) {
-                qDebug() << "Unable to copy" << QString(qtLoggingFile) << "to" << iniFileLocation;
+            QFile loggingFile(iniFileLocation.filePath(qtLoggingFile));
+            if (loggingFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+                QTextStream out(&loggingFile);
+                out << "[Rules]\n";
+                out << "*Log=false\n";
+                foreach(QString category, QGCLoggingCategoryRegister::instance()->registeredCategories()) {
+                    out << category << "=false\n";
+                }
+            } else {
+                qDebug() << "Unable to create logging file" << QString(qtLoggingFile) << "in" << iniFileLocation;
             }
         }
     }

--- a/src/QGCLoggingCategory.cc
+++ b/src/QGCLoggingCategory.cc
@@ -1,0 +1,42 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#include "QGCLoggingCategory.h"
+
+// Add Global logging categories (not class specific) here using QGC_LOGGING_CATEGORY
+    // There currently are no global categories
+
+QGCLoggingCategoryRegister* _instance = NULL;
+
+QGCLoggingCategoryRegister* QGCLoggingCategoryRegister::instance(void)
+{
+    if (!_instance) {
+        _instance = new QGCLoggingCategoryRegister();
+        Q_CHECK_PTR(_instance);
+    }
+    
+    return _instance;
+}

--- a/src/QGCLoggingCategory.h
+++ b/src/QGCLoggingCategory.h
@@ -1,0 +1,63 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#ifndef QGC_LOGGING_CATEGORY_H
+#define QGC_LOGGING_CATEGORY_H
+
+#include <QLoggingCategory>
+#include <QStringList>
+
+// Add Global logging categories (not class specific) here using Q_DECLARE_LOGGING_CATEGORY
+    // There currently are no global categories
+
+/// @def QGC_LOGGING_CATEGORY
+/// This is a QGC specific replacement for Q_LOGGING_CATEGORY. It will register the category name into a
+/// global list. It's usage is the same as Q_LOGGING_CATEOGRY.
+#define QGC_LOGGING_CATEGORY(name, ...) \
+    static QGCLoggingCategory qgcCategory(__VA_ARGS__); \
+    Q_LOGGING_CATEGORY(name, __VA_ARGS__)
+
+class QGCLoggingCategoryRegister
+{
+public:
+    static QGCLoggingCategoryRegister* instance(void);
+    
+    void registerCategory(const char* category) { _registeredCategories << category; }
+    const QStringList& registeredCategories(void) { return _registeredCategories; }
+    
+private:
+    QGCLoggingCategoryRegister(void) { }
+    
+    QStringList _registeredCategories;
+};
+        
+class QGCLoggingCategory
+{
+public:
+    QGCLoggingCategory(const char* category) { QGCLoggingCategoryRegister::instance()->registerCategory(category); }
+};
+
+#endif

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -29,10 +29,11 @@
 #include "QGCMAVLinkUASFactory.h"
 #include "QGC.h"
 #include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
 
 Q_DECLARE_METATYPE(mavlink_message_t)
 IMPLEMENT_QGC_SINGLETON(MAVLinkProtocol, MAVLinkProtocol)
-Q_LOGGING_CATEGORY(MAVLinkProtocolLog, "MAVLinkProtocolLog")
+QGC_LOGGING_CATEGORY(MAVLinkProtocolLog, "MAVLinkProtocolLog")
 
 const char* MAVLinkProtocol::_tempLogFileTemplate = "FlightDataXXXXXX"; ///< Template for temporary log file
 const char* MAVLinkProtocol::_logFileExtension = "mavlink";             ///< Extension for log files

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -18,8 +18,9 @@
 #include "SerialLink.h"
 #include "QGC.h"
 #include "MG.h"
+#include "QGCLoggingCategory.h"
 
-Q_LOGGING_CATEGORY(SerialLinkLog, "SerialLinkLog")
+QGC_LOGGING_CATEGORY(SerialLinkLog, "SerialLinkLog")
 
 SerialLink::SerialLink(SerialConfiguration* config)
 {

--- a/src/qgcunittest/MockLink.cc
+++ b/src/qgcunittest/MockLink.cc
@@ -22,6 +22,7 @@
  ======================================================================*/
 
 #include "MockLink.h"
+#include "QGCLoggingCategory.h"
 
 #include <QTimer>
 #include <QDebug>
@@ -29,7 +30,7 @@
 
 #include <string.h>
 
-Q_LOGGING_CATEGORY(MockLinkLog, "MockLinkLog")
+QGC_LOGGING_CATEGORY(MockLinkLog, "MockLinkLog")
 
 /// @file
 ///     @brief Mock implementation of a Link.

--- a/src/qgcunittest/MockQGCUASParamManager.cc
+++ b/src/qgcunittest/MockQGCUASParamManager.cc
@@ -23,11 +23,12 @@
 
 #include "MockQGCUASParamManager.h"
 #include "mavlink.h"
+#include "QGCLoggingCategory.h"
 
 #include <QTest>
 #include <QDebug>
 
-Q_LOGGING_CATEGORY(MockQGCUASParamManagerLog, "MockQGCUASParamManagerLog")
+QGC_LOGGING_CATEGORY(MockQGCUASParamManagerLog, "MockQGCUASParamManagerLog")
 
 MockQGCUASParamManager::MockQGCUASParamManager(void)
 {

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -31,8 +31,9 @@
 #include <Eigen/Geometry>
 #include "AutoPilotPluginManager.h"
 #include "QGCMessageBox.h"
+#include "QGCLoggingCategory.h"
 
-Q_LOGGING_CATEGORY(UASLog, "UASLog")
+QGC_LOGGING_CATEGORY(UASLog, "UASLog")
 
 #define UAS_DEFAULT_BATTERY_WARNLEVEL 20
 

--- a/src/uas/UASParameterCommsMgr.cc
+++ b/src/uas/UASParameterCommsMgr.cc
@@ -7,10 +7,11 @@
 #include "UASInterface.h"
 #include "MAVLinkProtocol.h"
 #include "MainWindow.h"
+#include "QGCLoggingCategory.h"
 
 #define RC_CAL_CHAN_MAX 8
 
-Q_LOGGING_CATEGORY(UASParameterCommsMgrLog, "UASParameterCommsMgrLog")
+QGC_LOGGING_CATEGORY(UASParameterCommsMgrLog, "UASParameterCommsMgrLog")
 
 UASParameterCommsMgr::UASParameterCommsMgr(QObject *parent) :
     QObject(parent),


### PR DESCRIPTION
Logging categories are now supported per Issues #1112.

QGC_LOGGING_CATEGORY macro should now be used instead of Q_LOGGING_CATEGORY. This is required to register all category names to the system.