### PR TITLE
Serial settings (QML)

### DIFF
--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -45,6 +45,7 @@ LinkConfiguration::LinkConfiguration(const QString& name)
     : _link(NULL)
     , _name(name)
     , _dynamic(false)
+    , _autoConnect(false)
 {
     _name = name;
     if (_name.isEmpty()) {
@@ -57,6 +58,7 @@ LinkConfiguration::LinkConfiguration(LinkConfiguration* copy)
     _link       = copy->link();
     _name       = copy->name();
     _dynamic    = copy->isDynamic();
+    _autoConnect= copy->isAutoConnect();
     Q_ASSERT(!_name.isEmpty());
 }
 
@@ -66,6 +68,7 @@ void LinkConfiguration::copyFrom(LinkConfiguration* source)
     _link       = source->link();
     _name       = source->name();
     _dynamic    = source->isDynamic();
+    _autoConnect= source->isAutoConnect();
 }
 
 /*!

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -40,9 +40,11 @@ public:
     LinkConfiguration(LinkConfiguration* copy);
     virtual ~LinkConfiguration() {}
 
-    Q_PROPERTY(QString          name        READ name           WRITE setName   NOTIFY nameChanged)
-    Q_PROPERTY(LinkInterface*   link        READ link           WRITE setLink   NOTIFY linkChanged)
+    Q_PROPERTY(QString          name        READ name           WRITE setName           NOTIFY nameChanged)
+    Q_PROPERTY(LinkInterface*   link        READ link           WRITE setLink           NOTIFY linkChanged)
     Q_PROPERTY(LinkType         linkType    READ type           CONSTANT)
+    Q_PROPERTY(bool             dynamic     READ isDynamic      WRITE setDynamic        NOTIFY dynamicChanged)
+    Q_PROPERTY(bool             autoConnect READ isAutoConnect  WRITE setAutoConnect    NOTIFY autoConnectChanged)
 
     // Property accessors
 
@@ -78,9 +80,21 @@ public:
     bool isDynamic() { return _dynamic; }
 
     /*!
+     *
+     * Is this an Auto Connect configuration?
+     * @return True if this is an Auto Connect configuration (connects automatically at boot time).
+     */
+    bool isAutoConnect() { return _autoConnect; }
+
+    /*!
      * Set if this is this a dynamic configuration. (decided at runtime)
     */
-    void setDynamic(bool dynamic = true) { _dynamic = dynamic; }
+    void setDynamic(bool dynamic = true) { _dynamic = dynamic; emit dynamicChanged(); }
+
+    /*!
+     * Set if this is this an Auto Connect configuration.
+    */
+    void setAutoConnect(bool autoc = true) { _autoConnect = autoc; emit autoConnectChanged(); }
 
     /// Virtual Methods
 
@@ -152,14 +166,17 @@ public:
     static LinkConfiguration* duplicateSettings(LinkConfiguration *source);
 
 signals:
-    void nameChanged(const QString& name);
-    void linkChanged(LinkInterface* link);
+    void nameChanged        (const QString& name);
+    void linkChanged        (LinkInterface* link);
+    void dynamicChanged     ();
+    void autoConnectChanged ();
 
 protected:
     LinkInterface* _link; ///< Link currently using this configuration (if any)
 private:
     QString _name;
