### PR TITLE
Adding the ability to add a waypoint.

### DIFF
--- a/src/ui/qmlcommon/QGCMapBackground.qml
+++ b/src/ui/qmlcommon/QGCMapBackground.qml
@@ -192,7 +192,7 @@ Item {
 
         /*
         // There is a bug currently in Qt where it fails to render a map taller than 6 tiles high. Until
-        // that's fixed, we can't rotate the map as it would require a larger map, which can easely grow
+        // that's fixed, we can't rotate the map as it would require a larger map, which can easily grow
         // larger than 6 tiles high.
         // https://bugreports.qt.io/browse/QTBUG-45508
         transform: Rotation {
@@ -212,6 +212,16 @@ Item {
 
         onZoomLevelChanged:{
             scaleTimer.restart()
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onDoubleClicked: {
+                var coord = map.toCoordinate(Qt.point(mouse.x, mouse.y));
+                map.addMarker(coord, polyLine.path.length);
+                polyLine.addCoordinate(coord);
+                map.changed = true;
+            }
         }
 
         function updateMarker(coord, wpid)


### PR DESCRIPTION
Small, incremental work on the new Mission Plan View. You can now add a new waypoint by double-clicking on a point on the map.

Waiting to sort out how we will handle these as well as how to edit individual waypoints (list view).