### PR TITLE
Android SerialPort work.

### DIFF
--- a/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java
+++ b/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java
@@ -162,10 +162,10 @@ public enum UsbSerialProber {
      */
     public static List<UsbSerialDriver> findAllDevices(final UsbManager usbManager) {
         final List<UsbSerialDriver> result = new ArrayList<UsbSerialDriver>();
-        Log.i("QGC_UsbSerialProber", "Looking for USB devices");
+        //Log.i("QGC_UsbSerialProber", "Looking for USB devices");
         // For each UsbDevice, call probe() for each prober.
         for (final UsbDevice usbDevice : usbManager.getDeviceList().values()) {
-            Log.i("QGC_UsbSerialProber", "Probing device: " + usbDevice.getDeviceName() + " mid: " + usbDevice.getVendorId() + " pid: " + usbDevice.getDeviceId());
+            //Log.i("QGC_UsbSerialProber", "Probing device: " + usbDevice.getDeviceName() + " mid: " + usbDevice.getVendorId() + " pid: " + usbDevice.getDeviceId());
             result.addAll(probeSingleDevice(usbManager, usbDevice));
         }
         return result;

--- a/android/src/org/qgroundcontrol/qgchelper/UsbDeviceJNI.java
+++ b/android/src/org/qgroundcontrol/qgchelper/UsbDeviceJNI.java
@@ -199,7 +199,7 @@ public class UsbDeviceJNI extends QtActivity
                 tempL = tempL + Integer.toString(deviceL.getVendorId()) + ":";
                 listL[countL] = tempL;
                 countL++;
-                Log.i(TAG, "Found " + tempL);
+                //Log.i(TAG, "Found " + tempL);
             }
         }
 
@@ -260,6 +260,7 @@ public class UsbDeviceJNI extends QtActivity
 
                     if (m_instance.m_UsbReceiver == null)
                     {
+                        Log.i(TAG, "Creating new broadcast receiver");
                         m_instance.m_UsbReceiver= new BroadcastReceiver()
                         {
                             public void onReceive(Context contextA, Intent intentA)
@@ -273,7 +274,6 @@ public class UsbDeviceJNI extends QtActivity
                                     {
                                         if (m_userData.containsKey(deviceL.getDeviceId()))
                                         {
-//                                            UsbDeviceJNI.close(deviceL.getDeviceId());
                                             nativeDeviceHasDisconnected(m_userData.get(deviceL.getDeviceId()));
                                         }
                                     }
@@ -294,6 +294,7 @@ public class UsbDeviceJNI extends QtActivity
                         Log.e(TAG, "UsbIoManager instance is null");
                     m_ioManager.put(idL, managerL);
                     m_Executor.submit(managerL);
+                    Log.i(TAG, "Port open successfull");
                     return idL;
                 }
             }
@@ -312,12 +313,10 @@ public class UsbDeviceJNI extends QtActivity
 
                 m_ioManager.remove(idL);
             }
-
+            Log.e(TAG, "Port open exception");
             return BAD_PORT;
         }
     }
-
-
 
     public static void startIoManager(int idA)
     {
@@ -334,8 +333,6 @@ public class UsbDeviceJNI extends QtActivity
         m_Executor.submit(managerL);
     }
 
-
-
     public static void stopIoManager(int idA)
     {
         if(m_ioManager.get(idA) == null)
@@ -344,9 +341,6 @@ public class UsbDeviceJNI extends QtActivity
         m_ioManager.get(idA).stop();
         m_ioManager.remove(idA);
     }
-
-
-
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
     //

--- a/libs/qtandroidserialport/src/qserialport.cpp
+++ b/libs/qtandroidserialport/src/qserialport.cpp
@@ -4,7 +4,7 @@
 ** Copyright (C) 2011 Sergey Belyashov <Sergey.Belyashov@gmail.com>
 ** Copyright (C) 2012 Laszlo Papp <lpapp@kde.org>
 ** Copyright (C) 2012 Andre Hartmann <aha_1980@gmx.de>
-** Contact: http://www.qt-project.org/legal
+** Contact: http://www.qt.io/licensing/
 **
 ** This file is part of the QtSerialPort module of the Qt Toolkit.
 **
