### PR TITLE
Change wording to Communication Lost

### DIFF
--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -565,7 +565,7 @@ Rectangle {
 
         QGCLabel {
             id:                     connectionLost
-            text:                   "CONNECTION LOST"
+            text:                   "COMMUNICATION LOST"
             font.pixelSize:         tbFontLarge
             font.weight:            Font.DemiBold
             color:                  colorRed


### PR DESCRIPTION
Connection Lost makes user think they need to Disconnect. When in reality if the Vehicle is still there they should just wait for the signal to come back (hopefully).