### PR TITLE
Show user friendly port name in Serial Settings combo box.

### DIFF
--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -62,7 +62,7 @@ SerialLink::~SerialLink()
 
 bool SerialLink::_isBootloader()
 {
-    QList<QSerialPortInfo> portList =  QSerialPortInfo::availablePorts();
+    QList<QSerialPortInfo> portList = QSerialPortInfo::availablePorts();
     if( portList.count() == 0){
         return false;
     }
@@ -580,15 +580,4 @@ void SerialConfiguration::loadSettings(QSettings& settings, const QString& root)
     if(settings.contains("parity"))      _parity       = settings.value("parity").toInt();
     if(settings.contains("portName"))    _portName     = settings.value("portName").toString();
     settings.endGroup();
-}
-
-QList<QString> SerialConfiguration::getCurrentPorts()
-{
-    QList<QString> ports;
-    QList<QSerialPortInfo> portList =  QSerialPortInfo::availablePorts();
-    foreach (const QSerialPortInfo &info, portList)
-    {
-        ports.append(info.systemLocation());
-    }
-    return ports;
 }

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -81,9 +81,6 @@ public:
     void saveSettings(QSettings& settings, const QString& root);
     void updateSettings();
 
-    /*! @brief Get a list of the currently available ports */
-    static QList<QString> getCurrentPorts();
-
 private:
     int _baud;
     int _dataBits;

--- a/src/ui/QGCLinkConfiguration.cc
+++ b/src/ui/QGCLinkConfiguration.cc
@@ -142,6 +142,7 @@ void QGCLinkConfiguration::_fixUnnamed(LinkConfiguration* config)
 #ifdef Q_OS_WIN32
                 tname.replace("\\\\.\\", "");
 #else
+                tname.replace("/dev/cu.", "");
                 tname.replace("/dev/", "");
 #endif
                 config->setName(QString("Serial Device on %1").arg(tname));

--- a/src/ui/SerialConfigurationWindow.h
+++ b/src/ui/SerialConfigurationWindow.h
@@ -53,7 +53,7 @@ public slots:
     void setParityNone(bool accept);
     void setParityOdd(bool accept);
     void setParityEven(bool accept);
-    void setPortName(QString port);
+    void setPortName(int index);
     void setBaudRate(int index);
     void setDataBits(int bits);
     void setStopBits(int bits);
@@ -72,8 +72,6 @@ protected:
     bool userConfigured; ///< Switch to detect if current values are user-selected and shouldn't be overriden
 
 private:
-
-    bool                  _userConfigured;
     Ui::serialSettings    _ui;
     SerialConfiguration*  _config;
     QTimer*               _portCheckTimer;

--- a/src/ui/SerialSettings.ui
+++ b/src/ui/SerialSettings.ui
@@ -32,16 +32,19 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>The serial port to which the system is connected. All ports listed here should work.</string>
+        <string>The serial port to which the system is connected.</string>
        </property>
        <property name="statusTip">
-        <string>The serial port to which the system is connected. All ports listed here should work.</string>
+        <string>The serial port to which the system is connected.</string>
        </property>
        <property name="whatsThis">
-        <string>The serial port to which the system is connected. All ports listed here should work.</string>
+        <string>The serial port to which the system is connected.</string>
        </property>
        <property name="editable">
-        <bool>true</bool>
+        <bool>false</bool>
+       </property>
+       <property name="maxCount">
+        <number>100</number>
        </property>
        <property name="sizeAdjustPolicy">
         <enum>QComboBox::AdjustToContents</enum>


### PR DESCRIPTION
Change to the **Serial Link Settings** dialog to show the *user friendly* port name in the serial port drop down box. The actual port name stored in the configuration is the full port name.
While at it, I've cleaned up a bit the serial settings code, which still contained some of the original code.