### PR TITLE
GPS Indicator fixes.

### DIFF
--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -190,16 +190,22 @@ Rectangle {
 
     function getGpsLockStatus() {
         if(activeVehicle) {
-            if(activeVehicle.satelliteLock == 0) {
-                return "No Satellite Link"
-            }
-            if(activeVehicle.satelliteLock == 1) {
-                return "No GPS Lock"
+            if(activeVehicle.satelliteLock < 2) {
+                return "No Satellite Lock"
             }
             if(activeVehicle.satelliteLock == 2) {
                 return "2D Lock"
             }
-            return "3D Lock"
+            if(activeVehicle.satelliteLock == 3) {
+                return "3D Lock"
+            }
+            if(activeVehicle.satelliteLock == 4) {
+                return "3D Lock with Differential"
+            }
+            if(activeVehicle.satelliteLock == 5) {
+                return "3D Lock with Relative Positioning"
+            }
+            return "Unkown Lock Type (" + activeVehicle.satelliteLock + ")"
         }
         return "N/A"
     }
@@ -226,14 +232,14 @@ Rectangle {
                 anchors.centerIn:   parent
                 QGCLabel {
                     id:         gpsLabel
-                    text:       (activeVehicle && (activeVehicle.satelliteCount > 0)) ? "GPS Status" : "GPS Data Unavailable"
+                    text:       (activeVehicle && activeVehicle.satelliteCount >= 0) ? "GPS Status" : "GPS Data Unavailable"
                     font.weight:Font.DemiBold
                     color:      colorWhite
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
                 GridLayout {
                     id:                 gpsGrid
-                    visible:            (activeVehicle && (activeVehicle.satelliteCount > 0))
+                    visible:            (activeVehicle && activeVehicle.satelliteCount >= 0)
                     anchors.margins:    ScreenTools.defaultFontPixelHeight
                     columnSpacing:      ScreenTools.defaultFontPixelWidth
                     anchors.horizontalCenter: parent.horizontalCenter

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -176,7 +176,7 @@ Row {
                 smooth:         true
                 width:          mainWindow.tbCellHeight * 0.65
                 height:         mainWindow.tbCellHeight * 0.5
-                opacity:        activeVehicle ? (activeVehicle.satelliteCount < 1 ? 0.5 : 1) : 0.5
+                opacity:        (activeVehicle && activeVehicle.satelliteCount >= 0) ? 1 : 0.5
                 anchors.verticalCenter: parent.verticalCenter
             }
             SignalStrength {
@@ -186,10 +186,10 @@ Row {
             }
         }
         QGCLabel {
-            text:           activeVehicle ? activeVehicle.satelliteCount : 0
+            text:           (activeVehicle && activeVehicle.satelliteCount >= 0) ? activeVehicle.satelliteCount : ""
+            visible:        (activeVehicle && activeVehicle.satelliteCount >= 0)
             font.pixelSize: tbFontSmall
             color:          colorWhite
-            opacity:        activeVehicle ? (activeVehicle.satelliteCount < 1 ? 0.5 : 1) : 0.5
             anchors.top:    parent.top
             anchors.leftMargin: gpsIcon.width
             anchors.left:   parent.left


### PR DESCRIPTION
This is in response to #2568 and #2566.

The indicator will only be enabled if GPS data is actually present. If there is no GPS receiver, you will see this:
![screen shot 2016-01-10 at 2 00 36 pm](https://cloud.githubusercontent.com/assets/749243/12223418/e5f17e7a-b7a4-11e5-9836-1b4c10007d24.png)

If there is a receiver but no signal (indoors for example), you get this:
![screen shot 2016-01-10 at 1 46 33 pm](https://cloud.githubusercontent.com/assets/749243/12223422/0513e3ce-b7a5-11e5-99d8-e1a21c737428.png)

With proper reception, you get the full data (though even with 13 satellites, I didn't get beyond "3D Lock"):
![screen shot 2016-01-10 at 2 11 34 pm](https://cloud.githubusercontent.com/assets/749243/12223429/21ebbe04-b7a5-11e5-8645-f4baa58f76cd.png)
