### PR TITLE
Add Reboot Required fact meta data

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -482,3 +482,13 @@ QString Fact::validate(const QString& cookedValue, bool convertOnly)
         return QString("Internal error: Meta data pointer missing");
     }
 }
+
+bool Fact::rebootRequired(void) const
+{
+    if (_metaData) {
+        return _metaData->rebootRequired();
+    } else {
+        qWarning() << "Meta data pointer missing";
+        return false;
+    }
+}

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -66,6 +66,7 @@ public:
     Q_PROPERTY(QString      minString               READ cookedMinString                                    CONSTANT)
     Q_PROPERTY(bool         minIsDefaultForType     READ minIsDefaultForType                                CONSTANT)
     Q_PROPERTY(QString      name                    READ name                                               CONSTANT)
+    Q_PROPERTY(bool         rebootRequired          READ rebootRequired                                     CONSTANT)
     Q_PROPERTY(QString      shortDescription        READ shortDescription                                   CONSTANT)
     Q_PROPERTY(FactMetaData::ValueType_t type       READ type                                               CONSTANT)
     Q_PROPERTY(QString      units                   READ cookedUnits                                        CONSTANT)
@@ -109,6 +110,7 @@ public:
     QString         rawValueString          (void) const;
     QString         cookedValueString       (void) const;
     bool            valueEqualsDefault      (void) const;
+    bool            rebootRequired          (void) const;
 
     void setRawValue        (const QVariant& value);
     void setCookedValue     (const QVariant& value);

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -51,6 +51,7 @@ FactMetaData::FactMetaData(QObject* parent)
     , _minIsDefaultForType(true)
     , _rawTranslator(_defaultTranslator)
     , _cookedTranslator(_defaultTranslator)
+    , _rebootRequired(false)
 {
 
 }
@@ -68,6 +69,7 @@ FactMetaData::FactMetaData(ValueType_t type, QObject* parent)
     , _minIsDefaultForType(true)
     , _rawTranslator(_defaultTranslator)
     , _cookedTranslator(_defaultTranslator)
+    , _rebootRequired(false)
 {
 
 }
@@ -100,6 +102,7 @@ const FactMetaData& FactMetaData::operator=(const FactMetaData& other)
     _cookedUnits            = other._cookedUnits;
     _rawTranslator          = other._rawTranslator;
     _cookedTranslator       = other._cookedTranslator;
+    _rebootRequired         = other._rebootRequired;
 
     return *this;
 }

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -81,6 +81,7 @@ public:
     ValueType_t     type                    (void) const { return _type; }
     QString         rawUnits                (void) const { return _rawUnits; }
     QString         cookedUnits             (void) const { return _cookedUnits; }
+    bool            rebootRequired          (void) const { return _rebootRequired; }
 
     Translator      rawTranslator           (void) const { return _rawTranslator; }
     Translator      cookedTranslator        (void) const { return _cookedTranslator; }
@@ -102,6 +103,7 @@ public:
     void setName            (const QString& name)               { _name = name; }
     void setShortDescription(const QString& shortDescription)   { _shortDescription = shortDescription; }
     void setRawUnits        (const QString& rawUnits);
+    void setRebootRequired  (bool rebootRequired)               { _rebootRequired = rebootRequired; }
 
     void setTranslators(Translator rawTranslator, Translator cookedTranslator);
 
@@ -150,6 +152,7 @@ private:
     QString         _cookedUnits;
     Translator      _rawTranslator;
     Translator      _cookedTranslator;
