### PR TITLE
Reboot message no longer needed

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -951,11 +951,6 @@ void RadioComponentController::_writeCalibration(void)
     
     _stopCalibration();
     _setInternalCalibrationValuesFromParameters();
-
-    if (_vehicle->apmFirmware() && functionMappingChanged && !_unitTestMode) {
-        // We can't emit this in unit test mode since it confused to Qml which is running in an invisible widget
-        emit functionMappingChangedAPMReboot();
-    }
 }
 
 /// @brief Starts the calibration process

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -918,7 +918,6 @@ void RadioComponentController::_writeCalibration(void)
     }
     
     // Write function mapping parameters
-    bool functionMappingChanged = false;
     for (size_t i=0; i<rcCalFunctionMax; i++) {
         int32_t paramChannel;
         if (_rgFunctionChannelMapping[i] == _chanMax()) {
@@ -933,7 +932,6 @@ void RadioComponentController::_writeCalibration(void)
             Fact* paramFact = getParameterFact(FactSystem::defaultComponentId, _functionInfo()[i].parameterName);
 
             if (paramFact && paramFact->rawValue().toInt() != paramChannel) {
-                functionMappingChanged = true;
                 paramFact = getParameterFact(FactSystem::defaultComponentId, _functionInfo()[i].parameterName);
                 if (paramFact) {
                     paramFact->setRawValue(paramChannel);


### PR DESCRIPTION
Since parameter system will pop message based on meta data. Fix for Issue #2603