### PR TITLE
New Custom Command Widget

### DIFF
--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -354,6 +354,8 @@ HEADERS += \
     src/ui/WaypointList.h \
     src/ui/WaypointViewOnlyView.h \
     src/ViewWidgets/ParameterEditorWidget.h \
+    src/ViewWidgets/CustomCommandWidget.h \
+    src/ViewWidgets/CustomCommandWidgetController.h \
     src/ViewWidgets/ViewWidgetController.h \
     src/Waypoint.h \
 
@@ -489,6 +491,8 @@ SOURCES += \
     src/ui/WaypointList.cc \
     src/ui/WaypointViewOnlyView.cc \
     src/ViewWidgets/ParameterEditorWidget.cc \
+    src/ViewWidgets/CustomCommandWidget.cc \
+    src/ViewWidgets/CustomCommandWidgetController.cc \
     src/ViewWidgets/ViewWidgetController.cc \
     src/Waypoint.cc \
 

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -34,6 +34,7 @@
         <file alias="QGroundControl/Controls/ParameterEditor.qml">src/QmlControls/ParameterEditor.qml</file>
 
         <file alias="ParameterEditorWidget.qml">src/ViewWidgets/ParameterEditorWidget.qml</file>
+        <file alias="CustomCommandWidget.qml">src/ViewWidgets/CustomCommandWidget.qml</file>
 
         <file alias="SetupViewButtonsConnected.qml">src/VehicleSetup/SetupViewButtonsConnected.qml</file>
         <file alias="SetupViewButtonsDisconnected.qml">src/VehicleSetup/SetupViewButtonsDisconnected.qml</file>

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -63,6 +63,7 @@
 #include "QGCLoggingCategory.h"
 #include "ViewWidgetController.h"
 #include "ParameterEditorController.h"
+#include "CustomCommandWidgetController.h"
 
 #ifdef QGC_RTLAB_ENABLED
 #include "OpalLink.h"
@@ -286,9 +287,10 @@ void QGCApplication::_initCommon(void)
     qmlRegisterType<QGCPalette>("QGroundControl.Palette", 1, 0, "QGCPalette");
 	qmlRegisterType<ViewWidgetController>("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
 	qmlRegisterType<ParameterEditorController>("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
+    qmlRegisterType<CustomCommandWidgetController>("QGroundControl.Controllers", 1, 0, "CustomCommandWidgetController");
+
     //-- Create QML Singleton Interfaces
     qmlRegisterSingletonType<ScreenTools>("QGroundControl.ScreenTools", 1, 0, "ScreenTools", screenToolsSingletonFactory);
-
 }
 
 bool QGCApplication::_initForNormalAppBoot(void)

--- a/src/ViewWidgets/CustomCommandWidget.cc
+++ b/src/ViewWidgets/CustomCommandWidget.cc
@@ -1,0 +1,30 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2010 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+#include "CustomCommandWidget.h"
+
+CustomCommandWidget::CustomCommandWidget(QWidget *parent) :
+    QGCQmlWidgetHolder(parent)
+{
+	setSource(QUrl::fromUserInput("qrc:/qml/CustomCommandWidget.qml"));
+}

--- a/src/ViewWidgets/CustomCommandWidget.h
+++ b/src/ViewWidgets/CustomCommandWidget.h
@@ -1,0 +1,40 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#ifndef CustomCommandWidget_H
+#define CustomCommandWidget_H
+
+#include "QGCQmlWidgetHolder.h"
+
+class CustomCommandWidget : public QGCQmlWidgetHolder
+{
+    Q_OBJECT
+	
+public:
+    CustomCommandWidget(QWidget *parent = 0);
+};
+
+#endif

--- a/src/ViewWidgets/CustomCommandWidget.qml
+++ b/src/ViewWidgets/CustomCommandWidget.qml
@@ -98,7 +98,11 @@ ViewWidget {
 
                 QGCButton {
                     text:       "Clear Qml file"
-                    onClicked:  controller.clearQmlFile()
+
+                    onClicked: {
+                        errorOutput.visible = false
+                        controller.clearQmlFile()
+                    }
                 }
             }
         }