@@ -13,9 +13,9 @@
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia. For licensing terms and
-** conditions see http://qt.digia.com/licensing. For further information
-** use the contact form at http://qt.digia.com/contact-us.
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
 **
 ** GNU Lesser General Public License Usage
 ** Alternatively, this file may be used under the terms of the GNU Lesser
@@ -26,8 +26,8 @@
 ** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
 ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
-** In addition, as a special exception, Digia gives you certain additional
-** rights. These rights are described in the Digia Qt LGPL Exception
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$

--- a/libs/qtandroidserialport/src/qserialport.h
+++ b/libs/qtandroidserialport/src/qserialport.h
@@ -2,7 +2,7 @@
 **
 ** Copyright (C) 2012 Denis Shienkov <denis.shienkov@gmail.com>
 ** Copyright (C) 2013 Laszlo Papp <lpapp@kde.org>
-** Contact: http://www.qt-project.org/legal
+** Contact: http://www.qt.io/licensing/
 **
 ** This file is part of the QtSerialPort module of the Qt Toolkit.
 **
@@ -11,9 +11,9 @@
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia. For licensing terms and
-** conditions see http://qt.digia.com/licensing. For further information
-** use the contact form at http://qt.digia.com/contact-us.
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
 **
 ** GNU Lesser General Public License Usage
 ** Alternatively, this file may be used under the terms of the GNU Lesser
@@ -24,8 +24,8 @@
 ** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
 ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
-** In addition, as a special exception, Digia gives you certain additional
-** rights. These rights are described in the Digia Qt LGPL Exception
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$

--- a/libs/qtandroidserialport/src/qserialport_android.cpp
+++ b/libs/qtandroidserialport/src/qserialport_android.cpp
@@ -3,39 +3,31 @@
 ** Copyright (C) 2012 Denis Shienkov <denis.shienkov@gmail.com>
 ** Copyright (C) 2012 Laszlo Papp <lpapp@kde.org>
 ** Copyright (C) 2012 Andre Hartmann <aha_1980@gmx.de>
-** Contact: http://www.qt-project.org/legal
+** Contact: http://www.qt.io/licensing/
 **
 ** This file is part of the QtSerialPort module of the Qt Toolkit.
 **
-** $QT_BEGIN_LICENSE:LGPL$
+** $QT_BEGIN_LICENSE:LGPL21$
 ** Commercial License Usage
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia.  For licensing terms and
-** conditions see http://qt.digia.com/licensing.  For further information
-** use the contact form at http://qt.digia.com/contact-us.
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
 **
 ** GNU Lesser General Public License Usage
 ** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
-** In addition, as a special exception, Digia gives you certain additional
-** rights.  These rights are described in the Digia Qt LGPL Exception
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
-**
-** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
-**
 **
 ** $QT_END_LICENSE$
 **
@@ -119,6 +111,33 @@ bool QSerialPortPrivate::open(QIODevice::OpenMode mode)
     rwMode = mode;
     __android_log_print(ANDROID_LOG_INFO, V_TAG, "Opening %s", systemLocation.toLatin1().data());
 
+    if (!hasRegisteredFunctions)
+    {
+        //  REGISTER THE C++ FUNCTION WITH JNI
+        QAndroidJniEnvironment envL;
+
+        JNINativeMethod methodsL[] {
+            {"nativeDeviceHasDisconnected", "(I)V",                   reinterpret_cast<void *>(jniDeviceHasDisconnected)},
+            {"nativeDeviceNewData",         "(I[B)V",                 reinterpret_cast<void *>(jniDeviceNewData)},
+            {"nativeDeviceException",       "(ILjava/lang/String;)V", reinterpret_cast<void *>(jniDeviceException)}
+        };
+
+        QAndroidJniObject javaClassL(V_jniClassName);
+        jclass objectClassL = envL->GetObjectClass(javaClassL.object<jobject>());
+        jint valL = envL->RegisterNatives(objectClassL, methodsL, sizeof(methodsL) / sizeof(JNINativeMethod));
+        envL->DeleteLocalRef(objectClassL);
+        hasRegisteredFunctions = true;
+
+        if (envL->ExceptionCheck())
+            envL->ExceptionClear();
+
+        if(valL < 0) {
+            __android_log_print(ANDROID_LOG_ERROR, V_TAG, "Error registering methods");
+            q_ptr->setError(QSerialPort::OpenError);
+            return false;
+        }
+    }
+
     QAndroidJniObject jnameL = QAndroidJniObject::fromString(systemLocation);
     deviceId = QAndroidJniObject::callStaticMethod<jint>(
         V_jniClassName,
@@ -141,33 +160,6 @@ bool QSerialPortPrivate::open(QIODevice::OpenMode mode)
         "getDeviceHandle",
         "(I)I",
         deviceId);
