### PR TITLE
Show detailed instructions on flash fail

### DIFF
--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -43,8 +43,9 @@ QGCView {
     readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
     readonly property string highlightSuffix:   "</font>"
     readonly property string welcomeText:       "QGroundControl can upgrade the firmware on Pixhawk devices, 3DR Radios and PX4 Flow Smart Cameras."
-    readonly property string plugInText:        highlightPrefix + "Plug in your device" + highlightSuffix + " via USB to " + highlightPrefix + "start" + highlightSuffix + " firmware upgrade. " +
-                                                "Make sure to connect " + highlightPrefix + "directly" + highlightSuffix + " to a powered USB port on your computer, not through a USB hub."
+    readonly property string plugInText:        highlightPrefix + "Plug in your device" + highlightSuffix + " via USB to " + highlightPrefix + "start" + highlightSuffix + " firmware upgrade. "
+    readonly property string flashFailText:     "If upgrade failed, make sure to connect " + highlightPrefix + "directly" + highlightSuffix + " to a powered USB port on your computer, not through a USB hub. " +
+                                                "Also make sure you are only powered via USB " + highlightPrefix + "not battery" + highlightSuffix + "."
     readonly property string qgcDisconnectText: "All QGroundControl connections to vehicles must be disconnected prior to firmware upgrade."
     property string usbUnplugText:              "Device must be disconnected from USB to start firmware upgrade. " +
                                                     highlightPrefix + "Disconnect {0}" + highlightSuffix + " from usb."
@@ -117,6 +118,7 @@ QGCView {
 
         onError: {
             hideDialog()
+            statusTextArea.append(flashFailText)
             flashCompleteWaitTimer.running = true
         }
 


### PR DESCRIPTION
- Simplified initial pre-flash wording back to Plugin in via USB. Was getting too long, with people likely not longer reading due to lenght.
- If flash fails, show detail instructions about USB, direct connect, no hub, no battery.

Fix for Issue #2563 