### PR TITLE
Added latest error message to Main Flight Display

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -112,40 +112,41 @@
         <file alias="FlightDisplay.qml">src/ui/flightdisplay/FlightDisplay.qml</file>
         <file alias="MapDisplay.qml">src/ui/mapdisplay/MapDisplay.qml</file>
         <!-- QML Main UI Components -->
-        <file alias="QGroundControl/FlightControls/qmldir">src/ui/qmlcommon/qmldir</file>
         <file alias="QGroundControl/FlightControls/QGCAltitudeWidget.qml">src/ui/qmlcommon/QGCAltitudeWidget.qml</file>
-        <file alias="QGroundControl/FlightControls/QGCAttitudeWidget.qml">src/ui/qmlcommon/QGCAttitudeWidget.qml</file>
+        <file alias="QGroundControl/FlightControls/QGCArtificialHorizon.qml">src/ui/qmlcommon/QGCArtificialHorizon.qml</file>
         <file alias="QGroundControl/FlightControls/QGCAttitudeInstrument.qml">src/ui/qmlcommon/QGCAttitudeInstrument.qml</file>
+        <file alias="QGroundControl/FlightControls/QGCAttitudeWidget.qml">src/ui/qmlcommon/QGCAttitudeWidget.qml</file>
         <file alias="QGroundControl/FlightControls/QGCCompass.qml">src/ui/qmlcommon/QGCCompass.qml</file>
         <file alias="QGroundControl/FlightControls/QGCCompassInstrument.qml">src/ui/qmlcommon/QGCCompassInstrument.qml</file>
         <file alias="QGroundControl/FlightControls/QGCCurrentAltitude.qml">src/ui/qmlcommon/QGCCurrentAltitude.qml</file>
         <file alias="QGroundControl/FlightControls/QGCCurrentSpeed.qml">src/ui/qmlcommon/QGCCurrentSpeed.qml</file>
+        <file alias="QGroundControl/FlightControls/QGCHudMessage.qml">src/ui/qmlcommon/QGCHudMessage.qml</file>
         <file alias="QGroundControl/FlightControls/QGCMapBackground.qml">src/ui/qmlcommon/QGCMapBackground.qml</file>
-        <file alias="QGroundControl/FlightControls/QGCPitchWidget.qml">src/ui/qmlcommon/QGCPitchWidget.qml</file>
-        <file alias="QGroundControl/FlightControls/QGCSpeedWidget.qml">src/ui/qmlcommon/QGCSpeedWidget.qml</file>
-        <file alias="QGroundControl/FlightControls/QGCSlider.qml">src/ui/qmlcommon/QGCSlider.qml</file>
-        <file alias="QGroundControl/FlightControls/QGCWaypointEditor.qml">src/ui/qmlcommon/QGCWaypointEditor.qml</file>
         <file alias="QGroundControl/FlightControls/QGCMapToolButton.qml">src/ui/qmlcommon/QGCMapToolButton.qml</file>
-        <file alias="QGroundControl/FlightControls/QGCArtificialHorizon.qml">src/ui/qmlcommon/QGCArtificialHorizon.qml</file>
+        <file alias="QGroundControl/FlightControls/QGCPitchWidget.qml">src/ui/qmlcommon/QGCPitchWidget.qml</file>
+        <file alias="QGroundControl/FlightControls/QGCSlider.qml">src/ui/qmlcommon/QGCSlider.qml</file>
+        <file alias="QGroundControl/FlightControls/QGCSpeedWidget.qml">src/ui/qmlcommon/QGCSpeedWidget.qml</file>
+        <file alias="QGroundControl/FlightControls/QGCWaypointEditor.qml">src/ui/qmlcommon/QGCWaypointEditor.qml</file>
+        <file alias="QGroundControl/FlightControls/qmldir">src/ui/qmlcommon/qmldir</file>
         <!-- QML Map Resources -->
         <file alias="QGroundControl/FlightControls/QGCWaypoint.qml">src/ui/qmlcommon/QGCWaypoint.qml</file>
         <!-- QML Main UI Resources -->
+        <file alias="attitudeDial.svg">src/ui/qmlcommon/attitudeDial.svg</file>
+        <file alias="attitudeInstrument.svg">src/ui/qmlcommon/attitudeInstrument.svg</file>
+        <file alias="attitudePointer.svg">src/ui/qmlcommon/attitudePointer.svg</file>
+        <file alias="buttonHome.svg">src/ui/qmlcommon/buttonHome.svg</file>
+        <file alias="buttonLeft.svg">src/ui/qmlcommon/buttonLeft.svg</file>
+        <file alias="buttonMore.svg">src/ui/qmlcommon/buttonMore.svg</file>
+        <file alias="buttonRight.svg">src/ui/qmlcommon/buttonRight.svg</file>
         <file alias="compass.svg">src/ui/qmlcommon/compass.svg</file>
