### PR TITLE
Fix artificial horizon (it was stuck)

### DIFF
--- a/src/FlightMap/Widgets/QGCArtificialHorizon.qml
+++ b/src/FlightMap/Widgets/QGCArtificialHorizon.qml
@@ -72,7 +72,7 @@ Item {
             Rotation {
                 origin.x: artificialHorizon.width  / 2
                 origin.y: artificialHorizon.height / 2
-                angle: root.visible ? -rollAngle : 0
+                angle:    -rollAngle
             }]
     }
 }

--- a/src/FlightMap/Widgets/QGCArtificialHorizon.qml
+++ b/src/FlightMap/Widgets/QGCArtificialHorizon.qml
@@ -35,6 +35,9 @@ Item {
     property real pitchAngle:   0
     clip:           true
     anchors.fill:   parent
+
+    property real angularScale: pitchAngle * root.height / 45
+
     Item {
         id: artificialHorizon
         width:  root.width  * 4
@@ -67,7 +70,7 @@ Item {
         }
         transform: [
             Translate {
-                y:  pitchAngle * 4
+                y:  angularScale
             },
             Rotation {
                 origin.x: artificialHorizon.width  / 2

--- a/src/FlightMap/Widgets/QGCArtificialHorizon.qml
+++ b/src/FlightMap/Widgets/QGCArtificialHorizon.qml
@@ -67,7 +67,7 @@ Item {
         }
         transform: [
             Translate {
-                y:  root.visible ? pitchAngle * 4 : 0
+                y:  pitchAngle * 4
             },
             Rotation {
                 origin.x: artificialHorizon.width  / 2


### PR DESCRIPTION
This fixes #2135 

The trick to get a circular mask relies on the root entity to be hidden (*visible: false*). The mask element makes only the masked out parts visible. The artificial horizon code had a check to see if it was *visible* and it wouldn't do anything if *hidden*.

![screen shot 2015-10-28 at 11 54 13 am](https://cloud.githubusercontent.com/assets/749243/10794457/584664be-7d6b-11e5-83fa-9559d00b9ee5.png)
