### PR TITLE
Moving image resources to their own QRC path.

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -4,6 +4,70 @@
         <file alias="FactSystemTest.qml">src/FactSystem/FactSystemTest.qml</file>
     </qresource>
 
+    <qresource prefix="/qmlimages">
+        <file alias="SafetyComponentTree.svg">src/AutoPilotPlugins/PX4/Images/SafetyComponentTree.svg</file>
+        <file alias="SafetyComponentHome.png">src/AutoPilotPlugins/PX4/Images/SafetyComponentHome.png</file>
+        <file alias="SafetyComponentArrowDown.png">src/AutoPilotPlugins/PX4/Images/SafetyComponentArrowDown.png</file>
+        <file alias="SafetyComponentPlane.png">src/AutoPilotPlugins/PX4/Images/SafetyComponentPlane.png</file>
+
+        <file alias="VehicleDown.png">src/AutoPilotPlugins/PX4/Images/VehicleDown.png</file>
+        <file alias="VehicleUpsideDown.png">src/AutoPilotPlugins/PX4/Images/VehicleUpsideDown.png</file>
+        <file alias="VehicleLeft.png">src/AutoPilotPlugins/PX4/Images/VehicleLeft.png</file>
+        <file alias="VehicleRight.png">src/AutoPilotPlugins/PX4/Images/VehicleRight.png</file>
+        <file alias="VehicleNoseDown.png">src/AutoPilotPlugins/PX4/Images/VehicleNoseDown.png</file>
+        <file alias="VehicleTailDown.png">src/AutoPilotPlugins/PX4/Images/VehicleTailDown.png</file>
+
+        <file alias="VehicleDownRotate.png">src/AutoPilotPlugins/PX4/Images/VehicleDownRotate.png</file>
+        <file alias="VehicleLeftRotate.png">src/AutoPilotPlugins/PX4/Images/VehicleLeftRotate.png</file>
+        <file alias="VehicleNoseDownRotate.png">src/AutoPilotPlugins/PX4/Images/VehicleNoseDownRotate.png</file>
+
+        <file alias="AirframeStandardPlane.png">src/AutoPilotPlugins/PX4/Images/AirframeStandardPlane.png</file>
+        <file alias="AirframeFlyingWing.png">src/AutoPilotPlugins/PX4/Images/AirframeFlyingWing.png</file>
+        <file alias="AirframeQuadRotorX.png">src/AutoPilotPlugins/PX4/Images/AirframeQuadRotorX.png</file>
+        <file alias="AirframeQuadRotorPlus.png">src/AutoPilotPlugins/PX4/Images/AirframeQuadRotorPlus.png</file>
+        <file alias="AirframeOctoRotorX.png">src/AutoPilotPlugins/PX4/Images/AirframeOctoRotorX.png</file>
+        <file alias="AirframeOctoRotorPlus.png">src/AutoPilotPlugins/PX4/Images/AirframeOctoRotorPlus.png</file>
+        <file alias="AirframeHexaRotorX.png">src/AutoPilotPlugins/PX4/Images/AirframeHexaRotorX.png</file>
+        <file alias="AirframeHexaRotorPlus.png">src/AutoPilotPlugins/PX4/Images/AirframeHexaRotorPlus.png</file>
+        <file alias="AirframeQuadRotorH.png">src/AutoPilotPlugins/PX4/Images/AirframeQuadRotorH.png</file>
+        <file alias="AirframeSimulation.png">src/AutoPilotPlugins/PX4/Images/AirframeSimulation.png</file>
+
+        <file alias="arrow-down.png">src/QmlControls/arrow-down.png</file>
+        <file alias="subMenuButtonImage.png">resources/CogWheels.png</file>
+        <file alias="SensorsComponentIcon.png">src/AutoPilotPlugins/PX4/Images/SensorsComponentIcon.png</file>
+        <file alias="RadioComponentIcon.png">src/AutoPilotPlugins/PX4/Images/RadioComponentIcon.png</file>
+        <file alias="FlightModesComponentIcon.png">src/AutoPilotPlugins/PX4/Images/FlightModesComponentIcon.png</file>
+        <file alias="AirframeComponentIcon.png">src/AutoPilotPlugins/PX4/Images/AirframeComponentIcon.png</file>
+        <file alias="SafetyComponentIcon.png">src/AutoPilotPlugins/PX4/Images/SafetyComponentIcon.png</file>
+        <file alias="PowerComponentIcon.png">src/AutoPilotPlugins/PX4/Images/PowerComponentIcon.png</file>
+        <file alias="FirmwareUpgradeIcon.png">src/VehicleSetup/FirmwareUpgradeIcon.png</file>
+        <file alias="VehicleSummaryIcon.png">src/VehicleSetup/VehicleSummaryIcon.png</file>
+
+        <file alias="PowerComponentBattery_01cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_01cell.svg</file>
+        <file alias="PowerComponentBattery_02cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_02cell.svg</file>
+        <file alias="PowerComponentBattery_03cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_03cell.svg</file>
+        <file alias="PowerComponentBattery_04cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_04cell.svg</file>
+        <file alias="PowerComponentBattery_05cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_05cell.svg</file>
+        <file alias="PowerComponentBattery_06cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_06cell.svg</file>
+
+        <file alias="attitudeDial.svg">src/ui/qmlcommon/attitudeDial.svg</file>
+        <file alias="attitudeInstrument.svg">src/ui/qmlcommon/attitudeInstrument.svg</file>
+        <file alias="attitudePointer.svg">src/ui/qmlcommon/attitudePointer.svg</file>
+        <file alias="buttonHome.svg">src/ui/qmlcommon/buttonHome.svg</file>
+        <file alias="buttonLeft.svg">src/ui/qmlcommon/buttonLeft.svg</file>
+        <file alias="buttonMore.svg">src/ui/qmlcommon/buttonMore.svg</file>
+        <file alias="buttonRight.svg">src/ui/qmlcommon/buttonRight.svg</file>
+        <file alias="compass.svg">src/ui/qmlcommon/compass.svg</file>
+        <file alias="compassInstrumentAirplane.svg">src/ui/qmlcommon/compassInstrumentAirplane.svg</file>
+        <file alias="compassInstrumentDial.svg">src/ui/qmlcommon/compassInstrumentDial.svg</file>
+        <file alias="compassNeedle.svg">src/ui/qmlcommon/compassNeedle.svg</file>
+        <file alias="crossHair.svg">src/ui/qmlcommon/crossHair.svg</file>
+        <file alias="rollDialWhite.svg">src/ui/qmlcommon/rollDialWhite.svg</file>
+        <file alias="rollPointerWhite.svg">src/ui/qmlcommon/rollPointerWhite.svg</file>
+        <file alias="scale.png">src/ui/qmlcommon/scale.png</file>
+        <file alias="scale_end.png">src/ui/qmlcommon/scale_end.png</file>
+    </qresource>
+
     <qresource prefix="/qml">
         <file alias="test.qml">src/test.qml</file>
         <file alias="QmlTest.qml">src/QmlControls/QmlTest.qml</file>
