### PR TITLE
Takeoff by clicking Vehicle

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -41,6 +41,8 @@
         <file alias="PowerComponent.qml">src/AutoPilotPlugins/PX4/PowerComponent.qml</file>
         <file alias="PowerComponentSummary.qml">src/AutoPilotPlugins/PX4/PowerComponentSummary.qml</file>
         <file alias="PX4FlowSensor.qml">src/VehicleSetup/PX4FlowSensor.qml</file>
+
+        <file alias="QGroundControl/Controls/qmldir">src/QmlControls/QGroundControl.Controls.qmldir</file>
         <file alias="QGroundControl/Controls/ClickableColor.qml">src/QmlControls/ClickableColor.qml</file>
         <file alias="QGroundControl/Controls/DropButton.qml">src/QmlControls/DropButton.qml</file>
         <file alias="QGroundControl/Controls/ExclusiveGroupItem.qml">src/QmlControls/ExclusiveGroupItem.qml</file>
@@ -72,7 +74,6 @@
         <file alias="QGroundControl/Controls/QGCViewDialog.qml">src/QmlControls/QGCViewDialog.qml</file>
         <file alias="QGroundControl/Controls/QGCViewMessage.qml">src/QmlControls/QGCViewMessage.qml</file>
         <file alias="QGroundControl/Controls/QGCViewPanel.qml">src/QmlControls/QGCViewPanel.qml</file>
-        <file alias="QGroundControl/Controls/qmldir">src/QmlControls/QGroundControl.Controls.qmldir</file>
         <file alias="QGroundControl/Controls/RoundButton.qml">src/QmlControls/RoundButton.qml</file>
         <file alias="QGroundControl/Controls/SignalStrength.qml">src/ui/toolbar/SignalStrength.qml</file>
         <file alias="QGroundControl/Controls/SubMenuButton.qml">src/QmlControls/SubMenuButton.qml</file>
@@ -80,6 +81,8 @@
         <file alias="QGroundControl/Controls/VehicleSummaryRow.qml">src/QmlControls/VehicleSummaryRow.qml</file>
         <file alias="QGroundControl/Controls/ViewWidget.qml">src/ViewWidgets/ViewWidget.qml</file>
         <file alias="QGroundControl/Controls/FactSliderPanel.qml">src/QmlControls/FactSliderPanel.qml</file>
+        <file alias="QGroundControl/Controls/TakeoffWidget.qml">src/QmlControls/TakeoffWidget.qml</file>
+
         <file alias="QGroundControl/FactControls/FactBitmask.qml">src/FactSystem/FactControls/FactBitmask.qml</file>
         <file alias="QGroundControl/FactControls/FactCheckBox.qml">src/FactSystem/FactControls/FactCheckBox.qml</file>
         <file alias="QGroundControl/FactControls/FactComboBox.qml">src/FactSystem/FactControls/FactComboBox.qml</file>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -103,6 +103,7 @@
         <file alias="QGroundControl/FlightMap/QGCAttitudeWidget.qml">src/FlightMap/Widgets/QGCAttitudeWidget.qml</file>
         <file alias="QGroundControl/FlightMap/QGCCompassWidget.qml">src/FlightMap/Widgets/QGCCompassWidget.qml</file>
         <file alias="QGroundControl/FlightMap/QGCInstrumentWidget.qml">src/FlightMap/Widgets/QGCInstrumentWidget.qml</file>
+        <file alias="QGroundControl/FlightMap/QGCInstrumentWidgetAlternate.qml">src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml</file>
         <file alias="QGroundControl/FlightMap/QGCPitchIndicator.qml">src/FlightMap/Widgets/QGCPitchIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/QGCSlider.qml">src/FlightMap/Widgets/QGCSlider.qml</file>
         <file alias="QGroundControl/FlightMap/QGCVideoBackground.qml">src/FlightMap/QGCVideoBackground.qml</file>

--- a/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
+++ b/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
@@ -102,6 +102,12 @@
       <output name="AUX3">feed-through of RC AUX3 channel</output>
     </airframe>
   </airframe_group>
+  <airframe_group image="OctoRotorXCoaxial" name="Octo Coax Wide">
+    <airframe id="12002" maintainer="Simon Wilks &lt;simon@uaventure.com&gt;" name="Steadidrone MAVRIK">
+      <maintainer>Simon Wilks &lt;simon@uaventure.com&gt;</maintainer>
+      <type>Octo Coax Wide</type>
+    </airframe>
+  </airframe_group>
   <airframe_group image="OctoRotorPlus" name="Octorotor +">
     <airframe id="9001" maintainer="Anton Babushkin &lt;anton@px4.io&gt;" name="Generic Octocopter + geometry">
       <maintainer>Anton Babushkin &lt;anton@px4.io&gt;</maintainer>
@@ -349,9 +355,13 @@
     </airframe>
   </airframe_group>
   <airframe_group image="VTOLDuoRotorTailSitter" name="VTOL Duo Tailsitter">
-    <airframe id="13001" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Duorotor Tailsitter">
+    <airframe id="13001" maintainer="Roman Bapst &lt;roman@px4.io&gt;" name="Caipiroshka Duo Tailsitter">
       <maintainer>Roman Bapst &lt;roman@px4.io&gt;</maintainer>
       <type>VTOL Duo Tailsitter</type>
+      <output name="MAIN1">motor left</output>
+      <output name="MAIN2">motor right</output>
+      <output name="MAIN5">elevon left</output>
+      <output name="MAIN6">elevon right</output>
     </airframe>
   </airframe_group>
   <airframe_group image="VTOLQuadRotorTailSitter" name="VTOL Quad Tailsitter">

