### PR TITLE
Flickable in Offline Maps

### DIFF
--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -29,12 +29,12 @@ This file is part of the QGROUNDCONTROL project
  *
  */
 
-#include <math.h>
-#include <QSettings>
-
 #include "QGCMapEngine.h"
 #include "QGCMapTileSet.h"
 #include "QGCMapEngineManager.h"
+
+#include <QSettings>
+#include <math.h>
 
 QGC_LOGGING_CATEGORY(QGCCachedTileSetLog, "QGCCachedTileSetLog")
 

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -27,14 +27,14 @@ This file is part of the QGROUNDCONTROL project
  *  Original work: The OpenPilot Team, http://www.openpilot.org Copyright (C) 2012.
  */
 
+#include "QGCMapEngine.h"
+
 #include <QRegExp>
 #include <QNetworkReply>
 #include <QEventLoop>
 #include <QTimer>
 #include <QString>
 #include <QByteArray>
-
-#include "QGCMapEngine.h"
 
 //-----------------------------------------------------------------------------
 UrlFactory::UrlFactory()

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -29,6 +29,9 @@ This file is part of the QGROUNDCONTROL project
  *
  */
 
+#include "QGCMapEngine.h"
+#include "QGCMapTileSet.h"
+
 #include <QVariant>
 #include <QtSql/QSqlQuery>
 #include <QSqlError>
@@ -38,9 +41,6 @@ This file is part of the QGROUNDCONTROL project
 #include <QFile>
 
 #include "time.h"
-
-#include "QGCMapEngine.h"
-#include "QGCMapTileSet.h"
 
 const char* kDefaultSet = "Default Tile Set";
 const QString kSession  = QLatin1String("QGeoTileWorkerSession");

--- a/src/QtLocationPlugin/QGeoCodeReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoCodeReplyQGC.cpp
@@ -44,6 +44,8 @@
 **
 ****************************************************************************/
 
+#include "QGeoCodeReplyQGC.h"
+
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonObject>
 #include <QtCore/QJsonArray>
@@ -53,8 +55,6 @@
 #include <QtPositioning/QGeoRectangle>
 #include <QSet>
 #include <QDebug>
