### PR TITLE
"Show Status Bar" menu entry more sensible.

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -625,7 +625,6 @@ void MainWindow::showStatusBarCallback(bool checked)
 {
     _showStatusBar = checked;
     checked ? statusBar()->show() : statusBar()->hide();
-    _ui.actionStatusBar->setText(checked ? "Hide Status Bar" : "Show Status Bar");
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -301,7 +301,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Status Bar</string>
+    <string>Show Status Bar</string>
    </property>
   </action>
   <action name="actionExperimentalPlanView">


### PR DESCRIPTION
The combination of using a dynamic menu entry string (Show / Hide Status Bar) IN COMBINATION with a tick is very confusing. It should only use one of both.