### PR TITLE
Increase MockLink load timeout

### DIFF
--- a/src/FactSystem/FactSystemTestBase.cc
+++ b/src/FactSystem/FactSystemTestBase.cc
@@ -71,7 +71,7 @@ void FactSystemTestBase::_init(MAV_AUTOPILOT autopilot)
     
     QSignalSpy spyPlugin(_plugin, SIGNAL(pluginReadyChanged(bool)));
     if (!_plugin->pluginReady()) {
-        QCOMPARE(spyPlugin.wait(20000), true);
+        QCOMPARE(spyPlugin.wait(60000), true);
     }
     Q_ASSERT(_plugin->pluginReady());
 }

--- a/src/FactSystem/FactSystemTestBase.cc
+++ b/src/FactSystem/FactSystemTestBase.cc
@@ -71,7 +71,7 @@ void FactSystemTestBase::_init(MAV_AUTOPILOT autopilot)
     
     QSignalSpy spyPlugin(_plugin, SIGNAL(pluginReadyChanged(bool)));
     if (!_plugin->pluginReady()) {
-        QCOMPARE(spyPlugin.wait(10000), true);
+        QCOMPARE(spyPlugin.wait(20000), true);
     }
     Q_ASSERT(_plugin->pluginReady());
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -168,9 +168,9 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting) :
             if (loggingFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
                 QTextStream out(&loggingFile);
                 out << "[Rules]\n";
-                out << "*Log.debug=true\n";
+                out << "*Log.debug=false\n";
                 foreach(QString category, QGCLoggingCategoryRegister::instance()->registeredCategories()) {
-                    out << category << ".debug=true\n";
+                    out << category << ".debug=false\n";
                 }
             } else {
                 qDebug() << "Unable to create logging file" << QString(qtLoggingFile) << "in" << iniFileLocation;

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -168,9 +168,9 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting) :
             if (loggingFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
                 QTextStream out(&loggingFile);
                 out << "[Rules]\n";
-                out << "*Log.debug=false\n";
+                out << "*Log.debug=true\n";
                 foreach(QString category, QGCLoggingCategoryRegister::instance()->registeredCategories()) {
-                    out << category << ".debug=false\n";
+                    out << category << ".debug=true\n";
                 }
             } else {
                 qDebug() << "Unable to create logging file" << QString(qtLoggingFile) << "in" << iniFileLocation;

--- a/src/VehicleSetup/SetupViewTest.cc
+++ b/src/VehicleSetup/SetupViewTest.cc
@@ -76,7 +76,7 @@ void SetupViewTest::_clickThrough_test(void)
     
     QSignalSpy spyPlugin(autopilot, SIGNAL(pluginReadyChanged(bool)));
     if (!autopilot->pluginReady()) {
-        QCOMPARE(spyPlugin.wait(10000), true);
+        QCOMPARE(spyPlugin.wait(20000), true);
     }
     Q_ASSERT(autopilot->pluginReady());
     

--- a/src/VehicleSetup/SetupViewTest.cc
+++ b/src/VehicleSetup/SetupViewTest.cc
@@ -76,7 +76,7 @@ void SetupViewTest::_clickThrough_test(void)
     
     QSignalSpy spyPlugin(autopilot, SIGNAL(pluginReadyChanged(bool)));
     if (!autopilot->pluginReady()) {
-        QCOMPARE(spyPlugin.wait(20000), true);
+        QCOMPARE(spyPlugin.wait(60000), true);
     }
     Q_ASSERT(autopilot->pluginReady());
     

--- a/src/qgcunittest/PX4RCCalibrationTest.cc
+++ b/src/qgcunittest/PX4RCCalibrationTest.cc
@@ -156,7 +156,7 @@ void PX4RCCalibrationTest::init(void)
     
     QSignalSpy spyPlugin(_autopilot, SIGNAL(pluginReadyChanged(bool)));
     if (!_autopilot->pluginReady()) {
-        QCOMPARE(spyPlugin.wait(20000), true);
+        QCOMPARE(spyPlugin.wait(60000), true);
     }
     Q_ASSERT(_autopilot->pluginReady());
     

--- a/src/qgcunittest/PX4RCCalibrationTest.cc
+++ b/src/qgcunittest/PX4RCCalibrationTest.cc
@@ -156,7 +156,7 @@ void PX4RCCalibrationTest::init(void)
     
     QSignalSpy spyPlugin(_autopilot, SIGNAL(pluginReadyChanged(bool)));
     if (!_autopilot->pluginReady()) {
-        QCOMPARE(spyPlugin.wait(10000), true);
+        QCOMPARE(spyPlugin.wait(20000), true);
     }
     Q_ASSERT(_autopilot->pluginReady());
     


### PR DESCRIPTION
When TC machine is loaded down it can take longer than 10 seconds to
load MockLink parameters