### PR TITLE
Add MockLink Start/Stop to Preferences

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -24,6 +24,7 @@
         <file alias="MavlinkSettings.qml">src/ui/preferences/MavlinkSettings.qml</file>
         <file alias="MissionEditor.qml">src/MissionEditor/MissionEditor.qml</file>
         <file alias="MissionEditorHelp.qml">src/MissionEditor/MissionEditorHelp.qml</file>
+        <file alias="MockLink.qml">src/ui/preferences/MockLink.qml</file>
         <file alias="PowerComponent.qml">src/AutoPilotPlugins/PX4/PowerComponent.qml</file>
         <file alias="PowerComponentSummary.qml">src/AutoPilotPlugins/PX4/PowerComponentSummary.qml</file>
         <file alias="PX4FlowSensor.qml">src/VehicleSetup/PX4FlowSensor.qml</file>

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -66,3 +66,83 @@ bool QGroundControlQmlGlobal::loadBoolGlobalSetting (const QString& key, bool de
     settings.beginGroup(kQmlGlobalKeyName);
     return settings.value(key, defaultValue).toBool();
 }
+
+#ifdef QT_DEBUG
+void QGroundControlQmlGlobal::_startMockLink(MockConfiguration* mockConfig)
+{
+    MockLink* mockLink = new MockLink(mockConfig);
+
+    LinkManager* linkManager = qgcApp()->toolbox()->linkManager();
+
+    linkManager->_addLink(mockLink);
+    linkManager->connectLink(mockLink);
+}
+#endif
+
+void QGroundControlQmlGlobal::startPX4MockLink(bool sendStatusText)
+{
+#ifdef QT_DEBUG
+    MockConfiguration   mockConfig("PX4 MockLink");
+
+    mockConfig.setFirmwareType(MAV_AUTOPILOT_PX4);
+    mockConfig.setVehicleType(MAV_TYPE_QUADROTOR);
+    mockConfig.setSendStatusText(sendStatusText);
+
+    _startMockLink(&mockConfig);
+#endif
+}
+
+void QGroundControlQmlGlobal::startGenericMockLink(bool sendStatusText)
+{
+#ifdef QT_DEBUG
+    MockConfiguration   mockConfig("Generic MockLink");
+
+    mockConfig.setFirmwareType(MAV_AUTOPILOT_GENERIC);
+    mockConfig.setVehicleType(MAV_TYPE_QUADROTOR);
+    mockConfig.setSendStatusText(sendStatusText);
+
+    _startMockLink(&mockConfig);
+#endif
+}
+
+void QGroundControlQmlGlobal::startAPMArduCopterMockLink(bool sendStatusText)
+{
+#ifdef QT_DEBUG
+    MockConfiguration   mockConfig("APM ArduCopter MockLink");
+
+    mockConfig.setFirmwareType(MAV_AUTOPILOT_ARDUPILOTMEGA);
+    mockConfig.setVehicleType(MAV_TYPE_QUADROTOR);
+    mockConfig.setSendStatusText(sendStatusText);
+
+    _startMockLink(&mockConfig);
+#endif
+}
+
+void QGroundControlQmlGlobal::startAPMArduPlaneMockLink(bool sendStatusText)
+{
+#ifdef QT_DEBUG
+    MockConfiguration   mockConfig("APM ArduPlane MockLink");
+
+    mockConfig.setFirmwareType(MAV_AUTOPILOT_ARDUPILOTMEGA);
+    mockConfig.setVehicleType(MAV_TYPE_FIXED_WING);
+    mockConfig.setSendStatusText(sendStatusText);
+
+    _startMockLink(&mockConfig);
+#endif
+}
+
+void QGroundControlQmlGlobal::stopAllMockLinks(void)
+{
+#ifdef QT_DEBUG
+    LinkManager* linkManager = qgcApp()->toolbox()->linkManager();
+
+    QList<LinkInterface*> links = linkManager->getLinks();
+    for (int i=0; i<links.count(); i++) {
+        LinkInterface* link = links[i];
+        MockLink* mockLink = qobject_cast<MockLink*>(link);
+        if (mockLink) {
+            linkManager->disconnectLink(mockLink);
+        }
+    }
+#endif
+}

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -89,6 +89,8 @@ void QGroundControlQmlGlobal::startPX4MockLink(bool sendStatusText)
     mockConfig.setSendStatusText(sendStatusText);
 
     _startMockLink(&mockConfig);
+#else
+    Q_UNUSED(sendStatusText);
 #endif
 }
 
@@ -102,6 +104,8 @@ void QGroundControlQmlGlobal::startGenericMockLink(bool sendStatusText)
     mockConfig.setSendStatusText(sendStatusText);
 
     _startMockLink(&mockConfig);
