### PR TITLE
Adding Battery Consumption to the tool bar.

### DIFF
--- a/src/QmlControls/MavManager.cc
+++ b/src/QmlControls/MavManager.cc
@@ -57,6 +57,7 @@ MavManager::MavManager(QObject *parent)
     , _refreshTimer(new QTimer(this))
     , _batteryVoltage(0.0)
     , _batteryPercent(0.0)
+    , _batteryConsumed(0.0)
     , _systemArmed(false)
     , _currentHeartbeatTimeout(0)
     , _waypointDistance(0.0)
@@ -108,6 +109,7 @@ void MavManager::_forgetUAS(UASInterface* uas)
         disconnect(_mav, &UASInterface::NavigationControllerDataChanged, this, &MavManager::_updateNavigationControllerData);
         disconnect(_mav, &UASInterface::heartbeatTimeout,                this, &MavManager::_heartbeatTimeout);
         disconnect(_mav, &UASInterface::batteryChanged,                  this, &MavManager::_updateBatteryRemaining);
+        disconnect(_mav, &UASInterface::batteryConsumedChanged,          this, &MavManager::_updateBatteryConsumedChanged);
         disconnect(_mav, &UASInterface::modeChanged,                     this, &MavManager::_updateMode);
         disconnect(_mav, &UASInterface::nameChanged,                     this, &MavManager::_updateName);
         disconnect(_mav, &UASInterface::systemTypeSet,                   this, &MavManager::_setSystemType);
@@ -157,6 +159,7 @@ void MavManager::_setActiveUAS(UASInterface* uas)
         connect(_mav, &UASInterface::NavigationControllerDataChanged,   this, &MavManager::_updateNavigationControllerData);
         connect(_mav, &UASInterface::heartbeatTimeout,                  this, &MavManager::_heartbeatTimeout);
         connect(_mav, &UASInterface::batteryChanged,                    this, &MavManager::_updateBatteryRemaining);
+        connect(_mav, &UASInterface::batteryConsumedChanged,            this, &MavManager::_updateBatteryConsumedChanged);
         connect(_mav, &UASInterface::modeChanged,                       this, &MavManager::_updateMode);
         connect(_mav, &UASInterface::nameChanged,                       this, &MavManager::_updateName);
         connect(_mav, &UASInterface::systemTypeSet,                     this, &MavManager::_setSystemType);
@@ -436,6 +439,15 @@ void MavManager::_updateBatteryRemaining(UASInterface*, double voltage, double, 
         emit batteryPercentChanged();
     }
 }
+
+void MavManager::_updateBatteryConsumedChanged(UASInterface*, double current_consumed)
+{
+    if(_batteryConsumed != current_consumed) {
+        _batteryConsumed = current_consumed;
+        emit batteryConsumedChanged();
+    }
+}
+
 
 void MavManager::_updateState(UASInterface*, QString name, QString)
 {

--- a/src/QmlControls/MavManager.h
+++ b/src/QmlControls/MavManager.h
@@ -76,6 +76,7 @@ public:
     Q_PROPERTY(bool         mavPresent          READ mavPresent         NOTIFY mavPresentChanged)
     Q_PROPERTY(double       batteryVoltage      READ batteryVoltage     NOTIFY batteryVoltageChanged)
     Q_PROPERTY(double       batteryPercent      READ batteryPercent     NOTIFY batteryPercentChanged)
+    Q_PROPERTY(double       batteryConsumed     READ batteryConsumed    NOTIFY batteryConsumedChanged)
     Q_PROPERTY(bool         systemArmed         READ systemArmed        NOTIFY systemArmedChanged)
     Q_PROPERTY(QString      currentMode         READ currentMode        NOTIFY currentModeChanged)
     Q_PROPERTY(QString      systemPixmap        READ systemPixmap       NOTIFY systemPixmapChanged)
@@ -103,6 +104,7 @@ public:
     int             satelliteCount      () { return _satelliteCount; }
     double          batteryVoltage      () { return _batteryVoltage; }
     double          batteryPercent      () { return _batteryPercent; }
+    double          batteryConsumed     () { return _batteryConsumed; }
     bool            systemArmed         () { return _systemArmed; }
     QString         currentMode         () { return _currentMode; }
     QString         systemPixmap        () { return _systemPixmap; }
@@ -130,6 +132,7 @@ signals:
     void mavPresentChanged      ();
     void batteryVoltageChanged  ();
     void batteryPercentChanged  ();
+    void batteryConsumedChanged ();
     void systemArmedChanged     ();
     void heartbeatTimeoutChanged();
     void currentModeChanged     ();
@@ -158,6 +161,7 @@ private slots:
     void _setActiveUAS                      (UASInterface* uas);
     void _checkUpdate                       ();
     void _updateBatteryRemaining            (UASInterface*, double voltage, double, double percent, int);
+    void _updateBatteryConsumedChanged      (UASInterface*, double current_consumed);
     void _updateArmingState                 (bool armed);
     void _updateState                       (UASInterface* system, QString name, QString description);
     void _updateMode                        (int system, QString name, QString description);
@@ -197,6 +201,7 @@ private:
     QList<int>      _changes;
     double          _batteryVoltage;
     double          _batteryPercent;
+    double          _batteryConsumed;
     bool            _systemArmed;
     QString         _currentState;
     QString         _currentMode;

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -559,6 +559,19 @@ void UAS::receiveMessage(LinkInterface* link, mavlink_message_t message)
         }
 
             break;
