### PR TITLE
Apm stuff v2

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.cc
@@ -54,7 +54,7 @@ QString APMAirframeComponent::description(void) const
 
 QString APMAirframeComponent::iconResource(void) const
 {
-    return "/qmlimages/AirframeComponentIcon.png";
+    return QStringLiteral("/qmlimages/AirframeComponentIcon.png");
 }
 
 bool APMAirframeComponent::requiresSetup(void) const
@@ -65,7 +65,7 @@ bool APMAirframeComponent::requiresSetup(void) const
 bool APMAirframeComponent::setupComplete(void) const
 {
     if (_requiresFrameSetup) {
-        return _autopilot->getParameterFact(FactSystem::defaultComponentId, "FRAME")->rawValue().toInt() >= 0;
+        return _autopilot->getParameterFact(FactSystem::defaultComponentId, QStringLiteral("FRAME"))->rawValue().toInt() >= 0;
     } else {
         return true;
     }
@@ -76,7 +76,7 @@ QStringList APMAirframeComponent::setupCompleteChangedTriggerList(void) const
     QStringList list;
 
     if (_requiresFrameSetup) {
-        list << "FRAME";
+        list << QStringLiteral("FRAME");
     }
 
     return list;
@@ -85,7 +85,7 @@ QStringList APMAirframeComponent::setupCompleteChangedTriggerList(void) const
 QUrl APMAirframeComponent::setupSource(void) const
 {
     if (_requiresFrameSetup) {
-        return QUrl::fromUserInput("qrc:/qml/APMAirframeComponent.qml");
+        return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMAirframeComponent.qml"));
     } else {
         return QUrl();
     }
@@ -94,7 +94,7 @@ QUrl APMAirframeComponent::setupSource(void) const
 QUrl APMAirframeComponent::summaryQmlSource(void) const
 {
     if (_requiresFrameSetup) {
-        return QUrl::fromUserInput("qrc:/qml/APMAirframeComponentSummary.qml");
+        return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMAirframeComponentSummary.qml"));
     } else {
         return QUrl();
     }

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.h
@@ -34,17 +34,17 @@ public:
     APMAirframeComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Virtuals from APMComponent
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    QStringList setupCompleteChangedTriggerList(void) const final;
 
     // Virtuals from VehicleComponent
-    virtual QString name(void) const;
-    virtual QString description(void) const;
-    virtual QString iconResource(void) const;
-    virtual bool requiresSetup(void) const;
-    virtual bool setupComplete(void) const;
-    virtual QUrl setupSource(void) const;
-    virtual QUrl summaryQmlSource(void) const;    
-    virtual QString prerequisiteSetup(void) const;
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    QUrl setupSource(void) const final;
+    QUrl summaryQmlSource(void) const final;
+    QString prerequisiteSetup(void) const final;
 
 private:
     bool            _requiresFrameSetup; ///< true: FRAME parameter must be set

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentAirframes.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentAirframes.cc
@@ -40,7 +40,7 @@ void APMAirframeComponentAirframes::insert(const QString& group, int groupId, co
         g = new AirframeType_t;
         g->name = group;
         g->type = groupId;
-        g->imageResource = image.isEmpty() ? "" : QString("qrc:/qmlimages/") + image;
+        g->imageResource = image.isEmpty() ? QString() : QStringLiteral("qrc:/qmlimages/") + image;
         rgAirframeTypes.insert(group, g);
     } else {
         g = rgAirframeTypes.value(group);

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -42,12 +42,12 @@ APMAirframeComponentController::APMAirframeComponentController(void) :
 {
     if (!_typesRegistered) {
         _typesRegistered = true;
-        qmlRegisterUncreatableType<APMAirframeType>("QGroundControl.Controllers", 1, 0, "APMAiframeType", "Can only reference APMAirframeType");
-        qmlRegisterUncreatableType<APMAirframe>("QGroundControl.Controllers", 1, 0, "APMAiframe", "Can only reference APMAirframe");
+        qmlRegisterUncreatableType<APMAirframeType>("QGroundControl.Controllers", 1, 0, "APMAiframeType", QStringLiteral("Can only reference APMAirframeType"));
+        qmlRegisterUncreatableType<APMAirframe>("QGroundControl.Controllers", 1, 0, "APMAiframe", QStringLiteral("Can only reference APMAirframe"));
     }
     _fillAirFrames();
 
-    Fact *frame = getParameterFact(FactSystem::defaultComponentId, "FRAME");
+    Fact *frame = getParameterFact(FactSystem::defaultComponentId, QStringLiteral("FRAME"));
     connect(frame, &Fact::vehicleUpdated, this, &APMAirframeComponentController::_factFrameChanged);
     _factFrameChanged(frame->rawValue());
 }
@@ -201,7 +201,7 @@ void APMAirframeComponentController::setCurrentAirframe(APMAirframe *t)
 
 void APMAirframeComponentController::setCurrentAirframeType(APMAirframeType *t)
 {
-    Fact *param = getParameterFact(-1, "FRAME");
+    Fact *param = getParameterFact(-1, QStringLiteral("FRAME"));
     Q_ASSERT(param);
     param->setRawValue(t->type());
 }

--- a/src/AutoPilotPlugins/APM/APMAirframeLoader.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeLoader.cc
@@ -57,7 +57,7 @@ void APMAirframeLoader::loadAirframeFactMetaData(void)
 
     Q_ASSERT(APMAirframeComponentAirframes::get().count() == 0);
 
-    QString airframeFilename = ":/AutoPilotPlugins/APM/APMAirframeFactMetaData.xml";
+    QString airframeFilename(QStringLiteral(":/AutoPilotPlugins/APM/APMAirframeFactMetaData.xml"));
 
     qCDebug(APMAirframeLoaderLog) << "Loading meta data file:" << airframeFilename;
 
@@ -82,14 +82,14 @@ void APMAirframeLoader::loadAirframeFactMetaData(void)
         if (xml.isStartElement()) {
             QString elementName = xml.name().toString();
             QXmlStreamAttributes attr = xml.attributes();
-            if (elementName == "airframe_group") {
-                airframeGroup = attr.value("name").toString();
-                image = attr.value("image").toString();
-                groupId = attr.value("id").toInt();
+            if (elementName == QLatin1Literal("airframe_group")) {
+                airframeGroup = attr.value(QStringLiteral("name")).toString();
+                image = attr.value(QStringLiteral("image")).toString();
+                groupId = attr.value(QStringLiteral("id")).toInt();
                 APMAirframeComponentAirframes::insert(airframeGroup, groupId, image);
-            } else if (elementName == "airframe") {
-                QString name = attr.value("name").toString();
-                QString file = attr.value("file").toString();
+            } else if (elementName == QLatin1Literal("airframe")) {
+                QString name = attr.value(QStringLiteral("name")).toString();
+                QString file = attr.value(QStringLiteral("file")).toString();
                 APMAirframeComponentAirframes::insert(airframeGroup, groupId, image, name, file);
             }
         }

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -70,64 +70,36 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
 
         if (parametersReady()) {
             _airframeComponent = new APMAirframeComponent(_vehicle, this);
-            if(_airframeComponent) {
-                _airframeComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_airframeComponent));
-            } else {
-                qWarning() << "new APMAirframeComponent failed";
-            }
+            _airframeComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_airframeComponent));
 
             _cameraComponent = new APMCameraComponent(_vehicle, this);
             _cameraComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_cameraComponent));
 
             _flightModesComponent = new APMFlightModesComponent(_vehicle, this);
