### PR TITLE
More Drop Button, Mission Editor, Map work

### DIFF
--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -141,6 +141,7 @@ INCLUDEPATH += \
     src/AutoPilotPlugins \
     src/comm \
     src/FlightDisplay \
+    src/FlightMap \
     src/input \
     src/Joystick \
     src/lib/qmapcontrol \
@@ -239,6 +240,7 @@ HEADERS += \
     src/comm/UDPLink.h \
     src/FlightDisplay/FlightDisplayWidget.h \
     src/FlightDisplay/FlightDisplayView.h \
+    src/FlightMap/FlightMapSettings.h \
     src/GAudioOutput.h \
     src/HomePositionManager.h \
     src/Joystick/Joystick.h \
@@ -374,6 +376,7 @@ SOURCES += \
     src/comm/UDPLink.cc \
     src/FlightDisplay/FlightDisplayWidget.cc \
     src/FlightDisplay/FlightDisplayView.cc \
+    src/FlightMap/FlightMapSettings.cc \
     src/GAudioOutput.cc \
     src/HomePositionManager.cc \
     src/Joystick/Joystick.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -43,6 +43,7 @@
         <file alias="PowerComponentBattery_04cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_04cell.svg</file>
         <file alias="PowerComponentBattery_05cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_05cell.svg</file>
         <file alias="PowerComponentBattery_06cell.svg">src/AutoPilotPlugins/PX4/Images/PowerComponentBattery_06cell.svg</file>
+
         <file alias="attitudeDial.svg">src/FlightMap/Images/attitudeDial.svg</file>
         <file alias="attitudeInstrument.svg">src/FlightMap/Images/attitudeInstrument.svg</file>
         <file alias="attitudePointer.svg">src//FlightMap/Images/attitudePointer.svg</file>
@@ -61,6 +62,8 @@
         <file alias="scale_end.png">src/FlightMap/Images/scale_end.png</file>
         <file alias="airplaneOutline.svg">src/FlightMap/Images/airplaneOutline.svg</file>
         <file alias="airplaneOpaque.svg">src/FlightMap/Images/airplaneOpaque.svg</file>
+        <file alias="MapType.svg">src/FlightMap/Images/MapType.svg</file>
+        <file alias="MapCenter.svg">src/FlightMap/Images/MapCenter.svg</file>
     </qresource>
     <qresource prefix="/qml">
         <file alias="test.qml">src/test.qml</file>
@@ -102,6 +105,7 @@
         <file alias="QGroundControl/Controls/MissionItemSummary.qml">src/QmlControls/MissionItemSummary.qml</file>
         <file alias="QGroundControl/Controls/MissionItemEditor.qml">src/QmlControls/MissionItemEditor.qml</file>
         <file alias="QGroundControl/Controls/DropButton.qml">src/QmlControls/DropButton.qml</file>
+        <file alias="QGroundControl/Controls/QGCCanvas.qml">src/QmlControls/QGCCanvas.qml</file>
 
         <!-- Vehicle Setup -->
         <file alias="SetupView.qml">src/VehicleSetup/SetupView.qml</file>

--- a/src/FlightDisplay/FlightDisplayView.cc
+++ b/src/FlightDisplay/FlightDisplayView.cc
@@ -91,19 +91,3 @@ FlightDisplayView::FlightDisplayView(QWidget *parent)
 FlightDisplayView::~FlightDisplayView()
 {
 }
-
-void FlightDisplayView::saveSetting(const QString &name, const QString& value)
-{
-    QSettings settings;
-    QString key(kMainFlightDisplayViewGroup);
-    key += "/" + name;
-    settings.setValue(key, value);
-}
-
-QString FlightDisplayView::loadSetting(const QString &name, const QString& defaultValue)
-{
-    QSettings settings;
-    QString key(kMainFlightDisplayViewGroup);
-    key += "/" + name;
-    return settings.value(key, defaultValue).toString();
-}

--- a/src/FlightDisplay/FlightDisplayView.h
+++ b/src/FlightDisplay/FlightDisplayView.h
@@ -38,9 +38,6 @@ public:
 
     Q_PROPERTY(bool hasVideo READ hasVideo CONSTANT)
 
