### PR TITLE
Fixing Qt event loop issue where UDP readReady signal would not work.

### DIFF
--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -90,7 +90,7 @@ UDPLink::UDPLink(UDPConfiguration* config)
     // http://blog.qt.digia.com/blog/2010/06/17/youre-doing-it-wrong/
     moveToThread(this);
 
-    qDebug() << "UDP Created " << _config->name();
+    //qDebug() << "UDP Created " << _config->name();
 }
 
 UDPLink::~UDPLink()
@@ -425,7 +425,7 @@ void UDPConfiguration::addHost(const QString& host, int port)
             qWarning() << "UDP:" << "Could not resolve host:" << host << "port:" << port;
         } else {
             _hosts[ipAdd] = port;
-            qDebug() << "UDP:" << "Adding Host:" << ipAdd << ":" << port;
+            //qDebug() << "UDP:" << "Adding Host:" << ipAdd << ":" << port;
         }
     }
 }
@@ -440,7 +440,7 @@ void UDPConfiguration::removeHost(const QString& host)
     tHost = tHost.trimmed();
     QMap<QString, int>::iterator i = _hosts.find(tHost);
     if(i != _hosts.end()) {
-        qDebug() << "UDP:" << "Removed host:" << host;
+        //qDebug() << "UDP:" << "Removed host:" << host;
         _hosts.erase(i);
     } else {
         qWarning() << "UDP:" << "Could not remove unknown host:" << host;

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -190,7 +190,7 @@ bool UDPLink::_writeBytes()
             } while (_config->nextHost(host, port));
             //-- Remove hosts that are no longer there
             foreach (QString ghost, goneHosts) {
-                _config->removeHost(host);
+                _config->removeHost(ghost);
             }
         }
         delete qdata;

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -219,7 +219,8 @@ private:
     QMutex              _mutex;
     QQueue<QByteArray*> _outQueue;
 
-    bool _writeBytes    ();
+    bool _dequeBytes    ();
+    void _sendBytes     (const char* data, qint64 size);
 
 };
 

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -36,6 +36,9 @@ This file is part of the QGROUNDCONTROL project
 #include <QMap>
 #include <QMutex>
 #include <QUdpSocket>
+#include <QMutexLocker>
+#include <QQueue>
+#include <QByteArray>
 
 #if defined(QGC_ZEROCONF_ENABLED)
 #include <dns_sd.h>
@@ -212,8 +215,11 @@ private:
     DNSServiceRef  _dnssServiceRef;
 #endif
 
-signals:
-    //Signals are defined by LinkInterface
+    bool                _running;
+    QMutex              _mutex;
+    QQueue<QByteArray*> _outQueue;
+
+    bool _writeBytes    ();
 
 };
 


### PR DESCRIPTION
For whatever reason, UDP connections would some times stop working. What I've found was that the ```readReady()``` signal would stop being called (outgoing datagrams were being sent just fine though). When the Pixhawk/Companion computer link was set to 57600, this would happen rarely but when the speed was set to 900k, the problem would show up quite often. In the case of the Android build, the issue was consistent at any speed and quite soon. As far as I could tell, Qt was getting stuck on a ```select()``` call and could not recover.

The fix was to stop using the ```readReady()``` signal and running my own loop. In the process, I also moved the *writes* to the link thread (it used to be in the MavLinkProtocol thread).

In addition, I've changed the addressing to ```AnyIPv4``` instead of ```Any```. On Qt 5.5, even though the connection was using IPv4, the *peer address* was being returned using IPv6 scheme and messing everything up. As nothing else in the pipeline supports IPv6, I saw no reason to allow binding to IPv6 interfaces.

