### PR TITLE
Add complex mission item exit coordinate support

### DIFF
--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -33,6 +33,7 @@ MapQuickItem {
     id: _item
 
     property var missionItem
+    property int sequenceNumber
 
     signal clicked
 
@@ -43,10 +44,9 @@ MapQuickItem {
         MissionItemIndexLabel {
             id:             _label
             isCurrentItem:  _isCurrentItem
-            label:          _sequenceNumber == 0 ? "H" : missionItem.sequenceNumber
+            label:          sequenceNumber == 0 ? "H" : sequenceNumber
             onClicked:      _item.clicked()
 
             property bool _isCurrentItem:   missionItem ? missionItem.isCurrentItem : false
-            property bool _sequenceNumber:  missionItem ? missionItem.sequenceNumber : 0
         }
 }

--- a/src/FlightMap/MapItems/MissionItemView.qml
+++ b/src/FlightMap/MapItems/MissionItemView.qml
@@ -41,6 +41,7 @@ MapItemView {
         visible:        object.specifiesCoordinate && (index != 0 || object.showHomePosition)
         z:              QGroundControl.zOrderMapItems
         missionItem:    object
+        sequenceNumber: object.sequenceNumber
 
         // These are the non-coordinate child mission items attached to this item
         Row {

--- a/src/FlightMap/Widgets/VibrationWidget.qml
+++ b/src/FlightMap/Widgets/VibrationWidget.qml
@@ -134,8 +134,6 @@ QGCFlickable {
             width:                  barRow.width
             height:                 1
             color:                  "red"
-
-            Component.onCompleted: console.log(anchors.topMargin, xBar.height, _barBadValue, _barMaximum, _barMinimum)
         }
 
         QGCLabel {

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -366,8 +366,42 @@ QGCView {
 
                 // Add the simple mission items to the map
                 MapItemView {
-                    model:          controller.visualItems
-                    delegate:       missionItemComponent
+                    model:      controller.visualItems
+                    delegate:   missionItemComponent
+                }
+
+                // Add the complex mission items to the map
+                MapItemView {
+                    model:      controller.complexVisualItems
+                    delegate:   polygonItemComponent
+                }
+
+                Component {
+                    id: polygonItemComponent
+
+                    MapPolygon {
+                        color:      'green'
+                        path:       object.polygonPath
+                        opacity:    0.5
+                    }
+                }
+
+                // Add the complex mission item exit coordinates
+                MapItemView {
+                    model:      controller.complexVisualItems
+                    delegate:   exitCoordinateComponent
+                }
+
+                Component {
+                    id: exitCoordinateComponent
+
+                    MissionItemIndicator {
+                        coordinate:     object.exitCoordinate
+                        z:              QGroundControl.zOrderMapItems
+                        missionItem:    object
+                        sequenceNumber: object.lastSequenceNumber
+                        visible:        object.specifiesCoordinate
+                    }
                 }
 
                 Component {
@@ -379,18 +413,18 @@ QGCView {
                         visible:        object.specifiesCoordinate
                         z:              QGroundControl.zOrderMapItems
                         missionItem:    object
+                        sequenceNumber: object.sequenceNumber
 
                         onClicked: setCurrentItem(object.sequenceNumber)
 
                         function updateItemIndicator()
                         {
-                            if (object.isCurrentItem && itemIndicator.visible) {
-                                if (object.specifiesCoordinate) {
-                                    // Setup our drag item
-                                        itemDragger.visible = true
-                                        itemDragger.missionItem = Qt.binding(function() { return object })
-                                        itemDragger.missionItemIndicator = Qt.binding(function() { return itemIndicator })
-                                }
+                            if (object.isCurrentItem && itemIndicator.visible &&
+                                    object.specifiesCoordinate && object.isSimpleItem) {
+                                // Setup our drag item
+                                itemDragger.visible = true
+                                itemDragger.missionItem = Qt.binding(function() { return object })
+                                itemDragger.missionItemIndicator = Qt.binding(function() { return itemIndicator })
                             }
                         }
 
@@ -418,22 +452,6 @@ QGCView {
                                 }
                             }
                         }
-                    }
-                }
-
-                // Add the complex mission items to the map
-                MapItemView {
-                    model:          controller.complexVisualItems
-                    delegate:       polygonItemComponent
-                }
-
-                Component {
-                    id: polygonItemComponent
-
-                    MapPolygon {
-                        color:      'green'
-                        path:       object.polygonPath
-                        opacity:    0.5
                     }
                 }
 

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -35,7 +35,8 @@ public:
     ComplexMissionItem(Vehicle* vehicle, QObject* parent = NULL);
     ComplexMissionItem(const ComplexMissionItem& other, QObject* parent = NULL);
 
-    Q_PROPERTY(QVariantList  polygonPath READ polygonPath NOTIFY polygonPathChanged)
+    Q_PROPERTY(QVariantList polygonPath         READ polygonPath        NOTIFY polygonPathChanged)
+    Q_PROPERTY(int          lastSequenceNumber  READ lastSequenceNumber NOTIFY lastSequenceNumberChanged)
 
     Q_INVOKABLE void clearPolygon(void);
     Q_INVOKABLE void addPolygonCoordinate(const QGeoCoordinate coordinate);
@@ -44,8 +45,8 @@ public:
 
     QList<MissionItem*>& missionItems(void) { return _missionItems; }
 
-    /// @return The next sequence number to use after this item. Takes into account child items of the complex item
-    int nextSequenceNumber(void) const;
+    /// @return The last sequence number used by this item. Takes into account child items of the complex item
+    int lastSequenceNumber(void) const;
 
     /// Load the complex mission item from Json
     ///     @param complexObject Complex mission item json object
@@ -58,11 +59,12 @@ public:
     bool            dirty                   (void) const final { return _dirty; }
     bool            isSimpleItem            (void) const final { return false; }
     bool            isStandaloneCoordinate  (void) const final { return false; }
-    bool            specifiesCoordinate     (void) const final { return true; }
+    bool            specifiesCoordinate     (void) const final;
     QString         commandDescription      (void) const final { return "Survey"; }
     QString         commandName             (void) const final { return "Survey"; }
     QGeoCoordinate  coordinate              (void) const final { return _coordinate; }
     QGeoCoordinate  exitCoordinate          (void) const final { return _exitCoordinate; }
+    int             sequenceNumber          (void) const final { return _sequenceNumber; }
 
     bool coordinateHasRelativeAltitude      (void) const final { return true; }
     bool exitCoordinateHasRelativeAltitude  (void) const final { return true; }
@@ -75,11 +77,13 @@ public:
 
 signals:
     void polygonPathChanged(void);
+    void lastSequenceNumberChanged(int lastSequenceNumber);
 
 private:
     void _clear(void);
     void _setExitCoordinate(const QGeoCoordinate& coordinate);
 
+    int                 _sequenceNumber;
     bool                _dirty;
     QVariantList        _polygonPath;
     QList<MissionItem*> _missionItems;

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -353,7 +353,7 @@ bool MissionController::_loadJsonMissionFile(const QByteArray& bytes, QmlObjectL
 
             nextSequenceNumber++;
         }
-    } while (nextSimpleItemIndex < itemArray.count() | nextComplexItemIndex < complexItems->count());
+    } while (nextSimpleItemIndex < itemArray.count() || nextComplexItemIndex < complexItems->count());
 
     if (json.contains(_jsonPlannedHomePositionKey)) {
         SimpleMissionItem* item = new SimpleMissionItem(_activeVehicle, this);

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -113,10 +113,11 @@ private:
     void _addPlannedHomePosition(QmlObjectListModel* visualItems, bool addToCenter);
     double _normalizeLat(double lat);
     double _normalizeLon(double lon);
-    bool _loadJsonMissionFile(const QByteArray& bytes, QmlObjectListModel* visualItems, QString& errorString);
+    bool _loadJsonMissionFile(const QByteArray& bytes, QmlObjectListModel* visualItems, QmlObjectListModel* complexItems, QString& errorString);
     bool _loadTextMissionFile(QTextStream& stream, QmlObjectListModel* visualItems, QString& errorString);
     void _loadMissionFromFile(const QString& file);
     void _saveMissionToFile(const QString& file);
+    int _nextSequenceNumber(void);
 
 private:
     bool                _editMode;

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -190,6 +190,9 @@ void SimpleMissionItem::_connectSignals(void)
     // These fact signals must alway signal out through SimpleMissionItem signals
     connect(&_missionItem._commandFact,     &Fact::valueChanged, this, &SimpleMissionItem::_sendCommandChanged);
     connect(&_missionItem._frameFact,       &Fact::valueChanged, this, &SimpleMissionItem::_sendFrameChanged);
+
+    // Sequence number is kept in mission iteem, so we need to propogate signal up as well
+    connect(&_missionItem, &MissionItem::sequenceNumberChanged, this, &SimpleMissionItem::sequenceNumberChanged);
 }
 
 void SimpleMissionItem::_setupMetaData(void)
@@ -574,7 +577,6 @@ void SimpleMissionItem::setCommand(MavlinkQmlSingleton::Qml_MAV_CMD command)
 void SimpleMissionItem::setCoordinate(const QGeoCoordinate& coordinate)
 {
     if (_missionItem.coordinate() != coordinate) {
-        qDebug() << _missionItem.coordinate() << coordinate;
         _missionItem.setCoordinate(coordinate);
     }
 }
@@ -582,5 +584,4 @@ void SimpleMissionItem::setCoordinate(const QGeoCoordinate& coordinate)
 void SimpleMissionItem::setSequenceNumber(int sequenceNumber)
 {
     _missionItem.setSequenceNumber(sequenceNumber);
-    VisualMissionItem::setSequenceNumber(sequenceNumber);
 }

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -101,6 +101,7 @@ public:
     QString         commandName             (void) const final;
     QGeoCoordinate  coordinate              (void) const final { return _missionItem.coordinate(); }
     QGeoCoordinate  exitCoordinate          (void) const final { return coordinate(); }
+    int             sequenceNumber          (void) const final { return _missionItem.sequenceNumber(); }
 
     bool coordinateHasRelativeAltitude      (void) const final { return _missionItem.relativeAltitude(); }
     bool exitCoordinateHasRelativeAltitude  (void) const final { return coordinateHasRelativeAltitude(); }

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -31,7 +31,6 @@ This file is part of the QGROUNDCONTROL project
 VisualMissionItem::VisualMissionItem(Vehicle* vehicle, QObject* parent)
     : QObject(parent)
     , _vehicle(vehicle)
-    , _sequenceNumber(0)
     , _isCurrentItem(false)
     , _dirty(false)
     , _altDifference(0.0)
@@ -45,7 +44,6 @@ VisualMissionItem::VisualMissionItem(Vehicle* vehicle, QObject* parent)
 VisualMissionItem::VisualMissionItem(const VisualMissionItem& other, QObject* parent)
     : QObject(parent)
     , _vehicle(NULL)
-    , _sequenceNumber(0)
     , _isCurrentItem(false)
     , _dirty(false)
     , _altDifference(0.0)
@@ -60,7 +58,6 @@ const VisualMissionItem& VisualMissionItem::operator=(const VisualMissionItem& o
 {
     _vehicle = other._vehicle;
 
-    setSequenceNumber(other._sequenceNumber);
     setIsCurrentItem(other._isCurrentItem);
     setDirty(other._dirty);
     setAltDifference(other._altDifference);
@@ -105,12 +102,4 @@ void VisualMissionItem::setAzimuth(double azimuth)
 {
     _azimuth = azimuth;
     emit azimuthChanged(_azimuth);
-}
-
-void VisualMissionItem::setSequenceNumber (int sequenceNumber)
-{
-    if (_sequenceNumber != sequenceNumber) {
-        _sequenceNumber = sequenceNumber;
-        emit sequenceNumberChanged(_sequenceNumber);
-    }
 }

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -99,7 +99,6 @@ public:
     double azimuth          (void) const { return _azimuth; }
     double distance         (void) const { return _distance; }
     bool   isCurrentItem    (void) const { return _isCurrentItem; }
-    int    sequenceNumber   (void) const { return _sequenceNumber; }
 
     QmlObjectListModel* childItems(void) { return &_childItems; }
 
@@ -111,10 +110,6 @@ public:
 
     Vehicle* vehicle(void) { return _vehicle; }
 
-    // Virtuals which may be overriden by derived classes
-
-    virtual void setSequenceNumber(int sequenceNumber);
-
     // Pure virtuals which must be provides by derived classes
 
     virtual bool            dirty                   (void) const = 0;
@@ -125,6 +120,7 @@ public:
     virtual QString         commandName             (void) const = 0;
     virtual QGeoCoordinate  coordinate              (void) const = 0;
     virtual QGeoCoordinate  exitCoordinate          (void) const = 0;
+    virtual int             sequenceNumber          (void) const = 0;
 
     virtual bool coordinateHasRelativeAltitude      (void) const = 0;
     virtual bool exitCoordinateHasRelativeAltitude  (void) const = 0;
@@ -132,6 +128,7 @@ public:
 
     virtual void setDirty           (bool dirty) = 0;
     virtual void setCoordinate      (const QGeoCoordinate& coordinate) = 0;
+    virtual void setSequenceNumber  (int sequenceNumber) = 0;
 
     /// Save the item(s) in Json format
     ///     @param saveObject Save the item to this json object
@@ -159,7 +156,6 @@ signals:
 
 protected:
     Vehicle*    _vehicle;
-    int         _sequenceNumber;
     bool        _isCurrentItem;
     bool        _dirty;
     double      _altDifference;             ///< Difference in altitude from previous waypoint


### PR DESCRIPTION
Plus many load/save fixes. Here is any example of what a mission with two structure scans in it would look like:
![screen shot 2016-02-26 at 9 33 14 am](https://cloud.githubusercontent.com/assets/5876851/13360398/f5a47cb2-dc6d-11e5-85b9-d1f1ccbd0104.png)
