### PR TITLE
enable _connectLogArm_test

### DIFF
--- a/src/qgcunittest/MavlinkLogTest.cc
+++ b/src/qgcunittest/MavlinkLogTest.cc
@@ -183,7 +183,7 @@ void MavlinkLogTest::_connectLogNoArm_test(void)
 
 void MavlinkLogTest::_connectLogArm_test(void)
 {
-    //_connectLogWorker(true);
+    _connectLogWorker(true);
 }
 
 void MavlinkLogTest::_deleteTempLogFiles_test(void)


### PR DESCRIPTION
Mavlinklogtest connectLogArm_test was temporarily disabled in #1887

@DonLakeFlyer you can push to the unittest branch off the main repo to try fixes or debugging hacks.