### PR TITLE
Fix compilation regarding isnan and isinf

### DIFF
--- a/src/comm/QGCFlightGearLink.cc
+++ b/src/comm/QGCFlightGearLink.cc
@@ -50,6 +50,8 @@ This file is part of the QGROUNDCONTROL project
 #include "Vehicle.h"
 #include "UAS.h"
 
+using std::isnan;
+
 // FlightGear _fgProcess start and connection is quite fragile. Uncomment the define below to get higher level of debug output
 // for tracking down problems.
 //#define DEBUG_FLIGHTGEAR_CONNECT

--- a/src/comm/QGCJSBSimLink.cc
+++ b/src/comm/QGCJSBSimLink.cc
@@ -41,6 +41,8 @@ This file is part of the QGROUNDCONTROL project
 #include "QGC.h"
 #include "QGCMessageBox.h"
 
+using std::isnan;
+
 QGCJSBSimLink::QGCJSBSimLink(Vehicle* vehicle, QString startupArguments, QString remoteHost, QHostAddress host, quint16 port)
     : _vehicle(vehicle)
     , socket(NULL)

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -39,6 +39,9 @@
 #include "Joystick.h"
 #include "QGCApplication.h"
 
+using std::isnan;
+using std::isinf;
+
 QGC_LOGGING_CATEGORY(UASLog, "UASLog")
 
 /**

--- a/src/ui/QGCDataPlot2D.cc
+++ b/src/ui/QGCDataPlot2D.cc
@@ -47,6 +47,9 @@ This file is part of the QGROUNDCONTROL project
 #include "QGCFileDialog.h"
 #include "QGCMessageBox.h"
 
+using std::isnan;
+using std::isinf;
+
 QGCDataPlot2D::QGCDataPlot2D(QWidget *parent) :
     QWidget(parent),
     plot(new IncrementalPlot(parent)),


### PR DESCRIPTION
isnan() is defined in math.h, and if we include the cmath
instead of math.h, they are defined in std namespace.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>