### PR TITLE
Show battery voltage if percentage not available.

### DIFF
--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -86,6 +86,9 @@ Row {
             if(activeVehicle.batteryPercent > 0.1) {
                 return activeVehicle.batteryPercent.toFixed(0) + "%"
             }
+            if(activeVehicle.batteryVoltage > 0) {
+                return activeVehicle.batteryVoltage.toFixed(1) + "V"
+            }
         }
         return "N/A"
     }


### PR DESCRIPTION
The Crossfire does not report battery percentage. Only current voltage.
I changed the toolbar battery indicator so it now shows the voltage (provided itself is available) if the battery percentage is not available.