### PR TITLE
Mavlink log test

### DIFF
--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -488,6 +488,7 @@ SOURCES += \
     src/qgcunittest/TCPLinkTest.cc \
     src/qgcunittest/TCPLoopBackServer.cc \
     src/qgcunittest/UnitTest.cc \
+    src/qgcunittest/UnitTestList.cc \
     src/VehicleSetup/SetupViewTest.cc \
 } # DebugBuild|WindowsDebugAndRelease
 } # MobileBuild

--- a/src/FactSystem/FactSystemTestGeneric.cc
+++ b/src/FactSystem/FactSystemTestGeneric.cc
@@ -27,8 +27,6 @@
 #include "FactSystemTestGeneric.h"
 #include "QGCMAVLink.h"
 
-UT_REGISTER_TEST(FactSystemTestGeneric)
-
 /// FactSystem Unit Test for PX4 autpilot
 FactSystemTestGeneric::FactSystemTestGeneric(void)
 {

--- a/src/FactSystem/FactSystemTestPX4.cc
+++ b/src/FactSystem/FactSystemTestPX4.cc
@@ -27,8 +27,6 @@
 #include "FactSystemTestPX4.h"
 #include "QGCMAVLink.h"
 
-UT_REGISTER_TEST(FactSystemTestPX4)
-
 /// FactSystem Unit Test for PX4 autpilot
 FactSystemTestPX4::FactSystemTestPX4(void)
 {

--- a/src/MissionItemTest.cc
+++ b/src/MissionItemTest.cc
@@ -24,8 +24,6 @@
 #include "MissionItemTest.h"
 #include "MissionItem.h"
 
-UT_REGISTER_TEST(MissionItemTest)
-
 const MissionItemTest::ItemInfo_t MissionItemTest::_rgItemInfo[] = {
     { 1, QGeoCoordinate(-10.0, -20.0, -30.0), MAV_CMD_NAV_WAYPOINT,         10.0, 20.0, 30.0, 1.0, true, false, MAV_FRAME_GLOBAL_RELATIVE_ALT },
     { 1, QGeoCoordinate(-10.0, -20.0, -30.0), MAV_CMD_NAV_LOITER_UNLIM,     10.0, 20.0, 30.0, 1.0, true, false, MAV_FRAME_GLOBAL_RELATIVE_ALT },

--- a/src/MissionManager/MissionControllerTest.cc
+++ b/src/MissionManager/MissionControllerTest.cc
@@ -25,8 +25,6 @@
 #include "LinkManager.h"
 #include "MultiVehicleManager.h"
 
-UT_REGISTER_TEST(MissionControllerTest)
-
 MissionControllerTest::MissionControllerTest(void)
     : _multiSpyMissionController(NULL)
     , _multiSpyMissionItem(NULL)

--- a/src/MissionManager/MissionManagerTest.cc
+++ b/src/MissionManager/MissionManagerTest.cc
@@ -25,9 +25,6 @@
 #include "LinkManager.h"
 #include "MultiVehicleManager.h"
 
-// FIXME: Temporarily disabled until this can be stabilized
-//UT_REGISTER_TEST(MissionManagerTest)
-
 const MissionManagerTest::TestCase_t MissionManagerTest::_rgTestCases[] = {
     { "0\t0\t3\t16\t10\t20\t30\t40\t-10\t-20\t-30\t1\r\n",  { 0, QGeoCoordinate(-10.0, -20.0, -30.0), MAV_CMD_NAV_WAYPOINT,     10.0, 20.0, 30.0, 40.0, true, false, MAV_FRAME_GLOBAL_RELATIVE_ALT } },
     { "1\t0\t3\t17\t10\t20\t30\t40\t-10\t-20\t-30\t1\r\n",  { 1, QGeoCoordinate(-10.0, -20.0, -30.0), MAV_CMD_NAV_LOITER_UNLIM, 10.0, 20.0, 30.0, 40.0, true, false, MAV_FRAME_GLOBAL_RELATIVE_ALT } },

--- a/src/VehicleSetup/SetupViewTest.cc
+++ b/src/VehicleSetup/SetupViewTest.cc
@@ -29,8 +29,6 @@
 #include "QGCMessageBox.h"
 #include "MultiVehicleManager.h"
 
-UT_REGISTER_TEST(SetupViewTest)
-
 void SetupViewTest::_clickThrough_test(void)
 {
     _connectMockLink();

--- a/src/main.cc
+++ b/src/main.cc
@@ -151,12 +151,12 @@ int main(int argc, char *argv[])
     Q_IMPORT_PLUGIN(QGeoServiceProviderFactoryQGC)
 
     bool runUnitTests = false;          // Run unit tests
-    bool stressUnitTests = false;       // Stress test unit tests
 
 #ifdef QT_DEBUG
     // We parse a small set of command line options here prior to QGCApplication in order to handle the ones
     // which need to be handled before a QApplication object is started.
 
+    bool stressUnitTests = false;       // Stress test unit tests
     bool quietWindowsAsserts = false;   // Don't let asserts pop dialog boxes
 
     QString unitTestOptions;

--- a/src/qgcunittest/FileDialogTest.cc
+++ b/src/qgcunittest/FileDialogTest.cc
@@ -29,8 +29,6 @@
 #include "FileDialogTest.h"
 #include "QGCFileDialog.h"
 
-UT_REGISTER_TEST(FileDialogTest)
-
 FileDialogTest::FileDialogTest(void)
 {
     

--- a/src/qgcunittest/FileManagerTest.cc
+++ b/src/qgcunittest/FileManagerTest.cc
@@ -29,8 +29,6 @@
 #include "UAS.h"
 #include "QGCApplication.h"
 
-//UT_REGISTER_TEST(FileManagerTest)
-
 FileManagerTest::FileManagerTest(void)
     : _fileServer(NULL)
     , _fileManager(NULL)

--- a/src/qgcunittest/FlightGearTest.cc
+++ b/src/qgcunittest/FlightGearTest.cc
@@ -29,8 +29,6 @@
 ///
 ///     @author Don Gagne <don@thegagnes.com>
 
-UT_REGISTER_TEST(FlightGearUnitTest)
-
 FlightGearUnitTest::FlightGearUnitTest(void)
 {
     

--- a/src/qgcunittest/GeoTest.cc
+++ b/src/qgcunittest/GeoTest.cc
@@ -29,8 +29,6 @@
 #include "GeoTest.h"
 #include "QGCGeo.h"
 
-UT_REGISTER_TEST(GeoTest)
-
 /*
 GeoTest::GeoTest(void)
 {

--- a/src/qgcunittest/LinkManagerTest.cc
+++ b/src/qgcunittest/LinkManagerTest.cc
@@ -30,8 +30,6 @@
 #include "MockLink.h"
 #include "QGCApplication.h"
 
-UT_REGISTER_TEST(LinkManagerTest)
-
 LinkManagerTest::LinkManagerTest(void) :
     _linkMgr(NULL),
     _multiSpy(NULL)

--- a/src/qgcunittest/MainWindowTest.cc
+++ b/src/qgcunittest/MainWindowTest.cc
@@ -31,9 +31,6 @@
 #include "QGCMessageBox.h"
 #include "MultiVehicleManager.h"
 
-// FIXME: Temporarily turned off
-//UT_REGISTER_TEST(MainWindowTest)
-
 void MainWindowTest::_connectWindowClose_test(MAV_AUTOPILOT autopilot)
 {
     _createMainWindow();

--- a/src/qgcunittest/MavlinkLogTest.cc
+++ b/src/qgcunittest/MavlinkLogTest.cc
@@ -34,9 +34,6 @@
 #include "UAS.h"
 #include "MultiVehicleManager.h"
 
-// FIXME: Temporarily disabled until this can be stabilized
-//UT_REGISTER_TEST(MavlinkLogTest)
-
 const char* MavlinkLogTest::_tempLogFileTemplate = "FlightDataXXXXXX"; ///< Template for temporary log file
 const char* MavlinkLogTest::_logFileExtension = "mavlink";             ///< Extension for log files
 const char* MavlinkLogTest::_saveLogFilename = "qgroundcontrol.mavlink.ut";        ///< Filename to save log files to

--- a/src/qgcunittest/MessageBoxTest.cc
+++ b/src/qgcunittest/MessageBoxTest.cc
@@ -29,8 +29,6 @@
 #include "MessageBoxTest.h"
 #include "QGCMessageBox.h"
 
-UT_REGISTER_TEST(MessageBoxTest)
-
 MessageBoxTest::MessageBoxTest(void)
 {
     

--- a/src/qgcunittest/PX4RCCalibrationTest.cc
+++ b/src/qgcunittest/PX4RCCalibrationTest.cc
@@ -31,7 +31,6 @@
 ///
 ///     @author Don Gagne <don@thegagnes.com>
 
-UT_REGISTER_TEST(RadioConfigTest)
 QGC_LOGGING_CATEGORY(RadioConfigTestLog, "RadioConfigTestLog")
 
 // This will check for the wizard buttons being enabled of disabled according to the mask you pass in.

--- a/src/qgcunittest/TCPLinkTest.cc
+++ b/src/qgcunittest/TCPLinkTest.cc
@@ -29,10 +29,6 @@
 ///
 ///     @author Don Gagne <don@thegagnes.com>
 
-// This unit test has gotten too flaky to run reliably under TeamCity. Removing for now till there is
-// time to debug.
-//UT_REGISTER_TEST(TCPLinkUnitTest)
-
 TCPLinkUnitTest::TCPLinkUnitTest(void)
     : _config(NULL)
     , _link(NULL)

--- a/src/qgcunittest/UnitTest.h
+++ b/src/qgcunittest/UnitTest.h
@@ -38,7 +38,7 @@
 #include "QGCMAVLink.h"
 #include "LinkInterface.h"
 
-#define UT_REGISTER_TEST(className) static UnitTestWrapper<className> t(#className);
+#define UT_REGISTER_TEST(className) static UnitTestWrapper<className> className(#className);
 
 class QGCMessageBox;
 class QGCFileDialog;

--- a/src/qgcunittest/UnitTestList.cc
+++ b/src/qgcunittest/UnitTestList.cc
@@ -1,0 +1,70 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+// We keep the list of all unit tests in a global location so it's easier to see which
+// ones are enabled/disabled
+
+#include "FactSystemTestGeneric.h"
+#include "FactSystemTestPX4.h"
+#include "FileDialogTest.h"
+#include "FlightGearTest.h"
+#include "GeoTest.h"
+#include "LinkManagerTest.h"
+#include "MessageBoxTest.h"
+#include "MissionItemTest.h"
+#include "MissionControllerTest.h"
+#include "PX4RCCalibrationTest.h"
+#include "SetupViewTest.h"
+#include "MavlinkLogTest.h"
+
+UT_REGISTER_TEST(FactSystemTestGeneric)
+UT_REGISTER_TEST(FactSystemTestPX4)
+UT_REGISTER_TEST(FileDialogTest)
+UT_REGISTER_TEST(FlightGearUnitTest)
+UT_REGISTER_TEST(GeoTest)
+UT_REGISTER_TEST(LinkManagerTest)
+UT_REGISTER_TEST(MavlinkLogTest)
+UT_REGISTER_TEST(MessageBoxTest)
+UT_REGISTER_TEST(MissionItemTest)
+UT_REGISTER_TEST(MissionControllerTest)
+UT_REGISTER_TEST(RadioConfigTest)
+UT_REGISTER_TEST(SetupViewTest)
+
+// List of unit test which are currently disabled.
+// If disabling a new test, include reason in comment.
+
+// Why is this one off?
+//UT_REGISTER_TEST(FileManagerTest)
+
+// FIXME: Temporarily disabled until this can be stabilized
+//UT_REGISTER_TEST(MainWindowTest)
+
+// FIXME: Temporarily disabled until this can be stabilized
+
+// FIXME: Temporarily disabled until this can be stabilized
+//UT_REGISTER_TEST(MissionManagerTest)
+
+// This unit test has gotten too flaky to run reliably under TeamCity. Removing for now till there is
+// time to debug.
+//UT_REGISTER_TEST(TCPLinkUnitTest)
+


### PR DESCRIPTION
- Centralize unit test declaration list into UnitTestList.cc. This way there is a single place to see what tests are on/off
- Added new --unittest-stress command line option. Works just like --unittest, but it runs the test 20 times in a row, to hopefully catch an intermittent failure.
- Turned MavlinkLogTest back on, since I'll need it for auto connect