### PR TITLE
Add AeroCore support to firmware upgrade utility and link manager.

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -167,7 +167,14 @@ void FirmwareUpgradeController::_getFirmwareFile(void)
         "http://px4-travis.s3.amazonaws.com/Firmware/beta/px4fmu-v2_default.px4",
         "http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v2_default.px4"
     };
-    
+
+    static const char* rgAeroCoreFirmware[3] =
+    {
+	"http://s3-us-west-2.amazonaws.com/gumstix-aerocore/PX4/stable/aerocore_default.px4",
+	"http://s3-us-west-2.amazonaws.com/gumstix-aerocore/PX4/beta/aerocore_default.px4",
+	"http://s3-us-west-2.amazonaws.com/gumstix-aerocore/PX4/master/aerocore_default.px4"
+    };
+
     static const char* rgPX4FlowFirmware[3] =
     {
         "http://px4-travis.s3.amazonaws.com/Flow/master/px4flow.px4",
@@ -190,7 +197,11 @@ void FirmwareUpgradeController::_getFirmwareFile(void)
         case _boardIDPX4FMUV2:
             prgFirmware = rgPX4FMUV2Firmware;
             break;
-            
+
+	case _boardIDAeroCore:
+            prgFirmware = rgAeroCoreFirmware;
+            break;
+
         default:
             prgFirmware = NULL;
             break;
@@ -427,7 +438,9 @@ void FirmwareUpgradeController::_downloadFinished(void)
             firmwareBoardID = _boardIDPX4Flow;
         } else if (downloadFilename.toLower().contains("px4fmu-v1")) {
             firmwareBoardID = _boardIDPX4FMUV1;
-        }
+        } else if (downloadFilename.toLower().contains("aerocore")) {
+            firmwareBoardID = _boardIDAeroCore;
+	}
         
         if (firmwareBoardID != 0 &&  firmwareBoardID != _boardID) {
             _appendStatusLog(tr("Downloaded firmware board id does not match hardware board id: %1 != %2").arg(firmwareBoardID).arg(_boardID));

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -127,6 +127,7 @@ private:
     static const int _boardIDPX4FMUV1 = 5;  ///< Board ID for PX4 V1 board
     static const int _boardIDPX4FMUV2 = 9;  ///< Board ID for PX4 V2 board
     static const int _boardIDPX4Flow = 6;   ///< Board ID for PX4 Flow board
+    static const int _boardIDAeroCore = 98;   ///< Board ID for Gumstix AeroCore board
 
     uint32_t    _boardID;           ///< Board ID
     uint32_t    _boardFlashSize;    ///< Flash size in bytes of board

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -481,7 +481,10 @@ void LinkManager::_updateConfigurationList(void)
                 }
             } else {
                 // Lets create a new Serial configuration automatically
-                pSerial = new SerialConfiguration(QString("Pixhawk on %1").arg(portInfo.portName().trimmed()));
+		if (portInfo.description() == "AeroCore")
+	                pSerial = new SerialConfiguration(QString("AeroCore on %1").arg(portInfo.portName().trimmed()));
+		else
+	                pSerial = new SerialConfiguration(QString("Pixhawk on %1").arg(portInfo.portName().trimmed()));
                 pSerial->setDynamic(true);
                 pSerial->setPreferred(true);
                 pSerial->setBaud(115200);


### PR DESCRIPTION
This will allow users to easily update their AeroCore boards rather than building the code themselves.

The link manager update just avoids some confusion.  When an AeroCore board is plugged in, it will show "AeroCore on /dev/..." rather than "Pixhawk on /dev/...".