### PR TITLE
basic ubuntu ppa instructions

### DIFF
--- a/deploy/ubuntu_ppa
+++ b/deploy/ubuntu_ppa
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+version="2.4"
+rsync -av --delete --exclude=.git ~/git/qgroundcontrol/ ~/tmp/qgroundcontrol-${version}/
+
+cd ~/tmp
+tar pczf qgroundcontrol_${version}.orig.tar.gz qgroundcontrol-${version}
+
+cd ~/tmp/qgroundcontrol-${version}/
+debuild -S
+
+dput ppa:qgroundcontrol/ppa qgroundcontrol_${version}-0ubuntu1_source.changes
+
+
+
+# test building the source deb locally
+debuild --prepend-path=/usr/lib/ccache -sa


### PR DESCRIPTION
I updated the Ubuntu ppa to Stable 2.4 by doing this. It could be turned into a proper script if we get the version out somehow and properly handle the paths.

I still can't register for the wiki (the captcha doesn't work?). Can you readd the instructions?