### PR TITLE
Fixing map cache for Qt 5.5.1

### DIFF
--- a/src/QtLocationPlugin/qgeotiledmappingmanagerengineqgc.h
+++ b/src/QtLocationPlugin/qgeotiledmappingmanagerengineqgc.h
@@ -77,6 +77,7 @@ public:
 private:
 #if QT_VERSION >= 0x050500
     QString m_customCopyright;
+    void _setCache(const QVariantMap &parameters);
 #endif
 };
 


### PR DESCRIPTION
Map cacheing for < 5.5.0 was broken and we were using whatever default was provided by QtLocation. Now we're properly creating and configuring a cache manager.

This also solves the weird message output by QtLocation:

```
Plugin uses uninitialized directory for QGeoTileCache which will was deleted during startup
```