### PR TITLE
Fix mission factPanel hookup in ESP WiFi thingy summary qml

### DIFF
--- a/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
@@ -16,7 +16,8 @@ FactPanel {
     FactPanelController { id: controller; factPanel: panel }
 
     ESP8266ComponentController {
-        id: esp8266
+        id:         esp8266
+        factPanel:  panel
     }
 
     property Fact debugEnabled:     controller.getParameterFact(esp8266.componentID, "DEBUG_ENABLED")


### PR DESCRIPTION
This was causing an error to popup about incorrect FactPanel hookup