### PR TITLE
Missed in conflicted merge

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -375,7 +375,19 @@ QGCView {
                             visible:        object.specifiesCoordinate
 
                             onClicked: {
-                                _showHomePositionManager = false
+                                disableToggles()
+                                if (_dropButtonsExclusiveGroup.current) {
+                                    _dropButtonsExclusiveGroup.current.checked = false
+                                }
+                                //-- Home?
+                                if (object.sequenceNumber === 0) {
+                                    homePositionManagerButton.checked = true
+                                    _showHomePositionManager = true
+                                //-- Otherwise it's a mission item
+                                } else {
+                                    addMissionItemsButton.checked = true
+                                    _addMissionItems = true
+                                }
                                 setCurrentItem(object.sequenceNumber)
                             }
 


### PR DESCRIPTION
This is to toggle off help view when clicking on items on the map and checking the appropriate buttons accordingly.