--- a/src/ViewWidgets/CustomCommandWidget.qml
+++ b/src/ViewWidgets/CustomCommandWidget.qml
@@ -1,0 +1,106 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+QGROUNDCONTROL is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+QGROUNDCONTROL is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+import QtQuick 2.2
+
+import QGroundControl.Palette 1.0
+import QGroundControl.Controls 1.0
+import QGroundControl.Controllers 1.0
+
+ViewWidget {
+	connectedComponent: commandComponenet
+
+	Component {
+		id: commandComponenet
+
+        Item {
+
+            CustomCommandWidgetController { id: controller }
+
+            Item {
+                anchors.top:    parent.top
+                anchors.bottom: buttonRow.top
+                width:          parent.width
+
+                QGCLabel {
+                    id:             errorOutput
+                    anchors.fill:   parent
+                    wrapMode:       Text.WordWrap
+                    visible:        false
+                }
+
+                QGCLabel {
+                    id:             warning
+                    anchors.fill:   parent
+                    wrapMode:       Text.WordWrap
+                    visible:        !controller.customQmlFile
+                    text:           "You can create your own commands and parameter editing user interface in this widget. " +
+                                        "You do this by providing your own Qml file. " +
+                                        "This support is a work in progress and the details may change somewhat in the future. " +
+                                        "By using this feature you are connecting directly to the internals of QGroundControl. " +
+                                        "Doing so incorrectly may cause instability both in QGroundControl and/or your vehicle. " +
+                                        "So make sure to test your changes thoroughly before using them in flight.\n\n" +
+                                        "Click 'Select Qml file' to provide your custom qml file.\n" +
+                                        "Click 'Clear Qml file' to reset to none.\n" +
+                                        "Example usage: http://www.qgroundcontrol.org/custom_command_qml_widgets"
+                }
+
+                Loader {
+                    id: loader
+                    anchors.fill:   parent
+                    source:         controller.customQmlFile
+                    visible:        controller.customQmlFile
+
+                    onStatusChanged: {
+                        if (loader.status == Loader.Error) {
+                            if (sourceComponent.status == Component.Error) {
+                                errorOutput.text = sourceComponent.errorString()
+                                errorOutput.visible = true
+                                loader.visible = false
+                            }
+                        }
+                    }
+                }
+            }
+
+            Row {
+                id:             buttonRow
+                spacing:        10
+                anchors.bottom: parent.bottom
+
+                QGCButton {
+                    text:       "Select Qml file..."
+                    onClicked:  controller.selectQmlFile()
+                }
+
+                QGCButton {
+                    text:       "Clear Qml file"
+                    onClicked:  controller.clearQmlFile()
+                }
+            }
+        }
+	}
+}

--- a/src/ViewWidgets/CustomCommandWidgetController.cc
+++ b/src/ViewWidgets/CustomCommandWidgetController.cc
@@ -1,0 +1,80 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+#include "CustomCommandWidgetController.h"
+#include "UASManager.h"
+#include "QGCMAVLink.h"
+#include "QGCFileDialog.h"
+
+#include <QSettings>
+
+const char* CustomCommandWidgetController::_settingsKey = "CustomCommand.QmlFile";
+
+CustomCommandWidgetController::CustomCommandWidgetController(void) :
+	_uas(NULL)
+{
+    _uas = UASManager::instance()->getActiveUAS();
+    Q_ASSERT(_uas);
+    
+    QSettings settings;
+    _customQmlFile = settings.value(_settingsKey).toString();
+}
+
+void CustomCommandWidgetController::sendCommand(int commandId, QVariant componentId, QVariant confirm, QVariant param1, QVariant param2, QVariant param3, QVariant param4, QVariant param5, QVariant param6, QVariant param7)
+{
+    Q_UNUSED(commandId);
+    Q_UNUSED(componentId);
+    Q_UNUSED(confirm);
+    Q_UNUSED(param1);
+    Q_UNUSED(param2);
+    Q_UNUSED(param3);
+    Q_UNUSED(param4);
+    Q_UNUSED(param5);
+    Q_UNUSED(param6);
+    Q_UNUSED(param7);
+    _uas->executeCommand((MAV_CMD)commandId, confirm.toInt(), param1.toFloat(), param2.toFloat(), param3.toFloat(), param4.toFloat(), param5.toFloat(), param6.toFloat(), param7.toFloat(), componentId.toInt());
+}
+
+void CustomCommandWidgetController::selectQmlFile(void)
+{
+    QSettings settings;
+    
+    QString qmlFile = QGCFileDialog::getOpenFileName(NULL, "Select custom Qml file", QString(), "Qml files (*.qml)");
+    if (qmlFile.isEmpty()) {
+        _customQmlFile.clear();
+        settings.remove(_settingsKey);
+    } else {
+        _customQmlFile = QString("file:%1").arg(qmlFile);
+        settings.setValue(_settingsKey, _customQmlFile);
+    }
+    
+    emit customQmlFileChanged(_customQmlFile);
+}
+
+void CustomCommandWidgetController::clearQmlFile(void)
+{
+    _customQmlFile.clear();
+    QSettings settings;
+    settings.remove(_settingsKey);
+    emit customQmlFileChanged(_customQmlFile);
+}

