### PR TITLE
Bump to 2.4 Developer Release

### DIFF
--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -19,7 +19,7 @@
 #define QGC_ORG_DOMAIN "org.qgroundcontrol"
 
 #define QGC_APPLICATION_VERSION_MAJOR 2
-#define QGC_APPLICATION_VERSION_MINOR 3
+#define QGC_APPLICATION_VERSION_MINOR 4
 
 // The following #definess can be overriden from the command line so that automated build systems can
 // add additional build identification.
@@ -32,7 +32,7 @@
 #endif
 
 #ifndef QGC_APPLICATION_VERSION_BUILDTYPE
-#define QGC_APPLICATION_VERSION_BUILDTYPE "(Stable)"
+#define QGC_APPLICATION_VERSION_BUILDTYPE "(Development)"
 #endif
 
 #endif // QGC_CONFIGURATION_H


### PR DESCRIPTION
Stable 2.3 is released. So switching master to 2.4 Development. Daily Builds are now back to dev builds.