### PR TITLE
Testing precompiled headers on OSX to speed up clang builds

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -300,6 +300,7 @@ HEADERS += \
 }
 
 WindowsBuild|MacBuild {
+    CONFIG += precompile_header
     PRECOMPILED_HEADER += src/stable_headers.h
     HEADERS += src/stable_headers.h
 }

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -299,7 +299,7 @@ HEADERS += \
     src/comm/MockLinkMissionItemHandler.h \
 }
 
-WindowsBuild {
+WindowsBuild|MacBuild {
     PRECOMPILED_HEADER += src/stable_headers.h
     HEADERS += src/stable_headers.h
 }


### PR DESCRIPTION
It would be nice if they didn't stall travis-ci.