### PR TITLE
Add the initial stub for the AirFrame configuration for APM

### DIFF
--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -204,5 +204,8 @@
         <file alias="AirframeFactMetaData.xml">src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml</file>
         <file alias="ParameterFactMetaData.xml">src/AutoPilotPlugins/PX4/ParameterFactMetaData.xml</file>
     </qresource>
+    <qresource prefix="/AutoPilotPlugins/APM">
+        <file alias="AirframeFactMetaData.xml">src/AutoPilotPlugins/APM/AirframeFactMetaData.xml</file>
+    </qresource>
 
 </RCC>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -292,7 +292,9 @@ HEADERS += \
     src/ui/uas/QGCUnconnectedInfoWidget.h \
     src/ui/uas/UASMessageView.h \
     src/AutoPilotPlugins/PX4/PX4AirframeLoader.h \
+    src/AutoPilotPlugins/APM/APMAirframeLoader.h \
     src/QmlControls/QGCImageProvider.h \
+    src/AutoPilotPlugins/APM/APMRemoteParamsDownloader.h
 
 WindowsBuild {
     PRECOMPILED_HEADER += src/stable_headers.h
@@ -403,7 +405,9 @@ SOURCES += \
     src/ui/uas/QGCUnconnectedInfoWidget.cc \
     src/ui/uas/UASMessageView.cc \
     src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc \
+    src/AutoPilotPlugins/APM/APMAirframeLoader.cc \
     src/QmlControls/QGCImageProvider.cc \
+    src/AutoPilotPlugins/APM/APMRemoteParamsDownloader.cc
 
 !iOSBuild {
 SOURCES += \
@@ -521,6 +525,7 @@ SOURCES += \
 
 INCLUDEPATH += \
     src/AutoPilotPlugins/PX4 \
+    src/AutoPilotPlugins/APM \
     src/FirmwarePlugin \
     src/Vehicle \
     src/VehicleSetup \
@@ -530,6 +535,8 @@ HEADERS+= \
     src/AutoPilotPlugins/AutoPilotPluginManager.h \
     src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h \
     src/AutoPilotPlugins/APM/APMAirframeComponent.h \
+    src/AutoPilotPlugins/APM/APMAirframeComponentController.h \
+    src/AutoPilotPlugins/APM/APMAirframeComponentAirframes.h \
     src/AutoPilotPlugins/APM/APMComponent.h \
     src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.h \
     src/AutoPilotPlugins/PX4/AirframeComponent.h \
@@ -574,7 +581,9 @@ SOURCES += \
     src/AutoPilotPlugins/AutoPilotPluginManager.cc \
     src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc \
     src/AutoPilotPlugins/APM/APMAirframeComponent.cc \
+    src/AutoPilotPlugins/APM/APMAirframeComponentController.cc \
     src/AutoPilotPlugins/APM/APMComponent.cc \
+    src/AutoPilotPlugins/APM/APMAirframeComponentAirframes.cc \
     src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.cc \
     src/AutoPilotPlugins/PX4/AirframeComponent.cc \
     src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc \

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.cc
@@ -59,7 +59,7 @@ bool APMAirframeComponent::setupComplete(void) const
 {
     // You'll need to figure out which parameters trigger setup complete
 #if 0
-    return _autopilot->getParameterFact(FactSystem::defaultComponentId, "SYS_AUTOSTART")->rawValue().toInt() != 0;
+    return _autopilot->getParameterFact(FactSystem::defaultComponentId, "SYS_AUTOSTART")->value().toInt() != 0;
 #else
     return true;
 #endif
@@ -67,37 +67,17 @@ bool APMAirframeComponent::setupComplete(void) const
 
 QString APMAirframeComponent::setupStateDescription(void) const
 {
-    const char* stateDescription;
-    
-    if (requiresSetup()) {
-        stateDescription = "Requires calibration";
-    } else {
-        stateDescription = "Calibrated";
-    }
-    return QString(stateDescription);
+    return QString(requiresSetup() ? "Requires calibration" : "Calibrated");
 }
 
 QStringList APMAirframeComponent::setupCompleteChangedTriggerList(void) const
 {
-    // You'll need to figure out which parameters trigger setup complete
-#if 0
-    return QStringList("SYS_AUTOSTART");
-#else
     return QStringList();
-#endif
 }
 
 QStringList APMAirframeComponent::paramFilterList(void) const
 {
-#if 0
-    QStringList list;
-    
-    list << "SYS_AUTOSTART";
-    
-    return list;
-#else
     return QStringList();
-#endif
 }
 
 QUrl APMAirframeComponent::setupSource(void) const

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
@@ -21,7 +21,7 @@
 
  ======================================================================*/
 
-import QtQuick 2.2
+import QtQuick 2.5
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 import QtQuick.Dialogs 1.2
@@ -39,13 +39,225 @@ QGCView {
 
     QGCPalette { id: qgcPal; colorGroupEnabled: panel.enabled }
 
+    property real _minW:        ScreenTools.defaultFontPixelWidth * 30
+    property real _boxWidth:    _minW
+    property real _boxSpace:    ScreenTools.defaultFontPixelWidth
+
+    function computeDimensions() {
+        var sw  = 0
+        var rw  = 0
+        var idx = Math.floor(scroll.width / (_minW + ScreenTools.defaultFontPixelWidth))
+        if(idx < 1) {
+            _boxWidth = scroll.width
+            _boxSpace = 0
+        } else {
+            _boxSpace = 0
+            if(idx > 1) {
+                _boxSpace = ScreenTools.defaultFontPixelWidth
+                sw = _boxSpace * (idx - 1)
+            }
+            rw = scroll.width - sw
+            _boxWidth = rw / idx
+        }
+    }
+
+    APMAirframeComponentController {
+        id:         controller
+        factPanel:  panel
+
+        Component.onCompleted: {
+            if (controller.showCustomConfigPanel) {
+                showDialog(customConfigDialogComponent, "Custom Airframe Config", 50, StandardButton.Reset)
+            }
+        }
+    }
+
+    Component {
+        id: customConfigDialogComponent
+
+        QGCViewMessage {
+            id:             customConfigDialog
+
+            message:        "Your vehicle is using a custom airframe configuration. " +
+                                "This configuration can only be modified through the Parameter Editor.\n\n" +
+                                "If you want to Reset your airframe configuration and select a standard configuration, click 'Reset' above."
+
+            property Fact sys_autostart: controller.getParameterFact(-1, "SYS_AUTOSTART")
+
+            function accept() {
+                sys_autostart.value = 0
+                customConfigDialog.hideDialog()
+            }
+        }
+    }
+
+    Component {
+        id: applyRestartDialogComponent
+
+        QGCViewDialog {
+            id: applyRestartDialog
+
+            function accept() {
+                controller.changeAutostart()
+                applyRestartDialog.hideDialog()
+            }
+
+            QGCLabel {
+                anchors.fill:   parent
+                wrapMode:       Text.WordWrap
+                text:           "Clicking Apply will save the changes you have made to your aiframe configuration. "
+            }
+        }
+    }
+
     QGCViewPanel {
         id:             panel
         anchors.fill:   parent
 
-        QGCLabel {
-            text: "Work in progress";
+        readonly property real spacerHeight: ScreenTools.defaultFontPixelHeight
+
+        Item {
+            id:             helpApplyRow
+            anchors.top:    parent.top
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            height:         Math.max(helpText.contentHeight, applyButton.height)
+
+            QGCLabel {
+                id:             helpText
+                width:          parent.width - applyButton.width - 5
+                text:           "Please select your airframe type. Click 'Apply' to save."
+                font.pixelSize: ScreenTools.mediumFontPixelSize
+                wrapMode:       Text.WordWrap
+            }
+
+            QGCButton {
+                id:             applyButton
+                anchors.right:  parent.right
+                text:           "Apply"
+
+                onClicked:      showDialog(applyRestartDialogComponent, "Apply", 50, StandardButton.Apply | StandardButton.Cancel)
+            }
         }
 
+        Item {
+            id:             lastSpacer
+            anchors.top:    helpApplyRow.bottom
+            height:         parent.spacerHeight
+            width:          10
+        }
+
+        Flickable {
+            id:             scroll
+            anchors.top:    lastSpacer.bottom
+            anchors.bottom: parent.bottom
+            width:          parent.width
+            clip:           true
+            contentHeight:  flowView.height
+            contentWidth:   parent.width
+            boundsBehavior:     Flickable.StopAtBounds
+            flickableDirection: Flickable.VerticalFlick
+
+            onWidthChanged: {
+                computeDimensions()
+            }
+
+            Flow {
+                id:         flowView
+                width:      scroll.width
+                spacing:    _boxSpace
+
+                ExclusiveGroup {
+                    id: airframeTypeExclusive
+                }
+
+                Repeater {
+                    model: controller.airframeTypesModel
+
+                    // Outer summary item rectangle
+                    delegate : Rectangle {
+                        id:     airframeBackground
+                        width:  _boxWidth
+                        height: ScreenTools.defaultFontPixelHeight * 14
+                        color:  (index != controller.currentAirframeType) ? qgcPal.windowShade : qgcPal.buttonHighlight
+
+                        readonly property real titleHeight: ScreenTools.defaultFontPixelHeight * 1.75
+                        readonly property real innerMargin: ScreenTools.defaultFontPixelWidth
+
+                        MouseArea {
+                                anchors.fill:   parent
+                                onClicked:      airframeCheckBox.checked = true;
+                            }
+
+                        Rectangle {
+                            id:     nameRect;
+                            width:  parent.width
+                            height: parent.titleHeight
+                            color:  qgcPal.windowShadeDark
+
+                            QGCLabel {
+                                anchors.fill:           parent
+                                color:                  qgcPal.buttonText
+                                verticalAlignment:      TextEdit.AlignVCenter
+                                horizontalAlignment:    TextEdit.AlignHCenter
+                                text:                   object.name
+                            }
+                        }
+
+                        Image {
+                            id:                 imageRect
+                            anchors.topMargin:  innerMargin
+                            anchors.top:        nameRect.bottom
+                            width:              parent.width * 0.75
+                            height:             parent.height - nameRect.height - combo.height - (innerMargin * 3)
+                            fillMode:           Image.PreserveAspectFit
+                            smooth:             true
+                            mipmap:             true
+                            source:             object.imageResource
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+
+                        QGCCheckBox {
+                            id:             airframeCheckBox
+                            checked:        object.name == controller.currentAirframeType
+                            exclusiveGroup: airframeTypeExclusive
+                            anchors.bottom: imageRect.bottom
+                            anchors.right:  parent.right
+                            anchors.rightMargin: innerMargin
+
+                            onCheckedChanged: {
+                                if (checked && combo.currentIndex != -1) {
+                                    controller.autostartId = object.airframes[combo.currentIndex].autostartId
+                                    airframeBackground.color = qgcPal.buttonHighlight;
+                                } else {
+                                    airframeBackground.color = qgcPal.windowShade;
+                                }
+                            }
+                        }
+
+                        QGCComboBox {
+                            id:                 combo
+                            objectName:         object.airframeType + "ComboBox"
+                            x:                  innerMargin
+                            anchors.topMargin:  innerMargin
+                            anchors.top:        imageRect.bottom
+                            width:              parent.width - (innerMargin * 2)
+                            currentIndex:       (name == controller.currentAirframeType) ? controller.currentVehicleIndex : -1
+                            model:              object.airframes
+
+                            onActivated: {
+                                if (index != -1) {
+                                    currentIndex = index
+                                    controller.autostartId = object.airframes[index].autostartId
+                                    controller.fileParams = object.airframes[index].params;
+                                    console.log(controller.fileParams + "changed!");
+                                    airframeCheckBox.checked = true;
+                                }
+                            }
+                        }
+                    }
+                } // Repeater - summary boxes
+            } // Flow - summary boxes
+        } // Scroll View - summary boxes
     } // QGCViewPanel
 } // QGCView

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentAirframes.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentAirframes.cc
@@ -1,0 +1,62 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#include "APMAirframeComponentAirframes.h"
+
+QMap<QString, APMAirframeComponentAirframes::AirframeType_t*> APMAirframeComponentAirframes::rgAirframeTypes;
+
+QMap<QString, APMAirframeComponentAirframes::AirframeType_t*>& APMAirframeComponentAirframes::get() {
+    return rgAirframeTypes;
+}
+
+void APMAirframeComponentAirframes::insert(const QString& group,const QString& image,const QString& name, const QString& file, int id)
+{
+    AirframeType_t *g;
+    if (!rgAirframeTypes.contains(group)) {
+        g = new AirframeType_t;
+        g->name = group;
+        g->imageResource = QString("qrc:/qmlimages/") + (!image.isEmpty() ? image : QString("AirframeStandardPlane.png"));
+        rgAirframeTypes.insert(group, g);
+    } else {
+        g = rgAirframeTypes.value(group);
+    }
+
+    AirframeInfo_t *i = new AirframeInfo_t;
+    i->name = name;
+    i->file = file;
+    i->autostartId = id;
+
+    g->rgAirframeInfo.append(i);
+}
+
+void APMAirframeComponentAirframes::clear() {
+    QList<AirframeType_t*> valueList = get().values();
+    foreach(AirframeType_t *pType, valueList) {
+        qDeleteAll(pType->rgAirframeInfo);
+        delete pType;
+    }
+    rgAirframeTypes.clear();
+}

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentAirframes.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentAirframes.h
@@ -1,0 +1,64 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#ifndef APMAirframeComponentAirframes_H
+#define APMAirframeComponentAirframes_H
+
+#include <QObject>
+#include <QQuickItem>
+#include <QList>
+#include <QMap>
+
+#include "UASInterface.h"
+#include "AutoPilotPlugin.h"
+
+/// MVC Controller for AirframeComponent.qml.
+class APMAirframeComponentAirframes
+{
+public:
+    typedef struct {
+        QString name;
+        QString file;
+        int         autostartId;
+    } AirframeInfo_t;
+    
+    typedef struct {
+        QString name;
+        QString imageResource;
+        QList<AirframeInfo_t*> rgAirframeInfo;
+    } AirframeType_t;
+
+    static QMap<QString, APMAirframeComponentAirframes::AirframeType_t*>& get();
+    static void clear();
+    static void insert(const QString& group,const QString& image,const QString& name, const QString& file, int id);
+    
+protected:
+    static QMap<QString, AirframeType_t*> rgAirframeTypes;
+    
+private:
+};
+
+#endif

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -1,0 +1,172 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#include "APMAirframeComponentController.h"
+#include "APMAirframeComponentAirframes.h"
+#include "APMRemoteParamsDownloader.h"
+#include "QGCMAVLink.h"
+#include "MultiVehicleManager.h"
+#include "AutoPilotPluginManager.h"
+#include "QGCApplication.h"
+#include "QGCMessageBox.h"
+
+#include <QVariant>
+#include <QQmlProperty>
+
+bool APMAirframeComponentController::_typesRegistered = false;
+
+APMAirframeComponentController::APMAirframeComponentController(void) :
+    _currentVehicleIndex(0),
+    _autostartId(0),
+    _showCustomConfigPanel(false),
+    _airframeTypesModel(new QmlObjectListModel(this))
+{
+    if (!_typesRegistered) {
+        _typesRegistered = true;
+        qmlRegisterUncreatableType<APMAirframeType>("QGroundControl.Controllers", 1, 0, "APMAiframeType", "Can only reference APMAirframeType");
+        qmlRegisterUncreatableType<APMAirframe>("QGroundControl.Controllers", 1, 0, "APMAiframe", "Can only reference APMAirframe");
+    }
+
+    APMRemoteParamsDownloader *paramDownloader = new APMRemoteParamsDownloader();
+    connect(paramDownloader, SIGNAL(finished()), this, SLOT(_fillAirFrames()));
+}
+
+APMAirframeComponentController::~APMAirframeComponentController()
+{
+
+}
+
+void APMAirframeComponentController::_fillAirFrames()
+{
+    // Load up member variables
+    bool autostartFound = false;
+    _autostartId = 0; //getParameterFact(FactSystem::defaultComponentId, "SYS_AUTOSTART")->value().toInt();
+
+    QList<APMAirframeType*> airframeTypes;
+    for (int tindex = 0; tindex < APMAirframeComponentAirframes::get().count(); tindex++) {
+        const APMAirframeComponentAirframes::AirframeType_t* pType = APMAirframeComponentAirframes::get().values().at(tindex);
+
+        APMAirframeType* airframeType = new APMAirframeType(pType->name, pType->imageResource, this);
+        Q_CHECK_PTR(airframeType);
+
+        for (int index = 0; index < pType->rgAirframeInfo.count(); index++) {
+            const APMAirframeComponentAirframes::AirframeInfo_t* pInfo = pType->rgAirframeInfo.at(index);
+            Q_CHECK_PTR(pInfo);
+
+            if (_autostartId == pInfo->autostartId) {
+                Q_ASSERT(!autostartFound);
+                autostartFound = true;
+                _currentAirframeType = pType->name;
+                _currentVehicleName = pInfo->name;
+                _currentVehicleIndex = index;
+            }
+            airframeType->addAirframe(pInfo->name, pInfo->file, pInfo->autostartId);
+        }
+        _airframeTypesModel->append(airframeType);
+    }
+
+    if (_autostartId != 0 && !autostartFound) {
+        _showCustomConfigPanel = true;
+        emit showCustomConfigPanelChanged(true);
+    }
+    emit loadAirframesCompleted();
+}
+
+void APMAirframeComponentController::changeAutostart(void)
+{
+    if (qgcApp()->toolbox()->multiVehicleManager()->vehicles()->count() > 1) {
+        QGCMessageBox::warning("APMAirframe Config", "You cannot change Airframe configuration while connected to multiple vehicles.");
+        return;
+    }
+
+    qgcApp()->setOverrideCursor(Qt::WaitCursor);
+    QDir dataLocation = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation).at(0)
+           + QDir::separator() + qApp->applicationName();
+
+    QFile parametersFile(dataLocation.absoluteFilePath(_currentFileParams));
+    parametersFile.open(QIODevice::ReadOnly);
+
+    QTextStream reader(&parametersFile);
+
+    while (!reader.atEnd()) {
+        QString line = reader.readLine().trimmed();
+        if (line.isEmpty() || line.at(0) == QChar('#')) {
+            continue;
+        }
+
+        QStringList aux = line.split(',');
+        Fact *param = getParameterFact(-1, aux.at(0));
+        if (!param) {
+            qDebug() << "Parameter not found:" << aux.at(0);
+            continue;
+        }
+        param->setRawValue(QVariant::fromValue(aux.at(1)));
+        qDebug() << "Setting the parameters" << aux;
+    }
+   qgcApp()->setOverrideCursor(Qt::ArrowCursor);
+}
+
+APMAirframeType::APMAirframeType(const QString& name, const QString& imageResource, QObject* parent) :
+    QObject(parent),
+    _name(name),
+    _imageResource(imageResource),
+    _dirty(false)
+{
+}
+
+APMAirframeType::~APMAirframeType()
+{
+}
+
+void APMAirframeType::addAirframe(const QString& name, const QString& file, int autostartId)
+{
+    APMAirframe* airframe = new APMAirframe(name, file, autostartId);
+    Q_CHECK_PTR(airframe);
+    
+    _airframes.append(QVariant::fromValue(airframe));
+}
+
+APMAirframe::APMAirframe(const QString& name, const QString& paramsFile, int autostartId, QObject* parent) :
+    QObject(parent),
+    _name(name),
+    _paramsFile(paramsFile),
+    _autostartId(autostartId)
+{
+}
+
+APMAirframe::~APMAirframe()
+{
+}
+
+QString APMAirframeType::imageResource() const
+{
+    return _imageResource;
+}
+
+QString APMAirframeType::name() const
+{
+    return _name;
+}

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.h
@@ -1,0 +1,125 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#ifndef APMAirframeComponentController_H
+#define APMAirframeComponentController_H
+
+#include <QObject>
+#include <QQuickItem>
+#include <QList>
+#include <QAbstractListModel>
+
+#include "UASInterface.h"
+#include "AutoPilotPlugin.h"
+#include "FactPanelController.h"
+#include "APMAirframeComponentAirframes.h"
+
+class APMAirframeModel;
+
+/// MVC Controller for APMAirframeComponent.qml.
+class APMAirframeComponentController : public FactPanelController
+{
+    Q_OBJECT
+    
+public:
+    APMAirframeComponentController(void);
+    ~APMAirframeComponentController();
+    
+    Q_PROPERTY(bool showCustomConfigPanel MEMBER _showCustomConfigPanel NOTIFY showCustomConfigPanelChanged)
+    Q_PROPERTY(QmlObjectListModel* airframeTypesModel MEMBER _airframeTypesModel CONSTANT)
+    Q_PROPERTY(QString currentAirframeType MEMBER _currentAirframeType CONSTANT)
+    Q_PROPERTY(QString currentVehicleName MEMBER _currentVehicleName CONSTANT)
+    Q_PROPERTY(int currentVehicleIndex MEMBER _currentVehicleIndex CONSTANT)
+    Q_PROPERTY(int autostartId MEMBER _autostartId NOTIFY autostartIdChanged)
+    Q_PROPERTY(QString fileParams MEMBER _currentFileParams)
+
+    Q_INVOKABLE void changeAutostart(void);
+    
+    int currentAirframeIndex(void);
+    void setCurrentAirframeIndex(int newIndex);
+    
+signals:
+    void loadAirframesCompleted();
+    void autostartIdChanged(int newAutostartId);
+    void showCustomConfigPanelChanged(bool show);
+    
+private slots:
+    void _fillAirFrames(void);
+
+private:
+    static bool _typesRegistered;
+    QString         _currentAirframeType;
+    QString         _currentVehicleName;
+    int             _currentVehicleIndex;
+    int             _autostartId;
+    QString         _currentFileParams;
+    bool            _showCustomConfigPanel;
+    int             _waitParamWriteSignalCount;
+    QmlObjectListModel    *_airframeTypesModel;
+};
+
+class APMAirframe : public QObject
+{
+    Q_OBJECT
+    
+public:
+    APMAirframe(const QString& name, const QString& paramsFile, int autostartId, QObject* parent = NULL);
+    ~APMAirframe();
+    
+    Q_PROPERTY(QString text MEMBER _name CONSTANT)
+    Q_PROPERTY(int autostartId MEMBER _autostartId CONSTANT)
+    Q_PROPERTY(QString params MEMBER _paramsFile CONSTANT)
+    
+private:
+    QString _name;
+    QString _paramsFile;
+    int     _autostartId;
+};
+
+class APMAirframeType : public QObject
+{
+    Q_OBJECT
+    
+public:
+    APMAirframeType(const QString& name, const QString& imageResource, QObject* parent = NULL);
+    ~APMAirframeType();
+    
+    Q_PROPERTY(QString name MEMBER _name CONSTANT)
+    Q_PROPERTY(QString imageResource MEMBER _imageResource CONSTANT)
+    Q_PROPERTY(QVariantList airframes MEMBER _airframes CONSTANT)
+    Q_PROPERTY(bool dirty MEMBER _dirty CONSTANT)
+    void addAirframe(const QString& name, const QString& paramsFile, int autostartId);
+    QString name() const;
+    QString imageResource() const;
+
+private:
+    QString         _name;
+    QString         _imageResource;
+    QVariantList    _airframes;
+    bool _dirty;
+};
+
+#endif

--- a/src/AutoPilotPlugins/APM/APMAirframeLoader.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeLoader.cc
@@ -1,0 +1,109 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
+/// @file
+///     @author Don Gagne <don@thegagnes.com>
+
+#include "APMAirframeLoader.h"
+#include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
+#include "APMAirframeComponentAirframes.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QDebug>
+
+QGC_LOGGING_CATEGORY(APMAirframeLoaderLog, "APMAirframeLoaderLog")
+
+bool APMAirframeLoader::_airframeMetaDataLoaded = false;
+
+APMAirframeLoader::APMAirframeLoader(AutoPilotPlugin* autopilot, UASInterface* uas, QObject* parent)
+{
+    Q_UNUSED(autopilot);
+    Q_UNUSED(uas);
+    Q_UNUSED(parent);
+    Q_ASSERT(uas);
+}
+
+/// Load Airframe Fact meta data
+void APMAirframeLoader::loadAirframeFactMetaData(void)
+{
+    if (_airframeMetaDataLoaded) {
+        return;
+    }
+
+    qCDebug(APMAirframeLoaderLog) << "Loading APM airframe fact meta data";
+
+    Q_ASSERT(APMAirframeComponentAirframes::get().count() == 0);
+
+    QString airframeFilename;
+
+    // We want unit test builds to always use the resource based meta data to provide repeatable results
+    if (!qgcApp()->runningUnitTests()) {
+        // First look for meta data that comes from a firmware download. Fall back to resource if not there.
+        QSettings settings;
+        QDir parameterDir = QFileInfo(settings.fileName()).dir();
+        airframeFilename = parameterDir.filePath("PX4AirframeFactMetaData.xml");
+    }
+    if (airframeFilename.isEmpty() || !QFile(airframeFilename).exists()) {
+        airframeFilename = ":/AutoPilotPlugins/APM/AirframeFactMetaData.xml";
+    }
+
+    qCDebug(APMAirframeLoaderLog) << "Loading meta data file:" << airframeFilename;
+
+    QFile xmlFile(airframeFilename);
+    Q_ASSERT(xmlFile.exists());
+
+    bool success = xmlFile.open(QIODevice::ReadOnly);
+    Q_UNUSED(success);
+    Q_ASSERT(success);
+
+    QXmlStreamReader xml(xmlFile.readAll());
+    xmlFile.close();
+    if (xml.hasError()) {
+        qCWarning(APMAirframeLoaderLog) << "Badly formed XML" << xml.errorString();
+        return;
+    }
+
+    QString airframeGroup;
+    QString image;
+
+    while (!xml.atEnd()) {
+        if (xml.isStartElement()) {
+            QString elementName = xml.name().toString();
+            if (elementName == "airframe_group") {
+                airframeGroup = xml.attributes().value("name").toString();
+                image = xml.attributes().value("image").toString();
+            } else if (elementName == "airframe") {
+                QString name = xml.attributes().value("name").toString();
+                QString id = xml.attributes().value("id").toString();
+                QString file = xml.attributes().value("file").toString();
+                APMAirframeComponentAirframes::insert(airframeGroup, image, name, file, id.toInt());
+            }
+        }
+        xml.readNext();
+    }
+
+    _airframeMetaDataLoaded = true;
+}

--- a/src/AutoPilotPlugins/APM/APMAirframeLoader.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeLoader.h
@@ -1,56 +1,59 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
-#ifndef APMAutoPilotPlugin_H
-#define APMAutoPilotPlugin_H
+#ifndef APMAirframeLoader_H
+#define APMAirframeLoader_H
 
+#include <QObject>
+#include <QMap>
+#include <QXmlStreamReader>
+#include <QLoggingCategory>
+
+#include "ParameterLoader.h"
+#include "FactSystem.h"
+#include "UASInterface.h"
 #include "AutoPilotPlugin.h"
-#include "Vehicle.h"
 
-class APMAirframeComponent;
-class APMAirframeLoader;
+/// @file APMAirframeLoader.h
+///     @author Lorenz Meier <lm@qgroundcontrol.org>
 
-/// This is the APM specific implementation of the AutoPilot class.
-class APMAutoPilotPlugin : public AutoPilotPlugin
+Q_DECLARE_LOGGING_CATEGORY(APMAirframeLoaderLog)
+
+/// Collection of Parameter Facts for PX4 AutoPilot
+
+class APMAirframeLoader : QObject
 {
     Q_OBJECT
 
 public:
-    APMAutoPilotPlugin(Vehicle* vehicle, QObject* parent);
-    ~APMAutoPilotPlugin();
+    /// @param uas Uas which this set of facts is associated with
+    APMAirframeLoader(AutoPilotPlugin* autpilot,UASInterface* uas, QObject* parent = NULL);
 
-    // Overrides from AutoPilotPlugin
-    virtual const QVariantList& vehicleComponents(void);
-
-public slots:
-    // FIXME: This is public until we restructure AutoPilotPlugin/FirmwarePlugin/Vehicle
-    void _parametersReadyPreChecks(bool missingParameters);
+    static void loadAirframeFactMetaData(void);
 
 private:
-    bool                    _incorrectParameterVersion; ///< true: parameter version incorrect, setup not allowed
-    QVariantList            _components;
-    APMAirframeComponent*   _airframeComponent;
-    APMAirframeLoader*      _airframeFacts;
+    static bool _airframeMetaDataLoaded;   ///< true: parameter meta data already loaded
+    static QMap<QString, FactMetaData*> _mapParameterName2FactMetaData; ///< Maps from a parameter name to FactMetaData
 };
 
-#endif
+#endif // APMAirframeLoader_H

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -27,6 +27,12 @@
 #include "UAS.h"
 #include "FirmwarePlugin/APM/APMParameterMetaData.h"  // FIXME: Hack
 #include "FirmwarePlugin/APM/APMFirmwarePlugin.h"  // FIXME: Hack
+#include "APMComponent.h"
+#include "APMAirframeComponent.h"
+#include "APMAirframeComponentAirframes.h"
+#include "APMAirframeComponentController.h"
+#include "APMAirframeLoader.h"
+#include "APMRemoteParamsDownloader.h"
 
 /// This is the AutoPilotPlugin implementatin for the MAV_AUTOPILOT_ARDUPILOT type.
 APMAutoPilotPlugin::APMAutoPilotPlugin(Vehicle* vehicle, QObject* parent)
@@ -35,6 +41,8 @@ APMAutoPilotPlugin::APMAutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     , _airframeComponent(NULL)
 {
     Q_ASSERT(vehicle);
+    _airframeFacts = new APMAirframeLoader(this, vehicle->uas(), this);
+    APMAirframeLoader::loadAirframeFactMetaData();
 }
 
 APMAutoPilotPlugin::~APMAutoPilotPlugin()
@@ -75,9 +83,9 @@ void APMAutoPilotPlugin::_parametersReadyPreChecks(bool missingParameters)
 										"Please perform a Firmware Upgrade if you wish to use Vehicle Setup.");
 	}
 #endif
-	
+    Q_UNUSED(missingParameters);
     _parametersReady = true;
-    _missingParameters = missingParameters;
+    _missingParameters = false;// missingParameters;
     emit missingParametersChanged(_missingParameters);
     emit parametersReadyChanged(_parametersReady);
 }

--- a/src/AutoPilotPlugins/APM/APMComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMComponent.cc
@@ -40,7 +40,7 @@ void APMComponent::setupTriggerSignals(void)
     // Watch for changed on trigger list params
     foreach (QString paramName, setupCompleteChangedTriggerList()) {
         Fact* fact = _autopilot->getParameterFact(FactSystem::defaultComponentId, paramName);
-        
+        qDebug() << "Param:" << paramName;
         connect(fact, &Fact::valueChanged, this, &APMComponent::_triggerUpdated);
     }
 }

