### PR TITLE
Pass mavlink_param_union_t to FactLoader

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -496,7 +496,8 @@ HEADERS += \
     src/uas/UASMessageHandler.h \
     src/ui/toolbar/MainToolBar.h \
     src/QmlControls/ScreenTools.h \
-    src/QGCLoggingCategory.h
+    src/QGCLoggingCategory.h \
+    src/MavParamHelper.h
 
 SOURCES += \
     src/main.cc \
@@ -637,7 +638,8 @@ SOURCES += \
     src/uas/UASMessageHandler.cc \
     src/ui/toolbar/MainToolBar.cc \
     src/QmlControls/ScreenTools.cc \
-    src/QGCLoggingCategory.cc
+    src/QGCLoggingCategory.cc \
+    src/MavParamHelper.cc
 
 #
 # Unit Test specific configuration goes here

--- a/src/FactSystem/FactLoader.h
+++ b/src/FactSystem/FactLoader.h
@@ -31,6 +31,7 @@
 
 #include "Fact.h"
 #include "UASInterface.h"
+#include "QGCMAVLink.h"
 
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
@@ -64,7 +65,7 @@ protected:
     virtual void _addMetaDataToFact(Fact* fact);
     
 private slots:
-    void _parameterUpdate(int uas, int component, QString parameterName, int mavType, QVariant value);
+    void _parameterUpdate(int uas, int component, QString parameterName, mavlink_param_union_t& paramUnion);
     void _valueUpdated(const QVariant& value);
     void _paramMgrParameterListUpToDate(void);
     

--- a/src/MavParamHelper.cc
+++ b/src/MavParamHelper.cc
@@ -1,0 +1,129 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#include "MavParamHelper.h"
+
+void MavParamVariantToUnion(const QVariant& varParam, MAV_PARAM_TYPE type, mavlink_param_union_t& paramUnion)
+{
+    bool cvtOk;
+    int intParam;
+    
+    switch (type) {
+        case MAV_PARAM_TYPE_UINT8:
+        case MAV_PARAM_TYPE_UINT16:
+        case MAV_PARAM_TYPE_UINT32:
+        case MAV_PARAM_TYPE_INT8:
+        case MAV_PARAM_TYPE_INT16:
+        case MAV_PARAM_TYPE_INT32:
+            intParam = varParam.toInt(&cvtOk);
+            Q_ASSERT(cvtOk);
+            switch (type) {
+                case MAV_PARAM_TYPE_UINT8:
+                    Q_ASSERT(!(intParam & 0xFFFFFF00));
+                    paramUnion.param_uint8 = (uint8_t)intParam;
+                    break;
+                    
+                case MAV_PARAM_TYPE_UINT16:
+                    Q_ASSERT(!(intParam & 0x7FFF0000));
+                    paramUnion.param_uint16 = (uint16_t)intParam;
+                    break;
+                    
+                case MAV_PARAM_TYPE_UINT32:
+                    Q_ASSERT(intParam >= 0);
+                    paramUnion.param_uint32 = (uint32_t)intParam;
+                    break;
+                    
+                case MAV_PARAM_TYPE_INT8:
+                    Q_ASSERT(!(intParam & 0x7FFFFF00));
+                    paramUnion.param_int8 = (int8_t)intParam;
+                    break;
+                    
+                case MAV_PARAM_TYPE_INT16:
+                    Q_ASSERT(!(intParam & 0x7FFF0000));
+                    paramUnion.param_int16 = (uint16_t)intParam;
+                    break;
+                    
+                case MAV_PARAM_TYPE_INT32:
+                    paramUnion.param_int32 = (int32_t)intParam;
+                    break;
+                    
+                default:
+                    // We shouldn't get here
+                    Q_ASSERT(false);
+                    break;
+            }
+            break;
+            
+        case MAV_PARAM_TYPE_REAL32:
+            paramUnion.param_float = varParam.toFloat(&cvtOk);
+            Q_ASSERT(cvtOk);
+            break;
+            
+        default:
+            // Type we don't handle
+            Q_ASSERT(false);
+            break;
+    }
+                      
+    paramUnion.type = type;
+}
+
+QVariant MavParamUnionToVariant(const mavlink_param_union_t& paramUnion)
+{
+    switch (paramUnion.type) {
+        case MAV_PARAM_TYPE_UINT8:
+            return QVariant::fromValue(paramUnion.param_uint8);
+            
+        case MAV_PARAM_TYPE_UINT16:
+            return QVariant::fromValue(paramUnion.param_uint16);
+            break;
+            
+        case MAV_PARAM_TYPE_UINT32:
+            return QVariant::fromValue(paramUnion.param_uint32);
+            break;
+            
+        case MAV_PARAM_TYPE_INT8:
+            return QVariant::fromValue(paramUnion.param_int8);
+            break;
+            
+        case MAV_PARAM_TYPE_INT16:
+            return QVariant::fromValue(paramUnion.param_int16);
+            break;
+            
+        case MAV_PARAM_TYPE_INT32:
+            return QVariant::fromValue(paramUnion.param_int32);
+            break;
+            
+        case MAV_PARAM_TYPE_REAL32:
+            return QVariant::fromValue(paramUnion.param_float);
+            break;
+            
+        default:
+            // Type we don't handle
+            Q_ASSERT(false);
+            return QVariant();
+    }
+}

