### PR TITLE
Send MAVLink message for all joystick modes

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -2578,7 +2578,6 @@ void UAS::setExternalControlSetpoint(float roll, float pitch, float yaw, float t
             const float newThrustCommand = thrust * axesScaling;
 
             // Send the MANUAL_COMMAND message
-            mavlink_message_t message;
             mavlink_msg_manual_control_pack(mavlink->getSystemId(), mavlink->getComponentId(), &message, this->uasId, newPitchCommand, newRollCommand, newThrustCommand, newYawCommand, buttons);
         }
 

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -2580,11 +2580,11 @@ void UAS::setExternalControlSetpoint(float roll, float pitch, float yaw, float t
             // Send the MANUAL_COMMAND message
             mavlink_message_t message;
             mavlink_msg_manual_control_pack(mavlink->getSystemId(), mavlink->getComponentId(), &message, this->uasId, newPitchCommand, newRollCommand, newThrustCommand, newYawCommand, buttons);
-            sendMessage(message);
-
-            // Emit an update in control values to other UI elements, like the HSI display
-            emit attitudeThrustSetPointChanged(this, roll, pitch, yaw, thrust, QGC::groundTimeMilliseconds());
         }
+
+        sendMessage(message);
+        // Emit an update in control values to other UI elements, like the HSI display
+        emit attitudeThrustSetPointChanged(this, roll, pitch, yaw, thrust, QGC::groundTimeMilliseconds());
     }
 }
 #endif


### PR DESCRIPTION
I was looking through the handling here and found that joystick updates only happen if manual mode is set. Might this be a bug or are the other modes unsupported/untested ATM?