### PR TITLE
Font's are now correctly and equally size across all OS

### DIFF
--- a/files/styles/style-dark.css
+++ b/files/styles/style-dark.css
@@ -7,7 +7,7 @@
 * {
     background-color: #222;
     color: #FFF;
-    font-size: 11px;
+    font-size: 12pt;
 }
 
 QWidget#viewModeWidget {
@@ -105,138 +105,6 @@ QGCMAVLinkLogPlayer QLabel:disabled {
     color: #AAA;
 }
 
-QGCToolBar {
-    border-top-color: #969696;
-    border-bottom-color: #484848;
-    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #4B4B4B, stop: 0.3 #404040, stop: 0.34 #383838, stop:1 #181818);
-    padding: 0;
-    margin: 0;
-}
-
-QGCToolBar QLabel {
-    font-size: 12pt;
-    font-weight: bold;
-    margin: 4px 2px;
-    padding: 0 2px;
-    border-radius: 4px;
-}
-
-QGCToolBar QLabel#toolBarBatteryBar {
-    color: #0F0;
-}
-
-QGCToolBar QLabel#toolBarTimeoutLabel {
-    color: #FFFFFF;
-    background-color: #FF0037;
-    font-size: 15pt;
-}
-
-QGCToolBar QLabel#toolBarSafetyLabel {
-    /* color is for this label defined within the code */
-    font-size: 15pt;
-}
-
-QGCToolBar QLabel#toolBarModeLabel {
-    color: #ACEBFE;
-    font-size: 15pt;
-}
-
-QGCToolBar QLabel#toolBarStateLabel {
-    color: #FEC654;
-    font-size: 15pt;
-}
-
-QGCToolBar QLabel#toolBarBatteryVoltageLabel {
-    color: #0F0;
-    font-size: 15pt;
-}
-
-QGCToolBar QLabel#toolBarWpLabel {
-    color: #ACEBFE;
-    font-size: 15pt;
-}
-
-QGCToolBar QLabel#toolBarMessageLabel {
-    color: #ACEBFE;
-}
-
-QGCToolBar QProgressBar {
-    margin: 4px 2px;
-}
-
-QGCToolBar QToolButton {
-    margin: 0;
-    padding: 0 2px;
-    border: none;
-    border-top: 1px solid #333;
-    border-bottom: 1px solid #333;
-    border-radius: 0;
-    height: 24px;
-    min-width: 30px;
-    margin-bottom: 4px;
-    text-align: left;
-    font-weight: bold;
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #AAA, stop: 1 #BBB);
-    color: #000;
-}
-
-QGCToolBar QToolButton:checked, QGCToolBar QToolButton:pressed, QGCToolBar QToolButton:checked:hover {
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #555, stop: 1 #777);
-    color: #FFF;
-}
-
-QGCToolBar QToolButton:hover {
-    color: #FFF;
-}
-
-QGCToolBar QToolButton#advancedButton {
-    margin-left: 0;
-    margin-right: 13px;
-    padding-right: 10px;
-    border-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-top-right-radius: 6px;
-    border-left: none;
-}
-
-QGCToolBar QToolButton#firstAction {
-    margin-left: 2px;
-    border-bottom-left-radius: 6px;
-    border-top-left-radius: 6px;
-    border-right: none;
-}
-
-QGCToolBar .QWidget {
-    margin: 0;
-    background-color: transparent;
-}
-
-QGCPX4SensorCalibration QLabel#magLabel {
-    font-size: 15pt;
-    font-weight: bold;
-    border-radius: 4px;
-    min-height: 25px;
-}
-
-QGCPX4SensorCalibration QLabel#gyroLabel {
-    font-size: 15pt;
-    font-weight: bold;
-    border-radius: 4px;
-    min-height: 25px;
-}
-
-QGCPX4SensorCalibration QLabel#accelLabel {
-    font-size: 15pt;
-    font-weight: bold;
-    border-radius: 4px;
-    min-height: 25px;
-}
-
-QGCPX4VehicleConfig QLabel#rcLabel {
-    color: #FEC654;
-    font-size: 18pt;
-}
-
 QGCToolWidgetItem {
     border: 1px solid #666;
     border-radius: 3px;
@@ -284,17 +152,9 @@ QLabel#noUas {
     font-size: 30pt;
 }
 
