### PR TITLE
If USB directly auto-connected to board, only send/receive on that link

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -207,11 +207,15 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         _addLink(link);
     }
 
+#if 0
+    // Unsure if this is the correct thing to do at this point. Trying without it.
+
     LinkInterface* usbDirectLink = _usbDirectLink();
     if (usbDirectLink && usbDirectLink != link) {
         // If we have a direct connection only listen to messages from that link
         return;
     }
+#endif
 
     // Give the plugin a change to adjust the message contents
     _firmwarePlugin->adjustMavlinkMessage(&message);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -207,6 +207,12 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         _addLink(link);
     }
 
+    LinkInterface* usbDirectLink = _usbDirectLink();
+    if (usbDirectLink && usbDirectLink != link) {
+        // If we have a direct connection only listen to messages from that link
+        return;
+    }
+
     // Give the plugin a change to adjust the message contents
     _firmwarePlugin->adjustMavlinkMessage(&message);
 
@@ -409,24 +415,55 @@ void Vehicle::sendMessage(mavlink_message_t message)
     emit _sendMessageOnThread(message);
 }
 
+void Vehicle::_sendMessageOnLink(LinkInterface* link, mavlink_message_t* message)
+{
+    // Give the plugin a chance to adjust
+    _firmwarePlugin->adjustMavlinkMessage(message);
+
+    static const uint8_t messageKeys[256] = MAVLINK_MESSAGE_CRCS;
+    mavlink_finalize_message_chan(message, _mavlink->getSystemId(), _mavlink->getComponentId(), link->getMavlinkChannel(), message->len, messageKeys[message->msgid]);
+
+    // Write message into buffer, prepending start sign
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    int len = mavlink_msg_to_send_buffer(buffer, message);
+
+    link->writeBytes((const char*)buffer, len);
+}
+
+/// @return Direct usb connection link to board if one, NULL if none
+LinkInterface* Vehicle::_usbDirectLink(void)
+{
+    foreach (LinkInterface* link, _links) {
+        if (link->isConnected()) {
+            SerialLink* pSerialLink = qobject_cast<SerialLink*>(link);
+            if (pSerialLink) {
+                LinkConfiguration* pLinkConfig = pSerialLink->getLinkConfiguration();
+                if (pLinkConfig) {
+                    SerialConfiguration* pSerialConfig = qobject_cast<SerialConfiguration*>(pLinkConfig);
+                    if (pSerialConfig && pSerialConfig->usbDirect()) {
+                        return link;
+                    }
+                }
+            }
+        }
+    }
+
+    return NULL;
+}
+
 void Vehicle::_sendMessage(mavlink_message_t message)
 {
+    // If we have a USB direct connection to the board, we only send messages on that link.
+    LinkInterface* usbDirectLink = _usbDirectLink();
+    if (usbDirectLink) {
+        _sendMessageOnLink(usbDirectLink, &message);
+        return;
+    }
+
     // Emit message on all links that are currently connected
     foreach (LinkInterface* link, _links) {
         if (link->isConnected()) {
-            MAVLinkProtocol* mavlink = _mavlink;
-
-            // Give the plugin a chance to adjust
-            _firmwarePlugin->adjustMavlinkMessage(&message);
-
-            static const uint8_t messageKeys[256] = MAVLINK_MESSAGE_CRCS;
-            mavlink_finalize_message_chan(&message, mavlink->getSystemId(), mavlink->getComponentId(), link->getMavlinkChannel(), message.len, messageKeys[message.msgid]);
-
-            // Write message into buffer, prepending start sign
-            uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
-            int len = mavlink_msg_to_send_buffer(buffer, &message);
-
-            link->writeBytes((const char*)buffer, len);
+            _sendMessageOnLink(link, &message);
         }
     }
 }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -363,6 +363,8 @@ private:
     void _missionManagerError(int errorCode, const QString& errorMsg);
     void _mapTrajectoryStart(void);
     void _mapTrajectoryStop(void);
+    void _sendMessageOnLink(LinkInterface* link, mavlink_message_t* message);
+    LinkInterface* _usbDirectLink(void);
 
     void    _addChange                      (int id);
     float   _oneDecimal                     (float value);

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -510,11 +510,13 @@ void LinkManager::_updateAutoConnectLinks(void)
                 case QGCSerialPortInfo::BoardTypePX4FMUV4:
                     if (_autoconnectPixhawk) {
                         pSerialConfig = new SerialConfiguration(QString("Pixhawk on %1").arg(portInfo.portName().trimmed()));
+                        pSerialConfig->setUsbDirect(true);
                     }
                     break;
                 case QGCSerialPortInfo::BoardTypeAeroCore:
                     if (_autoconnectPixhawk) {
                         pSerialConfig = new SerialConfiguration(QString("AeroCore on %1").arg(portInfo.portName().trimmed()));
+                        pSerialConfig->setUsbDirect(true);
                     }
                     break;
                 case QGCSerialPortInfo::BoardTypePX4Flow:

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -396,6 +396,7 @@ SerialConfiguration::SerialConfiguration(const QString& name) : LinkConfiguratio
     _parity     = QSerialPort::NoParity;
     _dataBits   = 8;
     _stopBits   = 1;
