### PR TITLE
Use common control for summary rows

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -23,9 +23,11 @@
         <file alias="QGroundControl/Controls/QGCComboBox.qml">src/QmlControls/QGCComboBox.qml</file>
         <file alias="QGroundControl/Controls/QGCColoredImage.qml">src/QmlControls/QGCColoredImage.qml</file>
         <file alias="QGroundControl/Controls/QGCToolBarButton.qml">src/QmlControls/QGCToolBarButton.qml</file>
+
         <file alias="QGroundControl/Controls/SubMenuButton.qml">src/QmlControls/SubMenuButton.qml</file>
         <file alias="QGroundControl/Controls/IndicatorButton.qml">src/QmlControls/IndicatorButton.qml</file>
         <file alias="QGroundControl/Controls/VehicleRotationCal.qml">src/QmlControls/VehicleRotationCal.qml</file>
+        <file alias="QGroundControl/Controls/VehicleSummaryRow.qml">src/QmlControls/VehicleSummaryRow.qml</file>
         <file alias="QGroundControl/Controls/arrow-down.png">src/QmlControls/arrow-down.png</file>
 
         <file alias="SetupViewButtonsConnected.qml">src/VehicleSetup/SetupViewButtonsConnected.qml</file>

--- a/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
@@ -8,43 +8,28 @@ import QGroundControl.Controls 1.0
 import QGroundControl.Controllers 1.0
 
 Column {
+    Fact { id: sysIdFact;           name: "MAV_SYS_ID" }
+    Fact { id: sysAutoStartFact;    name: "SYS_AUTOSTART" }
+
+    property bool autoStartSet: sysAutoStartFact.value != 0
+
     anchors.fill: parent
     anchors.margins: 8
 
     AirframeComponentController { id: controller }
 
-    Row {
-        width: parent.width
-
-        QGCLabel { id: systemId; text: "System ID:" }
-        FactLabel {
-            horizontalAlignment: Text.AlignRight
-            width: parent.width - systemId.contentWidth
-            fact: Fact { name: "MAV_SYS_ID" }
-        }
+    VehicleSummaryRow {
+        labelText: "System ID:"
+        valueText: sysIdFact.valueString
     }
 
-    Row {
-        width: parent.width
-
-        QGCLabel { id: airframeType; text: "Airframe type:" }
-        QGCLabel {
-            property Fact fact: Fact { name: "SYS_AUTOSTART" }
-            horizontalAlignment: Text.AlignRight
-            width: parent.width - airframeType.contentWidth
-            text: fact.value == 0 ? "Setup required" : controller.currentAirframeType
-        }
+    VehicleSummaryRow {
+        labelText: "Airframe type:"
+        valueText: autoStartSet ? controller.currentAirframeType : "Setup required"
     }
 
-    Row {
-        width: parent.width
-
-        QGCLabel { id: vehicle; text: "Vehicle:" }
-        QGCLabel {
-            property Fact fact: Fact { name: "SYS_AUTOSTART" }
-            horizontalAlignment: Text.AlignRight
-            width: parent.width - vehicle.contentWidth
-            text: fact.value == 0 ? "Setup required" : controller.currentVehicleName
-        }
+    VehicleSummaryRow {
+        labelText: "Vehicle:"
+        valueText: autoStartSet ? controller.currentVehicleName : "Setup required"
     }
 }

--- a/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
@@ -6,54 +6,31 @@ import QGroundControl.FactSystem 1.0
 import QGroundControl.Controls 1.0
 
 Column {
-    anchors.fill: parent
-    anchors.margins: 8
+    Fact { id: modeSwFact;      name: "RC_MAP_MODE_SW" }
+    Fact { id: posCtlSwFact;    name: "RC_MAP_POSCTL_SW" }
+    Fact { id: loiterSwFact;    name: "RC_MAP_LOITER_SW" }
+    Fact { id: returnSwFact;    name: "RC_MAP_RETURN_SW" }
 
-    Component {
-        id: component
+    anchors.fill:       parent
+    anchors.margins:    8
 
-        Row {
-            width: parent.width
-
-            QGCLabel { id: label; text: labelText }
-            QGCLabel {
-                property Fact fact: Fact { name: factName }
-                horizontalAlignment: Text.AlignRight
-                width: parent.width - label.contentWidth
-                text: fact.value == 0 ? zeroText : fact.value
-            }
-        }
+    VehicleSummaryRow {
+        labelText: "Mode switch:"
+        valueText: modeSwFact.value == 0 ? "Setup required" : modeSwFact.valueString
     }
 
-    Loader {
-        property string labelText: "Mode switch:"
-        property string zeroText: "Setup required"
-        property string factName: "RC_MAP_MODE_SW"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Position Ctl switch:"
+        valueText: posCtlSwFact.value == 0 ? "Disabled" : fact.valueString
     }
 
-    Loader {
-        property string labelText: "Position Ctl switch:"
-        property string zeroText: "Disabled"
-        property string factName: "RC_MAP_POSCTL_SW"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Position Ctl switch:"
+        valueText: loiterSwFact.value == 0 ? "Disabled" : fact.valueString
     }
 
-    Loader {
-        property string labelText: "Position Ctl switch:"
-        property string zeroText: "Disabled"
-        property string factName: "RC_MAP_LOITER_SW"
-        width: parent.width
-        sourceComponent: component
-    }
-
-    Loader {
-        property string labelText: "Return switch:"
-        property string zeroText: "Disabled"
-        property string factName: "RC_MAP_RETURN_SW"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Return switch:"
+        valueText: returnSwFact.value == 0 ? "Disabled" : fact.valueString
     }
 }

--- a/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
@@ -34,47 +34,25 @@ import QGroundControl.FactControls 1.0
 import QGroundControl.Controls 1.0
 
 Column {
-    anchors.fill: parent
-    anchors.margins: 8
+    Fact { id: batVChargedFact;     name: "BAT_V_CHARGED" }
+    Fact { id: batVEmptyFact;       name: "BAT_V_EMPTY" }
+    Fact { id: batCellsFact;        name: "BAT_N_CELLS" }
 
-    Row {
-        width: parent.width
-        QGCLabel { id: battFull; text: "Battery Full:" }
-        FactLabel {
-            fact: Fact { name: "BAT_V_CHARGED" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - battFull.contentWidth;
-        }
+    anchors.fill:       parent
+    anchors.margins:    8
+
+    VehicleSummaryRow {
+        labelText: "Battery Full:"
+        valueText: batVChargedFact.valueString
     }
 
-    Row {
-        width: parent.width
-        QGCLabel { id: battEmpty; text: "Battery Empty:" }
-        FactLabel {
-            fact: Fact { name: "BAT_V_EMPTY" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - battEmpty.contentWidth;
-        }
+    VehicleSummaryRow {
+        labelText: "Battery Empty:"
+        valueText: batVEmptyFact.valueString
     }
 
-    Row {
-        width: parent.width
-        QGCLabel { id: battCells; text: "Number of Cells:" }
-        FactLabel {
-            fact: Fact { name: "BAT_N_CELLS" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - battCells.contentWidth;
-        }
+    VehicleSummaryRow {
+        labelText: "Number of Cells:"
+        valueText: batCellsFact.valueString
     }
-
-    Row {
-        width: parent.width
-        QGCLabel { id: battDrop; text: "Voltage Drop:" }
-        FactLabel {
-            fact: Fact { name: "BAT_V_LOAD_DROP" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - battDrop.contentWidth;
-        }
-    }
-
 }

--- a/src/AutoPilotPlugins/PX4/RadioComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/RadioComponentSummary.qml
@@ -6,78 +6,49 @@ import QGroundControl.FactSystem 1.0
 import QGroundControl.Controls 1.0
 
 Column {
-    anchors.fill: parent
-    anchors.margins: 8
+    Fact { id: mapRollFact;     name: "RC_MAP_ROLL" }
+    Fact { id: mapPitchFact;    name: "RC_MAP_PITCH" }
+    Fact { id: mapYawFact;      name: "RC_MAP_YAW" }
+    Fact { id: mapThrottleFact; name: "RC_MAP_THROTTLE" }
+    Fact { id: mapFlapsFact;    name: "RC_MAP_FLAPS" }
+    Fact { id: mapAux1Fact;     name: "RC_MAP_AUX1" }
+    Fact { id: mapAux2Fact;     name: "RC_MAP_AUX2" }
 
-    Component {
-        id: component
+    anchors.fill:       parent
+    anchors.margins:    8
 
-        Row {
-            width: parent.width
-
-            QGCLabel { id: label; text: labelText }
-            QGCLabel {
-                Fact { id: fact; name: factName }
-                horizontalAlignment: Text.AlignRight
-                width: parent.width - label.contentWidth
-                text: fact.value == 0 ? zeroText : fact.value
-            }
-        }
+    VehicleSummaryRow {
+        labelText: "Roll:"
+        valueText: mapRollFact.value == 0 ? "Setup required" : mapRollFact.valueString
     }
 
-    Loader {
-        property string labelText: "Roll:"
-        property string zeroText: "Setup required"
-        property string factName: "RC_MAP_ROLL"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Pitch:"
+        valueText: mapPitchFact.value == 0 ? "Setup required" : mapPitchFact.valueString
     }
 
-    Loader {
-        property string labelText: "Pitch:"
-        property string zeroText: "Setup required"
-        property string factName: "RC_MAP_PITCH"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Yaw:"
+        valueText: mapYawFact.value == 0 ? "Setup required" : mapYawFact.valueString
     }
 
-    Loader {
-        property string labelText: "Yaw:"
-        property string zeroText: "Setup required"
-        property string factName: "RC_MAP_YAW"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Throttle:"
+        valueText: mapThrottleFact.value == 0 ? "Setup required" : mapThrottleFact.valueString
     }
 
-    Loader {
-        property string labelText: "Throttle:"
-        property string zeroText: "Setup required"
-        property string factName: "RC_MAP_THROTTLE"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Flaps:"
+        valueText: mapFlapsFact.value == 0 ? "Disabled" : mapFlapsFact.valueString
     }
 
-    Loader {
-        property string labelText: "Flaps:"
-        property string zeroText: "Disabled"
-        property string factName: "RC_MAP_FLAPS"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Aux1:"
+        valueText: mapAux1Fact.value == 0 ? "Disabled" : mapAux1Fact.valueString
     }
 
-    Loader {
-        property string labelText: "Aux1:"
-        property string zeroText: "Disabled"
-        property string factName: "RC_MAP_AUX1"
-        width: parent.width
-        sourceComponent: component
-    }
-
-    Loader {
-        property string labelText: "Aux2:"
-        property string zeroText: "Disabled"
-        property string factName: "RC_MAP_AUX2"
-        width: parent.width
-        sourceComponent: component
+    VehicleSummaryRow {
+        labelText: "Aux2:"
+        valueText: mapAux2Fact.value == 0 ? "Disabled" : mapAux2Fact.valueString
     }
 }

--- a/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
@@ -7,63 +7,37 @@ import QGroundControl.FactControls 1.0
 import QGroundControl.Controls 1.0
 
 Column {
-    anchors.fill: parent
-    anchors.margins: 8
+    Fact { id: returnAltFact;   name: "RTL_RETURN_ALT" }
+    Fact { id: descendAltFact;  name: "RTL_DESCEND_ALT" }
+    Fact { id: landDelayFact;   name: "RTL_LAND_DELAY" }
+    Fact { id: commDLLossFact;  name: "COM_DL_LOSS_EN" }
+    Fact { id: commRCLossFact;  name: "COM_RC_LOSS_T" }
 
-    Row {
-        width: parent.width
+    anchors.fill:       parent
+    anchors.margins:    8
 
-        QGCLabel { id: rtlMinAlt; text: "RTL min alt:" }
-        FactLabel {
-            fact: Fact { name: "RTL_RETURN_ALT" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - rtlMinAlt.contentWidth;
-        }
+    VehicleSummaryRow {
+        labelText: "RTL min alt:"
+        valueText: returnAltFact.valueString
     }
 
-    Row {
-        width: parent.width
-
-        QGCLabel { id: rtlHomeAlt; text: "RTL home alt:" }
-        FactLabel {
-            fact: Fact { name: "RTL_DESCEND_ALT" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - rtlHomeAlt.contentWidth;
-        }
+    VehicleSummaryRow {
+        labelText: "RTL home alt:"
+        valueText: descendAltFact.valueString
     }
 
-    Row {
-        width: parent.width
-
-        QGCLabel { id: rtlLoiter; text: "RTL loiter delay:" }
-        QGCLabel {
-            property Fact fact: Fact { name: "RTL_LAND_DELAY" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - rtlLoiter.contentWidth;
-            text: fact.value < 0 ? "Disabled" : fact.valueString
-        }
+    VehicleSummaryRow {
+        labelText: "RTL loiter delay:"
+        valueText: landDelayFact.value < 0 ? "Disabled" : landDelayFact.valueString
     }
 
-    Row {
-        width: parent.width
-
-        QGCLabel { id: commLoss; text: "Telemetry loss RTL:" }
-        QGCLabel {
-            property Fact fact: Fact { name: "COM_DL_LOSS_EN" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - commLoss.contentWidth;
-            text: fact.value != 1 ? "Disabled" : fact.valueString
-        }
+    VehicleSummaryRow {
+        labelText: "Telemetry loss RTL:"
+        valueText: commDLLossFact.value != -1 ? "Disabled" : commDLLossFact.valueString
     }
 
-    Row {
-        width: parent.width
-
-        QGCLabel { id: rcLoss; text: "RC loss RTL (seconds):" }
-        FactLabel {
-            fact: Fact { name: "COM_RC_LOSS_T" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - rcLoss.contentWidth;
-        }
+    VehicleSummaryRow {
+        labelText: "RC loss RTL (seconds):"
+        valueText: commRCLossFact.valueString
     }
 }

--- a/src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml
@@ -10,54 +10,32 @@ import QGroundControl.Controls 1.0
 */
 
 Column {
-    anchors.fill: parent
-    anchors.margins: 8
+    Fact { id: mag0IdFact;      name: "CAL_MAG0_ID" }
+    Fact { id: gyro0IdFact;     name: "CAL_GYRO0_ID" }
+    Fact { id: accel0IdFact;    name: "CAL_ACC0_ID" }
+    Fact { id: dPressOffFact;   name: "SENS_DPRES_OFF" }
 
-    Row {
-        width: parent.width
+    anchors.fill:       parent
+    anchors.margins:    8
 
-        QGCLabel { id: compass; text: "Compass:" }
-        QGCLabel {
-            property Fact fact:     Fact { name: "CAL_MAG0_ID" }
-            horizontalAlignment:    Text.AlignRight;
-            width:                  parent.width - compass.contentWidth;
-            text:                   fact.value  == 0 ? "Setup required" : "Ready"
+    VehicleSummaryRow {
+        labelText: "Compass:"
+        valueText: mag0IdFact.value  == 0 ? "Setup required" : "Ready"
         }
     }
 
     Row {
-        width: parent.width
-
-        QGCLabel { id: gyro; text: "Gyro:" }
-        QGCLabel {
-            property Fact fact:     Fact { name: "CAL_GYRO0_ID" }
-            horizontalAlignment:    Text.AlignRight;
-            width:                  parent.width - compass.contentWidth;
-            text:                   fact.value  == 0 ? "Setup required" : "Ready"
-        }
+        labelText: "Gyro:"
+        valueText: gyro0IdFact.value  == 0 ? "Setup required" : "Ready"
     }
 
     Row {
-        width: parent.width
-
-        QGCLabel { id: accel; text: "Accelerometer:" }
-        QGCLabel {
-            property Fact fact:     Fact { name: "CAL_ACC0_ID" }
-            horizontalAlignment:    Text.AlignRight;
-            width:                  parent.width - compass.contentWidth;
-            text:                   fact.value  == 0 ? "Setup required" : "Ready"
-        }
+        labelText: "Accelerometer:"
+        valueText: accel0IdFact.value  == 0 ? "Setup required" : "Ready"
     }
 
     Row {
-        width: parent.width
-
-        QGCLabel { id: airspeed; text: "Airspeed:" }
-        QGCLabel {
-            property Fact fact:     Fact { name: "SENS_DPRES_OFF" }
-            horizontalAlignment: Text.AlignRight;
-            width: parent.width - airspeed.contentWidth;
-            text: fact.value == 0.0 ? "Setup required" : "Ready"
-        }
+        labelText: "Airspeed:"
+        valueText: dPressOffFact.value  == 0 ? "Setup required" : "Ready"
     }
 }

--- a/src/QmlControls/VehicleSummaryRow.qml
+++ b/src/QmlControls/VehicleSummaryRow.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.2
+import QtQuick.Controls 1.2
+import QtQuick.Controls.Styles 1.2
+
+Row {
+    property string labelText: "Label"
+    property string valueText: "value"
+
+    width: parent.width
+
+    QGCLabel {
+        id:     label
+        text:   labelText
+    }
+    QGCLabel {
+        width:  parent.width - label.contentWidth
+        text:   valueText
+        horizontalAlignment: Text.AlignRight;
+    }
+}

--- a/src/QmlControls/qmldir
+++ b/src/QmlControls/qmldir
@@ -12,4 +12,5 @@ QGCToolBarButton 1.0 QGCToolBarButton.qml
 SubMenuButton 1.0 SubMenuButton.qml
 IndicatorButton 1.0 IndicatorButton.qml
 VehicleRotationCal 1.0 VehicleRotationCal.qml
+VehicleSummaryRow 1.0 VehicleSummaryRow.qml
 


### PR DESCRIPTION
Some of the text in the summary boxes was positioned incorrectly. Now uses a common control for rows so they are all the same.