-
-    if (!hasRegisteredFunctions)
-    {
-        //  REGISTER THE C++ FUNCTION WITH JNI
-        QAndroidJniEnvironment envL;
-
-        JNINativeMethod methodsL[] {
-            {"nativeDeviceHasDisconnected", "(I)V",                   reinterpret_cast<void *>(jniDeviceHasDisconnected)},
-            {"nativeDeviceNewData",         "(I[B)V",                 reinterpret_cast<void *>(jniDeviceNewData)},
-            {"nativeDeviceException",       "(ILjava/lang/String;)V", reinterpret_cast<void *>(jniDeviceException)}
-        };
-
-        QAndroidJniObject javaClassL(V_jniClassName);
-        jclass objectClassL = envL->GetObjectClass(javaClassL.object<jobject>());
-        jint valL = envL->RegisterNatives(objectClassL, methodsL, sizeof(methodsL) / sizeof(methodsL[0]));
-        envL->DeleteLocalRef(objectClassL);
-        hasRegisteredFunctions = true;
-
-        if (envL->ExceptionCheck())
-            envL->ExceptionClear();
-
-        if(valL < 0) {
-            __android_log_print(ANDROID_LOG_ERROR, V_TAG, "Error registering methods");
-            q_ptr->setError(QSerialPort::OpenError);
-            return false;
-        }
-    }
 
     if (rwMode == QIODevice::WriteOnly)
         stopReadThread();

--- a/libs/qtandroidserialport/src/qserialport_p.h
+++ b/libs/qtandroidserialport/src/qserialport_p.h
@@ -3,7 +3,7 @@
 ** Copyright (C) 2011-2012 Denis Shienkov <denis.shienkov@gmail.com>
 ** Copyright (C) 2011 Sergey Belyashov <Sergey.Belyashov@gmail.com>
 ** Copyright (C) 2012 Laszlo Papp <lpapp@kde.org>
-** Contact: http://www.qt-project.org/legal
+** Contact: http://www.qt.io/licensing/
 **
 ** This file is part of the QtSerialPort module of the Qt Toolkit.
 **
@@ -12,9 +12,9 @@
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia. For licensing terms and
-** conditions see http://qt.digia.com/licensing. For further information
-** use the contact form at http://qt.digia.com/contact-us.
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
 **
 ** GNU Lesser General Public License Usage
 ** Alternatively, this file may be used under the terms of the GNU Lesser
@@ -25,8 +25,8 @@
 ** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
 ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
-** In addition, as a special exception, Digia gives you certain additional
-** rights. These rights are described in the Digia Qt LGPL Exception
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$

--- a/libs/qtandroidserialport/src/qserialportinfo.cpp
+++ b/libs/qtandroidserialport/src/qserialportinfo.cpp
@@ -3,7 +3,7 @@
 ** Copyright (C) 2011-2012 Denis Shienkov <denis.shienkov@gmail.com>
 ** Copyright (C) 2011 Sergey Belyashov <Sergey.Belyashov@gmail.com>
 ** Copyright (C) 2012 Laszlo Papp <lpapp@kde.org>
-** Contact: http://www.qt-project.org/legal
+** Contact: http://www.qt.io/licensing/
 **
 ** This file is part of the QtSerialPort module of the Qt Toolkit.
 **
@@ -12,9 +12,9 @@
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia. For licensing terms and
-** conditions see http://qt.digia.com/licensing. For further information
-** use the contact form at http://qt.digia.com/contact-us.
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
 **
 ** GNU Lesser General Public License Usage
 ** Alternatively, this file may be used under the terms of the GNU Lesser
