### PR TITLE
Convert QGCMessageBox to QGCApplication::showMessage

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -23,7 +23,6 @@
 
 #include "APMAutoPilotPlugin.h"
 #include "AutoPilotPluginManager.h"
-#include "QGCMessageBox.h"
 #include "UAS.h"
 #include "FirmwarePlugin/APM/APMParameterMetaData.h"  // FIXME: Hack
 #include "FirmwarePlugin/APM/APMFirmwarePlugin.h"  // FIXME: Hack
@@ -76,8 +75,8 @@ void APMAutoPilotPlugin::_parametersReadyPreChecks(bool missingParameters)
     // should be used instead.
     if (parameterExists(FactSystem::defaultComponentId, "SENS_GYRO_XOFF")) {
         _incorrectParameterVersion = true;
-        QGCMessageBox::warning("Setup", "This version of GroundControl can only perform vehicle setup on a newer version of firmware. "
-										"Please perform a Firmware Upgrade if you wish to use Vehicle Setup.");
+        qgcApp()->showMessage("This version of GroundControl can only perform vehicle setup on a newer version of firmware. "
+                              "Please perform a Firmware Upgrade if you wish to use Vehicle Setup.");
 	}
 #endif
 	

--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -26,7 +26,6 @@
 
 #include "AutoPilotPlugin.h"
 #include "QGCApplication.h"
-#include "QGCMessageBox.h"
 #include "MainWindow.h"
 #include "ParameterLoader.h"
 #include "UAS.h"
@@ -63,7 +62,7 @@ void AutoPilotPlugin::_parametersReadyChanged(bool parametersReady)
 	if (parametersReady) {
 		_recalcSetupComplete();
 		if (!_setupComplete) {
-            qgcApp()->showToolBarMessage("One or more vehicle components require setup prior to flight.");
+            qgcApp()->showMessage("One or more vehicle components require setup prior to flight.");
 			
 			// Take the user to Vehicle Summary
             MainWindow::instance()->showSetupView();

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -308,7 +308,7 @@ void RadioComponentController::nextButtonClicked(void)
             if (_unitTestMode) {
                 emit nextButtonMessageBoxDisplayed();
             } else {
-                QGCMessageBox::warning(tr("Receiver"), tr("Detected %1 radio channels. To operate PX4, you need at least %2 channels.").arg(_chanCount).arg(_chanMinimum));
+                qgcApp()->showMessage(QString("Detected %1 radio channels. To operate PX4, you need at least %2 channels.").arg(_chanCount).arg(_chanMinimum));
             }
             return;
         }
@@ -567,7 +567,7 @@ void RadioComponentController::_saveFlapsDown(void)
         if (_unitTestMode) {
             emit nextButtonMessageBoxDisplayed();
         } else {
-            QGCMessageBox::warning(tr("Flaps switch"), tr("Flaps switch has not yet been detected."));
+            qgcApp()->showMessage("Flaps switch has not yet been detected.");
         }
         return;
     }

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -30,7 +30,6 @@
 #include "MultiVehicleManager.h"
 #include "AutoPilotPluginManager.h"
 #include "QGCApplication.h"
-#include "QGCMessageBox.h"
 
 #include <QVariant>
 #include <QQmlProperty>
