### PR TITLE
Enabling Zeroconf (Bonjour) on Mac OS/iOS

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -278,3 +278,19 @@ else:WindowsBuild {
     DEFINES += QGC_SPEECH_ENABLED
     LIBS    += -lOle32
 }
+
+#
+# [OPTIONAL] Zeroconf for UDP links
+#
+contains (DEFINES, DISABLE_ZEROCONF) {
+    message("Skipping support for Zeroconf (manual override from command line)")
+    DEFINES -= DISABLE_ZEROCONF
+# Otherwise the user can still disable this feature in the user_config.pri file.
+} else:exists(user_config.pri):infile(user_config.pri, DEFINES, DISABLE_ZEROCONF) {
+    message("Skipping support for Zeroconf (manual override from user_config.pri)")
+# Mac support is built into OS
+} else:MacBuild|iOSBuild {
+    message("Including support for Zeroconf (Bonjour)")
+    DEFINES += QGC_ZEROCONF_ENABLED
+}
+

--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -292,5 +292,7 @@ contains (DEFINES, DISABLE_ZEROCONF) {
 } else:MacBuild|iOSBuild {
     message("Including support for Zeroconf (Bonjour)")
     DEFINES += QGC_ZEROCONF_ENABLED
+} else {
+    message("Skipping support for Zeroconf (unsupported platform)")
 }
 

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -77,7 +77,9 @@ static QString get_ip_address(const QString& address)
 UDPLink::UDPLink(UDPConfiguration* config)
     : _socket(NULL)
     , _connectState(false)
+    #if defined(QGC_ZEROCONF_ENABLED)
     , _dnssServiceRef(NULL)
+    #endif
 {
     Q_ASSERT(config != NULL);
     _config = config;

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -205,9 +205,10 @@ private:
     bool _hardwareConnect();
     void _restartConnection();
 
-#if defined(QGC_ZEROCONF_ENABLED)
     void _registerZeroconf(uint16_t port, const std::string& regType);
     void _deregisterZeroconf();
+
+#if defined(QGC_ZEROCONF_ENABLED)
     DNSServiceRef  _dnssServiceRef;
 #endif
 

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -37,6 +37,10 @@ This file is part of the QGROUNDCONTROL project
 #include <QMutex>
 #include <QUdpSocket>
 
+#if defined(QGC_ZEROCONF_ENABLED)
+#include <dns_sd.h>
+#endif
+
 #include "QGCConfig.h"
 #include "LinkManager.h"
 
@@ -200,6 +204,12 @@ private:
 
     bool _hardwareConnect();
     void _restartConnection();
+
+#if defined(QGC_ZEROCONF_ENABLED)
+    void _registerZeroconf(uint16_t port, const std::string& regType);
+    void _deregisterZeroconf();
+    DNSServiceRef  _dnssServiceRef;
+#endif
 
 signals:
     //Signals are defined by LinkInterface


### PR DESCRIPTION
This will allow a client to find QGC without knowing its IP address. It greatly simplifies the configuration of UDP links.

For now it's only enabled for Mac OS and iOS (they both have support built in). Linux is next once I figure out how to deal with a system that doesn't have Avahi installed.

It is possible to use it for Windows but it would require installing the Bonjour SDK for Windows in order to build and to have the Bonjour service installed for it to run. Too much work for an experimental feature.

To use it, just browse for a service called: *_qgroundcontrol._udp*