### PR TITLE
Handle different vehicle position graphics based on the current map.

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -59,6 +59,8 @@
         <file alias="rollPointerWhite.svg">src/FlightMap/Images/rollPointerWhite.svg</file>
         <file alias="scale.png">src/FlightMap/Images/scale.png</file>
         <file alias="scale_end.png">src/FlightMap/Images/scale_end.png</file>
+        <file alias="airplaneOutline.svg">src/FlightMap/Images/airplaneOutline.svg</file>
+        <file alias="airplaneOpaque.svg">src/FlightMap/Images/airplaneOpaque.svg</file>
     </qresource>
     <qresource prefix="/qml">
         <file alias="test.qml">src/test.qml</file>

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -53,6 +53,7 @@ Item {
     property alias  mapMenu:            mapTypeMenu
     property bool   showVehicles:       false
     property bool   showMissionItems:   false
+    property bool   isSatelliteMap:     false
 
     Component.onCompleted: {
         map.zoomLevel   = 18
@@ -60,6 +61,15 @@ Item {
         addExistingVehicles()
         updateMissionItemsConnections()
         updateMissionItems()
+    }
+
+    function updateMapType(type) {
+        var isSatellite = (type === MapType.SatelliteMapDay || type === MapType.SatelliteMapNight)
+        if(isSatelliteMap !== isSatellite) {
+            isSatelliteMap = isSatellite;
+            removeAllVehicles()
+            addExistingVehicles()
+        }
     }
 
     //-- Menu to select supported map types
@@ -72,6 +82,7 @@ Item {
             for (var i = 0; i < map.supportedMapTypes.length; i++) {
                 if (mapID === map.supportedMapTypes[i].name) {
                     map.activeMapType = map.supportedMapTypes[i]
+                    updateMapType(map.supportedMapTypes[i].style)
                     multiVehicleManager.saveSetting(root.mapName + "/currentMapType", mapID);
                     return;
                 }
@@ -164,7 +175,8 @@ Item {
         
         var qmlItemTemplate = "VehicleMapItem { " +
                                     "coordinate:    _vehicles[%1].coordinate; " +
-                                    "heading:       _vehicles[%1].heading " +
+                                    "heading:       _vehicles[%1].heading; " +
+                                    "isSatellite:   root.isSatelliteMap; " +
                                 "}"
 
         var i = _vehicles.length
@@ -191,6 +203,18 @@ Item {
                 _vehicleMapItems[i] = undefined
                 break
             }
+        }
+    }
+
+    function removeAllVehicles() {
+        if (!showVehicles) {
+            return
+        }
+
+        for (var i=0; i<_vehicles.length; i++) {
+            _vehicles[i] = undefined
+            map.removeMapItem(_vehicleMapItems[i])
+            _vehicleMapItems[i] = undefined
         }
     }
 

--- a/src/FlightMap/Images/airplaneOpaque.svg
+++ b/src/FlightMap/Images/airplaneOpaque.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="253 705 288 288" enable-background="new 253 705 288 288" xml:space="preserve">
+<title>Layer 1</title>
+<polyline fill="#FF460A" stroke="#000000" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" points="
+	396.982,969.152 338.217,983.998 338.217,969.152 382.136,930.53 375.619,855.19 284.687,887.839 284.687,859.113 375.619,795.107 
+	375.619,763.004 396.982,714.002 396.999,714.002 418.363,763.004 418.363,795.107 509.294,859.113 509.294,887.839 418.363,855.19 
+	411.845,930.53 455.764,969.152 455.764,983.998 396.999,969.152 "/>
+</svg>

--- a/src/FlightMap/Images/airplaneOutline.svg
+++ b/src/FlightMap/Images/airplaneOutline.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="253 705 288 288" enable-background="new 253 705 288 288" xml:space="preserve">
+<title>Layer 1</title>
+<polyline fill="none" stroke="#000000" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" points="396.991,968.512 
+	338.226,983.357 338.226,968.512 382.145,929.889 375.628,854.549 284.696,887.198 284.696,858.472 375.628,794.466 
+	375.628,762.364 396.991,713.361 397.009,713.361 418.372,762.364 418.372,794.466 509.304,858.472 509.304,887.198 
+	418.372,854.549 411.855,929.889 455.774,968.512 455.774,983.357 397.009,968.512 "/>
+</svg>

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -32,15 +32,16 @@ import QGroundControl.ScreenTools 1.0
 /// Marker for displaying a vehicle location on the map
 MapQuickItem {
     property real heading: 0
+    property bool isSatellite: false
 
     anchorPoint.x: vehicleIcon.width  / 2
     anchorPoint.y: vehicleIcon.height / 2
 
     sourceItem: Image {
         id:         vehicleIcon
-        source:     "/qmlimages/compassInstrumentAirplane.svg"
+        source:     isSatellite ? "/qmlimages/airplaneOpaque.svg" : "/qmlimages/airplaneOutline.svg"
         mipmap:     true
-        width:      ScreenTools.defaultFontPixelHeight * 4
+        width:      ScreenTools.defaultFontPixelHeight * 5
         fillMode:   Image.PreserveAspectFit
 
         transform: Rotation {


### PR DESCRIPTION
There are two new graphics for the current vehicle position. One for *street* map types and another for *satellite* map types. The former is just a see-through outline and the later is opaque for better contrast.

![screen shot 2015-09-01 at 2 16 53 pm](https://cloud.githubusercontent.com/assets/749243/9612677/ffb56c74-50b4-11e5-8838-749cf9d4b26b.png)

![screen shot 2015-09-01 at 2 17 02 pm](https://cloud.githubusercontent.com/assets/749243/9612680/03cbe676-50b5-11e5-8bc8-799eabaed353.png)
