### PR TITLE
R.Pi2 Support

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -31,6 +31,10 @@ linux {
         message("Linux build")
         CONFIG += LinuxBuild
         DEFINES += __STDC_LIMIT_MACROS
+    } else : linux-rasp-pi2-g++ {
+        message("Linux R-Pi2 build")
+        CONFIG += LinuxBuild
+        DEFINES += __STDC_LIMIT_MACROS __rasp_pi2__
     } else : android-g++ {
         message("Android build")
         CONFIG += AndroidBuild MobileBuild

--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -103,9 +103,6 @@ LinuxBuild {
 
     # QT_INSTALL_LIBS
     QT_LIB_LIST = \
-        libicudata.so.54 \
-        libicui18n.so.54 \
-        libicuuc.so.54 \
         libQt5Core.so.5 \
         libQt5DBus.so.5 \
         libQt5Gui.so.5 \
@@ -123,14 +120,24 @@ LinuxBuild {
         libQt5Widgets.so.5 \
         libQt5XcbQpa.so.5
 
+    !contains(DEFINES, __rasp_pi2__) {
+      QT_LIB_LIST += \
+        libicudata.so.54 \
+        libicui18n.so.54 \
+        libicuuc.so.54
+    }
+
     for(QT_LIB, QT_LIB_LIST) {
         QMAKE_POST_LINK += && $$QMAKE_COPY --dereference $$[QT_INSTALL_LIBS]/$$QT_LIB $$DESTDIR/libs
     }
 
     # QT_INSTALL_PLUGINS
     QT_PLUGIN_LIST = \
-        platforms \
-        xcbglintegrations
+        platforms
+
+    !contains(DEFINES, __rasp_pi2__) {
+        QT_PLUGIN_LIST += xcbglintegrations
+    }
 
     for(QT_PLUGIN, QT_PLUGIN_LIST) {
         QMAKE_POST_LINK += && $$QMAKE_COPY --dereference --recursive $$[QT_INSTALL_PLUGINS]/$$QT_PLUGIN $$DESTDIR/libs

--- a/src/VideoStreaming/gstqtvideosink/utils/glutils.h
+++ b/src/VideoStreaming/gstqtvideosink/utils/glutils.h
@@ -34,7 +34,15 @@ This file is part of the QGROUNDCONTROL project
 #include <QOpenGLFunctions>
 #define getQOpenGLFunctions() QOpenGLContext::currentContext()->functions()
 #define QOpenGLFunctionsDef QOpenGLFunctions
-#else
+#endif
+
+#ifdef __rasp_pi2__
+#include <QOpenGLFunctions_ES2>
+#define getQOpenGLFunctions() QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_ES2>()
+#define QOpenGLFunctionsDef QOpenGLFunctions_ES2
+#endif
+
+#ifndef QOpenGLFunctionsDef
 #include <QOpenGLFunctions_2_0>
 #define getQOpenGLFunctions() QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_2_0>()
 #define QOpenGLFunctionsDef QOpenGLFunctions_2_0


### PR DESCRIPTION
Allows QGC to run on Raspberry Pi 2 with direct framebuffer (X/startx not needed). Memory split seems to need 128 for GPU. Qt5 needs to be configured with "-opengl es2 -qpa eglfs -device linux-rasp-pi2-g++".