### PR TITLE
Clean unused variables / Fix QObject macro

### DIFF
--- a/src/QGC.h
+++ b/src/QGC.h
@@ -69,17 +69,6 @@ namespace QGC
 const static int defaultSystemId = 255;
 const static int defaultComponentId = 0;
 
-const QColor colorCyan(55, 154, 195);
-const QColor colorRed(154, 20, 20);
-const QColor colorGreen(20, 200, 20);
-const QColor colorYellow(255, 255, 0);
-const QColor colorOrange(255, 140, 0);
-const QColor colorMagenta(255, 0, 55);
-const QColor colorDarkWhite(240, 240, 240);
-const QColor colorDarkYellow(180, 180, 0);
-const QColor colorBackground("#050508");
-const QColor colorBlack(0, 0, 0);
-
 /**
  * @brief Get the current ground time in microseconds.
  * @note This does not have microsecond precision, it is limited to millisecond precision.
@@ -101,6 +90,7 @@ const static int MAX_FLIGHT_TIME = 60 * 60 * 24 * 21;
 
 class SLEEP : public QThread
 {
+    Q_OBJECT
 public:
     using QThread::sleep;
     using QThread::msleep;


### PR DESCRIPTION
this simple patch cleans more than 500 warnings on my build
and it should be really safe to apply since it basically remove
unused variables.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>