### PR TITLE
Update NSIS script to include ANGLE dlls for windows, add NSIS script…

### DIFF
--- a/QGCInstaller.pri
+++ b/QGCInstaller.pri
@@ -49,5 +49,6 @@ installer {
         QMAKE_POST_LINK += $$escape_expand(\\n) $$quote("\"C:\\Program Files \(x86\)\\NSIS\\makensis.exe\"" /NOCD "\"/XOutFile $${DESTDIR_WIN}\\qgroundcontrol-installer-win32.exe\"" "$$BASEDIR_WIN\\deploy\\qgroundcontrol_installer.nsi")
 		#QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY qgroundcontrol.pdb $${DESTDIR_WIN}
 		#QMAKE_POST_LINK += $$escape_expand(\\n) del qgroundcontrol.pdb
+        OTHER_FILES += deploy/qgroundcontrol_installer.nsi
     }
 }

--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -170,6 +170,10 @@ WindowsBuild {
         $$BASEDIR\\libs\\lib\\sdl\\win32\\SDL.dll \
         $$BASEDIR\\libs\\thirdParty\\libxbee\\lib\\libxbee.dll \
         $$DLL_DIR\\icu*.dll \
+        $$DLL_DIR\\d3dcompiler*.dll \
+        $$DLL_DIR\\libEGL$${DLL_QT_DEBUGCHAR}.dll \
+        $$DLL_DIR\\libGLESv2$${DLL_QT_DEBUGCHAR}.dll \
+        $$DLL_DIR\\opengl32sw.dll \
         $$DLL_DIR\\Qt5Core$${DLL_QT_DEBUGCHAR}.dll \
         $$DLL_DIR\\Qt5Gui$${DLL_QT_DEBUGCHAR}.dll \
         $$DLL_DIR\\Qt5Location$${DLL_QT_DEBUGCHAR}.dll \
@@ -198,7 +202,7 @@ WindowsBuild {
     # Copy platform plugins
     P_DIR = $$[QT_INSTALL_PLUGINS]
     PLUGINS_DIR_WIN = $$replace(P_DIR, "/", "\\")
-    QMAKE_POST_LINK += $$escape_expand(\\n) mkdir "$$DESTDIR_WIN\\platforms"
+    QMAKE_POST_LINK += $$escape_expand(\\n) mkdir -p "$$DESTDIR_WIN\\platforms"
     QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY     \"$$PLUGINS_DIR_WIN\\platforms\\qwindows$${DLL_QT_DEBUGCHAR}.dll\" \"$$DESTDIR_WIN\\platforms\\qwindows$${DLL_QT_DEBUGCHAR}.dll\"
     QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$PLUGINS_DIR_WIN\\imageformats\" \"$$DESTDIR_WIN\\imageformats\"
     QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$PLUGINS_DIR_WIN\\sqldrivers\" \"$$DESTDIR_WIN\\sqldrivers\"


### PR DESCRIPTION
… to otherfiles on windows

We have some machines with buggy / non-compliant OpenGL implementations from Intel (HD3000, for example). They'll run for a short (variable) time and then crash inside the Intel OpenGL dlls. 

I have been manually overriding these machines with QT_OPENGL=angle set in the environment, but there are also explicitly [blacklisted devices in mainline Qt](https://github.com/qtproject/qtbase/blob/89cb92f838b43123f51bfddba433bfe54c0e855d/src/plugins/platforms/windows/openglblacklists/default.json). If we don't ship the DLLs added in this PR then we can't fall back to ANGLE or software OpenGL and we'll likely crash every time. Including these does increase the size of the installer a bit but I think it is a worthwhile tradeoff. This may help cases like #1782 as well. 