### PR TITLE
Position

### DIFF
--- a/ios/iOS-Info.plist
+++ b/ios/iOS-Info.plist
@@ -34,6 +34,10 @@
     <string>6.0</string>
     <key>ForAppStore</key>
     <string>No</string>
+    <key>NSLocationUsageDescription</key>
+    <string>Ground Station Location</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Ground Station Location</string>
     <key>UISupportedInterfaceOrientations</key>
     <array>
         <string>UIInterfaceOrientationLandscapeLeft</string>

--- a/ios/iOSForAppStore-Info.plist
+++ b/ios/iOSForAppStore-Info.plist
@@ -34,6 +34,10 @@
     <string>6.0</string>
     <key>ForAppStore</key>
     <string>Yes</string>
+    <key>NSLocationUsageDescription</key>
+    <string>Ground Station Location</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Ground Station Location</string>
     <key>UISupportedInterfaceOrientations</key>
     <array>
         <string>UIInterfaceOrientationLandscapeLeft</string>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -54,10 +54,10 @@ CONFIG += qt \
     thread
 
 QT += \
-    network \
     concurrent \
     gui \
     location \
+    network \
     opengl \
     positioning \
     qml \

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -49,7 +49,7 @@ Item {
 
     property var _activeVehicle:  multiVehicleManager.activeVehicle
 
-    readonly property var  _defaultVehicleCoordinate:   QtPositioning.coordinate(37.803784, -122.462276)
+    readonly property var  _defaultVehicleCoordinate:   mainWindow.tabletPosition
     readonly property real _defaultRoll:                0
     readonly property real _defaultPitch:               0
     readonly property real _defaultHeading:             0

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -39,8 +39,8 @@ FlightMap {
     id:             flightMap
     anchors.fill:   parent
     mapName:        _mapName
-    latitude:       root._defaultCoordinate.latitude
-    longitude:      root._defaultCoordinate.longitude
+    latitude:       mainWindow.tabletPosition.latitude
+    longitude:      mainWindow.tabletPosition.longitude
 
     property var    rootVehicleCoordinate:  _vehicleCoordinate
     property bool   _followVehicle:         true

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -43,8 +43,8 @@ import QGroundControl.Mavlink               1.0
 Map {
     id: _map
 
-    property real   latitude:           0
-    property real   longitude:          0
+    property real   latitude:           64.154549   //-- If you find yourself here on startup, something went wrong :)
+    property real   longitude:          -22.023540
     property real   heading:            0
     property bool   interactive:        true
     property string mapName:            'defaultMap'

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -46,7 +46,7 @@ QGCView {
     z: QGroundControl.zOrderTopMost
 
     readonly property int       _decimalPlaces:     8
-    readonly property real      _horizontalMargin:  ScreenTools.defaultFontPixelWidth / 2
+    readonly property real      _horizontalMargin:  ScreenTools.defaultFontPixelWidth  / 2
     readonly property real      _margin:            ScreenTools.defaultFontPixelHeight / 2
     readonly property var       _activeVehicle:     multiVehicleManager.activeVehicle
     readonly property real      _editFieldWidth:    ScreenTools.defaultFontPixelWidth * 16
@@ -103,7 +103,10 @@ QGCView {
     MissionController {
         id:         controller
 
-        Component.onCompleted: start(true /* editMode */)
+        Component.onCompleted: {
+            start(true /* editMode */)
+        }
+
         /*
         FIXME: autoSync is temporarily disconnected since it's still buggy
 
@@ -142,8 +145,12 @@ QGCView {
                 id:             editorMap
                 anchors.fill:   parent
                 mapName:        "MissionEditor"
-                latitude:       tabletPosition.latitude
-                longitude:      tabletPosition.longitude
+                latitude:       mainWindow.tabletPosition.latitude
+                longitude:      mainWindow.tabletPosition.longitude
+
+                Component.onCompleted: {
+                    console.log("Init coordinate " + mainWindow.tabletPosition.latitude)
+                }
 
                 readonly property real animationDuration: 500
 
@@ -695,6 +702,17 @@ QGCView {
                 } // Item - Home Position Manager
                 */
 
+                //-- Dismiss Drop Down (if any)
+                MouseArea {
+                    anchors.fill:   parent
+                    enabled:        _dropButtonsExclusiveGroup.current != null
+                    onClicked: {
+                        if(_dropButtonsExclusiveGroup.current)
+                            _dropButtonsExclusiveGroup.current.checked = false
+                        _dropButtonsExclusiveGroup.current = null
+                    }
+                }
+
                 //-- Help Panel
                 Loader {
                     id:         helpPanel
@@ -705,169 +723,186 @@ QGCView {
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
 
-
-                RoundButton {
-                    id:                 addMissionItemsButton
-                    anchors.margins:    _margin
-                    anchors.left:       parent.left
-                    y:                  (parent.height - (_toolButtonCount * height) - ((_toolButtonCount - 1) * _margin)) / 2
-                    buttonImage:        "/qmlimages/MapAddMission.svg"
-                    exclusiveGroup:     _dropButtonsExclusiveGroup
-                    z:                  QGroundControl.zOrderWidgets
-
-                    onCheckedChanged: {
-                        if (checked) {
-                            addMissionItemsButtonAutoOffTimer.start()
-                        } else {
-                            addMissionItemsButtonAutoOffTimer.stop()
-                        }
-                    }
-
-                    Timer {
-                        id:         addMissionItemsButtonAutoOffTimer
-                        interval:   _addMissionItemsButtonAutoOffTimeout
-                        repeat:     false
-
-                        onTriggered: addMissionItemsButton.checked = false
-                    }
+                Item {
+                    id:     toolbarSpacer
+                    height: mainWindow.tbHeight
+                    width:  1
                 }
 
-                RoundButton {
-                    id:                 deleteMissionItemButton
-                    anchors.margins:    _margin
-                    anchors.left:       parent.left
-                    anchors.top:        addMissionItemsButton.bottom
-                    buttonImage:        "/qmlimages/TrashDelete.svg"
-                    exclusiveGroup:     _dropButtonsExclusiveGroup
-                    z:                  QGroundControl.zOrderWidgets
+                //-- Vertical Tool Buttons
+                Column {
+                    id:                         toolColumn
+                    anchors.margins:            ScreenTools.defaultFontPixelHeight
+                    anchors.left:               parent.left
+                    anchors.top:                toolbarSpacer.bottom
+                    spacing:                    ScreenTools.defaultFontPixelHeight
 
-                    onClicked: {
-                        itemDragger.clearItem()
-                        controller.deleteCurrentMissionItem()
-                        checked = false
-                    }
-                }
+                    RoundButton {
+                        id:                 addMissionItemsButton
+                        buttonImage:        "/qmlimages/MapAddMission.svg"
+                        z:                  QGroundControl.zOrderWidgets
 
-                /*
-                  Home Position manager temporarily disable
-                RoundButton {
-                    id:                 homePositionManagerButton
-                    anchors.margins:    _margin
-                    anchors.left:       parent.left
-                    anchors.top:        deleteMissionItemButton.bottom
-                    buttonImage:        "/qmlimages/MapHome.svg"
-                    exclusiveGroup:     _dropButtonsExclusiveGroup
-                    z:                  QGroundControl.zOrderWidgets
-                }
-                */
-
-                DropButton {
-                    id:                 centerMapButton
-                    anchors.margins:    _margin
-                    anchors.left:       parent.left
-                    anchors.top:        deleteMissionItemButton.bottom
-                    dropDirection:      dropRight
-                    buttonImage:        "/qmlimages/MapCenter.svg"
-                    viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
-                    exclusiveGroup:     _dropButtonsExclusiveGroup
-                    z:                  QGroundControl.zOrderWidgets
-
-                    dropDownComponent: Component {
-                        Column {
-                            QGCLabel { text: "Center map:" }
-
-                            Row {
-                                spacing: ScreenTools.defaultFontPixelWidth
-
-                                QGCButton {
-                                    text:       "Home"
-                                    enabled:    liveHomePositionAvailable
-
-                                    onClicked: {
-                                        centerMapButton.hideDropDown()
-                                        editorMap.center = liveHomePosition
-                                    }
-                                }
-
-                                QGCButton {
-                                    text:       "Vehicle"
-                                    enabled:    activeVehicle && activeVehicle.latitude != 0 && activeVehicle.longitude != 0
-
-                                    property var activeVehicle: multiVehicleManager.activeVehicle
-
-                                    onClicked: {
-                                        centerMapButton.hideDropDown()
-                                        editorMap.latitude = activeVehicle.latitude
-                                        editorMap.longitude = activeVehicle.longitude
-                                    }
-                                }
+                        onCheckedChanged: {
+                            if (checked) {
+                                addMissionItemsButtonAutoOffTimer.start()
+                            } else {
+                                addMissionItemsButtonAutoOffTimer.stop()
                             }
                         }
+
+                        Timer {
+                            id:         addMissionItemsButtonAutoOffTimer
+                            interval:   _addMissionItemsButtonAutoOffTimeout
+                            repeat:     false
+
+                            onTriggered: addMissionItemsButton.checked = false
+                        }
                     }
-                }
 
-                DropButton {
-                    id:                 syncButton
-                    anchors.margins:    _margin
-                    anchors.left:       parent.left
-                    anchors.top:        centerMapButton.bottom
-                    dropDirection:      dropRight
-                    buttonImage:        _syncNeeded ? "/qmlimages/MapSyncChanged.svg" : "/qmlimages/MapSync.svg"
-                    viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
-                    exclusiveGroup:     _dropButtonsExclusiveGroup
-                    z:                  QGroundControl.zOrderWidgets
-                    dropDownComponent:  syncDropDownComponent
-                    enabled:            !_syncInProgress
-                }
+                    RoundButton {
+                        id:                 deleteMissionItemButton
+                        buttonImage:        "/qmlimages/TrashDelete.svg"
+                        z:                  QGroundControl.zOrderWidgets
+                        onClicked: {
+                            addMissionItemsButton.checked = false
+                            itemDragger.clearItem()
+                            controller.deleteCurrentMissionItem()
+                            checked = false
+                        }
+                    }
 
-                DropButton {
-                    id:                 mapTypeButton
-                    anchors.margins:    _margin
-                    anchors.left:       parent.left
-                    anchors.top:        syncButton.bottom
-                    dropDirection:      dropRight
-                    buttonImage:        "/qmlimages/MapType.svg"
-                    viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
-                    exclusiveGroup:     _dropButtonsExclusiveGroup
-                    z:                  QGroundControl.zOrderWidgets
+                    /*
+                      Home Position manager temporarily disable
+                    RoundButton {
+                        id:                 homePositionManagerButton
+                        buttonImage:        "/qmlimages/MapHome.svg"
+                        //exclusiveGroup:     _dropButtonsExclusiveGroup
+                        z:                  QGroundControl.zOrderWidgets
+                    }
+                    */
 
-                    dropDownComponent: Component {
-                        Column {
-                            QGCLabel { text: "Map type:" }
+                    DropButton {
+                        id:                 centerMapButton
+                        dropDirection:      dropRight
+                        buttonImage:        "/qmlimages/MapCenter.svg"
+                        viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
+                        exclusiveGroup:     _dropButtonsExclusiveGroup
+                        z:                  QGroundControl.zOrderWidgets
 
-                            Row {
-                                spacing: ScreenTools.defaultFontPixelWidth
+                        dropDownComponent: Component {
+                            Column {
+                                QGCLabel { text: "Center map:" }
 
-                                Repeater {
-                                    model: QGroundControl.flightMapSettings.mapTypes
+                                Row {
+                                    spacing: ScreenTools.defaultFontPixelWidth
 
                                     QGCButton {
-                                        checkable:      true
-                                        checked:        editorMap.mapType == text
-                                        text:           modelData
-                                        exclusiveGroup: _mapTypeButtonsExclusiveGroup
+                                        text:       "Home"
+                                        enabled:    liveHomePositionAvailable
 
                                         onClicked: {
-                                            editorMap.mapType = text
-                                            checked = true
-                                            mapTypeButton.hideDropDown()
+                                            centerMapButton.hideDropDown()
+                                            editorMap.center = liveHomePosition
+                                        }
+                                    }
+
+                                    QGCButton {
+                                        text:       "Vehicle"
+                                        enabled:    activeVehicle && activeVehicle.latitude != 0 && activeVehicle.longitude != 0
+
+                                        property var activeVehicle: multiVehicleManager.activeVehicle
+
+                                        onClicked: {
+                                            centerMapButton.hideDropDown()
+                                            editorMap.latitude = activeVehicle.latitude
+                                            editorMap.longitude = activeVehicle.longitude
                                         }
                                     }
                                 }
                             }
                         }
                     }
-                }
 
-                RoundButton {
-                    id:                 helpButton
-                    anchors.margins:    _margin
-                    anchors.left:       parent.left
-                    anchors.top:        mapTypeButton.bottom
-                    buttonImage:        "/qmlimages/Help.svg"
-                    exclusiveGroup:     _dropButtonsExclusiveGroup
-                    z:                  QGroundControl.zOrderWidgets
-                    checked:            _showHelp
+                    DropButton {
+                        id:                 syncButton
+                        dropDirection:      dropRight
+                        buttonImage:        _syncNeeded ? "/qmlimages/MapSyncChanged.svg" : "/qmlimages/MapSync.svg"
+                        viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
+                        exclusiveGroup:     _dropButtonsExclusiveGroup
+                        z:                  QGroundControl.zOrderWidgets
+                        dropDownComponent:  syncDropDownComponent
+                        enabled:            !_syncInProgress
+                    }
+
+                    DropButton {
+                        id:                 mapTypeButton
+                        dropDirection:      dropRight
+                        buttonImage:        "/qmlimages/MapType.svg"
+                        viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
+                        exclusiveGroup:     _dropButtonsExclusiveGroup
+                        z:                  QGroundControl.zOrderWidgets
+
+                        dropDownComponent: Component {
+                            Column {
+                                QGCLabel { text: "Map type:" }
+
+                                Row {
+                                    spacing: ScreenTools.defaultFontPixelWidth
+
+                                    Repeater {
+                                        model: QGroundControl.flightMapSettings.mapTypes
+
+                                        QGCButton {
+                                            checkable:      true
+                                            checked:        editorMap.mapType == text
+                                            text:           modelData
+                                            exclusiveGroup: _mapTypeButtonsExclusiveGroup
+
+                                            onClicked: {
+                                                editorMap.mapType = text
+                                                checked = true
+                                                mapTypeButton.hideDropDown()
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    //-- Zoom Map In
+                    RoundButton {
+                        id:                 mapZoomPlus
+                        visible:            !ScreenTools.isTinyScreen && !ScreenTools.isShortScreen
+                        buttonImage:        "/qmlimages/ZoomPlus.svg"
+                        z:                  QGroundControl.zOrderWidgets
+                        onClicked: {
+                            if(editorMap)
+                                editorMap.zoomLevel += 0.5
+                            checked = false
+                        }
+                    }
+
+                    //-- Zoom Map Out
+                    RoundButton {
+                        id:                 mapZoomMinus
+                        visible:            !ScreenTools.isTinyScreen && !ScreenTools.isShortScreen
+                        buttonImage:        "/qmlimages/ZoomMinus.svg"
+                        z:                  QGroundControl.zOrderWidgets
+                        onClicked: {
+                            if(editorMap)
+                                editorMap.zoomLevel -= 0.5
+                            checked = false
+                        }
+                    }
+
+                    RoundButton {
+                        id:                 helpButton
+                        buttonImage:        "/qmlimages/Help.svg"
+                        exclusiveGroup:     _dropButtonsExclusiveGroup
+                        z:                  QGroundControl.zOrderWidgets
+                        checked:            _showHelp
+                    }
                 }
 
                 Rectangle {

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -323,7 +323,6 @@ QGCApplication::~QGCApplication()
     if (mainWindow) {
         delete mainWindow;
     }
-
     shutdownVideoStreaming();
     delete _toolbox;
 }

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -31,6 +31,7 @@ Item {
     property bool isMobile:         ScreenToolsController.isMobile
     property bool isDebug:          ScreenToolsController.isDebug
     property bool isTinyScreen:     (Screen.width / Screen.pixelDensity) < 120 // 120mm
+    property bool isShortScreen:    (Screen.desktopAvailableHeight / Screen.desktopAvailableWidth) < 0.6 // Nexus 7 for example
 
     function mouseX() {
         return ScreenToolsController.mouseX()

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -30,8 +30,8 @@ Item {
     property bool isiOS:            ScreenToolsController.isiOS
     property bool isMobile:         ScreenToolsController.isMobile
     property bool isDebug:          ScreenToolsController.isDebug
-    property bool isTinyScreen:     (Screen.width / Screen.pixelDensity) < 120 // 120mm
-    property bool isShortScreen:    (Screen.desktopAvailableHeight / Screen.desktopAvailableWidth) < 0.6 // Nexus 7 for example
+    property bool isTinyScreen:     (Screen.width  / Screen.pixelDensity) < 120 // 120mm
+    property bool isShortScreen:    ScreenToolsController.isMobile && ((Screen.height / Screen.width) < 0.6) // Nexus 7 for example
 
     function mouseX() {
         return ScreenToolsController.mouseX()

--- a/src/ui/MainWindow.qml
+++ b/src/ui/MainWindow.qml
@@ -47,6 +47,9 @@ Item {
     property real avaiableHeight:   height - tbHeight
     property real menuButtonWidth:  (tbButtonWidth * 2) + (tbSpacing * 4) + 1
 
+    property var defaultPosition:   QtPositioning.coordinate(37.803784, -122.462276)
+    property var tabletPosition:    defaultPosition
+
     Connections {
 
         target: controller
@@ -86,17 +89,23 @@ Item {
     }
 
     //-- Detect tablet position
-    property var tabletPosition: QtPositioning.coordinate(37.803784, -122.462276)
     PositionSource {
         id:             positionSource
         updateInterval: 1000
-        active:         true // ScreenTools.isMobile
-
+        active:         false
         onPositionChanged: {
-            tabletPosition          = positionSource.position.coordinate
-            flightView.latitude     = tabletPosition.latitude
-            flightView.longitude    = tabletPosition.longitude
-            positionSource.active   = false
+            if(positionSource.valid) {
+                if(positionSource.position.coordinate.latitude) {
+                    if(Math.abs(positionSource.position.coordinate.latitude)  > 0.001) {
+                        if(positionSource.position.coordinate.longitude) {
+                            if(Math.abs(positionSource.position.coordinate.longitude)  > 0.001) {
+                                tabletPosition = positionSource.position.coordinate
+                            }
+                        }
+                    }
+                }
+            }
+            positionSource.stop()
         }
     }
 
@@ -146,20 +155,21 @@ Item {
         anchors.fill:       parent
         avaiableHeight:     mainWindow.avaiableHeight
         visible:            true
+        Component.onCompleted: {
+            positionSource.start()
+        }
     }
 
     Loader {
         id:                 planViewLoader
         anchors.fill:       parent
         visible:            false
-        property var tabletPosition:    mainWindow.tabletPosition
     }
 
     Loader {
         id:                 setupViewLoader
         anchors.fill:       parent
         visible:            false
-        property var tabletPosition:    mainWindow.tabletPosition
     }
 
 }


### PR DESCRIPTION
Fixed several issue with initial map coordinates.

Issue #2217: PositionSource, which is used to get the initial position from your tablet, was not stopping. Setting its *active* property to *false* had no effect. You have to call its *stop()* method instead.

Issue #2216: If PositionSource is not available (in some platforms), it returns NaN and no check was being made. This would cause the starting position to 0,0 (somewhere on the Atlantic Ocean, west of Africa).

On iOS, you have to manually configure the app for accessing location services (Qt does this for you on Android automatically). There is no documentation about this anywhere and none of the location examples in Qt work on iOS unless you manually edit and change the code.

The default starting coordinates for both Mission and Fly view maps are now handle by MainWindow. It defaults to Crissy Field park, next to the Golden Gate Bridge. If PositionSource works and provides a current, valid coordinate (only tablets for now), the system will use it as the default starting position.

On a minor note, the Zoom buttons in the Mission View are now disabled on *short* screens (the Nexus 7 for example). They don't fit.
