### PR TITLE
MissionManager read hardening unit test

### DIFF
--- a/src/MissionManager/MissionManagerTest.h
+++ b/src/MissionManager/MissionManagerTest.h
@@ -40,14 +40,16 @@ private slots:
     void init(void);
     void cleanup(void);
     
-    void _readEmptyVehicle(void);
-    void _roundTripItems(void);
-    void _testWriteFailureHandling(void);
+    void _testReadFailureHandling(void);
     
 private:
     void _checkInProgressValues(bool inProgress);
+    void _roundTripItems(MockLinkMissionItemHandler::FailureMode_t failureMode, MissionManager::ErrorCode_t errorCode, bool failFirstTimeOnly);
     void _writeItems(MockLinkMissionItemHandler::FailureMode_t failureMode, MissionManager::ErrorCode_t errorCode, bool failFirstTimeOnly);
 
+    void _readEmptyVehicle(void);
+    void _testWriteFailureHandling(void);
+    
     MockLink*       _mockLink;
     MissionManager* _missionManager;
     

--- a/src/comm/MockLinkMissionItemHandler.cc
+++ b/src/comm/MockLinkMissionItemHandler.cc
@@ -129,8 +129,8 @@ void MockLinkMissionItemHandler::_handleMissionRequest(const mavlink_message_t& 
     Q_ASSERT(request.target_system == _mockLink->vehicleId());
     Q_ASSERT(request.seq < _missionItems.count());
     
-    if ((_failureMode == FailReadRequest0NoResponse && request.seq != 0) ||
-        (_failureMode == FailReadRequest1NoResponse && request.seq != 1)) {
+    if ((_failureMode == FailReadRequest0NoResponse && request.seq == 0) ||
+        (_failureMode == FailReadRequest1NoResponse && request.seq == 1)) {
         qCDebug(MockLinkMissionItemHandlerLog) << "_handleMissionRequest not responding due to failure mode";
     } else {
         // FIXME: Track whether all items are requested, or requested in sequence


### PR DESCRIPTION
- Fixed found bugs in MissionManager

MissionManager is now fully hardened for both the read and write protocol sequences. Only thing left to do is unit test for correct response to unexpected mission messages while state machine is idle. Also need to hook error messages to ui.