### PR TITLE
Icons for Map Display

### DIFF
--- a/src/FlightMap/Images/MapCenter.svg
+++ b/src/FlightMap/Images/MapCenter.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
+<circle opacity="0.75" cx="36" cy="36" r="34.2"/>
+<g>
+	<circle fill="none" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" cx="36" cy="36" r="27"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" x1="8.899" y1="35.97" x2="22.219" y2="36.03"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" x1="35.97" y1="63.101" x2="36.03" y2="49.781"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" x1="63.101" y1="36.03" x2="49.781" y2="35.97"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" x1="36.03" y1="8.899" x2="35.97" y2="22.219"/>
+</g>
+</svg>

--- a/src/FlightMap/Images/MapHomeTearDrop.svg
+++ b/src/FlightMap/Images/MapHomeTearDrop.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
+<path d="M54,22.971C54,34.166,45.941,69.3,36,69.3S18,34.166,18,22.971S26.059,2.7,36,2.7S54,11.776,54,22.971z"/>
+<g>
+	<path fill="#FFFFFF" d="M28.8,38.643V20.286h2.429v7.538h9.541v-7.538H43.2v18.358h-2.429V29.99h-9.541v8.653H28.8z"/>
+</g>
+</svg>

--- a/src/FlightMap/Images/MapType.svg
+++ b/src/FlightMap/Images/MapType.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 72 72" enable-background="new 0 0 72 72" xml:space="preserve">
+<circle opacity="0.75" cx="36" cy="36" r="34.2"/>
+<g>
+	<polygon fill="#414042" stroke="#FFFFFF" stroke-miterlimit="10" points="63,39.345 36,59.4 9,39.345 36,19.291 	"/>
+	<polygon fill="#414042" stroke="#FFFFFF" stroke-miterlimit="10" points="63,32.655 36,52.709 9,32.655 36,12.6 	"/>
+</g>
+</svg>


### PR DESCRIPTION
@DonLakeFlyer 

These are the icons for the Map Display. Once you have them integrated (so I can see them within their context), I can tweak them.

MapCenter is to select where to center the map (Home or Vehicle)
MapType is to select the type of map display (Satellite, road, terrain, etc.)
MapHomeTearDrop is to denote the home position.

For the vehicle position, I'm assuming we can use the existing airplane icon.

This is a start. I assume there will be quite a few new icons to be created. When you find yourself in need of a new icon for something, just make a purple rectangle (or anything) as a placeholder and I can later replace it.