### PR TITLE
Reflow flight mode layout even when joystick control is enabled

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.qml
@@ -136,10 +136,9 @@ QGCView {
         running:    true
 
         onTriggered: {
+            recalcModePositions()
             if (rcInMode.value == 1) {
                 showDialog(joystickEnabledDialogComponent, title, 50, 0)
-            } else {
-                recalcModePositions()
             }
         }
     }


### PR DESCRIPTION
With COM_RC_IN_MODE the flight mode tab doesn't update QML layout and clips/overlaps in a cluttered fashion. This allows layout updates even when blocked by the modal joystick mode warning pane.

![image](https://cloud.githubusercontent.com/assets/2575/11348647/afc9848e-91f5-11e5-86dc-f99839053fa7.png)