@@ -30,7 +94,6 @@
         <file alias="QGroundControl/Controls/IndicatorButton.qml">src/QmlControls/IndicatorButton.qml</file>
         <file alias="QGroundControl/Controls/VehicleRotationCal.qml">src/QmlControls/VehicleRotationCal.qml</file>
         <file alias="QGroundControl/Controls/VehicleSummaryRow.qml">src/QmlControls/VehicleSummaryRow.qml</file>
-        <file alias="QGroundControl/Controls/arrow-down.png">src/QmlControls/arrow-down.png</file>
         <file alias="QGroundControl/Controls/ViewWidget.qml">src/ViewWidgets/ViewWidget.qml</file>
 
         <file alias="QGroundControl/Controls/QGCView.qml">src/QmlControls/QGCView.qml</file>
@@ -62,51 +125,9 @@
         <file alias="RadioComponentSummary.qml">src/AutoPilotPlugins/PX4/RadioComponentSummary.qml</file>
         <file alias="FlightModesComponentSummary.qml">src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml</file>
         <file alias="AirframeComponentSummary.qml">src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml</file>
-        <file alias="SafetyComponentTree.svg">src/AutoPilotPlugins/PX4/Images/SafetyComponentTree.svg</file>
-        <file alias="SafetyComponentHome.png">src/AutoPilotPlugins/PX4/Images/SafetyComponentHome.png</file>
-        <file alias="SafetyComponentArrowDown.png">src/AutoPilotPlugins/PX4/Images/SafetyComponentArrowDown.png</file>
-        <file alias="SafetyComponentPlane.png">src/AutoPilotPlugins/PX4/Images/SafetyComponentPlane.png</file>
-
-        <file alias="VehicleDown.png">src/AutoPilotPlugins/PX4/Images/VehicleDown.png</file>
-        <file alias="VehicleUpsideDown.png">src/AutoPilotPlugins/PX4/Images/VehicleUpsideDown.png</file>
-        <file alias="VehicleLeft.png">src/AutoPilotPlugins/PX4/Images/VehicleLeft.png</file>
-        <file alias="VehicleRight.png">src/AutoPilotPlugins/PX4/Images/VehicleRight.png</file>
-        <file alias="VehicleNoseDown.png">src/AutoPilotPlugins/PX4/Images/VehicleNoseDown.png</file>
-        <file alias="VehicleTailDown.png">src/AutoPilotPlugins/PX4/Images/VehicleTailDown.png</file>
-
-        <file alias="VehicleDownRotate.png">src/AutoPilotPlugins/PX4/Images/VehicleDownRotate.png</file>
-        <file alias="VehicleLeftRotate.png">src/AutoPilotPlugins/PX4/Images/VehicleLeftRotate.png</file>
-        <file alias="VehicleNoseDownRotate.png">src/AutoPilotPlugins/PX4/Images/VehicleNoseDownRotate.png</file>
 
         <!-- Airframe component resourecs -->
         <file alias="AirframeComponent.qml">src/AutoPilotPlugins/PX4/AirframeComponent.qml</file>
