### PR TITLE
Use ardupilotmega mavlink dialect as main dialect

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -7,29 +7,25 @@ WindowsBuild {
 
 #
 # [REQUIRED] Add support for the MAVLink communications protocol.
-# Some logic is involved here in selecting the proper dialect for
-# the selected autopilot system.
+# Mavlink dialect is hardwired to arudpilotmega for now. The reason being
+# the current codebase supports both PX4 and APM flight stack. PX4 flight stack
+# only usese common mavlink specifications, wherease APM flight stack uses custom
+# mavlink specifications which add to common. So by using the adupilotmega dialect
+# QGC can support both in the same codebase.
 #
-# If the user config file exists, it will be included. If this file
-# specifies the MAVLINK_CONF variable with a MAVLink dialect, support
-# for it will be compiled in to QGC. It will also create a
-# QGC_USE_{AUTOPILOT_NAME}_MESSAGES macro for use within the actual code.
-#
+# Once the mavlink helper routines include support for multiple dialects within
+# a single compiled codebase this hardwiring of dialect can go away. But until then
+# this "workaround" is needed.
+
 MAVLINKPATH_REL = libs/mavlink/include/mavlink/v1.0
 MAVLINKPATH = $$BASEDIR/$$MAVLINKPATH_REL
+MAVLINK_CONF = ardupilotmega
 DEFINES += MAVLINK_NO_DATA
 
 # First we select the dialect, checking for valid user selection
 # Users can override all other settings by specifying MAVLINK_CONF as an argument to qmake
 !isEmpty(MAVLINK_CONF) {
-    message($$sprintf("Using MAVLink dialect '%1' specified at the command line.", $$MAVLINK_CONF))
-}
-# Otherwise they can specify MAVLINK_CONF within user_config.pri
-else:exists(user_config.pri):infile(user_config.pri, MAVLINK_CONF) {
-    MAVLINK_CONF = $$fromfile(user_config.pri, MAVLINK_CONF)
-    !isEmpty(MAVLINK_CONF) {
-        message($$sprintf("Using MAVLink dialect '%1' specified in user_config.pri", $$MAVLINK_CONF))
-    }
+    message($$sprintf("Using MAVLink dialect '%1'.", $$MAVLINK_CONF))
 }
 
 # Then we add the proper include paths dependent on the dialect.


### PR DESCRIPTION
Currently QGC is compiled using the "common" mavlink dialect which is all that is needed for the PX4 Flight Stack . This means that the "ardupilotmega" dialect additions are not available for use with APM Stack vehicles. With QGC providing support for both PX4 and APM stacks it needs to be able to work with the APM dialect as well. Since PX4 uses common and ardupilotmega dialect is superset on top of common it should be fine to instead use the ardupilotmega dialect as the base dialect for QGC. This way both PX4 and APM flight stack gets full access to their message sets.

This approach is a "workaround" to the issue that the mavlink helper routines do not allow for multiple dialects to be compiled into the same codebase. It only works because PX4 uses only common. If PX4 used a superset dialect as well we would be stuck at this point. See Mavlink Issue https://github.com/mavlink/mavlink/issues/484.