### PR TITLE
Changed Home Position Manager to Flying Field Manager

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -117,6 +117,7 @@
         <file alias="QGroundControl/Controls/DropButton.qml">src/QmlControls/DropButton.qml</file>
         <file alias="QGroundControl/Controls/RoundButton.qml">src/QmlControls/RoundButton.qml</file>
         <file alias="QGroundControl/Controls/QGCCanvas.qml">src/QmlControls/QGCCanvas.qml</file>
+        <file alias="QGroundControl/Controls/ExclusiveGroupItem.qml">src/QmlControls/ExclusiveGroupItem.qml</file>
 
         <!-- Vehicle Setup -->
         <file alias="SetupView.qml">src/VehicleSetup/SetupView.qml</file>

--- a/src/QmlControls/ExclusiveGroupItem.qml
+++ b/src/QmlControls/ExclusiveGroupItem.qml
@@ -1,0 +1,18 @@
+import QtQuick                  2.4
+import QtQuick.Controls         1.2
+
+
+/// The ExclusiveGroupItem control can be used as a base class for a control which
+/// needs support for ExclusiveGroup
+Item {
+    id: _root
+
+    property bool checked: false
+    property ExclusiveGroup exclusiveGroup: null
+
+    onExclusiveGroupChanged: {
+        if (exclusiveGroup) {
+            exclusiveGroup.bindCheckable(_root)
+        }
+    }
+}

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -18,6 +18,7 @@ RoundButton         1.0 RoundButton.qml
 VehicleRotationCal  1.0 VehicleRotationCal.qml
 VehicleSummaryRow   1.0 VehicleSummaryRow.qml
 ViewWidget          1.0 ViewWidget.qml
+ExclusiveGroupItem  1.0 ExclusiveGroupItem.qml
 
 ParameterEditor         1.0 ParameterEditor.qml
 ParameterEditorDialog   1.0 ParameterEditorDialog.qml


### PR DESCRIPTION
This was done to reduce confusion around the fact that you don't really have a home position when you are editing offline. You are only simulating.

- naming changes
- Flying Field positions show up with "F" instead of "H". This is quick hack to differtiate between a live home position and a simulated flying field on.
- Fixed a bunch of button checked/right panel visible state problems. I think they all do the right thing now at the right time.

Just to reiterate what happen once you are connected to vehicle:
- the "F" indicator will go away and change to a real "H" home position indicator
- The Flying Field Manager will no longer be visible, instead you get static display of home position lat/lon/alt