### PR TITLE
Auto-Connect port stuff

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -302,6 +302,7 @@ WindowsBuild {
 
 !iOSBuild {
 HEADERS += \
+    src/comm/QGCSerialPortInfo.h \
     src/comm/SerialLink.h \
     src/ui/SerialConfigurationWindow.h \
 }
@@ -407,6 +408,7 @@ SOURCES += \
 
 !iOSBuild {
 SOURCES += \
+    src/comm/QGCSerialPortInfo.cc \
     src/comm/SerialLink.cc \
     src/ui/SerialConfigurationWindow.cc \
 }

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -109,23 +109,23 @@ void FirmwareUpgradeController::_foundBoard(bool firstAttempt, const QSerialPort
 {
     _foundBoardInfo = info;
     switch (type) {
-        case FoundBoardPX4FMUV1:
+        case QGCSerialPortInfo::BoardTypePX4FMUV1:
             _foundBoardType = "PX4 FMU V1";
             _startFlashWhenBootloaderFound = false;
             break;
-        case FoundBoardPX4FMUV2:
+        case QGCSerialPortInfo::BoardTypePX4FMUV2:
             _foundBoardType = "Pixhawk";
             _startFlashWhenBootloaderFound = false;
             break;
-        case FoundBoardAeroCore:
+        case QGCSerialPortInfo::BoardTypeAeroCore:
             _foundBoardType = "AeroCore";
             _startFlashWhenBootloaderFound = false;
             break;
-        case FoundBoardPX4Flow:
+        case QGCSerialPortInfo::BoardTypePX4Flow:
             _foundBoardType = "PX4 Flow";
             _startFlashWhenBootloaderFound = false;
             break;
-        case FoundBoard3drRadio:
+        case QGCSerialPortInfo::BoardType3drRadio:
             _foundBoardType = "3DR Radio";
             if (!firstAttempt) {
                 // Radio always flashes latest firmware, so we can start right away without

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.h
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.h
@@ -30,24 +30,16 @@
 
 #include "Bootloader.h"
 #include "FirmwareImage.h"
+#include "QGCSerialPortInfo.h"
 
 #include <QObject>
 #include <QThread>
 #include <QTimer>
 #include <QTime>
-#include <QSerialPortInfo>
 
 #include "qextserialport.h"
 
 #include <stdint.h>
-
-typedef enum {
-    FoundBoardPX4FMUV1,
-    FoundBoardPX4FMUV2,
-    FoundBoardPX4Flow,
-    FoundBoard3drRadio,
-    FoundBoardAeroCore
-} PX4FirmwareUpgradeFoundBoardType_t;
 
 class PX4FirmwareUpgradeThreadController;
 
@@ -64,7 +56,7 @@ public:
     
 signals:
     void updateProgress(int curr, int total);
-    void foundBoard(bool firstAttempt, const QSerialPortInfo& portInfo, int type);
+    void foundBoard(bool firstAttempt, const QGCSerialPortInfo& portInfo, int type);
     void noBoardFound(void);
     void boardGone(void);
     void foundBootloader(int bootloaderVersion, int boardID, int flashSize);
@@ -85,9 +77,9 @@ private slots:
     void _cancel(void);
     
 private:
-    bool _findBoardFromPorts(QSerialPortInfo& portInfo, PX4FirmwareUpgradeFoundBoardType_t& type);
-    bool _findBootloader(const QSerialPortInfo& portInfo, bool radioMode, bool errorOnNotFound);
-    void _3drRadioForceBootloader(const QSerialPortInfo& portInfo);
+    bool _findBoardFromPorts(QGCSerialPortInfo& portInfo, QGCSerialPortInfo::BoardType_t& boardType);
+    bool _findBootloader(const QGCSerialPortInfo& portInfo, bool radioMode, bool errorOnNotFound);
+    void _3drRadioForceBootloader(const QGCSerialPortInfo& portInfo);
     bool _erase(void);
     
     PX4FirmwareUpgradeThreadController* _controller;
@@ -100,7 +92,7 @@ private:
     
     bool                _foundBoard;            ///< true: board is currently connected
     bool                _findBoardFirstAttempt; ///< true: this is our first try looking for a board
-    QSerialPortInfo     _foundBoardPortInfo;    ///< port info for found board
+    QGCSerialPortInfo   _foundBoardPortInfo;    ///< port info for found board
 };
 
 /// @brief Provides methods to interact with the bootloader. The commands themselves are signalled
@@ -128,7 +120,7 @@ public:
     
 signals:
     /// @brief Emitted by the find board process when it finds a board.
-    void foundBoard(bool firstAttempt, const QSerialPortInfo &portInfo, int type);
+    void foundBoard(bool firstAttempt, const QGCSerialPortInfo &portInfo, int boardType);
     
     void noBoardFound(void);
     
@@ -163,7 +155,7 @@ signals:
     void _cancel(void);
     
 private slots:
-    void _foundBoard(bool firstAttempt, const QSerialPortInfo& portInfo, int type) { emit foundBoard(firstAttempt, portInfo, type); }
+    void _foundBoard(bool firstAttempt, const QGCSerialPortInfo& portInfo, int type) { emit foundBoard(firstAttempt, portInfo, type); }
     void _noBoardFound(void) { emit noBoardFound(); }
     void _boardGone(void) { emit boardGone(); }
     void _foundBootloader(int bootloaderVersion, int boardID, int flashSize) { emit foundBootloader(bootloaderVersion, boardID, flashSize); }

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -125,6 +125,9 @@ public:
     /// set into the link when it is added to LinkManager
     uint8_t getMavlinkChannel(void) const { Q_ASSERT(_mavlinkChannelSet); return _mavlinkChannel; }
 
+    /// @return true: "sh /etc/init.d/rc.usb" must be sent on link to start mavlink
+    virtual bool requiresUSBMavlinkStart(void) const { return false; }
+
     // These are left unimplemented in order to cause linker errors which indicate incorrect usage of
     // connect/disconnect on link directly. All connect/disconnect calls should be made through LinkManager.
     bool connect(void);

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -200,14 +200,16 @@ void MAVLinkProtocol::_linkStatusChanged(LinkInterface* link, bool connected)
         // Use the same shared pointer as LinkManager
         _connectedLinks.append(_linkMgr->sharedPointerForLink(link));
         
-        // Send command to start MAVLink
-        // XXX hacky but safe
-        // Start NSH
-        const char init[] = {0x0d, 0x0d, 0x0d, 0x0d};
-        link->writeBytes(init, sizeof(init));
-        const char* cmd = "sh /etc/init.d/rc.usb\n";
-        link->writeBytes(cmd, strlen(cmd));
-        link->writeBytes(init, 4);
+        if (link->requiresUSBMavlinkStart()) {
+            // Send command to start MAVLink
+            // XXX hacky but safe
+            // Start NSH
+            const char init[] = {0x0d, 0x0d, 0x0d, 0x0d};
+            link->writeBytes(init, sizeof(init));
+            const char* cmd = "sh /etc/init.d/rc.usb\n";
+            link->writeBytes(cmd, strlen(cmd));
+            link->writeBytes(init, 4);
+        }
     } else {
         bool found = false;
         for (int i=0; i<_connectedLinks.count(); i++) {

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -83,7 +83,7 @@ MockLink::MockLink(MockConfiguration* config)
     , _vehicleSystemId(128)     // FIXME: Pull from eventual parameter manager
     , _vehicleComponentId(200)  // FIXME: magic number?
     , _inNSH(false)
-    , _mavlinkStarted(false)
+    , _mavlinkStarted(true)
     , _mavBaseMode(MAV_MODE_FLAG_MANUAL_INPUT_ENABLED | MAV_MODE_FLAG_CUSTOM_MODE_ENABLED)
     , _mavState(MAV_STATE_STANDBY)
     , _firmwareType(MAV_AUTOPILOT_PX4)
@@ -336,10 +336,13 @@ void MockLink::_handleIncomingNSHBytes(const char* bytes, int cBytes)
     if (cBytes > 0) {
         qDebug() << "NSH:" << (const char*)bytes;
 
+#if 0
+        // MockLink not quite ready to handle this correctly yet
         if (strncmp(bytes, "sh /etc/init.d/rc.usb\n", cBytes) == 0) {
             // This is the mavlink start command
             _mavlinkStarted = true;
         }
+#endif
     }
 }
 

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -1,0 +1,106 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+#include "QGCSerialPortInfo.h"
+
+QGC_LOGGING_CATEGORY(QGCSerialPortInfoLog, "QGCSerialPortInfoLog")
+
+QGCSerialPortInfo::QGCSerialPortInfo(const QSerialPort & port) :
+    QSerialPortInfo(port)
+{
+
+}
+
+QGCSerialPortInfo::BoardType_t QGCSerialPortInfo::boardType(void) const
+{
+    if (isNull()) {
+        return BoardTypeUnknown;
+    }
+
+    BoardType_t boardType = BoardTypeUnknown;
+
+    switch (vendorIdentifier()) {
+        case px4VendorId:
+            if (productIdentifier() == pixhawkFMUV2ProductId || productIdentifier() == pixhawkFMUV2OldBootloaderProductId) {
+                qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V2";
+                boardType = BoardTypePX4FMUV2;
+            } else if (productIdentifier() == pixhawkFMUV1ProductId) {
+                qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V1";
+                boardType = BoardTypePX4FMUV1;
+            } else if (productIdentifier() == px4FlowProductId) {
+                qCDebug(QGCSerialPortInfoLog) << "Found PX4 Flow";
+                boardType = BoardTypePX4Flow;
+            } else if (productIdentifier() == AeroCoreProductId) {
+                qCDebug(QGCSerialPortInfoLog) << "Found AeroCore";
+                boardType = BoardTypeAeroCore;
+            }
+            break;
+        case threeDRRadioVendorId:
+            if (productIdentifier() == threeDRRadioProductId) {
+                qCDebug(QGCSerialPortInfoLog) << "Found 3DR Radio";
+                boardType = BoardType3drRadio;
+            }
+            break;
+    }
+
+    if (boardType == BoardTypeUnknown) {
+        // Fall back to port name matching which could lead to incorrect board mapping. But in some cases the
+        // vendor and product id do not come through correctly so this is used as a last chance detection method.
+        if (description() == "PX4 FMU v2.x" || description() == "PX4 BL FMU v2.x") {
+            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V2 (by name matching fallback)";
+            boardType = BoardTypePX4FMUV2;
+        } else if (description() == "PX4 FMU v1.x" || description() == "PX4 BL FMU v1.x") {
+            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V1 (by name matching fallback)";
+            boardType = BoardTypePX4FMUV1;
+        } else if (description().startsWith("PX4 FMU")) {
+            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU, assuming V2 (by name matching fallback)";
+            boardType = BoardTypePX4FMUV2;
+        }
+    }
+
+    return boardType;
+}
+
+QList<QGCSerialPortInfo> QGCSerialPortInfo::availablePorts(void)
+{
+    QList<QGCSerialPortInfo>    list;
+
+    foreach(QSerialPortInfo portInfo, QSerialPortInfo::availablePorts()) {
+        list << *((QGCSerialPortInfo*)&portInfo);
+    }
+
+    return list;
+}
+
+bool QGCSerialPortInfo::boardTypePixhawk(void) const
+{
+    BoardType_t boardType = this->boardType();
+
+    return boardType == BoardTypePX4FMUV1 || boardType == BoardTypePX4FMUV2 || boardType == BoardTypeAeroCore;
+}
+
+bool QGCSerialPortInfo::isBootloader(void) const
+{
+    // FIXME: Check SerialLink bootloade detect code which is different
+    return boardTypePixhawk() && description().contains("BL");
+}

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -81,6 +81,9 @@ QGCSerialPortInfo::BoardType_t QGCSerialPortInfo::boardType(void) const
         } else if (description().startsWith("PX4 FMU")) {
             qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU, assuming V2 (by name matching fallback)";
             boardType = BoardTypePX4FMUV2;
+        } else if (description() == "FT231X USB UART") {
+            qCDebug(QGCSerialPortInfoLog) << "Found possible Radio (by name matching fallback)";
+            boardType = BoardType3drRadio;
         }
     }
 

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -25,6 +25,12 @@
 
 QGC_LOGGING_CATEGORY(QGCSerialPortInfoLog, "QGCSerialPortInfoLog")
 
+QGCSerialPortInfo::QGCSerialPortInfo(void) :
+    QSerialPortInfo()
+{
+
+}
+
 QGCSerialPortInfo::QGCSerialPortInfo(const QSerialPort & port) :
     QSerialPortInfo(port)
 {

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -21,13 +21,35 @@
  
  ======================================================================*/
 
-#ifndef SerialPortIds_H
-#define SerialPortIds_H
+#ifndef QGCSerialPortInfo_H
+#define QGCSerialPortInfo_H
 
-// SerialPortInfo Vendor and Product Ids for known boards
-class SerialPortIds {
+#ifdef __android__
+    #include "qserialportinfo.h"
+#else
+    #include <QSerialPortInfo>
+#endif
 
+#include "QGCLoggingCategory.h"
+
+Q_DECLARE_LOGGING_CATEGORY(QGCSerialPortInfoLog)
+
+/// QGC's version of Qt QSerialPortInfo. It provides additional information about board types
+/// that QGC cares about.
+class QGCSerialPortInfo : public QSerialPortInfo
+{
 public:
+    typedef enum {
+        BoardTypePX4FMUV1,
+        BoardTypePX4FMUV2,
+        BoardTypePX4Flow,
+        BoardType3drRadio,
+        BoardTypeAeroCore,
+        BoardTypeUnknown
+    } BoardType_t;
+
+    // Vendor and products ids for the boards we care about
+
     static const int px4VendorId =                          9900;   ///< Vendor ID for Pixhawk board (V2 and V1) and PX4 Flow
 
     static const int pixhawkFMUV2ProductId =                17;     ///< Product ID for Pixhawk V2 board
@@ -40,6 +62,20 @@ public:
 
     static const int threeDRRadioVendorId =                 1027;   ///< Vendor ID for 3DR Radio
     static const int threeDRRadioProductId =                24597;  ///< Product ID for 3DR Radio
+
+    QGCSerialPortInfo(const QSerialPort & port);
+
+    /// Override of QSerialPortInfo::availablePorts
+    static QList<QGCSerialPortInfo> availablePorts(void);
+
+    BoardType_t boardType(void) const;
+
+    /// @return true: board is a Pixhawk board
+    bool boardTypePixhawk(void) const;
+
+    /// @return true: Board is currently in bootloader
+    bool isBootloader(void) const;
+
 };
 
 #endif

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -63,6 +63,7 @@ public:
     static const int threeDRRadioVendorId =                 1027;   ///< Vendor ID for 3DR Radio
     static const int threeDRRadioProductId =                24597;  ///< Product ID for 3DR Radio
 
+    QGCSerialPortInfo(void);
     QGCSerialPortInfo(const QSerialPort & port);
 
     /// Override of QSerialPortInfo::availablePorts

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -15,10 +15,8 @@
 
 #ifdef __android__
 #include "qserialport.h"
-#include "qserialportinfo.h"
 #else
 #include <QSerialPort>
-#include <QSerialPortInfo>
 #endif
 
 #include "SerialLink.h"
@@ -26,6 +24,7 @@
 #include "MG.h"
 #include "QGCLoggingCategory.h"
 #include "QGCApplication.h"
+#include "QGCSerialPortInfo.h"
 
 QGC_LOGGING_CATEGORY(SerialLinkLog, "SerialLinkLog")
 
@@ -378,6 +377,15 @@ void SerialLink::_emitLinkError(const QString& errorMsg)
 LinkConfiguration* SerialLink::getLinkConfiguration()
 {
     return _config;
+}
+
+bool SerialLink::requiresUSBMavlinkStart(void) const
+{
+    if (_port) {
+        return QGCSerialPortInfo(*_port).boardTypePixhawk();
+    } else {
+        return false;
+    }
 }
 
 //--------------------------------------------------------------------------

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -119,7 +119,8 @@ public:
     void    requestReset();
     bool    isConnected() const;
     qint64  getConnectionSpeed() const;
-    
+    bool    requiresUSBMavlinkStart(void) const;
+
     // These are left unimplemented in order to cause linker errors which indicate incorrect usage of
     // connect/disconnect on link directly. All connect/disconnect calls should be made through LinkManager.
     bool    connect(void);

--- a/src/main.cc
+++ b/src/main.cc
@@ -33,12 +33,12 @@ This file is part of the QGROUNDCONTROL project
 #include <QSslSocket>
 #include <QProcessEnvironment>
 
-#ifndef __mobile__
-    #include <QSerialPortInfo>
-#endif
-
 #include "QGCApplication.h"
 #include "MainWindow.h"
+
+#ifndef __mobile__
+    #include "QGCSerialPortInfo.h"
+#endif
 
 #ifdef QT_DEBUG
     #ifndef __mobile__
@@ -58,7 +58,7 @@ This file is part of the QGROUNDCONTROL project
 #endif
 
 #ifndef __mobile__
-Q_DECLARE_METATYPE(QSerialPortInfo)
+    Q_DECLARE_METATYPE(QGCSerialPortInfo)
 #endif
 
 #ifdef Q_OS_WIN
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
 #endif
     qRegisterMetaType<QAbstractSocket::SocketError>();
 #ifndef __mobile__
-    qRegisterMetaType<QSerialPortInfo>();
+    qRegisterMetaType<QGCSerialPortInfo>();
 #endif
 
     // We statically link our own QtLocation plugin


### PR DESCRIPTION
- Centralize board detection in QGCSerialPortInfo class. This also hides the android/non-android differences from consumers.
- Change code to use new QGCSerialPortInfo board detection logic.
- Add new requiresUSBMavlinkStart method to LinkInterface. This signals whether the mavlink start shell command is needed.
- Update MAVLinkProtocol to use requiresUSBMavlinkStart appropriately.