### PR TITLE
Lead the user through fixing setup problems

### DIFF
--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -26,21 +26,75 @@
 
 #include "AutoPilotPlugin.h"
 #include "QGCUASParamManagerInterface.h"
+#include "SetupView.h"
+#include "QGCApplication.h"
+#include "QGCMessageBox.h"
+#include "MainWindow.h"
 
 AutoPilotPlugin::AutoPilotPlugin(UASInterface* uas, QObject* parent) :
     QObject(parent),
     _uas(uas),
-    _pluginReady(false)
+    _pluginReady(false),
+	_setupComplete(false)
 {
     Q_ASSERT(_uas);
 	
 	connect(_uas, &UASInterface::disconnected, this, &AutoPilotPlugin::_uasDisconnected);
+	connect(this, &AutoPilotPlugin::pluginReadyChanged, this, &AutoPilotPlugin::_pluginReadyChanged);
 }
 
 void AutoPilotPlugin::_uasDisconnected(void)
 {
 	_pluginReady = false;
 	emit pluginReadyChanged(_pluginReady);
+}
+
+void AutoPilotPlugin::_pluginReadyChanged(bool pluginReady)
+{
+	if (pluginReady) {
+		_recalcSetupComplete();
+		if (!_setupComplete) {
+			QGCMessageBox::warning("Setup", "One or more vehicle components require setup prior to flight.");
+			
+			// Take the user to Vehicle Summary
+			MainWindow* mainWindow = MainWindow::instance();
+			Q_ASSERT(mainWindow);
+			mainWindow->getMainToolBar()->onSetupView();
+			qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+			QWidget* setupViewWidget = mainWindow->getCurrentViewWidget();
+			Q_ASSERT(setupViewWidget);
+			SetupView* setupView = qobject_cast<SetupView*>(setupViewWidget);
+			Q_ASSERT(setupView);
+			setupView->summaryButtonClicked();
+			qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+		}
+	}
+}
+
+void AutoPilotPlugin::_recalcSetupComplete(void)
+{
+	bool newSetupComplete = true;
+	
+	foreach(const QVariant componentVariant, vehicleComponents()) {
+		VehicleComponent* component = qobject_cast<VehicleComponent*>(qvariant_cast<QObject *>(componentVariant));
+		Q_ASSERT(component);
+		
+		if (!component->setupComplete()) {
+			newSetupComplete = false;
+			break;
+		}
+	}
+	
+	if (_setupComplete != newSetupComplete) {
+		_setupComplete = newSetupComplete;
+		emit setupCompleteChanged(_setupComplete);
+	}
+}
+
+bool AutoPilotPlugin::setupComplete(void)
+{
+	Q_ASSERT(_pluginReady);
+	return _setupComplete;
 }
 
 void AutoPilotPlugin::refreshAllParameters(void)

--- a/src/AutoPilotPlugins/AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.h
@@ -56,7 +56,10 @@ public:
 	
     /// List of VehicleComponent objects
     Q_PROPERTY(QVariantList vehicleComponents READ vehicleComponents CONSTANT)
-    
+
+	/// false: One or more vehicle components require setup
+	Q_PROPERTY(bool setupComplete READ setupComplete NOTIFY setupCompleteChanged)
+	
     /// Re-request the full set of parameters from the autopilot
 	Q_INVOKABLE void refreshAllParameters(void);
     
@@ -103,12 +106,15 @@ public:
     
     static void clearStaticData(void);
 	
+	// Property accessors
 	bool pluginReady(void) { return _pluginReady; }
+	bool setupComplete(void);
+	
     UASInterface* uas(void) { return _uas; }
     
 signals:
-    /// Signalled when plugin is ready for use
     void pluginReadyChanged(bool pluginReady);
+	void setupCompleteChanged(bool setupComplete);
 	
 protected:
     /// All access to AutoPilotPugin objects is through getInstanceForAutoPilotPlugin
@@ -119,9 +125,14 @@ protected:
 	
     UASInterface*   _uas;
     bool            _pluginReady;
+	bool			_setupComplete;
 	
 private slots:
 	void _uasDisconnected(void);
+	void _pluginReadyChanged(bool pluginReady);
+	
+private:
+	void _recalcSetupComplete(void);
 };
 
 #endif

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -231,22 +231,10 @@ void PX4AutoPilotPlugin::_pluginReadyPreChecks(void)
     // should be used instead.
     if (parameterExists("SENS_GYRO_XOFF")) {
         _incorrectParameterVersion = true;
-        QGCMessageBox::warning(tr("Setup"), tr("This version of GroundControl can only perform vehicle setup on a newer version of firmware. "
-                                               "Please perform a Firmware Upgrade if you wish to use Vehicle Setup."));
-    } else {
-        // Check for missing setup complete
-        foreach(const QVariant componentVariant, vehicleComponents()) {
-            VehicleComponent* component = qobject_cast<VehicleComponent*>(qvariant_cast<QObject *>(componentVariant));
-            Q_ASSERT(component);
-            
-            if (!component->setupComplete()) {
-                QGCMessageBox::warning(tr("Setup"), tr("One or more vehicle components require setup prior to flight. "
-                                                       "Please correct these by going to the Setup view."));
-                break;
-            }
-        }
-    }
-    
+        QGCMessageBox::warning("Setup", "This version of GroundControl can only perform vehicle setup on a newer version of firmware. "
+										"Please perform a Firmware Upgrade if you wish to use Vehicle Setup.");
+	}
+	
     _pluginReady = true;
     emit pluginReadyChanged(_pluginReady);
 }

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -57,8 +57,15 @@ Rectangle {
         }
 
         QGCLabel {
-            width: parent.width
-            text: "If any of the setup indicators below are shown as red YOU SHOULD NOT FLY until you complete the setup of those components."
+            width:			parent.width
+			wrapMode:		Text.WordWrap
+			color:			autopilot.setupComplete ? qgcPal.text : "red"
+			font.pointSize: autopilot.setupComplete ? qgcPal.dpiAdjustedDefaultFontPointSize : screenTools.dpiAdjustedPointSize(20)
+			text: autopilot.setupComplete ?
+						"Below you will find a summary of the settings for your vehicle. To the left are the setup buttons for deatiled settings for each component." :
+						"WARNING: One or more of your vehicle's components require setup prior to flight. It will be shown with a red circular indicator below. " +
+							"Find the matching setup button to the left and click it to get to the setup screen you need to complete. " +
+							"Once all indicators go green you will be ready to fly."
         }
 
         Item {


### PR DESCRIPTION
Trying to do some more hand holding without being too annoying...

Vehicle Summary for a vehicle which doesn't require setup:
![screen shot 2015-04-15 at 3 27 02 pm](https://cloud.githubusercontent.com/assets/5876851/7170822/382e4496-e386-11e4-8e3b-d958c1ca8403.png)

Connect to a vehicle which still required setup. You get this:
![screen shot 2015-04-15 at 3 25 04 pm](https://cloud.githubusercontent.com/assets/5876851/7170828/498c1268-e386-11e4-8ddf-6395c27783ba.png)

Click Ok and you are automatically taken to Vehicle Summary page which now looks like this:
![screen shot 2015-04-15 at 3 24 53 pm](https://cloud.githubusercontent.com/assets/5876851/7170834/58e271ee-e386-11e4-98fc-02b2e138cc11.png)
