### PR TITLE
Fix incorrect method name

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -103,7 +103,7 @@ QGCView {
         if (ScreenTools.isMobile) {
             _root.showDialog(mobileFileSaver, "Save Mission File", _root.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel)
         } else {
-            controller.saveToFile()
+            controller.saveMissionToFile()
         }
     }
 


### PR DESCRIPTION
Fix for Issue #2837. Screwed it up when I added mission load/save to tablet.