### PR TITLE
Airframe meta information

### DIFF
--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -339,6 +339,7 @@ HEADERS += \
     src/ViewWidgets/ParameterEditorWidget.h \
     src/ViewWidgets/ViewWidgetController.h \
     src/Waypoint.h \
+    src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
 
 !iOSBuild {
 HEADERS += \
@@ -470,6 +471,7 @@ SOURCES += \
     src/ViewWidgets/ParameterEditorWidget.cc \
     src/ViewWidgets/ViewWidgetController.cc \
     src/Waypoint.cc \
+    src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
 
 !iOSBuild {
 SOURCES += \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -137,9 +137,6 @@
         <file alias="QGroundControl/FlightControls/qmldir">src/ui/qmlcommon/qmldir</file>
         <file alias="QGroundControl/FlightControls/QGCWaypoint.qml">src/ui/qmlcommon/QGCWaypoint.qml</file>
     </qresource>
-    <qresource prefix="/AutoPilotPlugins/PX4">
-        <file alias="ParameterFactMetaData.xml">src/AutoPilotPlugins/PX4/ParameterFactMetaData.xml</file>
-    </qresource>
     <qresource prefix="/res">
         <file alias="LeftArrow">resources/LeftArrow.svg</file>
         <file alias="RightArrow">resources/RightArrow.svg</file>
@@ -246,5 +243,9 @@
     </qresource>
     <qresource prefix="/res/audio">
         <file alias="Alert">resources/audio/alert.wav</file>
+    </qresource>
+    <qresource prefix="/AutopilotPlugins/PX4">
+        <file alias="AirframeFactMetaData.xml">src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml</file>
+        <file alias="ParameterFactMetaData.xml">src/AutoPilotPlugins/PX4/ParameterFactMetaData.xml</file>
     </qresource>
 </RCC>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -244,7 +244,7 @@
     <qresource prefix="/res/audio">
         <file alias="Alert">resources/audio/alert.wav</file>
     </qresource>
-    <qresource prefix="/AutopilotPlugins/PX4">
+    <qresource prefix="/AutoPilotPlugins/PX4">
         <file alias="AirframeFactMetaData.xml">src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml</file>
         <file alias="ParameterFactMetaData.xml">src/AutoPilotPlugins/PX4/ParameterFactMetaData.xml</file>
     </qresource>

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
@@ -26,99 +26,43 @@
 
 #include "AirframeComponentAirframes.h"
 
-QMap<QString, AirframeComponentAirframes::AirframeType_t> AirframeComponentAirframes::rgAirframeTypes;
+QMap<QString, AirframeComponentAirframes::AirframeType_t*> AirframeComponentAirframes::rgAirframeTypes;
 
-AirframeComponentAirframes::AirframeComponentAirframes() {
+QMap<QString, AirframeComponentAirframes::AirframeType_t*>& AirframeComponentAirframes::get() {
 
-    // Standard planes
-    AirframeType_t standardPlane = { "Standard Airplane", "qrc:/qmlimages/AirframeStandardPlane.png", };
-    AirframeInfo_t easystar = {"Multiplex Easystar 1/2", 2100};
-    standardPlane.rgAirframeInfo.append(easystar);
-    rgAirframeTypes.insert("StandardPlane", standardPlane);
+    // Set a single airframe to prevent the UI from going crazy
+    if (rgAirframeTypes.count() == 0) {
+        // Standard planes
+        AirframeType_t *standardPlane = new AirframeType_t;
+        standardPlane->name = "Standard Airplane";
+        standardPlane->imageResource = "qrc:/qmlimages/AirframeStandardPlane.png";
+        AirframeInfo_t *easystar = new AirframeInfo_t;
+        easystar->name = "Multiplex Easystar 1/2";
+        easystar->autostartId = 2100;
+        standardPlane->rgAirframeInfo.append(easystar);
+        rgAirframeTypes.insert("StandardPlane", standardPlane);
+        qDebug() << "Adding plane config";
 
-    // Flying wings
+        // Flying wings
+    }
+
+    return rgAirframeTypes;
 }
 
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoStandardPlane[] = {
-//    { "Multiplex Easystar 1/2", 2100 },
-//    { "Generic AERT",           2101 },
-//    { "3DR Skywalker",          2102 },
-//    { "Skyhunter (1800 mm)",    2103 },
-//    { "Generic AETR",           2104 },
-//    { NULL,                     0 }
-//};
+void AirframeComponentAirframes::clear() {
 
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoSimulation[] = {
-//    { "Plane (HilStar, X-Plane)",   1000 },
-//    { "Plane (Rascal, FlightGear)", 1004 },
-//    { "Quad X HIL",                 1001 },
-//    { "Quad + HIL",                 1003 },
-//    { NULL,                         0 }
-//};
+    // Run through all and delete them
+    for (unsigned tindex = 0; tindex < AirframeComponentAirframes::get().count(); tindex++) {
 
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoFlyingWing[] = {
-//    { "Z-84 Wing Wing (845 mm)",        3033 },
-//    { "TBS Caipirinha (850 mm)",        3100 },
-//    { "Bormatec Camflyer Q (800 mm)",   3030 },
-//    { "FX-61 Phantom FPV (1550 mm)",    3031 },
-//    { "FX-79 Buffalo (2000 mm)",        3034 },
-//    { "Skywalker X5 (1180 mm)",         3032 },
-//    { "Viper v2 (3000 mm)",             3035 },
-//    { NULL,                             0 }
-//};
+        const AirframeComponentAirframes::AirframeType_t* pType = AirframeComponentAirframes::get().values().at(tindex);
 
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorX[] = {
-//    { "DJI F330 8\" Quad",      4010 },
-//    { "DJI F450 10\" Quad",     4011 },
-//    { "X frame Quad UAVCAN",    4012 },
-//    { "AR.Drone Frame Quad",    4008 },
-//    { NULL,                     0 }
-//};
+        for (unsigned index = 0; index < pType->rgAirframeInfo.count(); index++) {
+            const AirframeComponentAirframes::AirframeInfo_t* pInfo = pType->rgAirframeInfo.at(index);
+            delete pInfo;
+        }
 
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorPlus[] = {
-//    { "Generic 10\" Quad +", 5001 },
-//    { NULL,                     0 }
-//};
+        delete pType;
+    }
 
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoHexaRotorX[] = {
-//    { "Standard 10\" Hexa X",   6001 },
-//    { "Coaxial 10\" Hexa X",    11001 },
-//    { NULL,                     0 }
-//};
-
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoHexaRotorPlus[] = {
-//    { "Standard 10\" Hexa",     7001 },
-//    { NULL,                     0 }
-//};
-
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoOctoRotorX[] = {
-//    { "Standard 10\" Octo", 8001 },
-//    { "Coaxial 10\" Octo",  12001 },
-//    { NULL,                 0 }
-//};
-
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoOctoRotorPlus[] = {
-//    { "Standard 10\" Octo", 9001 },
-//    { NULL,                 0 }
-//};
-
-//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorH[] = {
-//    { "3DR Iris",           10016 },
-//    { "TBS Discovery",      10015 },
-//    { "SteadiDrone QU4D",   10017 },
-//    { NULL,                 0 }
-//};
-
-//const AirframeComponentAirframes::AirframeType_t AirframeComponentAirframes::rgAirframeTypes[] = {
-//    { "Standard Airplane",  "qrc:/qmlimages/AirframeStandardPlane.png",   AirframeComponentAirframes::_rgAirframeInfoStandardPlane },
-//    { "Flying Wing",        "qrc:/qmlimages/AirframeFlyingWing.png",      AirframeComponentAirframes::_rgAirframeInfoFlyingWing },
-//    { "QuadRotor X",        "qrc:/qmlimages/AirframeQuadRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorX },
-//    { "QuadRotor +",        "qrc:/qmlimages/AirframeQuadRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoQuadRotorPlus },
-//    { "HexaRotor X",        "qrc:/qmlimages/AirframeHexaRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoHexaRotorX },
-//    { "HexaRotor +",        "qrc:/qmlimages/AirframeHexaRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoHexaRotorPlus },
-//    { "OctoRotor X",        "qrc:/qmlimages/AirframeOctoRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoOctoRotorX },
-//    { "OctoRotor +",        "qrc:/qmlimages/AirframeOctoRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoOctoRotorPlus },
-//    { "QuadRotor H",        "qrc:/qmlimages/AirframeQuadRotorH.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorH },
-//    { "Simulation",         "qrc:/qmlimages/AirframeSimulation.png",      AirframeComponentAirframes::_rgAirframeInfoSimulation },
-//    { NULL,                 NULL,                                   NULL }
-//};
+    rgAirframeTypes.clear();
+}

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
@@ -26,86 +26,99 @@
 
 #include "AirframeComponentAirframes.h"
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoStandardPlane[] = {
-    { "Multiplex Easystar 1/2", 2100 },
-    { "Generic AERT",           2101 },
-    { "3DR Skywalker",          2102 },
-    { "Skyhunter (1800 mm)",    2103 },
-    { "Generic AETR",           2104 },
-    { NULL,                     0 }
-};
+QMap<QString, AirframeComponentAirframes::AirframeType_t> AirframeComponentAirframes::rgAirframeTypes;
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoSimulation[] = {
-    { "Plane (HilStar, X-Plane)",   1000 },
-    { "Plane (Rascal, FlightGear)", 1004 },
-    { "Quad X HIL",                 1001 },
-    { "Quad + HIL",                 1003 },
-    { NULL,                         0 }
-};
+AirframeComponentAirframes::AirframeComponentAirframes() {
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoFlyingWing[] = {
-    { "Z-84 Wing Wing (845 mm)",        3033 },
-    { "TBS Caipirinha (850 mm)",        3100 },
-    { "Bormatec Camflyer Q (800 mm)",   3030 },
-    { "FX-61 Phantom FPV (1550 mm)",    3031 },
-    { "FX-79 Buffalo (2000 mm)",        3034 },
-    { "Skywalker X5 (1180 mm)",         3032 },
-    { "Viper v2 (3000 mm)",             3035 },
-    { NULL,                             0 }
-};
+    // Standard planes
+    AirframeType_t standardPlane = { "Standard Airplane", "qrc:/qmlimages/AirframeStandardPlane.png", };
+    AirframeInfo_t easystar = {"Multiplex Easystar 1/2", 2100};
+    standardPlane.rgAirframeInfo.append(easystar);
+    rgAirframeTypes.insert("StandardPlane", standardPlane);
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorX[] = {
-    { "DJI F330 8\" Quad",      4010 },
-    { "DJI F450 10\" Quad",     4011 },
-    { "X frame Quad UAVCAN",    4012 },
-    { "AR.Drone Frame Quad",    4008 },
-    { NULL,                     0 }
-};
+    // Flying wings
+}
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorPlus[] = {
-    { "Generic 10\" Quad +", 5001 },
-    { NULL,                     0 }
-};
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoStandardPlane[] = {
+//    { "Multiplex Easystar 1/2", 2100 },
+//    { "Generic AERT",           2101 },
+//    { "3DR Skywalker",          2102 },
+//    { "Skyhunter (1800 mm)",    2103 },
+//    { "Generic AETR",           2104 },
+//    { NULL,                     0 }
+//};
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoHexaRotorX[] = {
-    { "Standard 10\" Hexa X",   6001 },
-    { "Coaxial 10\" Hexa X",    11001 },
-    { NULL,                     0 }
-};
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoSimulation[] = {
+//    { "Plane (HilStar, X-Plane)",   1000 },
+//    { "Plane (Rascal, FlightGear)", 1004 },
+//    { "Quad X HIL",                 1001 },
+//    { "Quad + HIL",                 1003 },
+//    { NULL,                         0 }
+//};
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoHexaRotorPlus[] = {
-    { "Standard 10\" Hexa",     7001 },
-    { NULL,                     0 }
-};
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoFlyingWing[] = {
+//    { "Z-84 Wing Wing (845 mm)",        3033 },
+//    { "TBS Caipirinha (850 mm)",        3100 },
+//    { "Bormatec Camflyer Q (800 mm)",   3030 },
+//    { "FX-61 Phantom FPV (1550 mm)",    3031 },
+//    { "FX-79 Buffalo (2000 mm)",        3034 },
+//    { "Skywalker X5 (1180 mm)",         3032 },
+//    { "Viper v2 (3000 mm)",             3035 },
+//    { NULL,                             0 }
+//};
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoOctoRotorX[] = {
-    { "Standard 10\" Octo", 8001 },
-    { "Coaxial 10\" Octo",  12001 },
-    { NULL,                 0 }
-};
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorX[] = {
+//    { "DJI F330 8\" Quad",      4010 },
+//    { "DJI F450 10\" Quad",     4011 },
+//    { "X frame Quad UAVCAN",    4012 },
+//    { "AR.Drone Frame Quad",    4008 },
+//    { NULL,                     0 }
+//};
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoOctoRotorPlus[] = {
-    { "Standard 10\" Octo", 9001 },
-    { NULL,                 0 }
-};
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorPlus[] = {
+//    { "Generic 10\" Quad +", 5001 },
+//    { NULL,                     0 }
+//};
 
-const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorH[] = {
-    { "3DR Iris",           10016 },
-    { "TBS Discovery",      10015 },
-    { "SteadiDrone QU4D",   10017 },
-    { NULL,                 0 }
-};
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoHexaRotorX[] = {
+//    { "Standard 10\" Hexa X",   6001 },
+//    { "Coaxial 10\" Hexa X",    11001 },
+//    { NULL,                     0 }
+//};
 
-const AirframeComponentAirframes::AirframeType_t AirframeComponentAirframes::rgAirframeTypes[] = {
-    { "Standard Airplane",  "qrc:/qmlimages/AirframeStandardPlane.png",   AirframeComponentAirframes::_rgAirframeInfoStandardPlane },
-    { "Flying Wing",        "qrc:/qmlimages/AirframeFlyingWing.png",      AirframeComponentAirframes::_rgAirframeInfoFlyingWing },
-    { "QuadRotor X",        "qrc:/qmlimages/AirframeQuadRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorX },
-    { "QuadRotor +",        "qrc:/qmlimages/AirframeQuadRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoQuadRotorPlus },
-    { "HexaRotor X",        "qrc:/qmlimages/AirframeHexaRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoHexaRotorX },
-    { "HexaRotor +",        "qrc:/qmlimages/AirframeHexaRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoHexaRotorPlus },
-    { "OctoRotor X",        "qrc:/qmlimages/AirframeOctoRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoOctoRotorX },
-    { "OctoRotor +",        "qrc:/qmlimages/AirframeOctoRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoOctoRotorPlus },
-    { "QuadRotor H",        "qrc:/qmlimages/AirframeQuadRotorH.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorH },
-    { "Simulation",         "qrc:/qmlimages/AirframeSimulation.png",      AirframeComponentAirframes::_rgAirframeInfoSimulation },
-    { NULL,                 NULL,                                   NULL }
-};
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoHexaRotorPlus[] = {
+//    { "Standard 10\" Hexa",     7001 },
+//    { NULL,                     0 }
+//};
+
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoOctoRotorX[] = {
+//    { "Standard 10\" Octo", 8001 },
+//    { "Coaxial 10\" Octo",  12001 },
+//    { NULL,                 0 }
+//};
+
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoOctoRotorPlus[] = {
+//    { "Standard 10\" Octo", 9001 },
+//    { NULL,                 0 }
+//};
+
+//const AirframeComponentAirframes::AirframeInfo_t AirframeComponentAirframes::_rgAirframeInfoQuadRotorH[] = {
+//    { "3DR Iris",           10016 },
+//    { "TBS Discovery",      10015 },
+//    { "SteadiDrone QU4D",   10017 },
+//    { NULL,                 0 }
+//};
+
+//const AirframeComponentAirframes::AirframeType_t AirframeComponentAirframes::rgAirframeTypes[] = {
+//    { "Standard Airplane",  "qrc:/qmlimages/AirframeStandardPlane.png",   AirframeComponentAirframes::_rgAirframeInfoStandardPlane },
+//    { "Flying Wing",        "qrc:/qmlimages/AirframeFlyingWing.png",      AirframeComponentAirframes::_rgAirframeInfoFlyingWing },
+//    { "QuadRotor X",        "qrc:/qmlimages/AirframeQuadRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorX },
+//    { "QuadRotor +",        "qrc:/qmlimages/AirframeQuadRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoQuadRotorPlus },
+//    { "HexaRotor X",        "qrc:/qmlimages/AirframeHexaRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoHexaRotorX },
+//    { "HexaRotor +",        "qrc:/qmlimages/AirframeHexaRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoHexaRotorPlus },
+//    { "OctoRotor X",        "qrc:/qmlimages/AirframeOctoRotorX.png",      AirframeComponentAirframes::_rgAirframeInfoOctoRotorX },
+//    { "OctoRotor +",        "qrc:/qmlimages/AirframeOctoRotorPlus.png",   AirframeComponentAirframes::_rgAirframeInfoOctoRotorPlus },
+//    { "QuadRotor H",        "qrc:/qmlimages/AirframeQuadRotorH.png",      AirframeComponentAirframes::_rgAirframeInfoQuadRotorH },
+//    { "Simulation",         "qrc:/qmlimages/AirframeSimulation.png",      AirframeComponentAirframes::_rgAirframeInfoSimulation },
+//    { NULL,                 NULL,                                   NULL }
+//};

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
@@ -57,7 +57,11 @@ void AirframeComponentAirframes::insert(QString& group, QString& image, QString&
     if (!rgAirframeTypes.contains(group)) {
         g = new AirframeType_t;
         g->name = group;
-        g->imageResource = QString("qrc:/qmlimages/").append(image);
+        if (image.length() > 0) {
+            g->imageResource = QString("qrc:/qmlimages/").append(image);
+        } else {
+            g->imageResource = QString("qrc:/qmlimages/AirframeStandardPlane.png");
+        }
         qDebug() << "IMAGE:" << g->imageResource;
         rgAirframeTypes.insert(group, g);
     } else {

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc
@@ -30,6 +30,7 @@ QMap<QString, AirframeComponentAirframes::AirframeType_t*> AirframeComponentAirf
 
 QMap<QString, AirframeComponentAirframes::AirframeType_t*>& AirframeComponentAirframes::get() {
 
+#if 0
     // Set a single airframe to prevent the UI from going crazy
     if (rgAirframeTypes.count() == 0) {
         // Standard planes
@@ -45,18 +46,39 @@ QMap<QString, AirframeComponentAirframes::AirframeType_t*>& AirframeComponentAir
 
         // Flying wings
     }
+#endif
 
     return rgAirframeTypes;
+}
+
+void AirframeComponentAirframes::insert(QString& group, QString& image, QString& name, int id)
+{
+    AirframeType_t *g;
+    if (!rgAirframeTypes.contains(group)) {
+        g = new AirframeType_t;
+        g->name = group;
+        g->imageResource = QString("qrc:/qmlimages/").append(image);
+        qDebug() << "IMAGE:" << g->imageResource;
+        rgAirframeTypes.insert(group, g);
+    } else {
+        g = rgAirframeTypes.value(group);
+    }
+
+    AirframeInfo_t *i = new AirframeInfo_t;
+    i->name = name;
+    i->autostartId = id;
+
+    g->rgAirframeInfo.append(i);
 }
 
 void AirframeComponentAirframes::clear() {
 
     // Run through all and delete them
-    for (unsigned tindex = 0; tindex < AirframeComponentAirframes::get().count(); tindex++) {
+    for (int tindex = 0; tindex < AirframeComponentAirframes::get().count(); tindex++) {
 
         const AirframeComponentAirframes::AirframeType_t* pType = AirframeComponentAirframes::get().values().at(tindex);
 
-        for (unsigned index = 0; index < pType->rgAirframeInfo.count(); index++) {
+        for (int index = 0; index < pType->rgAirframeInfo.count(); index++) {
             const AirframeComponentAirframes::AirframeInfo_t* pInfo = pType->rgAirframeInfo.at(index);
             delete pInfo;
         }

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
@@ -39,21 +39,22 @@
 class AirframeComponentAirframes
 {
 public:
-    AirframeComponentAirframes();
-
     typedef struct {
-        const char* name;
+        QString name;
         int         autostartId;
     } AirframeInfo_t;
     
     typedef struct {
-        const char* name;
-        const char* imageResource;
-        QList<AirframeInfo_t> rgAirframeInfo;
+        QString name;
+        QString imageResource;
+        QList<AirframeInfo_t*> rgAirframeInfo;
     } AirframeType_t;
+
+    static QMap<QString, AirframeComponentAirframes::AirframeType_t*>& get();
+    static void clear();
     
-public:
-    static QMap<QString, AirframeType_t> rgAirframeTypes;
+protected:
+    static QMap<QString, AirframeType_t*> rgAirframeTypes;
     
 private:
 };

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
@@ -30,6 +30,7 @@
 #include <QObject>
 #include <QQuickItem>
 #include <QList>
+#include <QMap>
 
 #include "UASInterface.h"
 #include "AutoPilotPlugin.h"
@@ -38,6 +39,8 @@
 class AirframeComponentAirframes
 {
 public:
+    AirframeComponentAirframes();
+
     typedef struct {
         const char* name;
         int         autostartId;
@@ -46,23 +49,13 @@ public:
     typedef struct {
         const char* name;
         const char* imageResource;
-        const AirframeInfo_t* rgAirframeInfo;
+        QList<AirframeInfo_t> rgAirframeInfo;
     } AirframeType_t;
     
 public:
-    static const AirframeType_t rgAirframeTypes[];
+    static QMap<QString, AirframeType_t> rgAirframeTypes;
     
 private:
-    static const AirframeInfo_t _rgAirframeInfoStandardPlane[];
-    static const AirframeInfo_t _rgAirframeInfoFlyingWing[];
-    static const AirframeInfo_t _rgAirframeInfoQuadRotorX[];
-    static const AirframeInfo_t _rgAirframeInfoQuadRotorPlus[];
-    static const AirframeInfo_t _rgAirframeInfoOctoRotorX[];
-    static const AirframeInfo_t _rgAirframeInfoOctoRotorPlus[];
-    static const AirframeInfo_t _rgAirframeInfoHexaRotorX[];
-    static const AirframeInfo_t _rgAirframeInfoHexaRotorPlus[];
-    static const AirframeInfo_t _rgAirframeInfoQuadRotorH[];
-    static const AirframeInfo_t _rgAirframeInfoSimulation[];
 };
 
 #endif

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
@@ -52,6 +52,7 @@ public:
 
     static QMap<QString, AirframeComponentAirframes::AirframeType_t*>& get();
     static void clear();
+    static void insert(QString& group, QString& image, QString& name, int id);
     
 protected:
     static QMap<QString, AirframeType_t*> rgAirframeTypes;

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -58,13 +58,19 @@ AirframeComponentController::AirframeComponentController(void) :
     
     bool autostartFound = false;
     _autostartId = getParameterFact(FactSystem::defaultComponentId, "SYS_AUTOSTART")->value().toInt();
+
+
     
-    for (const AirframeComponentAirframes::AirframeType_t* pType=&AirframeComponentAirframes::rgAirframeTypes[0]; pType->name != NULL; pType++) {
+    for (unsigned tindex = 0; tindex < AirframeComponentAirframes::rgAirframeTypes.count(); tindex++) {
+
+        const AirframeComponentAirframes::AirframeType_t* pType = &AirframeComponentAirframes::rgAirframeTypes.values().at(tindex);
+
         AirframeType* airframeType = new AirframeType(pType->name, pType->imageResource, this);
         Q_CHECK_PTR(airframeType);
-        
-        int index = 0;
-        for (const AirframeComponentAirframes::AirframeInfo_t* pInfo=&pType->rgAirframeInfo[0]; pInfo->name != NULL; pInfo++) {
+
+        for (unsigned index = 0; index < pType->rgAirframeInfo.count(); index++) {
+            const AirframeComponentAirframes::AirframeInfo_t* pInfo = &pType->rgAirframeInfo.at(index);
+
             if (_autostartId == pInfo->autostartId) {
                 Q_ASSERT(!autostartFound);
                 autostartFound = true;
@@ -73,7 +79,6 @@ AirframeComponentController::AirframeComponentController(void) :
                 _currentVehicleIndex = index;
             }
             airframeType->addAirframe(pInfo->name, pInfo->autostartId);
-            index++;
         }
         
         _airframeTypes.append(QVariant::fromValue(airframeType));

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -61,15 +61,16 @@ AirframeComponentController::AirframeComponentController(void) :
 
 
     
-    for (unsigned tindex = 0; tindex < AirframeComponentAirframes::rgAirframeTypes.count(); tindex++) {
+    for (int tindex = 0; tindex < AirframeComponentAirframes::get().count(); tindex++) {
 
-        const AirframeComponentAirframes::AirframeType_t* pType = &AirframeComponentAirframes::rgAirframeTypes.values().at(tindex);
+        const AirframeComponentAirframes::AirframeType_t* pType = AirframeComponentAirframes::get().values().at(tindex);
 
         AirframeType* airframeType = new AirframeType(pType->name, pType->imageResource, this);
         Q_CHECK_PTR(airframeType);
 
-        for (unsigned index = 0; index < pType->rgAirframeInfo.count(); index++) {
-            const AirframeComponentAirframes::AirframeInfo_t* pInfo = &pType->rgAirframeInfo.at(index);
+        for (int index = 0; index < pType->rgAirframeInfo.count(); index++) {
+            const AirframeComponentAirframes::AirframeInfo_t* pInfo = pType->rgAirframeInfo.at(index);
+            Q_CHECK_PTR(pInfo);
 
             if (_autostartId == pInfo->autostartId) {
                 Q_ASSERT(!autostartFound);

--- a/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
+++ b/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
@@ -59,7 +59,7 @@
       <type>Flying Wing</type>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Hexarotor +">
+  <airframe_group image="AirframeHexaRotorPlus.png" name="Hexarotor +">
     <airframe id="7001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Hexarotor + geometry">
       <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
       <type>Hexarotor +</type>
@@ -68,13 +68,13 @@
       <output name="AUX3">feed-through of RC AUX3 channel</output>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Hexarotor Coaxial&#10;Lorenz Meier &lt;lorenz@px4.io&gt;">
-    <airframe id="11001" maintainer="John Doe &lt;john@example.com&gt;" name="Generic Hexa coaxial geometry">
-      <type>Hexarotor Coaxial
-Lorenz Meier &lt;lorenz@px4.io&gt;</type>
+  <airframe_group image="" name="Hexarotor Coaxial">
+    <airframe id="11001" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Generic Hexa coaxial geometry">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Hexarotor Coaxial</type>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Hexarotor x">
+  <airframe_group image="AirframeHexaRotorX.png" name="Hexarotor x">
     <airframe id="6001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Hexarotor x geometry">
       <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
       <type>Hexarotor x</type>
@@ -83,7 +83,7 @@ Lorenz Meier &lt;lorenz@px4.io&gt;</type>
       <output name="AUX3">feed-through of RC AUX3 channel</output>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Octorotor +">
+  <airframe_group image="AirframeOctoRotorPlus.png" name="Octorotor +">
     <airframe id="9001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Octocopter + geometry">
       <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
       <type>Octorotor +</type>
@@ -92,13 +92,13 @@ Lorenz Meier &lt;lorenz@px4.io&gt;</type>
       <output name="AUX3">feed-through of RC AUX3 channel</output>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Octorotor Coaxial">
+  <airframe_group image="" name="Octorotor Coaxial">
     <airframe id="12001" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Generic 10&quot; Octo coaxial geometry">
       <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
       <type>Octorotor Coaxial</type>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Octorotor x">
+  <airframe_group image="AirframeOctoRotorX.png" name="Octorotor x">
     <airframe id="8001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Octocopter X geometry">
       <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
       <type>Octorotor x</type>
@@ -113,8 +113,8 @@ Lorenz Meier &lt;lorenz@px4.io&gt;</type>
       <type>Quadrotor +</type>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Quadrotor Wide">
-    <airframe id="10015" maintainer="Anton Babushkin &lt;anton@px4.io&gt;, Simon Wilks &lt;simon@px4.io&gt;" name="Team Blacksheep Discovery Quadcopter">
+  <airframe_group image="AirframeQuadRotorH.png" name="Quadrotor Wide">
+    <airframe id="10015" maintainer="Anton Babushkin &lt;anton@px4.io&gt;, Simon Wilks &lt;simon@px4.io&gt;" name="Team Blacksheep Discovery">
       <maintainer>Anton Babushkin &lt;anton@px4.io&gt;, Simon Wilks &lt;simon@px4.io&gt;</maintainer>
       <type>Quadrotor Wide</type>
     </airframe>
@@ -126,7 +126,7 @@ Lorenz Meier &lt;lorenz@px4.io&gt;</type>
       <maintainer>Thomas Gubler &lt;thomas@px4.io&gt;</maintainer>
       <type>Quadrotor Wide</type>
     </airframe>
-    <airframe id="10018" maintainer="Simon Wilks &lt;simon@px4.io&gt;" name="Team Blacksheep Discovery Long Range Quadcopter&#10;Setup: 15 x 5&quot; Props, 6S 4000mAh TBS LiPo, TBS 30A ESCs, TBS 400kV Motors">
+    <airframe id="10018" maintainer="Simon Wilks &lt;simon@px4.io&gt;" name="Team Blacksheep Discovery Endurance">
       <maintainer>Simon Wilks &lt;simon@px4.io&gt;</maintainer>
       <type>Quadrotor Wide</type>
     </airframe>
@@ -165,16 +165,14 @@ Lorenz Meier &lt;lorenz@px4.io&gt;</type>
       <maintainer>Pavel Kirienko &lt;pavel@px4.io&gt;</maintainer>
       <type>Quadrotor x</type>
     </airframe>
-    <airframe id="4020" maintainer="Thomas Gubler &lt;thomas@px4.io&gt;" name="Hobbyking Micro Integrated PCB Quadcopter&#10;with SimonK ESC firmware and Mystery A1510 motors">
+    <airframe id="4020" maintainer="Thomas Gubler &lt;thomas@px4.io&gt;" name="Hobbyking Micro PCB">
       <maintainer>Thomas Gubler &lt;thomas@px4.io&gt;</maintainer>
       <type>Quadrotor x</type>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Rover&#10;loading default values for the axialracing ax10&#10;load some defaults e.g. PWM values">
+  <airframe_group image="" name="Rover">
     <airframe id="50001" maintainer="John Doe &lt;john@example.com&gt;" name="Axial Racing AX10">
-      <type>Rover
-loading default values for the axialracing ax10
-load some defaults e.g. PWM values</type>
+      <type>Rover</type>
     </airframe>
   </airframe_group>
   <airframe_group image="AirframeSimulation.png" name="Simulation">
@@ -220,7 +218,7 @@ load some defaults e.g. PWM values</type>
       <output name="MAIN4">rudder</output>
       <output name="MAIN5">flaps</output>
     </airframe>
-    <airframe id="2102" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Skywalker (3DR or Generic)">
+    <airframe id="2102" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Skywalker (3DR Aero)">
       <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
       <type>Standard Plane</type>
       <output name="AUX1">feed-through of RC AUX1 channel</output>
@@ -255,33 +253,33 @@ load some defaults e.g. PWM values</type>
       <output name="MAIN5">flaps</output>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Tricopter Y+">
-    <airframe id="14001" maintainer="Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;" name="Generic Tricopter Y Geometry&#10;Yaw Servo +Output ==&gt; +Yaw Vehicle Rotation">
+  <airframe_group image="" name="Tricopter Y+">
+    <airframe id="14001" maintainer="Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;" name="Generic Tricopter Y+ Geometry">
       <maintainer>Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;</maintainer>
       <type>Tricopter Y+</type>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="Tricopter Y-">
-    <airframe id="14002" maintainer="Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;" name="Generic Tricopter Y Geometry&#10;Yaw Servo +Output ==&gt; -Yaw Vehicle Rotation">
+  <airframe_group image="" name="Tricopter Y-">
+    <airframe id="14002" maintainer="Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;" name="Generic Tricopter Y- Geometry">
       <maintainer>Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;</maintainer>
       <type>Tricopter Y-</type>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="VTOL Tailsitter">
-    <airframe id="13001" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Duorotor Tailsitter&#10;Generic configuration file for a tailsitter with motors in tandem configuration.">
+  <airframe_group image="" name="VTOL Tailsitter">
+    <airframe id="13001" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Duorotor Tailsitter">
       <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
       <type>VTOL Tailsitter</type>
     </airframe>
-    <airframe id="13003" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Quadrotor X Tailsitter&#10;Generic configuration file for a tailsitter with motors in X configuration.">
+    <airframe id="13003" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Quadrotor X Tailsitter">
       <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
       <type>VTOL Tailsitter</type>
     </airframe>
-    <airframe id="13004" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Quadrotor + Tailsitter&#10;Generic configuration file for a tailsitter with motors in X configuration.">
+    <airframe id="13004" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Quadrotor + Tailsitter">
       <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
       <type>VTOL Tailsitter</type>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeStandardPlane.png" name="VTOL Tiltrotor">
+  <airframe_group image="" name="VTOL Tiltrotor">
     <airframe id="13002" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="BirdsEyeView Aerobotics FireFly6">
       <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
       <type>VTOL Tiltrotor</type>

--- a/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
+++ b/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
@@ -1,0 +1,290 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<airframes>
+  <version>1</version>
+  <airframe_group image="AirframeFlyingWing.png" name="Flying Wing">
+    <airframe id="3030" maintainer="Simon Wilks &lt;simon@px4.io&gt;" name="IO Camflyer">
+      <maintainer>Simon Wilks &lt;simon@px4.io&gt;</maintainer>
+      <type>Flying Wing</type>
+      <url>https://pixhawk.org/platforms/planes/bormatec_camflyer_q</url>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+      <output name="MAIN1">left aileron</output>
+      <output name="MAIN2">right aileron</output>
+      <output name="MAIN4">throttle</output>
+    </airframe>
+    <airframe id="3031" maintainer="Simon Wilks &lt;simon@px4.io&gt;" name="Phantom FPV Flying Wing">
+      <maintainer>Simon Wilks &lt;simon@px4.io&gt;</maintainer>
+      <type>Flying Wing</type>
+      <url>https://pixhawk.org/platforms/planes/z-84_wing_wing</url>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+      <output name="MAIN1">left aileron</output>
+      <output name="MAIN2">right aileron</output>
+      <output name="MAIN4">throttle</output>
+    </airframe>
+    <airframe id="3032" maintainer="Thomas Gubler &lt;thomas@px4.io&gt;, Julian Oes &lt;julian@px4.io&gt;" name="Skywalker X5 Flying Wing">
+      <maintainer>Thomas Gubler &lt;thomas@px4.io&gt;, Julian Oes &lt;julian@px4.io&gt;</maintainer>
+      <type>Flying Wing</type>
+      <url>https://pixhawk.org/platforms/planes/skywalker_x5</url>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+      <output name="MAIN1">left aileron</output>
+      <output name="MAIN2">right aileron</output>
+      <output name="MAIN4">throttle</output>
+    </airframe>
+    <airframe id="3033" maintainer="Simon Wilks &lt;simon@px4.io&gt;" name="Wing Wing (aka Z-84) Flying Wing">
+      <maintainer>Simon Wilks &lt;simon@px4.io&gt;</maintainer>
+      <type>Flying Wing</type>
+      <url>https://pixhawk.org/platforms/planes/z-84_wing_wing</url>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+      <output name="MAIN1">left aileron</output>
+      <output name="MAIN2">right aileron</output>
+      <output name="MAIN4">throttle</output>
+    </airframe>
+    <airframe id="3034" maintainer="Simon Wilks &lt;simon@px4.io&gt;" name="FX-79 Buffalo Flying Wing">
+      <maintainer>Simon Wilks &lt;simon@px4.io&gt;</maintainer>
+      <type>Flying Wing</type>
+    </airframe>
+    <airframe id="3035" maintainer="Simon Wilks &lt;simon@px4.io&gt;" name="Viper">
+      <maintainer>Simon Wilks &lt;simon@px4.io&gt;</maintainer>
+      <type>Flying Wing</type>
+    </airframe>
+    <airframe id="3100" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="TBS Caipirinha">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Flying Wing</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Hexarotor +">
+    <airframe id="7001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Hexarotor + geometry">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
+      <type>Hexarotor +</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Hexarotor Coaxial&#10;Lorenz Meier &lt;lorenz@px4.io&gt;">
+    <airframe id="11001" maintainer="John Doe &lt;john@example.com&gt;" name="Generic Hexa coaxial geometry">
+      <type>Hexarotor Coaxial
+Lorenz Meier &lt;lorenz@px4.io&gt;</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Hexarotor x">
+    <airframe id="6001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Hexarotor x geometry">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
+      <type>Hexarotor x</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Octorotor +">
+    <airframe id="9001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Octocopter + geometry">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
+      <type>Octorotor +</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Octorotor Coaxial">
+    <airframe id="12001" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Generic 10&quot; Octo coaxial geometry">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Octorotor Coaxial</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Octorotor x">
+    <airframe id="8001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Octocopter X geometry">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
+      <type>Octorotor x</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeQuadRotorPlus.png" name="Quadrotor +">
+    <airframe id="5001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic 10&quot; Quad + geometry">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
+      <type>Quadrotor +</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Quadrotor Wide">
+    <airframe id="10015" maintainer="Anton Babushkin &lt;anton@px4.io&gt;, Simon Wilks &lt;simon@px4.io&gt;" name="Team Blacksheep Discovery Quadcopter">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;, Simon Wilks &lt;simon@px4.io&gt;</maintainer>
+      <type>Quadrotor Wide</type>
+    </airframe>
+    <airframe id="10016" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="3DR Iris Quadrotor">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
+      <type>Quadrotor Wide</type>
+    </airframe>
+    <airframe id="10017" maintainer="Thomas Gubler &lt;thomas@px4.io&gt;" name="Steadidrone QU4D">
+      <maintainer>Thomas Gubler &lt;thomas@px4.io&gt;</maintainer>
+      <type>Quadrotor Wide</type>
+    </airframe>
+    <airframe id="10018" maintainer="Simon Wilks &lt;simon@px4.io&gt;" name="Team Blacksheep Discovery Long Range Quadcopter&#10;Setup: 15 x 5&quot; Props, 6S 4000mAh TBS LiPo, TBS 30A ESCs, TBS 400kV Motors">
+      <maintainer>Simon Wilks &lt;simon@px4.io&gt;</maintainer>
+      <type>Quadrotor Wide</type>
+    </airframe>
+    <airframe id="10019" maintainer="Anton Matosov &lt;anton.matosov@gmail.com&gt;" name="HobbyKing SK450 DeadCat modification">
+      <maintainer>Anton Matosov &lt;anton.matosov@gmail.com&gt;</maintainer>
+      <type>Quadrotor Wide</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeQuadRotorX.png" name="Quadrotor x">
+    <airframe id="4001" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Generic Quadrotor X config">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Quadrotor x</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+    </airframe>
+    <airframe id="4008" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="AR.Drone Frame">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Quadrotor x</type>
+    </airframe>
+    <airframe id="4010" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="DJI Flame Wheel F330">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Quadrotor x</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+    </airframe>
+    <airframe id="4011" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="DJI Flame Wheel F450">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Quadrotor x</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+    </airframe>
+    <airframe id="4012" maintainer="Pavel Kirienko &lt;pavel@px4.io&gt;" name="F450-sized quadrotor with CAN">
+      <maintainer>Pavel Kirienko &lt;pavel@px4.io&gt;</maintainer>
+      <type>Quadrotor x</type>
+    </airframe>
+    <airframe id="4020" maintainer="Thomas Gubler &lt;thomas@px4.io&gt;" name="Hobbyking Micro Integrated PCB Quadcopter&#10;with SimonK ESC firmware and Mystery A1510 motors">
+      <maintainer>Thomas Gubler &lt;thomas@px4.io&gt;</maintainer>
+      <type>Quadrotor x</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Rover&#10;loading default values for the axialracing ax10&#10;load some defaults e.g. PWM values">
+    <airframe id="50001" maintainer="John Doe &lt;john@example.com&gt;" name="Axial Racing AX10">
+      <type>Rover
+loading default values for the axialracing ax10
+load some defaults e.g. PWM values</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeSimulation.png" name="Simulation">
+    <airframe id="1000" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="HILStar (XPlane)">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Simulation</type>
+      <output name="MAIN1">aileron</output>
+      <output name="MAIN2">elevator</output>
+      <output name="MAIN3">rudder</output>
+      <output name="MAIN4">throttle</output>
+    </airframe>
+    <airframe id="1001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="HIL Quadcopter X">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
+      <type>Simulation</type>
+    </airframe>
+    <airframe id="1003" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="HIL Quadcopter +">
+      <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
+      <type>Simulation</type>
+    </airframe>
+    <airframe id="1004" maintainer="Thomas Gubler &lt;thomas@px4.io&gt;" name="HIL Rascal 110 (Flightgear)">
+      <maintainer>Thomas Gubler &lt;thomas@px4.io&gt;</maintainer>
+      <type>Simulation</type>
+    </airframe>
+    <airframe id="1005" maintainer="Thomas Gubler &lt;thomas@px4.io&gt;" name="HIL Malolo 1 (Flightgear)">
+      <maintainer>Thomas Gubler &lt;thomas@px4.io&gt;</maintainer>
+      <type>Simulation</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Standard Plane">
+    <airframe id="2100" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Multiplex Easystar">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Standard Plane</type>
+    </airframe>
+    <airframe id="2101" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Standard AERT Plane">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Standard Plane</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+      <output name="MAIN1">aileron</output>
+      <output name="MAIN2">elevator</output>
+      <output name="MAIN3">throttle</output>
+      <output name="MAIN4">rudder</output>
+      <output name="MAIN5">flaps</output>
+    </airframe>
+    <airframe id="2102" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Skywalker (3DR or Generic)">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Standard Plane</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+      <output name="MAIN1">aileron</output>
+      <output name="MAIN2">elevator</output>
+      <output name="MAIN3">throttle</output>
+      <output name="MAIN4">rudder</output>
+      <output name="MAIN5">flaps</output>
+    </airframe>
+    <airframe id="2103" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Skyhunter 1800">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Standard Plane</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+      <output name="MAIN1">aileron</output>
+      <output name="MAIN2">elevator</output>
+      <output name="MAIN4">throttle</output>
+    </airframe>
+    <airframe id="2104" maintainer="Lorenz Meier &lt;lorenz@px4.io&gt;" name="Standard AETR Plane">
+      <maintainer>Lorenz Meier &lt;lorenz@px4.io&gt;</maintainer>
+      <type>Standard Plane</type>
+      <output name="AUX1">feed-through of RC AUX1 channel</output>
+      <output name="AUX2">feed-through of RC AUX2 channel</output>
+      <output name="AUX3">feed-through of RC AUX3 channel</output>
+      <output name="MAIN1">aileron</output>
+      <output name="MAIN2">elevator</output>
+      <output name="MAIN3">throttle</output>
+      <output name="MAIN4">rudder</output>
+      <output name="MAIN5">flaps</output>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Tricopter Y+">
+    <airframe id="14001" maintainer="Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;" name="Generic Tricopter Y Geometry&#10;Yaw Servo +Output ==&gt; +Yaw Vehicle Rotation">
+      <maintainer>Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;</maintainer>
+      <type>Tricopter Y+</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="Tricopter Y-">
+    <airframe id="14002" maintainer="Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;" name="Generic Tricopter Y Geometry&#10;Yaw Servo +Output ==&gt; -Yaw Vehicle Rotation">
+      <maintainer>Trent Lukaczyk &lt;aerialhedgehog@gmail.com&gt;</maintainer>
+      <type>Tricopter Y-</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="VTOL Tailsitter">
+    <airframe id="13001" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Duorotor Tailsitter&#10;Generic configuration file for a tailsitter with motors in tandem configuration.">
+      <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
+      <type>VTOL Tailsitter</type>
+    </airframe>
+    <airframe id="13003" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Quadrotor X Tailsitter&#10;Generic configuration file for a tailsitter with motors in X configuration.">
+      <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
+      <type>VTOL Tailsitter</type>
+    </airframe>
+    <airframe id="13004" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Quadrotor + Tailsitter&#10;Generic configuration file for a tailsitter with motors in X configuration.">
+      <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
+      <type>VTOL Tailsitter</type>
+    </airframe>
+  </airframe_group>
+  <airframe_group image="AirframeStandardPlane.png" name="VTOL Tiltrotor">
+    <airframe id="13002" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="BirdsEyeView Aerobotics FireFly6">
+      <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
+      <type>VTOL Tiltrotor</type>
+    </airframe>
+  </airframe_group>
+</airframes>

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
@@ -70,7 +70,7 @@ void PX4AirframeLoader::loadAirframeFactMetaData(void)
         airframeFilename = parameterDir.filePath("PX4AirframeFactMetaData.xml");
     }
     if (airframeFilename.isEmpty() || !QFile(airframeFilename).exists()) {
-        airframeFilename = ":/AutopilotPlugins/PX4/AirframeFactMetaData.xml";
+        airframeFilename = ":/AutoPilotPlugins/PX4/AirframeFactMetaData.xml";
     }
 
     qCDebug(PX4AirframeLoaderLog) << "Loading meta data file:" << airframeFilename;

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
@@ -1,0 +1,12 @@
+#include "PX4AirframeLoader.h"
+
+PX4AirframeLoader::PX4AirframeLoader()
+{
+
+}
+
+PX4AirframeLoader::~PX4AirframeLoader()
+{
+
+}
+

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
@@ -1,12 +1,307 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
 #include "PX4AirframeLoader.h"
+#include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
+#include "AirframeComponentAirframes.h"
 
-PX4AirframeLoader::PX4AirframeLoader()
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QDebug>
+
+QGC_LOGGING_CATEGORY(PX4AirframeLoaderLog, "PX4AirframeLoaderLog")
+
+bool PX4AirframeLoader::_airframeMetaDataLoaded = false;
+//QMap<QString, FactMetaData*> PX4AirframeLoader::_mapParameterName2FactMetaData;
+
+PX4AirframeLoader::PX4AirframeLoader(AutoPilotPlugin* autopilot, UASInterface* uas, QObject* parent)
 {
-
+    Q_ASSERT(uas);
 }
 
-PX4AirframeLoader::~PX4AirframeLoader()
+/// Load Airframe Fact meta data
+///
+/// The meta data comes from firmware airframes.xml file.
+void PX4AirframeLoader::loadAirframeFactMetaData(void)
 {
+    if (_airframeMetaDataLoaded) {
+        return;
+    }
+    _airframeMetaDataLoaded = true;
 
+    qCDebug(PX4AirframeLoaderLog) << "Loading PX4 airframe fact meta data";
+
+    Q_ASSERT(AirframeComponentAirframes::rgAirframeTypes.count() == 0);
+
+//    QString parameterFilename;
+
+//    // We want unit test builds to always use the resource based meta data to provide repeatable results
+//    if (!qgcApp()->runningUnitTests()) {
+//        // First look for meta data that comes from a firmware download. Fall back to resource if not there.
+//        QSettings settings;
+//        QDir parameterDir = QFileInfo(settings.fileName()).dir();
+//        parameterFilename = parameterDir.filePath("PX4AirframeFactMetaData.xml");
+//    }
+//    if (parameterFilename.isEmpty() || !QFile(parameterFilename).exists()) {
+//        parameterFilename = ":/AutoPilotPlugins/PX4/AirframeFactMetaData.xml";
+//    }
+
+//    qCDebug(PX4AirframeLoaderLog) << "Loading meta data file:" << parameterFilename;
+
+//    QFile xmlFile(parameterFilename);
+//    Q_ASSERT(xmlFile.exists());
+
+//    bool success = xmlFile.open(QIODevice::ReadOnly);
+//    Q_UNUSED(success);
+//    Q_ASSERT(success);
+
+//    QXmlStreamReader xml(xmlFile.readAll());
+//    xmlFile.close();
+//    if (xml.hasError()) {
+//        qWarning() << "Badly formed XML" << xml.errorString();
+//        return;
+//    }
+
+//    QString         factGroup;
+//    QString         errorString;
+//    FactMetaData*   metaData = NULL;
+//    int             xmlState = XmlStateNone;
+//    bool            badMetaData = true;
+
+//    while (!xml.atEnd()) {
+//        if (xml.isStartElement()) {
+//            QString elementName = xml.name().toString();
+
+//            if (elementName == "parameters") {
+//                if (xmlState != XmlStateNone) {
+//                    qWarning() << "Badly formed XML";
+//                    return;
+//                }
+//                xmlState = XmlStateFoundParameters;
+
+//            } else if (elementName == "version") {
+//                if (xmlState != XmlStateFoundParameters) {
+//                    qWarning() << "Badly formed XML";
+//                    return;
+//                }
+//                xmlState = XmlStateFoundVersion;
+
+//                bool convertOk;
+//                QString strVersion = xml.readElementText();
+//                int intVersion = strVersion.toInt(&convertOk);
+//                if (!convertOk) {
+//                    qWarning() << "Badly formed XML";
+//                    return;
+//                }
+//                if (intVersion <= 2) {
+//                    // We can't read these old files
+//                    qDebug() << "Parameter version stamp too old, skipping load. Found:" << intVersion << "Want: 3 File:" << parameterFilename;
+//                    return;
+//                }
+
+
+//            } else if (elementName == "group") {
+//                if (xmlState != XmlStateFoundVersion) {
+//                    // We didn't get a version stamp, assume older version we can't read
+//                    qDebug() << "Parameter version stamp not found, skipping load" << parameterFilename;
+//                    return;
+//                }
+//                xmlState = XmlStateFoundGroup;
+
+//                if (!xml.attributes().hasAttribute("name")) {
+//                    qWarning() << "Badly formed XML";
+//                    return;
+//                }
+//                factGroup = xml.attributes().value("name").toString();
+//                qCDebug(PX4AirframeLoaderLog) << "Found group: " << factGroup;
+
+//            } else if (elementName == "parameter") {
+//                if (xmlState != XmlStateFoundGroup) {
+//                    qWarning() << "Badly formed XML";
+//                    return;
+//                }
+//                xmlState = XmlStateFoundParameter;
+
+//                if (!xml.attributes().hasAttribute("name") || !xml.attributes().hasAttribute("type")) {
+//                    qWarning() << "Badly formed XML";
+//                    return;
+//                }
+
+//                QString name = xml.attributes().value("name").toString();
+//                QString type = xml.attributes().value("type").toString();
+//                QString strDefault = xml.attributes().value("default").toString();
+
+//                qCDebug(PX4AirframeLoaderLog) << "Found parameter name:" << name << " type:" << type << " default:" << strDefault;
+
+//                // Convert type from string to FactMetaData::ValueType_t
+
+//                struct String2Type {
+//                    const char*                 strType;
+//                    FactMetaData::ValueType_t   type;
+//                };
+
+//                static const struct String2Type rgString2Type[] = {
+//                    { "FLOAT",  FactMetaData::valueTypeFloat },
+//                    { "INT32",  FactMetaData::valueTypeInt32 },
+//                };
+//                static const size_t crgString2Type = sizeof(rgString2Type) / sizeof(rgString2Type[0]);
+
+//                bool found = false;
+//                FactMetaData::ValueType_t foundType;
+//                for (size_t i=0; i<crgString2Type; i++) {
+//                    const struct String2Type* info = &rgString2Type[i];
+
+//                    if (type == info->strType) {
+//                        found = true;
+//                        foundType = info->type;
+//                        break;
+//                    }
+//                }
+//                if (!found) {
+//                    qWarning() << "Parameter meta data with bad type:" << type << " name:" << name;
+//                    return;
+//                }
+
+//                // Now that we know type we can create meta data object and add it to the system
+
+//                metaData = new FactMetaData(foundType);
+//                Q_CHECK_PTR(metaData);
+//                if (_mapParameterName2FactMetaData.contains(name)) {
+//                    // We can't trust the meta dafa since we have dups
+//                    qCWarning(PX4AirframeLoaderLog) << "Duplicate parameter found:" << name;
+//                    badMetaData = true;
+//                    // Reset to default meta data
+//                    _mapParameterName2FactMetaData[name] = metaData;
+//                } else {
+//                    _mapParameterName2FactMetaData[name] = metaData;
+//                    metaData->setName(name);
+//                    metaData->setGroup(factGroup);
+
+//                    if (xml.attributes().hasAttribute("default") && !strDefault.isEmpty()) {
+//                        QVariant varDefault;
+
+//                        if (metaData->convertAndValidate(strDefault, false, varDefault, errorString)) {
+//                            metaData->setDefaultValue(varDefault);
+//                        } else {
+//                            qCWarning(PX4AirframeLoaderLog) << "Invalid default value, name:" << name << " type:" << type << " default:" << strDefault << " error:" << errorString;
+//                        }
+//                    }
+//                }
+
+//            } else {
+//                // We should be getting meta data now
+//                if (xmlState != XmlStateFoundParameter) {
+//                    qWarning() << "Badly formed XML";
+//                    return;
+//                }
+
+//                if (!badMetaData) {
+//                    if (elementName == "short_desc") {
+//                        Q_ASSERT(metaData);
+//                        QString text = xml.readElementText();
+//                        text = text.replace("\n", " ");
+//                        qCDebug(PX4AirframeLoaderLog) << "Short description:" << text;
+//                        metaData->setShortDescription(text);
+
+//                    } else if (elementName == "long_desc") {
+//                        Q_ASSERT(metaData);
+//                        QString text = xml.readElementText();
+//                        text = text.replace("\n", " ");
+//                        qCDebug(PX4AirframeLoaderLog) << "Long description:" << text;
+//                        metaData->setLongDescription(text);
+
+//                    } else if (elementName == "min") {
+//                        Q_ASSERT(metaData);
+//                        QString text = xml.readElementText();
+//                        qCDebug(PX4AirframeLoaderLog) << "Min:" << text;
+
+//                        QVariant varMin;
+//                        if (metaData->convertAndValidate(text, true /* convertOnly */, varMin, errorString)) {
+//                            metaData->setMin(varMin);
+//                        } else {
+//                            qCWarning(PX4AirframeLoaderLog) << "Invalid min value, name:" << metaData->name() << " type:" << metaData->type() << " min:" << text << " error:" << errorString;
+//                        }
+
+//                    } else if (elementName == "max") {
+//                        Q_ASSERT(metaData);
+//                        QString text = xml.readElementText();
+//                        qCDebug(PX4AirframeLoaderLog) << "Max:" << text;
+
+//                        QVariant varMax;
+//                        if (metaData->convertAndValidate(text, true /* convertOnly */, varMax, errorString)) {
+//                            metaData->setMax(varMax);
+//                        } else {
+//                            qCWarning(PX4AirframeLoaderLog) << "Invalid max value, name:" << metaData->name() << " type:" << metaData->type() << " max:" << text << " error:" << errorString;
+//                        }
+
+//                    } else if (elementName == "unit") {
+//                        Q_ASSERT(metaData);
+//                        QString text = xml.readElementText();
+//                        qCDebug(PX4AirframeLoaderLog) << "Unit:" << text;
+//                        metaData->setUnits(text);
+
+//                    } else {
+//                        qDebug() << "Unknown element in XML: " << elementName;
+//                    }
+//                }
+//            }
+//        } else if (xml.isEndElement()) {
+//            QString elementName = xml.name().toString();
+
+//            if (elementName == "parameter") {
+//                // Done loading this parameter, validate default value
+//                if (metaData->defaultValueAvailable()) {
+//                    QVariant var;
+
+//                    if (!metaData->convertAndValidate(metaData->defaultValue(), false /* convertOnly */, var, errorString)) {
+//                        qCWarning(PX4AirframeLoaderLog) << "Invalid default value, name:" << metaData->name() << " type:" << metaData->type() << " default:" << metaData->defaultValue() << " error:" << errorString;
+//                    }
+//                }
+
+//                // Reset for next parameter
+//                metaData = NULL;
+//                badMetaData = false;
+//                xmlState = XmlStateFoundGroup;
+//            } else if (elementName == "group") {
+//                xmlState = XmlStateFoundVersion;
+//            } else if (elementName == "parameters") {
+//                xmlState = XmlStateFoundParameters;
+//            }
+//        }
+//        xml.readNext();
+//    }
 }
 
+void PX4AirframeLoader::clearStaticData(void)
+{
+//    foreach(QString airframeName, AirframeComponentAirframes::rgAirframeTypes.keys()) {
+//        delete AirframeComponentAirframes::rgAirframeTypes[airframeName];
+//    }
+    AirframeComponentAirframes::rgAirframeTypes.clear();
+    _airframeMetaDataLoaded = false;
+}

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
@@ -1,0 +1,13 @@
+#ifndef PX4AIRFRAMELOADER_H
+#define PX4AIRFRAMELOADER_H
+
+#include <QObject>
+
+class PX4AirframeLoader
+{
+public:
+    PX4AirframeLoader();
+    ~PX4AirframeLoader();
+};
+
+#endif // PX4AIRFRAMELOADER_H

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
@@ -1,13 +1,69 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
 #ifndef PX4AIRFRAMELOADER_H
 #define PX4AIRFRAMELOADER_H
 
 #include <QObject>
+#include <QMap>
+#include <QXmlStreamReader>
+#include <QLoggingCategory>
 
-class PX4AirframeLoader
+#include "ParameterLoader.h"
+#include "FactSystem.h"
+#include "UASInterface.h"
+#include "AutoPilotPlugin.h"
+
+/// @file PX4AirframeLoader.h
+///     @author Lorenz Meier <lm@qgroundcontrol.org>
+
+Q_DECLARE_LOGGING_CATEGORY(PX4AirframeLoaderLog)
+
+/// Collection of Parameter Facts for PX4 AutoPilot
+
+class PX4AirframeLoader : QObject
 {
+    Q_OBJECT
+
 public:
-    PX4AirframeLoader();
-    ~PX4AirframeLoader();
+    /// @param uas Uas which this set of facts is associated with
+    PX4AirframeLoader(AutoPilotPlugin* autpilot,UASInterface* uas, QObject* parent = NULL);
+
+    static void loadAirframeFactMetaData(void);
+    static void clearStaticData(void);
+
+private:
+    enum {
+        XmlStateNone,
+        XmlStateFoundAirframes,
+        XmlStateFoundVersion,
+        XmlStateFoundGroup,
+        XmlStateFoundAirframe,
+        XmlStateDone
+    };
+
+    static bool _airframeMetaDataLoaded;   ///< true: parameter meta data already loaded
+    static QMap<QString, FactMetaData*> _mapParameterName2FactMetaData; ///< Maps from a parameter name to FactMetaData
 };
 
 #endif // PX4AIRFRAMELOADER_H

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -25,6 +25,7 @@
 #include "AutoPilotPluginManager.h"
 #include "UASManager.h"
 #include "PX4ParameterLoader.h"
+#include "PX4AirframeLoader.h"
 #include "FlightModesComponentController.h"
 #include "AirframeComponentController.h"
 #include "QGCMessageBox.h"
@@ -81,13 +82,18 @@ PX4AutoPilotPlugin::PX4AutoPilotPlugin(UASInterface* uas, QObject* parent) :
     
     connect(_parameterFacts, &PX4ParameterLoader::parametersReady, this, &PX4AutoPilotPlugin::_pluginReadyPreChecks);
     connect(_parameterFacts, &PX4ParameterLoader::parameterListProgress, this, &PX4AutoPilotPlugin::parameterListProgress);
+
+    _airframeFacts = new PX4AirframeLoader(this, uas, this);
+    Q_CHECK_PTR(_airframeFacts);
     
     PX4ParameterLoader::loadParameterFactMetaData();
+    PX4AirframeLoader::loadAirframeFactMetaData();
 }
 
 PX4AutoPilotPlugin::~PX4AutoPilotPlugin()
 {
     delete _parameterFacts;
+    delete _airframeFacts;
 }
 
 QList<AutoPilotPluginManager::FullMode_t> PX4AutoPilotPlugin::getModes(void)
@@ -259,6 +265,7 @@ QString PX4AutoPilotPlugin::getShortModeText(uint8_t baseMode, uint32_t customMo
 void PX4AutoPilotPlugin::clearStaticData(void)
 {
     PX4ParameterLoader::clearStaticData();
+    PX4AirframeLoader::clearStaticData();
 }
 
 const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
@@ -28,6 +28,7 @@
 #include "AutoPilotPluginManager.h"
 #include "UASInterface.h"
 #include "PX4ParameterLoader.h"
+#include "PX4AirframeLoader.h"
 #include "AirframeComponent.h"
 #include "RadioComponent.h"
 #include "FlightModesComponent.h"
@@ -72,7 +73,8 @@ private:
 	// Overrides from AutoPilotPlugin
 	virtual ParameterLoader* _getParameterLoader(void) { return _parameterFacts; }
 	
-    PX4ParameterLoader*      _parameterFacts;
+    PX4ParameterLoader*     _parameterFacts;
+    PX4AirframeLoader*      _airframeFacts;
     QVariantList            _components;
     AirframeComponent*      _airframeComponent;
     RadioComponent*         _radioComponent;


### PR DESCRIPTION
This adds airframe meta info handling from Firmware, which auto-exports all available configurations:

<img width="1275" alt="screen shot 2015-07-31 at 11 30 11" src="https://cloud.githubusercontent.com/assets/1208119/9005497/f80abc9e-377e-11e5-8e84-444a45aa6959.png">
