### PR TITLE
Started preferences panel

### DIFF
--- a/QGCApplication.pro
+++ b/QGCApplication.pro
@@ -270,7 +270,8 @@ HEADERS += \
     src/ui/uas/QGCUnconnectedInfoWidget.h \
     src/ui/uas/UASMessageView.h \
     src/MissionItem.h \
-    src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
+    src/AutoPilotPlugins/PX4/PX4AirframeLoader.h \
+    src/QGCSettings.h
 
 WindowsBuild {
     PRECOMPILED_HEADER += src/stable_headers.h
@@ -381,7 +382,8 @@ SOURCES += \
     src/ui/uas/QGCUnconnectedInfoWidget.cc \
     src/ui/uas/UASMessageView.cc \
     src/MissionItem.cc \
-    src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
+    src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc \
+    src/QGCSettings.cpp
 
 !iOSBuild {
 SOURCES += \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -64,6 +64,7 @@
         <file alias="JoystickConfig.qml">src/VehicleSetup/JoystickConfig.qml</file>
         <file alias="SetupParameterEditor.qml">src/VehicleSetup/SetupParameterEditor.qml</file>
         <file alias="DebugWindow.qml">src/VehicleSetup/DebugWindow.qml</file>
+        <file alias="GeneralSettings.qml">src/VehicleSetup/GeneralSettings.qml</file>
 
         <file alias="CustomCommandWidget.qml">src/ViewWidgets/CustomCommandWidget.qml</file>
         <file alias="SafetyComponent.qml">src/AutoPilotPlugins/PX4/SafetyComponent.qml</file>

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -47,6 +47,10 @@ QGCView {
     property Fact battLowVolt:      controller.getParameterFact(-1, "BAT_V_EMPTY")
     property Fact battVoltLoadDrop: controller.getParameterFact(-1, "BAT_V_LOAD_DROP")
 
+    readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
+    readonly property string highlightSuffix:   "</font>"
+
+
     function getBatteryImage()
     {
         switch(battNumCells.value) {
@@ -94,7 +98,7 @@ QGCView {
         onBatteryConnected:     showMessage("ESC Calibration", "Performing calibration. This will take a few seconds..", 0)
         onCalibrationFailed:    showMessage("ESC Calibration failed", errorMessage, StandardButton.Ok)
         onCalibrationSuccess:   showMessage("ESC Calibration", "Calibration complete. You can disconnect your battery now if you like.", StandardButton.Ok)
-        onConnectBattery:       showMessage("ESC Calibration", "<font color=\"yellow\">WARNING: Props must be removed from vehicle prior to performing ESC calibration.</font> Connect the battery now and calibration will begin.", 0)
+        onConnectBattery:       showMessage("ESC Calibration", highlightPrefix + "WARNING: Props must be removed from vehicle prior to performing ESC calibration." + highlightSuffix + " Connect the battery now and calibration will begin.", 0)
         onDisconnectBattery:    showMessage("ESC Calibration failed", "You must disconnect the battery prior to performing ESC Calibration. Disconnect your battery and try again.", StandardButton.Ok)
     }
 
@@ -239,7 +243,7 @@ QGCView {
 
                         QGCLabel {
                             color:  palette.warningText
-                            text:   "<font color=\"yellow\">WARNING: Propellers must be removed from vehicle prior to performing ESC calibration.</font>"
+                            text:   "WARNING: Propellers must be removed from vehicle prior to performing ESC calibration."
                         }
 
                         QGCLabel {
@@ -273,7 +277,7 @@ QGCView {
 
                         QGCLabel {
                             color:  palette.warningText
-                            text:   "<font color=\"yellow\">WARNING: Propellers must be removed from vehicle prior to performing UAVCAN ESC configuration.</font>"
+                            text:   "WARNING: Propellers must be removed from vehicle prior to performing UAVCAN ESC configuration."
                         }
 
                         QGCLabel {
@@ -341,7 +345,7 @@ QGCView {
                             wrapMode:   Text.WordWrap
                             text:       "Batteries show less voltage at high throttle. Enter the difference in Volts between idle throttle and full " +
                                             "throttle, divided by the number of battery cells. Leave at the default if unsure. " +
-                                            "<font color=\"yellow\">If this value is set too high, the battery might be deep discharged and damaged.</font>"
+                                            highlightPrefix + "If this value is set too high, the battery might be deep discharged and damaged." + highlightSuffix
                         }
 
                         Row {

--- a/src/FlightMap/FlightMapSettings.cc
+++ b/src/FlightMap/FlightMapSettings.cc
@@ -1,24 +1,24 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 #include "FlightMapSettings.h"
@@ -43,7 +43,7 @@ void FlightMapSettings::setToolbox(QGCToolbox *toolbox)
 
     qmlRegisterUncreatableType<FlightMapSettings> ("QGroundControl", 1, 0, "FlightMapSetting", "Reference only");
 
-    _supportedMapProviders << "Bing" << "Google" << "Open";
+    _supportedMapProviders << "Bing" << "Google" << "OpenStreetMap";
 
     _loadSettings();
 }
@@ -51,7 +51,7 @@ void FlightMapSettings::setToolbox(QGCToolbox *toolbox)
 void FlightMapSettings::_storeSettings(void)
 {
     QSettings settings;
-    
+
     settings.beginGroup(_settingsGroup);
     settings.setValue(_mapProviderKey, _supportedMapProviders.contains(_mapProvider) ? _mapProvider : _defaultMapProvider);
 }
@@ -59,14 +59,14 @@ void FlightMapSettings::_storeSettings(void)
 void FlightMapSettings::_loadSettings(void)
 {
     QSettings settings;
-    
+
     settings.beginGroup(_settingsGroup);
     _mapProvider = settings.value(_mapProviderKey, _defaultMapProvider).toString();
-    
+
     if (!_supportedMapProviders.contains(_mapProvider)) {
         _mapProvider = _defaultMapProvider;
     }
-    
+
     _setMapTypesForCurrentProvider();
 }
 
@@ -88,22 +88,22 @@ void FlightMapSettings::setMapProvider(const QString& mapProvider)
 void FlightMapSettings::_setMapTypesForCurrentProvider(void)
 {
     _mapTypes.clear();
-    
+
     if (_mapProvider == "Bing") {
         _mapTypes << "Street Map" << "Satellite Map" << "Hybrid Map";
     } else if (_mapProvider == "Google") {
         _mapTypes << "Street Map" << "Satellite Map" << "Terrain Map";
-    } else if (_mapProvider == "Open") {
+    } else if (_mapProvider == "OpenStreetMap") {
         _mapTypes << "Street Map";
     }
-    
+
     emit mapTypesChanged(_mapTypes);
 }
 
 QString FlightMapSettings::mapTypeForMapName(const QString& mapName)
 {
     QSettings settings;
-    
+
     settings.beginGroup(_settingsGroup);
     settings.beginGroup(mapName);
     settings.beginGroup(_mapProvider);
@@ -113,7 +113,7 @@ QString FlightMapSettings::mapTypeForMapName(const QString& mapName)
 void FlightMapSettings::setMapTypeForMapName(const QString& mapName, const QString& mapType)
 {
     QSettings settings;
-    
+
     settings.beginGroup(_settingsGroup);
     settings.beginGroup(mapName);
     settings.beginGroup(_mapProvider);
@@ -123,7 +123,7 @@ void FlightMapSettings::setMapTypeForMapName(const QString& mapName, const QStri
 void FlightMapSettings::saveMapSetting (const QString &mapName, const QString& key, const QString& value)
 {
     QSettings settings;
-    
+
     settings.beginGroup(_settingsGroup);
     settings.beginGroup(mapName);
     settings.setValue(key, value);
@@ -132,7 +132,7 @@ void FlightMapSettings::saveMapSetting (const QString &mapName, const QString& k
 QString FlightMapSettings::loadMapSetting (const QString &mapName, const QString& key, const QString& defaultValue)
 {
     QSettings settings;
-    
+
     settings.beginGroup(_settingsGroup);
     settings.beginGroup(mapName);
     return settings.value(key, defaultValue).toString();

--- a/src/FlightMap/FlightMapSettings.h
+++ b/src/FlightMap/FlightMapSettings.h
@@ -32,46 +32,51 @@ This file is part of the QGROUNDCONTROL project
 class FlightMapSettings : public QGCTool
 {
     Q_OBJECT
-    
+
 public:
     FlightMapSettings(QGCApplication* app);
 
     /// mapProvider is either Bing, Google or Open to specify to set of maps available
-    Q_PROPERTY(QString mapProvider READ mapProvider WRITE setMapProvider NOTIFY mapProviderChanged)
-    
+    Q_PROPERTY(QString      mapProvider     READ mapProvider    WRITE setMapProvider NOTIFY mapProviderChanged)
+
+    /// Map providers
+    Q_PROPERTY(QStringList  mapProviders    READ mapProviders   CONSTANT)
+
     /// Map types associated with current map provider
-    Q_PROPERTY(QStringList mapTypes MEMBER _mapTypes NOTIFY mapTypesChanged)
-    
-    Q_INVOKABLE QString mapTypeForMapName(const QString& mapName);
-    Q_INVOKABLE void setMapTypeForMapName(const QString& mapName, const QString& mapType);
-    
-    Q_INVOKABLE void    saveMapSetting (const QString &mapName, const QString& key, const QString& value);
-    Q_INVOKABLE QString loadMapSetting (const QString &mapName, const QString& key, const QString& defaultValue);
-    Q_INVOKABLE void    saveBoolMapSetting (const QString &mapName, const QString& key, bool value);
-    Q_INVOKABLE bool    loadBoolMapSetting (const QString &mapName, const QString& key, bool defaultValue);
+    Q_PROPERTY(QStringList  mapTypes        MEMBER _mapTypes    NOTIFY mapTypesChanged)
+
+    Q_INVOKABLE QString     mapTypeForMapName   (const QString& mapName);
+    Q_INVOKABLE void        setMapTypeForMapName(const QString& mapName, const QString& mapType);
+
+    Q_INVOKABLE void        saveMapSetting      (const QString &mapName, const QString& key, const QString& value);
+    Q_INVOKABLE QString     loadMapSetting      (const QString &mapName, const QString& key, const QString& defaultValue);
+    Q_INVOKABLE void        saveBoolMapSetting  (const QString &mapName, const QString& key, bool value);
+    Q_INVOKABLE bool        loadBoolMapSetting  (const QString &mapName, const QString& key, bool defaultValue);
 
     // Property accessors
-    
+
     QString mapProvider(void);
     void setMapProvider(const QString& mapProvider);
-    
+
     // Override from QGCTool
     virtual void setToolbox(QGCToolbox *toolbox);
+
+    QStringList mapProviders() { return _supportedMapProviders; }
 
 signals:
     void mapProviderChanged(const QString& mapProvider);
     void mapTypesChanged(const QStringList& mapTypes);
-    
+
 private:
     void _storeSettings(void);
     void _loadSettings(void);
-    
+
     void _setMapTypesForCurrentProvider(void);
-    
+
     QString     _mapProvider;               ///< Current map provider
     QStringList _supportedMapProviders;
     QStringList _mapTypes;                  ///< Map types associated with current map provider
-    
+
     static const char* _defaultMapProvider;
     static const char* _settingsGroup;
     static const char* _mapProviderKey;

--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -1,24 +1,24 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 /// @file
@@ -34,7 +34,7 @@ QList<QGCPalette*>   QGCPalette::_paletteObjects;
 QGCPalette::Theme QGCPalette::_theme = QGCPalette::Dark;
 
 QColor QGCPalette::_window[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
-    { QColor("#ffffff"), QColor("#ffffff") },
+    { QColor("#f9f8f4"), QColor("#f9f8f4") },
     { QColor(0x22, 0x22, 0x22), QColor(0x22, 0x22, 0x22) }
 };
 
@@ -54,8 +54,8 @@ QColor QGCPalette::_text[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
 };
 
 QColor QGCPalette::_warningText[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
-		{ QColor(0xFF, 0xFF, 0x00), QColor(0xFF, 0xFF, 0x00) },
-		{ QColor(0xFF, 0xFF, 0x00), QColor(0xFF, 0xFF, 0x00) }
+    { QColor("#cc0808"), QColor("#cc0808") },
+    { QColor("#e4e428"), QColor("#e4e428") }
 };
 
 QColor QGCPalette::_button[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
@@ -79,8 +79,8 @@ QColor QGCPalette::_buttonHighlightText[QGCPalette::_cThemes][QGCPalette::_cColo
 };
 
 QColor QGCPalette::_primaryButton[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
-    { QColor(0x58, 0x58, 0x58), QColor(152, 255, 252) },
-    { QColor(0x58, 0x58, 0x58), QColor(152, 255, 252) },
+    { QColor(0x58, 0x58, 0x58), QColor("#badec5") },
+    { QColor(0x58, 0x58, 0x58), QColor("#badec5") },
 };
 
 QColor QGCPalette::_primaryButtonText[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {

--- a/src/QGCSettings.cpp
+++ b/src/QGCSettings.cpp
@@ -1,0 +1,39 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+QGROUNDCONTROL is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+QGROUNDCONTROL is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+/**
+* @file
+*   @brief Implementation of class QGCSettings
+*
+*   @author Gus Grubba <mavlink@grubba.com>
+*
+*/
+
+
+#include "QGCSettings.h"
+
+QGCSettings::QGCSettings(QObject *parent) : QObject(parent)
+{
+
+}
+

--- a/src/QGCSettings.h
+++ b/src/QGCSettings.h
@@ -1,0 +1,50 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
+/**
+ * @file
+ *   @brief Definition of main class
+ *
+*   @author Gus Grubba <mavlink@grubba.com>
+ *
+ */
+
+
+#ifndef QGCSETTINGS_H
+#define QGCSETTINGS_H
+
+#include <QObject>
+
+class QGCSettings : public QObject
+{
+    Q_OBJECT
+public:
+    explicit QGCSettings(QObject *parent = 0);
+
+signals:
+
+public slots:
+
+};
+
+#endif // QGCSETTINGS_H

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -29,6 +29,8 @@
 
 #include <QObject>
 
+#include "QGCApplication.h"
+#include "MainWindow.h"
 #include "HomePositionManager.h"
 #include "FlightMapSettings.h"
 
@@ -65,8 +67,60 @@ public:
     qreal                   zOrderWidgets       ()      { return 100; }
     qreal                   zOrderMapItems      ()      { return 50; }
 
+    //-- TODO: This should be in ScreenTools but I don't understand the changes done there (ScreenToolsController versus ScreenTools)
+    Q_PROPERTY(bool     isDarkStyle         READ isDarkStyle     WRITE setIsDarkStyle    NOTIFY isDarkStyleChanged)
+    bool    isDarkStyle         ()              { return qgcApp()->styleIsDark(); }
+    void    setIsDarkStyle      (bool dark)     { qgcApp()->setStyle(dark); }
+
+    //-- Audio Muting
+    Q_PROPERTY(bool     isAudioMuted        READ isAudioMuted    WRITE setIsAudioMuted    NOTIFY isAudioMutedChanged)
+    bool    isAudioMuted        ()              { return qgcApp()->toolbox()->audioOutput()->isMuted(); }
+    void    setIsAudioMuted     (bool muted)    { qgcApp()->toolbox()->audioOutput()->mute(muted); }
+
+    //-- Low power mode
+    Q_PROPERTY(bool     isLowPowerMode      READ isLowPowerMode  WRITE setIsLowPowerMode   NOTIFY isLowPowerModeChanged)
+    bool    isLowPowerMode      ()              { return MainWindow::instance()->lowPowerModeEnabled(); }
+    void    setIsLowPowerMode   (bool low)      { MainWindow::instance()->enableLowPowerMode(low); }
+
+    //-- Prompt save log
+    Q_PROPERTY(bool     isSaveLogPrompt     READ isSaveLogPrompt WRITE setIsSaveLogPrompt  NOTIFY isSaveLogPromptChanged)
+    bool    isSaveLogPrompt     ()              { return qgcApp()->promptFlightDataSave(); }
+    void    setIsSaveLogPrompt  (bool prompt)   { qgcApp()->setPromptFlightDataSave(prompt); }
+
+    //-- ClearSettings
+    Q_INVOKABLE void    deleteAllSettingsNextBoot       () { qgcApp()->deleteAllSettingsNextBoot(); }
+    Q_INVOKABLE void    clearDeleteAllSettingsNextBoot  () { qgcApp()->clearDeleteAllSettingsNextBoot(); }
+
     //-- TODO: Make this into an actual preference.
     bool                    isAdvancedMode      ()      { return false; }
+
+    //
+    //-- Mavlink Protocol
+    //
+
+    //-- Emit heartbeat
+    Q_PROPERTY(bool     isHeartBeatEnabled  READ isHeartBeatEnabled  WRITE setIsHeartBeatEnabled  NOTIFY isHeartBeatEnabledChanged)
+    bool    isHeartBeatEnabled     ()              { return qgcApp()->toolbox()->mavlinkProtocol()->heartbeatsEnabled(); }
+    void    setIsHeartBeatEnabled  (bool enable)   { qgcApp()->toolbox()->mavlinkProtocol()->enableHeartbeats(enable); }
+
+    //-- Multiplexing
+    Q_PROPERTY(bool     isMultiplexingEnabled  READ isMultiplexingEnabled  WRITE setIsMultiplexingEnabled  NOTIFY isMultiplexingEnabledChanged)
+    bool    isMultiplexingEnabled   ()              { return qgcApp()->toolbox()->mavlinkProtocol()->multiplexingEnabled(); }
+    void    setIsMultiplexingEnabled(bool enable)   { qgcApp()->toolbox()->mavlinkProtocol()->enableMultiplexing(enable); }
+
+    //-- Version Check
+    Q_PROPERTY(bool     isVersionCheckEnabled  READ isVersionCheckEnabled  WRITE setIsVersionCheckEnabled  NOTIFY isVersionCheckEnabledChanged)
+    bool    isVersionCheckEnabled   ()              { return qgcApp()->toolbox()->mavlinkProtocol()->versionCheckEnabled(); }
+    void    setIsVersionCheckEnabled(bool enable)   { qgcApp()->toolbox()->mavlinkProtocol()->enableVersionCheck(enable); }
+
+signals:
+    void isDarkStyleChanged             (bool dark);
+    void isAudioMutedChanged            (bool muted);
+    void isLowPowerModeChanged          (bool lowPower);
+    void isSaveLogPromptChanged         (bool prompt);
+    void isHeartBeatEnabledChanged      (bool enabled);
+    void isMultiplexingEnabledChanged   (bool enabled);
+    void isVersionCheckEnabledChanged   (bool enabled);
 
 private:
     HomePositionManager*    _homePositionManager;

--- a/src/QmlControls/QmlTest.qml
+++ b/src/QmlControls/QmlTest.qml
@@ -12,19 +12,34 @@ Rectangle {
 
     Column {
 
-        Row {
-            ExclusiveGroup { id: themeGroup }
-
-            QGCRadioButton {
-                text: "Light"
-                exclusiveGroup: themeGroup
-                onClicked: { palette.globalTheme = QGCPalette.Light }
+        Rectangle {
+            width:  parent.width
+            height: themeChoice.height * 2
+            color:  palette.window
+            QGCLabel {
+                text: "Window Color"
+                anchors.left:           parent.left
+                anchors.leftMargin:     20
+                anchors.verticalCenter: parent.horizontalCenter
             }
-
-            QGCRadioButton {
-                text: "Dark"
-                exclusiveGroup: themeGroup
-                onClicked: { palette.globalTheme = QGCPalette.Dark }
+            Row {
+                id: themeChoice
+                anchors.centerIn: parent
+                anchors.margins: 20
+                spacing:         20
+                ExclusiveGroup { id: themeGroup }
+                QGCRadioButton {
+                    text: "Light"
+                    checked: palette.globalTheme === QGCPalette.Light
+                    exclusiveGroup: themeGroup
+                    onClicked: { palette.globalTheme = QGCPalette.Light }
+                }
+                QGCRadioButton {
+                    text: "Dark"
+                    checked: palette.globalTheme === QGCPalette.Dark
+                    exclusiveGroup: themeGroup
+                    onClicked: { palette.globalTheme = QGCPalette.Dark }
+                }
             }
         }
 
@@ -464,6 +479,38 @@ Rectangle {
                     horizontalAlignment: Text.AlignHCenter
                     property var palette: QGCPalette { colorGroupEnabled: true }
                     text: palette.textFieldText
+                }
+
+                // warningText
+                Loader {
+                    sourceComponent: rowHeader
+                    property var text: "warningText"
+                }
+                ClickableColor {
+                    property var palette: QGCPalette { colorGroupEnabled: false }
+                    color: palette.warningText
+                    onColorSelected: palette.warningText = color
+                }
+                ClickableColor {
+                    property var palette: QGCPalette { colorGroupEnabled: true }
+                    color: palette.warningText
+                    onColorSelected: palette.warningText = color
+                }
+                Text {
+                    width: 80
+                    height: 20
+                    color: "black"
+                    horizontalAlignment: Text.AlignHCenter
+                    property var palette: QGCPalette { colorGroupEnabled: false }
+                    text: palette.warningText
+                }
+                Text {
+                    width: 80
+                    height: 20
+                    color: "black"
+                    horizontalAlignment: Text.AlignHCenter
+                    property var palette: QGCPalette { colorGroupEnabled: true }
+                    text: palette.warningText
                 }
             }
 

--- a/src/QmlControls/ScreenToolsController.h
+++ b/src/QmlControls/ScreenToolsController.h
@@ -115,7 +115,7 @@ public:
 #endif
 
 signals:
-    void repaintRequested(void);
+    void repaintRequested();
 
 private slots:
     void _updateCanvas();

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -39,7 +39,7 @@ QGCView {
 
     // User visible strings
     readonly property string title:             "FIRMWARE"
-    readonly property string highlightPrefix:   "<font color=\"yellow\">"
+    readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
     readonly property string highlightSuffix:   "</font>"
     readonly property string welcomeText:       "QGroundControl can upgrade the firmware on Pixhawk devices, 3DR Radios and PX4 Flow Smart Cameras."
     readonly property string plugInText:        highlightPrefix + "Plug in your device" + highlightSuffix + " via USB to " + highlightPrefix + "start" + highlightSuffix + " firmware upgrade"
@@ -79,12 +79,12 @@ QGCView {
             initialBoardSearch = false
             statusTextArea.append(plugInText)
         }
- 
+
         onBoardGone: {
             initialBoardSearch = false
             statusTextArea.append(plugInText)
         }
- 
+
         onBoardFound: {
             if (initialBoardSearch) {
                 // Board was found right away, so something is already plugged in before we've started upgrade
@@ -138,7 +138,7 @@ QGCView {
 
         QGCViewDialog {
             anchors.fill: parent
- 
+
             property bool showFirmwareTypeSelection: advancedMode.checked
             property bool px4Flow:              controller.boardType == "PX4 Flow"
 
@@ -156,16 +156,16 @@ QGCView {
                 }
                 controller.flash(stack, firmwareType, vehicleType)
             }
- 
+
             function reject() {
                 cancelFlash()
                 hideDialog()
             }
- 
+
             ExclusiveGroup {
                 id: firmwareGroup
             }
- 
+
             ListModel {
                 id: firmwareTypeList
 
@@ -186,7 +186,7 @@ QGCView {
                     firmwareType:   FirmwareUpgradeController.CustomFirmware
                  }
             }
- 
+
             ListModel {
                 id: vehicleTypeList
 
@@ -240,7 +240,7 @@ QGCView {
                     firmwareType:   FirmwareUpgradeController.CustomFirmware
                  }
             }
- 
+
             Column {
                 anchors.fill:   parent
                 spacing:        defaultTextHeight

--- a/src/VehicleSetup/GeneralSettings.qml
+++ b/src/VehicleSetup/GeneralSettings.qml
@@ -1,0 +1,228 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
+import QtQuick                  2.5
+import QtQuick.Controls         1.2
+import QtQuick.Controls.Styles  1.2
+import QtQuick.Dialogs          1.1
+
+import QGroundControl                       1.0
+import QGroundControl.FactSystem            1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.MultiVehicleManager   1.0
+import QGroundControl.Palette               1.0
+
+Rectangle {
+    id:     _generalRoot
+    color:  qgcPal.windowShade
+
+    QGCPalette {
+        id:                 qgcPal
+        colorGroupEnabled:  enabled
+    }
+
+    Flickable {
+        clip:               true
+        anchors.fill:       parent
+        anchors.margins:    ScreenTools.defaultFontPixelWidth
+        contentHeight:      settingsColumn.height
+        contentWidth:       _generalRoot.width
+        flickableDirection: Flickable.VerticalFlick
+        boundsBehavior:     Flickable.StopAtBounds
+
+        Column {
+            id:                 settingsColumn
+            width:              _generalRoot.width
+            spacing:            ScreenTools.defaultFontPixelHeight
+            anchors.margins:    ScreenTools.defaultFontPixelWidth
+            QGCLabel {
+                text:   "General Settings"
+                font.pixelSize: ScreenTools.mediumFontPixelSize
+            }
+            Rectangle {
+                height: 1
+                width:  parent.width
+                color:  qgcPal.button
+            }
+            //-----------------------------------------------------------------
+            //-- Audio preferences
+            QGCCheckBox {
+                text:       "Mute all audio output"
+                checked:    QGroundControl.isAudioMuted
+                onClicked: {
+                    QGroundControl.isAudioMuted = checked
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Low power mode
+            QGCCheckBox {
+                text:       "Enable low power mode"
+                checked:    QGroundControl.isLowPowerMode
+                onClicked: {
+                    QGroundControl.isLowPowerMode = checked
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Prompt Save Log
+            QGCCheckBox {
+                text:       "Prompt to save Flight Data Log after each flight"
+                checked:    QGroundControl.isSaveLogPrompt
+                visible:    !ScreenTools.isMobile
+                onClicked: {
+                    QGroundControl.isSaveLogPrompt = checked
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Clear settings
+            QGCCheckBox {
+                id:         clearCheck
+                text:       "Clear all settings on next start"
+                checked:    false
+                onClicked: {
+                    checked ? clearDialog.visible = true : QGroundControl.clearDeleteAllSettingsNextBoot()
+                }
+                MessageDialog {
+                    id:         clearDialog
+                    visible:    false
+                    icon:       StandardIcon.Warning
+                    standardButtons: StandardButton.Yes | StandardButton.No
+                    title:      "Clear Settings"
+                    text:       "All saved settings will be reset the next time you start QGroundControl. Is this really what you want?"
+                    onYes: {
+                        QGroundControl.deleteAllSettingsNextBoot()
+                        clearDialog.visible = false
+                    }
+                    onNo: {
+                        clearCheck.checked  = false
+                        clearDialog.visible = false
+                    }
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Map Providers
+            Row {
+                spacing:    ScreenTools.defaultFontPixelWidth
+                QGCLabel {
+                    width: ScreenTools.defaultFontPixelWidth * 16
+                    text: "Map Providers"
+                }
+                QGCComboBox {
+                    id:     mapProviders
+                    width:  ScreenTools.defaultFontPixelWidth * 16
+                    model:  QGroundControl.flightMapSettings.mapProviders
+                    Component.onCompleted: {
+                        var index = mapProviders.find(QGroundControl.flightMapSettings.mapProvider)
+                        if (index < 0) {
+                            console.warn("Active map provider not in combobox", QGroundControl.flightMapSettings.mapProvider)
+                        } else {
+                            mapProviders.currentIndex = index
+                        }
+                    }
+                    onActivated: {
+                        if (index != -1) {
+                            currentIndex = index
+                            console.log("New map provider: " + model[index])
+                            QGroundControl.flightMapSettings.mapProvider = model[index]
+                        }
+                    }
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Palette Styles
+            Row {
+                spacing:    ScreenTools.defaultFontPixelWidth
+                QGCLabel {
+                    width: ScreenTools.defaultFontPixelWidth * 16
+                    text: "Style"
+                }
+                QGCComboBox {
+                    width: ScreenTools.defaultFontPixelWidth * 16
+                    model: [ "Dark", "Light" ]
+                    currentIndex: QGroundControl.isDarkStyle ? 0 : 1
+                    onActivated: {
+                        if (index != -1) {
+                            currentIndex = index
+                            console.log((index === 0) ? "Now it's Dark" : "Now it's Light")
+                            QGroundControl.isDarkStyle = index === 0 ? true : false
+                        }
+                    }
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Mavlink Settings
+            //-----------------------------------------------------------------
+            Rectangle {
+                height:     1
+                width:      parent.width
+                color:      qgcPal.button
+            }
+            QGCCheckBox {
+                id:         showMavlinkSettings
+                text:       "Show Advanced Mavlink Settings"
+                checked:    false
+            }
+            QGCLabel {
+                text:       "Mavlink Settings"
+                visible:    showMavlinkSettings.checked
+                font.pixelSize: ScreenTools.mediumFontPixelSize
+            }
+            Rectangle {
+                height:     1
+                width:      parent.width
+                color:      qgcPal.button
+                visible:    showMavlinkSettings.checked
+            }
+            //-----------------------------------------------------------------
+            //-- Mavlink Heartbeats
+            QGCCheckBox {
+                text:       "Emit heartbeat"
+                checked:    QGroundControl.isHeartBeatEnabled
+                visible:    showMavlinkSettings.checked
+                onClicked: {
+                    QGroundControl.isHeartBeatEnabled = checked
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Mavlink Multiplexing
+            QGCCheckBox {
+                text:       "Enable multiplexing (forward packets to all other links)"
+                checked:    QGroundControl.isMultiplexingEnabled
+                visible:    showMavlinkSettings.checked
+                onClicked: {
+                    QGroundControl.isMultiplexingEnabled = checked
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Mavlink Version Check
+            QGCCheckBox {
+                text:       "Only accept MAVs with same protocol version"
+                checked:    QGroundControl.isVersionCheckEnabled
+                visible:    showMavlinkSettings.checked
+                onClicked: {
+                    QGroundControl.isVersionCheckEnabled = checked
+                }
+            }
+        }
+    }
+}

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -115,6 +115,11 @@ Rectangle {
         panelLoader.source = "DebugWindow.qml";
     }
 
+    function showGeneralPanel()
+    {
+        panelLoader.source = "GeneralSettings.qml";
+    }
+
     Component.onCompleted: showSummaryPanel()
 
     Connections {
@@ -239,6 +244,15 @@ Rectangle {
                     text:           "SUMMARY"
 
                     onClicked: showSummaryPanel()
+                }
+
+                SubMenuButton {
+                    width:          _buttonWidth
+                    setupIndicator: false
+                    exclusiveGroup: setupButtonGroup
+                    visible:        true
+                    text:           "GENERAL"
+                    onClicked: showGeneralPanel()
                 }
 
                 SubMenuButton {


### PR DESCRIPTION
Started some basic preferences panel. I placed it as one of the buttons in the *Setup View*. I used the original QtWidgets preference panel as a guide. It's far from complete but all the settings there are functional. That is, they do get set and saved.

While at it, I tweaked the palette a bit. The *Warning* text was bright yellow for both themes, which made it almost impossible to read on a full white background (the window color for the *Light* theme). I also replaced a few hardcoded HTML color tags (all setting the text to bright yellow for warning), with the proper warning color set in the system palette.