### PR TITLE
More work on complex mission items

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -42,9 +42,12 @@
         <file alias="PowerComponent.qml">src/AutoPilotPlugins/PX4/PowerComponent.qml</file>
         <file alias="PowerComponentSummary.qml">src/AutoPilotPlugins/PX4/PowerComponentSummary.qml</file>
         <file alias="PX4FlowSensor.qml">src/VehicleSetup/PX4FlowSensor.qml</file>
+
+        <file alias="QGroundControl/Controls/qmldir">src/QmlControls/QGroundControl.Controls.qmldir</file>
         <file alias="QGroundControl/Controls/ClickableColor.qml">src/QmlControls/ClickableColor.qml</file>
         <file alias="QGroundControl/Controls/DropButton.qml">src/QmlControls/DropButton.qml</file>
         <file alias="QGroundControl/Controls/ExclusiveGroupItem.qml">src/QmlControls/ExclusiveGroupItem.qml</file>
+        <file alias="QGroundControl/Controls/FactSliderPanel.qml">src/QmlControls/FactSliderPanel.qml</file>
         <file alias="QGroundControl/Controls/IndicatorButton.qml">src/QmlControls/IndicatorButton.qml</file>
         <file alias="QGroundControl/Controls/JoystickThumbPad.qml">src/QmlControls/JoystickThumbPad.qml</file>
         <file alias="QGroundControl/Controls/MainToolBar.qml">src/ui/toolbar/MainToolBar.qml</file>
@@ -73,14 +76,16 @@
         <file alias="QGroundControl/Controls/QGCViewDialog.qml">src/QmlControls/QGCViewDialog.qml</file>
         <file alias="QGroundControl/Controls/QGCViewMessage.qml">src/QmlControls/QGCViewMessage.qml</file>
         <file alias="QGroundControl/Controls/QGCViewPanel.qml">src/QmlControls/QGCViewPanel.qml</file>
-        <file alias="QGroundControl/Controls/qmldir">src/QmlControls/QGroundControl.Controls.qmldir</file>
         <file alias="QGroundControl/Controls/RoundButton.qml">src/QmlControls/RoundButton.qml</file>
         <file alias="QGroundControl/Controls/SignalStrength.qml">src/ui/toolbar/SignalStrength.qml</file>
         <file alias="QGroundControl/Controls/SubMenuButton.qml">src/QmlControls/SubMenuButton.qml</file>
         <file alias="QGroundControl/Controls/VehicleRotationCal.qml">src/QmlControls/VehicleRotationCal.qml</file>
         <file alias="QGroundControl/Controls/VehicleSummaryRow.qml">src/QmlControls/VehicleSummaryRow.qml</file>
         <file alias="QGroundControl/Controls/ViewWidget.qml">src/ViewWidgets/ViewWidget.qml</file>
-        <file alias="QGroundControl/Controls/FactSliderPanel.qml">src/QmlControls/FactSliderPanel.qml</file>
+
+        <file alias="SimpleItemEditor.qml">src/MissionEditor/SimpleItemEditor.qml</file>
+        <file alias="SurveyItemEditor.qml">src/MissionEditor/SurveyItemEditor.qml</file>
+
         <file alias="QGroundControl/FactControls/FactBitmask.qml">src/FactSystem/FactControls/FactBitmask.qml</file>
         <file alias="QGroundControl/FactControls/FactCheckBox.qml">src/FactSystem/FactControls/FactCheckBox.qml</file>
         <file alias="QGroundControl/FactControls/FactComboBox.qml">src/FactSystem/FactControls/FactComboBox.qml</file>

--- a/src/JsonHelper.cc
+++ b/src/JsonHelper.cc
@@ -82,7 +82,19 @@ bool JsonHelper::toQGeoCoordinate(const QJsonValue& jsonValue, QGeoCoordinate& c
     return true;
 }
 
