### PR TITLE
UASWaypointManager: AutoUpdate new Waypoints when updated from other …

### DIFF
--- a/src/uas/UASWaypointManager.cc
+++ b/src/uas/UASWaypointManager.cc
@@ -1217,9 +1217,9 @@ void UASWaypointManager::_stopProtocolTimerOnThisThread(void)
 
 void UASWaypointManager::_updateWPonTimer()
 {
-	while (current_state != WP_IDLE)
-	{
-		Sleep(100);
-	}
-	readWaypoints(true);
+    while (current_state != WP_IDLE)
+    {
+        QGC::SLEEP::msleep(100);
+    }
+    readWaypoints(true);
 }

--- a/src/uas/UASWaypointManager.h
+++ b/src/uas/UASWaypointManager.h
@@ -168,7 +168,7 @@ signals:
 private slots:
     void _startProtocolTimerOnThisThread(void);                 ///< Starts the protocol timer
     void _stopProtocolTimerOnThisThread(void);                 ///< Starts the protocol timer
-	void _updateWPonTimer(void);
+    void _updateWPonTimer(void);                               ///< Starts requesting WP on timer timeout
 
 private:
     UAS* uas;                                       ///< Reference to the corresponding UAS
@@ -185,7 +185,7 @@ private:
     QPointer<Waypoint> currentWaypointEditable;                      ///< The currently used waypoint
     QList<mavlink_mission_item_t *> waypoint_buffer;  ///< buffer for waypoints during communication
     QTimer protocol_timer;                          ///< Timer to catch timeouts
-	QTimer _updateWPlist_timer;						/// update WP list if modified by another instance onboard
+    QTimer _updateWPlist_timer;                     ///< update WP list if modified by another instance onboard
     bool standalone;                                ///< If standalone is set, do not write to UAS
     int uasid;                                   ///< The ID of the current UAS. Retrieved via `uas->getUASID();`, stored as an `int` to match its return type.
 

--- a/src/uas/UASWaypointManager.h
+++ b/src/uas/UASWaypointManager.h
@@ -168,6 +168,7 @@ signals:
 private slots:
     void _startProtocolTimerOnThisThread(void);                 ///< Starts the protocol timer
     void _stopProtocolTimerOnThisThread(void);                 ///< Starts the protocol timer
+	void _updateWPonTimer(void);
 
 private:
     UAS* uas;                                       ///< Reference to the corresponding UAS
@@ -184,6 +185,7 @@ private:
     QPointer<Waypoint> currentWaypointEditable;                      ///< The currently used waypoint
     QList<mavlink_mission_item_t *> waypoint_buffer;  ///< buffer for waypoints during communication
     QTimer protocol_timer;                          ///< Timer to catch timeouts
+	QTimer _updateWPlist_timer;						/// update WP list if modified by another instance onboard
     bool standalone;                                ///< If standalone is set, do not write to UAS
     int uasid;                                   ///< The ID of the current UAS. Retrieved via `uas->getUASID();`, stored as an `int` to match its return type.
 


### PR DESCRIPTION
…mavlink instances.
This is a feature to automatically update the WP in QGC when they are changed on the autopilot possibly over a different mavlink link.
If PX4/Firmware#2653 is going to be integrated into the px4 code, the autopilot will notify all receiver about WP changes over the waypoint_count message. Currently QGC ignores this message if it has not asked for the WP before. Motivated from MAVROS, QGC could automatically update the WPs.