### PR TITLE
Font to pixels

### DIFF
--- a/resources/styles/style-dark.css
+++ b/resources/styles/style-dark.css
@@ -2,12 +2,16 @@
  This is the master style sheet as well as the dark style. This style sheet should contain both
  color and size/positioning information for all styled controls. This sheet is always loaded first
  Then the user specified style sheet is loaded after it to override and color settings.
+
+ Font sizes are defined with tokens, which are parsed and replaced at run time.
+
 */
 
 * {
     background-color: #222;
     color: #FFF;
-    font-size: 12pt;
+    font-size: FONT_NORMAL;
+    font-weight: lighter;
 }
 
 QWidget#viewModeWidget {
@@ -128,7 +132,7 @@ QGroupBox::title {
     subcontrol-position: top center;
     margin: 0 3px 0 3px;
     padding: 0 3px 0 0;
-    font: bold 8px;
+    font: bold FONT_SMALL;
     color: #DDD;
 }
 
@@ -149,7 +153,7 @@ QLabel:disabled {
 }
 
 QLabel#noUas {
-    font-size: 30pt;
+    font-size: FONT_LARGE;
 }
 
 QMessageBox {
@@ -158,7 +162,7 @@ QMessageBox {
 }
 
 QLabel#tabTitleLabel {
-    font-size: 28pt;
+    font-size: FONT_LARGE;
     font-weight: lighter;
     margin-top: 16px;
     margin-bottom: 8px;
@@ -166,7 +170,7 @@ QLabel#tabTitleLabel {
 
 QLabel#instructionLabel {
     color: #FEC654;
-    font-size: 26pt;
+    font-size: FONT_LARGE;
 }
 
 QLineEdit {
@@ -226,7 +230,7 @@ QPlainTextEdit {
     border: 1px solid #777;
     border-radius: 2px;
     font-family: "Monospace";
-    font: large;
+    font: FONT_SMALL;
 }
 
 QProgressBar {
@@ -529,11 +533,10 @@ UASQuickViewItem QLabel {
     padding: 0;
     margin: 0;
     min-height: 1em;
-    font-weight: bold;
 }
 
 UASQuickViewItem QLabel#value {
-    font-size: 20pt;
+    font-size: FONT_LARGE;
 }
 
 UASView {

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.qml
@@ -97,7 +97,7 @@ QGCView {
         QGCLabel {
             id:             header
             width:          parent.width
-            font.pointSize: ScreenTools.largeFontPointSize
+            font.pixelSize: ScreenTools.largeFontPixelSize
             text:           "AIRFRAME CONFIG"
         }
 

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
@@ -384,7 +384,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: ScreenTools.largeFontPointSize
+                    font.pixelSize: ScreenTools.largeFontPixelSize
                 }
 
                 Item { height: 20; width: 10 } // spacer
@@ -973,7 +973,7 @@ Item {
 
                 QGCLabel {
                     text: "FLIGHT MODES CONFIG"
-                    font.pointSize: ScreenTools.fontPointFactor * (20);
+                    font.pixelSize: ScreenTools.font20;
                 }
 
                 QGCLabel {

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -115,12 +115,12 @@ QGCView {
 
             QGCLabel {
                 text: "POWER CONFIG"
-                font.pointSize: ScreenTools.largeFontPointSize
+                font.pixelSize: ScreenTools.largeFontPixelSize
             }
 
             QGCLabel {
                 text: "Battery"
-                font.pointSize: ScreenTools.mediumFontPointSize
+                font.pixelSize: ScreenTools.mediumFontPixelSize
             }
 
             Rectangle {
@@ -234,7 +234,7 @@ QGCView {
 
             QGCLabel {
                 text:           "ESC Calibration"
-                font.pointSize: ScreenTools.mediumFontPointSize
+                font.pixelSize: ScreenTools.mediumFontPixelSize
             }
 
             Rectangle {
@@ -269,7 +269,7 @@ QGCView {
                     width: (parent.width / 2) - 5
                     QGCLabel {
                         text: "Propeller Function"
-                        font.pointSize: ScreenTools.fontPointFactor * (20);
+                        font.pixelSize: ScreenTools.font20;
                     }
                     Rectangle {
                         width: parent.width
@@ -282,7 +282,7 @@ QGCView {
                     width: (parent.width / 2) - 5
                     QGCLabel {
                         text: "Magnetometer Distortion"
-                        font.pointSize: ScreenTools.fontPointFactor * (20);
+                        font.pixelSize: ScreenTools.font20;
                     }
                     Rectangle {
                         width: parent.width
@@ -301,7 +301,7 @@ QGCView {
             }
             QGCLabel {
                 text: "Advanced Power Settings"
-                font.pointSize: ScreenTools.fontPointFactor * (20);
+                font.pixelSize: ScreenTools.font20;
                 visible: showAdvanced.checked
             }
             Rectangle {

--- a/src/AutoPilotPlugins/PX4/RadioComponent.qml
+++ b/src/AutoPilotPlugins/PX4/RadioComponent.qml
@@ -258,7 +258,7 @@ QGCView {
 
         QGCLabel {
             id:             header
-            font.pointSize: ScreenTools.largeFontPointSize
+            font.pixelSize: ScreenTools.largeFontPixelSize
             text:           "RADIO CONFIG"
         }
 

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -52,7 +52,7 @@ FactPanel {
 
         QGCLabel {
             text: "SAFETY CONFIG"
-            font.pointSize: ScreenTools.largeFontPointSize
+            font.pixelSize: ScreenTools.largeFontPixelSize
         }
 
         Item { height: 20; width: 10 } // spacer
@@ -60,7 +60,7 @@ FactPanel {
         //-----------------------------------------------------------------
         //-- Return Home Triggers
 
-        QGCLabel { text: "Triggers For Return Home"; font.pointSize: ScreenTools.mediumFontPointSize; }
+        QGCLabel { text: "Triggers For Return Home"; font.pixelSize: ScreenTools.mediumFontPixelSize; }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -119,7 +119,7 @@ FactPanel {
         //-----------------------------------------------------------------
         //-- Return Home Settings
 
-        QGCLabel { text: "Return Home Settings"; font.pointSize: ScreenTools.mediumFontPointSize; }
+        QGCLabel { text: "Return Home Settings"; font.pixelSize: ScreenTools.mediumFontPixelSize; }
 
         Item { height: 10; width: 10 } // spacer
 
@@ -290,7 +290,7 @@ FactPanel {
 
         QGCLabel {
             width:          parent.width
-            font.pointSize: ScreenTools.mediumFontPointSize
+            font.pixelSize: ScreenTools.mediumFontPixelSize
             text:           "Warning: You have an advanced safety configuration set using the NAV_RCL_OBC parameter. The above settings may not apply.";
             visible:        fact.value !== 0
             wrapMode:       Text.Wrap
@@ -300,7 +300,7 @@ FactPanel {
 
         QGCLabel {
             width:          parent.width
-            font.pointSize: ScreenTools.mediumFontPointSize
+            font.pixelSize: ScreenTools.mediumFontPixelSize
             text:           "Warning: You have an advanced safety configuration set using the NAV_DLL_OBC parameter. The above settings may not apply.";
             visible:        fact.value !== 0
             wrapMode:       Text.Wrap

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -57,8 +57,8 @@ QGCView {
     // Used to pass help text to the preCalibrationDialog dialog
     property string preCalibrationDialogHelp
 
-    readonly property int sideBarH1PointSize: (ScreenTools.defaultFontPointSize * 1.3 + 0.5)
-    readonly property int mainTextH1PointSize: (ScreenTools.defaultFontPointSize * 1.5 + 0.5)
+    readonly property int sideBarH1PointSize: (ScreenTools.defaultFontPizelSize * 1.3 + 0.5)
+    readonly property int mainTextH1PointSize: (ScreenTools.defaultFontPizelSize * 1.5 + 0.5)
 
     readonly property int rotationColumnWidth: 250
     readonly property var rotations: [
@@ -213,7 +213,7 @@ QGCView {
                     id: compass0ComponentLabel
 
                     QGCLabel {
-                        font.pointSize: sideBarH1PointSize
+                        font.pixelSize: sideBarH1PointSize
                         text: "External Compass Orientation"
                     }
 
@@ -280,7 +280,7 @@ QGCView {
 
             QGCLabel {
                 text: "SENSORS CONFIG"
-                font.pointSize: ScreenTools.largeFontPointSize
+                font.pixelSize: ScreenTools.largeFontPixelSize
             }
 
             Item { height: 20; width: 10 } // spacer
@@ -408,7 +408,7 @@ QGCView {
                         id:             orientationCalAreaHelpText
                         width:          parent.width
                         wrapMode:       Text.WordWrap
-                        font.pointSize: ScreenTools.fontPointFactor * (22);
+                        font.pixelSize: ScreenTools.font22;
                         anchors.top: orientationCalArea.top
                         anchors.left: orientationCalArea.left
                         anchors.topMargin: 15
@@ -480,7 +480,7 @@ QGCView {
                         spacing:            5
 
                         QGCLabel {
-                            font.pointSize: sideBarH1PointSize
+                            font.pixelSize: sideBarH1PointSize
                             text: "Autopilot Orientation"
                         }
 
@@ -506,7 +506,7 @@ QGCView {
                             id: compass0ComponentLabel2
 
                             QGCLabel {
-                                font.pointSize: sideBarH1PointSize
+                                font.pixelSize: sideBarH1PointSize
                                 text: "External Compass Orientation"
                             }
                         }
@@ -531,7 +531,7 @@ QGCView {
                             id: compass1ComponentLabel2
 
                             QGCLabel {
-                                font.pointSize: sideBarH1PointSize
+                                font.pixelSize: sideBarH1PointSize
                                 text: "External Compass 1 Orientation"
                             }
                         }
@@ -556,7 +556,7 @@ QGCView {
                             id: compass2ComponentLabel2
 
                             QGCLabel {
-                                font.pointSize: sidebarH1PointSize
+                                font.pixelSize: sidebarH1PointSize
                                 text: "Compass 2 Orientation"
                             }
                         }

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -57,8 +57,8 @@ QGCView {
     // Used to pass help text to the preCalibrationDialog dialog
     property string preCalibrationDialogHelp
 
-    readonly property int sideBarH1PointSize: (ScreenTools.defaultFontPizelSize * 1.3 + 0.5)
-    readonly property int mainTextH1PointSize: (ScreenTools.defaultFontPizelSize * 1.5 + 0.5)
+    readonly property int sideBarH1PointSize:  ScreenTools.mediumFontPixelSize
+    readonly property int mainTextH1PointSize: ScreenTools.mediumFontPixelSize // Seems to be unused
 
     readonly property int rotationColumnWidth: 250
     readonly property var rotations: [

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -655,33 +655,16 @@ void QGCApplication::_loadCurrentStyle(void)
         }
     }
     
-    // Now that we have the styles loaded we need to dpi adjust the font point sizes
-    
-    QString dpiAdjustedStyles;
-    if (success) {
-        QTextStream styleStream(&styles, QIODevice::ReadOnly);
-        QRegularExpression regex("font-size:.+(\\d\\d)pt;");
-        
-        while (!styleStream.atEnd()) {
-            QString adjustedLine;
-            QString line = styleStream.readLine();
-            
-            QRegularExpressionMatch match = regex.match(line);
-            if (match.hasMatch()) {
-                //qDebug() << "found:" << line << match.captured(1);
-                adjustedLine = QString("font-size: %1pt;").arg(ScreenTools::adjustFontPointSize_s(match.captured(1).toDouble()));
-                //qDebug() << "adjusted:" << adjustedLine;
-            } else {
-                adjustedLine = line;
-            }
-            
-            dpiAdjustedStyles += adjustedLine;
-        }
-    }
+    // Now that we have the styles loaded we need to adjust the font sizes.
 
-    if (!dpiAdjustedStyles.isEmpty()) {
-        setStyleSheet(dpiAdjustedStyles);
-    }
+    QString fSmall  = QString("%1px;").arg(ScreenTools::font10_s());
+    QString fNormal = QString("%1px;").arg(ScreenTools::defaultFontPizelSize_s());
+    QString fLarge  = QString("%1px;").arg(ScreenTools::largeFontPixelSize_s());
+
+    styles.replace("FONT_SMALL",  fSmall);
+    styles.replace("FONT_NORMAL", fNormal);
+    styles.replace("FONT_LARGE",  fLarge);
+    setStyleSheet(styles);
 
     if (!success) {
         // Fall back to plastique if we can't load our own

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -66,7 +66,7 @@ QGCView {
                     height:				defaultTextHeight + (ScreenTools.pixelSizeFactor * (9))
                     text:               group
                     verticalAlignment:	Text.AlignVCenter
-                    font.pointSize:     ScreenTools.fontPointFactor * (16);
+                    font.pixelSize:     ScreenTools.font16;
                 }
 
                 Rectangle {
@@ -142,7 +142,7 @@ QGCView {
                 height: firstButton.height
 
                 QGCLabel {
-                    font.pointSize: ScreenTools.fontPointFactor * (20)
+                    font.pixelSize: ScreenTools.font20;
                     visible:        fullMode
                     text:           "PARAMETER EDITOR"
                 }
@@ -202,7 +202,7 @@ QGCView {
                                     height:				contentHeight + (ScreenTools.pixelSizeFactor * (9))
                                     text:               "Component #: " + componentId.toString()
                                     verticalAlignment:	Text.AlignVCenter
-                                    font.pointSize:     ScreenTools.fontPointFactor * (16);
+                                    font.pixelSize:     ScreenTools.font16;
                                 }
 
                                 Repeater {

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -104,7 +104,7 @@ Button {
                         id:             text
                         antialiasing:   true
                         text:           control.text
-                        font.pointSize: ScreenTools.defaultFontPointSize
+                        font.pixelSize: ScreenTools.defaultFontPizelSize
 
                         anchors.verticalCenter: parent.verticalCenter
 

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -29,7 +29,7 @@ CheckBox {
                 id:             text
                 text:           control.text
                 antialiasing:   true
-                font.pointSize: ScreenTools.defaultFontPointSize
+                font.pixelSize: ScreenTools.defaultFontPizelSize
 
                 anchors.centerIn: parent
 

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -11,7 +11,7 @@ ComboBox {
     property bool __showHighlight: pressed | hovered
 
     style: ComboBoxStyle {
-        font.pointSize: ScreenTools.defaultFontPointSize
+        font.pixelSize: ScreenTools.defaultFontPizelSize
         textColor: __showHighlight ?
                     control.__qgcPal.buttonHighlightText :
                     control.__qgcPal.buttonText

--- a/src/QmlControls/QGCLabel.qml
+++ b/src/QmlControls/QGCLabel.qml
@@ -10,7 +10,7 @@ Text {
 
     property bool enabled: true
 
-    font.pointSize: ScreenTools.defaultFontPointSize
+    font.pixelSize: ScreenTools.defaultFontPizelSize
     color:          __qgcPal.text
     antialiasing:   true
 }

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -28,7 +28,7 @@ RadioButton {
             Text {
                 id:             text
                 text:           control.text
-                font.pointSize: ScreenTools.defaultFontPointSize
+                font.pixelSize: ScreenTools.defaultFontPizelSize
                 antialiasing:   true
 
                 anchors.centerIn: parent

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -50,7 +50,7 @@ TextField {
                 width: unitsLabelWidthGenerator.width
 
                 text: control.unitsLabel
-                font.pointSize: ScreenTools.defaultFontPointSize
+                font.pixelSize: ScreenTools.defaultFontPizelSize
                 antialiasing:   true
 
                 color: control.textColor

--- a/src/QmlControls/QmlTest.qml
+++ b/src/QmlControls/QmlTest.qml
@@ -483,5 +483,37 @@ Rectangle {
                 }
             }
         }
+        Row {
+            Column {
+                Text { font.pixelSize: 8;  color: "white"; text: "Text Test 8px"; }
+                Text { font.pixelSize: 9;  color: "white"; text: "Text Test 9px"; }
+                Text { font.pixelSize: 10; color: "white"; text: "Text Test 10px"; }
+                Text { font.pixelSize: 11; color: "white"; text: "Text Test 11px"; }
+                Text { font.pixelSize: 12; color: "white"; text: "Text Test 12px"; }
+                Text { font.pixelSize: 13; color: "white"; text: "Text Test 13px"; }
+                Text { font.pixelSize: 14; color: "white"; text: "Text Test 14px"; }
+                Text { font.pixelSize: 15; color: "white"; text: "Text Test 15px"; }
+                Text { font.pixelSize: 16; color: "white"; text: "Text Test 16px"; }
+                Text { font.pixelSize: 17; color: "white"; text: "Text Test 17px"; }
+                Text { font.pixelSize: 18; color: "white"; text: "Text Test 18px"; }
+                Text { font.pixelSize: 19; color: "white"; text: "Text Test 19px"; }
+                Text { font.pixelSize: 20; color: "white"; text: "Text Test 20px"; }
+            }
+            Column {
+                Text { font.pixelSize: 8;  color: "white"; text: "Text Test 8pt"; }
+                Text { font.pixelSize: 9;  color: "white"; text: "Text Test 9pt"; }
+                Text { font.pixelSize: 10; color: "white"; text: "Text Test 10pt"; }
+                Text { font.pixelSize: 11; color: "white"; text: "Text Test 11pt"; }
+                Text { font.pixelSize: 12; color: "white"; text: "Text Test 12pt"; }
+                Text { font.pixelSize: 13; color: "white"; text: "Text Test 13pt"; }
+                Text { font.pixelSize: 14; color: "white"; text: "Text Test 14pt"; }
+                Text { font.pixelSize: 15; color: "white"; text: "Text Test 15pt"; }
+                Text { font.pixelSize: 16; color: "white"; text: "Text Test 16pt"; }
+                Text { font.pixelSize: 17; color: "white"; text: "Text Test 17pt"; }
+                Text { font.pixelSize: 18; color: "white"; text: "Text Test 18pt"; }
+                Text { font.pixelSize: 19; color: "white"; text: "Text Test 19pt"; }
+                Text { font.pixelSize: 20; color: "white"; text: "Text Test 20pt"; }
+            }
+        }
     }
 }

--- a/src/QmlControls/QmlTest.qml
+++ b/src/QmlControls/QmlTest.qml
@@ -483,37 +483,5 @@ Rectangle {
                 }
             }
         }
-        Row {
-            Column {
-                Text { font.pixelSize: 8;  color: "white"; text: "Text Test 8px"; }
-                Text { font.pixelSize: 9;  color: "white"; text: "Text Test 9px"; }
-                Text { font.pixelSize: 10; color: "white"; text: "Text Test 10px"; }
-                Text { font.pixelSize: 11; color: "white"; text: "Text Test 11px"; }
-                Text { font.pixelSize: 12; color: "white"; text: "Text Test 12px"; }
-                Text { font.pixelSize: 13; color: "white"; text: "Text Test 13px"; }
-                Text { font.pixelSize: 14; color: "white"; text: "Text Test 14px"; }
-                Text { font.pixelSize: 15; color: "white"; text: "Text Test 15px"; }
-                Text { font.pixelSize: 16; color: "white"; text: "Text Test 16px"; }
-                Text { font.pixelSize: 17; color: "white"; text: "Text Test 17px"; }
-                Text { font.pixelSize: 18; color: "white"; text: "Text Test 18px"; }
-                Text { font.pixelSize: 19; color: "white"; text: "Text Test 19px"; }
-                Text { font.pixelSize: 20; color: "white"; text: "Text Test 20px"; }
-            }
-            Column {
-                Text { font.pixelSize: 8;  color: "white"; text: "Text Test 8pt"; }
-                Text { font.pixelSize: 9;  color: "white"; text: "Text Test 9pt"; }
-                Text { font.pixelSize: 10; color: "white"; text: "Text Test 10pt"; }
-                Text { font.pixelSize: 11; color: "white"; text: "Text Test 11pt"; }
-                Text { font.pixelSize: 12; color: "white"; text: "Text Test 12pt"; }
-                Text { font.pixelSize: 13; color: "white"; text: "Text Test 13pt"; }
-                Text { font.pixelSize: 14; color: "white"; text: "Text Test 14pt"; }
-                Text { font.pixelSize: 15; color: "white"; text: "Text Test 15pt"; }
-                Text { font.pixelSize: 16; color: "white"; text: "Text Test 16pt"; }
-                Text { font.pixelSize: 17; color: "white"; text: "Text Test 17pt"; }
-                Text { font.pixelSize: 18; color: "white"; text: "Text Test 18pt"; }
-                Text { font.pixelSize: 19; color: "white"; text: "Text Test 19pt"; }
-                Text { font.pixelSize: 20; color: "white"; text: "Text Test 20pt"; }
-            }
-        }
     }
 }

--- a/src/QmlControls/ScreenTools.cc
+++ b/src/QmlControls/ScreenTools.cc
@@ -28,7 +28,7 @@
 #include "MainWindow.h"
 
 // Pixel size, instead of a physical thing is actually a philosophical question when
-// it comes to Qt. Fonts are that and some heavy Kabalistic Voodoo added to the mix.
+// it comes to Qt.
 // The values below came from actually measuring the elements on the screen on these
 // devices. I have yet to find a constant from Qt so these things can be properly
 // computed at runtime.

--- a/src/QmlControls/ScreenTools.cc
+++ b/src/QmlControls/ScreenTools.cc
@@ -27,33 +27,53 @@
 #include "ScreenTools.h"
 #include "MainWindow.h"
 
-#include <QFont>
-#include <QFontMetrics>
+// Pixel size, instead of a physical thing is actually a philosophical question when
+// it comes to Qt. Fonts are that and some heavy Kabalistic Voodoo added to the mix.
+// The values below came from actually measuring the elements on the screen on these
+// devices. I have yet to find a constant from Qt so these things can be properly
+// computed at runtime.
 
-const double ScreenTools::_defaultFontPointSize = 13;
-const double ScreenTools::_mediumFontPointSize = 16;
-const double ScreenTools::_largeFontPointSize = 20;
+#if defined(Q_OS_OSX)
+double ScreenTools::_pixelFactor    = 1.0;
+#elif defined(__ios__)
+double ScreenTools::_pixelFactor    = 0.75;
+#elif defined(Q_OS_WIN)
+double ScreenTools::_pixelFactor    = 0.86;
+#elif defined(__android__)
+double ScreenTools::_pixelFactor    = 2.5;
+#elif defined(Q_OS_LINUX)
+double ScreenTools::_pixelFactor    = 1.0;
+#endif
+
+#if defined(__android__)
+#define FONT_FACTOR 2
+#else
+#define FONT_FACTOR 1
+#endif
+
+int ScreenTools::_font8  = 8  * FONT_FACTOR;
+int ScreenTools::_font9  = 9  * FONT_FACTOR;
+int ScreenTools::_font10 = 10 * FONT_FACTOR;
+int ScreenTools::_font11 = 11 * FONT_FACTOR;
+int ScreenTools::_font12 = 12 * FONT_FACTOR;
+int ScreenTools::_font13 = 13 * FONT_FACTOR;
+int ScreenTools::_font14 = 14 * FONT_FACTOR;
+int ScreenTools::_font15 = 15 * FONT_FACTOR;
+int ScreenTools::_font16 = 16 * FONT_FACTOR;
+int ScreenTools::_font17 = 17 * FONT_FACTOR;
+int ScreenTools::_font18 = 18 * FONT_FACTOR;
+int ScreenTools::_font19 = 19 * FONT_FACTOR;
+int ScreenTools::_font20 = 20 * FONT_FACTOR;
+int ScreenTools::_font21 = 21 * FONT_FACTOR;
+int ScreenTools::_font22 = 22 * FONT_FACTOR;
 
 ScreenTools::ScreenTools()
 {
     MainWindow* mainWindow = MainWindow::instance();
-    
     // Unit tests can run Qml without MainWindow
     if (mainWindow) {
-        connect(mainWindow, &MainWindow::repaintCanvas,     this, &ScreenTools::_updateCanvas);
-        connect(mainWindow, &MainWindow::pixelSizeChanged,  this, &ScreenTools::_updatePixelSize);
-        connect(mainWindow, &MainWindow::fontSizeChanged,   this, &ScreenTools::_updateFontSize);
+        connect(mainWindow, &MainWindow::repaintCanvas, this, &ScreenTools::_updateCanvas);
     }
-}
-
-qreal ScreenTools::adjustFontPointSize(qreal pointSize)
-{
-    return adjustFontPointSize_s(pointSize);
-}
-
-qreal ScreenTools::adjustFontPointSize_s(qreal pointSize)
-{
-    return pointSize * MainWindow::fontPointFactor();
 }
 
 qreal ScreenTools::adjustPixelSize(qreal pixelSize)
@@ -63,66 +83,10 @@ qreal ScreenTools::adjustPixelSize(qreal pixelSize)
 
 qreal ScreenTools::adjustPixelSize_s(qreal pixelSize)
 {
-    return pixelSize * MainWindow::pixelSizeFactor();
-}
-
-void ScreenTools::increasePixelSize()
-{
-    MainWindow::instance()->setPixelSizeFactor(MainWindow::pixelSizeFactor() + 0.025);
-}
-
-void ScreenTools::decreasePixelSize()
-{
-    MainWindow::instance()->setPixelSizeFactor(MainWindow::pixelSizeFactor() - 0.025);
-}
-
-void ScreenTools::increaseFontSize()
-{
-    MainWindow::instance()->setFontSizeFactor(MainWindow::fontPointFactor() + 0.025);
-}
-
-void ScreenTools::decreaseFontSize()
-{
-    MainWindow::instance()->setFontSizeFactor(MainWindow::fontPointFactor() - 0.025);
+    return pixelSize * _pixelFactor;
 }
 
 void ScreenTools::_updateCanvas()
 {
     emit repaintRequestedChanged();
-}
-
-void ScreenTools::_updatePixelSize()
-{
-    emit pixelSizeFactorChanged();
-}
-
-void ScreenTools::_updateFontSize()
-{
-    emit fontPointFactorChanged();
-    emit fontSizesChanged();
-}
-
-double ScreenTools::fontPointFactor()
-{
-    return MainWindow::fontPointFactor();
-}
-
-double ScreenTools::pixelSizeFactor()
-{
-    return MainWindow::pixelSizeFactor();
-}
-
-double ScreenTools::defaultFontPointSize(void)
-{
-    return _defaultFontPointSize * MainWindow::fontPointFactor();
-}
-
-double ScreenTools::mediumFontPointSize(void)
-{
-    return _mediumFontPointSize * MainWindow::fontPointFactor();
-}
-
-double ScreenTools::largeFontPointSize(void)
-{
-    return _largeFontPointSize * MainWindow::fontPointFactor();
 }

--- a/src/QmlControls/ScreenTools.h
+++ b/src/QmlControls/ScreenTools.h
@@ -80,46 +80,87 @@ public:
       @endcode
      */
 
-    Q_PROPERTY(bool     repaintRequested     READ repaintRequested     NOTIFY repaintRequestedChanged)
-    //! Returns the font point size factor
-    Q_PROPERTY(double   fontPointFactor      READ fontPointFactor      NOTIFY fontPointFactorChanged)
-    //! Returns the pixel size factor
-    Q_PROPERTY(double   pixelSizeFactor      READ pixelSizeFactor      NOTIFY pixelSizeFactorChanged)
-    
-    //! Returns the system wide default font point size (properly scaled)
-    Q_PROPERTY(double   defaultFontPointSize READ defaultFontPointSize NOTIFY fontSizesChanged)
-    //! Returns the system wide default font point size (properly scaled)
-    Q_PROPERTY(double   mediumFontPointSize READ mediumFontPointSize NOTIFY fontSizesChanged)
-    //! Returns the system wide default font point size (properly scaled)
-    Q_PROPERTY(double   largeFontPointSize READ largeFontPointSize NOTIFY fontSizesChanged)
+    //! Font sizes
+    Q_PROPERTY(int   font22   READ font22 CONSTANT)
+    Q_PROPERTY(int   font21   READ font21 CONSTANT)
+    Q_PROPERTY(int   font20   READ font20 CONSTANT)
+    Q_PROPERTY(int   font19   READ font19 CONSTANT)
+    Q_PROPERTY(int   font18   READ font18 CONSTANT)
+    Q_PROPERTY(int   font17   READ font17 CONSTANT)
+    Q_PROPERTY(int   font16   READ font16 CONSTANT)
+    Q_PROPERTY(int   font15   READ font15 CONSTANT)
+    Q_PROPERTY(int   font14   READ font14 CONSTANT)
+    Q_PROPERTY(int   font13   READ font13 CONSTANT)
+    Q_PROPERTY(int   font12   READ font12 CONSTANT)
+    Q_PROPERTY(int   font11   READ font11 CONSTANT)
+    Q_PROPERTY(int   font10   READ font10 CONSTANT)
+    Q_PROPERTY(int   font9    READ font9  CONSTANT)
+    Q_PROPERTY(int   font8    READ font8  CONSTANT)
 
-    //! Utility for adjusting font point size. Not dynamic (no signals)
-    Q_INVOKABLE qreal   adjustFontPointSize(qreal pointSize);
+    //! Returns the system wide default font point size (properly scaled)
+    Q_PROPERTY(int   defaultFontPizelSize   READ defaultFontPizelSize   CONSTANT)
+    //! Returns the system wide default font point size (properly scaled)
+    Q_PROPERTY(int   mediumFontPixelSize    READ mediumFontPixelSize    CONSTANT)
+    //! Returns the system wide default font point size (properly scaled)
+    Q_PROPERTY(int   largeFontPixelSize     READ largeFontPixelSize     CONSTANT)
+
+    Q_PROPERTY(bool     repaintRequested    READ repaintRequested       NOTIFY repaintRequestedChanged)
+    //! Returns the pixel size factor
+    Q_PROPERTY(double   pixelSizeFactor     READ pixelSizeFactor        CONSTANT)
+    
     //! Utility for adjusting pixel size. Not dynamic (no signals)
     Q_INVOKABLE qreal   adjustPixelSize(qreal pixelSize);
 
-    //! Utility for increasing pixel size.
-    Q_INVOKABLE void    increasePixelSize();
-    //! Utility for decreasing pixel size.
-    Q_INVOKABLE void    decreasePixelSize();
-    //! Utility for increasing font size.
-    Q_INVOKABLE void    increaseFontSize();
-    //! Utility for decreasing font size.
-    Q_INVOKABLE void    decreaseFontSize();
-
-    /// Static version of adjustFontPointSize of use in C++ code
-    static qreal adjustFontPointSize_s(qreal pointSize);
     /// Static version of adjustPixelSize of use in C++ code
     static qreal adjustPixelSize_s(qreal pixelSize);
 
     int     mouseX              () { return QCursor::pos().x(); }
     int     mouseY              () { return QCursor::pos().y(); }
     bool    repaintRequested    () { return true; }
-    double  fontPointFactor     ();
-    double  pixelSizeFactor     ();
-    double  defaultFontPointSize(void);
-    double  mediumFontPointSize(void);
-    double  largeFontPointSize(void);
+    double  pixelSizeFactor     () { return _pixelFactor; }
+
+    int   font22    () { return _font22; }
+    int   font21    () { return _font21; }
+    int   font20    () { return _font20; }
+    int   font19    () { return _font19; }
+    int   font18    () { return _font18; }
+    int   font17    () { return _font17; }
+    int   font16    () { return _font16; }
+    int   font15    () { return _font15; }
+    int   font14    () { return _font14; }
+    int   font13    () { return _font13; }
+    int   font12    () { return _font12; }
+    int   font11    () { return _font11; }
+    int   font10    () { return _font10; }
+    int   font9     () { return _font9; }
+    int   font8     () { return _font8; }
+
+    int  defaultFontPizelSize    () { return _font12; }
+    int  mediumFontPixelSize     () { return _font16; }
+    int  largeFontPixelSize      () { return _font20; }
+
+    /// Static version for use in C++ code
+    static int   font22_s    () { return _font22; }
+    static int   font21_s    () { return _font21; }
+    static int   font20_s    () { return _font20; }
+    static int   font19_s    () { return _font19; }
+    static int   font18_s    () { return _font18; }
+    static int   font17_s    () { return _font17; }
+    static int   font16_s    () { return _font16; }
+    static int   font15_s    () { return _font15; }
+    static int   font14_s    () { return _font14; }
+    static int   font13_s    () { return _font13; }
+    static int   font12_s    () { return _font12; }
+    static int   font11_s    () { return _font11; }
+    static int   font10_s    () { return _font10; }
+    static int   font9_s     () { return _font9; }
+    static int   font8_s     () { return _font8; }
+
+    static int  defaultFontPizelSize_s      () { return _font12; }
+    static int  mediumFontPixelSize_s       () { return _font16; }
+    static int  largeFontPixelSize_s        () { return _font20; }
+
+    static double  pixelSizeFactor_s        () { return _pixelFactor; }
 
 #if defined (__android__)
     bool    isAndroid           () { return true;  }
@@ -137,19 +178,29 @@ public:
 
 signals:
     void repaintRequestedChanged();
-    void pixelSizeFactorChanged();
-    void fontPointFactorChanged();
-    void fontSizesChanged();
 
 private slots:
     void _updateCanvas();
-    void _updatePixelSize();
-    void _updateFontSize();
 
 private:
-    static const double _defaultFontPointSize;
-    static const double _mediumFontPointSize;
-    static const double _largeFontPointSize;
+    // Font Sizes
+    static int _font8;
+    static int _font9;
+    static int _font10;
+    static int _font11;
+    static int _font12;
+    static int _font13;
+    static int _font14;
+    static int _font15;
+    static int _font16;
+    static int _font17;
+    static int _font18;
+    static int _font19;
+    static int _font20;
+    static int _font21;
+    static int _font22;
+    // UI Dimension Factors
+    static double _pixelFactor;
 };
 
 #endif

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -40,7 +40,7 @@ Button {
                 horizontalAlignment: TextEdit.AlignHCenter
 
                 text: control.text
-                font.pointSize: ScreenTools.defaultFontPointSize
+                font.pixelSize: ScreenTools.defaultFontPizelSize
                 antialiasing: true
                 color: __showHighlight ? __qgcPal.buttonHighlightText : __qgcPal.buttonText
 

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -70,10 +70,9 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         ScreenTools.fontPointFactor * (25);
+            font.pixelSize:         ScreenTools.font22;
             font.bold:              true
             color:                  "black"
-
             text: parent.calText
         }
         QGCLabel {
@@ -81,9 +80,8 @@ Rectangle {
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
-            font.pointSize:         ScreenTools.fontPointFactor * (25);
+            font.pixelSize:         ScreenTools.font22;
             color:                  calInProgress ? "yellow" : "white"
-
             text: parent.calText
         }
     }

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -74,7 +74,7 @@ QGCView {
 
             QGCLabel {
                 text: "FIRMWARE UPDATE"
-                font.pointSize: ScreenTools.fontPointFactor * (20);
+                font.pixelSize: ScreenTools.font20;
             }
 
             Item {
@@ -177,7 +177,7 @@ QGCView {
                 height:			300
                 readOnly:		true
                 frameVisible:	false
-                font.pointSize: ScreenTools.defaultFontPointSize
+                font.pixelSize: ScreenTools.defaultFontPizelSize
                 
                 text: qsTr("Please disconnect all vehicles from QGroundControl before selecting Upgrade.")
 

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -114,7 +114,7 @@ Rectangle {
                 verticalAlignment:      Text.AlignVCenter
                 horizontalAlignment:    Text.AlignHCenter
                 wrapMode:               Text.WordWrap
-                font.pointSize:         ScreenTools.mediumFontPointSize
+                font.pixelSize:         ScreenTools.mediumFontPixelSize
                 text:                   "Welcome to QGroundControl. " +
                                             "QGroundControl supports any <font color=\"orange\"><a href=\"http://www.qgroundcontrol.org/mavlink/start\">mavlink</a></font> enabled vehicle. " +
                                             "If you are using the <font color=\"orange\"><a href=\"https://pixhawk.org/choice\">PX4 Flight Stack</a></font>, you also get full support for setting up and calibrating your vehicle. "+
@@ -136,7 +136,7 @@ Rectangle {
                 verticalAlignment:      Text.AlignVCenter
                 horizontalAlignment:    Text.AlignHCenter
                 wrapMode:               Text.WordWrap
-                font.pointSize:         ScreenTools.mediumFontPointSize
+                font.pixelSize:         ScreenTools.mediumFontPixelSize
                 text:                   messagePanelText
             }
         }

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -46,7 +46,7 @@ Rectangle {
 
         QGCLabel {
             text: "VEHICLE SUMMARY"
-            font.pointSize: ScreenTools.fontPointFactor * (20);
+            font.pixelSize: ScreenTools.font20;
         }
 
         Item {
@@ -59,7 +59,7 @@ Rectangle {
             width:			parent.width
 			wrapMode:		Text.WordWrap
 			color:			setupComplete ? qgcPal.text : "red"
-            font.pointSize: setupComplete ? ScreenTools.defaultFontPointSize : ScreenTools.fontPointFactor * (20)
+            font.pixelSize: setupComplete ? ScreenTools.defaultFontPizelSize : ScreenTools.font20
 			text:           setupComplete ?
                                 "Below you will find a summary of the settings for your vehicle. To the left are the setup menus for each component." :
                                 "WARNING: Your vehicle requires setup prior to flight. Please resolve the items marked in red using the menu on the left."

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -83,29 +83,6 @@ This file is part of the QGROUNDCONTROL project
 
 #include "LogCompressor.h"
 
-// Pixel size, instead of a physical thing is actually a philosophical question when
-// it comes to Qt. Fonts are that and some heavy Kabalistic Voodoo added to the mix.
-// The values below came from actually measuring the elements on the screen on these
-// devices. I have yet to find a constant from Qt so these things can be properly
-// computed at runtime.
-
-#if defined(Q_OS_OSX)
-double MainWindow::_pixelFactor    = 1.0;
-double MainWindow::_fontFactor     = 1.0;
-#elif defined(__ios__)
-double MainWindow::_pixelFactor    = 1.0;
-double MainWindow::_fontFactor     = 1.0;
-#elif defined(Q_OS_WIN)
-double MainWindow::_pixelFactor    = 0.86;
-double MainWindow::_fontFactor     = 0.63;
-#elif defined(__android__)
-double MainWindow::_pixelFactor    = 2.0;
-double MainWindow::_fontFactor     = 1.23;
-#elif defined(Q_OS_LINUX)
-double MainWindow::_pixelFactor    = 1.0;
-double MainWindow::_fontFactor     = 0.85;
-#endif
-
 /// The key under which the Main Window settings are saved
 const char* MAIN_SETTINGS_GROUP = "QGC_MAINWINDOW";
 
@@ -689,8 +666,6 @@ void MainWindow::loadSettings()
     _autoReconnect  = settings.value("AUTO_RECONNECT",      _autoReconnect).toBool();
     _lowPowerMode   = settings.value("LOW_POWER_MODE",      _lowPowerMode).toBool();
     _showStatusBar  = settings.value("SHOW_STATUSBAR",      _showStatusBar).toBool();
-    _fontFactor     = settings.value("FONT_SIZE_FACTOR",    _fontFactor).toDouble();
-    _pixelFactor    = settings.value("PIXEL_SIZE_FACTOR",   _pixelFactor).toDouble();
     settings.endGroup();
 }
 
@@ -701,8 +676,6 @@ void MainWindow::storeSettings()
     settings.setValue("AUTO_RECONNECT",     _autoReconnect);
     settings.setValue("LOW_POWER_MODE",     _lowPowerMode);
     settings.setValue("SHOW_STATUSBAR",     _showStatusBar);
-    settings.setValue("FONT_SIZE_FACTOR",   _fontFactor);
-    settings.setValue("PIXEL_SIZE_FACTOR",  _pixelFactor);
     settings.endGroup();
     settings.setValue(_getWindowGeometryKey(), saveGeometry());
 	
@@ -1197,22 +1170,6 @@ void MainWindow::restoreLastUsedConnection()
 void MainWindow::_linkStateChange(LinkInterface*)
 {
     emit repaintCanvas();
-}
-
-void MainWindow::setPixelSizeFactor(double size) {
-    if(size < 0.1) {
-        size = 0.1;
-    }
-    _pixelFactor = size;
-    emit pixelSizeChanged();
-}
-
-void MainWindow::setFontSizeFactor(double size) {
-    if(size < 0.1) {
-        size = 0.1;
-    }
-    _fontFactor = size;
-    emit fontSizeChanged();
 }
 
 #ifdef QGC_MOUSE_ENABLED_LINUX

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -130,15 +130,6 @@ public:
     
     QWidget* getCurrentViewWidget(void) { return _currentViewWidget; }
 
-    //! Returns the font point size factor
-    static double   fontPointFactor() { return _fontFactor; }
-    //! Returns the pixel size factor
-    static double   pixelSizeFactor() { return _pixelFactor; }
-    //! Sets pixel size factor
-    void            setPixelSizeFactor(double size);
-    //! Sets font size factor
-    void            setFontSizeFactor(double size);
-
 public slots:
     /** @brief Show the application settings */
     void showSettings();
@@ -209,10 +200,6 @@ signals:
     void valueChanged(const int uasId, const QString& name, const QString& unit, const QVariant& value, const quint64 msec);
     /** Emitted when any the Canvas elements within QML wudgets need updating */
     void repaintCanvas();
-    /** Emitted when pixel size factor changes */
-    void pixelSizeChanged();
-    /** Emitted when pixel size factor changes */
-    void fontSizeChanged();
 
 #ifdef QGC_MOUSE_ENABLED_LINUX
     /** @brief Forward X11Event to catch 3DMouse inputs */
@@ -372,10 +359,6 @@ private:
 
     QString _getWindowStateKey();
     QString _getWindowGeometryKey();
-
-    // UI Dimension Factors
-    static double _pixelFactor;
-    static double _fontFactor;
 
 };
 

--- a/src/ui/flightdisplay/FlightDisplay.cc
+++ b/src/ui/flightdisplay/FlightDisplay.cc
@@ -31,7 +31,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QQmlEngine>
 #include <QSettings>
 
-#include "MainWindow.h"
+#include "ScreenTools.h"
 #include "FlightDisplay.h"
 #include "UASManager.h"
 
@@ -48,8 +48,8 @@ FlightDisplay::FlightDisplay(QWidget *parent)
         pl->setContentsMargins(0,0,0,0);
     }
 #ifndef __android__
-    setMinimumWidth( 380 * MainWindow::pixelSizeFactor());
-    setMinimumHeight(400 * MainWindow::pixelSizeFactor());
+    setMinimumWidth( 380 * ScreenTools::pixelSizeFactor_s());
+    setMinimumHeight(400 * ScreenTools::pixelSizeFactor_s());
 #endif
     setContextPropertyObject("flightDisplay", this);
     setSource(QUrl::fromUserInput("qrc:/qml/FlightDisplay.qml"));

--- a/src/ui/flightdisplay/FlightDisplay.qml
+++ b/src/ui/flightdisplay/FlightDisplay.qml
@@ -230,63 +230,6 @@ Item {
                         }
                     }
                 }
-                //-- Hack tool to find optimal scale factor
-                Column {
-                    id: fudgeColumn
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    spacing:    ScreenTools.adjustPixelSize(4)
-                    width:      parent.width
-                    QGCLabel {
-                        text: "Adjust Pixel Size Factor"
-                        anchors.horizontalCenter: parent.horizontalCenter
-                    }
-                    Row {
-                        spacing:    ScreenTools.adjustPixelSize(4)
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        Button {
-                            text: 'Inc'
-                            onClicked: {
-                                ScreenTools.increasePixelSize()
-                            }
-                        }
-                        Label {
-                            text: ScreenTools.pixelSizeFactor.toFixed(2)
-                            color: __qgcPal.text
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                        Button {
-                            text: 'Dec'
-                            onClicked: {
-                                ScreenTools.decreasePixelSize()
-                            }
-                        }
-                    }
-                    QGCLabel {
-                        text: "Adjust Font Size Factor"
-                        anchors.horizontalCenter: parent.horizontalCenter
-                    }
-                    Row {
-                        spacing:    ScreenTools.adjustPixelSize(4)
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        Button {
-                            text: 'Inc'
-                            onClicked: {
-                                ScreenTools.increaseFontSize()
-                            }
-                        }
-                        Label {
-                            text: ScreenTools.fontPointFactor.toFixed(2)
-                            color: __qgcPal.text
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-                        Button {
-                            text: 'Dec'
-                            onClicked: {
-                                ScreenTools.decreaseFontSize()
-                            }
-                        }
-                    }
-                }
             }
         }
     }

--- a/src/ui/mapdisplay/QGCMapDisplay.cc
+++ b/src/ui/mapdisplay/QGCMapDisplay.cc
@@ -31,7 +31,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QQmlEngine>
 #include <QSettings>
 
-#include "MainWindow.h"
+#include "ScreenTools.h"
 #include "QGCMapDisplay.h"
 #include "UASManager.h"
 
@@ -48,8 +48,8 @@ QGCMapDisplay::QGCMapDisplay(QWidget *parent)
         pl->setContentsMargins(0,0,0,0);
     }
 #ifndef __android__
-    setMinimumWidth( 380 * MainWindow::pixelSizeFactor());
-    setMinimumHeight(400 * MainWindow::pixelSizeFactor());
+    setMinimumWidth( 380 * ScreenTools::pixelSizeFactor_s());
+    setMinimumHeight(400 * ScreenTools::pixelSizeFactor_s());
 #endif
     setContextPropertyObject("mapEngine", this);
     setSource(QUrl::fromUserInput("qrc:/qml/MapDisplay.qml"));

--- a/src/ui/qmlcommon/QGCCompassInstrument.qml
+++ b/src/ui/qmlcommon/QGCCompassInstrument.qml
@@ -35,7 +35,7 @@ QGCMovableItem {
     id:                     root
     property real heading:  0
     property real size:     ScreenTools.pixelSizeFactor * (120)
-    property real _fontSize: ScreenTools.fontPointFactor * (12)
+    property int _fontSize: ScreenTools.font12
     width:                  size
     height:                 size
     Rectangle {
@@ -72,7 +72,7 @@ QGCMovableItem {
         QGCLabel {
             text:           heading.toFixed(0)
             font.weight:    Font.DemiBold
-            font.pointSize: _fontSize < 1 ? 1 : _fontSize;
+            font.pixelSize: _fontSize < 1 ? 1 : _fontSize;
             color: "white"
             anchors.centerIn: parent
         }

--- a/src/ui/qmlcommon/QGCPitchWidget.qml
+++ b/src/ui/qmlcommon/QGCPitchWidget.qml
@@ -40,7 +40,7 @@ Rectangle {
     property real _reticleSlot:     _reticleSpacing + _reticleHeight
     property real _longDash:        size * 0.40
     property real _shortDash:       size * 0.25
-    property real _fontSize:        ScreenTools.fontPointFactor * (11);
+    property real _fontSize:        ScreenTools.font11
     height: size * 0.9
     width:  size
     radius: ScreenTools.pixelSizeFactor * (8)
@@ -70,7 +70,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         smooth: true
                         font.weight: Font.DemiBold
-                        font.pointSize: _fontSize < 1 ? 1 : _fontSize;
+                        font.pixelSize: _fontSize < 1 ? 1 : _fontSize;
                         text: _pitch
                         color: "white"
                         visible: (_pitch != 0) && ((_pitch % 10) === 0)
@@ -81,7 +81,7 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         smooth: true
                         font.weight: Font.DemiBold
-                        font.pointSize: _fontSize < 1 ? 1 : _fontSize;
+                        font.pixelSize: _fontSize < 1 ? 1 : _fontSize;
                         text: _pitch
                         color: "white"
                         visible: (_pitch != 0) && ((_pitch % 10) === 0)

--- a/src/ui/qmlcommon/QGCSlider.qml
+++ b/src/ui/qmlcommon/QGCSlider.qml
@@ -83,7 +83,7 @@ Item {
             id:     label
             color:  "black"
             text:   slider.value.toFixed(2)
-            width:  font.pointSize * 3.5
+            width:  font.pixelSize * 3.5
             anchors.horizontalCenter:   labelRect.horizontalCenter
             horizontalAlignment:        Text.AlignHCenter
             anchors.verticalCenter:     labelRect.verticalCenter

--- a/src/ui/qmlcommon/QGCWaypoint.qml
+++ b/src/ui/qmlcommon/QGCWaypoint.qml
@@ -45,7 +45,7 @@ MapQuickItem {
         Text {
             id: number
             anchors.centerIn: parent
-            font.pointSize: 11
+            font.pixelSize: 11
             font.weight: Font.DemiBold
             color: "white"
             text: marker.waypointID

--- a/src/ui/toolbar/MainToolBar.cc
+++ b/src/ui/toolbar/MainToolBar.cc
@@ -57,7 +57,6 @@ MainToolBar::MainToolBar(QWidget* parent)
 {
     setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
     setObjectName("MainToolBar");
-    _updatePixelSize();
     setMinimumWidth(MainWindow::instance()->minimumWidth());
     // Get rid of layout default margins
     QLayout* pl = layout();
@@ -83,7 +82,6 @@ MainToolBar::MainToolBar(QWidget* parent)
     connect(LinkManager::instance(),     &LinkManager::linkConfigurationChanged, this, &MainToolBar::_updateConfigurations);
     connect(LinkManager::instance(),     &LinkManager::linkConnected,            this, &MainToolBar::_linkConnected);
     connect(LinkManager::instance(),     &LinkManager::linkDisconnected,         this, &MainToolBar::_linkDisconnected);
-    connect(MainWindow::instance(),      &MainWindow::pixelSizeChanged,          this, &MainToolBar::_updatePixelSize);
     // RSSI (didn't like standard connection)
     connect(MAVLinkProtocol::instance(),
         SIGNAL(radioStatusChanged(LinkInterface*, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned)), this,
@@ -387,10 +385,4 @@ void MainToolBar::_setProgressBarValue(float value)
 {
     _progressBarValue = value;
     emit progressBarValueChanged(value);
-}
-
-void MainToolBar::_updatePixelSize()
-{
-    setMinimumHeight(40 * MainWindow::pixelSizeFactor());
-    setMaximumHeight(40 * MainWindow::pixelSizeFactor());
 }

--- a/src/ui/toolbar/MainToolBar.cc
+++ b/src/ui/toolbar/MainToolBar.cc
@@ -31,6 +31,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QQmlEngine>
 
 #include "MainToolBar.h"
+#include "ScreenTools.h"
 #include "MainWindow.h"
 #include "UASMessageView.h"
 #include "UASMessageHandler.h"
@@ -63,6 +64,8 @@ MainToolBar::MainToolBar(QWidget* parent)
     if(pl) {
         pl->setContentsMargins(0,0,0,0);
     }
+    setMinimumHeight(40 * ScreenTools::pixelSizeFactor_s());
+    setMaximumHeight(40 * ScreenTools::pixelSizeFactor_s());
     // Tool Bar Preferences
     QSettings settings;
     settings.beginGroup(TOOL_BAR_SETTINGS_GROUP);

--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -113,7 +113,6 @@ private slots:
     void _linkDisconnected              (LinkInterface* link);
     void _leaveMessageView              ();
     void _setProgressBarValue           (float value);
-    void _updatePixelSize               ();
     void _remoteControlRSSIChanged      (uint8_t rssi);
     void _telemetryChanged              (LinkInterface* link, unsigned rxerrors, unsigned fixed, unsigned rssi, unsigned remrssi, unsigned txbuf, unsigned noise, unsigned remnoise);
 

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -338,7 +338,7 @@ Rectangle {
                     QGCLabel {
                         id: messageText
                         text: (MavManager.messageCount > 0) ? MavManager.messageCount : ''
-                        font.pointSize: ScreenTools.fontPointFactor * (14);
+                        font.pixelSize: ScreenTools.font14
                         font.weight: Font.DemiBold
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.horizontalCenter: parent.horizontalCenter
@@ -424,7 +424,7 @@ Rectangle {
                 QGCLabel {
                     id: satelitteText
                     text: MavManager.satelliteCount >= 0 ? MavManager.satelliteCount : 'NA'
-                    font.pointSize: MavManager.satelliteCount >= 0 ? ScreenTools.fontPointFactor * (14) : ScreenTools.fontPointFactor * (10)
+                    font.pixelSize: MavManager.satelliteCount >= 0 ? ScreenTools.font14 : ScreenTools.font10
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
@@ -459,7 +459,7 @@ Rectangle {
                     anchors.rightMargin: getProportionalDimmension(6)
                     anchors.verticalCenter: parent.verticalCenter
                     horizontalAlignment: Text.AlignRight
-                    font.pointSize: ScreenTools.fontPointFactor * (12);
+                    font.pixelSize: ScreenTools.font12
                     font.weight: Font.DemiBold
                     color: colorWhite
                 }
@@ -492,7 +492,7 @@ Rectangle {
                         anchors.right: parent.right
                         QGCLabel {
                             text: 'R '
-                            font.pointSize: ScreenTools.fontPointFactor * (11);
+                            font.pixelSize: ScreenTools.font11
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -500,7 +500,7 @@ Rectangle {
                             text: mainToolBar.telemetryRRSSI + 'dB'
                             width: getProportionalDimmension(30)
                             horizontalAlignment: Text.AlignRight
-                            font.pointSize: ScreenTools.fontPointFactor * (11);
+                            font.pixelSize: ScreenTools.font11
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -509,7 +509,7 @@ Rectangle {
                         anchors.right: parent.right
                         QGCLabel {
                             text: 'L '
-                            font.pointSize: ScreenTools.fontPointFactor * (11);
+                            font.pixelSize: ScreenTools.font11
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -517,7 +517,7 @@ Rectangle {
                             text: mainToolBar.telemetryLRSSI + 'dB'
                             width: getProportionalDimmension(30)
                             horizontalAlignment: Text.AlignRight
-                            font.pointSize: ScreenTools.fontPointFactor * (11);
+                            font.pixelSize: ScreenTools.font11
                             font.weight: Font.DemiBold
                             color: colorWhite
                         }
@@ -548,7 +548,7 @@ Rectangle {
                 QGCLabel {
                     visible: batteryStatus.visible && MavManager.batteryConsumed < 0.0
                     text: MavManager.batteryVoltage.toFixed(1) + 'V';
-                    font.pointSize: ScreenTools.fontPointFactor * (11);
+                    font.pixelSize: ScreenTools.font11
                     font.weight: Font.DemiBold
                     anchors.right: parent.right
                     anchors.rightMargin: getProportionalDimmension(6)
@@ -566,7 +566,7 @@ Rectangle {
                         text: MavManager.batteryVoltage.toFixed(1) + 'V';
                         width: getProportionalDimmension(30)
                         horizontalAlignment: Text.AlignRight
-                        font.pointSize: ScreenTools.fontPointFactor * (11);
+                        font.pixelSize: ScreenTools.font11
                         font.weight: Font.DemiBold
                         color: colorWhite
                     }
@@ -574,7 +574,7 @@ Rectangle {
                         text: MavManager.batteryConsumed.toFixed(0) + 'mA';
                         width: getProportionalDimmension(30)
                         horizontalAlignment: Text.AlignRight
-                        font.pointSize: ScreenTools.fontPointFactor * (11);
+                        font.pixelSize: ScreenTools.font11
                         font.weight: Font.DemiBold
                         color: colorWhite
                     }
@@ -599,7 +599,7 @@ Rectangle {
                     QGCLabel {
                         id: armedStatusText
                         text: (MavManager.systemArmed) ? qsTr("ARMED") :  qsTr("DISARMED")
-                        font.pointSize: ScreenTools.fontPointFactor * (12);
+                        font.pixelSize: ScreenTools.font12
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
                         color: (MavManager.systemArmed) ? colorOrangeText : colorGreenText
@@ -618,7 +618,7 @@ Rectangle {
                     QGCLabel {
                         id: stateStatusText
                         text: MavManager.currentState
-                        font.pointSize: ScreenTools.fontPointFactor * (12);
+                        font.pixelSize: ScreenTools.font12
                         font.weight: Font.DemiBold
                         anchors.centerIn: parent
                         color: (MavManager.currentState === "STANDBY") ? colorGreenText : colorRedText
@@ -639,7 +639,7 @@ Rectangle {
                 QGCLabel {
                     id: modeStatusText
                     text: MavManager.currentMode
-                    font.pointSize: ScreenTools.fontPointFactor * (12);
+                    font.pixelSize: ScreenTools.font12
                     font.weight: Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
@@ -660,7 +660,7 @@ Rectangle {
                 QGCLabel {
                     id: connectionStatusText
                     text: qsTr("CONNECTION LOST")
-                    font.pointSize: ScreenTools.fontPointFactor * (14);
+                    font.pixelSize: ScreenTools.font14
                     font.weight: Font.DemiBold
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter

--- a/src/ui/uas/UASQuickView.cc
+++ b/src/ui/uas/UASQuickView.cc
@@ -63,7 +63,8 @@ UASQuickView::~UASQuickView()
 void UASQuickView::columnActionTriggered()
 {
     bool ok = false;
-    int newcolumns = QInputDialog::getInt(this,"Columns","Enter number of columns",1,0,100,1,&ok);
+    int newcolumns = QInputDialog::getInt(
+        this,"Columns","Enter number of columns", m_columnCount, 1, 10, 1, &ok);
     if (!ok)
     {
         return;
@@ -110,7 +111,7 @@ void UASQuickView::loadSettings()
     QSettings settings;
     m_columnCount = settings.value("UAS_QUICK_VIEW_COLUMNS",1).toInt();
     int size = settings.beginReadArray("UAS_QUICK_VIEW_ITEMS");
-    for (int i=0;i<size;i++)
+    for (int i = 0; i < size; i++)
     {
         settings.setArrayIndex(i);
         QString nameval = settings.value("name").toString();
@@ -158,16 +159,16 @@ void UASQuickView::sortItems(int columncount)
         m_PropertyToLayoutIndexMap.remove(i.key());
         itemlist.append(i.value());
     }
-    //Item list has all the widgets availble, now re-add them to the layouts.
-    for (int i=0;i<m_verticalLayoutList.size();i++)
+    // Item list has all the widgets availble, now re-add them to the layouts.
+    for (int i = 0; i < m_verticalLayoutList.size(); i++)
     {
         ui.horizontalLayout->removeItem(m_verticalLayoutList[i]);
         m_verticalLayoutList[i]->deleteLater(); //removeItem de-parents the item.
     }
     m_verticalLayoutList.clear();
 
-    //Create a vertical layout for every intended column
-    for (int i=0;i<columncount;i++)
+    // Create a vertical layout for every intended column
+    for (int i = 0; i < columncount; i++)
     {
         QVBoxLayout *layout = new QVBoxLayout();
         ui.horizontalLayout->addItem(layout);
@@ -177,7 +178,7 @@ void UASQuickView::sortItems(int columncount)
 
     //Cycle through all items and add them to the layout
     int currcol = 0;
-    for (int i=0;i<itemlist.size();i++)
+    for (int i = 0; i < itemlist.size(); i++)
     {
         m_verticalLayoutList[currcol]->addWidget(itemlist[i]);
         currcol++;
@@ -206,6 +207,8 @@ void UASQuickView::recalculateItemTextSizing()
             minpixelsize = tempmin;
         }
     }
+    if(minpixelsize < 6)
+        minpixelsize = 6;
     for (QMap<QString,UASQuickViewItem*>::const_iterator i = uasPropertyToLabelMap.constBegin();i!=uasPropertyToLabelMap.constEnd();i++)
     {
         i.value()->setValuePixelSize(minpixelsize);

--- a/src/ui/uas/UASQuickViewTextItem.cc
+++ b/src/ui/uas/UASQuickViewTextItem.cc
@@ -10,27 +10,27 @@ UASQuickViewTextItem::UASQuickViewTextItem(QWidget *parent) : UASQuickViewItem(p
 
     // Create the title label. Scale the font based on available size.
     titleLabel = new QLabel(this);
-     titleLabel->setAlignment(Qt::AlignHCenter);
-     titleLabel->setSizePolicy(QSizePolicy::MinimumExpanding,QSizePolicy::Minimum);
-     titleLabel->setObjectName(QString::fromUtf8("title"));
-     QFont titlefont = titleLabel->font();
-     titlefont.setPixelSize(this->height() / 4.0);
-     titleLabel->setFont(titlefont);
-     layout->addWidget(titleLabel);
+    titleLabel->setAlignment(Qt::AlignHCenter);
+    titleLabel->setSizePolicy(QSizePolicy::MinimumExpanding,QSizePolicy::Minimum);
+    titleLabel->setObjectName(QString::fromUtf8("title"));
+    QFont titlefont = titleLabel->font();
+    titlefont.setPixelSize(this->height() / 4.0);
+    titleLabel->setFont(titlefont);
+    layout->addWidget(titleLabel);
 
-     // Create the value label. Scale the font based on available size.
-     valueLabel = new QLabel(this);
-     valueLabel->setAlignment(Qt::AlignHCenter);
-     valueLabel->setSizePolicy(QSizePolicy::MinimumExpanding,QSizePolicy::Minimum);
-     valueLabel->setObjectName(QString::fromUtf8("value"));
-     valueLabel->setText("0.00");
+    // Create the value label. Scale the font based on available size.
+    valueLabel = new QLabel(this);
+    valueLabel->setAlignment(Qt::AlignHCenter);
+    valueLabel->setSizePolicy(QSizePolicy::MinimumExpanding,QSizePolicy::Minimum);
+    valueLabel->setObjectName(QString::fromUtf8("value"));
+    valueLabel->setText("0.00");
     QFont valuefont = valueLabel->font();
     valuefont.setPixelSize(this->height() / 2.0);
     valueLabel->setFont(valuefont);
     layout->addWidget(valueLabel);
 
     // And make sure the items are evenly spaced in the UASQuickView.
-    layout->addSpacerItem(new QSpacerItem(20, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
+    layout->addSpacerItem(new QSpacerItem(10, 0, QSizePolicy::Minimum, QSizePolicy::Expanding));
     this->setLayout(layout);
 }
 void UASQuickViewTextItem::setValue(double value)
@@ -61,7 +61,7 @@ void UASQuickViewTextItem::setTitle(QString title)
 {
     if (title.indexOf(".") != -1 && title.indexOf(":") != -1)
     {
-        titleLabel->setText(title.mid(title.indexOf(".")+1));
+        titleLabel->setText(title.mid(title.indexOf(".") + 1));
     }
     else
     {
@@ -73,7 +73,7 @@ int UASQuickViewTextItem::minValuePixelSize()
     QFont valuefont = valueLabel->font();
     QFont titlefont = titleLabel->font();
     valuefont.setPixelSize(this->height());
-    titlefont.setPixelSize(valuefont.pixelSize() / 2.0);
+    titlefont.setPixelSize(valuefont.pixelSize() * 0.75);
     //spacerItem->setGeometry(QRect(0,0,20,this->height()/10.0));
 
     QFontMetrics metrics(valuefont);
@@ -87,18 +87,18 @@ int UASQuickViewTextItem::minValuePixelSize()
         //QFontMetrics titlefm( titlefont );
         //QRect titlebound = titlefm.boundingRect(0,0, titleLabel->width(), titleLabel->height(), Qt::TextWordWrap | Qt::AlignLeft, titleLabel->text());
 
-        if ((valbound.width() <= valueLabel->width() && valbound.height() <= valueLabel->height()))// && (titlebound.width() <= titleLabel->width() && titlebound.height() <= titleLabel->height()))
+        if ((valbound.width() <= valueLabel->width() && valbound.height() <= valueLabel->height())) // && (titlebound.width() <= titleLabel->width() && titlebound.height() <= titleLabel->height()))
             fit = true;
         else
         {
-            if (valuefont.pixelSize()-5 <= 0)
+            if (valuefont.pixelSize() - 1 <= 6)
             {
                 fit = true;
-                valuefont.setPixelSize(5);
+                valuefont.setPixelSize(6);
             }
             else
             {
-                valuefont.setPixelSize(valuefont.pixelSize() - 5);
+                valuefont.setPixelSize(valuefont.pixelSize() - 1);
             }
             //titlefont.setPixelSize(valuefont.pixelSize() / 2.0);
             //qDebug() << "Point size:" << valuefont.pixelSize() << valueLabel->width() << valueLabel->height();
@@ -111,7 +111,7 @@ void UASQuickViewTextItem::setValuePixelSize(int size)
     QFont valuefont = valueLabel->font();
     QFont titlefont = titleLabel->font();
     valuefont.setPixelSize(size);
-    titlefont.setPixelSize(valuefont.pixelSize() / 2.0);
+    titlefont.setPixelSize(valuefont.pixelSize() * 0.75);
     valueLabel->setFont(valuefont);
     titleLabel->setFont(titlefont);
     update();


### PR DESCRIPTION
Font point size simply does not work. Not only it differs from platform to platform, it even differs from QWidget to QtQuick within a same platform. We were using *factors* to accommodate the differences but the problem is that Qt does not support floating point for font sizes (point or pixels). As these factors were used, Qt would round down the sizes creating even more confusion.

Font **pixel** sizes however, are very close in all platforms. From what I measured, the greatest difference (not counting Android), was 0.97. Enough to justify replacing all font size references from points to pixels. On all platforms I tested, Android was the only one that required a doubling in size.

Gone are all "font size factors", and all the runtime computation. In its place, there are now constants for all used font sizes (8 to 22). These factors are defined at compile time per platform as needed (as I mentioned above, only Android needs a different size).

I've replaced all font sizes in the style sheet to *tokens*, which are then parsed and replaced appropriately at runtime.

I've also fixed (somewhat) the QuickView gadget as it was grossly messing up in all platforms. It is now at least readable, provided you have a reasonable number of items to display (it's still possible to make it horrible by adding a zillion items and/or columns). This will need a complete re-write, which is forthcoming anyway with the change over to QtQuick.

With that said, most *gadgets* don't fit docked next to the main view in small screens (smaller than 1280 wide). That's a function of the UI layout in each of them. Making the screen larger (provided you have a larger monitor), makes them normal and usable. On small screens, I see no point in running multiple gadgets side by side as the layout breaks apart.

Tested on:
* Mac OS (MacPro 30" 4k monitor and 27" monitor)
* Mac OS (MacBook Pro 13")
* Windows (24" monitor)
* Ubuntu (24" monitor)
* Android (7" Nexus tablet)
* iOS (iPad Retina)


