### PR TITLE
Pull full param list after calibration

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -267,6 +267,7 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
 
 void SensorsComponentController::_refreshParams(void)
 {
+    // Pull specified params first so red/green indicators update quickly
     _autopilot->refreshParameter("CAL_MAG0_ID");
     _autopilot->refreshParameter("CAL_GYRO0_ID");
     _autopilot->refreshParameter("CAL_ACC0_ID");
@@ -276,6 +277,9 @@ void SensorsComponentController::_refreshParams(void)
     _autopilot->refreshParameter("CAL_MAG1_ROT");
     _autopilot->refreshParameter("CAL_MAG2_ROT");
     _autopilot->refreshParameter("SENS_BOARD_ROT");
+    
+    // Pull full set in order to get all cal values back
+    _autopilot->refreshAllParameters();
 }
 
 bool SensorsComponentController::fixedWing(void)

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -52,6 +52,17 @@ Rectangle {
 
         Item {
             // Just used as a spacer
+            height: 15
+            width: 10
+        }
+
+        QGCLabel {
+            width: parent.width
+            text: "If any of the setup indicators below are shown as red YOU SHOULD NOT FLY until you complete the setup of those components."
+        }
+
+        Item {
+            // Just used as a spacer
             height: 20
             width: 10
         }


### PR DESCRIPTION
Also tweak vehicle summary to be more forceful about messaging to NOT FLY when setup items are not complete.