### PR TITLE
Add Copy Trims support

### DIFF
--- a/src/AutoPilotPlugins/PX4/RadioComponent.qml
+++ b/src/AutoPilotPlugins/PX4/RadioComponent.qml
@@ -42,6 +42,7 @@ QGCView {
 
     QGCPalette { id: qgcPal; colorGroupEnabled: panel.enabled }
 
+    readonly property string dialogTitle: "Radio Config"
     readonly property real labelToMonitorMargin: defaultTextWidth * 3
     property bool controllerCompleted: false
     property bool controllerAndViewReady: false
@@ -49,11 +50,15 @@ QGCView {
     function updateChannelCount()
     {
         if (controllerAndViewReady) {
+/*
+            FIXME: Turned off for now, since it prevents binding. Need to restructure to
+            allow binding and still check channel count
             if (controller.channelCount < controller.minChannelCount) {
-                showDialog(channelCountDialogComponent, "Radio Config", 50, 0)
+                showDialog(channelCountDialogComponent, dialogTitle, 50, 0)
             } else {
                 hideDialog()
             }
+*/
         }
     }
 
@@ -88,6 +93,32 @@ QGCView {
     QGCViewPanel {
         id:             panel
         anchors.fill:   parent
+
+        Component {
+            id: copyTrimsDialogComponent
+
+            QGCViewMessage {
+                message: "Center your sticks and move throttle all the way down, then press Ok to copy trims. After pressing Ok, reset the trims on your radio back to zero."
+
+                function accept() {
+                    hideDialog()
+                    controller.copyTrims()
+                }
+            }
+        }
+
+        Component {
+            id: zeroTrimsDialogComponent
+
+            QGCViewMessage {
+                message: "Before calibrating you should zero all your trims and subtrims. Click Ok to start Calibration."
+
+                function accept() {
+                    hideDialog()
+                    controller.nextButtonClicked()
+                }
+            }
+        }
 
         Component {
             id: channelCountDialogComponent
@@ -245,22 +276,6 @@ QGCView {
             anchors.right:  columnSpacer.left
             spacing:        10
 
-            Row {
-                spacing: 10
-
-                QGCLabel {
-                    anchors.baseline:   bindButton.baseline
-                    text:               "Place Spektrum satellite receiver in bind mode:"
-                }
-
-                QGCButton {
-                    id:     bindButton
-                    text:   "Spektrum Bind"
-
-                    onClicked: showDialog(spektrumBindDialogComponent, "Radio Config", 50, StandardButton.Ok | StandardButton.Cancel)
-                }
-            }
-
             // Attitude Controls
             Column {
                 width:      parent.width
@@ -412,7 +427,7 @@ QGCView {
                     primary:    true
                     text:       "Calibrate"
 
-                    onClicked: controller.nextButtonClicked()
+                    onClicked: showDialog(zeroTrimsDialogComponent, dialogTitle, 50, StandardButton.Ok | StandardButton.Cancel)
                 }
             } // Row - Buttons
 
@@ -422,6 +437,35 @@ QGCView {
                 width:      parent.width
                 wrapMode:   Text.WordWrap
             }
+
+            Item {
+                width: 10
+                height: defaultTextHeight * 2
+            }
+
+            QGCLabel { text: "Additional Radio setup:" }
+
+            Row {
+                spacing: 10
+
+                QGCLabel {
+                    anchors.baseline:   bindButton.baseline
+                    text:               "Place Spektrum satellite receiver in bind mode:"
+                }
+
+                QGCButton {
+                    id:     bindButton
+                    text:   "Spektrum Bind"
+
+                    onClicked: showDialog(spektrumBindDialogComponent, dialogTitle, 50, StandardButton.Ok | StandardButton.Cancel)
+                }
+            }
+
+            QGCButton {
+                text: "Copy Trims"
+                onClicked: showDialog(copyTrimsDialogComponent, dialogTitle, 50, StandardButton.Ok | StandardButton.Cancel)
+            }
+
         } // Column - Left Column
 
         Item {

--- a/src/AutoPilotPlugins/PX4/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/RadioComponentController.cc
@@ -1050,3 +1050,8 @@ void RadioComponentController::_signalAllAttiudeValueChanges(void)
     emit yawChannelReversedChanged(yawChannelReversed());
     emit throttleChannelReversedChanged(throttleChannelReversed());
 }
+
+void RadioComponentController::copyTrims(void)
+{
+    _uas->startCalibration(UASInterface::StartCalibrationRadio);
+}

--- a/src/AutoPilotPlugins/PX4/RadioComponentController.h
+++ b/src/AutoPilotPlugins/PX4/RadioComponentController.h
@@ -93,6 +93,7 @@ public:
     Q_INVOKABLE void skipButtonClicked(void);
     Q_INVOKABLE void nextButtonClicked(void);
     Q_INVOKABLE void start(void);
+    Q_INVOKABLE void copyTrims(void);
     
     int rollChannelRCValue(void);
     int pitchChannelRCValue(void);

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1473,6 +1473,9 @@ void UAS::startCalibration(UASInterface::StartCalibrationType calType)
         case StartCalibrationRadio:
             radioCal = 1;
             break;
+        case StartCalibrationCopyTrims:
+            radioCal = 2;
+            break;
         case StartCalibrationAccel:
             accelCal = 1;
             break;

--- a/src/uas/UASInterface.h
+++ b/src/uas/UASInterface.h
@@ -245,7 +245,8 @@ public:
         StartCalibrationAirspeed,
         StartCalibrationAccel,
         StartCalibrationLevel,
-        StartCalibrationEsc
+        StartCalibrationEsc,
+        StartCalibrationCopyTrims
     };
     
     /// Starts the specified calibration


### PR DESCRIPTION
Also:
- Prompts to reset trims to zero prior to calibrate
- Turned of radio check for now since it prevents spectrum bind. Too much change prior to Stable release to fix this now. Issue #1652.

@LorenzMeier I don't have much time today. I've done some amount of testing and it looks to be working. Can you test as well and then I'll start building Stable. I believe I have the list of things done.