### PR TITLE
Fix state of buttons (menu, toolbar)

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -553,9 +553,21 @@ void MainWindow::connectCommonActions()
     connect(_ui.actionFlight,   &QAction::triggered,    this, &MainWindow::showFlyView);
     connect(_ui.actionPlan,     &QAction::triggered,    this, &MainWindow::showPlanView);
     connect(_ui.actionSetup,    &QAction::triggered,    this, &MainWindow::showSetupView);
+    connect(_ui.actionFlight,   &QAction::triggered,    this, &MainWindow::handleActiveViewActionState);
+    connect(_ui.actionPlan,     &QAction::triggered,    this, &MainWindow::handleActiveViewActionState);
+    connect(_ui.actionSetup,    &QAction::triggered,    this, &MainWindow::handleActiveViewActionState);
 
     // Connect internal actions
     connect(MultiVehicleManager::instance(), &MultiVehicleManager::vehicleAdded, this, &MainWindow::_vehicleAdded);
+}
+
+void MainWindow::handleActiveViewActionState(bool triggered)
+{
+    Q_UNUSED(triggered);
+    QAction *triggeredAction = qobject_cast<QAction*>(sender());
+    _ui.actionFlight->setChecked(triggeredAction == _ui.actionFlight);
+    _ui.actionPlan->setChecked(triggeredAction == _ui.actionPlan);
+    _ui.actionSetup->setChecked(triggeredAction == _ui.actionSetup);
 }
 
 void MainWindow::_openUrl(const QString& url, const QString& errorMessage)

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -134,6 +134,15 @@ protected slots:
      */
     void showStatusBarCallback(bool checked);
 
+    /**
+     * @brief Disable the other QActions that trigger view mode changes
+     *
+     * When a user hits Ctrl+1, Ctrl+2, Ctrl+3  - only one view is set to active
+     * (and in the QML file for the MainWindow the others are set to have
+     * visibility = false), but on the Menu all of them would be selected making
+     * this incoherent.
+     */
+    void handleActiveViewActionState(bool triggered);
 signals:
     // Signals the Qml to show the specified view
     void showFlyView(void);

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -445,6 +445,13 @@ Rectangle {
                     flyButton.repaintChevron     = true;
                 }
             }
+            Connections {
+                target:controller
+                onShowFlyView:  { flyButton.checked   = true }
+                onShowPlanView: { planButton.checked  = true }
+                onShowSetupView:{ setupButton.checked = true }
+            }
+
 
             ExclusiveGroup { id: mainActionGroup }
 


### PR DESCRIPTION
When you selected via the Menu to go to Fly Mode, the QML
toolbar didn't followed the option, and if you selected
via the menu to go to all the three possible views (setup,
fly and plan) the menu would be all-selected.

This tries to keep consistency of things.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>