### PR TITLE
Flash auto-disconnect from vehicle

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -97,6 +97,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _updateCount(0)
     , _rcRSSI(0)
     , _rcRSSIstore(100.0)
+    , _autoDisconnect(false)
     , _connectionLost(false)
     , _connectionLostEnabled(true)
     , _missionManager(NULL)
@@ -1316,6 +1317,9 @@ void Vehicle::_connectionLostTimeout(void)
         _heardFrom = false;
         emit connectionLostChanged(true);
         _say(QString("connection lost to vehicle %1").arg(id()), GAudioOutput::AUDIO_SEVERITY_NOTICE);
+        if (_autoDisconnect) {
+            disconnectInactiveVehicle();
+        }
     }
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -124,6 +124,7 @@ public:
     Q_PROPERTY(uint                 messagesLost            READ messagesLost                           NOTIFY messagesLostChanged)
     Q_PROPERTY(bool                 fixedWing               READ fixedWing                              CONSTANT)
     Q_PROPERTY(bool                 multiRotor              READ multiRotor                             CONSTANT)
+    Q_PROPERTY(bool                 autoDisconnect          MEMBER _autoDisconnect                      NOTIFY autoDisconnectChanged)
 
     /// Resets link status counters
     Q_INVOKABLE void resetCounters  ();
@@ -318,6 +319,7 @@ signals:
     void missingParametersChanged(bool missingParameters);
     void connectionLostChanged(bool connectionLost);
     void connectionLostEnabledChanged(bool connectionLostEnabled);
+    void autoDisconnectChanged(bool autoDisconnectChanged);
 
     void messagesReceivedChanged    ();
     void messagesSentChanged        ();
@@ -480,6 +482,7 @@ private:
     QString         _formatedMessage;
     int             _rcRSSI;
     double          _rcRSSIstore;
+    bool            _autoDisconnect;    ///< true: Automatically disconnect vehicle when last connection goes away or lost heartbeat
 
     // Lost connection handling
     bool                _connectionLost;

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -43,7 +43,7 @@ QGCView {
     readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
     readonly property string highlightSuffix:   "</font>"
     readonly property string welcomeText:       "QGroundControl can upgrade the firmware on Pixhawk devices, 3DR Radios and PX4 Flow Smart Cameras."
-    readonly property string plugInText:        highlightPrefix + "Plug in your device" + highlightSuffix + " via USB to " + highlightPrefix + "start" + highlightSuffix + " firmware upgrade. "
+    readonly property string plugInText:        "<big>" + highlightPrefix + "Plug in your device" + highlightSuffix + " via USB to " + highlightPrefix + "start" + highlightSuffix + " firmware upgrade.</big>"
     readonly property string flashFailText:     "If upgrade failed, make sure to connect " + highlightPrefix + "directly" + highlightSuffix + " to a powered USB port on your computer, not through a USB hub. " +
                                                 "Also make sure you are only powered via USB " + highlightPrefix + "not battery" + highlightSuffix + "."
     readonly property string qgcUnplugText1:    "All QGroundControl connections to vehicles must be " + highlightPrefix + " disconnected " + highlightSuffix + "prior to firmware upgrade."
@@ -58,7 +58,6 @@ QGCView {
         statusTextArea.append(highlightPrefix + "Upgrade cancelled" + highlightSuffix)
         statusTextArea.append("------------------------------------------")
         controller.cancel()
-        flashCompleteWaitTimer.running = true
     }
 
     QGCPalette { id: qgcPal; colorGroupEnabled: panel.enabled }
@@ -103,6 +102,7 @@ QGCView {
                 // Board was found right away, so something is already plugged in before we've started upgrade
                 statusTextArea.append(qgcUnplugText1)
                 statusTextArea.append(qgcUnplugText2)
+                multiVehicleManager.activeVehicle.autoDisconnect = true
             } else {
                 // We end up here when we detect a board plugged in after we've started upgrade
                 statusTextArea.append(highlightPrefix + "Found device" + highlightSuffix + ": " + controller.boardType)
@@ -115,7 +115,6 @@ QGCView {
         onError: {
             hideDialog()
             statusTextArea.append(flashFailText)
-            flashCompleteWaitTimer.running = true
         }
     }
 
@@ -151,8 +150,8 @@ QGCView {
             }
 
             function reject() {
-                cancelFlash()
                 hideDialog()
+                cancelFlash()
             }
 
             ExclusiveGroup {


### PR DESCRIPTION
- Add Vehicle::autoDisconnect property. Set to true and Vehicle will automatically disconnect when it loses heartbeat
- When firmware upgrade asks to unplug board set autoDisconnect=true to improve usability flow. User no longer needs to click Disconnect for thing to proceed.
- Fix broken property in Qml which was preventing cancel from closing dialog

Fix for Issue #2770, #2695

Note that this was a simpler usability than a full firmware upgrade rewrite. A full upgrade re-write is still likely needed for even better usabilty and OTA upgrade. But that can now wait until 3.1