### PR TITLE
Auto-Hide guided mode bar

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -128,9 +128,13 @@ FlightMap {
         anchors.fill: parent
 
         onClicked: {
-            if (_activeVehicle && _activeVehicle.guidedMode) {
-                _gotoHereCoordinate = flightMap.toCoordinate(Qt.point(mouse.x, mouse.y))
-                flightWidgets.guidedModeBar.confirmAction(flightWidgets.guidedModeBar.confirmGoTo)
+            if (_activeVehicle) {
+                if (_activeVehicle.guidedMode && flightWidgets.guidedModeBar.state == "Shown") {
+                    _gotoHereCoordinate = flightMap.toCoordinate(Qt.point(mouse.x, mouse.y))
+                    flightWidgets.guidedModeBar.confirmAction(flightWidgets.guidedModeBar.confirmGoTo)
+                } else {
+                    flightWidgets.guidedModeBar.state = "Shown"
+                }
             }
         }
     }

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -71,7 +71,7 @@ Item {
             model: QGroundControl.multiVehicleManager.vehicles
 
             delegate:
-            QGCLabel {
+                QGCLabel {
                 width:                  gpsLockColumn.width
                 horizontalAlignment:    Text.AlignHCenter
                 visible:                !object.coordinateValid
@@ -268,15 +268,56 @@ Item {
     //-- Guided mode buttons
     Rectangle {
         id:                         _guidedModeBar
-        anchors.margins:            _margins
+        anchors.margins:            _barMargin
         anchors.bottom:             parent.bottom
         anchors.horizontalCenter:   parent.horizontalCenter
-        width:                      guidedModeButtons.width + (_margins * 2)
-        height:                     guidedModeButtons.height + (_margins * 2)
+        width:                      guidedModeColumn.width + (_margins * 2)
+        height:                     guidedModeColumn.height + (_margins * 2)
+        radius:                     _margins
         color:                      qgcPal.window
         visible:                    _activeVehicle
         opacity:                    0.9
         z:                          QGroundControl.zOrderWidgets
+        state:                      "Shown"
+
+        states: [
+            State {
+                name: "Shown"
+                PropertyChanges { target: showAnimation; running: true  }
+                PropertyChanges { target: guidedModeHideTimer; running: true }
+            },
+            State {
+                name: "Hidden"
+                PropertyChanges { target: hideAnimation; running: true  }
+            }
+        ]
+
+        PropertyAnimation {
+            id:             hideAnimation
+            target:         _guidedModeBar
+            property:       "_barMargin"
+            duration:       1000
+            easing.type:    Easing.InOutQuad
+            from:           _guidedModeBar._showMargin
+            to:             _guidedModeBar._hideMargin
+        }
+
+        PropertyAnimation {
+            id:             showAnimation
+            target:         _guidedModeBar
+            property:       "_barMargin"
+            duration:       250
+            easing.type:    Easing.InOutQuad
+            from:           _guidedModeBar._hideMargin
+            to:             _guidedModeBar._showMargin
+        }
+
+        Timer {
+            id:             guidedModeHideTimer
+            interval:       7000
+            running:        true
+            onTriggered:    _guidedModeBar.state = "Hidden"
+        }
 
         readonly property int confirmHome:          1
         readonly property int confirmLand:          2
@@ -289,6 +330,9 @@ Item {
         readonly property int confirmRetask:        9
 
         property int    confirmActionCode
+        property real   _showMargin:    _margins
+        property real   _hideMargin:    _margins - _guidedModeBar.height
+        property real   _barMargin:     _showMargin
 
         function actionConfirmed() {
             switch (confirmActionCode) {
@@ -335,9 +379,11 @@ Item {
             guidedModeBar.visible = true
             altitudeSlider.visible = false
             _flightMap._gotoHereCoordinate = QtPositioning.coordinate()
+            guidedModeHideTimer.restart()
         }
 
         function confirmAction(actionCode) {
+            guidedModeHideTimer.stop()
             confirmActionCode = actionCode
             switch (confirmActionCode) {
             case confirmArm:
@@ -357,6 +403,9 @@ Item {
             case confirmLand:
                 guidedModeConfirm.confirmText = "land"
                 break;
+            case confirmHome:
+                guidedModeConfirm.confirmText = "return to launch"
+                break;
             case confirmChangeAlt:
                 altitudeSlider.visible = true
                 altitudeSlider.setInitialValueAppSettingsDistanceUnits(_activeVehicle.altitudeAMSL.value)
@@ -373,78 +422,70 @@ Item {
             guidedModeConfirm.visible = true
         }
 
-        Row {
-            id:                 guidedModeButtons
+        Column {
+            id:                 guidedModeColumn
             anchors.margins:    _margins
             anchors.top:        parent.top
             anchors.left:       parent.left
             spacing:            _margins
 
-            QGCButton {
-                text:       _activeVehicle ? (_activeVehicle.armed ? (_activeVehicle.flying ? "Emergency Stop" : "Disarm") : "Arm") : ""
-                onClicked:  {
-                    if(_activeVehicle) {
-                        _guidedModeBar.confirmAction(_activeVehicle.armed ? (_activeVehicle.flying ? _guidedModeBar.confirmEmergencyStop : _guidedModeBar.confirmDisarm) : _guidedModeBar.confirmArm)
-                    }
-                }
-            }
+            Row {
+                spacing: _margins
 
-            QGCButton {
-                text:       "RTL"
-                visible:    _activeVehicle && _activeVehicle.guidedModeSupported && _activeVehicle.flying
-                onClicked:  {
-                    if(_activeVehicle) {
-                        _guidedModeBar.confirmAction(_guidedModeBar.confirmHome)
-                    }
+                QGCButton {
+                    text:       _activeVehicle.armed ? (_activeVehicle.flying ? "Emergency Stop" : "Disarm") : "Arm"
+                    onClicked:  _guidedModeBar.confirmAction(_activeVehicle.armed ? (_activeVehicle.flying ? _guidedModeBar.confirmEmergencyStop : _guidedModeBar.confirmDisarm) : _guidedModeBar.confirmArm)
                 }
-            }
 
-            QGCButton {
-                text:        _activeVehicle ? (_activeVehicle.flying ? "Land" : "Takeoff") : ""
-                visible:    _activeVehicle && _activeVehicle.guidedModeSupported && _activeVehicle.armed
-                onClicked: {
-                    if(_activeVehicle) {
-                        _guidedModeBar.confirmAction(_activeVehicle.flying ? _guidedModeBar.confirmLand : _guidedModeBar.confirmTakeoff)
-                    }
+                QGCButton {
+                    text:       "RTL"
+                    visible:    _activeVehicle.guidedModeSupported && _activeVehicle.flying
+                    onClicked:  _guidedModeBar.confirmAction(_guidedModeBar.confirmHome)
                 }
-            }
 
-            QGCButton {
-                text:       "Pause"
-                visible:    _activeVehicle && _activeVehicle.pauseVehicleSupported && _activeVehicle.flying
-                onClicked:  {
-                    if(_activeVehicle) {
+                QGCButton {
+                    text:        _activeVehicle.flying ? "Land" : "Takeoff"
+                    visible:    _activeVehicle.guidedModeSupported && _activeVehicle.armed
+                    onClicked:  _guidedModeBar.confirmAction(_activeVehicle.flying ? _guidedModeBar.confirmLand : _guidedModeBar.confirmTakeoff)
+                }
+
+                QGCButton {
+                    text:       "Pause"
+                    visible:    _activeVehicle.pauseVehicleSupported && _activeVehicle.flying
+                    onClicked:  {
+                        guidedModeHideTimer.restart()
                         _activeVehicle.pauseVehicle()
                     }
                 }
-            }
 
-            QGCButton {
-                text:       "Change Altitude"
-                visible:    _activeVehicle && _activeVehicle.guidedModeSupported && _activeVehicle.armed
-                onClicked:  {
-                    if(_activeVehicle) {
-                        _guidedModeBar.confirmAction(_guidedModeBar.confirmChangeAlt)
-                    }
+                QGCButton {
+                    text:       "Change Altitude"
+                    visible:    _activeVehicle.guidedModeSupported && _activeVehicle.armed
+                    onClicked:  _guidedModeBar.confirmAction(_guidedModeBar.confirmChangeAlt)
                 }
+            } // Row
+
+            QGCLabel {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text:       "Click in map to move vehicle"
+                visible:    _activeVehicle && _activeVehicle.guidedMode && _activeVehicle.flying
             }
-        }
+        } // Column
     } // Rectangle - Guided mode buttons
 
     MouseArea {
-        anchors.fill: parent
-        enabled: guidedModeConfirm.visible
-        onClicked: {
-            _guidedModeBar.rejectGuidedModeConfirm()
-        }
+        anchors.fill:   parent
+        enabled:        guidedModeConfirm.visible
+        onClicked:      _guidedModeBar.rejectGuidedModeConfirm()
     }
 
     // Action confirmation control
     SliderSwitch {
         id:                         guidedModeConfirm
-        anchors.top:                _guidedModeBar.top
-        anchors.bottom:             _guidedModeBar.bottom
+        anchors.bottomMargin:       _margins
+        anchors.bottom:             parent.bottom
         anchors.horizontalCenter:   parent.horizontalCenter
+        height:                     ScreenTools.defaultFontPixelHeight * 3
         visible:                    false
         z:                          QGroundControl.zOrderWidgets
 
@@ -453,11 +494,10 @@ Item {
             guidedModeBar.visible = true
             _guidedModeBar.actionConfirmed()
             altitudeSlider.visible = false
+            guidedModeHideTimer.restart()
         }
 
-        onReject: {
-            _guidedModeBar.rejectGuidedModeConfirm()
-        }
+        onReject: _guidedModeBar.rejectGuidedModeConfirm()
     }
 
     //-- Altitude slider


### PR DESCRIPTION
Guided mode bar will move down and get out of the way when you are not using it. Click in the map to bring it back. This was needed for small screens ilke iPhone. I have it turned on for all screen types now. We'll see if it's too annoying. If so, I'll make it optional and default to on for small height screens only.