-    bool    _dynamic;    ///< A connection added automatically and not persistent (unless it's edited).
+    bool    _dynamic;       ///< A connection added automatically and not persistent (unless it's edited).
+    bool    _autoConnect;   ///< This connection is started automatically at boot
 };
 
 #endif // LINKCONFIGURATION_H

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -326,7 +326,9 @@ void LinkManager::saveLinkConfigurationList()
 void LinkManager::loadLinkConfigurationList()
 {
     bool linksChanged = false;
+#ifdef QT_DEBUG
     bool mockPresent  = false;
+#endif
     QSettings settings;
     // Is the group even there?
     if(settings.contains(LinkConfiguration::settingsRoot() + "/count")) {

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -80,15 +80,25 @@ public:
     Q_PROPERTY(bool autoconnectPX4Flow                  READ autoconnectPX4Flow                 WRITE setAutoconnectPX4Flow     NOTIFY autoconnectPX4FlowChanged)
 
     /// LinkInterface Accessor
-    Q_PROPERTY(QmlObjectListModel* links                READ links                              CONSTANT)
+    Q_PROPERTY(QmlObjectListModel*  links               READ links                              CONSTANT)
     /// LinkConfiguration Accessor
-    Q_PROPERTY(QmlObjectListModel* linkConfigurations   READ linkConfigurations                 CONSTANT)
+    Q_PROPERTY(QmlObjectListModel*  linkConfigurations  READ linkConfigurations                                                 NOTIFY linkConfigurationsChanged)
     /// List of comm type strings
-    Q_PROPERTY(QStringList         linkTypeStrings      READ linkTypeStrings                    CONSTANT)
+    Q_PROPERTY(QStringList          linkTypeStrings     READ linkTypeStrings                    CONSTANT)
     /// List of supported baud rates for serial links
-    Q_PROPERTY(QStringList         serialBaudRates      READ serialBaudRates                    CONSTANT)
+    Q_PROPERTY(QStringList          serialBaudRates     READ serialBaudRates                    CONSTANT)
+    /// List of comm ports display names
+    Q_PROPERTY(QStringList          serialPortStrings   READ serialPortStrings                                                  NOTIFY commPortStringsChanged)
     /// List of comm ports
-    Q_PROPERTY(QStringList         serialPortStrings    READ serialPortStrings                                                    NOTIFY commPortStringsChanged)
+    Q_PROPERTY(QStringList          serialPorts         READ serialPorts                                                        NOTIFY commPortsChanged)
+
+    // Create/Edit Link Configuration
+    Q_INVOKABLE LinkConfiguration*  createConfiguration         (int type, const QString& name);
+    Q_INVOKABLE LinkConfiguration*  startConfigurationEditing   (LinkConfiguration* config);
+    Q_INVOKABLE void                cancelConfigurationEditing  (LinkConfiguration* config) { delete config; }
+    Q_INVOKABLE bool                endConfigurationEditing     (LinkConfiguration* config, LinkConfiguration* editedConfig);
+    Q_INVOKABLE bool                endCreateConfiguration      (LinkConfiguration* config);
+    Q_INVOKABLE void                removeConfiguration         (LinkConfiguration* config);
 
     // Property accessors
 
@@ -104,6 +114,7 @@ public:
     QStringList         linkTypeStrings     (void) const;
     QStringList         serialBaudRates     (void);
     QStringList         serialPortStrings   (void);
+    QStringList         serialPorts         (void);
 
     void setAutoconnectUDP      (bool autoconnect);
     void setAutoconnectPixhawk  (bool autoconnect);
@@ -186,8 +197,9 @@ signals:
     // No longer hearing from any vehicles on this link.
     void linkInactive(LinkInterface* link);
 
-    void linkConfigurationChanged();
     void commPortStringsChanged();
+    void commPortsChanged();
+    void linkConfigurationsChanged();
 
 private slots:
     void _linkConnected(void);
@@ -197,6 +209,8 @@ private slots:
 private:
     bool _connectionsSuspendedMsg(void);
     void _updateAutoConnectLinks(void);
+    void _updateSerialPorts();
+    void _fixUnnamed(LinkConfiguration* config);
 
 #ifndef __ios__
     SerialConfiguration* _autoconnectConfigurationsContainsPort(const QString& portName);
@@ -218,6 +232,7 @@ private:
 
     QStringList _autoconnectWaitList;
     QStringList _commPortList;
+    QStringList _commPortDisplayList;
 
     bool _autoconnectUDP;
     bool _autoconnectPixhawk;

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -395,12 +395,13 @@ SerialConfiguration::SerialConfiguration(const QString& name) : LinkConfiguratio
 
 SerialConfiguration::SerialConfiguration(SerialConfiguration* copy) : LinkConfiguration(copy)
 {
-    _baud       = copy->baud();
-    _flowControl= copy->flowControl();
-    _parity     = copy->parity();
-    _dataBits   = copy->dataBits();
-    _stopBits   = copy->stopBits();
-    _portName   = copy->portName();
+    _baud               = copy->baud();
+    _flowControl        = copy->flowControl();
+    _parity             = copy->parity();
+    _dataBits           = copy->dataBits();
+    _stopBits           = copy->stopBits();
+    _portName           = copy->portName();
+    _portDisplayName    = copy->portDisplayName();
 }
 
 void SerialConfiguration::copyFrom(LinkConfiguration *source)
@@ -408,12 +409,13 @@ void SerialConfiguration::copyFrom(LinkConfiguration *source)
     LinkConfiguration::copyFrom(source);
     SerialConfiguration* ssource = dynamic_cast<SerialConfiguration*>(source);
     Q_ASSERT(ssource != NULL);
-    _baud       = ssource->baud();
-    _flowControl= ssource->flowControl();
-    _parity     = ssource->parity();
-    _dataBits   = ssource->dataBits();
-    _stopBits   = ssource->stopBits();
-    _portName   = ssource->portName();
+    _baud               = ssource->baud();
+    _flowControl        = ssource->flowControl();
+    _parity             = ssource->parity();
+    _dataBits           = ssource->dataBits();
+    _stopBits           = ssource->stopBits();
+    _portName           = ssource->portName();
+    _portDisplayName    = ssource->portDisplayName();
 }
 
 void SerialConfiguration::updateSettings()
@@ -457,30 +459,45 @@ void SerialConfiguration::setPortName(const QString& portName)
     QString pname = portName.trimmed();
     if (!pname.isEmpty() && pname != _portName) {
         _portName = pname;
+        _portDisplayName = cleanPortDisplayname(pname);
     }
+}
+
+QString SerialConfiguration::cleanPortDisplayname(const QString name)
+{
+    QString pname = name.trimmed();
+#ifdef Q_OS_WIN32
+    pname.replace("\\\\.\\", "");
+#else
+    pname.replace("/dev/cu.", "");
+    pname.replace("/dev/", "");
+#endif
+    return pname;
 }
 
 void SerialConfiguration::saveSettings(QSettings& settings, const QString& root)
 {
     settings.beginGroup(root);
-    settings.setValue("baud",        _baud);
-    settings.setValue("dataBits",    _dataBits);
-    settings.setValue("flowControl", _flowControl);
-    settings.setValue("stopBits",    _stopBits);
-    settings.setValue("parity",      _parity);
-    settings.setValue("portName",    _portName);
+    settings.setValue("baud",           _baud);
+    settings.setValue("dataBits",       _dataBits);
+    settings.setValue("flowControl",    _flowControl);
+    settings.setValue("stopBits",       _stopBits);
+    settings.setValue("parity",         _parity);
+    settings.setValue("portName",       _portName);
+    settings.setValue("portDisplayName",_portDisplayName);
     settings.endGroup();
 }
 
 void SerialConfiguration::loadSettings(QSettings& settings, const QString& root)
 {
     settings.beginGroup(root);
-    if(settings.contains("baud"))        _baud         = settings.value("baud").toInt();
-    if(settings.contains("dataBits"))    _dataBits     = settings.value("dataBits").toInt();
-    if(settings.contains("flowControl")) _flowControl  = settings.value("flowControl").toInt();
-    if(settings.contains("stopBits"))    _stopBits     = settings.value("stopBits").toInt();
-    if(settings.contains("parity"))      _parity       = settings.value("parity").toInt();
-    if(settings.contains("portName"))    _portName     = settings.value("portName").toString();
+    if(settings.contains("baud"))           _baud           = settings.value("baud").toInt();
+    if(settings.contains("dataBits"))       _dataBits       = settings.value("dataBits").toInt();
+    if(settings.contains("flowControl"))    _flowControl    = settings.value("flowControl").toInt();
+    if(settings.contains("stopBits"))       _stopBits       = settings.value("stopBits").toInt();
+    if(settings.contains("parity"))         _parity         = settings.value("parity").toInt();
+    if(settings.contains("portName"))       _portName       = settings.value("portName").toString();
+    if(settings.contains("portDisplayName"))_portDisplayName= settings.value("portDisplayName").toString();
     settings.endGroup();
 }
 

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -66,22 +66,32 @@ public:
     SerialConfiguration(const QString& name);
     SerialConfiguration(SerialConfiguration* copy);
 
