### PR TITLE
Only show PX4 Flow config if generic firmware

### DIFF
--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -256,7 +256,7 @@ Rectangle {
                     id:             px4FlowButton
                     width:          mainWindow.menuButtonWidth
                     exclusiveGroup: setupButtonGroup
-                    visible:        _fullParameterVehicleAvailable
+                    visible:        QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle.genericFirmware : false
                     setupIndicator: false
                     text:           "PX4Flow"
                     onClicked:      showPX4FlowPanel()


### PR DESCRIPTION
Direct connect to PX4 Flow shows up as generic. Fix for #2317