### PR TITLE
Update firmware upgrade controller links for AeroCore firmware

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -170,9 +170,9 @@ void FirmwareUpgradeController::_getFirmwareFile(void)
 
     static const char* rgAeroCoreFirmware[3] =
     {
-	"http://s3-us-west-2.amazonaws.com/gumstix-aerocore/PX4/stable/aerocore_default.px4",
-	"http://s3-us-west-2.amazonaws.com/gumstix-aerocore/PX4/beta/aerocore_default.px4",
-	"http://s3-us-west-2.amazonaws.com/gumstix-aerocore/PX4/master/aerocore_default.px4"
+	"http://gumstix-aerocore.s3.amazonaws.com/PX4/stable/aerocore_default.px4",
+	"http://gumstix-aerocore.s3.amazonaws.com/PX4/beta/aerocore_default.px4",
+	"http://gumstix-aerocore.s3.amazonaws.com/PX4/master/aerocore_default.px4"
     };
 
     static const char* rgPX4FlowFirmware[3] =


### PR DESCRIPTION
I originally didn't realize we were able to use the cleaner versions of the AWS links.  This pull just brings the links in line with the format of other AWS links.