### PR TITLE
Acceptance radius fixes

### DIFF
--- a/src/MissionManager/MavCmdInfo.json
+++ b/src/MissionManager/MavCmdInfo.json
@@ -25,6 +25,12 @@
                 "units":            "seconds",
                 "default":          0,
                 "decimalPlaces":    0
+            },
+            "param2": {
+                "label":            "Accept radius:",
+                "units":            "meters",
+                "default":          3.0,
+                "decimalPlaces":    2
             }
         },
         {

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -95,7 +95,8 @@ private:
     void _setupMissionItems(bool loadFromVehicle, bool forceLoad);
     void _setupActiveVehicle(Vehicle* activeVehicle, bool forceLoadFromVehicle);
     void _calcPrevWaypointValues(bool homePositionValid, double homeAlt, MissionItem* item1, MissionItem* item2, double* azimuth, double* distance);
-    double _findLastAltitude(void);
+    bool _findLastAltitude(double* lastAltitude);
+    bool _findLastAcceptanceRadius(double* lastAcceptanceRadius);
 
 private:
     bool                _editMode;

--- a/src/MissionManager/MissionItem.cc
+++ b/src/MissionManager/MissionItem.cc
@@ -29,12 +29,7 @@ This file is part of the QGROUNDCONTROL project
 
 QGC_LOGGING_CATEGORY(MissionItemLog, "MissionItemLog")
 
-const double MissionItem::defaultTakeoffPitch =         15.0;
-const double MissionItem::defaultHeading =              0.0;
 const double MissionItem::defaultAltitude =             25.0;
-const double MissionItem::defaultAcceptanceRadius =     3.0;
-const double MissionItem::defaultLoiterOrbitRadius =    10.0;
-const double MissionItem::defaultLoiterTurns =          1.0;
 
 FactMetaData* MissionItem::_altitudeMetaData =          NULL;
 FactMetaData* MissionItem::_commandMetaData =           NULL;
@@ -122,6 +117,7 @@ MissionItem::MissionItem(QObject* parent)
     _connectSignals();
 
     setAutoContinue(true);
+    setDefaultsForCommand();
 }
 
 MissionItem::MissionItem(int             sequenceNumber,
@@ -770,13 +766,15 @@ void MissionItem::_syncCommandToSupportedCommand(const QVariant& value)
 
 void MissionItem::setDefaultsForCommand(void)
 {
+    // We set these global defaults first, then if there are param defaults they will get reset
+    setParam7(defaultAltitude);
+
     foreach (const MavCmdParamInfo* paramInfo, _mavCmdInfoMap[(MAV_CMD)command()]->paramInfoMap()) {
         Fact* rgParamFacts[7] = { &_param1Fact, &_param2Fact, &_param3Fact, &_param4Fact, &_param5Fact, &_param6Fact, &_param7Fact };
 
         rgParamFacts[paramInfo->param()-1]->setRawValue(paramInfo->defaultValue());
     }
 
-    setParam7(defaultAltitude);
     setAutoContinue(true);
     setFrame(specifiesCoordinate() ? MAV_FRAME_GLOBAL_RELATIVE_ALT : MAV_FRAME_MISSION);
     setRawEdit(false);

--- a/src/MissionManager/MissionItem.h
+++ b/src/MissionManager/MissionItem.h
@@ -167,12 +167,7 @@ public:
 
     bool relativeAltitude(void) { return frame() == MAV_FRAME_GLOBAL_RELATIVE_ALT; }
 
-    static const double defaultTakeoffPitch;
-    static const double defaultHeading;
     static const double defaultAltitude;
-    static const double defaultAcceptanceRadius;
-    static const double defaultLoiterOrbitRadius;
-    static const double defaultLoiterTurns;
 
 public slots:
     void setDefaultsForCommand(void);

--- a/src/MissionManager/MissionItemTest.cc
+++ b/src/MissionManager/MissionItemTest.cc
@@ -36,8 +36,9 @@ const MissionItemTest::ItemInfo_t MissionItemTest::_rgItemInfo[] = {
 };
 
 const MissionItemTest::FactValue_t MissionItemTest::_rgFactValuesWaypoint[] = {
-    { "Altitude:",  70.1234567 },
-    { "Hold:",      10.1234567 },
+    { "Altitude:",      70.1234567 },
+    { "Hold:",          10.1234567 },
+    { "Accept radius:", 20.1234567 },
 };
 
 const MissionItemTest::FactValue_t MissionItemTest::_rgFactValuesLoiterUnlim[] = {
@@ -175,4 +176,14 @@ void MissionItemTest::_test(void)
         delete item;
         delete loadedItem;
     }
+}
+
+void MissionItemTest::_testDefaultValues(void)
+{
+    MissionItem item;
+
+    item.setCommand(MAV_CMD_NAV_WAYPOINT);
+    item.setFrame(MAV_FRAME_GLOBAL_RELATIVE_ALT);
+    QCOMPARE(item.param2(), 3.0);
+    QCOMPARE(item.param7(), MissionItem::defaultAltitude);
 }

--- a/src/MissionManager/MissionItemTest.h
+++ b/src/MissionManager/MissionItemTest.h
@@ -44,8 +44,10 @@ public:
     
 private slots:
     void _test(void);
+    void _testDefaultValues(void);
     
 private:
+
     typedef struct {
         MAV_CMD        command;
         MAV_FRAME      frame;


### PR DESCRIPTION
This is a better fix for #2339 

- Acceptance radius move to friendly edit. This way fixed wing user can bump the radius
- Last acceptance radius is used for newer waypoints, just like altitude
- Updated unit test to check for incorrect defaults