-            if (_flightModesComponent) {
-                _flightModesComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_flightModesComponent));
-            } else {
-                qWarning() << "new APMFlightModesComponent failed";
-            }
+            _flightModesComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_flightModesComponent));
 
             _powerComponent = new APMPowerComponent(_vehicle, this);
-            if (_powerComponent) {
-                _powerComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_powerComponent));
-            } else {
-                qWarning() << "new APMPowerComponent failed";
-            }
+            _powerComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_powerComponent));
 
             _radioComponent = new APMRadioComponent(_vehicle, this);
-            if (_radioComponent) {
-                _radioComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
-            } else {
-                qWarning() << "new APMRadioComponent failed";
-            }
+            _radioComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
 
             _sensorsComponent = new APMSensorsComponent(_vehicle, this);
-            if (_sensorsComponent) {
-                _sensorsComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_sensorsComponent));
-            } else {
-                qWarning() << "new APMSensorsComponent failed";
-            }
+            _sensorsComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_sensorsComponent));
 
             _safetyComponent = new APMSafetyComponent(_vehicle, this);
-            if (_safetyComponent) {
-                _safetyComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_safetyComponent));
-            } else {
-                qWarning() << "new APMSafetyComponent failed";
-            }
+            _safetyComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_safetyComponent));
 
             _tuningComponent = new APMTuningComponent(_vehicle, this);
-            if (_tuningComponent) {
-                _tuningComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue((VehicleComponent*)_tuningComponent));
-            } else {
-                qWarning() << "new APMTuningComponent failed";
-            }
+            _tuningComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_tuningComponent));
         } else {
             qWarning() << "Call to vehicleCompenents prior to parametersReady";
         }

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
@@ -47,7 +47,7 @@ public:
     ~APMAutoPilotPlugin();
 
     // Overrides from AutoPilotPlugin
-    virtual const QVariantList& vehicleComponents(void);
+    const QVariantList& vehicleComponents(void) final;
 
     APMAirframeComponent*       airframeComponent   (void) { return _airframeComponent; }
     APMCameraComponent*         cameraComponent     (void) { return _cameraComponent; }

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
@@ -49,14 +49,14 @@ public:
     // Overrides from AutoPilotPlugin
     const QVariantList& vehicleComponents(void) final;
 
-    APMAirframeComponent*       airframeComponent   (void) { return _airframeComponent; }
-    APMCameraComponent*         cameraComponent     (void) { return _cameraComponent; }
-    APMFlightModesComponent*    flightModesComponent(void) { return _flightModesComponent; }
-    APMPowerComponent*          powerComponent      (void) { return _powerComponent; }
-    APMRadioComponent*          radioComponent      (void) { return _radioComponent; }
-    APMSafetyComponent*         safetyComponent     (void) { return _safetyComponent; }
-    APMSensorsComponent*        sensorsComponent    (void) { return _sensorsComponent; }
-    APMTuningComponent*         tuningComponent     (void) { return _tuningComponent; }
+    APMAirframeComponent*       airframeComponent   (void) const { return _airframeComponent; }
+    APMCameraComponent*         cameraComponent     (void) const { return _cameraComponent; }
+    APMFlightModesComponent*    flightModesComponent(void) const { return _flightModesComponent; }
+    APMPowerComponent*          powerComponent      (void) const { return _powerComponent; }
+    APMRadioComponent*          radioComponent      (void) const { return _radioComponent; }
+    APMSafetyComponent*         safetyComponent     (void) const { return _safetyComponent; }
+    APMSensorsComponent*        sensorsComponent    (void) const { return _sensorsComponent; }
+    APMTuningComponent*         tuningComponent     (void) const { return _tuningComponent; }
 
 public slots:
     // FIXME: This is public until we restructure AutoPilotPlugin/FirmwarePlugin/Vehicle

