### PR TITLE
Initial Complex mission item support

### DIFF
--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -99,6 +99,7 @@
         <file alias="MapAddMissionBlack.svg">src/FlightMap/Images/MapAddMissionBlack.svg</file>
         <file alias="MapCenter.svg">src/FlightMap/Images/MapCenter.svg</file>
         <file alias="MapCenterBlack.svg">src/FlightMap/Images/MapCenterBlack.svg</file>
+        <file alias="MapDrawShape.svg">src/FlightMap/Images/MapDrawShape.svg</file>
         <file alias="MapHome.svg">src/FlightMap/Images/MapHome.svg</file>
         <file alias="MapHomeBlack.svg">src/FlightMap/Images/MapHomeBlack.svg</file>
         <file alias="MapSync.svg">src/FlightMap/Images/MapSync.svg</file>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -261,6 +261,8 @@ HEADERS += \
     src/MissionManager/MissionController.h \
     src/MissionManager/MissionItem.h \
     src/MissionManager/MissionManager.h \
+    src/MissionManager/ComplexMissionItem.h \
+    src/MissionManager/SimpleMissionItem.h \
     src/QGC.h \
     src/QGCApplication.h \
     src/QGCComboBox.h \
@@ -388,6 +390,8 @@ SOURCES += \
     src/MissionManager/MissionController.cc \
     src/MissionManager/MissionItem.cc \
     src/MissionManager/MissionManager.cc \
+    src/MissionManager/ComplexMissionItem.cc \
+    src/MissionManager/SimpleMissionItem.cc \
     src/QGC.cc \
     src/QGCApplication.cc \
     src/QGCComboBox.cc \

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -34,6 +34,7 @@
 
 #include <QVariant>
 #include <QQmlProperty>
+#include <QStandardPaths>
 
 bool APMAirframeComponentController::_typesRegistered = false;
 

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -35,6 +35,7 @@
 #include <QVariant>
 #include <QQmlProperty>
 #include <QStandardPaths>
+#include <QDir>
 
 bool APMAirframeComponentController::_typesRegistered = false;
 

--- a/src/FactSystem/ParameterLoader.h
+++ b/src/FactSystem/ParameterLoader.h
@@ -29,6 +29,7 @@
 #include <QXmlStreamReader>
 #include <QLoggingCategory>
 #include <QMutex>
+#include <QDir>
 
 #include "FactSystem.h"
 #include "MAVLinkProtocol.h"

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.cc
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.cc
@@ -32,6 +32,7 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QDebug>
+#include <QStack>
 
 QGC_LOGGING_CATEGORY(APMParameterMetaDataLog, "APMParameterMetaDataLog")
 QGC_LOGGING_CATEGORY(APMParameterMetaDataVerboseLog, "APMParameterMetaDataVerboseLog")

--- a/src/FlightMap/Images/MapDrawShape.svg
+++ b/src/FlightMap/Images/MapDrawShape.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+   viewBox="-89 46 72 72" enable-background="new -89 46 72 72" xml:space="preserve">
+<g transform="matrix(0.96508576,0,0,0.94661676,-1.3508671,3.6129809)">
+  <path fill="none" stroke="#FFFFFF" stroke-width="1.2" stroke-miterlimit="4" d="m -69.288973,77.48289 22.722433,-9.307985 2.098859,4.288973 -23.726235,9.39924 1.186311,4.471483 23.908746,-9.855514 L -41,80.768061 -66.186312,91.079848 -65,95.551331 l 25.460076,-10.403042 -2.372624,7.391635 -13.140684,5.110266"/>
+</g>
+<path fill="none" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" d="m -44.193916,62.152091 10.76806,20.623574 -9.21673,19.346005 -24.638783,-3.011404 -6.205323,-25.186312 z"/>
+</svg>

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -285,6 +285,8 @@ QGCView {
                 anchors.fill:   parent
                 mapName:        "MissionEditor"
 
+                signal mapClicked(var coordinate)
+
                 readonly property real animationDuration: 500
 
                 // Initial map position duplicates Fly view position
@@ -301,15 +303,15 @@ QGCView {
                     anchors.fill: parent
 
                     onClicked: {
+                        var coordinate = editorMap.toCoordinate(Qt.point(mouse.x, mouse.y))
+                        coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
+                        coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
+                        coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
                         if (addMissionItemsButton.checked) {
-                            var coordinate = editorMap.toCoordinate(Qt.point(mouse.x, mouse.y))
-                            coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
-                            coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
-                            coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
-                            var index = controller.insertMissionItem(coordinate, controller.missionItems.count)
+                            var index = controller.insertSimpleMissionItem(coordinate, controller.missionItems.count)
                             setCurrentItem(index)
                         } else {
-                            editorMap.zoomLevel = editorMap.maxZoomLevel - 2
+                            editorMap.mapClicked(coordinate)
                         }
                     }
                 }
@@ -364,7 +366,7 @@ QGCView {
                     }
                 }
 
