### PR TITLE
Mission: Switch back to item #, plus alt display

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -48,6 +48,7 @@
         <file alias="QGroundControl/Controls/MainToolBarIndicators.qml">src/ui/toolbar/MainToolBarIndicators.qml</file>
         <file alias="QGroundControl/Controls/MissionItemEditor.qml">src/QmlControls/MissionItemEditor.qml</file>
         <file alias="QGroundControl/Controls/MissionItemIndexLabel.qml">src/QmlControls/MissionItemIndexLabel.qml</file>
+        <file alias="QGroundControl/Controls/MissionItemStatus.qml">src/MissionEditor/MissionItemStatus.qml</file>
         <file alias="QGroundControl/Controls/MissionCommandDialog.qml">src/QmlControls/MissionCommandDialog.qml</file>
         <file alias="QGroundControl/Controls/ModeSwitchDisplay.qml">src/QmlControls/ModeSwitchDisplay.qml</file>
         <file alias="QGroundControl/Controls/ParameterEditor.qml">src/QmlControls/ParameterEditor.qml</file>

--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -39,30 +39,11 @@ MapQuickItem {
     anchorPoint.x:  sourceItem.width  / 2
     anchorPoint.y:  sourceItem.height / 2
 
-    Connections {
-        target: missionItem
-
-        onCoordinateChanged:        recalcLabel()
-        onRelativeAltitudeChanged:  recalcLabel()
-    }
-
-    Component.onCompleted: recalcLabel()
-
-    function recalcLabel() {
-        var label = Math.round(object.coordinate.altitude)
-        if (!object.relativeAltitude) {
-            label = "=" + label
-        }
-        if (object.homePosition) {
-            label = "H" + label
-        }
-        _label.label = label
-    }
-
     sourceItem:
         MissionItemIndexLabel {
             id:             _label
             isCurrentItem:  missionItem.isCurrentItem
+            label:          missionItem.sequenceNumber
             onClicked:      _item.clicked()
         }
 }

--- a/src/FlightMap/MapItems/MissionItemView.qml
+++ b/src/FlightMap/MapItems/MissionItemView.qml
@@ -70,9 +70,6 @@ MapItemView {
             }
         }
 
-        /*
-          Turned off for now
-
         // These are the non-coordinate child mission items attached to this item
         Row {
             anchors.top:    parent.top
@@ -90,6 +87,5 @@ MapItemView {
                 }
             }
         }
-        */
     }
 }

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -347,9 +347,6 @@ QGCView {
                             onCommandChanged:       updateItemIndicator()
                         }
 
-                        /*
-                          Disabled for now: Not sure if they will come back
-
                         // These are the non-coordinate child mission items attached to this item
                         Row {
                             anchors.top:    parent.top
@@ -367,7 +364,6 @@ QGCView {
                                 }
                             }
                         }
-                        */
                     }
                 }
 
@@ -485,16 +481,6 @@ QGCView {
                             checked = false
                         }
                     }
-
-                    /*
-                      Home Position manager temporarily disable
-                    RoundButton {
-                        id:                 homePositionManagerButton
-                        buttonImage:        "/qmlimages/MapHome.svg"
-                        //exclusiveGroup:     _dropButtonsExclusiveGroup
-                        z:                  QGroundControl.zOrderWidgets
-                    }
-                    */
 
                     DropButton {
                         id:                 syncButton
@@ -620,48 +606,16 @@ QGCView {
                     }
                 }
 
