### PR TITLE
APM Auto tune, FactSystem bitmask support

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -76,6 +76,7 @@
         <file alias="QGroundControl/Controls/VehicleSummaryRow.qml">src/QmlControls/VehicleSummaryRow.qml</file>
         <file alias="QGroundControl/Controls/ViewWidget.qml">src/ViewWidgets/ViewWidget.qml</file>
         <file alias="QGroundControl/Controls/FactSliderPanel.qml">src/QmlControls/FactSliderPanel.qml</file>
+        <file alias="QGroundControl/FactControls/FactBitmask.qml">src/FactSystem/FactControls/FactBitmask.qml</file>
         <file alias="QGroundControl/FactControls/FactCheckBox.qml">src/FactSystem/FactControls/FactCheckBox.qml</file>
         <file alias="QGroundControl/FactControls/FactComboBox.qml">src/FactSystem/FactControls/FactComboBox.qml</file>
         <file alias="QGroundControl/FactControls/FactLabel.qml">src/FactSystem/FactControls/FactLabel.qml</file>

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -223,6 +223,26 @@ QVariantList Fact::enumValues(void) const
     }
 }
 
+QStringList Fact::bitmaskStrings(void) const
+{
+    if (_metaData) {
+        return _metaData->bitmaskStrings();
+    } else {
+        qWarning() << "Meta data pointer missing";
+        return QStringList();
+    }
+}
+
+QVariantList Fact::bitmaskValues(void) const
+{
+    if (_metaData) {
+        return _metaData->bitmaskValues();
+    } else {
+        qWarning() << "Meta data pointer missing";
+        return QVariantList();
+    }
+}
+
 QString Fact::_variantToString(const QVariant& variant) const
 {
     QString valueString;

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -47,6 +47,8 @@ public:
     const Fact& operator=(const Fact& other);
 
     Q_PROPERTY(int          componentId             READ componentId                                        CONSTANT)
+    Q_PROPERTY(QStringList  bitmaskStrings          READ bitmaskStrings                                     NOTIFY bitmaskStringsChanged)
+    Q_PROPERTY(QVariantList bitmaskValues           READ bitmaskValues                                      NOTIFY bitmaskValuesChanged)
     Q_PROPERTY(int          decimalPlaces           READ decimalPlaces                                      CONSTANT)
     Q_PROPERTY(QVariant     defaultValue            READ cookedDefaultValue                                 CONSTANT)
     Q_PROPERTY(QString      defaultValueString      READ cookedDefaultValueString                           CONSTANT)
@@ -74,7 +76,7 @@ public:
     /// Convert and validate value
     ///     @param convertOnly true: validate type conversion only, false: validate against meta data as well
     Q_INVOKABLE QString validate(const QString& cookedValue, bool convertOnly);
-    
+
     QVariant        cookedValue             (void) const;   /// Value after translation
     QVariant        rawValue                (void) const { return _rawValue; }  /// value prior to translation, careful
     int             componentId             (void) const;
@@ -83,6 +85,8 @@ public:
     QVariant        cookedDefaultValue      (void) const;
     bool            defaultValueAvailable   (void) const;
     QString         cookedDefaultValueString(void) const;
+    QStringList     bitmaskStrings             (void) const;
+    QVariantList    bitmaskValues              (void) const;
     int             enumIndex               (void);         // This is not const, since an unknown value can modify the enum lists
     QStringList     enumStrings             (void) const;
     QString         enumStringValue         (void);         // This is not const, since an unknown value can modify the enum lists
@@ -125,6 +129,8 @@ public:
     void _setName(const QString& name) { _name = name; }
     
 signals:
+    void bitmaskStringsChanged(void);
+    void bitmaskValuesChanged(void);
     void enumStringsChanged(void);
     void enumValuesChanged(void);
 

--- a/src/FactSystem/FactControls/FactBitmask.qml
+++ b/src/FactSystem/FactControls/FactBitmask.qml
@@ -1,0 +1,30 @@
+import QtQuick          2.5
+import QtQuick.Controls 1.2
+
+import QGroundControl.FactSystem    1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+
+Row {
+    spacing: ScreenTools.defaultFontPixelWidth
+
+    property Fact fact: Fact { }
+
+    Repeater {
+        model: fact.bitmaskStrings
+
+        QGCCheckBox {
+            text:       modelData
+            checked:    fact.value & fact.bitmaskValues[index]
+
+            onClicked: {
+                if (checked) {
+                    fact.value |= fact.bitmaskValues[index]
+                } else {
+                    fact.value &= ~fact.bitmaskValues[index]
+                }
+            }
+        }
+    }
+}

--- a/src/FactSystem/FactControls/FactComboBox.qml
+++ b/src/FactSystem/FactControls/FactComboBox.qml
@@ -18,7 +18,7 @@ QGCComboBox {
         if (indexModel) {
             fact.value = index
         } else {
-            fact.enumIndex = index
+            fact.value = fact.enumValues[index]
         }
     }
 }

--- a/src/FactSystem/FactControls/qmldir
+++ b/src/FactSystem/FactControls/qmldir
@@ -1,7 +1,8 @@
 Module QGroundControl.FactControls
 