+        <file alias="compassInstrumentAirplane.svg">src/ui/qmlcommon/compassInstrumentAirplane.svg</file>
+        <file alias="compassInstrumentDial.svg">src/ui/qmlcommon/compassInstrumentDial.svg</file>
         <file alias="compassNeedle.svg">src/ui/qmlcommon/compassNeedle.svg</file>
         <file alias="crossHair.svg">src/ui/qmlcommon/crossHair.svg</file>
         <file alias="rollDialWhite.svg">src/ui/qmlcommon/rollDialWhite.svg</file>
         <file alias="rollPointerWhite.svg">src/ui/qmlcommon/rollPointerWhite.svg</file>
         <file alias="scale.png">src/ui/qmlcommon/scale.png</file>
         <file alias="scale_end.png">src/ui/qmlcommon/scale_end.png</file>
-        <file alias="buttonLeft.svg">src/ui/qmlcommon/buttonLeft.svg</file>
-        <file alias="buttonRight.svg">src/ui/qmlcommon/buttonRight.svg</file>
-        <file alias="buttonHome.svg">src/ui/qmlcommon/buttonHome.svg</file>
-        <file alias="buttonMore.svg">src/ui/qmlcommon/buttonMore.svg</file>
-        <file alias="attitudeInstrument.svg">src/ui/qmlcommon/attitudeInstrument.svg</file>
-        <file alias="attitudeDial.svg">src/ui/qmlcommon/attitudeDial.svg</file>
-        <file alias="attitudePointer.svg">src/ui/qmlcommon/attitudePointer.svg</file>
-        <file alias="compassInstrumentAirplane.svg">src/ui/qmlcommon/compassInstrumentAirplane.svg</file>
-        <file alias="compassInstrumentDial.svg">src/ui/qmlcommon/compassInstrumentDial.svg</file>
     </qresource>
 
     <qresource prefix="/AutoPilotPlugins/PX4">

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -119,6 +119,7 @@ static QObject* screenToolsSingletonFactory(QQmlEngine*, QJSEngine*)
 static QObject* mavManagerSingletonFactory(QQmlEngine*, QJSEngine*)
 {
     MavManager* mavManager = new MavManager;
+    qgcApp()->setMavManager(mavManager);
     return mavManager;
 }
 
@@ -133,10 +134,11 @@ static QObject* mavManagerSingletonFactory(QQmlEngine*, QJSEngine*)
  **/
 
 
-QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting) :
-    QApplication(argc, argv),
-    _runningUnitTests(unitTesting),
-    _styleIsDark(true)
+QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
+    : QApplication(argc, argv)
+    , _runningUnitTests(unitTesting)
+    , _styleIsDark(true)
+    , _pMavManager(NULL)
 {
     Q_ASSERT(_app == NULL);
     _app = this;
@@ -341,7 +343,7 @@ void QGCApplication::_initCommon(void)
     //-- Create QML Singleton Interfaces
     qmlRegisterSingletonType<ScreenTools>("QGroundControl.ScreenTools", 1, 0, "ScreenTools", screenToolsSingletonFactory);
     qmlRegisterSingletonType<MavManager>("QGroundControl.MavManager", 1, 0, "MavManager", mavManagerSingletonFactory);
-    
+
     //-- Register Waypoint Interface
     qmlRegisterInterface<Waypoint>("Waypoint");
 }
@@ -709,7 +711,19 @@ void QGCApplication::_missingParamsDisplay(void)
     }
     _missingParams.clear();
     
-    QGCMessageBox::critical("Missing Parameters",
-                            QString("Parameters missing from firmware: %1.\n\n"
-                                    "You should quit QGroundControl immediately and update your firmware.").arg(params));
+    QGCMessageBox::critical(
+        "Missing Parameters",
+        QString("Parameters missing from firmware: %1.\n\n"
+                "You should quit QGroundControl immediately and update your firmware.").arg(params));
+}
+
+void QGCApplication::setMavManager(MavManager* pMgr)
+{
+    if(!_pMavManager)
+        _pMavManager = pMgr;
+}
+
+MavManager* QGCApplication::getMavManager()
+{
+    return _pMavManager;
 }

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -44,6 +44,7 @@
 // Work around circular header includes
 class QGCSingleton;
 class MainWindow;
