### PR TITLE
update android versionCode and google play instructions

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest package="org.mavlink.qgroundcontrol" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="2.7.1" android:versionCode="2" android:installLocation="auto">
+<manifest package="org.mavlink.qgroundcontrol" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="2.7.1-555-g8aa592d" android:versionCode="7" android:installLocation="auto">
     <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="-- %%INSERT_APP_NAME%% --" android:icon="@drawable/icon">
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qgroundcontrol.qgchelper.UsbDeviceJNI" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="sensorLandscape" android:launchMode="singleTask">
             <intent-filter>
@@ -48,7 +48,7 @@
             <!-- Background running -->
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="21"/>
+    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="22"/>
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
     <!-- Needed to keep working while 'asleep' -->


### PR DESCRIPTION
@DonLakeFlyer @LorenzMeier 

Opening this to provide basic instructions for updating the google play app.

To update the android app on google play the `versionCode` in android/AndroidManifest.xml must be incremented. The versionName is displayed, but versionCode is what android uses to update. I'll start committing this change everytime I update the build so that it's easier for others.

    android:versionName="2.7.1-548-g9417909" android:versionCode="6"

The app must be built in release mode and signed with the keystore `android/android_release.keystore`. I'll send the password.

Once a release apk is built you just login to https://play.google.com/apps/publish and select 'Upload new APK' under APK. I'm currently only uploading to the beta channel, although I've been calling it alpha.

Ideally this would be automated from travis-ci, but due to the way androiddeployqt works it's currently difficult.