--- a/src/AutoPilotPlugins/APM/APMCameraComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMCameraComponent.cc
@@ -47,7 +47,7 @@ QString APMCameraComponent::description(void) const
 
 QString APMCameraComponent::iconResource(void) const
 {
-    return "/qmlimages/CameraComponentIcon.png";
+    return QStringLiteral("/qmlimages/CameraComponentIcon.png");
 }
 
 bool APMCameraComponent::requiresSetup(void) const
@@ -67,12 +67,12 @@ QStringList APMCameraComponent::setupCompleteChangedTriggerList(void) const
 
 QUrl APMCameraComponent::setupSource(void) const
 {
-    return QUrl::fromUserInput("qrc:/qml/APMCameraComponent.qml");
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMCameraComponent.qml"));
 }
 
 QUrl APMCameraComponent::summaryQmlSource(void) const
 {
-    return QUrl::fromUserInput("qrc:/qml/APMCameraComponentSummary.qml");
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMCameraComponentSummary.qml"));
 }
 
 QString APMCameraComponent::prerequisiteSetup(void) const

--- a/src/AutoPilotPlugins/APM/APMCameraComponent.h
+++ b/src/AutoPilotPlugins/APM/APMCameraComponent.h
@@ -34,17 +34,17 @@ public:
     APMCameraComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Virtuals from PX4Component
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    QStringList setupCompleteChangedTriggerList(void) const final;
     
     // Virtuals from VehicleComponent
-    virtual QString name(void) const;
-    virtual QString description(void) const;
-    virtual QString iconResource(void) const;
-    virtual bool requiresSetup(void) const;
-    virtual bool setupComplete(void) const;
-    virtual QUrl setupSource(void) const;
-    virtual QUrl summaryQmlSource(void) const;
-    virtual QString prerequisiteSetup(void) const;
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    QUrl setupSource(void) const final;
+    QUrl summaryQmlSource(void) const final;
+    QString prerequisiteSetup(void) const final;
     
 private:
     const QString   _name;

--- a/src/AutoPilotPlugins/APM/APMCompassCal.cc
+++ b/src/AutoPilotPlugins/APM/APMCompassCal.cc
@@ -99,7 +99,7 @@ CalWorkerThread::calibrate_return CalWorkerThread::calibrate(void)
             worker_data.y[cur_mag] = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_points_maxcount));
             worker_data.z[cur_mag] = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_points_maxcount));
             if (worker_data.x[cur_mag] == NULL || worker_data.y[cur_mag] == NULL || worker_data.z[cur_mag] == NULL) {
-                _emitVehicleTextMessage("[cal] ERROR: out of memory");
+                _emitVehicleTextMessage(QStringLiteral("[cal] ERROR: out of memory"));
                 result = calibrate_return_error;
             }
         }
@@ -170,7 +170,7 @@ CalWorkerThread::calibrate_return CalWorkerThread::mag_calibration_worker(detect
 
     mag_worker_data_t* worker_data = (mag_worker_data_t*)(data);
 
-    _emitVehicleTextMessage("[cal] Rotate vehicle around the detected orientation");
+    _emitVehicleTextMessage(QStringLiteral("[cal] Rotate vehicle around the detected orientation"));
     _emitVehicleTextMessage(QString("[cal] Continue rotation for %1 seconds").arg(worker_data->calibration_interval_perside_seconds));
 
     uint64_t calibration_deadline = QGC::groundTimeUsecs() + worker_data->calibration_interval_perside_useconds;

--- a/src/AutoPilotPlugins/APM/APMCompassCal.cc
+++ b/src/AutoPilotPlugins/APM/APMCompassCal.cc
@@ -628,17 +628,13 @@ void APMCompassCal::startCalibration(void)
 
                         _rgSavedCompassOffsets[i][j] = paramFact->rawValue().toFloat();
                         paramFact->setRawValue(0.0);
-                    } else {
-                        _calWorkerThread->rgCompassAvailable[i] = false;
+                        goto has_compass;
                     }
                 }
-            } else {
-                _calWorkerThread->rgCompassAvailable[i] = false;
             }
-        } else {
-            _calWorkerThread->rgCompassAvailable[i] = false;
         }
-
+        _calWorkerThread->rgCompassAvailable[i] = false;
+    has_compass:
         qCDebug(APMCompassCalLog) << QStringLiteral("Compass %1 available: %2").arg(i).arg(_calWorkerThread->rgCompassAvailable[i]);
     }
 

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.cc
@@ -39,12 +39,12 @@ QString APMFlightModesComponent::name(void) const
 
 QString APMFlightModesComponent::description(void) const
 {
-    return QString("The Flight Modes Component is used to assign FLight Modes to Channel 5.");
+    return QStringLiteral("The Flight Modes Component is used to assign FLight Modes to Channel 5.");
 }
 
 QString APMFlightModesComponent::iconResource(void) const
 {
-    return "/qmlimages/FlightModesComponentIcon.png";
+    return QStringLiteral("/qmlimages/FlightModesComponentIcon.png");
 }
 
 bool APMFlightModesComponent::requiresSetup(void) const