--- a/src/AutoPilotPlugins/APM/APMRemoteParamsDownloader.cc
+++ b/src/AutoPilotPlugins/APM/APMRemoteParamsDownloader.cc
@@ -1,0 +1,215 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
+#include "APMRemoteParamsDownloader.h"
+
+#include <QMessageBox>
+#include <QDesktopServices>
+#include <QFile>
+#include <QFileDialog>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QTimer>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QCryptographicHash>
+#include <QApplication>
+
+#include "APMRemoteParamsDownloader.h"
+
+#define FRAME_PARAMS_LIST QUrl("https://api.github.com/repos/diydrones/ardupilot/contents/Tools/Frame_params")
+#define FRAME_PARAMS_URL "https://raw.github.com/diydrones/ardupilot/master/Tools/Frame_params/"
+
+static QString dataLocation;
+
+APMRemoteParamsDownloader::APMRemoteParamsDownloader() :
+    m_networkReply(NULL),
+    m_downloadedParamFile(NULL)
+{
+    dataLocation = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation).at(0)
+           + QDir::separator() + qApp->applicationName();
+    refreshParamList();
+
+    qDebug() << "DataLocation " << dataLocation;
+}
+
+QString APMRemoteParamsDownloader::statusText() const
+{
+    return m_statusText;
+}
+void APMRemoteParamsDownloader::setStatusText(const QString& text)
+{
+    m_statusText = text;
+}
+
+void APMRemoteParamsDownloader::refreshParamList()
+{
+    qDebug() << "refresh list of param files from server";
+    setStatusText(tr("Refresh Param file list"));
+
+    QUrl url = FRAME_PARAMS_LIST;
+    qDebug() << "Deletando o networkReply no refreshParamList";
+    m_networkReply->deleteLater();
+    m_networkReply = m_networkAccessManager.get(QNetworkRequest(url));
+    connect(m_networkReply, SIGNAL(finished()), this, SLOT(httpParamListFinished()));
+    connect(m_networkReply, SIGNAL(downloadProgress(qint64,qint64)),
+            this, SLOT(updateDataReadProgress(qint64,qint64)));
+}
+
+/* Returned Json Example
+    "_links": {
+        "git":"https://api.github.com/repos/diydrones/ardupilot/git/blobs/a7074e606d695566f9a8c87724ad52e5e3baba7d",
+        "html":"https://github.com/diydrones/ardupilot/blob/master/Tools/Frame_params/Parrot_Bebop.param",
+        "self":"https://api.github.com/repos/diydrones/ardupilot/contents/Tools/Frame_params/Parrot_Bebop.param?ref=master"
+    },
+    "download_url":"https://raw.githubusercontent.com/diydrones/ardupilot/master/Tools/Frame_params/Parrot_Bebop.param",
+    "git_url":"https://api.github.com/repos/diydrones/ardupilot/git/blobs/a7074e606d695566f9a8c87724ad52e5e3baba7d",
+    "html_url":"https://github.com/diydrones/ardupilot/blob/master/Tools/Frame_params/Parrot_Bebop.param",
+    "name":"Parrot_Bebop.param","path":"Tools/Frame_params/Parrot_Bebop.param",""
+    "sha":"a7074e606d695566f9a8c87724ad52e5e3baba7d",
+    "size":533,
+    "type":"file",
+    "url":"https://api.github.com/repos/diydrones/ardupilot/contents/Tools/Frame_params/Parrot_Bebop.param?ref=master"
+*/
+void APMRemoteParamsDownloader::startFileDownloadRequest()
+{
+    if (curr == end) {
+        // invalidate the iterators, clean memory.
+        m_documentArray = QJsonArray();
+        emit finished();
+        return;
+    }
+
+    QJsonObject obj = (*curr).toObject();
+    QUrl url(obj["download_url"].toString());
+
+    QDir parameterDir(dataLocation);
+    if (!parameterDir.exists())
+        parameterDir.mkpath(dataLocation);
+
+    QString filename = parameterDir.absoluteFilePath(obj["name"].toString());
+    /* The resulting JSON object has a 'sha' hash, but testing the sha hash against all of the below
+     * algorithms (even md4 or md5) didn't returned a single positive match.
+     *
+     * when they fix that I'll try to use the code below to only download the files that changed,
+     * so, currently I'm downloading everything.
+     */
+#if 0
+    QFileInfo info(filename);
+    if (info.exists()) {
+        QFile file(filename);
+        file.open(QIODevice::ReadOnly);
+        QByteArray file_data = file.readAll();
+        QByteArray sha1 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha1);
+        QByteArray md5 = QCryptographicHash::hash(file_data, QCryptographicHash::Md5);
+        QByteArray sha3_256 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha3_256);
+        QByteArray sha3_224 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha3_224);
+        QByteArray sha3_384 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha3_384);
+        QByteArray sha3_512 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha3_512);
+        QByteArray sha_256 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha256);
+        QByteArray sha_224 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha224);
+        QByteArray sha_384 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha384);
+        QByteArray sha_512 = QCryptographicHash::hash(file_data, QCryptographicHash::Sha512);
+        QByteArray md4 = QCryptographicHash::hash(file_data, QCryptographicHash::Md4);
+        qDebug() << sha1.toHex();
+        qDebug() << md5.toHex();
+        qDebug() << sha3_256.toHex();
+        qDebug() << sha3_224.toHex();
+        qDebug() << sha3_384.toHex();
+        qDebug() << sha3_512.toHex();
+        qDebug() << sha_256.toHex();
+        qDebug() << sha_224.toHex();
+        qDebug() << sha_384.toHex();
+        qDebug() << sha_512.toHex();
+        qDebug() << md4.toHex();
+        qDebug() << "----------";
+        qDebug() << obj["sha"].toString();
+    }
+#endif
+    if(m_downloadedParamFile)
+        m_downloadedParamFile->deleteLater();
+    m_downloadedParamFile = new QFile(filename);
+    m_downloadedParamFile->open(QIODevice::WriteOnly);
+
+    m_networkReply = m_networkAccessManager.get(QNetworkRequest(url));
+    connect(m_networkReply, SIGNAL(finished()), this, SLOT(httpFinished()));
+    connect(m_networkReply, SIGNAL(readyRead()), this, SLOT(httpReadyRead()));
+    connect(m_networkReply, SIGNAL(downloadProgress(qint64,qint64)), this, SLOT(updateDataReadProgress(qint64,qint64)));
+    curr++;
+}
+
+void APMRemoteParamsDownloader::httpFinished()
+{
+    qDebug() << "Finished:" << m_downloadedParamFile->fileName();
+    m_downloadedParamFile->flush();
+    m_downloadedParamFile->close();
+
+    if (m_networkReply->error()) {
+        m_downloadedParamFile->remove();
+        setStatusText(tr("Download failed: %1.").arg(m_networkReply->errorString()));
+    }
+
+    m_networkReply->deleteLater();
+    m_networkReply = NULL;
+    delete m_downloadedParamFile;
+    m_downloadedParamFile = NULL;
+
+    startFileDownloadRequest();
+}
+
+void APMRemoteParamsDownloader::httpReadyRead()
+{
+    if (m_downloadedParamFile)
+        m_downloadedParamFile->write(m_networkReply->readAll());
+}
+
+void APMRemoteParamsDownloader::updateDataReadProgress(qint64 bytesRead, qint64 totalBytes)
+{
+    Q_UNUSED(bytesRead);
+    Q_UNUSED(totalBytes);
+}
+
+void APMRemoteParamsDownloader::httpParamListFinished()
+{
+    if (m_networkReply->error()) {
+        qDebug() <<  "Download failed:" << m_networkReply->errorString();
+        return;
+    }
+    processDownloadedVersionObject(m_networkReply->readAll());
+    startFileDownloadRequest();
+}
+
+void APMRemoteParamsDownloader::processDownloadedVersionObject(const QByteArray &listObject)
+{
+    QJsonParseError jsonErrorChecker;
+    QJsonDocument jsonDocument = QJsonDocument::fromJson(listObject, &jsonErrorChecker);
+    if (jsonErrorChecker.error != QJsonParseError::NoError) {
+        qDebug() << "Json error while parsing document:" << jsonErrorChecker.errorString();
+        return;
+    }
+
+    m_documentArray = jsonDocument.array();
+    curr = m_documentArray.constBegin();
+    end = m_documentArray.constEnd();
+}

