### PR TITLE
Meta data values need string conversion as well

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -129,23 +129,28 @@ QVariant Fact::value(void) const
     return _value;
 }
 
-QString Fact::valueString(void) const
+QString Fact::_variantToString(const QVariant& variant) const
 {
     QString valueString;
 
     switch (type()) {
         case FactMetaData::valueTypeFloat:
-            valueString = QString("%1").arg(value().toFloat(), 0, 'g', decimalPlaces());
+            valueString = QString("%1").arg(variant.toFloat(), 0, 'f', decimalPlaces());
             break;
         case FactMetaData::valueTypeDouble:
-            valueString = QString("%1").arg(value().toDouble(), 0, 'g', decimalPlaces());
+            valueString = QString("%1").arg(variant.toDouble(), 0, 'f', decimalPlaces());
             break;
         default:
-            valueString = value().toString();
+            valueString = variant.toString();
             break;
     }
 
     return valueString;
+}
+
+QString Fact::valueString(void) const
+{
+    return _variantToString(value());
 }
 
 QVariant Fact::defaultValue(void) const
@@ -159,6 +164,11 @@ QVariant Fact::defaultValue(void) const
         qWarning() << "Meta data pointer missing";
         return QVariant(0);
     }
+}
+
+QString Fact::defaultValueString(void) const
+{
+    return _variantToString(defaultValue());
 }
 
 FactMetaData::ValueType_t Fact::type(void) const
@@ -206,6 +216,11 @@ QVariant Fact::min(void) const
     }
 }
 
+QString Fact::minString(void) const
+{
+    return _variantToString(min());
+}
+
 QVariant Fact::max(void) const
 {
     if (_metaData) {
@@ -214,6 +229,11 @@ QVariant Fact::max(void) const
         qWarning() << "Meta data pointer missing";
         return QVariant(0);
     }
+}
+
+QString Fact::maxString(void) const
+{
+    return _variantToString(max());
 }
 
 bool Fact::minIsDefaultForType(void) const

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -53,14 +53,17 @@ public:
     Q_PROPERTY(QVariant valueString             READ valueString                            NOTIFY valueChanged)
     Q_PROPERTY(QString  units                   READ units                                  CONSTANT)
     Q_PROPERTY(QVariant defaultValue            READ defaultValue                           CONSTANT)
+    Q_PROPERTY(QString  defaultValueString      READ defaultValueString                     CONSTANT)
     Q_PROPERTY(bool     defaultValueAvailable   READ defaultValueAvailable                  CONSTANT)
     Q_PROPERTY(bool     valueEqualsDefault      READ valueEqualsDefault                     NOTIFY valueChanged)
     Q_PROPERTY(FactMetaData::ValueType_t type   READ type                                   CONSTANT)
     Q_PROPERTY(QString  shortDescription        READ shortDescription                       CONSTANT)
     Q_PROPERTY(QString  longDescription         READ longDescription                        CONSTANT)
     Q_PROPERTY(QVariant min                     READ min                                    CONSTANT)
+    Q_PROPERTY(QString  minString               READ minString                              CONSTANT)
     Q_PROPERTY(bool     minIsDefaultForType     READ minIsDefaultForType                    CONSTANT)
     Q_PROPERTY(QVariant max                     READ max                                    CONSTANT)
+    Q_PROPERTY(QString  maxString               READ maxString                              CONSTANT)
     Q_PROPERTY(bool     maxIsDefaultForType     READ maxIsDefaultForType                    CONSTANT)
     Q_PROPERTY(int      decimalPlaces           READ decimalPlaces                          CONSTANT)
     
@@ -70,25 +73,30 @@ public:
     
     // Property system methods
     
-    QString name(void) const;
-    int componentId(void) const;
-    QVariant value(void) const;
-    QString valueString(void) const;
-    void setValue(const QVariant& value);
-    QVariant defaultValue(void) const;
-	bool defaultValueAvailable(void) const;
-    bool valueEqualsDefault(void) const;
+    QString     name(void) const;
+    int         componentId(void) const;
+    QVariant    value(void) const;
+    QString     valueString(void) const;
+    QVariant    defaultValue(void) const;
+    QString     defaultValueString(void) const;
+    bool        defaultValueAvailable(void) const;
+    bool        valueEqualsDefault(void) const;
+    QString     shortDescription(void) const;
+    QString     longDescription(void) const;
+    QString     units(void) const;
+    QVariant    min(void) const;
+    QString     minString(void) const;
+    bool        minIsDefaultForType(void) const;
+    QVariant    max(void) const;
+    QString     maxString(void) const;
+    bool        maxIsDefaultForType(void) const;
+    QString     group(void) const;
+    int         decimalPlaces(void) const;
+
     FactMetaData::ValueType_t type(void) const;
-    QString shortDescription(void) const;
-    QString longDescription(void) const;
-    QString units(void) const;
-    QVariant min(void) const;
-    bool minIsDefaultForType(void) const;
-    QVariant max(void) const;
-    bool maxIsDefaultForType(void) const;
-    QString group(void) const;
-    int decimalPlaces(void) const;
-    
+
+    void setValue(const QVariant& value);
+
     /// Sets and sends new value to vehicle even if value is the same
     void forceSetValue(const QVariant& value);
     
@@ -115,6 +123,8 @@ signals:
     void _containerValueChanged(const QVariant& value);
     
 private:
+    QString _variantToString(const QVariant& variant) const;
+
     QString                     _name;
     int                         _componentId;
     QVariant                    _value;

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -110,7 +110,7 @@ QGCViewDialog {
             visible: !fact.minIsDefaultForType
 
             QGCLabel { text: "Minimum value:" }
-            QGCLabel { text: fact.min }
+            QGCLabel { text: fact.minString }
         }
 
         Row {
@@ -118,14 +118,14 @@ QGCViewDialog {
             visible: !fact.maxIsDefaultForType
 
             QGCLabel { text: "Maximum value:" }
-            QGCLabel { text: fact.max }
+            QGCLabel { text: fact.maxString }
         }
 
         Row {
             spacing: defaultTextWidth
 
             QGCLabel { text: "Default value:" }
-            QGCLabel { text: fact.defaultValueAvailable ? fact.defaultValue : "none" }
+            QGCLabel { text: fact.defaultValueAvailable ? fact.defaultValueString : "none" }
         }
 
         QGCLabel {


### PR DESCRIPTION
Fix for Issue #2240.

Changed to “f” string conversion from “g” to get better results. BAT_V_CAPACITY now will show as 5200.000. This is because precision is not set for this param and it defaults to 3 past the decimal place.

With this change min/max/default value output string now use same precision formatting as associated parameters. So you get better output in the editor dialog.