### PR TITLE
Fixing crash bug.

### DIFF
--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -221,7 +221,7 @@ private:
     void _loadCurrentViewState(void);
 
 #ifndef __mobile__
-    void _createInnerDockWidget(const QString& widgetName);
+    bool _createInnerDockWidget(const QString& widgetName);
     void _buildCommonWidgets(void);
     void _hideAllDockWidgets(void);
     void _showDockWidget(const QString &name, bool show);


### PR DESCRIPTION
If a widget used by a previous (QGC) session was changed (the name or missing altogether), QGC would crash when trying to load it.
