### PR TITLE
Adding (optional) link status data to the WiFi Bridge panel.

### DIFF
--- a/src/AutoPilotPlugins/Common/ESP8266Component.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266Component.qml
@@ -24,6 +24,7 @@
 import QtQuick          2.5
 import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.FactSystem    1.0
@@ -42,10 +43,68 @@ QGCView {
     property int                _firstColumn:   ScreenTools.defaultFontPixelWidth * 20
     property int                _secondColumn:  ScreenTools.defaultFontPixelWidth * 12
     readonly property string    dialogTitle:    "controller WiFi Bridge"
+    property int                stStatus:       XMLHttpRequest.UNSENT
+    property int                stErrorCount:   0
+    property bool               stEnabled:      false
+    property bool               stResetCounters: false
 
     ESP8266ComponentController {
         id:             controller
         factPanel:      panel
+    }
+
+    Timer {
+        id: timer
+    }
+
+    function thisThingHasNoNumberLocaleSupport(n) {
+        return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",").replace(",,", ",")
+    }
+
+    function updateStatus() {
+        timer.stop()
+        var req = new XMLHttpRequest;
+        var url = "http://192.168.4.1/status.json"
+        if(stResetCounters) {
+            url = url + "?r=1"
+            stResetCounters = false
+        }
+        req.open("GET", url);
+        req.onreadystatechange = function() {
+            stStatus = req.readyState;
+            if (stStatus === XMLHttpRequest.DONE) {
+                var objectArray = JSON.parse(req.responseText);
+                if (objectArray.errors !== undefined) {
+                    console.log("Error fetching WiFi Bridge Status: " + objectArray.errors[0].message)
+                    stErrorCount = stErrorCount + 1
+                    if(stErrorCount < 2 && stEnabled)
+                        timer.start()
+                } else {
+                    if(stEnabled) {
+                        //-- This should work but it doesn't
+                        //   var n = 34523453.345
+                        //   n.toLocaleString()
+                        //   "34,523,453.345"
+                        vpackets.text   = thisThingHasNoNumberLocaleSupport(objectArray["vpackets"])
+                        vsent.text      = thisThingHasNoNumberLocaleSupport(objectArray["vsent"])
+                        vlost.text      = thisThingHasNoNumberLocaleSupport(objectArray["vlost"])
+                        gpackets.text   = thisThingHasNoNumberLocaleSupport(objectArray["gpackets"])
+                        gsent.text      = thisThingHasNoNumberLocaleSupport(objectArray["gsent"])
+                        glost.text      = thisThingHasNoNumberLocaleSupport(objectArray["glost"])
+                        stErrorCount    = 0
+                        wifiStatus.visible = true
+                        timer.start()
+                    }
+                }
+            }
+        }
+        req.send()
+    }
+
+    Component.onCompleted: {
+        timer.interval = 1000
+        timer.repeat = true
+        timer.triggered.connect(updateStatus)
     }
 
     property Fact wifiChannel:  controller.getParameterFact(controller.componentID, "WIFI_CHANNEL")
