### PR TITLE
Link Management Work

### DIFF
--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -12,7 +12,7 @@
 
 // If you need to make an incompatible changes to stored settings, bump this version number
 // up by 1. This will caused store settings to be cleared on next boot.
-#define QGC_SETTINGS_VERSION 5
+#define QGC_SETTINGS_VERSION 6
 
 #define QGC_APPLICATION_NAME "QGroundControl"
 #define QGC_ORG_NAME "QGroundControl.org"

--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -40,6 +40,7 @@ This file is part of the QGROUNDCONTROL project
 
 LinkConfiguration::LinkConfiguration(const QString& name)
     : _preferred(false)
+    , _dynamic(false)
 {
     _link = NULL;
     _name = name;
@@ -48,18 +49,20 @@ LinkConfiguration::LinkConfiguration(const QString& name)
 
 LinkConfiguration::LinkConfiguration(LinkConfiguration* copy)
 {
-    _link      = copy->getLink();
-    _name      = copy->name();
-    _preferred = copy->isPreferred();
+    _link       = copy->getLink();
+    _name       = copy->name();
+    _preferred  = copy->isPreferred();
+    _dynamic    = copy->isDynamic();
     Q_ASSERT(!_name.isEmpty());
 }
 
 void LinkConfiguration::copyFrom(LinkConfiguration* source)
 {
     Q_ASSERT(source != NULL);
-    _link      = source->getLink();
-    _name      = source->name();
-    _preferred = source->isPreferred();
+    _link       = source->getLink();
+    _name       = source->name();
+    _preferred  = source->isPreferred();
+    _dynamic    = source->isDynamic();
 }
 
 /*!

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -97,6 +97,18 @@ public:
     */
     void setPreferred(bool preferred = true) { _preferred = preferred; }
 
+    /*!
+     *
+     * Is this a dynamic configuration? (non persistent)
+     * @return True if this is an automatically added configuration.
+     */
+    bool isDynamic() { return _dynamic; }
+
+    /*!
+     * Set if this is this a dynamic configuration. (decided at runtime)
+    */
+    void setDynamic(bool dynamic = true) { _dynamic = dynamic; }
+
     /// Virtual Methods
 
     /*!
@@ -171,6 +183,7 @@ protected:
 private:
     QString _name;
     bool    _preferred;  ///< Determined internally if this is a preferred connection. It comes up first in the drop down box.
+    bool    _dynamic;    ///< A connection added automatically and not persistent (unless it's edited).
 };
 
 #endif // LINKCONFIGURATION_H

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -325,19 +325,24 @@ void LinkManager::saveLinkConfigurationList()
 {
     QSettings settings;
     settings.remove(LinkConfiguration::settingsRoot());
-    QString root(LinkConfiguration::settingsRoot());
-    settings.setValue(root + "/count", _linkConfigurations.count());
     int index = 0;
+    int count = 0;
     foreach (LinkConfiguration* pLink, _linkConfigurations) {
         Q_ASSERT(pLink != NULL);
-        root = LinkConfiguration::settingsRoot();
-        root += QString("/Link%1").arg(index++);
-        settings.setValue(root + "/name", pLink->name());
-        settings.setValue(root + "/type", pLink->type());
-        settings.setValue(root + "/preferred", pLink->isPreferred());
-        // Have the instance save its own values
-        pLink->saveSettings(settings, root);
+        if(!pLink->isDynamic())
+        {
+            QString root = LinkConfiguration::settingsRoot();
+            root += QString("/Link%1").arg(index++);
+            settings.setValue(root + "/name", pLink->name());
+            settings.setValue(root + "/type", pLink->type());
+            settings.setValue(root + "/preferred", pLink->isPreferred());
+            // Have the instance save its own values
+            pLink->saveSettings(settings, root);
+            count++;
+        }
     }
+    QString root(LinkConfiguration::settingsRoot());
+    settings.setValue(root + "/count", count);
     emit linkConfigurationChanged();
 }
 
@@ -427,6 +432,7 @@ void LinkManager::_updateConfigurationList(void)
         return;
     }
     bool saveList = false;
+    QStringList currentPorts;
     QList<QSerialPortInfo> portList = QSerialPortInfo::availablePorts();
     // Iterate Comm Ports
     foreach (QSerialPortInfo portInfo, portList) {
@@ -439,6 +445,8 @@ void LinkManager::_updateConfigurationList(void)
         qDebug() << "serialNumber:     " << portInfo.serialNumber();
         qDebug() << "vendorIdentifier: " << portInfo.vendorIdentifier();
 #endif
+        // Save port name
+        currentPorts << portInfo.systemLocation();
         // Is this a PX4?
         if (portInfo.vendorIdentifier() == 9900) {
             SerialConfiguration* pSerial = _findSerialConfiguration(portInfo.systemLocation());
@@ -451,6 +459,7 @@ void LinkManager::_updateConfigurationList(void)
             } else {
                 // Lets create a new Serial configuration automatically
                 pSerial = new SerialConfiguration(QString("Pixhawk on %1").arg(portInfo.portName().trimmed()));
+                pSerial->setDynamic(true);
                 pSerial->setPreferred(true);
                 pSerial->setBaud(115200);
                 pSerial->setPortName(portInfo.systemLocation());
@@ -458,6 +467,45 @@ void LinkManager::_updateConfigurationList(void)
                 saveList = true;
             }
         }
+        // Is this an FTDI Chip? It could be a 3DR Modem
+        if (portInfo.vendorIdentifier() == 1027) {
+            SerialConfiguration* pSerial = _findSerialConfiguration(portInfo.systemLocation());
+            if (pSerial) {
+                //-- If this port is configured make sure it has the preferred flag set, unless someone else already has it set.
+                if(!pSerial->isPreferred() && !saveList) {
+                    pSerial->setPreferred(true);
+                    saveList = true;
+                }
+            } else {
+                // Lets create a new Serial configuration automatically (an assumption at best)
+                pSerial = new SerialConfiguration(QString("3DR Radio on %1").arg(portInfo.portName().trimmed()));
+                pSerial->setDynamic(true);
+                pSerial->setPreferred(true);
+                pSerial->setBaud(57600);
+                pSerial->setPortName(portInfo.systemLocation());
+                addLinkConfiguration(pSerial);
+                saveList = true;
+            }
+        }
+    }
+    // Now we go through the current configuration list and make sure any dynamic config has gone away
+    QList<LinkConfiguration*>  _confToDelete;
+    foreach (LinkConfiguration* pLink, _linkConfigurations) {
+        Q_ASSERT(pLink != NULL);
+        // We only care about dynamic links
+        if(pLink->isDynamic()) {
+            if(pLink->type() == LinkConfiguration::TypeSerial) {
+                SerialConfiguration* pSerial = dynamic_cast<SerialConfiguration*>(pLink);
+                if(!currentPorts.contains(pSerial->portName())) {
+                    _confToDelete.append(pSerial);
+                }
+            }
+        }
+    }
+    // Now remove all links that are gone
+    foreach (LinkConfiguration* pDelete, _confToDelete) {
+        removeLinkConfiguration(pDelete);
+        saveList = true;
     }
     // Save configuration list, which will also trigger a signal for the UI
     if(saveList) {
@@ -468,28 +516,24 @@ void LinkManager::_updateConfigurationList(void)
 bool LinkManager::containsLink(LinkInterface* link)
 {
     bool found = false;
-    
     foreach (SharedLinkInterface sharedLink, _links) {
         if (sharedLink.data() == link) {
             found = true;
             break;
         }
     }
-    
     return found;
 }
 
 bool LinkManager::anyConnectedLinks(void)
 {
     bool found = false;
-    
     foreach (SharedLinkInterface sharedLink, _links) {
         if (sharedLink.data()->isConnected()) {
             found = true;
             break;
         }
     }
-    
     return found;
 }
 
@@ -500,7 +544,6 @@ SharedLinkInterface& LinkManager::sharedPointerForLink(LinkInterface* link)
             return _links[i];
         }
     }
-    
     // This should never happen
     Q_ASSERT(false);
     return _nullSharedLink;

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -326,7 +326,6 @@ void LinkManager::saveLinkConfigurationList()
     QSettings settings;
     settings.remove(LinkConfiguration::settingsRoot());
     int index = 0;
-    int count = 0;
     foreach (LinkConfiguration* pLink, _linkConfigurations) {
         Q_ASSERT(pLink != NULL);
         if(!pLink->isDynamic())
@@ -338,11 +337,10 @@ void LinkManager::saveLinkConfigurationList()
             settings.setValue(root + "/preferred", pLink->isPreferred());
             // Have the instance save its own values
             pLink->saveSettings(settings, root);
-            count++;
         }
     }
     QString root(LinkConfiguration::settingsRoot());
-    settings.setValue(root + "/count", count);
+    settings.setValue(root + "/count", index);
     emit linkConfigurationChanged();
 }
 

--- a/src/ui/SerialConfigurationWindow.cc
+++ b/src/ui/SerialConfigurationWindow.cc
@@ -215,21 +215,35 @@ bool SerialConfigurationWindow::setupPortList()
 void SerialConfigurationWindow::enableFlowControl(bool flow)
 {
     _config->setFlowControl(flow ? QSerialPort::HardwareControl : QSerialPort::NoFlowControl);
+    //-- If this was dynamic, it's now edited and persistent
+    _config->setDynamic(false);
 }
 
 void SerialConfigurationWindow::setParityNone(bool accept)
 {
-    if (accept) _config->setParity(QSerialPort::NoParity);
+    if (accept) {
+        _config->setParity(QSerialPort::NoParity);
+        //-- If this was dynamic, it's now edited and persistent
+        _config->setDynamic(false);
+    }
 }
 
 void SerialConfigurationWindow::setParityOdd(bool accept)
 {
-    if (accept) _config->setParity(QSerialPort::OddParity);
+    if (accept) {
+        _config->setParity(QSerialPort::OddParity);
+        //-- If this was dynamic, it's now edited and persistent
+        _config->setDynamic(false);
+    }
 }
 
 void SerialConfigurationWindow::setParityEven(bool accept)
 {
-    if (accept) _config->setParity(QSerialPort::EvenParity);
+    if (accept) {
+        _config->setParity(QSerialPort::EvenParity);
+        //-- If this was dynamic, it's now edited and persistent
+        _config->setDynamic(false);
+    }
 }
 
 void SerialConfigurationWindow::setPortName(int index)
@@ -238,6 +252,8 @@ void SerialConfigurationWindow::setPortName(int index)
     QString pname = _ui.portName->itemData(index).toString();
     if (_config->portName() != pname) {
         _config->setPortName(pname);
+        //-- If this was dynamic, it's now edited and persistent
+        _config->setDynamic(false);
     }
 }
 
@@ -245,14 +261,20 @@ void SerialConfigurationWindow::setBaudRate(int index)
 {
     int baud = _ui.baudRate->itemData(index).toInt();
     _config->setBaud(baud);
+    //-- If this was dynamic, it's now edited and persistent
+    _config->setDynamic(false);
 }
 
 void SerialConfigurationWindow::setDataBits(int bits)
 {
     _config->setDataBits(bits);
+    //-- If this was dynamic, it's now edited and persistent
+    _config->setDynamic(false);
 }
 
 void SerialConfigurationWindow::setStopBits(int bits)
 {
     _config->setStopBits(bits);
+    //-- If this was dynamic, it's now edited and persistent
+    _config->setDynamic(false);
 }

--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -71,7 +71,7 @@ public:
     Q_INVOKABLE void    onFlyView();
     Q_INVOKABLE void    onAnalyzeView();
     Q_INVOKABLE void    onConnect(QString conf);
-    Q_INVOKABLE void    onLinkConfigurationChanged(const QString& config);
+    Q_INVOKABLE void    onDisconnect(QString conf);
     Q_INVOKABLE void    onEnterMessageArea(int x, int y);
     Q_INVOKABLE QString getMavIconColor();
 
@@ -86,7 +86,6 @@ public:
     Q_PROPERTY(MessageType_t messageType        MEMBER _currentMessageType      NOTIFY messageTypeChanged)
     Q_PROPERTY(int           newMessageCount    MEMBER _currentMessageCount     NOTIFY newMessageCountChanged)
     Q_PROPERTY(int           messageCount       MEMBER _messageCount            NOTIFY messageCountChanged)
-    Q_PROPERTY(QString       currentConfig      MEMBER _currentConfig           NOTIFY currentConfigChanged)
     Q_PROPERTY(QString       systemPixmap       MEMBER _systemPixmap            NOTIFY systemPixmapChanged)
     Q_PROPERTY(int           satelliteCount     MEMBER _satelliteCount          NOTIFY satelliteCountChanged)
     Q_PROPERTY(QStringList   connectedList      MEMBER _connectedList           NOTIFY connectedListChanged)
@@ -160,8 +159,6 @@ private:
     double          _batteryVoltage;
     double          _batteryPercent;
     QStringList     _linkConfigurations;
-    QString         _currentConfig;
-    bool            _linkSelected;
     int             _connectionCount;
     bool            _systemArmed;
     QString         _currentState;


### PR DESCRIPTION
I've reworked how links are managed. Gone is the combo box with the links. Instead you will find one single *Connect* button. If nothing is physically connected to the computer and you don't have any connection configured, the only option it will provide is to *Add a Connection*. As you plug in a device, either a Pixhawk or a 3DR Radio Modem, these will be automatically added to the list. These automatically found devices are *Dynamic Devices*. They are not persistent and are also automatically removed from the list once you physically disconnect them from the computer.

Link configurations that are manually entered are *Persistent Links*. These will be saved and always displayed on the connection list. If you edit a *Dynamic* link, it becomes persistent and it will also be saved.

The *Connect* button has three different states. When nothing is connected, it shows *Connect*. If you have one single connection, it shows *Disconnect*. If you have more than one connection, it will also say *Disconnect* but once clicked, a menu will be displayed showing the connected links so you can choose which one to disconnect.

![screen shot 2015-04-15 at 10 30 58 pm](https://cloud.githubusercontent.com/assets/749243/7173211/b61e34f2-e3c1-11e4-8dbc-2fd6481125c1.png)

