### PR TITLE
Warning and explanation for voltage drop.

### DIFF
--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -310,8 +310,9 @@ QGCView {
                 visible:        showAdvanced.checked
             }
             Rectangle {
+                id: batteryRectangle
                 width: parent.width
-                height: 40
+                height: 140
                 color: palette.windowShade
                 visible: showAdvanced.checked
                 Column {
@@ -327,6 +328,23 @@ QGCView {
                             width: textEditWidth
                             fact: battVoltLoadDrop
                             showUnits: true
+                        }
+                    }
+                    QGCLabel {
+                        width: batteryRectangle.width - 30
+                        wrapMode: Text.WordWrap
+                        text: "All batteries have an internal resistance. This causes the voltage to drop when under load. " +
+                              "This value tells the flight controller how much to compensate when computing the true battery minimum voltage. " +
+                              "<font color=\"yellow\">If this value is set too high, the flight controller will allow the battery to drop bellow its minimum safety " +
+                              "voltage, which will cause damage to the battery.</font>"
+                    }
+                    Row {
+                        spacing: 10
+                        QGCLabel {
+                            text: "Compensated Minimum Voltage:"
+                        }
+                        QGCLabel {
+                            text: ((battNumCells.value * battLowVolt.value) - (battNumCells.value * battVoltLoadDrop.value)).toFixed(1) + ' V'
                         }
                     }
                 }

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -333,10 +333,9 @@ QGCView {
                     QGCLabel {
                         width: batteryRectangle.width - 30
                         wrapMode: Text.WordWrap
-                        text: "All batteries have an internal resistance. This causes the voltage to drop when under load. " +
-                              "This value tells the flight controller how much to compensate when computing the true battery minimum voltage. " +
-                              "<font color=\"yellow\">If this value is set too high, the flight controller will allow the battery to drop bellow its minimum safety " +
-                              "voltage, which will cause damage to the battery.</font>"
+                        text: "Batteries show less voltage at high throttle. Enter the difference in Volts between idle throttle and full " +
+                              "throttle, divided by the number of battery cells. Leave at the default if unsure. " +
+                              "<font color=\"yellow\">If this value is set too high, the battery might be deep discharged and damaged.</font>"
                     }
                     Row {
                         spacing: 10


### PR DESCRIPTION
Added some explanation and a warning on the use of *Voltage Drop* as discussed on issue #1701. I'm also now showing the computed compensated minimum voltage under load.

![screen shot 2015-07-04 at 12 24 36 pm](https://cloud.githubusercontent.com/assets/749243/8508686/fd2cbc00-2247-11e5-9b46-a84cc10a56f1.png)