-        <file alias="AirframeStandardPlane.png">src/AutoPilotPlugins/PX4/Images/AirframeStandardPlane.png</file>
-        <file alias="AirframeFlyingWing.png">src/AutoPilotPlugins/PX4/Images/AirframeFlyingWing.png</file>
-        <file alias="AirframeQuadRotorX.png">src/AutoPilotPlugins/PX4/Images/AirframeQuadRotorX.png</file>
-        <file alias="AirframeQuadRotorPlus.png">src/AutoPilotPlugins/PX4/Images/AirframeQuadRotorPlus.png</file>
-        <file alias="AirframeOctoRotorX.png">src/AutoPilotPlugins/PX4/Images/AirframeOctoRotorX.png</file>
-        <file alias="AirframeOctoRotorPlus.png">src/AutoPilotPlugins/PX4/Images/AirframeOctoRotorPlus.png</file>
-        <file alias="AirframeHexaRotorX.png">src/AutoPilotPlugins/PX4/Images/AirframeHexaRotorX.png</file>
-        <file alias="AirframeHexaRotorPlus.png">src/AutoPilotPlugins/PX4/Images/AirframeHexaRotorPlus.png</file>
-        <file alias="AirframeQuadRotorH.png">src/AutoPilotPlugins/PX4/Images/AirframeQuadRotorH.png</file>
-        <file alias="AirframeSimulation.png">src/AutoPilotPlugins/PX4/Images/AirframeSimulation.png</file>
-
-        <file alias="QGroundControl/Controls/subMenuButtonImage.png">resources/CogWheels.png</file>
-        <file alias="QGroundControl/Controls/SensorsComponentIcon.png">src/AutoPilotPlugins/PX4/Images/SensorsComponentIcon.png</file>
-        <file alias="QGroundControl/Controls/RadioComponentIcon.png">src/AutoPilotPlugins/PX4/Images/RadioComponentIcon.png</file>
-        <file alias="QGroundControl/Controls/FlightModesComponentIcon.png">src/AutoPilotPlugins/PX4/Images/FlightModesComponentIcon.png</file>
-        <file alias="QGroundControl/Controls/AirframeComponentIcon.png">src/AutoPilotPlugins/PX4/Images/AirframeComponentIcon.png</file>
-        <file alias="QGroundControl/Controls/SafetyComponentIcon.png">src/AutoPilotPlugins/PX4/Images/SafetyComponentIcon.png</file>
-        <file alias="QGroundControl/Controls/PowerComponentIcon.png">src/AutoPilotPlugins/PX4/Images/PowerComponentIcon.png</file>
-        <file alias="QGroundControl/Controls/FirmwareUpgradeIcon.png">src/VehicleSetup/FirmwareUpgradeIcon.png</file>
-        <file alias="QGroundControl/Controls/VehicleSummaryIcon.png">src/VehicleSetup/VehicleSummaryIcon.png</file>
-
-        <file alias="PowerComponentBattery_01cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_01cell.svg</file>
-        <file alias="PowerComponentBattery_02cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_02cell.svg</file>
-        <file alias="PowerComponentBattery_03cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_03cell.svg</file>
-        <file alias="PowerComponentBattery_04cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_04cell.svg</file>
-        <file alias="PowerComponentBattery_05cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_05cell.svg</file>
-        <file alias="PowerComponentBattery_06cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_06cell.svg</file>
         <!-- QML Main UI -->
         <file alias="MainToolBar.qml">src/ui/toolbar/MainToolBar.qml</file>
         <file alias="FlightDisplay.qml">src/ui/flightdisplay/FlightDisplay.qml</file>