+class MavManager;
 
 /**
  * @brief The main application and management class.
@@ -99,6 +100,12 @@ public:
     /// Used to report a missing Parameter. Warning will be displayed to user. Method may be called
     /// multiple times.
     void reportMissingParameter(int componentId, const QString& name);
+
+    /// When the singleton is created, it sets a pointer for subsequent use
+    void setMavManager(MavManager* pMgr);
+
+    /// MavManager accessor
+    MavManager* getMavManager();
     
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
@@ -166,7 +173,8 @@ private:
     static const int    _missingParamsDelayedDisplayTimerTimeout = 1000;  ///< Timeout to wait for next missing fact to come in before display
     QTimer              _missingParamsDelayedDisplayTimer;                ///< Timer use to delay missing fact display
     QStringList         _missingParams;                                  ///< List of missing facts to be displayed
-    
+    MavManager*         _pMavManager;
+
     /// Unit Test have access to creating and destroying singletons
     friend class UnitTest;
 };

--- a/src/uas/UASMessageHandler.cc
+++ b/src/uas/UASMessageHandler.cc
@@ -163,6 +163,17 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     message->_setFormatedText(QString("<p style=\"color:#CCCCCC\">[%2 - COMP:%3]<font style=\"%1\">%4 %5</font></p>").arg(style).arg(dateString).arg(compId).arg(severityText).arg(text));
     _messages.append(message);
     int count = _messages.count();
+    switch (severity)
+    {
+    case MAV_SEVERITY_EMERGENCY:
+    case MAV_SEVERITY_ALERT:
+    case MAV_SEVERITY_CRITICAL:
+    case MAV_SEVERITY_ERROR:
+        _latestError = severityText + " " + text;
+        break;
+    default:
+        break;
+    }
     _mutex.unlock();
     emit textMessageReceived(message);
     emit textMessageCountChanged(count);

--- a/src/uas/UASMessageHandler.h
+++ b/src/uas/UASMessageHandler.h
@@ -107,6 +107,10 @@ public:
      * @brief Get normal message count (Resets count once read)
      */
     int getNormalCount();
+    /**
+     * @brief Get latest error message
+     */
+    QString getLatestError()   { return _latestError; }
 public slots:
     /**
      * @brief Set currently active UAS
@@ -140,6 +144,7 @@ private:
     int _errorCount;
     int _warningCount;
     int _normalCount;
+    QString _latestError;
 };
 
 #endif // QGCMESSAGEHANDLER_H

--- a/src/ui/flightdisplay/FlightDisplay.qml
+++ b/src/ui/flightdisplay/FlightDisplay.qml
@@ -487,6 +487,15 @@ Item {
         z:                  10
     }
 
+    QGCHudMessage {
+        id:     hudMessage
+        y:      ScreenTools.pixelSizeFactor * (5)
+        width:  (parent.width - 520 > 200) ? parent.width - 520 : 200
+        height: ScreenTools.pixelSizeFactor * (30)
+        anchors.horizontalCenter: parent.horizontalCenter
+        z:      mapBackground.z + 1
+    }
+
     QGCCompassInstrument {
         id:                 compassInstrument
         y:                  ScreenTools.pixelSizeFactor * (5)
@@ -494,7 +503,7 @@ Item {
         size:               ScreenTools.pixelSizeFactor * (160)
         heading:            isNaN(MavManager.heading) ? 0 : MavManager.heading
         visible:            mapBackground.visible && showCompass
-        z:                  mapBackground.z + 1
+        z:                  mapBackground.z + 2
         onResetRequested: {
             y               = ScreenTools.pixelSizeFactor * (5)
             x               = ScreenTools.pixelSizeFactor * (85)
@@ -514,7 +523,7 @@ Item {
         visible:            mapBackground.visible && showAttitudeIndicator
         anchors.right:      root.right
         anchors.rightMargin: ScreenTools.pixelSizeFactor * (85)
-        z:                  mapBackground.z + 1
+        z:                  mapBackground.z + 2
         onResetRequested: {
             y                   = ScreenTools.pixelSizeFactor * (5)
             anchors.right       = root.right
@@ -531,7 +540,6 @@ Item {
         rollAngle:          roll
         pitchAngle:         pitch
         visible:            !mapBackground.visible
-        z:                  10
     }
 
     QGCAttitudeWidget {

--- a/src/ui/qmlcommon/QGCHudMessage.qml
+++ b/src/ui/qmlcommon/QGCHudMessage.qml
@@ -1,0 +1,93 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+/**
+ * @file
+ *   @brief QGC HUD Message
+ *   @author Gus Grubba <mavlink@grubba.com>
+ */
+
+import QtQuick 2.4
+import QtQuick.Controls 1.3
+
+import QGroundControl.Controls 1.0
+import QGroundControl.ScreenTools 1.0
+import QGroundControl.MavManager 1.0
+
+Item {
+    id: root
+    visible: MavManager.latestError !== ''
+    Rectangle {
+        anchors.fill:   parent
+        color:          Qt.rgba(0,0,0,0.75)
+        border.color:   Qt.rgba(1,1,1,0.75)
+        radius:         4
+        QGCLabel {
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter:   parent.verticalCenter
+            antialiasing: true
+            font.weight: Font.DemiBold
+            text:  MavManager.latestError
+            color: "#f84444"
+        }
+        OpacityAnimator {
+            id: vanish
+            target: root;
+            from:   1;
+            to:     0;
+            duration: 2000
+            running: false
+        }
+    }
+    Timer {
+        id: vanishTimer
+        interval: 30000
+        running:  false
+        repeat:   false
+        onTriggered: {
+            vanish.start();
+        }
+    }
+    MouseArea {
+        anchors.fill: parent
+        z: 1000
+        acceptedButtons: Qt.LeftButton
+        onClicked: {
+            if (mouse.button == Qt.LeftButton)
+            {
+                vanishTimer.stop();
+                vanish.stop();
+                root.opacity = 0;
+            }
+        }
+    }
+    Connections {
+        target: MavManager
+        onLatestErrorChanged: {
+            vanishTimer.stop();
+            vanish.stop();
+            vanishTimer.start();
+            root.opacity = 1;
+        }
+    }
+}

