### PR TITLE
Getting rid of warning on Mac OS

### DIFF
--- a/git_version.pri
+++ b/git_version.pri
@@ -23,4 +23,8 @@ CONFIG(debug) {
   GIT_VERSION_CXXFLAGS = $$QMAKE_CXXFLAGS_RELEASE
 }
 
-QMAKE_PRE_LINK += $$QGC_GIT_VER && $$QMAKE_CXX -c $$GIT_VERSION_CXXFLAGS git_version.cpp
+MacBuild {
+    QMAKE_PRE_LINK += $$QGC_GIT_VER && $$QMAKE_CXX -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET -c $$GIT_VERSION_CXXFLAGS git_version.cpp
+} else {
+    QMAKE_PRE_LINK += $$QGC_GIT_VER && $$QMAKE_CXX -c $$GIT_VERSION_CXXFLAGS git_version.cpp
+}


### PR DESCRIPTION
The inline build of git_version was using the *default* target SDK, which caused a warning as it didn't match the one used by the project as a whole.