### PR TITLE
Add --test-high-dpi command line option

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -154,6 +154,9 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     , _styleIsDark(true)
 	, _fakeMobile(false)
     , _useNewMissionEditor(false)
+#ifdef QT_DEBUG
+    , _testHighDPI(false)
+#endif
 {
     Q_ASSERT(_app == NULL);
     _app = this;
@@ -172,6 +175,9 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
         { "--clear-settings",   &fClearSettingsOptions, QString() },
         { "--full-logging",     &fullLogging,           QString() },
 		{ "--fake-mobile",      &_fakeMobile,           QString() },
+#ifdef QT_DEBUG
+        { "--test-high-dpi",    &_testHighDPI,          QString() },
+#endif
         // Add additional command line option flags here
     };
     

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -109,6 +109,10 @@ public:
     bool useNewMissionEditor(void) { return _useNewMissionEditor; }
     void setUseNewMissionEditor(bool use);
     
+#ifdef QT_DEBUG
+    bool testHighDPI(void) { return _testHighDPI; }
+#endif
+    
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
     void informationMessageBoxOnMainThread(const QString& title, const QString& msg);
@@ -179,6 +183,10 @@ private:
 	bool				_fakeMobile;	///< true: Fake ui into displaying mobile interface
 
     bool _useNewMissionEditor;  ///< true: Use new Mission Editor
+    
+#ifdef QT_DEBUG
+    bool _testHighDPI;  ///< true: double fonts sizes for simulating high dpi devices
+#endif
 
     /// Unit Test have access to creating and destroying singletons
     friend class UnitTest;

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -8,9 +8,9 @@ import QGroundControl.ScreenToolsController 1.0
 Item {
     signal repaintRequested
 
-    readonly property real defaultFontPixelSize:    _textMeasure.contentHeight * ScreenToolsController.defaultFontPixelSizeRatio
+    readonly property real defaultFontPixelSize:    _textMeasure.fontHeight * ScreenToolsController.defaultFontPixelSizeRatio
     readonly property real defaultFontPixelHeight:  defaultFontPixelSize
-    readonly property real defaultFontPixelWidth:   _textMeasure.contentWidth
+    readonly property real defaultFontPixelWidth:   _textMeasure.fontWidth
     readonly property real smallFontPixelSize:      defaultFontPixelSize * ScreenToolsController.smallFontPixelSizeRatio
     readonly property real mediumFontPixelSize:     defaultFontPixelSize * ScreenToolsController.mediumFontPixelSizeRatio
     readonly property real largeFontPixelSize:      defaultFontPixelSize * ScreenToolsController.largeFontPixelSizeRatio
@@ -28,8 +28,11 @@ Item {
     }
 
     Text {
-        id: _textMeasure
-        text: "X"
+        id:     _textMeasure
+        text:   "X"
+
+        property real fontWidth:    contentWidth * (ScreenToolsController.testHighDPI ? 2 : 1)
+        property real fontHeight:   contentHeight * (ScreenToolsController.testHighDPI ? 2 : 1)
     }
 
     Connections {

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -59,6 +59,14 @@ double ScreenToolsController::getQmlDefaultFontPixelSize(void)
         
         qmlWidgetHolder.setSource(QUrl::fromUserInput("qrc:/qml/ScreenToolsFontQuery.qml"));
     }
+
+    double qmlDefaultFontPixelSize = _qmlDefaultFontPixelSize;
     
-    return _qmlDefaultFontPixelSize;
+#ifdef QT_DEBUG
+    if (qgcApp()->testHighDPI()) {
+        qmlDefaultFontPixelSize *= 2;
+    }
+#endif
+    
+    return qmlDefaultFontPixelSize;
 }

--- a/src/QmlControls/ScreenToolsController.h
+++ b/src/QmlControls/ScreenToolsController.h
@@ -47,9 +47,10 @@ class ScreenToolsController : public QQuickItem
 public:
     ScreenToolsController();
 
-    Q_PROPERTY(bool     isAndroid           READ isAndroid  CONSTANT)
-    Q_PROPERTY(bool     isiOS               READ isiOS      CONSTANT)
-    Q_PROPERTY(bool     isMobile            READ isMobile   CONSTANT)
+    Q_PROPERTY(bool     isAndroid           READ isAndroid      CONSTANT)
+    Q_PROPERTY(bool     isiOS               READ isiOS          CONSTANT)
+    Q_PROPERTY(bool     isMobile            READ isMobile       CONSTANT)
+    Q_PROPERTY(bool     testHighDPI         READ testHighDPI    CONSTANT)
 
     //! Used to trigger a \c Canvas element repaint.
     /*!
@@ -111,6 +112,12 @@ public:
     bool    isAndroid           () { return false; }
     bool    isiOS               () { return false; }
     bool    isMobile            () { return qgcApp()->fakeMobile(); }
+#endif
+    
+#ifdef QT_DEBUG
+    bool testHighDPI(void) { return qgcApp()->testHighDPI(); }
+#else
+    bool testHighDPI(void) { return false; }
 #endif
 
 signals:


### PR DESCRIPTION
This allows for testing issues found on high dpi screen without needing a high dpi screen. it does this by doubling the font sizes:

![screen shot 2015-09-12 at 3 51 55 pm](https://cloud.githubusercontent.com/assets/5876851/9834231/ad89dcf4-5966-11e5-9395-7276cb32e0c4.png)