-QMessageBox QLabel {
-    font-size: 14pt;
-}
-
 QMessageBox {
     min-width: 400px;
     min-height: 300px;
-}
-
-QLabel#calibrationExplanationLabel {
-    font-size: 20pt;
 }
 
 QLabel#tabTitleLabel {

--- a/files/styles/style-light.css
+++ b/files/styles/style-light.css
@@ -88,61 +88,6 @@ QGCMAVLinkLogPlayer QLabel:disabled {
     color: #666;
 }
 
-QGCToolBar {
-    border-top-color: #969696;
-    border-bottom-color: #484848;
-    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #DDD, stop: 1 #999);
-}
-
-QGCToolBar QLabel#toolBarBatteryBar {
-    color: #008000;
-}
-
-QGCToolBar QLabel#toolBarTimeoutLabel {
-    color: #FFFFFF;
-    background-color: #FF0037;
-}
-
-QGCToolBar QLabel#toolBarModeLabel {
-    color: #475E66;
-}
-
-QGCToolBar QLabel#toolBarStateLabel {
-    color: #80632A;
-}
-
-QGCToolBar QLabel#toolBarBatteryVoltageLabel {
-    color: #008000;
-}
-
-QGCToolBar QLabel#toolBarWpLabel {
-    color: #475E66;
-}
-
-QGCToolBar QLabel#toolBarMessageLabel {
-    color: #475E66;
-}
-
-QGCToolBar QToolButton {
-    border-top: #DDD;
-    border-bottom: #DDD;
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #333, stop: 1 #444);
-    color: #FFF;
-}
-
-QGCToolBar QToolButton:checked, QGCToolBar QToolButton:pressed, QGCToolBar QToolButton:checked:hover {
-    background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #777, stop: 1 #999);
-    color: #FFF;
-}
-
-QGCToolBar QToolButton:hover {
-    color: #000;
-}
-
-QGCToolBar .QWidget {
-    background-color: transparent;
-}
-
 QGCToolWidgetItem {
     border-color: #666;
 }

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -197,12 +197,10 @@ Rectangle {
                                 text: "Battery Max:"
                                 color: palette.text
                                 width: 80
-                                font.pointSize: screenTools.dpiAdjustedPointSize(12);
                             }
                             QGCLabel {
                                 text: (battNumCells.value * battHighVolt.value).toFixed(1) + ' V'
                                 color: palette.text
-                                font.pointSize: screenTools.dpiAdjustedPointSize(12);
                             }
                         }
                         Row {
@@ -211,12 +209,10 @@ Rectangle {
                                 text: "Battery Min:"
                                 color: palette.text
                                 width: 80
-                                font.pointSize: screenTools.dpiAdjustedPointSize(12);
                             }
                             QGCLabel {
                                 text: (battNumCells.value * battLowVolt.value).toFixed(1) + ' V'
                                 color: palette.text
-                                font.pointSize: screenTools.dpiAdjustedPointSize(12);
                             }
                         }
                     }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -566,9 +566,33 @@ void QGCApplication::_loadCurrentStyle(void)
             success = false;
         }
     }
+    
+    // Now that we have the styles loaded we need to dpi adjust the font point sizes
+    
+    QString dpiAdjustedStyles;
+    if (success) {
+        QTextStream styleStream(&styles, QIODevice::ReadOnly);
+        QRegularExpression regex("font-size:.+(\\d\\d)pt;");
+        
+        while (!styleStream.atEnd()) {
+            QString adjustedLine;
+            QString line = styleStream.readLine();
+            
+            QRegularExpressionMatch match = regex.match(line);
+            if (match.hasMatch()) {
+                //qDebug() << "found:" << line << match.captured(1);
+                adjustedLine = QString("font-size: %1pt;").arg(ScreenTools::dpiAdjustedPointSize_s(match.captured(1).toDouble()));
+                //qDebug() << "adjusted:" << adjustedLine;
+            } else {
+                adjustedLine = line;
+            }
+            
+            dpiAdjustedStyles += adjustedLine;
+        }
+    }
 
