### PR TITLE
Radio cal fixes

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponent.qml
+++ b/src/AutoPilotPlugins/Common/RadioComponent.qml
@@ -108,7 +108,8 @@ QGCView {
             id: zeroTrimsDialogComponent
 
             QGCViewMessage {
-                message: "Before calibrating you should zero all your trims and subtrims. Click Ok to start Calibration."
+                message: "Before calibrating you should zero all your trims and subtrims. Click Ok to start Calibration.\n\n" +
+                         (QGroundControl.multiVehicleManager.activeVehicle.px4Firmware ? "" : "Please ensure all motor power is disconnected AND all props are removed from the vehicle.")
 
                 function accept() {
                     hideDialog()

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -854,7 +854,15 @@ void RadioComponentController::_writeCalibration(void)
         getParameterFact(FactSystem::defaultComponentId, trimTpl.arg(oneBasedChannel))->setRawValue((float)info->rcTrim);
         getParameterFact(FactSystem::defaultComponentId, minTpl.arg(oneBasedChannel))->setRawValue((float)info->rcMin);
         getParameterFact(FactSystem::defaultComponentId, maxTpl.arg(oneBasedChannel))->setRawValue((float)info->rcMax);
-        getParameterFact(FactSystem::defaultComponentId, revTpl.arg(oneBasedChannel))->setRawValue(info->reversed ? -1.0f : 1.0f);
+
+        // APM has a backwards interpretation of "reversed" on the Pitch control. So be careful.
+        float reversedParamValue;
+        if (_px4Vehicle() || info->function != rcCalFunctionPitch) {
+            reversedParamValue = info->reversed ? -1.0f : 1.0f;
+        } else {
+            reversedParamValue = info->reversed ? 1.0f : -1.0f;
+        }
+        getParameterFact(FactSystem::defaultComponentId, revTpl.arg(oneBasedChannel))->setRawValue(reversedParamValue);
     }
     
     // Write function mapping parameters

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -375,7 +375,7 @@ void Vehicle::_handleRCChannelsRaw(mavlink_message_t& message)
         if (channelValue == UINT16_MAX) {
             pwmValues[i] = -1;
         } else {
-            channelCount = i;
+            channelCount = i + 1;
             pwmValues[i] = channelValue;
         }
     }

--- a/src/qgcunittest/RadioConfigTest.cc
+++ b/src/qgcunittest/RadioConfigTest.cc
@@ -176,7 +176,7 @@ const struct RadioConfigTest::ChannelSettings RadioConfigTest::_rgChannelSetting
 
     // Channels 1-4: Mapped to attitude control function
     { RadioComponentController::rcCalFunctionRoll,			_testMinValue, _testMaxValue, _testCenterValue, true },
-    { RadioComponentController::rcCalFunctionPitch,			_testMinValue, _testMaxValue, _testCenterValue, false },
+    { RadioComponentController::rcCalFunctionPitch,			_testMinValue, _testMaxValue, _testCenterValue, true },
     { RadioComponentController::rcCalFunctionYaw,			_testMinValue, _testMaxValue, _testCenterValue, true },
     { RadioComponentController::rcCalFunctionThrottle,		_testMinValue, _testMaxValue, _testMinValue,    false },
 


### PR DESCRIPTION
- Channel count incorrect from Vehicle
- Show prop warning on side dialog for APM stack as well as in status text area
- APM Stack has Pitch channel concept of forward and reverse backwards from PX4 Stack. That led to an exciting first flight on my APM Stack Iris fully setup using QGC!