### PR TITLE
Autoconnect fixes

### DIFF
--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -158,6 +158,9 @@ public:
     // Called to signal app shutdown. Disconnects all links while turning off auto-connect.
     void shutdown(void);
 
+    /// @return true: specified link is an autoconnect link
+    bool isAutoconnectLink(LinkInterface* link);
+
     // Override from QGCTool
     virtual void setToolbox(QGCToolbox *toolbox);
 
@@ -216,7 +219,7 @@ private:
     QmlObjectListModel  _linkConfigurations;
     QmlObjectListModel  _autoconnectConfigurations;
 
-    QStringList _autoconnectWaitList;
+    QMap<QString, int>  _autoconnectWaitList;   ///< key: QGCSerialPortInfo.systemLocation, value: wait count
     QStringList _commPortList;
 
     bool _autoconnectUDP;
@@ -224,12 +227,14 @@ private:
     bool _autoconnect3DRRadio;
     bool _autoconnectPX4Flow;
 
-    static const char* _settingsGroup;
-    static const char* _autoconnectUDPKey;
-    static const char* _autoconnectPixhawkKey;
-    static const char* _autoconnect3DRRadioKey;
-    static const char* _autoconnectPX4FlowKey;
-    static const char* _defaultUPDLinkName;
+    static const char*  _settingsGroup;
+    static const char*  _autoconnectUDPKey;
+    static const char*  _autoconnectPixhawkKey;
+    static const char*  _autoconnect3DRRadioKey;
+    static const char*  _autoconnectPX4FlowKey;
+    static const char*  _defaultUPDLinkName;
+    static const int    _autoconnectUpdateTimerMSecs;
+    static const int    _autoconnectConnectDelayMSecs;
 };
 
 #endif

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -152,7 +152,6 @@ protected:
     int     _timeout;
     QMutex  _dataMutex;       // Mutex for reading data from _port
     QMutex  _writeMutex;      // Mutex for accessing the _transmitBuffer.
-    QString _type;
 
 private slots:
     void _readBytes(void);
@@ -168,7 +167,7 @@ private:
 
     // Internal methods
     void _emitLinkError(const QString& errorMsg);
-    bool _hardwareConnect(QString &_type);
+    bool _hardwareConnect(QSerialPort::SerialPortError& error, QString& errorString);
     bool _isBootloader();
     void _resetConfiguration();
 


### PR DESCRIPTION
#2320, #2311

- Boot Windows QGC, connect direct usb. Works now. Had to add OS specific delay. Windows about 3 seconds slower to connect than OS X.
- Boot QGC, connect direct usb, disconnect, connect again. Works now.
- Connect jmavsim HIL to piaxhawk. Boot QGC, no longe spits out port error from trying to connect to board which HIL is connected to