### PR TITLE
Validate against Acro switch setting

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
@@ -38,7 +38,8 @@ static const SwitchListItem switchList[] = {
     { "RC_MAP_MODE_SW",     "Mode Switch:" },                // First entry must be mode switch
     { "RC_MAP_POSCTL_SW",   "Position Control Switch:" },
     { "RC_MAP_LOITER_SW",   "Loiter Switch:" },
-    { "RC_MAP_RETURN_SW",   "Return Switch:" }
+    { "RC_MAP_RETURN_SW",   "Return Switch:" },
+    { "RC_MAP_ACRO_SW",     "Acro Switch:" },
 };
 static const size_t cSwitchList = sizeof(switchList) / sizeof(switchList[0]);
 

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
@@ -47,29 +47,31 @@ Item {
     Component {
         id: validComponent
 
-        Rectangle {
-            Fact { id: rc_map_throttle;     name: "RC_MAP_THROTTLE" }
-            Fact { id: rc_map_yaw;          name: "RC_MAP_YAW" }
-            Fact { id: rc_map_pitch;        name: "RC_MAP_PITCH" }
-            Fact { id: rc_map_roll;         name: "RC_MAP_ROLL" }
-            Fact { id: rc_map_flaps;        name: "RC_MAP_FLAPS" }
-            Fact { id: rc_map_aux1;         name: "RC_MAP_AUX1" }
-            Fact { id: rc_map_aux2;         name: "RC_MAP_AUX2" }
+        FactPanel {
+            Fact { id: rc_map_throttle;     name: "RC_MAP_THROTTLE"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_yaw;          name: "RC_MAP_YAW"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_pitch;        name: "RC_MAP_PITCH"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_roll;         name: "RC_MAP_ROLL"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_flaps;        name: "RC_MAP_FLAPS"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_aux1;         name: "RC_MAP_AUX1"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_aux2;         name: "RC_MAP_AUX2"; onFactMissing: showMissingFactOverlay(name) }
 
-            Fact { id: rc_map_mode_sw;      name: "RC_MAP_MODE_SW" }
-            Fact { id: rc_map_posctl_sw;    name: "RC_MAP_POSCTL_SW" }
-            Fact { id: rc_map_return_sw;    name: "RC_MAP_RETURN_SW" }
-            Fact { id: rc_map_offboard_sw;  name: "RC_MAP_OFFB_SW" }
-            Fact { id: rc_map_loiter_sw;    name: "RC_MAP_LOITER_SW" }
+            Fact { id: rc_map_mode_sw;      name: "RC_MAP_MODE_SW"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_posctl_sw;    name: "RC_MAP_POSCTL_SW"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_return_sw;    name: "RC_MAP_RETURN_SW"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_offboard_sw;  name: "RC_MAP_OFFB_SW"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_loiter_sw;    name: "RC_MAP_LOITER_SW"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_map_acro_sw;      name: "RC_MAP_ACRO_SW"; onFactMissing: showMissingFactOverlay(name) }
 
-            Fact { id: rc_assist_th;        name: "RC_ASSIST_TH" }
-            Fact { id: rc_posctl_th;        name: "RC_POSCTL_TH" }
-            Fact { id: rc_auto_th;          name: "RC_AUTO_TH" }
-            Fact { id: rc_loiter_th;        name: "RC_LOITER_TH" }
-            Fact { id: rc_return_th;        name: "RC_RETURN_TH" }
-            Fact { id: rc_offboard_th;      name: "RC_OFFB_TH" }
+            Fact { id: rc_posctl_th;        name: "RC_POSCTL_TH"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_return_th;        name: "RC_RETURN_TH"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_offboard_th;      name: "RC_OFFB_TH"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_loiter_th;        name: "RC_LOITER_TH"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_acro_th;          name: "RC_ACRO_TH"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_assist_th;        name: "RC_ASSIST_TH"; onFactMissing: showMissingFactOverlay(name) }
+            Fact { id: rc_auto_th;          name: "RC_AUTO_TH"; onFactMissing: showMissingFactOverlay(name) }
 
-            Fact { id: rc_th_user;          name: "RC_TH_USER" }
+            Fact { id: rc_th_user;          name: "RC_TH_USER"; onFactMissing: showMissingFactOverlay(name) }
 
             property int throttleChannel:   rc_map_throttle.value
             property int yawChannel:        rc_map_yaw.value
@@ -97,9 +99,6 @@ Item {
             readonly property int progressBarHeight: 200
 
             anchors.fill: parent
-
-
-            color: qgcPal.window
 
             Component {
                 id: dragHandle
@@ -136,7 +135,7 @@ Item {
                 id: unassignedModeTileComponent
 
                 Rectangle {
-                    Fact { id: fact; name: tileParam }
+                    Fact { id: fact; name: tileParam; onFactMissing: showMissingFactOverlay(name) }
                     property bool dragEnabled: fact.value == 0
 
                     id:             outerRect
@@ -222,7 +221,7 @@ Item {
                 id: assignedModeTileComponent
 
                 Rectangle {
-                    Fact { id: fact; name: tileDragEnabled ? tileParam : "" }
+                    Fact { id: fact; name: tileDragEnabled ? tileParam : ""; onFactMissing: showMissingFactOverlay(name) }
 
                     width:          tileWidth
                     height:         tileHeight

--- a/src/AutoPilotPlugins/PX4/FlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentController.cc
@@ -77,6 +77,12 @@ void FlightModesComponentController::_validateConfiguration(void)
         _channelCount = _chanMax;
     }
     
+    // Acro is not full supported yet. If Acro is mapped you uhave to set up the hard way.
+    if (_autoPilotPlugin->getParameterFact("RC_MAP_ACRO_SW")->value().toInt() != 0) {
+        _validConfiguration = false;
+        _configurationErrors += "Flight Mode setup does not yet support Acro switch";
+    }
+    
     // Make sure switches are valid and within channel range
     
     QStringList switchParams, switchNames;

--- a/src/qgcunittest/PX4RCCalibrationTest.cc
+++ b/src/qgcunittest/PX4RCCalibrationTest.cc
@@ -409,7 +409,7 @@ void PX4RCCalibrationTest::_fullCalibration_test(void)
                 // First make sure this function isn't being use for a switch
                 
                 QStringList switchList;
-                switchList << "RC_MAP_MODE_SW" << "RC_MAP_LOITER_SW" << "RC_MAP_RETURN_SW" << "RC_MAP_POSCTL_SW";
+                switchList << "RC_MAP_MODE_SW" << "RC_MAP_LOITER_SW" << "RC_MAP_RETURN_SW" << "RC_MAP_POSCTL_SW" << "RC_MAP_ACRO_SW";
                 
                 foreach (QString switchParam, switchList) {
                     Q_ASSERT(_autopilot->getParameterFact(switchParam)->value().toInt() != channel + 1);

--- a/src/ui/px4_configuration/PX4RCCalibration.cc
+++ b/src/ui/px4_configuration/PX4RCCalibration.cc
@@ -76,6 +76,7 @@ const struct PX4RCCalibration::FunctionInfo PX4RCCalibration::_rgFunctionInfo[PX
     { "RC_MAP_POSCTL_SW" },
     { "RC_MAP_LOITER_SW" },
     { "RC_MAP_RETURN_SW" },
+    { "RC_MAP_ACRO_SW" },
     { "RC_MAP_FLAPS" },
     { "RC_MAP_AUX1" },
     { "RC_MAP_AUX2" },

--- a/src/ui/px4_configuration/PX4RCCalibration.h
+++ b/src/ui/px4_configuration/PX4RCCalibration.h
@@ -78,7 +78,7 @@ private slots:
     
 private:
     /// @brief These identify the various controls functions. They are also used as indices into the _rgFunctioInfo
-    /// aray.
+    /// array.
     enum rcCalFunctions {
         rcCalFunctionRoll,
         rcCalFunctionPitch,
@@ -88,6 +88,7 @@ private:
         rcCalFunctionPosCtlSwitch,
         rcCalFunctionLoiterSwitch,
         rcCalFunctionReturnSwitch,
+        rcCalFunctionAcroSwitch,
         rcCalFunctionFlaps,
         rcCalFunctionAux1,
         rcCalFunctionAux2,


### PR DESCRIPTION
This is the first phase of Acro switch support. It just prevents QGC from doing the wrong thing if the acro switch is configured. Support for setting macro switch in Flight Mode setup is not yet supported.