### PR TITLE
Using proper Fact testing to test if the WiFi Bridge is present.

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -104,24 +104,11 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
             _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
 
             //-- Is there an ESP8266 Connected?
-#ifdef QT_DEBUG
-#ifndef __mobile__
-            //-- Unit test barfs if I ask for a parameter that does not exists. The whole poing of the
-            //   test below is to behave differently if ESP8266 is present or not.
-    if (!qgcApp()->runningUnitTests()) {
-#endif
-#endif
-            Fact* espVersion = getFact(FactSystem::ParameterProvider, MAV_COMP_ID_UDP_BRIDGE, "SW_VER");
-            if(espVersion && espVersion->componentId() == MAV_COMP_ID_UDP_BRIDGE) {
+            if(factExists(FactSystem::ParameterProvider, MAV_COMP_ID_UDP_BRIDGE, "SW_VER")) {
                 _esp8266Component = new PX4ESP8266Component(_vehicle, this);
                 _esp8266Component->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_esp8266Component));
             }
-#ifdef QT_DEBUG
-#ifndef __mobile__
-    }
-#endif
-#endif
 
             _flightModesComponent = new FlightModesComponent(_vehicle, this);
             _flightModesComponent->setupTriggerSignals();


### PR DESCRIPTION
Using ```factExists()``` instead of ```getFact()``` to see if the WiFi Bridge is present.