### PR TITLE
Fix default (non installer) release builds on Windows by removing VS …

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -113,11 +113,6 @@ CONFIG(debug, debug|release) {
     error(Unsupported build flavor)
 }
 
-# Need to special case Windows debug_and_release since VS Project creation in this case does strange things [QTBUG-40351]
-win32:debug_and_release {
-    CONFIG += WindowsDebugAndRelease
-}
-
 # Setup our build directories
 
 BASEDIR      = $$IN_PWD
@@ -183,12 +178,7 @@ ReleaseBuild {
 #
 # Unit Test specific configuration goes here
 #
-# We have to special case Windows debug_and_release builds because you can't have files
-# which are only in the debug variant [QTBUG-40351]. So in this case we include unit tests
-# even in the release variant. If you want a Windows release build with no unit tests run
-# qmake with CONFIG-=debug_and_release CONFIG+=release.
-#
 
-DebugBuild|WindowsDebugAndRelease {
+DebugBuild {
     DEFINES += UNITTEST_BUILD
 }

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -478,13 +478,8 @@ SOURCES += \
 #
 # Unit Test specific configuration goes here
 #
-# We have to special case Windows debug_and_release builds because you can't have files
-# which are only in the debug variant [QTBUG-40351]. So in this case we include unit tests
-# even in the release variant. If you want a Windows release build with no unit tests run
-# qmake with CONFIG-=debug_and_release CONFIG+=release.
-#
 
-DebugBuild|WindowsDebugAndRelease {
+DebugBuild {
 
 HEADERS += src/QmlControls/QmlTestWidget.h
 SOURCES += src/QmlControls/QmlTestWidget.cc
@@ -540,8 +535,8 @@ SOURCES += \
     src/qgcunittest/UnitTest.cc \
     src/qgcunittest/UnitTestList.cc \
     src/VehicleSetup/SetupViewTest.cc \
-} # DebugBuild|WindowsDebugAndRelease
-} # MobileBuild
+} # !MobileBuild
+} # DebugBuild
 
 #
 # Firmware Plugin Support


### PR DESCRIPTION
…hacks

Per [the bug](https://bugreports.qt.io/browse/QTBUG-40351?focusedCommentId=274152&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-274152) referenced by these workarounds this is no longer an issue in VS. The workarounds break a standard release build in QtCreator which is annoying, so let's remove them. 