### PR TITLE
Line chart widget: Auto-force ground time if offset is more than 3 seconds

### DIFF
--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -351,11 +351,15 @@ void LinechartWidget::appendData(int uasId, const QString& curve, const QString&
     {
         lastTimestamp = usec;
     } else if (usec != 0) {
-        // Difference larger than 5 secs, enforce ground time
-        if (((qint64)usec - (qint64)lastTimestamp) > 5000)
+        // Difference larger than 3 secs, enforce ground time
+        if (((qint64)usec - (qint64)lastTimestamp) > 3000)
         {
             autoGroundTimeSet = true;
-            if (activePlot) activePlot->groundTime();
+            // Tick ground time checkbox, but avoid state switching
+            timeButton->blockSignals(true);
+            timeButton->setChecked(true);
+            timeButton->blockSignals(false);
+            if (activePlot) activePlot->enforceGroundTime(true);
         }
     }
 


### PR DESCRIPTION
This change enforces ground time if the system is not synced well to the GCS clock. I think this greatly improves usability. If we replace the checkboxes visuals to make them easier to find people should have less issues with the live plot. It also ticks the ground time checkbox, but it does not leave it ticked on the next boot unless the user ticked it manually.

![schnappschuss 2015-03-16 10 12 15](https://cloud.githubusercontent.com/assets/1208119/6663264/2fa21aec-cbc5-11e4-8b5d-b357da2225ab.png)