--- a/src/ui/qmlcommon/qmldir
+++ b/src/ui/qmlcommon/qmldir
@@ -15,3 +15,4 @@ QGCAttitudeInstrument 1.0 QGCAttitudeInstrument.qml
 QGCCompassInstrument  1.0 QGCCompassInstrument.qml
 QGCArtificialHorizon  1.0 QGCArtificialHorizon.qml
 QGCWaypoint           1.0 QGCWaypoint.qml
+QGCHudMessage         1.0 QGCHudMessage.qml

--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -47,17 +47,7 @@ class MainToolBar : public QGCQmlWidgetHolder
 {
     Q_OBJECT
     Q_ENUMS(ViewType_t)
-    Q_ENUMS(MessageType_t)
 public:
-    MainToolBar(QWidget* parent = NULL);
-    ~MainToolBar();
-
-    typedef enum {
-        MessageNone,
-        MessageNormal,
-        MessageWarning,
-        MessageError
-    } MessageType_t;
 
     typedef enum {
         ViewNone    = -1,
@@ -66,6 +56,9 @@ public:
         ViewFly    , // MainWindow::VIEW_FLIGHT
         ViewSetup  , // MainWindow::VIEW_SETUP
     } ViewType_t;
+
+    MainToolBar(QWidget* parent = NULL);
+    ~MainToolBar();
 
     Q_INVOKABLE void    onSetupView();
     Q_INVOKABLE void    onPlanView();
@@ -78,9 +71,6 @@ public:
 
     Q_PROPERTY(ViewType_t    currentView        MEMBER _currentView             NOTIFY currentViewChanged)
     Q_PROPERTY(QStringList   configList         MEMBER _linkConfigurations      NOTIFY configListChanged)
-    Q_PROPERTY(MessageType_t messageType        MEMBER _currentMessageType      NOTIFY messageTypeChanged)
-    Q_PROPERTY(int           newMessageCount    MEMBER _currentMessageCount     NOTIFY newMessageCountChanged)
-    Q_PROPERTY(int           messageCount       MEMBER _messageCount            NOTIFY messageCountChanged)
     Q_PROPERTY(int           connectionCount    READ connectionCount            NOTIFY connectionCountChanged)
     Q_PROPERTY(QStringList   connectedList      MEMBER _connectedList           NOTIFY connectedListChanged)
     Q_PROPERTY(bool          showGPS            MEMBER _showGPS                 NOTIFY showGPSChanged)
@@ -104,9 +94,6 @@ signals:
     void connectionCountChanged         (int count);
     void currentViewChanged             ();
     void configListChanged              ();
-    void messageTypeChanged             (MessageType_t type);
-    void newMessageCountChanged         (int count);
-    void messageCountChanged            (int count);
     void connectedListChanged           (QStringList connectedList);
     void showGPSChanged                 (bool value);
     void showMavChanged                 (bool value);
@@ -124,7 +111,6 @@ private slots:
     void _updateConfigurations          ();
     void _linkConnected                 (LinkInterface* link);
     void _linkDisconnected              (LinkInterface* link);
-    void _handleTextMessage             (int newCount);
     void _leaveMessageView              ();
     void _setProgressBarValue           (float value);
     void _updatePixelSize               ();
@@ -141,12 +127,6 @@ private:
     ViewType_t      _currentView;
     QStringList     _linkConfigurations;
     int             _connectionCount;
-    int             _currentMessageCount;
-    int             _messageCount;
-    int             _currentErrorCount;
-    int             _currentWarningCount;
-    int             _currentNormalCount;
-    MessageType_t   _currentMessageType;
     QStringList     _connectedList;
     bool            _showGPS;
     bool            _showMav;

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -64,20 +64,20 @@ Rectangle {
     }
 
     function getMessageColor() {
-        if(mainToolBar.messageType === MainToolBar.MessageNone)
+        if(MavManager.messageType === MavManager.MessageNone)
             return qgcPal.button;
-        if(mainToolBar.messageType === MainToolBar.MessageNormal)
+        if(MavManager.messageType === MavManager.MessageNormal)
             return colorBlue;
-        if(mainToolBar.messageType === MainToolBar.MessageWarning)
+        if(MavManager.messageType === MavManager.MessageWarning)
             return colorOrange;
-        if(mainToolBar.messageType === MainToolBar.MessageError)
+        if(MavManager.messageType === MavManager.MessageError)
             return colorRed;
         // Cannot be so make make it obnoxious to show error
         return "purple";
     }
 
     function getMessageIcon() {
-        if(mainToolBar.messageType === MainToolBar.MessageNormal || mainToolBar.messageType === MainToolBar.MessageNone)
+        if(MavManager.messageType === MavManager.MessageNormal || MavManager.messageType === MavManager.MessageNone)
             return "qrc:/res/Megaphone";
         else
             return "qrc:/res/Yield";
@@ -311,7 +311,7 @@ Rectangle {
 
             Rectangle {
                 id: messages
-                width: (mainToolBar.messageCount > 99) ? getProportionalDimmension(65) : getProportionalDimmension(60)
+                width: (MavManager.messageCount > 99) ? getProportionalDimmension(65) : getProportionalDimmension(60)
                 height: cellHeight
                 visible: (mainToolBar.connectionCount > 0) && (mainToolBar.showMessages)
                 anchors.verticalCenter: parent.verticalCenter
@@ -337,7 +337,7 @@ Rectangle {
                     width: messages.width - messageIcon.width
                     QGCLabel {
                         id: messageText
-                        text: (mainToolBar.messageCount > 0) ? mainToolBar.messageCount : ''
+                        text: (MavManager.messageCount > 0) ? MavManager.messageCount : ''
                         font.pointSize: ScreenTools.fontPointFactor * (14);
                         font.weight: Font.DemiBold
                         anchors.verticalCenter: parent.verticalCenter
@@ -350,7 +350,7 @@ Rectangle {
                 Image {
                     id: dropDown
                     source: "QGroundControl/Controls/arrow-down.png"
-                    visible: (messages.showTriangle) && (mainToolBar.messageCount > 0)
+                    visible: (messages.showTriangle) && (MavManager.messageCount > 0)
                     anchors.bottom: parent.bottom
                     anchors.right: parent.right
                     anchors.bottomMargin: getProportionalDimmension(3)


### PR DESCRIPTION
Added a message area to the *Main Flight Display* (HUD), showing the latest error message (if any). The message will stay there for 30 seconds, after which, it fades out. If a new message comes in, it replaces the old one and the timeout is reset. Clicking on the message makes it go away.

This is an attempt to ameliorate the issue brought up by #1586.

![screen shot 2015-06-07 at 12 52 49 pm](https://cloud.githubusercontent.com/assets/749243/8024995/70eec11c-0d15-11e5-9c67-f3163ae3fedb.png)

In the process, I moved the message handling out of the Main Toolbar code and into the MavManager, which is shared by all QML elements. The original message icon in the Main Toolbar and its functionality are unchanged.