--- a/src/AutoPilotPlugins/PX4/ParameterFactMetaData.xml
+++ b/src/AutoPilotPlugins/PX4/ParameterFactMetaData.xml
@@ -262,9 +262,20 @@ velocity</short_desc>
     <parameter default="3" name="BAT_N_CELLS" type="INT32">
       <short_desc>Number of cells</short_desc>
       <long_desc>Defines the number of cells the attached battery consists of.</long_desc>
-      <min>1</min>
+      <min>2</min>
       <max>10</max>
       <unit>S</unit>
+      <values>
+        <value code="10">10S Battery</value>
+        <value code="3">3S Battery</value>
+        <value code="2">2S Battery</value>
+        <value code="5">5S Battery</value>
+        <value code="4">4S Battery</value>
+        <value code="7">7S Battery</value>
+        <value code="6">6S Battery</value>
+        <value code="9">9S Battery</value>
+        <value code="8">8S Battery</value>
+      </values>
     </parameter>
     <parameter default="-1.0" name="BAT_CAPACITY" type="FLOAT">
       <short_desc>Battery capacity</short_desc>
@@ -379,6 +390,10 @@ velocity</short_desc>
       <long_desc>Set to 1 to enable actions triggered when the datalink is lost.</long_desc>
       <min>0</min>
       <max>1</max>
+      <values>
+        <value code="1">ON: Datalink failse</value>
+        <value code="0">OFF: No Datalink failsafe</value>
+      </values>
     </parameter>
     <parameter default="10" name="COM_DL_LOSS_T" type="INT32">
       <short_desc>Datalink loss time threshold</short_desc>
@@ -452,6 +467,11 @@ velocity</short_desc>
       <long_desc>The default value of 0 requires a valid RC transmitter setup. Setting this to 1 disables RC input handling and the associated checks. A value of 2 will generate RC control data from manual input received via MAVLink instead of directly forwarding the manual input data.</long_desc>
       <min>0</min>
       <max>2</max>
+      <values>
+        <value code="1">Disable RC Input Checks</value>
+        <value code="0">RC Transmitter</value>
+        <value code="2">Virtual RC by Joystick</value>
+      </values>
     </parameter>
     <parameter default="0" name="COM_DISARM_LAND" type="INT32">
       <short_desc>Time-out for auto disarm after landing</short_desc>
@@ -1076,7 +1096,7 @@ velocity</short_desc>
   <group name="L1 Control">
     <parameter default="20.0" name="FW_L1_PERIOD" type="FLOAT">
       <short_desc>L1 period</short_desc>
-      <long_desc>This is the L1 distance and defines the tracking point ahead of the aircraft its following. A value of 25 meters works for most aircraft. Shorten slowly during tuning until response is sharp without oscillation.</long_desc>
+      <long_desc>This is the L1 distance and defines the tracking point ahead of the aircraft its following. A value of 18-25 meters works for most aircraft. Shorten slowly during tuning until response is sharp without oscillation.</long_desc>
       <min>12.0</min>
       <max>50.0</max>
     </parameter>
@@ -1170,8 +1190,8 @@ velocity</short_desc>
       <long_desc>0: disabled, 1: enabled</long_desc>
     </parameter>
     <parameter default="1.3" name="FW_AIRSPD_SCALE" type="FLOAT">
-      <short_desc>Takeoff and landing airspeed scale factor</short_desc>
-      <long_desc>Multiplying this factor with the minimum airspeed of the plane gives the target airspeed for takeoff and landing approach.</long_desc>
+      <short_desc>Landing airspeed scale factor</short_desc>
+      <long_desc>Multiplying this factor with the minimum airspeed of the plane gives the target airspeed the landing approach.</long_desc>
       <min>1.0</min>
       <max>1.5</max>
     </parameter>
@@ -1492,22 +1512,26 @@ velocity</short_desc>
       <long_desc>Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</long_desc>
       <min>0.15</min>
       <max>0.25</max>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.2" name="MC_PITCH_TC" type="FLOAT">
       <short_desc>Pitch time constant</short_desc>
       <long_desc>Reduce if the system is too twitchy, increase if the response is too slow and sluggish.</long_desc>
       <min>0.15</min>
       <max>0.25</max>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="6.5" name="MC_ROLL_P" type="FLOAT">
       <short_desc>Roll P gain</short_desc>
       <long_desc>Roll proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</long_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.15" name="MC_ROLLRATE_P" type="FLOAT">
       <short_desc>Roll rate P gain</short_desc>
       <long_desc>Roll rate proportional gain, i.e. control output for angular speed error 1 rad/s.</long_desc>
       <min>0.0</min>
+      <decimal>3</decimal>
     </parameter>
     <parameter default="0.05" name="MC_ROLLRATE_I" type="FLOAT">
       <short_desc>Roll rate I gain</short_desc>
@@ -1518,69 +1542,82 @@ velocity</short_desc>
       <short_desc>Roll rate D gain</short_desc>
       <long_desc>Roll rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</long_desc>
       <min>0.0</min>
+      <decimal>4</decimal>
     </parameter>
     <parameter default="0.0" name="MC_ROLLRATE_FF" type="FLOAT">
       <short_desc>Roll rate feedforward</short_desc>
       <long_desc>Improves tracking performance.</long_desc>
       <min>0.0</min>
