### PR TITLE
Bluetooth Cleanup

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -36,6 +36,7 @@ linux {
         CONFIG += AndroidBuild MobileBuild
         DEFINES += __android__
         DEFINES += __STDC_LIMIT_MACROS
+        DEFINES += QGC_ENABLE_BLUETOOTH
         target.path = $$DESTDIR
     } else {
         error("Unsuported Linux toolchain, only GCC 32- or 64-bit is supported")

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -44,6 +44,18 @@ exists(user_config.pri):infile(user_config.pri, CONFIG) {
     message($$sprintf("Using user-supplied additional config: '%1' specified in user_config.pri", $$fromfile(user_config.pri, CONFIG)))
 }
 
+# Bluetooth
+contains (DEFINES, QGC_DISABLE_BLUETOOTH) {
+    message("Skipping support for Bluetooth (manual override from command line)")
+    DEFINES -= QGC_ENABLE_BLUETOOTH
+} else:exists(user_config.pri):infile(user_config.pri, DEFINES, QGC_DISABLE_BLUETOOTH) {
+    message("Skipping support for Bluetooth (manual override from user_config.pri)")
+    DEFINES -= QGC_ENABLE_BLUETOOTH
+} else:exists(user_config.pri):infile(user_config.pri, DEFINES, QGC_ENABLE_BLUETOOTH) {
+    message("Including support for Bluetooth (manual override from user_config.pri)")
+    DEFINES += QGC_ENABLE_BLUETOOTH
+}
+
 LinuxBuild {
     CONFIG += link_pkgconfig
 }
@@ -74,7 +86,7 @@ QT += \
     serialport \
 }
 
