### PR TITLE
Sensor cal usability

### DIFF
--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -548,7 +548,8 @@ SOURCES += \
 #
 
 INCLUDEPATH += \
-    src/VehicleSetup
+    src/VehicleSetup \
+    src/AutoPilotPlugins/PX4 \
 
 FORMS += \
     src/VehicleSetup/SetupView.ui \

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.qml
@@ -39,12 +39,8 @@ QGCView {
     Component {
         id: view
 
-        FactPanel {
+        QGCViewPanel {
             id:             panel
-            anchors.fill:   parent
-
-            signal showDialog(Component component, string title, int charWidth, int buttons)
-            signal hideDialog
 
             Connections {
                 target: rootQGCView

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -38,14 +38,10 @@
 bool AirframeComponentController::_typesRegistered = false;
 
 AirframeComponentController::AirframeComponentController(void) :
-    _uas(NULL),
     _currentVehicleIndex(0),
     _autostartId(0),
     _showCustomConfigPanel(false)
 {
-    _uas = UASManager::instance()->getActiveUAS();
-    Q_ASSERT(_uas);
-
     if (!_typesRegistered) {
         _typesRegistered = true;
         qmlRegisterUncreatableType<AirframeType>("QGroundControl.Controllers", 1, 0, "AiframeType", "Can only reference AirframeType");

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.h
@@ -66,7 +66,6 @@ signals:
 private:
     static bool _typesRegistered;
     
-    UASInterface*       _uas;
     QVariantList        _airframeTypes;
     QString             _currentAirframeType;
     QString             _currentVehicleName;

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -75,9 +75,6 @@ PX4AutoPilotPlugin::PX4AutoPilotPlugin(UASInterface* uas, QObject* parent) :
 {
     Q_ASSERT(uas);
     
-    qmlRegisterType<FlightModesComponentController>("QGroundControl.Controllers", 1, 0, "FlightModesComponentController");
-    qmlRegisterType<AirframeComponentController>("QGroundControl.Controllers", 1, 0, "AirframeComponentController");
-    
     _parameterFacts = new PX4ParameterLoader(this, uas, this);
     Q_CHECK_PTR(_parameterFacts);
     

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.cc
@@ -110,11 +110,7 @@ QWidget* SensorsComponent::setupWidget(void) const
     QGCQmlWidgetHolder* holder = new QGCQmlWidgetHolder();
     Q_CHECK_PTR(holder);
     
-    holder->setAutoPilot(_autopilot);
-    
-    SensorsComponentController* controller = new SensorsComponentController(_autopilot, holder);
-    holder->setContextPropertyObject("controller", controller);
-    
+    holder->setAutoPilot(_autopilot);    
     holder->setSource(QUrl::fromUserInput("qrc:/qml/SensorsComponent.qml"));
     
     return holder;

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -32,534 +32,567 @@ import QGroundControl.Palette 1.0
 import QGroundControl.Controls 1.0
 import QGroundControl.ScreenTools 1.0
 
-Rectangle {
-    property QGCPalette qgcPal: QGCPalette { colorGroupEnabled: true }
+QGCView {
+    id:             rootQGCView
+    viewComponent:  view
 
-    readonly property int rotationColumnWidth: 200
-    readonly property var rotations: [
-        "ROTATION_NONE",
-        "ROTATION_YAW_45",
-        "ROTATION_YAW_90",
-        "ROTATION_YAW_135",
-        "ROTATION_YAW_180",
-        "ROTATION_YAW_225",
-        "ROTATION_YAW_270",
-        "ROTATION_YAW_315",
-        "ROTATION_ROLL_180",
-        "ROTATION_ROLL_180_YAW_45",
-        "ROTATION_ROLL_180_YAW_90",
-        "ROTATION_ROLL_180_YAW_135",
-        "ROTATION_PITCH_180",
-        "ROTATION_ROLL_180_YAW_225",
-        "ROTATION_ROLL_180_YAW_270",
-        "ROTATION_ROLL_180_YAW_315",
-        "ROTATION_ROLL_90",
-        "ROTATION_ROLL_90_YAW_45",
-        "ROTATION_ROLL_90_YAW_90",
-        "ROTATION_ROLL_90_YAW_135",
-        "ROTATION_ROLL_270",
-        "ROTATION_ROLL_270_YAW_45",
-        "ROTATION_ROLL_270_YAW_90",
-        "ROTATION_ROLL_270_YAW_135",
-        "ROTATION_PITCH_90",
-        "ROTATION_PITCH_270",
-        "ROTATION_ROLL_270_YAW_270"
-    ]
-
-    readonly property string statusTextAreaDefaultText: "Sensor config is a work in progress. Not all visuals for all calibration types fully implemented.\n\n" +
-                                                            "For Compass calibration you will need to rotate your vehicle through a number of positions. For this calibration is is best " +
-                                                            "to be connected to you vehicle via radio instead of USB since the USB cable will likely get in the way.\n\n" +
-                                                            "For Gyroscope calibration you will need to place your vehicle right side up on solid surface and leave it still.\n\n" +
-                                                            "For Accelerometer calibration you will need to place your vehicle on all six sides and hold it there for a few seconds.\n\n" +
-                                                            "For Airspeed calibration you will need to keep your airspeed sensor out of any wind.\n\n"
-
-    Fact { id: cal_mag0_id; name: "CAL_MAG0_ID" }
-    Fact { id: cal_mag1_id; name: "CAL_MAG1_ID" }
-    Fact { id: cal_mag2_id; name: "CAL_MAG2_ID" }
-    Fact { id: cal_mag0_rot; name: "CAL_MAG0_ROT" }
-    Fact { id: cal_mag1_rot; name: "CAL_MAG1_ROT" }
-    Fact { id: cal_mag2_rot; name: "CAL_MAG2_ROT" }
-
-    // Id > = signals compass available, rot < 0 signals internal compass
-    property bool showCompass0Rot: cal_mag0_id.value > 0 && cal_mag0_rot.value >= 0
-    property bool showCompass1Rot: cal_mag1_id.value > 0 && cal_mag1_rot.value >= 0
-    property bool showCompass2Rot: cal_mag2_id.value > 0 && cal_mag2_rot.value >= 0
-
-    color: qgcPal.window
-
-    // We use this bogus loader just so we can get an onLoaded signal to hook to in order to
-    // finish controller initialization.
     Component {
-        id: loadSignal;
-        Item { }
-    }
-    Loader {
-        sourceComponent: loadSignal
-        onLoaded: {
-            controller.statusLog = statusTextArea
-            controller.progressBar = progressBar
-            controller.compassButton = compassButton
-            controller.gyroButton = gyroButton
-            controller.accelButton = accelButton
-            controller.airspeedButton = airspeedButton
-            controller.cancelButton = cancelButton
-            controller.orientationCalAreaHelpText = orientationCalAreaHelpText
-        }
-    }
+        id: preCalibrationDialogComponent
 
-    Connections {
-        target: controller
+        QGCViewDialog {
+            id: preCalibrationDialog
 
-        onResetStatusTextArea: statusTextArea.text = statusTextAreaDefaultText
-        onSetCompassRotations: showCompassRotationOverlay()
-    }
+            Fact { id: sys_autostart; name: "SYS_AUTOSTART" }
 
-    Rectangle {
-        id:             overlay
-        anchors.fill:   parent
-        color:          qgcPal.window
-        opacity:        0.75
-        z:              100
-        visible:        false
-    }
-
-    Rectangle {
-        width:                      300
-        height:                     100
-        anchors.verticalCenter:     parent.verticalCenter
-        anchors.horizontalCenter:   parent.horizontalCenter
-        color:                      qgcPal.window
-        border.width:               1
-        border.color:               qgcPal.text
-        visible:                    controller.waitingForCancel
-        z:                          overlay.z + 1
-
-        onVisibleChanged: {
-            overlay.visible = visible
-        }
-
-        QGCLabel {
-            anchors.fill:           parent
-            verticalAlignment:      Text.AlignVCenter
-            horizontalAlignment:    Text.AlignHCenter
-            text:                   "Waiting for Cancel (may take a few seconds)"
-        }
-    }
-
-    Rectangle {
-        property string calibrationType
-
-        id:                         boardRotationOverlay
-        width:                      300
-        height:                     boardRotationOverlayColumn.height + 11
-        anchors.verticalCenter:     parent.verticalCenter
-        anchors.horizontalCenter:   parent.horizontalCenter
-        color:                      qgcPal.window
-        border.width:               1
-        border.color:               qgcPal.text
-        visible:                    false
-        z:                          overlay.z + 1
-
-        Column {
-            id:                 boardRotationOverlayColumn
-            anchors.topMargin:  10
-            anchors.top:        parent.top
-            width:              parent.width
-            spacing:            10
-
-            Column {
-                anchors.leftMargin:     10
-                anchors.rightMargin:    10
-                anchors.left:           parent.left
-                anchors.right:          parent.right
-                spacing:                10
-
-                QGCLabel {
-                    width:      parent.width
-                    wrapMode:   Text.WordWrap
-                    text:       "Please check and/or update board rotation before calibrating"
-                }
-
-                FactComboBox {
-                    width:  rotationColumnWidth
-                    model:  rotations
-                    fact:   Fact { name: "SENS_BOARD_ROT" }
-                }
+            function accept() {
+                sys_autostart.value = 0
+                customConfigDialog.hideDialog()
             }
 
-            QGCButton {
-                x:          1
-                width:      parent.width - 2
-                primary:    true
-                text:       "OK"
+            QGCLabel {
+                anchors.fill:   parent
+                wrapMode:       Text.WordWrap
+                text:           "Your vehicle is using a custom airframe configuration. " +
+                                "This configuration can only be modified through the Parameter Editor.\n\n" +
+                                "If you want to Reset your airframe configuration and select a standard configuration, click 'Reset' above."
+            }
+            Rectangle {
+                property string calibrationType
 
-                onClicked: {
-                    boardRotationOverlay.visible = false
-                    overlay.visible = false
+                id:                         boardRotationOverlay
+                width:                      300
+                height:                     boardRotationOverlayColumn.height + 11
+                anchors.verticalCenter:     parent.verticalCenter
+                anchors.horizontalCenter:   parent.horizontalCenter
+                color:                      qgcPal.window
+                border.width:               1
+                border.color:               qgcPal.text
+                visible:                    false
+                z:                          overlay.z + 1
 
-                    if (boardRotationOverlay.calibrationType == "gyro") {
-                        controller.calibrateGyro()
-                    } else if (boardRotationOverlay.calibrationType == "accel") {
-                        controller.calibrateAccel()
-                    } else if (boardRotationOverlay.calibrationType == "compass") {
-                        controller.calibrateCompass()
+                Column {
+                    id:                 boardRotationOverlayColumn
+                    anchors.topMargin:  10
+                    anchors.top:        parent.top
+                    width:              parent.width
+                    spacing:            10
+
+                    Column {
+                        anchors.leftMargin:     10
+                        anchors.rightMargin:    10
+                        anchors.left:           parent.left
+                        anchors.right:          parent.right
+                        spacing:                10
+
+                        QGCLabel {
+                            width:      parent.width
+                            wrapMode:   Text.WordWrap
+                            text:       "Please check and/or update board rotation before calibrating"
+                        }
+
+                        FactComboBox {
+                            width:  rotationColumnWidth
+                            model:  rotations
+                            fact:   Fact { name: "SENS_BOARD_ROT" }
+                        }
+                    }
+
+                    QGCButton {
+                        x:          1
+                        width:      parent.width - 2
+                        primary:    true
+                        text:       "OK"
+
+                        onClicked: {
+                            boardRotationOverlay.visible = false
+                            overlay.visible = false
+
+                            if (boardRotationOverlay.calibrationType == "gyro") {
+                                controller.calibrateGyro()
+                            } else if (boardRotationOverlay.calibrationType == "accel") {
+                                controller.calibrateAccel()
+                            } else if (boardRotationOverlay.calibrationType == "compass") {
+                                controller.calibrateCompass()
+                            }
+                        }
                     }
                 }
             }
         }
     }
 
-    function showBoardRotationOverlay(calibrationType) {
-        boardRotationOverlay.calibrationType = calibrationType
-        boardRotationOverlay.visible = true
-        overlay.visible = true
-    }
+    Component {
+        id: view
 
-    Rectangle {
-        id:                         compassRotationOverlay
-        width:                      300
-        height:                     compassRotationOverlayColumn.height + 11
-        anchors.verticalCenter:     parent.verticalCenter
-        anchors.horizontalCenter:   parent.horizontalCenter
-        color:                      qgcPal.window
-        border.width:               1
-        border.color:               qgcPal.text
-        visible:                    false
-        z:                          overlay.z + 1
+        // FIXME: Need to convert QGCViewPanel to FactPanel
+        QGCViewPanel {
+            anchors.fill: parent
 
-        Column {
-            id:                 compassRotationOverlayColumn
-            anchors.topMargin:  10
-            anchors.top:        parent.top
-            width:              parent.width
-            spacing:            10
+            QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
-            Column {
-                anchors.leftMargin:     10
-                anchors.rightMargin:    10
-                anchors.left:           parent.left
-                anchors.right:          parent.right
-                spacing:                10
+            readonly property int rotationColumnWidth: 200
+            readonly property var rotations: [
+                "ROTATION_NONE",
+                "ROTATION_YAW_45",
+                "ROTATION_YAW_90",
+                "ROTATION_YAW_135",
+                "ROTATION_YAW_180",
+                "ROTATION_YAW_225",
+                "ROTATION_YAW_270",
+                "ROTATION_YAW_315",
+                "ROTATION_ROLL_180",
+                "ROTATION_ROLL_180_YAW_45",
+                "ROTATION_ROLL_180_YAW_90",
+                "ROTATION_ROLL_180_YAW_135",
+                "ROTATION_PITCH_180",
+                "ROTATION_ROLL_180_YAW_225",
+                "ROTATION_ROLL_180_YAW_270",
+                "ROTATION_ROLL_180_YAW_315",
+                "ROTATION_ROLL_90",
+                "ROTATION_ROLL_90_YAW_45",
+                "ROTATION_ROLL_90_YAW_90",
+                "ROTATION_ROLL_90_YAW_135",
+                "ROTATION_ROLL_270",
+                "ROTATION_ROLL_270_YAW_45",
+                "ROTATION_ROLL_270_YAW_90",
+                "ROTATION_ROLL_270_YAW_135",
+                "ROTATION_PITCH_90",
+                "ROTATION_PITCH_270",
+                "ROTATION_ROLL_270_YAW_270"
+            ]
 
-                QGCLabel {
-                    width:      parent.width
-                    wrapMode:   Text.WordWrap
-                    text:       "Please check and/or update compass rotation(s)"
+            readonly property string statusTextAreaDefaultText: "For Compass calibration you will need to rotate your vehicle through a number of positions. For this calibration is is best " +
+                                                                    "to be connected to your vehicle via radio instead of USB since the USB cable will likely get in the way.\n\n" +
+                                                                    "For Gyroscope calibration you will need to place your vehicle right side up on solid surface and leave it still.\n\n" +
+                                                                    "For Accelerometer calibration you will need to place your vehicle on all six sides and hold it still there for a few seconds.\n\n" +
+                                                                    "For Airspeed calibration you will need to keep your airspeed sensor out of any wind and then blow across the sensor.\n\n"
+
+            Fact { id: cal_mag0_id; name: "CAL_MAG0_ID" }
+            Fact { id: cal_mag1_id; name: "CAL_MAG1_ID" }
+            Fact { id: cal_mag2_id; name: "CAL_MAG2_ID" }
+            Fact { id: cal_mag0_rot; name: "CAL_MAG0_ROT" }
+            Fact { id: cal_mag1_rot; name: "CAL_MAG1_ROT" }
+            Fact { id: cal_mag2_rot; name: "CAL_MAG2_ROT" }
+
+            // Id > = signals compass available, rot < 0 signals internal compass
+            property bool showCompass0Rot: cal_mag0_id.value > 0 && cal_mag0_rot.value >= 0
+            property bool showCompass1Rot: cal_mag1_id.value > 0 && cal_mag1_rot.value >= 0
+            property bool showCompass2Rot: cal_mag2_id.value > 0 && cal_mag2_rot.value >= 0
+
+            color: qgcPal.window
+
+            // We use this bogus loader just so we can get an onLoaded signal to hook to in order to
+            // finish controller initialization.
+            Component {
+                id: loadSignal;
+                Item { }
+            }
+            Loader {
+                sourceComponent: loadSignal
+                onLoaded: {
+                    controller.statusLog = statusTextArea
+                    controller.progressBar = progressBar
+                    controller.compassButton = compassButton
+                    controller.gyroButton = gyroButton
+                    controller.accelButton = accelButton
+                    controller.airspeedButton = airspeedButton
+                    controller.cancelButton = cancelButton
+                    controller.orientationCalAreaHelpText = orientationCalAreaHelpText
                 }
-
-                // Compass 0 rotation
-                Component {
-                    id: compass0ComponentLabel
-
-                    QGCLabel { text: "Compass Orientation" }
-                }
-                Component {
-                    id: compass0ComponentCombo
-
-                    FactComboBox {
-                        id:     compass0RotationCombo
-                        width:  rotationColumnWidth
-                        model:  rotations
-                        fact:   Fact { name: "CAL_MAG0_ROT" }
-                    }
-                }
-                Loader { sourceComponent: showCompass0Rot ? compass0ComponentLabel : null }
-                Loader { sourceComponent: showCompass0Rot ? compass0ComponentCombo : null }
-
-                // Compass 1 rotation
-                Component {
-                    id: compass1ComponentLabel
-
-                    QGCLabel { text: "Compass 1 Orientation" }
-                }
-                Component {
-                    id: compass1ComponentCombo
-
-                    FactComboBox {
-                        id:     compass1RotationCombo
-                        width:  rotationColumnWidth
-                        model:  rotations
-                        fact:   Fact { name: "CAL_MAG1_ROT" }
-                    }
-                }
-                Loader { sourceComponent: showCompass1Rot ? compass1ComponentLabel : null }
-                Loader { sourceComponent: showCompass1Rot ? compass1ComponentCombo : null }
-
-                // Compass 2 rotation
-                Component {
-                    id: compass2ComponentLabel
-
-                    QGCLabel { text: "Compass 2 Orientation" }
-                }
-                Component {
-                    id: compass2ComponentCombo
-
-                    FactComboBox {
-                        id:     compass1RotationCombo
-                        width:  rotationColumnWidth
-                        model:  rotations
-                        fact:   Fact { name: "CAL_MAG2_ROT" }
-                    }
-                }
-                Loader { sourceComponent: showCompass2Rot ? compass2ComponentLabel : null }
-                Loader { sourceComponent: showCompass2Rot ? compass2ComponentCombo : null }
             }
 
-            QGCButton {
-                x:          1
-                width:      parent.width - 2
-                primary:    true
-                text:       "OK"
+            Connections {
+                target: controller
 
-                onClicked: {
-                    compassRotationOverlay.visible = false
-                    overlay.visible = false
-               }
-            }
-        }
-    }
-
-    function showCompassRotationOverlay() {
-        if (showCompass0Rot || showCompass1Rot || showCompass2Rot) {
-            compassRotationOverlay.visible = true
-            overlay.visible = true
-        }
-    }
-
-    Column {
-        anchors.fill: parent
-
-        QGCLabel {
-            text: "SENSORS CONFIG"
-            font.pointSize: ScreenTools.fontPointFactor * (20);
-        }
-
-        Item { height: 20; width: 10 } // spacer
-
-        Row {
-            readonly property int buttonWidth: 120
-
-            spacing: 20
-
-            QGCLabel { text: "Calibrate:"; anchors.baseline: compassButton.baseline }
-
-            IndicatorButton {
-                property Fact fact: Fact { name: "CAL_MAG0_ID" }
-
-                id:             compassButton
-                width:          parent.buttonWidth
-                text:           "Compass"
-                indicatorGreen: fact.value != 0
-
-                onClicked: showBoardRotationOverlay("compass")
-            }
-
-            IndicatorButton {
-                property Fact fact: Fact { name: "CAL_GYRO0_ID" }
-
-                id:             gyroButton
-                width:          parent.buttonWidth
-                text:           "Gyroscope"
-                indicatorGreen: fact.value != 0
-
-                onClicked: showBoardRotationOverlay("gyro")
-            }
-
-            IndicatorButton {
-                property Fact fact: Fact { name: "CAL_ACC0_ID" }
-
-                id:             accelButton
-                width:          parent.buttonWidth
-                text:           "Accelerometer"
-                indicatorGreen: fact.value != 0
-
-                onClicked: showBoardRotationOverlay("accel")
-            }
-
-            IndicatorButton {
-                property Fact fact: Fact { name: "SENS_DPRES_OFF" }
-
-                id:             airspeedButton
-                width:          parent.buttonWidth
-                text:           "Airspeed"
-                visible:        controller.fixedWing
-                indicatorGreen: fact.value != 0
-                onClicked:      controller.calibrateAirspeed()
-            }
-
-            QGCButton {
-                id:         cancelButton
-                text:       "Cancel"
-                enabled:    false
-                onClicked:  controller.cancelCalibration()
-            }
-        }
-
-        Item { height: 20; width: 10 } // spacer
-
-        ProgressBar {
-            id: progressBar
-            width: parent.width - rotationColumnWidth
-        }
-
-        Item { height: 10; width: 10 } // spacer
-
-        Item {
-            readonly property int calibrationAreaHeight: 300
-            property int calDisplayAreaWidth: parent.width - rotationColumnWidth
-
-            width:  parent.width
-            height: parent.height - y
-
-            TextArea {
-                id:             statusTextArea
-                width:          parent.calDisplayAreaWidth
-                height:         parent.height
-                readOnly:       true
-                frameVisible:   false
-                text:           statusTextAreaDefaultText
-
-                style: TextAreaStyle {
-                    textColor: qgcPal.text
-                    backgroundColor: qgcPal.windowShade
-                }
+                onResetStatusTextArea: statusTextArea.text = statusTextAreaDefaultText
+                onSetCompassRotations: showCompassRotationOverlay()
             }
 
             Rectangle {
-                id:         orientationCalArea
-                width:      parent.calDisplayAreaWidth
-                height:     parent.height
-                visible:    controller.showOrientationCalArea
-                color:      qgcPal.windowShade
+                id:             overlay
+                anchors.fill:   parent
+                color:          qgcPal.window
+                opacity:        0.75
+                z:              100
+                visible:        false
+            }
 
-                QGCLabel {
-                    id:             orientationCalAreaHelpText
-                    width:          parent.width
-                    wrapMode:       Text.WordWrap
-                    font.pointSize: ScreenTools.fontPointFactor * (17);
+            Rectangle {
+                width:                      300
+                height:                     100
+                anchors.verticalCenter:     parent.verticalCenter
+                anchors.horizontalCenter:   parent.horizontalCenter
+                color:                      qgcPal.window
+                border.width:               1
+                border.color:               qgcPal.text
+                visible:                    controller.waitingForCancel
+                z:                          overlay.z + 1
+
+                onVisibleChanged: {
+                    overlay.visible = visible
                 }
 
-                Flow {
-                    y:          orientationCalAreaHelpText.height
-                    width:      parent.width
-                    height:     parent.height - orientationCalAreaHelpText.implicitHeight
-                    spacing:    5
+                QGCLabel {
+                    anchors.fill:           parent
+                    verticalAlignment:      Text.AlignVCenter
+                    horizontalAlignment:    Text.AlignHCenter
+                    text:                   "Waiting for Cancel (may take a few seconds)"
+                }
+            }
 
-                    VehicleRotationCal {
-                        visible:            controller.orientationCalDownSideVisible
-                        calValid:           controller.orientationCalDownSideDone
-                        calInProgress:      controller.orientationCalDownSideInProgress
-                        calInProgressText:  controller.orientationCalDownSideRotate ? "Rotate" : "Hold Still"
-                        imageSource:        controller.orientationCalDownSideRotate ? "qrc:///qml/VehicleDownRotate.png" : "qrc:///qml/VehicleDown.png"
+
+            function showBoardRotationOverlay(calibrationType) {
+                boardRotationOverlay.calibrationType = calibrationType
+                boardRotationOverlay.visible = true
+                overlay.visible = true
+            }
+
+            Rectangle {
+                id:                         compassRotationOverlay
+                width:                      300
+                height:                     compassRotationOverlayColumn.height + 11
+                anchors.verticalCenter:     parent.verticalCenter
+                anchors.horizontalCenter:   parent.horizontalCenter
+                color:                      qgcPal.window
+                border.width:               1
+                border.color:               qgcPal.text
+                visible:                    false
+                z:                          overlay.z + 1
+
+                Column {
+                    id:                 compassRotationOverlayColumn
+                    anchors.topMargin:  10
+                    anchors.top:        parent.top
+                    width:              parent.width
+                    spacing:            10
+
+                    Column {
+                        anchors.leftMargin:     10
+                        anchors.rightMargin:    10
+                        anchors.left:           parent.left
+                        anchors.right:          parent.right
+                        spacing:                10
+
+                        QGCLabel {
+                            width:      parent.width
+                            wrapMode:   Text.WordWrap
+                            text:       "Please check and/or update compass rotation(s)"
+                        }
+
+                        // Compass 0 rotation
+                        Component {
+                            id: compass0ComponentLabel
+
+                            QGCLabel { text: "Compass Orientation" }
+                        }
+                        Component {
+                            id: compass0ComponentCombo
+
+                            FactComboBox {
+                                id:     compass0RotationCombo
+                                width:  rotationColumnWidth
+                                model:  rotations
+                                fact:   Fact { name: "CAL_MAG0_ROT" }
+                            }
+                        }
+                        Loader { sourceComponent: showCompass0Rot ? compass0ComponentLabel : null }
+                        Loader { sourceComponent: showCompass0Rot ? compass0ComponentCombo : null }
+
+                        // Compass 1 rotation
+                        Component {
+                            id: compass1ComponentLabel
+
+                            QGCLabel { text: "Compass 1 Orientation" }
+                        }
+                        Component {
+                            id: compass1ComponentCombo
+
+                            FactComboBox {
+                                id:     compass1RotationCombo
+                                width:  rotationColumnWidth
+                                model:  rotations
+                                fact:   Fact { name: "CAL_MAG1_ROT" }
+                            }
+                        }
+                        Loader { sourceComponent: showCompass1Rot ? compass1ComponentLabel : null }
+                        Loader { sourceComponent: showCompass1Rot ? compass1ComponentCombo : null }
+
+                        // Compass 2 rotation
+                        Component {
+                            id: compass2ComponentLabel
+
+                            QGCLabel { text: "Compass 2 Orientation" }
+                        }
+                        Component {
+                            id: compass2ComponentCombo
+
+                            FactComboBox {
+                                id:     compass1RotationCombo
+                                width:  rotationColumnWidth
+                                model:  rotations
+                                fact:   Fact { name: "CAL_MAG2_ROT" }
+                            }
+                        }
+                        Loader { sourceComponent: showCompass2Rot ? compass2ComponentLabel : null }
+                        Loader { sourceComponent: showCompass2Rot ? compass2ComponentCombo : null }
                     }
-                    VehicleRotationCal {
-                        visible:            controller.orientationCalUpsideDownSideVisible
-                        calValid:           controller.orientationCalUpsideDownSideDone
-                        calInProgress:      controller.orientationCalUpsideDownSideInProgress
-                        calInProgressText:  "Hold Still"
-                        imageSource:        "qrc:///qml/VehicleUpsideDown.png"
+
+                    QGCButton {
+                        x:          1
+                        width:      parent.width - 2
+                        primary:    true
+                        text:       "OK"
+
+                        onClicked: {
+                            compassRotationOverlay.visible = false
+                            overlay.visible = false
+                       }
                     }
-                    VehicleRotationCal {
-                        visible:            controller.orientationCalNoseDownSideVisible
-                        calValid:           controller.orientationCalNoseDownSideDone
-                        calInProgress:      controller.orientationCalNoseDownSideInProgress
-                        calInProgressText:  controller.orientationCalNoseDownSideRotate ? "Rotate" : "Hold Still"
-                        imageSource:        controller.orientationCalNoseDownSideRotate ? "qrc:///qml/VehicleNoseDownRotate.png" : "qrc:///qml/VehicleNoseDown.png"
-                    }
-                    VehicleRotationCal {
-                        visible:            controller.orientationCalTailDownSideVisible
-                        calValid:           controller.orientationCalTailDownSideDone
-                        calInProgress:      controller.orientationCalTailDownSideInProgress
-                        calInProgressText:  "Hold Still"
-                        imageSource:        "qrc:///qml/VehicleTailDown.png"
-                    }
-                    VehicleRotationCal {
-                        visible:            controller.orientationCalLeftSideVisible
-                        calValid:           controller.orientationCalLeftSideDone
-                        calInProgress:      controller.orientationCalLeftSideInProgress
-                        calInProgressText:  controller.orientationCalLeftSideRotate ? "Rotate" : "Hold Still"
-                        imageSource:        controller.orientationCalLeftSideRotate ? "qrc:///qml/VehicleLeftRotate.png" : "qrc:///qml/VehicleLeft.png"
-                    }
-                    VehicleRotationCal {
-                        visible:            controller.orientationCalRightSideVisible
-                        calValid:           controller.orientationCalRightSideDone
-                        calInProgress:      controller.orientationCalRightSideInProgress
-                        calInProgressText:  "Hold Still"
-                        imageSource:        "qrc:///qml/VehicleRight.png"
-                    }
+                }
+            }
+
+            function showCompassRotationOverlay() {
+                if (showCompass0Rot || showCompass1Rot || showCompass2Rot) {
+                    compassRotationOverlay.visible = true
+                    overlay.visible = true
                 }
             }
 
             Column {
-                x: parent.width - rotationColumnWidth
+                anchors.fill: parent
 
-                QGCLabel { text: "Autpilot Orientation" }
-
-                FactComboBox {
-                    id:     boardRotationCombo
-                    width:  rotationColumnWidth;
-                    model:  rotations
-                    fact:   Fact { name: "SENS_BOARD_ROT" }
+                QGCLabel {
+                    text: "SENSORS CONFIG"
+                    font.pointSize: ScreenTools.fontPointFactor * (20);
                 }
 
-                // Compass 0 rotation
-                Component {
-                    id: compass0ComponentLabel2
+                Item { height: 20; width: 10 } // spacer
 
-                    QGCLabel { text: "Compass Orientation" }
-                }
-                Component {
-                    id: compass0ComponentCombo2
+                Row {
+                    readonly property int buttonWidth: 120
 
-                    FactComboBox {
-                        id:     compass0RotationCombo
-                        width:  rotationColumnWidth
-                        model:  rotations
-                        fact:   Fact { name: "CAL_MAG0_ROT" }
+                    spacing: 20
+
+                    QGCLabel { text: "Calibrate:"; anchors.baseline: compassButton.baseline }
+
+                    IndicatorButton {
+                        property Fact fact: Fact { name: "CAL_MAG0_ID" }
+
+                        id:             compassButton
+                        width:          parent.buttonWidth
+                        text:           "Compass"
+                        indicatorGreen: fact.value != 0
+
+                        onClicked: showBoardRotationOverlay("compass")
+                    }
+
+                    IndicatorButton {
+                        property Fact fact: Fact { name: "CAL_GYRO0_ID" }
+
+                        id:             gyroButton
+                        width:          parent.buttonWidth
+                        text:           "Gyroscope"
+                        indicatorGreen: fact.value != 0
+
+                        onClicked: showBoardRotationOverlay("gyro")
+                    }
+
+                    IndicatorButton {
+                        property Fact fact: Fact { name: "CAL_ACC0_ID" }
+
+                        id:             accelButton
+                        width:          parent.buttonWidth
+                        text:           "Accelerometer"
+                        indicatorGreen: fact.value != 0
+
+                        onClicked: showBoardRotationOverlay("accel")
+                    }
+
+                    IndicatorButton {
+                        property Fact fact: Fact { name: "SENS_DPRES_OFF" }
+
+                        id:             airspeedButton
+                        width:          parent.buttonWidth
+                        text:           "Airspeed"
+                        visible:        controller.fixedWing
+                        indicatorGreen: fact.value != 0
+                        onClicked:      controller.calibrateAirspeed()
+                    }
+
+                    QGCButton {
+                        id:         cancelButton
+                        text:       "Cancel"
+                        enabled:    false
+                        onClicked:  controller.cancelCalibration()
                     }
                 }
-                Loader { sourceComponent: showCompass0Rot ? compass0ComponentLabel2 : null }
-                Loader { sourceComponent: showCompass0Rot ? compass0ComponentCombo2 : null }
 
-                // Compass 1 rotation
-                Component {
-                    id: compass1ComponentLabel2
+                Item { height: 20; width: 10 } // spacer
 
-                    QGCLabel { text: "Compass 1 Orientation" }
+                ProgressBar {
+                    id: progressBar
+                    width: parent.width - rotationColumnWidth
                 }
-                Component {
-                    id: compass1ComponentCombo2
 
-                    FactComboBox {
-                        id:     compass1RotationCombo
-                        width:  rotationColumnWidth
-                        model:  rotations
-                        fact:   Fact { name: "CAL_MAG1_ROT" }
+                Item { height: 10; width: 10 } // spacer
+
+                Item {
+                    readonly property int calibrationAreaHeight: 300
+                    property int calDisplayAreaWidth: parent.width - rotationColumnWidth
+
+                    width:  parent.width
+                    height: parent.height - y
+
+                    TextArea {
+                        id:             statusTextArea
+                        width:          parent.calDisplayAreaWidth
+                        height:         parent.height
+                        readOnly:       true
+                        frameVisible:   false
+                        text:           statusTextAreaDefaultText
+
+                        style: TextAreaStyle {
+                            textColor: qgcPal.text
+                            backgroundColor: qgcPal.windowShade
+                        }
+                    }
+
+                    Rectangle {
+                        id:         orientationCalArea
+                        width:      parent.calDisplayAreaWidth
+                        height:     parent.height
+                        visible:    controller.showOrientationCalArea
+                        color:      qgcPal.windowShade
+
+                        QGCLabel {
+                            id:             orientationCalAreaHelpText
+                            width:          parent.width
+                            wrapMode:       Text.WordWrap
+                            font.pointSize: ScreenTools.fontPointFactor * (17);
+                        }
+
+                        Flow {
+                            y:          orientationCalAreaHelpText.height
+                            width:      parent.width
+                            height:     parent.height - orientationCalAreaHelpText.implicitHeight
+                            spacing:    5
+
+                            VehicleRotationCal {
+                                visible:            controller.orientationCalDownSideVisible
+                                calValid:           controller.orientationCalDownSideDone
+                                calInProgress:      controller.orientationCalDownSideInProgress
+                                calInProgressText:  controller.orientationCalDownSideRotate ? "Rotate" : "Hold Still"
+                                imageSource:        controller.orientationCalDownSideRotate ? "qrc:///qml/VehicleDownRotate.png" : "qrc:///qml/VehicleDown.png"
+                            }
+                            VehicleRotationCal {
+                                visible:            controller.orientationCalUpsideDownSideVisible
+                                calValid:           controller.orientationCalUpsideDownSideDone
+                                calInProgress:      controller.orientationCalUpsideDownSideInProgress
+                                calInProgressText:  "Hold Still"
+                                imageSource:        "qrc:///qml/VehicleUpsideDown.png"
+                            }
+                            VehicleRotationCal {
+                                visible:            controller.orientationCalNoseDownSideVisible
+                                calValid:           controller.orientationCalNoseDownSideDone
+                                calInProgress:      controller.orientationCalNoseDownSideInProgress
+                                calInProgressText:  controller.orientationCalNoseDownSideRotate ? "Rotate" : "Hold Still"
+                                imageSource:        controller.orientationCalNoseDownSideRotate ? "qrc:///qml/VehicleNoseDownRotate.png" : "qrc:///qml/VehicleNoseDown.png"
+                            }
+                            VehicleRotationCal {
+                                visible:            controller.orientationCalTailDownSideVisible
+                                calValid:           controller.orientationCalTailDownSideDone
+                                calInProgress:      controller.orientationCalTailDownSideInProgress
+                                calInProgressText:  "Hold Still"
+                                imageSource:        "qrc:///qml/VehicleTailDown.png"
+                            }
+                            VehicleRotationCal {
+                                visible:            controller.orientationCalLeftSideVisible
+                                calValid:           controller.orientationCalLeftSideDone
+                                calInProgress:      controller.orientationCalLeftSideInProgress
+                                calInProgressText:  controller.orientationCalLeftSideRotate ? "Rotate" : "Hold Still"
+                                imageSource:        controller.orientationCalLeftSideRotate ? "qrc:///qml/VehicleLeftRotate.png" : "qrc:///qml/VehicleLeft.png"
+                            }
+                            VehicleRotationCal {
+                                visible:            controller.orientationCalRightSideVisible
+                                calValid:           controller.orientationCalRightSideDone
+                                calInProgress:      controller.orientationCalRightSideInProgress
+                                calInProgressText:  "Hold Still"
+                                imageSource:        "qrc:///qml/VehicleRight.png"
+                            }
+                        }
+                    }
+
+                    Column {
+                        x: parent.width - rotationColumnWidth
+
+                        QGCLabel { text: "Autpilot Orientation" }
+
+                        FactComboBox {
+                            id:     boardRotationCombo
+                            width:  rotationColumnWidth;
+                            model:  rotations
+                            fact:   Fact { name: "SENS_BOARD_ROT" }
+                        }
+
+                        // Compass 0 rotation
+                        Component {
+                            id: compass0ComponentLabel2
+
+                            QGCLabel { text: "Compass Orientation" }
+                        }
+                        Component {
+                            id: compass0ComponentCombo2
+
+                            FactComboBox {
+                                id:     compass0RotationCombo
+                                width:  rotationColumnWidth
+                                model:  rotations
+                                fact:   Fact { name: "CAL_MAG0_ROT" }
+                            }
+                        }
+                        Loader { sourceComponent: showCompass0Rot ? compass0ComponentLabel2 : null }
+                        Loader { sourceComponent: showCompass0Rot ? compass0ComponentCombo2 : null }
+
+                        // Compass 1 rotation
+                        Component {
+                            id: compass1ComponentLabel2
+
+                            QGCLabel { text: "Compass 1 Orientation" }
+                        }
+                        Component {
+                            id: compass1ComponentCombo2
+
+                            FactComboBox {
+                                id:     compass1RotationCombo
+                                width:  rotationColumnWidth
+                                model:  rotations
+                                fact:   Fact { name: "CAL_MAG1_ROT" }
+                            }
+                        }
+                        Loader { sourceComponent: showCompass1Rot ? compass1ComponentLabel2 : null }
+                        Loader { sourceComponent: showCompass1Rot ? compass1ComponentCombo2 : null }
+
+                        // Compass 2 rotation
+                        Component {
+                            id: compass2ComponentLabel2
+
+                            QGCLabel { text: "Compass 2 Orientation" }
+                        }
+                        Component {
+                            id: compass2ComponentCombo2
+
+                            FactComboBox {
+                                id:     compass1RotationCombo
+                                width:  rotationColumnWidth
+                                model:  rotations
+                                fact:   Fact { name: "CAL_MAG2_ROT" }
+                            }
+                        }
+                        Loader { sourceComponent: showCompass2Rot ? compass2ComponentLabel2 : null }
+                        Loader { sourceComponent: showCompass2Rot ? compass2ComponentCombo2 : null }
                     }
                 }
-                Loader { sourceComponent: showCompass1Rot ? compass1ComponentLabel2 : null }
-                Loader { sourceComponent: showCompass1Rot ? compass1ComponentCombo2 : null }
-
-                // Compass 2 rotation
-                Component {
-                    id: compass2ComponentLabel2
-
-                    QGCLabel { text: "Compass 2 Orientation" }
-                }
-                Component {
-                    id: compass2ComponentCombo2
-
-                    FactComboBox {
-                        id:     compass1RotationCombo
-                        width:  rotationColumnWidth
-                        model:  rotations
-                        fact:   Fact { name: "CAL_MAG2_ROT" }
-                    }
-                }
-                Loader { sourceComponent: showCompass2Rot ? compass2ComponentLabel2 : null }
-                Loader { sourceComponent: showCompass2Rot ? compass2ComponentCombo2 : null }
             }
-        }
-    }
+        } // Rectangle
+    } // Component - view
 }
-

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -32,8 +32,7 @@
 #include <QVariant>
 #include <QQmlProperty>
 
-SensorsComponentController::SensorsComponentController(AutoPilotPlugin* autopilot, QObject* parent) :
-    QObject(parent),
+SensorsComponentController::SensorsComponentController(void) :
     _statusLog(NULL),
     _progressBar(NULL),
     _compassButton(NULL),
@@ -67,15 +66,8 @@ SensorsComponentController::SensorsComponentController(AutoPilotPlugin* autopilo
     _orientationCalLeftSideRotate(false),
     _orientationCalNoseDownSideRotate(false),
     _unknownFirmwareVersion(false),
-    _waitingForCancel(false),
-    _autopilot(autopilot)
+    _waitingForCancel(false)
 {
-    Q_ASSERT(_autopilot);
-    Q_ASSERT(_autopilot->pluginReady());
-    
-    _uas = _autopilot->uas();
-    Q_ASSERT(_uas);
-    
     // Mag rotation parameters are optional
     _showCompass0 = _autopilot->parameterExists("CAL_MAG0_ROT") &&
                         _autopilot->getParameterFact("CAL_MAG0_ROT")->value().toInt() >= 0;

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -392,6 +392,15 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
 
 void SensorsComponentController::_refreshParams(void)
 {
+    QStringList fastRefreshList;
+    
+    // We ask for a refresh on these first so that the rotation combo show up as fast as possible
+    fastRefreshList << "CAL_MAG0_ID" << "CAL_MAG1_ID" << "CAL_MAG2_ID" << "CAL_MAG0_ROT" << "CAL_MAG1_ROT" << "CAL_MAG2_ROT";
+    foreach (QString paramName, fastRefreshList) {
+        _autopilot->refreshParameter(FactSystem::defaultComponentId, paramName);
+    }
+    
+    // Now ask for all to refresh
     _autopilot->refreshParametersPrefix(FactSystem::defaultComponentId, "CAL_");
     _autopilot->refreshParametersPrefix(FactSystem::defaultComponentId, "SENS_");
 }

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -31,15 +31,15 @@
 #include <QQuickItem>
 
 #include "UASInterface.h"
-#include "AutoPilotPlugin.h"
+#include "FactPanelController.h"
 
 /// Sensors Component MVC Controller for SensorsComponent.qml.
-class SensorsComponentController : public QObject
+class SensorsComponentController : public FactPanelController
 {
     Q_OBJECT
     
 public:
-    SensorsComponentController(AutoPilotPlugin* autopilot, QObject* parent = NULL);
+    SensorsComponentController(void);
     
     Q_PROPERTY(bool fixedWing READ fixedWing CONSTANT)
     
@@ -167,9 +167,6 @@ private:
     
     bool _unknownFirmwareVersion;
     bool _waitingForCancel;
-    
-    AutoPilotPlugin*    _autopilot;
-    UASInterface*       _uas;
 };
 
 #endif

--- a/src/FactSystem/FactControls/FactPanel.qml
+++ b/src/FactSystem/FactControls/FactPanel.qml
@@ -31,7 +31,11 @@ import QGroundControl.FactSystem 1.0
 import QGroundControl.Controls 1.0
 import QGroundControl.Palette 1.0
 
-Item {
+Rectangle {
+    color: __qgcPal.window
+
+    QGCPalette { id: __qgcPal; colorGroupEnabled: true }
+
     property string __missingFacts: ""
 
     function showMissingFactOverlay(missingFactName) {
@@ -43,8 +47,6 @@ Item {
     }
 
     Rectangle {
-        QGCPalette { id: __qgcPal; colorGroupEnabled: true }
-
         id:             __missingFactOverlay
         anchors.fill:   parent
         z:              9999

--- a/src/FactSystem/FactControls/FactPanelController.cc
+++ b/src/FactSystem/FactControls/FactPanelController.cc
@@ -33,10 +33,10 @@ FactPanelController::FactPanelController(void) :
 	_autopilot(NULL),
     _factPanel(NULL)
 {
-    UASInterface* uas = UASManager::instance()->getActiveUAS();
-    Q_ASSERT(uas);
+    _uas = UASManager::instance()->getActiveUAS();
+    Q_ASSERT(_uas);
     
-    _autopilot = AutoPilotPluginManager::instance()->getInstanceForAutoPilotPlugin(uas);
+    _autopilot = AutoPilotPluginManager::instance()->getInstanceForAutoPilotPlugin(_uas);
     Q_ASSERT(_autopilot);
     Q_ASSERT(_autopilot->pluginReady());
     

--- a/src/FactSystem/FactControls/FactPanelController.h
+++ b/src/FactSystem/FactControls/FactPanelController.h
@@ -56,6 +56,7 @@ protected:
     /// Report a missing fact to the FactPanel Qml element
     void _reportMissingFact(const QString& missingFact);
     
+    UASInterface*       _uas;
 	AutoPilotPlugin*    _autopilot;
     
 private slots:

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -62,6 +62,9 @@
 #include "ViewWidgetController.h"
 #include "ParameterEditorController.h"
 #include "CustomCommandWidgetController.h"
+#include "FlightModesComponentController.h"
+#include "AirframeComponentController.h"
+#include "SensorsComponentController.h"
 
 #include "ScreenTools.h"
 #include "MavManager.h"
@@ -310,13 +313,20 @@ void QGCApplication::_initCommon(void)
     // setFont(fontDatabase.font(fontFamilyName, "Roman", 12));
     
     // Register our Qml objects
+    
     qmlRegisterType<QGCPalette>("QGroundControl.Palette", 1, 0, "QGCPalette");
+    
 	qmlRegisterType<ViewWidgetController>("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
 	qmlRegisterType<ParameterEditorController>("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
     qmlRegisterType<CustomCommandWidgetController>("QGroundControl.Controllers", 1, 0, "CustomCommandWidgetController");
+    qmlRegisterType<FlightModesComponentController>("QGroundControl.Controllers", 1, 0, "FlightModesComponentController");
+    qmlRegisterType<AirframeComponentController>("QGroundControl.Controllers", 1, 0, "AirframeComponentController");
+    qmlRegisterType<SensorsComponentController>("QGroundControl.Controllers", 1, 0, "SensorsComponentController");
+    
     //-- Create QML Singleton Interfaces
     qmlRegisterSingletonType<ScreenTools>("QGroundControl.ScreenTools", 1, 0, "ScreenTools", screenToolsSingletonFactory);
     qmlRegisterSingletonType<MavManager>("QGroundControl.MavManager", 1, 0, "MavManager", mavManagerSingletonFactory);
+    
     //-- Register Waypoint Interface
     qmlRegisterInterface<Waypoint>("Waypoint");
 }

--- a/src/QmlControls/QGCView.qml
+++ b/src/QmlControls/QGCView.qml
@@ -34,7 +34,7 @@ import QGroundControl.ScreenTools 1.0
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0
 
-Item {
+FactPanel {
     id: __rootItem
 
     property Component viewComponent
@@ -164,7 +164,7 @@ Item {
     Connections {
         target: __dialogComponentLoader.item
 
-        onHideDialog: __hideDialog()
+        onHideDialog: __rootItem.hideDialog()
     }
 
     Loader {

--- a/src/QmlControls/QGCView.qml
+++ b/src/QmlControls/QGCView.qml
@@ -106,7 +106,7 @@ Item {
         }
     }
 
-    function __showDialog(component, title, charWidth, buttons) {
+    function showDialog(component, title, charWidth, buttons) {
         __dialogCharWidth = charWidth
         __dialogTitle = title
 
@@ -117,7 +117,7 @@ Item {
         __dialogOverlay.visible = true
     }
 
-    function __showMessage(title, message, buttons) {
+    function showMessage(title, message, buttons) {
         __dialogCharWidth = 50
         __dialogTitle = title
         __messageDialogText = message
@@ -129,7 +129,7 @@ Item {
         __dialogOverlay.visible = true
     }
 
-    function __hideDialog() {
+    function hideDialog() {
         __dialogComponent = null
         __viewPanel.enabled = true
         __dialogOverlay.visible = false
@@ -156,9 +156,9 @@ Item {
     Connections {
         target: __viewPanel.item
 
-        onShowDialog:   __showDialog(component, title, charWidth, buttons)
-        onShowMessage:  __showMessage(title, message, buttons)
-        onHideDialog:   __hideDialog()
+        onShowDialog:   __rootItem.showDialog(component, title, charWidth, buttons)
+        onShowMessage:  __rootItem.showMessage(title, message, buttons)
+        onHideDialog:   __rootItem.hideDialog()
     }
 
     Connections {

--- a/src/QmlControls/QGCViewDialog.qml
+++ b/src/QmlControls/QGCViewDialog.qml
@@ -30,8 +30,11 @@ import QtQuick.Controls 1.3
 import QGroundControl.Controls 1.0
 import QGroundControl.Palette 1.0
 
-Rectangle {
-    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+import QGroundControl.FactSystem 1.0
+import QGroundControl.FactControls 1.0
+
+FactPanel {
+    QGCPalette { id: __qgcPal; colorGroupEnabled: enabled }
 
     signal hideDialog
 
@@ -43,5 +46,5 @@ Rectangle {
         hideDialog()
     }
 
-    color: qgcPal.windowShadeDark
+    color: __qgcPal.windowShadeDark
 }

--- a/src/QmlControls/QGCViewPanel.qml
+++ b/src/QmlControls/QGCViewPanel.qml
@@ -30,12 +30,15 @@ import QtQuick.Controls 1.3
 import QGroundControl.Palette 1.0
 import QGroundControl.Controls 1.0
 
-Rectangle {
-    property QGCPalette qgcPal: QGCPalette { colorGroupEnabled: enabled }
+import QGroundControl.FactSystem 1.0
+import QGroundControl.FactControls 1.0
+
+FactPanel {
+    QGCPalette { id: __qgcPal; colorGroupEnabled: enabled }
 
     signal showDialog(Component component, string title, int charWidth, int buttons)
     signal hideDialog
     signal showMessage(string title, string message, int buttons)
 
-    color: qgcPal.window
+    color: __qgcPal.window
 }

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -44,6 +44,8 @@ QGCView {
         QGCViewPanel {
             id: panel
 
+            QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
             FirmwareUpgradeController {
                 id:             controller
                 upgradeButton:  upgradeButton


### PR DESCRIPTION
There are quite a few changes in here which have been discussed in various forums to improve usability. Instead of including a massive amount of screens shots I'll let folks just run it and send comments.

While testing this I found a number of things which used to work but which are now broken with the latest firmware:
- I calibrated a board with an external mag but CAL_MAG1_ROT always came back as -1 not allowing me to set external mag rotation.
- Cancel is broken during mag cal. If you cancel during the rotate detection step, it will emit the calibration cancelled message and continue on and still do the calibration step. 
- The mag cal step which tries to detect rotation before calibrating a side seems flaky. I could get it to detect rotation maybe 50% of the time. For example if my board is flat on the table. And I'm mag calibrating the right side up position, I rotate the board in the plane on the table and it would not detect rotation. I would have to tip the board up (which isn't what you are supposed to do) to get it to detect rotation and move on to calibrate that orientation. 
- Gyro cal on the firmware side no longer uses the detect orientation routine which confuses the QGC state machine. QGC expects orientation detection for all gyro/mag/accel calibrations since it used the same UI to show visuals for all of these. Without this QGC never shows you the Hold Still message.