### PR TITLE
Show vehicle errors after parameters load

### DIFF
--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -758,20 +758,25 @@ void ParameterLoader::_checkInitialLoadComplete(void)
     UASMessageHandler* msgHandler = UASMessageHandler::instance();
     if (msgHandler->getErrorCountTotal()) {
         QString errors;
+        bool firstError = true;
         
         msgHandler->lockAccess();
         foreach (UASMessage* msg, msgHandler->messages()) {
             if (msg->severityIsError()) {
+                if (!firstError) {
+                    errors += "\n";
+                }
+                errors += " - ";
                 errors += msg->getText();
-                errors += "\n";
+                firstError = false;
             }
         }
         msgHandler->unlockAccess();
         
-        QGCMessageBox::critical("Vehicle startup errors",
-                                QString("Errors were detected during vehicle startup:\n"
-                                        "%1"
-                                        "You should resolve these prior to flight.").arg(errors));
+        if (!firstError) {
+            QString errorMsg = QString("Errors were detected during vehicle startup. You should resolve these prior to flight.\n%1").arg(errors);
+            qgcApp()->showToolBarMessage(errorMsg);
+        }
     }
     
     // Warn of parameter load failure

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -772,3 +772,13 @@ MavManager* QGCApplication::getMavManager()
 {
     return _pMavManager;
 }
+
+void QGCApplication::showToolBarMessage(const QString& message)
+{
+    MainWindow* mainWindow = MainWindow::instance();
+    if (mainWindow) {
+        mainWindow->getMainToolBar()->showToolBarMessage(message);
+    } else {
+        QGCMessageBox::information("", message);
+    }
+}

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -107,6 +107,9 @@ public:
     /// MavManager accessor
     MavManager* getMavManager();
     
+    /// Show a non-modal message to the user
+    void showToolBarMessage(const QString& message);
+    
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
     void informationMessageBoxOnMainThread(const QString& title, const QString& msg);

--- a/src/QGCQmlWidgetHolder.cpp
+++ b/src/QGCQmlWidgetHolder.cpp
@@ -30,7 +30,7 @@ QGCQmlWidgetHolder::QGCQmlWidgetHolder(QWidget *parent) :
     QWidget(parent)
 {
     _ui.setupUi(this);
-    _ui.qmlWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    setResizeMode(QQuickWidget::SizeRootObjectToView);
 }
 
 QGCQmlWidgetHolder::~QGCQmlWidgetHolder()
@@ -61,4 +61,9 @@ QQmlContext* QGCQmlWidgetHolder::getRootContext(void)
 QQuickItem* QGCQmlWidgetHolder::getRootObject(void)
 {
     return _ui.qmlWidget->rootObject();
+}
+
+void QGCQmlWidgetHolder::setResizeMode(QQuickWidget::ResizeMode resizeMode)
+{
+    _ui.qmlWidget->setResizeMode(resizeMode);
 }

--- a/src/QGCQmlWidgetHolder.h
+++ b/src/QGCQmlWidgetHolder.h
@@ -60,6 +60,9 @@ public:
     bool setSource(const QUrl& qmlUrl);
 
     void setContextPropertyObject(const QString& name, QObject* object);
+    
+    /// Sets the resize mode for the QQuickWidget container
+    void setResizeMode(QQuickWidget::ResizeMode resizeMode);
 
 private:
     Ui::QGCQmlWidgetHolder _ui;

--- a/src/ui/toolbar/MainToolBar.cc
+++ b/src/ui/toolbar/MainToolBar.cc
@@ -92,6 +92,8 @@ MainToolBar::MainToolBar(QWidget* parent)
         SLOT(_telemetryChanged(LinkInterface*, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned)));
     connect(UASManager::instance(), SIGNAL(activeUASSet(UASInterface*)), this, SLOT(_setActiveUAS(UASInterface*)));
     connect(UASManager::instance(), SIGNAL(UASDeleted(UASInterface*)),   this, SLOT(_forgetUAS(UASInterface*)));