+      <decimal>4</decimal>
     </parameter>
     <parameter default="6.5" name="MC_PITCH_P" type="FLOAT">
       <short_desc>Pitch P gain</short_desc>
       <long_desc>Pitch proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</long_desc>
       <min>0.0</min>
       <unit>1/s</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.15" name="MC_PITCHRATE_P" type="FLOAT">
       <short_desc>Pitch rate P gain</short_desc>
       <long_desc>Pitch rate proportional gain, i.e. control output for angular speed error 1 rad/s.</long_desc>
       <min>0.0</min>
+      <decimal>3</decimal>
     </parameter>
     <parameter default="0.05" name="MC_PITCHRATE_I" type="FLOAT">
       <short_desc>Pitch rate I gain</short_desc>
       <long_desc>Pitch rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</long_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.003" name="MC_PITCHRATE_D" type="FLOAT">
       <short_desc>Pitch rate D gain</short_desc>
       <long_desc>Pitch rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</long_desc>
       <min>0.0</min>
+      <decimal>4</decimal>
     </parameter>
     <parameter default="0.0" name="MC_PITCHRATE_FF" type="FLOAT">
       <short_desc>Pitch rate feedforward</short_desc>
       <long_desc>Improves tracking performance.</long_desc>
       <min>0.0</min>
+      <decimal>4</decimal>
     </parameter>
     <parameter default="2.8" name="MC_YAW_P" type="FLOAT">
       <short_desc>Yaw P gain</short_desc>
       <long_desc>Yaw proportional gain, i.e. desired angular speed in rad/s for error 1 rad.</long_desc>
       <min>0.0</min>
       <unit>1/s</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.2" name="MC_YAWRATE_P" type="FLOAT">
       <short_desc>Yaw rate P gain</short_desc>
       <long_desc>Yaw rate proportional gain, i.e. control output for angular speed error 1 rad/s.</long_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.1" name="MC_YAWRATE_I" type="FLOAT">
       <short_desc>Yaw rate I gain</short_desc>
       <long_desc>Yaw rate integral gain. Can be set to compensate static thrust difference or gravity center offset.</long_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.0" name="MC_YAWRATE_D" type="FLOAT">
       <short_desc>Yaw rate D gain</short_desc>
       <long_desc>Yaw rate differential gain. Small values help reduce fast oscillations. If value is too big oscillations will appear again.</long_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.0" name="MC_YAWRATE_FF" type="FLOAT">
       <short_desc>Yaw rate feedforward</short_desc>
       <long_desc>Improves tracking performance.</long_desc>
       <min>0.0</min>
+      <decimal>4</decimal>
     </parameter>
     <parameter default="0.5" name="MC_YAW_FF" type="FLOAT">
       <short_desc>Yaw feed forward</short_desc>
       <long_desc>Feed forward weight for manual yaw control. 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</long_desc>
       <min>0.0</min>
       <max>1.0</max>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="220.0" name="MC_ROLLRATE_MAX" type="FLOAT">
       <short_desc>Max roll rate</short_desc>
@@ -1588,6 +1625,7 @@ velocity</short_desc>
       <min>0.0</min>
       <max>360.0</max>
       <unit>deg/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="220.0" name="MC_PITCHRATE_MAX" type="FLOAT">
       <short_desc>Max pitch rate</short_desc>
@@ -1595,6 +1633,7 @@ velocity</short_desc>
       <min>0.0</min>
       <max>360.0</max>
       <unit>deg/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="120.0" name="MC_YAWRATE_MAX" type="FLOAT">
       <short_desc>Max yaw rate</short_desc>
@@ -1602,6 +1641,7 @@ velocity</short_desc>
       <min>0.0</min>
       <max>360.0</max>
       <unit>deg/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="45.0" name="MC_YAWRAUTO_MAX" type="FLOAT">
       <short_desc>Max yaw rate in auto mode</short_desc>
@@ -1609,23 +1649,27 @@ velocity</short_desc>
       <min>0.0</min>
       <max>120.0</max>
       <unit>deg/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="360.0" name="MC_ACRO_R_MAX" type="FLOAT">
       <short_desc>Max acro roll rate</short_desc>
       <min>0.0</min>
       <max>360.0</max>
       <unit>deg/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="360.0" name="MC_ACRO_P_MAX" type="FLOAT">
       <short_desc>Max acro pitch rate</short_desc>
       <min>0.0</min>
       <max>360.0</max>
       <unit>deg/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="360.0" name="MC_ACRO_Y_MAX" type="FLOAT">
       <short_desc>Max acro yaw rate</short_desc>
       <min>0.0</min>
       <unit>deg/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="1.0" name="MC_RATT_TH" type="FLOAT">
       <short_desc>Threshold for Rattitude mode</short_desc>
@@ -1633,6 +1677,7 @@ velocity</short_desc>
       <min>0.0</min>
       <max>1.0</max>
       <unit />
+      <decimal>2</decimal>
     </parameter>
     <parameter default="6.0" name="MP_ROLL_P" type="FLOAT">
       <short_desc>Roll P gain</short_desc>
@@ -1750,41 +1795,49 @@ velocity</short_desc>
       <long_desc>It's recommended to set it &gt; 0 to avoid free fall with zero thrust.</long_desc>
       <min>0.05</min>
       <max>1.0</max>
+      <decimal>3</decimal>
     </parameter>
     <parameter default="0.9" name="MPC_THR_MAX" type="FLOAT">
       <short_desc>Maximum thrust in auto thrust control</short_desc>
       <long_desc>Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</long_desc>
       <min>0.0</min>
       <max>0.95</max>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.08" name="MPC_MANTHR_MIN" type="FLOAT">
       <short_desc>Minimum manual thrust</short_desc>
       <long_desc>Minimum vertical thrust. It's recommended to set it &gt; 0 to avoid free fall with zero thrust.</long_desc>
       <min>0.0</min>
       <max>1.0</max>
