### PR TITLE
Fix telemetry radio RSSI calculation for SI1000 based modems

### DIFF
--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -291,8 +291,25 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                 // process telemetry status message
                 mavlink_radio_status_t rstatus;
                 mavlink_msg_radio_status_decode(&message, &rstatus);
+                int rssi = rstatus.rssi,
+                    remrssi = rstatus.remrssi;
+                // 3DR Si1k radio needs rssi fields to be converted to dBm
+                if (message.sysid == '3' && message.compid == 'D') {
+                    /* Per the Si1K datasheet figure 23.25 and SI AN474 code
+                     * samples the relationship between the RSSI register
+                     * and received power is as follows:
+                     *
+                     *                       10
+                     * inputPower = rssi * ------ 127
+                     *                       19
+                     *
+                     * Additionally limit to the only realistic range [-120,0] dBm
+                     */
+                    rssi    = qMin(qMax(qRound(static_cast<qreal>(rssi)    / 1.9 - 127.0), - 120), 0);
+                    remrssi = qMin(qMax(qRound(static_cast<qreal>(remrssi) / 1.9 - 127.0), - 120), 0);
+                }
 
-                emit radioStatusChanged(link, rstatus.rxerrors, rstatus.fixed, rstatus.rssi, rstatus.remrssi,
+                emit radioStatusChanged(link, rstatus.rxerrors, rstatus.fixed, rssi, remrssi,
                     rstatus.txbuf, rstatus.noise, rstatus.remnoise);
             }
 

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -269,8 +269,8 @@ signals:
      *
      * @param rxerrors receive errors
      * @param fixed count of error corrected packets
-     * @param rssi local signal strength
-     * @param remrssi remote signal strength
+     * @param rssi local signal strength in dBm
+     * @param remrssi remote signal strength in dBm
      * @param txbuf how full the tx buffer is as a percentage
      * @param noise background noise level
      * @param remnoise remote background noise level

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -275,7 +275,7 @@ signals:
      * @param noise background noise level
      * @param remnoise remote background noise level
      */
-    void radioStatusChanged(LinkInterface* link, unsigned rxerrors, unsigned fixed, unsigned rssi, unsigned remrssi,
+    void radioStatusChanged(LinkInterface* link, unsigned rxerrors, unsigned fixed, int rssi, int remrssi,
     unsigned txbuf, unsigned noise, unsigned remnoise);
     
     /// @brief Emitted when a temporary log file is ready for saving

--- a/src/ui/toolbar/MainToolBarController.cc
+++ b/src/ui/toolbar/MainToolBarController.cc
@@ -52,8 +52,8 @@ MainToolBarController::MainToolBarController(QObject* parent)
 
     // RSSI (didn't like standard connection)
     connect(qgcApp()->toolbox()->mavlinkProtocol(),
-        SIGNAL(radioStatusChanged(LinkInterface*, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned)), this,
-        SLOT(_telemetryChanged(LinkInterface*, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned, unsigned)));
+        SIGNAL(radioStatusChanged(LinkInterface*, unsigned, unsigned, int, int, unsigned, unsigned, unsigned)), this,
+        SLOT(_telemetryChanged(LinkInterface*, unsigned, unsigned, int, int, unsigned, unsigned, unsigned)));
 
     connect(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::activeVehicleChanged, this, &MainToolBarController::_activeVehicleChanged);
 }
@@ -96,7 +96,7 @@ void MainToolBarController::_activeVehicleChanged(Vehicle* vehicle)
     }
 }
 
-void MainToolBarController::_telemetryChanged(LinkInterface*, unsigned, unsigned, unsigned rssi, unsigned remrssi, unsigned, unsigned, unsigned)
+void MainToolBarController::_telemetryChanged(LinkInterface*, unsigned, unsigned, int rssi, int remrssi, unsigned, unsigned, unsigned)
 {
     if((unsigned)_telemetryLRSSI != rssi) {
         // According to the Silabs data sheet, the RSSI value is 0.5db per bit

--- a/src/ui/toolbar/MainToolBarController.cc
+++ b/src/ui/toolbar/MainToolBarController.cc
@@ -98,14 +98,12 @@ void MainToolBarController::_activeVehicleChanged(Vehicle* vehicle)
 
 void MainToolBarController::_telemetryChanged(LinkInterface*, unsigned, unsigned, int rssi, int remrssi, unsigned, unsigned, unsigned)
 {
-    if((unsigned)_telemetryLRSSI != rssi) {
-        // According to the Silabs data sheet, the RSSI value is 0.5db per bit
-        _telemetryLRSSI = rssi >> 1;
+    if(_telemetryLRSSI != rssi) {
+        _telemetryLRSSI = rssi;
         emit telemetryLRSSIChanged(_telemetryLRSSI);
     }
-    if((unsigned)_telemetryRRSSI != remrssi) {
-        // According to the Silabs data sheet, the RSSI value is 0.5db per bit
-        _telemetryRRSSI = remrssi >> 1;
+    if(_telemetryRRSSI != remrssi) {
+        _telemetryRRSSI = remrssi;
         emit telemetryRRSSIChanged(_telemetryRRSSI);
     }
 }

--- a/src/ui/toolbar/MainToolBarController.h
+++ b/src/ui/toolbar/MainToolBarController.h
@@ -80,7 +80,7 @@ signals:
 private slots:
     void _activeVehicleChanged          (Vehicle* vehicle);
     void _setProgressBarValue           (float value);
-    void _telemetryChanged              (LinkInterface* link, unsigned rxerrors, unsigned fixed, unsigned rssi, unsigned remrssi, unsigned txbuf, unsigned noise, unsigned remnoise);
+    void _telemetryChanged              (LinkInterface* link, unsigned rxerrors, unsigned fixed, int rssi, int remrssi, unsigned txbuf, unsigned noise, unsigned remnoise);
     void _delayedShowToolBarMessage     (void);
 
 private:

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -536,7 +536,7 @@ Row {
                     color: colorWhite
                 }
                 QGCLabel {
-                    text: _controller.telemetryRRSSI + 'dB'
+                    text: _controller.telemetryRRSSI + 'dBm'
                     width: getProportionalDimmension(30)
                     horizontalAlignment: Text.AlignRight
                     font.pixelSize: ScreenTools.smallFontPixelSize
@@ -553,7 +553,7 @@ Row {
                     color: colorWhite
                 }
                 QGCLabel {
-                    text: _controller.telemetryLRSSI + 'dB'
+                    text: _controller.telemetryLRSSI + 'dBm'
                     width: getProportionalDimmension(30)
                     horizontalAlignment: Text.AlignRight
                     font.pixelSize: ScreenTools.smallFontPixelSize


### PR DESCRIPTION
The old RSSI value was computed by halving the RSSI figure injected in the mavlink stream. Originally we were halving the injected value, likely based on this statement in the datasheet about RSSI resolution:

![image](https://cloud.githubusercontent.com/assets/2575/11378458/40183242-92b9-11e5-83d9-3a0002ef486d.png)


Actual input power follows the following curve:
![image](https://cloud.githubusercontent.com/assets/2575/11378471/5909a5d8-92b9-11e5-85a7-33ea1412f6f1.png)


This PR implements accurate input power calculations for telemetry radios that identify themselves matching the [DIYDrones Si1k firmware](https://github.com/Dronecode/SiK/blob/c264c6766ddf778e75fe0b901635ace90b0836f7/Firmware/radio/mavlink.c#L133). 