+    Q_PROPERTY(int      baud            READ baud               WRITE setBaud               NOTIFY baudChanged)
+    Q_PROPERTY(int      dataBits        READ dataBits           WRITE setDataBits           NOTIFY dataBitsChanged)
+    Q_PROPERTY(int      flowControl     READ flowControl        WRITE setFlowControl        NOTIFY flowControlChanged)
+    Q_PROPERTY(int      stopBits        READ stopBits           WRITE setStopBits           NOTIFY stopBitsChanged)
+    Q_PROPERTY(int      parity          READ parity             WRITE setParity             NOTIFY parityChanged)
+    Q_PROPERTY(QString  portName        READ portName           WRITE setPortName           NOTIFY portNameChanged)
+    Q_PROPERTY(QString  portDisplayName READ portDisplayName                                NOTIFY portDisplayNameChanged)
+
     int  baud()         { return _baud; }
     int  dataBits()     { return _dataBits; }
     int  flowControl()  { return _flowControl; }    ///< QSerialPort Enums
     int  stopBits()     { return _stopBits; }
     int  parity()       { return _parity; }         ///< QSerialPort Enums
 
-    const QString portName() { return _portName; }
+    const QString portName          () { return _portName; }
+    const QString portDisplayName   () { return _portDisplayName; }
 