+      <decimal>3</decimal>
     </parameter>
     <parameter default="0.9" name="MPC_MANTHR_MAX" type="FLOAT">
       <short_desc>Maximum manual thrust</short_desc>
       <long_desc>Limit max allowed thrust. Setting a value of one can put the system into actuator saturation as no spread between the motors is possible any more. A value of 0.8 - 0.9 is recommended.</long_desc>
       <min>0.0</min>
       <max>1.0</max>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="1.0" name="MPC_Z_P" type="FLOAT">
       <short_desc>Proportional gain for vertical position error</short_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.2" name="MPC_Z_VEL_P" type="FLOAT">
       <short_desc>Proportional gain for vertical velocity error</short_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.02" name="MPC_Z_VEL_I" type="FLOAT">
       <short_desc>Integral gain for vertical velocity error</short_desc>
       <long_desc>Non zero value allows hovering thrust estimation on stabilized or autonomous takeoff.</long_desc>
       <min>0.0</min>
+      <decimal>3</decimal>
     </parameter>
     <parameter default="0.0" name="MPC_Z_VEL_D" type="FLOAT">
       <short_desc>Differential gain for vertical velocity error</short_desc>
       <min>0.0</min>
+      <decimal>3</decimal>
     </parameter>
     <parameter default="3.0" name="MPC_Z_VEL_MAX" type="FLOAT">
       <short_desc>Maximum vertical velocity</short_desc>
@@ -1792,41 +1845,49 @@ velocity</short_desc>
       <min>0.0</min>
       <max>8.0</max>
       <unit>m/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="0.5" name="MPC_Z_FF" type="FLOAT">
       <short_desc>Vertical velocity feed forward</short_desc>
       <long_desc>Feed forward weight for altitude control in stabilized modes (ALTCTRL, POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</long_desc>
       <min>0.0</min>
       <max>1.0</max>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="1.0" name="MPC_XY_P" type="FLOAT">
       <short_desc>Proportional gain for horizontal position error</short_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.1" name="MPC_XY_VEL_P" type="FLOAT">
       <short_desc>Proportional gain for horizontal velocity error</short_desc>
       <min>0.0</min>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.02" name="MPC_XY_VEL_I" type="FLOAT">
       <short_desc>Integral gain for horizontal velocity error</short_desc>
       <long_desc>Non-zero value allows to resist wind.</long_desc>
       <min>0.0</min>
+      <decimal>3</decimal>
     </parameter>
     <parameter default="0.01" name="MPC_XY_VEL_D" type="FLOAT">
       <short_desc>Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again</short_desc>
       <min>0.0</min>
+      <decimal>3</decimal>
     </parameter>
     <parameter default="5.0" name="MPC_XY_VEL_MAX" type="FLOAT">
       <short_desc>Maximum horizontal velocity</short_desc>
       <long_desc>Maximum horizontal velocity in AUTO mode and endpoint for position stabilized mode (POSCTRL).</long_desc>
       <min>0.0</min>
       <unit>m/s</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.5" name="MPC_XY_FF" type="FLOAT">
       <short_desc>Horizontal velocity feed forward</short_desc>
       <long_desc>Feed forward weight for position control in position control mode (POSCTRL). 0 will give slow responce and no overshot, 1 - fast responce and big overshot.</long_desc>
       <min>0.0</min>
       <max>1.0</max>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="45.0" name="MPC_TILTMAX_AIR" type="FLOAT">
       <short_desc>Maximum tilt angle in air</short_desc>
@@ -1834,6 +1895,7 @@ velocity</short_desc>
       <min>0.0</min>
       <max>90.0</max>
       <unit>degree</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="12.0" name="MPC_TILTMAX_LND" type="FLOAT">
       <short_desc>Maximum tilt during landing</short_desc>
@@ -1841,66 +1903,78 @@ velocity</short_desc>
       <min>0.0</min>
       <max>90.0</max>
       <unit>degree</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="0.5" name="MPC_LAND_SPEED" type="FLOAT">
       <short_desc>Landing descend rate</short_desc>
       <min>0.0</min>
       <unit>m/s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="1.5" name="MPC_TKO_SPEED" type="FLOAT">
       <short_desc>Takeoff climb rate</short_desc>
       <min>0.0</min>
       <unit>m/s</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="35.0" name="MPC_MAN_R_MAX" type="FLOAT">
       <short_desc>Max manual roll</short_desc>
       <min>0.0</min>
       <max>90.0</max>
       <unit>degree</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="35.0" name="MPC_MAN_P_MAX" type="FLOAT">
       <short_desc>Max manual pitch</short_desc>
       <min>0.0</min>
       <max>90.0</max>
       <unit>degree</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="120.0" name="MPC_MAN_Y_MAX" type="FLOAT">
       <short_desc>Max manual yaw rate</short_desc>
       <min>0.0</min>
       <unit>degree / s</unit>
+      <decimal>1</decimal>
     </parameter>
     <parameter default="0.1" name="MPC_HOLD_XY_DZ" type="FLOAT">
       <short_desc>Deadzone of X,Y sticks where position hold is enabled</short_desc>
       <min>0.0</min>
       <max>1.0</max>
       <unit>%</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.1" name="MPC_HOLD_Z_DZ" type="FLOAT">
       <short_desc>Deadzone of Z stick where altitude hold is enabled</short_desc>
       <min>0.0</min>
       <max>1.0</max>
       <unit>%</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.5" name="MPC_HOLD_MAX_XY" type="FLOAT">
       <short_desc>Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)</short_desc>
       <min>0.0</min>
       <unit>m/s</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.5" name="MPC_HOLD_MAX_Z" type="FLOAT">
       <short_desc>Maximum vertical velocity for which position hold is enabled (use 0 to disable check)</short_desc>
       <min>0.0</min>
       <unit>m/s</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="5.0" name="MPC_VELD_LP" type="FLOAT">
       <short_desc>Low pass filter cut freq. for numerical velocity derivative</short_desc>
       <min>0.0</min>
       <unit>Hz</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="4.0" name="MPC_ACC_HOR_MAX" type="FLOAT">
       <short_desc>Maximum horizonal acceleration in velocity controlled modes</short_desc>
       <min>2.0</min>
       <max>10.0</max>
       <unit>m/s/s</unit>
