### PR TITLE
Virtual thumb joystick

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -258,6 +258,7 @@ HEADERS += \
     src/QGCFileDialog.h \
     src/QGCGeo.h \
     src/QGCLoggingCategory.h \
+    src/QGCMapPalette.h \
     src/QGCMessageBox.h \
     src/QGCPalette.h \
     src/QGCQmlWidgetHolder.h \
@@ -371,6 +372,7 @@ SOURCES += \
     src/QGCDockWidget.cc \
     src/QGCFileDialog.cc \
     src/QGCLoggingCategory.cc \
+    src/QGCMapPalette.cc \
     src/QGCPalette.cc \
     src/QGCQmlWidgetHolder.cpp \
     src/QGCQuickWidget.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -32,6 +32,7 @@
         <file alias="QGroundControl/Controls/DropButton.qml">src/QmlControls/DropButton.qml</file>
         <file alias="QGroundControl/Controls/ExclusiveGroupItem.qml">src/QmlControls/ExclusiveGroupItem.qml</file>
         <file alias="QGroundControl/Controls/IndicatorButton.qml">src/QmlControls/IndicatorButton.qml</file>
+        <file alias="QGroundControl/Controls/JoystickThumbPad.qml">src/QmlControls/JoystickThumbPad.qml</file>
         <file alias="QGroundControl/Controls/MainToolBar.qml">src/ui/toolbar/MainToolBar.qml</file>
         <file alias="QGroundControl/Controls/MainToolBarIndicators.qml">src/ui/toolbar/MainToolBarIndicators.qml</file>
         <file alias="QGroundControl/Controls/MissionItemEditor.qml">src/QmlControls/MissionItemEditor.qml</file>

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -56,6 +56,7 @@
 #include "QGCTemporaryFile.h"
 #include "QGCFileDialog.h"
 #include "QGCPalette.h"
+#include "QGCMapPalette.h"
 #include "QGCLoggingCategory.h"
 #include "ViewWidgetController.h"
 #include "ParameterEditorController.h"
@@ -334,7 +335,8 @@ void QGCApplication::_initCommon(void)
 
     // Register our Qml objects
 
-    qmlRegisterType<QGCPalette>("QGroundControl.Palette", 1, 0, "QGCPalette");
+    qmlRegisterType<QGCPalette>     ("QGroundControl.Palette", 1, 0, "QGCPalette");
+    qmlRegisterType<QGCMapPalette>  ("QGroundControl.Palette", 1, 0, "QGCMapPalette");
 
     qmlRegisterUncreatableType<AutoPilotPlugin>     ("QGroundControl.AutoPilotPlugin",  1, 0, "AutoPilotPlugin",        "Reference only");
     qmlRegisterUncreatableType<VehicleComponent>    ("QGroundControl.AutoPilotPlugin",  1, 0, "VehicleComponent",       "Reference only");

--- a/src/QGCMapPalette.cc
+++ b/src/QGCMapPalette.cc
@@ -1,0 +1,43 @@
+/*=====================================================================
+
+ QGroundControl Open Source Ground Control Station
+
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+ This file is part of the QGROUNDCONTROL project
+
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+ ======================================================================*/
+
+#include "QGCMapPalette.h"
+
+#include <QApplication>
+#include <QPalette>
+
+QColor QGCMapPalette::_thumbJoystick[QGCMapPalette::_cColorGroups] = { QColor("#ffffff"), QColor("#f000000") };
+
+QGCMapPalette::QGCMapPalette(QObject* parent) :
+    QObject(parent)
+{
+
+}
+
+void QGCMapPalette::setLightColors(bool lightColors)
+{
+    if ( _lightColors != lightColors) {
+        _lightColors = lightColors;
+        emit paletteChanged();
+    }
+}

--- a/src/QGCMapPalette.h
+++ b/src/QGCMapPalette.h
@@ -1,0 +1,64 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+/// QGCMapPalette is a variant of QGCPalette which is used to hold colors used for display over
+/// the map control. Since the coloring of a satellite map differs greatly from the coloring of
+/// a street map you need to be able to switch between sets of color based on map type.
+
+#ifndef QGCMapPalette_h
+#define QGCMapPalette_h
+
+#include <QObject>
+#include <QColor>
+
+class QGCMapPalette : public QObject
+{
+    Q_OBJECT
+    
+    Q_PROPERTY(bool lightColors READ lightColors WRITE setLightColors NOTIFY paletteChanged)
+
+    // The colors are:
+    //      thumbJoystick - Thumb joystick indicator
+
+    Q_PROPERTY(QColor thumbJoystick READ thumbJoystick NOTIFY paletteChanged)
+
+public:    
+    QGCMapPalette(QObject* parent = NULL);
+    
+    bool lightColors(void) const { return _lightColors; }
+    void setLightColors(bool lightColors);
+    
+    QColor thumbJoystick(void) const { return _thumbJoystick[_lightColors]; }
+
+signals:
+    void paletteChanged(void);
+    
+private:
+    bool _lightColors;
+
+    static const int _cColorGroups = 2;
+
+    static QColor _thumbJoystick[_cColorGroups];
+};
+
+#endif

