### PR TITLE
Automatic UDP Link Configuration

### DIFF
--- a/src/ui/QGCCommConfiguration.cc
+++ b/src/ui/QGCCommConfiguration.cc
@@ -190,4 +190,7 @@ void QGCCommConfiguration::on_nameEdit_textEdited(const QString &arg1)
 {
     Q_UNUSED(arg1);
     _updateUI();
+    if(_config) {
+        _config->setDynamic(false);
+    }
 }

--- a/src/ui/QGCLinkConfiguration.cc
+++ b/src/ui/QGCLinkConfiguration.cc
@@ -225,9 +225,14 @@ void QGCLinkConfiguration::_updateButtons()
     LinkConfiguration* config = NULL;
     QModelIndex index = _ui->linkView->currentIndex();
     bool enabled = (index.row() >= 0);
+    bool deleteEnabled = true;
     if(enabled) {
         config = _viewModel->getConfiguration(index.row());
         if(config) {
+            // Can't delete a dynamic link
+            if(config->isDynamic()) {
+                deleteEnabled = false;
+            }
             LinkInterface* link = config->getLink();
             if(link) {
                 _ui->connectLinkButton->setText("Disconnect");
@@ -237,7 +242,7 @@ void QGCLinkConfiguration::_updateButtons()
         }
     }
     _ui->connectLinkButton->setEnabled(enabled);
-    _ui->delLinkButton->setEnabled(config != NULL);
+    _ui->delLinkButton->setEnabled(config != NULL && deleteEnabled);
     _ui->editLinkButton->setEnabled(config != NULL);
 }
 

--- a/src/ui/QGCUDPLinkConfiguration.cc
+++ b/src/ui/QGCUDPLinkConfiguration.cc
@@ -90,6 +90,7 @@ void QGCUDPLinkConfiguration::on_portNumber_valueChanged(int arg1)
 {
     if(!_inConstructor) {
         _config->setLocalPort(arg1);
+        _config->setDynamic(false);
     }
 }
 


### PR DESCRIPTION
This is in response to the ongoing discussion in #1681. Until we come up with a solution on how to deal with the *Connect* and *Disconnect* buttons in the main tool bar. In the mean time, I've added code that automatically creates a *Default UDP Link*. QGC will not (yet) automatically connect this link. It just automatically adds to the list. This way you don't need to configure a new link in order to use UDP. It will be already added for you to the list. When you click the *Connect* button, it will be there. This is specially useful for mobile devices as the link management UI is still QtWidget based and it sucks on mobile devices.

The next step will be a more fundamental change in the *Connect*/*Disconnect* semantics, which we need to further discuss and come up with a proper solution.