--- a/src/MavParamHelper.h
+++ b/src/MavParamHelper.h
@@ -1,0 +1,38 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @brief Helper routines for working for mavlink parameter conversion
+///     @author Don Gagne <don@thegagnes.com>
+
+#ifndef MAVPARAMHELPER_H
+#define MAVPARAMHELPER_H
+
+#include "QGCMAVlink.h"
+
+#include <QVariant>
+
+void MavParamVariantToUnion(const QVariant& varParam, MAV_PARAM_TYPE type, mavlink_param_union_t& paramUnion);
+QVariant MavParamUnionToVariant(const mavlink_param_union_t& paramUnion);
+
+#endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -37,6 +37,8 @@ This file is part of the QGROUNDCONTROL project
 #ifdef QT_DEBUG
 #include "UnitTest.h"
 #include "CmdLineOptParser.h"
+#include "QGCMAVLink.h"
+
 #ifdef Q_OS_WIN
 #include <crtdbg.h>
 #endif
@@ -47,6 +49,7 @@ This file is part of the QGROUNDCONTROL project
 #undef main
 #endif
 
+Q_DECLARE_METATYPE(mavlink_param_union_t)
 
 #ifdef Q_OS_WIN
 
@@ -94,6 +97,9 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_WIN
     qInstallMessageHandler(msgHandler);
 #endif
+    
+    // Register our type that we want to use in signals
+    qRegisterMetaType<mavlink_param_union_t>();
 
     // The following calls to qRegisterMetaType are done to silence debug output which warns
     // that we use these types in signals, and without calling qRegisterMetaType we can't queue

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -930,7 +930,7 @@ protected:
     /** @brief Get the UNIX timestamp in milliseconds, ignore attitudeStamped mode */
     quint64 getUnixReferenceTime(quint64 time);
 
-    virtual void processParamValueMsg(mavlink_message_t& msg, const QString& paramName,const mavlink_param_value_t& rawValue, mavlink_param_union_t& paramValue);
+    virtual void processParamValueMsg(mavlink_message_t& msg, const QString& paramName,const mavlink_param_value_t& rawValue);
 
     int componentID[256];
     bool componentMulti[256];

--- a/src/uas/UASInterface.h
+++ b/src/uas/UASInterface.h
@@ -507,7 +507,7 @@ signals:
     void autoModeChanged(bool autoMode);
     void parameterChanged(int uas, int component, QString parameterName, QVariant value);
     void parameterChanged(int uas, int component, int parameterCount, int parameterId, QString parameterName, QVariant value);
-    void parameterUpdate(int uas, int component, QString parameterName, int type, QVariant value);
+    void parameterUpdate(int uas, int component, QString parameterName, mavlink_param_union_t& paramUnion);
     void patternDetected(int uasId, QString patternPath, float confidence, bool detected);
     void letterDetected(int uasId, QString letter, float confidence, bool detected);
     /**


### PR DESCRIPTION
This is the first baby step towards:
- Cleaning up the issues with unsupported mavlink types
- Making the FactSystem be then truth for parameters
- Getting rid of ParamManager and friends