### PR TITLE
Handle unknown enum values in meta data

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -165,7 +165,7 @@ QVariant Fact::cookedValue(void) const
     }
 }
 
-QString Fact::enumStringValue(void) const
+QString Fact::enumStringValue(void)
 {
     if (_metaData) {
         int enumIndex = this->enumIndex();
@@ -179,16 +179,23 @@ QString Fact::enumStringValue(void) const
     return QString();
 }
 
-int Fact::enumIndex(void) const
+int Fact::enumIndex(void)
 {
     if (_metaData) {
         int index = 0;
+
         foreach (QVariant enumValue, _metaData->enumValues()) {
             if (enumValue == rawValue()) {
                 return index;
             }
             index ++;
         }
+
+        // Current value is not in list, add it manually
+        _metaData->addEnumInfo(QString("Unknown: %1").arg(rawValue().toString()), rawValue());
+        emit enumStringsChanged();
+        emit enumValuesChanged();
+        return index;
     } else {
         qWarning() << "Meta data pointer missing";
     }

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -52,9 +52,9 @@ public:
     Q_PROPERTY(QString      defaultValueString      READ defaultValueString                                 CONSTANT)
     Q_PROPERTY(bool         defaultValueAvailable   READ defaultValueAvailable                              CONSTANT)
     Q_PROPERTY(int          enumIndex               READ enumIndex              WRITE setEnumIndex          NOTIFY valueChanged)
-    Q_PROPERTY(QStringList  enumStrings             READ enumStrings                                        CONSTANT)
+    Q_PROPERTY(QStringList  enumStrings             READ enumStrings                                        NOTIFY enumStringsChanged)
     Q_PROPERTY(QString      enumStringValue         READ enumStringValue        WRITE setEnumStringValue    NOTIFY valueChanged)
-    Q_PROPERTY(QVariantList enumValues              READ enumValues                                         CONSTANT)
+    Q_PROPERTY(QVariantList enumValues              READ enumValues                                         NOTIFY enumValuesChanged)
     Q_PROPERTY(QString      group                   READ group                                              CONSTANT)
     Q_PROPERTY(QString      longDescription         READ longDescription                                    CONSTANT)
     Q_PROPERTY(QVariant     max                     READ max                                                CONSTANT)
@@ -81,9 +81,9 @@ public:
     QVariant        defaultValue            (void) const;
     bool            defaultValueAvailable   (void) const;
     QString         defaultValueString      (void) const;
-    int             enumIndex               (void) const;
+    int             enumIndex               (void);         // This is not const, since an unknown value can modify the enum lists
     QStringList     enumStrings             (void) const;
-    QString         enumStringValue         (void) const;
+    QString         enumStringValue         (void);         // This is not const, since an unknown value can modify the enum lists
     QVariantList    enumValues              (void) const;
     QString         group                   (void) const;
     QString         longDescription         (void) const;
@@ -120,6 +120,9 @@ public:
     void _setName(const QString& name) { _name = name; }
     
 signals:
+    void enumStringsChanged(void);
+    void enumValuesChanged(void);
+
     /// QObject Property System signal for value property changes
     ///
     /// This signal is only meant for use by the QT property system. It should not be connected to by client code.

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -260,3 +260,9 @@ void FactMetaData::setTranslators(Translator rawTranslator, Translator cookedTra
     _rawTranslator = rawTranslator;
     _cookedTranslator = cookedTranslator;
 }
+
+void FactMetaData::addEnumInfo(const QString& name, const QVariant& value)
+{
+    _enumStrings << name;
+    _enumValues << value;
+}

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -79,6 +79,9 @@ public:
     Translator      rawTranslator           (void) const { return _rawTranslator; }
     Translator      cookedTranslator        (void) const { return _cookedTranslator; }
 
+    /// Used to add new values to the enum lists after the meta data has been loaded
+    void addEnumInfo(const QString& name, const QVariant& value);
+
     void setDecimalPlaces   (int decimalPlaces)                 { _decimalPlaces = decimalPlaces; }
     void setDefaultValue    (const QVariant& defaultValue);
     void setEnumInfo        (const QStringList& strings, const QVariantList& values);


### PR DESCRIPTION
- Fact system can handle unknown enum values by modifying the enum lists with and "Unknown: #" entry, where # will be replaced with he unknown value. This way if you are using a FactComboBox with indexModel=false (which means you are using enum meta data) and the value of the fact is not in the enum list, a new item will be added to the meta data. Then the fact signals changes to enum properties which in turn updates the combo box model with the new entry such that you can get a correct display even for values which were not originally in the enum meta data.
- Using the above, Mission Editor can now handle unknown MAV_CMDs which it may load from a file or get from a Vehicle without crashing.

Fixes for Issues #2384, #2371 