### PR TITLE
Fix for espeak / alsa errors for #3015

### DIFF
--- a/src/audio/QGCAudioWorker.cpp
+++ b/src/audio/QGCAudioWorker.cpp
@@ -87,7 +87,7 @@ QGCAudioWorker::QGCAudioWorker(QObject *parent) :
 void QGCAudioWorker::init()
 {
 #if defined Q_OS_LINUX && !defined __android__ && defined QGC_SPEECH_ENABLED
-    espeak_Initialize(AUDIO_OUTPUT_SYNCH_PLAYBACK, 500, NULL, 0); // initialize for playback with 500ms buffer and no options (see speak_lib.h)
+    espeak_Initialize(AUDIO_OUTPUT_PLAYBACK, 500, NULL, 0); // initialize for playback with 500ms buffer and no options (see speak_lib.h)
     espeak_VOICE *espeak_voice = espeak_GetCurrentVoice();
     espeak_voice->languages = "en-uk"; // Default to British English
     espeak_voice->identifier = NULL; // no specific voice file specified
@@ -152,7 +152,7 @@ void QGCAudioWorker::say(QString inText)
         // Set size of string for espeak: +1 for the null-character
         unsigned int espeak_size = strlen(text.toStdString().c_str()) + 1;
         espeak_Synth(text.toStdString().c_str(), espeak_size, 0, POS_CHARACTER, 0, espeakCHARS_AUTO, NULL, NULL);
-
+        espeak_Synchronize();
 #elif (defined __macos__) && defined QGC_SPEECH_ENABLED
         macSpeech.say(text.toStdString().c_str());
 #elif (defined __ios__) && defined QGC_SPEECH_ENABLED


### PR DESCRIPTION
Initialize espeak in async playback mode and explicitly synchronize after each synth operation in the worker thread.