### PR TITLE
Joystick: Fix throttle center point.

### DIFF
--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -386,11 +386,6 @@ void JoystickConfigController::_inputStickMin(Joystick::AxisFunction_t function,
             } else {
                 _rgAxisInfo[axis].axisMin = value;
             }
-
-            // Check if this is throttle and set trim accordingly
-            if (function == Joystick::throttleFunction) {
-                _rgAxisInfo[axis].axisTrim = value;
-            }
             
             qCDebug(JoystickConfigControllerLog) << "_inputStickMin saving values, function:axis:value:reversed" << function << axis << value << info->reversed;
             


### PR DESCRIPTION
The lines removed set the center point of the throttle axis to one extreme of the joystick range. This causes an offset value when the stick is centered if the joystick does not return exactly zero. This is important for vehicles with reversible throttle, such as ground robots or boats.

Note: I've tested this code and the joystick behavior is almost identical except that the center point is correct for throttle. The "center stick is zero throttle" and "full down stick is zero throttle" works correctly and produces the same output as the original.