+    bool            _rebootRequired;
 
     struct BuiltInTranslation_s {
         const char* rawUnits;

--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -296,8 +296,8 @@ void ParameterLoader::_valueUpdated(const QVariant& value)
     _writeParameterRaw(componentId, fact->name(), value);
     qCDebug(ParameterLoaderLog) << "Set parameter (componentId:" << componentId << "name:" << name << value << ")";
 
-    if (fact->rebootRequired()) {
-        qgcApp()->showMessage(QStringLiteral("Change of parameter %1 requires a Vehicle reboot to take affect").arg(name));
+    if (fact->rebootRequired() && !qgcApp()->runningUnitTests()) {
+        qgcApp()->showMessage(QStringLiteral("Change of parameter %1 requires a Vehicle reboot to take effect").arg(name));
     }
 }
 

--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -295,6 +295,10 @@ void ParameterLoader::_valueUpdated(const QVariant& value)
 
     _writeParameterRaw(componentId, fact->name(), value);
     qCDebug(ParameterLoaderLog) << "Set parameter (componentId:" << componentId << "name:" << name << value << ")";
+
+    if (fact->rebootRequired()) {
+        qgcApp()->showMessage(QStringLiteral("Change of parameter %1 requires a Vehicle reboot to take affect").arg(name));
+    }
 }
 
 void ParameterLoader::refreshAllParameters(void)

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.cc
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.cc
@@ -342,6 +342,7 @@ bool APMParameterMetaData::parseParameterAttributes(QXmlStreamReader& xml, APMFa
             // skip empty elements. Somehow I am getting lot of these. Dont know what to do with them.
         } else if (elementName == "field") {
             QString attributeName = xml.attributes().value("name").toString();
+
             if ( attributeName == "Range") {
                 QString range = xml.readElementText().trimmed();
                 QStringList rangeList = range.split(' ');
@@ -402,6 +403,11 @@ bool APMParameterMetaData::parseParameterAttributes(QXmlStreamReader& xml, APMFa
                 if (parseError) {
                     rawMetaData->bitmask.clear();
                 }
+            } else if (attributeName == "RebootRequired") {
+                QString strValue = xml.readElementText().trimmed();
+                if (strValue.compare("true", Qt::CaseInsensitive) == 0) {
+                    rawMetaData->rebootRequired = true;
+                }
             }
         } else if (elementName == "values") {
             // doing nothing individual value will follow anyway. May be used for sanity checking.
@@ -447,6 +453,7 @@ void APMParameterMetaData::addMetaDataToFact(Fact* fact, MAV_TYPE vehicleType)
 
     metaData->setName(rawMetaData->name);
     metaData->setGroup(rawMetaData->group);
+    metaData->setRebootRequired(rawMetaData->rebootRequired);
 
     if (!rawMetaData->shortDescription.isEmpty()) {
         metaData->setShortDescription(rawMetaData->shortDescription);

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.h
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.h
@@ -37,14 +37,19 @@
 class APMFactMetaDataRaw
 {
 public:
-    QString                  name;
-    QString                  group;
-    QString                  shortDescription;
-    QString                  longDescription;
-    QString                  min;
-    QString                  max;
-    QString                  incrementSize;
-    QString                  units;
+    APMFactMetaDataRaw(void)
+        : rebootRequired(false)
+    { }
+
+    QString name;
+    QString group;
+    QString shortDescription;
+    QString longDescription;
+    QString min;
+    QString max;
+    QString incrementSize;
+    QString units;
+    bool    rebootRequired;
     QList<QPair<QString, QString> > values;
     QList<QPair<QString, QString> > bitmask;
 };

--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
@@ -312,6 +312,14 @@ void PX4ParameterMetaData::_loadParameterFactMetaData(void)
                             qCWarning(PX4ParameterMetaDataLog) << "Invalid decimals value, name:" << metaData->name() << " type:" << metaData->type() << " decimals:" << text << " error: invalid number";
                         }
 
+                    } else if (elementName == "reboot_required") {
+                        Q_ASSERT(metaData);
+                        QString text = xml.readElementText();
+                        qCDebug(PX4ParameterMetaDataLog) << "RebootRequired:" << text;
+                        if (text.compare("true", Qt::CaseInsensitive) == 0) {
+                            metaData->setRebootRequired(true);
+                        }
+
                     } else {
                         qDebug() << "Unknown element in XML: " << elementName;
                     }


### PR DESCRIPTION
Fix for Issue #2465. Parameters which are marked as requiring reboot to take affect in meta data will now warn user with message if param is changed.

@LorenzMeier If you update the firmware parser to support a @RebootRequired param tag which outputs:
```
<reboot_required>true</reboot_required>
``` 
to the meta data xml this will work with PX4 as well.

@dogmaphobic This should help with your Radio parameters. Working to plumb component meta data through the system.

![screen shot 2016-01-13 at 10 33 18 am](https://cloud.githubusercontent.com/assets/5876851/12303796/35baa240-b9e1-11e5-92fa-86267de28caa.png)
