### PR TITLE
Reset internal param values after calibrate

### DIFF
--- a/src/ui/px4_configuration/PX4RCCalibration.cc
+++ b/src/ui/px4_configuration/PX4RCCalibration.cc
@@ -936,6 +936,7 @@ void PX4RCCalibration::_writeCalibration(void)
     paramMgr->sendPendingParameters(true, true);
     
     _stopCalibration();
+    _setInternalCalibrationValuesFromParameters();
 }
 
 void PX4RCCalibration::_updateView()


### PR DESCRIPTION
This way live rc update is correct after a calibrate. Fixes Issue #1297 