### PR TITLE
New parameter editor

### DIFF
--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -87,14 +87,6 @@ void ParameterLoader::_parameterUpdate(int uasId, int componentId, QString param
                                     "value:" << value <<
                                     ")";
     
-#if 1
-    // This code is handy for testing re-request logic. It drops ever other param update.
-    static int increment = 0;
-    if (increment++ & 1) {
-        return;
-    }
-#endif
-    
     _dataMutex.lock();
     
     // Restart our waiting for param timer

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -61,7 +61,7 @@ Rectangle {
     property real __textWidth:  __textControl.contentWidth
 
     Item {
-        id: editorOverlay
+        id: __editorOverlay
 
         anchors.fill:   parent
         visible:        false
@@ -105,7 +105,7 @@ Rectangle {
                         text:           "Cancel"
 
                         onClicked: {
-                            editorOverlay.visible = false
+                            __editorOverlay.visible = false
                         }
                     }
 
@@ -117,7 +117,7 @@ Rectangle {
 
                         onClicked: {
                             __editorOverlayFact.value = valueField.text
-                            editorOverlay.visible = false
+                            __editorOverlay.visible = false
                         }
                     }
                 }
@@ -176,10 +176,40 @@ Rectangle {
                         QGCLabel { text: "Default value:" }
                         QGCLabel { text: __editorOverlayFact.defaultValueAvailable ? __editorOverlayFact.defaultValue : "none" }
                     }
+
+                    QGCLabel {
+                        width:      parent.width
+                        wrapMode:   Text.WordWrap
+                        text:       "Warning: Modifying parameters while vehicle is in flight can lead to vehicle instability and possible vehicle loss. " +
+                                        "Make sure you know what you are doing and double-check your values before Save!"
+                    }
+                } // Column - Fact information
+            } // Column - Header + Fact information
+
+
+            QGCButton {
+                anchors.rightMargin:    __textWidth
+                anchors.right:          rcButton.left
+                anchors.bottom:         parent.bottom
+                visible:                __editorOverlayFact.defaultValueAvailable
+                text:                   "Reset to default"
+
+                onClicked: {
+                    __editorOverlayFact.value = __editorOverlayFact.defaultValue
+                    __editorOverlay.visible = false
                 }
             }
-        }
-    }
+
+            QGCButton {
+                id:             rcButton
+                anchors.right:  parent.right
+                anchors.bottom: parent.bottom
+                visible:        __editorOverlayFact.defaultValueAvailable
+                text:           "Set RC to Param..."
+                onClicked:      __controller.setRCToParam(__editorOverlayFact.name)
+            }
+        } // Rectangle - editorDialog
+    } // Item - editorOverlay
 
     Component {
         id: factRowsComponent
@@ -250,7 +280,7 @@ Rectangle {
 
                             onClicked: {
                                 __editorOverlayFact = modelFact
-                                editorOverlay.visible = true
+                                __editorOverlay.visible = true
                             }
                         }
                     }

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -210,7 +210,13 @@ Rectangle {
                         width:      parent.width
                         height:		__textHeight + (__screenTools.pixelSizeFactor * (9))
 
-                        Fact { id: modelFact; name: modelData + ":" + componentId }
+                        Fact {
+                            id: modelFact
+
+                            Component.onCompleted: {
+                                name = modelData + ":" + componentId
+                            }
+                        }
 
                         QGCLabel {
                             id:                 nameLabel

--- a/src/VehicleSetup/SetupParameterEditor.qml
+++ b/src/VehicleSetup/SetupParameterEditor.qml
@@ -28,40 +28,6 @@ import QGroundControl.Controls 1.0
 import QGroundControl.ScreenTools 1.0
 import QGroundControl.Palette 1.0
 
-Rectangle {
-	QGCPalette { id: qgcPal; colorGroupEnabled: true }
-	ScreenTools { id: screenTools }
-
-    color: qgcPal.window
-
-    // We use an ExclusiveGroup to maintain the visibility of a single editing control at a time
-    ExclusiveGroup {
-        id: exclusiveEditorGroup
-    }
-
-    Column {
-        anchors.fill:parent
-
-        QGCLabel {
-            text: "PARAMETER EDITOR"
-            font.pointSize: screenTools.fontPointFactor * (20)
-        }
-
-        Item {
-            height: 20
-            width:	5
-        }
-
-		QGCLabel {
-			id: infoLabel
-			width:      parent.width
-			wrapMode:   Text.WordWrap
-			text:       "Click a parameter value to modify. Right-click for additional options. Values which have been modified from the default are shown in orange. Use caution when modifying parameters here since the values are not checked for validity."
-		}
-
-		ParameterEditor {
-			width:	parent.width
-			height: parent.height - (infoLabel.y + infoLabel.height)
-		}
-    }
+ParameterEditor {
+    fullMode: true
 }


### PR DESCRIPTION
- Fixes Issue #1507 providing the ability to cancel a parameter change
- Much better perf since not all params are shown at once
- Much more tablet friendly UI

Screen shots from Galaxy Tab...

Groups are on the left. Select a group to show params for the group:
![screenshot_2015-04-28-16-00-08](https://cloud.githubusercontent.com/assets/5876851/7382597/01887ae8-edc6-11e4-8942-0caeea2dec16.png)

Click on a parameter opens a panel for editing with all meta data shown:
![screenshot_2015-04-28-16-00-19](https://cloud.githubusercontent.com/assets/5876851/7382602/08dbca3e-edc6-11e4-8d28-4282a2730df2.png)

Note 1: This Qml generates a binding loop error debug output which I believe is incorrect. I'm still looking at it. It doesn't prevent it from working.
Note 2: As I was typing this up I realized that I didn't put in reset to default and the rc map stuff in the new ui. I'll do that in a separate pull.