### PR TITLE
Airframe config

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -32,6 +32,8 @@
         <file alias="QGroundControl/Controls/VehicleSummaryRow.qml">src/QmlControls/VehicleSummaryRow.qml</file>
         <file alias="QGroundControl/Controls/arrow-down.png">src/QmlControls/arrow-down.png</file>
         <file alias="QGroundControl/Controls/ViewWidget.qml">src/ViewWidgets/ViewWidget.qml</file>
+        <file alias="QGroundControl/Controls/ViewWithDialog.qml">src/QmlControls/ViewWithDialog.qml</file>
+
         <file alias="QGroundControl/Controls/ParameterEditor.qml">src/QmlControls/ParameterEditor.qml</file>
 
         <file alias="ParameterEditorWidget.qml">src/ViewWidgets/ParameterEditorWidget.qml</file>

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -40,7 +40,8 @@ bool AirframeComponentController::_typesRegistered = false;
 AirframeComponentController::AirframeComponentController(void) :
     _uas(NULL),
     _currentVehicleIndex(0),
-    _autostartId(0)
+    _autostartId(0),
+    _showCustomConfigPanel(false)
 {
     _uas = UASManager::instance()->getActiveUAS();
     Q_ASSERT(_uas);
@@ -82,10 +83,9 @@ AirframeComponentController::AirframeComponentController(void) :
         _airframeTypes.append(QVariant::fromValue(airframeType));
     }
     
-    if (_autostartId != 0) {
-        // FIXME: Should be a user error
-        Q_UNUSED(autostartFound);
-        Q_ASSERT(autostartFound);
+    if (_autostartId != 0 && !autostartFound) {
+        _showCustomConfigPanel = true;
+        emit showCustomConfigPanelChanged(true);
     }
 }
 

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.h
@@ -44,6 +44,8 @@ public:
     AirframeComponentController(void);
     ~AirframeComponentController();
     
+    Q_PROPERTY(bool showCustomConfigPanel MEMBER _showCustomConfigPanel NOTIFY showCustomConfigPanelChanged)
+    
     Q_PROPERTY(QVariantList airframeTypes MEMBER _airframeTypes CONSTANT)
     
     Q_PROPERTY(QString currentAirframeType MEMBER _currentAirframeType CONSTANT)
@@ -59,6 +61,7 @@ public:
     
 signals:
     void autostartIdChanged(int newAutostartId);
+    void showCustomConfigPanelChanged(bool show);
     
 private:
     static bool _typesRegistered;
@@ -69,6 +72,7 @@ private:
     QString             _currentVehicleName;
     int                 _currentVehicleIndex;
     int                 _autostartId;
+    bool                _showCustomConfigPanel;
 };
 
 class Airframe : public QObject

