### PR TITLE
Singleton screen tools

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
@@ -36,7 +36,6 @@ Item {
     Loader {
         property FlightModesComponentController controller: FlightModesComponentController { }
         property QGCPalette qgcPal: QGCPalette { colorGroupEnabled: true }
-        property ScreenTools screenTools: ScreenTools { }
         property bool loading: true
 
         anchors.fill: parent
@@ -364,7 +363,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: screenTools.fontPointFactor * (20);
+                    font.pointSize: ScreenTools.fontPointFactor * (20);
                 }
 
                 Item { height: 20; width: 10 } // spacer
@@ -894,7 +893,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: screenTools.fontPointFactor * (20);
+                    font.pointSize: ScreenTools.fontPointFactor * (20);
                 }
 
                 QGCLabel {

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -45,7 +45,6 @@ Rectangle {
 
     property int firstColumnWidth: 220
     property int textEditWidth:    80
-    property ScreenTools screenTools: ScreenTools { }
 
     property Fact battNumCells: Fact { name: "BAT_N_CELLS" }
     property Fact battHighVolt: Fact { name: "BAT_V_CHARGED" }
@@ -98,13 +97,13 @@ Rectangle {
 
         QGCLabel {
             text: "POWER CONFIG"
-            font.pointSize: screenTools.fontPointFactor * (20);
+            font.pointSize: ScreenTools.fontPointFactor * (20);
         }
 
         QGCLabel {
             text: "Battery"
             color: palette.text
-            font.pointSize: screenTools.fontPointFactor * (20);
+            font.pointSize: ScreenTools.fontPointFactor * (20);
         }
 
         Rectangle {
@@ -162,7 +161,7 @@ Rectangle {
                         width: 40
                         antialiasing: true
                         Connections {
-                            target: screenTools
+                            target: ScreenTools
                             onRepaintRequestedChanged: {
                                 arrows.requestPaint();
                             }
@@ -231,7 +230,7 @@ Rectangle {
                 QGCLabel {
                     text: "Propeller Function"
                     color: palette.text
-                    font.pointSize: screenTools.fontPointFactor * (20);
+                    font.pointSize: ScreenTools.fontPointFactor * (20);
                 }
                 Rectangle {
                     width: parent.width
@@ -245,7 +244,7 @@ Rectangle {
                 QGCLabel {
                     text: "Magnetometer Distortion"
                     color: palette.text
-                    font.pointSize: screenTools.fontPointFactor * (20);
+                    font.pointSize: ScreenTools.fontPointFactor * (20);
                 }
                 Rectangle {
                     width: parent.width
@@ -264,7 +263,7 @@ Rectangle {
         QGCLabel {
             text: "Advanced Power Settings"
             color: palette.text
-            font.pointSize: screenTools.fontPointFactor * (20);
+            font.pointSize: ScreenTools.fontPointFactor * (20);
             visible: showAdvanced.checked
         }
         Rectangle {

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -38,7 +38,6 @@ Rectangle {
     height: 600
     color: palette.window
 
-    property ScreenTools screenTools: ScreenTools { }
     property int flightLineWidth: 2             // width of lines for flight graphic
     property int loiterAltitudeColumnWidth: 180 // width of loiter altitude column
     property int shadedMargin: 20               // margin inset for shaded areas
@@ -54,7 +53,7 @@ Rectangle {
 
         QGCLabel {
             text: "SAFETY CONFIG"
-            font.pointSize: screenTools.fontPointFactor * (20);
+            font.pointSize: ScreenTools.fontPointFactor * (20);
         }
 
         Item { height: 20; width: 10 } // spacer
@@ -62,7 +61,7 @@ Rectangle {
         //-----------------------------------------------------------------
         //-- Return Home Triggers
 
-        QGCLabel { text: "Triggers For Return Home"; color: palette.text; font.pointSize: screenTools.fontPointFactor * (20); }
+        QGCLabel { text: "Triggers For Return Home"; color: palette.text; font.pointSize: ScreenTools.fontPointFactor * (20); }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -121,7 +120,7 @@ Rectangle {
         //-----------------------------------------------------------------
         //-- Return Home Settings
 
-        QGCLabel { text: "Return Home Settings"; font.pointSize: screenTools.fontPointFactor * (20); }
+        QGCLabel { text: "Return Home Settings"; font.pointSize: ScreenTools.fontPointFactor * (20); }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -291,7 +290,7 @@ Rectangle {
         QGCLabel {
             property Fact fact: Fact { name: "NAV_RCL_OBC" }
             width: parent.width
-            font.pointSize: screenTools.fontPointFactor * (14);
+            font.pointSize: ScreenTools.fontPointFactor * (14);
             text: "Warning: You have an advanced safety configuration set using the NAV_RCL_OBC parameter. The above settings may not apply.";
             visible: fact.value !== 0
             wrapMode: Text.Wrap
@@ -299,7 +298,7 @@ Rectangle {
         QGCLabel {
             property Fact fact: Fact { name: "NAV_DLL_OBC" }
             width: parent.width
-            font.pointSize: screenTools.fontPointFactor * (14);
+            font.pointSize: ScreenTools.fontPointFactor * (14);
             text: "Warning: You have an advanced safety configuration set using the NAV_DLL_OBC parameter. The above settings may not apply.";
             visible: fact.value !== 0
             wrapMode: Text.Wrap

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -34,7 +34,6 @@ import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     property QGCPalette qgcPal: QGCPalette { colorGroupEnabled: true }
-    property ScreenTools screenTools: ScreenTools { }
 
     readonly property int rotationColumnWidth: 200
     readonly property var rotations: [
@@ -332,7 +331,7 @@ Rectangle {
 
         QGCLabel {
             text: "SENSORS CONFIG"
-            font.pointSize: screenTools.fontPointFactor * (20);
+            font.pointSize: ScreenTools.fontPointFactor * (20);
         }
 
         Item { height: 20; width: 10 } // spacer
@@ -437,7 +436,7 @@ Rectangle {
                     id:             orientationCalAreaHelpText
                     width:          parent.width
                     wrapMode:       Text.WordWrap
-                    font.pointSize: screenTools.fontPointFactor * (17);
+                    font.pointSize: ScreenTools.fontPointFactor * (17);
                 }
 
                 Flow {

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -90,8 +90,6 @@ const char* QGCApplication::_lightStyleFile = ":/res/styles/style-light.css";
  * This is called by the QtQuick engine for creating the singleton
  **/
 
-#include <QQmlEngine>
-
 static QObject* screenToolsSingletonFactory(QQmlEngine*, QJSEngine*)
 {
     ScreenTools* screenTools = new ScreenTools;

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -85,6 +85,20 @@ const char* QGCApplication::_darkStyleFile = ":/res/styles/style-dark.css";
 const char* QGCApplication::_lightStyleFile = ":/res/styles/style-light.css";
 
 /**
+ * @brief ScreenTools creation callback
+ *
+ * This is called by the QtQuick engine for creating the singleton
+ **/
+
+#include <QQmlEngine>
+
+static QObject* screenToolsSingletonFactory(QQmlEngine*, QJSEngine*)
+{
+    ScreenTools* screenTools = new ScreenTools;
+    return screenTools;
+}
+
+/**
  * @brief Constructor for the main application.
  *
  * This constructor initializes and starts the whole application. It takes standard
@@ -272,9 +286,11 @@ void QGCApplication::_initCommon(void)
     
     // Register our Qml objects
     qmlRegisterType<QGCPalette>("QGroundControl.Palette", 1, 0, "QGCPalette");
-    qmlRegisterType<ScreenTools>("QGroundControl.ScreenTools", 1, 0, "ScreenTools");
 	qmlRegisterType<ViewWidgetController>("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
 	qmlRegisterType<ParameterEditorController>("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
+    //-- Create QML Singleton Interfaces
+    qmlRegisterSingletonType<ScreenTools>("QGroundControl.ScreenTools", 1, 0, "ScreenTools", screenToolsSingletonFactory);
+
 }
 
 bool QGCApplication::_initForNormalAppBoot(void)
@@ -465,6 +481,7 @@ void QGCApplication::_createSingletons(void)
     MAVLinkProtocol* mavlink = MAVLinkProtocol::_createSingleton();
     Q_UNUSED(mavlink);
     Q_ASSERT(mavlink);
+
 }
 
 void QGCApplication::_destroySingletons(void)

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -41,7 +41,6 @@ Rectangle {
 	property bool fullMode: true
 
 	QGCPalette { id: __qgcPal; colorGroupEnabled: true }
-	ScreenTools { id: __screenTools }
 	ParameterEditorController { id: __controller }
 	QGCLabel { id: __textControl; text: "X"; visible: false }
 
@@ -219,10 +218,10 @@ Rectangle {
             x:      __leftMargin
 
             QGCLabel {
-                height:				__textHeight + (__screenTools.pixelSizeFactor * (9))
+                height:				__textHeight + (ScreenTools.pixelSizeFactor * (9))
                 text:               group
                 verticalAlignment:	Text.AlignVCenter
-                font.pointSize:     __screenTools.fontPointFactor * (16);
+                font.pointSize:     ScreenTools.fontPointFactor * (16);
             }
 
             Rectangle {
@@ -238,7 +237,7 @@ Rectangle {
                     Item {
                         x:			__leftMargin
                         width:      parent.width
-                        height:		__textHeight + (__screenTools.pixelSizeFactor * (9))
+                        height:		__textHeight + (ScreenTools.pixelSizeFactor * (9))
 
                         Fact {
                             id: modelFact
@@ -304,7 +303,7 @@ Rectangle {
             height: firstButton.height
 
             QGCLabel {
-                font.pointSize: __screenTools.fontPointFactor * (20)
+                font.pointSize: ScreenTools.fontPointFactor * (20)
                 visible:        fullMode
                 text:           "PARAMETER EDITOR"
             }
@@ -361,10 +360,10 @@ Rectangle {
                             readonly property int componentId: parseInt(modelData)
 
                             QGCLabel {
-                                height:				contentHeight + (__screenTools.pixelSizeFactor * (9))
+                                height:				contentHeight + (ScreenTools.pixelSizeFactor * (9))
                                 text:               "Component #: " + componentId.toString()
                                 verticalAlignment:	Text.AlignVCenter
-                                font.pointSize:     __screenTools.fontPointFactor * (16);
+                                font.pointSize:     ScreenTools.fontPointFactor * (16);
                             }
 
                             Repeater {
@@ -386,7 +385,7 @@ Rectangle {
 
                                     Item {
                                         width:  1
-                                        height: __screenTools.pixelSizeFactor * (3)
+                                        height: ScreenTools.pixelSizeFactor * (3)
                                     }
                                 } // Column - Group
                             } // Repeater - Groups

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -23,17 +23,15 @@ Button {
     property int __lastGlobalMouseX: 0
     property int __lastGlobalMouseY: 0
 
-    property ScreenTools __screenTools: ScreenTools { }
-
     Connections {
         target: __behavior
         onMouseXChanged: {
-            __lastGlobalMouseX = __screenTools.mouseX
-            __lastGlobalMouseY = __screenTools.mouseY
+            __lastGlobalMouseX = ScreenTools.mouseX
+            __lastGlobalMouseY = ScreenTools.mouseY
         }
         onMouseYChanged: {
-            __lastGlobalMouseX = __screenTools.mouseX
-            __lastGlobalMouseY = __screenTools.mouseY
+            __lastGlobalMouseX = ScreenTools.mouseX
+            __lastGlobalMouseY = ScreenTools.mouseY
         }
         onEntered: { __forceHoverOff; false; hoverTimer.start() }
         onExited: { __forceHoverOff; false; hoverTimer.stop() }
@@ -45,7 +43,7 @@ Button {
         repeat:     true
 
         onTriggered: {
-            if (__lastGlobalMouseX != __screenTools.mouseX || __lastGlobalMouseY != __screenTools.mouseY) {
+            if (__lastGlobalMouseX != ScreenTools.mouseX || __lastGlobalMouseY != ScreenTools.mouseY) {
                 __forceHoverOff = true
             } else {
                 __forceHoverOff = false
@@ -106,7 +104,7 @@ Button {
                         id:             text
                         antialiasing:   true
                         text:           control.text
-                        font.pointSize: __screenTools.defaultFontPointSize
+                        font.pointSize: ScreenTools.defaultFontPointSize
 
                         anchors.verticalCenter: parent.verticalCenter
 

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -7,7 +7,6 @@ import QGroundControl.ScreenTools 1.0
 
 CheckBox {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-    property ScreenTools __screenTools: ScreenTools { }
 
     style: CheckBoxStyle {
         label: Item {
@@ -30,7 +29,7 @@ CheckBox {
                 id:             text
                 text:           control.text
                 antialiasing:   true
-                font.pointSize: __screenTools.defaultFontPointSize
+                font.pointSize: ScreenTools.defaultFontPointSize
 
                 anchors.centerIn: parent
 

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -8,11 +8,10 @@ import QGroundControl.ScreenTools 1.0
 
 ComboBox {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-    property ScreenTools __screenTools: ScreenTools { }
     property bool __showHighlight: pressed | hovered
 
     style: ComboBoxStyle {
-        font.pointSize: __screenTools.defaultFontPointSize
+        font.pointSize: ScreenTools.defaultFontPointSize
         textColor: __showHighlight ?
                     control.__qgcPal.buttonHighlightText :
                     control.__qgcPal.buttonText

--- a/src/QmlControls/QGCLabel.qml
+++ b/src/QmlControls/QGCLabel.qml
@@ -7,11 +7,10 @@ import QGroundControl.ScreenTools 1.0
 
 Text {
     QGCPalette { id: __qgcPal; colorGroupEnabled: enabled }
-    property ScreenTools __screenTools: ScreenTools { }
 
     property bool enabled: true
 
-    font.pointSize: __screenTools.defaultFontPointSize
+    font.pointSize: ScreenTools.defaultFontPointSize
     color:          __qgcPal.text
     antialiasing:   true
 }

--- a/src/QmlControls/QGCMovableItem.qml
+++ b/src/QmlControls/QGCMovableItem.qml
@@ -8,10 +8,9 @@ import QGroundControl.ScreenTools 1.0
 
 Item {
     id: root
-    property ScreenTools __screenTools: ScreenTools { }
     property bool   allowDragging:  true
-    property real   minimumWidth:   __screenTools.pixelSizeFactor * (60)
-    property real   minimumHeight:  __screenTools.pixelSizeFactor * (60)
+    property real   minimumWidth:   ScreenTools.pixelSizeFactor * (60)
+    property real   minimumHeight:  ScreenTools.pixelSizeFactor * (60)
     property alias  tForm:          tform
     signal          resetRequested()
     transform: Scale {

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -7,7 +7,6 @@ import QGroundControl.ScreenTools 1.0
 
 RadioButton {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-    property ScreenTools __screenTools: ScreenTools { }
 
     style: RadioButtonStyle {
         label: Item {
@@ -29,7 +28,7 @@ RadioButton {
             Text {
                 id:             text
                 text:           control.text
-                font.pointSize: __screenTools.defaultFontPointSize
+                font.pointSize: ScreenTools.defaultFontPointSize
                 antialiasing:   true
 
                 anchors.centerIn: parent

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -10,7 +10,6 @@ TextField {
     property string unitsLabel: ""
 
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-    property ScreenTools __screenTools: ScreenTools { }
 
     textColor: __qgcPal.textFieldText
 
@@ -51,7 +50,7 @@ TextField {
                 width: unitsLabelWidthGenerator.width
 
                 text: control.unitsLabel
-                font.pointSize: __screenTools.defaultFontPointSize
+                font.pointSize: ScreenTools.defaultFontPointSize
                 antialiasing:   true
 
                 color: control.textColor

--- a/src/QmlControls/ScreenTools.h
+++ b/src/QmlControls/ScreenTools.h
@@ -58,14 +58,12 @@ public:
       @code
       import QGroundControl.ScreenTools 1.0
       ...
-      property ScreenTools screenTools: ScreenTools { }
-      ...
         Canvas {
             id: myCanvas
             height: 40
             width:  40
             Connections {
-                target: screenTools
+                target: ScreenTools
                 onRepaintRequestedChanged: {
                     myCanvas.requestPaint();
                 }

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -14,7 +14,6 @@ Button {
     property bool setupComplete: true
     property bool setupIndicator: true
     property string imageResource: "subMenuButtonImage.png"
-    property ScreenTools __screenTools: ScreenTools { }
 
     style: ButtonStyle {
         id: buttonStyle
@@ -41,7 +40,7 @@ Button {
                 horizontalAlignment: TextEdit.AlignHCenter
 
                 text: control.text
-                font.pointSize: __screenTools.defaultFontPointSize
+                font.pointSize: ScreenTools.defaultFontPointSize
                 antialiasing: true
                 color: __showHighlight ? __qgcPal.buttonHighlightText : __qgcPal.buttonText
 

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -42,7 +42,6 @@ Rectangle {
     property var imageSource: ""
 
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-    property ScreenTools __screenTools: ScreenTools { }
 
     width:  200
     height: 200
@@ -71,7 +70,7 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         __screenTools.fontPointFactor * (25);
+            font.pointSize:         ScreenTools.fontPointFactor * (25);
             font.bold:              true
             color:                  "black"
 
@@ -82,7 +81,7 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         __screenTools.fontPointFactor * (25);
+            font.pointSize:         ScreenTools.fontPointFactor * (25);
             color:                  calInProgress ? "yellow" : "white"
 
             text: parent.calText

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -36,7 +36,6 @@ Rectangle {
     height: 600
 
     property var qgcPal: QGCPalette { colorGroupEnabled: true }
-    property ScreenTools screenTools: ScreenTools { }
     property FirmwareUpgradeController controller: FirmwareUpgradeController {
         upgradeButton: upgradeButton
         progressBar: progressBar
@@ -51,7 +50,7 @@ Rectangle {
 
         QGCLabel {
             text: "FIRMWARE UPDATE"
-            font.pointSize: screenTools.fontPointFactor * (20);
+            font.pointSize: ScreenTools.fontPointFactor * (20);
         }
 
         Item {
@@ -119,7 +118,7 @@ Rectangle {
             height:			300
             readOnly:		true
             frameVisible:	false
-            font.pointSize: screenTools.defaultFontPointSize
+            font.pointSize: ScreenTools.defaultFontPointSize
             
 			text: qsTr("Please disconnect all vehicles from QGroundControl before selecting Upgrade.")
 

--- a/src/VehicleSetup/SetupParameterEditor.qml
+++ b/src/VehicleSetup/SetupParameterEditor.qml
@@ -28,39 +28,6 @@ import QGroundControl.Controls 1.0
 import QGroundControl.ScreenTools 1.0
 import QGroundControl.Palette 1.0
 
-Rectangle {
-	QGCPalette { id: qgcPal; colorGroupEnabled: true }
-
-    color: qgcPal.window
-
-    // We use an ExclusiveGroup to maintain the visibility of a single editing control at a time
-    ExclusiveGroup {
-        id: exclusiveEditorGroup
-    }
-
-    Column {
-        anchors.fill:parent
-
-        QGCLabel {
-            text: "PARAMETER EDITOR"
-            font.pointSize: ScreenTools.fontPointFactor * (20)
-        }
-
-        Item {
-            height: 20
-            width:	5
-        }
-
-		QGCLabel {
-			id: infoLabel
-			width:      parent.width
-			wrapMode:   Text.WordWrap
-			text:       "Click a parameter value to modify. Right-click for additional options. Values which have been modified from the default are shown in orange. Use caution when modifying parameters here since the values are not checked for validity."
-		}
-
-		ParameterEditor {
-			width:	parent.width
-			height: parent.height - (infoLabel.y + infoLabel.height)
-		}
-    }
+ParameterEditor {
+    fullMode: true
 }

--- a/src/VehicleSetup/SetupParameterEditor.qml
+++ b/src/VehicleSetup/SetupParameterEditor.qml
@@ -28,6 +28,39 @@ import QGroundControl.Controls 1.0
 import QGroundControl.ScreenTools 1.0
 import QGroundControl.Palette 1.0
 
-ParameterEditor {
-    fullMode: true
+Rectangle {
+	QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    color: qgcPal.window
+
+    // We use an ExclusiveGroup to maintain the visibility of a single editing control at a time
+    ExclusiveGroup {
+        id: exclusiveEditorGroup
+    }
+
+    Column {
+        anchors.fill:parent
+
+        QGCLabel {
+            text: "PARAMETER EDITOR"
+            font.pointSize: ScreenTools.fontPointFactor * (20)
+        }
+
+        Item {
+            height: 20
+            width:	5
+        }
+
+		QGCLabel {
+			id: infoLabel
+			width:      parent.width
+			wrapMode:   Text.WordWrap
+			text:       "Click a parameter value to modify. Right-click for additional options. Values which have been modified from the default are shown in orange. Use caution when modifying parameters here since the values are not checked for validity."
+		}
+
+		ParameterEditor {
+			width:	parent.width
+			height: parent.height - (infoLabel.y + infoLabel.height)
+		}
+    }
 }

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -35,7 +35,6 @@ Rectangle {
     height: 400
 
     property var qgcPal: QGCPalette { id: palette; colorGroupEnabled: true }
-    property ScreenTools screenTools: ScreenTools { }
 
     id: topLevel
     objectName: "topLevel"
@@ -47,7 +46,7 @@ Rectangle {
 
         QGCLabel {
             text: "VEHICLE SUMMARY"
-            font.pointSize: screenTools.fontPointFactor * (20);
+            font.pointSize: ScreenTools.fontPointFactor * (20);
         }
 
         Item {
@@ -60,7 +59,7 @@ Rectangle {
             width:			parent.width
 			wrapMode:		Text.WordWrap
 			color:			autopilot.setupComplete ? qgcPal.text : "red"
-            font.pointSize: autopilot.setupComplete ? screenTools.defaultFontPointSize : screenTools.fontPointFactor * (20)
+            font.pointSize: autopilot.setupComplete ? ScreenTools.defaultFontPointSize : ScreenTools.fontPointFactor * (20)
 			text: autopilot.setupComplete ?
 						"Below you will find a summary of the settings for your vehicle. To the left are the setup buttons for deatiled settings for each component." :
 						"WARNING: One or more of your vehicle's components require setup prior to flight. It will be shown with a red circular indicator below. " +

--- a/src/ui/flightdisplay/FlightDisplay.qml
+++ b/src/ui/flightdisplay/FlightDisplay.qml
@@ -40,7 +40,6 @@ import QGroundControl.Palette 1.0
 Item {
     id: root
 
-    property ScreenTools __screenTools: ScreenTools { }
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
 
     property real roll:    isNaN(flightDisplay.roll)    ? 0 : flightDisplay.roll
@@ -114,17 +113,17 @@ Item {
         }
         contentItem: Rectangle {
             color: __qgcPal.window
-            implicitWidth:  __screenTools.pixelSizeFactor * (360)
-            implicitHeight: __screenTools.pixelSizeFactor * (300)
+            implicitWidth:  ScreenTools.pixelSizeFactor * (360)
+            implicitHeight: ScreenTools.pixelSizeFactor * (300)
             Column {
                 id: dialogColumn
                 anchors.centerIn: parent
-                spacing:  __screenTools.adjustPixelSize(10)
+                spacing:  ScreenTools.adjustPixelSize(10)
                 width: parent.width
                 Grid {
                     columns: 2
-                    spacing:    __screenTools.pixelSizeFactor * (8)
-                    rowSpacing: __screenTools.pixelSizeFactor * (10)
+                    spacing:    ScreenTools.pixelSizeFactor * (8)
+                    rowSpacing: ScreenTools.pixelSizeFactor * (10)
                     anchors.horizontalCenter: parent.horizontalCenter
                     QGCCheckBox {
                         text: "Map Background"
@@ -221,30 +220,30 @@ Item {
                 Column {
                     id: fudgeColumn
                     anchors.horizontalCenter: parent.horizontalCenter
-                    spacing:    __screenTools.adjustPixelSize(4)
+                    spacing:    ScreenTools.adjustPixelSize(4)
                     width:      parent.width
                     QGCLabel {
                         text: "Adjust Pixel Size Factor"
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
                     Row {
-                        spacing:    __screenTools.adjustPixelSize(4)
+                        spacing:    ScreenTools.adjustPixelSize(4)
                         anchors.horizontalCenter: parent.horizontalCenter
                         Button {
                             text: 'Inc'
                             onClicked: {
-                                __screenTools.increasePixelSize()
+                                ScreenTools.increasePixelSize()
                             }
                         }
                         Label {
-                            text: __screenTools.pixelSizeFactor.toFixed(2)
+                            text: ScreenTools.pixelSizeFactor.toFixed(2)
                             color: __qgcPal.text
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         Button {
                             text: 'Dec'
                             onClicked: {
-                                __screenTools.decreasePixelSize()
+                                ScreenTools.decreasePixelSize()
                             }
                         }
                     }
@@ -253,23 +252,23 @@ Item {
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
                     Row {
-                        spacing:    __screenTools.adjustPixelSize(4)
+                        spacing:    ScreenTools.adjustPixelSize(4)
                         anchors.horizontalCenter: parent.horizontalCenter
                         Button {
                             text: 'Inc'
                             onClicked: {
-                                __screenTools.increaseFontSize()
+                                ScreenTools.increaseFontSize()
                             }
                         }
                         Label {
-                            text: __screenTools.fontPointFactor.toFixed(2)
+                            text: ScreenTools.fontPointFactor.toFixed(2)
                             color: __qgcPal.text
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         Button {
                             text: 'Dec'
                             onClicked: {
-                                __screenTools.decreaseFontSize()
+                                ScreenTools.decreaseFontSize()
                             }
                         }
                     }
@@ -497,16 +496,16 @@ Item {
 
     QGCCompassInstrument {
         id:                 compassInstrument
-        y:                  __screenTools.pixelSizeFactor * (5)
-        x:                  __screenTools.pixelSizeFactor * (85)
-        size:               __screenTools.pixelSizeFactor * (160)
+        y:                  ScreenTools.pixelSizeFactor * (5)
+        x:                  ScreenTools.pixelSizeFactor * (85)
+        size:               ScreenTools.pixelSizeFactor * (160)
         heading:            isNaN(flightDisplay.heading) ? 0 : flightDisplay.heading
         visible:            mapBackground.visible && showCompass
         z:                  mapBackground.z + 1
         onResetRequested: {
-            y               = __screenTools.pixelSizeFactor * (5)
-            x               = __screenTools.pixelSizeFactor * (85)
-            size            = __screenTools.pixelSizeFactor * (160)
+            y               = ScreenTools.pixelSizeFactor * (5)
+            x               = ScreenTools.pixelSizeFactor * (85)
+            size            = ScreenTools.pixelSizeFactor * (160)
             tForm.xScale    = 1
             tForm.yScale    = 1
         }
@@ -514,20 +513,20 @@ Item {
 
     QGCAttitudeInstrument {
         id:                 attitudeInstrument
-        y:                  __screenTools.pixelSizeFactor * (5)
-        size:               __screenTools.pixelSizeFactor * (160)
+        y:                  ScreenTools.pixelSizeFactor * (5)
+        size:               ScreenTools.pixelSizeFactor * (160)
         rollAngle:          roll
         pitchAngle:         pitch
         showPitch:          showPitchIndicator
         visible:            mapBackground.visible && showAttitudeIndicator
         anchors.right:      root.right
-        anchors.rightMargin: __screenTools.pixelSizeFactor * (85)
+        anchors.rightMargin: ScreenTools.pixelSizeFactor * (85)
         z:                  mapBackground.z + 1
         onResetRequested: {
-            y                   = __screenTools.pixelSizeFactor * (5)
+            y                   = ScreenTools.pixelSizeFactor * (5)
             anchors.right       = root.right
-            anchors.rightMargin = __screenTools.pixelSizeFactor * (85)
-            size                = __screenTools.pixelSizeFactor * (160)
+            anchors.rightMargin = ScreenTools.pixelSizeFactor * (85)
+            size                = ScreenTools.pixelSizeFactor * (160)
             tForm.xScale        = 1
             tForm.yScale        = 1
         }
@@ -547,8 +546,8 @@ Item {
         rollAngle:          roll
         pitchAngle:         pitch
         visible:            !mapBackground.visible && showAttitudeIndicator
-        width:              __screenTools.pixelSizeFactor * (260)
-        height:             __screenTools.pixelSizeFactor * (260)
+        width:              ScreenTools.pixelSizeFactor * (260)
+        height:             ScreenTools.pixelSizeFactor * (260)
         z:                  20
     }
 
@@ -559,15 +558,15 @@ Item {
         pitchAngle:         pitch
         rollAngle:          roll
         color:              Qt.rgba(0,0,0,0)
-        size:               __screenTools.pixelSizeFactor * (120)
+        size:               ScreenTools.pixelSizeFactor * (120)
         z:                  30
     }
 
     QGCAltitudeWidget {
         id:                 altitudeWidget
         anchors.right:      parent.right
-        width:              __screenTools.pixelSizeFactor * (60)
-        height:             parent.height * 0.65 > __screenTools.pixelSizeFactor * (280) ? __screenTools.pixelSizeFactor * (280) : parent.height * 0.65
+        width:              ScreenTools.pixelSizeFactor * (60)
+        height:             parent.height * 0.65 > ScreenTools.pixelSizeFactor * (280) ? ScreenTools.pixelSizeFactor * (280) : parent.height * 0.65
         altitude:           flightDisplay.altitudeWGS84
         z:                  30
     }
@@ -575,8 +574,8 @@ Item {
     QGCSpeedWidget {
         id:                 speedWidget
         anchors.left:       parent.left
-        width:              __screenTools.pixelSizeFactor * (60)
-        height:             parent.height * 0.65 > __screenTools.pixelSizeFactor * (280) ? __screenTools.pixelSizeFactor * (280) : parent.height * 0.65
+        width:              ScreenTools.pixelSizeFactor * (60)
+        height:             parent.height * 0.65 > ScreenTools.pixelSizeFactor * (280) ? ScreenTools.pixelSizeFactor * (280) : parent.height * 0.65
         speed:              flightDisplay.groundSpeed
         z:                  40
     }
@@ -584,7 +583,7 @@ Item {
     QGCCurrentSpeed {
         id: currentSpeed
         anchors.left:       parent.left
-        width:              __screenTools.pixelSizeFactor * (75)
+        width:              ScreenTools.pixelSizeFactor * (75)
         airspeed:           flightDisplay.airSpeed
         groundspeed:        flightDisplay.groundSpeed
         showAirSpeed:       true
@@ -596,7 +595,7 @@ Item {
     QGCCurrentAltitude {
         id: currentAltitude
         anchors.right:      parent.right
-        width:              __screenTools.pixelSizeFactor * (75)
+        width:              ScreenTools.pixelSizeFactor * (75)
         altitude:           flightDisplay.altitudeWGS84
         vertZ:              flightDisplay.climbRate
         showAltitude:       true
@@ -608,9 +607,9 @@ Item {
     QGCCompass {
         id:                 compassIndicator
         y:                  root.height * 0.7
-        x:                  root.width  * 0.5 - __screenTools.pixelSizeFactor * (60)
-        width:              __screenTools.pixelSizeFactor * (120)
-        height:             __screenTools.pixelSizeFactor * (120)
+        x:                  root.width  * 0.5 - ScreenTools.pixelSizeFactor * (60)
+        width:              ScreenTools.pixelSizeFactor * (120)
+        height:             ScreenTools.pixelSizeFactor * (120)
         heading:            isNaN(flightDisplay.heading) ? 0 : flightDisplay.heading
         visible:            !mapBackground.visible && showCompass
         z:                  70

--- a/src/ui/qmlcommon/QGCAltitudeWidget.qml
+++ b/src/ui/qmlcommon/QGCAltitudeWidget.qml
@@ -33,10 +33,9 @@ import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     id: root
-    property ScreenTools __screenTools: ScreenTools { }
     property real altitude:         50
-    property real _reticleSpacing:  __screenTools.pixelSizeFactor * (16)
-    property real _reticleHeight:   __screenTools.pixelSizeFactor * (2)
+    property real _reticleSpacing:  ScreenTools.pixelSizeFactor * (16)
+    property real _reticleHeight:   ScreenTools.pixelSizeFactor * (2)
     property real _reticleSlot:     _reticleSpacing + _reticleHeight
     property var  _speedArray:      []
     property int  _currentCenter:   0
@@ -65,7 +64,7 @@ Rectangle {
 
     anchors.verticalCenter: parent.verticalCenter
     smooth: true
-    radius: __screenTools.pixelSizeFactor * (5)
+    radius: ScreenTools.pixelSizeFactor * (5)
     border.color: Qt.rgba(1,1,1,0.25)
     gradient: Gradient {
         GradientStop { position: 0.0; color: Qt.rgba(0,0,0,0.65) }
@@ -74,7 +73,7 @@ Rectangle {
     }
     Rectangle {
         id:     clipRect
-        height: parent.height - __screenTools.pixelSizeFactor * (5)
+        height: parent.height - ScreenTools.pixelSizeFactor * (5)
         width:  parent.width
         clip:   true
         color:  Qt.rgba(0,0,0,0);
@@ -89,12 +88,12 @@ Rectangle {
                 anchors.left: parent.left
                 Rectangle {
                     property int _alt: modelData
-                    width:  (_alt % 10 === 0) ? __screenTools.pixelSizeFactor * (10) : __screenTools.pixelSizeFactor * (15)
+                    width:  (_alt % 10 === 0) ? ScreenTools.pixelSizeFactor * (10) : ScreenTools.pixelSizeFactor * (15)
                     height: _reticleHeight
                     color:  Qt.rgba(1,1,1,0.35)
                     QGCLabel {
                         visible: (_alt % 10 === 0)
-                        x: __screenTools.pixelSizeFactor * (20)
+                        x: ScreenTools.pixelSizeFactor * (20)
                         anchors.verticalCenter:   parent.verticalCenter
                         antialiasing: true
                         font.weight: Font.DemiBold

--- a/src/ui/qmlcommon/QGCAttitudeWidget.qml
+++ b/src/ui/qmlcommon/QGCAttitudeWidget.qml
@@ -33,7 +33,6 @@ import QGroundControl.ScreenTools 1.0
 Item {
     id: root
     anchors.centerIn: parent
-    property ScreenTools __screenTools: ScreenTools { }
     property real rollAngle :   0
     property real pitchAngle:   0
 

--- a/src/ui/qmlcommon/QGCCompass.qml
+++ b/src/ui/qmlcommon/QGCCompass.qml
@@ -33,7 +33,6 @@ import QGroundControl.ScreenTools 1.0
 
 Item {
     id:    root
-    property ScreenTools __screenTools: ScreenTools { }
     property real heading : 0
     Image {
         id: compass
@@ -59,8 +58,8 @@ Item {
     }
     Rectangle {
         anchors.centerIn: compass
-        width:  __screenTools.pixelSizeFactor * (40)
-        height: __screenTools.pixelSizeFactor * (25)
+        width:  ScreenTools.pixelSizeFactor * (40)
+        height: ScreenTools.pixelSizeFactor * (25)
         border.color: Qt.rgba(1,1,1,0.15)
         color: Qt.rgba(0,0,0,0.25)
         QGCLabel {

--- a/src/ui/qmlcommon/QGCCompassInstrument.qml
+++ b/src/ui/qmlcommon/QGCCompassInstrument.qml
@@ -33,10 +33,9 @@ import QGroundControl.ScreenTools 1.0
 
 QGCMovableItem {
     id:                     root
-    property ScreenTools screenTools: ScreenTools { }
     property real heading:  0
-    property real size:     screenTools.pixelSizeFactor * (120)
-    property real _fontSize: screenTools.fontPointFactor * (12)
+    property real size:     ScreenTools.pixelSizeFactor * (120)
+    property real _fontSize: ScreenTools.fontPointFactor * (12)
     width:                  size
     height:                 size
     Rectangle {

--- a/src/ui/qmlcommon/QGCCurrentAltitude.qml
+++ b/src/ui/qmlcommon/QGCCurrentAltitude.qml
@@ -33,20 +33,19 @@ import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     id: root
-    property ScreenTools __screenTools: ScreenTools { }
     property real altitude: 0
     property real vertZ:    0
     property bool showAltitude: true
     property bool showClimbRate: true
     anchors.verticalCenter: parent.verticalCenter
     width:  parent.width
-    height: (showAltitude && showClimbRate) ? __screenTools.pixelSizeFactor * (50) : __screenTools.pixelSizeFactor * (25)
+    height: (showAltitude && showClimbRate) ? ScreenTools.pixelSizeFactor * (50) : ScreenTools.pixelSizeFactor * (25)
     color: "black"
     border.color: Qt.rgba(1,1,1,0.25)
     opacity: 1.0
     Column{
         anchors.centerIn: parent
-        spacing: __screenTools.pixelSizeFactor * (4)
+        spacing: ScreenTools.pixelSizeFactor * (4)
         QGCLabel {
             text: 'h: ' + altitude.toFixed(0)
             font.weight: Font.DemiBold

--- a/src/ui/qmlcommon/QGCCurrentSpeed.qml
+++ b/src/ui/qmlcommon/QGCCurrentSpeed.qml
@@ -33,20 +33,19 @@ import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     id: root
-    property ScreenTools __screenTools: ScreenTools { }
     property real airspeed:         0
     property real groundspeed:      0
     property bool showAirSpeed:     true
     property bool showGroundSpeed:  true
     anchors.verticalCenter: parent.verticalCenter
     width:  parent.width
-    height: (showAirSpeed && showGroundSpeed) ? __screenTools.pixelSizeFactor * (50) : __screenTools.pixelSizeFactor * (25)
+    height: (showAirSpeed && showGroundSpeed) ? ScreenTools.pixelSizeFactor * (50) : ScreenTools.pixelSizeFactor * (25)
     color: "black"
     border.color: Qt.rgba(1,1,1,0.25)
     opacity: 1.0
     Column{
         anchors.centerIn: parent
-        spacing: __screenTools.pixelSizeFactor * (4)
+        spacing: ScreenTools.pixelSizeFactor * (4)
         QGCLabel {
             text: 'GS: ' + groundspeed.toFixed(0)
             font.weight: Font.DemiBold

--- a/src/ui/qmlcommon/QGCMapBackground.qml
+++ b/src/ui/qmlcommon/QGCMapBackground.qml
@@ -37,7 +37,6 @@ import QGroundControl.ScreenTools 1.0
 
 Rectangle {
     id: root
-    property ScreenTools __screenTools: ScreenTools { }
     property real latitude:     37.803784
     property real longitude :   -122.462276
     property real zoomLevel:    18
@@ -165,9 +164,9 @@ Rectangle {
         z: map.z + 20
         anchors {
             bottom: parent.bottom;
-            bottomMargin:   __screenTools.pixelSizeFactor * (15)
-            rightMargin:    __screenTools.pixelSizeFactor * (20)
-            leftMargin:     __screenTools.pixelSizeFactor * (20)
+            bottomMargin:   ScreenTools.pixelSizeFactor * (15)
+            rightMargin:    ScreenTools.pixelSizeFactor * (20)
+            leftMargin:     ScreenTools.pixelSizeFactor * (20)
             left: parent.left
         }
         width: parent.width - anchors.rightMargin - anchors.leftMargin
@@ -188,9 +187,9 @@ Rectangle {
         opacity: 1
         anchors {
             bottom: zoomSlider.top;
-            bottomMargin: __screenTools.pixelSizeFactor * (8);
+            bottomMargin: ScreenTools.pixelSizeFactor * (8);
             left: zoomSlider.left
-            leftMargin: __screenTools.pixelSizeFactor * (4)
+            leftMargin: ScreenTools.pixelSizeFactor * (4)
         }
         Image {
             id: scaleImageLeft
@@ -217,7 +216,7 @@ Rectangle {
             horizontalAlignment: Text.AlignHCenter
             anchors.bottom: parent.bottom
             anchors.left:   parent.left
-            anchors.bottomMargin: __screenTools.pixelSizeFactor * (10)
+            anchors.bottomMargin: ScreenTools.pixelSizeFactor * (10)
             text: "0 m"
         }
         Component.onCompleted: {

--- a/src/ui/qmlcommon/QGCMapToolButton.qml
+++ b/src/ui/qmlcommon/QGCMapToolButton.qml
@@ -11,7 +11,6 @@ Button {
     property var imageSource: undefined
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
     property bool __showHighlight: (pressed | hovered | checked) && !__forceHoverOff
-    property ScreenTools __screenTools: ScreenTools { }
 
     // This fixes the issue with button hover where if a Button is near the edge oa QQuickWidget you can
     // move the mouse fast enough such that the MouseArea does not trigger an onExited. This is turn
@@ -24,12 +23,12 @@ Button {
     Connections {
         target: __behavior
         onMouseXChanged: {
-            __lastGlobalMouseX = __screenTools.mouseX
-            __lastGlobalMouseY = __screenTools.mouseY
+            __lastGlobalMouseX = ScreenTools.mouseX
+            __lastGlobalMouseY = ScreenTools.mouseY
         }
         onMouseYChanged: {
-            __lastGlobalMouseX = __screenTools.mouseX
-            __lastGlobalMouseY = __screenTools.mouseY
+            __lastGlobalMouseX = ScreenTools.mouseX
+            __lastGlobalMouseY = ScreenTools.mouseY
         }
         onEntered: { __forceHoverOff; false; hoverTimer.start() }
         onExited:  { __forceHoverOff; false; hoverTimer.stop()  }
@@ -40,7 +39,7 @@ Button {
         interval:   250
         repeat:     true
         onTriggered: {
-            if (__lastGlobalMouseX != __screenTools.mouseX || __lastGlobalMouseY != __screenTools.mouseY) {
+            if (__lastGlobalMouseX != ScreenTools.mouseX || __lastGlobalMouseY != ScreenTools.mouseY) {
                 __forceHoverOff = true
             } else {
                 __forceHoverOff = false

--- a/src/ui/qmlcommon/QGCPitchWidget.qml
+++ b/src/ui/qmlcommon/QGCPitchWidget.qml
@@ -32,7 +32,6 @@ import QGroundControl.ScreenTools 1.0
 import QGroundControl.Controls 1.0
 
 Rectangle {
-    property ScreenTools screenTools: ScreenTools { }
     property real pitchAngle:       0
     property real rollAngle:        0
     property real size:             120
@@ -41,10 +40,10 @@ Rectangle {
     property real _reticleSlot:     _reticleSpacing + _reticleHeight
     property real _longDash:        size * 0.40
     property real _shortDash:       size * 0.25
-    property real _fontSize:        __screenTools.fontPointFactor * (11);
+    property real _fontSize:        ScreenTools.fontPointFactor * (11);
     height: size * 0.9
     width:  size
-    radius: screenTools.pixelSizeFactor * (8)
+    radius: ScreenTools.pixelSizeFactor * (8)
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.verticalCenter:   parent.verticalCenter
     clip: true

--- a/src/ui/qmlcommon/QGCSlider.qml
+++ b/src/ui/qmlcommon/QGCSlider.qml
@@ -45,7 +45,6 @@ import QGroundControl.ScreenTools 1.0
 Item {
     id: slider;
     height: 12
-    property ScreenTools __screenTools: ScreenTools { }
     property real value // value is read/write.
     property real minimum: 0
     property real maximum: 1
@@ -53,15 +52,15 @@ Item {
 
     Rectangle {
         anchors.fill:   parent
-        radius:         __screenTools.pixelSizeFactor * (6)
+        radius:         ScreenTools.pixelSizeFactor * (6)
         color:          Qt.rgba(0,0,0,0.65);
     }
 
     Rectangle {
         anchors.left:       parent.left
-        anchors.leftMargin: __screenTools.pixelSizeFactor * (4)
-        radius:             __screenTools.pixelSizeFactor * (4)
-        height:             __screenTools.pixelSizeFactor * (4)
+        anchors.leftMargin: ScreenTools.pixelSizeFactor * (4)
+        radius:             ScreenTools.pixelSizeFactor * (4)
+        height:             ScreenTools.pixelSizeFactor * (4)
         width:              handle.x - x
         color:              "#69bb17"
         anchors.verticalCenter: parent.verticalCenter
@@ -70,14 +69,14 @@ Item {
     Rectangle {
         id:                 labelRect
         width:              label.width
-        height:             label.height + __screenTools.pixelSizeFactor * (4)
-        radius:             __screenTools.pixelSizeFactor * (4)
+        height:             label.height + ScreenTools.pixelSizeFactor * (4)
+        radius:             ScreenTools.pixelSizeFactor * (4)
         smooth:             true
         color:              Qt.rgba(1,1,1,0.75);
-        border.width:       __screenTools.pixelSizeFactor * (1)
+        border.width:       ScreenTools.pixelSizeFactor * (1)
         border.color:       Qt.rgba(0,0,0,0.45);
         anchors.bottom:     handle.top
-        anchors.bottomMargin: __screenTools.pixelSizeFactor * (4)
+        anchors.bottomMargin: ScreenTools.pixelSizeFactor * (4)
         visible: mouseRegion.pressed
         x: Math.max(Math.min(handle.x + (handle.width - width ) / 2, slider.width - width), 0)
         QGCLabel{
@@ -94,7 +93,7 @@ Item {
     Rectangle {
         id:         handle;
         smooth:     true
-        width:      __screenTools.pixelSizeFactor * (26);
+        width:      ScreenTools.pixelSizeFactor * (26);
         y:          (slider.height - height) / 2;
         x:          (slider.value - slider.minimum) * slider.length / (slider.maximum - slider.minimum)
 

--- a/src/ui/qmlcommon/QGCSpeedWidget.qml
+++ b/src/ui/qmlcommon/QGCSpeedWidget.qml
@@ -33,15 +33,14 @@ import QGroundControl.Controls 1.0
 
 Rectangle {
     id: root
-    property ScreenTools __screenTools: ScreenTools { }
     property real speed:           0
-    property real _reticleSpacing: __screenTools.pixelSizeFactor * (10)
-    property real _reticleHeight:  __screenTools.pixelSizeFactor * (2)
+    property real _reticleSpacing: ScreenTools.pixelSizeFactor * (10)
+    property real _reticleHeight:  ScreenTools.pixelSizeFactor * (2)
     property real _reticleSlot:    _reticleSpacing + _reticleHeight
     anchors.verticalCenter: parent.verticalCenter
     z:10
     smooth: true
-    radius: __screenTools.pixelSizeFactor * (5)
+    radius: ScreenTools.pixelSizeFactor * (5)
     border.color: Qt.rgba(1,1,1,0.25)
     gradient: Gradient {
         GradientStop { position: 0.0; color: Qt.rgba(0,0,0,0.65) }
@@ -50,7 +49,7 @@ Rectangle {
     }
     Rectangle {
         id:     clipRect
-        height: parent.height - __screenTools.pixelSizeFactor * (5)
+        height: parent.height - ScreenTools.pixelSizeFactor * (5)
         width:  parent.width
         clip:   true
         color:  Qt.rgba(0,0,0,0);
@@ -64,14 +63,14 @@ Rectangle {
                 model: 40
                 Rectangle {
                     property int _speed: -(index - 20)
-                    width:  (_speed % 5 === 0) ? __screenTools.pixelSizeFactor * (10) : __screenTools.pixelSizeFactor * (15)
+                    width:  (_speed % 5 === 0) ? ScreenTools.pixelSizeFactor * (10) : ScreenTools.pixelSizeFactor * (15)
                     anchors.right: parent.right
                     height: _reticleHeight
                     color:  Qt.rgba(1,1,1,0.35)
                     QGCLabel {
                         visible: (_speed % 5 === 0)
                         anchors.horizontalCenter: parent.horizontalCenter
-                        anchors.horizontalCenterOffset: __screenTools.pixelSizeFactor * (-30)
+                        anchors.horizontalCenterOffset: ScreenTools.pixelSizeFactor * (-30)
                         anchors.verticalCenter:   parent.verticalCenter
                         antialiasing: true
                         font.weight: Font.DemiBold

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -41,7 +41,6 @@ Rectangle {
     id: toolBarHolder
 
     property var qgcPal: QGCPalette { id: palette; colorGroupEnabled: true }
-    property ScreenTools __screenTools: ScreenTools { }
 
     property int cellSpacerSize: mainToolBar.isMobile ? getProportionalDimmension(6) : getProportionalDimmension(4)
     property int cellHeight:     getProportionalDimmension(30)
@@ -196,7 +195,7 @@ Rectangle {
             anchors.verticalCenter: parent.verticalCenter
             visible:                !mainToolBar.isMobile
             Connections {
-                target: __screenTools
+                target: ScreenTools
                 onRepaintRequestedChanged: {
                     setupButton.repaintChevron   = true;
                     planButton.repaintChevron    = true;
@@ -338,7 +337,7 @@ Rectangle {
                     QGCLabel {
                         id: messageText
                         text: (mainToolBar.messageCount > 0) ? mainToolBar.messageCount : ''
-                        font.pointSize: __screenTools.fontPointFactor * (14);
+                        font.pointSize: ScreenTools.fontPointFactor * (14);
                         font.weight: Font.DemiBold
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -424,7 +423,7 @@ Rectangle {
                 QGCLabel {
                     id: satelitteText
                     text: mainToolBar.satelliteCount >= 0 ? mainToolBar.satelliteCount : 'NA'
-                    font.pointSize: mainToolBar.satelliteCount >= 0 ? __screenTools.fontPointFactor * (14) : __screenTools.fontPointFactor * (10)
+                    font.pointSize: mainToolBar.satelliteCount >= 0 ? ScreenTools.fontPointFactor * (14) : ScreenTools.fontPointFactor * (10)
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
@@ -459,7 +458,7 @@ Rectangle {
                     anchors.rightMargin: getProportionalDimmension(6)
                     anchors.verticalCenter: parent.verticalCenter
                     horizontalAlignment: Text.AlignRight
-                    font.pointSize: __screenTools.fontPointFactor * (12);
+                    font.pointSize: ScreenTools.fontPointFactor * (12);
                     font.weight: Font.DemiBold
                     color: colorWhite
                 }
@@ -492,7 +491,7 @@ Rectangle {
                         anchors.right: parent.right
                         QGCLabel {
                             text: 'R '
-                            font.pointSize: __screenTools.fontPointFactor * (11);
+                            font.pointSize: ScreenTools.fontPointFactor * (11);
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -500,7 +499,7 @@ Rectangle {
                             text: mainToolBar.telemetryRRSSI + 'dB'
                             width: getProportionalDimmension(30)
                             horizontalAlignment: Text.AlignRight
-                            font.pointSize: __screenTools.fontPointFactor * (11);
+                            font.pointSize: ScreenTools.fontPointFactor * (11);
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -509,7 +508,7 @@ Rectangle {
                         anchors.right: parent.right
                         QGCLabel {
                             text: 'L '
-                            font.pointSize: __screenTools.fontPointFactor * (11);
+                            font.pointSize: ScreenTools.fontPointFactor * (11);
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -517,7 +516,7 @@ Rectangle {
                             text: mainToolBar.telemetryLRSSI + 'dB'
                             width: getProportionalDimmension(30)
                             horizontalAlignment: Text.AlignRight
-                            font.pointSize: __screenTools.fontPointFactor * (11);
+                            font.pointSize: ScreenTools.fontPointFactor * (11);
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -549,7 +548,7 @@ Rectangle {
                 QGCLabel {
                     id: batteryText
                     text: mainToolBar.batteryVoltage.toFixed(1) + 'V';
-                    font.pointSize: __screenTools.fontPointFactor * (11);
+                    font.pointSize: ScreenTools.fontPointFactor * (11);
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
@@ -577,7 +576,7 @@ Rectangle {
                     QGCLabel {
                         id: armedStatusText
                         text: (mainToolBar.systemArmed) ? qsTr("ARMED") :  qsTr("DISARMED")
-                        font.pointSize: __screenTools.fontPointFactor * (12);
+                        font.pointSize: ScreenTools.fontPointFactor * (12);
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
                         color: (mainToolBar.systemArmed) ? colorOrangeText : colorGreenText
@@ -596,7 +595,7 @@ Rectangle {
                     QGCLabel {
                         id: stateStatusText
                         text: mainToolBar.currentState
-                        font.pointSize: __screenTools.fontPointFactor * (12);
+                        font.pointSize: ScreenTools.fontPointFactor * (12);
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
                         color: (mainToolBar.currentState === "STANDBY") ? colorGreenText : colorRedText
@@ -617,7 +616,7 @@ Rectangle {
                 QGCLabel {
                     id: modeStatusText
                     text: mainToolBar.currentMode
-                    font.pointSize: __screenTools.fontPointFactor * (12);
+                    font.pointSize: ScreenTools.fontPointFactor * (12);
                     font.weight: Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
@@ -638,7 +637,7 @@ Rectangle {
                 QGCLabel {
                     id: connectionStatusText
                     text: qsTr("CONNECTION LOST")
-                    font.pointSize: __screenTools.fontPointFactor * (14);
+                    font.pointSize: ScreenTools.fontPointFactor * (14);
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
This is a full implementation of Don's experiment in #1521.

I've turned ScreenTools into a *singleton* where only one instance of it exists for each instance of QQuickWidget. There will still be a same number of instances as there are instances of QQuickWidget objects but they are a few compared to the zillion they were before.

You still import it the way it's always been done:
```
import QGroundControl.ScreenTools 1.0
```
Where you would normally declare an instance:
```
        property ScreenTools __screenTools: ScreenTools { }
```
and reference it by this property name:
```
        font.pointSize: __screenTools.fontPointFactor * (20);
```
Now you don't need to create the instance at all. You just use it by name:
```
        font.pointSize: ScreenTools.fontPointFactor * (20);
```