+#else
+    Q_UNUSED(sendStatusText);
 #endif
 }
 
@@ -115,6 +119,8 @@ void QGroundControlQmlGlobal::startAPMArduCopterMockLink(bool sendStatusText)
     mockConfig.setSendStatusText(sendStatusText);
 
     _startMockLink(&mockConfig);
+#else
+    Q_UNUSED(sendStatusText);
 #endif
 }
 
@@ -128,6 +134,8 @@ void QGroundControlQmlGlobal::startAPMArduPlaneMockLink(bool sendStatusText)
     mockConfig.setSendStatusText(sendStatusText);
 
     _startMockLink(&mockConfig);
+#else
+    Q_UNUSED(sendStatusText);
 #endif
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -34,6 +34,10 @@
 #include "HomePositionManager.h"
 #include "FlightMapSettings.h"
 
+#ifdef QT_DEBUG
+#include "MockLink.h"
+#endif
+
 class QGCToolbox;
 
 class QGroundControlQmlGlobal : public QObject
@@ -57,6 +61,12 @@ public:
     Q_INVOKABLE QString loadGlobalSetting       (const QString& key, const QString& defaultValue);
     Q_INVOKABLE void    saveBoolGlobalSetting   (const QString& key, bool value);
     Q_INVOKABLE bool    loadBoolGlobalSetting   (const QString& key, bool defaultValue);
+
+    Q_INVOKABLE void    startPX4MockLink            (bool sendStatusText);
+    Q_INVOKABLE void    startGenericMockLink        (bool sendStatusText);
+    Q_INVOKABLE void    startAPMArduCopterMockLink  (bool sendStatusText);
+    Q_INVOKABLE void    startAPMArduPlaneMockLink   (bool sendStatusText);
+    Q_INVOKABLE void    stopAllMockLinks            (void);
 
     // Property accesors
 
@@ -123,6 +133,10 @@ signals:
     void isVersionCheckEnabledChanged   (bool enabled);
 
 private:
+#ifdef QT_DEBUG
+    void _startMockLink(MockConfiguration* mockConfig);
+#endif
+
     HomePositionManager*    _homePositionManager;
     FlightMapSettings*      _flightMapSettings;
 };

--- a/src/ui/MainWindowLeftPanel.qml
+++ b/src/ui/MainWindowLeftPanel.qml
@@ -172,6 +172,20 @@ Item {
             QGCButton {
                 width:      parent.width * 0.8
                 height:     ScreenTools.defaultFontPixelHeight * 2.5
+                text:       "Mock Link"
+                visible:    ScreenTools.isDebug
+                exclusiveGroup: panelActionGroup
+                anchors.horizontalCenter: parent.horizontalCenter
+                onClicked: {
+                    if(__rightPanel.source != "MockLink.qml") {
+                        __rightPanel.source = "MockLink.qml"
+                    }
+                    checked = true
+                }
+            }
+            QGCButton {
+                width:      parent.width * 0.8
+                height:     ScreenTools.defaultFontPixelHeight * 2.5
                 text:       "Debug"
                 visible:    ScreenTools.isDebug
                 exclusiveGroup: panelActionGroup

--- a/src/ui/preferences/MockLink.qml
+++ b/src/ui/preferences/MockLink.qml
@@ -1,0 +1,67 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
+import QtQuick 2.3
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+
+Rectangle {
+    color: qgcPal.window
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    Column {
+        anchors.margins:    ScreenTools.defaultFontPixelHeight
+        anchors.left:       parent.left
+        anchors.top:        parent.top
+        spacing:            ScreenTools.defaultFontPixelHeight
+
+        QGCButton {
+            text:       "PX4 Vehicle"
+            onClicked:  QGroundControl.startPX4MockLink(sendStatusText.checked)
+        }
+        QGCButton {
+            text:       "APM ArduCopter Vehicle"
+            onClicked:  QGroundControl.startAPMArduCopterMockLink(sendStatusText.checked)
+        }
+        QGCButton {
+            text:       "APM ArduPlane Vehicle"
+            onClicked:  QGroundControl.startAPMArduPlaneMockLink(sendStatusText.checked)
+        }
+        QGCButton {
+            text:       "Generic Vehicle"
+            onClicked:  QGroundControl.startGenericMockLink(sendStatusText.checked)
+        }
+        QGCCheckBox {
+            id:     sendStatusText
+            text:   "Send status text + voice"
+        }
+        QGCButton {
+            text:       "Stop All MockLinks"
+            onClicked:  QGroundControl.stopAllMockLinks()
+        }
+    }
+}


### PR DESCRIPTION
Preparation for auto-connect having no connect/disconnect buttons. Added debug only MockLink button to Qml Preferences to support mock link start/stop when there is no connect/disconnect button.