### PR TITLE
SD card delay detection changes

### DIFF
--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -117,29 +117,11 @@ QGCView {
             statusTextArea.append(flashFailText)
             flashCompleteWaitTimer.running = true
         }
-
-        onFlashComplete: flashCompleteWaitTimer.running = true
     }
 
     onCompleted: {
         if (controllerCompleted) {
             // We can only start the board search when the Qml and Controller are completely done loading
-            controller.startBoardSearch()
-        }
-    }
-
-    // After a flash completes we start this timer to trigger resetting the ui back to it's initial state of being ready to
-    // flash another board. We do this only after the timer triggers to leave the results of the previous flash on the screen
-    // for a small amount amount of time.
-
-    Timer {
-        id:         flashCompleteWaitTimer
-        interval:   15000
-
-        onTriggered: {
-            initialBoardSearch = true
-            progressBar.value = 0
-            statusTextArea.append(welcomeText)
             controller.startBoardSearch()
         }
     }

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -864,6 +864,6 @@ void LinkManager::_activeLinkCheck(void)
     }
 
     if (!found) {
-        qgcApp()->showMessage("You have connected to a Vehicle which does not have an SD Card inserted. Please insert an SD card and try again.");
+        qgcApp()->showMessage("Your Vehicle is not responding. If this continues please check that you have an SD Card inserted and try again.");
     }
 }

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -244,9 +244,9 @@ private:
     bool _autoconnect3DRRadio;
     bool _autoconnectPX4Flow;
 
-    QTimer                  _activeLinkCheckTimer;                  // Timer which checks for a vehicle showing up on a usb direct link
-    QList<LinkInterface*>   _activeLinkCheckList;                   // List of links we are waiting for a vehicle to show up on
-    static const int        _activeLinkCheckTimeoutMSecs = 7000;
+    QTimer                  _activeLinkCheckTimer;                  ///< Timer which checks for a vehicle showing up on a usb direct link
+    QList<LinkInterface*>   _activeLinkCheckList;                   ///< List of links we are waiting for a vehicle to show up on
+    static const int        _activeLinkCheckTimeoutMSecs = 10000;   ///< Amount of time to wait for a heatbeat. Keep in mind ArduPilot stack heartbeat is slow to come.
 
     static const char*  _settingsGroup;
     static const char*  _autoconnectUDPKey;


### PR DESCRIPTION
- Timeout was too slow for slower ardupilot boot and and/or cases where boot also needs to flash px4io
- Changed message wording: Your Vehicle is not responding. If this continues please check that you have an SD Card inserted and try again.
- Turn off firmware upgrade restart. Now if you flash, you wll have to leave firwmare upgrade and come back to flash again. The restart was causing problems with slower boots time and stealing port from auto-connect. This would cause intermittent failures of auto-connect after flashing

Fix for #2704