### PR TITLE
Telemetry RSSI

### DIFF
--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -93,6 +93,7 @@
         <file alias="Signal60.svg">src/ui/toolbar/Images/Signal60.svg</file>
         <file alias="Signal80.svg">src/ui/toolbar/Images/Signal80.svg</file>
         <file alias="Signal100.svg">src/ui/toolbar/Images/Signal100.svg</file>
+        <file alias="TelemRSSI.svg">src/ui/toolbar/Images/TelemRSSI.svg</file>
         <file alias="Yield.svg">src/ui/toolbar/Images/Yield.svg</file>
 
         <file alias="CogWheel.svg">src/MissionManager/CogWheel.svg</file>

--- a/src/ui/toolbar/Images/TelemRSSI.svg
+++ b/src/ui/toolbar/Images/TelemRSSI.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="194 896 108 72" style="enable-background:new 194 896 108 72;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:5.4819;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<path class="st0" d="M195.8,902.7c0.5-0.9,1.2-1.3,2.1-1.2l86.2,0.1c0.5,0,0.9,0.1,1.4,0.4c0.4,0.3,0.7,0.7,0.8,1.1
+	c0.4,0.9,0.2,1.7-0.6,2.6l-51.7,53.8c-0.6,0.5-1.2,0.7-1.9,0.7c-0.4-0.1-0.8-0.2-1.1-0.4c-0.2-0.2-0.5-0.4-0.6-0.6L217,938.2
+	l-8.8,4.2c-0.9,0.4-1.7,0.3-2.4-0.2c-0.7-0.5-1.1-1.2-1-2.2l1.9-17.9l-10.8-16.8C195.4,904.4,195.4,903.6,195.8,902.7L195.8,902.7z
+	 M202.4,906.2l8.3,13.1c0,0.1,0.1,0.3,0.1,0.5l0.1,0.3l58-13.7L202.4,906.2z M211.4,922.4l-1.4,13.6l66.5-29.1L211.4,922.4z
+	 M220,934.4c0.4,0.4,0.8,0.8,1,1.1l11.7,18.4L274,911L220,934.4z"/>
+<g>
+	<path id="path3890" inkscape:connector-curvature="0" class="st1" d="M262.1,957.3c8,8,21.1,8,29.1,0c8-8,8-21.1,0-29.1"/>
+	<path id="path3892" inkscape:connector-curvature="0" class="st1" d="M269.4,947.6c3.5,3.5,9,3.5,12.5,0c3.5-3.5,3.5-9,0-12.5"/>
+</g>
+</svg>

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -171,6 +171,16 @@ Rectangle {
         return colorGrey
     }
 
