### PR TITLE
Use QSharedPointer for cross-thread Link references

### DIFF
--- a/src/FactSystem/FactSystemTestBase.cc
+++ b/src/FactSystem/FactSystemTestBase.cc
@@ -48,7 +48,7 @@ void FactSystemTestBase::_init(MAV_AUTOPILOT autopilot)
     
     MockLink* link = new MockLink();
     link->setAutopilotType(autopilot);
-    _linkMgr->addLink(link);
+    _linkMgr->_addLink(link);
     _linkMgr->connectLink(link);
     
     // Wait for the uas to work it's way through the various threads

--- a/src/VehicleSetup/SetupViewButtons.qml
+++ b/src/VehicleSetup/SetupViewButtons.qml
@@ -35,7 +35,7 @@ Rectangle {
 
             QGCLabel {
                 width: parent.width
-                text: "You must be connected to your board to use all available setup options."
+                text: "Full setup options are only available when connected to vehicle and full parameter list has completed downloading."
                 wrapMode: Text.WordWrap
                 horizontalAlignment: Text.AlignHCenter
             }

--- a/src/VehicleSetup/SetupViewTest.cc
+++ b/src/VehicleSetup/SetupViewTest.cc
@@ -64,7 +64,7 @@ void SetupViewTest::_clickThrough_test(void)
     MockLink* link = new MockLink();
     Q_CHECK_PTR(link);
     link->setAutopilotType(MAV_AUTOPILOT_PX4);
-    LinkManager::instance()->addLink(link);
+    LinkManager::instance()->_addLink(link);
     linkMgr->connectLink(link);
     QTest::qWait(5000); // Give enough time for UI to settle and heartbeats to go through
     

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -212,6 +212,7 @@ void LinkManager::_deleteLink(LinkInterface* link)
             break;
         }
     }
+    Q_UNUSED(found);
     Q_ASSERT(found);
 
     _linkListMutex.unlock();

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -204,6 +204,7 @@ void MAVLinkProtocol::_linkStatusChanged(LinkInterface* link, bool connected)
                 break;
             }
         }
