### PR TITLE
ValueWidget inside instrument panel

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -186,6 +186,7 @@ INCLUDEPATH += \
     src/comm \
     src/FlightDisplay \
     src/FlightMap \
+    src/FlightMap/Widgets \
     src/input \
     src/Joystick \
     src/lib/qmapcontrol \
@@ -245,6 +246,7 @@ HEADERS += \
     src/comm/UDPLink.h \
     src/FlightDisplay/FlightDisplayViewController.h \
     src/FlightMap/FlightMapSettings.h \
+    src/FlightMap/Widgets/ValuesWidgetController.h \
     src/GAudioOutput.h \
     src/HomePositionManager.h \
     src/Joystick/Joystick.h \
@@ -370,6 +372,7 @@ SOURCES += \
     src/comm/UDPLink.cc \
     src/FlightDisplay/FlightDisplayViewController.cc \
     src/FlightMap/FlightMapSettings.cc \
+    src/FlightMap/Widgets/ValuesWidgetController.cc \
     src/GAudioOutput.cc \
     src/HomePositionManager.cc \
     src/Joystick/Joystick.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -92,6 +92,8 @@
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewVideo.qml">src/FlightDisplay/FlightDisplayViewVideo.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewWidgets.qml">src/FlightDisplay/FlightDisplayViewWidgets.qml</file>
         <file alias="QGroundControl/FlightDisplay/qmldir">src/FlightDisplay/qmldir</file>
+
+        <file alias="QGroundControl/FlightMap/qmldir">src/FlightMap/qmldir</file>
         <file alias="QGroundControl/FlightMap/FlightMap.qml">src/FlightMap/FlightMap.qml</file>
         <file alias="QGroundControl/FlightMap/MissionItemIndicator.qml">src/FlightMap/MapItems/MissionItemIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/MissionItemView.qml">src/FlightMap/MapItems/MissionItemView.qml</file>
@@ -104,8 +106,9 @@
         <file alias="QGroundControl/FlightMap/QGCPitchIndicator.qml">src/FlightMap/Widgets/QGCPitchIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/QGCSlider.qml">src/FlightMap/Widgets/QGCSlider.qml</file>
         <file alias="QGroundControl/FlightMap/QGCVideoBackground.qml">src/FlightMap/QGCVideoBackground.qml</file>
-        <file alias="QGroundControl/FlightMap/qmldir">src/FlightMap/qmldir</file>
+        <file alias="QGroundControl/FlightMap/ValuesWidget.qml">src/FlightMap/Widgets/ValuesWidget.qml</file>
         <file alias="QGroundControl/FlightMap/VehicleMapItem.qml">src/FlightMap/MapItems/VehicleMapItem.qml</file>
+
         <file alias="QGroundControl/ScreenTools/qmldir">src/QmlControls/QGroundControl.ScreenTools.qmldir</file>
         <file alias="QGroundControl/ScreenTools/ScreenTools.qml">src/QmlControls/ScreenTools.qml</file>
         <file alias="QmlTest.qml">src/QmlControls/QmlTest.qml</file>

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -524,3 +524,17 @@ void Fact::sendDeferredValueChangedSignal(void)
         emit valueChanged(cookedValue());
     }
 }
+
+QString Fact::enumOrValueString(void)
+{
+    if (_metaData) {
+        if (_metaData->enumStrings().count()) {
+            return enumStringValue();
+        } else {
+            return cookedValueString();
+        }
+    } else {
+        qWarning() << "Meta data pointer missing";
+    }
+    return QString();
+}

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -72,7 +72,8 @@ public:
     Q_PROPERTY(QString      units                   READ cookedUnits                                        CONSTANT)
     Q_PROPERTY(QVariant     value                   READ cookedValue            WRITE setCookedValue        NOTIFY valueChanged)
     Q_PROPERTY(bool         valueEqualsDefault      READ valueEqualsDefault                                 NOTIFY valueChanged)
-    Q_PROPERTY(QVariant     valueString             READ cookedValueString                                  NOTIFY valueChanged)
+    Q_PROPERTY(QString      valueString             READ cookedValueString                                  NOTIFY valueChanged)
+    Q_PROPERTY(QString      enumOrValueString       READ enumOrValueString                                  NOTIFY valueChanged)
 
     /// Convert and validate value
     ///     @param convertOnly true: validate type conversion only, false: validate against meta data as well
@@ -111,6 +112,7 @@ public:
     QString         cookedValueString       (void) const;
     bool            valueEqualsDefault      (void) const;
     bool            rebootRequired          (void) const;
+    QString         enumOrValueString       (void);         // This is not const, since an unknown value can modify the enum lists
 
     void setRawValue        (const QVariant& value);
     void setCookedValue     (const QVariant& value);

