### PR TITLE
Remove all message and file dialog code from mobile

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -190,18 +190,7 @@ INCLUDEPATH += \
     src/ViewWidgets \
 
 FORMS += \
-    src/QGCQmlWidgetHolder.ui \
     src/ui/MainWindow.ui \
-    src/ui/MAVLinkSettingsWidget.ui \
-    src/ui/QGCCommConfiguration.ui \
-    src/ui/QGCLinkConfiguration.ui \
-    src/ui/QGCMapRCToParamDialog.ui \
-    src/ui/QGCPluginHost.ui \
-    src/ui/QGCTCPLinkConfiguration.ui \
-    src/ui/QGCUDPLinkConfiguration.ui \
-    src/ui/SettingsDialog.ui \
-    src/ui/uas/QGCUnconnectedInfoWidget.ui \
-    src/ui/uas/UASMessageView.ui \
 
 DebugBuild {
 FORMS += \
@@ -215,19 +204,29 @@ FORMS += \
 
 !MobileBuild {
 FORMS += \
-    src/ui/LogReplayLinkConfigurationWidget.ui \
-    src/ui/QGCMAVLinkLogPlayer.ui \
+    src/QGCQmlWidgetHolder.ui \
+    src/ui/uas/QGCUnconnectedInfoWidget.ui \
+    src/ui/uas/UASMessageView.ui \
     src/ui/Linechart.ui \
+    src/ui/LogReplayLinkConfigurationWidget.ui \
     src/ui/MultiVehicleDockWidget.ui \
+    src/ui/MAVLinkSettingsWidget.ui \
+    src/ui/QGCCommConfiguration.ui \
     src/ui/QGCDataPlot2D.ui \
     src/ui/QGCHilConfiguration.ui \
     src/ui/QGCHilFlightGearConfiguration.ui \
     src/ui/QGCHilJSBSimConfiguration.ui \
     src/ui/QGCHilXPlaneConfiguration.ui \
+    src/ui/QGCLinkConfiguration.ui \
+    src/ui/QGCMapRCToParamDialog.ui \
     src/ui/QGCMAVLinkInspector.ui \
+    src/ui/QGCMAVLinkLogPlayer.ui \
+    src/ui/QGCTCPLinkConfiguration.ui \
+    src/ui/QGCUDPLinkConfiguration.ui \
     src/ui/QGCTabbedInfoView.ui \
     src/ui/QGCUASFileView.ui \
     src/ui/QGCUASFileViewMulti.ui \
+    src/ui/SettingsDialog.ui \
     src/ui/uas/UASQuickView.ui \
     src/ui/uas/UASQuickViewItemSelect.ui \
     src/ui/UASInfo.ui \
@@ -261,11 +260,9 @@ HEADERS += \
     src/QGCComboBox.h \
     src/QGCConfig.h \
     src/QGCDockWidget.h \
-    src/QGCFileDialog.h \
     src/QGCGeo.h \
     src/QGCLoggingCategory.h \
     src/QGCMapPalette.h \
-    src/QGCMessageBox.h \
     src/QGCPalette.h \
     src/QGCQmlWidgetHolder.h \
     src/QGCQuickWidget.h \
@@ -278,23 +275,11 @@ HEADERS += \
     src/QmlControls/QGCQGeoCoordinate.h \
     src/QmlControls/QGroundControlQmlGlobal.h \
     src/QmlControls/QmlObjectListModel.h \
-    src/uas/FileManager.h \
     src/uas/UAS.h \
     src/uas/UASInterface.h \
     src/uas/UASMessageHandler.h \
     src/ui/MainWindow.h \
-    src/ui/MAVLinkDecoder.h \
-    src/ui/MAVLinkSettingsWidget.h \
-    src/ui/QGCCommConfiguration.h \
-    src/ui/QGCLinkConfiguration.h \
-    src/ui/QGCMapRCToParamDialog.h \
-    src/ui/QGCPluginHost.h \
-    src/ui/QGCTCPLinkConfiguration.h \
-    src/ui/QGCUDPLinkConfiguration.h \
-    src/ui/SettingsDialog.h \
     src/ui/toolbar/MainToolBarController.h \
-    src/ui/uas/QGCUnconnectedInfoWidget.h \
-    src/ui/uas/UASMessageView.h \
     src/AutoPilotPlugins/PX4/PX4AirframeLoader.h \
     src/QmlControls/QGCImageProvider.h \
 
@@ -326,12 +311,13 @@ HEADERS += \
 !MobileBuild {
 HEADERS += \
     src/comm/LogReplayLink.h \
-    src/ui/LogReplayLinkConfigurationWidget.h \
-    src/ui/QGCMAVLinkLogPlayer.h \
     src/comm/QGCFlightGearLink.h \
     src/comm/QGCHilLink.h \
     src/comm/QGCJSBSimLink.h \
     src/comm/QGCXPlaneLink.h \
+    src/QGCFileDialog.h \
+    src/QGCMessageBox.h \
+    src/uas/FileManager.h \
     src/ui/HILDockWidget.h \
     src/ui/linechart/ChartPlot.h \
     src/ui/linechart/IncrementalPlot.h \
@@ -340,7 +326,19 @@ HEADERS += \
     src/ui/linechart/LinechartWidget.h \
     src/ui/linechart/Scrollbar.h \
     src/ui/linechart/ScrollZoomer.h \
+    src/ui/LogReplayLinkConfigurationWidget.h \
+    src/ui/MAVLinkDecoder.h \
+    src/ui/MAVLinkSettingsWidget.h \
     src/ui/MultiVehicleDockWidget.h \
+    src/ui/QGCCommConfiguration.h \
+    src/ui/QGCLinkConfiguration.h \
+    src/ui/QGCMAVLinkLogPlayer.h \
+    src/ui/QGCMapRCToParamDialog.h \
+    src/ui/QGCTCPLinkConfiguration.h \
+    src/ui/QGCUDPLinkConfiguration.h \
+    src/ui/SettingsDialog.h \
+    src/ui/uas/UASMessageView.h \
+    src/ui/uas/QGCUnconnectedInfoWidget.h \
     src/ui/QGCDataPlot2D.h \
     src/ui/QGCHilConfiguration.h \
     src/ui/QGCHilFlightGearConfiguration.h \
@@ -386,12 +384,11 @@ SOURCES += \
     src/QGCApplication.cc \
     src/QGCComboBox.cc \
     src/QGCDockWidget.cc \
-    src/QGCFileDialog.cc \
     src/QGCLoggingCategory.cc \
     src/QGCMapPalette.cc \
     src/QGCPalette.cc \
-    src/QGCQmlWidgetHolder.cpp \
     src/QGCQuickWidget.cc \
+    src/QGCQmlWidgetHolder.cpp \
     src/QGCTemporaryFile.cc \
     src/QGCToolbox.cc \
     src/QGCGeo.cc \
@@ -401,22 +398,10 @@ SOURCES += \
     src/QmlControls/QGCQGeoCoordinate.cc \
     src/QmlControls/QGroundControlQmlGlobal.cc \
     src/QmlControls/QmlObjectListModel.cc \
-    src/uas/FileManager.cc \
     src/uas/UAS.cc \
     src/uas/UASMessageHandler.cc \
     src/ui/MainWindow.cc \
-    src/ui/MAVLinkDecoder.cc \
-    src/ui/MAVLinkSettingsWidget.cc \
-    src/ui/QGCCommConfiguration.cc \
-    src/ui/QGCLinkConfiguration.cc \
-    src/ui/QGCMapRCToParamDialog.cpp \
-    src/ui/QGCPluginHost.cc \
-    src/ui/QGCTCPLinkConfiguration.cc \
-    src/ui/QGCUDPLinkConfiguration.cc \
-    src/ui/SettingsDialog.cc \
     src/ui/toolbar/MainToolBarController.cc \
-    src/ui/uas/QGCUnconnectedInfoWidget.cc \
-    src/ui/uas/UASMessageView.cc \
     src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc \
     src/QmlControls/QGCImageProvider.cc \
 
@@ -442,7 +427,19 @@ MobileBuild {
 
 !MobileBuild {
 SOURCES += \
+    src/ui/uas/UASMessageView.cc \
+    src/uas/FileManager.cc \
+    src/ui/uas/QGCUnconnectedInfoWidget.cc \
+    src/ui/SettingsDialog.cc \
+    src/ui/QGCTCPLinkConfiguration.cc \
+    src/ui/QGCUDPLinkConfiguration.cc \
+    src/ui/MAVLinkDecoder.cc \
+    src/ui/MAVLinkSettingsWidget.cc \
+    src/ui/QGCCommConfiguration.cc \
+    src/ui/QGCLinkConfiguration.cc \
+    src/ui/QGCMapRCToParamDialog.cpp \
     src/comm/LogReplayLink.cc \
+    src/QGCFileDialog.cc \
     src/ui/LogReplayLinkConfigurationWidget.cc \
     src/ui/QGCMAVLinkLogPlayer.cc \
     src/comm/QGCFlightGearLink.cc \

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -191,6 +191,7 @@ INCLUDEPATH += \
 
 FORMS += \
     src/ui/MainWindow.ui \
+    src/QGCQmlWidgetHolder.ui \
 
 DebugBuild {
 FORMS += \
@@ -204,7 +205,6 @@ FORMS += \
 
 !MobileBuild {
 FORMS += \
-    src/QGCQmlWidgetHolder.ui \
     src/ui/uas/QGCUnconnectedInfoWidget.ui \
     src/ui/uas/UASMessageView.ui \
     src/ui/Linechart.ui \

--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -28,7 +28,6 @@
 #include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
 #include "QGCApplication.h"
-#include "QGCMessageBox.h"
 #include "UASMessageHandler.h"
 #include "FirmwarePlugin.h"
 #include "UAS.h"

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -709,6 +709,7 @@ QGCView {
 
             Row {
                 spacing: ScreenTools.defaultFontPixelWidth
+                visible: !ScreenTools.isMobile
 
                 QGCButton {
                     text:       "Save to file..."

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -24,10 +24,13 @@ This file is part of the QGROUNDCONTROL project
 #include "MissionController.h"
 #include "MultiVehicleManager.h"
 #include "MissionManager.h"
-#include "QGCFileDialog.h"
 #include "CoordinateVector.h"
 #include "FirmwarePlugin.h"
 #include "QGCApplication.h"
+
+#ifndef __mobile__
+#include "QGCFileDialog.h"
+#endif
 
 QGC_LOGGING_CATEGORY(MissionControllerLog, "MissionControllerLog")
 
@@ -206,6 +209,7 @@ void MissionController::removeMissionItem(int index)
 
 void MissionController::loadMissionFromFile(void)
 {
+#ifndef __mobile__
     QString errorString;
     QString filename = QGCFileDialog::getOpenFileName(NULL, "Select Mission File to load");
 
@@ -252,10 +256,12 @@ void MissionController::loadMissionFromFile(void)
     }
 
     _initAllMissionItems();
+#endif
 }
 
 void MissionController::saveMissionToFile(void)
 {
+#ifndef __mobile__
     QString errorString;
     QString filename = QGCFileDialog::getSaveFileName(NULL, "Select file to save mission to");
 
@@ -278,6 +284,7 @@ void MissionController::saveMissionToFile(void)
     }
 
     _missionItems->setDirty(false);
+#endif
 }
 
 void MissionController::_calcPrevWaypointValues(bool homePositionValid, double homeAlt, MissionItem* currentItem, MissionItem* prevItem, double* azimuth, double* distance, double* altDifference)

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -46,7 +46,6 @@
 #include "MainWindow.h"
 #include "GAudioOutput.h"
 #include "CmdLineOptParser.h"
-#include "QGCMessageBox.h"
 #include "MainWindow.h"
 #include "UDPLink.h"
 #include "LinkManager.h"
@@ -54,7 +53,6 @@
 #include "UASMessageHandler.h"
 #include "AutoPilotPluginManager.h"
 #include "QGCTemporaryFile.h"
-#include "QGCFileDialog.h"
 #include "QGCPalette.h"
 #include "QGCMapPalette.h"
 #include "QGCLoggingCategory.h"
@@ -99,6 +97,8 @@
 #endif
 
 #ifndef __mobile__
+    #include "QGCFileDialog.h"
+    #include "QGCMessageBox.h"
     #include "FirmwareUpgradeController.h"
     #include "JoystickConfigController.h"
 #endif
@@ -450,6 +450,7 @@ bool QGCApplication::_initForNormalAppBoot(void)
     MainWindow* mainWindow = MainWindow::_create();
     Q_CHECK_PTR(mainWindow);
 
+#ifndef __mobile__
     // If we made it this far and we still don't have a location. Either the specfied location was invalid
     // or we coudn't create a default location. Either way, we need to let the user know and prompt for a new
     /// settings.
@@ -459,7 +460,6 @@ bool QGCApplication::_initForNormalAppBoot(void)
         mainWindow->showSettings();
     }
 
-#ifndef __mobile__
     // Now that main window is up check for lost log files
     connect(this, &QGCApplication::checkForLostLogFiles, toolbox()->mavlinkProtocol(), &MAVLinkProtocol::checkForLostLogFiles);
     emit checkForLostLogFiles();
@@ -593,14 +593,25 @@ void QGCApplication::informationMessageBoxOnMainThread(const QString& title, con
 
 void QGCApplication::warningMessageBoxOnMainThread(const QString& title, const QString& msg)
 {
+#ifdef __mobile__
+    Q_UNUSED(title)
+    showMessage(msg);
+#else
     QGCMessageBox::warning(title, msg);
+#endif
 }
 
 void QGCApplication::criticalMessageBoxOnMainThread(const QString& title, const QString& msg)
 {
+#ifdef __mobile__
+    Q_UNUSED(title)
+    showMessage(msg);
+#else
     QGCMessageBox::critical(title, msg);
+#endif
 }
 
+#ifndef __mobile__
 void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
 {
     bool saveError;
@@ -628,6 +639,7 @@ void QGCApplication::saveTempFlightDataLogOnMainThread(QString tempLogfile)
     } while(saveError); // if the file could not be overwritten, ask for new file
     QFile::remove(tempLogfile);
 }
+#endif
 
 void QGCApplication::setStyle(bool styleIsDark)
 {

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -138,8 +138,10 @@ public slots:
     /// You can connect to this slot to show a critical message box from a different thread.
     void criticalMessageBoxOnMainThread(const QString& title, const QString& msg);
     
+#ifndef __mobile__
     /// Save the specified Flight Data Log
     void saveTempFlightDataLogOnMainThread(QString tempLogfile);
+#endif
 
 signals:
     /// Signals that the style has changed

--- a/src/QGCFileDialog.h
+++ b/src/QGCFileDialog.h
@@ -24,6 +24,10 @@
 #ifndef QGCFILEDIALOG_H
 #define QGCFILEDIALOG_H
 
+#ifdef __mobile__
+#error Should not be included in mobile builds
+#endif
+
 #include <QFileDialog>
 
 /// @file

--- a/src/QGCMessageBox.h
+++ b/src/QGCMessageBox.h
@@ -24,6 +24,10 @@
 #ifndef QGCMESSAGEBOX_H
 #define QGCMESSAGEBOX_H
 
+#ifdef __mobile__
+#error Should not be included in mobile builds
+#endif
+
 #include <QMessageBox>
 
 #include "MainWindow.h"

--- a/src/QGCQuickWidget.cc
+++ b/src/QGCQuickWidget.cc
@@ -23,9 +23,9 @@
 
 #include "QGCQuickWidget.h"
 #include "AutoPilotPluginManager.h"
-#include "QGCMessageBox.h"
 #include "MultiVehicleManager.h"
 #include "JoystickManager.h"
+#include "QGCApplication.h"
 
 #include <QQmlContext>
 #include <QQmlEngine>

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -121,19 +121,22 @@ QGCView {
                             text:           "Search..."
                             onTriggered:    showDialog(searchDialogComponent, "Parameter Search", 50, StandardButton.Reset | StandardButton.Apply)
                         }
-                        MenuSeparator { }
+                        MenuSeparator { visible: !ScreenTools.isMobile }
                         MenuItem {
                             text:           "Load from file..."
                             onTriggered:	controller.loadFromFile()
+                            visible:        !ScreenTools.isMobile
                         }
                         MenuItem {
                             text:           "Save to file..."
                             onTriggered:	controller.saveToFile()
+                            visible:        !ScreenTools.isMobile
                         }
-                        MenuSeparator { }
+                        MenuSeparator { visible: !ScreenTools.isMobile }
                         MenuItem {
                             text:           "Clear RC to Param"
                             onTriggered:	controller.clearRCToParam()
+                            visible:        !ScreenTools.isMobile
                         }
                     }
                 }

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -26,10 +26,13 @@
 
 #include "ParameterEditorController.h"
 #include "AutoPilotPluginManager.h"
-#include "QGCFileDialog.h"
-#include "QGCMapRCToParamDialog.h"
 #include "MainWindow.h"
 #include "QGCApplication.h"
+
+#ifndef __mobile__
+#include "QGCFileDialog.h"
+#include "QGCMapRCToParamDialog.h"
+#endif
 
 /// @Brief Constructs a new ParameterEditorController Widget. This widget is used within the PX4VehicleConfig set of screens.
 ParameterEditorController::ParameterEditorController(void)
@@ -92,6 +95,7 @@ void ParameterEditorController::clearRCToParam(void)
 
 void ParameterEditorController::saveToFile(void)
 {
+#ifndef __mobile__
 	Q_ASSERT(_autopilot);
 	
     QString msgTitle("Save Parameters");
@@ -114,10 +118,12 @@ void ParameterEditorController::saveToFile(void)
 		_autopilot->writeParametersToStream(stream);
 		file.close();
 	}
+#endif
 }
 
 void ParameterEditorController::loadFromFile(void)
 {
+#ifndef __mobile__
     QString errors;
     
     Q_ASSERT(_autopilot);
@@ -144,6 +150,7 @@ void ParameterEditorController::loadFromFile(void)
             emit showErrorMessage(errors);
         }
     }
+#endif
 }
 
 void ParameterEditorController::refresh(void)
@@ -159,7 +166,11 @@ void ParameterEditorController::resetAllToDefaults(void)
 
 void ParameterEditorController::setRCToParam(const QString& paramName)
 {
+#ifdef __mobile__
+    Q_UNUSED(paramName)
+#else
 	Q_ASSERT(_uas);
     QGCMapRCToParamDialog * d = new QGCMapRCToParamDialog(paramName, _uas, qgcApp()->toolbox()->multiVehicleManager(), MainWindow::instance());
 	d->exec();
+#endif
 }

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -24,16 +24,15 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick 2.3
+import QtQuick          2.5
 import QtQuick.Controls 1.3
-import QtQuick.Controls.Styles 1.2
-import QtQuick.Dialogs 1.2
 
-import QGroundControl.Controls 1.0
-import QGroundControl.Palette 1.0
-import QGroundControl.Controllers 1.0
-import QGroundControl.FactSystem 1.0
-import QGroundControl.FactControls 1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.Controllers   1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
 
 QGCViewDialog {
     property Fact   fact
@@ -172,7 +171,7 @@ QGCViewDialog {
         anchors.right:  parent.right
         anchors.bottom: parent.bottom
         text:           "Set RC to Param..."
-        visible:        !validate
+        visible:        !validate && !ScreenTools.isMobile
         onClicked:      controller.setRCToParam(fact.name)
     }
 } // QGCViewDialog

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -106,7 +106,9 @@ void MAVLinkProtocol::setToolbox(QGCToolbox *toolbox)
    _heartbeatTimer.start(1000/_heartbeatRate);
 
    connect(this, &MAVLinkProtocol::protocolStatusMessage, _app, &QGCApplication::criticalMessageBoxOnMainThread);
+#ifndef __mobile__
    connect(this, &MAVLinkProtocol::saveTempFlightDataLog, _app, &QGCApplication::saveTempFlightDataLogOnMainThread);
+#endif
 
    connect(_multiVehicleManager->vehicles(), &QmlObjectListModel::countChanged, this, &MAVLinkProtocol::_vehicleCountChanged);
 

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -108,7 +108,9 @@ UAS::UAS(MAVLinkProtocol* protocol, Vehicle* vehicle, FirmwarePluginManager * fi
 
     airSpeed(std::numeric_limits<double>::quiet_NaN()),
     groundSpeed(std::numeric_limits<double>::quiet_NaN()),
+#ifndef __mobile__
     fileManager(this, vehicle),
+#endif
 
     attitudeKnown(false),
     attitudeStamped(false),
@@ -178,7 +180,9 @@ UAS::UAS(MAVLinkProtocol* protocol, Vehicle* vehicle, FirmwarePluginManager * fi
         componentMulti[i] = false;
     }
 
+#ifndef __mobile__
     connect(mavlink, SIGNAL(messageReceived(LinkInterface*,mavlink_message_t)), &fileManager, SLOT(receiveMessage(LinkInterface*,mavlink_message_t)));
+#endif
 
     color = UASInterface::getNextColor();
     connect(&statusTimeout, SIGNAL(timeout()), this, SLOT(updateState()));

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -36,11 +36,11 @@ This file is part of the QGROUNDCONTROL project
 #include <MAVLinkProtocol.h>
 #include <QVector3D>
 #include "QGCMAVLink.h"
-#include "FileManager.h"
 #include "Vehicle.h"
 #include "FirmwarePluginManager.h"
 
 #ifndef __mobile__
+#include "FileManager.h"
 #include "QGCHilLink.h"
 #include "QGCFlightGearLink.h"
 #include "QGCJSBSimLink.h"
@@ -353,7 +353,9 @@ public:
         temperature_var = var;
     }
 
+#ifndef __mobile__
     friend class FileManager;
+#endif
 
 protected: //COMMENTS FOR TEST UNIT
     /// LINK ID AND STATUS
@@ -431,7 +433,9 @@ protected: //COMMENTS FOR TEST UNIT
     double airSpeed;             ///< Airspeed
     double groundSpeed;          ///< Groundspeed
     double bearingToWaypoint;    ///< Bearing to next waypoint
+#ifndef __mobile__
     FileManager   fileManager;
+#endif
 
     /// ATTITUDE
     bool attitudeKnown;             ///< True if attitude was received, false else
@@ -483,9 +487,9 @@ public:
     /** @brief Get the human-readable status message for this code */
     void getStatusForCode(int statusCode, QString& uasState, QString& stateDescription);
 
-    virtual FileManager* getFileManager() {
-        return &fileManager;
-    }
+#ifndef __mobile__
+    virtual FileManager* getFileManager() { return &fileManager; }
+#endif
 
     /** @brief Get the HIL simulation */
 #ifndef __mobile__

--- a/src/uas/UASInterface.h
+++ b/src/uas/UASInterface.h
@@ -41,7 +41,9 @@ This file is part of the QGROUNDCONTROL project
 #include "LinkInterface.h"
 #include "ProtocolInterface.h"
 
+#ifndef __mobile__
 class FileManager;
+#endif
 
 /**
  * @brief Interface for all robots.
@@ -71,7 +73,9 @@ public:
     virtual double getPitch() const = 0;
     virtual double getYaw() const = 0;
 
+#ifndef __mobile__
     virtual FileManager* getFileManager() = 0;
+#endif
 
     /**
      * @brief Get the color for this UAS

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -46,11 +46,8 @@ This file is part of the QGROUNDCONTROL project
 #ifndef __mobile__
 #include "QGCMAVLinkLogPlayer.h"
 #endif
-#include "SettingsDialog.h"
 #include "MAVLinkDecoder.h"
 #include "QGCApplication.h"
-#include "QGCFileDialog.h"
-#include "QGCMessageBox.h"
 #include "MultiVehicleManager.h"
 #include "HomePositionManager.h"
 #include "LogCompressor.h"
@@ -58,6 +55,7 @@ This file is part of the QGROUNDCONTROL project
 #include "QGCImageProvider.h"
 
 #ifndef __mobile__
+#include "SettingsDialog.h"
 #include "QGCDataPlot2D.h"
 #include "Linecharts.h"
 #include "QGCUASFileViewMulti.h"
@@ -573,18 +571,24 @@ void MainWindow::handleActiveViewActionState(bool triggered)
 void MainWindow::_openUrl(const QString& url, const QString& errorMessage)
 {
     if(!QDesktopServices::openUrl(QUrl(url))) {
-        QMessageBox::critical(
-            this,
-            tr("Could not open information in browser"),
-            errorMessage);
+        qgcApp()->showMessage(QString("Could not open information in browser: %1").arg(errorMessage));
     }
 }
 
+#ifndef __mobile__
 void MainWindow::showSettings()
 {
     SettingsDialog settings(this);
     settings.exec();
 }
+
+void MainWindow::manageLinks()
+{
+    SettingsDialog settings(this, SettingsDialog::ShowCommLinks);
+    settings.exec();
+}
+
+#endif
 
 void MainWindow::_vehicleAdded(Vehicle* vehicle)
 {
@@ -601,12 +605,6 @@ void MainWindow::_storeCurrentViewState(void)
 #endif
 
     settings.setValue(_getWindowGeometryKey(), saveGeometry());
-}
-
-void MainWindow::manageLinks()
-{
-    SettingsDialog settings(this, SettingsDialog::ShowCommLinks);
-    settings.exec();
 }
 
 /// @brief Saves the last used connection

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -98,10 +98,10 @@ public:
     Q_INVOKABLE void acceptWindowClose(void);
 
 public slots:
-    /** @brief Show the application settings */
+#ifndef __mobile__
     void showSettings();
-
     void manageLinks();
+#endif
 
     /** @brief Save power by reducing update rates */
     void enableLowPowerMode(bool enabled) { _lowPowerMode = enabled; }

--- a/src/ui/toolbar/MainToolBarController.cc
+++ b/src/ui/toolbar/MainToolBarController.cc
@@ -130,13 +130,3 @@ void MainToolBarController::_setProgressBarValue(float value)
     _progressBarValue = value;
     emit progressBarValueChanged(value);
 }
-
-void MainToolBarController::showSettings(void)
-{
-    MainWindow::instance()->showSettings();
-}
-
-void MainToolBarController::manageLinks(void)
-{
-    MainWindow::instance()->manageLinks();
-}

--- a/src/ui/toolbar/MainToolBarController.h
+++ b/src/ui/toolbar/MainToolBarController.h
@@ -53,8 +53,6 @@ public:
     Q_INVOKABLE void    onSetupView();
     Q_INVOKABLE void    onPlanView();
     Q_INVOKABLE void    onFlyView();
-    Q_INVOKABLE void    showSettings(void);
-    Q_INVOKABLE void    manageLinks(void);
 
     Q_PROPERTY(double       height              MEMBER _toolbarHeight           NOTIFY heightChanged)
     Q_PROPERTY(float        progressBarValue    MEMBER _progressBarValue        NOTIFY progressBarValueChanged)


### PR DESCRIPTION
Mobile build will throw compile error is QGCMessageBox or QGCFileDialog are referenced.