### PR TITLE
Prioritize real joystick over virtual joystick.

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1215,5 +1215,8 @@ void Vehicle::_remoteControlRSSIChanged(uint8_t rssi)
 
 void Vehicle::virtualTabletJoystickValue(double roll, double pitch, double yaw, double thrust)
 {
-    _uas->setExternalControlSetpoint(roll, pitch, yaw, thrust, 0, JoystickModeRC);
+    // The following if statement prevents the virtualTabletJoystick from sending values if the standard joystick is enabled
+    if ( !_joystickEnabled ) {
+        _uas->setExternalControlSetpoint(roll, pitch, yaw, thrust, 0, JoystickModeRC);
+    }
 }


### PR DESCRIPTION
Added conditional statement to disable the virtualTabletJoystick output if a real joystick is connected and enabled. Without this, two different sets of values would be sent and would appear highly sporadic.