+      <decimal>2</decimal>
     </parameter>
     <parameter default="0.1" name="MPP_THR_MIN" type="FLOAT">
       <short_desc>Minimum thrust</short_desc>
@@ -2385,7 +2459,7 @@ velocity</short_desc>
       <min>0.0</min>
       <max>10.0</max>
     </parameter>
-    <parameter default="9.0" name="INAV_W_XY_FLOW" type="FLOAT">
+    <parameter default="0.8" name="INAV_W_XY_FLOW" type="FLOAT">
       <short_desc>XY axis weight for optical flow</short_desc>
       <long_desc>Weight (cutoff frequency) for optical flow (velocity) measurements.</long_desc>
       <min>0.0</min>
@@ -2409,12 +2483,11 @@ velocity</short_desc>
       <min>0.0</min>
       <max>0.1</max>
     </parameter>
-    <parameter default="0.15" name="INAV_FLOW_K" type="FLOAT">
+    <parameter default="1.35" name="INAV_FLOW_K" type="FLOAT">
       <short_desc>Optical flow scale factor</short_desc>
-      <long_desc>Factor to convert raw optical flow (in pixels) to radians [rad/px].</long_desc>
+      <long_desc>Factor to scale optical flow</long_desc>
       <min>0.0</min>
-      <max>1.0</max>
-      <unit>rad/px</unit>
+      <max>10.0</max>
     </parameter>
     <parameter default="0.3" name="INAV_FLOW_Q_MIN" type="FLOAT">
       <short_desc>Minimal acceptable optical flow quality</short_desc>
@@ -2422,13 +2495,7 @@ velocity</short_desc>
       <min>0.0</min>
       <max>1.0</max>
     </parameter>
-    <parameter default="0.05" name="INAV_LIDAR_FILT" type="FLOAT">
-      <short_desc>Weight for lidar filter</short_desc>
-      <long_desc>Lidar filter detects spikes on lidar measurements and used to detect new surface level.</long_desc>
-      <min>0.0</min>
-      <max>1.0</max>
-    </parameter>
-    <parameter default="0.5" name="INAV_LIDAR_ERR" type="FLOAT">
+    <parameter default="0.2" name="INAV_LIDAR_ERR" type="FLOAT">
       <short_desc>Sonar maximal error for new surface</short_desc>
       <long_desc>If sonar measurement error is larger than this value it skiped (spike) or accepted as new surface level (if offset is stable).</long_desc>
       <min>0.0</min>
@@ -2481,6 +2548,19 @@ velocity</short_desc>
       <long_desc>Disable mocap</long_desc>
       <min>0</min>
       <max>1</max>
+    </parameter>
+    <parameter default="0" name="INAV_LIDAR_EST" type="FLOAT">
+      <short_desc>Enable LIDAR for altitude estimation</short_desc>
+      <long_desc>Enable LIDAR for altitude estimation</long_desc>
+      <min>0</min>
+      <max>1</max>
+    </parameter>
+    <parameter default="0.0" name="INAV_LIDAR_OFF" type="FLOAT">
+      <short_desc>LIDAR calibration offset</short_desc>
+      <long_desc>LIDAR calibration offset. Value will be added to the measured distance</long_desc>
+      <min>-20</min>
+      <max>20</max>
+      <unit>m</unit>
     </parameter>
     <parameter default="0" name="CBRK_NO_VISION" type="INT32">
       <short_desc>Disable vision input</short_desc>
@@ -3960,6 +4040,12 @@ FW_AIRSPD_MIN * RWTO_AIRSPD_SCL</short_desc>
       <short_desc>Enable optimal recovery strategy for pitch-weak tailsitters</short_desc>
       <min>0</min>
       <max>1</max>
+    </parameter>
+    <parameter default="15.0" name="VT_TRANS_TIMEOUT" type="FLOAT">
+      <short_desc>Front transition timeout</short_desc>
+      <long_desc>Time in seconds after which transition will be cancelled. Disabled if set to 0.</long_desc>
+      <min>0.0</min>
+      <max>30.0</max>
     </parameter>
   </group>
   <group name="mTECS">

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -68,7 +68,7 @@ struct Modes2Name {
 };
 
 /// Tranlates from PX4 custom modes to flight mode names
