### PR TITLE
Zoom buttons back on

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -85,7 +85,8 @@ Map {
         anchors.bottom:     parent.bottom
         spacing:            ScreenTools.defaultFontPixelWidth / 2
         z:                  1000    // Must be on top for clicking
-        visible:            !ScreenTools.isMobile
+        // Pinch zoom doesn't seem to be working, so zoom buttons in mobile on for now
+        //visible:            !ScreenTools.isMobile
 
         Row {
             layoutDirection:    Qt.RightToLeft


### PR DESCRIPTION
Pinch zoom doesn’t seem to be working for some reason. Fix for Issue #1956