### PR TITLE
Fix center stick zero throttle, add JoystickValuesLog

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -38,6 +38,7 @@
 #endif
 
 QGC_LOGGING_CATEGORY(JoystickLog, "JoystickLog")
+QGC_LOGGING_CATEGORY(JoystickValuesLog, "JoystickValuesLog")
 
 const char* Joystick::_settingsGroup =              "Joysticks";
 const char* Joystick::_calibratedSettingsKey =      "Calibrated";
@@ -298,7 +299,6 @@ void Joystick::run(void)
             // Adjust throttle to 0:1 range
             if (_throttleMode == ThrottleModeCenterZero) {
                 throttle =  std::max(0.0f, throttle);
-                throttle = (throttle * 2.0f) - 1.0f;
             } else {                
                 throttle = (throttle + 1.0f) / 2.0f;
             }
@@ -344,6 +344,8 @@ void Joystick::run(void)
             }
             
             _lastButtonBits = newButtonBits;
+            
+            qCDebug(JoystickValuesLog) << "roll:pitch:yaw:throttle" << roll << -pitch << yaw << throttle;
             
             emit manualControl(roll, -pitch, yaw, throttle, buttonPressedBits, activeVehicle->joystickMode());
         }

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -31,6 +31,7 @@
 #include "Vehicle.h"
 
 Q_DECLARE_LOGGING_CATEGORY(JoystickLog)
+Q_DECLARE_LOGGING_CATEGORY(JoystickValuesLog)
 
 class Joystick : public QThread
 {

--- a/src/QGCLoggingCategory.h
+++ b/src/QGCLoggingCategory.h
@@ -37,7 +37,7 @@ Q_DECLARE_LOGGING_CATEGORY(FirmwareUpgradeLog)
 /// This is a QGC specific replacement for Q_LOGGING_CATEGORY. It will register the category name into a
 /// global list. It's usage is the same as Q_LOGGING_CATEOGRY.
 #define QGC_LOGGING_CATEGORY(name, ...) \
-    static QGCLoggingCategory qgcCategory(__VA_ARGS__); \
+    static QGCLoggingCategory qgcCategory ## name (__VA_ARGS__); \
     Q_LOGGING_CATEGORY(name, __VA_ARGS__)
 
 class QGCLoggingCategoryRegister


### PR DESCRIPTION
Set JoystickValuesLog=true in your qtlogging.ini file to get the values output which are being sent from the joystick to the UAS setpoint method.