### PR TITLE
Handling multi-platform sizing (fonts and pixels)

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
@@ -364,7 +364,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: screenTools.dpiAdjustedPointSize(20);
+                    font.pointSize: screenTools.fontPointFactor * (20);
                 }
 
                 Item { height: 20; width: 10 } // spacer
@@ -894,7 +894,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: screenTools.dpiAdjustedPointSize(20);
+                    font.pointSize: screenTools.fontPointFactor * (20);
                 }
 
                 QGCLabel {

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -98,13 +98,13 @@ Rectangle {
 
         QGCLabel {
             text: "POWER CONFIG"
-            font.pointSize: screenTools.dpiAdjustedPointSize(20);
+            font.pointSize: screenTools.fontPointFactor * (20);
         }
 
         QGCLabel {
             text: "Battery"
             color: palette.text
-            font.pointSize: screenTools.dpiAdjustedPointSize(20);
+            font.pointSize: screenTools.fontPointFactor * (20);
         }
 
         Rectangle {
@@ -231,7 +231,7 @@ Rectangle {
                 QGCLabel {
                     text: "Propeller Function"
                     color: palette.text
-                    font.pointSize: screenTools.dpiAdjustedPointSize(20);
+                    font.pointSize: screenTools.fontPointFactor * (20);
                 }
                 Rectangle {
                     width: parent.width
@@ -245,7 +245,7 @@ Rectangle {
                 QGCLabel {
                     text: "Magnetometer Distortion"
                     color: palette.text
-                    font.pointSize: screenTools.dpiAdjustedPointSize(20);
+                    font.pointSize: screenTools.fontPointFactor * (20);
                 }
                 Rectangle {
                     width: parent.width
@@ -264,7 +264,7 @@ Rectangle {
         QGCLabel {
             text: "Advanced Power Settings"
             color: palette.text
-            font.pointSize: screenTools.dpiAdjustedPointSize(20);
+            font.pointSize: screenTools.fontPointFactor * (20);
             visible: showAdvanced.checked
         }
         Rectangle {

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -54,7 +54,7 @@ Rectangle {
 
         QGCLabel {
             text: "SAFETY CONFIG"
-            font.pointSize: screenTools.dpiAdjustedPointSize(20);
+            font.pointSize: screenTools.fontPointFactor * (20);
         }
 
         Item { height: 20; width: 10 } // spacer
@@ -62,7 +62,7 @@ Rectangle {
         //-----------------------------------------------------------------
         //-- Return Home Triggers
 
-        QGCLabel { text: "Triggers For Return Home"; color: palette.text; font.pointSize: screenTools.dpiAdjustedPointSize(20); }
+        QGCLabel { text: "Triggers For Return Home"; color: palette.text; font.pointSize: screenTools.fontPointFactor * (20); }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -121,7 +121,7 @@ Rectangle {
         //-----------------------------------------------------------------
         //-- Return Home Settings
 
-        QGCLabel { text: "Return Home Settings"; font.pointSize: screenTools.dpiAdjustedPointSize(20); }
+        QGCLabel { text: "Return Home Settings"; font.pointSize: screenTools.fontPointFactor * (20); }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -291,7 +291,7 @@ Rectangle {
         QGCLabel {
             property Fact fact: Fact { name: "NAV_RCL_OBC" }
             width: parent.width
-            font.pointSize: screenTools.dpiAdjustedPointSize(14);
+            font.pointSize: screenTools.fontPointFactor * (14);
             text: "Warning: You have an advanced safety configuration set using the NAV_RCL_OBC parameter. The above settings may not apply.";
             visible: fact.value !== 0
             wrapMode: Text.Wrap
@@ -299,7 +299,7 @@ Rectangle {
         QGCLabel {
             property Fact fact: Fact { name: "NAV_DLL_OBC" }
             width: parent.width
-            font.pointSize: screenTools.dpiAdjustedPointSize(14);
+            font.pointSize: screenTools.fontPointFactor * (14);
             text: "Warning: You have an advanced safety configuration set using the NAV_DLL_OBC parameter. The above settings may not apply.";
             visible: fact.value !== 0
             wrapMode: Text.Wrap

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -91,7 +91,7 @@ Rectangle {
 
         QGCLabel {
             text: "SENSORS CONFIG"
-            font.pointSize: screenTools.dpiAdjustedPointSize(20);
+            font.pointSize: screenTools.fontPointFactor * (20);
         }
 
         Item { height: 20; width: 10 } // spacer

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -585,7 +585,7 @@ void QGCApplication::_loadCurrentStyle(void)
             QRegularExpressionMatch match = regex.match(line);
             if (match.hasMatch()) {
                 //qDebug() << "found:" << line << match.captured(1);
-                adjustedLine = QString("font-size: %1pt;").arg(ScreenTools::dpiAdjustedPointSize_s(match.captured(1).toDouble()));
+                adjustedLine = QString("font-size: %1pt;").arg(ScreenTools::adjustFontPointSize_s(match.captured(1).toDouble()));
                 //qDebug() << "adjusted:" << adjustedLine;
             } else {
                 adjustedLine = line;

--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -30,8 +30,6 @@
 #include <QApplication>
 #include <QPalette>
 
-const qreal QGCPalette::_defaultFontPointSize = 12;
-
 QList<QGCPalette*>   QGCPalette::_paletteObjects;
 
 QGCPalette::Theme QGCPalette::_theme = QGCPalette::Dark;
@@ -134,7 +132,3 @@ void QGCPalette::_themeChanged(void)
     emit paletteChanged();
 }
 
-qreal QGCPalette::dpiAdjustedDefaultFontPointSize(void)
-{
-    return ScreenTools::dpiAdjustedPointSize_s(_defaultFontPointSize);
-}

--- a/src/QGCPalette.h
+++ b/src/QGCPalette.h
@@ -83,10 +83,6 @@ class QGCPalette : public QObject
     // Text color for TextFields
     Q_PROPERTY(QColor textFieldText READ textFieldText NOTIFY paletteChanged)
     
-    Q_PROPERTY(qreal defaultFontPointSize MEMBER _defaultFontPointSize CONSTANT)
-    
-    Q_PROPERTY(qreal dpiAdjustedDefaultFontPointSize READ dpiAdjustedDefaultFontPointSize CONSTANT)
-    
 public:
     enum ColorGroup {
         Disabled = 0,
@@ -123,9 +119,7 @@ public:
     
     static Theme globalTheme(void) { return _theme; }
     static void setGlobalTheme(Theme newTheme);
-    
-    qreal dpiAdjustedDefaultFontPointSize(void);
-    
+
 signals:
     void paletteChanged(void);
     
@@ -154,8 +148,6 @@ private:
     
     static QColor _textField[_cThemes][_cColorGroups];
     static QColor _textFieldText[_cThemes][_cColorGroups];
-    
-    static const qreal _defaultFontPointSize;
     
     void _themeChanged(void);
     

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -182,7 +182,7 @@ property Fact __propertiesDialogFact: Fact { }
 
 						QGCLabel {
 							text: "Component #: " + componentId.toString()
-							font.pointSize: __screenTools.dpiAdjustedPointSize(__qgcPal.defaultFontPointSize + 4);
+                            font.pointSize: __screenTools.fontPointFactor * (16);
 						}
 
                         Item {
@@ -214,7 +214,7 @@ property Fact __propertiesDialogFact: Fact { }
                                                 x:					__leftMargin
                                                 text:				modelData
                                                 verticalAlignment:	Text.AlignVCenter
-                                                font.pointSize:		__screenTools.dpiAdjustedPointSize(__qgcPal.defaultFontPointSize + 2);
+                                                font.pointSize:		__screenTools.fontPointFactor * (__qgcPal.defaultFontPointSize + 2);
                                             }
                                         }
 

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -104,9 +104,9 @@ Button {
 
                     Text {
                         id:             text
-                        renderType:     Text.NativeRendering
+                        antialiasing:   true
                         text:           control.text
-                        font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+                        font.pointSize: __screenTools.defaultFontPointSize
 
                         anchors.verticalCenter: parent.verticalCenter
 

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -3,9 +3,11 @@ import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 
 import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 CheckBox {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    property ScreenTools __screenTools: ScreenTools { }
 
     style: CheckBoxStyle {
         label: Item {
@@ -27,7 +29,8 @@ CheckBox {
             Text {
                 id:             text
                 text:           control.text
-                font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+                antialiasing:   true
+                font.pointSize: __screenTools.defaultFontPointSize
 
                 anchors.centerIn: parent
 

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -4,14 +4,15 @@ import QtQuick.Controls.Styles 1.2
 import QtQuick.Controls.Private 1.0
 
 import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 ComboBox {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-
+    property ScreenTools __screenTools: ScreenTools { }
     property bool __showHighlight: pressed | hovered
 
     style: ComboBoxStyle {
-		font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+        font.pointSize: __screenTools.defaultFontPointSize
         textColor: __showHighlight ?
                     control.__qgcPal.buttonHighlightText :
                     control.__qgcPal.buttonText

--- a/src/QmlControls/QGCLabel.qml
+++ b/src/QmlControls/QGCLabel.qml
@@ -3,12 +3,15 @@ import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 
 import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 Text {
     QGCPalette { id: __qgcPal; colorGroupEnabled: enabled }
+    property ScreenTools __screenTools: ScreenTools { }
 
     property bool enabled: true
 
-    font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+    font.pointSize: __screenTools.defaultFontPointSize
     color:          __qgcPal.text
+    antialiasing:   true
 }

--- a/src/QmlControls/QGCMovableItem.qml
+++ b/src/QmlControls/QGCMovableItem.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.2
 import QtQuick.Controls 1.2
+import QGroundControl.ScreenTools 1.0
 
 // This item can be dragged around within its parent.
 // Double click issues a signal the parent can use to
@@ -7,9 +8,10 @@ import QtQuick.Controls 1.2
 
 Item {
     id: root
+    property ScreenTools __screenTools: ScreenTools { }
     property bool   allowDragging:  true
-    property real   minimumWidth:   60
-    property real   minimumHeight:  60
+    property real   minimumWidth:   __screenTools.pixelSizeFactor * (60)
+    property real   minimumHeight:  __screenTools.pixelSizeFactor * (60)
     property alias  tForm:          tform
     signal          resetRequested()
     transform: Scale {

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -3,9 +3,11 @@ import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 
 import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 RadioButton {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    property ScreenTools __screenTools: ScreenTools { }
 
     style: RadioButtonStyle {
         label: Item {
@@ -27,7 +29,8 @@ RadioButton {
             Text {
                 id:             text
                 text:           control.text
-                font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+                font.pointSize: __screenTools.defaultFontPointSize
+                antialiasing:   true
 
                 anchors.centerIn: parent
 

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -3,12 +3,14 @@ import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 
 import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 TextField {
     property bool showUnits: false
     property string unitsLabel: ""
 
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    property ScreenTools __screenTools: ScreenTools { }
 
     textColor: __qgcPal.textFieldText
 
@@ -17,6 +19,7 @@ TextField {
         text: unitsLabel
         width: contentWidth + ((parent.__contentHeight/3)*2)
         visible: false
+        antialiasing: true
     }
 
     style: TextFieldStyle {
@@ -31,7 +34,6 @@ TextField {
 
             Rectangle {
                 anchors.fill: parent
-
                 border.color: control.activeFocus ? "#47b" : "#999"
                 color: __qgcPal.textField
             }
@@ -49,7 +51,8 @@ TextField {
                 width: unitsLabelWidthGenerator.width
 
                 text: control.unitsLabel
-                font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+                font.pointSize: __screenTools.defaultFontPointSize
+                antialiasing:   true
 
                 color: control.textColor
                 visible: control.showUnits

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -54,11 +54,10 @@ QGCButton {
                 }
             }
         }
-        label: Label {
+        label: QGCLabel {
             text: button.text
-            font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
             horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
+            verticalAlignment:   Text.AlignVCenter
             color: showHighlight ? __qgcPal.buttonHighlightText : (button.checked ? __qgcPal.primaryButtonText : __qgcPal.buttonText)
         }
     }

--- a/src/QmlControls/ScreenTools.h
+++ b/src/QmlControls/ScreenTools.h
@@ -36,11 +36,6 @@
     @code
     import QGroundControl.ScreenTools 1.0
     @endcode
-    @remark As for the screen density functions, QtQuick provides the \c Screen type (defined in QtQuick.Window)
-    but as of Qt 5.4 (QtQuick.Window 2.2), this only works if the main window is QtQuick. As QGC is primarily
-    a Qt application and only some of its UI elements are QLM widgets, this does not work. Hence, these function
-    defined here.
-    @sa <a href="http://doc.qt.io/qt-5/qml-qtquick-window-screen.html">Screen QML Type</a>
 */
 
 /// This Qml control is used to return screen parameters
@@ -50,32 +45,6 @@ class ScreenTools : public QObject
 public:
     ScreenTools();
 
-    //! Returns the screen density in Dots Per Inch
-    Q_PROPERTY(double   screenDPI           READ screenDPI CONSTANT)
-    //! Returns a factor used to calculate the font point size to use
-    /*!
-      When defining fonts in point size, as in:
-      @code
-      Text {
-        text: "Foo Bar"
-        font.pointSize: 14
-      }
-      @endcode
-      The size is device dependent. If you define this based on a screen set to 72dpi (Mac OS), once
-      this is displayed on a different screen with a different pixel density, such as 96dpi (Windows),
-      the text will be displayed in the wrong size.
-      Use \c dpiFactor to accomodate for these differences. All font point sizes are given in 72dpi
-      and \c dpiFactor returns a factor to use for adjusting it to the current target screen.
-      @code
-      import QGroundControl.ScreenTools 1.0
-      property ScreenTools screenTools: ScreenTools { }
-      Text {
-        text: "Foo Bar"
-        font.pointSize: 14 * screenTools.dpiFactor
-      }
-      @endcode
-     */
-    Q_PROPERTY(double   dpiFactor           READ dpiFactor CONSTANT)
     //! Returns the global mouse X position
     Q_PROPERTY(int      mouseX              READ mouseX)
     //! Returns the global mouse Y position
@@ -108,35 +77,55 @@ public:
         }
       @endcode
      */
-    Q_PROPERTY(bool     repaintRequested    READ repaintRequested   NOTIFY repaintRequestedChanged)
 
-    //! Utility for adjusting font point size.
-    /*!
-      @sa dpiFactor
-     */
-    Q_INVOKABLE qreal   dpiAdjustedPointSize(qreal pointSize);
+    Q_PROPERTY(bool     repaintRequested     READ repaintRequested     NOTIFY repaintRequestedChanged)
+    //! Returns the font point size factor
+    Q_PROPERTY(double   fontPointFactor      READ fontPointFactor      NOTIFY fontPointFactorChanged)
+    //! Returns the pixel size factor
+    Q_PROPERTY(double   pixelSizeFactor      READ pixelSizeFactor      NOTIFY pixelSizeFactorChanged)
+    //! Returns the system wide default font point size (properly scaled)
+    Q_PROPERTY(double   defaultFontPointSize READ defaultFontPointSize NOTIFY defaultFontPointSizeChanged)
 
-    /// Static version of dpiAdjustedPointSize of use in C++ code
-    static qreal dpiAdjustedPointSize_s(qreal pointSize);
-    
-    double  screenDPI           () { return _dotsPerInch; }
-    double  dpiFactor           () { return _dpiFactor; }
+    //! Utility for adjusting font point size. Not dynamic (no signals)
+    Q_INVOKABLE qreal   adjustFontPointSize(qreal pointSize);
+    //! Utility for adjusting pixel size. Not dynamic (no signals)
+    Q_INVOKABLE qreal   adjustPixelSize(qreal pixelSize);
+
+    //! Utility for increasing pixel size.
+    Q_INVOKABLE void    increasePixelSize();
+    //! Utility for decreasing pixel size.
+    Q_INVOKABLE void    decreasePixelSize();
+    //! Utility for increasing font size.
+    Q_INVOKABLE void    increaseFontSize();
+    //! Utility for decreasing font size.
+    Q_INVOKABLE void    decreaseFontSize();
+
+    /// Static version of adjustFontPointSize of use in C++ code
+    static qreal adjustFontPointSize_s(qreal pointSize);
+    /// Static version of adjustPixelSize of use in C++ code
+    static qreal adjustPixelSize_s(qreal pixelSize);
+
     int     mouseX              () { return QCursor::pos().x(); }
     int     mouseY              () { return QCursor::pos().y(); }
     bool    repaintRequested    () { return true; }
+    double  fontPointFactor     ();
+    double  pixelSizeFactor     ();
+    double  defaultFontPointSize(void);
 
 signals:
     void repaintRequestedChanged();
+    void pixelSizeFactorChanged();
+    void fontPointFactorChanged();
+    void defaultFontPointSizeChanged();
 
 private slots:
     void _updateCanvas();
+    void _updatePixelSize();
+    void _updateFontSize();
 
 private:
-    static void _setDpiFactor(void);
-    
-    static bool _dpiFactorSet;
-    static double _dotsPerInch;
-    static double _dpiFactor;
+    static const double _defaultFontPointSize;
+
 };
 
 #endif

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls.Styles 1.2
 import QtGraphicalEffects 1.0
 
 import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 Button {
     checkable: true
@@ -13,6 +14,7 @@ Button {
     property bool setupComplete: true
     property bool setupIndicator: true
     property string imageResource: "subMenuButtonImage.png"
+    property ScreenTools __screenTools: ScreenTools { }
 
     style: ButtonStyle {
         id: buttonStyle
@@ -39,7 +41,8 @@ Button {
                 horizontalAlignment: TextEdit.AlignHCenter
 
                 text: control.text
-                font.pointSize: __qgcPal.dpiAdjustedDefaultFontPointSize
+                font.pointSize: __screenTools.defaultFontPointSize
+                antialiasing: true
                 color: __showHighlight ? __qgcPal.buttonHighlightText : __qgcPal.buttonText
 
                 Rectangle {

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -71,7 +71,7 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         __screenTools.dpiAdjustedPointSize(25);
+            font.pointSize:         __screenTools.fontPointFactor * (25);
             font.bold:              true
             color:                  "black"
 
@@ -82,7 +82,7 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         __screenTools.dpiAdjustedPointSize(25);
+            font.pointSize:         __screenTools.fontPointFactor * (25);
             color:                  calInProgress ? "yellow" : "white"
 
             text: parent.calText

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -51,7 +51,7 @@ Rectangle {
 
         QGCLabel {
             text: "FIRMWARE UPDATE"
-            font.pointSize: screenTools.dpiAdjustedPointSize(20);
+            font.pointSize: screenTools.fontPointFactor * (20);
         }
 
         Item {
@@ -119,7 +119,7 @@ Rectangle {
             height:			300
             readOnly:		true
             frameVisible:	false
-			font.pointSize: qgcPal.dpiAdjustedDefaultFontPointSize
+            font.pointSize: screenTools.defaultFontPointSize
             
 			text: qsTr("Please disconnect all vehicles from QGroundControl before selecting Upgrade.")
 

--- a/src/VehicleSetup/SetupParameterEditor.qml
+++ b/src/VehicleSetup/SetupParameterEditor.qml
@@ -44,7 +44,7 @@ Rectangle {
 
         QGCLabel {
             text: "PARAMETER EDITOR"
-            font.pointSize: screenTools.dpiAdjustedPointSize(20)
+            font.pointSize: screenTools.fontPointFactor * (20)
         }
 
         Item {

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -47,7 +47,7 @@ Rectangle {
 
         QGCLabel {
             text: "VEHICLE SUMMARY"
-            font.pointSize: screenTools.dpiAdjustedPointSize(20);
+            font.pointSize: screenTools.fontPointFactor * (20);
         }
 
         Item {
@@ -60,7 +60,7 @@ Rectangle {
             width:			parent.width
 			wrapMode:		Text.WordWrap
 			color:			autopilot.setupComplete ? qgcPal.text : "red"
-			font.pointSize: autopilot.setupComplete ? qgcPal.dpiAdjustedDefaultFontPointSize : screenTools.dpiAdjustedPointSize(20)
+            font.pointSize: autopilot.setupComplete ? screenTools.defaultFontPointSize : screenTools.fontPointFactor * (20)
 			text: autopilot.setupComplete ?
 						"Below you will find a summary of the settings for your vehicle. To the left are the setup buttons for deatiled settings for each component." :
 						"WARNING: One or more of your vehicle's components require setup prior to flight. It will be shown with a red circular indicator below. " +

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -82,6 +82,26 @@ This file is part of the QGROUNDCONTROL project
 
 #include "LogCompressor.h"
 
+// Pixel size, instead of a physical thing is actually a philosophical question when
+// it comes to Qt. Fonts are that and some heavy Kabalistic Voodoo added to the mix.
+// The values below came from actually measuring the elements on the screen on these
+// devices. I have yet to find a constant from Qt so these things can be properly
+// computed at runtime.
+
+#if defined(Q_OS_OSX)
+double MainWindow::_pixelFactor    = 1.0;
+double MainWindow::_fontFactor     = 1.0;
+#elif defined(Q_OS_WIN)
+double MainWindow::_pixelFactor    = 0.86;
+double MainWindow::_fontFactor     = 0.63;
+#elif defined(__android__)
+double MainWindow::_pixelFactor    = 2.0;
+double MainWindow::_fontFactor     = 1.23;
+#elif defined(Q_OS_LINUX)
+double MainWindow::_pixelFactor    = 1.0;
+double MainWindow::_fontFactor     = 0.85;
+#endif
+
 /// The key under which the Main Window settings are saved
 const char* MAIN_SETTINGS_GROUP = "QGC_MAINWINDOW";
 
@@ -226,6 +246,8 @@ MainWindow::MainWindow(QSplashScreen* splashScreen)
     emit initStatusChanged(tr("Restoring last view state"), Qt::AlignLeft | Qt::AlignBottom, QColor(62, 93, 141));
     // Restore the window setup
     _loadCurrentViewState();
+#ifndef __android__
+
     // Restore the window position and size
     emit initStatusChanged(tr("Restoring last window size"), Qt::AlignLeft | Qt::AlignBottom, QColor(62, 93, 141));
     if (settings.contains(_getWindowGeometryKey()))
@@ -265,6 +287,8 @@ MainWindow::MainWindow(QSplashScreen* splashScreen)
     // And that they will stay checked properly after user input
     connect(_ui.actionFullscreen, &QAction::triggered, this, &MainWindow::fullScreenActionItemCallback);
     connect(_ui.actionNormal,     &QAction::triggered, this, &MainWindow::normalActionItemCallback);
+#endif
+
     connect(_ui.actionStatusBar,  &QAction::triggered, this, &MainWindow::showStatusBarCallback);
 
     // Set OS dependent keyboard shortcuts for the main window, non OS dependent shortcuts are set in MainWindow.ui
@@ -295,6 +319,9 @@ MainWindow::MainWindow(QSplashScreen* splashScreen)
     if (!qgcApp()->runningUnitTests()) {
         _ui.actionStatusBar->setChecked(_showStatusBar);
         showStatusBarCallback(_showStatusBar);
+#ifdef __android__
+        menuBar()->hide();
+#endif
         show();
 #ifdef Q_OS_MAC
         // TODO HACK
@@ -733,9 +760,11 @@ void MainWindow::loadSettings()
     // Why the screaming?
     QSettings settings;
     settings.beginGroup(MAIN_SETTINGS_GROUP);
-    _autoReconnect = settings.value("AUTO_RECONNECT", _autoReconnect).toBool();
-    _lowPowerMode  = settings.value("LOW_POWER_MODE", _lowPowerMode).toBool();
-    _showStatusBar = settings.value("SHOW_STATUSBAR", _showStatusBar).toBool();
+    _autoReconnect  = settings.value("AUTO_RECONNECT",      _autoReconnect).toBool();
+    _lowPowerMode   = settings.value("LOW_POWER_MODE",      _lowPowerMode).toBool();
+    _showStatusBar  = settings.value("SHOW_STATUSBAR",      _showStatusBar).toBool();
+    _fontFactor     = settings.value("FONT_SIZE_FACTOR",    _fontFactor).toDouble();
+    _pixelFactor    = settings.value("PIXEL_SIZE_FACTOR",   _pixelFactor).toDouble();
     settings.endGroup();
     // Select the proper view. Default to the flight view or load the last one used if it's supported.
     VIEW_SECTIONS currentViewCandidate = (VIEW_SECTIONS) settings.value("CURRENT_VIEW", _currentView).toInt();
@@ -764,9 +793,11 @@ void MainWindow::storeSettings()
 {
     QSettings settings;
     settings.beginGroup(MAIN_SETTINGS_GROUP);
-    settings.setValue("AUTO_RECONNECT", _autoReconnect);
-    settings.setValue("LOW_POWER_MODE", _lowPowerMode);
-    settings.setValue("SHOW_STATUSBAR", _showStatusBar);
+    settings.setValue("AUTO_RECONNECT",     _autoReconnect);
+    settings.setValue("LOW_POWER_MODE",     _lowPowerMode);
+    settings.setValue("SHOW_STATUSBAR",     _showStatusBar);
+    settings.setValue("FONT_SIZE_FACTOR",   _fontFactor);
+    settings.setValue("PIXEL_SIZE_FACTOR",  _pixelFactor);
     settings.endGroup();
     settings.setValue(_getWindowGeometryKey(), saveGeometry());
 	
@@ -1317,6 +1348,22 @@ void MainWindow::restoreLastUsedConnection()
 void MainWindow::_linkStateChange(LinkInterface*)
 {
     emit repaintCanvas();
+}
+
+void MainWindow::setPixelSizeFactor(double size) {
+    if(size < 0.1) {
+        size = 0.1;
+    }
+    _pixelFactor = size;
+    emit pixelSizeChanged();
+}
+
+void MainWindow::setFontSizeFactor(double size) {
+    if(size < 0.1) {
+        size = 0.1;
+    }
+    _fontFactor = size;
+    emit fontSizeChanged();
 }
 
 #ifdef QGC_MOUSE_ENABLED_LINUX

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -129,6 +129,15 @@ public:
     
     QWidget* getCurrentViewWidget(void) { return _currentViewWidget; }
 
+    //! Returns the font point size factor
+    static double   fontPointFactor() { return _fontFactor; }
+    //! Returns the pixel size factor
+    static double   pixelSizeFactor() { return _pixelFactor; }
+    //! Sets pixel size factor
+    void            setPixelSizeFactor(double size);
+    //! Sets font size factor
+    void            setFontSizeFactor(double size);
+
 public slots:
     /** @brief Show the application settings */
     void showSettings();
@@ -202,6 +211,10 @@ signals:
     void valueChanged(const int uasId, const QString& name, const QString& unit, const QVariant& value, const quint64 msec);
     /** Emitted when any the Canvas elements within QML wudgets need updating */
     void repaintCanvas();
+    /** Emitted when pixel size factor changes */
+    void pixelSizeChanged();
+    /** Emitted when pixel size factor changes */
+    void fontSizeChanged();
 
 #ifdef QGC_MOUSE_ENABLED_LINUX
     /** @brief Forward X11Event to catch 3DMouse inputs */
@@ -369,6 +382,9 @@ private:
     QString _getWindowStateKey();
     QString _getWindowGeometryKey();
 
+    // UI Dimension Factors
+    static double _pixelFactor;
+    static double _fontFactor;
 
 };
 

--- a/src/ui/flightdisplay/FlightDisplay.qml
+++ b/src/ui/flightdisplay/FlightDisplay.qml
@@ -28,14 +28,20 @@ This file is part of the QGROUNDCONTROL project
  */
 
 import QtQuick 2.3
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.3
 import QtQuick.Controls.Styles 1.2
+import QtQuick.Dialogs 1.2
 
 import QGroundControl.FlightControls 1.0
+import QGroundControl.ScreenTools 1.0
+import QGroundControl.Controls 1.0
+import QGroundControl.Palette 1.0
 
-Rectangle {
+Item {
     id: root
-    color: Qt.rgba(0,0,0,0);
+
+    property ScreenTools __screenTools: ScreenTools { }
+    property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
 
     property real roll:    isNaN(flightDisplay.roll)    ? 0 : flightDisplay.roll
     property real pitch:   isNaN(flightDisplay.pitch)   ? 0 : flightDisplay.pitch
@@ -68,6 +74,203 @@ Rectangle {
         mapTypeMenu.update();
     }
 
+    // TODO: This is to replace the context menu but it is not working. Not only the buttons don't show,
+    // the default placement is random and mostly off screen on mobile devices.
+    Dialog {
+        id: optionsDialog
+        modality: Qt.WindowModal
+        title: "Flight Display Options"
+        standardButtons: StandardButton.Close | StandardButton.RestoreDefaults
+        onReset: {
+            showPitchIndicator = true;
+            flightDisplay.saveSetting("showPitchIndicator", setBool(showPitchIndicator));
+            showAttitudeIndicator = true;
+            flightDisplay.saveSetting("showAttitudeIndicator", setBool(showAttitudeIndicator));
+            showCompass = true;
+            flightDisplay.saveSetting("showCompass", setBool(showCompass));
+            altitudeWidget.visible = true;
+            flightDisplay.saveSetting("showAltitudeWidget", setBool(altitudeWidget.visible));
+            currentAltitude.showAltitude = true;
+            flightDisplay.saveSetting("showCurrentAltitude", setBool(currentAltitude.showAltitude));
+            currentAltitude.showClimbRate = true;
+            flightDisplay.saveSetting("showCurrentClimbRate", setBool(currentAltitude.showClimbRate));
+            speedWidget.visible = true;
+            flightDisplay.saveSetting("showSpeedWidget", setBool(speedWidget.visible));
+            currentSpeed.showAirSpeed = true;
+            flightDisplay.saveSetting("showCurrentAirSpeed", setBool(currentSpeed.showAirSpeed));
+            currentSpeed.showGroundSpeed = true;
+            flightDisplay.saveSetting("showCurrentGroundSpeed", setBool(currentSpeed.showGroundSpeed));
+            mapBackground.visible = false;
+            flightDisplay.saveSetting("showMapBackground", setBool(mapBackground.visible));
+            mapBackground.alwaysNorth = false;
+            flightDisplay.saveSetting("mapAlwaysPointsNorth", setBool(mapBackground.alwaysNorth));
+        }
+        contentItem: Rectangle {
+            color: __qgcPal.window
+            implicitWidth:  __screenTools.pixelSizeFactor * (360)
+            implicitHeight: __screenTools.pixelSizeFactor * (300)
+            Column {
+                id: dialogColumn
+                anchors.centerIn: parent
+                spacing:  __screenTools.adjustPixelSize(10)
+                width: parent.width
+                Grid {
+                    columns: 2
+                    spacing:    __screenTools.pixelSizeFactor * (8)
+                    rowSpacing: __screenTools.pixelSizeFactor * (10)
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    QGCCheckBox {
+                        text: "Map Background"
+                        checked: mapBackground.visible
+                        onClicked:
+                        {
+                            mapBackground.visible = !mapBackground.visible;
+                            flightDisplay.saveSetting("showMapBackground", setBool(mapBackground.visible));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Pitch Indicator"
+                        checked: showPitchIndicator
+                        onClicked:
+                        {
+                            showPitchIndicator = !showPitchIndicator;
+                            flightDisplay.saveSetting("showPitchIndicator", setBool(showPitchIndicator));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Attitude Indicator"
+                        checked: showAttitudeIndicator
+                        onClicked:
+                        {
+                            showAttitudeIndicator = !showAttitudeIndicator;
+                            flightDisplay.saveSetting("showAttitudeIndicator", setBool(showAttitudeIndicator));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Compass"
+                        checked: showCompass
+                        onClicked:
+                        {
+                            showCompass = !showCompass;
+                            flightDisplay.saveSetting("showCompass", setBool(showCompass));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Altitude Indicator"
+                        checked: altitudeWidget.visible
+                        onClicked:
+                        {
+                            altitudeWidget.visible = !altitudeWidget.visible;
+                            flightDisplay.saveSetting("showAltitudeWidget", setBool(altitudeWidget.visible));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Current Altitude"
+                        checked: currentAltitude.showAltitude
+                        onClicked:
+                        {
+                            currentAltitude.showAltitude = !currentAltitude.showAltitude;
+                            flightDisplay.saveSetting("showCurrentAltitude", setBool(currentAltitude.showAltitude));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Current Climb Rate"
+                        checked: currentAltitude.showClimbRate
+                        onClicked:
+                        {
+                            currentAltitude.showClimbRate = !currentAltitude.showClimbRate;
+                            flightDisplay.saveSetting("showCurrentClimbRate", setBool(currentAltitude.showClimbRate));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Speed Indicator"
+                        checked: speedWidget.visible
+                        onClicked:
+                        {
+                            speedWidget.visible = !speedWidget.visible;
+                            flightDisplay.saveSetting("showSpeedWidget", setBool(speedWidget.visible));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Current Air Speed"
+                        checked: currentSpeed.showAirSpeed
+                        onClicked:
+                        {
+                            currentSpeed.showAirSpeed = !currentSpeed.showAirSpeed;
+                            flightDisplay.saveSetting("showCurrentAirSpeed", setBool(currentSpeed.showAirSpeed));
+                        }
+                    }
+                    QGCCheckBox {
+                        text: "Current Ground Speed"
+                        checked: currentSpeed.showGroundSpeed
+                        onClicked:
+                        {
+                            currentSpeed.showGroundSpeed = !currentSpeed.showGroundSpeed;
+                            flightDisplay.saveSetting("showCurrentGroundSpeed", setBool(currentSpeed.showGroundSpeed));
+                        }
+                    }
+                }
+                //-- Hack tool to find optimal scale factor
+                Column {
+                    id: fudgeColumn
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing:    __screenTools.adjustPixelSize(4)
+                    width:      parent.width
+                    QGCLabel {
+                        text: "Adjust Pixel Size Factor"
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    Row {
+                        spacing:    __screenTools.adjustPixelSize(4)
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        Button {
+                            text: 'Inc'
+                            onClicked: {
+                                __screenTools.increasePixelSize()
+                            }
+                        }
+                        Label {
+                            text: __screenTools.pixelSizeFactor.toFixed(2)
+                            color: __qgcPal.text
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Button {
+                            text: 'Dec'
+                            onClicked: {
+                                __screenTools.decreasePixelSize()
+                            }
+                        }
+                    }
+                    QGCLabel {
+                        text: "Adjust Font Size Factor"
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    Row {
+                        spacing:    __screenTools.adjustPixelSize(4)
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        Button {
+                            text: 'Inc'
+                            onClicked: {
+                                __screenTools.increaseFontSize()
+                            }
+                        }
+                        Label {
+                            text: __screenTools.fontPointFactor.toFixed(2)
+                            color: __qgcPal.text
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Button {
+                            text: 'Dec'
+                            onClicked: {
+                                __screenTools.decreaseFontSize()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     Menu {
         id: contextMenu
 
@@ -81,6 +284,16 @@ Rectangle {
                 flightDisplay.saveSetting("showMapBackground", setBool(mapBackground.visible));
             }
         }
+
+        /*
+        MenuItem {
+            text: "Options Dialog"
+            onTriggered:
+            {
+                optionsDialog.open()
+            }
+        }
+        */
 
         /*
         MenuItem {
@@ -98,7 +311,7 @@ Rectangle {
         Menu {
             id: mapTypeMenu
             title: "Map Type..."
-            ExclusiveGroup { id: currentMapType }
+            ExclusiveGroup { id: currMapType }
             function setCurrentMap(map) {
                 for (var i = 0; i < mapBackground.mapItem.supportedMapTypes.length; i++) {
                     if (map === mapBackground.mapItem.supportedMapTypes[i].name) {
@@ -112,7 +325,7 @@ Rectangle {
                 var mItem = mapTypeMenu.addItem(map);
                 mItem.checkable = true
                 mItem.checked   = checked
-                mItem.exclusiveGroup = currentMapType
+                mItem.exclusiveGroup = currMapType
                 var menuSlot = function() {setCurrentMap(map);};
                 mItem.triggered.connect(menuSlot);
             }
@@ -277,16 +490,16 @@ Rectangle {
 
     QGCCompassInstrument {
         id:                 compassInstrument
-        y:                  5
-        x:                  85
-        size:               160
+        y:                  __screenTools.pixelSizeFactor * (5)
+        x:                  __screenTools.pixelSizeFactor * (85)
+        size:               __screenTools.pixelSizeFactor * (160)
         heading:            isNaN(flightDisplay.heading) ? 0 : flightDisplay.heading
         visible:            mapBackground.visible && showCompass
         z:                  mapBackground.z + 1
         onResetRequested: {
-            y               = 5
-            x               = 85
-            size            = 160
+            y               = __screenTools.pixelSizeFactor * (5)
+            x               = __screenTools.pixelSizeFactor * (85)
+            size            = __screenTools.pixelSizeFactor * (160)
             tForm.xScale    = 1
             tForm.yScale    = 1
         }
@@ -294,33 +507,42 @@ Rectangle {
 
     QGCAttitudeInstrument {
         id:                 attitudeInstrument
-        y:                  5
-        size:               160
+        y:                  __screenTools.pixelSizeFactor * (5)
+        size:               __screenTools.pixelSizeFactor * (160)
         rollAngle:          roll
         pitchAngle:         pitch
         showPitch:          showPitchIndicator
         visible:            mapBackground.visible && showAttitudeIndicator
         anchors.right:      root.right
-        anchors.rightMargin: 85
+        anchors.rightMargin: __screenTools.pixelSizeFactor * (85)
         z:                  mapBackground.z + 1
         onResetRequested: {
-            y                   = 5
+            y                   = __screenTools.pixelSizeFactor * (5)
             anchors.right       = root.right
-            anchors.rightMargin = 85
-            size                = 160
+            anchors.rightMargin = __screenTools.pixelSizeFactor * (85)
+            size                = __screenTools.pixelSizeFactor * (160)
             tForm.xScale        = 1
             tForm.yScale        = 1
         }
     }
 
-    QGCAttitudeWidget {
-        id:                 attitudeWidget
-        anchors.centerIn:   parent
+    QGCArtificialHorizon {
+        id:                 artificialHoriz
+        anchors.fill:       parent
         rollAngle:          roll
         pitchAngle:         pitch
-        showAttitude:       showAttitudeIndicator
         visible:            !mapBackground.visible
         z:                  10
+    }
+
+    QGCAttitudeWidget {
+        id:                 attitudeWidget
+        rollAngle:          roll
+        pitchAngle:         pitch
+        visible:            !mapBackground.visible && showAttitudeIndicator
+        width:              __screenTools.pixelSizeFactor * (260)
+        height:             __screenTools.pixelSizeFactor * (260)
+        z:                  20
     }
 
     QGCPitchWidget {
@@ -330,14 +552,15 @@ Rectangle {
         pitchAngle:         pitch
         rollAngle:          roll
         color:              Qt.rgba(0,0,0,0)
-        size:               120
+        size:               __screenTools.pixelSizeFactor * (120)
         z:                  30
     }
 
     QGCAltitudeWidget {
         id:                 altitudeWidget
         anchors.right:      parent.right
-        width:              60
+        width:              __screenTools.pixelSizeFactor * (60)
+        height:             parent.height * 0.65 > __screenTools.pixelSizeFactor * (280) ? __screenTools.pixelSizeFactor * (280) : parent.height * 0.65
         altitude:           flightDisplay.altitudeWGS84
         z:                  30
     }
@@ -345,7 +568,8 @@ Rectangle {
     QGCSpeedWidget {
         id:                 speedWidget
         anchors.left:       parent.left
-        width:              60
+        width:              __screenTools.pixelSizeFactor * (60)
+        height:             parent.height * 0.65 > __screenTools.pixelSizeFactor * (280) ? __screenTools.pixelSizeFactor * (280) : parent.height * 0.65
         speed:              flightDisplay.groundSpeed
         z:                  40
     }
@@ -353,7 +577,7 @@ Rectangle {
     QGCCurrentSpeed {
         id: currentSpeed
         anchors.left:       parent.left
-        width:              75
+        width:              __screenTools.pixelSizeFactor * (75)
         airspeed:           flightDisplay.airSpeed
         groundspeed:        flightDisplay.groundSpeed
         showAirSpeed:       true
@@ -365,7 +589,7 @@ Rectangle {
     QGCCurrentAltitude {
         id: currentAltitude
         anchors.right:      parent.right
-        width:              75
+        width:              __screenTools.pixelSizeFactor * (75)
         altitude:           flightDisplay.altitudeWGS84
         vertZ:              flightDisplay.climbRate
         showAltitude:       true
@@ -377,9 +601,9 @@ Rectangle {
     QGCCompass {
         id:                 compassIndicator
         y:                  root.height * 0.7
-        x:                  root.width  * 0.5 - 60
-        width:              120
-        height:             120
+        x:                  root.width  * 0.5 - __screenTools.pixelSizeFactor * (60)
+        width:              __screenTools.pixelSizeFactor * (120)
+        height:             __screenTools.pixelSizeFactor * (120)
         heading:            isNaN(flightDisplay.heading) ? 0 : flightDisplay.heading
         visible:            !mapBackground.visible && showCompass
         z:                  70
@@ -388,10 +612,10 @@ Rectangle {
     // Button at upper left corner
     Item {
         id:             optionsButton
-        x:              5
-        y:              5
-        width:          30
-        height:         30
+        x:              __screenTools.pixelSizeFactor * (5)
+        y:              __screenTools.pixelSizeFactor * (5)
+        width:          __screenTools.pixelSizeFactor * (30)
+        height:         __screenTools.pixelSizeFactor * (30)
         opacity:        0.85
         z:              1000
         Image {
@@ -405,13 +629,19 @@ Rectangle {
         }
         MouseArea {
             anchors.fill: parent
-            acceptedButtons: Qt.LeftButton
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: {
                 if (mouse.button == Qt.LeftButton)
                 {
-                    contextMenu.popup()
+                    contextMenu.popup();
+                }
+                // Experimental
+                if (mouse.button == Qt.RightButton)
+                {
+                    optionsDialog.open();
                 }
             }
         }
     }
+
 }

--- a/src/ui/flightdisplay/QGCFlightDisplay.cc
+++ b/src/ui/flightdisplay/QGCFlightDisplay.cc
@@ -31,6 +31,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QQmlEngine>
 #include <QSettings>
 
+#include "MainWindow.h"
 #include "QGCFlightDisplay.h"
 #include "UASManager.h"
 
@@ -67,8 +68,10 @@ QGCFlightDisplay::QGCFlightDisplay(QWidget *parent)
     if(pl) {
         pl->setContentsMargins(0,0,0,0);
     }
-    setMinimumWidth(380);
-    setMinimumHeight(360);
+#ifndef __android__
+    setMinimumWidth( 380 * MainWindow::pixelSizeFactor());
+    setMinimumHeight(400 * MainWindow::pixelSizeFactor());
+#endif
     setContextPropertyObject("flightDisplay", this);
     setSource(QUrl::fromUserInput("qrc:/qml/FlightDisplay.qml"));
     setVisible(true);

--- a/src/ui/mapdisplay/QGCMapDisplay.cc
+++ b/src/ui/mapdisplay/QGCMapDisplay.cc
@@ -31,6 +31,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QQmlEngine>
 #include <QSettings>
 
+#include "MainWindow.h"
 #include "QGCMapDisplay.h"
 #include "UASManager.h"
 
@@ -46,8 +47,10 @@ QGCMapDisplay::QGCMapDisplay(QWidget *parent)
     if(pl) {
         pl->setContentsMargins(0,0,0,0);
     }
-    setMinimumWidth(270);
-    setMinimumHeight(300);
+#ifndef __android__
+    setMinimumWidth( 380 * MainWindow::pixelSizeFactor());
+    setMinimumHeight(400 * MainWindow::pixelSizeFactor());
+#endif
     setContextPropertyObject("mapEngine", this);
     setSource(QUrl::fromUserInput("qrc:/qml/MapDisplay.qml"));
     setVisible(true);

--- a/src/ui/qmlcommon/QGCAltitudeWidget.qml
+++ b/src/ui/qmlcommon/QGCAltitudeWidget.qml
@@ -29,12 +29,14 @@ This file is part of the QGROUNDCONTROL project
 
 import QtQuick 2.4
 import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     id: root
+    property ScreenTools __screenTools: ScreenTools { }
     property real altitude:         50
-    property real _reticleSpacing:  16
-    property real _reticleHeight:   2
+    property real _reticleSpacing:  __screenTools.pixelSizeFactor * (16)
+    property real _reticleHeight:   __screenTools.pixelSizeFactor * (2)
     property real _reticleSlot:     _reticleSpacing + _reticleHeight
     property var  _speedArray:      []
     property int  _currentCenter:   0
@@ -62,9 +64,8 @@ Rectangle {
     }
 
     anchors.verticalCenter: parent.verticalCenter
-    height: parent.height * 0.65 > 280 ? 280 : parent.height * 0.65
     smooth: true
-    radius: 5
+    radius: __screenTools.pixelSizeFactor * (5)
     border.color: Qt.rgba(1,1,1,0.25)
     gradient: Gradient {
         GradientStop { position: 0.0; color: Qt.rgba(0,0,0,0.65) }
@@ -73,7 +74,7 @@ Rectangle {
     }
     Rectangle {
         id:     clipRect
-        height: parent.height - 5
+        height: parent.height - __screenTools.pixelSizeFactor * (5)
         width:  parent.width
         clip:   true
         color:  Qt.rgba(0,0,0,0);
@@ -88,12 +89,12 @@ Rectangle {
                 anchors.left: parent.left
                 Rectangle {
                     property int _alt: modelData
-                    width:  (_alt % 10 === 0) ? 10 : 15
+                    width:  (_alt % 10 === 0) ? __screenTools.pixelSizeFactor * (10) : __screenTools.pixelSizeFactor * (15)
                     height: _reticleHeight
                     color:  Qt.rgba(1,1,1,0.35)
                     QGCLabel {
                         visible: (_alt % 10 === 0)
-                        x: 20
+                        x: __screenTools.pixelSizeFactor * (20)
                         anchors.verticalCenter:   parent.verticalCenter
                         antialiasing: true
                         font.weight: Font.DemiBold

--- a/src/ui/qmlcommon/QGCAttitudeInstrument.qml
+++ b/src/ui/qmlcommon/QGCAttitudeInstrument.qml
@@ -32,10 +32,10 @@ import QGroundControl.Controls 1.0
 
 QGCMovableItem {
     id: root
-    property real rollAngle :   0
+    property real rollAngle:    0
     property real pitchAngle:   0
-    property real size:         100
     property bool showPitch:    true
+    property real size
 
     width:  size
     height: size
@@ -51,11 +51,9 @@ QGCMovableItem {
     Image {
         id:         pointer
         source:     "/qml/attitudePointer.svg"
-        width:      root.width
         mipmap:     true
         fillMode:   Image.PreserveAspectFit
-        anchors.bottom: parent.bottom
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.fill: parent
     }
     //----------------------------------------------------
     //-- Instrument Dial
@@ -63,10 +61,8 @@ QGCMovableItem {
         id:         instrumentDial
         source:     "/qml/attitudeDial.svg"
         mipmap:     true
-        width:      root.width
         fillMode:   Image.PreserveAspectFit
-        anchors.bottom: parent.bottom
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.fill: parent
         transform: Rotation {
             origin.x: root.width  / 2
             origin.y: root.height / 2
@@ -78,7 +74,7 @@ QGCMovableItem {
     QGCPitchWidget {
         id:                 pitchWidget
         visible:            root.showPitch
-        size:               parent.width * 0.65
+        size:               root.size * 0.65
         anchors.verticalCenter: parent.verticalCenter
         pitchAngle:         root.pitchAngle
         rollAngle:          root.rollAngle
@@ -91,17 +87,16 @@ QGCMovableItem {
         anchors.centerIn:   parent
         source:             "/qml/crossHair.svg"
         mipmap:             true
-        width:              parent.width * 0.75
+        width:              size * 0.75
         fillMode:           Image.PreserveAspectFit
     }
     //----------------------------------------------------
     //-- Instrument Pannel
     Image {
-        id:         pannel
-        width:      parent.width
-        source:     "/qml/attitudeInstrument.svg"
-        mipmap:     true
-        fillMode:   Image.PreserveAspectFit
-        anchors.centerIn: parent
+        id:             pannel
+        source:         "/qml/attitudeInstrument.svg"
+        mipmap:         true
+        fillMode:       Image.PreserveAspectFit
+        anchors.fill:   parent
     }
 }

--- a/src/ui/qmlcommon/QGCAttitudeWidget.qml
+++ b/src/ui/qmlcommon/QGCAttitudeWidget.qml
@@ -28,30 +28,24 @@ This file is part of the QGROUNDCONTROL project
  */
 
 import QtQuick 2.4
+import QGroundControl.ScreenTools 1.0
 
 Item {
     id: root
+    anchors.centerIn: parent
+    property ScreenTools __screenTools: ScreenTools { }
     property real rollAngle :   0
     property real pitchAngle:   0
-    property bool showAttitude: true
-
-    anchors.fill: parent
-
-    QGCArtificialHorizon {
-        rollAngle:          root.rollAngle
-        pitchAngle:         root.pitchAngle
-    }
 
     Image {
         id: rollDial
-        visible: root.showAttitude
-        anchors { bottom: root.verticalCenter; horizontalCenter: parent.horizontalCenter}
-        source: "/qml/rollDialWhite.svg"
-        mipmap: true
-        width:  260
-        fillMode: Image.PreserveAspectFit
+        anchors     { bottom: root.verticalCenter; horizontalCenter: parent.horizontalCenter}
+        source:     "/qml/rollDialWhite.svg"
+        mipmap:     true
+        width:      parent.width
+        fillMode:   Image.PreserveAspectFit
         transform: Rotation {
-            origin.x: rollDial.width  / 2
+            origin.x: rollDial.width / 2
             origin.y: rollDial.height
             angle:   -rollAngle
         }
@@ -59,21 +53,19 @@ Item {
 
     Image {
         id: pointer
-        visible: root.showAttitude
-        anchors { bottom: root.verticalCenter; horizontalCenter: parent.horizontalCenter}
-        source:             "/qml/rollPointerWhite.svg"
-        mipmap:             true
-        width:              rollDial.width
-        fillMode:           Image.PreserveAspectFit
+        anchors     { bottom: root.verticalCenter; horizontalCenter: parent.horizontalCenter}
+        source:     "/qml/rollPointerWhite.svg"
+        mipmap:     true
+        width:      rollDial.width
+        fillMode:   Image.PreserveAspectFit
     }
 
     Image {
         id:                 crossHair
-        visible:            root.showAttitude
         anchors.centerIn:   parent
         source:             "/qml/crossHair.svg"
         mipmap:             true
-        width:              260
+        width:              parent.width
         fillMode:           Image.PreserveAspectFit
     }
 }

--- a/src/ui/qmlcommon/QGCCompass.qml
+++ b/src/ui/qmlcommon/QGCCompass.qml
@@ -29,9 +29,11 @@ This file is part of the QGROUNDCONTROL project
 
 import QtQuick 2.4
 import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Item {
     id:    root
+    property ScreenTools __screenTools: ScreenTools { }
     property real heading : 0
     Image {
         id: compass
@@ -57,8 +59,8 @@ Item {
     }
     Rectangle {
         anchors.centerIn: compass
-        width:  40
-        height: 25
+        width:  __screenTools.pixelSizeFactor * (40)
+        height: __screenTools.pixelSizeFactor * (25)
         border.color: Qt.rgba(1,1,1,0.15)
         color: Qt.rgba(0,0,0,0.25)
         QGCLabel {

--- a/src/ui/qmlcommon/QGCCompassInstrument.qml
+++ b/src/ui/qmlcommon/QGCCompassInstrument.qml
@@ -32,11 +32,11 @@ import QGroundControl.Controls 1.0
 import QGroundControl.ScreenTools 1.0
 
 QGCMovableItem {
-    property ScreenTools screenTools: ScreenTools { }
     id:                     root
+    property ScreenTools screenTools: ScreenTools { }
     property real heading:  0
-    property real size:     120
-    property real _fontSize: screenTools.dpiAdjustedPointSize(size * 12 / 120)
+    property real size:     screenTools.pixelSizeFactor * (120)
+    property real _fontSize: screenTools.fontPointFactor * (12)
     width:                  size
     height:                 size
     Rectangle {
@@ -48,7 +48,7 @@ QGCMovableItem {
         id:                 pointer
         source:             "/qml/compassInstrumentAirplane.svg"
         mipmap:             true
-        width:              root.width * 0.75
+        width:              size * 0.75
         fillMode:           Image.PreserveAspectFit
         anchors.centerIn:   parent
         transform: Rotation {
@@ -61,9 +61,8 @@ QGCMovableItem {
         id:                 compassDial
         source:             "/qml/compassInstrumentDial.svg"
         mipmap:             true
-        width:              root.width
         fillMode:           Image.PreserveAspectFit
-        anchors.centerIn:   parent
+        anchors.fill:       parent
     }
     Rectangle {
         anchors.centerIn:   root

--- a/src/ui/qmlcommon/QGCCurrentAltitude.qml
+++ b/src/ui/qmlcommon/QGCCurrentAltitude.qml
@@ -29,22 +29,24 @@ This file is part of the QGROUNDCONTROL project
 
 import QtQuick 2.1
 import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     id: root
+    property ScreenTools __screenTools: ScreenTools { }
     property real altitude: 0
     property real vertZ:    0
     property bool showAltitude: true
     property bool showClimbRate: true
     anchors.verticalCenter: parent.verticalCenter
     width:  parent.width
-    height: (showAltitude && showClimbRate) ? 50 : 25
+    height: (showAltitude && showClimbRate) ? __screenTools.pixelSizeFactor * (50) : __screenTools.pixelSizeFactor * (25)
     color: "black"
     border.color: Qt.rgba(1,1,1,0.25)
     opacity: 1.0
     Column{
         anchors.centerIn: parent
-        spacing: 4
+        spacing: __screenTools.pixelSizeFactor * (4)
         QGCLabel {
             text: 'h: ' + altitude.toFixed(0)
             font.weight: Font.DemiBold

--- a/src/ui/qmlcommon/QGCCurrentSpeed.qml
+++ b/src/ui/qmlcommon/QGCCurrentSpeed.qml
@@ -29,22 +29,24 @@ This file is part of the QGROUNDCONTROL project
 
 import QtQuick 2.1
 import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     id: root
+    property ScreenTools __screenTools: ScreenTools { }
     property real airspeed:         0
     property real groundspeed:      0
     property bool showAirSpeed:     true
     property bool showGroundSpeed:  true
     anchors.verticalCenter: parent.verticalCenter
     width:  parent.width
-    height: (showAirSpeed && showGroundSpeed) ? 50 : 25
+    height: (showAirSpeed && showGroundSpeed) ? __screenTools.pixelSizeFactor * (50) : __screenTools.pixelSizeFactor * (25)
     color: "black"
     border.color: Qt.rgba(1,1,1,0.25)
     opacity: 1.0
     Column{
         anchors.centerIn: parent
-        spacing: 4
+        spacing: __screenTools.pixelSizeFactor * (4)
         QGCLabel {
             text: 'GS: ' + groundspeed.toFixed(0)
             font.weight: Font.DemiBold

--- a/src/ui/qmlcommon/QGCMapBackground.qml
+++ b/src/ui/qmlcommon/QGCMapBackground.qml
@@ -33,9 +33,11 @@ import QtLocation 5.3
 
 import QGroundControl.Controls 1.0
 import QGroundControl.FlightControls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     id: root
+    property ScreenTools __screenTools: ScreenTools { }
     property real latitude:     37.803784
     property real longitude :   -122.462276
     property real zoomLevel:    18
@@ -163,7 +165,9 @@ Rectangle {
         z: map.z + 20
         anchors {
             bottom: parent.bottom;
-            bottomMargin: 15; rightMargin: 20; leftMargin: 20
+            bottomMargin:   __screenTools.pixelSizeFactor * (15)
+            rightMargin:    __screenTools.pixelSizeFactor * (20)
+            leftMargin:     __screenTools.pixelSizeFactor * (20)
             left: parent.left
         }
         width: parent.width - anchors.rightMargin - anchors.leftMargin
@@ -184,9 +188,9 @@ Rectangle {
         opacity: 1
         anchors {
             bottom: zoomSlider.top;
-            bottomMargin: 8;
+            bottomMargin: __screenTools.pixelSizeFactor * (8);
             left: zoomSlider.left
-            leftMargin: 4
+            leftMargin: __screenTools.pixelSizeFactor * (4)
         }
         Image {
             id: scaleImageLeft
@@ -213,7 +217,7 @@ Rectangle {
             horizontalAlignment: Text.AlignHCenter
             anchors.bottom: parent.bottom
             anchors.left:   parent.left
-            anchors.bottomMargin: 10
+            anchors.bottomMargin: __screenTools.pixelSizeFactor * (10)
             text: "0 m"
         }
         Component.onCompleted: {

--- a/src/ui/qmlcommon/QGCPitchWidget.qml
+++ b/src/ui/qmlcommon/QGCPitchWidget.qml
@@ -41,10 +41,10 @@ Rectangle {
     property real _reticleSlot:     _reticleSpacing + _reticleHeight
     property real _longDash:        size * 0.40
     property real _shortDash:       size * 0.25
-    property real _fontSize:        screenTools.dpiAdjustedPointSize(size * 11 / 120);
+    property real _fontSize:        __screenTools.fontPointFactor * (11);
     height: size * 0.9
     width:  size
-    radius: 8
+    radius: screenTools.pixelSizeFactor * (8)
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.verticalCenter:   parent.verticalCenter
     clip: true

--- a/src/ui/qmlcommon/QGCSlider.qml
+++ b/src/ui/qmlcommon/QGCSlider.qml
@@ -40,10 +40,12 @@
 
 import QtQuick 2.1
 import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
 
 Item {
     id: slider;
     height: 12
+    property ScreenTools __screenTools: ScreenTools { }
     property real value // value is read/write.
     property real minimum: 0
     property real maximum: 1
@@ -51,15 +53,15 @@ Item {
 
     Rectangle {
         anchors.fill:   parent
-        radius:         6
+        radius:         __screenTools.pixelSizeFactor * (6)
         color:          Qt.rgba(0,0,0,0.65);
     }
 
     Rectangle {
         anchors.left:       parent.left
-        anchors.leftMargin: 4
-        radius:             4
-        height:             4
+        anchors.leftMargin: __screenTools.pixelSizeFactor * (4)
+        radius:             __screenTools.pixelSizeFactor * (4)
+        height:             __screenTools.pixelSizeFactor * (4)
         width:              handle.x - x
         color:              "#69bb17"
         anchors.verticalCenter: parent.verticalCenter
@@ -68,14 +70,14 @@ Item {
     Rectangle {
         id:                 labelRect
         width:              label.width
-        height:             label.height + 4
-        radius:             4
+        height:             label.height + __screenTools.pixelSizeFactor * (4)
+        radius:             __screenTools.pixelSizeFactor * (4)
         smooth:             true
         color:              Qt.rgba(1,1,1,0.75);
-        border.width:       1
+        border.width:       __screenTools.pixelSizeFactor * (1)
         border.color:       Qt.rgba(0,0,0,0.45);
         anchors.bottom:     handle.top
-        anchors.bottomMargin: 4
+        anchors.bottomMargin: __screenTools.pixelSizeFactor * (4)
         visible: mouseRegion.pressed
         x: Math.max(Math.min(handle.x + (handle.width - width ) / 2, slider.width - width), 0)
         QGCLabel{
@@ -92,7 +94,7 @@ Item {
     Rectangle {
         id:         handle;
         smooth:     true
-        width:      26;
+        width:      __screenTools.pixelSizeFactor * (26);
         y:          (slider.height - height) / 2;
         x:          (slider.value - slider.minimum) * slider.length / (slider.maximum - slider.minimum)
 

--- a/src/ui/qmlcommon/QGCSpeedWidget.qml
+++ b/src/ui/qmlcommon/QGCSpeedWidget.qml
@@ -33,16 +33,15 @@ import QGroundControl.Controls 1.0
 
 Rectangle {
     id: root
-    property ScreenTools screenTools: ScreenTools { }
+    property ScreenTools __screenTools: ScreenTools { }
     property real speed:           0
-    property real _reticleSpacing: 10
-    property real _reticleHeight:  2
+    property real _reticleSpacing: __screenTools.pixelSizeFactor * (10)
+    property real _reticleHeight:  __screenTools.pixelSizeFactor * (2)
     property real _reticleSlot:    _reticleSpacing + _reticleHeight
     anchors.verticalCenter: parent.verticalCenter
     z:10
-    height: parent.height * 0.65 > 280 ? 280 : parent.height * 0.65
     smooth: true
-    radius: 5
+    radius: __screenTools.pixelSizeFactor * (5)
     border.color: Qt.rgba(1,1,1,0.25)
     gradient: Gradient {
         GradientStop { position: 0.0; color: Qt.rgba(0,0,0,0.65) }
@@ -51,7 +50,7 @@ Rectangle {
     }
     Rectangle {
         id:     clipRect
-        height: parent.height - 5
+        height: parent.height - __screenTools.pixelSizeFactor * (5)
         width:  parent.width
         clip:   true
         color:  Qt.rgba(0,0,0,0);
@@ -65,14 +64,14 @@ Rectangle {
                 model: 40
                 Rectangle {
                     property int _speed: -(index - 20)
-                    width:  (_speed % 5 === 0) ? 10 : 15
+                    width:  (_speed % 5 === 0) ? __screenTools.pixelSizeFactor * (10) : __screenTools.pixelSizeFactor * (15)
                     anchors.right: parent.right
                     height: _reticleHeight
                     color:  Qt.rgba(1,1,1,0.35)
                     QGCLabel {
                         visible: (_speed % 5 === 0)
                         anchors.horizontalCenter: parent.horizontalCenter
-                        anchors.horizontalCenterOffset: -30
+                        anchors.horizontalCenterOffset: __screenTools.pixelSizeFactor * (-30)
                         anchors.verticalCenter:   parent.verticalCenter
                         antialiasing: true
                         font.weight: Font.DemiBold

--- a/src/ui/toolbar/MainToolBar.cc
+++ b/src/ui/toolbar/MainToolBar.cc
@@ -68,13 +68,7 @@ MainToolBar::MainToolBar(QWidget* parent)
 {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     setObjectName("MainToolBar");
-#ifdef __android__
-    setMinimumHeight(120);
-    setMaximumHeight(120);
-#else
-    setMinimumHeight(40);
-    setMaximumHeight(40);
-#endif
+    _updatePixelSize();
     setMinimumWidth(MainWindow::instance()->minimumWidth());
     // Get rid of layout default margins
     QLayout* pl = layout();
@@ -103,6 +97,7 @@ MainToolBar::MainToolBar(QWidget* parent)
     connect(LinkManager::instance(),     &LinkManager::linkConfigurationChanged, this, &MainToolBar::_updateConfigurations);
     connect(LinkManager::instance(),     &LinkManager::linkConnected,            this, &MainToolBar::_linkConnected);
     connect(LinkManager::instance(),     &LinkManager::linkDisconnected,         this, &MainToolBar::_linkDisconnected);
+    connect(MainWindow::instance(),      &MainWindow::pixelSizeChanged,          this, &MainToolBar::_updatePixelSize);
     // RSSI (didn't like standard connection)
     connect(MAVLinkProtocol::instance(),
         SIGNAL(radioStatusChanged(LinkInterface*, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned)), this,
@@ -697,4 +692,10 @@ void MainToolBar::_setProgressBarValue(float value)
 {
     _progressBarValue = value;
     emit progressBarValueChanged(value);
+}
+
+void MainToolBar::_updatePixelSize()
+{
+    setMinimumHeight(40 * MainWindow::pixelSizeFactor());
+    setMaximumHeight(40 * MainWindow::pixelSizeFactor());
 }

--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -161,6 +161,7 @@ private slots:
     void _setProgressBarValue           (float value);
     void _remoteControlRSSIChanged      (uint8_t rssi);
     void _telemetryChanged              (LinkInterface* link, unsigned rxerrors, unsigned fixed, unsigned rssi, unsigned remrssi, unsigned txbuf, unsigned noise, unsigned remnoise);
+    void _updatePixelSize               ();
 
 private:
     void _updateConnection              (LinkInterface *disconnectedLink = NULL);

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -41,7 +41,7 @@ Rectangle {
     id: toolBarHolder
 
     property var qgcPal: QGCPalette { id: palette; colorGroupEnabled: true }
-    property ScreenTools screenTools: ScreenTools { }
+    property ScreenTools __screenTools: ScreenTools { }
 
     property int cellSpacerSize: getProportionalDimmension(4)
     property int cellHeight:     getProportionalDimmension(30)
@@ -147,7 +147,7 @@ Rectangle {
             spacing:                -getProportionalDimmension(12)
             anchors.verticalCenter: parent.verticalCenter
             Connections {
-                target: screenTools
+                target: __screenTools
                 onRepaintRequestedChanged: {
                     setupButton.repaintChevron   = true;
                     planButton.repaintChevron    = true;
@@ -251,7 +251,7 @@ Rectangle {
                     QGCLabel {
                         id: messageText
                         text: (mainToolBar.messageCount > 0) ? mainToolBar.messageCount : ''
-                        font.pointSize: screenTools.dpiAdjustedPointSize(14);
+                        font.pointSize: __screenTools.fontPointFactor * (14);
                         font.weight: Font.DemiBold
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -337,7 +337,7 @@ Rectangle {
                 QGCLabel {
                     id: satelitteText
                     text: mainToolBar.satelliteCount
-                    font.pointSize: screenTools.dpiAdjustedPointSize(14);
+                    font.pointSize: __screenTools.fontPointFactor * (14);
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
@@ -372,7 +372,7 @@ Rectangle {
                     anchors.rightMargin: getProportionalDimmension(6)
                     anchors.verticalCenter: parent.verticalCenter
                     horizontalAlignment: Text.AlignRight
-                    font.pointSize: screenTools.dpiAdjustedPointSize(12);
+                    font.pointSize: __screenTools.fontPointFactor * (12);
                     font.weight: Font.DemiBold
                     color: colorWhite
                 }
@@ -405,7 +405,7 @@ Rectangle {
                         anchors.right: parent.right
                         QGCLabel {
                             text: 'R '
-                            font.pointSize: screenTools.dpiAdjustedPointSize(11);
+                            font.pointSize: __screenTools.fontPointFactor * (11);
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -413,7 +413,7 @@ Rectangle {
                             text: mainToolBar.telemetryRRSSI + 'dB'
                             width: getProportionalDimmension(30)
                             horizontalAlignment: Text.AlignRight
-                            font.pointSize: screenTools.dpiAdjustedPointSize(11);
+                            font.pointSize: __screenTools.fontPointFactor * (11);
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -422,7 +422,7 @@ Rectangle {
                         anchors.right: parent.right
                         QGCLabel {
                             text: 'L '
-                            font.pointSize: screenTools.dpiAdjustedPointSize(11);
+                            font.pointSize: __screenTools.fontPointFactor * (11);
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -430,7 +430,7 @@ Rectangle {
                             text: mainToolBar.telemetryLRSSI + 'dB'
                             width: getProportionalDimmension(30)
                             horizontalAlignment: Text.AlignRight
-                            font.pointSize: screenTools.dpiAdjustedPointSize(11);
+                            font.pointSize: __screenTools.fontPointFactor * (11);
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -462,7 +462,7 @@ Rectangle {
                 QGCLabel {
                     id: batteryText
                     text: mainToolBar.batteryVoltage.toFixed(1) + 'V';
-                    font.pointSize: screenTools.dpiAdjustedPointSize(12);
+                    font.pointSize: __screenTools.fontPointFactor * (12);
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
@@ -490,7 +490,7 @@ Rectangle {
                     QGCLabel {
                         id: armedStatusText
                         text: (mainToolBar.systemArmed) ? qsTr("ARMED") :  qsTr("DISARMED")
-                        font.pointSize: screenTools.dpiAdjustedPointSize(12);
+                        font.pointSize: __screenTools.fontPointFactor * (12);
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
                         color: (mainToolBar.systemArmed) ? colorOrangeText : colorGreenText
@@ -509,7 +509,7 @@ Rectangle {
                     QGCLabel {
                         id: stateStatusText
                         text: mainToolBar.currentState
-                        font.pointSize: screenTools.dpiAdjustedPointSize(12);
+                        font.pointSize: __screenTools.fontPointFactor * (12);
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
                         color: (mainToolBar.currentState === "STANDBY") ? colorGreenText : colorRedText
@@ -530,7 +530,7 @@ Rectangle {
                 QGCLabel {
                     id: modeStatusText
                     text: mainToolBar.currentMode
-                    font.pointSize: screenTools.dpiAdjustedPointSize(12);
+                    font.pointSize: __screenTools.fontPointFactor * (12);
                     font.weight: Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
@@ -551,7 +551,7 @@ Rectangle {
                 QGCLabel {
                     id: connectionStatusText
                     text: qsTr("CONNECTION LOST")
-                    font.pointSize: screenTools.dpiAdjustedPointSize(14);
+                    font.pointSize: __screenTools.fontPointFactor * (14);
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
Revamping global sizes for both font metrics as well as hard coded pixel dimensions.

This came about when realizing that there was no constant available to compute appropriate dimensions for the various platforms. There is no relationship between the system returned DPI and reality. Instead of returning a hard, physical value, it seems to return an abstract concept based on someone's philosophical rants.

This new system uses instead hard-coded *factors*, pre-computed for each platform and used accordingly. These factors can be changed (font and pixel size independently) and they are saved in the settings. The method for changing it though is somewhat hidden for the time being. Given that this mostly affects QML UI only (some style sheet based fonts used by QWidgets are handled as well), it should be in some proper QML preferences dialog, which is not yet done. For now, you can use the options button in the main flight display (right-click).

That dialog is an experiment in creating a preferences dialog within QML. It is not working (a row of buttons is supposed to be at the bottom, and on Android it's 2/3 off the screen). It looks like QML Dialogs, among other things are a casualty of using QML within QQuickWidget. These things depend on the application being run by QQmlApplicationEngine.

Now the UI looks the same everywhere:

![screencap copy](https://cloud.githubusercontent.com/assets/749243/7284201/e214aa08-e909-11e4-9dad-25d4e265429e.png)
