### PR TITLE
Hopefully fixes crash Lorenz is seeing.

### DIFF
--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -226,13 +226,9 @@ QGeoTiledMappingManagerEngineQGC::_setCache(const QVariantMap &parameters)
     QGeoTileCache* pTileCache = createTileCacheWithDir(cacheDir);
     if(pTileCache)
     {
-        //-- We're basically telling it to use 1kb (100k for Windows) of disk for cache. It doesn't like
+        //-- We're basically telling it to use 100k of disk for cache. It doesn't like
         //   values smaller than that and I could not find a way to make it NOT cache.
-#ifdef Q_OS_WIN
         pTileCache->setMaxDiskUsage(1024 * 100);
-#else
-        pTileCache->setMaxDiskUsage(1024);
-#endif
         pTileCache->setMaxMemoryUsage(memLimit);
     }
 }


### PR DESCRIPTION
I can't reproduce this here but the stack trace in #2850 is in the same place my Windows build had issues with. I'm basically trying to get Qt NOT to use disk cache (redundancy). There is no way to disable it altogether so I'm telling it to use 1kb of disk space. This worked for all but Windows, which crashed unless I set it to 100kb. Apparently I was being lucky.

I'm now setting it to 100kb for all platforms. This will all change when we switch to 5.6.