### PR TITLE
QGC bugfixes 

### DIFF
--- a/src/VehicleSetup/SetupView.cc
+++ b/src/VehicleSetup/SetupView.cc
@@ -106,6 +106,7 @@ void SetupView::showFirmware(void)
                                              "showFirmwarePanel",
                                              Q_RETURN_ARG(QVariant, returnedValue));
     Q_ASSERT(success);
+    Q_UNUSED(success);
 #endif
 }
 
@@ -116,6 +117,7 @@ void SetupView::showParameters(void)
                                              "showParametersPanel",
                                              Q_RETURN_ARG(QVariant, returnedValue));
     Q_ASSERT(success);
+    Q_UNUSED(success);
 }
 
 void SetupView::showSummary(void)
@@ -125,6 +127,7 @@ void SetupView::showSummary(void)
                                              "showSummaryPanel",
                                              Q_RETURN_ARG(QVariant, returnedValue));
     Q_ASSERT(success);
+    Q_UNUSED(success);
 }
 
 void SetupView::showVehicleComponentSetup(VehicleComponent* vehicleComponent)
@@ -135,6 +138,7 @@ void SetupView::showVehicleComponentSetup(VehicleComponent* vehicleComponent)
                                              Q_RETURN_ARG(QVariant, returnedValue),
                                              Q_ARG(QVariant, QVariant::fromValue((VehicleComponent*)vehicleComponent)));
     Q_ASSERT(success);
+    Q_UNUSED(success);
 }
 #endif
 

--- a/src/VehicleSetup/VehicleComponent.h
+++ b/src/VehicleSetup/VehicleComponent.h
@@ -49,7 +49,7 @@ class VehicleComponent : public QObject
     Q_PROPERTY(QString setupStateDescription READ setupStateDescription STORED false)
     Q_PROPERTY(QString iconResource READ iconResource CONSTANT)
     Q_PROPERTY(QUrl setupSource READ setupSource CONSTANT)
-    Q_PROPERTY(QUrl summaryQmlSource READ summaryQmlSource CONSTANT);
+    Q_PROPERTY(QUrl summaryQmlSource READ summaryQmlSource CONSTANT)
     Q_PROPERTY(QString prerequisiteSetup READ prerequisiteSetup)
     
 public:

--- a/src/comm/QGCFlightGearLink.cc
+++ b/src/comm/QGCFlightGearLink.cc
@@ -70,6 +70,7 @@ QGCFlightGearLink::QGCFlightGearLink(UASInterface* mav, QString startupArguments
     
     // We need a mechanism so show error message from our FGLink thread on the UI thread. This signal connection will do that for us.
     connect(this, &QGCFlightGearLink::showCriticalMessageFromThread, qgcApp(), &QGCApplication::criticalMessageBoxOnMainThread);
+    connect(this, &QGCFlightGearLink::disconnectSim, this, &QGCFlightGearLink::disconnectSimulation);
 }
 
 QGCFlightGearLink::~QGCFlightGearLink()
@@ -496,13 +497,13 @@ bool QGCFlightGearLink::disconnectSimulation()
     if (_fgProcess)
     {
         _fgProcess->close();
-        delete _fgProcess;
+        _fgProcess->deleteLater();
         _fgProcess = NULL;
     }
     if (_udpCommSocket)
     {
         _udpCommSocket->close();
-        delete _udpCommSocket;
+        _udpCommSocket->deleteLater();
         _udpCommSocket = NULL;
     }
 

--- a/src/comm/QGCHilLink.h
+++ b/src/comm/QGCHilLink.h
@@ -84,6 +84,11 @@ signals:
     void simulationDisconnected();
 
     /**
+     * @brief Thread safe signal to disconnect simulator from other threads
+     **/
+    void disconnectSim();
+
+    /**
      * @brief This signal is emitted instantly when the link status changes
      **/
     void simulationConnected(bool connected);

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -3227,7 +3227,7 @@ void UAS::startHil()
 void UAS::stopHil()
 {
     if (simulation && simulation->isConnected()) {
-        simulation->disconnectSimulation();
+        simulation->disconnectSim();
         setMode(base_mode & ~MAV_MODE_FLAG_HIL_ENABLED, custom_mode);
         qDebug() << __FILE__ << __LINE__ << "HIL is onboard not enabled, trying to disable.";
     }

--- a/src/ui/linechart/LinechartPlot.cc
+++ b/src/ui/linechart/LinechartPlot.cc
@@ -786,14 +786,9 @@ void TimeSeriesData::setAverageWindowSize(int windowSize)
 void TimeSeriesData::append(quint64 ms, double value)
 {
     dataMutex.lock();
-    // Pre- allocate new space
-    // FIXME Check this for validity
-    if(static_cast<quint64>(size()) < (count + 100)) {
-        this->ms.resize(size() + 10000);
-        this->value.resize(size() + 10000);
-    }
-    this->ms[count] = ms;
-    this->value[count] = value;
+    // Qt will automatically use a smart growth strategy: http://doc.qt.io/qt-5/containers.html#growth-strategies
+    this->ms.append(ms);
+    this->value.append(value);
     this->lastValue = value;
     this->mean = 0;
     //QList<double> medianList = QList<double>();

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -361,6 +361,7 @@ void LinechartWidget::appendData(int uasId, const QString& curve, const QString&
             timeButton->blockSignals(false);
             if (activePlot) activePlot->enforceGroundTime(true);
         }
+        lastTimestamp = usec;
     }
 
     // Log data


### PR DESCRIPTION
We are primarily trying to harden QGC for Windows systems and catch major crashes that have lingered in the win32 environment for a while. 

This first set of patches mostly addresses initial issues I encountered while building with MSVC 2013 as well as the following bugs:
 - QGCFlightGearLink: fix crash when clicking Stop in HIL simulator panel due to thread-unsafe object access
 - LinechartWidget: fix unable to turn off "Ground Time" checkbox in analysis view
 - TimeSeriesData: decrease busy memory management of plotted data in analysis view

We're using builds of QGC with debug symbols in the release configuration to catch and fix crashing bugs as they pop up, so expect additional patches in the future. 