--- a/src/AutoPilotPlugins/APM/APMRemoteParamsDownloader.h
+++ b/src/AutoPilotPlugins/APM/APMRemoteParamsDownloader.h
@@ -1,0 +1,46 @@
+#ifndef APMREMOTEPARAMSCONTROLLER_H
+#define APMREMOTEPARAMSCONTROLLER_H
+
+#include <QObject>
+#include <QNetworkAccessManager>
+#include <QUrl>
+#include <QJsonArray>
+
+class QNetworkReply;
+class QFile;
+class QUrl;
+
+class APMRemoteParamsDownloader : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString statusText READ statusText)
+public:
+    explicit APMRemoteParamsDownloader();
+    QString statusText() const;
+public slots:
+    void refreshParamList();
+    void httpParamListFinished();
+    void httpFinished();
+    void httpReadyRead();
+    void updateDataReadProgress(qint64 bytesRead, qint64 totalBytes);
+private:
+    void setStatusText(const QString& text);
+    void startFileDownloadRequest();
+    void manualListSetup();
+    void processDownloadedVersionObject(const QByteArray& listObject);
+    void startDownloadingRemoteParams();
+signals:
+    void finished();
+private:
+    QString m_statusText;
+    QNetworkAccessManager m_networkAccessManager;
+    QNetworkReply* m_networkReply;
+    QFile* m_downloadedParamFile;
+
+    // the list of needed documents.
+    QJsonArray m_documentArray;
+    QJsonArray::const_iterator curr;
+    QJsonArray::const_iterator end;
+};
+
+#endif // APMREMOTEPARAMSCONTROLLER_H