+        Q_UNUSED(found);
         Q_ASSERT(found);
         
         if (_connectedLinks.count() == 0) {

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -175,8 +175,12 @@ void MAVLinkProtocol::_linkStatusChanged(LinkInterface* link, bool connected)
     Q_ASSERT(link);
     
     if (connected) {
-        Q_ASSERT(!_connectedLinks.contains(link));
-        _connectedLinks.append(link);
+        foreach (SharedLinkInterface sharedLink, _connectedLinks) {
+            Q_ASSERT(sharedLink.data() != link);
+        }
+        
+        // Use the same shared pointer as LinkManager
+        _connectedLinks.append(LinkManager::instance()->sharedPointerForLink(link));
         
         if (_connectedLinks.count() == 1) {
             // This is the first link, we need to start logging
@@ -192,8 +196,15 @@ void MAVLinkProtocol::_linkStatusChanged(LinkInterface* link, bool connected)
         link->writeBytes(cmd, strlen(cmd));
         link->writeBytes(init, 4);
     } else {
-        Q_ASSERT(_connectedLinks.contains(link));
-        _connectedLinks.removeOne(link);
+        bool found = false;
+        for (int i=0; i<_connectedLinks.count(); i++) {
+            if (_connectedLinks[i].data() == link) {
+                found = true;
+                _connectedLinks.removeAt(i);
+                break;
+            }
+        }
+        Q_ASSERT(found);
         
         if (_connectedLinks.count() == 0) {
             // Last link is gone, close out logging

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -285,7 +285,10 @@ private:
     void _startLogging(void);
     void _stopLogging(void);
     
-    QList<LinkInterface*> _connectedLinks;  ///< List of all links connected to protocol
+    /// List of all links connected to protocol. We keep SharedLinkInterface objects
+    /// which are QSharedPointer's in order to maintain reference counts across threads.
+    /// This way Link deletion works correctly.
+    QList<SharedLinkInterface> _connectedLinks;
     
     bool _logSuspendError;      ///< true: Logging suspended due to error
     bool _logSuspendReplay;     ///< true: Logging suspended due to replay

--- a/src/comm/MAVLinkSimulationLink.cc
+++ b/src/comm/MAVLinkSimulationLink.cc
@@ -106,7 +106,7 @@ MAVLinkSimulationLink::MAVLinkSimulationLink(QString readFile, QString writeFile
     srand(QTime::currentTime().msec());
     maxTimeNoise = 0;
     this->id = getNextLinkId();
-    LinkManager::instance()->addLink(this);
+    LinkManager::instance()->_addLink(this);
 }
 
 MAVLinkSimulationLink::~MAVLinkSimulationLink()

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -102,12 +102,11 @@ private:
 class SerialLink : public LinkInterface
 {
     Q_OBJECT
+    
     friend class SerialConfiguration;
+    friend class LinkManager;
+    
 public:
-
-    SerialLink(SerialConfiguration* config);
-    ~SerialLink();
-
     // LinkInterface
 
     LinkConfiguration* getLinkConfiguration();
@@ -154,9 +153,13 @@ private slots:
     void _rerouteDisconnected(void);
 
 private:
+    // Links are only created/destroyed by LinkManager so constructor/destructor is not public
+    SerialLink(SerialConfiguration* config);
+    ~SerialLink();
+    
     // From LinkInterface
-    bool _connect(void);
-    bool _disconnect(void);
+    virtual bool _connect(void);
+    virtual bool _disconnect(void);
 
     // Internal methods
     void _emitLinkError(const QString& errorMsg);

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -115,12 +115,12 @@ private:
 class TCPLink : public LinkInterface
 {
     Q_OBJECT
+    
     friend class TCPLinkUnitTest;
     friend class TCPConfiguration;
-public:
-    TCPLink(TCPConfiguration* config);
-    ~TCPLink();
+    friend class LinkManager;
     
+public:
     QTcpSocket* getSocket(void) { return _socket; }
     
     void signalBytesWritten(void);
@@ -159,9 +159,13 @@ protected:
     virtual void run(void);
     
 private:
+    // Links are only created/destroyed by LinkManager so constructor/destructor is not public
+    TCPLink(TCPConfiguration* config);
+    ~TCPLink();
+    
     // From LinkInterface
-    bool _connect(void);
-    bool _disconnect(void);
+    virtual bool _connect(void);
+    virtual bool _disconnect(void);
 
     bool _hardwareConnect();
     void _restartConnection();

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -143,11 +143,11 @@ private:
 class UDPLink : public LinkInterface
 {
     Q_OBJECT
+    
     friend class UDPConfiguration;
+    friend class LinkManager;
+    
 public:
-    UDPLink(UDPConfiguration* config);
-    ~UDPLink();
-
     void requestReset() { }
     bool isConnected() const;
     QString getName() const;
@@ -192,6 +192,10 @@ protected:
     int                 _id;
 
 private:
+    // Links are only created/destroyed by LinkManager so constructor/destructor is not public
+    UDPLink(UDPConfiguration* config);
+    ~UDPLink();
+    
     // From LinkInterface
     virtual bool _connect(void);
     virtual bool _disconnect(void);

--- a/src/qgcunittest/LinkManagerTest.cc
+++ b/src/qgcunittest/LinkManagerTest.cc
@@ -78,7 +78,7 @@ void LinkManagerTest::_add_test(void)
     Q_ASSERT(_linkMgr->getLinks().count() == 0);
     
     MockLink* link = new MockLink();
-    _linkMgr->addLink(link);
+    _linkMgr->_addLink(link);
     
     QList<LinkInterface*> links = _linkMgr->getLinks();
     QCOMPARE(links.count(), 1);
@@ -91,8 +91,8 @@ void LinkManagerTest::_delete_test(void)
     Q_ASSERT(_linkMgr->getLinks().count() == 0);
     
     MockLink* link = new MockLink();
-    _linkMgr->addLink(link);
-    _linkMgr->deleteLink(link);
+    _linkMgr->_addLink(link);
+    _linkMgr->_deleteLink(link);
     
     QCOMPARE(_linkMgr->getLinks().count(), 0);
 }
@@ -104,7 +104,7 @@ void LinkManagerTest::_addSignals_test(void)
     Q_ASSERT(_multiSpy->checkNoSignals() == true);
     
     MockLink* link = new MockLink();
-    _linkMgr->addLink(link);
+    _linkMgr->_addLink(link);
     
     QCOMPARE(_multiSpy->checkOnlySignalByMask(newLinkSignalMask), true);
     QSignalSpy* spy = _multiSpy->getSpyByIndex(newLinkSignalIndex);
@@ -125,10 +125,10 @@ void LinkManagerTest::_deleteSignals_test(void)
     Q_ASSERT(_multiSpy->checkNoSignals() == true);
     
     MockLink* link = new MockLink();
-    _linkMgr->addLink(link);
+    _linkMgr->_addLink(link);
     _multiSpy->clearAllSignals();
     
-    _linkMgr->deleteLink(link);
+    _linkMgr->_deleteLink(link);
     
     QCOMPARE(_multiSpy->checkOnlySignalByMask(linkDeletedSignalMask), true);
     QSignalSpy* spy = _multiSpy->getSpyByIndex(linkDeletedSignalIndex);

--- a/src/qgcunittest/MainWindowTest.cc
+++ b/src/qgcunittest/MainWindowTest.cc
@@ -67,7 +67,7 @@ void MainWindowTest::_connectWindowClose_test(MAV_AUTOPILOT autopilot)
     MockLink* link = new MockLink();
     Q_CHECK_PTR(link);
     link->setAutopilotType(autopilot);
-    LinkManager::instance()->addLink(link);
+    LinkManager::instance()->_addLink(link);
     linkMgr->connectLink(link);
     QTest::qWait(5000); // Give enough time for UI to settle and heartbeats to go through
     

--- a/src/qgcunittest/MavlinkLogTest.cc
+++ b/src/qgcunittest/MavlinkLogTest.cc
@@ -140,7 +140,7 @@ void MavlinkLogTest::_connectLog_test(void)
     
     MockLink* link = new MockLink();
     Q_CHECK_PTR(link);
-    LinkManager::instance()->addLink(link);
+    LinkManager::instance()->_addLink(link);
     linkMgr->connectLink(link);
     QTest::qWait(5000); // Give enough time for UI to settle and heartbeats to go through
     

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -341,7 +341,11 @@ protected: //COMMENTS FOR TEST UNIT
     /// LINK ID AND STATUS
     int uasId;                    ///< Unique system ID
     QMap<int, QString> components;///< IDs and names of all detected onboard components
-    QList<LinkInterface*> links;  ///< List of links this UAS can be reached by
+    
+    /// List of all links associated with this UAS. We keep SharedLinkInterface objects which are QSharedPointer's in order to
+    /// maintain reference counts across threads. This way Link deletion works correctly.
+    QList<SharedLinkInterface> _links;
+    
     QList<int> unknownPackets;    ///< Packet IDs which are unknown and have been received
     MAVLinkProtocol* mavlink;     ///< Reference to the MAVLink instance
     CommStatus commStatus;        ///< Communication status
@@ -812,9 +816,6 @@ public slots:
     /** @brief Send a message over all links this UAS can be reached with (!= all links) */
     void sendMessage(mavlink_message_t message);
 
-    /** @brief Temporary Hack for sending packets to patch Antenna. Send a message over all serial links except for this UAS's */
-    void forwardMessage(mavlink_message_t message);
-
     /** @brief Set this UAS as the system currently in focus, e.g. in the main display widgets */
     void setSelected();
 
@@ -951,6 +952,9 @@ protected slots:
     void writeSettings();
     /** @brief Read settings from disk */
     void readSettings();
+    
+private:
+    bool _containsLink(LinkInterface* link);
 };
 
 

--- a/src/ui/QGCLinkConfiguration.cc
+++ b/src/ui/QGCLinkConfiguration.cc
@@ -104,10 +104,8 @@ void QGCLinkConfiguration::on_connectLinkButton_clicked()
                     LinkManager::instance()->disconnectLink(link);
                 }
             } else {
-                LinkInterface* link = LinkManager::instance()->createLink(config);
+                LinkInterface* link = LinkManager::instance()->createConnectedLink(config);
                 if(link) {
-                    // Connect it
-                    LinkManager::instance()->connectLink(link);
                     // Now go hunting for the parent so we can shut this down
                     QWidget* pQw = parentWidget();
                     while(pQw) {

--- a/src/ui/QGCMAVLinkLogPlayer.cc
+++ b/src/ui/QGCMAVLinkLogPlayer.cc
@@ -246,18 +246,7 @@ void QGCMAVLinkLogPlayer::updatePositionSliderUi(float percent)
 void QGCMAVLinkLogPlayer::_selectLogFileForPlayback(void)
 {
     // Disallow replay when any links are connected
-    
-    bool foundConnection = false;
-    LinkManager* linkMgr = LinkManager::instance();
-    QList<LinkInterface*> links = linkMgr->getLinks();
-    foreach(LinkInterface* link, links) {
-        if (link->isConnected()) {
-            foundConnection = true;
-            break;
-        }
-    }
-    
-    if (foundConnection) {
+    if (LinkManager::instance()->anyConnectedLinks()) {
         QGCMessageBox::information(tr("Log Replay"), tr("You must close all connections prior to replaying a log."));
         return;
     }
@@ -326,7 +315,7 @@ bool QGCMAVLinkLogPlayer::loadLogFile(const QString& file)
     // If there's an existing MAVLinkSimulationLink() being used for an old file,
     // we replace it.
     if (logLink) {
-        LinkManager::instance()->deleteLink(logLink);
+        LinkManager::instance()->_deleteLink(logLink);
     }
     logLink = new MAVLinkSimulationLink("");
 

--- a/src/ui/QGCToolBar.cc
+++ b/src/ui/QGCToolBar.cc
@@ -676,10 +676,8 @@ void QGCToolBar::_connectButtonClicked(bool checked)
             // Get the configuration name
             QString confName = _linkCombo->currentText();
             // Create a link for it
-            LinkInterface* link = _linkMgr->createLink(confName);
+            LinkInterface* link = _linkMgr->createConnectedLink(confName);
             if(link) {
-                // Connect it
-                _linkMgr->connectLink(link);
                 // Save last used connection
                 MainWindow::instance()->saveLastUsedConnection(confName);
             }

--- a/src/ui/toolbar/MainToolBar.cc
+++ b/src/ui/toolbar/MainToolBar.cc
@@ -163,10 +163,8 @@ void MainToolBar::onConnect(QString conf)
             // We don't want the combo box updating under our feet
             LinkManager::instance()->suspendConfigurationUpdates(true);
             // Create a link
-            LinkInterface* link = LinkManager::instance()->createLink(_currentConfig);
+            LinkInterface* link = LinkManager::instance()->createConnectedLink(_currentConfig);
             if(link) {
-                // Connect it
-                LinkManager::instance()->connectLink(link);
                 // Save last used connection
                 MainWindow::instance()->saveLastUsedConnection(_currentConfig);
             }

--- a/src/ui/uas/UASListWidget.cc
+++ b/src/ui/uas/UASListWidget.cc
@@ -118,7 +118,7 @@ void UASListWidget::updateStatus()
         LinkInterface* link = i.key();
 
         // Paranoid sanity check
-        if (!LinkManager::instance()->getLinks().contains(link))
+        if (!LinkManager::instance()->containsLink(link))
             continue;
 
         if (!link)


### PR DESCRIPTION
Also many LinkManager API changes to further isolate all link management inside LinkManager.

This fixes the shutdown issues where MAVLinkProtocol was still holding onto a deleted link. The issue is that you can't keep non-reference counted pointers to LinkInterface objects on another thread. If you do you run into all sorts of cross-thread signaling issues during shutdown. Which in turn leads the non-ui thread the reference a LinkInterface* after it has been deleted.

This change uses QSharedPointers for LinkInterface* objects kept in LinkManager. It also uses copies of these same QSharedPointers in MAVLinkProtocol and UAS we run on different threads. This way they are correctly reference counted and will shutdown in an orderly fashion when they are disconnected.

Another important point to note is that in general LinkManager is not needed to be thread-safe with respect to creating new links. The only thing in LinkManager that is thread-safe is _addLink and _deleteLink. They still need to be thread-safe due to some hack usage with MAVLinkSimulationLink which I still haven't fully gotten rid of.

So now when you disconnect a link, it is also automatically deleted without the need for the delayed delete thing.

@dogmaphobic Can you give this a thorough code review as well as some testing. I've hammered on it and it looks good. But needs extra eyes.