### PR TITLE
Airframeconfig usability fix

### DIFF
--- a/src/AutoPilotPlugins/PX4/AirframeComponent.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.qml
@@ -111,7 +111,7 @@ QGCView {
         QGCLabel {
             anchors.top:    headingSpacer.bottom
             width:          parent.width - applyButton.width - 5
-            text:           "Select your airframe type and specific vehicle bellow. Click 'Apply and Restart' when ready and your vehicle will be disconnected, rebooted to the new settings and re-connected."
+            text:           "Please select your airframe type. Click 'Apply and Restart' to reboot the autopilot. Please re-connect then manually."
             wrapMode:       Text.WordWrap
         }
 
@@ -221,11 +221,14 @@ QGCView {
                             anchors.top: image.bottom
                             width:  parent.width - (innerMargin * 2)
                             model:  modelData.airframes
-                            currentIndex: (modelData.name == controller.currentAirframeType) ? controller.currentVehicleIndex : 0
+                            currentIndex: (modelData.name == controller.currentAirframeType) ? controller.currentVehicleIndex : -1
 
                             onActivated: {
-                                controller.autostartId = modelData.airframes[currentIndex].autostartId
-                                airframeCheckBox.checked = true;
+                                if (index != -1) {
+                                    currentIndex = index
+                                    controller.autostartId = modelData.airframes[index].autostartId
+                                    airframeCheckBox.checked = true;
+                                }
                             }
                         }
                     }

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.qml
@@ -151,12 +151,18 @@ QGCView {
 
                     // Outer summary item rectangle
                     Rectangle {
+                        id:     airframeBackground
                         readonly property real titleHeight: 30
                         readonly property real innerMargin: 10
 
                         width:  250
                         height: 200
-                        color:  qgcPal.windowShade
+                        color:  (modelData.name != controller.currentAirframeType) ? qgcPal.windowShade : qgcPal.buttonHighlight
+
+                        MouseArea {
+                                anchors.fill: parent
+                                onClicked: airframeCheckBox.checked = true
+                            }
 
                         Rectangle {
                             id:     title
@@ -200,6 +206,9 @@ QGCView {
                             onCheckedChanged: {
                                 if (checked && combo.currentIndex != -1) {
                                     controller.autostartId = modelData.airframes[combo.currentIndex].autostartId
+                                    airframeBackground.color = qgcPal.buttonHighlight;
+                                } else {
+                                    airframeBackground.color = qgcPal.windowShade;
                                 }
                             }
                         }
@@ -214,10 +223,9 @@ QGCView {
                             model:  modelData.airframes
                             currentIndex: (modelData.name == controller.currentAirframeType) ? controller.currentVehicleIndex : 0
 
-                            onCurrentIndexChanged: {
-                                if (airframeCheckBox.checked) {
-                                    controller.autostartId = modelData.airframes[currentIndex].autostartId
-                                }
+                            onActivated: {
+                                controller.autostartId = modelData.airframes[currentIndex].autostartId
+                                airframeCheckBox.checked = true;
                             }
                         }
                     }

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -127,7 +127,7 @@ void AirframeComponentController::_waitParamWriteSignal(QVariant value)
         // Now that both params have made it to the vehicle we can reboot it. All these signals are flying
         // around on the main thread, so we need to allow the stack to unwind back to the event loop before
         // we reboot.
-        QTimer::singleShot(100, this, &AirframeComponentController::_rebootAfterStackUnwind);
+        QTimer::singleShot(800, this, &AirframeComponentController::_rebootAfterStackUnwind);
     }
 }
 
@@ -135,8 +135,10 @@ void AirframeComponentController::_rebootAfterStackUnwind(void)
 {    
     _uas->executeCommand(MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN, 1, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0);
     qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
-    QGC::SLEEP::sleep(1);
-    qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+    for (unsigned i = 0; i < 2000; i++) {
+        QGC::SLEEP::usleep(500);
+        qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+    }
     LinkManager::instance()->disconnectAll();
     qgcApp()->restoreOverrideCursor();
 }


### PR DESCRIPTION
This fixes a couple of usability issues with airframe config where things had to be done in a certain order and things that intuitively are expected (like clicking on an icon to select) didn't work.

I also fixed timing / race issues with param handling in the process and tested the result quite intensively successfully. When this PR is in its probably a good time to cut a new stable.