### PR TITLE
Acro switch support

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentController.cc
@@ -72,19 +72,13 @@ void FlightModesComponentController::_validateConfiguration(void)
         _channelCount = _chanMax;
     }
     
-    // Acro is not full supported yet. If Acro is mapped you uhave to set up the hard way.
-    if (getParameterFact(FactSystem::defaultComponentId, "RC_MAP_ACRO_SW")->value().toInt() != 0) {
-        _validConfiguration = false;
-        _configurationErrors += "Flight Mode setup does not yet support Acro switch";
-    }
-    
     // Make sure switches are valid and within channel range
     
     QStringList switchParams, switchNames;
     QList<int> switchMappings;
     
-    switchParams << "RC_MAP_MODE_SW" << "RC_MAP_RETURN_SW" << "RC_MAP_LOITER_SW" << "RC_MAP_POSCTL_SW" << "RC_MAP_OFFB_SW";
-    switchNames << "Mode Switch" << "Return Switch" << "Loiter Switch" << "PosCtl Switch" << "Offboard Switch";
+    switchParams << "RC_MAP_MODE_SW" << "RC_MAP_RETURN_SW" << "RC_MAP_LOITER_SW" << "RC_MAP_POSCTL_SW" << "RC_MAP_OFFB_SW" << "RC_MAP_ACRO_SW";
+    switchNames << "Mode Switch" << "Return Switch" << "Loiter Switch" << "PosCtl Switch" << "Offboard Switch" << "Acro Switch";
     
     for(int i=0; i<switchParams.count(); i++) {
         int map = getParameterFact(FactSystem::defaultComponentId, switchParams[i])->value().toInt();
@@ -224,3 +218,7 @@ double FlightModesComponentController::posCtlSwitchLiveRange(void)
     return _switchLiveRange("RC_MAP_POSCTL_SW");
 }
 
+double FlightModesComponentController::acroSwitchLiveRange(void)
+{
+    return _switchLiveRange("RC_MAP_ACRO_SW");
+}

--- a/src/AutoPilotPlugins/PX4/FlightModesComponentController.h
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentController.h
@@ -54,6 +54,7 @@ public:
     Q_PROPERTY(double posCtlSwitchLiveRange READ posCtlSwitchLiveRange NOTIFY switchLiveRangeChanged)
     Q_PROPERTY(double returnSwitchLiveRange READ returnSwitchLiveRange NOTIFY switchLiveRangeChanged)
     Q_PROPERTY(double offboardSwitchLiveRange READ offboardSwitchLiveRange NOTIFY switchLiveRangeChanged)
+    Q_PROPERTY(double acroSwitchLiveRange READ acroSwitchLiveRange NOTIFY switchLiveRangeChanged)
     
     Q_PROPERTY(bool sendLiveRCSwitchRanges READ sendLiveRCSwitchRanges WRITE setSendLiveRCSwitchRanges NOTIFY liveRCSwitchRangesChanged)
     
@@ -62,6 +63,7 @@ public:
     double posCtlSwitchLiveRange(void);
     double returnSwitchLiveRange(void);
     double offboardSwitchLiveRange(void);
+    double acroSwitchLiveRange(void);
     
     bool sendLiveRCSwitchRanges(void) { return _liveRCValues; }
     void setSendLiveRCSwitchRanges(bool start);


### PR DESCRIPTION
Support for the Acro switch in Flight Mode setup. Given the fact that whenever I go into flight modes the various switch combinations make my head hurt this could use some testing from someone other than me. 

The Acro switch works just like PostCtl and Loiter switches in that:
- It can be assigned to the same channel as the mode switch
- It can be assigned to a completely separate channel
- It can be assigned to the same channel as the PostCtl and/or Loiter switches