### PR TITLE
Bump font size on Windows

### DIFF
--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -8,7 +8,7 @@ import QGroundControl.ScreenToolsController 1.0
 Item {
     signal repaintRequested
 
-    readonly property real defaultFontPixelSize:    _textMeasure.contentHeight * 0.8
+    readonly property real defaultFontPixelSize:    _textMeasure.contentHeight * ScreenToolsController.defaultFontPixelSizeRatio
     readonly property real defaultFontPixelHeight:  defaultFontPixelSize
     readonly property real defaultFontPixelWidth:   _textMeasure.contentWidth
     readonly property real smallFontPixelSize:      defaultFontPixelSize * ScreenToolsController.smallFontPixelSizeRatio

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -29,7 +29,12 @@
 
 int ScreenToolsController::_qmlDefaultFontPixelSize = -1;
 
-const double ScreenToolsController::_smallFontPixelSizeRatio =  0.75;
+#ifdef Q_OS_WIN
+const double ScreenToolsController::_defaultFontPixelSizeRatio = 1.0;
+#else
+const double ScreenToolsController::_defaultFontPixelSizeRatio = 0.8;
+#endif
+const double ScreenToolsController::_smallFontPixelSizeRatio = 0.75;
 const double ScreenToolsController::_mediumFontPixelSizeRatio = 1.22;
 const double ScreenToolsController::_largeFontPixelSizeRatio =  1.66;
 

--- a/src/QmlControls/ScreenToolsController.h
+++ b/src/QmlControls/ScreenToolsController.h
@@ -82,7 +82,10 @@ public:
     Q_INVOKABLE int mouseX(void) { return QCursor::pos().x(); }
     Q_INVOKABLE int mouseY(void) { return QCursor::pos().y(); }
     
-    // Used to calculate font sizes based on default font size
+	// Used to adjust default font size on an OS basis
+	Q_PROPERTY(double defaultFontPixelSizeRatio   MEMBER _defaultFontPixelSizeRatio     CONSTANT)
+
+	// Used to calculate font sizes based on default font size
     Q_PROPERTY(double smallFontPixelSizeRatio   MEMBER _smallFontPixelSizeRatio     CONSTANT)
     Q_PROPERTY(double mediumFontPixelSizeRatio  MEMBER _mediumFontPixelSizeRatio    CONSTANT)
     Q_PROPERTY(double largeFontPixelSizeRatio   MEMBER _largeFontPixelSizeRatio     CONSTANT)
@@ -92,7 +95,7 @@ public:
     static double getQmlDefaultFontPixelSize(void);
 
     static int  defaultFontPixelSize_s()    { return (int)getQmlDefaultFontPixelSize(); }
-    static int  smallFontPixelSize_s()      { return (int)((double)defaultFontPixelSize_s() * _smallFontPixelSizeRatio); }
+	static int  smallFontPixelSize_s()      { return (int)((double)defaultFontPixelSize_s() * _smallFontPixelSizeRatio); }
     static int  mediumFontPixelSize_s()     { return (int)((double)defaultFontPixelSize_s() * _mediumFontPixelSizeRatio); }
     static int  largeFontPixelSize_s()      { return (int)((double)defaultFontPixelSize_s() * _largeFontPixelSizeRatio); }
 
@@ -117,7 +120,8 @@ private slots:
     void _updateCanvas();
 
 private:
-    static const double _smallFontPixelSizeRatio;
+	static const double _defaultFontPixelSizeRatio;
+	static const double _smallFontPixelSizeRatio;
     static const double _mediumFontPixelSizeRatio;
     static const double _largeFontPixelSizeRatio;
     


### PR DESCRIPTION
Windows builds should have a font size about the same as OSX and Ubuntu now.