@@ -25,8 +25,8 @@
 ** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
 ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
-** In addition, as a special exception, Digia gives you certain additional
-** rights. These rights are described in the Digia Qt LGPL Exception
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$

--- a/libs/qtandroidserialport/src/qserialportinfo.h
+++ b/libs/qtandroidserialport/src/qserialportinfo.h
@@ -2,7 +2,7 @@
 **
 ** Copyright (C) 2012 Denis Shienkov <denis.shienkov@gmail.com>
 ** Copyright (C) 2012 Laszlo Papp <lpapp@kde.org>
-** Contact: http://www.qt-project.org/legal
+** Contact: http://www.qt.io/licensing/
 **
 ** This file is part of the QtSerialPort module of the Qt Toolkit.
 **
@@ -11,9 +11,9 @@
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia. For licensing terms and
-** conditions see http://qt.digia.com/licensing. For further information
-** use the contact form at http://qt.digia.com/contact-us.
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
 **
 ** GNU Lesser General Public License Usage
 ** Alternatively, this file may be used under the terms of the GNU Lesser
@@ -24,8 +24,8 @@
 ** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
 ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
-** In addition, as a special exception, Digia gives you certain additional
-** rights. These rights are described in the Digia Qt LGPL Exception
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$

--- a/libs/qtandroidserialport/src/qserialportinfo_android.cpp
+++ b/libs/qtandroidserialport/src/qserialportinfo_android.cpp
@@ -3,39 +3,31 @@
 ** Copyright (C) 2011-2012 Denis Shienkov <denis.shienkov@gmail.com>
 ** Copyright (C) 2011 Sergey Belyashov <Sergey.Belyashov@gmail.com>
 ** Copyright (C) 2012 Laszlo Papp <lpapp@kde.org>
-** Contact: http://www.qt-project.org/legal
+** Contact: http://www.qt.io/licensing/
 **
 ** This file is part of the QtSerialPort module of the Qt Toolkit.
 **
-** $QT_BEGIN_LICENSE:LGPL$
+** $QT_BEGIN_LICENSE:LGPL21$
 ** Commercial License Usage
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia.  For licensing terms and
-** conditions see http://qt.digia.com/licensing.  For further information
-** use the contact form at http://qt.digia.com/contact-us.
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
 **
 ** GNU Lesser General Public License Usage
 ** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+** General Public License version 2.1 or version 3 as published by the Free
+** Software Foundation and appearing in the file LICENSE.LGPLv21 and
+** LICENSE.LGPLv3 included in the packaging of this file. Please review the
+** following information to ensure the GNU Lesser General Public License
+** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
+** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
-** In addition, as a special exception, Digia gives you certain additional
-** rights.  These rights are described in the Digia Qt LGPL Exception
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
-**
-** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
-**
 **
 ** $QT_END_LICENSE$
 **
@@ -56,11 +48,11 @@ QT_BEGIN_NAMESPACE
 static const char V_jniClassName[] {"org/qgroundcontrol/qgchelper/UsbDeviceJNI"};
 static const char V_TAG[] {"QGC_QSerialPortInfo"};
 
