### PR TITLE
Initial map position changes, plus GCS position on map

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -50,7 +50,6 @@ Item {
 
     property var _activeVehicle:  multiVehicleManager.activeVehicle
 
-    readonly property var  _defaultVehicleCoordinate:   mainWindow.tabletPosition
     readonly property real _defaultRoll:                0
     readonly property real _defaultPitch:               0
     readonly property real _defaultHeading:             0
@@ -70,8 +69,6 @@ Item {
     property real _roll:                _activeVehicle ? (isNaN(_activeVehicle.roll)    ? _defaultRoll    : _activeVehicle.roll)    : _defaultRoll
     property real _pitch:               _activeVehicle ? (isNaN(_activeVehicle.pitch)   ? _defaultPitch   : _activeVehicle.pitch)   : _defaultPitch
     property real _heading:             _activeVehicle ? (isNaN(_activeVehicle.heading) ? _defaultHeading : _activeVehicle.heading) : _defaultHeading
-
-    property var  _vehicleCoordinate:   _activeVehicle ? (_activeVehicle.coordinateValid ? _activeVehicle.coordinate : _defaultVehicleCoordinate) : _defaultVehicleCoordinate
 
     property real _altitudeWGS84:       _activeVehicle ? _activeVehicle.altitudeWGS84 : _defaultAltitudeWGS84
     property real _groundSpeed:         _activeVehicle ? _activeVehicle.groundSpeed   : _defaultGroundSpeed
@@ -120,7 +117,6 @@ Item {
                     _flightMap.zoomLevel = _savedZoomLevel
                 else
                     _savedZoomLevel = _flightMap.zoomLevel
-                _flightMap.updateMapPosition(true /* force */)
             } else {
                 _flightVideo = item
             }

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -39,18 +39,15 @@ FlightMap {
     id:             flightMap
     anchors.fill:   parent
     mapName:        _mapName
-    latitude:       mainWindow.tabletPosition.latitude
-    longitude:      mainWindow.tabletPosition.longitude
 
-    property var    rootVehicleCoordinate:  _vehicleCoordinate
-    property bool   _followVehicle:         true
+    property bool   _followVehicle:                 true
+    property bool   _activeVehicleCoordinateValid:  multiVehicleManager.activeVehicle ? multiVehicleManager.activeVehicle.coordinateValid : false
+    property var    activeVehicleCoordinate:        multiVehicleManager.activeVehicle ? multiVehicleManager.activeVehicle.coordinate : QtPositioning.coordinate()
 
-    onRootVehicleCoordinateChanged: updateMapPosition(false /* force */)
-
-    function updateMapPosition(force) {
-        if (_followVehicle || force) {
-            flightMap.latitude  = root._vehicleCoordinate.latitude
-            flightMap.longitude = root._vehicleCoordinate.longitude
+    onActiveVehicleCoordinateChanged: {
+        if (_followVehicle && activeVehicleCoordinate.isValid) {
+            _initialMapPositionSet = true
+            flightMap.center  = activeVehicleCoordinate
         }
     }
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -121,6 +121,8 @@ const char* QGCApplication::_settingsVersionKey             = "SettingsVersion";
 const char* QGCApplication::_promptFlightDataSave           = "PromptFLightDataSave";
 const char* QGCApplication::_promptFlightDataSaveNotArmed   = "PromptFLightDataSaveNotArmed";
 const char* QGCApplication::_styleKey                       = "StyleIsDark";
+const char* QGCApplication::_defaultMapPositionLatKey       = "DefaultMapPositionLat";
+const char* QGCApplication::_defaultMapPositionLonKey       = "DefaultMapPositionLon";
 
 const char* QGCApplication::_darkStyleFile          = ":/res/styles/style-dark.css";
 const char* QGCApplication::_lightStyleFile         = ":/res/styles/style-light.css";
@@ -176,6 +178,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 #endif
     , _toolbox(NULL)
     , _bluetoothAvailable(false)
+    , _defaultMapPosition(37.803784, -122.462276)
 {
     Q_ASSERT(_app == NULL);
     _app = this;
@@ -317,6 +320,9 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
         settings.clear();
         settings.setValue(_settingsVersionKey, QGC_SETTINGS_VERSION);
     }
+
+    _defaultMapPosition.setLatitude(settings.value(_defaultMapPositionLatKey, 37.803784).toDouble());
+    _defaultMapPosition.setLongitude(settings.value(_defaultMapPositionLonKey, -122.462276).toDouble());
 
     // Initialize Bluetooth
 #ifdef QGC_ENABLE_BLUETOOTH
@@ -710,4 +716,13 @@ void QGCApplication::_showSetupVehicleComponent(VehicleComponent* vehicleCompone
     QVariant varComponent = QVariant::fromValue(vehicleComponent);
 
     QMetaObject::invokeMethod(_rootQmlObject(), "showSetupVehicleComponent", Q_RETURN_ARG(QVariant, varReturn), Q_ARG(QVariant, varComponent));
+}
+
+void QGCApplication::setDefaultMapPosition(QGeoCoordinate& defaultMapPosition)
+{
+    QSettings settings;
+
+    settings.setValue(_defaultMapPositionLatKey, defaultMapPosition.latitude());
+    settings.setValue(_defaultMapPositionLonKey, defaultMapPosition.longitude());
+    _defaultMapPosition = defaultMapPosition;
 }

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -121,6 +121,9 @@ public:
     /// Do we have Bluetooth Support?
     bool isBluetoothAvailable() { return _bluetoothAvailable; }
 
+    QGeoCoordinate defaultMapPosition(void) { return _defaultMapPosition; }
+    void setDefaultMapPosition(QGeoCoordinate& defaultMapPosition);
+
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
     void informationMessageBoxOnMainThread(const QString& title, const QString& msg);
@@ -184,12 +187,6 @@ private:
     QQmlApplicationEngine* _qmlAppEngine;
 #endif
 
-    static const char* _settingsVersionKey;             ///< Settings key which hold settings version
-    static const char* _deleteAllSettingsKey;           ///< If this settings key is set on boot, all settings will be deleted
-    static const char* _promptFlightDataSave;           ///< Settings key for promptFlightDataSave
-    static const char* _promptFlightDataSaveNotArmed;   ///< Settings key for promptFlightDataSaveNotArmed
-    static const char* _styleKey;                       ///< Settings key for UI style
-
     bool _runningUnitTests; ///< true: running unit tests, false: normal app
 
     static const char*  _darkStyleFile;
@@ -209,6 +206,16 @@ private:
     QGCToolbox* _toolbox;
 
     bool _bluetoothAvailable;
+
+    QGeoCoordinate _defaultMapPosition;    ///< Map position when all other sources fail
+
+    static const char* _settingsVersionKey;             ///< Settings key which hold settings version
+    static const char* _deleteAllSettingsKey;           ///< If this settings key is set on boot, all settings will be deleted
+    static const char* _promptFlightDataSave;           ///< Settings key for promptFlightDataSave
+    static const char* _promptFlightDataSaveNotArmed;   ///< Settings key for promptFlightDataSaveNotArmed
+    static const char* _styleKey;                       ///< Settings key for UI style
+    static const char* _defaultMapPositionLatKey;       ///< Settings key for default map location
+    static const char* _defaultMapPositionLonKey;       ///< Settings key for default map location
 
     /// Unit Test have access to creating and destroying singletons
     friend class UnitTest;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -42,7 +42,6 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
     , _virtualTabletJoystick(false)
     , _offlineEditingFirmwareTypeFact(QString(), "OfflineEditingFirmwareType", FactMetaData::valueTypeUint32, (uint32_t)MAV_AUTOPILOT_ARDUPILOTMEGA)
     , _offlineEditingFirmwareTypeMetaData(FactMetaData::valueTypeUint32)
-
 {
     QSettings settings;
     _virtualTabletJoystick = settings.value(_virtualTabletJoystickKey, false). toBool();

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -76,6 +76,8 @@ public:
 
     Q_PROPERTY(Fact*    offlineEditingFirmwareType READ offlineEditingFirmwareType CONSTANT)
 
+    Q_PROPERTY(QGeoCoordinate defaultMapPosition READ defaultMapPosition CONSTANT)
+
     Q_INVOKABLE void    saveGlobalSetting       (const QString& key, const QString& value);
     Q_INVOKABLE QString loadGlobalSetting       (const QString& key, const QString& defaultValue);
     Q_INVOKABLE void    saveBoolGlobalSetting   (const QString& key, bool value);
@@ -113,6 +115,8 @@ public:
     bool    isVersionCheckEnabled   () { return _toolbox->mavlinkProtocol()->versionCheckEnabled(); }
     int     mavlinkSystemID         () { return _toolbox->mavlinkProtocol()->getSystemId(); }
 
+    QGeoCoordinate defaultMapPosition() { return qgcApp()->defaultMapPosition(); }
+
     Fact*   offlineEditingFirmwareType () { return &_offlineEditingFirmwareTypeFact; }
 
     //-- TODO: Make this into an actual preference.
@@ -144,7 +148,6 @@ signals:
     void mavlinkSystemIDChanged         (int id);
 
 private:
-
     FlightMapSettings*      _flightMapSettings;
     HomePositionManager*    _homePositionManager;
     LinkManager*            _linkManager;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -281,6 +281,7 @@ void Vehicle::_handleHomePosition(mavlink_message_t& message)
 
     if (emitHomePositionChanged) {
         qCDebug(VehicleLog) << "New home position" << newHomePosition;
+        qgcApp()->setDefaultMapPosition(_homePosition);
         emit homePositionChanged(_homePosition);
     }
     if (emitHomePositionAvailableChanged) {

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -33,9 +33,9 @@ import QGroundControl.FlightDisplay         1.0
 import QGroundControl.ScreenTools           1.0
 import QGroundControl.MultiVehicleManager   1.0
 
-/// Inner common QML for MainWindow
+/// Inner common QML for mainWindow
 Item {
-    id:         mainWindow
+    id: mainWindow
 
     signal reallyClose
 
@@ -50,10 +50,7 @@ Item {
     property real   tbButtonWidth:      tbCellHeight * 1.35
     property real   availableHeight:    height - tbHeight
     property real   menuButtonWidth:    (tbButtonWidth * 2) + (tbSpacing * 4) + 1
-
-    property var    defaultPosition:    QtPositioning.coordinate(37.803784, -122.462276)
-    property var    tabletPosition:     defaultPosition
-
+    property var    gcsPosition:        QtPositioning.coordinate()  // Starts as invalid coordinate
     property var    currentPopUp:       null
     property real   currentCenterX:     0
     property var    activeVehicle:      multiVehicleManager.activeVehicle
@@ -179,20 +176,20 @@ Item {
     PositionSource {
         id:             positionSource
         updateInterval: 1000
-        active:         false
+        active:         true
+
         onPositionChanged: {
             if(positionSource.valid) {
                 if(positionSource.position.coordinate.latitude) {
                     if(Math.abs(positionSource.position.coordinate.latitude)  > 0.001) {
                         if(positionSource.position.coordinate.longitude) {
                             if(Math.abs(positionSource.position.coordinate.longitude)  > 0.001) {
-                                tabletPosition = positionSource.position.coordinate
+                                gcsPosition = positionSource.position.coordinate
                             }
                         }
                     }
                 }
             }
-            positionSource.stop()
         }
     }
 
@@ -299,9 +296,6 @@ Item {
         anchors.fill:       parent
         availableHeight:    mainWindow.availableHeight
         visible:            true
-        Component.onCompleted: {
-            positionSource.start()
-        }
     }
 
     Loader {


### PR DESCRIPTION
- Last known vehicle home position is saved as a setting
- Initial position for maps is last known home position. If last known home is not available, default to San Fran location.
- If GCS position is available, it will move to that position one time and override the last known home position
- Fly view: If Follow Vehicle is set, that supercedes all of the above
- Edit view: If Vehicle has gps lock, map will move to vehicle location one time, superceding all of the above
- GCS position is shown on map if available

Fix for issue #2560

![screenshot_2016-01-13-20-52-00](https://cloud.githubusercontent.com/assets/5876851/12316122/d2d2d86c-ba37-11e5-9044-5d9fad52b9af.png)
