### PR TITLE
Set initial size for log download.

### DIFF
--- a/src/ViewWidgets/LogDownload.cc
+++ b/src/ViewWidgets/LogDownload.cc
@@ -28,6 +28,7 @@ LogDownload::LogDownload(const QString& title, QAction* action, QWidget *parent)
 {
     Q_UNUSED(title);
     Q_UNUSED(action);
+    resize(800, 600);
     setSource(QUrl::fromUserInput("qrc:/qml/LogDownload.qml"));
     loadSettings();
 }

--- a/src/ViewWidgets/LogDownload.qml
+++ b/src/ViewWidgets/LogDownload.qml
@@ -72,7 +72,7 @@ QGCView {
 
             TableViewColumn {
                 title: "Id"
-                width: ScreenTools.defaultFontPixelWidth * 4
+                width: ScreenTools.defaultFontPixelWidth * 6
                 horizontalAlignment: Text.AlignHCenter
                 delegate : Text  {
                     horizontalAlignment: Text.AlignHCenter
@@ -85,7 +85,7 @@ QGCView {
 
             TableViewColumn {
                 title: "Date"
-                width: ScreenTools.defaultFontPixelWidth * 30
+                width: ScreenTools.defaultFontPixelWidth * 34
                 horizontalAlignment: Text.AlignHCenter
                 delegate : Text  {
                     text: {
@@ -107,7 +107,7 @@ QGCView {
 
             TableViewColumn {
                 title: "Size"
-                width: ScreenTools.defaultFontPixelWidth * 12
+                width: ScreenTools.defaultFontPixelWidth * 18
                 horizontalAlignment: Text.AlignHCenter
                 delegate : Text  {
                     horizontalAlignment: Text.AlignRight
@@ -120,7 +120,7 @@ QGCView {
 
             TableViewColumn {
                 title: "Status"
-                width: ScreenTools.defaultFontPixelWidth * 18
+                width: ScreenTools.defaultFontPixelWidth * 22
                 horizontalAlignment: Text.AlignHCenter
                 delegate : Text  {
                     horizontalAlignment: Text.AlignHCenter


### PR DESCRIPTION
This is in response to #2649. Note that this is just for the first time you load Log Download. Whatever size you change to will be saved and restored in subsequent sessions.