### PR TITLE
Fix GPS icon when no GPS is present.

### DIFF
--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -88,7 +88,7 @@ public:
     Q_PROPERTY(int           newMessageCount    MEMBER _currentMessageCount     NOTIFY newMessageCountChanged)
     Q_PROPERTY(int           messageCount       MEMBER _messageCount            NOTIFY messageCountChanged)
     Q_PROPERTY(QString       systemPixmap       MEMBER _systemPixmap            NOTIFY systemPixmapChanged)
-    Q_PROPERTY(int           satelliteCount     MEMBER _satelliteCount          NOTIFY satelliteCountChanged)
+    Q_PROPERTY(int           satelliteCount     READ   satelliteCount           NOTIFY satelliteCountChanged)
     Q_PROPERTY(QStringList   connectedList      MEMBER _connectedList           NOTIFY connectedListChanged)
     Q_PROPERTY(bool          mavPresent         READ mavPresent                 NOTIFY mavPresentChanged)
     Q_PROPERTY(QString       currentState       MEMBER _currentState            NOTIFY currentStateChanged)
@@ -104,6 +104,7 @@ public:
     Q_PROPERTY(int           telemetryLRSSI     READ telemetryLRSSI             NOTIFY telemetryLRSSIChanged)
 
     bool        mavPresent              () { return _mav != NULL; }
+    int         satelliteCount          () { return _satelliteCount; }
     int         remoteRSSI              () { return _remoteRSSI; }
     int         telemetryRRSSI          () { return _telemetryRRSSI; }
     int         telemetryLRSSI          () { return _telemetryLRSSI; }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -315,7 +315,7 @@ Rectangle {
 
             Rectangle {
                 id: satelitte
-                width:  getProportionalDimmension(50)
+                width:  getProportionalDimmension(55)
                 height: cellHeight
                 visible: showMavStatus() && (mainToolBar.showGPS)
                 anchors.verticalCenter: parent.verticalCenter
@@ -336,8 +336,8 @@ Rectangle {
 
                 QGCLabel {
                     id: satelitteText
-                    text: mainToolBar.satelliteCount
-                    font.pointSize: __screenTools.fontPointFactor * (14);
+                    text: mainToolBar.satelliteCount >= 0 ? mainToolBar.satelliteCount : 'NA'
+                    font.pointSize: mainToolBar.satelliteCount >= 0 ? __screenTools.fontPointFactor * (14) : __screenTools.fontPointFactor * (10)
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right


### PR DESCRIPTION
This fixes #1500.
If there is no GPS, the icon is gray and shows *NA*.

![screen shot 2015-04-25 at 10 06 31 am](https://cloud.githubusercontent.com/assets/749243/7333195/412a92a2-eb33-11e4-8718-6343643b1ef7.png)