--- a/src/AutoPilotPlugins/APM/AirframeFactMetaData.xml
+++ b/src/AutoPilotPlugins/APM/AirframeFactMetaData.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<airframes>
+  <version>1</version>
+  <airframe_group image="AirframeQuadRotorX.png" name="Quadrotor x"/>
+      <airframe id="10020" name="3DR Aero M" file="3DR_AERO_M.param"/>
+      <airframe id="10021" name="3DR Aero RTF" file="3DR_Aero_RTF.param"/>
+      <airframe id="10022" name="3DR Iris+" file="3DR_Iris+.param"/>
+      <airframe id="10023" name="3DR QUAD X4 RTF" file="3DR_QUAD_X4_RTF.param"/>
+      <airframe id="10024" name="3DR Rover" file="3DR_Rover.param"/>
+      <airframe id="10025" name="3DR Tarot" file="3DR_Tarot.bgsc"/>
+      <airframe id="10026" name="3DR X8+ RTF" file="3DR_X8+_RTF.param"/>
+      <airframe id="10027" name="3DR X8-M RTF" file="3DR_X8-M_RTF.param"/>
+      <airframe id="10028" name="3DR X8" file="3DR_X8_RTF.param"/>
+      <airframe id="10029" name="3DR Y6A" file="3DR_Y6A_RTF.param"/>
+      <airframe id="10030" name="3DR Y6B" file="3DR_Y6B_RTF.param"/>
+      <airframe id="10031" name="Iris with GoPro" file="Iris with Front Mount Go Pro.param"/>
+      <airframe id="10032" name="Iris with Tarot" file="Iris with Tarot Gimbal.param"/>
+      <airframe id="10033" name="Iris" file="Iris.param"/>
+      <airframe id="10034" name="Parrot Bebop" file="Parrot_Bebop.param"/>
+      <airframe id="10035" name="Storm32" file="SToRM32-MAVLink.param"/>
+  </airframe_group>
+<airframes>

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -74,6 +74,7 @@
 #include "APM/ArduCopterFirmwarePlugin.h"
 #include "APM/ArduPlaneFirmwarePlugin.h"
 #include "APM/ArduRoverFirmwarePlugin.h"
