### PR TITLE
Tablet app close

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -52,9 +52,7 @@ MissionController::MissionController(QObject *parent)
 
 MissionController::~MissionController()
 {
-    // Start with empty list
-    _missionItems = new QmlObjectListModel(this);
-    _initAllMissionItems();
+
 }
 
 void MissionController::start(bool editMode)

--- a/src/ui/MainWindowHybrid.qml
+++ b/src/ui/MainWindowHybrid.qml
@@ -23,6 +23,7 @@ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
 
 import QtQuick          2.5
 import QtQuick.Controls 1.2
+import QtQuick.Dialogs  1.2
 
 import QGroundControl.Controls 1.0
 
@@ -41,7 +42,7 @@ Item {
     }
 
     function showWindowCloseMessage() {
-        mainWindowInner.item.showWindowCloseMessage()
+        windowCloseDialog.open()
     }
 
     // The following are use for unit testing only
@@ -70,6 +71,17 @@ Item {
         id:             mainWindowInner
         anchors.fill:   parent
         source:         "MainWindowInner.qml"
+    }
+
+    MessageDialog {
+        id:                 windowCloseDialog
+        title:              "QGroundControl close"
+        text:               "There are still active connections to vehicles. Do you want to disconnect these before closing?"
+        standardButtons:    StandardButton.Yes | StandardButton.Cancel
+        modality:           Qt.ApplicationModal
+        visible:            false
+
+        onYes: controller.acceptWindowClose()
     }
 }
 

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -64,7 +64,7 @@ Item {
         flightView.visible          = true
         setupViewLoader.visible     = false
         planViewLoader.visible      = false
-        toolbar.checkFlyButton()
+        toolBar.checkFlyButton()
     }
 
     function showPlanView() {
@@ -91,10 +91,6 @@ Item {
         setupViewLoader.visible     = true
         planViewLoader.visible      = false
         toolBar.checkSetupButton()
-    }
-
-    function showWindowCloseMessage() {
-        windowCloseDialog.open()
     }
 
     // The following are use for unit testing only
@@ -202,17 +198,6 @@ Item {
         indicatorDropdown.sourceComponent = dropItem
         indicatorDropdown.visible = true
         currentPopUp = indicatorDropdown
-    }
-
-    MessageDialog {
-        id:                 windowCloseDialog
-        title:              "QGroundControl close"
-        text:               "There are still active connections to vehicles. Do you want to disconnect these before closing?"
-        standardButtons:    StandardButton.Yes | StandardButton.Cancel
-        modality:           Qt.ApplicationModal
-        visible:            false
-
-        onYes: controller.acceptWindowClose()
     }
 
     //-- Left Settings Menu


### PR DESCRIPTION
Fix for Issue #2372. Tablet crashes if you close while in the debugger. That seems to be new. But regular users will never notice.