### PR TITLE
Fix redraw issues with OpenGL canvases when link states change.

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -205,6 +205,10 @@ MainWindow::MainWindow(QSplashScreen* splashScreen)
     connect(this, SIGNAL(x11EventOccured(XEvent*)), mouse, SLOT(handleX11Event(XEvent*)));
 #endif //QGC_MOUSE_ENABLED_LINUX
 
+    // These also cause the screen to redraw so we need to update any OpenGL canvases in QML controls
+    connect(LinkManager::instance(), &LinkManager::linkConnected,    this, &MainWindow::_linkStateChange);
+    connect(LinkManager::instance(), &LinkManager::linkDisconnected, this, &MainWindow::_linkStateChange);
+
     // Connect link
     if (_autoReconnect)
     {
@@ -1346,6 +1350,11 @@ void MainWindow::restoreLastUsedConnection()
         // Create a link for it
         LinkManager::instance()->createConnectedLink(connection);
     }
+}
+
+void MainWindow::_linkStateChange(LinkInterface*)
+{
+    emit repaintCanvas();
 }
 
 #ifdef QGC_MOUSE_ENABLED_LINUX

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -294,6 +294,7 @@ private slots:
     void _showDockWidgetAction(bool show);
     void _loadCustomWidgetFromFile(void);
     void _createNewCustomWidget(void);
+    void _linkStateChange(LinkInterface*);
 #ifdef UNITTEST_BUILD
     void _showQmlTestWidget(void);
 #endif


### PR DESCRIPTION
This should fix issue #1386 and the newly-brought-to-life issue when a link is (truly) disconnected (PR #1392). A link state change also causes the UI to fully redraw. Whenever there is a full redraw, the canvases used within QML elements must be forcefully redrawn as they don't get the hint on their own...