### PR TITLE
Reset internal state correctly

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -32,6 +32,8 @@
 #include <QVariant>
 #include <QQmlProperty>
 
+QGC_LOGGING_CATEGORY(SensorsComponentControllerLog, "SensorsComponentControllerLog")
+
 SensorsComponentController::SensorsComponentController(void) :
     _statusLog(NULL),
     _progressBar(NULL),
@@ -106,8 +108,36 @@ void SensorsComponentController::_startVisualCalibration(void)
     _airspeedButton->setEnabled(false);
     _levelButton->setEnabled(false);
     _cancelButton->setEnabled(true);
+
+    _resetInternalState();
     
     _progressBar->setProperty("value", 0);
+}
+
+void SensorsComponentController::_resetInternalState(void)
+{
+    _orientationCalDownSideDone = true;
+    _orientationCalUpsideDownSideDone = true;
+    _orientationCalLeftSideDone = true;
+    _orientationCalRightSideDone = true;
+    _orientationCalTailDownSideDone = true;
+    _orientationCalNoseDownSideDone = true;
+    _orientationCalDownSideInProgress = false;
+    _orientationCalUpsideDownSideInProgress = false;
+    _orientationCalLeftSideInProgress = false;
+    _orientationCalRightSideInProgress = false;
+    _orientationCalNoseDownSideInProgress = false;
+    _orientationCalTailDownSideInProgress = false;
+    _orientationCalDownSideRotate = false;
+    _orientationCalUpsideDownSideRotate = false;
+    _orientationCalLeftSideRotate = false;
+    _orientationCalRightSideRotate = false;
+    _orientationCalNoseDownSideRotate = false;
+    _orientationCalTailDownSideRotate = false;
+
+    emit orientationCalSidesRotateChanged();
+    emit orientationCalSidesDoneChanged();
+    emit orientationCalSidesInProgressChanged();
 }
 
 void SensorsComponentController::_stopCalibration(SensorsComponentController::StopCalibrationCode code)
@@ -122,20 +152,7 @@ void SensorsComponentController::_stopCalibration(SensorsComponentController::St
     _cancelButton->setEnabled(false);
     
     if (code == StopCalibrationSuccess) {
-        _orientationCalDownSideDone = true;
-        _orientationCalUpsideDownSideDone = true;
-        _orientationCalLeftSideDone = true;
-        _orientationCalRightSideDone = true;
-        _orientationCalTailDownSideDone = true;
-        _orientationCalNoseDownSideDone = true;
-        _orientationCalDownSideInProgress = false;
-        _orientationCalUpsideDownSideInProgress = false;
-        _orientationCalLeftSideInProgress = false;
-        _orientationCalRightSideInProgress = false;
-        _orientationCalNoseDownSideInProgress = false;
-        _orientationCalTailDownSideInProgress = false;
-        emit orientationCalSidesDoneChanged();
-        emit orientationCalSidesInProgressChanged();
+        _resetInternalState();
         
         _progressBar->setProperty("value", 1);
     } else {
@@ -226,6 +243,7 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
     }
 
     _appendStatusLog(text);
+    qCDebug(SensorsComponentControllerLog) << text;
     
     if (_unknownFirmwareVersion) {
         // We don't know how to do visual cal with the version of firwmare

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -32,6 +32,9 @@
 
 #include "UASInterface.h"
 #include "FactPanelController.h"
+#include "QGCLoggingCategory.h"
+
+Q_DECLARE_LOGGING_CATEGORY(SensorsComponentControllerLog)
 
 /// Sensors Component MVC Controller for SensorsComponent.qml.
 class SensorsComponentController : public FactPanelController
@@ -115,6 +118,7 @@ private:
     void _appendStatusLog(const QString& text);
     void _refreshParams(void);
     void _hideAllCalAreas(void);
+    void _resetInternalState(void);
     
     enum StopCalibrationCode {
         StopCalibrationSuccess,


### PR DESCRIPTION
This fixes rotate images showing up at the wrong time. Fixes Issue #1989 