-                // Add the mission items to the map
+                // Add the simple mission items to the map
                 MapItemView {
                     model:          controller.missionItems
                     delegate:       missionItemComponent
@@ -418,6 +420,22 @@ QGCView {
                                 }
                             }
                         }
+                    }
+                }
+
+                // Add the complex mission items to the map
+                MapItemView {
+                    model:          controller.complexMissionItems
+                    delegate:       polygonItemComponent
+                }
+
+                Component {
+                    id: polygonItemComponent
+
+                    MapPolygon {
+                        color:      'green'
+                        path:       object.polygonPath
+                        opacity:    0.5
                     }
                 }
 
@@ -482,7 +500,7 @@ QGCView {
                             }
 
                             onInsert: {
-                                controller.insertMissionItem(editorMap.center, i)
+                                controller.insertSimpleMissionItem(editorMap.center, i)
                                 setCurrentItem(i)
                             }
 
@@ -520,6 +538,23 @@ QGCView {
                         id:                 addMissionItemsButton
                         buttonImage:        "/qmlimages/MapAddMission.svg"
                         z:                  QGroundControl.zOrderWidgets
+                    }
+
+                    RoundButton {
+                        id:                 addShapeButton
+                        buttonImage:        "/qmlimages/MapDrawShape.svg"
+                        z:                  QGroundControl.zOrderWidgets
+                        visible:            QGroundControl.experimentalSurvey
+
+                        onClicked: {
+                            var coordinate = editorMap.center
+                            coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
+                            coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
+                            coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
+                            var index = controller.insertComplexMissionItem(coordinate, controller.missionItems.count)
+                            setCurrentItem(index)
+                            checked = false
+                        }
                     }
 
                     DropButton {

--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -1,0 +1,87 @@
+/*===================================================================
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2010 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+#include "ComplexMissionItem.h"
+
+ComplexMissionItem::ComplexMissionItem(Vehicle* vehicle, QObject* parent)
+    : MissionItem(vehicle, parent)
+{
+
+}
+
+ComplexMissionItem::ComplexMissionItem(Vehicle*       vehicle,
+                         int             sequenceNumber,
+                         MAV_CMD         command,
+                         MAV_FRAME       frame,
+                         double          param1,
+                         double          param2,
+                         double          param3,
+                         double          param4,
+                         double          param5,
+                         double          param6,
+                         double          param7,
+                         bool            autoContinue,
+                         bool            isCurrentItem,
+                         QObject*        parent)
+    : MissionItem(vehicle, sequenceNumber, command, frame, param1, param2, param3, param4, param5, param6, param7, autoContinue, isCurrentItem, parent)
+{
+
+}
+
+ComplexMissionItem::ComplexMissionItem(const ComplexMissionItem& other, QObject* parent)
+    : MissionItem(other, parent)
+{
+
+}
+
+const ComplexMissionItem& ComplexMissionItem::operator=(const ComplexMissionItem& other)
+{
+    static_cast<MissionItem&>(*this) = other;
+
+    return *this;
+}
+
+QVariantList ComplexMissionItem::polygonPath(void)
+{
+    return _polygonPath;
+#if 0
+    QVariantList list;
+
+    list << QVariant::fromValue(QGeoCoordinate(-35.362686830000001, 149.16410282999999))
+         << QVariant::fromValue(QGeoCoordinate(-35.362660579999996, 149.16606619999999))
+         << QVariant::fromValue(QGeoCoordinate(-35.363832989999999, 149.16505769));
+
+    return list;
+#endif
+}
+
+void ComplexMissionItem::clearPolygon(void)
+{
+    _polygonPath.clear();
+    emit polygonPathChanged();
+}
+
+void ComplexMissionItem::addPolygonCoordinate(const QGeoCoordinate coordinate)
+{
+    _polygonPath << QVariant::fromValue(coordinate);
+    emit polygonPathChanged();
+}

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -1,0 +1,73 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+#ifndef ComplexMissionItem_H
+#define ComplexMissionItem_H
+
+#include "MissionItem.h"
+
+class ComplexMissionItem : public MissionItem
+{
+    Q_OBJECT
+    
+public:
+    ComplexMissionItem(Vehicle* vehicle, QObject* parent = NULL);
+
+    ComplexMissionItem(Vehicle*        vehicle,
+                int             sequenceNumber,
+                MAV_CMD         command,
+                MAV_FRAME       frame,
+                double          param1,
+                double          param2,
+                double          param3,
+                double          param4,
+                double          param5,
+                double          param6,
+                double          param7,
+                bool            autoContinue,
+                bool            isCurrentItem,
+                QObject*        parent = NULL);
+
+    ComplexMissionItem(const ComplexMissionItem& other, QObject* parent = NULL);
+
+    const ComplexMissionItem& operator=(const ComplexMissionItem& other);
+
+    Q_PROPERTY(QVariantList  polygonPath READ polygonPath NOTIFY polygonPathChanged)
+
+    Q_INVOKABLE void clearPolygon(void);
+    Q_INVOKABLE void addPolygonCoordinate(const QGeoCoordinate coordinate);
+
+    QVariantList polygonPath(void);
+
+    // Overrides from MissionItem base class
+    bool            simpleItem      (void) const final { return false; }
+    QGeoCoordinate  exitCoordinate  (void) const final { return coordinate(); }
+
+signals:
+    void polygonPathChanged(void);
+
+private:
+    QVariantList _polygonPath;
+};
+
+#endif

--- a/src/MissionManager/MissionCommands.cc
+++ b/src/MissionManager/MissionCommands.cc
@@ -27,6 +27,8 @@ This file is part of the QGROUNDCONTROL project
 #include "QGCApplication.h"
 #include "QGroundControlQmlGlobal.h"
 
+#include <QQmlEngine>
+
 MissionCommands::MissionCommands(QGCApplication* app)
     : QGCTool(app)
     , _commonMissionCommands(QStringLiteral(":/json/MavCmdInfoCommon.json"))

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -27,6 +27,8 @@ This file is part of the QGROUNDCONTROL project
 #include "CoordinateVector.h"
 #include "FirmwarePlugin.h"
 #include "QGCApplication.h"
+#include "SimpleMissionItem.h"
+#include "ComplexMissionItem.h"
 
 #ifndef __mobile__
 #include "QGCFileDialog.h"
@@ -45,6 +47,7 @@ MissionController::MissionController(QObject *parent)
     : QObject(parent)
     , _editMode(false)
     , _missionItems(NULL)
+    , _complexMissionItems(NULL)
     , _activeVehicle(NULL)
     , _autoSync(false)
     , _firstItemsFromVehicle(false)
@@ -124,9 +127,9 @@ void MissionController::sendMissionItems(void)
     }
 }
 
-int MissionController::insertMissionItem(QGeoCoordinate coordinate, int i)
+int MissionController::insertSimpleMissionItem(QGeoCoordinate coordinate, int i)
 {
-    MissionItem * newItem = new MissionItem(_activeVehicle, this);
+    MissionItem * newItem = new SimpleMissionItem(_activeVehicle, this);
     newItem->setSequenceNumber(_missionItems->count());
     newItem->setCoordinate(coordinate);
     newItem->setCommand(MAV_CMD_NAV_WAYPOINT);
@@ -146,6 +149,22 @@ int MissionController::insertMissionItem(QGeoCoordinate coordinate, int i)
         }
     }
     _missionItems->insert(i, newItem);
+
+    _recalcAll();
+
+    return _missionItems->count() - 1;
+}
+
+int MissionController::insertComplexMissionItem(QGeoCoordinate coordinate, int i)
+{
+    ComplexMissionItem * newItem = new ComplexMissionItem(_activeVehicle, this);
+    newItem->setSequenceNumber(_missionItems->count());
+    newItem->setCoordinate(coordinate);
+    newItem->setCommand(MAV_CMD_NAV_WAYPOINT);
+    _initMissionItem(newItem);
+
+    _missionItems->insert(i, newItem);
+    _complexMissionItems->append(newItem);
 
     _recalcAll();
 
@@ -218,7 +237,7 @@ bool MissionController::_loadJsonMissionFile(const QByteArray& bytes, QmlObjectL
                 return false;
             }
 
-            MissionItem* item = new MissionItem(_activeVehicle, this);
+            MissionItem* item = new SimpleMissionItem(_activeVehicle, this);
             if (item->load(itemValue.toObject(), errorString)) {
                 missionItems->append(item);
             } else {
@@ -228,7 +247,7 @@ bool MissionController::_loadJsonMissionFile(const QByteArray& bytes, QmlObjectL
     }
 
     if (json.contains(_jsonPlannedHomePositionKey)) {
-        MissionItem* item = new MissionItem(_activeVehicle, this);
+        MissionItem* item = new SimpleMissionItem(_activeVehicle, this);
 
         if (item->load(json[_jsonPlannedHomePositionKey].toObject(), errorString)) {
             missionItems->insert(0, item);
@@ -263,7 +282,7 @@ bool MissionController::_loadTextMissionFile(QTextStream& stream, QmlObjectListM
 
     if (versionOk) {
         while (!stream.atEnd()) {
-            MissionItem* item = new MissionItem(_activeVehicle, this);
+            MissionItem* item = new SimpleMissionItem(_activeVehicle, this);
 
             if (item->load(stream)) {
                 missionItems->append(item);
@@ -612,13 +631,24 @@ void MissionController::_initAllMissionItems(void)
 
     qDebug() << "home item" << homeItem->coordinate();
 
+    QmlObjectListModel* newComplexItems = new QmlObjectListModel(this);
+
     for (int i=0; i<_missionItems->count(); i++) {
-        _initMissionItem(qobject_cast<MissionItem*>(_missionItems->get(i)));
+        MissionItem* item = qobject_cast<MissionItem*>(_missionItems->get(i));
+
+        if (!item->simpleItem()) {
+            newComplexItems->append(item);
+        }
+        _initMissionItem(item);
     }
+
+    delete _complexMissionItems;
+    _complexMissionItems = newComplexItems;
 
     _recalcAll();
 
     emit missionItemsChanged();
+    emit complexMissionItemsChanged();
 
     _missionItems->setDirty(false);
 
@@ -773,6 +803,11 @@ QmlObjectListModel* MissionController::missionItems(void)
     return _missionItems;
 }
 
+QmlObjectListModel* MissionController::complexMissionItems(void)
+{
+    return _complexMissionItems;
+}
+
 bool MissionController::_findLastAltitude(double* lastAltitude)
 {
     bool found = false;
@@ -831,7 +866,7 @@ double MissionController::_normalizeLon(double lon)
 /// Add the home position item to the front of the list
 void MissionController::_addPlannedHomePosition(QmlObjectListModel* missionItems, bool addToCenter)
 {
-    MissionItem* homeItem = new MissionItem(_activeVehicle, this);
+    MissionItem* homeItem = new SimpleMissionItem(_activeVehicle, this);
     missionItems->insert(0, homeItem);
 
     if (missionItems->count() > 1  && addToCenter) {

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -29,6 +29,8 @@ This file is part of the QGROUNDCONTROL project
 #include "QmlObjectListModel.h"
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
+#include "MavlinkQmlSingleton.h"
+#include "MissionItem.h"
 
 Q_DECLARE_LOGGING_CATEGORY(MissionControllerLog)
 
@@ -41,6 +43,7 @@ public:
     ~MissionController();
 
     Q_PROPERTY(QmlObjectListModel*  missionItems                READ missionItems                   NOTIFY missionItemsChanged)
+    Q_PROPERTY(QmlObjectListModel*  complexMissionItems         READ complexMissionItems            NOTIFY complexMissionItemsChanged)
     Q_PROPERTY(QmlObjectListModel*  waypointLines               READ waypointLines                  NOTIFY waypointLinesChanged)
     Q_PROPERTY(bool                 autoSync                    READ autoSync   WRITE setAutoSync   NOTIFY autoSyncChanged)
     Q_PROPERTY(bool                 syncInProgress              READ syncInProgress                 NOTIFY syncInProgressChanged)
@@ -57,11 +60,15 @@ public:
     Q_INVOKABLE QStringList getMobileMissionFiles(void);
 
     /// @param i: index to insert at
-    Q_INVOKABLE int insertMissionItem(QGeoCoordinate coordinate, int i);
+    Q_INVOKABLE int insertSimpleMissionItem(QGeoCoordinate coordinate, int i);
+
+    /// @param i: index to insert at
+    Q_INVOKABLE int insertComplexMissionItem(QGeoCoordinate coordinate, int i);
 
     // Property accessors
 
     QmlObjectListModel* missionItems(void);
+    QmlObjectListModel* complexMissionItems(void);
     QmlObjectListModel* waypointLines(void) { return &_waypointLines; }
     bool autoSync(void) { return _autoSync; }
     void setAutoSync(bool autoSync);
@@ -69,6 +76,7 @@ public:
 
 signals:
     void missionItemsChanged(void);
+    void complexMissionItemsChanged(void);
     void waypointLinesChanged(void);
     void autoSyncChanged(bool autoSync);
     void newItemsFromVehicle(void);
@@ -111,6 +119,7 @@ private:
 private:
     bool                _editMode;
     QmlObjectListModel* _missionItems;
+    QmlObjectListModel* _complexMissionItems;
     QmlObjectListModel  _waypointLines;
     Vehicle*            _activeVehicle;
     bool                _autoSync;

--- a/src/MissionManager/MissionControllerTest.cc
+++ b/src/MissionManager/MissionControllerTest.cc
@@ -137,7 +137,7 @@ void MissionControllerTest::_testAddWaypointWorker(MAV_AUTOPILOT firmwareType)
 
     QGeoCoordinate coordinate(37.803784, -122.462276);
 
-    _missionController->insertMissionItem(coordinate, _missionController->missionItems()->count());
+    _missionController->insertSimpleMissionItem(coordinate, _missionController->missionItems()->count());
 
     QCOMPARE(_multiSpyMissionController->checkOnlySignalsByMask(waypointLinesChangedSignalMask), true);
 
@@ -182,7 +182,7 @@ void MissionControllerTest::_testOfflineToOnlineWorker(MAV_AUTOPILOT firmwareTyp
     _missionController = new MissionController();
     Q_CHECK_PTR(_missionController);
     _missionController->start(true /* editMode */);