-QList<QSerialPortInfo> availablePortsByFiltersOfDevices()
+QList<QSerialPortInfo> availablePortsByFiltersOfDevices(bool &ok)
 {
     QList<QSerialPortInfo> serialPortInfoList;
 
-    __android_log_print(ANDROID_LOG_INFO, V_TAG, "Collecting device list");
+    //__android_log_print(ANDROID_LOG_INFO, V_TAG, "Collecting device list");
     QAndroidJniObject resultL = QAndroidJniObject::callStaticObjectMethod(
         V_jniClassName,
         "availableDevicesInfo",
@@ -68,6 +60,7 @@ QList<QSerialPortInfo> availablePortsByFiltersOfDevices()
     
     if (!resultL.isValid()) {
         __android_log_print(ANDROID_LOG_ERROR, V_TAG, "Error from availableDevicesInfo");
+        ok = false;
         return serialPortInfoList;
     }
 
@@ -75,24 +68,24 @@ QList<QSerialPortInfo> availablePortsByFiltersOfDevices()
     jobjectArray objArrayL = resultL.object<jobjectArray>();
     int countL = envL->GetArrayLength(objArrayL);
 
-    for (int iL=0; iL<countL; iL++)
+    for (int iL = 0; iL < countL; iL++)
     {
-        QSerialPortInfo infoL;
+        QSerialPortInfoPrivate priv;
         jstring stringL = (jstring)(envL->GetObjectArrayElement(objArrayL, iL));
         const char *rawStringL = envL->GetStringUTFChars(stringL, 0);
-        __android_log_print(ANDROID_LOG_INFO, V_TAG, "Adding device: %s", rawStringL);
+        //__android_log_print(ANDROID_LOG_INFO, V_TAG, "Adding device: %s", rawStringL);
         QStringList strListL = QString::fromUtf8(rawStringL).split(QStringLiteral(":"));
         envL->ReleaseStringUTFChars(stringL, rawStringL);
 
-        infoL.d_ptr->portName               = strListL[0];
-        infoL.d_ptr->device                 = strListL[0];
-        infoL.d_ptr->manufacturer           = strListL[1];
-        infoL.d_ptr->productIdentifier      = strListL[2].toInt();
-        infoL.d_ptr->hasProductIdentifier   = (infoL.d_ptr->productIdentifier != 0) ? true: false;
-        infoL.d_ptr->vendorIdentifier       = strListL[3].toInt();
-        infoL.d_ptr->hasVendorIdentifier    = (infoL.d_ptr->vendorIdentifier  != 0) ? true: false;
+        priv.portName               = strListL[0];
+        priv.device                 = strListL[0];
+        priv.manufacturer           = strListL[1];
+        priv.productIdentifier      = strListL[2].toInt();
+        priv.hasProductIdentifier   = (priv.productIdentifier != 0) ? true: false;
+        priv.vendorIdentifier       = strListL[3].toInt();
+        priv.hasVendorIdentifier    = (priv.vendorIdentifier  != 0) ? true: false;
 
-        serialPortInfoList.append(infoL);
+        serialPortInfoList.append(priv);
     }
 
     return serialPortInfoList;
@@ -100,17 +93,20 @@ QList<QSerialPortInfo> availablePortsByFiltersOfDevices()
 
 QList<QSerialPortInfo> availablePortsBySysfs()
 {
-    return availablePortsByFiltersOfDevices();
+    bool ok;
+    return availablePortsByFiltersOfDevices(ok);
 }
 
 QList<QSerialPortInfo> availablePortsByUdev()
 {
-    return availablePortsByFiltersOfDevices();
+    bool ok;
+    return availablePortsByFiltersOfDevices(ok);
 }
 
 QList<QSerialPortInfo> QSerialPortInfo::availablePorts()
 {
-    return availablePortsByFiltersOfDevices();
+    bool ok;
+    return availablePortsByFiltersOfDevices(ok);
 }
 
 QList<qint32> QSerialPortInfo::standardBaudRates()

--- a/libs/qtandroidserialport/src/qserialportinfo_p.h
+++ b/libs/qtandroidserialport/src/qserialportinfo_p.h
@@ -3,7 +3,7 @@
 ** Copyright (C) 2011-2012 Denis Shienkov <denis.shienkov@gmail.com>
 ** Copyright (C) 2011 Sergey Belyashov <Sergey.Belyashov@gmail.com>
 ** Copyright (C) 2012 Laszlo Papp <lpapp@kde.org>
-** Contact: http://www.qt-project.org/legal
+** Contact: http://www.qt.io/licensing/
 **
 ** This file is part of the QtSerialPort module of the Qt Toolkit.
 **
@@ -12,9 +12,9 @@
 ** Licensees holding valid commercial Qt licenses may use this file in
 ** accordance with the commercial license agreement provided with the
 ** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia. For licensing terms and
-** conditions see http://qt.digia.com/licensing. For further information
-** use the contact form at http://qt.digia.com/contact-us.
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see http://www.qt.io/terms-conditions. For further
+** information use the contact form at http://www.qt.io/contact-us.
 **
 ** GNU Lesser General Public License Usage
 ** Alternatively, this file may be used under the terms of the GNU Lesser
@@ -25,8 +25,8 @@
 ** requirements will be met: https://www.gnu.org/licenses/lgpl.html and
 ** http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
 **
-** In addition, as a special exception, Digia gives you certain additional
-** rights. These rights are described in the Digia Qt LGPL Exception
+** As a special exception, The Qt Company gives you certain additional
+** rights. These rights are described in The Qt Company LGPL Exception
 ** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
 **
 ** $QT_END_LICENSE$

--- a/libs/qtandroidserialport/src/qtandroidserialport.pri
+++ b/libs/qtandroidserialport/src/qtandroidserialport.pri
@@ -21,8 +21,6 @@ android {
 
     CONFIG += mobility
 
-    INCLUDEPATH += $$PWD/qt4support/include
-
     HEADERS += $$PUBLIC_HEADERS $$PRIVATE_HEADERS
 
 }

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -93,6 +93,7 @@ bool SerialLink::_isBootloader()
  **/
 void SerialLink::run()
 {
+#ifndef __android__
     // Initialize the connection
     if (!_hardwareConnect(_type)) {
         // Need to error out here.
@@ -103,6 +104,7 @@ void SerialLink::run()
         _emitLinkError("Error connecting: " + err);
         return;
     }
+#endif
 
     qint64  msecs = QDateTime::currentMSecsSinceEpoch();
     qint64  initialmsecs = QDateTime::currentMSecsSinceEpoch();
@@ -255,10 +257,13 @@ bool SerialLink::_disconnect(void)
             _stopp = true;
         }
         wait(); // This will terminate the thread and close the serial port
-        return true;
+    } else {
+        _transmitBuffer.clear(); //clear the output buffer to avoid sending garbage at next connect
+        qCDebug(SerialLinkLog) << "Already disconnected";
     }
-    _transmitBuffer.clear(); //clear the output buffer to avoid sending garbage at next connect
-    qCDebug(SerialLinkLog) << "Already disconnected";
+#ifdef __android__
+    LinkManager::instance()->suspendConfigurationUpdates(false);
+#endif
     return true;
 }
 
