### PR TITLE
Initial Qt 5.6 build support.

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -60,7 +60,11 @@ linux {
         DEFINES += __macos__
         CONFIG += x86_64
         CONFIG -= x86
+equals(QT_MAJOR_VERSION, 5) | greaterThan(QT_MINOR_VERSION, 5) {
+        QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
+} else {
         QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.6
+}
         QMAKE_MAC_SDK = macosx10.11
         QMAKE_CXXFLAGS += -fvisibility=hidden
     } else {

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -103,6 +103,9 @@ MacBuild {
     QMAKE_INFO_PLIST    = Custom-Info.plist
     ICON                = $${BASEDIR}/resources/icons/macx.icns
     OTHER_FILES        += Custom-Info.plist
+equals(QT_MAJOR_VERSION, 5) | greaterThan(QT_MINOR_VERSION, 5) {
+    LIBS               += -framework ApplicationServices
+}
 }
 
 iOSBuild {

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -53,7 +53,8 @@ Map {
     zoomLevel:                  18
     center:                     QGroundControl.lastKnownHomePosition
     gesture.flickDeceleration:  3000
-    gesture.activeGestures:     MapGestureArea.ZoomGesture | MapGestureArea.PanGesture | MapGestureArea.FlickGesture
+    // This no longer exists in Qt 5.6. The options below also happen the be the default anyway.
+    //gesture.activeGestures:     MapGestureArea.ZoomGesture | MapGestureArea.PanGesture | MapGestureArea.FlickGesture
 
     plugin: Plugin { name: "QGroundControl" }
 

--- a/src/QtLocationPlugin/QGCLocationPlugin.pri
+++ b/src/QtLocationPlugin/QGCLocationPlugin.pri
@@ -2,18 +2,12 @@
 QT  += location-private positioning-private network
 
 contains(QT_VERSION, 5.5.1) {
-
     message(Using Local QtLocation headers for Qt 5.5.1)
-
     INCLUDEPATH += \
         $$PWD/qtlocation/include \
-
 } else {
-
     message(Using Default QtLocation headers)
-
     INCLUDEPATH += $$QT.location.includes
-
 }
 
 HEADERS += \

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.h
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.h
@@ -48,7 +48,6 @@
 #define QGEOTILEFETCHERQGC_H
 
 #include <QtLocation/private/qgeotilefetcher_p.h>
-#include <QtLocation/private/qgeotilecache_p.h>
 #include "QGCMapUrlEngine.h"
 
 class QGeoTiledMappingManagerEngine;

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -54,7 +54,13 @@
 #include <QtLocation/private/qgeotiledmapdata_p.h>
 #else
 #include <QtLocation/private/qgeotiledmap_p.h>
+#if QT_VERSION >= 0x050600
+#include <QtLocation/private/qgeofiletilecache_p.h>
+#else
+#include <QtLocation/private/qgeotilecache_p.h>
 #endif
+#endif
+
 #include <QDir>
 #include <QStandardPaths>
 
@@ -225,7 +231,12 @@ QGeoTiledMappingManagerEngineQGC::_setCache(const QVariantMap &parameters)
     if(memLimit < 1024 * 1024)
         memLimit = 1024 * 1024;
     //-- Disable Qt's disk cache (set memory cache otherwise Qtlocation won't work)
+#if QT_VERSION >= 0x050600
+    QAbstractGeoTileCache *pTileCache = new QGeoFileTileCache(cacheDir);
+    setTileCache(pTileCache);
+#else
     QGeoTileCache* pTileCache = createTileCacheWithDir(cacheDir);
+#endif
     if(pTileCache)
     {
         //-- We're basically telling it to use 100k of disk for cache. It doesn't like


### PR DESCRIPTION
First shot at a Qt 5.6 build. Mostly, an update on the location plugin to conform with the new interfaces. For Mac OS, I had to bump the target platform to 10.7 (from 10.6) and include a framework for TTS, which apparently is no longer added automatically by qmake.

Tested on Mac OS, iOS and Ubuntu.

Map elements (like vehicle position, waypoints and lines in between them) are not showing up on Mac OS or Ubuntu. They do show up fine on iOS.