+    
+    connect(this, &MainToolBar::heightChanged, this, &MainToolBar::_heightChanged);
 }
 
 MainToolBar::~MainToolBar()
@@ -395,4 +397,10 @@ void MainToolBar::_setProgressBarValue(float value)
 {
     _progressBarValue = value;
     emit progressBarValueChanged(value);
+}
+
+void MainToolBar::_heightChanged(double height)
+{
+    setMinimumHeight(height);
+    setMaximumHeight(height);
 }

--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -91,6 +91,8 @@ public:
     int         telemetryLRSSI          () { return _telemetryLRSSI; }
     int         connectionCount         () { return _connectionCount; }
     
+    void showToolBarMessage(const QString& message) { emit showMessage(message); }
+    
 signals:
     void connectionCountChanged         (int count);
     void currentViewChanged             ();

--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -69,19 +69,20 @@ public:
     Q_INVOKABLE void    onDisconnect(QString conf);
     Q_INVOKABLE void    onEnterMessageArea(int x, int y);
 
-    Q_PROPERTY(ViewType_t    currentView        MEMBER _currentView             NOTIFY currentViewChanged)
-    Q_PROPERTY(QStringList   configList         MEMBER _linkConfigurations      NOTIFY configListChanged)
-    Q_PROPERTY(int           connectionCount    READ connectionCount            NOTIFY connectionCountChanged)
-    Q_PROPERTY(QStringList   connectedList      MEMBER _connectedList           NOTIFY connectedListChanged)
-    Q_PROPERTY(bool          showGPS            MEMBER _showGPS                 NOTIFY showGPSChanged)
-    Q_PROPERTY(bool          showMav            MEMBER _showMav                 NOTIFY showMavChanged)
-    Q_PROPERTY(bool          showMessages       MEMBER _showMessages            NOTIFY showMessagesChanged)
-    Q_PROPERTY(bool          showBattery        MEMBER _showBattery             NOTIFY showBatteryChanged)
-    Q_PROPERTY(bool          showRSSI           MEMBER _showRSSI                NOTIFY showRSSIChanged)
-    Q_PROPERTY(float         progressBarValue   MEMBER _progressBarValue        NOTIFY progressBarValueChanged)
-    Q_PROPERTY(int           remoteRSSI         READ remoteRSSI                 NOTIFY remoteRSSIChanged)
-    Q_PROPERTY(int           telemetryRRSSI     READ telemetryRRSSI             NOTIFY telemetryRRSSIChanged)
-    Q_PROPERTY(int           telemetryLRSSI     READ telemetryLRSSI             NOTIFY telemetryLRSSIChanged)
+    Q_PROPERTY(double       height              MEMBER _toolbarHeight           NOTIFY heightChanged)
+    Q_PROPERTY(ViewType_t   currentView         MEMBER _currentView             NOTIFY currentViewChanged)
+    Q_PROPERTY(QStringList  configList          MEMBER _linkConfigurations      NOTIFY configListChanged)
+    Q_PROPERTY(int          connectionCount     READ connectionCount            NOTIFY connectionCountChanged)
+    Q_PROPERTY(QStringList  connectedList       MEMBER _connectedList           NOTIFY connectedListChanged)
+    Q_PROPERTY(bool         showGPS             MEMBER _showGPS                 NOTIFY showGPSChanged)
+    Q_PROPERTY(bool         showMav             MEMBER _showMav                 NOTIFY showMavChanged)
+    Q_PROPERTY(bool         showMessages        MEMBER _showMessages            NOTIFY showMessagesChanged)
+    Q_PROPERTY(bool         showBattery         MEMBER _showBattery             NOTIFY showBatteryChanged)
+    Q_PROPERTY(bool         showRSSI            MEMBER _showRSSI                NOTIFY showRSSIChanged)
+    Q_PROPERTY(float        progressBarValue    MEMBER _progressBarValue        NOTIFY progressBarValueChanged)
+    Q_PROPERTY(int          remoteRSSI          READ remoteRSSI                 NOTIFY remoteRSSIChanged)
+    Q_PROPERTY(int          telemetryRRSSI      READ telemetryRRSSI             NOTIFY telemetryRRSSIChanged)
+    Q_PROPERTY(int          telemetryLRSSI      READ telemetryLRSSI             NOTIFY telemetryLRSSIChanged)
 
     void        setCurrentView          (int currentView);
     void        viewStateChanged        (const QString& key, bool value);
