### PR TITLE
Fix checkbox aligment.

### DIFF
--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -30,8 +30,7 @@ CheckBox {
                 text:           control.text
                 antialiasing:   true
                 font.pixelSize: ScreenTools.defaultFontPixelSize
-            //  This messes up when a *width*, which is wider than the control is given
-            //  anchors.centerIn: parent
+                anchors.verticalCenter: parent.verticalCenter
                 color: control.__qgcPal.text
             }
         }

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -2,7 +2,7 @@
 
 QGroundControl Open Source Ground Control Station
 
-(c) 2009 - 2013 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+(c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
 
 This file is part of the QGROUNDCONTROL project
 
@@ -83,9 +83,9 @@ This file is part of the QGROUNDCONTROL project
 const char* MAIN_SETTINGS_GROUP = "QGC_MAINWINDOW";
 
 #ifndef __mobile__
-enum DockWidgetTypes { 
-    MAVLINK_INSPECTOR, 
-    CUSTOM_COMMAND, 
+enum DockWidgetTypes {
+    MAVLINK_INSPECTOR,
+    CUSTOM_COMMAND,
     ONBOARD_FILES,
     STATUS_DETAILS,
     INFO_VIEW,
@@ -368,7 +368,7 @@ void MainWindow::_createInnerDockWidget(const QString& widgetName)
 {
     QGCDockWidget* widget = NULL;
     QAction *action = _mapName2Action[widgetName];
-    
+
     switch(action->data().toInt()) {
         case MAVLINK_INSPECTOR:
             widget = new QGCMAVLinkInspector(widgetName, action, qgcApp()->toolbox()->mavlinkProtocol(),this);


### PR DESCRIPTION
The original code was *centering* the text within the parent. That caused the text to be away from the *checkbox* if the control was sized larger than its contents. I had removed that and now I noticed that on Android, the *checkbox* was out of alignment. Now I realized what this was trying to do.

This is the proper fix. Instead of centering, it's using vertical alignment.