### PR TITLE
Mobile tweaks

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -186,14 +186,12 @@ INCLUDEPATH += \
 
 FORMS += \
     src/QGCQmlWidgetHolder.ui \
-    src/ui/LogReplayLinkConfigurationWidget.ui \
     src/ui/MainWindow.ui \
     src/ui/MAVLinkSettingsWidget.ui \
     src/ui/MockLinkConfiguration.ui \
     src/ui/QGCCommConfiguration.ui \
     src/ui/QGCLinkConfiguration.ui \
     src/ui/QGCMapRCToParamDialog.ui \
-    src/ui/QGCMAVLinkLogPlayer.ui \
     src/ui/QGCPluginHost.ui \
     src/ui/QGCTCPLinkConfiguration.ui \
     src/ui/QGCUDPLinkConfiguration.ui \
@@ -208,6 +206,8 @@ FORMS += \
 
 !MobileBuild {
 FORMS += \
+    src/ui/LogReplayLinkConfigurationWidget.ui \
+    src/ui/QGCMAVLinkLogPlayer.ui \
     src/ui/Linechart.ui \
     src/ui/MultiVehicleDockWidget.ui \
     src/ui/QGCDataPlot2D.ui \
@@ -230,7 +230,6 @@ HEADERS += \
     src/comm/LinkConfiguration.h \
     src/comm/LinkInterface.h \
     src/comm/LinkManager.h \
-    src/comm/LogReplayLink.h \
     src/comm/MAVLinkProtocol.h \
     src/comm/MockLink.h \
     src/comm/MockLinkFileServer.h \
@@ -276,7 +275,6 @@ HEADERS += \
     src/uas/UAS.h \
     src/uas/UASInterface.h \
     src/uas/UASMessageHandler.h \
-    src/ui/LogReplayLinkConfigurationWidget.h \
     src/ui/MainWindow.h \
     src/ui/MAVLinkDecoder.h \
     src/ui/MAVLinkSettingsWidget.h \
@@ -284,7 +282,6 @@ HEADERS += \
     src/ui/QGCCommConfiguration.h \
     src/ui/QGCLinkConfiguration.h \
     src/ui/QGCMapRCToParamDialog.h \
-    src/ui/QGCMAVLinkLogPlayer.h \
     src/ui/QGCPluginHost.h \
     src/ui/QGCTCPLinkConfiguration.h \
     src/ui/QGCUDPLinkConfiguration.h \
@@ -309,6 +306,9 @@ HEADERS += \
 
 !MobileBuild {
 HEADERS += \
+    src/comm/LogReplayLink.h \
+    src/ui/LogReplayLinkConfigurationWidget.h \
+    src/ui/QGCMAVLinkLogPlayer.h \
     src/comm/QGCFlightGearLink.h \
     src/comm/QGCHilLink.h \
     src/comm/QGCJSBSimLink.h \
@@ -348,7 +348,6 @@ SOURCES += \
     src/CmdLineOptParser.cc \
     src/comm/LinkConfiguration.cc \
     src/comm/LinkManager.cc \
-    src/comm/LogReplayLink.cc \
     src/comm/MAVLinkProtocol.cc \
     src/comm/MockLink.cc \
     src/comm/MockLinkFileServer.cc \
@@ -388,7 +387,6 @@ SOURCES += \
     src/uas/FileManager.cc \
     src/uas/UAS.cc \
     src/uas/UASMessageHandler.cc \
-    src/ui/LogReplayLinkConfigurationWidget.cc \
     src/ui/MainWindow.cc \
     src/ui/MAVLinkDecoder.cc \
     src/ui/MAVLinkSettingsWidget.cc \
@@ -396,7 +394,6 @@ SOURCES += \
     src/ui/QGCCommConfiguration.cc \
     src/ui/QGCLinkConfiguration.cc \
     src/ui/QGCMapRCToParamDialog.cpp \
-    src/ui/QGCMAVLinkLogPlayer.cc \
     src/ui/QGCPluginHost.cc \
     src/ui/QGCTCPLinkConfiguration.cc \
     src/ui/QGCUDPLinkConfiguration.cc \
@@ -416,6 +413,9 @@ SOURCES += \
 
 !MobileBuild {
 SOURCES += \
+    src/comm/LogReplayLink.cc \
+    src/ui/LogReplayLinkConfigurationWidget.cc \
+    src/ui/QGCMAVLinkLogPlayer.cc \
     src/comm/QGCFlightGearLink.cc \
     src/comm/QGCJSBSimLink.cc \
     src/comm/QGCXPlaneLink.cc \

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -188,7 +188,6 @@ FORMS += \
     src/QGCQmlWidgetHolder.ui \
     src/ui/MainWindow.ui \
     src/ui/MAVLinkSettingsWidget.ui \
-    src/ui/MockLinkConfiguration.ui \
     src/ui/QGCCommConfiguration.ui \
     src/ui/QGCLinkConfiguration.ui \
     src/ui/QGCMapRCToParamDialog.ui \
@@ -198,6 +197,11 @@ FORMS += \
     src/ui/SettingsDialog.ui \
     src/ui/uas/QGCUnconnectedInfoWidget.ui \
     src/ui/uas/UASMessageView.ui \
+
+DebugBuild {
+FORMS += \
+    src/ui/MockLinkConfiguration.ui \
+}
 
 !iOSBuild {
 FORMS += \
@@ -231,9 +235,6 @@ HEADERS += \
     src/comm/LinkInterface.h \
     src/comm/LinkManager.h \
     src/comm/MAVLinkProtocol.h \
-    src/comm/MockLink.h \
-    src/comm/MockLinkFileServer.h \
-    src/comm/MockLinkMissionItemHandler.h \
     src/comm/ProtocolInterface.h \
     src/comm/QGCMAVLink.h \
     src/comm/TCPLink.h \
@@ -278,7 +279,6 @@ HEADERS += \
     src/ui/MainWindow.h \
     src/ui/MAVLinkDecoder.h \
     src/ui/MAVLinkSettingsWidget.h \
-    src/ui/MockLinkConfiguration.h \
     src/ui/QGCCommConfiguration.h \
     src/ui/QGCLinkConfiguration.h \
     src/ui/QGCMapRCToParamDialog.h \
@@ -291,6 +291,14 @@ HEADERS += \
     src/ui/uas/UASMessageView.h \
     src/AutoPilotPlugins/PX4/PX4AirframeLoader.h \
     src/QmlControls/QGCImageProvider.h \
+
+DebugBuild {
+HEADERS += \
+    src/comm/MockLink.h \
+    src/comm/MockLinkFileServer.h \
+    src/comm/MockLinkMissionItemHandler.h \
+    src/ui/MockLinkConfiguration.h \
+}
 
 WindowsBuild {
     PRECOMPILED_HEADER += src/stable_headers.h
@@ -349,9 +357,6 @@ SOURCES += \
     src/comm/LinkConfiguration.cc \
     src/comm/LinkManager.cc \
     src/comm/MAVLinkProtocol.cc \
-    src/comm/MockLink.cc \
-    src/comm/MockLinkFileServer.cc \
-    src/comm/MockLinkMissionItemHandler.cc \
     src/comm/TCPLink.cc \
     src/comm/UDPLink.cc \
     src/FlightDisplay/FlightDisplayViewController.cc \
@@ -390,7 +395,6 @@ SOURCES += \
     src/ui/MainWindow.cc \
     src/ui/MAVLinkDecoder.cc \
     src/ui/MAVLinkSettingsWidget.cc \
-    src/ui/MockLinkConfiguration.cc \
     src/ui/QGCCommConfiguration.cc \
     src/ui/QGCLinkConfiguration.cc \
     src/ui/QGCMapRCToParamDialog.cpp \
@@ -403,6 +407,14 @@ SOURCES += \
     src/ui/uas/UASMessageView.cc \
     src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc \
     src/QmlControls/QGCImageProvider.cc \
+
+DebugBuild {
+SOURCES += \
+    src/comm/MockLink.cc \
+    src/comm/MockLinkFileServer.cc \
+    src/comm/MockLinkMissionItemHandler.cc \
+    src/ui/MockLinkConfiguration.cc \
+}
 
 !iOSBuild {
 SOURCES += \

--- a/src/FactSystem/FactSystemTestBase.cc
+++ b/src/FactSystem/FactSystemTestBase.cc
@@ -1,24 +1,24 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 /// @file
@@ -26,7 +26,9 @@
 
 #include "FactSystemTestBase.h"
 #include "LinkManager.h"
+#ifdef QT_DEBUG
 #include "MockLink.h"
+#endif
 #include "MultiVehicleManager.h"
 #include "QGCApplication.h"
 #include "QGCMessageBox.h"
@@ -37,15 +39,15 @@
 /// FactSystem Unit Test
 FactSystemTestBase::FactSystemTestBase(void)
 {
-    
+
 }
 
 void FactSystemTestBase::_init(MAV_AUTOPILOT autopilot)
 {
     UnitTest::init();
-    
+
     _connectMockLink(autopilot);
-    
+
     _plugin = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->autopilotPlugin();
     Q_ASSERT(_plugin);
 }
@@ -63,7 +65,7 @@ void FactSystemTestBase::_parameter_default_component_id_test(void)
     QVERIFY(fact != NULL);
     QVariant factValue = fact->rawValue();
     QCOMPARE(factValue.isValid(), true);
-    
+
     QCOMPARE(factValue.toInt(), 3);
 }
 
@@ -74,17 +76,17 @@ void FactSystemTestBase::_parameter_specific_component_id_test(void)
     QVERIFY(fact != NULL);
     QVariant factValue = fact->rawValue();
     QCOMPARE(factValue.isValid(), true);
-    
-    
+
+
     QCOMPARE(factValue.toInt(), 3);
-    
+
     // Test another component id
     QVERIFY(_plugin->factExists(FactSystem::ParameterProvider, 51, "COMPONENT_51"));
     fact = _plugin->getFact(FactSystem::ParameterProvider, 51, "COMPONENT_51");
     QVERIFY(fact != NULL);
     factValue = fact->rawValue();
     QCOMPARE(factValue.isValid(), true);
-    
+
     QCOMPARE(factValue.toInt(), 51);
 }
 
@@ -92,18 +94,18 @@ void FactSystemTestBase::_parameter_specific_component_id_test(void)
 void FactSystemTestBase::_qml_test(void)
 {
     QGCQuickWidget* widget = new QGCQuickWidget;
-    
+
     widget->setAutoPilot(_plugin);
-    
+
     widget->setSource(QUrl::fromUserInput("qrc:unittest/FactSystemTest.qml"));
-    
+
     QQuickItem* rootObject = widget->rootObject();
     QObject* control = rootObject->findChild<QObject*>("testControl");
     QVERIFY(control != NULL);
     QVariant qmlValue = control->property("text").toInt();
 
     QCOMPARE(qmlValue.toInt(), 3);
-    
+
     delete widget;
 }
 
@@ -111,25 +113,25 @@ void FactSystemTestBase::_qml_test(void)
 void FactSystemTestBase::_qmlUpdate_test(void)
 {
     QGCQuickWidget* widget = new QGCQuickWidget;
-    
+
     widget->setAutoPilot(_plugin);
-    
+
     widget->setSource(QUrl::fromUserInput("qrc:unittest/FactSystemTest.qml"));
-    
+
     // Change the value
-    
+
     QVariant paramValue = 12;
     _plugin->getParameterFact(FactSystem::defaultComponentId, "RC_MAP_THROTTLE")->setRawValue(paramValue);
 
     QTest::qWait(500); // Let the signals flow through
-    
+
     // Make sure the qml has the right value
-    
+
     QQuickItem* rootObject = widget->rootObject();
     QObject* control = rootObject->findChild<QObject*>("testControl");
     QVERIFY(control != NULL);
     QCOMPARE(control->property("text").toInt(), 12);
-    
+
     delete widget;
 }
 

--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -33,7 +33,9 @@ This file is part of the QGROUNDCONTROL project
 #endif
 #include "UDPLink.h"
 #include "TCPLink.h"
+#ifndef __mobile__
 #include "LogReplayLink.h"
+#endif
 
 #ifdef QT_DEBUG
 #include "MockLink.h"
@@ -99,9 +101,11 @@ LinkConfiguration* LinkConfiguration::createSettings(int type, const QString& na
         case LinkConfiguration::TypeTcp:
             config = new TCPConfiguration(name);
             break;
+#ifndef __mobile__
         case LinkConfiguration::TypeLogReplay:
             config = new LogReplayLinkConfiguration(name);
             break;
+#endif
 #ifdef QT_DEBUG
         case LinkConfiguration::TypeMock:
             config = new MockConfiguration(name);
@@ -130,9 +134,11 @@ LinkConfiguration* LinkConfiguration::duplicateSettings(LinkConfiguration* sourc
         case TypeTcp:
             dupe = new TCPConfiguration(dynamic_cast<TCPConfiguration*>(source));
             break;
+#ifndef __mobile__
         case TypeLogReplay:
             dupe = new LogReplayLinkConfiguration(dynamic_cast<LogReplayLinkConfiguration*>(source));
             break;
+#endif
 #ifdef QT_DEBUG
         case TypeMock:
             dupe = new MockConfiguration(dynamic_cast<MockConfiguration*>(source));

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -69,8 +69,12 @@ public:
         TypeXbee,       ///< XBee Proprietary Link
         TypeOpal,       ///< Opal-RT Link
 #endif
+#ifdef QT_DEBUG
         TypeMock,       ///< Mock Link for Unitesting
+#endif
+#ifndef __mobile__
         TypeLogReplay,
+#endif
         TypeLast        // Last type value (type >= TypeLast == invalid)
     };
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -124,9 +124,11 @@ LinkInterface* LinkManager::createConnectedLink(LinkConfiguration* config)
         case LinkConfiguration::TypeTcp:
             pLink = new TCPLink(dynamic_cast<TCPConfiguration*>(config));
             break;
+#ifndef __mobile__
         case LinkConfiguration::TypeLogReplay:
             pLink = new LogReplayLink(dynamic_cast<LogReplayLinkConfiguration*>(config));
             break;
+#endif
 #ifdef QT_DEBUG
         case LinkConfiguration::TypeMock:
             pLink = new MockLink(dynamic_cast<MockConfiguration*>(config));
@@ -357,9 +359,11 @@ void LinkManager::loadLinkConfigurationList()
                                 case LinkConfiguration::TypeTcp:
                                     pLink = (LinkConfiguration*)new TCPConfiguration(name);
                                     break;
+#ifndef __mobile__
                                 case LinkConfiguration::TypeLogReplay:
                                     pLink = (LinkConfiguration*)new LogReplayLinkConfiguration(name);
                                     break;
+#endif
 #ifdef QT_DEBUG
                                 case LinkConfiguration::TypeMock:
                                     pLink = (LinkConfiguration*)new MockConfiguration(name);
@@ -697,8 +701,12 @@ QStringList LinkManager::linkTypeStrings(void) const
 #endif
         list += "UDP";
         list += "TCP";
+#ifdef QT_DEBUG
         list += "Mock Link";
+#endif
+#ifndef __mobile__
         list += "Log Replay";
+#endif
     }
     return list;
 }
@@ -771,16 +779,20 @@ bool LinkManager::endCreateConfiguration(LinkConfiguration* config)
 
 LinkConfiguration* LinkManager::createConfiguration(int type, const QString& name)
 {
+#ifndef __ios__
     if((LinkConfiguration::LinkType)type == LinkConfiguration::TypeSerial)
         _updateSerialPorts();
+#endif
     return LinkConfiguration::createSettings(type, name);
 }
 
 LinkConfiguration* LinkManager::startConfigurationEditing(LinkConfiguration* config)
 {
     Q_ASSERT(config != NULL);
+#ifndef __ios__
     if(config->type() == LinkConfiguration::TypeSerial)
         _updateSerialPorts();
+#endif
     return LinkConfiguration::duplicateSettings(config);
 }
 
@@ -816,13 +828,15 @@ void LinkManager::_fixUnnamed(LinkConfiguration* config)
                     }
                 }
                 break;
+#ifndef __mobile__
             case LinkConfiguration::TypeLogReplay: {
-                LogReplayLinkConfiguration* tconfig = dynamic_cast<LogReplayLinkConfiguration*>(config);
-                if(tconfig) {
-                    config->setName(QString("Log Replay %1").arg(tconfig->logFilenameShort()));
+                    LogReplayLinkConfiguration* tconfig = dynamic_cast<LogReplayLinkConfiguration*>(config);
+                    if(tconfig) {
+                        config->setName(QString("Log Replay %1").arg(tconfig->logFilenameShort()));
+                    }
                 }
-            }
                 break;
+#endif
 #ifdef QT_DEBUG
             case LinkConfiguration::TypeMock:
                 config->setName(

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -37,7 +37,9 @@ This file is part of the PIXHAWK project
 #include "QGCToolbox.h"
 #include "ProtocolInterface.h"
 #include "MAVLinkProtocol.h"
+#ifndef __mobile__
 #include "LogReplayLink.h"
+#endif
 #include "QmlObjectListModel.h"
 
 #ifndef __ios__

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -43,7 +43,9 @@ This file is part of the QGROUNDCONTROL project
 #include "MAVLinkProtocol.h"
 #include "MainWindow.h"
 #include "GAudioOutput.h"
+#ifndef __mobile__
 #include "QGCMAVLinkLogPlayer.h"
+#endif
 #include "SettingsDialog.h"
 #include "MAVLinkDecoder.h"
 #include "QGCApplication.h"

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -42,7 +42,9 @@ This file is part of the QGROUNDCONTROL project
 #include "UASInterface.h"
 #include "LogCompressor.h"
 #include "QGCMAVLinkInspector.h"
+#ifndef __mobile__
 #include "QGCMAVLinkLogPlayer.h"
+#endif
 #include "MAVLinkDecoder.h"
 #include "Vehicle.h"
 #include "QGCDockWidget.h"
@@ -157,11 +159,12 @@ signals:
 #endif //QGC_MOUSE_ENABLED_LINUX
 
 public:
+#ifndef __mobile__
     QGCMAVLinkLogPlayer* getLogPlayer()
     {
         return logPlayer;
     }
-
+#endif
 protected:
     void connectCommonActions();
 
@@ -171,8 +174,9 @@ protected:
     QSettings settings;
 
     QPointer<MAVLinkDecoder> mavlinkDecoder;
+#ifndef __mobile__
     QGCMAVLinkLogPlayer* logPlayer;
-
+#endif
 #ifdef QGC_MOUSE_ENABLED_WIN
     /** @brief 3d Mouse support (WIN only) */
     Mouse3DInput* mouseInput;               ///< 3dConnexion 3dMouse SDK

--- a/src/ui/MainWindow.qml
+++ b/src/ui/MainWindow.qml
@@ -44,7 +44,7 @@ Item {
     property real   tbHeight:           ScreenTools.isMobile ? (ScreenTools.isTinyScreen ? (mainWindow.width * 0.0666) : (mainWindow.width * 0.05)) : ScreenTools.defaultFontPixelSize * 4
     property int    tbCellHeight:       tbHeight * 0.75
     property real   tbSpacing:          ScreenTools.isMobile ? width * 0.00824 : 9.54
-    property real   tbButtonWidth:      tbCellHeight * 1.3
+    property real   tbButtonWidth:      tbCellHeight * 1.35
     property real   availableHeight:    height - tbHeight
     property real   menuButtonWidth:    (tbButtonWidth * 2) + (tbSpacing * 4) + 1
 

--- a/src/ui/MainWindowLeftPanel.qml
+++ b/src/ui/MainWindowLeftPanel.qml
@@ -149,7 +149,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
             }
             QGCButton {
-                width:      parent.width * 0.8
+                width:      parent.width * 0.85
                 height:     ScreenTools.defaultFontPixelHeight * 2.5
                 text:       "General"
                 exclusiveGroup: panelActionGroup
@@ -162,7 +162,7 @@ Item {
                 }
             }
             QGCButton {
-                width:      parent.width * 0.8
+                width:      parent.width * 0.85
                 height:     ScreenTools.defaultFontPixelHeight * 2.5
                 text:       "Comm Links"
                 exclusiveGroup: panelActionGroup
@@ -175,7 +175,7 @@ Item {
                 }
             }
             QGCButton {
-                width:      parent.width * 0.8
+                width:      parent.width * 0.85
                 height:     ScreenTools.defaultFontPixelHeight * 2.5
                 text:       "MavLink"
                 exclusiveGroup: panelActionGroup
@@ -188,7 +188,7 @@ Item {
                 }
             }
             QGCButton {
-                width:      parent.width * 0.8
+                width:      parent.width * 0.85
                 height:     ScreenTools.defaultFontPixelHeight * 2.5
                 text:       "Mock Link"
                 visible:    ScreenTools.isDebug
@@ -202,7 +202,7 @@ Item {
                 }
             }
             QGCButton {
-                width:      parent.width * 0.8
+                width:      parent.width * 0.85
                 height:     ScreenTools.defaultFontPixelHeight * 2.5
                 text:       "Debug"
                 visible:    ScreenTools.isDebug

--- a/src/ui/QGCCommConfiguration.cc
+++ b/src/ui/QGCCommConfiguration.cc
@@ -37,7 +37,9 @@ This file is part of the QGROUNDCONTROL project
 #include "QGCUDPLinkConfiguration.h"
 #include "QGCTCPLinkConfiguration.h"
 #include "MockLinkConfiguration.h"
+#ifndef __mobile__
 #include "LogReplayLinkConfigurationWidget.h"
+#endif
 #include "QGCCommConfiguration.h"
 #include "ui_QGCCommConfiguration.h"
 
@@ -54,7 +56,9 @@ QGCCommConfiguration::QGCCommConfiguration(QWidget *parent, LinkConfiguration *c
 #endif
     _ui->typeCombo->addItem(tr("UDP"),          LinkConfiguration::TypeUdp);
     _ui->typeCombo->addItem(tr("TCP"),          LinkConfiguration::TypeTcp);
+#ifndef __mobile__
     _ui->typeCombo->addItem(tr("Log replay"),   LinkConfiguration::TypeLogReplay);
+#endif
 #ifdef QT_DEBUG
     _ui->typeCombo->addItem(tr("Mock"),         LinkConfiguration::TypeMock);
 #endif
@@ -143,13 +147,15 @@ void QGCCommConfiguration::_loadTypeConfigWidget(int type)
             _ui->typeCombo->setCurrentIndex(_ui->typeCombo->findData(LinkConfiguration::TypeTcp));
         }
         break;
+#ifndef __mobile__
         case LinkConfiguration::TypeLogReplay: {
-            QWidget* conf = new LogReplayLinkConfigurationWidget((LogReplayLinkConfiguration*)_config, this);
-            _ui->linkScrollArea->setWidget(conf);
-            _ui->linkGroupBox->setTitle("Log Replay");
-            _ui->typeCombo->setCurrentIndex(_ui->typeCombo->findData(LinkConfiguration::TypeLogReplay));
-        }
+                QWidget* conf = new LogReplayLinkConfigurationWidget((LogReplayLinkConfiguration*)_config, this);
+                _ui->linkScrollArea->setWidget(conf);
+                _ui->linkGroupBox->setTitle("Log Replay");
+                _ui->typeCombo->setCurrentIndex(_ui->typeCombo->findData(LinkConfiguration::TypeLogReplay));
+            }
             break;
+#endif
 #ifdef QT_DEBUG
         case LinkConfiguration::TypeMock: {
             QWidget* conf = new MockLinkConfiguration((MockConfiguration*)_config, this);

--- a/src/ui/QGCCommConfiguration.cc
+++ b/src/ui/QGCCommConfiguration.cc
@@ -36,7 +36,9 @@ This file is part of the QGROUNDCONTROL project
 #endif
 #include "QGCUDPLinkConfiguration.h"
 #include "QGCTCPLinkConfiguration.h"
+#ifdef QT_DEBUG
 #include "MockLinkConfiguration.h"
+#endif
 #ifndef __mobile__
 #include "LogReplayLinkConfigurationWidget.h"
 #endif

--- a/src/ui/QGCLinkConfiguration.cc
+++ b/src/ui/QGCLinkConfiguration.cc
@@ -165,13 +165,15 @@ void QGCLinkConfiguration::_fixUnnamed(LinkConfiguration* config)
                     }
                 }
                 break;
+#ifndef __mobile__
             case LinkConfiguration::TypeLogReplay: {
-                LogReplayLinkConfiguration* tconfig = dynamic_cast<LogReplayLinkConfiguration*>(config);
-                if(tconfig) {
-                    config->setName(QString("Log Replay %1").arg(tconfig->logFilenameShort()));
+                    LogReplayLinkConfiguration* tconfig = dynamic_cast<LogReplayLinkConfiguration*>(config);
+                    if(tconfig) {
+                        config->setName(QString("Log Replay %1").arg(tconfig->logFilenameShort()));
+                    }
                 }
-            }
                 break;
+#endif
 #ifdef QT_DEBUG
             case LinkConfiguration::TypeMock:
                 config->setName(

--- a/src/ui/preferences/LinkSettings.qml
+++ b/src/ui/preferences/LinkSettings.qml
@@ -333,7 +333,7 @@ Rectangle {
                 spacing:            ScreenTools.defaultFontPixelWidth
                 anchors.margins:    ScreenTools.defaultFontPixelWidth
                 anchors.bottom:     parent.bottom
-                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.right:      parent.right
                 QGCButton {
                     width:      ScreenTools.defaultFontPixelWidth * 10
                     text:       "OK"


### PR DESCRIPTION
Some fixes for Mobile

* Disabled *Mock Links* altogether for Release builds
* Disabled *Log Replay* for mobile. The File Picker does not work on mobile platforms and there is no way to use it.
* Adjusted the size in the *Settings* panel buttons. The default font is too big and there is no way to define a smaller font size for QGCButtons.