-
-#include "QGeoCodeReplyQGC.h"
 
 enum QGeoCodeTypeGoogle {
     GeoCodeTypeUnknown,
@@ -193,7 +193,7 @@ void QGeoCodeReplyQGC::networkReplyFinished()
 
     QJsonDocument document = QJsonDocument::fromJson(m_reply->readAll());
     QJsonObject object = document.object();
-    
+
     if (object.value(QStringLiteral("status")) != QStringLiteral("OK")) {
         QString error = object.value(QStringLiteral("status")).toString();
         qWarning() << m_reply->url() << "returned" << error;
@@ -210,13 +210,13 @@ void QGeoCodeReplyQGC::networkReplyFinished()
             continue;
 
         QJsonObject geocode = results[i].toObject();
-        
+
         QGeoAddress address;
         if (geocode.contains(QStringLiteral("formatted_address"))) {
             address.setText(geocode.value(QStringLiteral("formatted_address")).toString());
         }
-        
-        
+
+
         if (geocode.contains(QStringLiteral("address_components"))) {
             QJsonArray ac = geocode.value(QStringLiteral("address_components")).toArray();
 

--- a/src/QtLocationPlugin/QGeoCodingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoCodingManagerEngineQGC.cpp
@@ -44,6 +44,9 @@
 **
 ****************************************************************************/
 
+#include "QGeoCodingManagerEngineQGC.h"
+#include "QGeoCodeReplyQGC.h"
+
 #include <QtCore/QVariantMap>
 #include <QtCore/QUrl>
 #include <QtCore/QUrlQuery>
@@ -55,10 +58,6 @@
 #include <QtPositioning/QGeoAddress>
 #include <QtPositioning/QGeoShape>
 #include <QtPositioning/QGeoRectangle>
-#include <QDebug>
-
-#include "QGeoCodingManagerEngineQGC.h"
-#include "QGeoCodeReplyQGC.h"
 
 static QString addressToQuery(const QGeoAddress &address)
 {
@@ -120,7 +119,7 @@ QGeoCodeReply *QGeoCodingManagerEngineQGC::geocode(const QString &address, int l
     url.setQuery(query);
     request.setUrl(url);
     //qDebug() << url;
-    
+
     QNetworkReply *reply = m_networkManager->get(request);
     reply->setParent(0);
 

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -44,12 +44,12 @@
 **
 ****************************************************************************/
 
+#include "QGCMapEngine.h"
+#include "QGeoMapReplyQGC.h"
+
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QFile>
-
-#include "QGCMapEngine.h"
-#include "QGeoMapReplyQGC.h"
 
 //-----------------------------------------------------------------------------
 QGeoTiledMapReplyQGC::QGeoTiledMapReplyQGC(QNetworkAccessManager *networkManager, const QNetworkRequest &request, const QGeoTileSpec &spec, QObject *parent)

--- a/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.cpp
+++ b/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.cpp
@@ -44,12 +44,11 @@
 **
 ****************************************************************************/
 
-#include <QtLocation/private/qgeotiledmappingmanagerengine_p.h>
-
-#include "qdebug.h"
 #include "QGeoServiceProviderPluginQGC.h"
 #include "QGeoTiledMappingManagerEngineQGC.h"
 #include "QGeoCodingManagerEngineQGC.h"
+
+#include <QtLocation/private/qgeotiledmappingmanagerengine_p.h>
 
 Q_EXTERN_C Q_DECL_EXPORT const char *qt_plugin_query_metadata();
 Q_EXTERN_C Q_DECL_EXPORT QT_PREPEND_NAMESPACE(QObject) *qt_plugin_instance();

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -44,13 +44,13 @@
 **
 ****************************************************************************/
 
-#include <QtCore/QLocale>
-#include <QtNetwork/QNetworkRequest>
-#include <QtLocation/private/qgeotilespec_p.h>
-
 #include "QGCMapEngine.h"
 #include "QGeoTileFetcherQGC.h"
 #include "QGeoMapReplyQGC.h"
+
+#include <QtCore/QLocale>
+#include <QtNetwork/QNetworkRequest>
+#include <QtLocation/private/qgeotilespec_p.h>
 
 //-----------------------------------------------------------------------------
 QGeoTileFetcherQGC::QGeoTileFetcherQGC(QGeoTiledMappingManagerEngine *parent)

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -44,6 +44,10 @@
 **
 ****************************************************************************/
 
+#include "QGCMapEngine.h"
+#include "QGeoTiledMappingManagerEngineQGC.h"
+#include "QGeoTileFetcherQGC.h"
+
 #include <QtLocation/private/qgeocameracapabilities_p.h>
 #include <QtLocation/private/qgeomaptype_p.h>
 #if QT_VERSION < 0x050500
@@ -53,10 +57,6 @@
 #endif
 #include <QDir>
 #include <QStandardPaths>
-
-#include "QGCMapEngine.h"
-#include "QGeoTiledMappingManagerEngineQGC.h"
-#include "QGeoTileFetcherQGC.h"
 
 #if QT_VERSION >= 0x050500
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -611,170 +611,177 @@ Rectangle {
         anchors.bottom:     parent.bottom
         anchors.margins:    ScreenTools.defaultFontPixelWidth
         visible:            false
-
-        Column {
-            width:          parent.width
-            spacing:        ScreenTools.defaultFontPixelHeight
-            Item {
-                height:     ScreenTools.defaultFontPixelHeight * 0.5
-                width:      1
-            }
-            Rectangle {
-                width:      infoWidth
-                height:     nameLabel.height + (ScreenTools.defaultFontPixelHeight * 2)
-                color:      __qgcPal.window
-                radius:     ScreenTools.defaultFontPixelHeight * 0.5
-                anchors.horizontalCenter: parent.horizontalCenter
+        QGCFlickable {
+            id:                 infoScroll
+            anchors.fill:       parent
+            contentHeight:      infoColumn.height
+            flickableDirection: Flickable.VerticalFlick
+            clip:               true
+            Column {
+                id:             infoColumn
+                width:          parent.width
+                spacing:        ScreenTools.defaultFontPixelHeight
+                Item {
+                    height:     ScreenTools.defaultFontPixelHeight * 0.5
+                    width:      1
+                }
+                Rectangle {
+                    width:      infoWidth
+                    height:     nameLabel.height + (ScreenTools.defaultFontPixelHeight * 2)
+                    color:      __qgcPal.window
+                    radius:     ScreenTools.defaultFontPixelHeight * 0.5
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    QGCLabel {
+                        id:     nameLabel
+                        text:   _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.name : ""
+                        font.pixelSize:   ScreenTools.isAndroid ? ScreenTools.mediumFontPixelSize : ScreenTools.largeFontPixelSize
+                        anchors.centerIn: parent
+                    }
+                }
                 QGCLabel {
-                    id:     nameLabel
-                    text:   _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.name : ""
-                    font.pixelSize:   ScreenTools.isAndroid ? ScreenTools.mediumFontPixelSize : ScreenTools.largeFontPixelSize
-                    anchors.centerIn: parent
+                    id:     descLabel
+                    text:   _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.description : ""
+                    anchors.horizontalCenter: parent.horizontalCenter
                 }
-            }
-            QGCLabel {
-                id:     descLabel
-                text:   _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.description : ""
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-            Rectangle {
-                id:         infoRect
-                width:      infoWidth
-                height:     infoGrid.height + (ScreenTools.defaultFontPixelHeight * 4)
-                color:      __qgcPal.window
-                radius:     ScreenTools.defaultFontPixelHeight * 0.5
-                anchors.horizontalCenter: parent.horizontalCenter
-                GridLayout {
-                    id:                 infoGrid
-                    columns:            2
-                    anchors.centerIn:   parent
-                    anchors.margins:    ScreenTools.defaultFontPixelWidth  * 2
-                    rowSpacing:         ScreenTools.defaultFontPixelWidth
-                    columnSpacing:      ScreenTools.defaultFontPixelHeight * 2
-                    QGCLabel {
-                        text:       "Map Type:"
-                        visible:    !isDefaultSet
-                    }
-                    QGCLabel {
-                        text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.mapTypeStr : ""
-                        visible:    !isDefaultSet
-                    }
-                    QGCLabel {
-                        text:       "Min Zoom:"
-                        visible:    !isDefaultSet
-                    }
-                    QGCLabel {
-                        text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.minZoom : ""
-                        visible:    !isDefaultSet
-                    }
-                    QGCLabel {
-                        text:       "Max Zoom:"
-                        visible:    !isDefaultSet
-                    }
-                    QGCLabel {
-                        text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.maxZoom : ""
-                        visible:    !isDefaultSet
-                    }
-                    QGCLabel {
-                        text:       isDefaultSet ? "Default Set Size:" : "Total Size:"
-                    }
-                    QGCLabel {
-                        text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.tilesSizeStr : ""
-                    }
-                    QGCLabel {
-                        text:       isDefaultSet ? "Default Set Tile Count:" : "Total Tile Count:"
-                    }
-                    QGCLabel {
-                        text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.numTilesStr : ""
-                    }
-                    QGCLabel {
-                        text:       isDefaultSet ? "Total Size (All Sets):" : "Downloaded Size:"
-                    }
-                    QGCLabel {
-                        text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.savedSizeStr : ""
-                    }
-                    QGCLabel {
-                        text:       isDefaultSet ? "Total Count (All Sets):" : "Downloaded Count:"
-                    }
-                    QGCLabel {
-                        text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.savedTilesStr : ""
-                    }
-                    QGCLabel {
-                        text:       "Error Count:"
-                        visible:    !isDefaultSet && _offlineMapRoot._currentSelection && !_offlineMapRoot._currentSelection.complete
-                    }
-                    QGCLabel {
-                        text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.errorCountStr : ""
-                        visible:    !isDefaultSet && _offlineMapRoot._currentSelection && !_offlineMapRoot._currentSelection.complete
-                    }
-                }
-            }
-            Item {
-                height:     ScreenTools.defaultFontPixelHeight * 0.5
-                width:      1
-            }
-            Row {
-                anchors.horizontalCenter: parent.horizontalCenter
-                spacing: ScreenTools.defaultFontPixelWidth
-                QGCButton {
-                    width:      ScreenTools.defaultFontPixelWidth * 18
-                    text:       "Delete"
-                    enabled:    _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.deleting)
-                    onClicked: {
-                        if(_offlineMapRoot._currentSelection)
-                            deleteDialog.visible = true
-                    }
-                    MessageDialog {
-                        id:         deleteDialog
-                        visible:    false
-                        icon:       StandardIcon.Warning
-                        standardButtons: StandardButton.Yes | StandardButton.No
-                        title:      "Delete Tile Set"
-                        text:       {
-                            if(_offlineMapRoot._currentSelection) {
-                                var blurb = "Delete " + _offlineMapRoot._currentSelection.name + " and all its tiles.\nIs this really what you want?"
-                                if(_offlineMapRoot._currentSelection.defaultSet)
-                                    return blurb + "\nNote that deleteting the Default Set deletes all tiles from all sets."
-                                else
-                                    return blurb
-                            }
-                            return ""
+                Rectangle {
+                    id:         infoRect
+                    width:      infoWidth
+                    height:     infoGrid.height + (ScreenTools.defaultFontPixelHeight * 4)
+                    color:      __qgcPal.window
+                    radius:     ScreenTools.defaultFontPixelHeight * 0.5
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    GridLayout {
+                        id:                 infoGrid
+                        columns:            2
+                        anchors.centerIn:   parent
+                        anchors.margins:    ScreenTools.defaultFontPixelWidth  * 2
+                        rowSpacing:         ScreenTools.defaultFontPixelWidth
+                        columnSpacing:      ScreenTools.defaultFontPixelHeight * 2
+                        QGCLabel {
+                            text:       "Map Type:"
+                            visible:    !isDefaultSet
                         }
-                        onYes: {
+                        QGCLabel {
+                            text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.mapTypeStr : ""
+                            visible:    !isDefaultSet
+                        }
+                        QGCLabel {
+                            text:       "Min Zoom:"
+                            visible:    !isDefaultSet
+                        }
+                        QGCLabel {
+                            text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.minZoom : ""
+                            visible:    !isDefaultSet
+                        }
+                        QGCLabel {
+                            text:       "Max Zoom:"
+                            visible:    !isDefaultSet
+                        }
+                        QGCLabel {
+                            text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.maxZoom : ""
+                            visible:    !isDefaultSet
+                        }
+                        QGCLabel {
+                            text:       isDefaultSet ? "Default Set Size:" : "Total Size:"
+                        }
+                        QGCLabel {
+                            text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.tilesSizeStr : ""
+                        }
+                        QGCLabel {
+                            text:       isDefaultSet ? "Default Set Tile Count:" : "Total Tile Count:"
+                        }
+                        QGCLabel {
+                            text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.numTilesStr : ""
+                        }
+                        QGCLabel {
+                            text:       isDefaultSet ? "Total Size (All Sets):" : "Downloaded Size:"
+                        }
+                        QGCLabel {
+                            text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.savedSizeStr : ""
+                        }
+                        QGCLabel {
+                            text:       isDefaultSet ? "Total Count (All Sets):" : "Downloaded Count:"
+                        }
+                        QGCLabel {
+                            text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.savedTilesStr : ""
+                        }
+                        QGCLabel {
+                            text:       "Error Count:"
+                            visible:    !isDefaultSet && _offlineMapRoot._currentSelection && !_offlineMapRoot._currentSelection.complete
+                        }
+                        QGCLabel {
+                            text:       _offlineMapRoot._currentSelection ? _offlineMapRoot._currentSelection.errorCountStr : ""
+                            visible:    !isDefaultSet && _offlineMapRoot._currentSelection && !_offlineMapRoot._currentSelection.complete
+                        }
+                    }
+                }
+                Item {
+                    height:     ScreenTools.defaultFontPixelHeight * 0.5
+                    width:      1
+                }
+                Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: ScreenTools.defaultFontPixelWidth
+                    QGCButton {
+                        width:      ScreenTools.defaultFontPixelWidth * 18
+                        text:       "Delete"
+                        enabled:    _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.deleting)
+                        onClicked: {
                             if(_offlineMapRoot._currentSelection)
-                                QGroundControl.mapEngineManager.deleteTileSet(_offlineMapRoot._currentSelection)
-                            deleteDialog.visible = false
-                            showList()
+                                deleteDialog.visible = true
                         }
-                        onNo: {
-                            deleteDialog.visible = false
+                        MessageDialog {
+                            id:         deleteDialog
+                            visible:    false
+                            icon:       StandardIcon.Warning
+                            standardButtons: StandardButton.Yes | StandardButton.No
+                            title:      "Delete Tile Set"
+                            text:       {
+                                if(_offlineMapRoot._currentSelection) {
+                                    var blurb = "Delete " + _offlineMapRoot._currentSelection.name + " and all its tiles.\nIs this really what you want?"
+                                    if(_offlineMapRoot._currentSelection.defaultSet)
+                                        return blurb + "\nNote that deleteting the Default Set deletes all tiles from all sets."
+                                    else
+                                        return blurb
+                                }
+                                return ""
+                            }
+                            onYes: {
+                                if(_offlineMapRoot._currentSelection)
+                                    QGroundControl.mapEngineManager.deleteTileSet(_offlineMapRoot._currentSelection)
+                                deleteDialog.visible = false
+                                showList()
+                            }
+                            onNo: {
+                                deleteDialog.visible = false
+                            }
                         }
                     }
-                }
-                QGCButton {
-                    text:       "Resume Download"
-                    width:      ScreenTools.defaultFontPixelWidth * 18
-                    enabled:    _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.deleting && !_offlineMapRoot._currentSelection.downloading)
-                    visible:    !isDefaultSet && _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.complete && !_offlineMapRoot._currentSelection.downloading)
-                    onClicked: {
-                        if(_offlineMapRoot._currentSelection)
-                            _offlineMapRoot._currentSelection.resumeDownloadTask()
+                    QGCButton {
+                        text:       "Resume Download"
+                        width:      ScreenTools.defaultFontPixelWidth * 18
+                        enabled:    _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.deleting && !_offlineMapRoot._currentSelection.downloading)
+                        visible:    !isDefaultSet && _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.complete && !_offlineMapRoot._currentSelection.downloading)
+                        onClicked: {
+                            if(_offlineMapRoot._currentSelection)
+                                _offlineMapRoot._currentSelection.resumeDownloadTask()
+                        }
                     }
-                }
-                QGCButton {
-                    text:       "Cancel Download"
-                    width:      ScreenTools.defaultFontPixelWidth * 18
-                    enabled:    _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.deleting && _offlineMapRoot._currentSelection.downloading)
-                    visible:    !isDefaultSet && _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.complete && _offlineMapRoot._currentSelection.downloading)
-                    onClicked: {
-                        if(_offlineMapRoot._currentSelection)
-                            _offlineMapRoot._currentSelection.cancelDownloadTask()
+                    QGCButton {
+                        text:       "Cancel Download"
+                        width:      ScreenTools.defaultFontPixelWidth * 18
+                        enabled:    _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.deleting && _offlineMapRoot._currentSelection.downloading)
+                        visible:    !isDefaultSet && _offlineMapRoot._currentSelection && (!_offlineMapRoot._currentSelection.complete && _offlineMapRoot._currentSelection.downloading)
+                        onClicked: {
+                            if(_offlineMapRoot._currentSelection)
+                                _offlineMapRoot._currentSelection.cancelDownloadTask()
+                        }
                     }
-                }
-                QGCButton {
-                    text:       "Back"
-                    width:      ScreenTools.defaultFontPixelWidth * 18
-                    onClicked:  showList()
+                    QGCButton {
+                        text:       "Back"
+                        width:      ScreenTools.defaultFontPixelWidth * 18
+                        onClicked:  showList()
+                    }
                 }
             }
         }
@@ -794,113 +801,121 @@ Rectangle {
                 maxCacheMemSize.text = QGroundControl.mapEngineManager.maxMemCache
             }
         }
-        Column {
-            width:          parent.width
-            spacing:        ScreenTools.defaultFontPixelHeight
-            Item {
-                height:     ScreenTools.defaultFontPixelHeight
-                width:      1
-            }
-            Rectangle {
-                width:      infoWidth
-                height:     optionsLabel.height + (ScreenTools.defaultFontPixelHeight * 2)
-                color:      __qgcPal.window
-                radius:     ScreenTools.defaultFontPixelHeight * 0.5
-                anchors.horizontalCenter: parent.horizontalCenter
-                QGCLabel {
-                    id:     optionsLabel
-                    text:   "Offline Map Options"
-                    font.pixelSize:     ScreenTools.isAndroid ? ScreenTools.mediumFontPixelSize : ScreenTools.largeFontPixelSize
-                    anchors.centerIn:   parent
+        QGCFlickable {
+            id:                 optionsScroll
+            anchors.fill:       parent
+            contentHeight:      optionsColumn.height
+            flickableDirection: Flickable.VerticalFlick
+            clip:               true
+            Column {
+                id:             optionsColumn
+                width:          parent.width
+                spacing:        ScreenTools.defaultFontPixelHeight
+                Item {
+                    height:     ScreenTools.defaultFontPixelHeight
+                    width:      1
                 }
-            }
-            Rectangle {
-                id:         optionsRect
-                width:      optionsGrid.width  + (ScreenTools.defaultFontPixelWidth * 4)
-                height:     optionsGrid.height + (ScreenTools.defaultFontPixelHeight * 4)
-                color:      __qgcPal.window
-                radius:     ScreenTools.defaultFontPixelHeight * 0.5
-                anchors.horizontalCenter: parent.horizontalCenter
-                GridLayout {
-                    id:                 optionsGrid
-                    columns:            2
-                    anchors.centerIn:   parent
-                    anchors.margins:    ScreenTools.defaultFontPixelWidth  * 2
-                    rowSpacing:         ScreenTools.defaultFontPixelWidth  * 1.5
-                    columnSpacing:      ScreenTools.defaultFontPixelHeight * 2
+                Rectangle {
+                    width:      infoWidth
+                    height:     optionsLabel.height + (ScreenTools.defaultFontPixelHeight * 2)
+                    color:      __qgcPal.window
+                    radius:     ScreenTools.defaultFontPixelHeight * 0.5
+                    anchors.horizontalCenter: parent.horizontalCenter
                     QGCLabel {
-                        text:       "Max Cache Disk Size (MB):"
+                        id:     optionsLabel
+                        text:   "Offline Map Options"
+                        font.pixelSize:     ScreenTools.isAndroid ? ScreenTools.mediumFontPixelSize : ScreenTools.largeFontPixelSize
+                        anchors.centerIn:   parent
                     }
-                    QGCTextField {
-                        id:             maxCacheSize
-                        maximumLength:  6
-                        inputMethodHints: Qt.ImhDigitsOnly
-                        validator: IntValidator {bottom: 1; top: 262144;}
-                    }
-                    QGCLabel {
-                        text:       "Max Cache Memory Size (MB):"
-                    }
-                    QGCTextField {
-                        id:             maxCacheMemSize
-                        maximumLength:  4
-                        inputMethodHints: Qt.ImhDigitsOnly
-                        validator: IntValidator {bottom: 1; top: 4096;}
-                    }
-                    Item {
-                        Layout.columnSpan:  2
-                        Layout.fillWidth:   true
-                        implicitHeight:     ScreenTools.defaultFontPixelHeight * 1.5
+                }
+                Rectangle {
+                    id:         optionsRect
+                    width:      optionsGrid.width  + (ScreenTools.defaultFontPixelWidth * 4)
+                    height:     optionsGrid.height + (ScreenTools.defaultFontPixelHeight * 4)
+                    color:      __qgcPal.window
+                    radius:     ScreenTools.defaultFontPixelHeight * 0.5
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    GridLayout {
+                        id:                 optionsGrid
+                        columns:            2
+                        anchors.centerIn:   parent
+                        anchors.margins:    ScreenTools.defaultFontPixelWidth  * 2
+                        rowSpacing:         ScreenTools.defaultFontPixelWidth  * 1.5
+                        columnSpacing:      ScreenTools.defaultFontPixelHeight * 2
                         QGCLabel {
-                            anchors.centerIn: parent
-                            text: "Memory cache changes require a restart to take effect."
-                            font.pixelSize: ScreenTools.defaultFontPixelSize * 0.85
+                            text:       "Max Cache Disk Size (MB):"
+                        }
+                        QGCTextField {
+                            id:             maxCacheSize
+                            maximumLength:  6
+                            inputMethodHints: Qt.ImhDigitsOnly
+                            validator: IntValidator {bottom: 1; top: 262144;}
+                        }
+                        QGCLabel {
+                            text:       "Max Cache Memory Size (MB):"
+                        }
+                        QGCTextField {
+                            id:             maxCacheMemSize
+                            maximumLength:  4
+                            inputMethodHints: Qt.ImhDigitsOnly
+                            validator: IntValidator {bottom: 1; top: 4096;}
+                        }
+                        Item {
+                            Layout.columnSpan:  2
+                            Layout.fillWidth:   true
+                            implicitHeight:     ScreenTools.defaultFontPixelHeight * 1.5
+                            QGCLabel {
+                                anchors.centerIn: parent
+                                text: "Memory cache changes require a restart to take effect."
+                                font.pixelSize: ScreenTools.defaultFontPixelSize * 0.85
+                            }
+                        }
+                        Rectangle {
+                            Layout.columnSpan:  2
+                            Layout.fillWidth:   true
+                            implicitHeight:     1
+                            color:              __qgcPal.text
+                        }
+                        QGCLabel {
+                            text: "MapBox Access Token"
+                        }
+                        QGCTextField {
+                            id:                 mapBoxToken
+                            Layout.fillWidth:   true
+                            maximumLength:      256
+                            implicitWidth :     ScreenTools.defaultFontPixelWidth * 30
+                        }
+                        Item {
+                            Layout.columnSpan:  2
+                            Layout.fillWidth:   true
+                            implicitHeight:     ScreenTools.defaultFontPixelHeight * 1.5
+                            QGCLabel {
+                                anchors.centerIn: parent
+                                text: "With an access token, you can use MapBox Maps."
+                                font.pixelSize: ScreenTools.defaultFontPixelSize * 0.85
+                            }
                         }
                     }
-                    Rectangle {
-                        Layout.columnSpan:  2
-                        Layout.fillWidth:   true
-                        implicitHeight:     1
-                        color:              __qgcPal.text
-                    }
-                    QGCLabel {
-                        text: "MapBox Access Token"
-                    }
-                    QGCTextField {
-                        id:                 mapBoxToken
-                        Layout.fillWidth:   true
-                        maximumLength:      256
-                        implicitWidth :     ScreenTools.defaultFontPixelWidth * 30
-                    }
-                    Item {
-                        Layout.columnSpan:  2
-                        Layout.fillWidth:   true
-                        implicitHeight:     ScreenTools.defaultFontPixelHeight * 1.5
-                        QGCLabel {
-                            anchors.centerIn: parent
-                            text: "With an access token, you can use MapBox Maps."
-                            font.pixelSize: ScreenTools.defaultFontPixelSize * 0.85
+                }
+                Row {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: ScreenTools.defaultFontPixelWidth
+                    QGCButton {
+                        text:       "Save"
+                        width:      ScreenTools.defaultFontPixelWidth * 18
+                        onClicked:  {
+                            QGroundControl.mapEngineManager.mapboxToken  = mapBoxToken.text
+                            QGroundControl.mapEngineManager.maxDiskCache = parseInt(maxCacheSize.text)
+                            QGroundControl.mapEngineManager.maxMemCache  = parseInt(maxCacheMemSize.text)
+                            showList()
                         }
                     }
-                }
-            }
-            Row {
-                anchors.horizontalCenter: parent.horizontalCenter
-                spacing: ScreenTools.defaultFontPixelWidth
-                QGCButton {
-                    text:       "Save"
-                    width:      ScreenTools.defaultFontPixelWidth * 18
-                    onClicked:  {
-                        QGroundControl.mapEngineManager.mapboxToken  = mapBoxToken.text
-                        QGroundControl.mapEngineManager.maxDiskCache = parseInt(maxCacheSize.text)
-                        QGroundControl.mapEngineManager.maxMemCache  = parseInt(maxCacheMemSize.text)
-                        showList()
-                    }
-                }
-                QGCButton {
-                    text:       "Cancel"
-                    width:      ScreenTools.defaultFontPixelWidth * 18
-                    onClicked:  {
-                        showList()
+                    QGCButton {
+                        text:       "Cancel"
+                        width:      ScreenTools.defaultFontPixelWidth * 18
+                        onClicked:  {
+                            showList()
+                        }
                     }
                 }
             }

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -26,9 +26,10 @@
 
 #include "QGCMapEngineManager.h"
 #include "QGCApplication.h"
-#include <QSettings>
 #include "QGCMapTileSet.h"
 #include "QGCMapUrlEngine.h"
+
+#include <QSettings>
 #include <QStorageInfo>
 #include <stdio.h>
 


### PR DESCRIPTION
The Nexus 7 (Android) has a very wide but short window. Some parts of the Offline maps UI did not fit the height. I've added Flickable where appropriate.

While at it, I've reordered the header files as requested by @DonLakeFlyer.

![screen](https://cloud.githubusercontent.com/assets/749243/13185420/0c839b48-d70f-11e5-9a4d-ce1266b6fc32.png)
