### PR TITLE
Add note to Windows developers to turn off -MP when using jom. 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ install:
   - cinst nsis -y -installArgs /D="%programfiles(x86)%\NSIS"
 
 build_script:
-  - C:\Qt\5.4\msvc2013_opengl\bin\qmake -r CONFIG-=debug_and_release CONFIG+=%CONFIG% CONFIG+=WarningsAsErrorsOn qgroundcontrol.pro
+  - C:\Qt\5.4\msvc2013_opengl\bin\qmake -r CONFIG-=debug_and_release CONFIG+=%CONFIG% CONFIG+=WarningsAsErrorsOn CONFIG+=jombuild qgroundcontrol.pro
   - jom -j 4
 
 test_script:

--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -168,8 +168,11 @@ WindowsBuild {
 	DEFINES += __STDC_LIMIT_MACROS
 	# Specify multi-process compilation within Visual Studio.
 	# (drastically improves compilation times for multi-core computers)
-	QMAKE_CXXFLAGS_DEBUG += -MP
-	QMAKE_CXXFLAGS_RELEASE += -MP
+	!jombuild {
+		message("When using jom/QtCreator please add CONFIG+=jombuild to your project build settings")
+		QMAKE_CXXFLAGS_DEBUG += -MP
+		QMAKE_CXXFLAGS_RELEASE += -MP
+	}
 }
 
 #


### PR DESCRIPTION
Specify we're using jom in appveyor. Helps to address #1928 