### PR TITLE
Improvements to Log Downloading

### DIFF
--- a/src/ViewWidgets/LogDownloadController.h
+++ b/src/ViewWidgets/LogDownloadController.h
@@ -125,13 +125,13 @@ private:
 //-----------------------------------------------------------------------------
 struct LogDownloadData {
     LogDownloadData(QGCLogEntry* entry);
-    QMap<uint32_t, uint32_t> gaps;
-    QFile                    file;
-    QString                  filename;
-    uint                     ID;
-    QGCLogEntry*             entry;
-    uint                     written;
-    QElapsedTimer            elapsed;
+    QHash<uint32_t, uint32_t> gaps;
+    QFile                     file;
+    QString                   filename;
+    uint                      ID;
+    QGCLogEntry*              entry;
+    uint                      written;
+    QElapsedTimer             elapsed;
 };
 
 //-----------------------------------------------------------------------------

--- a/src/ViewWidgets/LogDownloadController.h
+++ b/src/ViewWidgets/LogDownloadController.h
@@ -123,18 +123,6 @@ private:
 };
 
 //-----------------------------------------------------------------------------
-struct LogDownloadData {
-    LogDownloadData(QGCLogEntry* entry);
-    QHash<uint32_t, uint32_t> gaps;
-    QFile                     file;
-    QString                   filename;
-    uint                      ID;
-    QGCLogEntry*              entry;
-    uint                      written;
-    QElapsedTimer             elapsed;
-};
-
-//-----------------------------------------------------------------------------
 class LogDownloadController : public FactPanelController
 {
     Q_OBJECT
@@ -170,7 +158,8 @@ private slots:
 private:
 
     bool _entriesComplete   ();
-    bool _logComplete       ();
+    bool _chunkComplete     () const;
+    bool _logComplete       () const;
     void _findMissingEntries();
     void _receivedAllEntries();
     void _receivedAllData   ();

--- a/src/ViewWidgets/LogDownloadController.h
+++ b/src/ViewWidgets/LogDownloadController.h
@@ -28,6 +28,7 @@
 #include <QTimer>
 #include <QAbstractListModel>
 #include <QLocale>
+#include <QElapsedTimer>
 
 #include <memory>
 
@@ -39,7 +40,7 @@ class  MultiVehicleManager;
 class  UASInterface;
 class  Vehicle;
 class  QGCLogEntry;
-class  LogDownloadData;
+struct LogDownloadData;
 
 Q_DECLARE_LOGGING_CATEGORY(LogDownloadLog)
 
@@ -122,16 +123,15 @@ private:
 };
 
 //-----------------------------------------------------------------------------
-class LogDownloadData {
-public:
+struct LogDownloadData {
     LogDownloadData(QGCLogEntry* entry);
-    QList<uint>     offsets;
-    QFile           file;
-    QString         filename;
-    uint            ID;
-    QTimer          processDataTimer;
-    QGCLogEntry*    entry;
-    uint            written;
+    QMap<uint32_t, uint32_t> gaps;
+    QFile                    file;
+    QString                  filename;
+    uint                     ID;
+    QGCLogEntry*             entry;
+    uint                     written;
+    QElapsedTimer            elapsed;
 };
 
 //-----------------------------------------------------------------------------

--- a/src/ui/MAVLinkDecoder.cc
+++ b/src/ui/MAVLinkDecoder.cc
@@ -37,6 +37,7 @@ MAVLinkDecoder::MAVLinkDecoder(MAVLinkProtocol* protocol, QObject *parent) :
     messageFilter.insert(MAVLINK_MSG_ID_DATA_STREAM, false);
     messageFilter.insert(MAVLINK_MSG_ID_GPS_STATUS, false);
     messageFilter.insert(MAVLINK_MSG_ID_RC_CHANNELS_RAW, false);
+    messageFilter.insert(MAVLINK_MSG_ID_LOG_DATA, false);
     #ifdef MAVLINK_MSG_ID_ENCAPSULATED_DATA
     messageFilter.insert(MAVLINK_MSG_ID_ENCAPSULATED_DATA, false);
     #endif


### PR DESCRIPTION
The LogDownloadController had a gap handling mechanism that was not very efficient (particularly with large log files). This map-based approach should improve things considerably for large files.

Additionally the MavlinkDecoder was assaulting the UI thread with updates from the LOG_DATA mavlink messages, so we've gone ahead and filtered that out. 

I have tested with a couple of log files and some simulated dropped packets and things seem to be working normally. Hash checks matched on the downloaded files vs. straight from the SD card. Unfortunately small sparsely spaced gaps are slow to finish up because the timeout has to occur after every segment.

I wouldn't mind a bit more testing and feedback though.