### PR TITLE
Parameter editor keys

### DIFF
--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -59,6 +59,7 @@ QGCViewDialog {
             validationError.text = fact.validate(validateValue, false /* convertOnly */)
             forceSave.visible = true
         }
+        valueField.forceActiveFocus();
     }
 
     Column {
@@ -82,6 +83,14 @@ QGCViewDialog {
         QGCTextField {
             id:     valueField
             text:   validate ? validateValue : fact.valueString
+
+            onAccepted: accept()
+
+            Keys.onReleased: {
+                if (event.key == Qt.Key_Escape) {
+                    reject()
+                }
+            }
         }
 
         QGCLabel { text: fact.name }

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -60,4 +60,10 @@ TextField {
 
         padding.right: control.showUnits ? unitsLabelWidthGenerator.width : control.__contentHeight/3
     }
+
+    onActiveFocusChanged: {
+        if (activeFocus) {
+            selectAll()
+        }
+    }
 }


### PR DESCRIPTION
- Escape key - Closes editor dialog
- Enter key - Saves editor dialog
- Moving focus into a QGCTextField will now select all text automatically
- Focus automatically placed into text field in editor dialog

This should make parameter editing way faster. So far Esc/Enter key support only in parameter editor dialog. I'll look at transferring that to other dialogs as well.