-    void setBaud        (int baud);
-    void setDataBits    (int databits);
-    void setFlowControl (int flowControl);          ///< QSerialPort Enums
-    void setStopBits    (int stopBits);
-    void setParity      (int parity);               ///< QSerialPort Enums
-    void setPortName    (const QString& portName);
+    void setBaud            (int baud);
+    void setDataBits        (int databits);
+    void setFlowControl     (int flowControl);          ///< QSerialPort Enums
+    void setStopBits        (int stopBits);
+    void setParity          (int parity);               ///< QSerialPort Enums
+    void setPortName        (const QString& portName);
 
     static QStringList supportedBaudRates();
+    static QString cleanPortDisplayname(const QString name);
 
     /// From LinkConfiguration
     LinkType type() { return LinkConfiguration::TypeSerial; }
@@ -89,6 +99,15 @@ public:
     void loadSettings(QSettings& settings, const QString& root);
     void saveSettings(QSettings& settings, const QString& root);
     void updateSettings();
+
+signals:
+    void baudChanged            ();
+    void dataBitsChanged        ();
+    void flowControlChanged     ();
+    void stopBitsChanged        ();
+    void parityChanged          ();
+    void portNameChanged        ();
+    void portDisplayNameChanged ();
 
 private:
     static void _initBaudRates();
@@ -100,8 +119,8 @@ private:
     int _stopBits;
     int _parity;
     QString _portName;
+    QString _portDisplayName;
 };
-
 
 /**
  * @brief The SerialLink class provides cross-platform access to serial links.

--- a/src/ui/preferences/LinkSettings.qml
+++ b/src/ui/preferences/LinkSettings.qml
@@ -362,6 +362,8 @@ Rectangle {
                 QGCButton {
                     width:      ScreenTools.defaultFontPixelWidth * 10
                     text:       "OK"
+                    //-- TODO: For now, only allow Serial (the only one completed)
+                    enabled:    editConfig && editConfig.linkType === LinkConfiguration.TypeSerial
                     onClicked: {
                         // Save editting
                         editConfig.name = nameField.text
@@ -393,7 +395,7 @@ Rectangle {
     Component {
         id: serialLinkSettings
         Column {
-            width:              parent.width
+            width:              serialLinkSettings.width
             spacing:            ScreenTools.defaultFontPixelHeight / 2
             QGCLabel {
                 id:     serialLabel
@@ -601,7 +603,7 @@ Rectangle {
     Component {
         id: udpLinkSettings
         Column {
-            width:              parent.width
+            width:              udpLinkSettings.width
             spacing:            ScreenTools.defaultFontPixelHeight / 2
             QGCLabel {
                 id:     udpLabel
@@ -637,7 +639,7 @@ Rectangle {
     Component {
         id: tcpLinkSettings
         Column {
-            width:              parent.width
+            width:              tcpLinkSettings.width
             spacing:            ScreenTools.defaultFontPixelHeight / 2
             QGCLabel {
                 id:     tcpLabel
@@ -681,7 +683,7 @@ Rectangle {
     Component {
         id: logLinkSettings
         Column {
-            width:              parent.width
+            width:              logLinkSettings.width
             spacing:            ScreenTools.defaultFontPixelHeight / 2
             QGCLabel {
                 text:   "Log Replay Link Settings"
@@ -700,7 +702,7 @@ Rectangle {
     Component {
         id: mockLinkSettings
         Column {
-            width:              parent.width
+            width:              mockLinkSettings.width
             spacing:            ScreenTools.defaultFontPixelHeight / 2
             QGCLabel {
                 text:   "Mock Link Settings"


### PR DESCRIPTION
More work done with the link config in QML.
Serial configuration is complete.

Note that I've added an *Auto Connect* settings for link configurations but this is not yet used. More on that once I finish all link configurations.

Fixed an issue with the configuration save function. It was using the total count of configs but it should not count *dynamic* links. You would end up with bogus entries in the settings file.