+#include "APM/APMAirframeComponentController.h"
 #include "PX4/PX4FirmwarePlugin.h"
 #include "Vehicle.h"
 #include "MavlinkQmlSingleton.h"
@@ -352,6 +353,7 @@ void QGCApplication::_initCommon(void)
     qmlRegisterType<ParameterEditorController>      ("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
     qmlRegisterType<FlightModesComponentController> ("QGroundControl.Controllers", 1, 0, "FlightModesComponentController");
     qmlRegisterType<AirframeComponentController>    ("QGroundControl.Controllers", 1, 0, "AirframeComponentController");
+    qmlRegisterType<APMAirframeComponentController>    ("QGroundControl.Controllers", 1, 0, "APMAirframeComponentController");
     qmlRegisterType<SensorsComponentController>     ("QGroundControl.Controllers", 1, 0, "SensorsComponentController");
     qmlRegisterType<PowerComponentController>       ("QGroundControl.Controllers", 1, 0, "PowerComponentController");
     qmlRegisterType<RadioComponentController>       ("QGroundControl.Controllers", 1, 0, "RadioComponentController");


### PR DESCRIPTION
This commit introduces the APM Airframe configuration. The interface
is the same as the PX4 one, but the way we deal with the uas is a bit different

Since the APM stack doesn't provide a xml with airframe definitions a
new one was created by hand with only the values that we need, wich will
trigger a download of the parameters file from the mavlink github

There are still a few rougth edges ( that I blame for testing it on an ardupilot emulator than a real device ) but I think it's an mergeable work.

![apm-groundcontrol](https://cloud.githubusercontent.com/assets/4027216/11428696/7e433ede-9455-11e5-9c45-c317cef2a6c1.png)

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>