### PR TITLE
qmake only copy linux libs for installer

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -99,54 +99,55 @@ WindowsBuild {
 }
 
 LinuxBuild {
-    QMAKE_POST_LINK += && mkdir -p $$DESTDIR/libs
+    installer {
+        QMAKE_POST_LINK += && mkdir -p $$DESTDIR/libs
 
-    # QT_INSTALL_LIBS
-    QT_LIB_LIST = \
-        libQt5Core.so.5 \
-        libQt5DBus.so.5 \
-        libQt5Gui.so.5 \
-        libQt5Location.so.5 \
-        libQt5Network.so.5 \
-        libQt5OpenGL.so.5 \
-        libQt5Positioning.so.5 \
-        libQt5PrintSupport.so.5 \
-        libQt5Qml.so.5 \
-        libQt5Quick.so.5 \
-        libQt5QuickWidgets.so.5 \
-        libQt5SerialPort.so.5 \
-        libQt5Svg.so.5 \
-        libQt5Test.so.5 \
-        libQt5Widgets.so.5 \
-        libQt5XcbQpa.so.5
+        # QT_INSTALL_LIBS
+        QT_LIB_LIST = \
+            libQt5Core.so.5 \
+            libQt5DBus.so.5 \
+            libQt5Gui.so.5 \
+            libQt5Location.so.5 \
+            libQt5Network.so.5 \
+            libQt5OpenGL.so.5 \
+            libQt5Positioning.so.5 \
+            libQt5PrintSupport.so.5 \
+            libQt5Qml.so.5 \
+            libQt5Quick.so.5 \
+            libQt5QuickWidgets.so.5 \
+            libQt5SerialPort.so.5 \
+            libQt5Svg.so.5 \
+            libQt5Test.so.5 \
+            libQt5Widgets.so.5 \
+            libQt5XcbQpa.so.5
 
-    !contains(DEFINES, __rasp_pi2__) {
-      QT_LIB_LIST += \
-        libicudata.so.54 \
-        libicui18n.so.54 \
-        libicuuc.so.54
+        !contains(DEFINES, __rasp_pi2__) {
+            QT_LIB_LIST += \
+                libicudata.so.54 \
+                libicui18n.so.54 \
+                libicuuc.so.54
+        }
+
+        for(QT_LIB, QT_LIB_LIST) {
+            QMAKE_POST_LINK += && $$QMAKE_COPY --dereference $$[QT_INSTALL_LIBS]/$$QT_LIB $$DESTDIR/libs
+        }
+
+        # QT_INSTALL_PLUGINS
+        QT_PLUGIN_LIST = platforms
+
+        !contains(DEFINES, __rasp_pi2__) {
+            QT_PLUGIN_LIST += xcbglintegrations
+        }
+
+        for(QT_PLUGIN, QT_PLUGIN_LIST) {
+            QMAKE_POST_LINK += && $$QMAKE_COPY --dereference --recursive $$[QT_INSTALL_PLUGINS]/$$QT_PLUGIN $$DESTDIR/libs
+        }
+
+        # QT_INSTALL_QML
+        QMAKE_POST_LINK += && $$QMAKE_COPY --dereference --recursive $$[QT_INSTALL_QML] $$DESTDIR/libs
+
+        # QGroundControl start script
+        QMAKE_POST_LINK += && $$QMAKE_COPY $$BASEDIR/deploy/qgroundcontrol-start.sh $$DESTDIR
     }
-
-    for(QT_LIB, QT_LIB_LIST) {
-        QMAKE_POST_LINK += && $$QMAKE_COPY --dereference $$[QT_INSTALL_LIBS]/$$QT_LIB $$DESTDIR/libs
-    }
-
-    # QT_INSTALL_PLUGINS
-    QT_PLUGIN_LIST = \
-        platforms
-
-    !contains(DEFINES, __rasp_pi2__) {
-        QT_PLUGIN_LIST += xcbglintegrations
-    }
-
-    for(QT_PLUGIN, QT_PLUGIN_LIST) {
-        QMAKE_POST_LINK += && $$QMAKE_COPY --dereference --recursive $$[QT_INSTALL_PLUGINS]/$$QT_PLUGIN $$DESTDIR/libs
-    }
-
-    # QT_INSTALL_QML
-    QMAKE_POST_LINK += && $$QMAKE_COPY --dereference --recursive $$[QT_INSTALL_QML] $$DESTDIR/libs   
-   
-    # QGroundControl start script
-    QMAKE_POST_LINK += && $$QMAKE_COPY $$BASEDIR/deploy/qgroundcontrol-start.sh $$DESTDIR
 }
 


### PR DESCRIPTION
Otherwise the installer is created for every debug and release build, which often fails outside of Ubuntu with Qt from the online installer.