### PR TITLE
Review iterations over QStrings

### DIFF
--- a/src/AutoPilotPlugins/APM/APMRadioComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMRadioComponent.cc
@@ -59,7 +59,7 @@ bool APMRadioComponent::setupComplete(void) const
     // controls to be mapped.
     QStringList attitudeMappings;
     attitudeMappings << "RCMAP_ROLL" << "RCMAP_PITCH" << "RCMAP_YAW" << "RCMAP_THROTTLE";
-    foreach(QString mapParam, attitudeMappings) {
+    foreach(const QString &mapParam, attitudeMappings) {
         if (_autopilot->getParameterFact(FactSystem::defaultComponentId, mapParam)->rawValue().toInt() == 0) {
             return false;
         }

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -395,7 +395,7 @@ void APMSensorsComponentController::_refreshParams(void)
     
     fastRefreshList << "COMPASS_OFS_X" << "COMPASS_OFS_X" << "COMPASS_OFS_X"
                     << "INS_ACCOFFS_X" << "INS_ACCOFFS_Y" << "INS_ACCOFFS_Z";
-    foreach (QString paramName, fastRefreshList) {
+    foreach (const QString &paramName, fastRefreshList) {
         _autopilot->refreshParameter(FactSystem::defaultComponentId, paramName);
     }
     

--- a/src/AutoPilotPlugins/PX4/FlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentController.cc
@@ -119,7 +119,7 @@ void FlightModesComponentController::_init(void)
     QStringList attitudeParams;
     
     attitudeParams << "RC_MAP_THROTTLE" << "RC_MAP_YAW" << "RC_MAP_PITCH" << "RC_MAP_ROLL" << "RC_MAP_FLAPS" << "RC_MAP_AUX1" << "RC_MAP_AUX2";
-    foreach(QString attitudeParam, attitudeParams) {
+    foreach(const QString &attitudeParam, attitudeParams) {
         int channel = getParameterFact(-1, attitudeParam)->rawValue().toInt();
         if (channel != 0) {
             usedChannels << channel;
@@ -195,7 +195,7 @@ void FlightModesComponentController::_validateConfiguration(void)
     
     thresholdParams << "RC_ASSIST_TH" << "RC_AUTO_TH" << "RC_ACRO_TH" << "RC_POSCTL_TH" << "RC_LOITER_TH" << "RC_RETURN_TH" << "RC_OFFB_TH";
     
-    foreach(QString thresholdParam, thresholdParams) {
+    foreach(const QString &thresholdParam, thresholdParams) {
         float threshold = getParameterFact(-1, thresholdParam)->rawValue().toFloat();
         if (threshold < 0.0f || threshold > 1.0f) {
             _validConfiguration = false;
@@ -735,7 +735,7 @@ void FlightModesComponentController::generateThresholds(void)
     
     thresholdParams << "RC_ASSIST_TH" << "RC_AUTO_TH" << "RC_ACRO_TH" << "RC_POSCTL_TH" << "RC_LOITER_TH" << "RC_RETURN_TH" << "RC_OFFB_TH";
     
-    foreach(QString thresholdParam, thresholdParams) {
+    foreach(const QString &thresholdParam, thresholdParams) {
         getParameterFact(-1, thresholdParam)->setRawValue(0.0f);
     }
     

--- a/src/AutoPilotPlugins/PX4/PX4Component.cc
+++ b/src/AutoPilotPlugins/PX4/PX4Component.cc
@@ -38,7 +38,7 @@ PX4Component::PX4Component(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject
 void PX4Component::setupTriggerSignals(void)
 {
     // Watch for changed on trigger list params
-    foreach (QString paramName, setupCompleteChangedTriggerList()) {
+    foreach (const QString &paramName, setupCompleteChangedTriggerList()) {
         Fact* fact = _autopilot->getParameterFact(FactSystem::defaultComponentId, paramName);
         
         connect(fact, &Fact::valueChanged, this, &PX4Component::_triggerUpdated);

--- a/src/AutoPilotPlugins/PX4/PX4RadioComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4RadioComponent.cc
@@ -59,7 +59,7 @@ bool PX4RadioComponent::setupComplete(void) const
         // controls to be mapped.
         QStringList attitudeMappings;
         attitudeMappings << "RC_MAP_ROLL" << "RC_MAP_PITCH" << "RC_MAP_YAW" << "RC_MAP_THROTTLE";
-        foreach(QString mapParam, attitudeMappings) {
+        foreach(const QString &mapParam, attitudeMappings) {
             if (_autopilot->getParameterFact(FactSystem::defaultComponentId, mapParam)->rawValue().toInt() == 0) {
                 return false;
             }

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.cc
@@ -61,7 +61,7 @@ bool SensorsComponent::requiresSetup(void) const
 
 bool SensorsComponent::setupComplete(void) const
 {
-    foreach(QString triggerParam, setupCompleteChangedTriggerList()) {
+    foreach(const QString &triggerParam, setupCompleteChangedTriggerList()) {
         if (_autopilot->getParameterFact(FactSystem::defaultComponentId, triggerParam)->rawValue().toFloat() == 0.0f) {
             return false;
         }

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -434,7 +434,7 @@ void SensorsComponentController::_refreshParams(void)
     
     // We ask for a refresh on these first so that the rotation combo show up as fast as possible
     fastRefreshList << "CAL_MAG0_ID" << "CAL_MAG1_ID" << "CAL_MAG2_ID" << "CAL_MAG0_ROT" << "CAL_MAG1_ROT" << "CAL_MAG2_ROT";
-    foreach (QString paramName, fastRefreshList) {
+    foreach (const QString &paramName, fastRefreshList) {
         _autopilot->refreshParameter(FactSystem::defaultComponentId, paramName);
     }
     

--- a/src/FactSystem/FactControls/FactPanelController.cc
+++ b/src/FactSystem/FactControls/FactPanelController.cc
@@ -61,7 +61,7 @@ void FactPanelController::setFactPanel(QQuickItem* panel)
     // missing fact notices that were waiting to go out
 
     _factPanel = panel;
-    foreach (QString missingParam, _delayedMissingParams) {
+    foreach (const QString &missingParam, _delayedMissingParams) {
         _notifyPanelMissingParameter(missingParam);
     }
     _delayedMissingParams.clear();
@@ -112,7 +112,7 @@ bool FactPanelController::_allParametersExists(int componentId, QStringList name
 {
     bool noMissingFacts = true;
 
-    foreach (QString name, names) {
+    foreach (const QString &name, names) {
         if (_autopilot && !_autopilot->parameterExists(componentId, name)) {
             _reportMissingParameter(componentId, name);
             noMissingFacts = false;

--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -380,7 +380,7 @@ void ParameterLoader::refreshParametersPrefix(int componentId, const QString& na
     componentId = _actualComponentId(componentId);
     qCDebug(ParameterLoaderLog) << "refreshParametersPrefix (component id:" << componentId << "name:" << namePrefix << ")";
 
-    foreach(QString name, _mapParameterName2Variant[componentId].keys()) {
+    foreach(const QString &name, _mapParameterName2Variant[componentId].keys()) {
         if (name.startsWith(namePrefix)) {
             refreshParameter(componentId, name);
         }
@@ -415,7 +415,7 @@ QStringList ParameterLoader::parameterNames(int componentId)
 {
     QStringList names;
 
-    foreach(QString paramName, _mapParameterName2Variant[_actualComponentId(componentId)].keys()) {
+    foreach(const QString &paramName, _mapParameterName2Variant[_actualComponentId(componentId)].keys()) {
         names << paramName;
     }
 
@@ -425,7 +425,7 @@ QStringList ParameterLoader::parameterNames(int componentId)
 void ParameterLoader::_setupGroupMap(void)
 {
     foreach (int componentId, _mapParameterName2Variant.keys()) {
-        foreach (QString name, _mapParameterName2Variant[componentId].keys()) {
+        foreach (const QString &name, _mapParameterName2Variant[componentId].keys()) {
             Fact* fact = _mapParameterName2Variant[componentId][name].value<Fact*>();
             _mapGroup2ParameterName[componentId][fact->group()] += name;
         }
@@ -471,7 +471,7 @@ void ParameterLoader::_waitingParamTimeout(void)
 
     if (!paramsRequested) {
         foreach(int componentId, _waitingWriteParamNameMap.keys()) {
-            foreach(QString paramName, _waitingWriteParamNameMap[componentId].keys()) {
+            foreach(const QString &paramName, _waitingWriteParamNameMap[componentId].keys()) {
                 paramsRequested = true;
                 _waitingWriteParamNameMap[componentId][paramName]++;   // Bump retry count
                 _writeParameterRaw(componentId, paramName, _autopilot->getFact(FactSystem::ParameterProvider, componentId, paramName)->rawValue());
@@ -486,7 +486,7 @@ void ParameterLoader::_waitingParamTimeout(void)
 
     if (!paramsRequested) {
         foreach(int componentId, _waitingReadParamNameMap.keys()) {
-            foreach(QString paramName, _waitingReadParamNameMap[componentId].keys()) {
+            foreach(const QString &paramName, _waitingReadParamNameMap[componentId].keys()) {
                 paramsRequested = true;
                 _waitingReadParamNameMap[componentId][paramName]++;   // Bump retry count
                 _readParameterRaw(componentId, paramName, -1);
@@ -715,7 +715,7 @@ void ParameterLoader::writeParametersToStream(QTextStream &stream)
     stream << "# MAV ID  COMPONENT ID  PARAM NAME  VALUE (FLOAT)\n";
 
     foreach (int componentId, _mapParameterName2Variant.keys()) {
-        foreach (QString paramName, _mapParameterName2Variant[componentId].keys()) {
+        foreach (const QString &paramName, _mapParameterName2Variant[componentId].keys()) {
             Fact* fact = _mapParameterName2Variant[componentId][paramName].value<Fact*>();
             Q_ASSERT(fact);
 

--- a/src/HomePositionManager.cc
+++ b/src/HomePositionManager.cc
@@ -97,7 +97,7 @@ void HomePositionManager::_loadSettings(void)
     
     settings.beginGroup(_settingsGroup);
     
-    foreach(QString name, settings.childGroups()) {
+    foreach(const QString &name, settings.childGroups()) {
         QGeoCoordinate coordinate;
         
         qDebug() << "Load setting" << name;

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -145,7 +145,7 @@ QVariantList JoystickManager::joysticks(void)
 {
     QVariantList list;
     
-    foreach (QString name, _name2JoystickMap.keys()) {
+    foreach (const QString &name, _name2JoystickMap.keys()) {
         list += QVariant::fromValue(_name2JoystickMap[name]);
     }
     

--- a/src/LogCompressor.cc
+++ b/src/LogCompressor.cc
@@ -172,7 +172,7 @@ void LogCompressor::run()
             // Fill holes if necessary
             if (holeFillingEnabled) {
                 int index = 0;
-                foreach (QString str, list) {
+                foreach (const QString& str, list) {
                     if (str == "" || str == "NaN") {
                         list.replace(index, lastList.at(index));
                     }

--- a/src/MissionManager/MissionCommands.cc
+++ b/src/MissionManager/MissionCommands.cc
@@ -130,7 +130,7 @@ void MissionCommands::_loadMavCmdInfoJson(void)
         // Make sure we have the required keys
         QStringList requiredKeys;
         requiredKeys << _idJsonKey << _rawNameJsonKey;
-        foreach (QString key, requiredKeys) {
+        foreach (const QString &key, requiredKeys) {
             if (!jsonObject.contains(key)) {
                 qWarning() << "Mission required key" << key;
                 return;
@@ -211,7 +211,7 @@ void MissionCommands::_loadMavCmdInfoJson(void)
                 paramInfo->_units =         paramObject.value(_unitsJsonKey).toString();
 
                 QStringList enumValues = paramObject.value(_enumValuesJsonKey).toString().split(",", QString::SkipEmptyParts);
-                foreach (QString enumValue, enumValues) {
+                foreach (const QString &enumValue, enumValues) {
                     bool    convertOk;
                     double  value = enumValue.toDouble(&convertOk);
 
@@ -295,7 +295,7 @@ const QStringList MissionCommands::categories(Vehicle* vehicle) const
 {
     QStringList list;
 
-    foreach (QString category, _categoryToMavCmdInfoListMap[_firmwareTypeFromVehicle(vehicle)].keys()) {
+    foreach (const QString &category, _categoryToMavCmdInfoListMap[_firmwareTypeFromVehicle(vehicle)].keys()) {
         list << category;
     }
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -226,7 +226,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
                 filterRules += ".debug=false\n";
             }
         } else {
-            foreach(QString rule, logList) {
+            foreach(const QString &rule, logList) {
                 filterRules += rule;
                 filterRules += ".debug=true\n";
             }
@@ -261,7 +261,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
                     QTextStream out(&loggingFile);
                     out << "[Rules]\n";
                     out << "*Log.debug=false\n";
-                    foreach(QString category, QGCLoggingCategoryRegister::instance()->registeredCategories()) {
+                    foreach(const QString &category, QGCLoggingCategoryRegister::instance()->registeredCategories()) {
                         out << category << ".debug=false\n";
                     }
                 } else {
@@ -737,7 +737,7 @@ void QGCApplication::_missingParamsDisplay(void)
     Q_ASSERT(_missingParams.count());
 
     QString params;
-    foreach (QString name, _missingParams) {
+    foreach (const QString &name, _missingParams) {
         if (params.isEmpty()) {
             params += name;
         } else {

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -69,7 +69,7 @@ QStringList ParameterEditorController::searchParametersForComponent(int componen
 {
     QStringList list;
     
-    foreach(QString paramName, _autopilot->parameterNames(componentId)) {
+    foreach(const QString &paramName, _autopilot->parameterNames(componentId)) {
         if (searchText.isEmpty()) {
             list += paramName;
         } else {

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -98,7 +98,7 @@ void initializeVideoStreaming(int &argc, char* argv[])
     qgcputenv("GST_PLUGIN_PATH_1_0",          currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
     qgcputenv("GST_PLUGIN_PATH",              currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
 //    QStringList env = QProcessEnvironment::systemEnvironment().keys();
-//    foreach(QString key, env) {
+//    foreach(const QString &key, env) {
 //        qDebug() << key << QProcessEnvironment::systemEnvironment().value(key);
 //    }
 #endif

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -562,7 +562,7 @@ void MockLink::_handleParamRequestList(const mavlink_message_t& msg)
         uint16_t paramIndex = 0;
         int cParameters = _mapParamName2Value[componentId].count();
 
-        foreach(QString paramName, _mapParamName2Value[componentId].keys()) {
+        foreach(const QString &paramName, _mapParamName2Value[componentId].keys()) {
             char paramId[MAVLINK_MSG_ID_PARAM_VALUE_LEN];
             mavlink_message_t       responseMsg;
 
@@ -596,7 +596,7 @@ void MockLink::_handleParamRequestList(const mavlink_message_t& msg)
         int cParameters = _mapParamName2Value[componentId].count();
         bool skipParam = true;
 
-        foreach(QString paramName, _mapParamName2Value[componentId].keys()) {
+        foreach(const QString &paramName, _mapParamName2Value[componentId].keys()) {
             if (skipParam) {
                 // We've already sent the first param
                 skipParam = false;

--- a/src/comm/QGCFlightGearLink.cc
+++ b/src/comm/QGCFlightGearLink.cc
@@ -988,7 +988,7 @@ void QGCFlightGearLink::_printFgfsOutput(void)
    QByteArray byteArray = _fgProcess->readAllStandardOutput();
    QStringList strLines = QString(byteArray).split("\n");
 
-   foreach (QString line, strLines){
+   foreach (const QString &line, strLines){
     qDebug() << line;
    }
 }
@@ -1000,7 +1000,7 @@ void QGCFlightGearLink::_printFgfsError(void)
    QByteArray byteArray = _fgProcess->readAllStandardError();
    QStringList strLines = QString(byteArray).split("\n");
 
-   foreach (QString line, strLines){
+   foreach (const QString &line, strLines){
     qDebug() << line;
    }
 }

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -231,7 +231,7 @@ void UDPLink::_sendBytes(const char* data, qint64 size)
             }
         } while (_config->nextHost(host, port));
         //-- Remove hosts that are no longer there
-        foreach (QString ghost, goneHosts) {
+        foreach (const QString& ghost, goneHosts) {
             _config->removeHost(ghost);
         }
     }

--- a/src/qgcunittest/MavlinkLogTest.cc
+++ b/src/qgcunittest/MavlinkLogTest.cc
@@ -51,7 +51,7 @@ void MavlinkLogTest::init(void)
     // Make sure temp directory is clear of mavlink logs
     QDir tmpDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
     QStringList logFiles(tmpDir.entryList(QStringList(QString("*.%1").arg(_logFileExtension)), QDir::Files));
-    foreach(QString logFile, logFiles) {
+    foreach(const QString &logFile, logFiles) {
         bool success = tmpDir.remove(logFile);
         Q_UNUSED(success);
         Q_ASSERT(success);

--- a/src/qgcunittest/RadioConfigTest.cc
+++ b/src/qgcunittest/RadioConfigTest.cc
@@ -407,7 +407,7 @@ void RadioConfigTest::_fullCalibrationWorker(MAV_AUTOPILOT firmwareType)
                     QStringList switchList;
                     switchList << "RC_MAP_MODE_SW" << "RC_MAP_LOITER_SW" << "RC_MAP_RETURN_SW" << "RC_MAP_POSCTL_SW" << "RC_MAP_ACRO_SW";
 
-                    foreach (QString switchParam, switchList) {
+                    foreach (const QString &switchParam, switchList) {
                         Q_ASSERT(_autopilot->getParameterFact(FactSystem::defaultComponentId, switchParam)->rawValue().toInt() != channel + 1);
                     }
                 }

--- a/src/ui/linechart/LinechartPlot.cc
+++ b/src/ui/linechart/LinechartPlot.cc
@@ -183,7 +183,7 @@ void LinechartPlot::setActive(bool active)
 
 void LinechartPlot::removeTimedOutCurves()
 {
-    foreach(QString key, lastUpdate.keys())
+    foreach(const QString &key, lastUpdate.keys())
     {
         quint64 time = lastUpdate.value(key);
         if (QGC::groundTimeMilliseconds() - time > 10000)
@@ -499,7 +499,7 @@ bool LinechartPlot::isVisible(QString id)
 bool LinechartPlot::anyCurveVisible()
 {
     bool visible = false;
-    foreach (QString key, curves.keys())
+    foreach (const QString &key, curves.keys())
     {
         if (curves.value(key)->isVisible())
         {

--- a/src/ui/linechart/LinechartWidget.cc
+++ b/src/ui/linechart/LinechartWidget.cc
@@ -673,7 +673,7 @@ void LinechartWidget::removeCurve(QString curve)
 void LinechartWidget::recolor()
 {
     activePlot->styleChanged(qgcApp()->styleIsDark());
-    foreach (QString key, colorIcons.keys())
+    foreach (const QString &key, colorIcons.keys())
     {
         QWidget* colorIcon = colorIcons.value(key, 0);
         if (colorIcon && !colorIcon->styleSheet().isEmpty())
@@ -713,7 +713,7 @@ void LinechartWidget::filterCurves(const QString &filter)
     {
         /* Hide Elements which do not match the filter pattern */
         QStringMatcher stringMatcher(filter, Qt::CaseInsensitive);
-        foreach (QString key, colorIcons.keys())
+        foreach (const QString &key, colorIcons.keys())
         {
             if (stringMatcher.indexIn(key) < 0)
             {
@@ -728,7 +728,7 @@ void LinechartWidget::filterCurves(const QString &filter)
     else
     {
         /* Show all Elements */
-        foreach (QString key, colorIcons.keys())
+        foreach (const QString &key, colorIcons.keys())
         {
             filterCurve(key, true);
         }
@@ -796,7 +796,7 @@ QString LinechartWidget::getCurveName(const QString& key, bool shortEnabled)
 
 void LinechartWidget::setShortNames(bool enable)
 {
-    foreach (QString key, curveNames.keys())
+    foreach (const QString &key, curveNames.keys())
     {
         curveNameLabels.value(key)->setText(getCurveName(key, enable));
     }


### PR DESCRIPTION
There are many ways of iterating over lists in C++/Qt.
In the specific case of QStrings, it is known [1] that using
foreach with const references avoids the creation of new
QString objects in each iteration, reducing the time consumed
by the loops.

[1] https://blog.qt.io/blog/2009/01/23/iterating-efficiently/

Signed-off-by: Anselmo L. S. Melo <anselmo.melo@intel.com>