### PR TITLE
Joystick fixes

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
@@ -68,12 +68,13 @@ QString FlightModesComponent::iconResource(void) const
 
 bool FlightModesComponent::requiresSetup(void) const
 {
-    return true;
+    return _autopilot->getParameterFact(-1, "COM_RC_IN_MODE")->value().toInt() == 1 ? false : true;
 }
 
 bool FlightModesComponent::setupComplete(void) const
 {
-    return _autopilot->getParameterFact(FactSystem::defaultComponentId, "RC_MAP_MODE_SW")->value().toInt() != 0;
+    return _autopilot->getParameterFact(-1, "COM_RC_IN_MODE")->value().toInt() == 1 ||
+            _autopilot->getParameterFact(FactSystem::defaultComponentId, "RC_MAP_MODE_SW")->value().toInt() != 0;
 }
 
 QString FlightModesComponent::setupStateDescription(void) const
@@ -116,13 +117,18 @@ QUrl FlightModesComponent::summaryQmlSource(void) const
 
 QString FlightModesComponent::prerequisiteSetup(void) const
 {
-    PX4AutoPilotPlugin* plugin = dynamic_cast<PX4AutoPilotPlugin*>(_autopilot);
-    Q_ASSERT(plugin);
+    if (_autopilot->getParameterFact(-1, "COM_RC_IN_MODE")->value().toInt() == 1) {
+        // No RC input
+        return QString();
+    } else {
+        PX4AutoPilotPlugin* plugin = dynamic_cast<PX4AutoPilotPlugin*>(_autopilot);
+        Q_ASSERT(plugin);
 
-    if (!plugin->airframeComponent()->setupComplete()) {
-        return plugin->airframeComponent()->name();
-    } else if (!plugin->radioComponent()->setupComplete()) {
-        return plugin->radioComponent()->name();
+        if (!plugin->airframeComponent()->setupComplete()) {
+            return plugin->airframeComponent()->name();
+        } else if (!plugin->radioComponent()->setupComplete()) {
+            return plugin->radioComponent()->name();
+        }
     }
     
     return QString();

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
@@ -42,6 +42,9 @@ QGCView {
 
     // User visible strings
 
+    readonly property string title:                     "FLIGHT MODES CONFIG"
+
+
     property string topHelpText:                        "Assign Flight Modes to radio control channels and adjust the thresholds for triggering them. " +
                                                         "You can assign multiple flight modes to a single channel. " +
                                                         "Turn your radio control on to test switch settings. " +
@@ -117,6 +120,8 @@ QGCView {
 
     readonly property real modeSpacing: ScreenTools.defaultFontPixelHeight / 3
 
+    property Fact rcInMode: controller.getParameterFact(-1, "COM_RC_IN_MODE")
+
     QGCPalette { id: qgcPal; colorGroupEnabled: panel.enabled }
 
     FlightModesComponentController {
@@ -130,7 +135,13 @@ QGCView {
         interval:   200
         running:    true
 
-        onTriggered: recalcModePositions()
+        onTriggered: {
+            if (rcInMode.value == 1) {
+                showDialog(joystickEnabledDialogComponent, title, 50, 0)
+            } else {
+                recalcModePositions()
+            }
+        }
     }
 
     function recalcModePositions() {
@@ -188,6 +199,14 @@ QGCView {
         id:             panel
         anchors.fill:   parent
 
+        Component {
+            id: joystickEnabledDialogComponent
+
+            QGCViewMessage {
+                message: "Flight Mode Config is disabled since you have a Joystick enabled."
+            }
+        }
+
         ScrollView {
             id:                         scroll
             anchors.fill:               parent
@@ -201,7 +220,7 @@ QGCView {
                     id:             header
                     width:          parent.width
                     font.pixelSize: ScreenTools.largeFontPixelSize
-                    text:           "FLIGHT MODES CONFIG"
+                    text:           title
                 }
 
                 Item {

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -107,28 +107,20 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
         Q_ASSERT(_vehicle);
         
         if (pluginReady()) {
-            bool noRCTransmitter = false;
-            if (parameterExists(FactSystem::defaultComponentId, "COM_RC_IN_MODE")) {
-                Fact* rcFact = getParameterFact(FactSystem::defaultComponentId, "COM_RC_IN_MODE");
-                noRCTransmitter = rcFact->value().toInt() == 1;
-            }
-
             _airframeComponent = new AirframeComponent(_vehicle->uas(), this);
             Q_CHECK_PTR(_airframeComponent);
             _airframeComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_airframeComponent));
             
-            if (!noRCTransmitter) {
-                _radioComponent = new RadioComponent(_vehicle->uas(), this);
-                Q_CHECK_PTR(_radioComponent);
-                _radioComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
-                
-                _flightModesComponent = new FlightModesComponent(_vehicle->uas(), this);
-                Q_CHECK_PTR(_flightModesComponent);
-                _flightModesComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_flightModesComponent));
-            }
+            _radioComponent = new RadioComponent(_vehicle->uas(), this);
+            Q_CHECK_PTR(_radioComponent);
+            _radioComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
+            
+            _flightModesComponent = new FlightModesComponent(_vehicle->uas(), this);
+            Q_CHECK_PTR(_flightModesComponent);
+            _flightModesComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_flightModesComponent));
             
             _sensorsComponent = new SensorsComponent(_vehicle->uas(), this);
             Q_CHECK_PTR(_sensorsComponent);

--- a/src/AutoPilotPlugins/PX4/RadioComponent.qml
+++ b/src/AutoPilotPlugins/PX4/RadioComponent.qml
@@ -47,10 +47,12 @@ QGCView {
     property bool controllerCompleted: false
     property bool controllerAndViewReady: false
 
+    property Fact rcInMode: controller.getParameterFact(-1, "COM_RC_IN_MODE")
+
     function updateChannelCount()
     {
         if (controllerAndViewReady) {
-            if (joystickManager.activeJoystick && joystickManager.activeJoystick.enabled) {
+            if (rcInMode.value == 1) {
                 showDialog(joystickEnabledDialogComponent, dialogTitle, 50, 0)
             }
 /*

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -66,7 +66,6 @@ public:
     Q_PROPERTY(QString name READ name CONSTANT)
     
     Q_PROPERTY(bool calibrated MEMBER _calibrated NOTIFY calibratedChanged)
-    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
     
     Q_PROPERTY(int buttonCount MEMBER _buttonCount CONSTANT)
     Q_PROPERTY(int axisCount MEMBER _axisCount CONSTANT)
@@ -80,7 +79,7 @@ public:
     Q_PROPERTY(int throttleMode READ throttleMode WRITE setThrottleMode NOTIFY throttleModeChanged)
     
     /// Start the polling thread which will in turn emit joystick signals
-    void startPolling(void);
+    void startPolling(Vehicle* vehicle);
     void stopPolling(void);
     
     void setCalibration(int axis, Calibration_t& calibration);
@@ -97,11 +96,11 @@ public:
     int throttleMode(void);
     void setThrottleMode(int mode);
     
-    bool enabled(void);
-    void setEnabled(bool enabled);
+    /// Calibration is about to start
+    void startCalibration(void);
     
-    bool calibrating(void) { return _calibrating; }
-    void setCalibrating(bool calibrating) { _calibrating = calibrating; }
+    /// Calibration has ended
+    void stopCalibration(void);
     
 signals:
     void calibratedChanged(bool calibrated);
@@ -140,7 +139,6 @@ private:
     bool    _exitThread;    ///< true: signal thread to exit
     
     QString _name;
-    bool    _enabled;
     bool    _calibrated;
     bool    _calibrating;
     int     _axisCount;
@@ -157,6 +155,9 @@ private:
     quint16             _lastButtonBits;
     
     ThrottleMode_t      _throttleMode;
+    
+    Vehicle*            _activeVehicle;
+    bool                _pollingStartedForCalibration;
 #endif // __mobile__
     
 private:
@@ -166,7 +167,6 @@ private:
     static const char* _calibratedSettingsKey;
     static const char* _buttonActionSettingsKey;
     static const char* _throttleModeSettingsKey;
-    static const char* _enabledSettingsKey;
 };
     
 #endif

--- a/src/Vehicle/MultiVehicleManager.h
+++ b/src/Vehicle/MultiVehicleManager.h
@@ -82,7 +82,7 @@ signals:
     void _deleteVehiclePhase2Signal(void);
     
 private slots:
-    void _deleteVehiclePhase1(void);
+    void _deleteVehiclePhase1(Vehicle* vehicle);
     void _deleteVehiclePhase2(void);
     void _setActiveVehiclePhase2(void);
     void _autopilotPluginReadyChanged(bool pluginReady);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -891,7 +891,10 @@ void Vehicle::setJoystickEnabled(bool enabled)
     if (!fact) {
         qCWarning(JoystickLog) << "Missing COM_RC_IN_MODE parameter";
     }
-    fact->setValue(enabled ? 1 : 0);
+    
+    if (fact->value().toInt() != 2) {
+        fact->setValue(enabled ? 1 : 0);
+    }
     
     _joystickEnabled = enabled;
     _startJoystick(_joystickEnabled);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -29,6 +29,7 @@
 #include "AutoPilotPluginManager.h"
 #include "UASMessageHandler.h"
 #include "UAS.h"
+#include "JoystickManager.h"
 
 QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
 
@@ -36,15 +37,18 @@ QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
 #define DEFAULT_LAT  38.965767f
 #define DEFAULT_LON -120.083923f
 
-const char* Vehicle::_settingsGroup =           "Vehicle%1";   // %1 replace with mavlink system id
-const char* Vehicle::_joystickModeSettingsKey = "JoystickMode";
+const char* Vehicle::_settingsGroup =               "Vehicle%1";        // %1 replaced with mavlink system id
+const char* Vehicle::_joystickModeSettingsKey =     "JoystickMode";
+const char* Vehicle::_joystickEnabledSettingsKey =  "JoystickEnabled";
 
 Vehicle::Vehicle(LinkInterface* link, int vehicleId, MAV_AUTOPILOT firmwareType)
     : _id(vehicleId)
+    , _active(false)
     , _firmwareType(firmwareType)
     , _firmwarePlugin(NULL)
     , _autopilotPlugin(NULL)
     , _joystickMode(JoystickModeRC)
+    , _joystickEnabled(false)
     , _uas(NULL)
     , _mav(NULL)
     , _currentMessageCount(0)
@@ -81,8 +85,6 @@ Vehicle::Vehicle(LinkInterface* link, int vehicleId, MAV_AUTOPILOT firmwareType)
     , _wpm(NULL)
     , _updateCount(0)
 {
-    _loadSettings();
-    
     _addLink(link);
     
     connect(MAVLinkProtocol::instance(), &MAVLinkProtocol::messageReceived, this, &Vehicle::_mavlinkMessageReceived);
@@ -96,9 +98,9 @@ Vehicle::Vehicle(LinkInterface* link, int vehicleId, MAV_AUTOPILOT firmwareType)
     connect(_uas, &UAS::latitudeChanged, this, &Vehicle::setLatitude);
     connect(_uas, &UAS::longitudeChanged, this, &Vehicle::setLongitude);
     
-    _firmwarePlugin = FirmwarePluginManager::instance()->firmwarePluginForAutopilot(firmwareType);
+    _firmwarePlugin = FirmwarePluginManager::instance()->firmwarePluginForAutopilot(firmwareType);    
     _autopilotPlugin = AutoPilotPluginManager::instance()->newAutopilotPluginForVehicle(this);
-    
+
     // Refresh timer
     connect(_refreshTimer, SIGNAL(timeout()), this, SLOT(_checkUpdate()));
     _refreshTimer->setInterval(UPDATE_TIMER);
@@ -145,6 +147,8 @@ Vehicle::Vehicle(LinkInterface* link, int vehicleId, MAV_AUTOPILOT firmwareType)
     }
     _setSystemType(_mav, _mav->getSystemType());
     _updateArmingState(_mav->isArmed());
+    
+    _loadSettings();
 }
 
 Vehicle::~Vehicle()
@@ -225,7 +229,7 @@ void Vehicle::_linkDisconnected(LinkInterface* link)
     }
     
     if (_links.count() == 0) {
-        emit allLinksDisconnected();
+        emit allLinksDisconnected(this);
     }
 }
 
@@ -836,6 +840,8 @@ void Vehicle::_loadSettings(void)
     if (!convertOk) {
         _joystickMode = JoystickModeRC;
     }
+    
+    _joystickEnabled = settings.value(_joystickEnabledSettingsKey, false).toBool();
 }
 
 void Vehicle::_saveSettings(void)
@@ -845,6 +851,7 @@ void Vehicle::_saveSettings(void)
     settings.beginGroup(QString(_settingsGroup).arg(_id));
     
     settings.setValue(_joystickModeSettingsKey, _joystickMode);
+    settings.setValue(_joystickEnabledSettingsKey, _joystickEnabled);
 }
 
 int Vehicle::joystickMode(void)
@@ -868,7 +875,54 @@ QStringList Vehicle::joystickModes(void)
 {
     QStringList list;
     
-    list << "Simulate RC" << "Attitude" << "Position" << "Force" << "Velocity";
+    list << "Normal" << "Attitude" << "Position" << "Force" << "Velocity";
     
     return list;
+}
+
+bool Vehicle::joystickEnabled(void)
+{
+    return _joystickEnabled;
+}
+
+void Vehicle::setJoystickEnabled(bool enabled)
+{
+    Fact* fact = _autopilotPlugin->getParameterFact(FactSystem::defaultComponentId, "COM_RC_IN_MODE");
+    if (!fact) {
+        qCWarning(JoystickLog) << "Missing COM_RC_IN_MODE parameter";
+    }
+    fact->setValue(enabled ? 1 : 0);
+    
+    _joystickEnabled = enabled;
+    _startJoystick(_joystickEnabled);
+    _saveSettings();
+}
+
+void Vehicle::_startJoystick(bool start)
+{
+    Joystick* joystick = JoystickManager::instance()->activeJoystick();
+    
+    if (joystick) {
+#ifndef __mobile__
+        if (start) {
+            if (_joystickEnabled) {
+                joystick->startPolling(this);
+            }
+        } else {
+            joystick->stopPolling();
+        }
+#endif
+    }
+}
+
+bool Vehicle::active(void)
+{
+    return _active;
+}
+
+void Vehicle::setActive(bool active)
+{
+    _active = active;
+    
+    _startJoystick(_active);
 }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -102,7 +102,7 @@ public:
     Q_PROPERTY(int manualControlReservedButtonCount READ manualControlReservedButtonCount CONSTANT)
     
     typedef enum {
-        JoystickModeRC,         ///< Joystick emulates am RC Transmitter
+        JoystickModeRC,         ///< Joystick emulates an RC Transmitter
         JoystickModeAttitude,
         JoystickModePosition,
         JoystickModeForce,
@@ -118,6 +118,16 @@ public:
     /// List of joystick mode names
     Q_PROPERTY(QStringList joystickModes READ joystickModes CONSTANT)
     QStringList joystickModes(void);
+    
+    // Enable/Disable joystick for this vehicle
+    Q_PROPERTY(bool joystickEnabled READ joystickEnabled WRITE setJoystickEnabled NOTIFY joystickEnabledChanged)
+    bool joystickEnabled(void);
+    void setJoystickEnabled(bool enabled);
+    
+    // Is vehicle active with respect to current active vehicle in QGC
+    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
+    bool active(void);
+    void setActive(bool active);
     
     // Property accesors
     int id(void) { return _id; }
@@ -199,9 +209,11 @@ public slots:
     void setLongitude(double longitude);
     
 signals:
-    void allLinksDisconnected(void);
+    void allLinksDisconnected(Vehicle* vehicle);
     void coordinateChanged(QGeoCoordinate coordinate);
     void joystickModeChanged(int mode);
+    void joystickEnabledChanged(bool enabled);
+    void activeChanged(bool active);
     
     /// Used internally to move sendMessage call to main thread
     void _sendMessageOnThread(mavlink_message_t message);
@@ -274,15 +286,17 @@ private:
     void _addLink(LinkInterface* link);
     void _loadSettings(void);
     void _saveSettings(void);
+    void _startJoystick(bool start);
     
     bool    _isAirplane                     ();
     void    _addChange                      (int id);
     float   _oneDecimal                     (float value);
 
 private:
-    int             _id;            ///< Mavlink system id
-    MAV_AUTOPILOT   _firmwareType;
+    int     _id;            ///< Mavlink system id
+    bool    _active;
     
+    MAV_AUTOPILOT       _firmwareType;
     FirmwarePlugin*     _firmwarePlugin;
     AutoPilotPlugin*    _autopilotPlugin;
     
@@ -292,6 +306,7 @@ private:
     QList<SharedLinkInterface> _links;
     
     JoystickMode_t  _joystickMode;
+    bool            _joystickEnabled;
     
     UAS* _uas;
     
@@ -341,5 +356,6 @@ private:
     
     static const char* _settingsGroup;
     static const char* _joystickModeSettingsKey;
+    static const char* _joystickEnabledSettingsKey;
 };
 #endif

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -126,6 +126,7 @@ signals:
     void nextButtonMessageBoxDisplayed(void);
 
 private slots:
+    void _activeJoystickChanged(Joystick* joystick);
     void _axisValueChanged(int axis, int value);
    
 private:
@@ -160,6 +161,8 @@ private:
         int                         axisMax;    ///< Maximum axis value
         int                         axisTrim;   ///< Trim position
     };
+    
+    Joystick* _activeJoystick;
     
     int _currentStep;  ///< Current step of state machine
     

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -198,6 +198,7 @@ Rectangle {
             SubMenuButton {
                 width:          buttonWidth
                 imageResource:  modelData.iconResource
+                setupIndicator: modelData.requiresSetup
                 setupComplete:  modelData.setupComplete
                 exclusiveGroup: setupButtonGroup
                 text:           modelData.name.toUpperCase()


### PR DESCRIPTION
Changes to follow these rules:
COM_RC_IN_MODE = 2
- All config screen enabled and run as if there was normal RC connected
COM_RC_IN_MODE = 1
- Radio Config disabled
- Flight Mode Config disabled

As well as these changes:
- Change Simulate RC joystick mode to Normal
- Disable “Enabled” check box if COM_RC_IN_MODE > 1
- Move enabled to first setting
- Fixed bugs with active joystick changing in config
- Moved Joystick enabled save setting to Vehicle instead of globally on joystick
