### PR TITLE
Allow firmware flash for unknown board ids

### DIFF
--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -121,7 +121,7 @@ Rectangle {
             frameVisible:	false
 			font.pointSize: qgcPal.dpiAdjustedDefaultFontPointSize
             
-			text: qsTr("Please disconnect all connections and unplug board from USB before selecting Upgrade.")
+			text: qsTr("Please disconnect all vehicles from QGroundControl before selecting Upgrade.")
 
             style: TextAreaStyle {
                 textColor: qgcPal.text

--- a/src/VehicleSetup/PX4Bootloader.cc
+++ b/src/VehicleSetup/PX4Bootloader.cc
@@ -439,10 +439,6 @@ bool PX4Bootloader::getBoardInfo(QextSerialPort* port, uint32_t& bootloaderVersi
     if (!getBoardInfo(port, INFO_BOARD_ID, _boardID)) {
         goto Error;
     }
-    if (_boardID != _boardIDPX4Flow && _boardID != _boardIDPX4FMUV1 && _boardID != _boardIDPX4FMUV2 && _boardID != _boardIDuNode) {
-        _errorString = tr("Unsupported board: %1").arg(_boardID);
-        goto Error;
-    }
     
     if (!getBoardInfo(port, INFO_FLASH_SIZE, _boardFlashSize)) {
         qWarning() << _errorString;

--- a/src/VehicleSetup/PX4Bootloader.h
+++ b/src/VehicleSetup/PX4Bootloader.h
@@ -142,11 +142,6 @@ private:
     bool _bootloaderVerifyRev2(QextSerialPort* port, const QString firmwareFilename);
     bool _bootloaderVerifyRev3(QextSerialPort* port);
     
-    static const int _boardIDPX4FMUV1 = 5;  ///< Board ID for PX4 V1 board
-    static const int _boardIDPX4FMUV2 = 9;  ///< Board ID for PX4 V2 board
-    static const int _boardIDPX4Flow = 6;   ///< Board ID for PX4 Floaw board
-    static const int _boardIDuNode  = 29;   ///< Board ID for uNode board
-    
     uint32_t    _boardID;           ///< board id for currently connected board
     uint32_t    _boardFlashSize;    ///< flash size for currently connected board
     uint32_t    _imageCRC;          ///< CRC for image in currently selected firmware file


### PR DESCRIPTION
- Unknown board ids are force to custom firmware load
- Board id must still match board id in px4
- Flash of .bin is allowed in all cases