### PR TITLE
Log fixes, MavlinkLogTest::_connectLogArm_test

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -219,17 +219,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
                 filterRules += ".debug=true\n";
             }
         }
-        
-        if (_runningUnitTests) {
-            // We need to turn off these warnings until the firmware meta data is cleaned up
-            filterRules += "PX4ParameterLoaderLog.warning=false\n";
-        }
     } else {
-        if (_runningUnitTests) {
-            // We need to turn off these warnings until the firmware meta data is cleaned up
-            QLoggingCategory::setFilterRules(QStringLiteral("PX4ParameterLoaderLog.warning=false"));
-        }
-        
         // First thing we want to do is set up the qtlogging.ini file. If it doesn't already exist we copy
         // it to the correct location. This way default debug builds will have logging turned off.
 

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -31,7 +31,7 @@
 #include <string.h>
 
 QGC_LOGGING_CATEGORY(MockLinkLog, "MockLinkLog")
-QGC_LOGGING_CATEGORY(MockLinkLogVerbose, "MockLinkLogVerbose")
+QGC_LOGGING_CATEGORY(MockLinkVerboseLog, "MockLinkVerboseLog")
 
 /// @file
 ///     @brief Mock implementation of a Link.
@@ -216,7 +216,7 @@ void MockLink::_loadParams(void)
                 break;
         }
 
-        qCDebug(MockLinkLogVerbose) << "Loading param" << paramName << paramValue;
+        qCDebug(MockLinkVerboseLog) << "Loading param" << paramName << paramValue;
 
         _mapParamName2Value[componentId][paramName] = paramValue;
         _mapParamName2MavParamType[paramName] = static_cast<MAV_PARAM_TYPE>(paramType);

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -33,7 +33,7 @@
 #include "QGCMAVLink.h"
 
 Q_DECLARE_LOGGING_CATEGORY(MockLinkLog)
-Q_DECLARE_LOGGING_CATEGORY(MockLinkLogVerbose)
+Q_DECLARE_LOGGING_CATEGORY(MockLinkVerboseLog)
 
 /// @file
 ///     @brief Mock implementation of a Link.

--- a/src/qgcunittest/MavlinkLogTest.cc
+++ b/src/qgcunittest/MavlinkLogTest.cc
@@ -180,7 +180,7 @@ void MavlinkLogTest::_connectLogNoArm_test(void)
 
 void MavlinkLogTest::_connectLogArm_test(void)
 {
-    //_connectLogWorker(true);
+    _connectLogWorker(true);
 }
 
 void MavlinkLogTest::_deleteTempLogFiles_test(void)


### PR DESCRIPTION
Was failing due to incorrectly named MockLinkLogVerbose category which would get past the *Log.debug=false rule. Then it would blow out the log files size limit on AppVeyor.

I hope :)