### PR TITLE
More editor changes

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -65,6 +65,7 @@
         <file alias="airplaneOpaque.svg">src/FlightMap/Images/airplaneOpaque.svg</file>
         <file alias="ZoomPlus.svg">src/FlightMap/Images/ZoomPlus.svg</file>
         <file alias="ZoomMinus.svg">src/FlightMap/Images/ZoomMinus.svg</file>
+        <file alias="TrashDelete.svg">src/FlightMap/Images/TrashDelete.svg</file>
 
         <!-- Map Buttons -->
         <file alias="Help.svg">src/FlightMap/Images/Help.svg</file>

--- a/src/MissionEditor/MissionEditorController.h
+++ b/src/MissionEditor/MissionEditorController.h
@@ -37,18 +37,20 @@ public:
     MissionEditorController(QWidget* parent = NULL);
     ~MissionEditorController();
 
-    Q_PROPERTY(QmlObjectListModel*  missionItems                READ missionItems               NOTIFY missionItemsChanged)
-    Q_PROPERTY(QmlObjectListModel*  waypointLines               READ waypointLines              NOTIFY waypointLinesChanged)
-    Q_PROPERTY(bool                 canEdit                     READ canEdit                    NOTIFY canEditChanged)
-    Q_PROPERTY(bool                 liveHomePositionAvailable   READ liveHomePositionAvailable  NOTIFY liveHomePositionAvailableChanged)
-    Q_PROPERTY(QGeoCoordinate       liveHomePosition            READ liveHomePosition           NOTIFY liveHomePositionChanged)
+    Q_PROPERTY(QmlObjectListModel*  missionItems                READ missionItems                   NOTIFY missionItemsChanged)
+    Q_PROPERTY(QmlObjectListModel*  waypointLines               READ waypointLines                  NOTIFY waypointLinesChanged)
+    Q_PROPERTY(bool                 canEdit                     READ canEdit                        NOTIFY canEditChanged)
+    Q_PROPERTY(bool                 liveHomePositionAvailable   READ liveHomePositionAvailable      NOTIFY liveHomePositionAvailableChanged)
+    Q_PROPERTY(QGeoCoordinate       liveHomePosition            READ liveHomePosition               NOTIFY liveHomePositionChanged)
+    Q_PROPERTY(bool                 autoSync                    READ autoSync   WRITE setAutoSync   NOTIFY autoSyncChanged)
     
     Q_INVOKABLE int addMissionItem(QGeoCoordinate coordinate);
     Q_INVOKABLE void getMissionItems(void);
-    Q_INVOKABLE void setMissionItems(void);
+    Q_INVOKABLE void sendMissionItems(void);
     Q_INVOKABLE void loadMissionFromFile(void);
     Q_INVOKABLE void saveMissionToFile(void);
     Q_INVOKABLE void removeMissionItem(int index);
+    Q_INVOKABLE void deleteCurrentMissionItem(void);
 
     // Property accessors
     
@@ -57,6 +59,8 @@ public:
     bool canEdit(void) { return _canEdit; }
     bool liveHomePositionAvailable(void) { return _liveHomePositionAvailable; }
     QGeoCoordinate liveHomePosition(void) { return _liveHomePosition; }
+    bool autoSync(void) { return _autoSync; }
+    void setAutoSync(bool autoSync);
 
 signals:
     void missionItemsChanged(void);
@@ -64,6 +68,7 @@ signals:
     void waypointLinesChanged(void);
     void liveHomePositionAvailableChanged(bool homePositionAvailable);
     void liveHomePositionChanged(const QGeoCoordinate& homePosition);
+    void autoSyncChanged(bool autoSync);
     
 private slots:
     void _newMissionItemsAvailable();
@@ -72,6 +77,8 @@ private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);
     void _activeVehicleHomePositionAvailableChanged(bool homePositionAvailable);
     void _activeVehicleHomePositionChanged(const QGeoCoordinate& homePosition);
+    void _dirtyChanged(bool dirty);
+    void _inProgressChanged(bool inProgress);
 
 private:
     void _recalcSequence(void);
@@ -82,6 +89,7 @@ private:
     void _deinitAllMissionItems(void);
     void _initMissionItem(MissionItem* item);
     void _deinitMissionItem(MissionItem* item);
+    void _autoSyncSend(void);
 
 private:
     QmlObjectListModel* _missionItems;
@@ -90,6 +98,10 @@ private:
     Vehicle*            _activeVehicle;
     bool                _liveHomePositionAvailable;
     QGeoCoordinate      _liveHomePosition;
+    bool                _autoSync;
+    bool                _firstMissionItemSync;
+    bool                _expectingNewMissionItems;
+    bool                _queuedSend;
 
     static const char* _settingsGroup;
 };

--- a/src/MissionItem.cc
+++ b/src/MissionItem.cc
@@ -878,10 +878,14 @@ bool MissionItem::canEdit(void)
 
 void MissionItem::setDirty(bool dirty)
 {
-    _dirty = dirty;
-    // We want to emit dirtyChanged even if _dirty didn't change. This can be handy signal for
-    // any value within the item changing.
-    emit dirtyChanged(_dirty);
+    if (!_homePositionSpecialCase || !dirty) {
+        // Home position never affects dirty bit
+
+        _dirty = dirty;
+        // We want to emit dirtyChanged even if _dirty didn't change. This can be handy signal for
+        // any value within the item changing.
+        emit dirtyChanged(_dirty);
+    }
 }
 
 void MissionItem::_factValueChanged(QVariant value)

--- a/src/QmlControls/MissionItemEditor.qml
+++ b/src/QmlControls/MissionItemEditor.qml
@@ -19,7 +19,7 @@ Rectangle {
     signal clicked
     signal remove
 
-    height: innerItem.height + (_margin * 2)
+    height: innerItem.height + (_margin * 3)
     color:  missionItem.isCurrentItem ? qgcPal.buttonHighlight : qgcPal.windowShade
     radius: _radius
 

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -69,9 +69,9 @@ Item {
     function showToolbarMessage(message) {
         toolBarMessage.text = message
         if (toolBarMessage.contentHeight > toolBarMessageCloseButton.height) {
-            mainToolBar.height = toolBarHeight + toolBarMessage.contentHeight + (verticalMargins * 2)
+            toolBarHolder.height = toolBarHeight + toolBarMessage.contentHeight + (verticalMargins * 2)
         } else {
-            mainToolBar.height = toolBarHeight + toolBarMessageCloseButton.height + (verticalMargins * 2)
+            toolBarHolder.height = toolBarHeight + toolBarMessageCloseButton.height + (verticalMargins * 2)
         }
         toolBarMessageArea.visible = true
     }
@@ -864,7 +864,7 @@ Item {
 
             onClicked: {
                 parent.visible = false
-                _controller.height = toolBarHeight
+                toolBarHolder.height = toolBarHeight
                 _controller.onToolBarMessageClosed()
             }
         }


### PR DESCRIPTION
- Transitioning from offline to online handled correctly
- Added "AutoSync" capability. Turn it on and the vehicle will be kept in sync automatically with your changes. Turned on by default. You can turn off via Sync Tool. Disabled if vehicle is armed.
- Fix toolbar messages, Issue #2025 

Transition from offline to online:
![screen shot 2015-10-17 at 4 41 20 pm](https://cloud.githubusercontent.com/assets/5876851/10561889/4768119e-74f4-11e5-860d-a7f862d12e38.png)
