### PR TITLE
Advanced Power Config

### DIFF
--- a/src/AutoPilotPlugins/PX4/ParameterFactMetaData.xml
+++ b/src/AutoPilotPlugins/PX4/ParameterFactMetaData.xml
@@ -30,6 +30,7 @@
             <short_desc>Battery capacity</short_desc>
             <long_desc>Defines the capacity of the attached battery.</long_desc>
             <default>-1.0</default>
+            <unit>mA</unit>
         </parameter>
         <parameter name="BAT_V_SCALE_IO" type="INT32">
             <short_desc>Scaling factor for battery voltage sensor on PX4IO</short_desc>

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -273,7 +273,7 @@ Rectangle {
         }
         Rectangle {
             width: parent.width
-            height: 80
+            height: 40
             color: palette.windowShade
             visible: showAdvanced.checked
             Column {
@@ -288,16 +288,6 @@ Rectangle {
                         id: battDropField
                         width: textEditWidth
                         fact: Fact { name: "BAT_V_LOAD_DROP" }
-                        showUnits: true
-                    }
-                }
-                Row {
-                    spacing: 10
-                    QGCLabel { text: "Battery Capacity"; width: firstColumnWidth; anchors.baseline: battCapacityField.baseline}
-                    FactTextField {
-                        id: battCapacityField
-                        width: textEditWidth
-                        fact: Fact { name: "BAT_CAPACITY" }
                         showUnits: true
                     }
                 }

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -44,7 +44,7 @@ Rectangle {
     color:  palette.window
 
     property int firstColumnWidth: 220
-    property int textEditWidth:    60
+    property int textEditWidth:    80
     property ScreenTools screenTools: ScreenTools { }
 
     property Fact battNumCells: Fact { name: "BAT_N_CELLS" }
@@ -109,7 +109,7 @@ Rectangle {
 
         Rectangle {
             width: parent.width
-            height: 160
+            height: 120
             color: palette.windowShade
 
             Column {
@@ -152,17 +152,6 @@ Rectangle {
                                 id: battLowField
                                 width: textEditWidth
                                 fact: Fact { name: "BAT_V_EMPTY" }
-                                showUnits: true
-                            }
-                        }
-                        Row {
-                            spacing: 10
-                            visible: showAdvanced.checked
-                            QGCLabel { text: "Voltage Drop on Full Load (per cell)"; width: firstColumnWidth; anchors.baseline: battDropField.baseline}
-                            FactTextField {
-                                id: battDropField
-                                width: textEditWidth
-                                fact: Fact { name: "BAT_V_LOAD_DROP" }
                                 showUnits: true
                             }
                         }
@@ -275,6 +264,44 @@ Rectangle {
         QGCCheckBox {
             id: showAdvanced
             text: "Show Advanced Settings"
+        }
+        QGCLabel {
+            text: "Advanced Power Settings"
+            color: palette.text
+            font.pointSize: screenTools.dpiAdjustedPointSize(20);
+            visible: showAdvanced.checked
+        }
+        Rectangle {
+            width: parent.width
+            height: 80
+            color: palette.windowShade
+            visible: showAdvanced.checked
+            Column {
+                id: advBatteryColumn
+                spacing: 10
+                anchors.verticalCenter: parent.verticalCenter
+                x: (parent.x + 20)
+                Row {
+                    spacing: 10
+                    QGCLabel { text: "Voltage Drop on Full Load (per cell)"; width: firstColumnWidth; anchors.baseline: battDropField.baseline}
+                    FactTextField {
+                        id: battDropField
+                        width: textEditWidth
+                        fact: Fact { name: "BAT_V_LOAD_DROP" }
+                        showUnits: true
+                    }
+                }
+                Row {
+                    spacing: 10
+                    QGCLabel { text: "Battery Capacity"; width: firstColumnWidth; anchors.baseline: battCapacityField.baseline}
+                    FactTextField {
+                        id: battCapacityField
+                        width: textEditWidth
+                        fact: Fact { name: "BAT_CAPACITY" }
+                        showUnits: true
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Cleanup of Power Settings

Advanced power settings are now in their own area and no longer appear within the basic power settings area when enabled. While at it, I've added "Battery Capacity" to the advanced section.

![screen shot 2015-03-18 at 3 21 06 pm](https://cloud.githubusercontent.com/assets/749243/6717393/79c82166-cd82-11e4-8c02-0f93a6260863.png)
