### PR TITLE
New parameter cache loading spec

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -434,3 +434,28 @@ FactMetaData::ValueType_t FactMetaData::stringToType(const QString& typeString, 
 
     return valueTypeDouble;
 }
+
+size_t FactMetaData::typeToSize(ValueType_t type)
+{
+    switch (type) {
+        case valueTypeUint8:
+        case valueTypeInt8:
+            return 1;
+
+        case valueTypeUint16:
+        case valueTypeInt16:
+            return 2;
+
+        case valueTypeUint32:
+        case valueTypeInt32:
+        case valueTypeFloat:
+            return 4;
+
+        case valueTypeDouble:
+            return 8;
+
+        default:
+            qWarning() << "Unsupported fact value type" << type;
+            return 4;
+    }
+}

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -121,7 +121,7 @@ public:
     static const int defaultDecimalPlaces = 3;
 
     static ValueType_t stringToType(const QString& typeString, bool& unknownType);
-    static size_t typeToSize(ValueType_t);
+    static size_t typeToSize(ValueType_t type);
 
 private:
     QVariant _minForType(void) const;

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -121,6 +121,7 @@ public:
     static const int defaultDecimalPlaces = 3;
 
     static ValueType_t stringToType(const QString& typeString, bool& unknownType);
+    static size_t typeToSize(ValueType_t);
 
 private:
     QVariant _minForType(void) const;

--- a/src/FactSystem/ParameterLoader.h
+++ b/src/FactSystem/ParameterLoader.h
@@ -112,9 +112,6 @@ protected:
     void _waitingParamTimeout(void);
     void _tryCacheLookup(void);
     void _initialRequestTimeout(void);
-    
-private slots:
-    void _timeoutRefreshAll();
 
 private:
     static QVariant _stringToTypedVariant(const QString& string, FactMetaData::ValueType_t type, bool failOk = false);
@@ -160,7 +157,6 @@ private:
     
     QTimer _initialRequestTimeoutTimer;
     QTimer _waitingParamTimeoutTimer;
-    QTimer _cacheTimeoutTimer;
     
     QMutex _dataMutex;
     

--- a/src/FactSystem/ParameterLoader.h
+++ b/src/FactSystem/ParameterLoader.h
@@ -53,8 +53,11 @@ public:
     
     ~ParameterLoader();
 
+    /// @return Directory of parameter caches
+    static QDir parameterCacheDir();
+
     /// @return Location of parameter cache file
-    static QString parameterCacheFile(void);
+    static QString parameterCacheFile(int uasId, int componentId);
     
     /// Returns true if the full set of facts are ready
     bool parametersAreReady(void) { return _parametersReady; }
@@ -120,8 +123,8 @@ private:
     void _setupGroupMap(void);
     void _readParameterRaw(int componentId, const QString& paramName, int paramIndex);
     void _writeParameterRaw(int componentId, const QString& paramName, const QVariant& value);
-    void _writeLocalParamCache();
-    void _tryCacheHashLoad(int uasId, QVariant hash_value);
+    void _writeLocalParamCache(int uasId, int componentId);
+    void _tryCacheHashLoad(int uasId, int componentId, QVariant hash_value);
 
     MAV_PARAM_TYPE _factTypeToMavType(FactMetaData::ValueType_t factType);
     FactMetaData::ValueType_t _mavTypeToFactType(MAV_PARAM_TYPE mavType);

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -374,7 +374,9 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 
         QFile::remove(PX4AirframeLoader::aiframeMetaDataFile());
         QFile::remove(PX4ParameterMetaData::parameterMetaDataFile());
-        QFile::remove(ParameterLoader::parameterCacheFile());
+        QDir paramDir(ParameterLoader::parameterCacheDir());
+        paramDir.removeRecursively();
+        paramDir.mkpath(paramDir.absolutePath());
     }
 
     _lastKnownHomePosition.setLatitude(settings.value(_lastKnownHomePositionLatKey, 37.803784).toDouble());


### PR DESCRIPTION
 - Request list of all parameters, expecting device to lead each component with _HASH_CHECK cache value
 - Test for hash collision, if so our cache is valid and respond with _HASH_CHECK to stop listing
 - Else: let listing continue as normal to get updated param values
 - Store each cache by systemID + componentID

For #2586 and PX4/Firmware#3764