--- a/src/FactSystem/FactSystem.cc
+++ b/src/FactSystem/FactSystem.cc
@@ -43,6 +43,7 @@ void FactSystem::setToolbox(QGCToolbox *toolbox)
     QGCTool::setToolbox(toolbox);
 
     qmlRegisterType<Fact>               (_factSystemQmlUri, 1, 0, "Fact");
-    qmlRegisterType<Fact>               (_factSystemQmlUri, 1, 0, "FactGroup");
     qmlRegisterType<FactPanelController>(_factSystemQmlUri, 1, 0, "FactPanelController");
+
+    qmlRegisterUncreatableType<FactGroup>(_factSystemQmlUri, 1, 0, "FactGroup", "ReferenceOnly");
 }

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -39,8 +39,10 @@ import QGroundControl.Controllers   1.0
 import QGroundControl.FactSystem    1.0
 
 /// Flight Display View
-Item {
-    id: root
+QGCView {
+    id:             root
+    viewPanel:      _panel
+    topDialogMargin: height - availableHeight
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
@@ -139,143 +141,149 @@ Item {
         px4JoystickCheck()
     }
 
-    //-- Map View
-    //   For whatever reason, if FlightDisplayViewMap is the root item, changing
-    //   width/height has no effect.
-    Item {
-        id: _flightMapContainer
-        z:  _mainIsMap ? root.z + 1 : root.z + 2
-        anchors.left:   root.left
-        anchors.bottom: root.bottom
-        visible:        _mainIsMap || _isPipVisible
-        width:          _mainIsMap ? root.width  : pipSize
-        height:         _mainIsMap ? root.height : pipSize * (9/16)
-        states: [
-            State {
-                name:   "pipMode"
-                PropertyChanges {
-                    target:             _flightMapContainer
-                    anchors.margins:    ScreenTools.defaultFontPixelHeight
+    QGCViewPanel {
+        id:             _panel
+        anchors.fill:   parent
+
+        //-- Map View
+        //   For whatever reason, if FlightDisplayViewMap is the _panel item, changing
+        //   width/height has no effect.
+        Item {
+            id: _flightMapContainer
+            z:  _mainIsMap ? _panel.z + 1 : _panel.z + 2
+            anchors.left:   _panel.left
+            anchors.bottom: _panel.bottom
+            visible:        _mainIsMap || _isPipVisible
+            width:          _mainIsMap ? _panel.width  : pipSize
+            height:         _mainIsMap ? _panel.height : pipSize * (9/16)
+            states: [
+                State {
+                    name:   "pipMode"
+                    PropertyChanges {
+                        target:             _flightMapContainer
+                        anchors.margins:    ScreenTools.defaultFontPixelHeight
+                    }
+                },
+                State {
+                    name:   "fullMode"
+                    PropertyChanges {
+                        target:             _flightMapContainer
+                        anchors.margins:    0
+                    }
                 }
-            },
-            State {
-                name:   "fullMode"
-                PropertyChanges {
-                    target:             _flightMapContainer
-                    anchors.margins:    0
-                }
-            }
-        ]
-        FlightDisplayViewMap {
-            id:             _flightMap
-            anchors.fill:   parent
-        }
-    }
-
-    //-- Video View
-    FlightDisplayViewVideo {
-        id:             _flightVideo
-        z:              _mainIsMap ? root.z + 2 : root.z + 1
-        width:          !_mainIsMap ? root.width  : pipSize
-        height:         !_mainIsMap ? root.height : pipSize * (9/16)
-        anchors.left:   root.left
-        anchors.bottom: root.bottom
-        visible:        _controller.hasVideo && (!_mainIsMap || _isPipVisible)
-        states: [
-            State {
-                name:   "pipMode"
-                PropertyChanges {
-                    target: _flightVideo
-                    anchors.margins:    ScreenTools.defaultFontPixelHeight
-                }
-            },
-            State {
-                name:   "fullMode"
-                PropertyChanges {
-                    target: _flightVideo
-                    anchors.margins:    0
-                }
-            }
-        ]
-    }
-
-    QGCPipable {
-        id:                 _flightVideoPipControl
-        z:                  _flightVideo.z + 3
-        width:              pipSize
-        height:             pipSize * (9/16)
-        anchors.left:       root.left
-        anchors.bottom:     root.bottom
-        anchors.margins:    ScreenTools.defaultFontPixelHeight
-        isHidden:           !_isPipVisible
-        isDark:             isBackgroundDark
-        onActivated: {
-            _mainIsMap = !_mainIsMap
-            setStates()
-        }
-        onHideIt: {
-            setPipVisibility(!state)
-        }
-    }
-
-    //-- Widgets
-    Loader {
-        id:                 widgetsLoader
-        z:                  root.z + 4
-        anchors.right:      parent.right
-        anchors.left:       parent.left
-        anchors.bottom:     parent.bottom
-        height:             availableHeight
-        property bool isBackgroundDark: root.isBackgroundDark
-    }
-
-    //-- Virtual Joystick
-    Item {
-        id:                         multiTouchItem
-        z:                          root.z + 5
-        width:                      parent.width  - (_flightVideoPipControl.width / 2)
-        height:                     thumbAreaHeight
-        visible:                    QGroundControl.virtualTabletJoystick
-        anchors.bottom:             _flightVideoPipControl.top
-        anchors.bottomMargin:       ScreenTools.defaultFontPixelHeight * 2
-        anchors.horizontalCenter:   parent.horizontalCenter
-
-        readonly property real thumbAreaHeight: Math.min(parent.height * 0.25, ScreenTools.defaultFontPixelWidth * 16)
-
-        QGCMapPalette { id: mapPal; lightColors: !isBackgroundDark }
-
-        Timer {
-            interval:   40  // 25Hz, same as real joystick rate
-            running:    QGroundControl.virtualTabletJoystick && _activeVehicle
-            repeat:     true
-            onTriggered: {
-                if (_activeVehicle) {
-                    _activeVehicle.virtualTabletJoystickValue(rightStick.xAxis, rightStick.yAxis, leftStick.xAxis, leftStick.yAxis)
-                }
+            ]
+            FlightDisplayViewMap {
+                id:             _flightMap
+                anchors.fill:   parent
             }
         }
 
-        JoystickThumbPad {
-            id:                     leftStick
-            anchors.leftMargin:     xPositionDelta
-            anchors.bottomMargin:   -yPositionDelta
-            anchors.left:           parent.left
-            anchors.bottom:         parent.bottom
-            width:                  parent.thumbAreaHeight
-            height:                 parent.thumbAreaHeight
-            yAxisThrottle:          true
-            lightColors:            !isBackgroundDark
+        //-- Video View
+        FlightDisplayViewVideo {
+            id:             _flightVideo
+            z:              _mainIsMap ? _panel.z + 2 : _panel.z + 1
+            width:          !_mainIsMap ? _panel.width  : pipSize
+            height:         !_mainIsMap ? _panel.height : pipSize * (9/16)
+            anchors.left:   _panel.left
+            anchors.bottom: _panel.bottom
+            visible:        _controller.hasVideo && (!_mainIsMap || _isPipVisible)
+            states: [
+                State {
+                    name:   "pipMode"
+                    PropertyChanges {
+                        target: _flightVideo
+                        anchors.margins:    ScreenTools.defaultFontPixelHeight
+                    }
+                },
+                State {
+                    name:   "fullMode"
+                    PropertyChanges {
+                        target: _flightVideo
+                        anchors.margins:    0
+                    }
+                }
+            ]
         }
 
-        JoystickThumbPad {
-            id:                     rightStick
-            anchors.rightMargin:    -xPositionDelta
-            anchors.bottomMargin:   -yPositionDelta
-            anchors.right:          parent.right
-            anchors.bottom:         parent.bottom
-            width:                  parent.thumbAreaHeight
-            height:                 parent.thumbAreaHeight
-            lightColors:            !isBackgroundDark
+        QGCPipable {
+            id:                 _flightVideoPipControl
+            z:                  _flightVideo.z + 3
+            width:              pipSize
+            height:             pipSize * (9/16)
+            anchors.left:       _panel.left
+            anchors.bottom:     _panel.bottom
+            anchors.margins:    ScreenTools.defaultFontPixelHeight
+            isHidden:           !_isPipVisible
+            isDark:             isBackgroundDark
+            onActivated: {
+                _mainIsMap = !_mainIsMap
+                setStates()
+            }
+            onHideIt: {
+                setPipVisibility(!state)
+            }
+        }
+
+        //-- Widgets
+        Loader {
+            id:                 widgetsLoader
+            z:                  _panel.z + 4
+            anchors.right:      parent.right
+            anchors.left:       parent.left
+            anchors.bottom:     parent.bottom
+            height:             availableHeight
+            property bool isBackgroundDark: root.isBackgroundDark
+            property var qgcView: root
+        }
+
+        //-- Virtual Joystick
+        Item {
+            id:                         multiTouchItem
+            z:                          _panel.z + 5
+            width:                      parent.width  - (_flightVideoPipControl.width / 2)
+            height:                     thumbAreaHeight
+            visible:                    QGroundControl.virtualTabletJoystick
+            anchors.bottom:             _flightVideoPipControl.top
+            anchors.bottomMargin:       ScreenTools.defaultFontPixelHeight * 2
+            anchors.horizontalCenter:   parent.horizontalCenter
+
+            readonly property real thumbAreaHeight: Math.min(parent.height * 0.25, ScreenTools.defaultFontPixelWidth * 16)
+
+            QGCMapPalette { id: mapPal; lightColors: !isBackgroundDark }
+
+            Timer {
+                interval:   40  // 25Hz, same as real joystick rate
+                running:    QGroundControl.virtualTabletJoystick && _activeVehicle
+                repeat:     true
+                onTriggered: {
+                    if (_activeVehicle) {
+                        _activeVehicle.virtualTabletJoystickValue(rightStick.xAxis, rightStick.yAxis, leftStick.xAxis, leftStick.yAxis)
+                    }
+                }
+            }
+
+            JoystickThumbPad {
+                id:                     leftStick
+                anchors.leftMargin:     xPositionDelta
+                anchors.bottomMargin:   -yPositionDelta
+                anchors.left:           parent.left
+                anchors.bottom:         parent.bottom
+                width:                  parent.thumbAreaHeight
+                height:                 parent.thumbAreaHeight
+                yAxisThrottle:          true
+                lightColors:            !isBackgroundDark
+            }
+
+            JoystickThumbPad {
+                id:                     rightStick
+                anchors.rightMargin:    -xPositionDelta
+                anchors.bottomMargin:   -yPositionDelta
+                anchors.right:          parent.right
+                anchors.bottom:         parent.bottom
+                width:                  parent.thumbAreaHeight
+                height:                 parent.thumbAreaHeight
+                lightColors:            !isBackgroundDark
+            }
         }
     }
 }

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -38,9 +38,7 @@ import QGroundControl.FlightMap     1.0
 Item {
     id: _root
 
-    readonly property string _InstrumentVisibleKey: "IsInstrumentPanelVisible"
-
-    property var _activeVehicle:         multiVehicleManager.activeVehicle
+    property var _activeVehicle: multiVehicleManager.activeVehicle
 
     QGCMapPalette { id: mapPal; lightColors: !isBackgroundDark }
 

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -36,11 +36,11 @@ import QGroundControl.Vehicle       1.0
 import QGroundControl.FlightMap     1.0
 
 Item {
+    id: _root
 
     readonly property string _InstrumentVisibleKey: "IsInstrumentPanelVisible"
 
-    property bool   _isInstrumentVisible:   QGroundControl.loadBoolGlobalSetting(_InstrumentVisibleKey, true)
-    property var    _activeVehicle:         multiVehicleManager.activeVehicle
+    property var _activeVehicle:         multiVehicleManager.activeVehicle
 
     QGCMapPalette { id: mapPal; lightColors: !isBackgroundDark }
 
@@ -96,7 +96,7 @@ Item {
         anchors.margins:        ScreenTools.defaultFontPixelHeight
         anchors.right:          parent.right
         anchors.verticalCenter: parent.verticalCenter
-        visible:                _isInstrumentVisible && !QGroundControl.virtualTabletJoystick
+        visible:                !QGroundControl.virtualTabletJoystick
         size:                   getGadgetWidth()
         active:                 _activeVehicle != null
         heading:                _heading
@@ -107,10 +107,8 @@ Item {
         airSpeedFact:           _airSpeedFact
         isSatellite:            _mainIsMap ? _flightMap ? _flightMap.isSatelliteMap : true : true
         z:                      QGroundControl.zOrderWidgets
-        onClicked: {
-            _isInstrumentVisible = false
-            QGroundControl.saveBoolGlobalSetting(_InstrumentVisibleKey, false)
-        }
+        qgcView:                parent.parent.qgcView
+        maxHeight:              parent.height - (ScreenTools.defaultFontPixelHeight * 2)
     }
 
     //-- Alternate Instrument Panel
@@ -158,35 +156,6 @@ Item {
                 width:          parent.width
                 color:          "white"
                 horizontalAlignment: TextEdit.AlignHCenter
-            }
-        }
-    }
-
-    //-- Show (Hidden) Instrument Panel
-    Rectangle {
-        id:                     openButton
-        anchors.right:          parent.right
-        anchors.bottom:         parent.bottom
-        anchors.margins:        ScreenTools.defaultFontPixelHeight
-        height:                 ScreenTools.defaultFontPixelSize * 2
-        width:                  ScreenTools.defaultFontPixelSize * 2
-        radius:                 ScreenTools.defaultFontPixelSize / 3
-        visible:                !_isInstrumentVisible && !QGroundControl.virtualTabletJoystick
-        color:                  isBackgroundDark ? Qt.rgba(0,0,0,0.75) : Qt.rgba(0,0,0,0.5)
-        Image {
-            width:              parent.width  * 0.75
-            height:             parent.height * 0.75
-            source:             "/res/buttonLeft.svg"
-            mipmap:             true
-            fillMode:           Image.PreserveAspectFit
-            anchors.verticalCenter:     parent.verticalCenter
-            anchors.horizontalCenter:   parent.horizontalCenter
-        }
-        MouseArea {
-            anchors.fill: parent
-            onClicked: {
-                _isInstrumentVisible = true
-                QGroundControl.saveBoolGlobalSetting(_InstrumentVisibleKey, true)
             }
         }
     }

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -32,12 +32,14 @@ import QtQuick 2.4
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.FactSystem    1.0
+import QGroundControl.FlightMap     1.0
 
-Item {
-    id:     root
-    height: size
-
-    signal clicked
+Rectangle {
+    id:     instrumentPanel
+    height: compass.y + compass.height + _topBottomMargin
+    width:  size
+    radius: size / 2
+    color:  isSatellite ? Qt.rgba(1,1,1,0.75) : Qt.rgba(0,0,0,0.75)
 
     property alias  heading:        compass.heading
     property alias  rollAngle:      attitude.rollAngle
@@ -45,6 +47,8 @@ Item {
     property real   size:           _defaultSize
     property bool   isSatellite:    false
     property bool   active:         false
+    property var    qgcView
+    property real   maxHeight
 
     property Fact   _emptyFact:         Fact { }
     property Fact   groundSpeedFact:    _emptyFact
@@ -57,122 +61,59 @@ Item {
     property real   _bigFontSize:   ScreenTools.defaultFontPixelSize * 2.5  * _sizeRatio
     property real   _normalFontSize:ScreenTools.defaultFontPixelSize * 1.5  * _sizeRatio
     property real   _labelFontSize: ScreenTools.defaultFontPixelSize * 0.75 * _sizeRatio
+    property real   _spacing:       ScreenTools.defaultFontPixelSize * 0.33
+    property real   _topBottomMargin: (size * 0.05) / 2
+    property real   _availableValueHeight: maxHeight - (attitude.height + _spacer1.height + _spacer2.height + compass.height + (_spacing * 4))
 
-    //-- Instrument Panel
+    MouseArea {
+        anchors.fill: parent
+        onClicked: _valuesWidget.showPicker()
+    }
+
+    QGCAttitudeWidget {
+        id:             attitude
+        y:              _topBottomMargin
+        size:           parent.width * 0.95
+        active:         active
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
+
     Rectangle {
-        id:                     instrumentPanel
-        height:                 instruments.height + (size * 0.05)
-        width:                  root.size
-        radius:                 root.size / 2
-        color:                  isSatellite ? Qt.rgba(1,1,1,0.75) : Qt.rgba(0,0,0,0.75)
-        anchors.right:          parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        Column {
-            id:                 instruments
-            width:              parent.width
-            spacing:            ScreenTools.defaultFontPixelSize * 0.33
-            anchors.verticalCenter: parent.verticalCenter
-            //-- Attitude Indicator
-            QGCAttitudeWidget {
-                id:             attitude
-                size:           parent.width * 0.95
-                active:         root.active
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-            //-- Altitude
-            Rectangle {
-                height:         1
-                width:          parent.width * 0.9
-                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-            QGCLabel {
-                text:           altitudeFact.shortDescription + " (" + altitudeFact.units + ")"
-                font.pixelSize: _labelFontSize
-                width:          parent.width
-                height:         _labelFontSize
-                color:          isSatellite ? "black" : "white"
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-            QGCLabel {
-                text:           altitudeFact.valueString
-                font.pixelSize: _bigFontSize
-                font.weight:    Font.DemiBold
-                width:          parent.width
-                color:          isSatellite ? "black" : "white"
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-            //-- Ground Speed
-            Rectangle {
-                height:         1
-                width:          parent.width * 0.9
-                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
-                anchors.horizontalCenter: parent.horizontalCenter
-                visible:        airSpeedFact.value <= 0 && !ScreenTools.isTinyScreen
-            }
-            QGCLabel {
-                text:           groundSpeedFact.shortDescription + " (" + groundSpeedFact.units + ")"
-                font.pixelSize: _labelFontSize
-                width:          parent.width
-                height:         _labelFontSize
-                color:          isSatellite ? "black" : "white"
-                horizontalAlignment: TextEdit.AlignHCenter
-                visible:        airSpeedFact.value <= 0 && !ScreenTools.isTinyScreen
-            }
-            QGCLabel {
-                text:           groundSpeedFact.valueString
-                font.pixelSize: _normalFontSize
-                font.weight:    Font.DemiBold
-                width:          parent.width
-                color:          isSatellite ? "black" : "white"
-                horizontalAlignment: TextEdit.AlignHCenter
-                visible:        airSpeedFact.value <= 0 && !ScreenTools.isTinyScreen
-            }
-            //-- Air Speed
-            Rectangle {
-                height:         1
-                width:          parent.width * 0.9
-                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
-                anchors.horizontalCenter: parent.horizontalCenter
-                visible:        airSpeedFact.value > 0 && !ScreenTools.isTinyScreen
-            }
-            QGCLabel {
-                text:           airSpeedFact.shortDescription + " (" + airSpeedFact.units + ")"
-                font.pixelSize: _labelFontSize
-                width:          parent.width
-                height:         _labelFontSize
-                color:          isSatellite ? "black" : "white"
-                visible:        airSpeedFact.value > 0 && !ScreenTools.isTinyScreen
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-            QGCLabel {
-                text:           airSpeedFact.valueString
-                font.pixelSize: _normalFontSize
-                font.weight:    Font.DemiBold
-                width:          parent.width
-                color:          isSatellite ? "black" : "white"
-                visible:        airSpeedFact.value > 0 && !ScreenTools.isTinyScreen
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-            //-- Compass
-            Rectangle {
-                height:         1
-                width:          parent.width * 0.9
-                color:          isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-            QGCCompassWidget {
-                id:             compass
-                size:           parent.width * 0.95
-                active:         root.active
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-        }
-        MouseArea {
-            anchors.fill: parent
-            onClicked: {
-                onClicked: root.clicked()
-            }
-        }
+        id:                 _spacer1
+        anchors.topMargin:  _spacing
+        anchors.top:        attitude.bottom
+        height:             1
+        width:              parent.width * 0.9
+        color:              isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
+
+    ValuesWidget {
+        id:                 _valuesWidget
+        anchors.topMargin:  _spacing
+        anchors.top:        _spacer1.bottom
+        width:              parent.width
+        qgcView:            instrumentPanel.qgcView
+        textColor:          isSatellite ? "black" : "white"
+        maxHeight:          _availableValueHeight
+    }
+
+    Rectangle {
+        id:                 _spacer2
+        anchors.topMargin:  _spacing
+        anchors.top:        _valuesWidget.bottom
+        height:             1
+        width:              parent.width * 0.9
+        color:              isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
+
+    QGCCompassWidget {
+        id:                 compass
+        anchors.topMargin:  _spacing
+        anchors.top:        _spacer2.bottom
+        size:               parent.width * 0.95
+        active:             active
+        anchors.horizontalCenter: parent.horizontalCenter
     }
 }

--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -1,0 +1,267 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+import QtQuick          2.4
+import QtQuick.Dialogs  1.2
+
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.Controllers   1.0
+import QGroundControl.Palette       1.0
+import QGroundControl               1.0
+
+QGCFlickable {
+    id:                 _root
+    visible:            _activeVehicle
+    height:             Math.min(maxHeight, _smallFlow.y + _smallFlow.height)
+    contentHeight:      _smallFlow.y + _smallFlow.height
+    flickableDirection: Flickable.VerticalFlick
+    clip:               true
+
+    property var    qgcView
+    property color  textColor
+    property var    maxHeight
+
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property real   _margins:       ScreenTools.defaultFontPixelWidth / 2
+
+    QGCPalette { id:qgcPal; colorGroupEnabled: true }
+
+    ValuesWidgetController {
+        id: controller
+    }
+
+    function showPicker() {
+        qgcView.showDialog(propertyPicker, "Value Widget Setup", qgcView.showDialogDefaultWidth, StandardButton.Ok)
+    }
+
+    MouseArea {
+        anchors.fill:   parent
+        onClicked:      showPicker()
+    }
+
+    Column {
+        id:         _largeColumn
+        width:      parent.width
+        spacing:    _margins
+
+        Repeater {
+            model: _activeVehicle ? controller.largeValues : 0
+
+            Column {
+                id:     valueColumn
+                width:  _largeColumn.width
+
+                property Fact fact: _activeVehicle.getFact(modelData.replace("Vehicle.", ""))
+
+                QGCLabel {
+                    width:                  parent.width
+                    horizontalAlignment:    Text.AlignHCenter
+                    color:                  textColor
+                    text:                   fact.shortDescription + (fact.units ? " (" + fact.units + ")" : "")
+                }
+                QGCLabel {
+                    width:                  parent.width
+                    horizontalAlignment:    Text.AlignHCenter
+                    font.pixelSize:         ScreenTools.largeFontPixelSize
+                    font.weight:            Font.DemiBold
+                    color:                  textColor
+                    text:                   fact.valueString
+                }
+            }
+        } // Repeater - Large
+    } // Column - Large
+
+    Flow {
+        id:                 _smallFlow
+        width:              parent.width
+        anchors.topMargin:  _margins
+        anchors.top:        _largeColumn.bottom
+        layoutDirection:    Qt.LeftToRight
+        spacing:            _margins
+
+        Repeater {
+            model: _activeVehicle ? controller.smallValues : 0
+
+            Column {
+                id:     valueColumn
+                width:  (_root.width / 2) - (_margins / 2) - 0.1
+                clip:   true
+
+                property Fact fact: _activeVehicle.getFact(modelData.replace("Vehicle.", ""))
+
+                QGCLabel {
+                    width:                  parent.width
+                    horizontalAlignment:    Text.AlignHCenter
+                    font.pixelSize:         ScreenTools.smallFontPixelSize
+                    color:                  textColor
+                    text:                   fact.shortDescription
+                }
+                QGCLabel {
+                    width:                  parent.width
+                    horizontalAlignment:    Text.AlignHCenter
+                    color:                  textColor
+                    text:                   fact.enumOrValueString
+                }
+                QGCLabel {
+                    width:                  parent.width
+                    horizontalAlignment:    Text.AlignHCenter
+                    font.pixelSize:         ScreenTools.smallFontPixelSize
+                    color:                  textColor
+                    text:                   fact.units
+                }
+            }
+        } // Repeater - Small
+    } // Flow
+
+    Component {
+        id: propertyPicker
+
+        QGCViewDialog {
+            id: _propertyPickerDialog
+
+            QGCLabel {
+                id:     _label
+                text:   "Select the values you want to display:"
+            }
+
+            Loader {
+                anchors.left:       parent.left
+                anchors.right:      parent.right
+                anchors.topMargin:  _margins
+                anchors.top:        _label.bottom
+                anchors.bottom:     parent.bottom
+                sourceComponent:    factGroupList
+
+                property var factGroup:     _activeVehicle
+                property var factGroupName: "Vehicle"
+            }
+        }
+    }
+
+    Component {
+        id: factGroupList
+
+        // You must push in the following properties from the Loader
+        // property var factGroup
+        // property string factGroupName
+
+        Column {
+            id:         _root
+            spacing:    _margins
+
+            QGCLabel {
+                width:      parent.width
+                wrapMode:   Text.WordWrap
+                text:       factGroup ? factGroupName : "Vehicle must be connected to assign values."
+            }
+
+            Repeater {
+                model: factGroup ? factGroup.factNames : 0
+
+                Row {
+                    spacing: _margins
+
+                    property string propertyName: factGroupName + "." + modelData
+
+                    function contains(list, value) {
+                        for (var i=0; i<list.length; i++) {
+                            if (list[i] === value) {
+                                return true
+                            }
+                        }
+                        return false
+                    }
+
+                    function removeFromList(list, value) {
+                        var newList = []
+                        for (var i=0; i<list.length; i++) {
+                            if (list[i] !== value) {
+                                newList.push(list[i])
+                            }
+                        }
+                        return newList
+                    }
+
+                    function addToList(list, value) {
+                        var found = false
+                        for (var i=0; i<list.length; i++) {
+                            if (list[i] === value) {
+                                found = true
+                                break
+                            }
+                        }
+                        if (!found) {
+                            list.push(value)
+                        }
+                        return list
+                    }
+
+                    function updateValues() {
+                        if (_addCheckBox.checked) {
+                            if (_largeCheckBox.checked) {
+                                controller.largeValues = addToList(controller.largeValues, propertyName)
+                                controller.smallValues = removeFromList(controller.smallValues, propertyName)
+                            } else {
+                                controller.smallValues = addToList(controller.smallValues, propertyName)
+                                controller.largeValues = removeFromList(controller.largeValues, propertyName)
+                            }
+                        } else {
+                            controller.largeValues = removeFromList(controller.largeValues, propertyName)
+                            controller.smallValues = removeFromList(controller.smallValues, propertyName)
+                        }
+                    }
+
+                    QGCCheckBox {
+                        id:         _addCheckBox
+                        text:       factGroup.getFact(modelData).shortDescription
+                        checked:    _largeCheckBox.checked || parent.contains(controller.smallValues, propertyName)
+                        onClicked:  updateValues()
+                    }
+
+                    QGCCheckBox {
+                        id:         _largeCheckBox
+                        text:       "large"
+                        checked:    parent.contains(controller.largeValues, propertyName)
+                        enabled:    _addCheckBox.checked
+                        onClicked:  updateValues()
+                    }
+                }
+            }
+
+            Item { height: 1; width: 1 }
+
+            Repeater {
+                model: factGroup ? factGroup.factGroupNames : 0
+
+                Loader {
+                    sourceComponent: factGroupList
+
+                    property var    factGroup:      _root ? _root.parent.factGroup.getFactGroup(modelData) : undefined
+                    property string factGroupName:  _root ? _root.parent.factGroupName + "." + modelData : undefined
+                }
+            }
+        }
+    }
+}

--- a/src/FlightMap/Widgets/ValuesWidgetController.cc
+++ b/src/FlightMap/Widgets/ValuesWidgetController.cc
@@ -1,0 +1,64 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+#include "ValuesWidgetController.h"
+
+#include <QSettings>
+
+const char* ValuesWidgetController::_groupKey =         "ValuesWidget";
+const char* ValuesWidgetController::_largeValuesKey =   "large";
+const char* ValuesWidgetController::_smallValuesKey =   "small";
+
+ValuesWidgetController::ValuesWidgetController(void)
+{
+    QSettings settings;
+    QStringList largeDefaults;
+
+    settings.beginGroup(_groupKey);
+
+    largeDefaults << "Vehicle.altitudeWGS84" << "Vehicle.groundSpeed";
+    _largeValues = settings.value(_largeValuesKey, largeDefaults).toStringList();
+    _smallValues = settings.value(_smallValuesKey, QStringList()).toStringList();
+}
+
+void ValuesWidgetController::setLargeValues(const QStringList& values)
+{
+    QSettings settings;
+
+    settings.beginGroup(_groupKey);
+    settings.setValue(_largeValuesKey, values);
+
+    _largeValues = values;
+    emit largeValuesChanged(values);
+}
+
+void ValuesWidgetController::setSmallValues(const QStringList& values)
+{
+    QSettings settings;
+
+    settings.beginGroup(_groupKey);
+    settings.setValue(_smallValuesKey, values);
+
+    _smallValues = values;
+    emit smallValuesChanged(values);
+}

--- a/src/FlightMap/Widgets/ValuesWidgetController.h
+++ b/src/FlightMap/Widgets/ValuesWidgetController.h
@@ -1,0 +1,57 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+#ifndef ValuesWidgetController_H
+#define ValuesWidgetController_H
+
+#include <QObject>
+
+class ValuesWidgetController : public QObject
+{
+    Q_OBJECT
+    
+public:
+    ValuesWidgetController(void);
+
+    Q_PROPERTY(QStringList largeValues READ largeValues WRITE setLargeValues NOTIFY largeValuesChanged)
+    Q_PROPERTY(QStringList smallValues READ smallValues WRITE setSmallValues NOTIFY smallValuesChanged)
+
+    QStringList largeValues(void) const { return _largeValues; }
+    QStringList smallValues(void) const { return _smallValues; }
+    void setLargeValues(const QStringList& values);
+    void setSmallValues(const QStringList& values);
+
+signals:
+    void largeValuesChanged(QStringList values);
+    void smallValuesChanged(QStringList values);
+
+private:
+    QStringList _largeValues;
+    QStringList _smallValues;
+
+    static const char* _groupKey;
+    static const char* _largeValuesKey;
+    static const char* _smallValuesKey;
+};
+
+#endif

--- a/src/FlightMap/qmldir
+++ b/src/FlightMap/qmldir
@@ -12,6 +12,7 @@ QGCCompassWidget        1.0 QGCCompassWidget.qml
 QGCInstrumentWidget     1.0 QGCInstrumentWidget.qml
 QGCPitchIndicator       1.0 QGCPitchIndicator.qml
 QGCSlider               1.0 QGCSlider.qml
+ValuesWidget            1.0 ValuesWidget.qml
 
 # Map items
 MissionItemIndicator    1.0 MissionItemIndicator.qml

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -98,6 +98,7 @@
 #include "VideoReceiver.h"
 #include "LogDownloadController.h"
 #include "PX4AirframeLoader.h"
+#include "ValuesWidgetController.h"
 
 #ifndef __ios__
     #include "SerialLink.h"
@@ -445,6 +446,7 @@ void QGCApplication::_initCommon(void)
     qmlRegisterType<MainToolBarController>              ("QGroundControl.Controllers", 1, 0, "MainToolBarController");
     qmlRegisterType<MissionController>                  ("QGroundControl.Controllers", 1, 0, "MissionController");
     qmlRegisterType<FlightDisplayViewController>        ("QGroundControl.Controllers", 1, 0, "FlightDisplayViewController");
+    qmlRegisterType<ValuesWidgetController>             ("QGroundControl.Controllers", 1, 0, "ValuesWidgetController");
 
 #ifndef __mobile__
     qmlRegisterType<ViewWidgetController>           ("QGroundControl.Controllers", 1, 0, "ViewWidgetController");


### PR DESCRIPTION
Instrument panel now has a configurable center section where you can pick the values you want to show there. There are two formats for value display: large and small.

Here is the default setup which pretty much matches the original visuals. Except the text is slightly smaller to fit more items. These are two large value widgets.
![screen shot 2016-02-13 at 6 17 05 pm](https://cloud.githubusercontent.com/assets/5876851/13031404/007ab804-d282-11e5-8f75-d501541c0ba9.png)

Here is an example of what it looks like with a couple small value widgets added:
![screen shot 2016-02-13 at 6 16 53 pm](https://cloud.githubusercontent.com/assets/5876851/13031418/4ac96d42-d282-11e5-8c1b-b4b6b0defbf1.png)

Click on the control to pick values to show. Picker is functional, still needs better visuals:
![screen shot 2016-02-13 at 6 41 50 pm](https://cloud.githubusercontent.com/assets/5876851/13031420/58f84f96-d282-11e5-8a38-d3e84dc3aa1d.png)
The values you can choose from will grow as I build out the Vehicle object model.
