### PR TITLE
Message box

### DIFF
--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -103,6 +103,7 @@
     <qresource prefix="/res">
         <file alias="AntennaRC">resources/Antenna_RC.svg</file>
         <file alias="AntennaT">resources/Antenna_T.svg</file>
+        <file alias="ArrowDown.svg">resources/ArrowDown.svg</file>
         <file alias="buttonLeft.svg">resources/buttonLeft.svg</file>
         <file alias="buttonRight.svg">resources/buttonRight.svg</file>
         <file alias="JoystickBezel.png">resources/JoystickBezel.png</file>

--- a/resources/ArrowDown.svg
+++ b/resources/ArrowDown.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 72 72" style="enable-background:new 0 0 72 72;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:14.3358;stroke-miterlimit:10;}
+	.st1{fill:#FFFFFF;}
+</style>
+<g>
+	<g>
+		<line class="st0" x1="36" y1="37.4" x2="35.8" y2="8.9"/>
+		<g>
+			<polygon class="st1" points="53.8,32 36.2,63.1 18.1,32.3 			"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -39,7 +39,7 @@ MapQuickItem {
 
     anchorPoint.x:  vehicleIcon.width  / 2
     anchorPoint.y:  vehicleIcon.height / 2
-    visible:        vehicle.coordinateValid
+    visible:        vehicle && vehicle.coordinateValid
 
     sourceItem: Image {
         id:         vehicleIcon
@@ -51,7 +51,7 @@ MapQuickItem {
         transform: Rotation {
             origin.x:   vehicleIcon.width  / 2
             origin.y:   vehicleIcon.height / 2
-            angle:      vehicle.heading
+            angle:      vehicle ? vehicle.heading : 0
         }
     }
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -715,7 +715,7 @@ void QGCApplication::showMessage(const QString& message)
 {
     MainWindow* mainWindow = MainWindow::instance();
     if (mainWindow) {
-        mainWindow->showToolbarMessage(message);
+        mainWindow->showMessage(message);
     } else {
         QGCMessageBox::information("", message);
     }

--- a/src/uas/UASMessageHandler.cc
+++ b/src/uas/UASMessageHandler.cc
@@ -109,7 +109,7 @@ void UASMessageHandler::_activeVehicleChanged(Vehicle* vehicle)
     if (vehicle)
     {
         UAS* uas = vehicle->uas();
-        
+
         // Connect to the new UAS.
         clearMessages();
         _activeUAS = uas;
@@ -135,18 +135,17 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     case MAV_SEVERITY_ALERT:
     case MAV_SEVERITY_CRITICAL:
     case MAV_SEVERITY_ERROR:
-        //Use set RGB values from given color from QGC
-        style = QString("color: rgb(%1, %2, %3); font-weight:bold").arg(QGC::colorRed.red()).arg(QGC::colorRed.green()).arg(QGC::colorRed.blue());
+        style = QString("color: #f95e5e; font-weight:bold");
         _errorCount++;
         _errorCountTotal++;
         break;
     case MAV_SEVERITY_NOTICE:
     case MAV_SEVERITY_WARNING:
-        style = QString("color: rgb(%1, %2, %3); font-weight:bold").arg(QGC::colorOrange.red()).arg(QGC::colorOrange.green()).arg(QGC::colorOrange.blue());
+        style = QString("color: #f9b55e; font-weight:bold");
         _warningCount++;
         break;
     default:
-        style = QString("color:white; font-weight:bold");
+        style = QString("color: #ffffff; font-weight:bold");
         _normalCount++;
         break;
     }
@@ -187,7 +186,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     // Finally preppend the properly-styled text with a timestamp.
     QString dateString = QDateTime::currentDateTime().toString("hh:mm:ss.zzz");
     UASMessage* message = new UASMessage(compId, severity, text);
-    message->_setFormatedText(QString("<p style=\"color:#CCCCCC\">[%2 - COMP:%3]<font style=\"%1\">%4 %5</font></p>").arg(style).arg(dateString).arg(compId).arg(severityText).arg(text));
+    message->_setFormatedText(QString("<p style=\"color:#e0e0f0\">[%2 - COMP:%3]<font style=\"%1\">%4 %5</font></p>").arg(style).arg(dateString).arg(compId).arg(severityText).arg(text));
     _messages.append(message);
     int count = _messages.count();
     if (message->severityIsError()) {
@@ -196,7 +195,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     _mutex.unlock();
     emit textMessageReceived(message);
     emit textMessageCountChanged(count);
-    
+
     if (_showErrorsInToolbar && message->severityIsError()) {
         _app->showMessage(message->getText());
     }

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -675,3 +675,8 @@ void MainWindow::_storeVisibleWidgetsSettings(void)
     settings.setValue(_visibleWidgetsKey, widgetNames);
 }
 #endif
+
+void MainWindow::showMessage(const QString message)
+{
+    emit showCriticalMessage(message);
+}

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -91,6 +91,9 @@ public:
     /// @brief Saves the last used connection
     void saveLastUsedConnection(const QString connection);
 
+    /// @brief Show message in lower message window
+    void showMessage(const QString message);
+
 public slots:
     /** @brief Show the application settings */
     void showSettings();
@@ -138,7 +141,7 @@ signals:
     void showPlanView(void);
     void showSetupView(void);
 
-    void showToolbarMessage(const QString& message);
+    void showCriticalMessage(const QString& message);
 
     // These are used for unit testing
     void showSetupFirmware(void);

--- a/src/ui/MainWindow.qml
+++ b/src/ui/MainWindow.qml
@@ -93,7 +93,7 @@ Item {
             planViewLoader.visible      = false
         }
 
-        onShowToolbarMessage: toolBar.showToolbarMessage(message)
+        onShowCriticalMessage: showCriticalMessage(message)
 
         // The following are use for unit testing only
 
@@ -121,6 +121,18 @@ Item {
                 }
             }
             positionSource.stop()
+        }
+    }
+
+    property var messageQueue: []
+
+    function showCriticalMessage(message) {
+        if(criticalMmessageArea.visible) {
+            messageQueue.push(message)
+        } else {
+            criticalMessageText.text = message
+            criticalMmessageArea.visible = true
+            mainWindow.setMapInteractive(false)
         }
     }
 
@@ -264,7 +276,7 @@ Item {
 
         width:              mainWindow.width  * 0.5
         height:             mainWindow.height * 0.5
-        color:              Qt.rgba(0,0,0,0.75)
+        color:              Qt.rgba(0,0,0,0.8)
         visible:            false
         radius:             ScreenTools.defaultFontPixelHeight * 0.5
         anchors.horizontalCenter:   parent.horizontalCenter
@@ -301,6 +313,95 @@ Item {
                 anchors.fill:   parent
                 onClicked: {
                     messageArea.close()
+                }
+            }
+        }
+    }
+    //-------------------------------------------------------------------------
+    //-- Critical Message Area
+    Rectangle {
+        id:                 criticalMmessageArea
+
+        function close() {
+            //-- Are there messages in the waiting queue?
+            if(mainWindow.messageQueue.length) {
+                criticalMessageText.text = ""
+                //-- Show all messages in queue
+                for (var i = 0; i < mainWindow.messageQueue.length; i++) {
+                    criticalMessageText.append(mainWindow.messageQueue[i])
+                }
+                //-- Clear it
+                mainWindow.messageQueue = []
+            } else {
+                criticalMessageText.text = ""
+                mainWindow.setMapInteractive(true)
+                criticalMmessageArea.visible = false
+            }
+        }
+
+        width:              mainWindow.width  * 0.55
+        height:             ScreenTools.defaultFontPixelHeight * ScreenTools.fontHRatio * 6
+        color:              Qt.rgba(0,0,0,0.8)
+        visible:            false
+        radius:             ScreenTools.defaultFontPixelHeight * 0.5
+        anchors.horizontalCenter:   parent.horizontalCenter
+        anchors.bottom:             parent.bottom
+        anchors.bottomMargin:       ScreenTools.defaultFontPixelHeight
+        Flickable {
+            id:                 criticalMessageFlick
+            anchors.margins:    ScreenTools.defaultFontPixelHeight
+            anchors.fill:       parent
+            contentHeight:      criticalMessageText.height
+            contentWidth:       criticalMessageText.width
+            boundsBehavior:     Flickable.StopAtBounds
+            pixelAligned:       true
+            clip:               true
+            TextEdit {
+                id:             criticalMessageText
+                width:          criticalMmessageArea.width - criticalClose.width - (ScreenTools.defaultFontPixelHeight * 2)
+                anchors.left:   parent.left
+                readOnly:       true
+                textFormat:     TextEdit.RichText
+                font.weight:    Font.DemiBold
+                wrapMode:       TextEdit.WordWrap
+                color:          "#fdfd3b"
+            }
+        }
+        //-- Dismiss Critical Message
+        Image {
+            id:                 criticalClose
+            anchors.margins:    ScreenTools.defaultFontPixelHeight
+            anchors.top:        parent.top
+            anchors.right:      parent.right
+            width:              ScreenTools.defaultFontPixelHeight * 1.5
+            height:             ScreenTools.defaultFontPixelHeight * 1.5
+            source:             "/res/XDelete.svg"
+            fillMode:           Image.PreserveAspectFit
+            mipmap:             true
+            smooth:             true
+            MouseArea {
+                anchors.fill:   parent
+                onClicked: {
+                    criticalMmessageArea.close()
+                }
+            }
+        }
+        //-- More text below indicator
+        Image {
+            anchors.margins:    ScreenTools.defaultFontPixelHeight
+            anchors.bottom:     parent.bottom
+            anchors.right:      parent.right
+            width:              ScreenTools.defaultFontPixelHeight * 1.5
+            height:             ScreenTools.defaultFontPixelHeight * 1.5
+            source:             "/res/ArrowDown.svg"
+            fillMode:           Image.PreserveAspectFit
+            mipmap:             true
+            smooth:             true
+            visible:            criticalMessageText.lineCount > 5
+            MouseArea {
+                anchors.fill:   parent
+                onClicked: {
+                    criticalMessageFlick.flick(0,-500)
                 }
             }
         }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -147,11 +147,6 @@ Rectangle {
 
     MainToolBarController { id: _controller }
 
-    function showToolbarMessage(message) {
-        toolBarMessage.text = message
-        toolBarMessageArea.visible = true
-    }
-
     function getBatteryColor() {
         if(activeVehicle) {
             if(activeVehicle.batteryPercent > 75) {
@@ -595,44 +590,4 @@ Rectangle {
         color:          colorGreen
     }
 
-    // Toolbar message area
-    Rectangle {
-        id:             toolBarMessageArea
-        x:              toolBar.parent.width * 0.225
-        y:              toolBar.parent.height - (ScreenTools.defaultFontPixelHeight * ScreenTools.fontHRatio * 6)
-        width:          toolBar.parent.width * 0.55
-        height:         ScreenTools.defaultFontPixelHeight * ScreenTools.fontHRatio * 6
-        color:          Qt.rgba(0,0,0,0.65)
-        visible:        false
-        ScrollView {
-            width:              toolBarMessageArea.width - toolBarMessageCloseButton.width
-            anchors.top:        parent.top
-            anchors.bottom:     parent.bottom
-            frameVisible:       false
-            horizontalScrollBarPolicy:  Qt.ScrollBarAlwaysOff
-            verticalScrollBarPolicy:    Qt.ScrollBarAlwaysOff
-            QGCLabel {
-                id:                 toolBarMessage
-                width:              toolBarMessageArea.width - toolBarMessageCloseButton.width
-                wrapMode:           Text.WordWrap
-                color:              "#e4e428"
-                lineHeightMode:     Text.ProportionalHeight
-                lineHeight:         1.15
-                anchors.margins:    mainWindow.tbSpacing
-            }
-        }
-        QGCButton {
-            id:                 toolBarMessageCloseButton
-            primary:            true
-            text:               "Close"
-            anchors.right:      parent.right
-            anchors.bottom:     parent.bottom
-            anchors.margins:    mainWindow.tbSpacing
-            onClicked: {
-                toolBarMessageArea.visible = false
-                _controller.onToolBarMessageClosed()
-            }
-        }
-    }
-
-} // Rectangle
+}

--- a/src/ui/toolbar/MainToolBarController.cc
+++ b/src/ui/toolbar/MainToolBarController.cc
@@ -46,15 +46,12 @@ MainToolBarController::MainToolBarController(QObject* parent)
     , _progressBarValue(0.0f)
     , _telemetryRRSSI(0)
     , _telemetryLRSSI(0)
-    , _toolbarMessageVisible(false)
 {
     _activeVehicleChanged(qgcApp()->toolbox()->multiVehicleManager()->activeVehicle());
-
     // RSSI (didn't like standard connection)
     connect(qgcApp()->toolbox()->mavlinkProtocol(),
         SIGNAL(radioStatusChanged(LinkInterface*, unsigned, unsigned, int, int, unsigned, unsigned, unsigned)), this,
         SLOT(_telemetryChanged(LinkInterface*, unsigned, unsigned, int, int, unsigned, unsigned, unsigned)));
-
     connect(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::activeVehicleChanged, this, &MainToolBarController::_activeVehicleChanged);
 }
 
@@ -132,46 +129,6 @@ void MainToolBarController::_setProgressBarValue(float value)
 {
     _progressBarValue = value;
     emit progressBarValueChanged(value);
-}
-
-void MainToolBarController::showToolBarMessage(const QString& message)
-{
-    _toolbarMessageQueueMutex.lock();
-
-    if (_toolbarMessageQueue.count() == 0 && !_toolbarMessageVisible) {
-        QTimer::singleShot(500, this, &MainToolBarController::_delayedShowToolBarMessage);
-    }
-
-    _toolbarMessageQueue += message;
-
-    _toolbarMessageQueueMutex.unlock();
-}
-
-void MainToolBarController::_delayedShowToolBarMessage(void)
-{
-    QString messages;
-
-    if (!_toolbarMessageVisible) {
-        _toolbarMessageQueueMutex.lock();
-
-        foreach (QString message, _toolbarMessageQueue) {
-            messages += message + "\n";
-        }
-        _toolbarMessageQueue.clear();
-
-        _toolbarMessageQueueMutex.unlock();
-
-        if (!messages.isEmpty()) {
-            _toolbarMessageVisible = true;
-            emit showMessage(messages);
-        }
-    }
-}
-
-void MainToolBarController::onToolBarMessageClosed(void)
-{
-    _toolbarMessageVisible = false;
-    _delayedShowToolBarMessage();
 }
 
 void MainToolBarController::showSettings(void)

--- a/src/ui/toolbar/MainToolBarController.h
+++ b/src/ui/toolbar/MainToolBarController.h
@@ -53,7 +53,6 @@ public:
     Q_INVOKABLE void    onSetupView();
     Q_INVOKABLE void    onPlanView();
     Q_INVOKABLE void    onFlyView();
-    Q_INVOKABLE void    onToolBarMessageClosed(void);
     Q_INVOKABLE void    showSettings(void);
     Q_INVOKABLE void    manageLinks(void);
 
@@ -77,8 +76,6 @@ public:
     unsigned int telemetryLNoise        () { return _telemetryLNoise; }
     unsigned int telemetryRNoise        () { return _telemetryRNoise; }
 
-    void showToolBarMessage(const QString& message);
-
 signals:
     void progressBarValueChanged        (float value);
     void telemetryRRSSIChanged          (int value);
@@ -90,14 +87,10 @@ signals:
     void telemetryLNoiseChanged         (unsigned int value);
     void telemetryRNoiseChanged         (unsigned int value);
 
-    /// Shows a non-modal message below the toolbar
-    void showMessage(const QString& message);
-
 private slots:
     void _activeVehicleChanged          (Vehicle* vehicle);
     void _setProgressBarValue           (float value);
     void _telemetryChanged              (LinkInterface* link, unsigned rxerrors, unsigned fixed, int rssi, int remrssi, unsigned txbuf, unsigned noise, unsigned remnoise);
-    void _delayedShowToolBarMessage     (void);
 
 private:
     Vehicle*        _vehicle;
@@ -114,7 +107,6 @@ private:
 
     double          _toolbarHeight;
 
-    bool            _toolbarMessageVisible;
     QStringList     _toolbarMessageQueue;
     QMutex          _toolbarMessageQueueMutex;
 };

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -58,10 +58,12 @@ Row {
                 return colorOrange;
             if (activeVehicle.messageTypeError)
                 return colorRed;
+            // Cannot be so make make it obnoxious to show error
+            console.log("Invalid vehicle message type")
+            return "purple";
         }
-        // Cannot be so make make it obnoxious to show error
-        console.log("Invalid vehicle message type")
-        return "purple";
+        //-- It can only get here when closing (vehicle gone while window active)
+        return "white";
     }
 
     function getBatteryVoltageText() {


### PR DESCRIPTION
Routing *critical* messages through the MainWindow (QML) instead of through the toolbar. I've also moved the logic that handles queueing up subsequent messages to the MainWindow.

If there are more messages than can be displayed in the dialog, an arrow is shown, indicating you can scroll down to see more messages.

While at it, I've also tweaked the text colors for the system messages (the upper system message dialog) as indicated in #2356.