### PR TITLE
Size ListView to content height

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -373,13 +373,17 @@ QGCView {
                     MouseArea {
                         // This MouseArea prevents the Map below it from getting Mouse events. Without this
                         // things like mousewheel will scroll the Flickable and then scroll the map as well.
-                        anchors.fill:       parent
+                        anchors.fill:       editorListView
                         preventStealing:    true
                         onWheel:            wheel.accepted = true
                     }
 
                     ListView {
-                        anchors.fill:   parent
+                        id:             editorListView
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        anchors.top:    parent.top
+                        height:         Math.min(contentHeight, parent.height)
                         spacing:        _margin / 2
                         orientation:    ListView.Vertical
                         model:          controller.missionItems


### PR DESCRIPTION
This allows you to click/add waypoints under the list view if it isn't taking up the screen real estate. For fix Issue #2785