### PR TITLE
Detect running instance and prevent loading second instance.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -35,6 +35,8 @@ This file is part of the QGROUNDCONTROL project
 
 #include "QGCApplication.h"
 
+#define  SINGLE_INSTANCE_PORT   14499
+
 #ifndef __mobile__
     #include "QGCSerialPortInfo.h"
 #endif
@@ -118,6 +120,16 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
 
 int main(int argc, char *argv[])
 {
+
+#ifndef __mobile__
+    //-- Test for another instance already running. If that's the case, we simply exit.
+    QHostAddress host("127.0.0.1");
+    QUdpSocket socket;
+    if(!socket.bind(host, SINGLE_INSTANCE_PORT, QAbstractSocket::DontShareAddress)) {
+        qWarning() << "Another instance already running. Exiting.";
+        exit(-1);
+    }
+#endif
 
 #ifdef Q_OS_MAC
 #ifndef __ios__


### PR DESCRIPTION
In response to #2524.

Using (arbitrarily chosen) port 14999 to detect instance. Cannot use normal (default) port because that can be changed and there is no simple way to detect it until is too late.