@@ -98,7 +97,7 @@ AirframeComponentController::~AirframeComponentController()
 void AirframeComponentController::changeAutostart(void)
 {
     if (qgcApp()->toolbox()->multiVehicleManager()->vehicles()->count() > 1) {
-		QGCMessageBox::warning("Airframe Config", "You cannot change airframe configuration while connected to multiple vehicles.");
+        qgcApp()->showMessage("You cannot change airframe configuration while connected to multiple vehicles.");
 		return;
 	}
 	

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -26,10 +26,10 @@
 #include "PX4AirframeLoader.h"
 #include "FlightModesComponentController.h"
 #include "AirframeComponentController.h"
-#include "QGCMessageBox.h"
 #include "UAS.h"
 #include "FirmwarePlugin/PX4/PX4ParameterMetaData.h"  // FIXME: Hack
 #include "FirmwarePlugin/PX4/PX4FirmwarePlugin.h"  // FIXME: Hack
+#include "QGCApplication.h"
 
 /// @file
 ///     @brief This is the AutoPilotPlugin implementatin for the MAV_AUTOPILOT_PX4 type.
@@ -139,8 +139,8 @@ void PX4AutoPilotPlugin::_parametersReadyPreChecks(bool missingParameters)
     // should be used instead.
     if (parameterExists(FactSystem::defaultComponentId, "SENS_GYRO_XOFF")) {
         _incorrectParameterVersion = true;
-        QGCMessageBox::warning("Setup", "This version of GroundControl can only perform vehicle setup on a newer version of firmware. "
-										"Please perform a Firmware Upgrade if you wish to use Vehicle Setup.");
+        qgcApp()->showMessage("This version of GroundControl can only perform vehicle setup on a newer version of firmware. "
+                              "Please perform a Firmware Upgrade if you wish to use Vehicle Setup.");
 	}
 	
     _parametersReady = true;

--- a/src/AutoPilotPlugins/PX4/PowerComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.cc
@@ -26,7 +26,6 @@
 
 #include "PowerComponentController.h"
 #include "QGCMAVLink.h"
-#include "QGCMessageBox.h"
 #include "UAS.h"
 
 #include <QVariant>

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -26,8 +26,8 @@
 
 #include "SensorsComponentController.h"
 #include "QGCMAVLink.h"
-#include "QGCMessageBox.h"
 #include "UAS.h"
+#include "QGCApplication.h"
 
 #include <QVariant>
 #include <QQmlProperty>
@@ -181,7 +181,7 @@ void SensorsComponentController::_stopCalibration(SensorsComponentController::St
         default:
             // Assume failed
             _hideAllCalAreas();
-            QGCMessageBox::warning("Calibration", "Calibration failed. Calibration log will be displayed.");
+            qgcApp()->showMessage("Calibration failed. Calibration log will be displayed.");
             break;
     }
     

--- a/src/FactSystem/FactControls/FactPanelController.cc
+++ b/src/FactSystem/FactControls/FactPanelController.cc
@@ -23,8 +23,8 @@
 
 #include "FactPanelController.h"
 #include "MultiVehicleManager.h"
-#include "QGCMessageBox.h"
 #include "UAS.h"
+#include "QGCApplication.h"
 
 #include <QQmlEngine>
 
@@ -150,5 +150,5 @@ void FactPanelController::_showInternalError(const QString& errorMsg)
 {
     _notifyPanelErrorMsg(QString("Internal Error: %1").arg(errorMsg));
     qCWarning(FactPanelControllerLog) << "Internal Error" << errorMsg;
-    QGCMessageBox::critical("Internal Error", errorMsg);
+    qgcApp()->showMessage(errorMsg);
 }

--- a/src/FactSystem/FactSystemTestBase.cc
+++ b/src/FactSystem/FactSystemTestBase.cc
@@ -31,7 +31,6 @@
 #endif
 #include "MultiVehicleManager.h"
 #include "QGCApplication.h"
-#include "QGCMessageBox.h"
 #include "QGCQuickWidget.h"
 
 #include <QQuickItem>

--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -848,18 +848,17 @@ void ParameterLoader::_checkInitialLoadComplete(void)
 
         if (errorsFound) {
             QString errorMsg = QString("<b>Critical safety issue detected:</b><br>%1").arg(errors);
-            qgcApp()->showToolBarMessage(errorMsg);
+            qgcApp()->showMessage(errorMsg);
         }
     }
 
     // Warn of parameter load failure
 
     if (initialLoadFailures) {
-        QGCMessageBox::critical("Parameter Load Failure",
-                                "QGroundControl was unable to retrieve the full set of parameters from the vehicle. "
-                                "This will cause QGroundControl to be unable to display it's full user interface. "
-                                "If you are using modified firmware, you may need to resolve any vehicle startup errors to resolve the issue. "
-                                "If you are using standard firmware, you may need to upgrade to a newer version to resolve the issue.");
+        qgcApp()->showMessage("QGroundControl was unable to retrieve the full set of parameters from the vehicle. "
+                              "This will cause QGroundControl to be unable to display it's full user interface. "
+                              "If you are using modified firmware, you may need to resolve any vehicle startup errors to resolve the issue. "
+                              "If you are using standard firmware, you may need to upgrade to a newer version to resolve the issue.");
         qCWarning(ParameterLoaderLog) << "The following parameter indices could not be loaded after the maximum number of retries: " << indexList;
         emit parametersReady(true);
     } else {

--- a/src/HomePositionManager.cc
+++ b/src/HomePositionManager.cc
@@ -31,7 +31,6 @@
 #include "UASInterface.h"
 #include "HomePositionManager.h"
 #include "QGC.h"
-#include "QGCMessageBox.h"
 #include "QGCApplication.h"
 #include "MultiVehicleManager.h"
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -26,8 +26,8 @@ This file is part of the QGROUNDCONTROL project
 #include "MissionManager.h"
 #include "QGCFileDialog.h"
 #include "CoordinateVector.h"
-#include "QGCMessageBox.h"
 #include "FirmwarePlugin.h"
+#include "QGCApplication.h"
 
 QGC_LOGGING_CATEGORY(MissionControllerLog, "MissionControllerLog")
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -393,9 +393,8 @@ void QGCApplication::_initCommon(void)
     if (settingsUpgraded) {
         settings.clear();
         settings.setValue(_settingsVersionKey, QGC_SETTINGS_VERSION);
-        QGCMessageBox::information(tr("Settings Cleared"),
-                                   tr("The format for QGroundControl saved settings has been modified. "
-                                      "Your saved settings have been reset to defaults."));
+        showMessage("The format for QGroundControl saved settings has been modified. "
+                    "Your saved settings have been reset to defaults.");
     }
 
     // Load saved files location and validate
@@ -588,7 +587,8 @@ QGCApplication* qgcApp(void)
 
 void QGCApplication::informationMessageBoxOnMainThread(const QString& title, const QString& msg)
 {
-    QGCMessageBox::information(title, msg);
+    Q_UNUSED(title);
+    showMessage(msg);
 }
 
 void QGCApplication::warningMessageBoxOnMainThread(const QString& title, const QString& msg)
@@ -709,7 +709,7 @@ void QGCApplication::_missingParamsDisplay(void)
                 "You should quit QGroundControl immediately and update your firmware.").arg(params));
 }
 
