### PR TITLE
Reset heartbeat timeout on new connection.

### DIFF
--- a/src/ui/toolbar/MainToolBar.cc
+++ b/src/ui/toolbar/MainToolBar.cc
@@ -334,6 +334,9 @@ void MainToolBar::_setActiveUAS(UASInterface* active)
         QGCUASParamManagerInterface* paramMgr = _mav->getParamManager();
         Q_ASSERT(paramMgr);
         connect(paramMgr, SIGNAL(parameterListProgress(float)),              this, SLOT(_setProgressBarValue(float)));
+        // Reset connection lost (if any)
+        _currentHeartbeatTimeout = 0;
+        emit heartbeatTimeoutChanged(_currentHeartbeatTimeout);
     }
     // Let toolbar know about it
     emit mavPresentChanged(_mav != NULL);


### PR DESCRIPTION
This fixes #1481.
The heartbeat timeout was not being reset on new connections.