### PR TITLE
"Fix" for hanging on exit when Video Streaming build is enabled.

### DIFF
--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -114,7 +114,16 @@ void initializeVideoStreaming(int &argc, char* argv[])
 
 void shutdownVideoStreaming()
 {
+    /* From: http://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/gstreamer-Gst.html#gst-deinit
+     *
+     * "It is normally not needed to call this function in a normal application as the resources will automatically
+     * be freed when the program terminates. This function is therefore mostly used by testsuites and other memory
+     * profiling tools."
+     *
+     * It's causing a hang on exit. It hangs while deleting some thread.
+     *
 #if defined(QGC_GST_STREAMING)
-    gst_deinit();
+     gst_deinit();
 #endif
+    */
 }


### PR DESCRIPTION
The destruction order changed and I could not figure why the thread was hanging on a select(). The solution was simply: *don't do it*.