### PR TITLE
Animation fix

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -186,7 +186,7 @@ QGCView {
                 Component {
                     id: compass0ComponentLabel
 
-                    QGCLabel { text: "Compass Orientation" }
+                    QGCLabel { text: "External Compass Orientation" }
                 }
                 Component {
                     id: compass0ComponentCombo
@@ -470,7 +470,7 @@ QGCView {
                     Column {
                         x: parent.width - rotationColumnWidth
 
-                        QGCLabel { text: "Autpilot Orientation" }
+                        QGCLabel { text: "Autopilot Orientation" }
 
                         FactComboBox {
                             id:     boardRotationCombo
@@ -483,7 +483,7 @@ QGCView {
                         Component {
                             id: compass0ComponentLabel2
 
-                            QGCLabel { text: "Compass Orientation" }
+                            QGCLabel { text: "External Compass Orientation" }
                         }
                         Component {
                             id: compass0ComponentCombo2

--- a/src/QmlControls/QGCView.qml
+++ b/src/QmlControls/QGCView.qml
@@ -106,7 +106,15 @@ FactPanel {
         }
     }
 
+    function __stopAllAnimations() {
+        if (__animateHideDialog.running) {
+            __animateHideDialog.stop()
+        }
+    }
+
     function showDialog(component, title, charWidth, buttons) {
+        __stopAllAnimations()
+
         __dialogCharWidth = charWidth
         __dialogTitle = title
 
@@ -120,6 +128,8 @@ FactPanel {
     }
 
     function showMessage(title, message, buttons) {
+        __stopAllAnimations()
+
         __dialogCharWidth = 50
         __dialogTitle = title
         __messageDialogText = message


### PR DESCRIPTION
Showing a new dialog while the animation from a previous hide was still playing would lead to the panel still being overlaid.

Also fixed some typos, and changed some naming.