-void QGCApplication::showToolBarMessage(const QString& message)
+void QGCApplication::showMessage(const QString& message)
 {
     MainWindow* mainWindow = MainWindow::instance();
     if (mainWindow) {

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -116,7 +116,7 @@ public:
     void reportMissingParameter(int componentId, const QString& name);
 
     /// Show a non-modal message to the user
-    void showToolBarMessage(const QString& message);
+    void showMessage(const QString& message);
 
 	/// @return true: Fake ui into showing mobile interface
 	bool fakeMobile(void) { return _fakeMobile; }

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -27,9 +27,9 @@
 #include "ParameterEditorController.h"
 #include "AutoPilotPluginManager.h"
 #include "QGCFileDialog.h"
-#include "QGCMessageBox.h"
 #include "QGCMapRCToParamDialog.h"
 #include "MainWindow.h"
+#include "QGCApplication.h"
 
 /// @Brief Constructs a new ParameterEditorController Widget. This widget is used within the PX4VehicleConfig set of screens.
 ParameterEditorController::ParameterEditorController(void)
@@ -106,7 +106,7 @@ void ParameterEditorController::saveToFile(void)
 		QFile file(fileName);
         
 		if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-            QGCMessageBox::critical(msgTitle, "Unable to create file");
+            qgcApp()->showMessage("Unable to create file");
 			return;
 		}
         
@@ -132,7 +132,7 @@ void ParameterEditorController::loadFromFile(void)
         QFile file(fileName);
         
         if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            QGCMessageBox::critical(msgTitle, "Unable to open file");
+            qgcApp()->showMessage("Unable to open file");
             return;
         }
         

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1080,7 +1080,7 @@ void Vehicle::sendMessageMultiple(mavlink_message_t message)
 void Vehicle::_missionManagerError(int errorCode, const QString& errorMsg)
 {
     Q_UNUSED(errorCode);
-    qgcApp()->showToolBarMessage(QString("Error during Mission communication with Vehicle: %1").arg(errorMsg));
+    qgcApp()->showMessage(QString("Error during Mission communication with Vehicle: %1").arg(errorMsg));
 }
 
 void Vehicle::_addNewMapTrajectoryPoint(void)

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -28,8 +28,7 @@
 #include "FirmwareUpgradeController.h"
 #include "Bootloader.h"
 #include "QGCFileDialog.h"
