### PR TITLE
Fixed the load waypoint bug - points from the list out of sync with points on the map

### DIFF
--- a/src/uas/UASWaypointManager.cc
+++ b/src/uas/UASWaypointManager.cc
@@ -585,8 +585,11 @@ void UASWaypointManager::loadWaypoints(const QString &loadFile)
             Waypoint *t = new Waypoint();
             if(t->load(in))
             {
-                t->setId(waypointsEditable.count());
-                waypointsEditable.insert(waypointsEditable.count(), t);
+              //Use the existing function to add waypoints to the map instead of doing it manually
+              //Indeed, we should connect our waypoints to the map in order to synchronize them
+              //t->setId(waypointsEditable.count());
+              // waypointsEditable.insert(waypointsEditable.count(), t);
+              addWaypointEditable(t, false);
             }
             else
             {


### PR DESCRIPTION
When you load a waypoint files, the changes you do in the waypoint list (for example, changing the longitude of a waypoint) are not applied to the points displayed on the map.

Reproduce the bug: Load a waypoint file, and try to modify a waypoint longitude with the spin box in the waypoints list.

What does this fix do: In the loadWaypoints function, it uses the function addEditableWaypoint to add the waypoints instead of adding them directly to the map. This function was used before in the code, for example when we get the waypoints for the UAS.