### PR TITLE
Hacked version of ScreenToolsSingleton

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -37,6 +37,7 @@
 #include <QPainter>
 #include <QStyleFactory>
 #include <QAction>
+#include <QQmlEngine>
 
 #include <QDebug>
 
@@ -208,6 +209,17 @@ QGCApplication::~QGCApplication()
     _destroySingletons();
 }
 
+static QObject* ScreenToolsSingletonFactory(QQmlEngine *engine, QJSEngine *jsEngine)
+{
+    Q_UNUSED(engine)
+    Q_UNUSED(jsEngine)
+    
+    ScreenTools* screenTools = new ScreenTools;
+    QQmlEngine::setObjectOwnership(screenTools, QQmlEngine::CppOwnership);
+    
+    return screenTools;
+}
+
 void QGCApplication::_initCommon(void)
 {
     QSettings settings;
@@ -273,6 +285,7 @@ void QGCApplication::_initCommon(void)
     // Register our Qml objects
     qmlRegisterType<QGCPalette>("QGroundControl.Palette", 1, 0, "QGCPalette");
     qmlRegisterType<ScreenTools>("QGroundControl.ScreenTools", 1, 0, "ScreenTools");
+    qmlRegisterSingletonType<ScreenTools>("QGroundControl.ScreenTools", 1, 0, "ScreenToolsSingleton", ScreenToolsSingletonFactory);
 	qmlRegisterType<ViewWidgetController>("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
 	qmlRegisterType<ParameterEditorController>("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
 }

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -42,6 +42,11 @@ Rectangle {
 
     color: qgcPal.window
 
+Component.onCompleted: {
+    console.log("ScreenToolSingleton");
+    console.log(ScreenToolsSingleton.defaultFontPointSize);
+}
+
     Column {
         anchors.fill: parent
 


### PR DESCRIPTION
Just a hack to show it working for Gus. The issue is that since we have multiple engines and the singleton is coming from the C++ side of things you need to make sure the object ownership stays on the C++ side. Otherwise the Java GC will take ownership of the object and free it in one QmlEngine and it will get trashed in all other QmlEngine instances.