### PR TITLE
Fix Windows postbuild error

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -199,7 +199,7 @@ WindowsBuild {
     # Copy platform plugins
     P_DIR = $$[QT_INSTALL_PLUGINS]
     PLUGINS_DIR_WIN = $$replace(P_DIR, "/", "\\")
-    QMAKE_POST_LINK += $$escape_expand(\\n) mkdir -p "$$DESTDIR_WIN\\platforms"
+    QMAKE_POST_LINK += $$escape_expand(\\n) if not exist \"$$DESTDIR_WIN\\platforms\" mkdir \"$$DESTDIR_WIN\\platforms\"
     QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY     \"$$PLUGINS_DIR_WIN\\platforms\\qwindows$${DLL_QT_DEBUGCHAR}.dll\" \"$$DESTDIR_WIN\\platforms\\qwindows$${DLL_QT_DEBUGCHAR}.dll\"
     QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$PLUGINS_DIR_WIN\\imageformats\" \"$$DESTDIR_WIN\\imageformats\"
     QMAKE_POST_LINK += $$escape_expand(\\n) $$QMAKE_COPY_DIR \"$$PLUGINS_DIR_WIN\\sqldrivers\" \"$$DESTDIR_WIN\\sqldrivers\"


### PR DESCRIPTION
I get this error when i build the app in Windows.

> mkdir -p D:\Projects\QGroundControl\debug\platforms
> A subdirectory or file D:\Projects\QGroundControl\debug\platforms already exists.
Error occurred while processing: D:\Projects\QGroundControl\debug\platforms.
jom: D:\Projects\QGroundControl\Makefile.QGCApplication.Debug [debug\qgroundcontrol.exe] Error 1
jom: D:\Projects\QGroundControl\Makefile.QGCApplication [debug] Error 2
jom: D:\Projects\QGroundControl\Makefile [sub-QGCApplication-pro-make_first-ordered] Error 2
14:31:52: The process "C:\Utils\Qt\Tools\QtCreator\bin\jom.exe" exited with code 2.
> Error while building/deploying project qgroundcontrol (kit: Desktop Qt 5.4.2 MSVC2013 OpenGL 32bit)
When executing step "Make"

It happens because windows version of mkdir have no -p key.
I've also added escape characters before double quotes.