### PR TITLE
VTOL tilt-rotor airspeed sensor

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponent.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.cc
@@ -89,7 +89,8 @@ QStringList SensorsComponent::setupCompleteChangedTriggerList(void) const
     triggers << "CAL_MAG0_ID" << "CAL_GYRO0_ID" << "CAL_ACC0_ID";
     if (_uas->getSystemType() == MAV_TYPE_FIXED_WING ||
         _uas->getSystemType() == MAV_TYPE_VTOL_DUOROTOR ||
-        _uas->getSystemType() == MAV_TYPE_VTOL_QUADROTOR) {
+        _uas->getSystemType() == MAV_TYPE_VTOL_QUADROTOR ||
+        _uas->getSystemType() == MAV_TYPE_VTOL_TILTROTOR) {
         triggers << "SENS_DPRES_OFF";
     }
     
@@ -117,7 +118,8 @@ QUrl SensorsComponent::summaryQmlSource(void) const
     qDebug() << _uas->getSystemType();
     if (_uas->getSystemType() == MAV_TYPE_FIXED_WING ||
         _uas->getSystemType() == MAV_TYPE_VTOL_DUOROTOR ||
-        _uas->getSystemType() == MAV_TYPE_VTOL_QUADROTOR) {
+        _uas->getSystemType() == MAV_TYPE_VTOL_QUADROTOR ||
+        _uas->getSystemType() == MAV_TYPE_VTOL_TILTROTOR) {
         summaryQml = "qrc:/qml/SensorsComponentSummaryFixedWing.qml";
     } else {
         summaryQml = "qrc:/qml/SensorsComponentSummary.qml";

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -431,7 +431,8 @@ bool SensorsComponentController::fixedWing(void)
     Q_ASSERT(uas);
     return uas->getSystemType() == MAV_TYPE_FIXED_WING ||
             uas->getSystemType() == MAV_TYPE_VTOL_DUOROTOR ||
-            uas->getSystemType() == MAV_TYPE_VTOL_QUADROTOR;
+            uas->getSystemType() == MAV_TYPE_VTOL_QUADROTOR ||
+            uas->getSystemType() == MAV_TYPE_VTOL_TILTROTOR;
 }
 
 void SensorsComponentController::_updateAndEmitShowOrientationCalArea(bool show)


### PR DESCRIPTION
Do not merge.
missing submodule pull request : https://github.com/mavlink/mavlink/pull/372

Added MAV_TYPE_VTOL_TILTROTOR for vtol tilt-rotor airspeed sensor calibration.