### PR TITLE
Joystick message fixes

### DIFF
--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -96,11 +96,17 @@ public:
     int throttleMode(void);
     void setThrottleMode(int mode);
     
-    /// Calibration is about to start
-    void startCalibration(void);
+    typedef enum {
+        CalibrationModeOff,         // Not calibrating
+        CalibrationModeMonitor,     // Monitors are active, continue to send to vehicle if already polling
+        CalibrationModeCalibrating, // Calibrating, stop sending joystick to vehicle
+    } CalibrationMode_t;
     
-    /// Calibration has ended
-    void stopCalibration(void);
+    /// Set the current calibration mode
+    void startCalibrationMode(CalibrationMode_t mode);
+    
+    /// Clear the current calibration mode
+    void stopCalibrationMode(CalibrationMode_t mode);
     
 signals:
     void calibratedChanged(bool calibrated);
@@ -140,9 +146,10 @@ private:
     
     QString _name;
     bool    _calibrated;
-    bool    _calibrating;
     int     _axisCount;
     int     _buttonCount;
+    
+    CalibrationMode_t   _calibrationMode;
     
     static const int    _cAxes = 4;
     int                 _rgAxisValues[_cAxes];

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -73,7 +73,7 @@ JoystickConfigController::JoystickConfigController(void)
     _activeJoystickChanged(joystickManager->activeJoystick());
     _loadSettings();
     _resetInternalCalibrationValues();
-    _activeJoystick->startCalibration();
+    _activeJoystick->startCalibrationMode(Joystick::CalibrationModeMonitor);
 }
 
 void JoystickConfigController::start(void)
@@ -84,7 +84,7 @@ void JoystickConfigController::start(void)
 
 JoystickConfigController::~JoystickConfigController()
 {
-    _activeJoystick->stopCalibration();
+    _activeJoystick->stopCalibrationMode(Joystick::CalibrationModeMonitor);
     _storeSettings();
 }
 
@@ -548,6 +548,7 @@ void JoystickConfigController::_startCalibration(void)
 {
     Q_ASSERT(_axisCount >= _axisMinimum);
     
+    _activeJoystick->startCalibrationMode(Joystick::CalibrationModeCalibrating);
     _resetInternalCalibrationValues();
     
     _nextButton->setProperty("text", "Next");
@@ -562,6 +563,7 @@ void JoystickConfigController::_stopCalibration(void)
 {
     _currentStep = -1;
     
+    _activeJoystick->stopCalibrationMode(Joystick::CalibrationModeCalibrating);
     _setInternalCalibrationValuesFromSettings();
     
     _statusText->setProperty("text", "");


### PR DESCRIPTION
When on Joystick config page:
- Not calibrating: If joystick is enabled, joystick messages should
continue to go to vehicle