### PR TITLE
Add Error Message when FW is not found on Server.

### DIFF
--- a/src/QGCFileDownload.cc
+++ b/src/QGCFileDownload.cc
@@ -121,6 +121,10 @@ void QGCFileDownload::_downloadError(QNetworkReply::NetworkError code)
     
     if (code == QNetworkReply::OperationCanceledError) {
         errorMsg = "Download cancelled";
+
+    } else if (code == QNetworkReply::ContentNotFoundError) {
+        errorMsg = "Error: File Not Found";
+
     } else {
         errorMsg = QString("Error during download. Error: %1").arg(code);
     }

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -575,10 +575,30 @@ void FirmwareUpgradeController::_downloadError(QNetworkReply::NetworkError code)
     
     if (code == QNetworkReply::OperationCanceledError) {
         errorMsg = "Download cancelled";
+
+    } else if (code == QNetworkReply::ContentNotFoundError) {
+        errorMsg = QString("Error: File Not Found. Please check %1 firmware version is available.")
+                      .arg(firmwareTypeAsString(_selectedFirmwareType));
+
     } else {
         errorMsg = QString("Error during download. Error: %1").arg(code);
     }
     _errorCancel(errorMsg);
+}
+
+/// @brief returns firmware type as a string
+QString FirmwareUpgradeController::firmwareTypeAsString(FirmwareType_t type) const
+{
+    switch (type) {
+    case StableFirmware:
+        return "stable";
+    case DeveloperFirmware:
+        return "developer";
+    case BetaFirmware:
+        return "beta";
+    default:
+        return "custom";
+    }
 }
 
 /// @brief Signals completion of one of the specified bootloader commands. Moves the state machine to the

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -208,6 +208,8 @@ void FirmwareUpgradeController::_initFirmwareHash()
         { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/px4fmu-v4_default.px4"},
         { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/px4fmu-v4_default.px4"},
         { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v4_default.px4"},
+        { AutoPilotStackAPM, StableFirmware,    QuadFirmware,           "http://firmware.diydrones.com/Copter/stable/PX4-quad/ArduCopter-v4.px4"},
+        { AutoPilotStackAPM, BetaFirmware,      QuadFirmware,           "http://firmware.diydrones.com/Copter/beta/PX4-quad/ArduCopter-v4.px4"},
         { AutoPilotStackAPM, DeveloperFirmware, QuadFirmware,           "http://firmware.diydrones.com/Copter/latest/PX4-quad/ArduCopter-v4.px4"}
     };
 

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -147,9 +147,10 @@ public:
 
     FirmwareType_t selectedFirmwareType(void) { return _selectedFirmwareType; }
     void setSelectedFirmwareType(FirmwareType_t firmwareType);
+    QString firmwareTypeAsString(FirmwareType_t type) const;
 
     QStringList apmAvailableVersions(void);
-    
+
 signals:
     void boardFound(void);
     void noBoardFound(void);


### PR DESCRIPTION
This change will display a message to a the user when a FW image is not found as

`Error: File Not Found. Please check beta firmware version is available`
`Error: File Not Found. Please check developer firmware version is available`
`Error: File Not Found. Please check stable firmware version is available`
etc..

ie.

```
QGroundControl can upgrade the firmware on Pixhawk devices, 3DR Radios and PX4 Flow Smart Cameras.
All QGroundControl connections to vehicles must be disconnected prior to firmware upgrade.
Please unplug your Pixhawk and/or Radio from USB.
Plug in your device via USB to start firmware upgrade. 
Found device: Pixhawk
Connected to bootloader:
Version: 5
Board ID: 11
Flash size: 2080768
Downloading firmware...
From: http://firmware.diydrones.com/Copter/beta/PX4-quad/ArduCopter-v4.px4
Error: File Not Found. Please check beta firmware version is available.
Upgrade cancelled
------------------------------------------
If upgrade failed, make sure to connect directly to a powered USB port on your computer, not through a USB hub. Also make sure you are only powered via USB not battery.
Download complete
```