+    function getRSSIColor(value) {
+        if(value >= 0)
+            return colorGrey;
+        if(value > -60)
+            return colorGreen;
+        if(value > -90)
+            return colorOrange;
+        return colorRed;
+    }
+
     Component.onCompleted: {
         //-- TODO: Get this from the actual state
         flyButton.checked = true
@@ -277,6 +287,85 @@ Rectangle {
                     }
                     QGCLabel {
                         text:   activeVehicle ? (activeVehicle.rcRSSI + "%") : 0
+                    }
+                }
+            }
+            Component.onCompleted: {
+                var pos = mapFromItem(toolBar, centerX - (width / 2), toolBar.height)
+                x = pos.x
+                y = pos.y + ScreenTools.defaultFontPixelHeight
+            }
+        }
+    }
+
+    //---------------------------------------------
+    // Telemetry RSSI Info
+    Component {
+        id: telemRSSIInfo
+        Rectangle {
+            color:          Qt.rgba(0,0,0,0.75)
+            width:          telemCol.width   + ScreenTools.defaultFontPixelWidth  * 3
+            height:         telemCol.height  + ScreenTools.defaultFontPixelHeight * 2
+            radius:         ScreenTools.defaultFontPixelHeight * 0.5
+            Column {
+                id:                 telemCol
+                spacing:            ScreenTools.defaultFontPixelHeight * 0.5
+                width:              Math.max(telemGrid.width, telemLabel.width)
+                anchors.margins:    ScreenTools.defaultFontPixelHeight
+                anchors.centerIn:   parent
+                QGCLabel {
+                    id:         telemLabel
+                    text:       "Telemetry RSSI Status"
+                    font.weight:Font.DemiBold
+                    anchors.horizontalCenter: parent.horizontalCenter
+                }
+                GridLayout {
+                    id:                 telemGrid
+                    anchors.margins:    ScreenTools.defaultFontPixelHeight
+                    columnSpacing:      ScreenTools.defaultFontPixelWidth
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    columns: 2
+                    QGCLabel {
+                        text:   "Local RSSI:"
+                    }
+                    QGCLabel {
+                        text:   _controller.telemetryLRSSI + " dBm"
+                    }
+                    QGCLabel {
+                        text:   "Remote RSSI:"
+                    }
+                    QGCLabel {
+                        text:   _controller.telemetryRRSSI + " dBm"
+                    }
+                    QGCLabel {
+                        text:   "RX Errors:"
+                    }
+                    QGCLabel {
+                        text:   _controller.telemetryRXErrors
+                    }
+                    QGCLabel {
+                        text:   "Errors Fixed:"
+                    }
+                    QGCLabel {
+                        text:   _controller.telemetryFixed
+                    }
+                    QGCLabel {
+                        text:   "TX Buffer:"
+                    }
+                    QGCLabel {
+                        text:   _controller.telemetryTXBuffer
+                    }
+                    QGCLabel {
+                        text:   "Local Noise:"
+                    }
+                    QGCLabel {
+                        text:   _controller.telemetryLNoise
+                    }
+                    QGCLabel {
+                        text:   "Remote Noise:"
+                    }
+                    QGCLabel {
+                        text:   _controller.telemetryRNoise
                     }
                 }
             }

--- a/src/ui/toolbar/MainToolBarController.cc
+++ b/src/ui/toolbar/MainToolBarController.cc
@@ -96,7 +96,7 @@ void MainToolBarController::_activeVehicleChanged(Vehicle* vehicle)
     }
 }
 