-    Q_INVOKABLE void    saveSetting (const QString &key, const QString& value);
-    Q_INVOKABLE QString loadSetting (const QString &key, const QString& defaultValue);
-
 #if defined(QGC_GST_STREAMING)
     bool    hasVideo            () { return true; }
 #else

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -32,6 +32,7 @@ import QtQuick.Controls 1.3
 import QtLocation       5.3
 import QtPositioning    5.3
 
+import QGroundControl                       1.0
 import QGroundControl.Controls              1.0
 import QGroundControl.FlightMap             1.0
 import QGroundControl.ScreenTools           1.0
@@ -47,6 +48,7 @@ Map {
     property real   heading:            0
     property bool   interactive:        true
     property string mapName:            'defaultMap'
+    property string mapType:            QGroundControl.flightMapSettings.mapTypeForMapName(mapName)
     property alias  mapWidgets:         controlWidgets
     property bool   isSatelliteMap:     false
         
@@ -61,45 +63,20 @@ Map {
     plugin: Plugin { name: "QGroundControl" }
 
     ExclusiveGroup { id: mapTypeGroup }
-    
-    // Map type selection MenuItem
-    Component {
-        id: menuItemComponent
-        
-        MenuItem {
-            checkable:      true
-            checked:        text == _map.activeMapType.name
-            exclusiveGroup: mapTypeGroup
-            visible:        _map.visible
-            
-            onTriggered: setCurrentMap(text)
-        }
-    }
-    
-    // Set the current map type to the specified type name
-    function setCurrentMap(name) {
+
+    Component.onCompleted: onMapTypeChanged
+
+    onMapTypeChanged: {
+        QGroundControl.flightMapSettings.setMapTypeForMapName(mapName, mapType)
+        var fullMapName = QGroundControl.flightMapSettings.mapProvider + " " + mapType
         for (var i = 0; i < _map.supportedMapTypes.length; i++) {
-            if (name === _map.supportedMapTypes[i].name) {
+            if (fullMapName === _map.supportedMapTypes[i].name) {
                 _map.activeMapType = _map.supportedMapTypes[i]
-                multiVehicleManager.saveSetting(_map.mapName + "/currentMapType", name);
-                return;
+                return
             }
         }
     }
-    
-    // Add menu map types to the specified menu and sets the current map type from settings
-    function addMapMenuItems(menu) {
-        var savedMapName = multiVehicleManager.loadSetting(_map.mapName + "/currentMapType", "")
-        
-        setCurrentMap(savedMapName)
-        
-        for (var i = 0; i < _map.supportedMapTypes.length; i++) {
-            var menuItem = menuItemComponent.createObject()
-            menuItem.text = _map.supportedMapTypes[i].name
-            menu.insertItem(menu.items.length, menuItem)
-        }
-    }
-    
+
     /// Map control widgets
     Column {
         id:                 controlWidgets

--- a/src/FlightMap/FlightMapSettings.cc
+++ b/src/FlightMap/FlightMapSettings.cc
@@ -1,0 +1,140 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+#include "FlightMapSettings.h"
+
+#include <QSettings>
+#include <QtQml>
+
+IMPLEMENT_QGC_SINGLETON(FlightMapSettings, FlightMapSettings)
+
+const char* FlightMapSettings::_defaultMapProvider =    "Bing";                 // Bing is default since it support full street/satellite/hybrid set
+const char* FlightMapSettings::_settingsGroup =         "FlightMapSettings";
+const char* FlightMapSettings::_mapProviderKey =        "MapProvider";
+const char* FlightMapSettings::_mapTypeKey =            "MapType";
+
+FlightMapSettings::FlightMapSettings(QObject* parent)
+    : QObject(parent)
+    , _mapProvider(_defaultMapProvider)
+{
+    qmlRegisterUncreatableType<FlightMapSettings> ("QGroundControl", 1, 0, "FlightMapSetting", "Reference only");
+    
+    _supportedMapProviders << "Bing" << "Google" << "Open";
+    
+    _loadSettings();
+}
+
+FlightMapSettings::~FlightMapSettings()
+{
+
+}
+
+void FlightMapSettings::_storeSettings(void)
+{
+    QSettings settings;
+    
+    settings.beginGroup(_settingsGroup);
+    settings.setValue(_mapProviderKey, _supportedMapProviders.contains(_mapProvider) ? _mapProvider : _defaultMapProvider);
+}
+
+void FlightMapSettings::_loadSettings(void)
+{
+    QSettings settings;
+    
+    settings.beginGroup(_settingsGroup);
+    _mapProvider = settings.value(_mapProviderKey, _defaultMapProvider).toString();
+    
+    if (!_supportedMapProviders.contains(_mapProvider)) {
+        _mapProvider = _defaultMapProvider;
+    }
+    
+    _setMapTypesForCurrentProvider();
+}
+
+QString FlightMapSettings::mapProvider(void)
+{
+    return _mapProvider;
+}
+
+void FlightMapSettings::setMapProvider(const QString& mapProvider)
+{
+    if (_supportedMapProviders.contains(mapProvider)) {
+        _mapProvider = mapProvider;
+        _storeSettings();
+        _setMapTypesForCurrentProvider();
+        emit mapProviderChanged(mapProvider);
+    }
+}
+
+void FlightMapSettings::_setMapTypesForCurrentProvider(void)
+{
+    _mapTypes.clear();
+    
+    if (_mapProvider == "Bing") {
+        _mapTypes << "Street Map" << "Satellite Map" << "Hybrid Map";
+    } else if (_mapProvider == "Google") {
+        _mapTypes << "Street Map" << "Satellite Map" << "Terrain Map";
+    } else if (_mapProvider == "Open") {
+        _mapTypes << "Street Map";
+    }
+    
+    emit mapTypesChanged(_mapTypes);
+}
+
+QString FlightMapSettings::mapTypeForMapName(const QString& mapName)
+{
+    QSettings settings;
+    
+    settings.beginGroup(_settingsGroup);
+    settings.beginGroup(mapName);
+    settings.beginGroup(_mapProvider);
+    return settings.value(_mapTypeKey, "Street Map").toString();
+}
+
+void FlightMapSettings::setMapTypeForMapName(const QString& mapName, const QString& mapType)
+{
+    QSettings settings;
+    
+    settings.beginGroup(_settingsGroup);
+    settings.beginGroup(mapName);
+    settings.beginGroup(_mapProvider);
+    settings.setValue(_mapTypeKey, mapType);
+}
+
+void FlightMapSettings::saveMapSetting (const QString &mapName, const QString& key, const QString& value)
+{
+    QSettings settings;
+    
+    settings.beginGroup(_settingsGroup);
+    settings.beginGroup(mapName);
+    settings.setValue(key, value);
+}
+
+QString FlightMapSettings::loadMapSetting (const QString &mapName, const QString& key, const QString& defaultValue)
+{
+    QSettings settings;
+    
+    settings.beginGroup(_settingsGroup);
+    settings.beginGroup(mapName);
+    return settings.value(key, defaultValue).toString();
+}

--- a/src/FlightMap/FlightMapSettings.h
+++ b/src/FlightMap/FlightMapSettings.h
@@ -1,0 +1,79 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+#ifndef FlightMapSettings_H
+#define FlightMapSettings_H
+
+#include "QGCSingleton.h"
+
+#include <QStringList>
+
+class FlightMapSettings : public QObject
+{
+    Q_OBJECT
+    
+    DECLARE_QGC_SINGLETON(FlightMapSettings, FlightMapSettings)
+
+public:
+    /// mapProvider is either Bing, Google or Open to specify to set of maps available
+    Q_PROPERTY(QString mapProvider READ mapProvider WRITE setMapProvider NOTIFY mapProviderChanged)
+    
+    /// Map types associated with current map provider
+    Q_PROPERTY(QStringList mapTypes MEMBER _mapTypes NOTIFY mapTypesChanged)
+    
+    Q_INVOKABLE QString mapTypeForMapName(const QString& mapName);
+    Q_INVOKABLE void setMapTypeForMapName(const QString& mapName, const QString& mapType);
+    
+    Q_INVOKABLE void    saveMapSetting (const QString &mapName, const QString& key, const QString& value);
+    Q_INVOKABLE QString loadMapSetting (const QString &mapName, const QString& key, const QString& defaultValue);
+    
+    // Property accessors
+    
+    QString mapProvider(void);
+    void setMapProvider(const QString& mapProvider);
+    
+signals:
+    void mapProviderChanged(const QString& mapProvider);
+    void mapTypesChanged(const QStringList& mapTypes);
+    
+private:
+    /// @brief All access to FlightMapSettings singleton is through FlightMapSettings::instance
+    FlightMapSettings(QObject* parent = NULL);
+    ~FlightMapSettings();
+    
+    void _storeSettings(void);
+    void _loadSettings(void);
+    
+    void _setMapTypesForCurrentProvider(void);
+    
+    QString     _mapProvider;               ///< Current map provider
+    QStringList _supportedMapProviders;
+    QStringList _mapTypes;                  ///< Map types associated with current map provider
+    
+    static const char* _defaultMapProvider;
+    static const char* _settingsGroup;
+    static const char* _mapProviderKey;
+    static const char* _mapTypeKey;
+};
+
+#endif

--- a/src/HomePositionManager.cc
+++ b/src/HomePositionManager.cc
@@ -25,6 +25,7 @@
 #include <QApplication>
 #include <QTimer>
 #include <QSettings>
+#include <QtQml>
 
 #include "UAS.h"
 #include "UASInterface.h"
@@ -51,6 +52,8 @@ HomePositionManager::HomePositionManager(QObject* parent)
     , homeLon(8.549444)
     , homeAlt(470.0)
 {
+    qmlRegisterUncreatableType<HomePositionManager> ("QGroundControl", 1, 0, "HomePositionManager", "Reference only");
+    
     _loadSettings();
 }
 

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -104,7 +104,7 @@ QGCView {
                     anchors.right:          mapTypeButton.left
                     anchors.top:            mapTypeButton.top
                     dropDirection:          dropDown
-                    label:                  "C"
+                    buttonImage:            "/qmlimages/MapCenter.svg"
                     viewportMargins:        ScreenTools.defaultFontPixelWidth / 2
 
                     dropDownComponent: Component {
@@ -114,14 +114,48 @@ QGCView {
                             QGCButton {
                                 text: "Home"
 
-                                onClicked: centerMapButton.hideDropDown()
+                                onClicked: {
+                                    centerMapButton.hideDropDown()
+                                    editorMap.center = QtPositioning.coordinate(_homePositionCoordinate.latitude, _homePositionCoordinate.longitude)
+                                    _showHomePositionManager = true
+                                }
                             }
+
+/*
+
+This code will need to wait for Qml 5.5 support since Map.visibleRegion is only in Qt 5.5
 
                             QGCButton {
                                 text: "All Items"
 
-                                onClicked: centerMapButton.hideDropDown()
+                                onClicked: {
+                                    centerMapButton.hideDropDown()
+
+                                    // Begin with only the home position in the region
+                                    var region = QtPositioning.rectangle(QtPositioning.coordinate(_homePositionCoordinate.latitude, _homePositionCoordinate.longitude),
+                                                                         QtPositioning.coordinate(_homePositionCoordinate.latitude, _homePositionCoordinate.longitude))
+
+                                    // Now expand the region to include all mission items
+                                    for (var i=0; i<_missionItems.count; i++) {
+                                        var missionItem = _missionItems.get(i)
+
+                                        region.topLeft.latitude = Math.max(missionItem.coordinate.latitude, region.topLeft.latitude)
+                                        region.topLeft.longitude = Math.min(missionItem.coordinate.longitude, region.topLeft.longitude)
+
+                                        region.topRight.latitude = Math.max(missionItem.coordinate.latitude, region.topRight.latitude)
+                                        region.topRight.longitude = Math.max(missionItem.coordinate.longitude, region.topRight.longitude)
+
+                                        region.bottomLeft.latitude = Math.min(missionItem.coordinate.latitude, region.bottomLeft.latitude)
+                                        region.bottomLeft.longitude = Math.min(missionItem.coordinate.longitude, region.bottomLeft.longitude)
+
+                                        region.bottomRight.latitude = Math.min(missionItem.coordinate.latitude, region.bottomRight.latitude)
+                                        region.bottomRight.longitude = Math.max(missionItem.coordinate.longitude, region.bottomRight.longitude)
+                                    }
+
+                                    editorMap.visibleRegion = region
+                                }
                             }
+*/
                         }
                     }
                 }
@@ -132,29 +166,26 @@ QGCView {
                     anchors.top:        parent.top
                     anchors.right:      parent.right
                     dropDirection:      dropDown
-                    label:              "M"
+                    buttonImage:        "/qmlimages/MapType.svg"
                     viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
 
                     dropDownComponent: Component {
                         Row {
                             spacing: ScreenTools.defaultFontPixelWidth
 
-                            QGCButton {
-                                text: "Street"
+                            Repeater {
+                                model: QGroundControl.flightMapSettings.mapTypes
 
-                                onClicked: mapTypeButton.hideDropDown()
-                            }
+                                QGCButton {
+                                    checkable:  true
+                                    checked:    editorMap.mapType == text
+                                    text:       modelData
 
-                            QGCButton {
-                                text: "Satellite"
-
-                                onClicked: mapTypeButton.hideDropDown()
-                            }
-
-                            QGCButton {
-                                text: "Hybrid"
-
-                                onClicked: mapTypeButton.hideDropDown()
+                                    onClicked: {
+                                        editorMap.mapType = text
+                                        mapTypeButton.hideDropDown()
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -83,6 +83,7 @@
 #include "MissionManager.h"
 #include "QGroundControlQmlGlobal.h"
 #include "HomePositionManager.h"
+#include "FlightMapSettings.h"
 
 #ifndef __ios__
     #include "SerialLink.h"
@@ -313,7 +314,6 @@ void QGCApplication::_initCommon(void)
     qmlRegisterUncreatableType<JoystickManager>     ("QGroundControl.JoystickManager",  1, 0, "JoystickManager",        "Reference only");
     qmlRegisterUncreatableType<Joystick>            ("QGroundControl.JoystickManager",  1, 0, "Joystick",               "Reference only");
     qmlRegisterUncreatableType<QmlObjectListModel>  ("QGroundControl",                  1, 0, "QmlObjectListModel",     "Reference only");
-    qmlRegisterUncreatableType<HomePositionManager> ("QGroundControl",                  1, 0, "HomePositionManager",    "Reference only");
     
     qmlRegisterType<ViewWidgetController>           ("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
     qmlRegisterType<ParameterEditorController>      ("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
@@ -551,6 +551,16 @@ void QGCApplication::_createSingletons(void)
     // The order here is important since the singletons reference each other
 
     // No dependencies
+    FlightMapSettings* flightMapSettings = FlightMapSettings::_createSingleton();
+    Q_UNUSED(flightMapSettings);
+    Q_ASSERT(flightMapSettings);
+    
+    // No dependencies
+    HomePositionManager* homePositionManager = HomePositionManager::_createSingleton();
+    Q_UNUSED(homePositionManager);
+    Q_ASSERT(homePositionManager);
+
+    // No dependencies
     FirmwarePlugin* firmwarePlugin = GenericFirmwarePlugin::_createSingleton();
     Q_UNUSED(firmwarePlugin);
     Q_ASSERT(firmwarePlugin);
@@ -584,22 +594,17 @@ void QGCApplication::_createSingletons(void)
     Q_UNUSED(linkManager);
     Q_ASSERT(linkManager);
 
-    // Needs LinkManager
-    HomePositionManager* uasManager = HomePositionManager::_createSingleton();
-    Q_UNUSED(uasManager);
-    Q_ASSERT(uasManager);
-
-    // Need HomePositionManager
+    // Need MultiVehicleManager
     AutoPilotPluginManager* pluginManager = AutoPilotPluginManager::_createSingleton();
     Q_UNUSED(pluginManager);
     Q_ASSERT(pluginManager);
 
-    // Need HomePositionManager
+    // Need MultiVehicleManager
     UASMessageHandler* messageHandler = UASMessageHandler::_createSingleton();
     Q_UNUSED(messageHandler);
     Q_ASSERT(messageHandler);
 
-    // Needs HomePositionManager
+    // Needs MultiVehicleManager
     FactSystem* factSystem = FactSystem::_createSingleton();
     Q_UNUSED(factSystem);
     Q_ASSERT(factSystem);
@@ -631,7 +636,6 @@ void QGCApplication::_destroySingletons(void)
     FactSystem::_deleteSingleton();
     UASMessageHandler::_deleteSingleton();
     AutoPilotPluginManager::_deleteSingleton();
-    HomePositionManager::_deleteSingleton();
     LinkManager::_deleteSingleton();
     GAudioOutput::_deleteSingleton();
     JoystickManager::_deleteSingleton();
@@ -640,6 +644,8 @@ void QGCApplication::_destroySingletons(void)
     GenericFirmwarePlugin::_deleteSingleton();
     PX4FirmwarePlugin::_deleteSingleton();
     APMFirmwarePlugin::_deleteSingleton();
+    HomePositionManager::_deleteSingleton();
+    FlightMapSettings::_deleteSingleton();
 }
 
 void QGCApplication::informationMessageBoxOnMainThread(const QString& title, const QString& msg)

--- a/src/QmlControls/DropButton.qml
+++ b/src/QmlControls/DropButton.qml
@@ -8,8 +8,8 @@ import QGroundControl.Palette       1.0
 Item {
     id: _root
 
-    property alias  label:              buttonLabel.text
-    property alias  radius:             button.radius
+    property alias  buttonImage:        button.source
+    property real   radius:             (ScreenTools.defaultFontPixelHeight * 3) / 2
     property int    dropDirection:      dropDown
     property alias  dropDownComponent:  dropDownLoader.sourceComponent
     property real   viewportMargins:    0
@@ -144,33 +144,24 @@ Item {
     }
 
     // Button
-    Rectangle {
+    Image {
         id:             button
         anchors.fill:   parent
-        radius:         (ScreenTools.defaultFontPixelHeight * 3) / 2
-        color:          qgcPal.button
+        fillMode:       Image.PreserveAspectFit
         opacity:        _showDropDown ? 1.0 : 0.75
-
-        QGCLabel {
-            id:                     buttonLabel
-            anchors.fill:           parent
-            horizontalAlignment:    Text.AlignHCenter
-            verticalAlignment:      Text.AlignVCenter
-            color:                  "white"
-        }
 
         MouseArea {
             anchors.fill: parent
 
             onClicked: _showDropDown = !_showDropDown
         }
-    } // Rectangle - button
+    } // Image - button
 
     Item {
         id:         dropDownItem
         visible:    _showDropDown
 
-        Canvas {
+        QGCCanvas {
             id:             arrowCanvas
             anchors.fill:   parent
 
@@ -224,6 +215,13 @@ Item {
                 id: dropDownLoader
                 x:  _dropMargin
                 y:  _dropMargin
+
+                Connections {
+                    target: dropDownLoader.item
+
+                    onWidthChanged: _calcPositions()
+                    onHeightChanged: _calcPositions()
+                }
             }
         }
     } // Item - dropDownItem

--- a/src/QmlControls/QGCCanvas.qml
+++ b/src/QmlControls/QGCCanvas.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.2
+import QtQuick.Controls 1.2
+import QtQuick.Controls.Styles 1.2
+
+import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
+
+/// Canvas has some sort of bug in it which can cause it to not paint when top level Views
+/// are switched. In order to fix this we ahve a signal hacked into ScreenTools to force
+/// a repaint.
+Canvas {
+    Connections {
+        target: ScreenTools
+
+        onRepaintRequested: arrowCanvas.requestPaint()
+    }
+}

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -9,6 +9,7 @@ QGCComboBox         1.0 QGCComboBox.qml
 QGCColoredImage     1.0 QGCColoredImage.qml
 QGCToolBarButton    1.0 QGCToolBarButton.qml
 QGCMovableItem      1.0 QGCMovableItem.qml
+QGCCanvas           1.0 QGCCanvas.qml
 
 SubMenuButton       1.0 SubMenuButton.qml
 IndicatorButton     1.0 IndicatorButton.qml

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -29,6 +29,7 @@
 QGroundControlQmlGlobal::QGroundControlQmlGlobal(QObject* parent)
     : QObject(parent)
     , _homePositionManager(HomePositionManager::instance())
+    , _flightMapSettings(FlightMapSettings::instance())
 {
 
 }

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -30,6 +30,7 @@
 #include <QObject>
 
 #include "HomePositionManager.h"
+#include "FlightMapSettings.h"
 
 class QGroundControlQmlGlobal : public QObject
 {
@@ -39,14 +40,17 @@ public:
     QGroundControlQmlGlobal(QObject* parent = NULL);
     ~QGroundControlQmlGlobal();
     
-    Q_PROPERTY(HomePositionManager* homePositionManager READ homePositionManager CONSTANT)
+    Q_PROPERTY(HomePositionManager* homePositionManager READ homePositionManager    CONSTANT)
+    Q_PROPERTY(FlightMapSettings*   flightMapSettings   READ flightMapSettings      CONSTANT)
     
     // Property accesors
     
-    HomePositionManager* homePositionManager(void) { return _homePositionManager; }
+    HomePositionManager*    homePositionManager(void)   { return _homePositionManager; }
+    FlightMapSettings*      flightMapSettings(void)     { return _flightMapSettings; }
     
 private:
     HomePositionManager*    _homePositionManager;
+    FlightMapSettings*      _flightMapSettings;
 };
 
 #endif

--- a/src/ui/SettingsDialog.cc
+++ b/src/ui/SettingsDialog.cc
@@ -37,6 +37,7 @@
 #include "QGCFileDialog.h"
 #include "QGCMessageBox.h"
 #include "MainToolBar.h"
+#include "FlightMapSettings.h"
 
 SettingsDialog::SettingsDialog(QWidget *parent, int showTab, Qt::WindowFlags flags) :
 QDialog(parent, flags),
@@ -94,7 +95,18 @@ _ui(new Ui::SettingsDialog)
     connect(_ui->styleChooser, SIGNAL(currentIndexChanged(int)), this, SLOT(styleChanged(int)));
     connect(_ui->browseSavedFilesLocation, &QPushButton::clicked, this, &SettingsDialog::_selectSavedFilesDirectory);
     connect(_ui->buttonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::_validateBeforeClose);
+    
+    // Flight Map settings
+    
+    FlightMapSettings* fmSettings = FlightMapSettings::instance();
+    _ui->bingMapRadio->setChecked(fmSettings->mapProvider() == "Bing");
+    _ui->googleMapRadio->setChecked(fmSettings->mapProvider() == "Google");
+    _ui->openMapRadio->setChecked(fmSettings->mapProvider() == "Open");
 
+    connect(_ui->bingMapRadio,      &QRadioButton::clicked, this, &SettingsDialog::_bingMapRadioClicked);
+    connect(_ui->googleMapRadio,    &QRadioButton::clicked, this, &SettingsDialog::_googleMapRadioClicked);
+    connect(_ui->openMapRadio,      &QRadioButton::clicked, this, &SettingsDialog::_openMapRadioClicked);
+    
     switch (showTab) {
         case ShowCommLinks:
             _ui->tabWidget->setCurrentWidget(pLinkConf);
@@ -192,4 +204,25 @@ void SettingsDialog::on_showMav_clicked(bool checked)
 void SettingsDialog::on_showRSSI_clicked(bool checked)
 {
     _mainWindow->getMainToolBar()->viewStateChanged(TOOL_BAR_SHOW_RSSI, checked);
+}
+
+void SettingsDialog::_bingMapRadioClicked(bool checked)
+{
+    if (checked) {
+        FlightMapSettings::instance()->setMapProvider("Bing");
+    }
+}
+
+void SettingsDialog::_googleMapRadioClicked(bool checked)
+{
+    if (checked) {
+        FlightMapSettings::instance()->setMapProvider("Google");
+    }
+}
+
+void SettingsDialog::_openMapRadioClicked(bool checked)
+{
+    if (checked) {
+        FlightMapSettings::instance()->setMapProvider("Open");
+    }
 }

--- a/src/ui/SettingsDialog.h
+++ b/src/ui/SettingsDialog.h
@@ -62,6 +62,10 @@ private slots:
     void on_showMav_clicked(bool checked);
 
     void on_showRSSI_clicked(bool checked);
+    
+    void _bingMapRadioClicked(bool checked);
+    void _googleMapRadioClicked(bool checked);
+    void _openMapRadioClicked(bool checked);
 
 private:
     MainWindow*         _mainWindow;

--- a/src/ui/SettingsDialog.ui
+++ b/src/ui/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>596</height>
+    <height>689</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -113,6 +113,36 @@
            <height>0</height>
           </size>
          </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Map Provider</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QRadioButton" name="bingMapRadio">
+            <property name="text">
+             <string>Bing</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="googleMapRadio">
+            <property name="text">
+             <string>Google</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="openMapRadio">
+            <property name="text">
+             <string>Open Streets</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
- FlightMapSettings is the new object which is used to store all map settings with. Access from Qml using QGroundControl.flightMapSettings.
- You now pick the map provider from Settings: Bing, Google, Open Street. Bing is the default since it provides a hybrid map.
- Map type selection implemented in Mission Editor and Fly view. You now just pick Street, Satetellite and so forth.'
- Add new QGCCanvas control which automatically fixed the repatin problem with Canvas.