-    if (!styles.isEmpty()) {
-        setStyleSheet(styles);
+    if (!dpiAdjustedStyles.isEmpty()) {
+        setStyleSheet(dpiAdjustedStyles);
     }
 
     if (!success) {

--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -25,9 +25,12 @@
 ///     @author Don Gagne <don@thegagnes.com>
 
 #include "QGCPalette.h"
+#include "ScreenTools.h"
 
 #include <QApplication>
 #include <QPalette>
+
+const qreal QGCPalette::_defaultFontPointSize = 12;
 
 QList<QGCPalette*>   QGCPalette::_paletteObjects;
 
@@ -129,4 +132,9 @@ void QGCPalette::setGlobalTheme(Theme newTheme)
 void QGCPalette::_themeChanged(void)
 {
     emit paletteChanged();
+}
+
+qreal QGCPalette::dpiAdjustedDefaultFontPointSize(void)
+{
+    return ScreenTools::dpiAdjustedPointSize_s(_defaultFontPointSize);
 }

--- a/src/QGCPalette.h
+++ b/src/QGCPalette.h
@@ -82,7 +82,11 @@ class QGCPalette : public QObject
     
     // Text color for TextFields
     Q_PROPERTY(QColor textFieldText READ textFieldText NOTIFY paletteChanged)
-        
+    
+    Q_PROPERTY(qreal defaultFontPointSize MEMBER _defaultFontPointSize CONSTANT)
+    
+    Q_PROPERTY(qreal dpiAdjustedDefaultFontPointSize READ dpiAdjustedDefaultFontPointSize CONSTANT)
+    
 public:
     enum ColorGroup {
         Disabled = 0,
@@ -120,6 +124,8 @@ public:
     static Theme globalTheme(void) { return _theme; }
     static void setGlobalTheme(Theme newTheme);
     
+    qreal dpiAdjustedDefaultFontPointSize(void);
+    
 signals:
     void paletteChanged(void);
     
@@ -148,6 +154,8 @@ private:
     
     static QColor _textField[_cThemes][_cColorGroups];
     static QColor _textFieldText[_cThemes][_cColorGroups];
+    
+    static const qreal _defaultFontPointSize;
     
     void _themeChanged(void);
     

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -103,10 +103,13 @@ Button {
                     }
 
                     Text {
-                        id: text
-                        renderType: Text.NativeRendering
+                        id:             text
+                        renderType:     Text.NativeRendering
+                        text:           control.text
+                        font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+
                         anchors.verticalCenter: parent.verticalCenter
-                        text: control.text
+
                         color: __showHighlight ?
                             control.__qgcPal.buttonHighlightText :
                             (primary ? control.__qgcPal.primaryButtonText : control.__qgcPal.buttonText)

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -25,9 +25,12 @@ CheckBox {
                 opacity: 0.6
             }
             Text {
-                id: text
-                text: control.text
+                id:             text
+                text:           control.text
+                font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+
                 anchors.centerIn: parent
+
                 color: control.__qgcPal.text
             }
         }

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -11,6 +11,7 @@ ComboBox {
     property bool __showHighlight: pressed | hovered
 
     style: ComboBoxStyle {
+		font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
         textColor: __showHighlight ?
                     control.__qgcPal.buttonHighlightText :
                     control.__qgcPal.buttonText

--- a/src/QmlControls/QGCLabel.qml
+++ b/src/QmlControls/QGCLabel.qml
@@ -5,8 +5,10 @@ import QtQuick.Controls.Styles 1.2
 import QGroundControl.Palette 1.0
 
 Text {
-    property var __palette: QGCPalette { colorGroupEnabled: enabled }
+    QGCPalette { id: __qgcPal; colorGroupEnabled: enabled }
+
     property bool enabled: true
 
-    color: __palette.text
+    font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+    color:          __qgcPal.text
 }

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -25,9 +25,12 @@ RadioButton {
                 opacity: 0.6
             }
             Text {
-                id: text
-                text: control.text
+                id:             text
+                text:           control.text
+                font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+
                 anchors.centerIn: parent
+
                 color: control.__qgcPal.text
             }
         }

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -49,6 +49,8 @@ TextField {
                 width: unitsLabelWidthGenerator.width
 
                 text: control.unitsLabel
+                font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+
                 color: control.textColor
                 visible: control.showUnits
             }

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -53,6 +53,7 @@ QGCButton {
         }
         label: Label {
             text: button.text
+            font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             color: showHighlight ? __qgcPal.buttonHighlightText : (button.checked ? __qgcPal.primaryButtonText : __qgcPal.buttonText)

--- a/src/QmlControls/ScreenTools.cc
+++ b/src/QmlControls/ScreenTools.cc
@@ -27,24 +27,43 @@
 #include "ScreenTools.h"
 #include "MainWindow.h"
 
+#include <QFont>
+#include <QFontMetrics>
+
+bool ScreenTools::_dpiFactorSet = false;
+double ScreenTools::_dotsPerInch = 96.0;
+double ScreenTools::_dpiFactor = 72.0 / 96.0;
+
 ScreenTools::ScreenTools()
-    : _dotsPerInch(96.0)
-    , _dpiFactor( 72.0 / 96.0)
 {
-    // Get screen DPI to manage font sizes on different platforms
-    QScreen *srn = QGuiApplication::primaryScreen();
-    if(srn && srn->logicalDotsPerInch() > 50.0) {
-        _dotsPerInch = (double)srn->logicalDotsPerInch(); // Font point sizes are based on Mac 72dpi
-        _dpiFactor = 72.0 / _dotsPerInch;
-    } else {
-        qWarning() << "System not reporting logical DPI, which is used to compute the appropriate font size. The default being used is 96dpi. If the text within buttons and UI elements are too big or too small, that's the reason.";
-    }
     connect(MainWindow::instance(), &MainWindow::repaintCanvas, this, &ScreenTools::_updateCanvas);
 }
 
 qreal ScreenTools::dpiAdjustedPointSize(qreal pointSize)
 {
+    return dpiAdjustedPointSize_s(pointSize);
+}
+
+qreal ScreenTools::dpiAdjustedPointSize_s(qreal pointSize)
+{
+    _setDpiFactor();
     return pointSize * _dpiFactor;
+}
+
+void ScreenTools::_setDpiFactor(void)
+{
+    if (!_dpiFactorSet) {
+        _dpiFactorSet = true;
+        
+        // Get screen DPI to manage font sizes on different platforms
+        QScreen *srn = QGuiApplication::primaryScreen();
+        if(srn && srn->logicalDotsPerInch() > 50.0) {
+            _dotsPerInch = (double)srn->logicalDotsPerInch(); // Font point sizes are based on Mac 72dpi
+            _dpiFactor = 72.0 / _dotsPerInch;
+        } else {
+            qWarning() << "System not reporting logical DPI, which is used to compute the appropriate font size. The default being used is 96dpi. If the text within buttons and UI elements are too big or too small, that's the reason.";
+        }
+    }
 }
 
 void ScreenTools::_updateCanvas()

--- a/src/QmlControls/ScreenTools.h
+++ b/src/QmlControls/ScreenTools.h
@@ -116,6 +116,9 @@ public:
      */
     Q_INVOKABLE qreal   dpiAdjustedPointSize(qreal pointSize);
 
+    /// Static version of dpiAdjustedPointSize of use in C++ code
+    static qreal dpiAdjustedPointSize_s(qreal pointSize);
+    
     double  screenDPI           () { return _dotsPerInch; }
     double  dpiFactor           () { return _dpiFactor; }
     int     mouseX              () { return QCursor::pos().x(); }
@@ -129,9 +132,11 @@ private slots:
     void _updateCanvas();
 
 private:
-    double _dotsPerInch;
-    double _dpiFactor;
-
+    static void _setDpiFactor(void);
+    
+    static bool _dpiFactorSet;
+    static double _dotsPerInch;
+    static double _dpiFactor;
 };
 
 #endif

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -39,7 +39,7 @@ Button {
                 horizontalAlignment: TextEdit.AlignHCenter
 
                 text: control.text
-                font.pixelSize: 12
+                font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
                 color: __showHighlight ? __qgcPal.buttonHighlightText : __qgcPal.buttonText
 
                 Rectangle {

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -30,7 +30,7 @@ import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-    property ScreenTools screenTools: ScreenTools { }
+    property ScreenTools __screenTools: ScreenTools { }
 
     // Indicates whether calibration is valid for this control
     property bool calValid: false
@@ -63,23 +63,23 @@ Rectangle {
             smooth: true
         }
 
-        Label {
+        QGCLabel {
             width:                  parent.width
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         screenTools.dpiAdjustedPointSize(25);
+            font.pointSize:         __screenTools.dpiAdjustedPointSize(25);
             font.bold:              true
             color:                  "black"
 
             text: parent.calText
         }
-        Label {
+        QGCLabel {
             width:                  parent.width
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         screenTools.dpiAdjustedPointSize(25);
+            font.pointSize:         __screenTools.dpiAdjustedPointSize(25);
             color:                  calInProgress ? "yellow" : "white"
 
             text: parent.calText

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -114,11 +114,15 @@ Rectangle {
 
         TextArea {
             id: statusTextArea
-            width: parent.width
-            height: 300
-            readOnly: true
-            frameVisible: false
-            text: qsTr("Please disconnect all connections and unplug board from USB before selecting Upgrade.")
+
+            width:			parent.width
+            height:			300
+            readOnly:		true
+            frameVisible:	false
+			font.pointSize: qgcPal.dpiAdjustedDefaultFontPointSize
+            
+			text: qsTr("Please disconnect all connections and unplug board from USB before selecting Upgrade.")
+
             style: TextAreaStyle {
                 textColor: qgcPal.text
                 backgroundColor: qgcPal.windowShade

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -90,11 +90,10 @@ Rectangle {
                         color: qgcPal.windowShadeDark
 
                         // Title text
-                        Text {
+                        QGCLabel {
                             anchors.fill:   parent
 
                             color:          qgcPal.buttonText
-                            font.pixelSize: 12
                             text:           modelData.name.toUpperCase()
 
                             verticalAlignment:      TextEdit.AlignVCenter

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -238,7 +238,7 @@ Rectangle {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
                     width: messages.width - messageIcon.width
-                    Text {
+                    QGCLabel {
                         id: messageText
                         text: (mainToolBar.messageCount > 0) ? mainToolBar.messageCount : ''
                         font.pointSize: screenTools.dpiAdjustedPointSize(14);
@@ -326,7 +326,7 @@ Rectangle {
                     smooth: true
                 }
 
-                Text {
+                QGCLabel {
                     id: satelitteText
                     text: (mainToolBar.satelliteCount > 0) ? mainToolBar.satelliteCount : ''
                     font.pointSize: screenTools.dpiAdjustedPointSize(14);
@@ -361,7 +361,7 @@ Rectangle {
                     smooth: true
                 }
 
-                Text {
+                QGCLabel {
                     id: batteryText
                     text: mainToolBar.batteryVoltage.toFixed(1) + ' V';
                     font.pointSize: screenTools.dpiAdjustedPointSize(14);
@@ -389,7 +389,7 @@ Rectangle {
                     border.color: "#00000000"
                     border.width: 0
 
-                    Text {
+                    QGCLabel {
                         id: armedStatusText
                         text: (mainToolBar.systemArmed) ? qsTr("ARMED") :  qsTr("DISARMED")
                         font.pointSize: screenTools.dpiAdjustedPointSize(12);
@@ -408,7 +408,7 @@ Rectangle {
                     border.color: "#00000000"
                     border.width: 0
 
-                    Text {
+                    QGCLabel {
                         id: stateStatusText
                         text: mainToolBar.currentState
                         font.pointSize: screenTools.dpiAdjustedPointSize(12);
@@ -429,7 +429,7 @@ Rectangle {
                 border.color: "#00000000"
                 border.width: 0
 
-                Text {
+                QGCLabel {
                     id: modeStatusText
                     text: mainToolBar.currentMode
                     font.pointSize: screenTools.dpiAdjustedPointSize(12);
@@ -450,7 +450,7 @@ Rectangle {
                 border.color: "#00000000"
                 border.width: 0
 
-                Text {
+                QGCLabel {
                     id: connectionStatusText
                     text: qsTr("CONNECTION LOST")
                     font.pointSize: screenTools.dpiAdjustedPointSize(14);


### PR DESCRIPTION
- Added new dpiAdjustedDefaultFontPointSize to QGCPallete for use in controls
- All Qml controls default to the above point size
- Widget style sheets font sizes are dpi adjusted at boot time
- Fixed some incorrect pixel font size usage

The above changes should limit the need for specifying your own font size. You only need to do that when you want something other than default. In that case you still must always use ScreenTools::dpiAdjustPointSize in your Qml.