### PR TITLE
add STM32F4Discovery to supported board by adding BoardID to bootloader

### DIFF
--- a/src/VehicleSetup/PX4Bootloader.cc
+++ b/src/VehicleSetup/PX4Bootloader.cc
@@ -439,7 +439,7 @@ bool PX4Bootloader::getBoardInfo(QextSerialPort* port, uint32_t& bootloaderVersi
     if (!getBoardInfo(port, INFO_BOARD_ID, _boardID)) {
         goto Error;
     }
-    if (_boardID != _boardIDPX4Flow && _boardID != _boardIDPX4FMUV1 && _boardID != _boardIDPX4FMUV2 && _boardID != _boardIDuNode) {
+    if (_boardID != _boardIDPX4Flow && _boardID != _boardIDPX4FMUV1 && _boardID != _boardIDPX4FMUV2 && _boardID != _boardIDuNode != _boardIDSTM32F4Discovery && _boardID ) {
         _errorString = tr("Unsupported board: %1").arg(_boardID);
         goto Error;
     }

--- a/src/VehicleSetup/PX4Bootloader.cc
+++ b/src/VehicleSetup/PX4Bootloader.cc
@@ -439,7 +439,7 @@ bool PX4Bootloader::getBoardInfo(QextSerialPort* port, uint32_t& bootloaderVersi
     if (!getBoardInfo(port, INFO_BOARD_ID, _boardID)) {
         goto Error;
     }
-    if (_boardID != _boardIDPX4Flow && _boardID != _boardIDPX4FMUV1 && _boardID != _boardIDPX4FMUV2 && _boardID != _boardIDuNode != _boardIDSTM32F4Discovery && _boardID ) {
+    if (_boardID != _boardIDPX4Flow && _boardID != _boardIDPX4FMUV1 && _boardID != _boardIDPX4FMUV2 && _boardID != _boardIDuNode && _boardID !=_boardIDSTM32F4Discovery) {
         _errorString = tr("Unsupported board: %1").arg(_boardID);
         goto Error;
     }

--- a/src/VehicleSetup/PX4Bootloader.h
+++ b/src/VehicleSetup/PX4Bootloader.h
@@ -146,6 +146,7 @@ private:
     static const int _boardIDPX4FMUV2 = 9;  ///< Board ID for PX4 V2 board
     static const int _boardIDPX4Flow = 6;   ///< Board ID for PX4 Floaw board
     static const int _boardIDuNode  = 29;   ///< Board ID for uNode board
+    static const int _boardIDSTM32F4Discovery = 99; ///< Board ID for STM32F4Discovery board
     
     uint32_t    _boardID;           ///< board id for currently connected board
     uint32_t    _boardFlashSize;    ///< flash size for currently connected board


### PR DESCRIPTION
I just tryed to connect the stm32f4discoveryboard with qgroundcontrol.
Before doing this a installed the px4bootloader on the discovery.
If I manual upload firmware with the px4bootloader its working without any problems.
If I connect with qgroundcontrol I get:

    Board found: Port: \.\COM30
    Description: \.\COM30
    Attemping to communicate with bootloader...
    Error: Get Board Info: Unsupported board: 99

in the Qgroundcontrol terminal it's:
Found Board:
port name: "com30"
description: PX4 FMU
vendor ID 9900
product id 1
Bootloader error: "Get Board Info: Unsupported board: 99""""

=> according to https://github.com/PX4/Firmware/blob/master/Images/px4-stm32f4discovery.prototype
the Board ID is 99

=> not tested