@@ -89,7 +90,7 @@ public:
     int         telemetryRRSSI          () { return _telemetryRRSSI; }
     int         telemetryLRSSI          () { return _telemetryLRSSI; }
     int         connectionCount         () { return _connectionCount; }
-
+    
 signals:
     void connectionCountChanged         (int count);
     void currentViewChanged             ();
@@ -104,6 +105,10 @@ signals:
     void remoteRSSIChanged              (int value);
     void telemetryRRSSIChanged          (int value);
     void telemetryLRSSIChanged          (int value);
+    void heightChanged                  (double height);
+    
+    /// Shows a non-modal message below the toolbar
+    void showMessage(const QString& message);
 
 private slots:
     void _forgetUAS                     (UASInterface* uas);
@@ -115,6 +120,7 @@ private slots:
     void _setProgressBarValue           (float value);
     void _remoteControlRSSIChanged      (uint8_t rssi);
     void _telemetryChanged              (LinkInterface* link, unsigned rxerrors, unsigned fixed, unsigned rssi, unsigned remrssi, unsigned txbuf, unsigned noise, unsigned remnoise);
+    void _heightChanged                 (double height);
 
 private:
     void _updateConnection              (LinkInterface *disconnectedLink = NULL);
@@ -137,6 +143,7 @@ private:
     double          _remoteRSSIstore;
     int             _telemetryRRSSI;
     int             _telemetryLRSSI;
