### PR TITLE
ArduPilot takeoff mission command does not specify coordinate

### DIFF
--- a/src/FirmwarePlugin/APM/MavCmdInfoFixedWing.json
+++ b/src/FirmwarePlugin/APM/MavCmdInfoFixedWing.json
@@ -7,7 +7,7 @@
             "rawName":              "MAV_CMD_NAV_TAKEOFF",
             "friendlyName":         "Takeoff",
             "description":          "Take off from the ground.",
-            "specifiesCoordinate":  true,
+            "specifiesCoordinate":  false,
             "friendlyEdit":         true,
             "category":             "Basic",
             "param1": {

--- a/src/FirmwarePlugin/APM/MavCmdInfoMultiRotor.json
+++ b/src/FirmwarePlugin/APM/MavCmdInfoMultiRotor.json
@@ -7,7 +7,7 @@
             "rawName":              "MAV_CMD_NAV_TAKEOFF",
             "friendlyName":         "Takeoff",
             "description":          "Take off from the ground.",
-            "specifiesCoordinate":  true,
+            "specifiesCoordinate":  false,
             "friendlyEdit":         true,
             "category":             "Basic"
         },

--- a/src/MissionManager/MissionControllerTest.cc
+++ b/src/MissionManager/MissionControllerTest.cc
@@ -191,7 +191,7 @@ void MissionControllerTest::_testAddWaypointWorker(MAV_AUTOPILOT firmwareType)
     QVERIFY(item);
 
     QCOMPARE(item->command(), MavlinkQmlSingleton::MAV_CMD_NAV_TAKEOFF);
-    QCOMPARE(homeItem->childItems()->count(), 0);
+    QCOMPARE(homeItem->childItems()->count(), firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA ? 1 : 0);
     QCOMPARE(item->childItems()->count(), 0);
 
     int expectedLineCount;

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -799,29 +799,24 @@ void MockLink::setMissionItemFailureMode(MockLinkMissionItemHandler::FailureMode
 
 void MockLink::_sendHomePosition(void)
 {
-    // APM stack does not yet support HOME_POSITION
+    mavlink_message_t msg;
 
-    if (_firmwareType != MAV_AUTOPILOT_ARDUPILOTMEGA) {
+    float bogus[4];
+    bogus[0] = 0.0f;
+    bogus[1] = 0.0f;
+    bogus[2] = 0.0f;
+    bogus[3] = 0.0f;
 
-        mavlink_message_t msg;
-
-        float bogus[4];
-        bogus[0] = 0.0f;
-        bogus[1] = 0.0f;
-        bogus[2] = 0.0f;
-        bogus[3] = 0.0f;
-
-        mavlink_msg_home_position_pack(_vehicleSystemId,
-                                       _vehicleComponentId,
-                                       &msg,
-                                       (int32_t)(_vehicleLatitude * 1E7),
-                                       (int32_t)(_vehicleLongitude * 1E7),
-                                       (int32_t)(_vehicleAltitude * 1000),
-                                       0.0f, 0.0f, 0.0f,
-                                       &bogus[0],
-                                       0.0f, 0.0f, 0.0f);
-        respondWithMavlinkMessage(msg);
-    }
+    mavlink_msg_home_position_pack(_vehicleSystemId,
+                                   _vehicleComponentId,
+                                   &msg,
+                                   (int32_t)(_vehicleLatitude * 1E7),
+                                   (int32_t)(_vehicleLongitude * 1E7),
+                                   (int32_t)(_vehicleAltitude * 1000),
+                                   0.0f, 0.0f, 0.0f,
+                                   &bogus[0],
+            0.0f, 0.0f, 0.0f);
+    respondWithMavlinkMessage(msg);
 }
 
 void MockLink::_sendGpsRawInt(void)


### PR DESCRIPTION
Fix for Issue #2699. Use new command override mechanism to fix it.