### PR TITLE
Standalone coordinate support for mission items

### DIFF
--- a/src/MissionManager/MavCmdInfo.json
+++ b/src/MissionManager/MavCmdInfo.json
@@ -150,6 +150,7 @@
             "friendlyName":         "Region of interest (nav)",
             "description":          "Sets the region of interest for cameras.",
             "specifiesCoordinate":  true,
+            "standaloneCoordinate": true,
             "friendlyEdit":         true,
             "category":             "Camera",
             "param1": {
@@ -393,11 +394,12 @@
         { "id": 191, "rawName": "MAV_CMD_DO_GO_AROUND", "friendlyName": "MAV_CMD_DO_GO_AROUND" },
         { "id": 200, "rawName": "MAV_CMD_DO_CONTROL_VIDEO", "friendlyName": "MAV_CMD_DO_CONTROL_VIDEO" },
         {
-            "id":           201,
-            "rawName":      "MAV_CMD_DO_SET_ROI",
-            "friendlyName": "Region of interest (cmd)" ,
-            "description":  "Sets the region of interest for cameras.",
+            "id":                   201,
+            "rawName":              "MAV_CMD_DO_SET_ROI",
+            "friendlyName":         "Region of interest (cmd)" ,
+            "description":          "Sets the region of interest for cameras.",
             "specifiesCoordinate":  true,
+            "standaloneCoordinate": true,
             "friendlyEdit":         true,
             "category":             "Camera",
             "param1": {

--- a/src/MissionManager/MissionCommands.cc
+++ b/src/MissionManager/MissionCommands.cc
@@ -49,6 +49,7 @@ const QString MissionCommands::_param3JsonKey               (QStringLiteral("par
 const QString MissionCommands::_param4JsonKey               (QStringLiteral("param4"));
 const QString MissionCommands::_paramJsonKeyFormat          (QStringLiteral("param%1"));
 const QString MissionCommands::_rawNameJsonKey              (QStringLiteral("rawName"));
+const QString MissionCommands::_standaloneCoordinateJsonKey (QStringLiteral("standaloneCoordinate"));
 const QString MissionCommands::_specifiesCoordinateJsonKey  (QStringLiteral("specifiesCoordinate"));
 const QString MissionCommands::_unitsJsonKey                (QStringLiteral("units"));
 const QString MissionCommands::_versionJsonKey              (QStringLiteral("version"));
@@ -129,9 +130,9 @@ void MissionCommands::_loadMavCmdInfoJson(void)
 
         QStringList             keys;
         QList<QJsonValue::Type> types;
-        keys << _idJsonKey << _rawNameJsonKey << _friendlyNameJsonKey << _descriptionJsonKey << _specifiesCoordinateJsonKey << _friendlyEditJsonKey
+        keys << _idJsonKey << _rawNameJsonKey << _friendlyNameJsonKey << _descriptionJsonKey << _standaloneCoordinateJsonKey << _specifiesCoordinateJsonKey <<_friendlyEditJsonKey
              << _param1JsonKey << _param2JsonKey << _param3JsonKey << _param4JsonKey << _categoryJsonKey;
-        types << QJsonValue::Double << QJsonValue::String << QJsonValue::String<< QJsonValue::String << QJsonValue::Bool << QJsonValue::Bool
+        types << QJsonValue::Double << QJsonValue::String << QJsonValue::String<< QJsonValue::String << QJsonValue::Bool << QJsonValue::Bool << QJsonValue::Bool
               << QJsonValue::Object << QJsonValue::Object << QJsonValue::Object << QJsonValue::Object << QJsonValue::String;
         if (!_validateKeyTypes(jsonObject, keys, types)) {
             return;
@@ -144,6 +145,7 @@ void MissionCommands::_loadMavCmdInfoJson(void)
         mavCmdInfo->_rawName =                jsonObject.value(_rawNameJsonKey).toString();
         mavCmdInfo->_friendlyName =           jsonObject.value(_friendlyNameJsonKey).toString(QString());
         mavCmdInfo->_description =            jsonObject.value(_descriptionJsonKey).toString(QString());
+        mavCmdInfo->_standaloneCoordinate =   jsonObject.value(_standaloneCoordinateJsonKey).toBool(false);
         mavCmdInfo->_specifiesCoordinate =    jsonObject.value(_specifiesCoordinateJsonKey).toBool(false);
         mavCmdInfo->_friendlyEdit =           jsonObject.value(_friendlyEditJsonKey).toBool(false);
 
@@ -153,6 +155,7 @@ void MissionCommands::_loadMavCmdInfoJson(void)
                                     << mavCmdInfo->_rawName
                                     << mavCmdInfo->_friendlyName
                                     << mavCmdInfo->_description
+                                    << mavCmdInfo->_standaloneCoordinate
                                     << mavCmdInfo->_specifiesCoordinate
                                     << mavCmdInfo->_friendlyEdit;
 

--- a/src/MissionManager/MissionCommands.h
+++ b/src/MissionManager/MissionCommands.h
@@ -88,13 +88,14 @@ public:
 
     }
 
-    Q_PROPERTY(QString  category            READ category               CONSTANT)
-    Q_PROPERTY(MavlinkQmlSingleton::Qml_MAV_CMD command READ command    CONSTANT)
-    Q_PROPERTY(QString  description         READ description            CONSTANT)
-    Q_PROPERTY(bool     friendlyEdit        READ friendlyEdit           CONSTANT)
-    Q_PROPERTY(QString  friendlyName        READ friendlyName           CONSTANT)
-    Q_PROPERTY(QString  rawName             READ rawName                CONSTANT)
-    Q_PROPERTY(bool     specifiesCoordinate READ specifiesCoordinate    CONSTANT)
+    Q_PROPERTY(QString  category                READ category               CONSTANT)
+    Q_PROPERTY(MavlinkQmlSingleton::Qml_MAV_CMD command READ command        CONSTANT)
+    Q_PROPERTY(QString  description             READ description            CONSTANT)
+    Q_PROPERTY(bool     friendlyEdit            READ friendlyEdit           CONSTANT)
+    Q_PROPERTY(QString  friendlyName            READ friendlyName           CONSTANT)
+    Q_PROPERTY(QString  rawName                 READ rawName                CONSTANT)
+    Q_PROPERTY(bool     standaloneCoordinate    READ standaloneCoordinate   CONSTANT)
+    Q_PROPERTY(bool     specifiesCoordinate     READ specifiesCoordinate    CONSTANT)
 
     QString category            (void) const { return _category; }
     MavlinkQmlSingleton::Qml_MAV_CMD command(void) const { return (MavlinkQmlSingleton::Qml_MAV_CMD)_command; }
@@ -102,6 +103,7 @@ public:
     bool    friendlyEdit        (void) const { return _friendlyEdit; }
     QString friendlyName        (void) const { return _friendlyName; }
     QString rawName             (void) const { return _rawName; }
+    bool    standaloneCoordinate(void) const { return _standaloneCoordinate; }
     bool    specifiesCoordinate (void) const { return _specifiesCoordinate; }
 
     const QMap<int, MavCmdParamInfo*>& paramInfoMap(void) const { return _paramInfoMap; }
@@ -114,6 +116,7 @@ private:
     QString                     _friendlyName;
     QMap<int, MavCmdParamInfo*> _paramInfoMap;
     QString                     _rawName;
+    bool                        _standaloneCoordinate;
     bool                        _specifiesCoordinate;
 
     friend class MissionCommands;
@@ -170,6 +173,7 @@ private:
     static const QString _param4JsonKey;
     static const QString _paramJsonKeyFormat;
     static const QString _rawNameJsonKey;
+    static const QString _standaloneCoordinateJsonKey;
     static const QString _specifiesCoordinateJsonKey;
     static const QString _unitsJsonKey;
     static const QString _versionJsonKey;

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -346,7 +346,7 @@ void MissionController::_recalcWaypointLines(void)
         item->setAzimuth(0.0);
         item->setDistance(-1.0);
 
-        if (item->specifiesCoordinate()) {
+        if (item->specifiesCoordinate() && !item->standaloneCoordinate()) {
             if (firstCoordinateItem) {
                 if (item->command() == MavlinkQmlSingleton::MAV_CMD_NAV_TAKEOFF) {
                     // The first coordinate we hit is a takeoff command so link back to home position if valid
@@ -628,7 +628,7 @@ bool MissionController::_findLastAltitude(double* lastAltitude)
     for (int i=0; i<_missionItems->count(); i++) {
         MissionItem* item = qobject_cast<MissionItem*>(_missionItems->get(i));
 
-        if (item->specifiesCoordinate()) {
+        if (item->specifiesCoordinate() && !item->standaloneCoordinate()) {
             foundAltitude = item->param7();
             found = true;
         }

--- a/src/MissionManager/MissionItem.cc
+++ b/src/MissionManager/MissionItem.cc
@@ -504,6 +504,11 @@ void MissionItem::setParam7(double param)
     }
 }
 
+bool MissionItem::standaloneCoordinate(void) const
+{
+    return _mavCmdInfoMap[(MAV_CMD)command()]->standaloneCoordinate();
+}
+
 bool MissionItem::specifiesCoordinate(void) const
 {
     return _mavCmdInfoMap[(MAV_CMD)command()]->specifiesCoordinate();

--- a/src/MissionManager/MissionItem.h
+++ b/src/MissionManager/MissionItem.h
@@ -68,23 +68,24 @@ public:
 
     const MissionItem& operator=(const MissionItem& other);
     
-    Q_PROPERTY(double           altDifference       READ altDifference          WRITE setAltDifference      NOTIFY altDifferenceChanged)        ///< Change in altitude from previous waypoint
-    Q_PROPERTY(double           azimuth             READ azimuth                WRITE setAzimuth            NOTIFY azimuthChanged)              ///< Azimuth to previous waypoint
-    Q_PROPERTY(QString          category            READ category                                           NOTIFY commandChanged)
-    Q_PROPERTY(MavlinkQmlSingleton::Qml_MAV_CMD command READ command            WRITE setCommand            NOTIFY commandChanged)
-    Q_PROPERTY(QString          commandDescription  READ commandDescription                                 NOTIFY commandChanged)
-    Q_PROPERTY(QString          commandName         READ commandName                                        NOTIFY commandChanged)
-    Q_PROPERTY(QGeoCoordinate   coordinate          READ coordinate             WRITE setCoordinate         NOTIFY coordinateChanged)
-    Q_PROPERTY(bool             dirty               READ dirty                  WRITE setDirty              NOTIFY dirtyChanged)
-    Q_PROPERTY(double           distance            READ distance               WRITE setDistance           NOTIFY distanceChanged)             ///< Distance to previous waypoint
-    Q_PROPERTY(bool             friendlyEditAllowed READ friendlyEditAllowed                                NOTIFY friendlyEditAllowedChanged)
-    Q_PROPERTY(bool             homePosition        READ homePosition                                       CONSTANT)                           ///< true: This item is being used as a home position indicator
-    Q_PROPERTY(bool             homePositionValid   READ homePositionValid      WRITE setHomePositionValid  NOTIFY homePositionValidChanged)    ///< true: Home position should be shown
-    Q_PROPERTY(bool             isCurrentItem       READ isCurrentItem          WRITE setIsCurrentItem      NOTIFY isCurrentItemChanged)
-    Q_PROPERTY(bool             rawEdit             READ rawEdit                WRITE setRawEdit            NOTIFY rawEditChanged)              ///< true: raw item editing with all params
-    Q_PROPERTY(int              sequenceNumber      READ sequenceNumber         WRITE setSequenceNumber     NOTIFY sequenceNumberChanged)
-    Q_PROPERTY(bool             specifiesCoordinate READ specifiesCoordinate                                NOTIFY commandChanged)
-    Q_PROPERTY(Fact*            supportedCommand    READ supportedCommand                                   NOTIFY commandChanged)
+    Q_PROPERTY(double           altDifference           READ altDifference          WRITE setAltDifference      NOTIFY altDifferenceChanged)        ///< Change in altitude from previous waypoint
+    Q_PROPERTY(double           azimuth                 READ azimuth                WRITE setAzimuth            NOTIFY azimuthChanged)              ///< Azimuth to previous waypoint
+    Q_PROPERTY(QString          category                READ category                                           NOTIFY commandChanged)
+    Q_PROPERTY(MavlinkQmlSingleton::Qml_MAV_CMD command READ command                WRITE setCommand            NOTIFY commandChanged)
+    Q_PROPERTY(QString          commandDescription      READ commandDescription                                 NOTIFY commandChanged)
+    Q_PROPERTY(QString          commandName             READ commandName                                        NOTIFY commandChanged)
+    Q_PROPERTY(QGeoCoordinate   coordinate              READ coordinate             WRITE setCoordinate         NOTIFY coordinateChanged)
+    Q_PROPERTY(bool             dirty                   READ dirty                  WRITE setDirty              NOTIFY dirtyChanged)
+    Q_PROPERTY(double           distance                READ distance               WRITE setDistance           NOTIFY distanceChanged)             ///< Distance to previous waypoint
+    Q_PROPERTY(bool             friendlyEditAllowed     READ friendlyEditAllowed                                NOTIFY friendlyEditAllowedChanged)
+    Q_PROPERTY(bool             homePosition            READ homePosition                                       CONSTANT)                           ///< true: This item is being used as a home position indicator
+    Q_PROPERTY(bool             homePositionValid       READ homePositionValid      WRITE setHomePositionValid  NOTIFY homePositionValidChanged)    ///< true: Home position should be shown
+    Q_PROPERTY(bool             isCurrentItem           READ isCurrentItem          WRITE setIsCurrentItem      NOTIFY isCurrentItemChanged)
+    Q_PROPERTY(bool             rawEdit                 READ rawEdit                WRITE setRawEdit            NOTIFY rawEditChanged)              ///< true: raw item editing with all params
+    Q_PROPERTY(int              sequenceNumber          READ sequenceNumber         WRITE setSequenceNumber     NOTIFY sequenceNumberChanged)
+    Q_PROPERTY(bool             standaloneCoordinate    READ standaloneCoordinate                               NOTIFY commandChanged)
+    Q_PROPERTY(bool             specifiesCoordinate     READ specifiesCoordinate                                NOTIFY commandChanged)
+    Q_PROPERTY(Fact*            supportedCommand        READ supportedCommand                                   NOTIFY commandChanged)
 
     // These properties are used to display the editing ui
     Q_PROPERTY(QmlObjectListModel*  checkboxFacts   READ checkboxFacts  NOTIFY uiModelChanged)
@@ -112,6 +113,7 @@ public:
     bool            isCurrentItem       (void) const    { return _isCurrentItem; }
     bool            rawEdit             (void) const;
     int             sequenceNumber      (void) const    { return _sequenceNumber; }
+    bool            standaloneCoordinate(void) const;
     bool            specifiesCoordinate (void) const;
     Fact*           supportedCommand    (void)          { return &_supportedCommandFact; }
 

--- a/src/QmlControls/MissionCommandDialog.qml
+++ b/src/QmlControls/MissionCommandDialog.qml
@@ -49,7 +49,6 @@ QGCViewDialog {
 
         function categorySelected(category) {
             commandList.model = QGroundControl.missionCommands.getCommandsForCategory(category)
-            console.log("changing model", category)
         }
 
         Component.onCompleted: {
@@ -71,33 +70,13 @@ QGCViewDialog {
         spacing:            ScreenTools.defaultFontPixelHeight / 2
         orientation:        ListView.Vertical
 
-        onModelChanged: {
-            var currentCategory = categoryCombo.currentText
-
-            currentIndex = -1
-            if (missionItem.category == currentCategory) {
-                var commandList = QGroundControl.missionCommands.getCommandsForCategory(currentCategory)
-                for (var i=0; i<commandList.count; i++) {
-                    if (commandList.get(i).command == missionItem.command) {
-                        currentIndex = i
-                        break
-                    }
-                }
-            }
-        }
-
-        highlight: Rectangle {
-            color: qgcPal.buttonHighlight
-        }
-
         delegate: Rectangle {
             width:  parent.width
             height: commandColumn.height + ScreenTools.defaultFontPixelSize
-            color:  currentItem ? qgcPal.buttonHighlight : qgcPal.button
+            color:  qgcPal.button
 
-            property var    mavCmdInfo:     object
-            property bool   currentItem:    commandList.currentItem == this
-            property var    textColor:      currentItem ? qgcPal.buttonHighlightText : qgcPal.buttonText
+            property var    mavCmdInfo: object
+            property var    textColor:  qgcPal.buttonText
 
             Column {
                 id:                 commandColumn


### PR DESCRIPTION
A standalone coordinate is a mission item which specifies a coordinate, so you can still drag it around. But waypoint lines do not pass through it. ROI mission items are an example of this.