### PR TITLE
Work around for pinch zoom bug in Qt (Qt Location)

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -289,4 +289,11 @@ Map {
         }
     }
 */
+
+    MouseArea {
+        //-- TODO: Check if this is still needed when we switch to 5.5.1
+        //-- Workaround for QTBUG-46388 (Pinch zoom doesn't work without it on mobile)
+        anchors.fill: parent
+    }
+
 } // Map


### PR DESCRIPTION
This is the workaround found in the *Places* example code in Qt (as explained in #1963). It should be fixed for 5.5.1 but in the mean time, this works.