@@ -276,6 +281,19 @@ bool SerialLink::_connect(void)
         QMutexLocker locker(&this->_stoppMutex);
         _stopp = false;
     }
+#ifdef __android__
+    LinkManager::instance()->suspendConfigurationUpdates(true);
+    // Initialize the connection
+    if (!_hardwareConnect(_type)) {
+        // Need to error out here.
+        QString err("Could not create port.");
+        if (_port) {
+            err = _port->errorString();
+        }
+        _emitLinkError("Error connecting: " + err);
+        return false;
+    }
+#endif
     start(HighPriority);
     return true;
 }
@@ -338,6 +356,9 @@ bool SerialLink::_hardwareConnect(QString &type)
 
     // After the bootloader times out, it still can take a second or so for the Pixhawk USB driver to come up and make
     // the port available for open. So we retry a few times to wait for it.
+#ifdef __android__
+    _port->open(QIODevice::ReadWrite);
+#else
     for (int openRetries = 0; openRetries < 4; openRetries++) {
         if (!_port->open(QIODevice::ReadWrite)) {
             qCDebug(SerialLinkLog) << "Port open failed, retrying";
@@ -346,6 +367,7 @@ bool SerialLink::_hardwareConnect(QString &type)
             break;
         }
     }
+#endif
     if (!_port->isOpen() ) {
         emit communicationUpdate(getName(),"Error opening port: " + _port->errorString());
         _port->close();


### PR DESCRIPTION
Still not working right...

The issues are beyond what I understand about Java and/or Android. These changes, besides some cosmetic ones to match the current Qt file headers, take it a bit further but in general, this whole Qt SerialPort layer for Android is not working. Too many crashes (it doesn't at all like being called from a different thread for instance). I'm trying to track down Mike Goza, who originally wrote this and submitted as a patch to Qt (which was never integrated). In the mean time, the only reliable way to connect to Android is UPD/TCP and even that needs to be hardcoded for the moment, as the UI for setting up connections (Qt Widgets) os not usable within Android/iOS.