### PR TITLE
Limit font pixel size to work around OSX El Capitan problem

### DIFF
--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -12,8 +12,11 @@ Item {
     readonly property real defaultFontPixelHeight:  defaultFontPixelSize
     readonly property real defaultFontPixelWidth:   _textMeasure.fontWidth
     readonly property real smallFontPixelSize:      defaultFontPixelSize * ScreenToolsController.smallFontPixelSizeRatio
-    readonly property real mediumFontPixelSize:     defaultFontPixelSize * ScreenToolsController.mediumFontPixelSizeRatio
-    readonly property real largeFontPixelSize:      defaultFontPixelSize * ScreenToolsController.largeFontPixelSizeRatio
+
+    // On OSX ElCapitan with Qt 5.4.0 any font pixel size above 19 shows garbage test. No idea why at this point.
+    // Will remove Math.min when problem is figure out.
+    readonly property real mediumFontPixelSize:     Math.min(defaultFontPixelSize * ScreenToolsController.mediumFontPixelSizeRatio, 19)
+    readonly property real largeFontPixelSize:      Math.min(defaultFontPixelSize * ScreenToolsController.largeFontPixelSizeRatio, 19)
 
     property bool isAndroid:        ScreenToolsController.isAndroid
     property bool isiOS:            ScreenToolsController.isiOS


### PR DESCRIPTION
Anything about 19 shows crap:
![screen shot 2015-10-09 at 2 11 02 pm](https://cloud.githubusercontent.com/assets/5876851/10405788/3b698ad6-6e90-11e5-84ff-ac147620d2c2.png)
