### PR TITLE
Remove delay waiting for bootloader

### DIFF
--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
@@ -263,8 +263,6 @@ bool PX4FirmwareUpgradeThreadWorker::_findBootloader(const QSerialPortInfo& port
         }
     }
     
-    QGC::SLEEP::msleep(2000);
-    
     if (_bootloader->sync(_bootloaderPort)) {
         bool success;
         


### PR DESCRIPTION
Hopefully this will fix Issue #1718. Delay was in there for 3DR Radio but it seems to work fine without it. Delay was putting thing right on the edge of the bootloader timeout. So if you were unlucky you could miss the bootloader going by.