### PR TITLE
Remove Full Screen menu action (and its opposite, Normal as well)

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -236,14 +236,6 @@ MainWindow::MainWindow()
             move((scrSize.width() - w) / 2, (scrSize.height() - h) / 2);
         }
     }
-
-    // Make sure the proper fullscreen/normal menu item is checked properly.
-    _ui.actionFullscreen->setChecked(isFullScreen());
-    _ui.actionNormal->setChecked(!isFullScreen());
-
-    // And that they will stay checked properly after user input
-    connect(_ui.actionFullscreen, &QAction::triggered, this, &MainWindow::fullScreenActionItemCallback);
-    connect(_ui.actionNormal,     &QAction::triggered, this, &MainWindow::normalActionItemCallback);
 #endif
 
     connect(_ui.actionStatusBar,  &QAction::triggered, this, &MainWindow::showStatusBarCallback);
@@ -253,12 +245,10 @@ MainWindow::MainWindow()
     _ui.actionSetup->setShortcut(QApplication::translate("MainWindow", "Meta+1", 0));
     _ui.actionPlan->setShortcut(QApplication::translate("MainWindow", "Meta+2", 0));
     _ui.actionFlight->setShortcut(QApplication::translate("MainWindow", "Meta+3", 0));
-    _ui.actionFullscreen->setShortcut(QApplication::translate("MainWindow", "Meta+Return", 0));
 #else
     _ui.actionSetup->setShortcut(QApplication::translate("MainWindow", "Ctrl+1", 0));
     _ui.actionPlan->setShortcut(QApplication::translate("MainWindow", "Ctrl+2", 0));
     _ui.actionFlight->setShortcut(QApplication::translate("MainWindow", "Ctrl+3", 0));
-    _ui.actionFullscreen->setShortcut(QApplication::translate("MainWindow", "Ctrl+Return", 0));
 #endif
 
     _ui.actionFlight->setChecked(true);
@@ -402,26 +392,6 @@ void MainWindow::_showDockWidgetAction(bool show)
     _showDockWidget(rgDockWidgetNames[action->data().toInt()], show);
 }
 #endif
-
-void MainWindow::fullScreenActionItemCallback(bool)
-{
-    if (!_ui.actionFullscreen->isChecked())
-        _ui.actionFullscreen->setChecked(true);
-    _ui.actionNormal->setChecked(false);
-}
-
-void MainWindow::normalActionItemCallback(bool)
-{
-    if (!_ui.actionNormal->isChecked())
-        _ui.actionNormal->setChecked(true);
-    _ui.actionFullscreen->setChecked(false);
-
-    // Qt documentation says that just call showNormal and it will return properly
-    // So calling showMaximized.
-    if (isFullScreen()) {
-        showMaximized();
-    }
-}
 
 void MainWindow::showStatusBarCallback(bool checked)
 {

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -116,18 +116,6 @@ public slots:
 
 protected slots:
     /**
-     * @brief Unchecks the normalActionItem.
-     * Used as a triggered() callback by the fullScreenAction to make sure only one of it or the
-     * normalAction are checked at a time, as they're mutually exclusive.
-     */
-    void fullScreenActionItemCallback(bool);
-    /**
-     * @brief Unchecks the fullScreenActionItem.
-     * Used as a triggered() callback by the normalAction to make sure only one of it or the
-     * fullScreenAction are checked at a time, as they're mutually exclusive.
-     */
-    void normalActionItemCallback(bool);
-    /**
      * @brief Enable/Disable Status Bar
      */
     void showStatusBarCallback(bool checked);

--- a/src/ui/MainWindow.ui
+++ b/src/ui/MainWindow.ui
@@ -51,7 +51,7 @@
      <x>0</x>
      <y>0</y>
      <width>1024</width>
-     <height>20</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuMGround">
@@ -80,8 +80,6 @@
     <addaction name="actionPlan"/>
     <addaction name="actionFlight"/>
     <addaction name="separator"/>
-    <addaction name="actionFullscreen"/>
-    <addaction name="actionNormal"/>
     <addaction name="separator"/>
     <addaction name="actionStatusBar"/>
    </widget>
@@ -159,31 +157,6 @@
     <enum>QAction::PreferencesRole</enum>
    </property>
   </action>
-  <action name="actionFullscreen">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Fullscreen</string>
-   </property>
-  </action>
-  <action name="actionNormal">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Normal</string>
-   </property>
-   <property name="shortcut">
-    <string>Esc</string>
-   </property>
-  </action>
   <action name="actionSetup">
    <property name="checkable">
     <bool>true</bool>
@@ -242,22 +215,6 @@
     <hint type="destinationlabel">
      <x>299</x>
      <y>199</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>actionFullscreen</sender>
-   <signal>triggered()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>showFullScreen()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>399</x>
-     <y>249</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This is in response to #2452. It's a bug in Qt and instead of leaving there not functioning, I've removed it altogether. You can always maximize the window using the OS' own features.