-#include "QGCMessageBox.h"
-
+#include "QGCApplication.h"
 
 struct FirmwareToUrlElement_t {
     FirmwareUpgradeController::AutoPilotStackType_t    stackType;

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -23,7 +23,6 @@
 
 #include "JoystickConfigController.h"
 #include "JoystickManager.h"
-#include "QGCMessageBox.h"
 #include "QGCApplication.h"
 
 #include <QSettings>
@@ -197,7 +196,7 @@ void JoystickConfigController::nextButtonClicked(void)
     if (_currentStep == -1) {
         // Need to have enough channels
         if (_axisCount < _axisMinimum) {
-            QGCMessageBox::warning(tr("Joystick"), tr("Detected %1 joystick axes. To operate PX4, you need at least %2 axes.").arg(_axisCount).arg(_axisMinimum));
+            qgcApp()->showMessage(QString("Detected %1 joystick axes. To operate PX4, you need at least %2 axes.").arg(_axisCount).arg(_axisMinimum));
             return;
         }
         _startCalibration();

--- a/src/VehicleSetup/SetupViewTest.cc
+++ b/src/VehicleSetup/SetupViewTest.cc
@@ -26,8 +26,8 @@
 
 #include "SetupViewTest.h"
 #include "MockLink.h"
-#include "QGCMessageBox.h"
 #include "MultiVehicleManager.h"
+#include "QGCApplication.h"
 
 void SetupViewTest::_clickThrough_test(void)
 {

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -39,7 +39,6 @@ This file is part of the QGROUNDCONTROL project
 
 #include "LinkManager.h"
 #include "MainWindow.h"
-#include "QGCMessageBox.h"
 #include "QGCApplication.h"
 #include "QGCApplication.h"
 #include "UDPLink.h"
@@ -276,8 +275,7 @@ void LinkManager::_deleteLink(LinkInterface* link)
 bool LinkManager::_connectionsSuspendedMsg(void)
 {
     if (_connectionsSuspended) {
-        QGCMessageBox::information(tr("Connect not allowed"),
-                                   tr("Connect not allowed: %1").arg(_connectionsSuspendedReason));
+        qgcApp()->showMessage(QString("Connect not allowed: %1").arg(_connectionsSuspendedReason));
         return true;
     } else {
         return false;
@@ -618,14 +616,14 @@ void LinkManager::_vehicleHeartbeatInfo(LinkInterface* link, int vehicleId, int 
                                 << vehicleType;
 
         if (vehicleId == _mavlinkProtocol->getSystemId()) {
-            _app->showToolBarMessage(QString("Warning: A vehicle is using the same system id as QGroundControl: %1").arg(vehicleId));
+            _app->showMessage(QString("Warning: A vehicle is using the same system id as QGroundControl: %1").arg(vehicleId));
         }
 
         QSettings settings;
         bool mavlinkVersionCheck = settings.value("VERSION_CHECK_ENABLED", true).toBool();
         if (mavlinkVersionCheck && vehicleMavlinkVersion != MAVLINK_VERSION) {
             _ignoreVehicleIds += vehicleId;
-            _app->showToolBarMessage(QString("The MAVLink protocol version on vehicle #%1 and QGroundControl differ! "
+            _app->showMessage(QString("The MAVLink protocol version on vehicle #%1 and QGroundControl differ! "
                                                  "It is unsafe to use different MAVLink versions. "
                                                  "QGroundControl therefore refuses to connect to vehicle #%1, which sends MAVLink version %2 (QGroundControl uses version %3).").arg(vehicleId).arg(vehicleMavlinkVersion).arg(MAVLINK_VERSION));
             return;

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -34,10 +34,10 @@
 #endif
 #include <Eigen/Geometry>
 #include "FirmwarePluginManager.h"
-#include "QGCMessageBox.h"
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
 #include "Joystick.h"
+#include "QGCApplication.h"
 
 QGC_LOGGING_CATEGORY(UASLog, "UASLog")
 

--- a/src/uas/UASMessageHandler.cc
+++ b/src/uas/UASMessageHandler.cc
@@ -198,7 +198,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     emit textMessageCountChanged(count);
     
     if (_showErrorsInToolbar && message->severityIsError()) {
-        _app->showToolBarMessage(message->getText());
+        _app->showMessage(message->getText());
     }
 }
 


### PR DESCRIPTION
- Changed QGCApplication::showToolbarMessage to showMessage since it isn't in the toolbar any more
- Converted a pile of QGCMessageBox usage to QGCApplication::showMessage

A baby step towards native QML top level window for mobile