### PR TITLE
Home position manager

### DIFF
--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -264,6 +264,7 @@ HEADERS += \
     src/QmlControls/MavlinkQmlSingleton.h \
     src/QmlControls/ParameterEditorController.h \
     src/QmlControls/ScreenToolsController.h \
+    src/QmlControls/QGroundControlQmlGlobal.h \
     src/QmlControls/QmlObjectListModel.h \
     src/SerialPortIds.h \
     src/uas/FileManager.h \
@@ -394,6 +395,7 @@ SOURCES += \
     src/QGCTemporaryFile.cc \
     src/QmlControls/ParameterEditorController.cc \
     src/QmlControls/ScreenToolsController.cc \
+    src/QmlControls/QGroundControlQmlGlobal.cc \
     src/QmlControls/QmlObjectListModel.cc \
     src/uas/FileManager.cc \
     src/uas/UAS.cc \

--- a/src/HomePositionManager.cc
+++ b/src/HomePositionManager.cc
@@ -40,24 +40,47 @@
 
 IMPLEMENT_QGC_SINGLETON(HomePositionManager, HomePositionManager)
 
-HomePositionManager::HomePositionManager(QObject* parent) :
-    QObject(parent),
-    homeLat(47.3769),
-    homeLon(8.549444),
-    homeAlt(470.0),
-    homeFrame(MAV_FRAME_GLOBAL)
+const char* HomePositionManager::_settingsGroup =   "HomePositionManager";
+const char* HomePositionManager::_latitudeKey =     "Latitude";
+const char* HomePositionManager::_longitudeKey =    "Longitude";
+const char* HomePositionManager::_altitudeKey =     "Altitude";
+
+HomePositionManager::HomePositionManager(QObject* parent)
+    : QObject(parent)
+    , homeLat(47.3769)
+    , homeLon(8.549444)
+    , homeAlt(470.0)
 {
-    loadSettings();
+    _loadSettings();
 }
 
 HomePositionManager::~HomePositionManager()
 {
-    storeSettings();
+
 }
 
-void HomePositionManager::storeSettings()
+void HomePositionManager::_storeSettings(void)
 {
     QSettings settings;
+    
+    settings.remove(_settingsGroup);
+    settings.beginGroup(_settingsGroup);
+    
+    for (int i=0; i<_homePositions.count(); i++) {
+        HomePosition* homePos = qobject_cast<HomePosition*>(_homePositions[i]);
+        
+        qDebug() << "Saving" << homePos->name();
+        
+        settings.beginGroup(homePos->name());
+        settings.setValue(_latitudeKey, homePos->coordinate().latitude());
+        settings.setValue(_longitudeKey, homePos->coordinate().longitude());
+        settings.setValue(_altitudeKey, homePos->coordinate().altitude());
+        settings.endGroup();
+    }
+    
+    settings.endGroup();
+    
+    // Deprecated settings for old editor
     settings.beginGroup("QGC_UASMANAGER");
     settings.setValue("HOMELAT", homeLat);
     settings.setValue("HOMELON", homeLon);
@@ -65,9 +88,36 @@ void HomePositionManager::storeSettings()
     settings.endGroup();
 }
 
