### PR TITLE
Values picker dialog: Clip to inner size

### DIFF
--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -160,6 +160,7 @@ QGCFlickable {
                 anchors.fill:       parent
                 contentHeight:      _loader.y + _loader.height
                 flickableDirection: Flickable.VerticalFlick
+                clip:               true
 
                 QGCLabel {
                     id:     _label


### PR DESCRIPTION
Scrolling was going up under title bar. Here you can see the problem from my 7" tablet:
![screenshot_2016-02-25-18-44-36](https://cloud.githubusercontent.com/assets/5876851/13338534/c6b99a46-dbd6-11e5-972a-d011aaba233f.jpg)
