### PR TITLE
README.md update Ubuntu instructions for Qt 5.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,10 @@ Supported builds are 64 bit, built using the clang compiler.
 ### Build on Linux
 Supported builds for Linux are 32 or 64-bit, built using gcc.
 
-#### Install Qt5.4 and SDL1.2 prerequistites
+#### Install Qt 5 and SDL1.2 prerequistites
 * For Fedora: `sudo yum install qt-creator qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtserialport-devel qt5-qtsvg-devel qt5-qtwebkit-devel SDL-devel SDL-static systemd-devel qt5-qtgraphicaleffects qt5-qtquickcontrols qt5-qtlocation-devel`
 * For Arch Linux: `pacman -Sy qtcreator qt5-base qt5-declarative qt5-serialport qt5-svg qt5-webkit`
-* For Ubuntu: Please be aware that the time of writing, Qt5.4 is unavailable in the official repositories Ubuntu 14.04/Mint 17
-    * Add this PPA for Qt5.4: `sudo add-apt-repository ppa:beineri/opt-qt542-trusty`
-        * If you get a 404 error from "apt-get update" below, open System Settings:Software & Updates:Other Software and edit the entry for opt-qt542-trusty to reference Distribution: trusty.
-    * Run the following in your terminal: `sudo apt-get update && sudo apt-get install qt54tools qt54base qt54declarative qt54serialport qt54svg qt54webkit qt54quickcontrols qt54xmlpatterns qt54x11extras qt54websockets qt54sensors qt54script qt54quick1 qt54multimedia qt54location qt54imageformats qt54graphicaleffects qt54connectivity libsdl1.2-dev libudev-dev`
-    * Next, set the environment variables by executing in the terminal: `source /opt/qt54/bin/qt54-env.sh` or copy and paste the contents to your `~/.profile` file to set them on login.
-    * Verify that the variables have been set: `echo $PATH && echo $QTDIR`. The output should read `/opt/qt54/bin:...` and `/opt/qt54`.
+* For Ubuntu: Install Qt 5.5.1 using the Qt online installer. http://download.qt.io/official_releases/online_installers/qt-unified-linux-x64-online.run
 
 If you get this error when running qgroundcontrol: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version 'GLIBCXX_3.4.20' not found. You need to either update to the latest gcc, or install the latest libstdc++.6 using: sudo apt-get install libstdc++6.
 


### PR DESCRIPTION
Maintaining these specific instructions for multiple distros is unsustainable and seems to be fairly brittle. I was thinking something like just pointing everyone to the right version of the qt online installer, but I don't want to just delete the Arch and Fedora instructions that others have added.