-    _missionController->insertMissionItem(QGeoCoordinate(37.803784, -122.462276), _missionController->missionItems()->count());
+    _missionController->insertSimpleMissionItem(QGeoCoordinate(37.803784, -122.462276), _missionController->missionItems()->count());
 
     // Go online to empty vehicle
     MissionControllerManagerTest::_initForFirmwareType(firmwareType);

--- a/src/MissionManager/MissionItem.cc
+++ b/src/MissionManager/MissionItem.cc
@@ -28,8 +28,6 @@ This file is part of the QGROUNDCONTROL project
 #include "QGCApplication.h"
 #include "JsonHelper.h"
 
-QGC_LOGGING_CATEGORY(MissionItemLog, "MissionItemLog")
-
 const double MissionItem::defaultAltitude =             25.0;
 
 FactMetaData* MissionItem::_altitudeMetaData =          NULL;
@@ -70,22 +68,6 @@ static const struct EnumInfo_s _rgMavFrameInfo[] = {
 { "MAV_FRAME_GLOBAL_TERRAIN_ALT",       MAV_FRAME_GLOBAL_TERRAIN_ALT },
 { "MAV_FRAME_GLOBAL_TERRAIN_ALT_INT",   MAV_FRAME_GLOBAL_TERRAIN_ALT_INT },
 };
