### PR TITLE
More message box removal

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -26,8 +26,8 @@
 ///     @author Don Gagne <don@thegagnes.com
 
 #include "RadioComponentController.h"
-#include "QGCMessageBox.h"
 #include "AutoPilotPluginManager.h"
+#include "QGCApplication.h"
 
 #include <QSettings>
 

--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -657,7 +657,6 @@ void ParameterLoader::_saveToEEPROM(void)
 QString ParameterLoader::readParametersFromStream(QTextStream& stream)
 {
     QString errors;
-    bool userWarned = false;
 
     while (!stream.atEnd()) {
         QString line = stream.readLine();
@@ -665,16 +664,8 @@ QString ParameterLoader::readParametersFromStream(QTextStream& stream)
             QStringList wpParams = line.split("\t");
             int lineMavId = wpParams.at(0).toInt();
             if (wpParams.size() == 5) {
-                if (!userWarned && (_vehicle->id() != lineMavId)) {
-                    userWarned = true;
-                    QString msg("The parameters in the stream have been saved from System Id %1, but the current vehicle has the System Id %2.");
-                    QGCMessageBox::StandardButton button = QGCMessageBox::warning("Parameter Load",
-                                                                                  msg.arg(lineMavId).arg(_vehicle->id()),
-                                                                                  QGCMessageBox::Ok | QGCMessageBox::Cancel,
-                                                                                  QGCMessageBox::Cancel);
-                    if (button == QGCMessageBox::Cancel) {
-                        return QString();
-                    }
+                if (_vehicle->id() != lineMavId) {
+                    return QString("The parameters in the stream have been saved from System Id %1, but the current vehicle has the System Id %2.").arg(lineMavId).arg(_vehicle->id());
                 }
 
                 int     componentId = wpParams.at(1).toInt();

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -455,9 +455,7 @@ bool QGCApplication::_initForNormalAppBoot(void)
     /// settings.
     QString savedFilesLocation = settings.value(_savedFilesLocationKey).toString();
     if (savedFilesLocation.isEmpty()) {
-        QGCMessageBox::warning(
-            tr("Bad save location"),
-            tr("The location to save files to is invalid, or cannot be written to. Please provide a new one."));
+        showMessage("The location to save files to is invalid, or cannot be written to. Please provide a new one.");
         mainWindow->showSettings();
     }
 
@@ -705,10 +703,7 @@ void QGCApplication::_missingParamsDisplay(void)
     }
     _missingParams.clear();
 
-    QGCMessageBox::critical(
-        "Missing Parameters",
-        QString("Parameters missing from firmware: %1.\n\n"
-                "You should quit QGroundControl immediately and update your firmware.").arg(params));
+    showMessage(QString("Parameters missing from firmware: %1.\n\nYou should quit QGroundControl immediately and update your firmware.").arg(params));
 }
 
 void QGCApplication::showMessage(const QString& message)
@@ -717,6 +712,6 @@ void QGCApplication::showMessage(const QString& message)
     if (mainWindow) {
         mainWindow->showToolbarMessage(message);
     } else {
-        QGCMessageBox::information("", message);
+        qWarning() << "showMessage with no mainWindow" << message;
     }
 }

--- a/src/QGCQuickWidget.cc
+++ b/src/QGCQuickWidget.cc
@@ -60,7 +60,7 @@ bool QGCQuickWidget::setSource(const QUrl& qmlUrl)
             errorList += error.toString();
             errorList += "\n";
         }
-        QGCMessageBox::warning(tr("Qml Error"), tr("Source not ready: Status(%1)\nErrors:\n%2").arg(status()).arg(errorList));
+        qgcApp()->showMessage(QString("Source not ready: Status(%1)\nErrors:\n%2").arg(status()).arg(errorList));
         return false;
     }
     

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -91,6 +91,9 @@ public:
     /// @brief Saves the last used connection
     void saveLastUsedConnection(const QString connection);
 
+    // Called from MainWindow.qml when the user accepts the window close dialog
+    Q_INVOKABLE void acceptWindowClose(void);
+
 public slots:
     /** @brief Show the application settings */
     void showSettings();
@@ -132,6 +135,7 @@ protected slots:
      * this incoherent.
      */
     void handleActiveViewActionState(bool triggered);
+
 signals:
     // Signals the Qml to show the specified view
     void showFlyView(void);
@@ -139,6 +143,7 @@ signals:
     void showSetupView(void);
 
     void showToolbarMessage(const QString& message);
+    void showWindowCloseMessage(void);
 
     // These are used for unit testing
     void showSetupFirmware(void);

--- a/src/ui/MainWindow.qml
+++ b/src/ui/MainWindow.qml
@@ -23,6 +23,7 @@ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
 
 import QtQuick          2.5
 import QtQuick.Controls 1.2
+import QtQuick.Dialogs  1.2
 import QtPositioning    5.2
 
 import QGroundControl                       1.0
@@ -94,6 +95,8 @@ Item {
         }
 
         onShowToolbarMessage: toolBar.showToolbarMessage(message)
+
+        onShowWindowCloseMessage: windowCloseDialog.open()
 
         // The following are use for unit testing only
 
@@ -173,11 +176,22 @@ Item {
     function showPopUp(dropItem, centerX) {
         if(currentPopUp) {
             currentPopUp.close()
-        }
+          }
         indicatorDropdown.centerX = centerX
         indicatorDropdown.sourceComponent = dropItem
         indicatorDropdown.visible = true
         currentPopUp = indicatorDropdown
+    }
+
+    MessageDialog {
+        id:                 windowCloseDialog
+        title:              "QGroundControl close"
+        text:               "There are still active connections to vehicles. Do you want to disconnect these before closing?"
+        standardButtons:    StandardButton.Yes | StandardButton.Cancel
+        modality:           Qt.ApplicationModal
+        visible:            false
+
+        onYes: controller.acceptWindowClose()
     }
 
     //-- Left Settings Menu


### PR DESCRIPTION
This removes the last QGCMessageBox usage which is on the mobile code path.

Next pull: Remove QGCMessageBox.h and QGCFileDialog.h/cc from the mobile build and see if anything else breaks.
Next next pull: Fork MainWindow into desktop hybrid model and mobile native model.