+
+        case MAVLINK_MSG_ID_BATTERY_STATUS:
+        {
+            if (multiComponentSourceDetected && wrongComponent)
+            {
+                break;
+            }
+            mavlink_battery_status_t bat_status;
+            mavlink_msg_battery_status_decode(&message, &bat_status);
+            emit batteryConsumedChanged(this, (double)bat_status.current_consumed);
+        }
+            break;
+
         case MAVLINK_MSG_ID_SYS_STATUS:
         {
             if (multiComponentSourceDetected && wrongComponent)

--- a/src/uas/UASInterface.h
+++ b/src/uas/UASInterface.h
@@ -488,6 +488,7 @@ signals:
      * @param seconds estimated remaining flight time in seconds
      */
     void batteryChanged(UASInterface* uas, double voltage, double current, double percent, int seconds);
+    void batteryConsumedChanged(UASInterface* uas, double current_consumed);
     void statusChanged(UASInterface* uas, QString status);
     void actuatorChanged(UASInterface*, int actId, double value);
     void thrustChanged(UASInterface*, double thrust);

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -526,15 +526,14 @@ Rectangle {
             }
 
             Rectangle {
-                id: battery
-                width: getProportionalDimmension(60)
+                id: batteryStatus
+                width:  MavManager.batteryConsumed < 0.0 ? getProportionalDimmension(60) : getProportionalDimmension(80)
                 height: cellHeight
                 visible: showMavStatus() && (mainToolBar.showBattery)
                 anchors.verticalCenter: parent.verticalCenter
                 color:  getBatteryColor();
                 border.color: "#00000000"
                 border.width: 0
-
                 Image {
                     source: getBatteryIcon();
                     height: getProportionalDimmension(20)
@@ -547,15 +546,37 @@ Rectangle {
                 }
 
                 QGCLabel {
-                    id: batteryText
+                    visible: batteryStatus.visible && MavManager.batteryConsumed < 0.0
                     text: MavManager.batteryVoltage.toFixed(1) + 'V';
                     font.pointSize: ScreenTools.fontPointFactor * (11);
                     font.weight: Font.DemiBold
-                    anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
                     anchors.rightMargin: getProportionalDimmension(6)
                     horizontalAlignment: Text.AlignRight
                     color: colorWhite
+                }
+
+                Column {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.right:          parent.right
+                    anchors.rightMargin:    getProportionalDimmension(6)
+                    visible: batteryStatus.visible && MavManager.batteryConsumed >= 0.0
+                    QGCLabel {
+                        text: MavManager.batteryVoltage.toFixed(1) + 'V';
+                        width: getProportionalDimmension(30)
+                        horizontalAlignment: Text.AlignRight
+                        font.pointSize: ScreenTools.fontPointFactor * (11);
+                        font.weight: Font.DemiBold
+                        color: colorWhite
+                    }
+                    QGCLabel {
+                        text: MavManager.batteryConsumed.toFixed(0) + 'mA';
+                        width: getProportionalDimmension(30)
+                        horizontalAlignment: Text.AlignRight
+                        font.pointSize: ScreenTools.fontPointFactor * (11);
+                        font.weight: Font.DemiBold
+                        color: colorWhite
+                    }
                 }
             }
 


### PR DESCRIPTION
Adding battery consumption to the toolbar.

It doesn't seem to be working though. I haven't had the time to dig too deep but even with full throttle, the rate of increase didn't change from that shown at idle (disarmed and motors off). After a minute or so of full throttle (theoretically a good 2A discharge), it still shows around 100mA.

P.S. Throttle response seems to be completely out of whack. Again, I didn't have time to dig further but at first only three motors (out of six) started and moving the throttle all the way up did nothing. After quite a while, all of the sudden, all motors started at full throttle scaring the crap out of me. All this in *Manual* mode.

P.P.S The error messages are related to the radio as I was messing with it and it kept connecting and disconnecting before I started the tests.

![screen shot 2015-05-18 at 3 49 49 pm](https://cloud.githubusercontent.com/assets/749243/7689009/1e07440e-fd77-11e4-992f-cea30b25244f.png)
