### PR TITLE
Android stay on

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <manifest package="org.mavlink.qgroundcontrol" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="2.8.0" android:versionCode="2152" android:installLocation="auto">
     <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="-- %%INSERT_APP_NAME%% --" android:icon="@drawable/icon">
-        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qgroundcontrol.qgchelper.UsbDeviceJNI" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="sensorLandscape" android:launchMode="singleTask">
+        <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qgroundcontrol.qgchelper.UsbDeviceJNI" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="sensorLandscape" android:launchMode="singleTask" android:keepScreenOn="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/src/org/qgroundcontrol/qgchelper/UsbDeviceJNI.java
+++ b/android/src/org/qgroundcontrol/qgchelper/UsbDeviceJNI.java
@@ -43,6 +43,7 @@ import android.content.IntentFilter;
 import android.hardware.usb.*;
 import android.widget.Toast;
 import android.util.Log;
+import android.os.PowerManager;
 //-- Text To Speech
 import android.os.Bundle;
 import android.speech.tts.TextToSpeech;
@@ -53,7 +54,7 @@ import org.qtproject.qt5.android.bindings.QtApplication;
 
 public class UsbDeviceJNI extends QtActivity implements TextToSpeech.OnInitListener
 {
-    public static int BAD_PORT = 0;
+    public  static int BAD_PORT = 0;
     private static UsbDeviceJNI m_instance;
     private static UsbManager m_manager;    //  ANDROID USB HOST CLASS
     private static List<UsbSerialDriver> m_devices; //  LIST OF CURRENT DEVICES
@@ -65,6 +66,7 @@ public class UsbDeviceJNI extends QtActivity implements TextToSpeech.OnInitListe
     private final static ExecutorService m_Executor = Executors.newSingleThreadExecutor();
     private static final String TAG = "QGC_UsbDeviceJNI";
     private static TextToSpeech  m_tts;
+    private static PowerManager.WakeLock m_wl;
 
     private final static UsbIoManager.Listener m_Listener =
             new UsbIoManager.Listener()
@@ -113,6 +115,8 @@ public class UsbDeviceJNI extends QtActivity implements TextToSpeech.OnInitListe
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         m_tts = new TextToSpeech(this,this);
+        PowerManager pm = (PowerManager)m_instance.getSystemService(Context.POWER_SERVICE);
+        m_wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK, "QGroundControl");
     }
 
     @Override
@@ -128,6 +132,24 @@ public class UsbDeviceJNI extends QtActivity implements TextToSpeech.OnInitListe
     {
         Log.i(TAG, "Say: " + msg);
         m_tts.speak(msg, TextToSpeech.QUEUE_FLUSH, null);
+    }
+
+    public static void keepScreenOn()
+    {
+        if(m_wl != null) {
+            m_wl.acquire();
+            Log.i(TAG, "SCREEN_BRIGHT_WAKE_LOCK acquired.");
+        } else {
+            Log.i(TAG, "SCREEN_BRIGHT_WAKE_LOCK not acquired!!!");
+        }
+    }
+
+    public static void restoreScreenOn()
+    {
+        if(m_wl != null) {
+            m_wl.release();
+            Log.i(TAG, "SCREEN_BRIGHT_WAKE_LOCK released.");
+        }
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -40,7 +40,10 @@
 QGC_LOGGING_CATEGORY(MultiVehicleManagerLog, "MultiVehicleManagerLog")
 
 const char* MultiVehicleManager::_gcsHeartbeatEnabledKey = "gcsHeartbeatEnabled";
+
+#if defined __android__
 static const char* kJniClassName = "org/qgroundcontrol/qgchelper/UsbDeviceJNI";
+#endif
 
 MultiVehicleManager::MultiVehicleManager(QGCApplication* app)
     : QGCTool(app)


### PR DESCRIPTION
I tried all possible permutations of the desired `getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);` with no effect whatsoever (as reported by many people at stakoverflow). The issue, I think, is that it needs to be called at a point in the Activity creation process we have no access (that's within the Qt bootstrap code).

I'm using the PowerManager class to force Android from dimming and turning off the screen *while* a vehicle is connected. If there are no vehicles connected, I restore to normal (to save the battery).