@@ -76,97 +135,228 @@ QGCView {
 
                 Rectangle {
                     width:  parent.width
-                    height: wifiCol.height + (ScreenTools.defaultFontPixelHeight * 2)
+                    height: wifiStatus.visible ? Math.max(wifiCol.height, wifiStatus.height) + (ScreenTools.defaultFontPixelHeight * 2) : wifiCol.height + (ScreenTools.defaultFontPixelHeight * 2)
                     color:  palette.windowShade
-                    Column {
-                        id:                 wifiCol
-                        anchors.margins:    ScreenTools.defaultFontPixelHeight / 2
+                    Row {
                         anchors.verticalCenter: parent.verticalCenter
-                        anchors.left:       parent.left
-                        spacing:            ScreenTools.defaultFontPixelHeight / 2
-                        Row {
-                            spacing: ScreenTools.defaultFontPixelWidth
-                            QGCLabel {
-                                text:           "WiFi Channel"
-                                width:          _firstColumn
-                                anchors.baseline: channelField.baseline
+                        spacing: ScreenTools.defaultFontPixelWidth
+                        Rectangle {
+                            height:     parent.height
+                            width:      1
+                            color:      palette.window
+                        }
+                        Column {
+                            id:                 wifiCol
+                            anchors.verticalCenter: parent.verticalCenter
+                            spacing:            ScreenTools.defaultFontPixelHeight / 2
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:           "WiFi Channel"
+                                    width:          _firstColumn
+                                    anchors.baseline: channelField.baseline
+                                }
+                                QGCComboBox {
+                                    id:             channelField
+                                    width:          _secondColumn
+                                    model:          controller.wifiChannels
+                                    currentIndex:   wifiChannel ? wifiChannel.value - 1 : 0
+                                    onActivated: {
+                                        wifiChannel.value = index + 1
+                                    }
+                                }
                             }
-                            QGCComboBox {
-                                id:             channelField
-                                width:          _secondColumn
-                                model:          controller.wifiChannels
-                                currentIndex:   wifiChannel ? wifiChannel.value - 1 : 0
-                                onActivated: {
-                                    wifiChannel.value = index + 1
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:           "WiFi SSID"
+                                    width:          _firstColumn
+                                    anchors.baseline: ssidField.baseline
+                                    }
+                                QGCTextField {
+                                    id:             ssidField
+                                    width:          _secondColumn
+                                    text:           controller.wifiSSID
+                                    maximumLength:  16
+                                    onEditingFinished: {
+                                        controller.wifiSSID = text
+                                    }
+                                }
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:           "WiFi Password"
+                                    width:          _firstColumn
+                                    anchors.baseline: passwordField.baseline
+                                    }
+                                QGCTextField {
+                                    id:             passwordField
+                                    width:          _secondColumn
+                                    text:           controller.wifiPassword
+                                    maximumLength:  16
+                                    onEditingFinished: {
+                                        controller.wifiPassword = text
+                                    }
+                                }
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:           "UART Baud Rate"
+                                    width:          _firstColumn
+                                    anchors.baseline:   baudField.baseline
+                                }
+                                QGCComboBox {
+                                    id:             baudField
+                                    width:          _secondColumn
+                                    model:          controller.baudRates
+                                    currentIndex:   controller.baudIndex
+                                    onActivated: {
+                                        controller.baudIndex = index
+                                    }
+                                }
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:           "QGC UDP Port"
+                                    width:          _firstColumn
+                                    anchors.baseline: qgcportField.baseline
+                                }
+                                QGCTextField {
+                                    id:             qgcportField
+                                    width:          _secondColumn
+                                    text:           hostPort ? hostPort.valueString : ""
+                                    validator:      IntValidator {bottom: 1024; top: 65535;}
+                                    inputMethodHints: Qt.ImhDigitsOnly
+                                    onEditingFinished: {
+                                        hostPort.value = text
+                                    }
                                 }
                             }
                         }
-                        Row {
-                            spacing: ScreenTools.defaultFontPixelWidth
-                            QGCLabel {
-                                text:           "WiFi SSID"
-                                width:          _firstColumn
-                                anchors.baseline: ssidField.baseline
-                                }
-                            QGCTextField {
-                                id:             ssidField
-                                width:          _secondColumn
-                                text:           controller.wifiSSID
-                                maximumLength:  16
-                                onEditingFinished: {
-                                    controller.wifiSSID = text
-                                }
-                            }
+                        Rectangle {
+                            height:         parent.height
+                            width:          1
+                            color:          palette.text
+                            visible:        wifiStatus.visible
                         }
-                        Row {
-                            spacing: ScreenTools.defaultFontPixelWidth
+                        Column {
+                            id:                 wifiStatus
+                            anchors.margins:    ScreenTools.defaultFontPixelHeight / 2
+                            spacing:            ScreenTools.defaultFontPixelHeight / 2
+                            visible:            false
                             QGCLabel {
-                                text:           "WiFi Password"
-                                width:          _firstColumn
-                                anchors.baseline: passwordField.baseline
-                                }
-                            QGCTextField {
-                                id:             passwordField
-                                width:          _secondColumn
-                                text:           controller.wifiPassword
-                                maximumLength:  16
-                                onEditingFinished: {
-                                    controller.wifiPassword = text
-                                }
+                                text:           "Bridge/Vehicle Link"
+                                font.weight:    Font.DemiBold
                             }
-                        }
-                        Row {
-                            spacing: ScreenTools.defaultFontPixelWidth
-                            QGCLabel {
-                                text:           "UART Baud Rate"
-                                width:          _firstColumn
-                                anchors.baseline:   baudField.baseline
-                            }
-                            QGCComboBox {
-                                id:             baudField
-                                width:          _secondColumn
-                                model:          controller.baudRates
-                                currentIndex:   controller.baudIndex
-                                onActivated: {
-                                    controller.baudIndex = index
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Received"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    id:         vpackets
                                 }
                             }
-                        }
-                        Row {
-                            spacing: ScreenTools.defaultFontPixelWidth
-                            QGCLabel {
-                                text:           "QGC UDP Port"
-                                width:          _firstColumn
-                                anchors.baseline: qgcportField.baseline
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Lost"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    id:         vlost
+                                }
                             }
-                            QGCTextField {
-                                id:             qgcportField
-                                width:          _secondColumn
-                                text:           hostPort ? hostPort.valueString : ""
-                                validator:      IntValidator {bottom: 1024; top: 65535;}
-                                inputMethodHints: Qt.ImhDigitsOnly
-                                onEditingFinished: {
-                                    hostPort.value = text
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Sent"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    id:         vsent
+                                }
+                            }
+                            Rectangle {
+                                height:         1
+                                width:          parent.width
+                                color:          palette.text
+                            }
+                            QGCLabel {
+                                text:           "Bridge/QGC Link"
+                                font.weight:    Font.DemiBold
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Received"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    id:         gpackets
+                                }
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Lost"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    id:         glost
+                                }
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Sent"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    id:         gsent
+                                }
+                            }
+                            Rectangle {
+                                height:         1
+                                width:          parent.width
+                                color:          palette.text
+                            }
+                            QGCLabel {
+                                text:           "QGC/Bridge Link"
+                                font.weight:    Font.DemiBold
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Received"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    text:       controller.vehicle ? thisThingHasNoNumberLocaleSupport(controller.vehicle.messagesReceived) : 0
+                                }
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Lost"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    text:       controller.vehicle ? thisThingHasNoNumberLocaleSupport(controller.vehicle.messagesLost) : 0
+                                }
+                            }
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                QGCLabel {
+                                    text:       "Messages Sent"
+                                    width:      _firstColumn
+                                }
+                                QGCLabel {
+                                    text:       controller.vehicle ? thisThingHasNoNumberLocaleSupport(controller.vehicle.messagesSent) : 0
                                 }
                             }
                         }