--- a/src/QGCQuickWidget.cc
+++ b/src/QGCQuickWidget.cc
@@ -39,6 +39,7 @@
 QGCQuickWidget::QGCQuickWidget(QWidget* parent) :
     QQuickWidget(parent)
 {
+    setAttribute(Qt::WA_AcceptTouchEvents);
     rootContext()->engine()->addImportPath("qrc:/qml");
     rootContext()->setContextProperty("multiVehicleManager", qgcApp()->toolbox()->multiVehicleManager());
     rootContext()->setContextProperty("joystickManager", qgcApp()->toolbox()->joystickManager());

--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -1,0 +1,74 @@
+import QtQuick                  2.5
+import QtQuick.Controls         1.2
+
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+
+Rectangle {
+    radius:         width / 2
+    border.color:   mapPal.thumbJoystick
+    border.width:   2
+    color:          "transparent"
+
+    property alias  lightColors:            mapPal.lightColors  /// true: use light colors from QGCMapPalette for drawing
+    property var    stickPosition:          Qt.point(0, 0)
+    property real   xAxis:                  0                   /// Value range [-1,1], negative values left stick, positive values right stick
+    property real   yAxis:                  0                   /// Value range [-1,1], negative values up stick, positive values down stick
+    property bool   yAxisThrottle:          false               /// true: yAxis used for throttle, range [1,0], positive value are stick up
+
+    property bool   _stickCenteredOnce: false
+
+    QGCMapPalette { id: mapPal }
+
+    onWidthChanged: {
+        if (!_stickCenteredOnce && width != 0) {
+            reCenter()
+        }
+    }
+
+    onStickPositionChanged: {
+        var xAxisTemp = stickPosition.x / width
+        xAxisTemp *= 2.0
+        xAxisTemp -= 1.0
+        xAxis = xAxisTemp
+
+        var yAxisTemp = stickPosition.y / width
+        yAxisTemp *= 2.0
+        yAxisTemp -= 1.0
+        if (yAxisThrottle) {
+            yAxisTemp = ((yAxisTemp * -1.0) / 2.0) + 0.5
+        }
+        yAxis = yAxisTemp
+    }
+
+    function reCenter()
+    {
+        stickPosition = Qt.point(width / 2, width / 2)
+    }
+
+    Column {
+        QGCLabel { text: xAxis }
+        QGCLabel { text: yAxis }
+    }
+
+    Rectangle {
+        anchors.margins:    parent.width / 4
+        anchors.fill:       parent
+        radius:             width / 2
+        border.color:       mapPal.thumbJoystick
+        border.width:       2
+        color:              "transparent"
+    }
+
+    Rectangle {
+        width:  hatWidth
+        height: hatWidth
+        radius: hatWidthHalf
+        color:  mapPal.thumbJoystick
+        x:      stickPosition.x - hatWidthHalf
+        y:      stickPosition.y - hatWidthHalf
+
+        readonly property real hatWidth:        ScreenTools.defaultFontPixelHeight
+        readonly property real hatWidthHalf:    ScreenTools.defaultFontPixelHeight / 2
+    }
+}

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -1,38 +1,32 @@
 Module QGroundControl.Controls
 
-QGCLabel            1.0 QGCLabel.qml
-QGCButton           1.0 QGCButton.qml
-QGCRadioButton      1.0 QGCRadioButton.qml
-QGCCheckBox         1.0 QGCCheckBox.qml
-QGCTextField        1.0 QGCTextField.qml
-QGCComboBox         1.0 QGCComboBox.qml
-QGCColoredImage     1.0 QGCColoredImage.qml
-QGCToolBarButton    1.0 QGCToolBarButton.qml
-QGCMovableItem      1.0 QGCMovableItem.qml
-
-SubMenuButton       1.0 SubMenuButton.qml
-IndicatorButton     1.0 IndicatorButton.qml
-DropButton          1.0 DropButton.qml
-RoundButton         1.0 RoundButton.qml
-VehicleRotationCal  1.0 VehicleRotationCal.qml
-VehicleSummaryRow   1.0 VehicleSummaryRow.qml
-ViewWidget          1.0 ViewWidget.qml
-ExclusiveGroupItem  1.0 ExclusiveGroupItem.qml
-
+ClickableColor          1.0 ClickableColor.qml
+DropButton              1.0 DropButton.qml
+ExclusiveGroupItem      1.0 ExclusiveGroupItem.qml
+IndicatorButton         1.0 IndicatorButton.qml
+JoystickThumbPad        1.0 JoystickThumbPad.qml
+MainToolBar             1.0 MainToolBar.qml
+MissionItemEditor       1.0 MissionItemEditor.qml
+MissionItemIndexLabel   1.0 MissionItemIndexLabel.qml
+ModeSwitchDisplay       1.0 ModeSwitchDisplay.qml
 ParameterEditor         1.0 ParameterEditor.qml
 ParameterEditorDialog   1.0 ParameterEditorDialog.qml
-
-ModeSwitchDisplay   1.0 ModeSwitchDisplay.qml
-
-QGCView             1.0 QGCView.qml
-QGCViewPanel        1.0 QGCViewPanel.qml
-QGCViewDialog       1.0 QGCViewDialog.qml
-QGCViewMessage      1.0 QGCViewMessage.qml
-
-MissionItemIndexLabel   1.0 MissionItemIndexLabel.qml
-MissionItemEditor       1.0 MissionItemEditor.qml
-
-MainToolBar         1.0 MainToolBar.qml
-SignalStrength      1.0 SignalStrength.qml
-
-ClickableColor      1.0 ClickableColor.qml
+QGCButton               1.0 QGCButton.qml
+QGCCheckBox             1.0 QGCCheckBox.qml
+QGCColoredImage         1.0 QGCColoredImage.qml
+QGCComboBox             1.0 QGCComboBox.qml
+QGCLabel                1.0 QGCLabel.qml
+QGCMovableItem          1.0 QGCMovableItem.qml
+QGCRadioButton          1.0 QGCRadioButton.qml
+QGCTextField            1.0 QGCTextField.qml
+QGCToolBarButton        1.0 QGCToolBarButton.qml
+QGCView                 1.0 QGCView.qml
+QGCViewDialog           1.0 QGCViewDialog.qml
+QGCViewMessage          1.0 QGCViewMessage.qml
+QGCViewPanel            1.0 QGCViewPanel.qml
+RoundButton             1.0 RoundButton.qml
+SignalStrength          1.0 SignalStrength.qml
+SubMenuButton           1.0 SubMenuButton.qml
+VehicleRotationCal      1.0 VehicleRotationCal.qml
+VehicleSummaryRow       1.0 VehicleSummaryRow.qml
+ViewWidget              1.0 ViewWidget.qml

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1074,3 +1074,8 @@ void Vehicle::_remoteControlRSSIChanged(uint8_t rssi)
         emit rcRSSIChanged(_rcRSSI);
     }
 }
