### PR TITLE
Formatting log sizes using locale specific separators.

### DIFF
--- a/src/ViewWidgets/LogDownload.qml
+++ b/src/ViewWidgets/LogDownload.qml
@@ -36,10 +36,6 @@ QGCView {
 
     property real _margins: ScreenTools.defaultFontPixelHeight
 
-    function numberWithCommas(x) {
-        return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",").replace(/,,/g, ",");
-    }
-
     LogDownloadController {
         id:         controller
         factPanel:  panel
@@ -113,7 +109,7 @@ QGCView {
                     horizontalAlignment: Text.AlignRight
                     text: {
                         var o = controller.model.get(styleData.row)
-                        return o ? numberWithCommas(o.size) : ""
+                        return o ? o.sizeStr : ""
                     }
                 }
             }

--- a/src/ViewWidgets/LogDownloadController.cc
+++ b/src/ViewWidgets/LogDownloadController.cc
@@ -39,6 +39,8 @@
 
 QGC_LOGGING_CATEGORY(LogDownloadLog, "LogDownloadLog")
 
+static QLocale kLocale;
+
 //----------------------------------------------------------------------------------------
 LogDownloadData::LogDownloadData(QGCLogEntry* entry_)
     : ID(entry_->id())
@@ -49,7 +51,7 @@ LogDownloadData::LogDownloadData(QGCLogEntry* entry_)
 }
 
 //----------------------------------------------------------------------------------------
-QGCLogEntry:: QGCLogEntry(uint logId, const QDateTime& dateTime, uint logSize, bool received)
+QGCLogEntry::QGCLogEntry(uint logId, const QDateTime& dateTime, uint logSize, bool received)
     : _logID(logId)
     , _logSize(logSize)
     , _logTimeUTC(dateTime)
@@ -57,6 +59,13 @@ QGCLogEntry:: QGCLogEntry(uint logId, const QDateTime& dateTime, uint logSize, b
     , _selected(false)
 {
     _status = "Pending";
+}
+
+//----------------------------------------------------------------------------------------
+QString
+QGCLogEntry::sizeStr() const
+{
+    return kLocale.toString(_logSize);
 }
 
 //----------------------------------------------------------------------------------------
@@ -275,7 +284,8 @@ LogDownloadController::_logData(UASInterface* uas, uint32_t ofs, uint16_t id, ui
             if(_downloadData->file.write((const char*)data, count)) {
                 _downloadData->written += count;
                 //-- Update status
-                _downloadData->entry->setStatus(QString::number(_downloadData->written));
+                QString comma_value = kLocale.toString(_downloadData->written);
+                _downloadData->entry->setStatus(comma_value);
                 result = true;
                 //-- reset retries
                 _retries = 0;

--- a/src/ViewWidgets/LogDownloadController.h
+++ b/src/ViewWidgets/LogDownloadController.h
@@ -27,6 +27,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QAbstractListModel>
+#include <QLocale>
 
 #include <memory>
 
@@ -80,6 +81,7 @@ class QGCLogEntry : public QObject {
     Q_PROPERTY(uint         id          READ id                             CONSTANT)
     Q_PROPERTY(QDateTime    time        READ time                           NOTIFY timeChanged)
     Q_PROPERTY(uint         size        READ size                           NOTIFY sizeChanged)
+    Q_PROPERTY(QString      sizeStr     READ sizeStr                        NOTIFY sizeChanged)
     Q_PROPERTY(bool         received    READ received                       NOTIFY receivedChanged)
     Q_PROPERTY(bool         selected    READ selected   WRITE setSelected   NOTIFY selectedChanged)
     Q_PROPERTY(QString      status      READ status                         NOTIFY statusChanged)
@@ -89,6 +91,7 @@ public:
 
     uint        id          () const { return _logID; }
     uint        size        () const { return _logSize; }
+    QString     sizeStr     () const;
     QDateTime   time        () const { return _logTimeUTC; }
     bool        received    () const { return _received; }
     bool        selected    () const { return _selected; }


### PR DESCRIPTION
This is in response to #2706.
Formatting the log sizes and the downloaded amount using separators.
