### PR TITLE
Fixing list of items in Quick Info View

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -572,7 +572,9 @@ void MainWindow::_createInnerDockWidget(const QString& widgetName)
     } else if (widgetName == _hudDockWidgetName) {
         widget = new HUD(320,240,this);
     } else if (widgetName == _uasInfoViewDockWidgetName) {
-        widget = new QGCTabbedInfoView(this);
+        QGCTabbedInfoView* pInfoView = new QGCTabbedInfoView(this);
+        pInfoView->addSource(mavlinkDecoder);
+        widget = pInfoView;
     } else if (widgetName == _debugConsoleDockWidgetName) {
         widget = new DebugConsole(this);
     } else {


### PR DESCRIPTION
This fixes issue #1366.

Not sure when this changed as it seems it predates me but the Quick Info View was missing a call to let it know where to get data from.

Now you get the full gory, unwieldy list of options to choose from (meaning, we really need to rethink this dialog):

![screen shot 2015-03-19 at 3 10 55 pm](https://cloud.githubusercontent.com/assets/749243/6738806/c689b44c-ce4a-11e4-9d3d-254df6c94d76.png)


