### PR TITLE
bitwise and, not boolean and, to check for bitmasks.

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -174,7 +174,7 @@ void LinkManager::_addLink(LinkInterface* link)
 
         // Find a mavlink channel to use for this link
         for (int i=0; i<32; i++) {
-            if (!(_mavlinkChannelsUsedBitMask && 1 << i)) {
+            if (!(_mavlinkChannelsUsedBitMask & 1 << i)) {
                 mavlink_reset_channel_status(i);
                 link->_setMavlinkChannel(i);
                 _mavlinkChannelsUsedBitMask |= i << i;


### PR DESCRIPTION
Seems that a typo is preventing a bitwise operation.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>