-void MainToolBarController::_telemetryChanged(LinkInterface*, unsigned, unsigned, int rssi, int remrssi, unsigned, unsigned, unsigned)
+void MainToolBarController::_telemetryChanged(LinkInterface*, unsigned rxerrors, unsigned fixed, int rssi, int remrssi, unsigned txbuf, unsigned noise, unsigned remnoise)
 {
     if(_telemetryLRSSI != rssi) {
         _telemetryLRSSI = rssi;
@@ -105,6 +105,26 @@ void MainToolBarController::_telemetryChanged(LinkInterface*, unsigned, unsigned
     if(_telemetryRRSSI != remrssi) {
         _telemetryRRSSI = remrssi;
         emit telemetryRRSSIChanged(_telemetryRRSSI);
+    }
+    if(_telemetryRXErrors != rxerrors) {
+        _telemetryRXErrors = rxerrors;
+        emit telemetryRXErrorsChanged(_telemetryRXErrors);
+    }
+    if(_telemetryFixed != fixed) {
+        _telemetryFixed = fixed;
+        emit telemetryFixedChanged(_telemetryFixed);
+    }
+    if(_telemetryTXBuffer != txbuf) {
+        _telemetryTXBuffer = txbuf;
+        emit telemetryTXBufferChanged(_telemetryTXBuffer);
+    }
+    if(_telemetryLNoise != noise) {
+        _telemetryLNoise = noise;
+        emit telemetryLNoiseChanged(_telemetryLNoise);
+    }
+    if(_telemetryRNoise != remnoise) {
+        _telemetryRNoise = remnoise;
+        emit telemetryRNoiseChanged(_telemetryRNoise);
     }
 }
 

--- a/src/ui/toolbar/MainToolBarController.h
+++ b/src/ui/toolbar/MainToolBarController.h
@@ -61,10 +61,21 @@ public:
     Q_PROPERTY(float        progressBarValue    MEMBER _progressBarValue        NOTIFY progressBarValueChanged)
     Q_PROPERTY(int          telemetryRRSSI      READ telemetryRRSSI             NOTIFY telemetryRRSSIChanged)
     Q_PROPERTY(int          telemetryLRSSI      READ telemetryLRSSI             NOTIFY telemetryLRSSIChanged)
+    Q_PROPERTY(unsigned int telemetryRXErrors   READ telemetryRXErrors          NOTIFY telemetryRXErrorsChanged)
+    Q_PROPERTY(unsigned int telemetryFixed      READ telemetryFixed             NOTIFY telemetryFixedChanged)
+    Q_PROPERTY(unsigned int telemetryTXBuffer   READ telemetryTXBuffer          NOTIFY telemetryTXBufferChanged)
+    Q_PROPERTY(unsigned int telemetryLNoise     READ telemetryLNoise            NOTIFY telemetryLNoiseChanged)
+    Q_PROPERTY(unsigned int telemetryRNoise     READ telemetryRNoise            NOTIFY telemetryRNoiseChanged)
 
     void        viewStateChanged        (const QString& key, bool value);
+
     int         telemetryRRSSI          () { return _telemetryRRSSI; }
     int         telemetryLRSSI          () { return _telemetryLRSSI; }
+    unsigned int telemetryRXErrors      () { return _telemetryRXErrors; }
+    unsigned int telemetryFixed         () { return _telemetryFixed; }
+    unsigned int telemetryTXBuffer      () { return _telemetryTXBuffer; }
+    unsigned int telemetryLNoise        () { return _telemetryLNoise; }
+    unsigned int telemetryRNoise        () { return _telemetryRNoise; }
 
     void showToolBarMessage(const QString& message);
 
@@ -73,6 +84,11 @@ signals:
     void telemetryRRSSIChanged          (int value);
     void telemetryLRSSIChanged          (int value);
     void heightChanged                  (double height);
+    void telemetryRXErrorsChanged       (unsigned int value);
+    void telemetryFixedChanged          (unsigned int value);
+    void telemetryTXBufferChanged       (unsigned int value);
+    void telemetryLNoiseChanged         (unsigned int value);
+    void telemetryRNoiseChanged         (unsigned int value);
 
     /// Shows a non-modal message below the toolbar
     void showMessage(const QString& message);
@@ -90,6 +106,12 @@ private:
     double          _remoteRSSIstore;
     int             _telemetryRRSSI;
     int             _telemetryLRSSI;
+    uint32_t        _telemetryRXErrors;
+    uint32_t        _telemetryFixed;
+    uint32_t        _telemetryTXBuffer;
+    uint32_t        _telemetryLNoise;
+    uint32_t        _telemetryRNoise;
+
     double          _toolbarHeight;
 
     bool            _toolbarMessageVisible;

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -228,6 +228,39 @@ Row {
     }
 
     //-------------------------------------------------------------------------
+    //-- Telemetry RSSI
+    Item {
+        id:         telemRssi
+        width:      telemIcon.width
+        height:     mainWindow.tbCellHeight
+        visible:    _controller.telemetryLRSSI < 0
+        Image {
+            id:             telemIcon
+            source:         "/qmlimages/TelemRSSI.svg"
+            fillMode:       Image.PreserveAspectFit
+            mipmap:         true
+            smooth:         true
+            height:         parent.height * 0.5
+            width:          height * 1.5
+            visible:        false
+            anchors.verticalCenter: parent.verticalCenter
+        }
+        ColorOverlay {
+            id:             telemOverlay
+            anchors.fill:   telemIcon
+            source:         telemIcon
+            color:          getRSSIColor(_controller.telemetryLRSSI)
+        }
+        MouseArea {
+            anchors.fill:   parent
+            onClicked: {
+                var centerX = mapToItem(toolBar, x, y).x + (width / 2)
+                mainWindow.showPopUp(telemRSSIInfo, centerX)
+            }
+        }
+    }
+
+    //-------------------------------------------------------------------------
     //-- Battery Indicator
     Item {
         id: batteryStatus


### PR DESCRIPTION
Added a Telemetry RSSI indicator to the toolbar.

As the others, when clicking the icon, you will have access to the full batch of Telemetry RSSI status data.

Note that if you are not using a radio, or telemetry RSSI data is not available, the icon will not be displayed at all.

![screen shot 2015-11-27 at 7 03 29 pm](https://cloud.githubusercontent.com/assets/749243/11449174/f737f39a-9539-11e5-9237-a6cd897467e3.png)
