### PR TITLE
Mobile virtual keyboard fixes, plus font

### DIFF
--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -14,8 +14,11 @@ QGCTextField {
     property Fact   fact:           null
     property string _validateString
 
-    text:       fact.valueString
-    unitsLabel: fact.units
+    text:               fact.valueString
+    unitsLabel:         fact.units
+
+    // At this point all Facts are numeric
+    inputMethodHints:   Qt.ImhFormattedNumbersOnly
 
     onEditingFinished: {
         if (qgcView) {

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -84,6 +84,9 @@ QGCViewDialog {
             id:     valueField
             text:   validate ? validateValue : fact.valueString
 
+            // At this point all Facts are numeric
+            inputMethodHints:   Qt.ImhFormattedNumbersOnly
+
             onAccepted: accept()
 
             Keys.onReleased: {

--- a/src/QmlControls/QGCViewDialog.qml
+++ b/src/QmlControls/QGCViewDialog.qml
@@ -39,10 +39,12 @@ FactPanel {
     signal hideDialog
 
     function accept() {
+        Qt.inputMethod.hide()
         hideDialog()
     }
 
     function reject() {
+        Qt.inputMethod.hide()
         hideDialog()
     }
 

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -15,8 +15,8 @@ Item {
 
     // On OSX ElCapitan with Qt 5.4.0 any font pixel size above 19 shows garbage test. No idea why at this point.
     // Will remove Math.min when problem is figure out.
-    readonly property real mediumFontPixelSize:     Math.min(defaultFontPixelSize * ScreenToolsController.mediumFontPixelSizeRatio, 19)
-    readonly property real largeFontPixelSize:      Math.min(defaultFontPixelSize * ScreenToolsController.largeFontPixelSizeRatio, 19)
+    readonly property real mediumFontPixelSize:     Math.min(defaultFontPixelSize * ScreenToolsController.mediumFontPixelSizeRatio, ScreenToolsController.isMobile ? 10000 : 19)
+    readonly property real largeFontPixelSize:      Math.min(defaultFontPixelSize * ScreenToolsController.largeFontPixelSizeRatio, ScreenToolsController.isMobile ? 10000 : 19)
 
     property bool isAndroid:        ScreenToolsController.isAndroid
     property bool isiOS:            ScreenToolsController.isiOS


### PR DESCRIPTION
- Use numeric virtual keyboard for FactTectField and parameter edtior dialog field
- Close virtual keyboad when QGCViewDialog closes
- Don't do El Capitan hack on Mobile