### PR TITLE
Notify user of vehicle boot errors

### DIFF
--- a/src/uas/UASMessageHandler.cc
+++ b/src/uas/UASMessageHandler.cc
@@ -38,6 +38,19 @@ UASMessage::UASMessage(int componentid, int severity, QString text)
     _text     = text;
 }
 
+bool UASMessage::severityIsError()
+{
+    switch (_severity) {
+        case MAV_SEVERITY_EMERGENCY:
+        case MAV_SEVERITY_ALERT:
+        case MAV_SEVERITY_CRITICAL:
+        case MAV_SEVERITY_ERROR:
+            return true;
+        default:
+            return false;
+    }
+}
+
 IMPLEMENT_QGC_SINGLETON(UASMessageHandler, UASMessageHandler)
 
 UASMessageHandler::UASMessageHandler(QObject *parent)

--- a/src/uas/UASMessageHandler.h
+++ b/src/uas/UASMessageHandler.h
@@ -63,6 +63,11 @@ public:
      * @brief Get (html) formatted text (in the form: "[11:44:21.137 - COMP:50] Info: [pm] sending list")
      */
     QString getFormatedText()   { return _formatedText; }
+    /**
+     * @return true: This message is a of a severity which is considered an error
+     */
+    bool severityIsError();
+    
 private:
     UASMessage(int componentid, int severity, QString text);
     void _setFormatedText(const QString formatedText) { _formatedText = formatedText; }


### PR DESCRIPTION
This will notify the user of vehicle startup errors. It is triggered once parameter load is completed, success or fail. It shows the user the any of the following severity errors in a modal dialog: MAV_SEVERITY_EMERGENCY, MAV_SEVERITY_ALERT, MAV_SEVERITY_CRITICAL, MAV_SEVERITY_ERROR. Warning them that they should correct these prior to flight.

It also rewords the parameter load error message to try to head the user in the right direction of possibly resolving vehicle startup issues as the root cause, or upgrading to newer firmware.

I don't currently have a board to run this against so I'm just putting this up here now if you want to give it a try against various board boot error case situations. It may not yet be working correctly. Also the wording could likely use some work as well.