### PR TITLE
Fix UDP Auto-Connect for iOS.

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -95,10 +95,9 @@ void LinkManager::setToolbox(QGCToolbox *toolbox)
    _mavlinkProtocol = _toolbox->mavlinkProtocol();
    connect(_mavlinkProtocol, &MAVLinkProtocol::vehicleHeartbeatInfo, this, &LinkManager::_vehicleHeartbeatInfo);
 
-#ifndef __ios__
     connect(&_portListTimer, &QTimer::timeout, this, &LinkManager::_updateAutoConnectLinks);
     _portListTimer.start(1000);
-#endif
+    
 }
 
 LinkInterface* LinkManager::createConnectedLink(LinkConfiguration* config, bool autoconnectLink)
@@ -415,7 +414,6 @@ SerialConfiguration* LinkManager::_autoconnectConfigurationsContainsPort(const Q
 }
 #endif
 
-#ifndef __ios__
 void LinkManager::_updateAutoConnectLinks(void)
 {
     if (_connectionsSuspended || qgcApp()->runningUnitTests()) {
@@ -429,7 +427,8 @@ void LinkManager::_updateAutoConnectLinks(void)
         createConnectedLink(_autoconnectUDPConfig, true /* persistenLink */);
     }
 
-
+    
+#ifndef __ios__
     QStringList currentPorts;
     QList<QGCSerialPortInfo> portList = QGCSerialPortInfo::availablePorts();
 
@@ -522,8 +521,8 @@ void LinkManager::_updateAutoConnectLinks(void)
         _autoconnectConfigurations.removeOne(pDeleteConfig);
         delete pDeleteConfig;
     }
+#endif // __ios__
 }
-#endif
 
 bool LinkManager::anyConnectedLinks(void)
 {

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -139,7 +139,7 @@ public:
     ///                 false: if autoconnect link, link is marked as inactive and linkInactive is signalled
     ///                 false: if not autoconnect link, link is disconnected
     Q_INVOKABLE bool disconnectLink(LinkInterface* link, bool disconnectAutoconnectLink);
-    
+
     /// Called to notify that a heartbeat was received with the specified information. Will transition
     /// a link to active as needed.
     ///     @param link Heartbeat came through on this link
@@ -205,9 +205,7 @@ private:
     bool    _configurationsLoaded;                      ///< true: Link configurations have been loaded
     bool    _connectionsSuspended;                      ///< true: all new connections should not be allowed
     QString _connectionsSuspendedReason;                ///< User visible reason for suspension
-#ifndef __ios__
     QTimer  _portListTimer;
-#endif
     uint32_t _mavlinkChannelsUsedBitMask;
 
     MAVLinkProtocol*    _mavlinkProtocol;

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -201,18 +201,21 @@ Rectangle {
 
             QGCCheckBox {
                 text:       "Pixhawk"
+                visible:    !ScreenTools.isiOS
                 checked:    QGroundControl.linkManager.autoconnectPixhawk
                 onClicked:  QGroundControl.linkManager.autoconnectPixhawk = checked
             }
 
             QGCCheckBox {
                 text:       "3DR Radio"
+                visible:    !ScreenTools.isiOS
                 checked:    QGroundControl.linkManager.autoconnect3DRRadio
                 onClicked:  QGroundControl.linkManager.autoconnect3DRRadio = checked
             }
 
             QGCCheckBox {
                 text:       "PX4 Flow"
+                visible:    !ScreenTools.isiOS
                 checked:    QGroundControl.linkManager.autoconnectPX4Flow
                 onClicked:  QGroundControl.linkManager.autoconnectPX4Flow = checked
             }


### PR DESCRIPTION
The Auto-Connect setup for UDP is now inside a function that used to be only used for Serial Connections. That function has always been disabled for iOS (as it doesn't support serial links). As a result, the UDP initialization was being skipped on iOS.

In addition, I've removed the auto-connect options in the general settings dialog for connections not supported by iOS.