### PR TITLE
Tweak SetupButton width

### DIFF
--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -49,7 +49,7 @@ Button {
 
                     readonly property real indicatorRadius: 4
 
-                    x: parent.width - (indicatorRadius * 2) - 5
+                    x: parent.width - (indicatorRadius * 2) - 3
                     y: (parent.height - (indicatorRadius * 2)) / 2
                     width: indicatorRadius * 2
                     height: indicatorRadius * 2

--- a/src/VehicleSetup/SetupView.ui
+++ b/src/VehicleSetup/SetupView.ui
@@ -36,13 +36,13 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>120</width>
+       <width>125</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>120</width>
+       <width>125</width>
        <height>16777215</height>
       </size>
      </property>


### PR DESCRIPTION
This prevents the indicator from overlapping the “Flight Modes” text