### PR TITLE
Force Default Group to top of parameter editor list

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -34,7 +34,7 @@
 
 FactMetaData::FactMetaData(ValueType_t type, QObject* parent) :
     QObject(parent),
-    _group("Default Group"),
+    _group("*Default Group"),
     _type(type),
     _defaultValue(0),
     _defaultValueAvailable(false),


### PR DESCRIPTION
Should help usability for users not being able to find custom parameters they add which don't have meta data. Also will help with catching missing meta data from standard builds.