### PR TITLE
Stop paying attention to heartbeats while downloading logs.

### DIFF
--- a/src/ViewWidgets/LogDownloadController.cc
+++ b/src/ViewWidgets/LogDownloadController.cc
@@ -326,8 +326,7 @@ LogDownloadController::_receivedAllData()
         _requestLogData(_downloadData->ID, 0, _downloadData->entry->size());
     } else {
         _resetSelection();
-        _downloadingLogs = false;
-        emit downloadingLogsChanged();
+        _setDownloading(false);
     }
 }
 
@@ -456,8 +455,7 @@ LogDownloadController::download(void)
             }
         }
         //-- Start download process
-        _downloadingLogs = true;
-        emit downloadingLogsChanged();
+        _setDownloading(true);
         _receivedAllData();
     }
 }
@@ -547,6 +545,15 @@ LogDownloadController::_prepareLogDownload()
 
 //----------------------------------------------------------------------------------------
 void
+LogDownloadController::_setDownloading(bool active)
+{
+    _downloadingLogs = active;
+    _vehicle->setConnectionLostEnabled(!active);
+    emit downloadingLogsChanged();
+}
+
+//----------------------------------------------------------------------------------------
+void
 LogDownloadController::eraseAll(void)
 {
     if(_vehicle && _uas) {
@@ -577,8 +584,7 @@ LogDownloadController::cancel(void)
         _downloadData = 0;
     }
     _resetSelection(true);
-    _downloadingLogs = false;
-    emit downloadingLogsChanged();
+    _setDownloading(false);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/ViewWidgets/LogDownloadController.h
+++ b/src/ViewWidgets/LogDownloadController.h
@@ -176,6 +176,7 @@ private:
     void _requestLogList    (uint32_t start = 0, uint32_t end = 0xFFFF);
     void _requestLogData    (uint8_t id, uint32_t offset = 0, uint32_t count = 0xFFFFFFFF);
     bool _prepareLogDownload();
+    void _setDownloading    (bool active);
 
     QGCLogEntry* _getNextSelected();
 


### PR DESCRIPTION
APM stops sending heartbeats while streaming log files. Need to stop paying attention to heartbeats while downloading logs in order to prevent QGC from "Losing Connection". Same as in Accel Cal.