### PR TITLE
Move connection lost handling to Vehicle

### DIFF
--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -384,8 +384,6 @@ protected: //COMMENTS FOR TEST UNIT
     MAVLinkProtocol* mavlink;     ///< Reference to the MAVLink instance
     float receiveDropRate;        ///< Percentage of packets that were dropped on the MAV's receiving link (from GCS and other MAVs)
     float sendDropRate;           ///< Percentage of packets that were not received from the MAV by the GCS
-    quint64 lastHeartbeat;        ///< Time of the last heartbeat message
-    QTimer statusTimeout;       ///< Timer for various status timeouts
 
     /// BASIC UAS TYPE, NAME AND STATE
     uint8_t base_mode;                 ///< The current mode of the MAV
@@ -423,7 +421,6 @@ protected: //COMMENTS FOR TEST UNIT
     double manualThrust;        ///< Thrust set by human pilot (radians)
 
     /// POSITION
-    bool positionLock;          ///< Status if position information is available or not
     bool isGlobalPositionKnown; ///< If the global position has been received for this MAV
 
     double localX;
@@ -591,9 +588,6 @@ public slots:
     /** @brief Receive a message from one of the communication links. */
     virtual void receiveMessage(mavlink_message_t message);
 
-    /** @brief Update the system state */
-    void updateState();
-
     void startCalibration(StartCalibrationType calType);
     void stopCalibration(void);
 
@@ -607,8 +601,6 @@ public slots:
     void unsetRCToParameterMap();
 signals:
     void loadChanged(UASInterface* uas, double load);
-    /** @brief Propagate a heartbeat received from the system */
-    //void heartbeat(UASInterface* uas); // Defined in UASInterface already
     void imageStarted(quint64 timestamp);
     /** @brief A new camera image has arrived */
     void imageReady(UASInterface* uas);

--- a/src/uas/UASInterface.h
+++ b/src/uas/UASInterface.h
@@ -256,7 +256,6 @@ signals:
     void batteryConsumedChanged(UASInterface* uas, double current_consumed);
     void statusChanged(UASInterface* uas, QString status);
     void thrustChanged(UASInterface*, double thrust);
-    void heartbeat(UASInterface* uas);
     void attitudeChanged(UASInterface*, double roll, double pitch, double yaw, quint64 usec);
     void attitudeChanged(UASInterface*, int component, double roll, double pitch, double yaw, quint64 usec);
     void attitudeRotationRatesChanged(int uas, double rollrate, double pitchrate, double yawrate, quint64 usec);
@@ -313,8 +312,6 @@ signals:
     void localizationChanged(UASInterface* uas, int fix);
 
     // ERROR AND STATUS SIGNALS
-    /** @brief Heartbeat timed out or was regained */
-    void heartbeatTimeout(bool timeout, unsigned int ms);
     /** @brief Name of system changed */
     void nameChanged(QString newName);
     /** @brief Core specifications have changed */
@@ -329,12 +326,6 @@ signals:
 
     /** @brief Command Ack */
     void commandAck (UASInterface* uas, uint8_t compID, uint16_t command, uint8_t result);
-
-protected:
-
-    // TIMEOUT CONSTANTS
-    static const unsigned int timeoutIntervalHeartbeat = 3500 * 1000; ///< Heartbeat timeout is 3.5 seconds
-
 };
 
 Q_DECLARE_INTERFACE(UASInterface, "org.qgroundcontrol/1.0")

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -584,10 +584,10 @@ Rectangle {
         anchors.right:          parent.right
         anchors.verticalCenter: parent.verticalCenter
 
-        property bool vehicleInactive: activeVehicle ? activeVehicle.heartbeatTimeout != 0 : false
+        property bool vehicleConnectionLost: activeVehicle ? activeVehicle.connectionLost : false
 
         Loader {
-            source:                 activeVehicle && !parent.vehicleInactive ? "MainToolBarIndicators.qml" : ""
+            source:                 activeVehicle && !parent.vehicleConnectionLost ? "MainToolBarIndicators.qml" : ""
             anchors.left:           parent.left
             anchors.verticalCenter: parent.verticalCenter
         }
@@ -600,7 +600,7 @@ Rectangle {
             color:                  colorRed
             anchors.left:           parent.left
             anchors.verticalCenter: parent.verticalCenter
-            visible:                parent.vehicleInactive
+            visible:                parent.vehicleConnectionLost
 
         }
 
@@ -609,7 +609,7 @@ Rectangle {
             anchors.right:          parent.right
             anchors.verticalCenter: parent.verticalCenter
             text:                   "Disconnect"
-            visible:                parent.vehicleInactive
+            visible:                parent.vehicleConnectionLost
             onClicked:              activeVehicle.disconnectInactiveVehicle()
         }
     }


### PR DESCRIPTION
- heartbeatTimeout stuff is gone
- Vehicle.connectionLost indicates connection state
- Vehice.connectionLostEnabled allows you to turn on/off connection lost checking. This is why I made the change. For APM stack when you are doing accel cal it doesn't send heartbeats. I need to turn off connection lost singalling while that is running.