### PR TITLE
Pull Mac Qt version from S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ install:
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-mac-clang.tar.bz2
       && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-mac-clang.tar.bz2 -C ~/qt-install
-      && export QMAKE_PATH=clang_64
+      && export QMAKE_PATH=Qt5.5-mac-clang/5.5/clang_64
       ;
     elif [[ "${TRAVIS_OS_NAME}" = "osx" && "${SPEC}" = "ios" ]]; then
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-ios.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ install:
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-linux.tar.bz2
       && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-linux.tar.bz2 -C ~/qt-install
+      && export QMAKE_PATH=gcc_64
       && export CXX="g++-4.8"
       && export CC="gcc-4.8"
       && export DISPLAY=:99.0
@@ -89,11 +90,13 @@ install:
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-mac-clang.tar.bz2
       && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-mac-clang.tar.bz2 -C ~/qt-install
+      && export QMAKE_PATH=clang_64
       ;
     elif [[ "${TRAVIS_OS_NAME}" = "osx" && "${SPEC}" = "ios" ]]; then
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-ios.tar.bz2
       && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-ios.tar.bz2 -C ~/qt-install
+      && export QMAKE_PATH=ios
       ;
     elif [ "${TRAVIS_OS_NAME}" = "android" ]; then
          wget http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin
@@ -105,6 +108,7 @@ install:
       && wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-linux.tar.bz2
       && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-linux.tar.bz2 -C ~/qt-install
+      && export QMAKE_PATH=android_armv7
       ;
     fi
 
@@ -119,7 +123,7 @@ before_script:
   - export PATH=~/bin:$PATH
   - if [[ "${TRAVIS_OS_NAME}" = "android" && "${CONFIG}" = "installer" && -z ${ANDROID_STOREPASS} ]]; then export CONFIG=release; fi
   - if [[ "${CONFIG}" != "doxygen" && "${SPEC}" != "ios" ]]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && ~/qt-install/qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG} CONFIG+=WarningsAsErrorsOn -spec ${SPEC}; fi
-  - if [ "${SPEC}" = "ios" ]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && ~/qt-install/qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=WarningsAsErrorsOn CONFIG-=debug_and_release CONFIG+=release; fi
+  - if [ "${SPEC}" = "ios" ]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && ~/qt-install/$QMAKE_PATH/bin/qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=WarningsAsErrorsOn CONFIG-=debug_and_release CONFIG+=release; fi
 
 script:
   - if [ "${TRAVIS_OS_NAME}" = "android" ]; then cd ${TRAVIS_BUILD_DIR} && ./tools/update_android_version.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ install:
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-linux.tar.bz2
       && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-linux.tar.bz2 -C ~/qt-install
-      && export QMAKE_PATH=gcc_64
+      && export QMAKE_PATH=Qt/5.5/gcc_64
       && export CXX="g++-4.8"
       && export CC="gcc-4.8"
       && export DISPLAY=:99.0
@@ -108,7 +108,7 @@ install:
       && wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-linux.tar.bz2
       && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-linux.tar.bz2 -C ~/qt-install
-      && export QMAKE_PATH=android_armv7
+      && export QMAKE_PATH=Qt/5.5/android_armv7
       ;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,14 +88,12 @@ install:
     elif [[ "${TRAVIS_OS_NAME}" = "osx" && "${SPEC}" != "ios" ]]; then
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-mac-clang.tar.bz2
       && mkdir -p ~/qt-mac-clang
-      && tar jxf Qt5.5.1-mac-clang.tar.bz2 -C ~/qt-mac-clang
-      && export PATH=~/qt-mac-clang/clang_64/bin:$PATH
+      && tar jxf Qt5.5.1-mac-clang.tar.bz2 -C ~/qt-install
       ;
     elif [[ "${TRAVIS_OS_NAME}" = "osx" && "${SPEC}" = "ios" ]]; then
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-ios.tar.bz2
       && mkdir -p ~/qt-ios
-      && tar jxf Qt5.5.1-ios.tar.bz2 -C ~/qt-ios
-      && export PATH=~/qt-ios/ios/bin:$PATH
+      && tar jxf Qt5.5.1-ios.tar.bz2 -C ~/qt-install
       ;
     elif [ "${TRAVIS_OS_NAME}" = "android" ]; then
          wget http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin
@@ -105,8 +103,7 @@ install:
       && export ANDROID_NDK_ROOT=`pwd`/android-ndk-r10e
       && export ANDROID_SDK_ROOT=/usr/local/android-sdk
       && wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-linux.tar.bz2
-      && tar jxf Qt5.5.1-linux.tar.bz2 -C /tmp
-      && export PATH=/tmp/Qt/5.5/android_armv7/bin:$PATH
+      && tar jxf Qt5.5.1-linux.tar.bz2 -C ~/qt-install
       ;
     fi
 
@@ -120,8 +117,8 @@ before_script:
   - ln -s /usr/bin/ccache ~/bin/gcc-4.8
   - export PATH=~/bin:$PATH
   - if [[ "${TRAVIS_OS_NAME}" = "android" && "${CONFIG}" = "installer" && -z ${ANDROID_STOREPASS} ]]; then export CONFIG=release; fi