-MobileBuild {
+contains(DEFINES, QGC_ENABLE_BLUETOOTH) {
 QT += \
     bluetooth \
 }
@@ -284,7 +296,7 @@ WindowsBuild {
     HEADERS += src/stable_headers.h
 }
 
-MobileBuild {
+contains(DEFINES, QGC_ENABLE_BLUETOOTH) {
     HEADERS += \
     src/comm/BluetoothLink.h \
 }
@@ -402,7 +414,7 @@ SOURCES += \
     src/ui/SerialConfigurationWindow.cc \
 }
 
-MobileBuild {
+contains(DEFINES, QGC_ENABLE_BLUETOOTH) {
     SOURCES += \
     src/comm/BluetoothLink.cc \
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -37,6 +37,10 @@
 #include <QStyleFactory>
 #include <QAction>
 
+#ifdef QGC_ENABLE_BLUETOOTH
+#include <QBluetoothLocalDevice>
+#endif
+
 #include <QDebug>
 
 #include "VideoStreaming.h"
@@ -170,6 +174,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     , _testHighDPI(false)
 #endif
     , _toolbox(NULL)
+    , _bluetoothAvailable(false)
 {
     Q_ASSERT(_app == NULL);
     _app = this;
@@ -318,6 +323,15 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
         settings.clear();
         settings.setValue(_settingsVersionKey, QGC_SETTINGS_VERSION);
     }
+
+    // Initialize Bluetooth
+#ifdef QGC_ENABLE_BLUETOOTH
+    QBluetoothLocalDevice localDevice;
+    if (localDevice.isValid())
+    {
+        _bluetoothAvailable = true;
+    }
+#endif
 
     // Initialize Video Streaming
     initializeVideoStreaming(argc, argv);

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -1,24 +1,24 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 /**
@@ -72,35 +72,35 @@ class QGCApplication : public
 #endif
 {
     Q_OBJECT
-    
+
 public:
     QGCApplication(int &argc, char* argv[], bool unitTesting);
     ~QGCApplication();
-    
+
     /// @brief Sets the persistent flag to delete all settings the next time QGroundControl is started.
     void deleteAllSettingsNextBoot(void);
-    
+
     /// @brief Clears the persistent flag to delete all settings the next time QGroundControl is started.
     void clearDeleteAllSettingsNextBoot(void);
-    
+
     /// @brief Returns the location of user visible saved file associated with QGroundControl
     QString savedFilesLocation(void);
-    
+
     /// @brief Sets the location of user visible saved file associated with QGroundControl
     void setSavedFilesLocation(QString& location);
-    
+
     /// @brief Location to save and load parameter files from.
     QString savedParameterFilesLocation(void);
-    
+
     /// @brief Location to save and load mavlink log files from
     QString mavlinkLogFilesLocation(void);
-    
+
     /// @brief Validates that the specified location will work for the saved files location.
     bool validatePossibleSavedFilesLocation(QString& location);
-    
+
     /// @return true: Prompt to save log file when vehicle goes away
     bool promptFlightDataSave(void);
-    
+
     /// @return true: Prompt to save log file even if vehicle was not armed
     bool promptFlightDataSaveNotArmed(void);
 
@@ -109,13 +109,13 @@ public:
 
     /// @brief Returns truee if unit test are being run
     bool runningUnitTests(void) { return _runningUnitTests; }
-    
+
     /// @return true: dark ui style, false: light ui style
     bool styleIsDark(void) { return _styleIsDark; }
-    
+
     /// Set the current UI style
     void setStyle(bool styleIsDark);
-    
+
     /// Used to report a missing Parameter. Warning will be displayed to user. Method may be called
     /// multiple times.
     void reportMissingParameter(int componentId, const QString& name);
@@ -123,26 +123,29 @@ public:
     /// Show a non-modal message to the user
     void showMessage(const QString& message);
 
-	/// @return true: Fake ui into showing mobile interface
-	bool fakeMobile(void) { return _fakeMobile; }
-    
+    /// @return true: Fake ui into showing mobile interface
+    bool fakeMobile(void) { return _fakeMobile; }
+
 #ifdef QT_DEBUG
     bool testHighDPI(void) { return _testHighDPI; }
 #endif
 
     // Still working on getting rid of this and using dependency injection instead for everything
     QGCToolbox* toolbox(void) { return _toolbox; }
-    
+
+    /// Do we have Bluetooth Support?
+    bool isBluetoothAvailable() { return _bluetoothAvailable; }
+
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
     void informationMessageBoxOnMainThread(const QString& title, const QString& msg);
-    
+
     /// You can connect to this slot to show a warning message box from a different thread.
     void warningMessageBoxOnMainThread(const QString& title, const QString& msg);
-    
+
     /// You can connect to this slot to show a critical message box from a different thread.
     void criticalMessageBoxOnMainThread(const QString& title, const QString& msg);
-    
+
     void showFlyView(void);
     void showPlanView(void);
     void showSetupView(void);
@@ -158,14 +161,14 @@ signals:
     /// Signals that the style has changed
     ///     @param darkStyle true: dark style, false: light style
     void styleChanged(bool darkStyle);
-    
+
     /// This is connected to MAVLinkProtocol::checkForLostLogFiles. We signal this to ourselves to call the slot
     /// on the MAVLinkProtocol thread;
     void checkForLostLogFiles(void);
-    
+
 public:
     // Although public, these methods are internal and should only be called by UnitTest code
-    
+
     /// @brief Perform initialize which is common to both normal application running and unit tests.
     ///         Although public should only be called by main.
     void _initCommon(void);
@@ -173,7 +176,7 @@ public:
     /// @brief Intialize the application for normal application boot. Or in other words we are not going to run
     ///         unit tests. Although public should only be called by main.
     bool _initForNormalAppBoot(void);
-    
+
     /// @brief Intialize the application for normal application boot. Or in other words we are not going to run
     ///         unit tests. Although public should only be called by main.
     bool _initForUnitTests(void);
@@ -182,12 +185,12 @@ public:
     void _showSetupParameters(void);
     void _showSetupSummary(void);
     void _showSetupVehicleComponent(VehicleComponent* vehicleComponent);
-    
+
     static QGCApplication*  _app;   ///< Our own singleton. Should be reference directly by qgcApp
-    
+
 private slots:
     void _missingParamsDisplay(void);
-    
+
 private:
     void _loadCurrentStyle(void);
     QObject* _rootQmlObject(void);
@@ -195,35 +198,37 @@ private:
 #ifdef __mobile__
     QQmlApplicationEngine* _qmlAppEngine;
 #endif
-    
+
     static const char* _settingsVersionKey;             ///< Settings key which hold settings version
     static const char* _deleteAllSettingsKey;           ///< If this settings key is set on boot, all settings will be deleted
     static const char* _savedFilesLocationKey;          ///< Settings key for user visible saved files location
     static const char* _promptFlightDataSave;           ///< Settings key for promptFlightDataSave
     static const char* _promptFlightDataSaveNotArmed;   ///< Settings key for promptFlightDataSaveNotArmed
     static const char* _styleKey;                       ///< Settings key for UI style
-    
+
     static const char* _defaultSavedFileDirectoryName;      ///< Default name for user visible save file directory
     static const char* _savedFileMavlinkLogDirectoryName;   ///< Name of mavlink log subdirectory
     static const char* _savedFileParameterDirectoryName;    ///< Name of parameter subdirectory
 
     bool _runningUnitTests; ///< true: running unit tests, false: normal app
-    
+
     static const char*  _darkStyleFile;
     static const char*  _lightStyleFile;
     bool                _styleIsDark;      ///< true: dark style, false: light style
-    
+
     static const int    _missingParamsDelayedDisplayTimerTimeout = 1000;  ///< Timeout to wait for next missing fact to come in before display
     QTimer              _missingParamsDelayedDisplayTimer;                ///< Timer use to delay missing fact display
     QStringList         _missingParams;                                  ///< List of missing facts to be displayed
 
-	bool				_fakeMobile;	///< true: Fake ui into displaying mobile interface
-    
+    bool				_fakeMobile;	///< true: Fake ui into displaying mobile interface
+
 #ifdef QT_DEBUG
     bool _testHighDPI;  ///< true: double fonts sizes for simulating high dpi devices
 #endif
 
     QGCToolbox* _toolbox;
+
+    bool _bluetoothAvailable;
 
     /// Unit Test have access to creating and destroying singletons
     friend class UnitTest;

--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -36,7 +36,7 @@ This file is part of the QGROUNDCONTROL project
 #ifndef __mobile__
 #include "LogReplayLink.h"
 #endif
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
 #include "BluetoothLink.h"
 #endif
 #ifdef QT_DEBUG
@@ -103,7 +103,7 @@ LinkConfiguration* LinkConfiguration::createSettings(int type, const QString& na
         case LinkConfiguration::TypeTcp:
             config = new TCPConfiguration(name);
             break;
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
     case LinkConfiguration::TypeBluetooth:
         config = new BluetoothConfiguration(name);
         break;
@@ -141,10 +141,10 @@ LinkConfiguration* LinkConfiguration::duplicateSettings(LinkConfiguration* sourc
         case TypeTcp:
             dupe = new TCPConfiguration(dynamic_cast<TCPConfiguration*>(source));
             break;
-#ifdef __mobile__
-    case TypeBluetooth:
-        dupe = new BluetoothConfiguration(dynamic_cast<BluetoothConfiguration*>(source));
-        break;
+#ifdef QGC_ENABLE_BLUETOOTH
+        case TypeBluetooth:
+            dupe = new BluetoothConfiguration(dynamic_cast<BluetoothConfiguration*>(source));
+            break;
 #endif
 #ifndef __mobile__
         case TypeLogReplay:

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -64,7 +64,7 @@ public:
 #endif
         TypeUdp,        ///< UDP Link
         TypeTcp,        ///< TCP Link
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
         TypeBluetooth,  ///< Bluetooth Link
 #endif
 #if 0

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -39,10 +39,9 @@ This file is part of the QGROUNDCONTROL project
 
 #include "LinkManager.h"
 #include "QGCApplication.h"
-#include "QGCApplication.h"
 #include "UDPLink.h"
 #include "TCPLink.h"
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
 #include "BluetoothLink.h"
 #endif
 
@@ -125,7 +124,7 @@ LinkInterface* LinkManager::createConnectedLink(LinkConfiguration* config)
         case LinkConfiguration::TypeTcp:
             pLink = new TCPLink(dynamic_cast<TCPConfiguration*>(config));
             break;
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
         case LinkConfiguration::TypeBluetooth:
             pLink = new BluetoothLink(dynamic_cast<BluetoothConfiguration*>(config));
             break;
@@ -361,7 +360,7 @@ void LinkManager::loadLinkConfigurationList()
                                 case LinkConfiguration::TypeTcp:
                                     pLink = (LinkConfiguration*)new TCPConfiguration(name);
                                     break;
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
                                 case LinkConfiguration::TypeBluetooth:
                                     pLink = (LinkConfiguration*)new BluetoothConfiguration(name);
                                     break;
@@ -708,7 +707,7 @@ QStringList LinkManager::linkTypeStrings(void) const
 #endif
         list += "UDP";
         list += "TCP";
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
         list += "Bluetooth";
 #endif
 #ifdef QT_DEBUG
@@ -839,7 +838,7 @@ void LinkManager::_fixUnnamed(LinkConfiguration* config)
                     }
                 }
                 break;
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
             case LinkConfiguration::TypeBluetooth: {
                     BluetoothConfiguration* tconfig = dynamic_cast<BluetoothConfiguration*>(config);
                     if(tconfig) {
@@ -887,4 +886,9 @@ void LinkManager::removeConfiguration(LinkConfiguration* config)
 bool LinkManager::isAutoconnectLink(LinkInterface* link)
 {
     return _autoconnectConfigurations.contains(link->getLinkConfiguration());
+}
+
+bool LinkManager::isBluetoothAvailable(void)
+{
+    return qgcApp()->isBluetoothAvailable();
 }

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -80,6 +80,7 @@ public:
     Q_PROPERTY(bool autoconnectPixhawk                  READ autoconnectPixhawk                 WRITE setAutoconnectPixhawk     NOTIFY autoconnectPixhawkChanged)
     Q_PROPERTY(bool autoconnect3DRRadio                 READ autoconnect3DRRadio                WRITE setAutoconnect3DRRadio    NOTIFY autoconnect3DRRadioChanged)
     Q_PROPERTY(bool autoconnectPX4Flow                  READ autoconnectPX4Flow                 WRITE setAutoconnectPX4Flow     NOTIFY autoconnectPX4FlowChanged)
+    Q_PROPERTY(bool isBluetoothAvailable                READ isBluetoothAvailable               CONSTANT)
 
     /// LinkInterface Accessor
     Q_PROPERTY(QmlObjectListModel*  links               READ links                              CONSTANT)
@@ -104,12 +105,13 @@ public:
 
     // Property accessors
 
-    bool anyConnectedLinks(void);
-    bool anyActiveLinks(void);
-    bool autoconnectUDP(void)       { return _autoconnectUDP; }
-    bool autoconnectPixhawk(void)   { return _autoconnectPixhawk; }
-    bool autoconnect3DRRadio(void)  { return _autoconnect3DRRadio; }
-    bool autoconnectPX4Flow(void)   { return _autoconnectPX4Flow; }
+    bool anyConnectedLinks          (void);
+    bool anyActiveLinks             (void);
+    bool autoconnectUDP             (void)  { return _autoconnectUDP; }
+    bool autoconnectPixhawk         (void)  { return _autoconnectPixhawk; }
+    bool autoconnect3DRRadio        (void)  { return _autoconnect3DRRadio; }
+    bool autoconnectPX4Flow         (void)  { return _autoconnectPX4Flow; }
+    bool isBluetoothAvailable       (void);
 
     QmlObjectListModel* links               (void) { return &_links; }
     QmlObjectListModel* linkConfigurations  (void) { return &_linkConfigurations; }

--- a/src/main.cc
+++ b/src/main.cc
@@ -49,7 +49,7 @@ This file is part of the QGROUNDCONTROL project
     #endif
 #endif
 
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
 #include <QtBluetooth/QBluetoothSocket>
 #endif
 
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
 #ifndef __ios__
     qRegisterMetaType<QSerialPort::SerialPortError>();
 #endif
-#ifdef __mobile__
+#ifdef QGC_ENABLE_BLUETOOTH
     qRegisterMetaType<QBluetoothSocket::SocketError>();
     qRegisterMetaType<QBluetoothServiceInfo>();
 #endif

--- a/src/ui/preferences/BluetoothSettings.qml
+++ b/src/ui/preferences/BluetoothSettings.qml
@@ -39,9 +39,16 @@ Item {
         // No need
     }
 
+    QGCLabel {
+        text:       "Bluetooth Not Available"
+        visible:    !QGroundControl.linkManager.isBluetoothAvailable
+        anchors.centerIn: parent
+    }
+
     Column {
         id:         btColumn
         spacing:    ScreenTools.defaultFontPixelHeight / 2
+        visible:    QGroundControl.linkManager.isBluetoothAvailable
 
         ExclusiveGroup { id: linkGroup }
 


### PR DESCRIPTION
Cleaning up support for Bluetooth

I was having threading issues with Bluetooth and moved the code to the main thread. There is no good reason for it to be on its own thread any way, given that IO happens on a separate thread already and signals are used to tell you when to read data.

Bluetooth support is only built by default on Android builds. You can manually add support for it by defining ```DEFINES += QGC_ENABLE_BLUETOOTH``` (either on the command line or through user_config.pri).

The opposite is also possible (if you want it for any reason). On Android, you can define ```QGC_DISABLE_BLUETOOTH``` to force its exclusion.

Because Bluetooth is possible it doesn't mean it is available. This is especially true for Desktop builds where the computer may not have Bluetooth hardware. Because of that, I've added runtime functions to tell you if Bluetooth is available or not.

Note that Qt does not support Bluetooth on Windows at all.

iOS, by design, will not allow Bluetooth connection to a non *approved* device. As such, I could not test the code against the Crossfire (nor find a way around the restriction).