### PR TITLE
Support load/save

### DIFF
--- a/src/MissionEditor/MissionEditor.h
+++ b/src/MissionEditor/MissionEditor.h
@@ -35,11 +35,14 @@ public:
     MissionEditor(QWidget* parent = NULL);
     ~MissionEditor();
 
-    Q_PROPERTY(QmlObjectListModel* missionItems READ missionItemsModel NOTIFY missionItemsChanged)
+    Q_PROPERTY(QmlObjectListModel*  missionItems    READ missionItemsModel  NOTIFY missionItemsChanged)
+    Q_PROPERTY(bool                 canEdit         READ canEdit            NOTIFY canEditChanged)
     
     Q_INVOKABLE int addMissionItem(QGeoCoordinate coordinate);
     Q_INVOKABLE void getMissionItems(void);
     Q_INVOKABLE void setMissionItems(void);
+    Q_INVOKABLE void loadMissionFromFile(void);
+    Q_INVOKABLE void saveMissionToFile(void);
     Q_INVOKABLE void removeMissionItem(int index);
     Q_INVOKABLE void moveUp(int index);
     Q_INVOKABLE void moveDown(int index);
@@ -47,9 +50,11 @@ public:
     // Property accessors
     
     QmlObjectListModel* missionItemsModel(void) { return _missionItems; }
+    bool canEdit(void) { return _canEdit; }
     
 signals:
     void missionItemsChanged(void);
+    void canEditChanged(bool canEdit);
     
 private slots:
     void _newMissionItemsAvailable();
@@ -59,6 +64,7 @@ private:
     
 private:
     QmlObjectListModel* _missionItems;
+    bool                _canEdit;           ///< true: UI can edit these items, false: can't edit, can only send to vehicle or save
     
     static const char* _settingsGroup;
 };

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -40,8 +40,8 @@ QGCView {
     readonly property real  _defaultLatitude:   37.803784
     readonly property real  _defaultLongitude:  -122.462276
     readonly property int   _decimalPlaces:     7
-    readonly property real  _horizontalMargin:   ScreenTools.defaultFontPixelWidth / 2
-    readonly property real  _verticalMargin:     ScreenTools.defaultFontPixelHeight / 2
+    readonly property real  _horizontalMargin:  ScreenTools.defaultFontPixelWidth / 2
+    readonly property real  _verticalMargin:    ScreenTools.defaultFontPixelHeight / 2
     readonly property var   _activeVehicle:     multiVehicleManager.activeVehicle
 
     property var _missionItems: controller.missionItems
@@ -153,6 +153,20 @@ QGCView {
 
                                 onTriggered: controller.setMissionItems()
                             }
+
+                            MenuSeparator { }
+
+                            MenuItem {
+                                text:       "Load mission from file..."
+
+                                onTriggered: controller.loadMissionFromFile()
+                            }
+
+                            MenuItem {
+                                text:       "Save mission to file..."
+
+                                onTriggered: controller.saveMissionToFile()
+                            }
                         }
                     }
 
@@ -166,7 +180,7 @@ QGCView {
                         anchors.bottom:     parent.bottom
                         spacing:            _verticalMargin
                         orientation:        ListView.Vertical
-                        model:              controller.missionItems
+                        model:              controller.canEdit ? controller.missionItems : 0
 
                         property real _maxItemHeight: 0
 
@@ -200,6 +214,18 @@ QGCView {
                         visible:            controller.missionItems.count == 0
                         wrapMode:           Text.WordWrap
                         text:               "Click in the map to add Mission Items"
+                    }
+
+                    QGCLabel {
+                        anchors.topMargin:  _verticalMargin
+                        anchors.left:       parent.left
+                        anchors.right:      parent.right
+                        anchors.top:        toolsButton.bottom
+                        anchors.bottom:     parent.bottom
+                        visible:            !controller.canEdit
+                        wrapMode:           Text.WordWrap
+                        text:               "The set of mission items you have loaded cannot be edited by QGroundControl. " +
+                                            "You will only be able to save these to a file, or send them to a vehicle."
                     }
                 } // Item
             } // Rectangle - mission item list

--- a/src/MissionItem.h
+++ b/src/MissionItem.h
@@ -35,6 +35,9 @@
 #include "MavlinkQmlSingleton.h"
 #include "QmlObjectListModel.h"
 #include "Fact.h"
+#include "QGCLoggingCategory.h"
+
+Q_DECLARE_LOGGING_CATEGORY(MissionItemLog)
 
 class MissionItem : public QObject
 {
@@ -104,6 +107,9 @@ public:
     void setYawDegrees(double yaw);
     
     // C++ only methods
+    
+    /// Returns true if this item can be edited in the ui
+    bool canEdit(void);
 
     double latitude(void)  const { return _latitudeFact->value().toDouble(); }
     double longitude(void) const { return _longitudeFact->value().toDouble(); }

--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -34,6 +34,7 @@ MissionManager::MissionManager(Vehicle* vehicle)
     : QThread()
     , _vehicle(vehicle)
     , _cMissionItems(0)
+    , _canEdit(true)
     , _ackTimeoutTimer(NULL)
     , _retryAck(AckNone)
 {
@@ -230,6 +231,11 @@ void MissionManager::_handleMissionItem(const mavlink_message_t& message)
                                         missionItem.frame,
                                         missionItem.command);
     _missionItems.append(item);
+    
+    if (!item->canEdit()) {
+        _canEdit = false;
+        emit canEditChanged(false);
+    }
     
     int nextSequenceNumber = missionItem.seq + 1;
     if (nextSequenceNumber == _cMissionItems) {

--- a/src/MissionManager/MissionManager.h
+++ b/src/MissionManager/MissionManager.h
@@ -47,13 +47,17 @@ public:
     MissionManager(Vehicle* vehicle);
     ~MissionManager();
     
-    Q_PROPERTY(bool                 inProgress   READ inProgress    CONSTANT)
-    Q_PROPERTY(QmlObjectListModel*  missionItems READ missionItems  CONSTANT)
+    Q_PROPERTY(bool                 inProgress      READ inProgress     CONSTANT)
+    Q_PROPERTY(QmlObjectListModel*  missionItems    READ missionItems   CONSTANT)
+    Q_PROPERTY(bool                 canEdit         READ canEdit        NOTIFY  canEditChanged)
     
     // Property accessors
     
     bool inProgress(void) { return _retryAck != AckNone; }
     QmlObjectListModel* missionItems(void) { return &_missionItems; }
+    bool canEdit(void) { return _canEdit; }
+    
+    // C++ methods
     
     void requestMissionItems(void);
     
@@ -63,9 +67,13 @@ public:
     /// Returns a copy of the current set of mission items. Caller is responsible for
     /// freeing returned object.
     QmlObjectListModel* copyMissionItems(void);
-    
+
 signals:
+    // Public signals
+    void canEditChanged(bool canEdit);
     void newMissionItemsAvailable(void);
+    
+    // Internal signals
     void _requestMissionItemsOnThread(void);
     void _writeMissionItemsOnThread(void);
     
@@ -100,6 +108,7 @@ private:
     Vehicle*            _vehicle;
     
     int                 _cMissionItems;     ///< Mission items on vehicle
+    bool                _canEdit;           ///< true: Mission items are editable in the ui
 
     QTimer*             _ackTimeoutTimer;
     AckType_t           _retryAck;


### PR DESCRIPTION
Also understand the concept of missions which cannot be edited. Only a subset of the possible mission items are supported for visual editing. If the mission can not be edited, you can still send it to the vehicle or save it to a file. This way the UI supports the most common set of mission actions/settings and then loading from a file supports everything possible.