### PR TITLE
Add switch for using old/new mission editor

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -158,6 +158,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     , _runningUnitTests(unitTesting)
     , _styleIsDark(true)
 	, _fakeMobile(false)
+    , _useNewMissionEditor(false)
 {
     Q_ASSERT(_app == NULL);
     _app = this;
@@ -418,6 +419,9 @@ bool QGCApplication::_initForNormalAppBoot(void)
 
     _styleIsDark = settings.value(_styleKey, _styleIsDark).toBool();
     _loadCurrentStyle();
+    
+    // Temp hack for new mission editor
+    _useNewMissionEditor = settings.value("UseNewMissionEditor", false).toBool();
     
     // Show splash screen
     QPixmap splashImage(":/res/SplashScreen");
@@ -800,4 +804,12 @@ void QGCApplication::showToolBarMessage(const QString& message)
     } else {
         QGCMessageBox::information("", message);
     }
+}
+
+void QGCApplication::setUseNewMissionEditor(bool use)
+{
+    // Temp hack for new mission editor
+    QSettings settings;
+    
+    settings.setValue("UseNewMissionEditor", use);
 }

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -106,6 +106,9 @@ public:
 	/// @return true: Fake ui into showing mobile interface
 	bool fakeMobile(void) { return _fakeMobile; }
     
+    bool useNewMissionEditor(void) { return _useNewMissionEditor; }
+    void setUseNewMissionEditor(bool use);
+    
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
     void informationMessageBoxOnMainThread(const QString& title, const QString& msg);
@@ -174,6 +177,8 @@ private:
     QStringList         _missingParams;                                  ///< List of missing facts to be displayed
 
 	bool				_fakeMobile;	///< true: Fake ui into displaying mobile interface
+
+    bool _useNewMissionEditor;  ///< true: Use new Mission Editor
 
     /// Unit Test have access to creating and destroying singletons
     friend class UnitTest;

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -709,7 +709,6 @@ void MainWindow::connectCommonActions()
     perspectives->addAction(_ui.actionFlight);
     perspectives->addAction(_ui.actionSimulationView);
     perspectives->addAction(_ui.actionPlan);
-    perspectives->addAction(_ui.actionMissionEditor);
     perspectives->addAction(_ui.actionSetup);
     perspectives->setExclusive(true);
 
@@ -729,15 +728,10 @@ void MainWindow::connectCommonActions()
         _ui.actionSimulationView->setChecked(true);
         _ui.actionSimulationView->activate(QAction::Trigger);
     }
-    if (_currentView == VIEW_PLAN)
+    if (_currentView == VIEW_PLAN || _currentView == VIEW_MISSIONEDITOR)
     {
         _ui.actionPlan->setChecked(true);
         _ui.actionPlan->activate(QAction::Trigger);
-    }
-    if (_currentView == VIEW_MISSIONEDITOR)
-    {
-        _ui.actionMissionEditor->setChecked(true);
-        _ui.actionMissionEditor->activate(QAction::Trigger);
     }
     if (_currentView == VIEW_SETUP)
     {
@@ -757,7 +751,9 @@ void MainWindow::connectCommonActions()
     connect(_ui.actionSimulationView,   SIGNAL(triggered()), this, SLOT(loadSimulationView()));
     connect(_ui.actionAnalyze,          SIGNAL(triggered()), this, SLOT(loadAnalyzeView()));
     connect(_ui.actionPlan,             SIGNAL(triggered()), this, SLOT(loadPlanView()));
-    connect(_ui.actionMissionEditor,    SIGNAL(triggered()), this, SLOT(loadMissionEditorView()));
+    
+    _ui.actionUseMissionEditor->setChecked(qgcApp()->useNewMissionEditor());
+    connect(_ui.actionUseMissionEditor, &QAction::triggered, this, &MainWindow::_setUseMissionEditor);
     
     // Help Actions
     connect(_ui.actionOnline_Documentation, SIGNAL(triggered()), this, SLOT(showHelp()));
@@ -1005,23 +1001,22 @@ void MainWindow::loadAnalyzeView()
 
 void MainWindow::loadPlanView()
 {
-    if (_currentView != VIEW_PLAN)
-    {
-        _storeCurrentViewState();
-        _currentView = VIEW_PLAN;
-        _ui.actionPlan->setChecked(true);
-        _loadCurrentViewState();
-    }
-}
-
-void MainWindow::loadMissionEditorView()
-{
-    if (_currentView != VIEW_MISSIONEDITOR)
-    {
-        _storeCurrentViewState();
-        _currentView = VIEW_MISSIONEDITOR;
-        _ui.actionMissionEditor->setChecked(true);
-        _loadCurrentViewState();
+    if (qgcApp()->useNewMissionEditor()) {
+        if (_currentView != VIEW_MISSIONEDITOR)
+        {
+            _storeCurrentViewState();
+            _currentView = VIEW_MISSIONEDITOR;
+            _ui.actionPlan->setChecked(true);
+            _loadCurrentViewState();
+        }
+    } else {
+        if (_currentView != VIEW_PLAN)
+        {
+            _storeCurrentViewState();
+            _currentView = VIEW_PLAN;
+            _ui.actionPlan->setChecked(true);
+            _loadCurrentViewState();
+        }
     }
 }
 
@@ -1118,3 +1113,8 @@ void MainWindow::_showQmlTestWidget(void)
     new QmlTestWidget();
 }
 #endif
+
+void MainWindow::_setUseMissionEditor(bool checked)
+{
+    qgcApp()->setUseNewMissionEditor(checked);
+}

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -135,7 +135,6 @@ public slots:
     void loadSimulationView();
     void loadAnalyzeView();
     void loadPlanView();
-    void loadMissionEditorView();
     
     void manageLinks();
 
@@ -176,6 +175,8 @@ protected slots:
      * @brief Enable/Disable Status Bar
      */
     void showStatusBarCallback(bool checked);
+    
+    void _setUseMissionEditor(bool checked);
 
 signals:
     void initStatusChanged(const QString& message, int alignment, const QColor &color);

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -62,6 +62,7 @@
     <addaction name="actionMuteAudioOutput"/>
     <addaction name="actionAdd_Link"/>
     <addaction name="actionSettings"/>
+    <addaction name="actionUseMissionEditor"/>
     <addaction name="separator"/>
     <addaction name="actionExit"/>
    </widget>
@@ -79,7 +80,6 @@
     </property>
     <addaction name="actionSetup"/>
     <addaction name="actionPlan"/>
-    <addaction name="actionMissionEditor"/>
     <addaction name="actionFlight"/>
     <addaction name="actionAnalyze"/>
     <addaction name="separator"/>
@@ -249,6 +249,17 @@
    </property>
    <property name="text">
     <string>New Mission Editor</string>
+   </property>
+   <property name="toolTip">
+    <string>Mission Editor</string>
+   </property>
+  </action>
+  <action name="actionUseMissionEditor">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Use new mission editor (reboot required)</string>
    </property>
    <property name="toolTip">
     <string>Mission Editor</string>


### PR DESCRIPTION
The file menu now has a menu item which says: "Use new mission editor (reboot required)". This allows you to switch globally between the new and old mission editor. After you change the settings you must exit and reboot for it to take affect. If you don't reboot, strange things will happen in the future. Plan will now take you the the right place, based on the setting of this swich.

The reason for this is that I'm about to work on the new Mission Item backend. It will not be able to coexist with the old waypoint manager. It's an either/or selection. So leave this alone to continue using the existing code (which works). Check it to use the new code from top to bottom (which is not fully implemented yet).