### PR TITLE
Fix GPS indicator so it handles non existing HDOP/VDOP values.

### DIFF
--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -259,7 +259,7 @@ Rectangle {
                         color:  colorWhite
                     }
                     QGCLabel {
-                        text:   activeVehicle ? (activeVehicle.satRawHDOP.toFixed(0)) : "N/A"
+                        text:   activeVehicle ? (activeVehicle.satRawHDOP < 10000 ? activeVehicle.satRawHDOP.toFixed(0) : "N/A") : "N/A"
                         color:  colorWhite
                     }
                     QGCLabel {
@@ -267,7 +267,7 @@ Rectangle {
                         color:  colorWhite
                     }
                     QGCLabel {
-                        text:   activeVehicle ? (activeVehicle.satRawVDOP.toFixed(0)) : "N/A"
+                        text:   activeVehicle ? (activeVehicle.satRawVDOP < 10000 ? activeVehicle.satRawVDOP.toFixed(0) : "N/A") : "N/A"
                         color:  colorWhite
                     }
                     QGCLabel {


### PR DESCRIPTION
This is in response to #2561. If the value (HDOP or VDOP) is not present, it's initialized to some large number (1e10f). The GPS indicator was not testing for this and showing it any way.