### PR TITLE
set QGC version from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ ui_*
 *.so*
 *.moc
 *.prl
+git_version.cpp
+git_version.obj

--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -18,9 +18,10 @@
 # -------------------------------------------------
 
 include(QGCCommon.pri)
+include(git_version.pri)
 
 TARGET = qgroundcontrol
-TEMPLATE =  app
+TEMPLATE = app
 
 # Load additional config flags from user_config.pri
 exists(user_config.pri):infile(user_config.pri, CONFIG) {

--- a/deploy/ubuntu_ppa
+++ b/deploy/ubuntu_ppa
@@ -1,17 +1,28 @@
 #! /bin/bash
 
-version="2.4"
-rsync -av --delete --exclude=.git ~/git/qgroundcontrol/ ~/tmp/qgroundcontrol-${version}/
+tmpdir=`mktemp -d`
+long_version=`git describe --always --tags`
+short_version=`git describe --always --tags | cut -d "-" -f 1,2`
 
-cd ~/tmp
-tar pczf qgroundcontrol_${version}.orig.tar.gz qgroundcontrol-${version}
+version=${long_version:1}
+dir_version=${short_version:1}
+echo $version
 
-cd ~/tmp/qgroundcontrol-${version}/
+debchange -v ${version} --distribution trusty
+
+qmake -r qgroundcontrol.pro
+make git_ver
+
+rsync -av --delete --exclude={.git,build-release,release,Makefile\*} . ${tmpdir}/qgroundcontrol-${dir_version}/
+
+cd ${tmpdir}
+tar pczf qgroundcontrol_${dir_version}.orig.tar.gz qgroundcontrol-${dir_version}
+
+cd ${tmpdir}/qgroundcontrol-${dir_version}/
 debuild -S
 
-dput ppa:qgroundcontrol/ppa qgroundcontrol_${version}-0ubuntu1_source.changes
-
+dput ppa:qgroundcontrol/ppa ${tmpdir}/qgroundcontrol_${version}_source.changes
 
 
 # test building the source deb locally
-debuild --prepend-path=/usr/lib/ccache -sa
+#debuild --prepend-path=/usr/lib/ccache -sa

--- a/git_version.pri
+++ b/git_version.pri
@@ -1,0 +1,26 @@
+# set the QGC version from git
+
+exists ($$PWD/.git) {
+  GIT_DESCRIBE = $$system(git --git-dir $$PWD/.git --work-tree $$PWD describe --always --tags)
+  WindowsBuild {
+    QGC_GIT_VER = echo extern \"C\" { const char *git_version() { return \"$$GIT_DESCRIBE\"; } } > git_version.cpp
+    LIBS += git_version.obj
+  } else {
+    QGC_GIT_VER = echo \"extern \\\"C\\\" { const char *git_version() { return \\\"$$GIT_DESCRIBE\\\"; } }\" > git_version.cpp
+    LIBS += git_version.o
+  }
+}
+
+WindowsBuild {
+  LIBS += git_version.obj
+} else {
+  LIBS += git_version.o
+}
+
+CONFIG(debug) {
+  GIT_VERSION_CXXFLAGS = $$QMAKE_CXXFLAGS_DEBUG
+} else {
+  GIT_VERSION_CXXFLAGS = $$QMAKE_CXXFLAGS_RELEASE
+}
+
+QMAKE_PRE_LINK += $$QGC_GIT_VER && $$QMAKE_CXX -c $$GIT_VERSION_CXXFLAGS git_version.cpp

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -22,6 +22,8 @@ CONFIG  +=  ordered
 SUBDIRS  =  ./QGCLocationPlugin.pro
 SUBDIRS +=  ./QGCApplication.pro
 
+include(git_version.pri)
+
 QGCApplication.depends = QGCLocationPlugin
 
 message(Qt version $$[QT_VERSION])
@@ -30,3 +32,6 @@ message(Qt version $$[QT_VERSION])
     error("Unsupported Qt version, 5.4+ is required")
 }
 
+message(QGroundControl version $${GIT_DESCRIBE})
+git_ver.commands = $$QGC_GIT_VER
+QMAKE_EXTRA_TARGETS += git_ver

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -48,6 +48,7 @@ GST_PLUGIN_STATIC_DECLARE(QTVIDEOSINK_NAME);
 G_END_DECLS
 #endif
 
+#include "git_version.h"
 #include "configuration.h"
 #include "QGC.h"
 #include "QGCApplication.h"
@@ -251,10 +252,12 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     setOrganizationName(QGC_ORG_NAME);
     setOrganizationDomain(QGC_ORG_DOMAIN);
 
-    // Version string is build from component parts. Format is:
-    //  vMajor.Minor.BuildNumber BuildType
-    QString versionString("v%1.%2.%3 %4");
-    versionString = versionString.arg(QGC_APPLICATION_VERSION_MAJOR).arg(QGC_APPLICATION_VERSION_MINOR).arg(QGC_APPLICATION_VERSION_BUILDNUMBER).arg(QGC_APPLICATION_VERSION_BUILDTYPE);
+    QString versionString(git_version());
+    // stable versions are on tags (v1.2.3)
+    // development versions are full git describe versions (v1.2.3-18-g879e8b3)
+    if (versionString.length() > 8) {
+        versionString.append(" (Development)");
+    }
     this->setApplicationVersion(versionString);
 
     // Set settings format

--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -18,21 +18,4 @@
 #define QGC_ORG_NAME "QGroundControl.org"
 #define QGC_ORG_DOMAIN "org.qgroundcontrol"
 
-#define QGC_APPLICATION_VERSION_MAJOR 2
-#define QGC_APPLICATION_VERSION_MINOR 7
-
-// The following #definess can be overriden from the command line so that automated build systems can
-// add additional build identification.
-
-// Only comes from command line
-//#define QGC_APPLICATION_VERSION_COMMIT "..."
-
-#ifndef QGC_APPLICATION_VERSION_BUILDNUMBER
-#define QGC_APPLICATION_VERSION_BUILDNUMBER 1
-#endif
-
-#ifndef QGC_APPLICATION_VERSION_BUILDTYPE
-#define QGC_APPLICATION_VERSION_BUILDTYPE "(Stable)"
-#endif
-
 #endif // QGC_CONFIGURATION_H

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -191,7 +191,7 @@ void MAVLinkProtocol::_linkStatusChanged(LinkInterface* link, bool connected)
         // Send command to start MAVLink
         // XXX hacky but safe
         // Start NSH
-        const char init[] = {0x0d, 0x0d, 0x0d};
+        const char init[] = {0x0d, 0x0d, 0x0d, 0x0d};
         link->writeBytes(init, sizeof(init));
         const char* cmd = "sh /etc/init.d/rc.usb\n";
         link->writeBytes(cmd, strlen(cmd));

--- a/src/git_version.h
+++ b/src/git_version.h
@@ -1,0 +1,3 @@
+extern "C" {
+	const char *git_version();
+}


### PR DESCRIPTION
This PR uses `git describe` to set the QGC version.

For example the current version displayed for this branch is
v2.6.0-50-gb4f941e

Which means v2.6.0 + 50 commits and git sha b4f941e. A stable version (directly on a tag) would only display the version (eg v2.6.1)

When it's time for a new stable release just drop a new tag. No need to update QGCConfig.h

I'll likely need to tweak this to work on windows.