--- a/src/ViewWidgets/CustomCommandWidgetController.cc
+++ b/src/ViewWidgets/CustomCommandWidgetController.cc
@@ -27,6 +27,7 @@
 #include "QGCFileDialog.h"
 
 #include <QSettings>
+#include <Qurl>
 
 const char* CustomCommandWidgetController::_settingsKey = "CustomCommand.QmlFile";
 
@@ -64,7 +65,8 @@ void CustomCommandWidgetController::selectQmlFile(void)
         _customQmlFile.clear();
         settings.remove(_settingsKey);
     } else {
-        _customQmlFile = QString("file:%1").arg(qmlFile);
+		QUrl url = QUrl::fromLocalFile(qmlFile);
+		_customQmlFile = url.toString();
         settings.setValue(_settingsKey, _customQmlFile);
     }
     

--- a/src/ViewWidgets/CustomCommandWidgetController.cc
+++ b/src/ViewWidgets/CustomCommandWidgetController.cc
@@ -27,7 +27,7 @@
 #include "QGCFileDialog.h"
 
 #include <QSettings>
-#include <Qurl>
+#include <QUrl>
 
 const char* CustomCommandWidgetController::_settingsKey = "CustomCommand.QmlFile";
 

--- a/src/ViewWidgets/CustomCommandWidgetController.h
+++ b/src/ViewWidgets/CustomCommandWidgetController.h
@@ -1,0 +1,55 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+#ifndef CustomCommandWidgetController_H
+#define CustomCommandWidgetController_H
+
+#include <QObject>
+
+#include "UASInterface.h"
+#include "AutoPilotPlugin.h"
+#include "UASManagerInterface.h"
+
+class CustomCommandWidgetController : public QObject
+{
+	Q_OBJECT
+	
+public:
+	CustomCommandWidgetController(void);
+    
+    Q_PROPERTY(QString customQmlFile MEMBER _customQmlFile NOTIFY customQmlFileChanged)
+	
+	Q_INVOKABLE void sendCommand(int commandId, QVariant componentId, QVariant confirm, QVariant param1, QVariant param2, QVariant param3, QVariant param4, QVariant param5, QVariant param6, QVariant param7);
+    Q_INVOKABLE void selectQmlFile(void);
+    Q_INVOKABLE void clearQmlFile(void);
+    
+signals:
+    void customQmlFileChanged(const QString& customQmlFile);
+	
+private:
+	UASInterface*       _uas;
+    QString             _customQmlFile;
+    static const char*  _settingsKey;
+};
+
+#endif

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -70,6 +70,7 @@ This file is part of the QGROUNDCONTROL project
 #include "QGCFileDialog.h"
 #include "QGCMessageBox.h"
 #include "QGCDockWidget.h"
+#include "CustomCommandWidget.h"
 
 #ifdef UNITTEST_BUILD
 #include "QmlControls/QmlTestWidget.h"
@@ -109,6 +110,7 @@ const char* MainWindow::_uasListDockWidgetName = "UNMANNED_SYSTEM_LIST_DOCKWIDGE
 const char* MainWindow::_waypointsDockWidgetName = "WAYPOINT_LIST_DOCKWIDGET";
 const char* MainWindow::_mavlinkDockWidgetName = "MAVLINK_INSPECTOR_DOCKWIDGET";
 const char* MainWindow::_parametersDockWidgetName = "PARAMETER_INTERFACE_DOCKWIDGET";
+const char* MainWindow::_customCommandWidgetName = "CUSTOM_COMMAND_DOCKWIDGET";
 const char* MainWindow::_filesDockWidgetName = "FILE_VIEW_DOCKWIDGET";
 const char* MainWindow::_uasStatusDetailsDockWidgetName = "UAS_STATUS_DETAILS_DOCKWIDGET";
 const char* MainWindow::_mapViewDockWidgetName = "MAP_VIEW_DOCKWIDGET";
