### PR TITLE
Add support for load/save mission on tablet

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -92,8 +92,20 @@ QGCView {
     }
 
     function loadFromFile() {
-        controller.loadMissionFromFile()
-        fitViewportToMissionItems()
+        if (ScreenTools.isMobile) {
+            _root.showDialog(mobileFilePicker, "Select Mission File", _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
+        } else {
+            controller.loadMissionFromFile()
+            fitViewportToMissionItems()
+        }
+    }
+
+    function saveToFile() {
+        if (ScreenTools.isMobile) {
+            _root.showDialog(mobileFileSaver, "Save Mission File", _root.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel)
+        } else {
+            controller.saveToFile()
+        }
     }
 
     function normalizeLat(lat) {
@@ -174,6 +186,56 @@ QGCView {
     }
 
     property int _moveDialogMissionItemIndex
+
+    Component {
+        id: mobileFilePicker
+
+        QGCViewDialog {
+            ListView {
+                anchors.margins:    _margin
+                anchors.fill:       parent
+                spacing:            _margin / 2
+                orientation:    ListView.Vertical
+                model: controller.getMobileMissionFiles()
+
+                delegate: QGCButton {
+                    text: modelData
+
+                    onClicked: {
+                        hideDialog()
+                        controller.loadMobileMissionFromFile(modelData)
+                        fitViewportToMissionItems()
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: mobileFileSaver
+
+        QGCViewDialog {
+            function accept() {
+                hideDialog()
+                console.log(filenameTextField.text)
+                controller.saveMobileMissionToFile(filenameTextField.text)
+            }
+
+            Column {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        ScreenTools.defaultFontPixelHeight
+
+                QGCLabel {
+                    text: "File name:"
+                }
+
+                QGCTextField {
+                    id: filenameTextField
+                }
+            }
+        }
+    }
 
     Component {
         id: moveDialog
@@ -655,14 +717,13 @@ QGCView {
 
             Row {
                 spacing: ScreenTools.defaultFontPixelWidth
-                visible: !ScreenTools.isMobile
 
                 QGCButton {
                     text:       "Save to file..."
 
                     onClicked: {
                         syncButton.hideDropDown()
-                        controller.saveMissionToFile()
+                        saveToFile()
                     }
                 }
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -412,7 +412,7 @@ void MissionController::saveMissionToFile(void)
     if (filename.isEmpty()) {
         return;
     }
-    saveMissionToFile(filename);
+    _saveMissionToFile(filename);
 #endif
 }
 
@@ -424,7 +424,7 @@ void MissionController::saveMobileMissionToFile(const QString& filename)
         return;
     }
 
-    _saveMissionToFile(docDirs.at(0) + QDir::separator() + missionFilename);
+    _saveMissionToFile(docDirs.at(0) + QDir::separator() + filename);
 }
 
 void MissionController::loadMobileMissionFromFile(const QString& filename)

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -184,7 +184,6 @@ void MissionController::removeAllMissionItems(void)
     }
 }
 
-#ifndef __mobile__
 bool MissionController::_loadJsonMissionFile(const QByteArray& bytes, QmlObjectListModel* missionItems, QString& errorString)
 {
     QJsonParseError jsonParseError;
@@ -242,9 +241,7 @@ bool MissionController::_loadJsonMissionFile(const QByteArray& bytes, QmlObjectL
 
     return true;
 }
-#endif
 
-#ifndef __mobile__
 bool MissionController::_loadTextMissionFile(QTextStream& stream, QmlObjectListModel* missionItems, QString& errorString)
 {
     bool addPlannedHomePosition = false;
@@ -295,13 +292,10 @@ bool MissionController::_loadTextMissionFile(QTextStream& stream, QmlObjectListM
 
     return true;
 }
-#endif
 
-void MissionController::loadMissionFromFile(void)
+void MissionController::_loadMissionFromFile(const QString& filename)
 {
-#ifndef __mobile__
     QString errorString;
-    QString filename = QGCFileDialog::getOpenFileName(NULL, "Select Mission File to load", QString(), "Mission file (*.mission);;All Files (*.*)");
 
     if (filename.isEmpty()) {
         return;
@@ -342,23 +336,34 @@ void MissionController::loadMissionFromFile(void)
     }
 
     _initAllMissionItems();
+}
+
+void MissionController::loadMissionFromFile(void)
+{
+#ifndef __mobile__
+    QString filename = QGCFileDialog::getOpenFileName(NULL, "Select Mission File to load", QString(), "Mission file (*.mission);;All Files (*.*)");
+
+    if (filename.isEmpty()) {
+        return;
+    }
+    _loadMissionFromFile(filename);
 #endif
 }
 
-void MissionController::saveMissionToFile(void)
+void MissionController::_saveMissionToFile(const QString& filename)
 {
-#ifndef __mobile__
-    QString filename = QGCFileDialog::getSaveFileName(NULL, "Select file to save mission to", QString(), "Mission file (*.mission);;All Files (*.*)");
+    qDebug() << filename;
 
     if (filename.isEmpty()) {
         return;
     }
 
+    QString missionFilename = filename;
     if (!QFileInfo(filename).fileName().contains(".")) {
-        filename += ".mission";
+        missionFilename += ".mission";
     }
 
-    QFile file(filename);
+    QFile file(missionFilename);
 
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         qgcApp()->showMessage(file.errorString());
@@ -397,7 +402,39 @@ void MissionController::saveMissionToFile(void)
     }
 
     _missionItems->setDirty(false);
+}
+
+void MissionController::saveMissionToFile(void)
+{
+#ifndef __mobile__
+    QString filename = QGCFileDialog::getSaveFileName(NULL, "Select file to save mission to", QString(), "Mission file (*.mission);;All Files (*.*)");
+
+    if (filename.isEmpty()) {
+        return;
+    }
+    saveMissionToFile(filename);
 #endif
+}
+
+void MissionController::saveMobileMissionToFile(const QString& filename)
+{
+    QStringList docDirs = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
+    if (docDirs.count() <= 0) {
+        qWarning() << "No Documents location";
+        return;
+    }
+
+    _saveMissionToFile(docDirs.at(0) + QDir::separator() + missionFilename);
+}
+
+void MissionController::loadMobileMissionFromFile(const QString& filename)
+{
+    QStringList docDirs = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
+    if (docDirs.count() <= 0) {
+        qWarning() << "No Documents location";
+        return;
+    }
+    _loadMissionFromFile(docDirs.at(0) + QDir::separator() + filename);
 }
 
 void MissionController::_calcPrevWaypointValues(double homeAlt, MissionItem* currentItem, MissionItem* prevItem, double* azimuth, double* distance, double* altDifference)
@@ -833,4 +870,24 @@ void MissionController::_currentMissionItemChanged(int sequenceNumber)
             item->setIsCurrentItem(item->sequenceNumber() == sequenceNumber);
         }
     }
+}
+
+QStringList MissionController::getMobileMissionFiles(void)
+{
+    QStringList missionFiles;
+
+    QStringList docDirs = QStandardPaths::standardLocations(QStandardPaths::DocumentsLocation);
+    if (docDirs.count() <= 0) {
+        qWarning() << "No Documents location";
+        return QStringList();
+    }
+    QDir missionDir = docDirs.at(0);
+
+    QFileInfoList missionFileInfoList = missionDir.entryInfoList(QStringList(QStringLiteral("*.mission")),  QDir::Files, QDir::Name);
+
+    foreach (const QFileInfo& missionFileInfo, missionFileInfoList) {
+        missionFiles << missionFileInfo.baseName() + ".mission";
+    }
+
+    return missionFiles;
 }

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -49,8 +49,11 @@ public:
     Q_INVOKABLE void sendMissionItems(void);
     Q_INVOKABLE void loadMissionFromFile(void);
     Q_INVOKABLE void saveMissionToFile(void);
+    Q_INVOKABLE void loadMobileMissionFromFile(const QString& file);
+    Q_INVOKABLE void saveMobileMissionToFile(const QString& file);
     Q_INVOKABLE void removeMissionItem(int index);
     Q_INVOKABLE void removeAllMissionItems(void);
+    Q_INVOKABLE QStringList getMobileMissionFiles(void);
 
     /// @param i: index to insert at
     Q_INVOKABLE int insertMissionItem(QGeoCoordinate coordinate, int i);
@@ -97,10 +100,10 @@ private:
     void _addPlannedHomePosition(QmlObjectListModel* missionItems, bool addToCenter);
     double _normalizeLat(double lat);
     double _normalizeLon(double lon);
-#ifndef __mobile__
     bool _loadJsonMissionFile(const QByteArray& bytes, QmlObjectListModel* missionItems, QString& errorString);
     bool _loadTextMissionFile(QTextStream& stream, QmlObjectListModel* missionItems, QString& errorString);
-#endif
+    void _loadMissionFromFile(const QString& file);
+    void _saveMissionToFile(const QString& file);
 
 private:
     bool                _editMode;


### PR DESCRIPTION
Fix for Issue #2788. Nothing fancy, but functional. Files must be in Documents location and end in .mission extension.