-FactPanel 1.0 FactPanel.qml
-FactLabel 1.0 FactLabel.qml
-FactTextField 1.0 FactTextField.qml
-FactCheckBox 1.0 FactCheckBox.qml
-FactComboBox 1.0 FactComboBox.qml
+FactBitmask     1.0 FactBitmask.qml
+FactCheckBox    1.0 FactCheckBox.qml
+FactComboBox    1.0 FactComboBox.qml
+FactLabel       1.0 FactLabel.qml
+FactPanel       1.0 FactPanel.qml
+FactTextField   1.0 FactTextField.qml

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -83,6 +83,8 @@ const FactMetaData& FactMetaData::operator=(const FactMetaData& other)
     _decimalPlaces          = other._decimalPlaces;
     _rawDefaultValue        = other._rawDefaultValue;
     _defaultValueAvailable  = other._defaultValueAvailable;
+    _bitmaskStrings         = other._bitmaskStrings;
+    _bitmaskValues          = other._bitmaskValues;
     _enumStrings            = other._enumStrings;
     _enumValues             = other._enumValues;
     _group                  = other._group;
@@ -306,6 +308,24 @@ bool FactMetaData::convertAndValidateCooked(const QVariant& cookedValue, bool co
     return convertOk && errorString.isEmpty();
 }
 
+void FactMetaData::setBitmaskInfo(const QStringList& strings, const QVariantList& values)
+{
+    if (strings.count() != values.count()) {
+        qWarning() << "Count mismatch strings:values" << strings.count() << values.count();
+        return;
+    }
+
+    _bitmaskStrings = strings;
+    _bitmaskValues = values;
+    _setBuiltInTranslator();
+}
+
+void FactMetaData::addBitmaskInfo(const QString& name, const QVariant& value)
+{
+    _bitmaskStrings << name;
+    _bitmaskValues << value;
+}
+
 void FactMetaData::setEnumInfo(const QStringList& strings, const QVariantList& values)
 {
     if (strings.count() != values.count()) {
@@ -316,6 +336,12 @@ void FactMetaData::setEnumInfo(const QStringList& strings, const QVariantList& v
     _enumStrings = strings;
     _enumValues = values;
     _setBuiltInTranslator();
+}
+
+void FactMetaData::addEnumInfo(const QString& name, const QVariant& value)
+{
+    _enumStrings << name;
+    _enumValues << value;
 }
 
 void FactMetaData::setTranslators(Translator rawTranslator, Translator cookedTranslator)
@@ -340,12 +366,6 @@ void FactMetaData::_setBuiltInTranslator(void)
             }
         }
     }
-}
-
-void FactMetaData::addEnumInfo(const QString& name, const QVariant& value)
-{
-    _enumStrings << name;
-    _enumValues << value;
 }
 
 QVariant FactMetaData::_degreesToRadians(const QVariant& degrees)

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -64,6 +64,8 @@ public:
     QVariant        rawDefaultValue         (void) const;
     QVariant        cookedDefaultValue      (void) const { return _rawTranslator(rawDefaultValue()); }
     bool            defaultValueAvailable   (void) const { return _defaultValueAvailable; }
+    QStringList     bitmaskStrings          (void) const { return _bitmaskStrings; }
+    QVariantList    bitmaskValues           (void) const { return _bitmaskValues; }
     QStringList     enumStrings             (void) const { return _enumStrings; }
     QVariantList    enumValues              (void) const { return _enumValues; }
     QString         group                   (void) const { return _group; }
@@ -83,11 +85,15 @@ public:
     Translator      rawTranslator           (void) const { return _rawTranslator; }
     Translator      cookedTranslator        (void) const { return _cookedTranslator; }
 
+    /// Used to add new values to the bitmask lists after the meta data has been loaded
+    void addBitmaskInfo(const QString& name, const QVariant& value);
+
     /// Used to add new values to the enum lists after the meta data has been loaded
     void addEnumInfo(const QString& name, const QVariant& value);
 
     void setDecimalPlaces   (int decimalPlaces)                 { _decimalPlaces = decimalPlaces; }
     void setRawDefaultValue (const QVariant& rawDefaultValue);
+    void setBitmaskInfo     (const QStringList& strings, const QVariantList& values);
     void setEnumInfo        (const QStringList& strings, const QVariantList& values);
     void setGroup           (const QString& group)              { _group = group; }
     void setLongDescription (const QString& longDescription)    { _longDescription = longDescription;}
@@ -128,6 +134,8 @@ private:
     int             _decimalPlaces;
     QVariant        _rawDefaultValue;
     bool            _defaultValueAvailable;
+    QStringList     _bitmaskStrings;
+    QVariantList    _bitmaskValues;
     QStringList     _enumStrings;
     QVariantList    _enumValues;
     QString         _group;

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.h
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.h
@@ -46,12 +46,14 @@ public:
     QString                  incrementSize;
     QString                  units;
     QList<QPair<QString, QString> > values;
+    QList<QPair<QString, QString> > bitmask;
 };
 
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
 Q_DECLARE_LOGGING_CATEGORY(APMParameterMetaDataLog)
+Q_DECLARE_LOGGING_CATEGORY(APMParameterMetaDataVerboseLog)
 
 /// Collection of Parameter Facts for PX4 AutoPilot
 


### PR DESCRIPTION
- Add AutoTune to APM Copter Tuning config. Issue #2493
- Added support for bitmask meta data to FactSystem
- Parse bitmask parameter meta data from APM meta data
- Add new FactBitmask control which automatically generates a set of checkboxes from a Fact with bitmask meta data. An example is shown below in the image for AutoTune Axes: 
```
FactBitmask {
    fact: controller.getParameterFact(-1, "AUTOTUNE_AXES")
}
```

![screen shot 2015-12-29 at 2 19 21 pm](https://cloud.githubusercontent.com/assets/5876851/12043280/73456168-ae38-11e5-86ee-d57b0d05f551.png)
