### PR TITLE
Include .pdb in windows installer

### DIFF
--- a/QGCInstaller.pri
+++ b/QGCInstaller.pri
@@ -29,10 +29,12 @@ installer {
     }
 
     WindowsBuild {
-		QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY $${DESTDIR_WIN}\\qgroundcontrol.pdb
-		QMAKE_POST_LINK += $$escape_expand(\\n) del $${DESTDIR_WIN}\\qgroundcontrol.pdb
+		# The pdb moving command are commented out for now since we are including the .pdb in the installer. This makes it much
+		# easier to debug user crashes.
+		#QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY $${DESTDIR_WIN}\\qgroundcontrol.pdb
+		#QMAKE_POST_LINK += $$escape_expand(\\n) del $${DESTDIR_WIN}\\qgroundcontrol.pdb
         QMAKE_POST_LINK += $$escape_expand(\\n) $$quote("\"C:\\Program Files \(x86\)\\NSIS\\makensis.exe\"" /NOCD "\"/XOutFile $${DESTDIR_WIN}\\qgroundcontrol-installer-win32.exe\"" "$$BASEDIR_WIN\\deploy\\qgroundcontrol_installer.nsi")
-		QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY qgroundcontrol.pdb $${DESTDIR_WIN}
-		QMAKE_POST_LINK += $$escape_expand(\\n) del qgroundcontrol.pdb
+		#QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY qgroundcontrol.pdb $${DESTDIR_WIN}
+		#QMAKE_POST_LINK += $$escape_expand(\\n) del qgroundcontrol.pdb
     }
 }


### PR DESCRIPTION
Daily builds include groundcontrol.pdb in installer to aid in debugging user crashes.