### PR TITLE
Android Video Streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ thirdParty/qserialport/bin/
 thirdParty/qserialport/lib/
 libs/thirdParty/libxbee/lib/
 GeneratedFiles/
+gstreamer-1.0-android*
 
 *.autosave
 .settings/

--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -19,10 +19,6 @@
 
 QMAKE_POST_LINK += echo "Copying files"
 
-AndroidBuild {
-    INSTALLS += $$DESTDIR
-}
-
 #
 # Copy the application resources to the associated place alongside the application
 #

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -903,10 +903,9 @@ void Vehicle::setJoystickEnabled(bool enabled)
 
 void Vehicle::_startJoystick(bool start)
 {
-    Joystick* joystick = JoystickManager::instance()->activeJoystick();
-    
-    if (joystick) {
 #ifndef __mobile__
+    Joystick* joystick = JoystickManager::instance()->activeJoystick();
+    if (joystick) {
         if (start) {
             if (_joystickEnabled) {
                 joystick->startPolling(this);
@@ -914,8 +913,10 @@ void Vehicle::_startJoystick(bool start)
         } else {
             joystick->stopPolling();
         }
-#endif
     }
+#else
+    Q_UNUSED(start);
+#endif
 }
 
 bool Vehicle::active(void)

--- a/src/VideoStreaming/README.md
+++ b/src/VideoStreaming/README.md
@@ -54,8 +54,10 @@ TODO: Binaries found in http://gstreamer.freedesktop.org/data/pkg/ios
 
 ### Android
 
-TODO: Binaries found in http://gstreamer.freedesktop.org/data/pkg/android
-(work in progress)
+Binaries found in http://gstreamer.freedesktop.org/data/pkg/android
+Download the [gstreamer-1.0-android-armv7-1.5.2.tar.bz2](http://gstreamer.freedesktop.org/data/pkg/android/1.5.2/gstreamer-1.0-android-armv7-1.5.2.tar.bz2) archive (assuming you want the ARM V7 platform) and extract it to the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). That's where the build system will look for it.
+
+Note that Android is not fully tested. For instance, as of this writing, there isn't even a way to enable the Video Streaming from the Flight Display.
 
 ### Windows
 

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -56,7 +56,26 @@ LinuxBuild {
         INCLUDEPATH += \
             $$GST_ROOT/include/gstreamer-1.0 \
             $$GST_ROOT/include/glib-2.0 \
-            $$GST_ROOT/lib/gstreamer-1.0\include \
+            $$GST_ROOT/lib/gstreamer-1.0/include \
+            $$GST_ROOT/lib/glib-2.0/include
+    }
+} else:AndroidBuild {
+    #- gstreamer assumed to be installed in $$PWD/../../android/gstreamer-1.0-android-armv7-1.5.2
+    GST_ROOT = $$PWD/../../gstreamer-1.0-android-armv7-1.5.2
+    exists($$GST_ROOT) {
+        QMAKE_CXXFLAGS  += -pthread
+        CONFIG          += VideoEnabled
+        LIBS            += -L$$GST_ROOT/lib \
+            -lgstvideo-1.0 \
+            -lgstfft-1.0 -lm  \
+            -lgstnet-1.0 -lgio-2.0 \
+            -lgstaudio-1.0 -lgstbase-1.0 -lgstreamer-1.0 -lgobject-2.0 \
+            -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lorc-0.4 -liconv -lffi -lintl
+
+        INCLUDEPATH += \
+            $$GST_ROOT/include/gstreamer-1.0 \
+            $$GST_ROOT/lib/gstreamer-1.0/include \
+            $$GST_ROOT/include/glib-2.0 \
             $$GST_ROOT/lib/glib-2.0/include
     }
 }
@@ -137,6 +156,10 @@ VideoEnabled {
             message("  You can download it from http://gstreamer.freedesktop.org/data/pkg/windows/")
             message("  Select the devel AND runtime packages and install them (x86, not the 64-Bit)")
             message("  It will be installed in C:/gstreamer. You need to update you PATH to point to the bin directory.")
+        }
+        AndroidBuild {
+            message("  You can download it from http://gstreamer.freedesktop.org/data/pkg/android/")
+            message("  Uncompress the archive into the qgc root source directory (same directory where qgroundcontrol.pro is found.")
         }
     } else {
         message("Skipping support for video streaming (Unsupported platform)")


### PR DESCRIPTION
Added libraries for building video streaming for Android. Not tested as Video Streaming has been removed from the Flight Display and there is currently no way to enable Video Background on mobile devices.