--- a/src/QmlControls/ViewWithDialog.qml
+++ b/src/QmlControls/ViewWithDialog.qml
@@ -1,0 +1,221 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+import QtQuick 2.3
+import QtQuick.Controls 1.3
+import QtQuick.Dialogs 1.2
+
+import QGroundControl.Controls 1.0
+import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
+import QGroundControl.FactSystem 1.0
+import QGroundControl.FactControls 1.0
+
+Item {
+    property Component viewComponent
+
+    function __showDialog(component, title, charWidth, buttons) {
+        __acceptButton.visible = false
+        __rejectButton.visible = false
+        __dialogCharWidth = charWidth
+        __dialogTitle = title
+
+        if (buttons & StandardButton.Ok) {
+            __acceptButton.text = "Ok"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.Open) {
+            __acceptButton.text = "Open"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.Save) {
+            __acceptButton.text = "Save"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.Cancel) {
+            __rejectButton.text = "Cancel"
+            __rejectButton.visible = true
+        } else if (buttons & StandardButton.Close) {
+            __rejectButton.text = "Cancel"
+            __rejectButton.visible = true
+        } else if (buttons & StandardButton.Apply) {
+            __acceptButton.text = "Apply"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.Open) {
+            __acceptButton.text = "Open"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.SaveAll) {
+            __acceptButton.text = "Save All"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.Yes) {
+            __acceptButton.text = "Yes"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.YesToAll) {
+            __acceptButton.text = "Yes to All"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.No) {
+            __rejectButton.text = "No"
+            __rejectButton.visible = true
+        } else if (buttons & StandardButton.NoToAll) {
+            __rejectButton.text = "No to All"
+            __rejectButton.visible = true
+        } else if (buttons & StandardButton.Abort) {
+            __rejectButton.text = "Abort"
+            __rejectButton.visible = true
+        } else if (buttons & StandardButton.Retry) {
+            __acceptButton.text = "Retry"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.Reset) {
+            __acceptButton.text = "Reset"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.RestoreToDefaults) {
+            __acceptButton.text = "Restore to Defaults"
+            __acceptButton.visible = true
+        } else if (buttons & StandardButton.Ignore) {
+            __acceptButton.text = "Ignore"
+            __acceptButton.visible = true
+        }
+        __dialogComponent = component
+        __viewPanel.enabled = false
+        __dialogOverlay.visible = true
+    }
+
+    function __hideDialog() {
+        __dialogComponent = null
+        __viewPanel.enabled = true
+        __dialogOverlay.visible = false
+    }
+
+    QGCPalette { id: __qgcPal; colorGroupEnabled: true }
+    QGCLabel { id: __textMeasure; text: "X"; visible: false }
+
+    property real __textHeight: __textMeasure.contentHeight
+    property real __textWidth:  __textMeasure.contentWidth
+
+    /// The width of the dialog panel in characters
+    property int __dialogCharWidth: 75
+
+    /// The title for the dialog panel
+    property string __dialogTitle
+
+    property Component __dialogComponent
+
+    Component.onCompleted: __viewPanel.item.doWorkAfterComponentCompleted()
+
+    Connections {
+        target: __viewPanel.item
+
+        onShowDialog: __showDialog(component, title, charWidth, buttons)
+        onHideDialog: __hideDialog()
+    }
+
+    Connections {
+        target: __dialogComponentLoader.item
+
+        onHideDialog: __hideDialog()
+    }
+
+    Loader {
+        id:                 __viewPanel
+        anchors.fill:       parent
+        focus:              true
+        sourceComponent:    viewComponent
+    }
+
+    Item {
+        id:             __dialogOverlay
+        visible:        false
+        anchors.fill:   parent
+        z:              5000
+
+        // This covers the parent with an transparent section
+        Rectangle {
+            anchors.top:    parent.top
+            anchors.bottom: parent.bottom
+            anchors.left:   parent.left
+            anchors.right:  __dialogPanel.left
+            opacity:        0.80
+            color:          __qgcPal.window
+        }
+
+        // This is the main dialog panel which is anchored to the right edge
+        Rectangle {
+            id:             __dialogPanel
+            width:          __textWidth * __dialogCharWidth
+            height:         parent.height
+            anchors.right:  parent.right
+            color:          __qgcPal.windowShadeDark
+
+            Rectangle {
+                id:     __header
+                width:  parent.width
+                height: __acceptButton.height
+                color:  __qgcPal.windowShade
+
+                function __hidePanel() {
+                    __fullPanel.visible = false
+                }
+
+                QGCLabel {
+                    x:                  __textWidth
+                    height:             parent.height
+                    verticalAlignment:	Text.AlignVCenter
+                    text:               __dialogTitle
+                }
+
+                QGCButton {
+                    id:             __rejectButton
+                    anchors.right:  __acceptButton.left
+                    anchors.bottom: parent.bottom
+
+                    onClicked: __dialogComponentLoader.item.reject()
+                }
+
+                QGCButton {
+                    id:             __acceptButton
+                    anchors.right:  parent.right
+                    primary:        true
+
+                    onClicked: __dialogComponentLoader.item.accept()
+                }
+            }
+
+            Item {
+                id:             __spacer
+                width:          10
+                height:         10
+                anchors.top:    __header.bottom
+            }
+
+            Loader {
+                id:                 __dialogComponentLoader
+                anchors.margins:    5
+                anchors.left:       parent.left
+                anchors.right:      parent.right
+                anchors.top:        __spacer.bottom
+                anchors.bottom:     parent.bottom
+                sourceComponent:    __dialogComponent
+            }
+        } // Rectangle - Dialog panel
+    } // Item - Dialog overlay
+}

--- a/src/QmlControls/qmldir
+++ b/src/QmlControls/qmldir
@@ -16,4 +16,5 @@ VehicleRotationCal 1.0 VehicleRotationCal.qml
 VehicleSummaryRow 1.0 VehicleSummaryRow.qml
 ParameterEditor 1.0 ParameterEditor.qml
 ViewWidget 1.0 ViewWidget.qml
+ViewWithDialog 1.0 ViewWithDialog.qml
 


### PR DESCRIPTION
This fixes a number of bugs in airframe config:
Issue #1543 - You can now scroll the config screen if it doesn't fit
Issue #1539  - Non-standard airframe configs are now supported. It will detect this and show you:
![screen shot 2015-05-09 at 10 08 52 am](https://cloud.githubusercontent.com/assets/5876851/7551234/71bf8a4a-f636-11e4-9f26-4cd8c8e75a49.png)
It also allows you to reset you airframe config if you want to switch from non-standard to standard using the Reset button.

The right hand dialog overlay is implemented using a new standard control I implemented: ViewWithDialog. This control allows you to specify the view you want to show and then pop up those right hand dialog overlay thingies as needed. Both the view an dialog are FactPanel's. It's not quite ready for general use. I'm going to convert more stuff over to it like Sensor Cal to get rotations before/after. Also the Parameter Editor which already uses this style of dialog for editing, but has the the bug Issue #1544, which ViewWithDialog fixes.

Once I convert those two over I should has used ViewWithDialog enough to know it's has enough support for generic usage. Then it can become a standard part of our ui toolbox.