### PR TITLE
Starting window size

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -246,6 +246,7 @@ MainWindow::MainWindow(QSplashScreen* splashScreen)
             int w = scrSize.width()  > 1600 ? 1600 : scrSize.width();
             int h = scrSize.height() >  800 ?  800 : scrSize.height();
             resize(w, h);
+            move((scrSize.width() - w) / 2, (scrSize.height() - h) / 2);
         }
     }
 

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -235,15 +235,17 @@ MainWindow::MainWindow(QSplashScreen* splashScreen)
     else
     {
         // Adjust the size
-        const int screenWidth  = QApplication::desktop()->width();
-        const int screenHeight = QApplication::desktop()->height();
-        if (screenWidth < 1500)
+        QScreen* scr = QApplication::primaryScreen();
+        QSize scrSize = scr->availableSize();
+        if (scrSize.width() <= 1280)
         {
-            resize(screenWidth, screenHeight - 80);
+            resize(scrSize.width(), scrSize.height());
         }
         else
         {
-            resize(screenWidth*0.67f, qMin(screenHeight, (int)(screenWidth*0.67f*0.67f)));
+            int w = scrSize.width()  > 1600 ? 1600 : scrSize.width();
+            int h = scrSize.height() >  800 ?  800 : scrSize.height();
+            resize(w, h);
         }
     }
 


### PR DESCRIPTION
This deals with issue #1467.

On smaller screens (1280 or less), it goes full (available) screen. On larger screens it goes up to 1600x800 as an initial size.

The original code was using the *Desktop* size to compute how large a window could go. On Windows, when you have multiple displays, the *Desktop* is the combined area spanning all displays.