-// FIXME: Doens't handle fixed-wing/multi-rotor name differences
+
 static const struct Modes2Name rgModes2Name[] = {
     { PX4_CUSTOM_MAIN_MODE_MANUAL,      0,                                  "Manual",           true },
     { PX4_CUSTOM_MAIN_MODE_ACRO,        0,                                  "Acro",             true },
@@ -77,12 +77,12 @@ static const struct Modes2Name rgModes2Name[] = {
     { PX4_CUSTOM_MAIN_MODE_ALTCTL,      0,                                  "Altitude Control", true },
     { PX4_CUSTOM_MAIN_MODE_POSCTL,      0,                                  "Position Control", true },
     { PX4_CUSTOM_MAIN_MODE_OFFBOARD,    0,                                  "Offboard Control", true },
-    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_READY,     "Auto Ready",       false },
-    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF,   "Taking Off",       false },
-    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_LOITER,    "Loiter",           true },
-    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_MISSION,   "Mission",          true },
-    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_RTL,       "Return To Land",   true },
-    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_LAND,      "Landing",          false },
+    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_READY,     "Auto: Ready",       false },
+    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF,   "Auto: Takeoff",       false },
+    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_LOITER,    "Auto: Pause",           true },
+    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_MISSION,   "Auto: Mission",          true },
+    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_RTL,       "Auto: Return To Land",   true },
+    { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_LAND,      "Auto: Landing",          false },
 };
 
 

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -72,10 +72,10 @@ QGCView {
     property real _heading:             _activeVehicle ? _activeVehicle.heading.value : _defaultHeading
 
 
-    property Fact _emptyFact:           Fact { }
-    property Fact _groundSpeedFact:     _activeVehicle ? _activeVehicle.groundSpeed   : _emptyFact
-    property Fact _airSpeedFact:        _activeVehicle ? _activeVehicle.airSpeed      : _emptyFact
-    property Fact _altitudeAMSLFact:    _activeVehicle ? _activeVehicle.altitudeAMSL : _emptyFact
+    property Fact _emptyFact:               Fact { }
+    property Fact _groundSpeedFact:         _activeVehicle ? _activeVehicle.groundSpeed      : _emptyFact
+    property Fact _airSpeedFact:            _activeVehicle ? _activeVehicle.airSpeed         : _emptyFact
+    property Fact _altitudeRelativeFact:    _activeVehicle ? _activeVehicle.altitudeRelative : _emptyFact
 
     property bool activeVehicleJoystickEnabled: _activeVehicle ? _activeVehicle.joystickEnabled : false
 

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -83,8 +83,23 @@ FlightMap {
                     coordinate:     object.coordinate
                     isSatellite:    flightMap.isSatelliteMap
                     size:           _mainIsMap ? ScreenTools.defaultFontPixelHeight * 5 : ScreenTools.defaultFontPixelHeight * 2
-                    z:              QGroundControl.zOrderMapItems
+                    z:              QGroundControl.zOrderMapItems + 1
+
+                    onClicked: {
+                        if (object.active) {
+                            takeoffWidget.x = x + width
+                            takeoffWidget.y = y
+                            takeoffWidget.vehicle = object
+                            takeoffWidget.visible = true
+                        }
+                    }
             }
+    }
+
+    TakeoffWidget {
+        id:         takeoffWidget
+        visible:    false
+        z:          QGroundControl.zOrderMapItems + 1
     }
 
     // Add the mission items to the map

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -38,7 +38,8 @@ import QGroundControl.FlightMap     1.0
 Item {
     id: _root
 
-    property var _activeVehicle: multiVehicleManager.activeVehicle
+    property var    _activeVehicle: multiVehicleManager.activeVehicle
+    property bool   _isSatellite:   _mainIsMap ? _flightMap ? _flightMap.isSatelliteMap : true : true
 
     QGCMapPalette { id: mapPal; lightColors: !isBackgroundDark }
 
@@ -103,59 +104,42 @@ Item {
         altitudeFact:           _altitudeAMSLFact
         groundSpeedFact:        _groundSpeedFact
         airSpeedFact:           _airSpeedFact
-        isSatellite:            _mainIsMap ? _flightMap ? _flightMap.isSatelliteMap : true : true
+        isSatellite:            _isSatellite
         z:                      QGroundControl.zOrderWidgets
         qgcView:                parent.parent.qgcView
         maxHeight:              parent.height - (ScreenTools.defaultFontPixelHeight * 2)
     }
 
-    //-- Alternate Instrument Panel
-    Rectangle {
+    QGCInstrumentWidgetAlternate {
+        id:                     instrumentGadgetAlternate
+        anchors.margins:        ScreenTools.defaultFontPixelHeight
+        anchors.top:            parent.top
+        anchors.right:          parent.right
+        visible:                QGroundControl.virtualTabletJoystick
+        width:                  getGadgetWidth()
+        active:                 _activeVehicle != null
+        heading:                _heading
+        rollAngle:              _roll
+        pitchAngle:             _pitch
+        altitudeFact:           _altitudeAMSLFact
+        groundSpeedFact:        _groundSpeedFact
+        airSpeedFact:           _airSpeedFact
+        isSatellite:            _isSatellite
+        z:                      QGroundControl.zOrderWidgets
+    }
+
+    ValuesWidget {
+        anchors.topMargin:  ScreenTools.defaultFontPixelHeight
+        anchors.top:        instrumentGadgetAlternate.bottom
+        anchors.left:       instrumentGadgetAlternate.left
+        width:              getGadgetWidth()
+        qgcView:            parent.parent.qgcView
+        textColor:          _isSatellite ? "white" : "black"
         visible:            QGroundControl.virtualTabletJoystick
-        anchors.margins:    ScreenTools.defaultFontPixelHeight
-        anchors.right:      parent.right
-        anchors.bottom:     parent.bottom
-        width:              pipSize
-        height:             pipSize * (9/16)
-        color:              Qt.rgba(0,0,0,0.75)
-        Column {
-            id:                 instruments
-            width:              parent.width
-            spacing:            ScreenTools.defaultFontPixelSize * 0.33
-            anchors.verticalCenter: parent.verticalCenter
-            QGCLabel {
-                text:           _altitudeAMSLFact.shortDescription + "(" + _altitudeAMSLFact.units + ")"
-                font.pixelSize: ScreenTools.defaultFontPixelSize * 0.75
-                width:          parent.width
-                height:         ScreenTools.defaultFontPixelSize * 0.75
-                color:          "white"
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-            QGCLabel {
-                text:           _altitudeAMSLFact.valueString
-                font.pixelSize: ScreenTools.defaultFontPixelSize * 1.5
-                font.weight:    Font.DemiBold
-                width:          parent.width
-                color:          "white"
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-            QGCLabel {
-                text:           _groundSpeedFact.shortDescription + "(" + _groundSpeedFact.units + ")"
-                font.pixelSize: ScreenTools.defaultFontPixelSize * 0.75
-                width:          parent.width
-                height:         ScreenTools.defaultFontPixelSize * 0.75
-                color:          "white"
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-            QGCLabel {
-                text:           _groundSpeedFact.valueString
-                font.pixelSize: ScreenTools.defaultFontPixelSize
-                font.weight:    Font.DemiBold
-                width:          parent.width
-                color:          "white"
-                horizontalAlignment: TextEdit.AlignHCenter
-            }
-        }
+        maxHeight:          multiTouchItem.y - y
+
+        Component.onCompleted: console.log(y)
+        onHeightChanged: console.log(y, height, multiTouchItem.y)
     }
 
     //-- Vertical Tool Buttons

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -101,7 +101,7 @@ Item {
         heading:                _heading
         rollAngle:              _roll
         pitchAngle:             _pitch
-        altitudeFact:           _altitudeAMSLFact
+        altitudeFact:           _altitudeRelativeFact
         groundSpeedFact:        _groundSpeedFact
         airSpeedFact:           _airSpeedFact
         isSatellite:            _isSatellite
@@ -121,7 +121,7 @@ Item {
         heading:                _heading
         rollAngle:              _roll
         pitchAngle:             _pitch
-        altitudeFact:           _altitudeAMSLFact
+        altitudeFact:           _altitudeRelativeFact
         groundSpeedFact:        _groundSpeedFact
         airSpeedFact:           _airSpeedFact
         isSatellite:            _isSatellite
@@ -137,9 +137,6 @@ Item {
         textColor:          _isSatellite ? "white" : "black"
         visible:            QGroundControl.virtualTabletJoystick
         maxHeight:          multiTouchItem.y - y
-
-        Component.onCompleted: console.log(y)
-        onHeightChanged: console.log(y, height, multiTouchItem.y)
     }
 
     //-- Vertical Tool Buttons

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -33,9 +33,13 @@ import QGroundControl.Vehicle       1.0
 
 /// Marker for displaying a vehicle location on the map
 MapQuickItem {
+    id: root
+
     property var    vehicle                ///< Vehicle object
     property bool   isSatellite:    false  ///< true: satellite map is showing
     property real   size:           ScreenTools.defaultFontPixelHeight * 5
+
+    signal clicked
 
     anchorPoint.x:  vehicleIcon.width  / 2
     anchorPoint.y:  vehicleIcon.height / 2
@@ -52,6 +56,11 @@ MapQuickItem {
             origin.x:   vehicleIcon.width  / 2
             origin.y:   vehicleIcon.height / 2
             angle:      vehicle ? vehicle.heading.value : 0
+        }
+
+        MouseArea {
+            anchors.fill:   parent
+            onClicked:      root.clicked()
         }
     }
 }

--- a/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
@@ -1,0 +1,79 @@
+/*=====================================================================
+
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+import QtQuick 2.4
+
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FlightMap     1.0
+
+/// Instrument panel shown when virtual thumbsticks are visible
+Rectangle {
+    id:     root
+    height: _outerRadius * 2
+    radius: _outerRadius
+    color:  isSatellite ? Qt.rgba(1,1,1,0.75) : Qt.rgba(0,0,0,0.75)
+
+    property alias  heading:        compass.heading
+    property alias  rollAngle:      attitude.rollAngle
+    property alias  pitchAngle:     attitude.pitchAngle
+    property real   size:           _defaultSize
+    property bool   isSatellite:    false
+    property bool   active:         false
+
+    property Fact   _emptyFact:         Fact { }
+    property Fact   groundSpeedFact:    _emptyFact
+    property Fact   airSpeedFact:       _emptyFact
+    property Fact   altitudeFact:       _emptyFact
+
+    property real   _innerRadius: (width - (_topBottomMargin * 3)) / 4
+    property real   _outerRadius: _innerRadius + _topBottomMargin
+
+    property real   _defaultSize:   ScreenTools.defaultFontPixelSize * (9)
+
+    property real   _sizeRatio:     ScreenTools.isTinyScreen ? (size / _defaultSize) * 0.5 : size / _defaultSize
+    property real   _bigFontSize:   ScreenTools.defaultFontPixelSize * 2.5  * _sizeRatio
+    property real   _normalFontSize:ScreenTools.defaultFontPixelSize * 1.5  * _sizeRatio
+    property real   _labelFontSize: ScreenTools.defaultFontPixelSize * 0.75 * _sizeRatio
+    property real   _spacing:       ScreenTools.defaultFontPixelSize * 0.33
+    property real   _topBottomMargin: (size * 0.05) / 2
+
+    QGCAttitudeWidget {
+        id:                 attitude
+        anchors.leftMargin: _topBottomMargin
+        anchors.left:       parent.left
+        size:               _innerRadius * 2
+        active:             active
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
+    QGCCompassWidget {
+        id:                 compass
+        anchors.leftMargin: _spacing
+        anchors.left:       attitude.right
+        size:               _innerRadius * 2
+        active:             active
+        anchors.verticalCenter: parent.verticalCenter
+    }
+}

--- a/src/FlightMap/qmldir
+++ b/src/FlightMap/qmldir
@@ -5,14 +5,15 @@ FlightMap               1.0 FlightMap.qml
 QGCVideoBackground      1.0 QGCVideoBackground.qml
 
 # Widgets
-QGCArtificialHorizon    1.0 QGCArtificialHorizon.qml
-QGCAttitudeHUD          1.0 QGCAttitudeHUD.qml
-QGCAttitudeWidget       1.0 QGCAttitudeWidget.qml
-QGCCompassWidget        1.0 QGCCompassWidget.qml
-QGCInstrumentWidget     1.0 QGCInstrumentWidget.qml
-QGCPitchIndicator       1.0 QGCPitchIndicator.qml
-QGCSlider               1.0 QGCSlider.qml
-ValuesWidget            1.0 ValuesWidget.qml
+QGCArtificialHorizon            1.0 QGCArtificialHorizon.qml
+QGCAttitudeHUD                  1.0 QGCAttitudeHUD.qml
+QGCAttitudeWidget               1.0 QGCAttitudeWidget.qml
+QGCCompassWidget                1.0 QGCCompassWidget.qml
+QGCInstrumentWidget             1.0 QGCInstrumentWidget.qml
+QGCInstrumentWidgetAlternate    1.0 QGCInstrumentWidgetAlternate.qml
+QGCPitchIndicator               1.0 QGCPitchIndicator.qml
+QGCSlider                       1.0 QGCSlider.qml
+ValuesWidget                    1.0 ValuesWidget.qml
 
 # Map items
 MissionItemIndicator    1.0 MissionItemIndicator.qml

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -32,6 +32,7 @@ QGCViewPanel            1.0 QGCViewPanel.qml
 RoundButton             1.0 RoundButton.qml
 SignalStrength          1.0 SignalStrength.qml
 SubMenuButton           1.0 SubMenuButton.qml
+TakeoffWidget           1.0 TakeoffWidget.qml
 VehicleRotationCal      1.0 VehicleRotationCal.qml
 VehicleSummaryRow       1.0 VehicleSummaryRow.qml
 ViewWidget              1.0 ViewWidget.qml

--- a/src/QmlControls/TakeoffWidget.qml
+++ b/src/QmlControls/TakeoffWidget.qml
@@ -1,0 +1,48 @@
+import QtQuick          2.2
+import QtQuick.Controls 1.2
+
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.Vehicle       1.0
+
+// This control is used when the activeVehicle on the Fly view is clicked. It gives the user
+// the options for taking off.
+Item {
+    id: root
+
+    property var vehicle
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
+    Slider {
+        id:             slider
+        orientation:    Qt.Vertical
+        minimumValue:   0
+        maximumValue:   100
+        stepSize:       1
+        value:          10
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Column {
+        anchors.margins:    ScreenTools.defaultFontPixelWidth
+        anchors.left:       slider.right
+        spacing:            ScreenTools.defaultFontPixelWidth
+        anchors.verticalCenter: slider.verticalCenter
+
+        QGCButton {
+            text:               "Takeoff to " + slider.value + " meters"
+
+            onClicked: {
+                root.visible = false
+                vehicle.takeoff(slider.value)
+            }
+        }
+
+        QGCButton {
+            text:       "Cancel"
+            onClicked:  root.visible= false
+        }
+    }
+}

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1221,6 +1221,27 @@ void Vehicle::_setCoordinateValid(bool coordinateValid)
     }
 }
 
+void Vehicle::takeoff(double altitudeRelative)
+{
+    mavlink_message_t msg;
+    mavlink_command_long_t cmd;
+
+    cmd.command = MAV_CMD_NAV_TAKEOFF;
+    cmd.confirmation = 0;
+    cmd.param1 = 0.0f;
+    cmd.param2 = 0.0f;
+    cmd.param3 = 0.0f;
+    cmd.param4 = 0.0f;
+    cmd.param5 = 0.0f;
+    cmd.param6 = 0.0f;
+    cmd.param7 = altitudeRelative;
+    cmd.target_system = id();
+    cmd.target_component = 0;
+
+    mavlink_msg_command_long_encode(_mavlink->getSystemId(), _mavlink->getComponentId(), &msg, &cmd);
+
+    sendMessage(msg);
+}
 
 VehicleGPSFactGroup::VehicleGPSFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/GPSFact.json", parent)

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -233,6 +233,9 @@ public:
     Q_INVOKABLE void virtualTabletJoystickValue(double roll, double pitch, double yaw, double thrust);
     Q_INVOKABLE void disconnectInactiveVehicle(void);
 
+    /// Takeoff vehicle from ground straight up to specified relative altitude
+    Q_INVOKABLE void takeoff(double altitudeRelative);
+
     // Property accessors
 
     QGeoCoordinate coordinate(void) { return _coordinate; }


### PR DESCRIPTION
This should let us get started on wringing out user model and firmware issues:
![screen shot 2016-02-14 at 1 43 28 pm](https://cloud.githubusercontent.com/assets/5876851/13036666/0733feb2-d322-11e5-98e4-fa0d9f6f34fb.png)
Related to Issue #2803

QGC sends a MAV_CMD_NAV_TAKEOFF ins response to this ui with alt set and lot/lon=0.

Tried it with master SITL in Manual and POSTL with/without virtual thumbs. It sort of reacted to the command but never went up to the full height.