+    _usbDirect  = false;
 }
 
 SerialConfiguration::SerialConfiguration(SerialConfiguration* copy) : LinkConfiguration(copy)
@@ -407,6 +408,7 @@ SerialConfiguration::SerialConfiguration(SerialConfiguration* copy) : LinkConfig
     _stopBits           = copy->stopBits();
     _portName           = copy->portName();
     _portDisplayName    = copy->portDisplayName();
+    _usbDirect          = copy->_usbDirect;
 }
 
 void SerialConfiguration::copyFrom(LinkConfiguration *source)
@@ -421,6 +423,7 @@ void SerialConfiguration::copyFrom(LinkConfiguration *source)
     _stopBits           = ssource->stopBits();
     _portName           = ssource->portName();
     _portDisplayName    = ssource->portDisplayName();
+    _usbDirect          = ssource->_usbDirect;
 }
 
 void SerialConfiguration::updateSettings()
@@ -562,3 +565,10 @@ void SerialConfiguration::_initBaudRates()
     kSupportedBaudRates << "921600";
 }
 
+void SerialConfiguration::setUsbDirect(bool usbDirect)
+{
+    if (_usbDirect != usbDirect) {
+        _usbDirect = usbDirect;
+        emit usbDirectChanged(_usbDirect);
+    }
+}

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -73,12 +73,14 @@ public:
     Q_PROPERTY(int      parity          READ parity             WRITE setParity             NOTIFY parityChanged)
     Q_PROPERTY(QString  portName        READ portName           WRITE setPortName           NOTIFY portNameChanged)
     Q_PROPERTY(QString  portDisplayName READ portDisplayName                                NOTIFY portDisplayNameChanged)
+    Q_PROPERTY(bool     usbDirect       READ usbDirect          WRITE setUsbDirect          NOTIFY usbDirectChanged)        ///< true: direct usb connection to board
 
     int  baud()         { return _baud; }
     int  dataBits()     { return _dataBits; }
     int  flowControl()  { return _flowControl; }    ///< QSerialPort Enums
     int  stopBits()     { return _stopBits; }
     int  parity()       { return _parity; }         ///< QSerialPort Enums
+    bool usbDirect()    { return _usbDirect; }
 
     const QString portName          () { return _portName; }
     const QString portDisplayName   () { return _portDisplayName; }
@@ -89,6 +91,7 @@ public:
     void setStopBits        (int stopBits);
     void setParity          (int parity);               ///< QSerialPort Enums
     void setPortName        (const QString& portName);
+    void setUsbDirect       (bool usbDirect);
 
     static QStringList supportedBaudRates();
     static QString cleanPortDisplayname(const QString name);
@@ -109,6 +112,7 @@ signals:
     void parityChanged          ();
     void portNameChanged        ();
     void portDisplayNameChanged ();
+    void usbDirectChanged       (bool usbDirect);
 
 private:
     static void _initBaudRates();
@@ -121,6 +125,7 @@ private:
     int _parity;
     QString _portName;
     QString _portDisplayName;
+    bool _usbDirect;
 };
 
 /**

--- a/src/uas/FileManager.cc
+++ b/src/uas/FileManager.cc
@@ -308,10 +308,8 @@ void FileManager::_writeFileDatablock(void)
     _sendRequest(&request);
 }
 
-void FileManager::receiveMessage(LinkInterface* link, mavlink_message_t message)
+void FileManager::receiveMessage(mavlink_message_t message)
 {
-    Q_UNUSED(link);
-
     // receiveMessage is signalled will all mavlink messages so we need to filter everything else out but ours.
     if (message.msgid != MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL) {
         return;

--- a/src/uas/FileManager.h
+++ b/src/uas/FileManager.h
@@ -87,7 +87,7 @@ signals:
     void commandProgress(int value);
 
 public slots:
-    void receiveMessage(LinkInterface* link, mavlink_message_t message);
+    void receiveMessage(mavlink_message_t message);
 	
 private slots:
 	void _ackTimeout(void);

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -181,7 +181,7 @@ UAS::UAS(MAVLinkProtocol* protocol, Vehicle* vehicle, FirmwarePluginManager * fi
     }
 
 #ifndef __mobile__
-    connect(mavlink, SIGNAL(messageReceived(LinkInterface*,mavlink_message_t)), &fileManager, SLOT(receiveMessage(LinkInterface*,mavlink_message_t)));
+    connect(_vehicle, &Vehicle::mavlinkMessageReceived, &fileManager, &FileManager::receiveMessage);
 #endif
 
     color = UASInterface::getNextColor();


### PR DESCRIPTION
This is a fix for #2433. It allows for Setup screens to not get confused by multiple messages from multiple links. But it specifically does not fix FTP for reasons which I don't understand. There does appear to be some unpredictable behavior on the firmware side if you connect usb, which also powers up your radio. Sometimes the radio will be seen by QGC first and then from the on nothing comes through the USB link side of things. Don't understand that behavior either.