-bool JsonHelper::validateKeyTypes(QJsonObject& jsonObject, const QStringList& keys, const QList<QJsonValue::Type>& types, QString& errorString)
+void JsonHelper::writeQGeoCoordinate(QJsonValue& jsonValue, const QGeoCoordinate& coordinate, bool writeAltitude)
+{
+    QJsonArray coordinateArray;
+
+    coordinateArray << coordinate.latitude() << coordinate.longitude();
+    if (writeAltitude) {
+        coordinateArray << coordinate.altitude();
+    }
+
+    jsonValue = QJsonValue(coordinateArray);
+}
+
+bool JsonHelper::validateKeyTypes(const QJsonObject& jsonObject, const QStringList& keys, const QList<QJsonValue::Type>& types, QString& errorString)
 {
     for (int i=0; i<keys.count(); i++) {
         if (jsonObject.contains(keys[i])) {

--- a/src/JsonHelper.h
+++ b/src/JsonHelper.h
@@ -31,9 +31,11 @@ class JsonHelper
 {
 public:
     static bool validateRequiredKeys(const QJsonObject& jsonObject, const QStringList& keys, QString& errorString);
-    static bool validateKeyTypes(QJsonObject& jsonObject, const QStringList& keys, const QList<QJsonValue::Type>& types, QString& errorString);
+    static bool validateKeyTypes(const QJsonObject& jsonObject, const QStringList& keys, const QList<QJsonValue::Type>& types, QString& errorString);
     static bool toQGeoCoordinate(const QJsonValue& jsonValue, QGeoCoordinate& coordinate, bool altitudeRequired, QString& errorString);
     static bool parseEnum(QJsonObject& jsonObject, QStringList& enumStrings, QStringList& enumValues, QString& errorString);
+
+    static void writeQGeoCoordinate(QJsonValue& jsonValue, const QGeoCoordinate& coordinate, bool writeAltitude);
 
     static const char*  _enumStringsJsonKey;
     static const char*  _enumValuesJsonKey;

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -552,6 +552,7 @@ QGCView {
                             var index = controller.insertComplexMissionItem(coordinate, controller.visualItems.count)
                             setCurrentItem(index)
                             checked = false
+                            addMissionItemsButton.checked = false
                         }
                     }
 

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -49,7 +49,6 @@ Rectangle {
     property real   _gradient:          _statusValid ? Math.atan(_currentMissionItem.altDifference / _currentMissionItem.distance) : 0
     property real   _gradientPercent:   isNaN(_gradient) ? 0 : _gradient * 100
     property real   _azimuth:           _statusValid ? _currentMissionItem.azimuth : -1
-    property real   _isHomePosition:    _statusValid ? _currentMissionItem.homePosition : false
     property bool   _statusValid:       currentMissionItem != undefined
     property string _distanceText:      _statusValid ? _distance.toFixed(2) + " m" : ""
     property string _altText:           _statusValid ? _altDifference.toFixed(2) + " m" : ""

--- a/src/MissionEditor/SimpleItemEditor.qml
+++ b/src/MissionEditor/SimpleItemEditor.qml
@@ -1,0 +1,123 @@
+import QtQuick                  2.2
+import QtQuick.Controls         1.2
+import QtQuick.Controls.Styles  1.2
+import QtQuick.Dialogs          1.2
+
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.Palette       1.0
+
+// Editor for Simple mission items
+Rectangle {
+    id:                 valuesRect
+    width:              availableWidth
+    height:             valuesItem.height
+    color:              qgcPal.windowShadeDark
+    visible:            missionItem.isCurrentItem
+    radius:             _radius
+
+    // The following properties must be available up the hierachy chain
+    //property real   availableWidth    ///< Width for control
+    //property var    missionItem       ///< Mission Item for editor
+
+    Item {
+        id:                 valuesItem
+        anchors.margins:    _margin
+        anchors.left:       parent.left
+        anchors.right:      parent.right
+        anchors.top:        parent.top
+        height:             valuesColumn.height + (_margin * 2)
+
+        Column {
+            id:             valuesColumn
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            anchors.top:    parent.top
+            spacing:        _margin
+
+            QGCLabel {
+                width:      parent.width
+                wrapMode:   Text.WordWrap
+                text:       missionItem.sequenceNumber == 0 ?
+                                "Planned home position." :
+                                (missionItem.rawEdit ?
+                                     "Provides advanced access to all commands/parameters. Be very careful!" :
+                                     missionItem.commandDescription)
+            }
+
+            Repeater {
+                model: missionItem.comboboxFacts
+
+                Item {
+                    width:  valuesColumn.width
+                    height: comboBoxFact.height
+
+                    QGCLabel {
+                        id:                 comboBoxLabel
+                        anchors.baseline:   comboBoxFact.baseline
+                        text:               object.name
+                        visible:            object.name != ""
+                    }
+
+                    FactComboBox {
+                        id:             comboBoxFact
+                        anchors.right:  parent.right
+                        width:          comboBoxLabel.visible ? _editFieldWidth : parent.width
+                        indexModel:     false
+                        model:          object.enumStrings
+                        fact:           object
+                    }
+                }
+            }
+
+            Repeater {
+                model: missionItem.textFieldFacts
+
+                Item {
+                    width:  valuesColumn.width
+                    height: textField.height
+
+                    QGCLabel {
+                        id:                 textFieldLabel
+                        anchors.baseline:   textField.baseline
+                        text:               object.name
+                    }
+
+                    FactTextField {
+                        id:             textField
+                        anchors.right:  parent.right
+                        width:          _editFieldWidth
+                        showUnits:      true
+                        fact:           object
+                        visible:        !_root.readOnly
+                    }
+
+                    FactLabel {
+                        anchors.baseline:   textFieldLabel.baseline
+                        anchors.right:      parent.right
+                        fact:               object
+                        visible:            _root.readOnly
+                    }
+                }
+            }
+
+            Repeater {
+                model: missionItem.checkboxFacts
+
+                FactCheckBox {
+                    text:   object.name
+                    fact:   object
+                }
+            }
+
+            QGCButton {
+                text:       "Move Home to map center"
+                visible:    missionItem.homePosition
+                onClicked:  editorRoot.moveHomeToMapCenter()
+                anchors.horizontalCenter: parent.horizontalCenter
+            }
+        } // Column
+    } // Item
+} // Rectangle

--- a/src/MissionEditor/SurveyItemEditor.qml
+++ b/src/MissionEditor/SurveyItemEditor.qml
@@ -1,0 +1,62 @@
+import QtQuick                  2.2
+import QtQuick.Controls         1.2
+
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.Palette       1.0
+
+// Editor for Survery mission items
+Rectangle {
+    id:         _root
+    height:     editorColumn.height + (_margin * 2)
+    width:      availableWidth
+    color:      qgcPal.windowShadeDark
+    radius:     _radius
+
+    // The following properties must be available up the hierachy chain
+    //property real   availableWidth    ///< Width for control
+    //property var    missionItem       ///< Mission Item for editor
+
+    property bool _addPointsMode:   false
+    property real _margin:          ScreenTools.defaultFontPixelWidth / 2
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    Column {
+        id:                 editorColumn
+        anchors.margins:    _margin
+        anchors.top:        parent.top
+        anchors.left:       parent.left
+        width:              availableWidth
+        spacing:            _margin
+
+        Connections {
+            target: editorMap
+
+            onMapClicked: {
+                if (_addPointsMode) {
+                    missionItem.addPolygonCoordinate(coordinate)
+                }
+            }
+        }
+
+        QGCLabel {
+            text:       "Fly a grid pattern over a defined area."
+            wrapMode:   Text.WordWrap
+        }
+
+        QGCButton {
+            text: _addPointsMode ? "Finished" : "Draw Polygon"
+            onClicked: {
+                if (_addPointsMode) {
+                    _addPointsMode = false
+                } else {
+                    missionItem.clearPolygon()
+                    _addPointsMode = true
+                }
+            }
+        }
+    }
+}

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -1,24 +1,24 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
- (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
+ (c) 2009 - 2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 #ifndef ComplexMissionItem_H
@@ -30,7 +30,7 @@
 class ComplexMissionItem : public VisualMissionItem
 {
     Q_OBJECT
-    
+
 public:
     ComplexMissionItem(Vehicle* vehicle, QObject* parent = NULL);
     ComplexMissionItem(const ComplexMissionItem& other, QObject* parent = NULL);
@@ -40,12 +40,18 @@ public:
     Q_INVOKABLE void clearPolygon(void);
     Q_INVOKABLE void addPolygonCoordinate(const QGeoCoordinate coordinate);
 
-    QVariantList polygonPath(void);
+    QVariantList polygonPath(void) { return _polygonPath; }
 
-    const QList<MissionItem*>& missionItems(void) { return _missionItems; }
+    QList<MissionItem*>& missionItems(void) { return _missionItems; }
 
     /// @return The next sequence number to use after this item. Takes into account child items of the complex item
     int nextSequenceNumber(void) const;
+
+    /// Load the complex mission item from Json
+    ///     @param complexObject Complex mission item json object
+    ///     @param[out] errorString Error if load fails
+    /// @return true: load success, false: load failed, errorString set
+    bool load(const QJsonObject& complexObject, QString& errorString);
 
     // Overrides from VisualMissionItem
 
@@ -56,24 +62,36 @@ public:
     QString         commandDescription      (void) const final { return "Survey"; }
     QString         commandName             (void) const final { return "Survey"; }
     QGeoCoordinate  coordinate              (void) const final { return _coordinate; }
-    QGeoCoordinate  exitCoordinate          (void) const final { return _coordinate; }
+    QGeoCoordinate  exitCoordinate          (void) const final { return _exitCoordinate; }
 
     bool coordinateHasRelativeAltitude      (void) const final { return true; }
     bool exitCoordinateHasRelativeAltitude  (void) const final { return true; }
     bool exitCoordinateSameAsEntry          (void) const final { return false; }
 
     void setDirty           (bool dirty) final;
-    void setCoordinate      (const QGeoCoordinate& coordinate);
-    bool save               (QJsonObject& missionObject, QJsonArray& missionItems, QString& errorString) final;
+    void setCoordinate      (const QGeoCoordinate& coordinate) final;
+    void setSequenceNumber  (int sequenceNumber) final;
+    void save               (QJsonObject& saveObject) const final;
 
 signals:
     void polygonPathChanged(void);
 
 private:
+    void _clear(void);
+    void _setExitCoordinate(const QGeoCoordinate& coordinate);
+
     bool                _dirty;
     QVariantList        _polygonPath;
     QList<MissionItem*> _missionItems;
     QGeoCoordinate      _coordinate;
+    QGeoCoordinate      _exitCoordinate;
+
+    static const char* _jsonVersionKey;
+    static const char* _jsonTypeKey;
+    static const char* _jsonPolygonKey;
+    static const char* _jsonIdKey;
+
+    static const char* _complexType;
 };
 
 #endif

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -75,6 +75,8 @@ public:
     void setAutoSync(bool autoSync);
     bool syncInProgress(void);
 
+    static const char* jsonSimpleItemsKey;  ///< Key for simple items in a json file
+
 signals:
     void visualItemsChanged(void);
     void complexVisualItemsChanged(void);
@@ -131,7 +133,7 @@ private:
     static const char*  _jsonVersionKey;
     static const char*  _jsonGroundStationKey;
     static const char*  _jsonMavAutopilotKey;
-    static const char*  _jsonItemsKey;
+    static const char*  _jsonComplexItemsKey;
     static const char*  _jsonPlannedHomePositionKey;
 };
 

--- a/src/MissionManager/MissionItem.cc
+++ b/src/MissionManager/MissionItem.cc
@@ -148,7 +148,7 @@ MissionItem::~MissionItem()
 {    
 }
 
-void MissionItem::save(QJsonObject& json)
+void MissionItem::save(QJsonObject& json) const
 {
     json[_jsonTypeKey] = _itemType;
     json[_jsonIdKey] = sequenceNumber();

--- a/src/MissionManager/MissionItem.h
+++ b/src/MissionManager/MissionItem.h
@@ -103,7 +103,7 @@ public:
     void setParam7          (double param7);
     void setCoordinate      (const QGeoCoordinate& coordinate);
     
-    void save(QJsonObject& json);
+    void save(QJsonObject& json) const;
     bool load(QTextStream &loadStream);
     bool load(const QJsonObject& json, QString& errorString);
 

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -244,16 +244,9 @@ SimpleMissionItem::~SimpleMissionItem()
 {    
 }
 
-bool SimpleMissionItem::save(QJsonObject& missionObject, QJsonArray& missionItems, QString& errorString)
+void SimpleMissionItem::save(QJsonObject& saveObject) const
 {
-    Q_UNUSED(missionObject);
-    Q_UNUSED(errorString);
-
-    QJsonObject itemObject;
-    _missionItem.save(itemObject);
-    missionItems.append(itemObject);
-
-    return true;
+    _missionItem.save(saveObject);
 }
 
 bool SimpleMissionItem::load(QTextStream &loadStream)
@@ -584,4 +577,10 @@ void SimpleMissionItem::setCoordinate(const QGeoCoordinate& coordinate)
         qDebug() << _missionItem.coordinate() << coordinate;
         _missionItem.setCoordinate(coordinate);
     }
+}
+
+void SimpleMissionItem::setSequenceNumber(int sequenceNumber)
+{
+    _missionItem.setSequenceNumber(sequenceNumber);
+    VisualMissionItem::setSequenceNumber(sequenceNumber);
 }

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -107,8 +107,9 @@ public:
     bool exitCoordinateSameAsEntry          (void) const final { return true; }
 
     void setDirty           (bool dirty) final;
-    void setCoordinate      (const QGeoCoordinate& coordinate);
-    bool save               (QJsonObject& missionObject, QJsonArray& missionItems, QString& errorString) final;
+    void setCoordinate      (const QGeoCoordinate& coordinate) final;
+    void setSequenceNumber  (int sequenceNumber) final;
+    void save               (QJsonObject& saveObject) const final;
 
 public slots:
     void setDefaultsForCommand(void);

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -108,9 +108,12 @@ public:
     void setAltPercent      (double altPercent);
     void setAzimuth         (double azimuth);
     void setDistance        (double distance);
-    void setSequenceNumber  (int sequenceNumber);
 
     Vehicle* vehicle(void) { return _vehicle; }
+
+    // Virtuals which may be overriden by derived classes
+
+    virtual void setSequenceNumber(int sequenceNumber);
 
     // Pure virtuals which must be provides by derived classes
 
@@ -130,11 +133,9 @@ public:
     virtual void setDirty           (bool dirty) = 0;
     virtual void setCoordinate      (const QGeoCoordinate& coordinate) = 0;
 
-    /// Save the item in Json format
-    ///     @param missionObject Top level object for entire mission file
-    ///     @param missionItems Array of mission items
-    /// @return false: save failed, errorString set
-    virtual bool save(QJsonObject& missionObject, QJsonArray& missionItems, QString& errorString) = 0;
+    /// Save the item(s) in Json format
+    ///     @param saveObject Save the item to this json object
+    virtual void save(QJsonObject& saveObject) const = 0;
 
 signals:
     void altDifferenceChanged           (double altDifference);


### PR DESCRIPTION
- Load/Save working. You can now round trip a complex mission item (like a survey) without having it devolve into just a huge pile of waypoints.
- Entry point working. A complex mission item has both and entry and exit waypoint.

Here is an example after I reloaded from a mission file. You can see the entry into the survey area:
![screen shot 2016-02-25 at 3 20 33 pm](https://cloud.githubusercontent.com/assets/5876851/13338085/08f648a8-dbd4-11e5-8240-4e1b7d30ff78.png)