-void HomePositionManager::loadSettings()
+void HomePositionManager::_loadSettings(void)
 {
     QSettings settings;
+    
+    _homePositions.clear();
+    
+    settings.beginGroup(_settingsGroup);
+    
+    foreach(QString name, settings.childGroups()) {
+        QGeoCoordinate coordinate;
+        
+        qDebug() << "Load setting" << name;
+        
+        settings.beginGroup(name);
+        coordinate.setLatitude(settings.value(_latitudeKey).toDouble());
+        coordinate.setLongitude(settings.value(_longitudeKey).toDouble());
+        coordinate.setAltitude(settings.value(_altitudeKey).toDouble());
+        settings.endGroup();
+        
+        _homePositions.append(new HomePosition(name, coordinate, this));
+    }
+    
+    settings.endGroup();
+    
+    if (_homePositions.count() == 0) {
+        _homePositions.append(new HomePosition("ETH Campus", QGeoCoordinate(47.3769, 8.549444, 470.0)));
+    }
+    
+    // Deprecated settings for old editor
+
     settings.beginGroup("QGC_UASMANAGER");
     bool changed =  setHomePosition(settings.value("HOMELAT", homeLat).toDouble(),
                                     settings.value("HOMELON", homeLon).toDouble(),
@@ -97,9 +147,6 @@ bool HomePositionManager::setHomePosition(double lat, double lon, double alt)
         if (fabs(homeLon - lon) > 1e-7) changed = true;
         if (fabs(homeAlt - alt) > 0.5f) changed = true;
 
-        // Initialize conversion reference in any case
-        initReference(lat, lon, alt);
-
         if (changed)
         {
             homeLat = lat;
@@ -125,75 +172,81 @@ bool HomePositionManager::setHomePositionAndNotify(double lat, double lon, doubl
 	return changed;
 }
 
-void HomePositionManager::initReference(const double & latitude, const double & longitude, const double & altitude)
+void HomePositionManager::updateHomePosition(const QString& name, const QGeoCoordinate& coordinate)
 {
-    Eigen::Matrix3d R;
-    double s_long, s_lat, c_long, c_lat;
-    sincos(latitude * DEG2RAD, &s_lat, &c_lat);
-    sincos(longitude * DEG2RAD, &s_long, &c_long);
-
-    R(0, 0) = -s_long;
-    R(0, 1) = c_long;
-    R(0, 2) = 0;
-
-    R(1, 0) = -s_lat * c_long;
-    R(1, 1) = -s_lat * s_long;
-    R(1, 2) = c_lat;
-
-    R(2, 0) = c_lat * c_long;
-    R(2, 1) = c_lat * s_long;
-    R(2, 2) = s_lat;
-
-    ecef_ref_orientation_ = Eigen::Quaterniond(R);
-
-    ecef_ref_point_ = wgs84ToEcef(latitude, longitude, altitude);
+    HomePosition * homePos = NULL;
+    
+    for (int i=0; i<_homePositions.count(); i++) {
+        homePos = qobject_cast<HomePosition*>(_homePositions[i]);
+        if (homePos->name() == name) {
+            break;
+        }
+        homePos = NULL;
+    }
+    
+    if (homePos == NULL) {
+        HomePosition* homePos = new HomePosition(name, coordinate, this);
+        _homePositions.append(homePos);
+    } else {
+        homePos->setName(name);
+        homePos->setCoordinate(coordinate);
+    }
+    
+    _storeSettings();
 }
 
-Eigen::Vector3d HomePositionManager::wgs84ToEcef(const double & latitude, const double & longitude, const double & altitude)
+void HomePositionManager::deleteHomePosition(const QString& name)
 {
-    const double a = 6378137.0; // semi-major axis
-    const double e_sq = 6.69437999014e-3; // first eccentricity squared
-
-    double s_long, s_lat, c_long, c_lat;
-    sincos(latitude * DEG2RAD, &s_lat, &c_lat);
-    sincos(longitude * DEG2RAD, &s_long, &c_long);
-
-    const double N = a / sqrt(1 - e_sq * s_lat * s_lat);
-
-    Eigen::Vector3d ecef;
-
-    ecef[0] = (N + altitude) * c_lat * c_long;
-    ecef[1] = (N + altitude) * c_lat * s_long;
-    ecef[2] = (N * (1 - e_sq) + altitude) * s_lat;
-
-    return ecef;
+    // Don't allow delete of last position
+    if (_homePositions.count() == 1) {
+        return;
+    }
+    
+    qDebug() << "Attempting delete" << name;
+    
+    for (int i=0; i<_homePositions.count(); i++) {
+        if (qobject_cast<HomePosition*>(_homePositions[i])->name() == name) {
+            qDebug() << "Deleting" << name;
+            _homePositions.removeAt(i);
+            break;
+        }
+    }
+    
+    _storeSettings();
 }
 
-Eigen::Vector3d HomePositionManager::ecefToEnu(const Eigen::Vector3d & ecef)
+HomePosition::HomePosition(const QString& name, const QGeoCoordinate& coordinate, QObject* parent)
+    : QObject(parent)
+    , _coordinate(coordinate)
 {
-    return ecef_ref_orientation_ * (ecef - ecef_ref_point_);
+    setObjectName(name);
 }
 
-void HomePositionManager::wgs84ToEnu(const double& lat, const double& lon, const double& alt, double* east, double* north, double* up)
+HomePosition::~HomePosition()
 {
-    Eigen::Vector3d ecef = wgs84ToEcef(lat, lon, alt);
-    Eigen::Vector3d enu = ecefToEnu(ecef);
-    *east = enu.x();
-    *north = enu.y();
-    *up = enu.z();
+    
 }
 
-void HomePositionManager::enuToWgs84(const double& x, const double& y, const double& z, double* lat, double* lon, double* alt)
+QString HomePosition::name(void)
 {
-    *lat=homeLat+y/MEAN_EARTH_DIAMETER*360./PI;
-    *lon=homeLon+x/MEAN_EARTH_DIAMETER*360./PI/cos(homeLat*UMR);
-    *alt=homeAlt+z;
+    return objectName();
 }
 
-void HomePositionManager::nedToWgs84(const double& x, const double& y, const double& z, double* lat, double* lon, double* alt)
+void HomePosition::setName(const QString& name)
 {
-    *lat=homeLat+x/MEAN_EARTH_DIAMETER*360./PI;
-    *lon=homeLon+y/MEAN_EARTH_DIAMETER*360./PI/cos(homeLat*UMR);
-    *alt=homeAlt-z;
+    setObjectName(name);
+    HomePositionManager::instance()->_storeSettings();
+    emit nameChanged(name);
 }
 
+QGeoCoordinate HomePosition::coordinate(void)
+{
+    return _coordinate;
+}
+
+void HomePosition::setCoordinate(const QGeoCoordinate& coordinate)
+{
+    _coordinate = coordinate;
+    HomePositionManager::instance()->_storeSettings();
+    emit coordinateChanged(coordinate);
+}

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -27,6 +27,7 @@ import QtQuick.Dialogs  1.2
 import QtLocation       5.3
 import QtPositioning    5.3
 
+import QGroundControl               1.0
 import QGroundControl.FlightMap     1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0
@@ -37,14 +38,18 @@ import QGroundControl.Palette       1.0
 QGCView {
     viewPanel: panel
 
-    readonly property real  _defaultLatitude:   37.803784
-    readonly property real  _defaultLongitude:  -122.462276
     readonly property int   _decimalPlaces:     7
     readonly property real  _horizontalMargin:  ScreenTools.defaultFontPixelWidth / 2
     readonly property real  _verticalMargin:    ScreenTools.defaultFontPixelHeight / 2
     readonly property var   _activeVehicle:     multiVehicleManager.activeVehicle
+    readonly property real  _editFieldWidth:    ScreenTools.defaultFontPixelWidth * 16
 
-    property var _missionItems: controller.missionItems
+    property var    _missionItems:              controller.missionItems
+    property bool   _showHomePositionManager:   false
+
+    property var    _homePositionManager:       QGroundControl.homePositionManager
+    property string _homePositionName:          _homePositionManager.homePositions.get(0).name
+    property var    _homePositionCoordinate:    _homePositionManager.homePositions.get(0).coordinate
 
     QGCPalette { id: _qgcPal; colorGroupEnabled: enabled }
 
@@ -68,8 +73,8 @@ QGCView {
                 anchors.top:    parent.top
                 anchors.bottom: parent.bottom
                 mapName:        "MissionEditor"
-                latitude:       _defaultLatitude
-                longitude:      _defaultLongitude
+                latitude:       _homePositionCoordinate.latitude
+                longitude:      _homePositionCoordinate.longitude
 
                 QGCLabel {
                     anchors.right: parent.right
@@ -83,10 +88,19 @@ QGCView {
                         var coordinate = editorMap.toCoordinate(Qt.point(mouse.x, mouse.y))
                         coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
                         coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
-                        coordinate.altitude = 0
-                        var index = controller.addMissionItem(coordinate)
-                        setCurrentItem(index)
+                        coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
+                        if (_showHomePositionManager) {
+                            _homePositionCoordinate = coordinate
+                        } else {
+                            var index = controller.addMissionItem(coordinate)
+                            setCurrentItem(index)
+                        }
                     }
+                }
+
+                MissionItemIndicator {
+                    label:          "H"
+                    coordinate:     _homePositionCoordinate
                 }
 
                 // Add the mission items to the map
@@ -141,6 +155,16 @@ QGCView {
                             id: toolMenu
 
                             MenuItem {
+                                text:       "Manage Home Position"
+                                checkable:  true
+                                checked:    _showHomePositionManager
+
+                                onTriggered: _showHomePositionManager = checked
+                            }
+
+                            MenuSeparator { }
+
+                            MenuItem {
                                 text:       "Get mission items from vehicle"
                                 enabled:    _activeVehicle && !_activeVehicle.missionManager.inProgress
 
@@ -184,63 +208,234 @@ QGCView {
                         }
                     }
 
-                    // Mission item list
-                    ListView {
-                        id:                 missionItemSummaryList
+                    // Mission Item Editor
+                    Item {
                         anchors.topMargin:  _verticalMargin
                         anchors.left:       parent.left
                         anchors.right:      parent.right
                         anchors.top:        toolsButton.bottom
                         anchors.bottom:     parent.bottom
-                        spacing:            _verticalMargin
-                        orientation:        ListView.Vertical
-                        model:              controller.canEdit ? controller.missionItems : 0
+                        visible:            !_showHomePositionManager
 
-                        property real _maxItemHeight: 0
+                        ListView {
+                            id:             missionItemSummaryList
+                            anchors.fill:   parent
+                            spacing:        _verticalMargin
+                            orientation:    ListView.Vertical
+                            model:          controller.canEdit ? controller.missionItems : 0
 
-                        delegate:
-                            MissionItemEditor {
-                                missionItem:    object
-                                width:          parent.width
+                            property real _maxItemHeight: 0
 
-                                onClicked:  setCurrentItem(object.sequenceNumber)
+                            delegate:
+                                MissionItemEditor {
+                                    missionItem:    object
+                                    width:          parent.width
 
-                                onRemove: {
-                                    var newCurrentItem = object.sequenceNumber - 1
-                                    controller.removeMissionItem(object.sequenceNumber)
-                                    if (_missionItems.count) {
-                                        newCurrentItem = Math.min(_missionItems.count - 1, newCurrentItem)
-                                        setCurrentItem(newCurrentItem)
+                                    onClicked:  setCurrentItem(object.sequenceNumber)
+
+                                    onRemove: {
+                                        var newCurrentItem = object.sequenceNumber - 1
+                                        controller.removeMissionItem(object.sequenceNumber)
+                                        if (_missionItems.count) {
+                                            newCurrentItem = Math.min(_missionItems.count - 1, newCurrentItem)
+                                            setCurrentItem(newCurrentItem)
+                                        }
+                                    }
+
+                                    onMoveUp:   controller.moveUp(object.sequenceNumber)
+                                    onMoveDown: controller.moveDown(object.sequenceNumber)
+                                }
+                        } // ListView
+
+                        QGCLabel {
+                            anchors.fill:   parent
+                            visible:        controller.missionItems.count == 0
+                            wrapMode:       Text.WordWrap
+                            text:           "Click in the map to add Mission Items"
+                        }
+
+                        QGCLabel {
+                            anchors.fill:   parent
+                            visible:        !controller.canEdit
+                            wrapMode:       Text.WordWrap
+                            text:           "The set of mission items you have loaded cannot be edited by QGroundControl. " +
+                                            "You will only be able to save these to a file, or send them to a vehicle."
+                        }
+                    } // Item - Mission Item editor
+
+                    // Home Position Manager
+                    Item {
+                        anchors.topMargin:  _verticalMargin
+                        anchors.left:       parent.left
+                        anchors.right:      parent.right
+                        anchors.top:        toolsButton.bottom
+                        anchors.bottom:     parent.bottom
+                        visible:            _showHomePositionManager
+
+                        Column {
+                            anchors.fill: parent
+
+                            QGCLabel {
+                                font.pixelSize: ScreenTools.mediumFontPixelSize
+                                text:           "Home Position Manager"
+                            }
+
+                            Item {
+                                width: 10
+                                height: ScreenTools.defaultFontPixelHeight
+                            }
+
+                            QGCLabel {
+                                text: "Select home position to use:"
+                            }
+
+                            QGCComboBox {
+                                id:         homePosCombo
+                                width:      parent.width
+                                textRole:   "text"
+                                model:      _homePositionManager.homePositions
+
+                                onCurrentIndexChanged: {
+                                    if (currentIndex != -1) {
+                                        var homePos = _homePositionManager.homePositions.get(currentIndex)
+                                        _homePositionName = homePos.name
+                                        _homePositionCoordinate = homePos.coordinate
+                                    }
+                                }
+                            }
+
+                            Item {
+                                width: 10
+                                height: ScreenTools.defaultFontPixelHeight
+                            }
+
+                            QGCLabel {
+                                width:      parent.width
+                                wrapMode:   Text.WordWrap
+                                text:       "To add a new home position, click in the Map to set the position. Then give it a name and click Add."
+                            }
+
+                            Item {
+                                width: 10
+                                height: ScreenTools.defaultFontPixelHeight / 3
+                            }
+
+                            Item {
+                                width:  parent.width
+                                height: nameField.height
+
+                                QGCLabel {
+                                    anchors.baseline:   nameField.baseline
+                                    text:               "Name:"
+                                }
+
+                                QGCTextField {
+                                    id:             nameField
+                                    anchors.right:  parent.right
+                                    width:          _editFieldWidth
+                                    text:           _homePositionName
+                                }
+                            }
+
+                            Item {
+                                width: 10
+                                height: ScreenTools.defaultFontPixelHeight / 3
+                            }
+
+                            Item {
+                                width:  parent.width
+                                height: latitudeField.height
+
+                                QGCLabel {
+                                    anchors.baseline:   latitudeField.baseline
+                                    text:               "Lat:"
+                                }
+
+                                QGCTextField {
+                                    id:             latitudeField
+                                    anchors.right:  parent.right
+                                    width:          _editFieldWidth
+                                    text:           _homePositionCoordinate.latitude
+                                }
+                            }
+
+                            Item {
+                                width: 10
+                                height: ScreenTools.defaultFontPixelHeight / 3
+                            }
+
+                            Item {
+                                width:  parent.width
+                                height: longitudeField.height
+
+                                QGCLabel {
+                                    anchors.baseline:   longitudeField.baseline
+                                    text:               "Lon:"
+                                }
+
+                                QGCTextField {
+                                    id:             longitudeField
+                                    anchors.right:  parent.right
+                                    width:          _editFieldWidth
+                                    text:           _homePositionCoordinate.longitude
+                                }
+                            }
+
+                            Item {
+                                width: 10
+                                height: ScreenTools.defaultFontPixelHeight / 3
+                            }
+
+                            Item {
+                                width:  parent.width
+                                height: altitudeField.height
+
+                                QGCLabel {
+                                    anchors.baseline:   altitudeField.baseline
+                                    text:               "Alt:"
+                                }
+
+                                QGCTextField {
+                                    id:             altitudeField
+                                    anchors.right:  parent.right
+                                    width:          _editFieldWidth
+                                    text:           _homePositionCoordinate.altitude
+                                }
+                            }
+
+                            Item {
+                                width: 10
+                                height: ScreenTools.defaultFontPixelHeight
+                            }
+
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+
+                                QGCButton {
+                                    text: "Add/Update"
+
+                                    onClicked: {
+                                        _homePositionManager.updateHomePosition(nameField.text, QtPositioning.coordinate(latitudeField.text, longitudeField.text, altitudeField.text))
+                                        homePosCombo.currentIndex = homePosCombo.find(nameField.text)
                                     }
                                 }
 
-                                onMoveUp:   controller.moveUp(object.sequenceNumber)
-                                onMoveDown: controller.moveDown(object.sequenceNumber)
+                                QGCButton {
+                                    text: "Delete"
+
+                                    onClicked: {
+                                        homePosCombo.currentIndex = -1
+                                        _homePositionManager.deleteHomePosition(nameField.text)
+                                        homePosCombo.currentIndex = 0
+                                        var homePos = _homePositionManager.homePositions.get(0)
+                                        _homePositionName = homePos.name
+                                        _homePositionCoordinate = homePos.coordinate
+                                    }
+                                }
                             }
-                    } // ListView
+                        } // Column
+                    } // Item - Home Position Manager
 
-                    QGCLabel {
-                        anchors.topMargin:  _verticalMargin
-                        anchors.left:       parent.left
-                        anchors.right:      parent.right
-                        anchors.top:        toolsButton.bottom
-                        anchors.bottom:     parent.bottom
-                        visible:            controller.missionItems.count == 0
-                        wrapMode:           Text.WordWrap
-                        text:               "Click in the map to add Mission Items"
-                    }
-
-                    QGCLabel {
-                        anchors.topMargin:  _verticalMargin
-                        anchors.left:       parent.left
-                        anchors.right:      parent.right
-                        anchors.top:        toolsButton.bottom
-                        anchors.bottom:     parent.bottom
-                        visible:            !controller.canEdit
-                        wrapMode:           Text.WordWrap
-                        text:               "The set of mission items you have loaded cannot be edited by QGroundControl. " +
-                                            "You will only be able to save these to a file, or send them to a vehicle."
-                    }
                 } // Item
             } // Rectangle - mission item list
         } // Item - split view container

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -81,6 +81,8 @@
 #include "JoystickManager.h"
 #include "QmlObjectListModel.h"
 #include "MissionManager.h"
+#include "QGroundControlQmlGlobal.h"
+#include "HomePositionManager.h"
 
 #ifndef __ios__
     #include "SerialLink.h"
@@ -123,6 +125,11 @@ static QObject* screenToolsControllerSingletonFactory(QQmlEngine*, QJSEngine*)
 static QObject* mavlinkQmlSingletonFactory(QQmlEngine*, QJSEngine*)
 {
     return new MavlinkQmlSingleton;
+}
+
+static QObject* qgroundcontrolQmlGlobalSingletonFactory(QQmlEngine*, QJSEngine*)
+{
+    return new QGroundControlQmlGlobal;
 }
 
 #if defined(QGC_GST_STREAMING)
@@ -298,14 +305,15 @@ void QGCApplication::_initCommon(void)
     
     qmlRegisterType<QGCPalette>("QGroundControl.Palette", 1, 0, "QGCPalette");
     
-    qmlRegisterUncreatableType<AutoPilotPlugin>     ("QGroundControl.AutoPilotPlugin",  1, 0, "AutoPilotPlugin",    "Can only reference, cannot create");
-    qmlRegisterUncreatableType<VehicleComponent>    ("QGroundControl.AutoPilotPlugin",  1, 0, "VehicleComponent",   "Can only reference, cannot create");
-    qmlRegisterUncreatableType<Vehicle>             ("QGroundControl.Vehicle",          1, 0, "Vehicle",            "Can only reference, cannot create");
-    qmlRegisterUncreatableType<MissionItem>         ("QGroundControl.Vehicle",          1, 0, "MissionItem",        "Can only reference, cannot create");
-    qmlRegisterUncreatableType<MissionManager>      ("QGroundControl.Vehicle",          1, 0, "MissionManager",     "Can only reference, cannot create");
-    qmlRegisterUncreatableType<JoystickManager>     ("QGroundControl.JoystickManager",  1, 0, "JoystickManager",    "Reference only");
-    qmlRegisterUncreatableType<Joystick>            ("QGroundControl.JoystickManager",  1, 0, "Joystick",           "Reference only");
-    qmlRegisterUncreatableType<QmlObjectListModel>  ("QGroundControl",                  1, 0, "QmlObjectListModel", "Reference only");
+    qmlRegisterUncreatableType<AutoPilotPlugin>     ("QGroundControl.AutoPilotPlugin",  1, 0, "AutoPilotPlugin",        "Reference only");
+    qmlRegisterUncreatableType<VehicleComponent>    ("QGroundControl.AutoPilotPlugin",  1, 0, "VehicleComponent",       "Reference only");
+    qmlRegisterUncreatableType<Vehicle>             ("QGroundControl.Vehicle",          1, 0, "Vehicle",                "Reference only");
+    qmlRegisterUncreatableType<MissionItem>         ("QGroundControl.Vehicle",          1, 0, "MissionItem",            "Reference only");
+    qmlRegisterUncreatableType<MissionManager>      ("QGroundControl.Vehicle",          1, 0, "MissionManager",         "Reference only");
+    qmlRegisterUncreatableType<JoystickManager>     ("QGroundControl.JoystickManager",  1, 0, "JoystickManager",        "Reference only");
+    qmlRegisterUncreatableType<Joystick>            ("QGroundControl.JoystickManager",  1, 0, "Joystick",               "Reference only");
+    qmlRegisterUncreatableType<QmlObjectListModel>  ("QGroundControl",                  1, 0, "QmlObjectListModel",     "Reference only");
+    qmlRegisterUncreatableType<HomePositionManager> ("QGroundControl",                  1, 0, "HomePositionManager",    "Reference only");
     
     qmlRegisterType<ViewWidgetController>           ("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
     qmlRegisterType<ParameterEditorController>      ("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
@@ -323,8 +331,9 @@ void QGCApplication::_initCommon(void)
 #endif
     
     // Register Qml Singletons
-    qmlRegisterSingletonType<ScreenToolsController> ("QGroundControl.ScreenToolsController",    1, 0, "ScreenToolsController",  screenToolsControllerSingletonFactory);
-    qmlRegisterSingletonType<MavlinkQmlSingleton>   ("QGroundControl.Mavlink",                  1, 0, "Mavlink",                mavlinkQmlSingletonFactory);
+    qmlRegisterSingletonType<QGroundControlQmlGlobal>   ("QGroundControl",                          1, 0, "QGroundControl",         qgroundcontrolQmlGlobalSingletonFactory);
+    qmlRegisterSingletonType<ScreenToolsController>     ("QGroundControl.ScreenToolsController",    1, 0, "ScreenToolsController",  screenToolsControllerSingletonFactory);
+    qmlRegisterSingletonType<MavlinkQmlSingleton>       ("QGroundControl.Mavlink",                  1, 0, "Mavlink",                mavlinkQmlSingletonFactory);
     
     // Show user an upgrade message if the settings version has been bumped up
     bool settingsUpgraded = false;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -1,0 +1,39 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#include "QGroundControlQmlGlobal.h"
+
+QGroundControlQmlGlobal::QGroundControlQmlGlobal(QObject* parent)
+    : QObject(parent)
+    , _homePositionManager(HomePositionManager::instance())
+{
+
+}
+
+QGroundControlQmlGlobal::~QGroundControlQmlGlobal()
+{
+
+}

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -1,0 +1,52 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#ifndef QGroundControlQmlGlobal_H
+#define QGroundControlQmlGlobal_H
+
+#include <QObject>
+
+#include "HomePositionManager.h"
+
+class QGroundControlQmlGlobal : public QObject
+{
+    Q_OBJECT
+
+public:
+    QGroundControlQmlGlobal(QObject* parent = NULL);
+    ~QGroundControlQmlGlobal();
+    
+    Q_PROPERTY(HomePositionManager* homePositionManager READ homePositionManager CONSTANT)
+    
+    // Property accesors
+    
+    HomePositionManager* homePositionManager(void) { return _homePositionManager; }
+    
+private:
+    HomePositionManager*    _homePositionManager;
+};
+
+#endif

--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -29,6 +29,7 @@
 #include <QDebug>
 
 const int QmlObjectListModel::ObjectRole = Qt::UserRole;
+const int QmlObjectListModel::TextRole = Qt::UserRole + 1;
 
 QmlObjectListModel::QmlObjectListModel(QObject* parent)
     : QAbstractListModel(parent)
@@ -60,6 +61,8 @@ QVariant QmlObjectListModel::data(const QModelIndex &index, int role) const
     
     if (role == ObjectRole) {
         return QVariant::fromValue(_objectList[index.row()]);
+    } else if (role == TextRole) {
+        return QVariant::fromValue(_objectList[index.row()]->objectName());
     } else {
         return QVariant();
     }
@@ -70,6 +73,7 @@ QHash<int, QByteArray> QmlObjectListModel::roleNames(void) const
     QHash<int, QByteArray> hash;
     
     hash[ObjectRole] = "object";
+    hash[TextRole] = "text";
     
     return hash;
 }

--- a/src/QmlControls/QmlObjectListModel.h
+++ b/src/QmlControls/QmlObjectListModel.h
@@ -65,6 +65,7 @@ private:
     QList<QObject*> _objectList;
         
     static const int ObjectRole;
+    static const int TextRole;
 };
 
 #endif

--- a/src/comm/QGCFlightGearLink.cc
+++ b/src/comm/QGCFlightGearLink.cc
@@ -38,6 +38,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QMessageBox>
 
 #include <iostream>
+#include <Eigen/Eigen>
 
 #include "QGCFlightGearLink.h"
 #include "QGC.h"

--- a/src/comm/QGCXPlaneLink.cc
+++ b/src/comm/QGCXPlaneLink.cc
@@ -33,10 +33,13 @@ This file is part of the QGROUNDCONTROL project
 #include <QDebug>
 #include <QMutexLocker>
 #include <QNetworkInterface>
+#include <QHostInfo>
+
 #include <iostream>
+#include <Eigen/Eigen>
+
 #include "QGCXPlaneLink.h"
 #include "QGC.h"
-#include <QHostInfo>
 #include "UAS.h"
 #include "UASInterface.h"
 #include "QGCMessageBox.h"

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -2784,9 +2784,8 @@ void UAS::home()
     double latitude = HomePositionManager::instance()->getHomeLatitude();
     double longitude = HomePositionManager::instance()->getHomeLongitude();
     double altitude = HomePositionManager::instance()->getHomeAltitude();
-    int frame = HomePositionManager::instance()->getHomeFrame();
 
-    mavlink_msg_command_long_pack(mavlink->getSystemId(), mavlink->getComponentId(), &msg, uasId, MAV_COMP_ID_ALL, MAV_CMD_OVERRIDE_GOTO, 1, MAV_GOTO_DO_CONTINUE, MAV_GOTO_HOLD_AT_CURRENT_POSITION, frame, 0, latitude, longitude, altitude);
+    mavlink_msg_command_long_pack(mavlink->getSystemId(), mavlink->getComponentId(), &msg, uasId, MAV_COMP_ID_ALL, MAV_CMD_OVERRIDE_GOTO, 1, MAV_GOTO_DO_CONTINUE, MAV_GOTO_HOLD_AT_CURRENT_POSITION, MAV_FRAME_GLOBAL, 0, latitude, longitude, altitude);
     _vehicle->sendMessage(msg);
 }
 

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -609,7 +609,6 @@ void MainWindow::closeEvent(QCloseEvent *event)
     
     _storeCurrentViewState();
     storeSettings();
-    HomePositionManager::instance()->storeSettings();
     event->accept();
 }
 


### PR DESCRIPTION
New Mission Editor now has a Home Position Manager which is availble from the Tools menu.This allows you to save multiple named home positions. This is handy to save multiple flying locations that you can then use as starting points to create missions from. Selecting a home position from the combo will take you there on the map.

![screen shot 2015-09-26 at 7 57 27 pm](https://cloud.githubusercontent.com/assets/5876851/10120924/24b7401e-6489-11e5-89d1-450555d64c76.png)
