### PR TITLE
Had the airplane flying backwards...

### DIFF
--- a/src/ui/qmlcommon/QGCCompassInstrument.qml
+++ b/src/ui/qmlcommon/QGCCompassInstrument.qml
@@ -54,7 +54,7 @@ QGCMovableItem {
         transform: Rotation {
             origin.x:   pointer.width  / 2
             origin.y:   pointer.height / 2
-            angle:      -heading
+            angle:      heading
         }
     }
     Image {


### PR DESCRIPTION
When I created the new compass indicator, I made it so the compass is fixed and the indicator (the airplane icon) rotates, while my previous, main indicator has the compass spinning while the pointer is fixed. In the process, I forgot to flip the heading so the airplane was rotating in the opposite direction (tail first).