-                Rectangle {
+                MissionItemStatus {
                     id:                 waypointValuesDisplay
-                    anchors.margins:    margins
+                    anchors.margins:    ScreenTools.defaultFontPixelWidth
                     anchors.left:       parent.left
                     anchors.bottom:     parent.bottom
-                    width:              distanceLabel.width + (margins * 2)
-                    height:             valuesColumn.height + (margins * 2)
-                    radius:             ScreenTools.defaultFontPixelWidth
-                    color:              qgcPal.window
-                    opacity:            0.80
-                    visible:            _currentMissionItem ? _currentMissionItem.distance != -1 : false
-
-                    readonly property real margins: ScreenTools.defaultFontPixelWidth
-
-                    property real _altDifference:   _currentMissionItem ? _currentMissionItem.altDifference : 0
-                    property real _azimuth:         _currentMissionItem ? _currentMissionItem.azimuth : 0
-                    property real _distance:        _currentMissionItem ? _currentMissionItem.distance : 0
-
-                    Column {
-                        id:                 valuesColumn
-                        anchors.leftMargin: parent.margins
-                        anchors.topMargin:  parent.margins
-                        anchors.left:       parent.left
-                        anchors.top:        parent.top
-
-                        QGCLabel {
-                            id:     distanceLabel
-                            color:  qgcPal.text
-                            text:   "Distance: " + Math.round(waypointValuesDisplay._distance) + " meters"
-                        }
-
-                        QGCLabel {
-                            color:  qgcPal.text
-                            text:   "Alt diff: " + Math.round(waypointValuesDisplay._altDifference) + " meters"
-                        }
-
-                        QGCLabel {
-                            color:  qgcPal.text
-                            text:   "Azimuth: " + Math.round(waypointValuesDisplay._azimuth)
-                        }
-
-                    }
+                    z:                  QGroundControl.zOrderTopMost
+                    currentMissionItem: _currentMissionItem
+                    missionItems:       controller.missionItems
+                    expandedWidth:      missionItemEditor.x - (ScreenTools.defaultFontPixelWidth * 2)
+                    homePositionValid: liveHomePositionAvailable
                 }
             } // FlightMap
         } // Item - split view container

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -1,0 +1,141 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+import QtQuick          2.5
+import QtQuick.Controls 1.3
+
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.Palette       1.0
+
+Rectangle {
+    property var    currentMissionItem          ///< Mission item to display status for
+    property var    missionItems                ///< List of all available mission items
+    property real   expandedWidth               ///< Width of control when expanded
+    property bool   homePositionValid:  false   /// true: home position in missionItems[0] is valid
+
+    width:      _expanded ? expandedWidth : _collapsedWidth
+    height:     expandLabel.y + expandLabel.height + _margins
+    radius:     ScreenTools.defaultFontPixelWidth
+    color:      qgcPal.window
+    opacity:    0.80
+    clip:       true
+
+    readonly property real margins: ScreenTools.defaultFontPixelWidth
+
+    property real   _collapsedWidth:    distanceLabel.width + (margins * 2)
+    property bool   _expanded:          true
+    property real   _distance:          _currentMissionItem ? _currentMissionItem.distance : -1
+    property real   _altDifference:     _currentMissionItem ? _currentMissionItem.altDifference : -1
+    property real   _azimuth:           _currentMissionItem ? _currentMissionItem.azimuth : -1
+    property real   _isHomePosition:    _currentMissionItem ? _currentMissionItem.homePosition : false
+    property bool   _statusValid:       _distance != -1 && ((_isHomePosition && homePositionValid) || !_isHomePosition)
+    property string _distanceText:      _statusValid ? Math.round(_distance) + " meters" : ""
+    property string _altText:           _statusValid ? Math.round(_altDifference) + " meters" : ""
+    property string _azimuthText:       _statusValid ? Math.round(_azimuth) : ""
+
+    readonly property real _margins:    ScreenTools.defaultFontPixelWidth
+
+    MouseArea {
+        anchors.fill:   parent
+        onClicked:      _expanded = !_expanded
+    }
+
+    QGCLabel {
+        id:                 distanceLabel
+        anchors.margins:    _margins
+        anchors.left:       parent.left
+        anchors.top:        parent.top
+        text:               "Distance: " + _distanceText
+    }
+
+    QGCLabel {
+        id:                 altLabel
+        anchors.left:       distanceLabel.left
+        anchors.top:        distanceLabel.bottom
+        text:               "Alt diff: " + _altText
+    }
+
+    QGCLabel {
+        id:                 azimuthLabel
+        anchors.left:       altLabel.left
+        anchors.top:        altLabel.bottom
+        text:               "Azimuth: " + _azimuthText
+    }
+
+    QGCLabel {
+        id:                 expandLabel
+        anchors.left:       azimuthLabel.left
+        anchors.top:        azimuthLabel.bottom
+        text:               _expanded ? "<<" : ">>"
+    }
+
+    Flickable {
+        anchors.leftMargin:     _margins
+        anchors.rightMargin:    _margins
+        anchors.left:           distanceLabel.right
+        anchors.right:          parent.right
+        anchors.top:            parent.top
+        anchors.bottom:         parent.bottom
+
+        Row {
+            id:             graphRow
+            anchors.top:    parent.top
+            anchors.bottom: parent.bottom
+            spacing:        ScreenTools.smallFontPixelWidth
+
+            Repeater {
+                model: missionItems
+
+                Item {
+                    height: graphRow.height
+                    width:  ScreenTools.smallFontPixelWidth * 2
+
+                    property real availableHeight: height - ScreenTools.smallFontPixelHeight - indicator.height
+
+                    // If home position is not valid we are graphing relative based on a home alt of 0. Because of this
+                    // we cannot graph absolute altitudes since we have no basis for comparison against the relative values.
+                    property bool graphAbsolute:    homePositionValid
+
+                    MissionItemIndexLabel {
+                        id:                         indicator
+                        anchors.horizontalCenter:   parent.horizontalCenter
+                        y:                          availableHeight - (availableHeight * object.altPercent)
+                        small:                      true
+                        isCurrentItem:              object.isCurrentItem
+                        label:                      object.homePosition ? "H" : object.sequenceNumber
+                        visible:                    object.relativeAltitude ? true : (object.homePosition || graphAbsolute)
+                    }
+
+                    QGCLabel {
+                        anchors.bottom:             parent.bottom
+                        anchors.horizontalCenter:   parent.horizontalCenter
+                        font.pixelSize:             ScreenTools.smallFontPixelSize
+                        text:                       (object.relativeAltitude ? "" : "=") + object.coordinate.altitude
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/src/MissionManager/MissionItem.cc
+++ b/src/MissionManager/MissionItem.cc
@@ -81,6 +81,8 @@ MissionItem::MissionItem(QObject* parent)
     , _dirty(false)
     , _sequenceNumber(0)
     , _isCurrentItem(false)
+    , _altDifference(0.0)
+    , _altPercent(0.0)
     , _azimuth(0.0)
     , _distance(0.0)
     , _homePositionSpecialCase(false)
@@ -140,6 +142,7 @@ MissionItem::MissionItem(int             sequenceNumber,
     , _sequenceNumber(sequenceNumber)
     , _isCurrentItem(isCurrentItem)
     , _altDifference(0.0)
+    , _altPercent(0.0)
     , _azimuth(0.0)
     , _distance(0.0)
     , _homePositionSpecialCase(false)
@@ -198,6 +201,7 @@ MissionItem::MissionItem(const MissionItem& other, QObject* parent)
     , _sequenceNumber(0)
     , _isCurrentItem(false)
     , _altDifference(0.0)
+    , _altPercent(0.0)
     , _azimuth(0.0)
     , _distance(0.0)
     , _homePositionSpecialCase(false)
@@ -243,6 +247,7 @@ const MissionItem& MissionItem::operator=(const MissionItem& other)
     setAutoContinue(other.autoContinue());
     setIsCurrentItem(other._isCurrentItem);
     setAltDifference(other._altDifference);
+    setAltPercent(other._altPercent);
     setAzimuth(other._azimuth);
     setDistance(other._distance);
     setHomePositionSpecialCase(other._homePositionSpecialCase);
@@ -732,6 +737,12 @@ void MissionItem::setAltDifference(double altDifference)
 {
     _altDifference = altDifference;
     emit altDifferenceChanged(_altDifference);
+}
+
+void MissionItem::setAltPercent(double altPercent)
+{
+    _altPercent = altPercent;
+    emit altPercentChanged(_altPercent);
 }
 
 void MissionItem::setAzimuth(double azimuth)

--- a/src/MissionManager/MissionItem.h
+++ b/src/MissionManager/MissionItem.h
@@ -69,6 +69,7 @@ public:
     const MissionItem& operator=(const MissionItem& other);
     
     Q_PROPERTY(double           altDifference           READ altDifference          WRITE setAltDifference      NOTIFY altDifferenceChanged)        ///< Change in altitude from previous waypoint
+    Q_PROPERTY(double           altPercent              READ altPercent             WRITE setAltPercent         NOTIFY altPercentChanged)           ///< Percent of total altitude change in mission altitude
     Q_PROPERTY(double           azimuth                 READ azimuth                WRITE setAzimuth            NOTIFY azimuthChanged)              ///< Azimuth to previous waypoint
     Q_PROPERTY(QString          category                READ category                                           NOTIFY commandChanged)
     Q_PROPERTY(MavlinkQmlSingleton::Qml_MAV_CMD command READ command                WRITE setCommand            NOTIFY commandChanged)
@@ -100,6 +101,7 @@ public:
     // Property accesors
     
     double          altDifference       (void) const    { return _altDifference; }
+    double          altPercent          (void) const    { return _altPercent; }
     double          azimuth             (void) const    { return _azimuth; }
     QString         category            (void) const;
     MavlinkQmlSingleton::Qml_MAV_CMD command(void) const { return (MavlinkQmlSingleton::Qml_MAV_CMD)_commandFact.cookedValue().toInt(); };
@@ -139,9 +141,10 @@ public:
     void setHomePositionValid(bool homePositionValid);
     void setHomePositionSpecialCase(bool homePositionSpecialCase) { _homePositionSpecialCase = homePositionSpecialCase; }
 
-    void setAltDifference(double altDifference);
-    void setAzimuth(double azimuth);
-    void setDistance(double distance);
+    void setAltDifference   (double altDifference);
+    void setAltPercent      (double altPercent);
+    void setAzimuth         (double azimuth);
+    void setDistance        (double distance);
 
     // C++ only methods
 
@@ -180,6 +183,7 @@ public slots:
 
 signals:
     void altDifferenceChanged       (double altDifference);
+    void altPercentChanged          (double altPercent);
     void azimuthChanged             (double azimuth);
     void commandChanged             (MavlinkQmlSingleton::Qml_MAV_CMD command);
     void coordinateChanged          (const QGeoCoordinate& coordinate);
@@ -220,6 +224,7 @@ private:
     int         _sequenceNumber;
     bool        _isCurrentItem;
     double      _altDifference;             ///< Difference in altitude from previous waypoint
+    double      _altPercent;                ///< Percent of total altitude change in mission
     double      _azimuth;                   ///< Azimuth to previous waypoint
     double      _distance;                  ///< Distance to previous waypoint
     bool        _homePositionSpecialCase;   ///< true: This item is being used as a ui home position indicator

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -1,4 +1,4 @@
-import QtQuick                  2.2
+import QtQuick                  2.5
 import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.2
 
@@ -8,31 +8,33 @@ import QGroundControl.Palette     1.0
 Rectangle {
     property alias  label:          _label.text
     property bool   isCurrentItem:  false
+    property bool   small:          false
 
     signal clicked
 
-    readonly property real _margin: ScreenTools.defaultFontPixelWidth / 4
-
-    QGCPalette { id: qgcPal }
-
-    width:          _label.width + (_margin * 2)
-    height:         _label.height +  (_margin * 2)
-    radius:         _margin
-    border.width:   1
+    width:          _width
+    height:         _width
+    radius:         _width / 2
+    border.width:   small ? 1 : 2
     border.color:   "white"
     color:          isCurrentItem ? "green" : qgcPal.mapButtonHighlight
 
+    property real _width: small ? ScreenTools.smallFontPixelSize * 1.5 : ScreenTools.mediumFontPixelSize * 1.5
+
+    QGCPalette { id: qgcPal }
+
     MouseArea {
-        anchors.fill:   parent
-        onClicked:      parent.clicked()
+        anchors.fill: parent
+
+        onClicked: parent.clicked()
     }
 
     QGCLabel {
         id:                     _label
-        anchors.margins:        _margin
-        anchors.left:           parent.left
-        anchors.top:            parent.top
+        anchors.fill:           parent
+        horizontalAlignment:    Text.AlignHCenter
+        verticalAlignment:      Text.AlignVCenter
         color:                  "white"
-        font.pixelSize:         ScreenTools.defaultFontPixelSize
+        font.pixelSize:         small ? ScreenTools.smallFontPixelSize : ScreenTools.mediumFontPixelSize
     }
 }

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -9,6 +9,7 @@ MainToolBar             1.0 MainToolBar.qml
 MissionCommandDialog    1.0 MissionCommandDialog.qml
 MissionItemEditor       1.0 MissionItemEditor.qml
 MissionItemIndexLabel   1.0 MissionItemIndexLabel.qml
+MissionItemStatus       1.0 MissionItemStatus.qml
 ModeSwitchDisplay       1.0 ModeSwitchDisplay.qml
 ParameterEditor         1.0 ParameterEditor.qml
 ParameterEditorDialog   1.0 ParameterEditorDialog.qml

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -13,6 +13,8 @@ Item {
     readonly property real defaultFontPixelHeight:  defaultFontPixelSize
     readonly property real defaultFontPixelWidth:   _textMeasure.fontWidth
     readonly property real smallFontPixelSize:      defaultFontPixelSize * ScreenToolsController.smallFontPixelSizeRatio
+    readonly property real smallFontPixelHeight:    smallFontPixelSize
+    readonly property real smallFontPixelWidth:     defaultFontPixelWidth * ScreenToolsController.smallFontPixelSizeRatio
 
     // To proportionally scale fonts
 


### PR DESCRIPTION
Decided showing altitude in item indicator looked like crap. Back to showing item number in indicator. Instead adding altitude map to little distance between waypoint thingy. You can open and close it to get it out of the way.

<img width="1010" alt="screen shot 2015-12-07 at 7 58 28 pm" src="https://cloud.githubusercontent.com/assets/5876851/11647529/c9a31e50-9d1d-11e5-99d4-1c240d10189f.png">

<img width="1011" alt="screen shot 2015-12-07 at 7 58 17 pm" src="https://cloud.githubusercontent.com/assets/5876851/11647534/d3439458-9d1d-11e5-802a-91c88450975e.png">
