### PR TITLE
Don't delete link configuration if there is still an active link.

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -506,9 +506,12 @@ void LinkManager::_updateConfigurationList(void)
         // We only care about dynamic links
         if(pLink->isDynamic()) {
             if(pLink->type() == LinkConfiguration::TypeSerial) {
-                SerialConfiguration* pSerial = dynamic_cast<SerialConfiguration*>(pLink);
-                if(!currentPorts.contains(pSerial->portName())) {
-                    _confToDelete.append(pSerial);
+                // Don't mess with connected link. Let it deal with the disapearing device.
+                if(pLink->getLink() == NULL) {
+                    SerialConfiguration* pSerial = dynamic_cast<SerialConfiguration*>(pLink);
+                    if(!currentPorts.contains(pSerial->portName())) {
+                        _confToDelete.append(pSerial);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The LinkManager keeps checking to see when new (serial) interfaces show up. When that happens, it checks if it's something that can be used (either a PX4 or a 3DR Radio Modem) and automatically creates a link configuration for it. At the same time, if it sees that a previously automatic link is no longer present, it removes it from the list.

This fix prevents removing a link configuration if an active link is still using it. Once the active link goes down, the configuration will then be properly disposed of.

This fixes the crash reported in #1548 as the code was trying to copy the active link's link configuration and, depending on timing, it could have already been deleted.

Note that this fixes the crash but just moves the problem some place else. Once you reboot the PX4, the link is physically disconnected (while the PX4 is rebooting the physical link disappears). If the serial link catches it early on, it emits a *link disconnected* signal and ```UAS::_linkDisconnected(LinkInterface* link)``` removes it causing an assert crash in:

https://github.com/mavlink/qgroundcontrol/blob/master/src/QGCApplication.cc#L663

If the timing is right and QGC actually manages to reconnect, I'm getting a crash in:

https://github.com/mavlink/qgroundcontrol/blob/master/src/AutoPilotPlugins/PX4/AirframeComponent.cc#L145

At that point, restarting QGC, it can no longer connect to the PX4. When you hit *Connect*, it looks like it's connected but no data is coming from the serial port. The only way to fix this is to power cycle the PX4.




