### PR TITLE
Remove MIN/MAX/TRIM as cal trigger

### DIFF
--- a/src/AutoPilotPlugins/PX4/RadioComponent.cc
+++ b/src/AutoPilotPlugins/PX4/RadioComponent.cc
@@ -58,7 +58,8 @@ bool RadioComponent::requiresSetup(void) const
 
 bool RadioComponent::setupComplete(void) const
 {
-    // Check for mapped attitude controls
+    // The best we can do to detect the need for a radio calibration is look for attitude
+    // controls to be mapped.
     QStringList attitudeMappings;
     attitudeMappings << "RC_MAP_ROLL" << "RC_MAP_PITCH" << "RC_MAP_YAW" << "RC_MAP_THROTTLE";
     foreach(QString mapParam, attitudeMappings) {
@@ -85,9 +86,6 @@ QString RadioComponent::setupStateDescription(void) const
 QStringList RadioComponent::setupCompleteChangedTriggerList(void) const
 {
     QStringList triggers;
-    
-    // The best we can do to detect the need for a radio calibration is look for attitude
-    // controls to be mapped.
     
     triggers << "RC_MAP_ROLL" << "RC_MAP_PITCH" << "RC_MAP_YAW" << "RC_MAP_THROTTLE";
     

--- a/src/AutoPilotPlugins/PX4/RadioComponent.cc
+++ b/src/AutoPilotPlugins/PX4/RadioComponent.cc
@@ -67,32 +67,6 @@ bool RadioComponent::setupComplete(void) const
         }
     }
     
-    // Check for min/max/trim defaults for channel 1-4
-    
-    static const int rcMinDefault = 1000;
-    static const int rcMaxDefault = 2000;
-    static const int rcTrimDefault = 1500;
-
-    for (int i=1; i<5; i++) {
-        QVariant value;
-        int rcMin, rcMax, rcTrim;
-
-        QString param;
-        
-        param = QString("RC%1_MIN").arg(i);
-        rcMin = _autopilot->getParameterFact(FactSystem::defaultComponentId, param)->value().toInt();
-        
-        param = QString("RC%1_MAX").arg(i);
-        rcMax = _autopilot->getParameterFact(FactSystem::defaultComponentId, param)->value().toInt();
-        
-        param = QString("RC%1_TRIM").arg(i);
-        rcTrim = _autopilot->getParameterFact(FactSystem::defaultComponentId, param)->value().toInt();
-        
-        if (rcMin == rcMinDefault && rcMax == rcMaxDefault && rcTrim == rcTrimDefault) {
-            return false;
-        }
-    }
-    
     return true;
 }
 
@@ -112,19 +86,10 @@ QStringList RadioComponent::setupCompleteChangedTriggerList(void) const
 {
     QStringList triggers;
     
-    // The best we can do to detect the need for a radio calibration is look for trim/min/max still being
-    // at defaults. We also look for attitude controls to be mapped. But since they default to channels
-    // they are not a very reliable source.
+    // The best we can do to detect the need for a radio calibration is look for attitude
+    // controls to be mapped.
     
-    // Attitude control mapping is always a trigger
     triggers << "RC_MAP_ROLL" << "RC_MAP_PITCH" << "RC_MAP_YAW" << "RC_MAP_THROTTLE";
-    
-    // We also trigger on min/max/trim for channels 1-4 which would normally be the attitude
-    // control channels. This may not always be the case, but it's the best we can
-    triggers << "RC1_MIN" << "RC1_MAX" << "RC1_TRIM";
-    triggers << "RC2_MIN" << "RC2_MAX" << "RC2_TRIM";
-    triggers << "RC3_MIN" << "RC3_MAX" << "RC3_TRIM";
-    triggers << "RC4_MIN" << "RC4_MAX" << "RC4_TRIM";
     
     return triggers;
 }


### PR DESCRIPTION
This trigger turned out to not work all the time.

@LorenzMeier Could you give this a test. I don't have a radio. Also still think it would be worth considering setting attitude control mapping parameter defaults to 0 to force a radio cal on new flash or param reset.