@@ -202,6 +392,31 @@ QGCView {
                             onNo: {
                                 rebootDialog.visible = false
                             }
+                        }
+                    }
+                    QGCButton {
+                        text:   stEnabled ? "Hide Status" : "Show Status"
+                        width:  ScreenTools.defaultFontPixelWidth * 16
+                        onClicked: {
+                            stEnabled = !stEnabled
+                            if(stEnabled)
+                                updateStatus()
+                            else {
+                                wifiStatus.visible = false
+                                timer.stop()
+                            }
+                        }
+                    }
+                    QGCButton {
+                        text:       "Reset Counters"
+                        visible:    stEnabled
+                        enabled:    stEnabled
+                        width:      ScreenTools.defaultFontPixelWidth * 16
+                        onClicked: {
+                            stResetCounters = true;
+                            updateStatus()
+                            if(controller.vehicle)
+                                controller.vehicle.resetCounters()
                         }
                     }
                 }

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
@@ -58,9 +58,10 @@ public:
     Q_PROPERTY(QStringList      baudRates       READ baudRates                              CONSTANT)
     Q_PROPERTY(int              baudIndex       READ baudIndex      WRITE setBaudIndex      NOTIFY baudIndexChanged)
     Q_PROPERTY(bool             busy            READ busy                                   NOTIFY busyChanged)