-
-QDebug operator<<(QDebug dbg, const MissionItem& missionItem)
-{
-    QDebugStateSaver saver(dbg);
-    dbg.nospace() << "MissionItem(" << missionItem.coordinate() << ")";
-    
-    return dbg;
-}
-
-QDebug operator<<(QDebug dbg, const MissionItem* missionItem)
-{
-    QDebugStateSaver saver(dbg);
-    dbg.nospace() << "MissionItem(" << missionItem->coordinate() << ")";
-    
-    return dbg;
-}
 
 MissionItem::MissionItem(Vehicle* vehicle, QObject* parent)
     : QObject(parent)

--- a/src/MissionManager/MissionItemTest.cc
+++ b/src/MissionManager/MissionItemTest.cc
@@ -22,7 +22,7 @@
  ======================================================================*/
 
 #include "MissionItemTest.h"
-#include "MissionItem.h"
+#include "SimpleMissionItem.h"
 
 const MissionItemTest::ItemInfo_t MissionItemTest::_rgItemInfo[] = {
     { MAV_CMD_NAV_WAYPOINT,     MAV_FRAME_GLOBAL_RELATIVE_ALT },
@@ -184,7 +184,7 @@ void MissionItemTest::_test(void)
 
 void MissionItemTest::_testDefaultValues(void)
 {
-    MissionItem item(NULL /* Vehicle */);
+    SimpleMissionItem item(NULL /* Vehicle */);
 
     item.setCommand(MAV_CMD_NAV_WAYPOINT);
     item.setFrame(MAV_FRAME_GLOBAL_RELATIVE_ALT);

--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -29,6 +29,7 @@
 #include "FirmwarePlugin.h"
 #include "MAVLinkProtocol.h"
 #include "QGCApplication.h"
+#include "SimpleMissionItem.h"
 
 QGC_LOGGING_CATEGORY(MissionManagerLog, "MissionManagerLog")
 
@@ -64,7 +65,7 @@ void MissionManager::writeMissionItems(const QmlObjectListModel& missionItems)
     int firstIndex = skipFirstItem ? 1 : 0;
     
     for (int i=firstIndex; i<missionItems.count(); i++) {
-        _missionItems.append(new MissionItem(*qobject_cast<const MissionItem*>(missionItems[i])));
+        _missionItems.append(new SimpleMissionItem(*qobject_cast<const SimpleMissionItem*>(missionItems[i])));
 
         MissionItem* item = qobject_cast<MissionItem*>(_missionItems.get(_missionItems.count() - 1));
 
@@ -252,7 +253,7 @@ void MissionManager::_handleMissionItem(const mavlink_message_t& message)
         _requestItemRetryCount = 0;
         _itemIndicesToRead.removeOne(missionItem.seq);
 
-        MissionItem* item = new MissionItem(_vehicle,
+        MissionItem* item = new SimpleMissionItem(_vehicle,
                                             missionItem.seq,
                                             (MAV_CMD)missionItem.command,
                                             (MAV_FRAME)missionItem.frame,
@@ -432,7 +433,7 @@ QmlObjectListModel* MissionManager::copyMissionItems(void)
     QmlObjectListModel* list = new QmlObjectListModel();
     
     for (int i=0; i<_missionItems.count(); i++) {
-        list->append(new MissionItem(*qobject_cast<const MissionItem*>(_missionItems[i])));
+        list->append(new SimpleMissionItem(*qobject_cast<const SimpleMissionItem*>(_missionItems[i])));
     }
     
     return list;

--- a/src/MissionManager/MissionManagerTest.cc
+++ b/src/MissionManager/MissionManagerTest.cc
@@ -24,6 +24,7 @@
 #include "MissionManagerTest.h"
 #include "LinkManager.h"
 #include "MultiVehicleManager.h"
+#include "SimpleMissionItem.h"
 
 const MissionManagerTest::TestCase_t MissionManagerTest::_rgTestCases[] = {
     { "0\t0\t3\t16\t10\t20\t30\t40\t-10\t-20\t-30\t1\r\n",  { 0, QGeoCoordinate(-10.0, -20.0, -30.0), MAV_CMD_NAV_WAYPOINT,     10.0, 20.0, 30.0, 40.0, true, false, MAV_FRAME_GLOBAL_RELATIVE_ALT } },
@@ -48,7 +49,7 @@ void MissionManagerTest::_writeItems(MockLinkMissionItemHandler::FailureMode_t f
     QmlObjectListModel* list = new QmlObjectListModel();
     
     // Editor has a home position item on the front, so we do the same
-    MissionItem* homeItem = new MissionItem(NULL /* Vehicle */, this);
+    SimpleMissionItem* homeItem = new SimpleMissionItem(NULL /* Vehicle */, this);
     homeItem->setHomePositionSpecialCase(true);
     homeItem->setCommand(MavlinkQmlSingleton::MAV_CMD_NAV_WAYPOINT);
     homeItem->setCoordinate(QGeoCoordinate(47.3769, 8.549444, 0));
@@ -58,7 +59,7 @@ void MissionManagerTest::_writeItems(MockLinkMissionItemHandler::FailureMode_t f
     for (size_t i=0; i<_cTestCases; i++) {
         const TestCase_t* testCase = &_rgTestCases[i];
         
-        MissionItem* item = new MissionItem(NULL /* Vehicle */, list);
+        SimpleMissionItem* item = new SimpleMissionItem(NULL /* Vehicle */, list);
         
         QTextStream loadStream(testCase->itemStream, QIODevice::ReadOnly);
         QVERIFY(item->load(loadStream));

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -1,0 +1,61 @@
+/*===================================================================
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2010 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+#include "SimpleMissionItem.h"
+
+SimpleMissionItem::SimpleMissionItem(Vehicle* vehicle, QObject* parent)
+    : MissionItem(vehicle, parent)
+{
+
+}
+
+SimpleMissionItem::SimpleMissionItem(Vehicle*       vehicle,
+                         int             sequenceNumber,
+                         MAV_CMD         command,
+                         MAV_FRAME       frame,
+                         double          param1,
+                         double          param2,
+                         double          param3,
+                         double          param4,
+                         double          param5,
+                         double          param6,
+                         double          param7,
+                         bool            autoContinue,
+                         bool            isCurrentItem,
+                         QObject*        parent)
+    : MissionItem(vehicle, sequenceNumber, command, frame, param1, param2, param3, param4, param5, param6, param7, autoContinue, isCurrentItem, parent)
+{
+
+}
+
+SimpleMissionItem::SimpleMissionItem(const SimpleMissionItem& other, QObject* parent)
+    : MissionItem(other, parent)
+{
+
+}
+
+const SimpleMissionItem& SimpleMissionItem::operator=(const SimpleMissionItem& other)
+{
+    static_cast<MissionItem&>(*this) = other;
+
+    return *this;
+}

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -1,0 +1,62 @@
+/*=====================================================================
+ 
+ QGroundControl Open Source Ground Control Station
+ 
+ (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ 
+ This file is part of the QGROUNDCONTROL project
+ 
+ QGROUNDCONTROL is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ QGROUNDCONTROL is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+ 
+ ======================================================================*/
+
+#ifndef SimpleMissionItem_H
+#define SimpleMissionItem_H
+
+#include "MissionItem.h"
+
+class SimpleMissionItem : public MissionItem
+{
+    Q_OBJECT
+    
+public:
+    SimpleMissionItem(Vehicle* vehicle, QObject* parent = NULL);
+
+    SimpleMissionItem(Vehicle*        vehicle,
+                int             sequenceNumber,
+                MAV_CMD         command,
+                MAV_FRAME       frame,
+                double          param1,
+                double          param2,
+                double          param3,
+                double          param4,
+                double          param5,
+                double          param6,
+                double          param7,
+                bool            autoContinue,
+                bool            isCurrentItem,
+                QObject*        parent = NULL);
+
+    SimpleMissionItem(const SimpleMissionItem& other, QObject* parent = NULL);
+
+    const SimpleMissionItem& operator=(const SimpleMissionItem& other);
+
+    // Overrides from MissionItem base class
+    bool            simpleItem      (void) const final { return true; }
+    QGeoCoordinate  exitCoordinate  (void) const final { return coordinate(); }
+
+private:
+};
+
+#endif

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -34,6 +34,7 @@
 
 #include <QApplication>
 #include <QTimer>
+#include <QQmlApplicationEngine>
 
 #include "LinkConfiguration.h"
 #include "LinkManager.h"

--- a/src/QGCLoggingCategory.cc
+++ b/src/QGCLoggingCategory.cc
@@ -30,7 +30,7 @@
 QGC_LOGGING_CATEGORY(FirmwareUpgradeLog,        "FirmwareUpgradeLog")
 QGC_LOGGING_CATEGORY(FirmwareUpgradeVerboseLog, "FirmwareUpgradeVerboseLog")
 QGC_LOGGING_CATEGORY(MissionCommandsLog,        "MissionCommandsLog")
-
+QGC_LOGGING_CATEGORY(MissionItemLog,            "MissionItemLog")
 
 QGCLoggingCategoryRegister* _instance = NULL;
 

--- a/src/QGCLoggingCategory.h
+++ b/src/QGCLoggingCategory.h
@@ -34,6 +34,7 @@
 Q_DECLARE_LOGGING_CATEGORY(FirmwareUpgradeLog)
 Q_DECLARE_LOGGING_CATEGORY(FirmwareUpgradeVerboseLog)
 Q_DECLARE_LOGGING_CATEGORY(MissionCommandsLog)
+Q_DECLARE_LOGGING_CATEGORY(MissionItemLog)
 
 /// @def QGC_LOGGING_CATEGORY
 /// This is a QGC specific replacement for Q_LOGGING_CATEGORY. It will register the category name into a

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -34,6 +34,8 @@
 #include "MainWindow.h"
 #endif
 
+#include <QStandardPaths>
+
 /// @Brief Constructs a new ParameterEditorController Widget. This widget is used within the PX4VehicleConfig set of screens.
 ParameterEditorController::ParameterEditorController(void)
 {

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -206,3 +206,18 @@ void QGroundControlQmlGlobal::setVirtualTabletJoystick(bool enabled)
         emit virtualTabletJoystickChanged(enabled);
     }
 }
+
+bool QGroundControlQmlGlobal::experimentalSurvey(void) const
+{
+    QSettings settings;
+
+    return settings.value("ExperimentalSurvey", false).toBool();
+}
+
+void QGroundControlQmlGlobal::setExperimentalSurvey(bool experimentalSurvey)
+{
+    QSettings settings;
+
+    settings.setValue("ExperimentalSurvey", experimentalSurvey);
+    emit experimentalSurveyChanged(experimentalSurvey);
+}

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -79,6 +79,9 @@ public:
     Q_PROPERTY(QGeoCoordinate lastKnownHomePosition READ lastKnownHomePosition CONSTANT)
     Q_PROPERTY(QGeoCoordinate flightMapPosition MEMBER _flightMapPosition NOTIFY flightMapPositionChanged)
 
+    /// @ return: true: experimental survey ip code is turned on
+    Q_PROPERTY(bool experimentalSurvey READ experimentalSurvey WRITE setExperimentalSurvey NOTIFY experimentalSurveyChanged)
+
     Q_INVOKABLE void    saveGlobalSetting       (const QString& key, const QString& value);
     Q_INVOKABLE QString loadGlobalSetting       (const QString& key, const QString& defaultValue);
     Q_INVOKABLE void    saveBoolGlobalSetting   (const QString& key, bool value);
@@ -133,6 +136,9 @@ public:
     void    setIsVersionCheckEnabled    (bool enable);
     void    setMavlinkSystemID          (int  id);
 
+    bool experimentalSurvey(void) const;
+    void setExperimentalSurvey(bool experimentalSurvey);
+
     // Overrides from QGCTool
     virtual void setToolbox(QGCToolbox* toolbox);
 
@@ -146,6 +152,7 @@ signals:
     void isVersionCheckEnabledChanged   (bool enabled);
     void mavlinkSystemIDChanged         (int id);
     void flightMapPositionChanged       (QGeoCoordinate flightMapPosition);
+    void experimentalSurveyChanged      (bool experimentalSurvey);
 
 private:
     FlightMapSettings*      _flightMapSettings;

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -26,11 +26,14 @@
 
 #include "QGCMapEngineManager.h"
 #include "QGCApplication.h"
-#include <QSettings>
 #include "QGCMapTileSet.h"
 #include "QGCMapUrlEngine.h"
-#include <QStorageInfo>
+
 #include <stdio.h>
+
+#include <QQmlEngine>
+#include <QSettings>
+#include <QStorageInfo>
 
 QGC_LOGGING_CATEGORY(QGCMapEngineManagerLog, "QGCMapEngineManagerLog")
 

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -30,6 +30,8 @@
 #include "UAS.h"
 #include "QGCApplication.h"
 
+#include <QQmlEngine>
+
 QGC_LOGGING_CATEGORY(MultiVehicleManagerLog, "MultiVehicleManagerLog")
 
 const char* MultiVehicleManager::_gcsHeartbeatEnabledKey = "gcsHeartbeatEnabled";

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -33,7 +33,6 @@
 #include "FactGroup.h"
 #include "LinkInterface.h"
 #include "QGCMAVLink.h"
-#include "MissionItem.h"
 #include "QmlObjectListModel.h"
 #include "MAVLinkProtocol.h"
 #include "UASMessageHandler.h"

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -31,6 +31,9 @@
 #include "QGCApplication.h"
 #include "QGCFileDownload.h"
 
+#include <QStandardPaths>
+#include <QRegularExpression>
+
 struct FirmwareToUrlElement_t {
     FirmwareUpgradeController::AutoPilotStackType_t    stackType;
     FirmwareUpgradeController::FirmwareType_t          firmwareType;

--- a/src/ViewWidgets/LogDownloadController.cc
+++ b/src/ViewWidgets/LogDownloadController.cc
@@ -34,6 +34,8 @@
 #include <QDebug>
 #include <QSettings>
 #include <QUrl>
+#include <QBitArray>
+#include <QtCore/qmath.h>
 
 #define kTimeOutMilliseconds 500
 #define kGUIRateMilliseconds 17

--- a/src/main.cc
+++ b/src/main.cc
@@ -34,6 +34,7 @@ This file is part of the QGROUNDCONTROL project
 #include <QProcessEnvironment>
 #include <QHostAddress>
 #include <QUdpSocket>
+#include <QtPlugin>
 
 #include "QGCApplication.h"
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -32,6 +32,8 @@ This file is part of the QGROUNDCONTROL project
 #include <QApplication>
 #include <QSslSocket>
 #include <QProcessEnvironment>
+#include <QHostAddress>
+#include <QUdpSocket>
 
 #include "QGCApplication.h"
 

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -242,6 +242,8 @@ Rectangle {
                 width:  parent.width
             }
 
+            //-----------------------------------------------------------------
+            //-- Offline mission editing settings
             Row {
                 spacing: ScreenTools.defaultFontPixelWidth
 
@@ -256,6 +258,19 @@ Rectangle {
                     fact:       QGroundControl.offlineEditingFirmwareType
                     indexModel: false
                 }
+            }
+
+            Item {
+                height: ScreenTools.defaultFontPixelHeight / 2
+                width:  parent.width
+            }
+
+            //-----------------------------------------------------------------
+            //-- Experimental Survey settings
+            QGCCheckBox {
+                text:       "Experimental Survey [WIP - no bugs reports please]"
+                checked:    QGroundControl.experimentalSurvey
+                onClicked:  QGroundControl.experimentalSurvey = checked
             }
         }
     }


### PR DESCRIPTION
Complex Mission Item described:
- Encapsulates a set of individual mission items into a single entity
- While Mission Editing a complex mission item is represented as a single item in the list
- Has it's own visual representation on the map
- Has it's own mini-editor in the right hand item list
- Has an entry and exit waypoint
- A mission can include multiple complex mission items
- Full load/save round tripping for all of it's information beyond just the mission items themselves

This is the initial work towards the above goal. The first usage of a Complex mission item will be a Survey Grid. Another example to come later would be Structure Scan.

Initial Survey support is hidden behind a "Experimental Survey [WIP - no bugs reports please]" checkbox in General Settings. Still a very long way to go but it is showing signs of life.

![screen shot 2016-02-18 at 7 26 38 pm](https://cloud.githubusercontent.com/assets/5876851/13166188/cc1fe6aa-d679-11e5-9175-86d2248194e4.png)

Related to Issue #2726