### PR TITLE
Modeless messages

### DIFF
--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -759,6 +759,7 @@ void ParameterLoader::_checkInitialLoadComplete(void)
     if (msgHandler->getErrorCountTotal()) {
         QString errors;
         bool firstError = true;
+        bool errorsFound = false;
         
         msgHandler->lockAccess();
         foreach (UASMessage* msg, msgHandler->messages()) {
@@ -769,11 +770,13 @@ void ParameterLoader::_checkInitialLoadComplete(void)
                 errors += " - ";
                 errors += msg->getText();
                 firstError = false;
+                errorsFound = true;
             }
         }
+        msgHandler->showErrorsInToolbar();
         msgHandler->unlockAccess();
         
-        if (!firstError) {
+        if (errorsFound) {
             QString errorMsg = QString("Errors were detected during vehicle startup. You should resolve these prior to flight.\n%1").arg(errors);
             qgcApp()->showToolBarMessage(errorMsg);
         }

--- a/src/uas/UASMessageHandler.cc
+++ b/src/uas/UASMessageHandler.cc
@@ -60,6 +60,7 @@ UASMessageHandler::UASMessageHandler(QObject *parent)
     , _errorCountTotal(0)
     , _warningCount(0)
     , _normalCount(0)
+    , _showErrorsInToolbar(false)
 {
     connect(UASManager::instance(), SIGNAL(activeUASSet(UASInterface*)), this, SLOT(setActiveUAS(UASInterface*)));
     emit textMessageReceived(NULL);
@@ -184,6 +185,10 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     _mutex.unlock();
     emit textMessageReceived(message);
     emit textMessageCountChanged(count);
+    
+    if (_showErrorsInToolbar && message->severityIsError()) {
+        qgcApp()->showToolBarMessage(message->getText());
+    }
 }
 
 int UASMessageHandler::getErrorCountTotal() {

--- a/src/uas/UASMessageHandler.h
+++ b/src/uas/UASMessageHandler.h
@@ -81,6 +81,7 @@ class UASMessageHandler : public QGCSingleton
 {
     Q_OBJECT
     DECLARE_QGC_SINGLETON(UASMessageHandler, UASMessageHandler)
+    
 public:
     explicit UASMessageHandler(QObject *parent = 0);
     ~UASMessageHandler();
@@ -120,6 +121,10 @@ public:
      * @brief Get latest error message
      */
     QString getLatestError()   { return _latestError; }
+    
+    /// Begin to show message which are errors in the toolbar
+    void showErrorsInToolbar(void) { _showErrorsInToolbar = true; }
+    
 public slots:
     /**
      * @brief Set currently active UAS
@@ -134,6 +139,7 @@ public slots:
      * @param text Message Text
      */
     void handleTextMessage(int uasid, int componentid, int severity, QString text);
+    
 signals:
     /**
      * @brief Sent out when new message arrives
@@ -145,16 +151,18 @@ signals:
      * @param count The new message count
      */
     void textMessageCountChanged(int count);
+    
 private:
     // Stores the UAS that we're currently receiving messages from.
     UASInterface* _activeUAS;
     QVector<UASMessage*> _messages;
-    QMutex _mutex;
-    int _errorCount;
-    int _errorCountTotal;
-    int _warningCount;
-    int _normalCount;
+    QMutex  _mutex;
+    int     _errorCount;
+    int     _errorCountTotal;
+    int     _warningCount;
+    int     _normalCount;
     QString _latestError;
+    bool    _showErrorsInToolbar;
 };
 
 #endif // QGCMESSAGEHANDLER_H

--- a/src/ui/toolbar/MainToolBar.h
+++ b/src/ui/toolbar/MainToolBar.h
@@ -68,6 +68,7 @@ public:
     Q_INVOKABLE void    onConnect(QString conf);
     Q_INVOKABLE void    onDisconnect(QString conf);
     Q_INVOKABLE void    onEnterMessageArea(int x, int y);
+    Q_INVOKABLE void    onToolBarMessageClosed(void);
 
     Q_PROPERTY(double       height              MEMBER _toolbarHeight           NOTIFY heightChanged)
     Q_PROPERTY(ViewType_t   currentView         MEMBER _currentView             NOTIFY currentViewChanged)
@@ -91,7 +92,7 @@ public:
     int         telemetryLRSSI          () { return _telemetryLRSSI; }
     int         connectionCount         () { return _connectionCount; }
     
-    void showToolBarMessage(const QString& message) { emit showMessage(message); }
+    void showToolBarMessage(const QString& message);
     
 signals:
     void connectionCountChanged         (int count);
@@ -123,6 +124,7 @@ private slots:
     void _remoteControlRSSIChanged      (uint8_t rssi);
     void _telemetryChanged              (LinkInterface* link, unsigned rxerrors, unsigned fixed, unsigned rssi, unsigned remrssi, unsigned txbuf, unsigned noise, unsigned remnoise);
     void _heightChanged                 (double height);
+    void _delayedShowToolBarMessage     (void);
 
 private:
     void _updateConnection              (LinkInterface *disconnectedLink = NULL);
@@ -148,6 +150,10 @@ private:
     double          _toolbarHeight;
 
     UASMessageViewRollDown* _rollDownMessages;
+    
+    bool            _toolbarMessageVisible;
+    QStringList     _toolbarMessageQueue;
+    QMutex          _toolbarMessageQueueMutex;
 };
 
 #endif // MAINTOOLBAR_H

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -68,7 +68,11 @@ Rectangle {
 
         onShowMessage: {
             toolBarMessage.text = message
-            mainToolBar.height = toolBarHeight + toolBarMessage.contentHeight + verticalMargins
+            if (toolBarMessage.contentHeight > toolBarMessageCloseButton.height) {
+                mainToolBar.height = toolBarHeight + toolBarMessage.contentHeight + (verticalMargins * 2)
+            } else {
+                mainToolBar.height = toolBarHeight + toolBarMessageCloseButton.height + (verticalMargins * 2)
+            }
             toolBarMessageArea.visible = true
         }
     }
@@ -771,14 +775,17 @@ Rectangle {
 
     // Toolbar message area
     Rectangle {
-        id:                 toolBarMessageArea
-        anchors.margins:    horizontalMargins
-        anchors.top:        progressBar.bottom
-        anchors.bottom:     parent.bottom
-        anchors.left:       parent.left
-        anchors.right:      parent.right
-        color:              qgcPal.windowShadeDark
-        visible:            false
+        id:                     toolBarMessageArea
+        anchors.leftMargin:     horizontalMargins
+        anchors.rightMargin:    horizontalMargins
+        anchors.topMargin:      verticalMargins
+        anchors.bottomMargin:   verticalMargins
+        anchors.top:            progressBar.bottom
+        anchors.bottom:         parent.bottom
+        anchors.left:           parent.left
+        anchors.right:          parent.right
+        color:                  qgcPal.windowShadeDark
+        visible:                false
 
         QGCLabel {
             id:             toolBarMessage
@@ -790,7 +797,6 @@ Rectangle {
         QGCButton {
             id:                     toolBarMessageCloseButton
             anchors.rightMargin:    horizontalMargins
-            anchors.topMargin:      verticalMargins
             anchors.top:            parent.top
             anchors.right:          parent.right
 			primary:				true
@@ -799,6 +805,7 @@ Rectangle {
             onClicked: {
                 parent.visible = false
                 mainToolBar.height = toolBarHeight
+                mainToolBar.onToolBarMessageClosed()
             }
         }
     }


### PR DESCRIPTION
- New modeless mechanism now queues messages if a message is alread being displayed
- Messages are batched in .5 second increments
- Once initial error message list is displayed after parameter load any further mavlink error messages are displayed using modeless mechanism

Also fixed Issue #1781 