@@ -440,6 +442,7 @@ void MainWindow::_buildCommonWidgets(void)
         { _waypointsDockWidgetName,         "Mission Plan",             Qt::BottomDockWidgetArea },
         { _mavlinkDockWidgetName,           "MAVLink Inspector",        Qt::RightDockWidgetArea },
         { _parametersDockWidgetName,        "Parameter Editor",			Qt::RightDockWidgetArea },
+        { _customCommandWidgetName,         "Custom Command",			Qt::RightDockWidgetArea },
         { _filesDockWidgetName,             "Onboard Files",            Qt::RightDockWidgetArea },
         { _uasStatusDetailsDockWidgetName,  "Status Details",           Qt::RightDockWidgetArea },
         { _mapViewDockWidgetName,           "Map view",                 Qt::RightDockWidgetArea },
@@ -556,6 +559,8 @@ void MainWindow::_createInnerDockWidget(const QString& widgetName)
         widget = new QGCMAVLinkInspector(MAVLinkProtocol::instance(),this);
     } else if (widgetName == _parametersDockWidgetName) {
         widget = new ParameterEditorWidget(this);
+    } else if (widgetName == _customCommandWidgetName) {
+        widget = new CustomCommandWidget(this);
     } else if (widgetName == _filesDockWidgetName) {
         widget = new QGCUASFileViewMulti(this);
     } else if (widgetName == _uasStatusDetailsDockWidgetName) {

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -328,6 +328,7 @@ private:
     static const char* _waypointsDockWidgetName;
     static const char* _mavlinkDockWidgetName;
     static const char* _parametersDockWidgetName;
+    static const char* _customCommandWidgetName;
     static const char* _filesDockWidgetName;
     static const char* _uasStatusDetailsDockWidgetName;
     static const char* _mapViewDockWidgetName;


### PR DESCRIPTION
This allows you to build your own custom command widgets using Qml. You can access the new widgets from the menu.

You must be connected to a vehicle to get this:
![screen shot 2015-04-29 at 12 25 33 pm](https://cloud.githubusercontent.com/assets/5876851/7399495/3a1ca078-ee6b-11e4-8996-1ebc2b2ee78c.png)

Here is the example file running:
![screen shot 2015-04-29 at 12 26 04 pm](https://cloud.githubusercontent.com/assets/5876851/7399499/4673adb2-ee6b-11e4-93d2-bb79824d6fa6.png)

If youre Qml has errors, it shows up in the widget like this:
![screen shot 2015-04-29 at 12 26 53 pm](https://cloud.githubusercontent.com/assets/5876851/7399511/579eec78-ee6b-11e4-8e8a-04aa6d7a275a.png)

Here is the example Qml file from the wiki:
```javascript
// This is an example Custom Command Qml file. You have full access to the entire Qml language
// for creating any user interface you like. From the ui you can affect the following changes
// with respect to your vehicle:
//    1) Sending COMMAND_LONG commands out over mavlink using QGCButton control
//    2) Modifying parameters
//
// When developing custom Qml file implementations. You must restart QGroundControl to pick up
// the changes. You need to do this even if you select Clear Qml file. Not sure what at the this
// point. Qt must be caching the files somewhere.

import QtQuick 2.2

import QGroundControl.Controls 1.0
import QGroundControl.FactSystem 1.0
import QGroundControl.FactControls 1.0

Item {

    // Your own custom changes start here - everything else above is always required

    Column {
        // The QGCButton control is provided by QGroundControl.Controls. It is a wrapper around
        // the standard Qml Button element which using the default QGC font and color palette.

        QGCButton {
            text: "Set Home to current position"
            onClicked: controller.sendCommand(179, 50, 0, 1, 0, 0, 0, 0, 0, 0)
        }

        // The FactTextField control is provides by GroundControl.FactControls. It is a wrapper
        // around the Qml TextField element which allows you to bind it directly to any parameter.
        // The parameter is changed automatically when you click enter or click away from the field.
        // Understand that there is currently no value validation. So you may crash your vehicle by
        // setting a parameter to an incorrect value. Validation will come in the future.

        // Be very careful when referencing parameters. If you specify a parameter which does not exist
        // QGroundControl will warn and shutdown.

        FactTextField {
            fact: Fact { name: "MAV_SYS_ID" }
        }
    }

    // Your own custom changes end here - everything else below is always required
}
```