### PR TITLE
Low pass filter on RC RSSI

### DIFF
--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -134,6 +134,7 @@ private:
     bool            _showBattery;
     float           _progressBarValue;
     int             _remoteRSSI;
+    double          _remoteRSSIstore;
     int             _telemetryRRSSI;
     int             _telemetryLRSSI;
 


### PR DESCRIPTION
PWM RSSI has too much jitter. This is an attempt at low pass filtering it to smooth it out.

@LorenzMeier Could you please validate this? It looks fine to me but I would like your opinion (maybe you want to handle this on the Firmware side?)

This is a sample of incoming data, low pass filtered value and displayed value:

```
100 100     100
100 100     100
100 100     100
 99 99.9    100
100 99.91   100
100 99.919  100
100 99.9271 100
100 99.9344 100
100 99.9409 100
100 99.9468 100
 99 99.8522 100
100 99.8669 100
100 99.8802 100
100 99.8922 100
100 99.903  100
100 99.9127 100
100 99.9214 100
100 99.9293 100
100 99.9363 100
100 99.9427 100
100 99.9484 100
 99 99.8536 100
100 99.8682 100
100 99.8814 100
100 99.8933 100
100 99.9039 100
100 99.9135 100
100 99.9222 100
```