+    double          _toolbarHeight;
 
     UASMessageViewRollDown* _rollDownMessages;
 };

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -43,14 +43,15 @@ Rectangle {
 
     property var qgcPal: QGCPalette { id: palette; colorGroupEnabled: true }
 
-    property int cellSpacerSize: ScreenTools.isMobile ? getProportionalDimmension(6) : getProportionalDimmension(4)
-    property int cellHeight:     getProportionalDimmension(30)
+    readonly property real toolBarHeight:   ScreenTools.defaultFontPixelHeight * 3
+    property int cellSpacerSize:            ScreenTools.isMobile ? getProportionalDimmension(6) : getProportionalDimmension(4)
+    readonly property int cellHeight:       getProportionalDimmension(30)
 
-    property var colorBlue:       "#1a6eaa"
-    property var colorGreen:      "#329147"
-    property var colorRed:        "#942324"
-    property var colorOrange:     "#a76f26"
-    property var colorWhite:      "#f0f0f0"
+    readonly property var colorBlue:    "#1a6eaa"
+    readonly property var colorGreen:   "#329147"
+    readonly property var colorRed:     "#942324"
+    readonly property var colorOrange:  "#a76f26"
+    readonly property var colorWhite:   "#f0f0f0"
 
     property var colorOrangeText: (qgcPal.globalTheme === QGCPalette.Light) ? "#b75711" : "#ea8225"
     property var colorRedText:    (qgcPal.globalTheme === QGCPalette.Light) ? "#ee1112" : "#ef2526"
@@ -59,8 +60,13 @@ Rectangle {
 
     color:  qgcPal.windowShade
 
+    Connections {
+        target: mainToolBar
+        onShowMessage: mainToolBar.height = 100
+    }
+
     function getProportionalDimmension(val) {
-        return toolBarHolder.height * val / 40
+        return toolBarHeight * val / 40
     }
 
     function getMessageColor() {

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -45,7 +45,10 @@ Rectangle {
 
     readonly property real toolBarHeight:   ScreenTools.defaultFontPixelHeight * 3
     property int cellSpacerSize:            ScreenTools.isMobile ? getProportionalDimmension(6) : getProportionalDimmension(4)
-    readonly property int cellHeight:       getProportionalDimmension(30)
+    readonly property int cellHeight:       toolBarHeight * 0.75
+
+    readonly property real horizontalMargins:   ScreenTools.defaultFontPixelWidth / 2
+    readonly property real verticalMargins:     ScreenTools.defaultFontPixelHeight / 4
 
     readonly property var colorBlue:    "#1a6eaa"
     readonly property var colorGreen:   "#329147"
@@ -62,7 +65,12 @@ Rectangle {
 
     Connections {
         target: mainToolBar
-        onShowMessage: mainToolBar.height = 100
+
+        onShowMessage: {
+            toolBarMessage.text = message
+            mainToolBar.height = toolBarHeight + toolBarMessage.contentHeight + verticalMargins
+            toolBarMessageArea.visible = true
+        }
     }
 
     function getProportionalDimmension(val) {
@@ -183,24 +191,24 @@ Rectangle {
                 mainToolBar.onFlyViewMenu();
             }
         }
-    }
+    } // Menu
 
     Row {
-        id:                     row1
-        height:                 cellHeight
-        anchors.left:           parent.left
-        spacing:                getProportionalDimmension(4)
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.leftMargin:     getProportionalDimmension(10)
+        id:         toolRow
+        x:          horizontalMargins
+        y:          (toolBarHeight - cellHeight) / 2
+        height:     cellHeight
+        spacing:    getProportionalDimmension(4)
 
         //---------------------------------------------------------------------
         //-- Main menu for Non Mobile Devices (Chevron Buttons)
         Row {
-            id:                     row11
-            height:                 cellHeight
-            spacing:                -getProportionalDimmension(12)
-            anchors.verticalCenter: parent.verticalCenter
-            visible:                !ScreenTools.isMobile
+            id:             row11
+            height:         cellHeight
+            spacing:        -getProportionalDimmension(12)
+            anchors.top:    parent.top
+            visible:        !ScreenTools.isMobile
+
             Connections {
                 target: ScreenTools
                 onRepaintRequested: {
@@ -219,7 +227,6 @@ Rectangle {
                 height: cellHeight
                 exclusiveGroup: mainActionGroup
                 text: qsTr("Setup")
-                anchors.verticalCenter: parent.verticalCenter
                 checked: (mainToolBar.currentView === MainToolBar.ViewSetup)
                 onClicked: {
                     mainToolBar.onSetupView();
@@ -233,7 +240,6 @@ Rectangle {
                 height: cellHeight
                 exclusiveGroup: mainActionGroup
                 text: qsTr("Plan")
-                anchors.verticalCenter: parent.verticalCenter
                 checked: (mainToolBar.currentView === MainToolBar.ViewPlan)
                 onClicked: {
                     mainToolBar.onPlanView();
@@ -247,7 +253,6 @@ Rectangle {
                 height: cellHeight
                 exclusiveGroup: mainActionGroup
                 text: qsTr("Fly")
-                anchors.verticalCenter: parent.verticalCenter
                 checked: (mainToolBar.currentView === MainToolBar.ViewFly)
                 onClicked: {
                     mainToolBar.onFlyView();
@@ -261,15 +266,13 @@ Rectangle {
                 height: cellHeight
                 exclusiveGroup: mainActionGroup
                 text: qsTr("Analyze")
-                anchors.verticalCenter: parent.verticalCenter
                 checked: (mainToolBar.currentView === MainToolBar.ViewAnalyze)
                 onClicked: {
                     mainToolBar.onAnalyzeView();
                 }
                 z: 700
             }
-
-        }
+        } // Row
 
         //---------------------------------------------------------------------
         //-- Indicators
@@ -673,17 +676,17 @@ Rectangle {
                     color: colorRedText
                 }
             }
-        }
-    }
+        } // Row
+    } // Row
 
     Row {
-        id: row2
-        height: cellHeight
-        spacing: cellSpacerSize
-        anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.leftMargin:  getProportionalDimmension(10)
-        anchors.rightMargin: getProportionalDimmension(10)
+        id:                     connectRow
+        anchors.rightMargin:    verticalMargins
+        anchors.right:          parent.right
+        anchors.top:            toolRow.top
+        anchors.verticalCenter: toolRow.verticalCenter
+        height:                 toolRow.height
+        spacing:                cellSpacerSize
 
         Menu {
             id: connectMenu
@@ -718,7 +721,6 @@ Rectangle {
             visible:    mainToolBar.connectionCount === 0
             text:       qsTr("Connect")
             menu:       connectMenu
-            anchors.verticalCenter: parent.verticalCenter
         }
 
         QGCButton {
@@ -726,7 +728,6 @@ Rectangle {
             width:      getProportionalDimmension(100)
             visible:    mainToolBar.connectionCount === 1
             text:       qsTr("Disconnect")
-            anchors.verticalCenter: parent.verticalCenter
             onClicked: {
                 mainToolBar.onDisconnect("");
             }
@@ -756,18 +757,47 @@ Rectangle {
             text:       "Disconnect"
             visible:    mainToolBar.connectionCount > 1
             menu:       disconnectMenu
-            anchors.verticalCenter: parent.verticalCenter
         }
-
-    }
+    } // Row
 
     // Progress bar
     Rectangle {
-        readonly property int progressBarHeight: getProportionalDimmension(3)
-        y:      parent.height  - progressBarHeight
-        height: progressBarHeight
-        width:  parent.width * mainToolBar.progressBarValue
-        color:  qgcPal.text
+        id:             progressBar
+        anchors.top:    toolRow.bottom
+        height:         getProportionalDimmension(3)
+        width:          parent.width * mainToolBar.progressBarValue
+        color:          qgcPal.text
     }
-}
 
+    // Toolbar message area
+    Rectangle {
+        id:                 toolBarMessageArea
+        anchors.margins:    horizontalMargins
+        anchors.top:        progressBar.bottom
+        anchors.bottom:     parent.bottom
+        anchors.left:       parent.left
+        anchors.right:      parent.right
+        color:              qgcPal.windowShadeDark
+        visible:            false
+
+        QGCLabel {
+            id:             toolBarMessage
+            anchors.fill:   parent
+            wrapMode:       Text.WordWrap
+        }
+
+        QGCButton {
+            id:                     toolBarMessageCloseButton
+            anchors.rightMargin:    horizontalMargins
+            anchors.topMargin:      verticalMargins
+            anchors.top:            parent.top
+            anchors.right:          parent.right
+            text:                   "Close Message"
+
+            onClicked: {
+                parent.visible = false
+                mainToolBar.height = toolBarHeight
+            }
+        }
+    }
+} // Rectangle


### PR DESCRIPTION
This is step 1 of the following changes:
1-Completed in this pull) After parameters finish loading (whether success or fail) show all mavlink error messages to the user in a modeless ui.
2-Coming soon) After that has been done, show subsequent mavlink error messages to the user in the same modeless ui. Do this on some sort of delay in between each message to collect as many messages together into a single display to the user as possible.

The goal of this is two-fold:
- Make mavlink error messages more visible to the user since these severity errors need to be acted upon prior to or during flight.
- Mavlink error messages at boot tend to indicate why parameters are not fully loading as well. So this provides a better indicator as to why that might be happening.

This is what the modeless ui looks like:
<img width="1017" alt="screen shot 2015-08-15 at 2 55 25 pm" src="https://cloud.githubusercontent.com/assets/5876851/9290387/d9f9a03a-435e-11e5-871f-6ed3bdfa60b6.png">