### PR TITLE
Talking battery, plus other stuff

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -92,10 +92,6 @@ QT += \
     bluetooth \
 }
 
-contains(DEFINES, QGC_NOTIFY_TUNES_ENABLED) {
-    QT += multimedia
-}
-
 #  testlib is needed even in release flavor for QSignalSpy support
 QT += testlib
 

--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -23,7 +23,7 @@ QGCTextField {
     inputMethodHints:   Qt.ImhFormattedNumbersOnly
 
     onEditingFinished: {
-        if (qgcView) {
+        if (typeof qgcView !== 'undefined' && qgcView) {
             var errorString = fact.validate(text, false /* convertOnly */)
             if (errorString == "") {
                 fact.value = text

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -40,6 +40,9 @@ const char* FactGroup::_versionJsonKey =            "version";
 const char* FactGroup::_typeJsonKey =               "type";
 const char* FactGroup::_shortDescriptionJsonKey =   "shortDescription";
 const char* FactGroup::_unitsJsonKey =              "units";
+const char* FactGroup::_defaultValueJsonKey =       "defaultValue";
+const char* FactGroup::_minJsonKey =                "min";
+const char* FactGroup::_maxJsonKey =                "max";
 
 FactGroup::FactGroup(int updateRateMsecs, const QString& metaDataFile, QObject* parent)
     : QObject(parent)
@@ -187,8 +190,8 @@ void FactGroup::_loadMetaData(const QString& jsonFilename)
 
         QStringList             keys;
         QList<QJsonValue::Type> types;
-        keys << _nameJsonKey << _decimalPlacesJsonKey;
-        types << QJsonValue::String << QJsonValue::Double;
+        keys << _nameJsonKey << _decimalPlacesJsonKey << _typeJsonKey << _shortDescriptionJsonKey << _unitsJsonKey << _defaultValueJsonKey << _minJsonKey << _maxJsonKey;
+        types << QJsonValue::String << QJsonValue::Double << QJsonValue::String << QJsonValue::String << QJsonValue::String << QJsonValue::Double << QJsonValue::Double << QJsonValue::Double;
         if (!JsonHelper::validateKeyTypes(jsonObject, keys, types, errorString)) {
             qWarning() << errorString;
             return;
@@ -218,6 +221,16 @@ void FactGroup::_loadMetaData(const QString& jsonFilename)
         metaData->setDecimalPlaces(jsonObject.value(_decimalPlacesJsonKey).toInt(0));
         metaData->setShortDescription(jsonObject.value(_shortDescriptionJsonKey).toString());
         metaData->setRawUnits(jsonObject.value(_unitsJsonKey).toString());
+
+        if (jsonObject.contains(_defaultValueJsonKey)) {
+            metaData->setRawDefaultValue(jsonObject.value(_defaultValueJsonKey).toDouble());
+        }
+        if (jsonObject.contains(_minJsonKey)) {
+            metaData->setRawMin(jsonObject.value(_minJsonKey).toDouble());
+        }
+        if (jsonObject.contains(_maxJsonKey)) {
+            metaData->setRawMax(jsonObject.value(_maxJsonKey).toDouble());
+        }
 
         for (int i=0; i<enumValues.count(); i++) {
             QVariant    enumVariant;

--- a/src/FactSystem/FactGroup.h
+++ b/src/FactSystem/FactGroup.h
@@ -78,6 +78,9 @@ private:
     static const char*  _versionJsonKey;
     static const char*  _shortDescriptionJsonKey;
     static const char*  _unitsJsonKey;
+    static const char*  _defaultValueJsonKey;
+    static const char*  _minJsonKey;
+    static const char*  _maxJsonKey;
 };
 
 #endif

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -131,7 +131,7 @@ Item {
             Rectangle {
                 anchors.fill:   _valuesWidget
                 color:          _backgroundColor
-                visible:        !_showCompass && _activeVehicle
+                visible:        !_showCompass
                 radius:         _spacing
             }
 
@@ -144,7 +144,6 @@ Item {
                 maxHeight:          _availableValueHeight
             }
         }
-
 
         Rectangle {
             id:                 _spacer2

--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -33,7 +33,6 @@ import QGroundControl               1.0
 
 QGCFlickable {
     id:                 _root
-    visible:            _activeVehicle
     height:             Math.min(maxHeight, _smallFlow.y + _smallFlow.height)
     contentHeight:      _smallFlow.y + _smallFlow.height
     flickableDirection: Flickable.VerticalFlick
@@ -43,7 +42,7 @@ QGCFlickable {
     property color  textColor
     property var    maxHeight
 
-    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.disconnectedVehicle
     property real   _margins:       ScreenTools.defaultFontPixelWidth / 2
 
     QGCPalette { id:qgcPal; colorGroupEnabled: true }

--- a/src/FlightMap/Widgets/VibrationWidget.qml
+++ b/src/FlightMap/Widgets/VibrationWidget.qml
@@ -33,7 +33,6 @@ import QGroundControl               1.0
 
 QGCFlickable {
     id:                 _root
-    visible:            _activeVehicle
     height:             Math.min(maxHeight, innerItem.height)
     contentHeight:      innerItem.height
     flickableDirection: Flickable.VerticalFlick
@@ -43,7 +42,7 @@ QGCFlickable {
     property color  backgroundColor
     property var    maxHeight
 
-    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.disconnectedVehicle
     property real   _margins:       ScreenTools.defaultFontPixelWidth / 2
     property real   _barWidth:      Math.round(ScreenTools.defaultFontPixelWidth * 3)
 

--- a/src/GAudioOutput.cc
+++ b/src/GAudioOutput.cc
@@ -88,12 +88,11 @@ bool GAudioOutput::isMuted()
     return muted;
 }
 
-bool GAudioOutput::say(const QString& inText, int severity)
+bool GAudioOutput::say(const QString& inText)
 {
-    if (!muted) {
+    if (!muted && !qgcApp()->runningUnitTests()) {
 #if defined __android__
 #if defined QGC_SPEECH_ENABLED
-        Q_UNUSED(severity);
         static const char V_jniClassName[] {"org/qgroundcontrol/qgchelper/UsbDeviceJNI"};
         QAndroidJniEnvironment env;
         if (env->ExceptionCheck()) {
@@ -105,7 +104,7 @@ bool GAudioOutput::say(const QString& inText, int severity)
         QAndroidJniObject::callStaticMethod<void>(V_jniClassName, "say", "(Ljava/lang/String;)V", javaMessage.object<jstring>());
 #endif
 #else
-        emit textToSpeak(inText, severity);
+        emit textToSpeak(inText);
 #endif
     }
     return true;

--- a/src/GAudioOutput.h
+++ b/src/GAudioOutput.h
@@ -79,14 +79,14 @@ public:
     bool isMuted();
 
 public slots:
-    /** @brief Say this text if current output priority matches */
-    bool say(const QString& text, int severity = 6);
+    /** @brief Say this text */
+    bool say(const QString& text);
     /** @brief Mute/unmute sound */
     void mute(bool mute);
 
 signals:
     void mutedChanged(bool);
-    bool textToSpeak(QString text, int severity = 1);
+    bool textToSpeak(QString text);
     void beepOnce();
 
 protected:

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -55,7 +55,7 @@ public:
     Q_PROPERTY(LinkManager*         linkManager         READ linkManager            CONSTANT)
     Q_PROPERTY(MissionCommands*     missionCommands     READ missionCommands        CONSTANT)
     Q_PROPERTY(MultiVehicleManager* multiVehicleManager READ multiVehicleManager    CONSTANT)
-    Q_PROPERTY(QGCMapEngineManager*  mapEngineManager  READ mapEngineManager     CONSTANT)
+    Q_PROPERTY(QGCMapEngineManager* mapEngineManager    READ mapEngineManager       CONSTANT)
 
     Q_PROPERTY(qreal                zOrderTopMost       READ zOrderTopMost          CONSTANT) ///< z order for top most items, toolbar, main window sub view
     Q_PROPERTY(qreal                zOrderWidgets       READ zOrderWidgets          CONSTANT) ///< z order value to widgets, for example: zoom controls, hud widgetss

--- a/src/Vehicle/BatteryFact.json
+++ b/src/Vehicle/BatteryFact.json
@@ -17,6 +17,16 @@
             "units":            "%"
         },
         {
+            "name":             "percentRemainingAnnounce",
+            "shortDescription": "Percent",
+            "type":             "int32",
+            "decimalPlaces":    0,
+            "units":            "%",
+            "defaultValue":     30,
+            "min":              0,
+            "max":              100
+        },
+        {
             "name":             "mahConsumed",
             "shortDescription": "Consumed",
             "type":             "int32",

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -50,6 +50,7 @@ MultiVehicleManager::MultiVehicleManager(QGCApplication* app)
     , _activeVehicleAvailable(false)
     , _parameterReadyVehicleAvailable(false)
     , _activeVehicle(NULL)
+    , _disconnectedVehicle(NULL)
     , _firmwarePluginManager(NULL)
     , _autopilotPluginManager(NULL)
     , _joystickManager(NULL)
@@ -66,6 +67,8 @@ MultiVehicleManager::MultiVehicleManager(QGCApplication* app)
     if (_gcsHeartbeatEnabled) {
         _gcsHeartbeatTimer.start();
     }
+
+    _disconnectedVehicle = new Vehicle(this);
 }
 
 void MultiVehicleManager::setToolbox(QGCToolbox *toolbox)

--- a/src/Vehicle/MultiVehicleManager.h
+++ b/src/Vehicle/MultiVehicleManager.h
@@ -57,6 +57,9 @@ public:
     Q_PROPERTY(QmlObjectListModel*  vehicles                        READ vehicles                                                       CONSTANT)
     Q_PROPERTY(bool                 gcsHeartBeatEnabled             READ gcsHeartbeatEnabled            WRITE setGcsHeartbeatEnabled    NOTIFY gcsHeartBeatEnabledChanged)
 
+    /// A disconnected vehicle is used to access FactGroup information for the Vehicle object when no active vehicle is available
+    Q_PROPERTY(Vehicle*             disconnectedVehicle             MEMBER _disconnectedVehicle                                         CONSTANT)
+
     // Methods
 
     Q_INVOKABLE Vehicle* getVehicleById(int vehicleId);
@@ -104,6 +107,7 @@ private:
     bool        _activeVehicleAvailable;            ///< true: An active vehicle is available
     bool        _parameterReadyVehicleAvailable;    ///< true: An active vehicle with ready parameters is available
     Vehicle*    _activeVehicle;                     ///< Currently active vehicle from a ui perspective
+    Vehicle*    _disconnectedVehicle;               ///< Disconnected vechicle for FactGroup access
 
     QList<Vehicle*> _vehiclesBeingDeleted;          ///< List of Vehicles being deleted in queued phases
     Vehicle*        _vehicleBeingSetActive;         ///< Vehicle being set active in queued phases

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -29,6 +29,7 @@
 
 #include <QObject>
 #include <QGeoCoordinate>
+#include <QElapsedTimer>
 
 #include "FactGroup.h"
 #include "LinkInterface.h"
@@ -36,6 +37,7 @@
 #include "QmlObjectListModel.h"
 #include "MAVLinkProtocol.h"
 #include "UASMessageHandler.h"
+#include "SettingsFact.h"
 
 class UAS;
 class UASInterface;
@@ -66,12 +68,12 @@ public:
     Q_PROPERTY(Fact* clipCount2 READ clipCount2 CONSTANT)
     Q_PROPERTY(Fact* clipCount3 READ clipCount3 CONSTANT)
 
-    Fact* xAxis(void)       { return &_xAxisFact; }
-    Fact* yAxis(void)       { return &_yAxisFact; }
-    Fact* zAxis(void)       { return &_zAxisFact; }
-    Fact* clipCount1(void)  { return &_clipCount1Fact; }
-    Fact* clipCount2(void)  { return &_clipCount2Fact; }
-    Fact* clipCount3(void)  { return &_clipCount3Fact; }
+    Fact* xAxis         (void) { return &_xAxisFact; }
+    Fact* yAxis         (void) { return &_yAxisFact; }
+    Fact* zAxis         (void) { return &_zAxisFact; }
+    Fact* clipCount1    (void) { return &_clipCount1Fact; }
+    Fact* clipCount2    (void) { return &_clipCount2Fact; }
+    Fact* clipCount3    (void) { return &_clipCount3Fact; }
 
     void setVehicle(Vehicle* vehicle);
 
@@ -103,9 +105,9 @@ public:
     Q_PROPERTY(Fact* speed          READ speed          CONSTANT)
     Q_PROPERTY(Fact* verticalSpeed  READ verticalSpeed  CONSTANT)
 
-    Fact* direction(void)       { return &_directionFact; }
-    Fact* speed(void)           { return &_speedFact; }
-    Fact* verticalSpeed(void)   { return &_verticalSpeedFact; }
+    Fact* direction     (void) { return &_directionFact; }
+    Fact* speed         (void) { return &_speedFact; }
+    Fact* verticalSpeed (void) { return &_verticalSpeedFact; }
 
     void setVehicle(Vehicle* vehicle);
 
@@ -133,11 +135,11 @@ public:
     Q_PROPERTY(Fact* count              READ count              CONSTANT)
     Q_PROPERTY(Fact* lock               READ lock               CONSTANT)
 
-    Fact* hdop(void)                { return &_hdopFact; }
-    Fact* vdop(void)                { return &_vdopFact; }
-    Fact* courseOverGround(void)    { return &_courseOverGroundFact; }
-    Fact* count(void)               { return &_countFact; }
-    Fact* lock(void)                { return &_lockFact; }
+    Fact* hdop              (void) { return &_hdopFact; }
+    Fact* vdop              (void) { return &_vdopFact; }
+    Fact* courseOverGround  (void) { return &_courseOverGroundFact; }
+    Fact* count             (void) { return &_countFact; }
+    Fact* lock              (void) { return &_lockFact; }
 
     void setVehicle(Vehicle* vehicle);
 
@@ -175,23 +177,32 @@ public:
     Q_PROPERTY(Fact* mahConsumed        READ mahConsumed        CONSTANT)
     Q_PROPERTY(Fact* current            READ current            CONSTANT)
     Q_PROPERTY(Fact* temperature        READ temperature        CONSTANT)
-    Q_PROPERTY(Fact* cellCount          READ cellCount        CONSTANT)
+    Q_PROPERTY(Fact* cellCount          READ cellCount          CONSTANT)
 
-    Fact* voltage(void)             { return &_voltageFact; }
-    Fact* percentRemaining(void)    { return &_percentRemainingFact; }
-    Fact* mahConsumed(void)         { return &_mahConsumedFact; }
-    Fact* current(void)             { return &_currentFact; }
-    Fact* temperature(void)         { return &_temperatureFact; }
-    Fact* cellCount(void)           { return &_cellCountFact; }
+    /// If percentRemaining falls below this value, warning will be output through speech
+    Q_PROPERTY(Fact* percentRemainingAnnounce READ percentRemainingAnnounce CONSTANT)
+
+    Fact* voltage                   (void) { return &_voltageFact; }
+    Fact* percentRemaining          (void) { return &_percentRemainingFact; }
+    Fact* percentRemainingAnnounce  (void) { return &_percentRemainingAnnounceFact; }
+    Fact* mahConsumed               (void) { return &_mahConsumedFact; }
+    Fact* current                   (void) { return &_currentFact; }
+    Fact* temperature               (void) { return &_temperatureFact; }
+    Fact* cellCount                 (void) { return &_cellCountFact; }
+
 
     void setVehicle(Vehicle* vehicle);
 
     static const char* _voltageFactName;
     static const char* _percentRemainingFactName;
+    static const char* _percentRemainingAnnounceFactName;
     static const char* _mahConsumedFactName;
     static const char* _currentFactName;
     static const char* _temperatureFactName;
     static const char* _cellCountFactName;
+
+    static const char* _settingsGroup;
+    static const int   _percentRemainingAnnounceDefault;
 
     static const double _voltageUnavailable;
     static const int    _percentRemainingUnavailable;
@@ -201,13 +212,15 @@ public:
     static const int    _cellCountUnavailable;
 
 private:
-    Vehicle*    _vehicle;
-    Fact        _voltageFact;
-    Fact        _percentRemainingFact;
-    Fact        _mahConsumedFact;
-    Fact        _currentFact;
-    Fact        _temperatureFact;
-    Fact        _cellCountFact;
+    Vehicle*        _vehicle;
+    Fact            _voltageFact;
+    Fact            _percentRemainingFact;
+    Fact            _mahConsumedFact;
+    Fact            _currentFact;
+    Fact            _temperatureFact;
+    Fact            _cellCountFact;
+
+    static SettingsFact    _percentRemainingAnnounceFact;
 };
 
 class Vehicle : public FactGroup
@@ -222,6 +235,11 @@ public:
             FirmwarePluginManager*  firmwarePluginManager,
             AutoPilotPluginManager* autopilotPluginManager,
             JoystickManager*        joystickManager);
+
+    // The following is used to create a disconnected Vehicle. A disconnected vehicle is primarily used to access FactGroup information
+    // without needing a real connection.
+    Vehicle(QObject* parent = NULL);
+
     ~Vehicle();
 
     Q_PROPERTY(int                  id                      READ id                                     CONSTANT)
@@ -505,6 +523,7 @@ private slots:
     void _addNewMapTrajectoryPoint(void);
     void _parametersReady(bool parametersReady);
     void _remoteControlRSSIChanged(uint8_t rssi);
+    void _announceflightModeChanged(const QString& flightMode);
 
     void _handleTextMessage                 (int newCount);
     void _handletextMessageReceived         (UASMessage* message);
@@ -540,11 +559,13 @@ private:
     void _mapTrajectoryStart(void);
     void _mapTrajectoryStop(void);
     void _connectionActive(void);
-    void _say(const QString& text, int severity);
+    void _say(const QString& text);
+    QString _vehicleIdSpeech(void);
 
 private:
     int     _id;            ///< Mavlink system id
     bool    _active;
+    bool    _disconnectedVehicle;   ///< This Vehicle is a "disconnected" vehicle for ui use when no active vehicle is available
 
     MAV_AUTOPILOT       _firmwareType;
     MAV_TYPE            _vehicleType;
@@ -634,6 +655,9 @@ private:
     uint8_t             _messageSeq;
     uint8_t             _compID;
     bool                _heardFrom;
+
+    static const int    _lowBatteryAnnounceRepeatMSecs; // Amount of time in between each low battery announcement
+    QElapsedTimer       _lowBatteryAnnounceTimer;
 
     // FactGroup facts
 

--- a/src/audio/QGCAudioWorker.h
+++ b/src/audio/QGCAudioWorker.h
@@ -3,9 +3,6 @@
 
 #include <QObject>
 #include <QTimer>
-#ifdef QGC_NOTIFY_TUNES_ENABLED
-#include <QSound>
-#endif
 
 #if defined _MSC_VER && defined QGC_SPEECH_ENABLED
 // Documentation: http://msdn.microsoft.com/en-us/library/ee125082%28v=VS.85%29.aspx
@@ -29,19 +26,13 @@ public:
 signals:
 
 public slots:
-    /** @brief Say this text if current output priority matches */
-    void say(QString text, int severity = 1);
-
-    /** @brief Sound a single beep */
-    void beep();
+    /** @brief Say this text */
+    void say(QString text);
 
 protected:
     int voiceIndex;   ///< The index of the flite voice to use (awb, slt, rms)
 #if defined _MSC_VER && defined QGC_SPEECH_ENABLED
     ISpVoice *pVoice;
-#endif
-#ifdef QGC_NOTIFY_TUNES_ENABLED
-    QSound *sound;
 #endif
     bool emergency;   ///< Emergency status flag
     QTimer *emergencyTimer;

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -77,8 +77,6 @@ public:
 
     /** @brief The time interval the robot is switched on */
     quint64 getUptime() const;
-    /** @brief Add one measurement and get low-passed voltage */
-    float filterVoltage(float value);
 
     Q_PROPERTY(double   latitude                READ getLatitude            WRITE setLatitude           NOTIFY latitudeChanged)
     Q_PROPERTY(double   longitude               READ getLongitude           WRITE setLongitude          NOTIFY longitudeChanged)
@@ -376,21 +374,6 @@ protected: //COMMENTS FOR TEST UNIT
     uint32_t custom_mode;         ///< The current mode of the MAV
     int status;                   ///< The current status of the MAV
 
-    // dongfang: This looks like a candidate for being moved off to a separate class.
-    /// BATTERY / ENERGY
-    float startVoltage;         ///< Voltage at system start
-    float tickVoltage;          ///< Voltage where 0.1 V ticks are told
-    float lastTickVoltageValue; ///< The last voltage where a tick was announced
-    float tickLowpassVoltage;   ///< Lowpass-filtered voltage for the tick announcement
-    float warnLevelPercent;     ///< Warning level, in percent
-    double currentVoltage;      ///< Voltage currently measured
-    float lpVoltage;            ///< Low-pass filtered voltage
-    double currentCurrent;      ///< Battery current currently measured
-    bool batteryRemainingEstimateEnabled; ///< If the estimate is enabled, QGC will try to estimate the remaining battery life
-    float chargeLevel;          ///< Charge level of battery, in percent
-    bool lowBattAlarm;          ///< Switch if battery is low
-
-
     /// TIMEKEEPING
     quint64 startTime;            ///< The time the UAS was switched on
     quint64 onboardTimeOffset;
@@ -486,8 +469,6 @@ protected: //COMMENTS FOR TEST UNIT
 #endif
 
 public:
-    /** @brief Get the current charge level */
-    float getChargeLevel();
     /** @brief Get the human-readable status message for this code */
     void getStatusForCode(int statusCode, QString& uasState, QString& stateDescription);
 
@@ -558,9 +539,6 @@ public slots:
     /** @brief Stops the UAV's Hardware-in-the-Loop simulation status **/
     void stopHil();
 #endif
-
-    void startLowBattAlarm();
-    void stopLowBattAlarm();
 
     /** @brief Set the values for the manual control of the vehicle */
     void setExternalControlSetpoint(float roll, float pitch, float yaw, float thrust, quint16 buttons, int joystickMode);

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -40,6 +40,8 @@ Rectangle {
     anchors.fill:       parent
     anchors.margins:    ScreenTools.defaultFontPixelWidth
 
+    property Fact _percentRemainingAnnounce: QGroundControl.multiVehicleManager.disconnectedVehicle.battery.percentRemainingAnnounce
+
     QGCPalette {
         id:                 qgcPal
         colorGroupEnabled:  enabled
@@ -125,6 +127,32 @@ Rectangle {
                         clearCheck.checked  = false
                         clearDialog.visible = false
                     }
+                }
+            }
+            //-----------------------------------------------------------------
+            //-- Battery talker
+            Row {
+                spacing: ScreenTools.defaultFontPixelWidth
+
+                QGCCheckBox {
+                    id:                 announcePercentCheckbox
+                    anchors.baseline:   announcePercent.baseline
+                    text:               "Announce battery percent lower than:"
+                    checked:            _percentRemainingAnnounce.value != 0
+
+                    onClicked: {
+                        if (checked) {
+                            _percentRemainingAnnounce.value = _percentRemainingAnnounce.defaultValueString
+                        } else {
+                            _percentRemainingAnnounce.value = 0
+                        }
+                    }
+                }
+
+                FactTextField {
+                    id:         announcePercent
+                    fact:       _percentRemainingAnnounce
+                    enabled:    announcePercentCheckbox.checked
                 }
             }
 


### PR DESCRIPTION
* New configurable talking battery warning. You can set the precent remaining in settings
* New MultiVehicleManager::disconnectedVehicle. This is a disconnected Vehicle object which you can use to get access to FactGroup meta data without a vehicle
* Updated a number of the spoken message to use Vehicle::_vehicleIdSpeak which will say only "Vehicle" if there is only on vehicle, or "Vehicle #" is there are multiple vehicles

Fix for Issue #2901