### PR TITLE
Easier command line logging options

### DIFF
--- a/src/CmdLineOptParser.cc
+++ b/src/CmdLineOptParser.cc
@@ -51,7 +51,9 @@ void ParseCmdLineOptions(int&           argc,                   ///< count of ar
             
             if (arg.startsWith(QString("%1:").arg(optionStr), Qt::CaseInsensitive)) {
                 found = true;
-                prgOpts[iOption].optionArg = arg.right(arg.length() - (optionStr.length() + 1));
+                if (prgOpts[iOption].optionArg) {
+                    *prgOpts[iOption].optionArg = arg.right(arg.length() - (optionStr.length() + 1));
+                }
             } else if (arg.compare(optionStr, Qt::CaseInsensitive) == 0) {
                 found = true;
             }

--- a/src/CmdLineOptParser.h
+++ b/src/CmdLineOptParser.h
@@ -36,7 +36,7 @@
 typedef struct {
     const char* optionStr;      ///< command line option, for example "--foo"
     bool*       optionFound;    ///< if option is found this variable will be set to true
-    QString     optionArg;      ///< Option has additional argument, form is option:arg
+    QString*    optionArg;      ///< Option has additional argument, form is option:arg
 } CmdLineOpt_t;
 
 void ParseCmdLineOptions(int&           argc,

--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -36,6 +36,7 @@
 #include <QDebug>
 
 QGC_LOGGING_CATEGORY(ParameterLoaderLog, "ParameterLoaderLog")
+QGC_LOGGING_CATEGORY(ParameterLoaderVerboseLog, "ParameterLoaderVerboseLog")
 
 Fact ParameterLoader::_defaultFact;
 
@@ -130,7 +131,7 @@ void ParameterLoader::_parameterUpdate(int uasId, int componentId, QString param
     _waitingReadParamIndexMap[componentId].remove(parameterId);
     _waitingReadParamNameMap[componentId].remove(parameterName);
     _waitingWriteParamNameMap[componentId].remove(parameterName);
-    qCDebug(ParameterLoaderLog) << "_waitingReadParamIndexMap:" << _waitingReadParamIndexMap[componentId];
+    qCDebug(ParameterLoaderVerboseLog) << "_waitingReadParamIndexMap:" << _waitingReadParamIndexMap[componentId];
     qCDebug(ParameterLoaderLog) << "_waitingReadParamNameMap" << _waitingReadParamNameMap[componentId];
     qCDebug(ParameterLoaderLog) << "_waitingWriteParamNameMap" << _waitingWriteParamNameMap[componentId];
 

--- a/src/FactSystem/ParameterLoader.h
+++ b/src/FactSystem/ParameterLoader.h
@@ -40,6 +40,7 @@
 ///     @author Don Gagne <don@thegagnes.com>
 
 Q_DECLARE_LOGGING_CATEGORY(ParameterLoaderLog)
+Q_DECLARE_LOGGING_CATEGORY(ParameterLoaderVerboseLog)
 
 /// Connects to Parameter Manager to load/update Facts
 class ParameterLoader : public QObject

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -214,6 +214,12 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
                 filterRules += ".debug=true\n";
             }
         }
+        
+        if (_runningUnitTests) {
+            // We need to turn off these warnings until the firmware meta data is cleaned up
+            filterRules += "PX4ParameterLoaderLog.warning=false\n";
+        }
+        
         qDebug() << "Filter rules" << filterRules;
         QLoggingCategory::setFilterRules(filterRules);
     } else {
@@ -244,7 +250,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
         }
 
         if (loggingDirectoryOk) {
-            qDebug () << iniFileLocation;
+            qDebug () << "Logging ini file directory" << iniFileLocation.absolutePath();
             if (!iniFileLocation.exists(qtLoggingFile)) {
                 QFile loggingFile(iniFileLocation.filePath(qtLoggingFile));
                 if (loggingFile.open(QIODevice::WriteOnly | QIODevice::Text)) {

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -180,14 +180,15 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     // Parse command line options
     
     bool fClearSettingsOptions = false; // Clear stored settings
-    bool fullLogging = false; // Turn on all logging
+    bool logging = false;               // Turn on logging
+    QString loggingOptions;
     
     CmdLineOpt_t rgCmdLineOptions[] = {
-        { "--clear-settings",   &fClearSettingsOptions, QString() },
-        { "--full-logging",     &fullLogging,           QString() },
-		{ "--fake-mobile",      &_fakeMobile,           QString() },
+        { "--clear-settings",   &fClearSettingsOptions, NULL },
+        { "--logging",          &logging,               &loggingOptions },
+		{ "--fake-mobile",      &_fakeMobile,           NULL },
 #ifdef QT_DEBUG
-        { "--test-high-dpi",    &_testHighDPI,          QString() },
+        { "--test-high-dpi",    &_testHighDPI,          NULL },
 #endif
         // Add additional command line option flags here
     };
@@ -197,8 +198,24 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 #ifdef __mobile__
     QLoggingCategory::setFilterRules(QStringLiteral("*Log.debug=false"));
 #else
-    if (fullLogging) {
-        QLoggingCategory::setFilterRules(QStringLiteral("*Log=true"));
+    if (logging) {
+        QString filterRules;
+        QStringList logList = loggingOptions.split(",");
+        
+        if (logList[0] == "full") {
+            filterRules += "*Log.debug=true\n";
+            for(int i=1; i<logList.count(); i++) {
+                filterRules += logList[i];
+                filterRules += ".debug=false\n";
+            }
+        } else {
+            foreach(QString rule, logList) {
+                filterRules += rule;
+                filterRules += ".debug=true\n";
+            }
+        }
+        qDebug() << "Filter rules" << filterRules;
+        QLoggingCategory::setFilterRules(filterRules);
     } else {
         if (_runningUnitTests) {
             // We need to turn off these warnings until the firmware meta data is cleaned up

--- a/src/main.cc
+++ b/src/main.cc
@@ -135,9 +135,10 @@ int main(int argc, char *argv[])
 
     bool quietWindowsAsserts = false;   // Don't let asserts pop dialog boxes
 
+    QString unitTestOptions;
     CmdLineOpt_t rgCmdLineOptions[] = {
-        { "--unittest",             &runUnitTests,          QString() },
-        { "--no-windows-assert-ui", &quietWindowsAsserts,   QString() },
+        { "--unittest",             &runUnitTests,          &unitTestOptions },
+        { "--no-windows-assert-ui", &quietWindowsAsserts,   NULL },
         // Add additional command line option flags here
     };
 
@@ -181,7 +182,7 @@ int main(int argc, char *argv[])
         }
 
         // Run the test
-        int failures = UnitTest::run(rgCmdLineOptions[0].optionArg);
+        int failures = UnitTest::run(unitTestOptions);
         if (failures == 0) {
             qDebug() << "ALL TESTS PASSED";
         } else {


### PR DESCRIPTION
http://www.qgroundcontrol.org/bugreporting
http://www.qgroundcontrol.org/command_line_options

Also notice that GGC with no command line options will output qtlogging.ini location so you can find that more easily if you want to go that route instead.