+
+void Vehicle::virtualTabletJoystickValue(double roll, double pitch, double yaw, double thrust)
+{
+    _uas->setExternalControlSetpoint(roll, pitch, yaw, thrust, 0, JoystickModeRC);
+}

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -124,12 +124,13 @@ public:
     // Called when the message drop-down is invoked to clear current count
     Q_INVOKABLE void        resetMessages();
 
+    Q_INVOKABLE void virtualTabletJoystickValue(double roll, double pitch, double yaw, double thrust);
+
     // Property accessors
 
     QGeoCoordinate coordinate(void) { return _coordinate; }
     bool coordinateValid(void)      { return _coordinateValid; }
     QmlObjectListModel* missionItemsModel(void);
-
 
     typedef enum {
         JoystickModeRC,         ///< Joystick emulates an RC Transmitter

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1508,7 +1508,6 @@ void UAS::executeCommand(MAV_CMD command, int confirmation, float param1, float 
 * Set the manual control commands.
 * This can only be done if the system has manual inputs enabled and is armed.
 */
-#ifndef __mobile__
 void UAS::setExternalControlSetpoint(float roll, float pitch, float yaw, float thrust, quint16 buttons, int joystickMode)
 {
     if (!_vehicle) {
@@ -1690,7 +1689,6 @@ void UAS::setExternalControlSetpoint(float roll, float pitch, float yaw, float t
         emit attitudeThrustSetPointChanged(this, roll, pitch, yaw, thrust, QGC::groundTimeMilliseconds());
     }
 }
-#endif
 
 #ifndef __mobile__
 void UAS::setManual6DOFControlCommands(double x, double y, double z, double roll, double pitch, double yaw)

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -555,9 +555,7 @@ public slots:
     void stopLowBattAlarm();
 
     /** @brief Set the values for the manual control of the vehicle */
-#ifndef __mobile__
     void setExternalControlSetpoint(float roll, float pitch, float yaw, float thrust, quint16 buttons, int joystickMode);
-#endif
 
     /** @brief Set the values for the 6dof manual control of the vehicle */
 #ifndef __mobile__

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -234,10 +234,9 @@ Rectangle {
             //-----------------------------------------------------------------
             //-- Virtual joystick settings
             QGCCheckBox {
-                text:       "Thumb Joystick (WIP - be careful!)"
+                text:       "Virtual Joystick"
                 checked:    QGroundControl.virtualTabletJoystick
                 onClicked:  QGroundControl.virtualTabletJoystick = checked
-                visible:    ScreenTools.isMobile
             }
         }
     }


### PR DESCRIPTION
- Turn on virtual joystick from QML General settings. May at some point move to Joystick config as new joystick type for dropdown. Still considering.
- Virtual joystick is available on both desktop (use with mouse) and mobile (use with thumbs)
- Add new QGCMapPalette which is used for light/dark color palette for different map types