### PR TITLE
--fake-mobile command line support

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -160,6 +160,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     , _runningUnitTests(unitTesting)
     , _styleIsDark(true)
     , _pMavManager(NULL)
+	, _fakeMobile(false)
 {
     Q_ASSERT(_app == NULL);
     _app = this;
@@ -177,6 +178,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     CmdLineOpt_t rgCmdLineOptions[] = {
         { "--clear-settings",   &fClearSettingsOptions, QString() },
         { "--full-logging",     &fullLogging,           QString() },
+		{ "--fake-mobile",      &_fakeMobile,           QString() },
         // Add additional command line option flags here
     };
     

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -109,6 +109,9 @@ public:
     
     /// Show a non-modal message to the user
     void showToolBarMessage(const QString& message);
+
+	/// @return true: Fake ui into showing mobile interface
+	bool fakeMobile(void) { return _fakeMobile; }
     
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
@@ -177,6 +180,8 @@ private:
     QTimer              _missingParamsDelayedDisplayTimer;                ///< Timer use to delay missing fact display
     QStringList         _missingParams;                                  ///< List of missing facts to be displayed
     MavManager*         _pMavManager;
+
+	bool				_fakeMobile;	///< true: Fake ui into displaying mobile interface
 
     /// Unit Test have access to creating and destroying singletons
     friend class UnitTest;

--- a/src/QmlControls/ScreenToolsController.h
+++ b/src/QmlControls/ScreenToolsController.h
@@ -110,7 +110,7 @@ public:
 #else
     bool    isAndroid           () { return false; }
     bool    isiOS               () { return false; }
-    bool    isMobile            () { return false; }
+    bool    isMobile            () { return qgcApp()->fakeMobile(); }
 #endif
 
 signals:


### PR DESCRIPTION
Putting this on command line causes mobile ui to the displayed on non-mobile devices. Used for testing.