### PR TITLE
Reset compass offsets to previous if cal cancelled

### DIFF
--- a/src/AutoPilotPlugins/APM/APMCompassCal.h
+++ b/src/AutoPilotPlugins/APM/APMCompassCal.h
@@ -54,6 +54,8 @@ public:
     mavlink_raw_imu_t       lastRawImu;
     mavlink_scaled_imu_t    rgLastScaledImu[max_mags];
 
+    static const char*      rgCompassParams[3][4];
+
 signals:
     void vehicleTextMessage(int vehicleId, int compId, int severity, QString text);
 
@@ -135,8 +137,6 @@ private:
                             bool	side_data_collected[detect_orientation_side_count],	///< Sides for which data still needs calibration
                             void*	worker_data);                                       ///< Opaque data passed to worker routine
 
-    bool reject_sample(float sx, float sy, float sz, float x[], float y[], float z[], unsigned count, unsigned max_count);
-
     calibrate_return calibrate(void);
     calibrate_return mag_calibration_worker(detect_orientation_return orientation, void* data);
     unsigned progress_percentage(mag_worker_data_t* worker_data);
@@ -174,6 +174,7 @@ private:
 
     Vehicle*            _vehicle;
     CalWorkerThread*    _calWorkerThread;
+    float               _rgSavedCompassOffsets[3][3];
 };
 
 #endif

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -74,7 +74,7 @@ APMSensorsComponentController::APMSensorsComponentController(void) :
     APMAutoPilotPlugin * apmPlugin = qobject_cast<APMAutoPilotPlugin*>(_vehicle->autopilotPlugin());
 
     _sensorsComponent = apmPlugin->sensorsComponent();
-    connect(apmPlugin, &APMAutoPilotPlugin::setupCompleteChanged, this, &APMSensorsComponentController::setupNeededChanged);
+    connect(_sensorsComponent, &VehicleComponent::setupCompleteChanged, this, &APMSensorsComponentController::setupNeededChanged);
 }
 
 /// Appends the specified text to the status log area in the ui


### PR DESCRIPTION
Also fixed problem with setup complete signaling after positive calibration completed. Indicators were not going green when they should have.

Fixed for Issue #2442