+    Q_PROPERTY(Vehicle*         vehicle         READ vehicle        CONSTANT)
 
     Q_INVOKABLE void restoreDefaults();
-    Q_INVOKABLE void reboot();
+    Q_INVOKABLE void reboot         ();
 
     int             componentID     () { return MAV_COMP_ID_UDP_BRIDGE; }
     QString         version         ();
@@ -70,6 +71,7 @@ public:
     QStringList     baudRates       () { return _baudRates; }
     int             baudIndex       ();
     bool            busy            () { return _waitType != WAIT_FOR_NOTHING; }
+    Vehicle*        vehicle         () { return _vehicle; }
 
     void        setWifiSSID         (QString id);
     void        setWifiPassword     (QString pwd);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -119,6 +119,12 @@ public:
     Q_PROPERTY(bool                 genericFirmware         READ genericFirmware                        CONSTANT)
     Q_PROPERTY(bool                 connectionLost          READ connectionLost                         NOTIFY connectionLostChanged)
     Q_PROPERTY(bool                 connectionLostEnabled   READ connectionLostEnabled  WRITE setConnectionLostEnabled NOTIFY connectionLostEnabledChanged)
+    Q_PROPERTY(uint                 messagesReceived        READ messagesReceived                       NOTIFY messagesReceivedChanged)
+    Q_PROPERTY(uint                 messagesSent            READ messagesSent                           NOTIFY messagesSentChanged)
+    Q_PROPERTY(uint                 messagesLost            READ messagesLost                           NOTIFY messagesLostChanged)
+
+    /// Resets link status counters
+    Q_INVOKABLE void resetCounters  ();
 
     /// Returns the number of buttons which are reserved for firmware use in the MANUAL_CONTROL mavlink
     /// message. For example PX4 Flight Stack reserves the first 8 buttons to simulate rc switches.
@@ -275,6 +281,9 @@ public:
     bool            genericFirmware     () { return !px4Firmware() && !apmFirmware(); }
     bool            connectionLost      () const { return _connectionLost; }
     bool            connectionLostEnabled() const { return _connectionLostEnabled; }
+    uint            messagesReceived    () { return _messagesReceived; }
+    uint            messagesSent        () { return _messagesSent; }
+    uint            messagesLost        () { return _messagesLost; }
 
     void setConnectionLostEnabled(bool connectionLostEnabled);
 
@@ -304,6 +313,10 @@ signals:
     void missingParametersChanged(bool missingParameters);
     void connectionLostChanged(bool connectionLost);
     void connectionLostEnabledChanged(bool connectionLostEnabled);
+
+    void messagesReceivedChanged    ();
+    void messagesSentChanged        ();
+    void messagesLostChanged        ();
 
     /// Used internally to move sendMessage call to main thread
     void _sendMessageOnThread(mavlink_message_t message);
@@ -505,6 +518,13 @@ private:
     int                         _flowImageIndex;
 
     bool _allLinksInactiveSent; ///< true: allLinkInactive signal already sent one time
+
+    uint                _messagesReceived;
+    uint                _messagesSent;
+    uint                _messagesLost;
+    uint8_t             _messageSeq;
+    uint8_t             _compID;
+    bool                _heardFrom;
 
     // Settings keys
     static const char* _settingsGroup;


### PR DESCRIPTION
This is optional. You need to click the *Show Status* button to enable it. Data is collected from the WiFi bridge using dynamic json requests as well as directly from QGC's link. This way we can identify where the errors are occurring. In the case below, the errors are at the QGC's UDP receiving end.

*Reset Counters* allows you to synchronize the counters. Each new session of either end will start with 0s, making the end that continues to run to continue *counting*.

![screen shot 2016-02-03 at 11 19 31 pm](https://cloud.githubusercontent.com/assets/749243/12805863/03e5d80e-cace-11e5-945f-807dc150a037.png)
P.S. The message counts don't match because the QGC data is in real time while the Bridge data comes in 1Hz Query/Response interval.
