### PR TITLE
Remove font query from QWidget side of code

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -133,7 +133,6 @@
         <file alias="JoystickConfig.qml">src/VehicleSetup/JoystickConfig.qml</file>
         <file alias="SetupParameterEditor.qml">src/VehicleSetup/SetupParameterEditor.qml</file>
 
-        <file alias="ScreenToolsFontQuery.qml">src/QmlControls/ScreenToolsFontQuery.qml</file>
         <file alias="CustomCommandWidget.qml">src/ViewWidgets/CustomCommandWidget.qml</file>
         <file alias="SafetyComponent.qml">src/AutoPilotPlugins/PX4/SafetyComponent.qml</file>
         <file alias="RadioComponent.qml">src/AutoPilotPlugins/PX4/RadioComponent.qml</file>

--- a/resources/styles/style-dark.css
+++ b/resources/styles/style-dark.css
@@ -10,8 +10,6 @@
 * {
     background-color: #222;
     color: #FFF;
-    font-size: FONT_NORMAL;
-    font-weight: lighter;
 }
 
 QWidget#viewModeWidget {
@@ -132,7 +130,7 @@ QGroupBox::title {
     subcontrol-position: top center;
     margin: 0 3px 0 3px;
     padding: 0 3px 0 0;
-    font: bold FONT_SMALL;
+    font: bold;
     color: #DDD;
 }
 
@@ -152,25 +150,18 @@ QLabel:disabled {
     border-color: #444;
 }
 
-QLabel#noUas {
-    font-size: FONT_LARGE;
-}
-
 QMessageBox {
     min-width: 400px;
     min-height: 300px;
 }
 
 QLabel#tabTitleLabel {
-    font-size: FONT_LARGE;
-    font-weight: lighter;
     margin-top: 16px;
     margin-bottom: 8px;
 }
 
 QLabel#instructionLabel {
     color: #FEC654;
-    font-size: FONT_LARGE;
 }
 
 QLineEdit {
@@ -229,8 +220,6 @@ QMenuBar::item:disabled {
 QPlainTextEdit {
     border: 1px solid #777;
     border-radius: 2px;
-    font-family: "Monospace";
-    font: FONT_SMALL;
 }
 
 QProgressBar {
@@ -533,10 +522,6 @@ UASQuickViewItem QLabel {
     padding: 0;
     margin: 0;
     min-height: 1em;
-}
-
-UASQuickViewItem QLabel#value {
-    font-size: FONT_LARGE;
 }
 
 UASView {

--- a/src/FlightDisplay/FlightDisplayWidget.cc
+++ b/src/FlightDisplay/FlightDisplayWidget.cc
@@ -44,10 +44,8 @@ FlightDisplayWidget::FlightDisplayWidget(const QString& title, QAction* action, 
     if(pl) {
         pl->setContentsMargins(0,0,0,0);
     }
-#ifndef __android__
-    setMinimumWidth( 31 * ScreenToolsController::defaultFontPixelSize_s());
-    setMinimumHeight(33 * ScreenToolsController::defaultFontPixelSize_s());
-#endif
+    setMinimumWidth(300);
+    setMinimumHeight(300);
     setContextPropertyObject("flightDisplay", this);
 
     /*

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -759,17 +759,6 @@ void QGCApplication::_loadCurrentStyle(void)
         }
     }
     
-    // Now that we have the styles loaded we need to adjust the font sizes.
-    
-    QString fSmall  = QString("%1px;").arg(ScreenToolsController::smallFontPixelSize_s());
-    QString fNormal = QString("%1px;").arg(ScreenToolsController::defaultFontPixelSize_s());
-    QString fLarge  = QString("%1px;").arg(ScreenToolsController::largeFontPixelSize_s());
-    
-    qDebug() << fSmall << fNormal << fLarge;
-
-    styles.replace("FONT_SMALL",  fSmall);
-    styles.replace("FONT_NORMAL", fNormal);
-    styles.replace("FONT_LARGE",  fLarge);
     setStyleSheet(styles);
 
     if (!success) {

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -27,8 +27,6 @@
 #include "ScreenToolsController.h"
 #include "MainWindow.h"
 
-int ScreenToolsController::_qmlDefaultFontPixelSize = -1;
-
 #ifdef Q_OS_WIN
 const double ScreenToolsController::_defaultFontPixelSizeRatio = 1.0;
 #else
@@ -52,21 +50,3 @@ void ScreenToolsController::_updateCanvas()
     emit repaintRequested();
 }
 
-double ScreenToolsController::getQmlDefaultFontPixelSize(void)
-{
-    if (_qmlDefaultFontPixelSize == -1) {
-        QGCQmlWidgetHolder qmlWidgetHolder(QString(), NULL);
-        
-        qmlWidgetHolder.setSource(QUrl::fromUserInput("qrc:/qml/ScreenToolsFontQuery.qml"));
-    }
-
-    double qmlDefaultFontPixelSize = _qmlDefaultFontPixelSize;
-    
-#ifdef QT_DEBUG
-    if (qgcApp()->testHighDPI()) {
-        qmlDefaultFontPixelSize *= 2;
-    }
-#endif
-    
-    return qmlDefaultFontPixelSize;
-}

--- a/src/QmlControls/ScreenToolsController.h
+++ b/src/QmlControls/ScreenToolsController.h
@@ -91,15 +91,6 @@ public:
     Q_PROPERTY(double mediumFontPixelSizeRatio  MEMBER _mediumFontPixelSizeRatio    CONSTANT)
     Q_PROPERTY(double largeFontPixelSizeRatio   MEMBER _largeFontPixelSizeRatio     CONSTANT)
     
-    Q_PROPERTY(double qmlDefaultFontPixelSize MEMBER _qmlDefaultFontPixelSize)
-    
-    static double getQmlDefaultFontPixelSize(void);
-
-    static int  defaultFontPixelSize_s()    { return (int)getQmlDefaultFontPixelSize(); }
-	static int  smallFontPixelSize_s()      { return (int)((double)defaultFontPixelSize_s() * _smallFontPixelSizeRatio); }
-    static int  mediumFontPixelSize_s()     { return (int)((double)defaultFontPixelSize_s() * _mediumFontPixelSizeRatio); }
-    static int  largeFontPixelSize_s()      { return (int)((double)defaultFontPixelSize_s() * _largeFontPixelSizeRatio); }
-
 #if defined (__android__)
     bool    isAndroid           () { return true;  }
     bool    isiOS               () { return false; }
@@ -131,8 +122,6 @@ private:
 	static const double _smallFontPixelSizeRatio;
     static const double _mediumFontPixelSizeRatio;
     static const double _largeFontPixelSizeRatio;
-    
-    static int _qmlDefaultFontPixelSize;
 };
 
 #endif

--- a/src/QmlControls/ScreenToolsFontQuery.qml
+++ b/src/QmlControls/ScreenToolsFontQuery.qml
@@ -1,9 +1,0 @@
-import QtQuick 2.2
-import QtQuick.Controls 1.2
-
-import QGroundControl.ScreenTools 1.0
-import QGroundControl.ScreenToolsController 1.0
-
-Item {
-    Component.onCompleted: ScreenToolsController.qmlDefaultFontPixelSize = ScreenTools.defaultFontPixelSize
-}


### PR DESCRIPTION
For QWidget we will just use the Qt default font sizes. This removes the extra QQuickWidget creation which breaks boot Qml Profiling