@@ -64,12 +64,12 @@ QStringList APMFlightModesComponent::setupCompleteChangedTriggerList(void) const
 
 QUrl APMFlightModesComponent::setupSource(void) const
 {
-    return QUrl::fromUserInput("qrc:/qml/APMFlightModesComponent.qml");
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMFlightModesComponent.qml"));
 }
 
 QUrl APMFlightModesComponent::summaryQmlSource(void) const
 {
-    return QUrl::fromUserInput("qrc:/qml/APMFlightModesComponentSummary.qml");
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMFlightModesComponentSummary.qml"));
 }
 
 QString APMFlightModesComponent::prerequisiteSetup(void) const

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.h
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.h
@@ -34,17 +34,17 @@ public:
     APMFlightModesComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Virtuals from PX4Component
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    QStringList setupCompleteChangedTriggerList(void) const final;
     
     // Virtuals from VehicleComponent
-    virtual QString name(void) const;
-    virtual QString description(void) const;
-    virtual QString iconResource(void) const;
-    virtual bool requiresSetup(void) const;
-    virtual bool setupComplete(void) const;
-    virtual QUrl setupSource(void) const;
-    virtual QUrl summaryQmlSource(void) const;
-    virtual QString prerequisiteSetup(void) const;
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    QUrl setupSource(void) const final;
+    QUrl summaryQmlSource(void) const final;
+    QString prerequisiteSetup(void) const final;
     
 private:
     const QString   _name;

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
@@ -34,7 +34,8 @@ APMFlightModesComponentController::APMFlightModesComponentController(void)
     , _fixedWing(_vehicle->vehicleType() == MAV_TYPE_FIXED_WING)
 {
     QStringList usedParams;
-    usedParams << "FLTMODE1" << "FLTMODE2" << "FLTMODE3" << "FLTMODE4" << "FLTMODE5" << "FLTMODE6";
+    usedParams << QStringLiteral("FLTMODE1") << QStringLiteral("FLTMODE2") << QStringLiteral("FLTMODE3")
+               << QStringLiteral("FLTMODE4") << QStringLiteral("FLTMODE5") << QStringLiteral("FLTMODE6");
     if (!_allParametersExists(FactSystem::defaultComponentId, usedParams)) {
         return;
     }

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
@@ -47,8 +47,8 @@ public:
     Q_PROPERTY(QVariantList channelOptionEnabled    READ channelOptionEnabled   NOTIFY channelOptionEnabledChanged)
     Q_PROPERTY(bool     fixedWing                   MEMBER _fixedWing           CONSTANT)
 
-    int activeFlightMode(void) { return _activeFlightMode; }
-    QVariantList channelOptionEnabled(void) { return _rgChannelOptionEnabled; }
+    int activeFlightMode(void) const { return _activeFlightMode; }
+    QVariantList channelOptionEnabled(void) const { return _rgChannelOptionEnabled; }
 
 signals:
     void activeFlightModeChanged(int activeFlightMode);

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.cc
@@ -43,7 +43,7 @@ QString APMPowerComponent::description(void) const
 
 QString APMPowerComponent::iconResource(void) const
 {
-    return "/qmlimages/PowerComponentIcon.png";
+    return QStringLiteral("/qmlimages/PowerComponentIcon.png");
 }
 
 bool APMPowerComponent::requiresSetup(void) const
@@ -53,26 +53,26 @@ bool APMPowerComponent::requiresSetup(void) const
 
 bool APMPowerComponent::setupComplete(void) const
 {
-    return _autopilot->getParameterFact(FactSystem::defaultComponentId, "BATT_CAPACITY")->rawValue().toInt() != 0;
+    return _autopilot->getParameterFact(FactSystem::defaultComponentId, QStringLiteral("BATT_CAPACITY"))->rawValue().toInt() != 0;
 }
 
 QStringList APMPowerComponent::setupCompleteChangedTriggerList(void) const
 {
     QStringList list;
 
-    list << "BATT_CAPACITY";
+    list << QStringLiteral("BATT_CAPACITY");
 
     return list;
 }
 
 QUrl APMPowerComponent::setupSource(void) const
 {
-    return QUrl::fromUserInput("qrc:/qml/APMPowerComponent.qml");
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMPowerComponent.qml"));
 }
 
 QUrl APMPowerComponent::summaryQmlSource(void) const
 {
-    return QUrl::fromUserInput("qrc:/qml/APMPowerComponentSummary.qml");
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMPowerComponentSummary.qml"));
 }
 
 QString APMPowerComponent::prerequisiteSetup(void) const

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.h
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.h
@@ -34,17 +34,17 @@ public:
     APMPowerComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Virtuals from PX4Component
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    QStringList setupCompleteChangedTriggerList(void) const final;
     
     // Virtuals from VehicleComponent
-    virtual QString     name                    (void) const;
-    virtual QString     description             (void) const;
-    virtual QString     iconResource            (void) const;
-    virtual bool        requiresSetup           (void) const;
-    virtual bool        setupComplete           (void) const;
-    virtual QUrl        setupSource             (void) const;
-    virtual QUrl        summaryQmlSource        (void) const;
-    virtual QString     prerequisiteSetup       (void) const;
+    QString     name                    (void) const final;
+    QString     description             (void) const final;
+    QString     iconResource            (void) const final;
+    bool        requiresSetup           (void) const final;
+    bool        setupComplete           (void) const final;
+    QUrl        setupSource             (void) const final;
+    QUrl        summaryQmlSource        (void) const final;
+    QString     prerequisiteSetup       (void) const final;
     
 private:
     const QString   _name;

--- a/src/AutoPilotPlugins/APM/APMRadioComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMRadioComponent.cc
@@ -53,7 +53,7 @@ QString APMRadioComponent::description(void) const
 
 QString APMRadioComponent::iconResource(void) const
 {
-    return "/qmlimages/RadioComponentIcon.png";
+    return QStringLiteral("/qmlimages/RadioComponentIcon.png");
 }
 
 bool APMRadioComponent::requiresSetup(void) const
@@ -100,12 +100,12 @@ QStringList APMRadioComponent::setupCompleteChangedTriggerList(void) const
 
 QUrl APMRadioComponent::setupSource(void) const
 {
-    return QUrl::fromUserInput("qrc:/qml/RadioComponent.qml");
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/RadioComponent.qml"));
 }
 
 QUrl APMRadioComponent::summaryQmlSource(void) const
 {
-    return QUrl::fromUserInput("qrc:/qml/APMRadioComponentSummary.qml");
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMRadioComponentSummary.qml"));
 }
 
 QString APMRadioComponent::prerequisiteSetup(void) const

--- a/src/AutoPilotPlugins/APM/APMRadioComponent.h
+++ b/src/AutoPilotPlugins/APM/APMRadioComponent.h
@@ -35,17 +35,17 @@ public:
     APMRadioComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Virtuals from PX4Component
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    QStringList setupCompleteChangedTriggerList(void) const final;
     
     // Virtuals from VehicleComponent
-    virtual QString name(void) const;
-    virtual QString description(void) const;
-    virtual QString iconResource(void) const;
-    virtual bool requiresSetup(void) const;
-    virtual bool setupComplete(void) const;
-    virtual QUrl setupSource(void) const;
-    virtual QUrl summaryQmlSource(void) const;
-    virtual QString prerequisiteSetup(void) const;
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    QUrl setupSource(void) const final;
+    QUrl summaryQmlSource(void) const final;
+    QString prerequisiteSetup(void) const final;
 
 private slots:
     void _triggerChanged(void);

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.cc
@@ -47,7 +47,7 @@ QString APMSafetyComponent::description(void) const
 
 QString APMSafetyComponent::iconResource(void) const
 {
-    return "/qmlimages/SafetyComponentIcon.png";
+    return QStringLiteral("/qmlimages/SafetyComponentIcon.png");
 }
 
 bool APMSafetyComponent::requiresSetup(void) const
@@ -72,7 +72,7 @@ QUrl APMSafetyComponent::setupSource(void) const
 
     switch (_vehicle->vehicleType()) {
         case MAV_TYPE_FIXED_WING:
-            qmlFile = "qrc:/qml/APMSafetyComponentPlane.qml";
+            qmlFile = QStringLiteral("qrc:/qml/APMSafetyComponentPlane.qml");
             break;
         case MAV_TYPE_QUADROTOR:
         case MAV_TYPE_COAXIAL:
@@ -80,13 +80,13 @@ QUrl APMSafetyComponent::setupSource(void) const
         case MAV_TYPE_HEXAROTOR:
         case MAV_TYPE_OCTOROTOR:
         case MAV_TYPE_TRICOPTER:
-            qmlFile = "qrc:/qml/APMSafetyComponentCopter.qml";
+            qmlFile = QStringLiteral("qrc:/qml/APMSafetyComponentCopter.qml");
             break;
         case MAV_TYPE_GROUND_ROVER:
-            qmlFile = "qrc:/qml/APMSafetyComponentRover.qml";
+            qmlFile = QStringLiteral("qrc:/qml/APMSafetyComponentRover.qml");
             break;
         default:
-            qmlFile = "qrc:/qml/APMNotSupported.qml";
+            qmlFile = QStringLiteral("qrc:/qml/APMNotSupported.qml");
             break;
     }
 
@@ -99,7 +99,7 @@ QUrl APMSafetyComponent::summaryQmlSource(void) const
 
     switch (_vehicle->vehicleType()) {
         case MAV_TYPE_FIXED_WING:
-            qmlFile = "qrc:/qml/APMSafetyComponentSummaryPlane.qml";
+            qmlFile = QStringLiteral("qrc:/qml/APMSafetyComponentSummaryPlane.qml");
             break;
         case MAV_TYPE_QUADROTOR:
         case MAV_TYPE_COAXIAL:
@@ -107,13 +107,13 @@ QUrl APMSafetyComponent::summaryQmlSource(void) const
         case MAV_TYPE_HEXAROTOR:
         case MAV_TYPE_OCTOROTOR:
         case MAV_TYPE_TRICOPTER:
-            qmlFile = "qrc:/qml/APMSafetyComponentSummaryCopter.qml";
+            qmlFile = QStringLiteral("qrc:/qml/APMSafetyComponentSummaryCopter.qml");
             break;
         case MAV_TYPE_GROUND_ROVER:
-            qmlFile = "qrc:/qml/APMSafetyComponentSummaryRover.qml";
+            qmlFile = QStringLiteral("qrc:/qml/APMSafetyComponentSummaryRover.qml");
             break;
         default:
-            qmlFile = "qrc:/qml/APMNotSupported.qml";
+            qmlFile = QStringLiteral("qrc:/qml/APMNotSupported.qml");
             break;
     }
 

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.h
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.h
@@ -34,17 +34,17 @@ public:
     APMSafetyComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Virtuals from PX4Component
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    QStringList setupCompleteChangedTriggerList(void) const final;
     
     // Virtuals from VehicleComponent
-    virtual QString name(void) const;
-    virtual QString description(void) const;
-    virtual QString iconResource(void) const;
-    virtual bool requiresSetup(void) const;
-    virtual bool setupComplete(void) const;
-    virtual QUrl setupSource(void) const;
-    virtual QUrl summaryQmlSource(void) const;
-    virtual QString prerequisiteSetup(void) const;
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    QUrl setupSource(void) const final;
+    QUrl summaryQmlSource(void) const final;
+    QString prerequisiteSetup(void) const final;
     
 private:
     const QString   _name;

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.cc
@@ -115,10 +115,10 @@ bool APMSensorsComponent::compassSetupNeeded(void) const
     QStringList devicesIds;
     QStringList rgOffsets[cCompass];
 
-    devicesIds << "COMPASS_DEV_ID" << "COMPASS_DEV_ID2" << "COMPASS_DEV_ID3";
-    rgOffsets[0] << "COMPASS_OFS_X" << "COMPASS_OFS_X" << "COMPASS_OFS_X";
-    rgOffsets[1] << "COMPASS_OFS2_X" << "COMPASS_OFS2_X" << "COMPASS_OFS2_X";
-    rgOffsets[2] << "COMPASS_OFS3_X" << "COMPASS_OFS3_X" << "COMPASS_OFS3_X";
+    devicesIds << QStringLiteral("COMPASS_DEV_ID") << QStringLiteral("COMPASS_DEV_ID2") << QStringLiteral("COMPASS_DEV_ID3");
+    rgOffsets[0] << QStringLiteral("COMPASS_OFS_X") << QStringLiteral("COMPASS_OFS_X") << QStringLiteral("COMPASS_OFS_X");
+    rgOffsets[1] << QStringLiteral("COMPASS_OFS2_X") << QStringLiteral("COMPASS_OFS2_X") << QStringLiteral("COMPASS_OFS2_X");
+    rgOffsets[2] << QStringLiteral("COMPASS_OFS3_X") << QStringLiteral("COMPASS_OFS3_X") << QStringLiteral("COMPASS_OFS3_X");
 
     for (size_t i=0; i<cCompass; i++) {
         if (_autopilot->getParameterFact(FactSystem::defaultComponentId, devicesIds[i])->rawValue().toInt() != 0) {
@@ -141,14 +141,14 @@ bool APMSensorsComponent::accelSetupNeeded(void) const
     QStringList rgOffsets[cAccel];
 
     if (_autopilot->parameterExists(FactSystem::defaultComponentId, "INS_USE")) {
-        insUse << "INS_USE" << "INS_USE2" << "INS_USE3";
-        rgOffsets[0] << "INS_ACCOFFS_X" << "INS_ACCOFFS_Y" << "INS_ACCOFFS_Z";
-        rgOffsets[1] << "INS_ACC2OFFS_X" << "INS_ACC2OFFS_Y" << "INS_ACC2OFFS_Z";
-        rgOffsets[2] << "INS_ACC3OFFS_X" << "INS_ACC3OFFS_Y" << "INS_ACC3OFFS_Z";
+        insUse << QStringLiteral("INS_USE") << QStringLiteral("INS_USE2") << QStringLiteral("INS_USE3");
+        rgOffsets[0] << QStringLiteral("INS_ACCOFFS_X") << QStringLiteral("INS_ACCOFFS_Y") << QStringLiteral("INS_ACCOFFS_Z");
+        rgOffsets[1] << QStringLiteral("INS_ACC2OFFS_X") << QStringLiteral("INS_ACC2OFFS_Y") << QStringLiteral("INS_ACC2OFFS_Z");
+        rgOffsets[2] << QStringLiteral("INS_ACC3OFFS_X") << QStringLiteral("INS_ACC3OFFS_Y") << QStringLiteral("INS_ACC3OFFS_Z");
     } else {
         // For older firmwares which don't support the INS_USE parameter we can't determine which secondary accels are in use.
         // So we just base things off the the first accel.
-        rgOffsets[0] << "INS_ACCOFFS_X" << "INS_ACCOFFS_Y" << "INS_ACCOFFS_Z";
+        rgOffsets[0] << QStringLiteral("INS_ACCOFFS_X") << QStringLiteral("INS_ACCOFFS_Y") << QStringLiteral("INS_ACCOFFS_Z");
     }
 
     for (size_t i=0; i<cAccel; i++) {

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.h
@@ -37,17 +37,17 @@ public:
     bool accelSetupNeeded(void) const;
 
     // Virtuals from APMComponent
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    QStringList setupCompleteChangedTriggerList(void) const final;
     
     // Virtuals from VehicleComponent
-    virtual QString name(void) const;
-    virtual QString description(void) const;
-    virtual QString iconResource(void) const;
-    virtual bool requiresSetup(void) const;
-    virtual bool setupComplete(void) const;
-    virtual QUrl setupSource(void) const;
-    virtual QUrl summaryQmlSource(void) const;
-    virtual QString prerequisiteSetup(void) const;
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    QUrl setupSource(void) const final;
+    QUrl summaryQmlSource(void) const final;
+    QString prerequisiteSetup(void) const final;
     
 private:
     const QString   _name;

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -186,7 +186,7 @@ void APMSensorsComponentController::_stopCalibration(APMSensorsComponentControll
     default:
         // Assume failed
         _hideAllCalAreas();
-        qgcApp()->showMessage("Calibration failed. Calibration log will be displayed.");
+        qgcApp()->showMessage(QStringLiteral("Calibration failed. Calibration log will be displayed."));
         break;
     }
     
@@ -219,11 +219,12 @@ void APMSensorsComponentController::_handleUASTextMessage(int uasId, int compId,
         return;
     }
 
-    if (text.startsWith("PreArm:") || text.startsWith("EKF") || text.startsWith("Arm") || text.startsWith("Initialising")) {
+    if (text.startsWith(QLatin1Literal("PreArm:")) || text.startsWith(QLatin1Literal("EKF"))
+            || text.startsWith(QLatin1Literal("Arm")) || text.startsWith(QLatin1Literal("Initialising"))) {
         return;
     }
 
-    if (text.contains("progress <")) {
+    if (text.contains(QLatin1Literal("progress <"))) {
         QString percent = text.split("<").last().split(">").first();
         bool ok;
         int p = percent.toInt(&ok);
@@ -234,39 +235,39 @@ void APMSensorsComponentController::_handleUASTextMessage(int uasId, int compId,
         return;
     }
 
-    QString anyKey("and press any");
+    QString anyKey(QStringLiteral("and press any"));
     if (text.contains(anyKey)) {
-        text = text.left(text.indexOf(anyKey)) + "and click Next to continue.";
+        text = text.left(text.indexOf(anyKey)) + QStringLiteral("and click Next to continue.");
         _nextButton->setEnabled(true);
     }
 
     _appendStatusLog(text);
     qCDebug(APMSensorsComponentControllerLog) << text << severity;
 
-    if (text.contains("Calibration successful")) {
+    if (text.contains(QLatin1String("Calibration successful"))) {
         _stopCalibration(StopCalibrationSuccess);
         return;
     }
 
-    if (text.contains("FAILED")) {
+    if (text.contains(QLatin1String("FAILED"))) {
         _stopCalibration(StopCalibrationFailed);
         return;
     }
 
     // All calibration messages start with [cal]
-    QString calPrefix("[cal] ");
+    QString calPrefix(QStringLiteral("[cal] "));
     if (!text.startsWith(calPrefix)) {
         return;
     }
     text = text.right(text.length() - calPrefix.length());
 
-    QString calStartPrefix("calibration started: ");
+    QString calStartPrefix(QStringLiteral("calibration started: "));
     if (text.startsWith(calStartPrefix)) {
         text = text.right(text.length() - calStartPrefix.length());
         
         _startVisualCalibration();
         
-        if (text == "accel" || text == "mag" || text == "gyro") {
+        if (text == QLatin1Literal("accel") || text == QLatin1Literal("mag") || text == QLatin1Literal("gyro")) {
             // Reset all progress indication
             _orientationCalDownSideDone = false;
             _orientationCalUpsideDownSideDone = false;
@@ -318,36 +319,36 @@ void APMSensorsComponentController::_handleUASTextMessage(int uasId, int compId,
         return;
     }
     
-    if (text.endsWith("orientation detected")) {
+    if (text.endsWith(QLatin1Literal("orientation detected"))) {
         QString side = text.section(" ", 0, 0);
         qDebug() << "Side started" << side;
         
-        if (side == "down") {
+        if (side == QLatin1Literal("down")) {
             _orientationCalDownSideInProgress = true;
             if (_magCalInProgress) {
                 _orientationCalDownSideRotate = true;
             }
-        } else if (side == "up") {
+        } else if (side == QLatin1Literal("up")) {
             _orientationCalUpsideDownSideInProgress = true;
             if (_magCalInProgress) {
                 _orientationCalUpsideDownSideRotate = true;
             }
-        } else if (side == "left") {
+        } else if (side == QLatin1Literal("left")) {
             _orientationCalLeftSideInProgress = true;
             if (_magCalInProgress) {
                 _orientationCalLeftSideRotate = true;
             }
-        } else if (side == "right") {
+        } else if (side == QLatin1Literal("right")) {
             _orientationCalRightSideInProgress = true;
             if (_magCalInProgress) {
                 _orientationCalRightSideRotate = true;
             }
-        } else if (side == "front") {
+        } else if (side == QLatin1Literal("front")) {
             _orientationCalNoseDownSideInProgress = true;
             if (_magCalInProgress) {
                 _orientationCalNoseDownSideRotate = true;
             }
-        } else if (side == "back") {
+        } else if (side == QLatin1Literal("back")) {
             _orientationCalTailDownSideInProgress = true;
             if (_magCalInProgress) {
                 _orientationCalTailDownSideRotate = true;
@@ -365,31 +366,31 @@ void APMSensorsComponentController::_handleUASTextMessage(int uasId, int compId,
         return;
     }
     
-    if (text.endsWith("side done, rotate to a different side")) {
+    if (text.endsWith(QLatin1Literal("side done, rotate to a different side"))) {
         QString side = text.section(" ", 0, 0);
         qDebug() << "Side finished" << side;
         
-        if (side == "down") {
+        if (side == QLatin1Literal("down")) {
             _orientationCalDownSideInProgress = false;
             _orientationCalDownSideDone = true;
             _orientationCalDownSideRotate = false;
-        } else if (side == "up") {
+        } else if (side == QLatin1Literal("up")) {
             _orientationCalUpsideDownSideInProgress = false;
             _orientationCalUpsideDownSideDone = true;
             _orientationCalUpsideDownSideRotate = false;
-        } else if (side == "left") {
+        } else if (side == QLatin1Literal("left")) {
             _orientationCalLeftSideInProgress = false;
             _orientationCalLeftSideDone = true;
             _orientationCalLeftSideRotate = false;
-        } else if (side == "right") {
+        } else if (side == QLatin1Literal("right")) {
             _orientationCalRightSideInProgress = false;
             _orientationCalRightSideDone = true;
             _orientationCalRightSideRotate = false;
-        } else if (side == "front") {
+        } else if (side == QLatin1Literal("front")) {
             _orientationCalNoseDownSideInProgress = false;
             _orientationCalNoseDownSideDone = true;
             _orientationCalNoseDownSideRotate = false;
-        } else if (side == "back") {
+        } else if (side == QLatin1Literal("back")) {
             _orientationCalTailDownSideInProgress = false;
             _orientationCalTailDownSideDone = true;
             _orientationCalTailDownSideRotate = false;
@@ -403,18 +404,17 @@ void APMSensorsComponentController::_handleUASTextMessage(int uasId, int compId,
         return;
     }
     
-    QString calCompletePrefix("calibration done:");
-    if (text.startsWith(calCompletePrefix)) {
+    if (text.startsWith(QLatin1Literal("calibration done:"))) {
         _stopCalibration(StopCalibrationSuccess);
         return;
     }
 
-    if (text.startsWith("calibration cancelled")) {
+    if (text.startsWith(QLatin1Literal("calibration cancelled"))) {
         _stopCalibration(_waitingForCancel ? StopCalibrationCancelled : StopCalibrationFailed);
         return;
     }
 
-    if (text.startsWith("calibration failed")) {
+    if (text.startsWith(QLatin1Literal("calibration failed"))) {
         _stopCalibration(StopCalibrationFailed);
         return;
     }
@@ -424,15 +424,15 @@ void APMSensorsComponentController::_refreshParams(void)
 {
     QStringList fastRefreshList;
     
-    fastRefreshList << "COMPASS_OFS_X" << "COMPASS_OFS_X" << "COMPASS_OFS_X"
-                    << "INS_ACCOFFS_X" << "INS_ACCOFFS_Y" << "INS_ACCOFFS_Z";
+    fastRefreshList << QStringLiteral("COMPASS_OFS_X") << QStringLiteral("COMPASS_OFS_X") << QStringLiteral("COMPASS_OFS_X")
+                    << QStringLiteral("INS_ACCOFFS_X") << QStringLiteral("INS_ACCOFFS_Y") << QStringLiteral("INS_ACCOFFS_Z");
     foreach (const QString &paramName, fastRefreshList) {
         _autopilot->refreshParameter(FactSystem::defaultComponentId, paramName);
     }
     
     // Now ask for all to refresh
-    _autopilot->refreshParametersPrefix(FactSystem::defaultComponentId, "COMPASS_");
-    _autopilot->refreshParametersPrefix(FactSystem::defaultComponentId, "INS_");
+    _autopilot->refreshParametersPrefix(FactSystem::defaultComponentId, QStringLiteral("COMPASS_"));
+    _autopilot->refreshParametersPrefix(FactSystem::defaultComponentId, QStringLiteral("INS_"));
 }
 
 bool APMSensorsComponentController::fixedWing(void)

--- a/src/AutoPilotPlugins/APM/APMTuningComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMTuningComponent.cc
@@ -73,7 +73,7 @@ QUrl APMTuningComponent::setupSource(void) const
         case MAV_TYPE_OCTOROTOR:
         case MAV_TYPE_TRICOPTER:
             // Older firmwares do not have CH9_OPT, we don't support Tuning on older firmwares
-            if (_autopilot->parameterExists(-1, "CH9_OPT")) {
+            if (_autopilot->parameterExists(-1, QStringLiteral("CH9_OPT"))) {
                 qmlFile = QStringLiteral("qrc:/qml/APMTuningComponentCopter.qml");
             }
             break;

--- a/src/AutoPilotPlugins/APM/APMTuningComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMTuningComponent.cc
@@ -43,7 +43,7 @@ QString APMTuningComponent::description(void) const
 
 QString APMTuningComponent::iconResource(void) const
 {
-    return "/qmlimages/TuningComponentIcon.png";
+    return QStringLiteral("/qmlimages/TuningComponentIcon.png");
 }
 
 bool APMTuningComponent::requiresSetup(void) const
@@ -74,7 +74,7 @@ QUrl APMTuningComponent::setupSource(void) const
         case MAV_TYPE_TRICOPTER:
             // Older firmwares do not have CH9_OPT, we don't support Tuning on older firmwares
             if (_autopilot->parameterExists(-1, "CH9_OPT")) {
-                qmlFile = "qrc:/qml/APMTuningComponentCopter.qml";
+                qmlFile = QStringLiteral("qrc:/qml/APMTuningComponentCopter.qml");
             }
             break;
         default:

--- a/src/AutoPilotPlugins/APM/APMTuningComponent.h
+++ b/src/AutoPilotPlugins/APM/APMTuningComponent.h
@@ -34,17 +34,17 @@ public:
     APMTuningComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Virtuals from PX4Component
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    QStringList setupCompleteChangedTriggerList(void) const final;
     
     // Virtuals from VehicleComponent
-    virtual QString name(void) const;
-    virtual QString description(void) const;
-    virtual QString iconResource(void) const;
-    virtual bool requiresSetup(void) const;
-    virtual bool setupComplete(void) const;
-    virtual QUrl setupSource(void) const;
-    virtual QUrl summaryQmlSource(void) const;
-    virtual QString prerequisiteSetup(void) const;
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    QUrl setupSource(void) const final;
+    QUrl summaryQmlSource(void) const final;
+    QString prerequisiteSetup(void) const final;
     
 private:
     const QString   _name;


### PR DESCRIPTION
A cleaned version of the staled branch: 
- Don't check for null pointers after a new, they won't be null, ever.
- use QStringLiteral / QLatin1Literal when they should be used
- fix some const correctness
- don't create virtual methods on overrides, use 'override' or 'final' keywords when needed.