### PR TITLE
Enable binding mode commands to joystick buttons

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -174,7 +174,7 @@ bool PX4FirmwarePlugin::setFlightMode(const QString& flightMode, uint8_t* base_m
 
 int PX4FirmwarePlugin::manualControlReservedButtonCount(void)
 {
-    return 8;   // 8 buttons reserved for rc switch simulation
+    return 0;   // 0 buttons reserved for rc switch simulation
 }
 
 void PX4FirmwarePlugin::adjustMavlinkMessage(mavlink_message_t* message)

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -347,9 +347,7 @@ void Joystick::run(void)
                     }
 
                     // Mark the button as pressed as long as its pressed
-                    if (buttonIndex < reservedButtonCount) {
-                        buttonPressedBits |= buttonBit;
-                    }
+                    buttonPressedBits |= buttonBit;
                 }
             }
             

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -347,7 +347,9 @@ void Joystick::run(void)
                     }
 
                     // Mark the button as pressed as long as its pressed
-                    buttonPressedBits |= buttonBit;
+                    if (buttonIndex < reservedButtonCount) {
+                        buttonPressedBits |= buttonBit;
+                    }
                 }
             }
             
@@ -461,6 +463,10 @@ QStringList Joystick::actions(void)
     QStringList list;
 
     list << "Arm" << "Disarm";
+
+    if (_activeVehicle) {
+        list << _activeVehicle->flightModes();
+    }
     
     return list;
 }
@@ -558,6 +564,8 @@ void Joystick::_buttonAction(const QString& action)
         _activeVehicle->setArmed(true);
     } else if (action == "Disarm") {
         _activeVehicle->setArmed(false);
+    } else if (_activeVehicle->flightModes().contains(action)) {
+        _activeVehicle->setFlightMode(action);
     } else {
         qCDebug(JoystickLog) << "_buttonAction unknown action:" << action;
     }


### PR DESCRIPTION
This is the corresponding QGC support for https://github.com/PX4/Firmware/pull/3307 in PX4. It enables binding gamepad buttons to discrete mode switch commands. 