@@ -130,23 +151,6 @@
         <file alias="QGroundControl/FlightControls/qmldir">src/ui/qmlcommon/qmldir</file>
         <!-- QML Map Resources -->
         <file alias="QGroundControl/FlightControls/QGCWaypoint.qml">src/ui/qmlcommon/QGCWaypoint.qml</file>
-        <!-- QML Main UI Resources -->
-        <file alias="attitudeDial.svg">src/ui/qmlcommon/attitudeDial.svg</file>
-        <file alias="attitudeInstrument.svg">src/ui/qmlcommon/attitudeInstrument.svg</file>
-        <file alias="attitudePointer.svg">src/ui/qmlcommon/attitudePointer.svg</file>
-        <file alias="buttonHome.svg">src/ui/qmlcommon/buttonHome.svg</file>
-        <file alias="buttonLeft.svg">src/ui/qmlcommon/buttonLeft.svg</file>
-        <file alias="buttonMore.svg">src/ui/qmlcommon/buttonMore.svg</file>
-        <file alias="buttonRight.svg">src/ui/qmlcommon/buttonRight.svg</file>
-        <file alias="compass.svg">src/ui/qmlcommon/compass.svg</file>
-        <file alias="compassInstrumentAirplane.svg">src/ui/qmlcommon/compassInstrumentAirplane.svg</file>
-        <file alias="compassInstrumentDial.svg">src/ui/qmlcommon/compassInstrumentDial.svg</file>
-        <file alias="compassNeedle.svg">src/ui/qmlcommon/compassNeedle.svg</file>
-        <file alias="crossHair.svg">src/ui/qmlcommon/crossHair.svg</file>
-        <file alias="rollDialWhite.svg">src/ui/qmlcommon/rollDialWhite.svg</file>
-        <file alias="rollPointerWhite.svg">src/ui/qmlcommon/rollPointerWhite.svg</file>
-        <file alias="scale.png">src/ui/qmlcommon/scale.png</file>
-        <file alias="scale_end.png">src/ui/qmlcommon/scale_end.png</file>
     </qresource>
 
     <qresource prefix="/AutoPilotPlugins/PX4">

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.cc
@@ -132,7 +132,7 @@ QString AirframeComponent::description(void) const
 
 QString AirframeComponent::iconResource(void) const
 {
-    return "AirframeComponentIcon.png";
+    return "/qmlimages/AirframeComponentIcon.png";
 }
 
 bool AirframeComponent::requiresSetup(void) const

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
@@ -96,15 +96,15 @@ const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rg
 };
 
 const AirframeComponentAirframes::AirframeType_t AirframeComponentAirframes::rgAirframeTypes[] = {
-    { "Standard Airplane",  "qrc:/qml/AirframeStandardPlane.png",   AirframeComponentAirframes::_rgAirframeInfoStandardPlane },
-    { "Flying Wing",        "qrc:/qml/AirframeFlyingWing.png",      AirframeComponentAirframes::_rgAirframeInfoFlyingWing },
-    { "QuadRotor X",        "qrc:/qml/AirframeQuadRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorX },
-    { "QuadRotor +",        "qrc:/qml/AirframeQuadRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoQuadRotorPlus },
-    { "HexaRotor X",        "qrc:/qml/AirframeHexaRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoHexaRotorX },
-    { "HexaRotor +",        "qrc:/qml/AirframeHexaRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoHexaRotorPlus },
-    { "OctoRotor X",        "qrc:/qml/AirframeOctoRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoOctoRotorX },
-    { "OctoRotor +",        "qrc:/qml/AirframeOctoRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoOctoRotorPlus },
-    { "QuadRotor H",        "qrc:/qml/AirframeQuadRotorH.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorH },
-    { "Simulation",         "qrc:/qml/AirframeSimulation.png",      AirframeComponentAirframes::_rgAirframeInfoSimulation },
+    { "Standard Airplane",  "qrc:/qmlimages/AirframeStandardPlane.png",   AirframeComponentAirframes::_rgAirframeInfoStandardPlane },
+    { "Flying Wing",        "qrc:/qmlimages/AirframeFlyingWing.png",      AirframeComponentAirframes::_rgAirframeInfoFlyingWing },
+    { "QuadRotor X",        "qrc:/qmlimages/AirframeQuadRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorX },
+    { "QuadRotor +",        "qrc:/qmlimages/AirframeQuadRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoQuadRotorPlus },
+    { "HexaRotor X",        "qrc:/qmlimages/AirframeHexaRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoHexaRotorX },
+    { "HexaRotor +",        "qrc:/qmlimages/AirframeHexaRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoHexaRotorPlus },
+    { "OctoRotor X",        "qrc:/qmlimages/AirframeOctoRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoOctoRotorX },
+    { "OctoRotor +",        "qrc:/qmlimages/AirframeOctoRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoOctoRotorPlus },
+    { "QuadRotor H",        "qrc:/qmlimages/AirframeQuadRotorH.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorH },
+    { "Simulation",         "qrc:/qmlimages/AirframeSimulation.png",      AirframeComponentAirframes::_rgAirframeInfoSimulation },
     { NULL,                 NULL,                                   NULL }
 };

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
@@ -63,7 +63,7 @@ QString FlightModesComponent::description(void) const
 
 QString FlightModesComponent::iconResource(void) const
 {
-    return "FlightModesComponentIcon.png";
+    return "/qmlimages/FlightModesComponentIcon.png";
 }
 
 bool FlightModesComponent::requiresSetup(void) const

--- a/src/AutoPilotPlugins/PX4/PowerComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.cc
@@ -46,7 +46,7 @@ QString PowerComponent::description(void) const
 
 QString PowerComponent::iconResource(void) const
 {
-    return "PowerComponentIcon.png";
+    return "/qmlimages/PowerComponentIcon.png";
 }
 
 bool PowerComponent::requiresSetup(void) const

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -54,13 +54,13 @@ QGCView {
     function getBatteryImage()
     {
         switch(battNumCells.value) {
-            case 1:  return "/qml/PowerComponentBattery_01cell.svg";
-            case 2:  return "/qml/PowerComponentBattery_02cell.svg"
-            case 3:  return "/qml/PowerComponentBattery_03cell.svg"
-            case 4:  return "/qml/PowerComponentBattery_04cell.svg"
-            case 5:  return "/qml/PowerComponentBattery_05cell.svg"
-            case 6:  return "/qml/PowerComponentBattery_06cell.svg"
-            default: return "/qml/PowerComponentBattery_01cell.svg";
+            case 1:  return "/qmlimages/PowerComponentBattery_01cell.svg";
+            case 2:  return "/qmlimages/PowerComponentBattery_02cell.svg"
+            case 3:  return "/qmlimages/PowerComponentBattery_03cell.svg"
+            case 4:  return "/qmlimages/PowerComponentBattery_04cell.svg"
+            case 5:  return "/qmlimages/PowerComponentBattery_05cell.svg"
+            case 6:  return "/qmlimages/PowerComponentBattery_06cell.svg"
+            default: return "/qmlimages/PowerComponentBattery_01cell.svg";
         }
     }
 

--- a/src/AutoPilotPlugins/PX4/RadioComponent.cc
+++ b/src/AutoPilotPlugins/PX4/RadioComponent.cc
@@ -48,7 +48,7 @@ QString RadioComponent::description(void) const
 
 QString RadioComponent::iconResource(void) const
 {
-    return "RadioComponentIcon.png";
+    return "/qmlimages/RadioComponentIcon.png";
 }
 
 bool RadioComponent::requiresSetup(void) const

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.cc
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.cc
@@ -46,7 +46,7 @@ QString SafetyComponent::description(void) const
 
 QString SafetyComponent::iconResource(void) const
 {
-    return "SafetyComponentIcon.png";
+    return "/qmlimages/SafetyComponentIcon.png";
 }
 
 bool SafetyComponent::requiresSetup(void) const

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -213,7 +213,7 @@ FactPanel {
                         QGCColoredImage {
                             id:         planeImage
                             y:          parent.height - planeWidth - 40
-                            source:     "/qml/SafetyComponentPlane.png"
+                            source:     "/qmlimages/SafetyComponentPlane.png"
                             fillMode:   Image.PreserveAspectFit
                             width:      planeWidth
                             height:     planeWidth
@@ -226,7 +226,7 @@ FactPanel {
                             y:          parent.height - height - 20
                             width:      80
                             height:     parent.height / 2
-                            source:     "/qml/SafetyComponentTree.svg"
+                            source:     "/qmlimages/SafetyComponentTree.svg"
                             fillMode:   Image.Stretch
                             smooth:     true
                             color:      palette.windowShadeDark
@@ -237,7 +237,7 @@ FactPanel {
                             y:          parent.height - height
                             width:      100
                             height:     parent.height * .75
-                            source:     "/qml/SafetyComponentTree.svg"
+                            source:     "/qmlimages/SafetyComponentTree.svg"
                             fillMode:   Image.PreserveAspectFit
                             smooth:     true
                             color:      palette.button
@@ -246,7 +246,7 @@ FactPanel {
                         QGCColoredImage {
                             x:          parent.width - (arrowWidth/2) - 1
                             y:          parent.height - homeWidth - arrowToHomeSpacing - 2
-                            source:     "/qml/SafetyComponentArrowDown.png"
+                            source:     "/qmlimages/SafetyComponentArrowDown.png"
                             fillMode:   Image.PreserveAspectFit
                             width:      arrowWidth
                             height:     arrowWidth
@@ -258,7 +258,7 @@ FactPanel {
                             id:         homeImage
                             x:          parent.width - (homeWidth / 2)
                             y:          parent.height - homeWidth
-                            source:     "/qml/SafetyComponentHome.png"
+                            source:     "/qmlimages/SafetyComponentHome.png"
                             fillMode:   Image.PreserveAspectFit
                             width:      homeWidth
                             height:     homeWidth

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.cc
@@ -51,7 +51,7 @@ QString SensorsComponent::description(void) const
 
 QString SensorsComponent::iconResource(void) const
 {
-    return "SensorsComponentIcon.png";
+    return "/qmlimages/SensorsComponentIcon.png";
 }
 
 bool SensorsComponent::requiresSetup(void) const

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -430,42 +430,42 @@ QGCView {
                             calValid:           controller.orientationCalDownSideDone
                             calInProgress:      controller.orientationCalDownSideInProgress
                             calInProgressText:  controller.orientationCalDownSideRotate ? "Rotate" : "Hold Still"
-                            imageSource:        controller.orientationCalDownSideRotate ? "qrc:///qml/VehicleDownRotate.png" : "qrc:///qml/VehicleDown.png"
+                            imageSource:        controller.orientationCalDownSideRotate ? "qrc:///qmlimages/VehicleDownRotate.png" : "qrc:///qmlimages/VehicleDown.png"
                         }
                         VehicleRotationCal {
                             visible:            controller.orientationCalUpsideDownSideVisible
                             calValid:           controller.orientationCalUpsideDownSideDone
                             calInProgress:      controller.orientationCalUpsideDownSideInProgress
                             calInProgressText:  "Hold Still"
-                            imageSource:        "qrc:///qml/VehicleUpsideDown.png"
+                            imageSource:        "qrc:///qmlimages/VehicleUpsideDown.png"
                         }
                         VehicleRotationCal {
                             visible:            controller.orientationCalNoseDownSideVisible
                             calValid:           controller.orientationCalNoseDownSideDone
                             calInProgress:      controller.orientationCalNoseDownSideInProgress
                             calInProgressText:  controller.orientationCalNoseDownSideRotate ? "Rotate" : "Hold Still"
-                            imageSource:        controller.orientationCalNoseDownSideRotate ? "qrc:///qml/VehicleNoseDownRotate.png" : "qrc:///qml/VehicleNoseDown.png"
+                            imageSource:        controller.orientationCalNoseDownSideRotate ? "qrc:///qmlimages/VehicleNoseDownRotate.png" : "qrc:///qmlimages/VehicleNoseDown.png"
                         }
                         VehicleRotationCal {
                             visible:            controller.orientationCalTailDownSideVisible
                             calValid:           controller.orientationCalTailDownSideDone
                             calInProgress:      controller.orientationCalTailDownSideInProgress
                             calInProgressText:  "Hold Still"
-                            imageSource:        "qrc:///qml/VehicleTailDown.png"
+                            imageSource:        "qrc:///qmlimages/VehicleTailDown.png"
                         }
                         VehicleRotationCal {
                             visible:            controller.orientationCalLeftSideVisible
                             calValid:           controller.orientationCalLeftSideDone
                             calInProgress:      controller.orientationCalLeftSideInProgress
                             calInProgressText:  controller.orientationCalLeftSideRotate ? "Rotate" : "Hold Still"
-                            imageSource:        controller.orientationCalLeftSideRotate ? "qrc:///qml/VehicleLeftRotate.png" : "qrc:///qml/VehicleLeft.png"
+                            imageSource:        controller.orientationCalLeftSideRotate ? "qrc:///qmlimages/VehicleLeftRotate.png" : "qrc:///qmlimages/VehicleLeft.png"
                         }
                         VehicleRotationCal {
                             visible:            controller.orientationCalRightSideVisible
                             calValid:           controller.orientationCalRightSideDone
                             calInProgress:      controller.orientationCalRightSideInProgress
                             calInProgressText:  "Hold Still"
-                            imageSource:        "qrc:///qml/VehicleRight.png"
+                            imageSource:        "qrc:///qmlimages/VehicleRight.png"
                         }
                     }
                 }

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -76,7 +76,7 @@ Button {
                 Image {
                     id: imageItem
                     visible: control.menu !== null
-                    source: "arrow-down.png"
+                    source: "/qmlimages/arrow-down.png"
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
                     anchors.rightMargin: padding.right

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -30,7 +30,7 @@ ComboBox {
             Image {
                 id: imageItem
                 visible: control.menu !== null
-                source: "arrow-down.png"
+                source: "/qmlimages/arrow-down.png"
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.right: parent.right
                 anchors.rightMargin: dropDownButtonWidth / 2

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -13,7 +13,7 @@ Button {
     text: "Button"
     property bool setupComplete: true
     property bool setupIndicator: true
-    property string imageResource: "subMenuButtonImage.png"
+    property string imageResource: "/qmlimages/subMenuButtonImage.png"
 
     style: ButtonStyle {
         id: buttonStyle

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -149,7 +149,7 @@ Rectangle {
         SubMenuButton {
             id:             summaryButton
             width:          buttonWidth
-            imageResource: "VehicleSummaryIcon.png"
+            imageResource: "/qmlimages/VehicleSummaryIcon.png"
             setupIndicator: false
             exclusiveGroup: setupButtonGroup
             text:           "SUMMARY"
@@ -160,7 +160,7 @@ Rectangle {
         SubMenuButton {
             id:             firmwareButton
             width:          buttonWidth
-            imageResource:  "FirmwareUpgradeIcon.png"
+            imageResource:  "/qmlimages/FirmwareUpgradeIcon.png"
             setupIndicator: false
             exclusiveGroup: setupButtonGroup
             visible:        controller.showFirmware

--- a/src/ui/mapdisplay/MapDisplay.qml
+++ b/src/ui/mapdisplay/MapDisplay.qml
@@ -82,7 +82,7 @@ Rectangle {
                 Image {
                     id:             buttomImg
                     anchors.fill:   parent
-                    source:         showWaypointEditor ? "/qml/buttonRight.svg" : "/qml/buttonLeft.svg"
+                    source:         showWaypointEditor ? "/qmlimages/buttonRight.svg" : "/qmlimages/buttonLeft.svg"
                     mipmap:         true
                     smooth:         true
                     antialiasing:   true
@@ -144,25 +144,25 @@ Rectangle {
             QGCMapToolButton {
                 width:  50
                 height: 50
-                imageSource: "/qml/buttonHome.svg"
+                imageSource: "/qmlimages/buttonHome.svg"
                 exclusiveGroup: mainActionGroup
             }
             QGCMapToolButton {
                 width:  50
                 height: 50
-                imageSource: "/qml/buttonHome.svg"
+                imageSource: "/qmlimages/buttonHome.svg"
                 exclusiveGroup: mainActionGroup
             }
             QGCMapToolButton {
                 width:  50
                 height: 50
-                imageSource: "/qml/buttonHome.svg"
+                imageSource: "/qmlimages/buttonHome.svg"
                 exclusiveGroup: mainActionGroup
             }
             QGCMapToolButton {
                 width:  50
                 height: 50
-                imageSource: "/qml/buttonHome.svg"
+                imageSource: "/qmlimages/buttonHome.svg"
                 exclusiveGroup: mainActionGroup
             }
         }

--- a/src/ui/qmlcommon/QGCAttitudeInstrument.qml
+++ b/src/ui/qmlcommon/QGCAttitudeInstrument.qml
@@ -51,7 +51,7 @@ QGCMovableItem {
     //-- Pointer
     Image {
         id:         pointer
-        source:     "/qml/attitudePointer.svg"
+        source:     "/qmlimages/attitudePointer.svg"
         mipmap:     true
         fillMode:   Image.PreserveAspectFit
         anchors.fill: parent
@@ -60,7 +60,7 @@ QGCMovableItem {
     //-- Instrument Dial
     Image {
         id:         instrumentDial
-        source:     "/qml/attitudeDial.svg"
+        source:     "/qmlimages/attitudeDial.svg"
         mipmap:     true
         fillMode:   Image.PreserveAspectFit
         anchors.fill: parent
@@ -86,7 +86,7 @@ QGCMovableItem {
     Image {
         id:                 crossHair
         anchors.centerIn:   parent
-        source:             "/qml/crossHair.svg"
+        source:             "/qmlimages/crossHair.svg"
         mipmap:             true
         width:              size * 0.75
         fillMode:           Image.PreserveAspectFit
@@ -95,7 +95,7 @@ QGCMovableItem {
     //-- Instrument Pannel
     Image {
         id:             pannel
-        source:         "/qml/attitudeInstrument.svg"
+        source:         "/qmlimages/attitudeInstrument.svg"
         mipmap:         true
         fillMode:       Image.PreserveAspectFit
         anchors.fill:   parent

--- a/src/ui/qmlcommon/QGCAttitudeWidget.qml
+++ b/src/ui/qmlcommon/QGCAttitudeWidget.qml
@@ -39,7 +39,7 @@ Item {
     Image {
         id: rollDial
         anchors     { bottom: root.verticalCenter; horizontalCenter: parent.horizontalCenter}
-        source:     "/qml/rollDialWhite.svg"
+        source:     "/qmlimages/rollDialWhite.svg"
         mipmap:     true
         width:      parent.width
         fillMode:   Image.PreserveAspectFit
@@ -53,7 +53,7 @@ Item {
     Image {
         id: pointer
         anchors     { bottom: root.verticalCenter; horizontalCenter: parent.horizontalCenter}
-        source:     "/qml/rollPointerWhite.svg"
+        source:     "/qmlimages/rollPointerWhite.svg"
         mipmap:     true
         width:      rollDial.width
         fillMode:   Image.PreserveAspectFit
@@ -62,7 +62,7 @@ Item {
     Image {
         id:                 crossHair
         anchors.centerIn:   parent
-        source:             "/qml/crossHair.svg"
+        source:             "/qmlimages/crossHair.svg"
         mipmap:             true
         width:              parent.width
         fillMode:           Image.PreserveAspectFit

--- a/src/ui/qmlcommon/QGCCompass.qml
+++ b/src/ui/qmlcommon/QGCCompass.qml
@@ -37,7 +37,7 @@ Item {
     Image {
         id: compass
         anchors.centerIn: parent
-        source: "/qml/compass.svg"
+        source: "/qmlimages/compass.svg"
         mipmap: true
         width: root.width
         fillMode: Image.PreserveAspectFit
@@ -51,7 +51,7 @@ Item {
         id: pointer
         anchors.bottom: compass.top
         anchors.horizontalCenter: root.horizontalCenter
-        source: "/qml/compassNeedle.svg"
+        source: "/qmlimages/compassNeedle.svg"
         smooth:   true
         width:    compass.width * 0.1
         fillMode: Image.PreserveAspectFit

--- a/src/ui/qmlcommon/QGCCompassInstrument.qml
+++ b/src/ui/qmlcommon/QGCCompassInstrument.qml
@@ -45,7 +45,7 @@ QGCMovableItem {
     }
     Image {
         id:                 pointer
-        source:             "/qml/compassInstrumentAirplane.svg"
+        source:             "/qmlimages/compassInstrumentAirplane.svg"
         mipmap:             true
         width:              size * 0.75
         fillMode:           Image.PreserveAspectFit
@@ -58,7 +58,7 @@ QGCMovableItem {
     }
     Image {
         id:                 compassDial
-        source:             "/qml/compassInstrumentDial.svg"
+        source:             "/qmlimages/compassInstrumentDial.svg"
         mipmap:             true
         fillMode:           Image.PreserveAspectFit
         anchors.fill:       parent

--- a/src/ui/qmlcommon/QGCMapBackground.qml
+++ b/src/ui/qmlcommon/QGCMapBackground.qml
@@ -336,19 +336,19 @@ Item {
         }
         Image {
             id: scaleImageLeft
-            source: "/qml/scale_end.png"
+            source: "/qmlimages/scale_end.png"
             anchors.bottom: parent.bottom
             anchors.left: parent.left
         }
         Image {
             id: scaleImage
-            source: "/qml/scale.png"
+            source: "/qmlimages/scale.png"
             anchors.bottom: parent.bottom
             anchors.left: scaleImageLeft.right
         }
         Image {
             id: scaleImageRight
-            source: "/qml/scale_end.png"
+            source: "/qmlimages/scale_end.png"
             anchors.bottom: parent.bottom
             anchors.left: scaleImage.right
         }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -282,7 +282,7 @@ Rectangle {
                 Image {
                     id:             buttomImg
                     anchors.fill:   parent
-                    source:         "/qml/buttonMore.svg"
+                    source:         "/qmlimages/buttonMore.svg"
                     mipmap:         true
                     smooth:         true
                     antialiasing:   true
@@ -349,7 +349,7 @@ Rectangle {
 
                 Image {
                     id: dropDown
-                    source: "QGroundControl/Controls/arrow-down.png"
+                    source: "/qmlimages/arrow-down.png"
                     visible: (messages.showTriangle) && (MavManager.messageCount > 0)
                     anchors.bottom: parent.bottom
                     anchors.right: parent.right


### PR DESCRIPTION
This is a cosmetic but rather large change. It can wait.

Both QML files and Image resources are all in the same QRC root (qml). That causes quite a bit of clutter when using Qt Creator as you have to browse through a zillion images in order to find the QML file you are looking for.