### PR TITLE
Fix font sizing for small screens

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -92,7 +92,7 @@ Item {
     //-- Instrument Panel
     QGCInstrumentWidget {
         id:                     instrumentGadget
-        anchors.margins:        ScreenTools.defaultFontPixelHeight
+        anchors.margins:        ScreenTools.defaultFontPixelHeight / 2
         anchors.right:          parent.right
         anchors.verticalCenter: parent.verticalCenter
         visible:                !QGroundControl.virtualTabletJoystick
@@ -106,12 +106,12 @@ Item {
         isSatellite:            _isSatellite
         z:                      QGroundControl.zOrderWidgets
         qgcView:                parent.parent.qgcView
-        maxHeight:              parent.height - (ScreenTools.defaultFontPixelHeight * 2)
+        maxHeight:              parent.height - (anchors.margins * 2)
     }
 
     QGCInstrumentWidgetAlternate {
         id:                     instrumentGadgetAlternate
-        anchors.margins:        ScreenTools.defaultFontPixelHeight
+        anchors.margins:        ScreenTools.defaultFontPixelHeight / 2
         anchors.top:            parent.top
         anchors.right:          parent.right
         visible:                QGroundControl.virtualTabletJoystick

--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -89,6 +89,7 @@ QGCFlickable {
                     width:                  parent.width
                     horizontalAlignment:    Text.AlignHCenter
                     color:                  textColor
+                    fontSizeMode:           Text.HorizontalFit
                     text:                   fact.shortDescription + (fact.units ? " (" + fact.units + ")" : "")
                 }
                 QGCLabel {
@@ -96,6 +97,7 @@ QGCFlickable {
                     horizontalAlignment:    Text.AlignHCenter
                     font.pixelSize:         ScreenTools.largeFontPixelSize * (largeValue ? 1.3 : 1.0)
                     font.weight:            largeValue ? Font.ExtraBold : Font.Normal
+                    fontSizeMode:           Text.HorizontalFit
                     color:                  textColor
                     text:                   fact.valueString
                 }
@@ -125,6 +127,7 @@ QGCFlickable {
                     width:                  parent.width
                     horizontalAlignment:    Text.AlignHCenter
                     font.pixelSize:         ScreenTools.smallFontPixelSize
+                    fontSizeMode:           Text.HorizontalFit
                     color:                  textColor
                     text:                   fact.shortDescription
                 }
@@ -132,12 +135,14 @@ QGCFlickable {
                     width:                  parent.width
                     horizontalAlignment:    Text.AlignHCenter
                     color:                  textColor
+                    fontSizeMode:           Text.HorizontalFit
                     text:                   fact.enumOrValueString
                 }
                 QGCLabel {
                     width:                  parent.width
                     horizontalAlignment:    Text.AlignHCenter
                     font.pixelSize:         ScreenTools.smallFontPixelSize
+                    fontSizeMode:           Text.HorizontalFit
                     color:                  textColor
                     text:                   fact.units
                 }
@@ -151,21 +156,27 @@ QGCFlickable {
         QGCViewDialog {
             id: _propertyPickerDialog
 
-            QGCLabel {
-                id:     _label
-                text:   "Select the values you want to display:"
-            }
+            QGCFlickable {
+                anchors.fill:       parent
+                contentHeight:      _loader.y + _loader.height
+                flickableDirection: Flickable.VerticalFlick
 
-            Loader {
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                anchors.topMargin:  _margins
-                anchors.top:        _label.bottom
-                anchors.bottom:     parent.bottom
-                sourceComponent:    factGroupList
+                QGCLabel {
+                    id:     _label
+                    text:   "Select the values you want to display:"
+                }
 
-                property var factGroup:     _activeVehicle
-                property var factGroupName: "Vehicle"
+                Loader {
+                    id:                 _loader
+                    anchors.left:       parent.left
+                    anchors.right:      parent.right
+                    anchors.topMargin:  _margins
+                    anchors.top:        _label.bottom
+                    sourceComponent:    factGroupList
+
+                    property var factGroup:     _activeVehicle
+                    property var factGroupName: "Vehicle"
+                }
             }
         }
     }

--- a/src/Vehicle/VehicleFact.json
+++ b/src/Vehicle/VehicleFact.json
@@ -46,7 +46,7 @@
         },
         {
             "name":             "altitudeRelative",
-            "shortDescription": "Altitude (home)",
+            "shortDescription": "Altitude-rel",
             "type":             "double",
             "decimalPlaces":    1,
             "units":            "m"


### PR DESCRIPTION
- This is all in the ValuesWidget which is the center of the instrument panel.
- Also changed user text for Vehicle.altitudeRelative to "Altitude-rel" from "Altitude (home)". Previous text was taking too much space. We'll see if anyone else has better suggestions.