### PR TITLE
fixed spelling error in toolbar battery consumed

### DIFF
--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -571,7 +571,7 @@ Rectangle {
                         color: colorWhite
                     }
                     QGCLabel {
-                        text: MavManager.batteryConsumed.toFixed(0) + 'mA';
+                        text: MavManager.batteryConsumed.toFixed(0) + 'mAh';
                         width: getProportionalDimmension(30)
                         horizontalAlignment: Text.AlignRight
                         font.pixelSize: ScreenTools.smallFontPixelSize


### PR DESCRIPTION
As this info shows  consumed energy, its unit should be mAh instead of mA (which is a current)