### PR TITLE
Remove Flightgear and JSBSim and only leave options which work

### DIFF
--- a/src/ui/QGCHilConfiguration.cc
+++ b/src/ui/QGCHilConfiguration.cc
@@ -114,17 +114,19 @@ void QGCHilConfiguration::on_simComboBox_currentIndexChanged(int index)
             connect(xplane, SIGNAL(statusMessage(QString)), ui->statusLabel, SLOT(setText(QString)));
         }
     }
-    else if (4)
-    {
-        // Ensure the sim exists and is disabled
-        _vehicle->uas()->enableHilJSBSim(false, "");
-        QGCHilJSBSimConfiguration* hfgconf = new QGCHilJSBSimConfiguration(_vehicle, this);
-        hfgconf->show();
-        ui->simulatorConfigurationLayout->addWidget(hfgconf);
-        QGCJSBSimLink* jsb = dynamic_cast<QGCJSBSimLink*>(_vehicle->uas()->getHILSimulation());
-        if (jsb)
-        {
-            connect(jsb, SIGNAL(statusMessage(QString)), ui->statusLabel, SLOT(setText(QString)));
-        }
-    }
+// Disabling JSB Sim since its not well maintained,
+// but as refactoring is pending we're not ditching the code yet
+//    else if (4)
+//    {
+//        // Ensure the sim exists and is disabled
+//        _vehicle->uas()->enableHilJSBSim(false, "");
+//        QGCHilJSBSimConfiguration* hfgconf = new QGCHilJSBSimConfiguration(_vehicle, this);
+//        hfgconf->show();
+//        ui->simulatorConfigurationLayout->addWidget(hfgconf);
+//        QGCJSBSimLink* jsb = dynamic_cast<QGCJSBSimLink*>(_vehicle->uas()->getHILSimulation());
+//        if (jsb)
+//        {
+//            connect(jsb, SIGNAL(statusMessage(QString)), ui->statusLabel, SLOT(setText(QString)));
+//        }
+//    }
 }

--- a/src/ui/QGCHilConfiguration.ui
+++ b/src/ui/QGCHilConfiguration.ui
@@ -52,11 +52,6 @@
        <string>X-Plane 9</string>
       </property>
      </item>
-     <item>
-      <property name="text">
-       <string>JSBSim</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
@@ -69,7 +64,7 @@
    <item row="2" column="0" colspan="2">
     <widget class="QLabel" name="statusLabel">
      <property name="text">
-      <string></string>
+      <string/>
      </property>
     </widget>
    </item>

--- a/src/ui/QGCHilFlightGearConfiguration.cc
+++ b/src/ui/QGCHilFlightGearConfiguration.cc
@@ -29,18 +29,18 @@ QGCHilFlightGearConfiguration::QGCHilFlightGearConfiguration(Vehicle* vehicle, Q
     QStringList items;
     if (_vehicle->vehicleType() == MAV_TYPE_FIXED_WING)
     {
-        items << "EasyStar";
+        /*items << "EasyStar";*/
         items << "Rascal110-JSBSim";
-        items << "c172p";
+        /*items << "c172p";
         items << "YardStik";
-        items << "Malolo1";
+        items << "Malolo1";*/
         _mavSettingsSubGroup = _mavSettingsSubGroupFixedWing;
     }
-    else if (_vehicle->vehicleType() == MAV_TYPE_QUADROTOR)
+    /*else if (_vehicle->vehicleType() == MAV_TYPE_QUADROTOR)
     {
         items << "arducopter";
         _mavSettingsSubGroup = _mavSettingsSubGroupQuadRotor;
-    }
+    }*/
     else
     {
         // FIXME: Should disable all input, won't work. Show error message in the status label thing.


### PR DESCRIPTION
@DonLakeFlyer This is not a complete cleanup, but I'd like to do that once we figure out HIL in general. Also need to think about simulation on tablets (so users can learn how to use QGC). Right now just making sure the options which are displayed actually work.