### PR TITLE
Enable Android Video Streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ thirdParty/qserialport/bin/
 thirdParty/qserialport/lib/
 libs/thirdParty/libxbee/lib/
 GeneratedFiles/
+gstreamer-1.0-android*
 
 *.autosave
 .settings/

--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -668,12 +668,14 @@ INCLUDEPATH += \
 HEADERS += \
     src/VideoStreaming/VideoItem.h \
     src/VideoStreaming/VideoReceiver.h \
+    src/VideoStreaming/VideoStreaming.h \
     src/VideoStreaming/VideoSurface.h \
     src/VideoStreaming/VideoSurface_p.h \
 
 SOURCES += \
     src/VideoStreaming/VideoItem.cc \
     src/VideoStreaming/VideoReceiver.cc \
+    src/VideoStreaming/VideoStreaming.cc \
     src/VideoStreaming/VideoSurface.cc \
 
 contains (DEFINES, DISABLE_VIDEOSTREAMING) {

--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -19,10 +19,6 @@
 
 QMAKE_POST_LINK += echo "Copying files"
 
-AndroidBuild {
-    INSTALLS += $$DESTDIR
-}
-
 #
 # Copy the application resources to the associated place alongside the application
 #

--- a/libs/qtandroidserialport/src/qserialportinfo_android.cpp
+++ b/libs/qtandroidserialport/src/qserialportinfo_android.cpp
@@ -50,6 +50,8 @@ static const char V_TAG[] {"QGC_QSerialPortInfo"};
 
 extern void cleanJavaException();
 
+static int gErrorCount = 0;
+
 QList<QSerialPortInfo> availablePortsByFiltersOfDevices(bool &ok)
 {
     QList<QSerialPortInfo> serialPortInfoList;
@@ -61,9 +63,15 @@ QList<QSerialPortInfo> availablePortsByFiltersOfDevices(bool &ok)
         "()[Ljava/lang/String;");
     
     if (!resultL.isValid()) {
-        __android_log_print(ANDROID_LOG_ERROR, V_TAG, "Error from availableDevicesInfo");
+        //-- If 5 consecutive errors, ignore it.
+        if(gErrorCount < 5) {
+            gErrorCount++;
+            __android_log_print(ANDROID_LOG_ERROR, V_TAG, "Error from availableDevicesInfo");
+        }
         ok = false;
         return serialPortInfoList;
+    } else {
+        gErrorCount = 0;
     }
 
     QAndroidJniEnvironment envL;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -899,10 +899,9 @@ void Vehicle::setJoystickEnabled(bool enabled)
 
 void Vehicle::_startJoystick(bool start)
 {
-    Joystick* joystick = JoystickManager::instance()->activeJoystick();
-    
-    if (joystick) {
 #ifndef __mobile__
+    Joystick* joystick = JoystickManager::instance()->activeJoystick();
+    if (joystick) {
         if (start) {
             if (_joystickEnabled) {
                 joystick->startPolling(this);
@@ -910,8 +909,10 @@ void Vehicle::_startJoystick(bool start)
         } else {
             joystick->stopPolling();
         }
-#endif
     }
+#else
+    Q_UNUSED(start);
+#endif
 }
 
 bool Vehicle::active(void)

--- a/src/VideoStreaming/README.md
+++ b/src/VideoStreaming/README.md
@@ -59,8 +59,8 @@ TODO: Binaries found in http://gstreamer.freedesktop.org/data/pkg/ios
 
 ### Android
 
-TODO: Binaries found in http://gstreamer.freedesktop.org/data/pkg/android
-(work in progress)
+Binaries found in http://gstreamer.freedesktop.org/data/pkg/android
+Download the [gstreamer-1.0-android-armv7-1.5.2.tar.bz2](http://gstreamer.freedesktop.org/data/pkg/android/1.5.2/gstreamer-1.0-android-armv7-1.5.2.tar.bz2) archive (assuming you want the ARM V7 platform) and extract it to the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). That's where the build system will look for it.
 
 ### Windows
 

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -41,7 +41,7 @@ This file is part of the QGROUNDCONTROL project
 #if defined(QGC_GST_STREAMING)
     G_BEGIN_DECLS
     // Our own plugin
-    GST_PLUGIN_STATIC_DECLARE(QTVIDEOSINK_NAME);
+    GST_PLUGIN_STATIC_DECLARE(QGC_VIDEOSINK_PLUGIN);
     // The static plugins we use
 #if defined(__mobile__)
     GST_PLUGIN_STATIC_DECLARE(coreelements);
@@ -64,7 +64,7 @@ void initializeVideoStreaming(int &argc, char* argv[])
         g_error_free(error);
     }
     // Our own plugin
-    GST_PLUGIN_STATIC_REGISTER(QTVIDEOSINK_NAME);
+    GST_PLUGIN_STATIC_REGISTER(QGC_VIDEOSINK_PLUGIN);
     // The static plugins we use
 #if defined(__mobile__)
     GST_PLUGIN_STATIC_REGISTER(coreelements);
@@ -94,10 +94,12 @@ void initializeVideoStreaming(int &argc, char* argv[])
 #endif
 #endif
 
+#else
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+#endif
     qmlRegisterType<VideoItem>              ("QGroundControl.QgcQtGStreamer", 1, 0, "VideoItem");
     qmlRegisterUncreatableType<VideoSurface>("QGroundControl.QgcQtGStreamer", 1, 0, "VideoSurface", QLatin1String("VideoSurface from QML is not supported"));
-
-#endif
 }
 
 void shutdownVideoStreaming()

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -1,0 +1,108 @@
+    /*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Initialization
+ *   @author Gus Grubba <mavlink@grubba.com>
+ */
+
+#include <QtQml>
+#include <QDebug>
+
+#if defined(QGC_GST_STREAMING)
+#include <gst/gst.h>
+#endif
+
+#include "VideoStreaming.h"
+#include "VideoItem.h"
+#include "VideoSurface.h"
+
+#if defined(QGC_GST_STREAMING)
+    G_BEGIN_DECLS
+    // Our own plugin
+    GST_PLUGIN_STATIC_DECLARE(QTVIDEOSINK_NAME);
+    // The static plugins we use
+#if defined(__mobile__)
+    GST_PLUGIN_STATIC_DECLARE(coreelements);
+    GST_PLUGIN_STATIC_DECLARE(libav);
+    GST_PLUGIN_STATIC_DECLARE(rtp);
+    GST_PLUGIN_STATIC_DECLARE(udp);
+    GST_PLUGIN_STATIC_DECLARE(videoparsersbad);
+    GST_PLUGIN_STATIC_DECLARE(x264);
+#endif
+    G_END_DECLS
+#endif
+
+void initializeVideoStreaming(int &argc, char* argv[])
+{
+#if defined(QGC_GST_STREAMING)
+    // Initialize GStreamer
+    GError* error = NULL;
+    if (!gst_init_check(&argc, &argv, &error)) {
+        qCritical() << "gst_init_check() failed: " << error->message;
+        g_error_free(error);
+    }
+    // Our own plugin
+    GST_PLUGIN_STATIC_REGISTER(QTVIDEOSINK_NAME);
+    // The static plugins we use
+#if defined(__mobile__)
+    GST_PLUGIN_STATIC_REGISTER(coreelements);
+    GST_PLUGIN_STATIC_REGISTER(libav);
+    GST_PLUGIN_STATIC_REGISTER(rtp);
+    GST_PLUGIN_STATIC_REGISTER(udp);
+    GST_PLUGIN_STATIC_REGISTER(videoparsersbad);
+    GST_PLUGIN_STATIC_REGISTER(x264);
+#endif
+
+#ifdef Q_OS_MAC
+#ifndef __ios__
+#ifdef QGC_INSTALL_RELEASE
+    QString currentDir = QCoreApplication::applicationDirPath();
+    qgcputenv("GST_PLUGIN_SCANNER",           currentDir, "/gst-plugin-scanner");
+    qgcputenv("GTK_PATH",                     currentDir, "/../Frameworks/GStreamer.framework/Versions/Current");
+    qgcputenv("GIO_EXTRA_MODULES",            currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gio/modules");
+    qgcputenv("GST_PLUGIN_SYSTEM_PATH_1_0",   currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+    qgcputenv("GST_PLUGIN_SYSTEM_PATH",       currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+    qgcputenv("GST_PLUGIN_PATH_1_0",          currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+    qgcputenv("GST_PLUGIN_PATH",              currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+//    QStringList env = QProcessEnvironment::systemEnvironment().keys();
+//    foreach(QString key, env) {
+//        qDebug() << key << QProcessEnvironment::systemEnvironment().value(key);
+//    }
+#endif
+#endif
+#endif
+
+    qmlRegisterType<VideoItem>              ("QGroundControl.QgcQtGStreamer", 1, 0, "VideoItem");
+    qmlRegisterUncreatableType<VideoSurface>("QGroundControl.QgcQtGStreamer", 1, 0, "VideoSurface", QLatin1String("VideoSurface from QML is not supported"));
+
+#endif
+}
+
+void shutdownVideoStreaming()
+{
+#if defined(QGC_GST_STREAMING)
+    gst_deinit();
+#endif
+}

--- a/src/VideoStreaming/VideoStreaming.h
+++ b/src/VideoStreaming/VideoStreaming.h
@@ -1,0 +1,36 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Initialization
+ *   @author Gus Grubba <mavlink@grubba.com>
+ */
+
+#ifndef VIDEO_STREAMING_H
+#define VIDEO_STREAMING_H
+
+extern void initializeVideoStreaming    (int &argc, char *argv[]);
+extern void shutdownVideoStreaming      ();
+
+#endif // VIDEO_STREAMING_H

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -102,7 +102,7 @@ VideoEnabled {
         QGC_GST_STREAMING \
         GST_PLUGIN_BUILD_STATIC \
         QTGLVIDEOSINK_NAME=qt5glvideosink \
-        QTVIDEOSINK_NAME=qt5videosink
+        QGC_VIDEOSINK_PLUGIN=qt5videosink
 
     INCLUDEPATH += \
         $$PWD/gstqtvideosink \

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -65,11 +65,25 @@ LinuxBuild {
     exists($$GST_ROOT) {
         QMAKE_CXXFLAGS  += -pthread
         CONFIG          += VideoEnabled
-        LIBS            += -L$$GST_ROOT/lib \
+
+        # We want to link these plugins statically
+        LIBS += -L$$GST_ROOT/lib/gstreamer-1.0/static \
             -lgstvideo-1.0 \
+            -lgstcoreelements \
+            -lgstudp \
+            -lgstrtp \
+            -lgstx264 \
+            -lgstlibav \
+            -lgstvideoparsersbad
+
+        # Rest of GStreamer dependencies
+        LIBS += -L$$GST_ROOT/lib \
             -lgstfft-1.0 -lm  \
             -lgstnet-1.0 -lgio-2.0 \
-            -lgstaudio-1.0 -lgstbase-1.0 -lgstreamer-1.0 -lgobject-2.0 \
+            -lgstaudio-1.0 -lgstcodecparsers-1.0 -lgstbase-1.0 \
+            -lgstreamer-1.0 -lgsttag-1.0 -lgstrtp-1.0 -lgstpbutils-1.0 \
+            -lgstvideo-1.0 -lavformat -lavcodec -lavresample -lavutil -lx264 \
+            -lbz2 -lgobject-2.0 \
             -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lorc-0.4 -liconv -lffi -lintl
 
         INCLUDEPATH += \

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -56,7 +56,26 @@ LinuxBuild {
         INCLUDEPATH += \
             $$GST_ROOT/include/gstreamer-1.0 \
             $$GST_ROOT/include/glib-2.0 \
-            $$GST_ROOT/lib/gstreamer-1.0\include \
+            $$GST_ROOT/lib/gstreamer-1.0/include \
+            $$GST_ROOT/lib/glib-2.0/include
+    }
+} else:AndroidBuild {
+    #- gstreamer assumed to be installed in $$PWD/../../android/gstreamer-1.0-android-armv7-1.5.2
+    GST_ROOT = $$PWD/../../gstreamer-1.0-android-armv7-1.5.2
+    exists($$GST_ROOT) {
+        QMAKE_CXXFLAGS  += -pthread
+        CONFIG          += VideoEnabled
+        LIBS            += -L$$GST_ROOT/lib \
+            -lgstvideo-1.0 \
+            -lgstfft-1.0 -lm  \
+            -lgstnet-1.0 -lgio-2.0 \
+            -lgstaudio-1.0 -lgstbase-1.0 -lgstreamer-1.0 -lgobject-2.0 \
+            -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lorc-0.4 -liconv -lffi -lintl
+
+        INCLUDEPATH += \
+            $$GST_ROOT/include/gstreamer-1.0 \
+            $$GST_ROOT/lib/gstreamer-1.0/include \
+            $$GST_ROOT/include/glib-2.0 \
             $$GST_ROOT/lib/glib-2.0/include
     }
 }
@@ -137,6 +156,10 @@ VideoEnabled {
             message("  You can download it from http://gstreamer.freedesktop.org/data/pkg/windows/")
             message("  Select the devel AND runtime packages and install them (x86, not the 64-Bit)")
             message("  It will be installed in C:/gstreamer. You need to update you PATH to point to the bin directory.")
+        }
+        AndroidBuild {
+            message("  You can download it from http://gstreamer.freedesktop.org/data/pkg/android/")
+            message("  Uncompress the archive into the qgc root source directory (same directory where qgroundcontrol.pro is found.")
         }
     } else {
         message("Skipping support for video streaming (Unsupported platform)")

--- a/src/VideoStreaming/gstqtvideosink/gstqtvideosinkplugin.cpp
+++ b/src/VideoStreaming/gstqtvideosink/gstqtvideosinkplugin.cpp
@@ -41,12 +41,12 @@ GST_DEBUG_CATEGORY(gst_qt5gstvideosink_debug);
 static gboolean plugin_init(GstPlugin *plugin)
 {
     GST_DEBUG_CATEGORY_INIT(gst_qt5gstvideosink_debug,
-                            G_STRINGIFY(QTVIDEOSINK_NAME), 0,
+                            G_STRINGIFY(QGC_VIDEOSINK_PLUGIN), 0,
                             "Debug category for GstQtVideoSink");
 
-	if(!gst_element_register(plugin, G_STRINGIFY(QTVIDEOSINK_NAME),
+	if(!gst_element_register(plugin, G_STRINGIFY(QGC_VIDEOSINK_PLUGIN),
                 GST_RANK_NONE, GST_TYPE_QT_VIDEO_SINK)) {
-        GST_ERROR("Failed to register " G_STRINGIFY(QTVIDEOSINK_NAME));
+        GST_ERROR("Failed to register " G_STRINGIFY(QGC_VIDEOSINK_PLUGIN));
         return FALSE;
     }
 #ifndef GST_QT_VIDEO_SINK_NO_OPENGL
@@ -76,7 +76,7 @@ static gboolean plugin_init(GstPlugin *plugin)
 GST_PLUGIN_DEFINE (
     GST_VERSION_MAJOR,
     GST_VERSION_MINOR,
-    QTVIDEOSINK_NAME,
+    QGC_VIDEOSINK_PLUGIN,
     "A video sink that can draw on any Qt surface",
     plugin_init,
     PACKAGE_VERSION,


### PR DESCRIPTION
Video on Android is now fully functional.

It took quite a bit of trial an error to figure out the used plugins so I could link them statically but the work was worthwhile as it will be the same for iOS.

Sorry for the messy commit but there were so many changes in between that I got way too out of sync and I completely botched the merge/rebase in #1849. Started it all from scratch with this one.

![screen1](https://cloud.githubusercontent.com/assets/749243/9751293/decbbf10-5670-11e5-9f5b-bef372df359a.png)
