### PR TITLE
Tweaking the SliderSwitch controller.

### DIFF
--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -136,8 +136,10 @@
         <file alias="AntennaRC">resources/Antenna_RC.svg</file>
         <file alias="AntennaT">resources/Antenna_T.svg</file>
         <file alias="ArrowDown.svg">resources/ArrowDown.svg</file>
+        <file alias="ArrowRight.svg">resources/ArrowRight.svg</file>
         <file alias="buttonLeft.svg">resources/buttonLeft.svg</file>
         <file alias="buttonRight.svg">resources/buttonRight.svg</file>
+        <file alias="cancel.svg">resources/cancel.svg</file>
         <file alias="gear.svg">resources/gear.svg</file>
         <file alias="JoystickBezel.png">resources/JoystickBezel.png</file>
         <file alias="JoystickBezelLight.png">resources/JoystickBezelLight.png</file>

--- a/resources/ArrowRight.svg
+++ b/resources/ArrowRight.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 72 72" style="enable-background:new 0 0 72 72;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:14.3358;stroke-miterlimit:10;}
+	.st1{fill:#FFFFFF;}
+</style>
+<g>
+	<g>
+		<line class="st0" x1="37.405" y1="36.011" x2="8.877" y2="35.789"/>
+		<g>
+			<polygon class="st1" points="32.315,18.1 63.123,36.211 32.037,53.84 			"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/resources/cancel.svg
+++ b/resources/cancel.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 28.35 28.35" style="enable-background:new 0 0 28.35 28.35;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FF1B00;stroke-width:2.171;stroke-miterlimit:10;}
+</style>
+<circle class="st0" cx="14.173" cy="14.173" r="10.63"/>
+<line class="st0" x1="6.657" y1="21.69" x2="21.69" y2="6.657"/>
+</svg>

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -480,7 +480,7 @@ Item {
         anchors.top:                _guidedModeBar.top
         anchors.bottom:             _guidedModeBar.bottom
         anchors.horizontalCenter:   parent.horizontalCenter
-        showReject:                 true
+        //showReject:                 true
         visible:                    false
         z:                          QGroundControl.zOrderWidgets
 

--- a/src/QmlControls/SliderSwitch.qml
+++ b/src/QmlControls/SliderSwitch.qml
@@ -8,7 +8,7 @@ import QGroundControl.Palette       1.0
 /// control on an iPhone.
 Rectangle {
     id:     _root
-    width:  label.contentWidth + (_diameter * 2) + (_border * 4)
+    width:  label.contentWidth + (_diameter * 2.5) + (_border * 4)
     radius: height /2
     color:  qgcPal.window
 
@@ -16,6 +16,7 @@ Rectangle {
     signal reject   ///< Action rejected
 
     property string confirmText ///< Text for slider
+    property bool   showReject: false
 
     property real _border: 4
     property real _diameter: height - (_border * 2)
@@ -39,11 +40,25 @@ Rectangle {
         color:      qgcPal.windowShade
         opacity:    0.8
 
+        QGCColoredImage {
+            anchors.centerIn:       parent
+            width:                  parent.width  * 0.8
+            height:                 parent.height * 0.8
+            fillMode:               Image.PreserveAspectFit
+            smooth:                 false
+            mipmap:                 false
+            color:                  qgcPal.text
+            cache:                  false
+            source:                 "/res/ArrowRight.svg"
+        }
+
+        /*
         QGCLabel {
             anchors.horizontalCenter:   parent.horizontalCenter
             anchors.verticalCenter:     parent.verticalCenter
             text: ">"
         }
+        */
 
         MouseArea {
             id:             sliderDragArea
@@ -54,7 +69,7 @@ Rectangle {
             drag.minimumX:  _border
             drag.maximumX:  _maxXDrag
 
-            property real _maxXDrag:    _root.width - ((_diameter + _border) * 2)
+            property real _maxXDrag:    _root.width - ((_diameter + _border) * (showReject ? 2 : 1))
             property bool dragActive:   drag.active
 
             onDragActiveChanged: {
@@ -78,12 +93,24 @@ Rectangle {
         radius:                 _diameter / 2
         color:                  qgcPal.windowShade
         opacity:                0.8
+        visible:                showReject
 
+        Image {
+            anchors.centerIn:       parent
+            width:                  parent.width  * 0.8
+            height:                 parent.height * 0.8
+            fillMode:               Image.PreserveAspectFit
+            smooth:                 true
+            source:                 "/res/cancel.svg"
+        }
+
+        /*
         QGCLabel {
             anchors.horizontalCenter:   parent.horizontalCenter
             anchors.verticalCenter:     parent.verticalCenter
             text: "X"
         }
+        */
 
         MouseArea {
             anchors.fill:   parent


### PR DESCRIPTION
* Replaced the text "buttons" with proper icons.
* Adjusted the slider width to give a bit more room for the message within.
* Made the "Reject" button optional (and disabled it within he UI). This is closer to the normal iOS controller. Clicking anywhere outside the slider dismisses it. I found it confusing. A bit of a contradiction with the command "Slide to *Action*", when the arrow points to a "Cancel".

If you think the "X" to cancel should be there, it's just a matter of enabling the `showReject` property to *true*.

The UI (with *showReject* disabled):

![img_0115](https://cloud.githubusercontent.com/assets/749243/13810426/2da4318e-eb46-11e5-9f40-f091204556e8.PNG)

The "Reject Button" when enabled:

![screen shot 2016-03-16 at 6 58 27 am](https://cloud.githubusercontent.com/assets/749243/13810301/84a545b4-eb45-11e5-9689-f4c87e0850d6.png)

