### PR TITLE
Flight view continue

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -56,8 +56,9 @@ Item {
 
     readonly property string _mapName:                  "FlightDisplayView"
     readonly property string _showMapBackgroundKey:     "/showMapBackground"
+    readonly property string _mainIsMapKey:             "MainFlyWindowIsMap"
 
-    property bool _mainIsMap:           !_controller.hasVideo
+    property bool _mainIsMap:           QGroundControl.loadBoolGlobalSetting(_mainIsMapKey, true)
 
     property real _roll:                _activeVehicle ? (isNaN(_activeVehicle.roll)    ? _defaultRoll    : _activeVehicle.roll)    : _defaultRoll
     property real _pitch:               _activeVehicle ? (isNaN(_activeVehicle.pitch)   ? _defaultPitch   : _activeVehicle.pitch)   : _defaultPitch
@@ -158,6 +159,7 @@ Item {
                 _mainIsMap = !_mainIsMap
                 pip.visible = false
                 reloadContents();
+                QGroundControl.saveBoolGlobalSetting(_mainIsMapKey, _mainIsMap)
             }
         }
     }

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -77,13 +77,17 @@ Item {
     //-- Instrument Pannel
     QGCInstrumentWidget {
         anchors.margins:    ScreenTools.defaultFontPixelHeight
-        anchors.bottom:     parent.bottom
         anchors.right:      parent.right
+        anchors.bottom:     parent.bottom
         size:               ScreenTools.defaultFontPixelSize * (9)
         active:             _activeVehicle != null
         heading:            _heading
         rollAngle:          _roll
         pitchAngle:         _pitch
+        altitude:           _altitudeWGS84
+        groundSpeed:        _groundSpeed
+        airSpeed:           _airSpeed
+        climbRate:          _climbRate
         isSatellite:        _mainIsMap ? _flightMap ? _flightMap.isSatelliteMap : true : true
         z:                  QGroundControl.zOrderWidgets
     }

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -76,20 +76,20 @@ Item {
 
     //-- Instrument Pannel
     QGCInstrumentWidget {
-        anchors.margins:    ScreenTools.defaultFontPixelHeight
-        anchors.right:      parent.right
-        anchors.bottom:     parent.bottom
-        size:               ScreenTools.defaultFontPixelSize * (9)
-        active:             _activeVehicle != null
-        heading:            _heading
-        rollAngle:          _roll
-        pitchAngle:         _pitch
-        altitude:           _altitudeWGS84
-        groundSpeed:        _groundSpeed
-        airSpeed:           _airSpeed
-        climbRate:          _climbRate
-        isSatellite:        _mainIsMap ? _flightMap ? _flightMap.isSatelliteMap : true : true
-        z:                  QGroundControl.zOrderWidgets
+        anchors.margins:        ScreenTools.defaultFontPixelHeight
+        anchors.right:          parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        size:                   ScreenTools.defaultFontPixelSize * (9)
+        active:                 _activeVehicle != null
+        heading:                _heading
+        rollAngle:              _roll
+        pitchAngle:             _pitch
+        altitude:               _altitudeWGS84
+        groundSpeed:            _groundSpeed
+        airSpeed:               _airSpeed
+        climbRate:              _climbRate
+        isSatellite:            _mainIsMap ? _flightMap ? _flightMap.isSatelliteMap : true : true
+        z:                      QGroundControl.zOrderWidgets
     }
 
     //-- Vertical Tool Buttons
@@ -97,7 +97,7 @@ Item {
         id:                         toolColumn
         anchors.margins:            ScreenTools.defaultFontPixelHeight
         anchors.left:               parent.left
-        anchors.top:                parent.top
+        anchors.verticalCenter:     parent.verticalCenter
         spacing:                    ScreenTools.defaultFontPixelHeight
 
         //-- Map Center Control

--- a/src/FlightMap/Images/compassInstrumentDial.svg
+++ b/src/FlightMap/Images/compassInstrumentDial.svg
@@ -1,84 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 288 288" enable-background="new 0 0 288 288" xml:space="preserve">
-<circle opacity="0.15" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-miterlimit="10" cx="144" cy="144" r="126"/>
-<circle fill="none" cx="144" cy="144" r="124.342"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="144" y1="21.684" x2="144" y2="41.579"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="82.842" y1="38.071" x2="92.789" y2="55.301"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="38.071" y1="82.842" x2="55.301" y2="92.789"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="21.684" y1="144" x2="41.579" y2="144"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="38.071" y1="205.158" x2="55.301" y2="195.211"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="82.842" y1="249.929" x2="92.789" y2="232.699"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="144" y1="266.316" x2="144" y2="246.421"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="205.158" y1="249.929" x2="195.211" y2="232.699"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="249.929" y1="205.158" x2="232.699" y2="195.211"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="266.316" y1="144" x2="246.421" y2="144"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="249.929" y1="82.842" x2="232.699" y2="92.789"/>
-<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="205.158" y1="38.071" x2="195.211" y2="55.301"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="144" y1="21.684" x2="144" y2="34.496"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="122.76" y1="23.542" x2="124.985" y2="36.159"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="102.166" y1="29.061" x2="106.547" y2="41.1"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="82.842" y1="38.071" x2="89.248" y2="49.167"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="65.377" y1="50.301" x2="73.612" y2="60.115"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="50.301" y1="65.377" x2="60.115" y2="73.612"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="38.071" y1="82.842" x2="49.167" y2="89.248"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="29.061" y1="102.166" x2="41.1" y2="106.547"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="23.542" y1="122.76" x2="36.159" y2="124.985"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="21.684" y1="144" x2="34.496" y2="144"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="23.542" y1="165.24" x2="36.159" y2="163.015"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="29.061" y1="185.834" x2="41.1" y2="181.453"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="38.071" y1="205.158" x2="49.167" y2="198.752"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="50.301" y1="222.623" x2="60.115" y2="214.388"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="65.377" y1="237.699" x2="73.612" y2="227.885"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="82.842" y1="249.929" x2="89.248" y2="238.833"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="102.166" y1="258.939" x2="106.547" y2="246.9"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="122.76" y1="264.458" x2="124.985" y2="251.841"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="144" y1="266.316" x2="144" y2="253.504"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="165.24" y1="264.458" x2="163.015" y2="251.841"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="185.834" y1="258.939" x2="181.453" y2="246.9"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="205.158" y1="249.929" x2="198.752" y2="238.833"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="222.623" y1="237.699" x2="214.388" y2="227.885"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="237.699" y1="222.623" x2="227.885" y2="214.388"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="249.929" y1="205.158" x2="238.833" y2="198.752"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="258.939" y1="185.834" x2="246.9" y2="181.453"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="264.458" y1="165.24" x2="251.841" y2="163.015"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="266.316" y1="144" x2="253.504" y2="144"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="264.458" y1="122.76" x2="251.841" y2="124.985"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="258.939" y1="102.166" x2="246.9" y2="106.547"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="249.929" y1="82.842" x2="238.833" y2="89.248"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="237.699" y1="65.377" x2="227.885" y2="73.612"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="222.623" y1="50.301" x2="214.388" y2="60.115"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="205.158" y1="38.071" x2="198.752" y2="49.167"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="185.834" y1="29.061" x2="181.453" y2="41.1"/>
-<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="165.24" y1="23.542" x2="163.015" y2="36.159"/>
+	 viewBox="-161 253 288 288" enable-background="new -161 253 288 288" xml:space="preserve">
+<circle opacity="0.15" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-miterlimit="10" enable-background="new    " cx="-17" cy="397" r="138.6"/>
+<circle fill="none" cx="-17" cy="397" r="136.776"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="-17" y1="262.452" x2="-17" y2="284.337"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="-84.274" y1="280.478" x2="-73.332" y2="299.431"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="-133.522" y1="329.726" x2="-114.569" y2="340.668"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="-151.548" y1="397" x2="-129.663" y2="397"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="-133.522" y1="464.274" x2="-114.569" y2="453.332"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="-84.274" y1="513.522" x2="-73.332" y2="494.569"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="-17" y1="531.548" x2="-17" y2="509.663"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="50.274" y1="513.522" x2="39.332" y2="494.569"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="99.522" y1="464.274" x2="80.569" y2="453.332"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="117.548" y1="397" x2="95.663" y2="397"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="99.522" y1="329.726" x2="80.569" y2="340.668"/>
+<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="50.274" y1="280.478" x2="39.332" y2="299.431"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-17" y1="262.452" x2="-17" y2="276.546"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-40.364" y1="264.496" x2="-37.917" y2="278.375"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-63.017" y1="270.567" x2="-58.198" y2="283.81"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-84.274" y1="280.478" x2="-77.227" y2="292.684"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-103.485" y1="293.931" x2="-94.427" y2="304.727"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-120.069" y1="310.515" x2="-109.273" y2="319.573"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-133.522" y1="329.726" x2="-121.316" y2="336.773"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-143.433" y1="350.983" x2="-130.19" y2="355.802"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-149.504" y1="373.636" x2="-135.625" y2="376.083"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-151.548" y1="397" x2="-137.454" y2="397"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-149.504" y1="420.364" x2="-135.625" y2="417.917"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-143.433" y1="443.017" x2="-130.19" y2="438.198"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-133.522" y1="464.274" x2="-121.316" y2="457.227"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-120.069" y1="483.485" x2="-109.273" y2="474.427"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-103.485" y1="500.069" x2="-94.427" y2="489.273"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-84.274" y1="513.522" x2="-77.227" y2="501.316"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-63.017" y1="523.433" x2="-58.198" y2="510.19"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-40.364" y1="529.504" x2="-37.917" y2="515.625"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="-17" y1="531.548" x2="-17" y2="517.454"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="6.364" y1="529.504" x2="3.916" y2="515.625"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="29.017" y1="523.433" x2="24.198" y2="510.19"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="50.274" y1="513.522" x2="43.227" y2="501.316"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="69.485" y1="500.069" x2="60.427" y2="489.273"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="86.069" y1="483.485" x2="75.273" y2="474.427"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="99.522" y1="464.274" x2="87.316" y2="457.227"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="109.433" y1="443.017" x2="96.19" y2="438.198"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="115.504" y1="420.364" x2="101.625" y2="417.917"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="117.548" y1="397" x2="103.454" y2="397"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="115.504" y1="373.636" x2="101.625" y2="376.083"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="109.433" y1="350.983" x2="96.19" y2="355.802"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="99.522" y1="329.726" x2="87.316" y2="336.773"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="86.069" y1="310.515" x2="75.273" y2="319.573"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="69.485" y1="293.931" x2="60.427" y2="304.727"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="50.274" y1="280.478" x2="43.227" y2="292.684"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="29.017" y1="270.567" x2="24.198" y2="283.81"/>
+<line fill="none" stroke="#FFFFFF" stroke-linecap="round" stroke-miterlimit="10" x1="6.364" y1="264.496" x2="3.916" y2="278.375"/>
 <g>
-	<path fill="#F1F2F2" d="M50.594,153.945l-5.279-19.895h2.701l3.026,13.042c0.326,1.366,0.606,2.723,0.841,4.071
-		c0.507-2.126,0.805-3.352,0.896-3.678l3.786-13.435h3.176l2.85,10.07c0.715,2.497,1.23,4.845,1.547,7.043
-		c0.253-1.258,0.584-2.701,0.991-4.329l3.121-12.784h2.646l-5.455,19.895h-2.538l-4.193-15.159
-		c-0.353-1.267-0.561-2.045-0.624-2.334c-0.208,0.914-0.403,1.692-0.584,2.334l-4.221,15.159H50.594z"/>
+	<path fill="#F1F2F2" d="M-119.747,407.94l-5.807-21.885h2.971l3.329,14.346c0.359,1.503,0.667,2.995,0.925,4.478
+		c0.558-2.339,0.885-3.687,0.986-4.046l4.165-14.779h3.494l3.135,11.077c0.787,2.747,1.353,5.329,1.702,7.747
+		c0.278-1.384,0.642-2.971,1.09-4.762l3.433-14.062h2.911l-6.001,21.885h-2.792l-4.612-16.675c-0.388-1.394-0.617-2.25-0.686-2.567
+		c-0.229,1.005-0.443,1.861-0.642,2.567l-4.643,16.675L-119.747,407.94L-119.747,407.94z"/>
 </g>
 <g>
-	<path fill="#F1F2F2" d="M136.457,234.726l2.402-0.21c0.114,0.962,0.379,1.752,0.795,2.369c0.416,0.617,1.06,1.115,1.935,1.496
-		c0.875,0.381,1.859,0.571,2.953,0.571c0.971,0,1.828-0.144,2.572-0.433c0.744-0.289,1.298-0.685,1.661-1.188
-		c0.363-0.503,0.544-1.052,0.544-1.647c0-0.604-0.175-1.131-0.525-1.581c-0.35-0.451-0.927-0.829-1.732-1.135
-		c-0.516-0.201-1.658-0.514-3.425-0.938s-3.005-0.825-3.714-1.201c-0.919-0.481-1.602-1.078-2.053-1.791
-		c-0.451-0.713-0.677-1.511-0.677-2.395c0-0.971,0.276-1.879,0.827-2.723c0.551-0.844,1.356-1.485,2.415-1.923
-		s2.235-0.656,3.53-0.656c1.426,0,2.684,0.23,3.774,0.689c1.089,0.459,1.926,1.135,2.512,2.028c0.586,0.892,0.901,1.903,0.945,3.031
-		l-2.441,0.184c-0.131-1.216-0.575-2.135-1.331-2.756c-0.757-0.621-1.875-0.932-3.354-0.932c-1.54,0-2.661,0.282-3.365,0.846
-		c-0.704,0.564-1.057,1.245-1.057,2.041c0,0.691,0.249,1.26,0.748,1.706c0.49,0.446,1.77,0.903,3.839,1.371
-		c2.069,0.468,3.488,0.877,4.258,1.227c1.12,0.516,1.947,1.17,2.48,1.962s0.801,1.704,0.801,2.736c0,1.024-0.293,1.988-0.879,2.894
-		c-0.586,0.906-1.428,1.61-2.525,2.113c-1.098,0.503-2.334,0.755-3.708,0.755c-1.741,0-3.199-0.254-4.376-0.761
-		s-2.1-1.271-2.769-2.29C136.845,237.164,136.492,236.012,136.457,234.726z"/>
+	<path fill="#F1F2F2" d="M-25.297,496.799l2.642-0.231c0.125,1.058,0.417,1.927,0.874,2.606s1.166,1.227,2.128,1.646
+		c0.962,0.419,2.045,0.628,3.248,0.628c1.068,0,2.011-0.158,2.829-0.476c0.818-0.318,1.428-0.753,1.827-1.307
+		c0.399-0.553,0.598-1.157,0.598-1.812c0-0.664-0.193-1.244-0.577-1.739c-0.385-0.496-1.02-0.912-1.905-1.248
+		c-0.568-0.221-1.824-0.565-3.768-1.032s-3.306-0.908-4.085-1.321c-1.011-0.529-1.762-1.186-2.258-1.97
+		c-0.496-0.784-0.745-1.662-0.745-2.635c0-1.068,0.304-2.067,0.91-2.995s1.492-1.634,2.656-2.115
+		c1.165-0.482,2.459-0.722,3.883-0.722c1.569,0,2.952,0.253,4.151,0.758c1.198,0.505,2.119,1.248,2.763,2.231
+		c0.645,0.981,0.991,2.093,1.04,3.334l-2.685,0.202c-0.144-1.338-0.632-2.349-1.464-3.032c-0.833-0.683-2.062-1.025-3.689-1.025
+		c-1.694,0-2.927,0.31-3.702,0.931c-0.774,0.62-1.163,1.37-1.163,2.245c0,0.76,0.274,1.386,0.823,1.877
+		c0.539,0.491,1.947,0.993,4.223,1.508s3.837,0.965,4.684,1.35c1.232,0.568,2.142,1.287,2.728,2.158
+		c0.586,0.871,0.881,1.874,0.881,3.01c0,1.126-0.322,2.187-0.967,3.183c-0.645,0.997-1.571,1.771-2.777,2.324
+		c-1.208,0.553-2.567,0.831-4.079,0.831c-1.915,0-3.519-0.279-4.814-0.837s-2.31-1.398-3.046-2.519
+		C-24.87,499.48-25.259,498.213-25.297,496.799z"/>
 </g>
 <g>
-	<path fill="#F1F2F2" d="M227.472,154.355v-19.895h14.385v2.348h-11.752v6.093h11.006v2.334h-11.006v6.772h12.213v2.348H227.472z"/>
+	<path fill="#F1F2F2" d="M74.819,408.391v-21.885h15.823v2.583H77.715v6.702h12.107v2.567H77.715v7.449H91.15v2.583H74.819
+		L74.819,408.391z"/>
 </g>
 <g>
-	<path fill="#F1F2F2" d="M136.071,67.065V47.17h2.701l10.45,15.62V47.17h2.524v19.895h-2.701l-10.45-15.634v15.634H136.071z"/>
+	<path fill="#F1F2F2" d="M-25.722,312.371v-21.884h2.971l11.495,17.182v-17.182h2.776v21.884h-2.971l-11.495-17.197v17.197H-25.722z
+		"/>
 </g>
-<polygon fill="#F1F2F2" points="139.026,268.342 144,258.395 148.974,268.342 "/>
-<polygon fill="#F1F2F2" points="268.342,148.974 258.395,144 268.342,139.026 "/>
-<polygon fill="#F1F2F2" points="148.974,19.658 144,29.605 139.026,19.658 "/>
-<polygon fill="#F1F2F2" points="19.658,139.026 29.605,144 19.658,148.974 "/>
+<polygon fill="#F1F2F2" points="-22.471,533.776 -17,522.834 -11.529,533.776 "/>
+<polygon fill="#F1F2F2" points="119.776,402.471 108.834,397 119.776,391.529 "/>
+<polygon fill="#F1F2F2" points="-11.529,260.224 -17,271.165 -22.471,260.224 "/>
+<polygon fill="#F1F2F2" points="-153.776,391.529 -142.835,397 -153.776,402.471 "/>
 </svg>

--- a/src/FlightMap/Widgets/QGCCompassWidget.qml
+++ b/src/FlightMap/Widgets/QGCCompassWidget.qml
@@ -49,9 +49,7 @@ Item {
         id:             borderRect
         anchors.fill:   parent
         radius:         width / 2
-        color:          "#202020"
-        border.color:   "black"
-        border.width:   2
+        color:          "black"
     }
 
     Item {

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -88,7 +88,7 @@ Item {
                     horizontalAlignment: TextEdit.AlignHCenter
                 }
                 QGCLabel {
-                    text:           altitude
+                    text:           altitude.toFixed(1)
                     font.weight:    Font.DemiBold
                     color:          isSatellite ? "black" : "white"
                 }
@@ -110,7 +110,7 @@ Item {
                     horizontalAlignment: TextEdit.AlignHCenter
                 }
                 QGCLabel {
-                    text:           groundSpeed
+                    text:           groundSpeed.toFixed(1)
                     font.weight:    Font.DemiBold
                     color:          isSatellite ? "black" : "white"
                 }
@@ -134,7 +134,7 @@ Item {
                     horizontalAlignment: TextEdit.AlignHCenter
                 }
                 QGCLabel {
-                    text:           airSpeed
+                    text:           airSpeed.toFixed(1)
                     font.weight:    Font.DemiBold
                     color:          isSatellite ? "black" : "white"
                 }
@@ -156,7 +156,7 @@ Item {
                     horizontalAlignment: TextEdit.AlignHCenter
                 }
                 QGCLabel {
-                    text:           climbRate
+                    text:           climbRate.toFixed(1)
                     font.weight:    Font.DemiBold
                     color:          isSatellite ? "black" : "white"
                 }

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -39,7 +39,10 @@ Item {
     property alias  heading:        compass.heading
     property alias  rollAngle:      attitude.rollAngle
     property alias  pitchAngle:     attitude.pitchAngle
-
+    property real   altitude:       0
+    property real   groundSpeed:    0
+    property real   airSpeed:       0
+    property real   climbRate:      0
     property real   size:           ScreenTools.defaultFontPixelSize * (10)
     property bool   isSatellite:    false
     property bool   active:         false
@@ -49,29 +52,127 @@ Item {
     //-- Instrument Pannel
     Rectangle {
         id:                 instrumentPannel
-        anchors.right:      parent.right
-        anchors.bottom:     parent.bottom
-        height:             root.size
-        width:              instruments.width + ScreenTools.defaultFontPixelSize
+        height:             instruments.height + ScreenTools.defaultFontPixelSize
+        width:              root.size
         radius:             root.size / 2
         visible:            _isVisible
-        color:              isSatellite ? Qt.rgba(1,1,1,0.5) : Qt.rgba(0,0,0,0.5)
-        Row {
+        color:              isSatellite ? Qt.rgba(1,1,1,0.75) : Qt.rgba(0,0,0,0.75)
+        anchors.right:      parent.right
+        anchors.bottom:     parent.bottom
+        Column {
             id:                 instruments
-            height:             parent.height
-            spacing:            ScreenTools.defaultFontPixelSize / 2
-            anchors.horizontalCenter:   parent.horizontalCenter
+            width:              parent.width
+            spacing:            ScreenTools.defaultFontPixelSize * 0.33
+            anchors.verticalCenter: parent.verticalCenter
+            //-- Attitude Indicator
             QGCAttitudeWidget {
                 id:             attitude
-                size:           parent.height * 0.9
+                size:           parent.width * 0.9
                 active:         root.active
-                anchors.verticalCenter: parent.verticalCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            //-- Altitude
+            Rectangle {
+                height:         1
+                width:          parent.width * 0.9
+                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            Row {
+                width: root.size * 0.8
+                anchors.horizontalCenter: parent.horizontalCenter
+                QGCLabel {
+                    text:           "H"
+                    width:          parent.width * 0.45
+                    color:          isSatellite ? "black" : "white"
+                    horizontalAlignment: TextEdit.AlignHCenter
+                }
+                QGCLabel {
+                    text:           altitude
+                    font.weight:    Font.DemiBold
+                    color:          isSatellite ? "black" : "white"
+                }
+            }
+            //-- Ground Speed
+            Rectangle {
+                height:         1
+                width:          parent.width * 0.9
+                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            Row {
+                width: root.size * 0.8
+                anchors.horizontalCenter: parent.horizontalCenter
+                QGCLabel {
+                    text:           "GS"
+                    width:          parent.width * 0.45
+                    color:          isSatellite ? "black" : "white"
+                    horizontalAlignment: TextEdit.AlignHCenter
+                }
+                QGCLabel {
+                    text:           groundSpeed
+                    font.weight:    Font.DemiBold
+                    color:          isSatellite ? "black" : "white"
+                }
+            }
+            //-- Air Speed
+            Rectangle {
+                height:         1
+                width:          parent.width * 0.9
+                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible:        airSpeed > 0
+            }
+            Row {
+                width: root.size * 0.8
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible:        airSpeed > 0
+                QGCLabel {
+                    text:           "AS"
+                    width:          parent.width * 0.45
+                    color:          isSatellite ? "black" : "white"
+                    horizontalAlignment: TextEdit.AlignHCenter
+                }
+                QGCLabel {
+                    text:           airSpeed
+                    font.weight:    Font.DemiBold
+                    color:          isSatellite ? "black" : "white"
+                }
+            }
+            //-- Climb Rate
+            Rectangle {
+                height:         1
+                width:          parent.width * 0.9
+                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+            Row {
+                width: root.size * 0.8
+                anchors.horizontalCenter: parent.horizontalCenter
+                QGCLabel {
+                    text:           "VS"
+                    width:          parent.width * 0.45
+                    color:          isSatellite ? "black" : "white"
+                    horizontalAlignment: TextEdit.AlignHCenter
+                }
+                QGCLabel {
+                    text:           climbRate
+                    font.weight:    Font.DemiBold
+                    color:          isSatellite ? "black" : "white"
+                }
+            }
+            //-- Compass
+            Rectangle {
+                height:         1
+                width:          parent.width * 0.9
+                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+                anchors.horizontalCenter: parent.horizontalCenter
             }
             QGCCompassWidget {
                 id:             compass
-                size:           parent.height * 0.9
+                size:           parent.width * 0.9
                 active:         root.active
-                anchors.verticalCenter: parent.verticalCenter
+                anchors.horizontalCenter: parent.horizontalCenter
             }
         }
         MouseArea {

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -83,14 +83,18 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 QGCLabel {
                     text:           "H"
+                    font.pixelSize: ScreenTools.defaultFontPixelSize * 1.25
                     width:          parent.width * 0.45
                     color:          isSatellite ? "black" : "white"
                     horizontalAlignment: TextEdit.AlignHCenter
                 }
                 QGCLabel {
                     text:           altitude.toFixed(1)
+                    font.pixelSize: ScreenTools.defaultFontPixelSize * 1.25
                     font.weight:    Font.DemiBold
+                    width:          parent.width * 0.549
                     color:          isSatellite ? "black" : "white"
+                    horizontalAlignment: TextEdit.AlignHCenter
                 }
             }
             //-- Ground Speed
@@ -105,14 +109,18 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 QGCLabel {
                     text:           "GS"
+                    font.pixelSize: ScreenTools.defaultFontPixelSize * 0.75
                     width:          parent.width * 0.45
                     color:          isSatellite ? "black" : "white"
                     horizontalAlignment: TextEdit.AlignHCenter
                 }
                 QGCLabel {
                     text:           groundSpeed.toFixed(1)
+                    font.pixelSize: ScreenTools.defaultFontPixelSize * 0.75
                     font.weight:    Font.DemiBold
+                    width:          parent.width * 0.549
                     color:          isSatellite ? "black" : "white"
+                    horizontalAlignment: TextEdit.AlignHCenter
                 }
             }
             //-- Air Speed
@@ -129,14 +137,18 @@ Item {
                 visible:        airSpeed > 0
                 QGCLabel {
                     text:           "AS"
+                    font.pixelSize: ScreenTools.defaultFontPixelSize * 0.75
                     width:          parent.width * 0.45
                     color:          isSatellite ? "black" : "white"
                     horizontalAlignment: TextEdit.AlignHCenter
                 }
                 QGCLabel {
                     text:           airSpeed.toFixed(1)
+                    font.pixelSize: ScreenTools.defaultFontPixelSize * 0.75
                     font.weight:    Font.DemiBold
+                    width:          parent.width * 0.549
                     color:          isSatellite ? "black" : "white"
+                    horizontalAlignment: TextEdit.AlignHCenter
                 }
             }
             //-- Climb Rate
@@ -151,14 +163,18 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 QGCLabel {
                     text:           "VS"
+                    font.pixelSize: ScreenTools.defaultFontPixelSize * 0.75
                     width:          parent.width * 0.45
                     color:          isSatellite ? "black" : "white"
                     horizontalAlignment: TextEdit.AlignHCenter
                 }
                 QGCLabel {
                     text:           climbRate.toFixed(1)
+                    font.pixelSize: ScreenTools.defaultFontPixelSize * 0.75
                     font.weight:    Font.DemiBold
+                    width:          parent.width * 0.549
                     color:          isSatellite ? "black" : "white"
+                    horizontalAlignment: TextEdit.AlignHCenter
                 }
             }
             //-- Compass

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -51,14 +51,14 @@ Item {
 
     //-- Instrument Pannel
     Rectangle {
-        id:                 instrumentPannel
-        height:             instruments.height + ScreenTools.defaultFontPixelSize
-        width:              root.size
-        radius:             root.size / 2
-        visible:            _isVisible
-        color:              isSatellite ? Qt.rgba(1,1,1,0.75) : Qt.rgba(0,0,0,0.75)
-        anchors.right:      parent.right
-        anchors.bottom:     parent.bottom
+        id:                     instrumentPannel
+        height:                 instruments.height + ScreenTools.defaultFontPixelSize
+        width:                  root.size
+        radius:                 root.size / 2
+        visible:                _isVisible
+        color:                  isSatellite ? Qt.rgba(1,1,1,0.75) : Qt.rgba(0,0,0,0.75)
+        anchors.right:          parent.right
+        anchors.verticalCenter: parent.verticalCenter
         Column {
             id:                 instruments
             width:              parent.width
@@ -185,14 +185,14 @@ Item {
 
     //-- Show Instruments
     Rectangle {
-        id:                 openButton
-        anchors.right:      parent.right
-        anchors.bottom:     parent.bottom
-        height:             ScreenTools.defaultFontPixelSize * 2
-        width:              ScreenTools.defaultFontPixelSize * 2
-        radius:             ScreenTools.defaultFontPixelSize / 3
-        visible:            !_isVisible
-        color:              isSatellite ? Qt.rgba(1,1,1,0.5) : Qt.rgba(0,0,0,0.5)
+        id:                     openButton
+        anchors.right:          parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        height:                 ScreenTools.defaultFontPixelSize * 2
+        width:                  ScreenTools.defaultFontPixelSize * 2
+        radius:                 ScreenTools.defaultFontPixelSize / 3
+        visible:                !_isVisible
+        color:                  isSatellite ? Qt.rgba(1,1,1,0.5) : Qt.rgba(0,0,0,0.5)
         Image {
             width:              parent.width  * 0.75
             height:             parent.height * 0.75

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -1,30 +1,32 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
 #include "QGroundControlQmlGlobal.h"
+
+static const char* kQmlGlobalKeyName = "QGCQml";
 
 QGroundControlQmlGlobal::QGroundControlQmlGlobal(QObject* parent)
     : QObject(parent)
@@ -37,4 +39,32 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QObject* parent)
 QGroundControlQmlGlobal::~QGroundControlQmlGlobal()
 {
 
+}
+
+void QGroundControlQmlGlobal::saveGlobalSetting (const QString& key, const QString& value)
+{
+    QSettings settings;
+    settings.beginGroup(kQmlGlobalKeyName);
+    settings.setValue(key, value);
+}
+
+QString QGroundControlQmlGlobal::loadGlobalSetting (const QString& key, const QString& defaultValue)
+{
+    QSettings settings;
+    settings.beginGroup(kQmlGlobalKeyName);
+    return settings.value(key, defaultValue).toString();
+}
+
+void QGroundControlQmlGlobal::saveBoolGlobalSetting (const QString& key, bool value)
+{
+    QSettings settings;
+    settings.beginGroup(kQmlGlobalKeyName);
+    settings.setValue(key, value);
+}
+
+bool QGroundControlQmlGlobal::loadBoolGlobalSetting (const QString& key, bool defaultValue)
+{
+    QSettings settings;
+    settings.beginGroup(kQmlGlobalKeyName);
+    return settings.value(key, defaultValue).toBool();
 }

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -47,6 +47,11 @@ public:
     Q_PROPERTY(qreal                zOrderWidgets       READ zOrderWidgets          CONSTANT) ///< z order value to widgets, for example: zoom controls, hud widgetss
     Q_PROPERTY(qreal                zOrderMapItems      READ zOrderMapItems         CONSTANT) ///< z order value for map items, for example: mission item indicators
 
+    Q_INVOKABLE void    saveGlobalSetting       (const QString& key, const QString& value);
+    Q_INVOKABLE QString loadGlobalSetting       (const QString& key, const QString& defaultValue);
+    Q_INVOKABLE void    saveBoolGlobalSetting   (const QString& key, bool value);
+    Q_INVOKABLE bool    loadBoolGlobalSetting   (const QString& key, bool defaultValue);
+
     // Property accesors
 
     HomePositionManager*    homePositionManager ()      { return _homePositionManager; }


### PR DESCRIPTION
I made the *Instrument Panel* vertical to optimize screen real estate.
I've added some basic telemetry data to the panel. For now we have:

* Altitude (WGS84)
* Ground Speed
* Air Speed (Only shows if there is one to show)
* Vertical Speed (Climb Rate)

Once we figure out what else should go there I can add it. These are some possibilities:

* Altitude Above Ground
* Some kind of a timer, possibly started when armed
* Distance from Ground Station (Ground Station needs its own GPS coordinates for this)

![screen shot 2015-10-27 at 1 47 46 pm](https://cloud.githubusercontent.com/assets/749243/10767364/2844f58c-7cb2-11e5-8792-7696a81fbd59.png)

While at it, I've added a save/restore setting for *Map Is Main* for the fly view. I've also added a global settings set of functions to QGroundControlQmlGlobal to handle it. 