-  - if [[ "${CONFIG}" != "doxygen" && "${SPEC}" != "ios" ]]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG} CONFIG+=WarningsAsErrorsOn -spec ${SPEC}; fi
-  - if [ "${SPEC}" = "ios" ]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=WarningsAsErrorsOn CONFIG-=debug_and_release CONFIG+=release; fi
+  - if [[ "${CONFIG}" != "doxygen" && "${SPEC}" != "ios" ]]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && ~/qt-install/qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG} CONFIG+=WarningsAsErrorsOn -spec ${SPEC}; fi
+  - if [ "${SPEC}" = "ios" ]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && ~/qt-install/qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=WarningsAsErrorsOn CONFIG-=debug_and_release CONFIG+=release; fi
 
 script:
   - if [ "${TRAVIS_OS_NAME}" = "android" ]; then cd ${TRAVIS_BUILD_DIR} && ./tools/update_android_version.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ cache:
   directories:
     - $HOME/.ccache
 
-
 before_install:
   - cd ${TRAVIS_BUILD_DIR} && git fetch --unshallow && git fetch --all --tags
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then mkdir -p ~/.config/QtProject/ && cp ${TRAVIS_BUILD_DIR}/test/qtlogging.ini ~/.config/QtProject/; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ before_script:
   - ln -s /usr/bin/ccache ~/bin/gcc-4.8
   - export PATH=~/bin:$PATH
   - if [[ "${TRAVIS_OS_NAME}" = "android" && "${CONFIG}" = "installer" && -z ${ANDROID_STOREPASS} ]]; then export CONFIG=release; fi
-  - if [[ "${CONFIG}" != "doxygen" && "${SPEC}" != "ios" ]]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && ~/qt-install/qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG} CONFIG+=WarningsAsErrorsOn -spec ${SPEC}; fi
+  - if [[ "${CONFIG}" != "doxygen" && "${SPEC}" != "ios" ]]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && ~/qt-install/$QMAKE_PATH/bin/qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG} CONFIG+=WarningsAsErrorsOn -spec ${SPEC}; fi
   - if [ "${SPEC}" = "ios" ]; then mkdir ${SHADOW_BUILD_DIR} && cd ${SHADOW_BUILD_DIR} && ~/qt-install/$QMAKE_PATH/bin/qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=WarningsAsErrorsOn CONFIG-=debug_and_release CONFIG+=release; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,10 +86,10 @@ install:
       && sh -e /etc/init.d/xvfb start
       ;
     elif [[ "${TRAVIS_OS_NAME}" = "osx" && "${SPEC}" != "ios" ]]; then
-         brew update;
-         brew update
-      && brew install qt5
-      && export PATH=/usr/local/opt/qt5/bin:$PATH
+         wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-mac-clang.tar.bz2
+      && mkdir -p ~/qt-mac-clang
+      && tar jxf Qt5.5.1-mac-clang.tar.bz2 -C ~/qt-mac-clang
+      && export PATH=~/qt-mac-clang/clang_64/bin:$PATH
       ;
     elif [[ "${TRAVIS_OS_NAME}" = "osx" && "${SPEC}" = "ios" ]]; then
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-ios.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ before_install:
 install:
   - if [[ "${TRAVIS_OS_NAME}" = "linux" && "${CONFIG}" != "doxygen" ]]; then
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-linux.tar.bz2
-      && tar jxf Qt5.5.1-linux.tar.bz2 -C /tmp
-      && export PATH=/tmp/Qt/5.5/gcc_64/bin:$PATH
+      && mkdir -p ~/qt-install
+      && tar jxf Qt5.5.1-linux.tar.bz2 -C ~/qt-install
       && export CXX="g++-4.8"
       && export CC="gcc-4.8"
       && export DISPLAY=:99.0
@@ -87,12 +87,12 @@ install:
       ;
     elif [[ "${TRAVIS_OS_NAME}" = "osx" && "${SPEC}" != "ios" ]]; then
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-mac-clang.tar.bz2
-      && mkdir -p ~/qt-mac-clang
+      && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-mac-clang.tar.bz2 -C ~/qt-install
       ;
     elif [[ "${TRAVIS_OS_NAME}" = "osx" && "${SPEC}" = "ios" ]]; then
          wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-ios.tar.bz2
-      && mkdir -p ~/qt-ios
+      && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-ios.tar.bz2 -C ~/qt-install
       ;
     elif [ "${TRAVIS_OS_NAME}" = "android" ]; then
@@ -103,6 +103,7 @@ install:
       && export ANDROID_NDK_ROOT=`pwd`/android-ndk-r10e
       && export ANDROID_SDK_ROOT=/usr/local/android-sdk
       && wget https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.5.1-linux.tar.bz2
+      && mkdir -p ~/qt-install
       && tar jxf Qt5.5.1-linux.tar.bz2 -C ~/qt-install
       ;
     fi


### PR DESCRIPTION
Before: Qt installed using brew install. This doesn't work because brew install floats to latest Qt version and we need stick with a specific version. Qt 5.5 for now.
After: Qt installed from custom download uploaded to S3.

Fix for issue #3058.