### PR TITLE
Status bar

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -721,7 +721,7 @@ void MainWindow::loadSettings()
     settings.beginGroup(MAIN_SETTINGS_GROUP);
     _autoReconnect = settings.value("AUTO_RECONNECT", _autoReconnect).toBool();
     _lowPowerMode  = settings.value("LOW_POWER_MODE", _lowPowerMode).toBool();
-    _showStatusBar = settings.value("SHOW_STATUSBAR", _lowPowerMode).toBool();
+    _showStatusBar = settings.value("SHOW_STATUSBAR", _showStatusBar).toBool();
     settings.endGroup();
     // Select the proper view. Default to the flight view or load the last one used if it's supported.
     VIEW_SECTIONS currentViewCandidate = (VIEW_SECTIONS) settings.value("CURRENT_VIEW", _currentView).toInt();

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -642,6 +642,7 @@ void MainWindow::showStatusBarCallback(bool checked)
 {
     _showStatusBar = checked;
     checked ? statusBar()->show() : statusBar()->hide();
+    _ui.actionStatusBar->setText(checked ? "Hide Status Bar" : "Show Status Bar");
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -126,6 +126,7 @@ void MainWindow::deleteInstance(void)
 MainWindow::MainWindow(QSplashScreen* splashScreen)
     : _autoReconnect(false)
     , _lowPowerMode(false)
+    , _showStatusBar(false)
     , _centerStackActionGroup(new QActionGroup(this))
     , _simulationLink(NULL)
     , _centralLayout(NULL)
@@ -255,8 +256,9 @@ MainWindow::MainWindow(QSplashScreen* splashScreen)
     }
 
     // And that they will stay checked properly after user input
-    QObject::connect(_ui.actionFullscreen, SIGNAL(triggered()), this, SLOT(fullScreenActionItemCallback()));
-    QObject::connect(_ui.actionNormal,     SIGNAL(triggered()), this, SLOT(normalActionItemCallback()));
+    connect(_ui.actionFullscreen, &QAction::triggered, this, &MainWindow::fullScreenActionItemCallback);
+    connect(_ui.actionNormal,     &QAction::triggered, this, &MainWindow::normalActionItemCallback);
+    connect(_ui.actionStatusBar,  &QAction::triggered, this, &MainWindow::showStatusBarCallback);
 
     // Set OS dependent keyboard shortcuts for the main window, non OS dependent shortcuts are set in MainWindow.ui
 #ifdef Q_OS_MACX
@@ -284,6 +286,8 @@ MainWindow::MainWindow(QSplashScreen* splashScreen)
     emit initStatusChanged(tr("Done"), Qt::AlignLeft | Qt::AlignBottom, QColor(62, 93, 141));
 
     if (!qgcApp()->runningUnitTests()) {
+        _ui.actionStatusBar->setChecked(_showStatusBar);
+        showStatusBarCallback(_showStatusBar);
         show();
 #ifdef Q_OS_MAC
         // TODO HACK
@@ -624,14 +628,20 @@ void MainWindow::_showHILConfigurationWidgets(void)
     }
 }
 
-void MainWindow::fullScreenActionItemCallback()
+void MainWindow::fullScreenActionItemCallback(bool)
 {
     _ui.actionNormal->setChecked(false);
 }
 
-void MainWindow::normalActionItemCallback()
+void MainWindow::normalActionItemCallback(bool)
 {
     _ui.actionFullscreen->setChecked(false);
+}
+
+void MainWindow::showStatusBarCallback(bool checked)
+{
+    _showStatusBar = checked;
+    checked ? statusBar()->show() : statusBar()->hide();
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)
@@ -710,6 +720,7 @@ void MainWindow::loadSettings()
     settings.beginGroup(MAIN_SETTINGS_GROUP);
     _autoReconnect = settings.value("AUTO_RECONNECT", _autoReconnect).toBool();
     _lowPowerMode  = settings.value("LOW_POWER_MODE", _lowPowerMode).toBool();
+    _showStatusBar = settings.value("SHOW_STATUSBAR", _lowPowerMode).toBool();
     settings.endGroup();
     // Select the proper view. Default to the flight view or load the last one used if it's supported.
     VIEW_SECTIONS currentViewCandidate = (VIEW_SECTIONS) settings.value("CURRENT_VIEW", _currentView).toInt();
@@ -739,6 +750,7 @@ void MainWindow::storeSettings()
     settings.beginGroup(MAIN_SETTINGS_GROUP);
     settings.setValue("AUTO_RECONNECT", _autoReconnect);
     settings.setValue("LOW_POWER_MODE", _lowPowerMode);
+    settings.setValue("SHOW_STATUSBAR", _showStatusBar);
     settings.endGroup();
     settings.setValue(_getWindowGeometryKey(), saveGeometry());
     // Save the last current view in any case

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -187,13 +187,17 @@ protected slots:
      * Used as a triggered() callback by the fullScreenAction to make sure only one of it or the
      * normalAction are checked at a time, as they're mutually exclusive.
      */
-    void fullScreenActionItemCallback();
+    void fullScreenActionItemCallback(bool);
     /**
      * @brief Unchecks the fullScreenActionItem.
      * Used as a triggered() callback by the normalAction to make sure only one of it or the
      * fullScreenAction are checked at a time, as they're mutually exclusive.
      */
-    void normalActionItemCallback();
+    void normalActionItemCallback(bool);
+    /**
+     * @brief Enable/Disable Status Bar
+     */
+    void showStatusBarCallback(bool checked);
 
 signals:
     void initStatusChanged(const QString& message, int alignment, const QColor &color);
@@ -348,6 +352,7 @@ private:
 
     bool                    _autoReconnect;
     bool                    _lowPowerMode;           ///< If enabled, QGC reduces the update rates of all widgets
+    bool                    _showStatusBar;
     QActionGroup*           _centerStackActionGroup;
     MAVLinkSimulationLink*  _simulationLink;
     QList<QGCToolWidget*>   _customWidgets;

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -75,7 +75,7 @@
    </widget>
    <widget class="QMenu" name="menuPerspectives">
     <property name="title">
-     <string>Perspectives</string>
+     <string>View</string>
     </property>
     <addaction name="actionSetup"/>
     <addaction name="actionMissionView"/>
@@ -84,6 +84,8 @@
     <addaction name="separator"/>
     <addaction name="actionFullscreen"/>
     <addaction name="actionNormal"/>
+    <addaction name="separator"/>
+    <addaction name="actionStatusBar"/>
    </widget>
    <widget class="QMenu" name="menuAdvanced">
     <property name="title">
@@ -333,6 +335,14 @@
    </property>
    <property name="text">
     <string>Local 3D View</string>
+   </property>
+  </action>
+  <action name="actionStatusBar">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Status Bar</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
I renamed the *Perspectives* menu to a more standard *View* menu. In addition, I've added an option to show and hide the Status Bar, giving more screen real estate when you don't need the log playback.

![screen shot 2015-04-04 at 11 00 41 pm](https://cloud.githubusercontent.com/assets/749243/6995569/b4609c6e-db1e-11e4-8ce6-5e4d628bc3dc.png)
