### PR TITLE
Toolbar/Instruments respect palette

### DIFF
--- a/src/FactSystem/FactControls/FactCheckBox.qml
+++ b/src/FactSystem/FactControls/FactCheckBox.qml
@@ -11,8 +11,6 @@ QGCCheckBox {
     property variant checkedValue: 1
     property variant uncheckedValue: 0
 
-    property var __qgcpal: QGCPalette { colorGroupEnabled: true }
-
     partiallyCheckedEnabled: fact.value != checkedValue && fact.value != uncheckedValue
     checkedState: fact.value == checkedValue ? Qt.Checked : (fact.value == uncheckedValue ? Qt.Unchecked : Qt.PartiallyChecked)
 

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -40,12 +40,14 @@ Item {
 
     property alias guidedModeBar: _guidedModeBar
 
-    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
-    property bool   _isSatellite:   _mainIsMap ? _flightMap ? _flightMap.isSatelliteMap : true : true
+    property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _isSatellite:           _mainIsMap ? (_flightMap ? _flightMap.isSatelliteMap : true) : true
+    property bool   _lightWidgetBorders:    _mainIsMap ? (_flightMap ? _flightMap.isSatelliteMap : true) : true
 
     readonly property real _margins: ScreenTools.defaultFontPixelHeight / 2
 
     QGCMapPalette { id: mapPal; lightColors: !isBackgroundDark }
+    QGCPalette { id: qgcPal }
 
     function getGadgetWidth() {
         if(ScreenTools.isMobile) {
@@ -111,7 +113,7 @@ Item {
         pitchAngle:             _pitch
         groundSpeedFact:        _groundSpeedFact
         airSpeedFact:           _airSpeedFact
-        isSatellite:            _isSatellite
+        lightBorders:           _lightWidgetBorders
         z:                      QGroundControl.zOrderWidgets
         qgcView:                parent.parent.qgcView
         maxHeight:              parent.height - (anchors.margins * 2)
@@ -156,12 +158,13 @@ Item {
 
         //-- Map Center Control
         DropButton {
-            id:                     centerMapDropButton
-            dropDirection:          dropRight
-            buttonImage:            "/qmlimages/MapCenter.svg"
-            viewportMargins:        ScreenTools.defaultFontPixelWidth / 2
-            exclusiveGroup:         _dropButtonsExclusiveGroup
-            z:                      QGroundControl.zOrderWidgets
+            id:                 centerMapDropButton
+            dropDirection:      dropRight
+            buttonImage:        "/qmlimages/MapCenter.svg"
+            viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
+            exclusiveGroup:     _dropButtonsExclusiveGroup
+            z:                  QGroundControl.zOrderWidgets
+            lightBorders:       _lightWidgetBorders
 
             dropDownComponent: Component {
                 Row {
@@ -197,12 +200,13 @@ Item {
 
         //-- Map Type Control
         DropButton {
-            id:                     mapTypeButton
-            dropDirection:          dropRight
-            buttonImage:            "/qmlimages/MapType.svg"
-            viewportMargins:        ScreenTools.defaultFontPixelWidth / 2
-            exclusiveGroup:         _dropButtonsExclusiveGroup
-            z:                      QGroundControl.zOrderWidgets
+            id:                 mapTypeButton
+            dropDirection:      dropRight
+            buttonImage:        "/qmlimages/MapType.svg"
+            viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
+            exclusiveGroup:     _dropButtonsExclusiveGroup
+            z:                  QGroundControl.zOrderWidgets
+            lightBorders:       _lightWidgetBorders
 
             dropDownComponent: Component {
                 Column {
@@ -247,6 +251,8 @@ Item {
             buttonImage:        "/qmlimages/ZoomPlus.svg"
             exclusiveGroup:     _dropButtonsExclusiveGroup
             z:                  QGroundControl.zOrderWidgets
+            lightBorders:       _lightWidgetBorders
+
             onClicked: {
                 if(_flightMap)
                     _flightMap.zoomLevel += 0.5
@@ -261,6 +267,8 @@ Item {
             buttonImage:        "/qmlimages/ZoomMinus.svg"
             exclusiveGroup:     _dropButtonsExclusiveGroup
             z:                  QGroundControl.zOrderWidgets
+            lightBorders:       _lightWidgetBorders
+
             onClicked: {
                 if(_flightMap)
                     _flightMap.zoomLevel -= 0.5
@@ -278,7 +286,7 @@ Item {
         width:                      guidedModeColumn.width + (_margins * 2)
         height:                     guidedModeColumn.height + (_margins * 2)
         radius:                     _margins
-        color:                      qgcPal.window
+        color:                      _lightWidgetBorders ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
         visible:                    _activeVehicle
         opacity:                    0.9
         z:                          QGroundControl.zOrderWidgets

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -34,6 +34,7 @@ import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FlightMap     1.0
+import QGroundControl.Palette       1.0
 
 Item {
     id:     instrumentPanel
@@ -44,7 +45,7 @@ Item {
     property alias  rollAngle:      attitudeWidget.rollAngle
     property alias  pitchAngle:     attitudeWidget.pitchAngle
     property real   size:           _defaultSize
-    property bool   isSatellite:    false
+    property bool   lightBorders:   true
     property bool   active:         false
     property var    qgcView
     property real   maxHeight
@@ -55,7 +56,7 @@ Item {
 
     property real   _defaultSize:   ScreenTools.defaultFontPixelSize * (9)
 
-    property color  _backgroundColor:   isSatellite ? Qt.rgba(1,1,1,0.75) : Qt.rgba(0,0,0,0.75)
+    property color  _backgroundColor:   qgcPal.window
     property real   _spacing:           ScreenTools.defaultFontPixelSize * 0.33
     property real   _topBottomMargin:   (size * 0.05) / 2
     property real   _availableValueHeight: maxHeight - (attitudeWidget.height + _spacer1.height + _spacer2.height + (_spacing * 4)) - (_showCompass ? compass.height : 0)
@@ -63,12 +64,16 @@ Item {
 
     readonly property bool _showCompass:    !ScreenTools.isShortScreen
 
+    QGCPalette { id: qgcPal }
+
     Rectangle {
         anchors.left:   parent.left
         anchors.right:  parent.right
         height:         (_showCompass ? instrumentColumn.height : attitudeWidget.height) + (_topBottomMargin * 2)
         radius:         size / 2
         color:          _backgroundColor
+        border.width:   1
+        border.color:   lightBorders ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
     }
 
     MouseArea {
@@ -104,7 +109,6 @@ Item {
                 opacity:            0.5
                 width:              attitudeWidget.width * 0.15
                 fillMode:           Image.PreserveAspectFit
-                visible:            _activeVehicle
 
                 MouseArea {
                     anchors.fill:   parent
@@ -120,7 +124,7 @@ Item {
             id:                 _spacer1
             height:             1
             width:              parent.width * 0.9
-            color:              isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+            color:              qgcPal.text
             anchors.horizontalCenter: parent.horizontalCenter
         }
 
@@ -139,7 +143,7 @@ Item {
                 id:                 _valuesWidget
                 width:              parent.width
                 qgcView:            instrumentPanel.qgcView
-                textColor:          isSatellite ? "black" : "white"
+                textColor:          qgcPal.text
                 backgroundColor:    _backgroundColor
                 maxHeight:          _availableValueHeight
             }
@@ -149,7 +153,7 @@ Item {
             id:                 _spacer2
             height:             1
             width:              parent.width * 0.9
-            color:              isSatellite ? Qt.rgba(0,0,0,0.25) : Qt.rgba(1,1,1,0.25)
+            color:              qgcPal.text
             visible:            _showCompass
             anchors.horizontalCenter: parent.horizontalCenter
         }

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -64,6 +64,7 @@ QGCView {
     property var    _currentMissionItem
     property bool   _firstVehiclePosition:  true
     property var    activeVehiclePosition:  _activeVehicle ? _activeVehicle.coordinate : QtPositioning.coordinate()
+    property bool   _lightWidgetBorders:    editorMap.isSatelliteMap
 
     onActiveVehiclePositionChanged: updateMapToVehiclePosition()
 
@@ -524,16 +525,18 @@ QGCView {
                     spacing:                    ScreenTools.defaultFontPixelHeight
 
                     RoundButton {
-                        id:                 addMissionItemsButton
-                        buttonImage:        "/qmlimages/MapAddMission.svg"
-                        z:                  QGroundControl.zOrderWidgets
+                        id:             addMissionItemsButton
+                        buttonImage:    "/qmlimages/MapAddMission.svg"
+                        z:              QGroundControl.zOrderWidgets
+                        lightBorders:   _lightWidgetBorders
                     }
 
                     RoundButton {
-                        id:                 addShapeButton
-                        buttonImage:        "/qmlimages/MapDrawShape.svg"
-                        z:                  QGroundControl.zOrderWidgets
-                        visible:            QGroundControl.experimentalSurvey
+                        id:             addShapeButton
+                        buttonImage:    "/qmlimages/MapDrawShape.svg"
+                        z:              QGroundControl.zOrderWidgets
+                        visible:        QGroundControl.experimentalSurvey
+                        lightBorders:   _lightWidgetBorders
 
                         onClicked: {
                             var coordinate = editorMap.center
@@ -557,6 +560,7 @@ QGCView {
                         dropDownComponent:  syncDropDownComponent
                         enabled:            !controller.syncInProgress
                         rotateImage:        controller.syncInProgress
+                        lightBorders:       _lightWidgetBorders
                     }
 
                     DropButton {
@@ -566,6 +570,7 @@ QGCView {
                         viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
                         exclusiveGroup:     _dropButtonsExclusiveGroup
                         z:                  QGroundControl.zOrderWidgets
+                        lightBorders:       _lightWidgetBorders
 
                         dropDownComponent: Component {
                             Column {
@@ -615,6 +620,7 @@ QGCView {
                         viewportMargins:    ScreenTools.defaultFontPixelWidth / 2
                         exclusiveGroup:     _dropButtonsExclusiveGroup
                         z:                  QGroundControl.zOrderWidgets
+                        lightBorders:       _lightWidgetBorders
 
                         dropDownComponent: Component {
                             Column {
@@ -646,10 +652,12 @@ QGCView {
 
                     //-- Zoom Map In
                     RoundButton {
-                        id:                 mapZoomPlus
-                        visible:            !ScreenTools.isTinyScreen && !ScreenTools.isShortScreen
-                        buttonImage:        "/qmlimages/ZoomPlus.svg"
-                        z:                  QGroundControl.zOrderWidgets
+                        id:             mapZoomPlus
+                        visible:        !ScreenTools.isTinyScreen && !ScreenTools.isShortScreen
+                        buttonImage:    "/qmlimages/ZoomPlus.svg"
+                        z:              QGroundControl.zOrderWidgets
+                        lightBorders:   _lightWidgetBorders
+
                         onClicked: {
                             if(editorMap)
                                 editorMap.zoomLevel += 0.5
@@ -659,10 +667,12 @@ QGCView {
 
                     //-- Zoom Map Out
                     RoundButton {
-                        id:                 mapZoomMinus
-                        visible:            !ScreenTools.isTinyScreen && !ScreenTools.isShortScreen
-                        buttonImage:        "/qmlimages/ZoomMinus.svg"
-                        z:                  QGroundControl.zOrderWidgets
+                        id:             mapZoomMinus
+                        visible:        !ScreenTools.isTinyScreen && !ScreenTools.isShortScreen
+                        buttonImage:    "/qmlimages/ZoomMinus.svg"
+                        z:              QGroundControl.zOrderWidgets
+                        lightBorders:   _lightWidgetBorders
+
                         onClicked: {
                             if(editorMap)
                                 editorMap.zoomLevel -= 0.5

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -656,13 +656,12 @@ void QGCApplication::_loadCurrentStyle(void)
     }
 
     if (success && !_styleIsDark) {
-        qDebug() << "LOADING LIGHT";
         // Load the slave light stylesheet.
         QFile styleSheet(_lightStyleFile);
         if (styleSheet.open(QIODevice::ReadOnly | QIODevice::Text)) {
             styles += styleSheet.readAll();
         } else {
-            qDebug() << "Unable to load slave light sheet:";
+            qWarning() << "Unable to load slave light sheet:";
             success = false;
         }
     }

--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -59,7 +59,7 @@ QColor QGCPalette::_warningText[QGCPalette::_cThemes][QGCPalette::_cColorGroups]
 };
 
 QColor QGCPalette::_button[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
-    { QColor("#ffffff"), QColor("#ffffff") },
+    { QColor("#ffffff"), QColor("#91d1e4") },
     { QColor(0x58, 0x58, 0x58), QColor(98, 98, 100) },
 };
 
@@ -69,7 +69,7 @@ QColor QGCPalette::_buttonText[QGCPalette::_cThemes][QGCPalette::_cColorGroups] 
 };
 
 QColor QGCPalette::_buttonHighlight[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
-    { QColor("#e4e4e4"), QColor("#91d1e4") },
+    { QColor("#e4e4e4"), QColor("#33b5e5") },
     { QColor(0x58, 0x58, 0x58), QColor(237, 235, 51) },
 };
 
@@ -106,6 +106,17 @@ QColor QGCPalette::_mapButton[QGCPalette::_cThemes][QGCPalette::_cColorGroups] =
 QColor QGCPalette::_mapButtonHighlight[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
     { QColor(0x58, 0x58, 0x58), QColor(190, 120, 28) },
     { QColor(0x58, 0x58, 0x58), QColor(190, 120, 28) },
+};
+
+// Map widget colors are not affecting by theming
+QColor QGCPalette::_mapWidgetBorderLight[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
+    { QColor(255, 255, 255), QColor(255, 255, 255) },
+    { QColor(255, 255, 255), QColor(255, 255, 255) },
+};
+
+QColor QGCPalette::_mapWidgetBorderDark[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
+    { QColor(0, 0, 0), QColor(0, 0, 0) },
+    { QColor(0, 0, 0), QColor(0, 0, 0) },
 };
 
 QGCPalette::QGCPalette(QObject* parent) :

--- a/src/QGCPalette.h
+++ b/src/QGCPalette.h
@@ -80,6 +80,8 @@ class QGCPalette : public QObject
     Q_PROPERTY(QColor textFieldText         READ textFieldText          WRITE setTextFieldText          NOTIFY paletteChanged)
     Q_PROPERTY(QColor mapButton             READ mapButton              WRITE setMapButton              NOTIFY paletteChanged)
     Q_PROPERTY(QColor mapButtonHighlight    READ mapButtonHighlight     WRITE setMapButtonHighlight     NOTIFY paletteChanged)
+    Q_PROPERTY(QColor mapWidgetBorderLight  READ mapWidgetBorderLight   WRITE setMapWidgetBorderLight   NOTIFY paletteChanged)
+    Q_PROPERTY(QColor mapWidgetBorderDark   READ mapWidgetBorderDark    WRITE setMapWidgetBorderDark    NOTIFY paletteChanged)
 
 public:
     enum ColorGroup {
@@ -113,6 +115,8 @@ public:
     QColor textFieldText(void)          const { return _textFieldText[_theme][_colorGroupEnabled ? 1 : 0]; }
     QColor mapButton(void)              const { return _mapButton[_theme][_colorGroupEnabled ? 1 : 0]; }
     QColor mapButtonHighlight(void)     const { return _mapButtonHighlight[_theme][_colorGroupEnabled ? 1 : 0]; }
+    QColor mapWidgetBorderLight(void)   const { return _mapWidgetBorderLight[_theme][_colorGroupEnabled ? 1 : 0]; }
+    QColor mapWidgetBorderDark(void)    const { return _mapWidgetBorderDark[_theme][_colorGroupEnabled ? 1 : 0]; }
 
     void setWindow(QColor& color)               { _window[_theme][_colorGroupEnabled ? 1 : 0] = color; _signalPaletteChangeToAll(); }
     void setWindowShade(QColor& color)          { _windowShade[_theme][_colorGroupEnabled ? 1 : 0] = color; _signalPaletteChangeToAll(); }
@@ -129,6 +133,8 @@ public:
     void setTextFieldText(QColor& color)        { _textFieldText[_theme][_colorGroupEnabled ? 1 : 0] = color; _signalPaletteChangeToAll(); }
     void setMapButton(QColor& color)            { _mapButton[_theme][_colorGroupEnabled ? 1 : 0] = color; _signalPaletteChangeToAll(); }
     void setMapButtonHighlight(QColor& color)   { _mapButtonHighlight[_theme][_colorGroupEnabled ? 1 : 0] = color; _signalPaletteChangeToAll(); }
+    void setMapWidgetBorderLight(QColor& color) { _mapWidgetBorderLight[_theme][_colorGroupEnabled ? 1 : 0] = color; _signalPaletteChangeToAll(); }
+    void setMapWidgetBorderDark(QColor& color)  { _mapWidgetBorderDark[_theme][_colorGroupEnabled ? 1 : 0] = color; _signalPaletteChangeToAll(); }
 
     static Theme globalTheme(void) { return _theme; }
     static void setGlobalTheme(Theme newTheme);
@@ -168,6 +174,9 @@ private:
     
     static QColor _mapButton[_cThemes][_cColorGroups];
     static QColor _mapButtonHighlight[_cThemes][_cColorGroups];
+
+    static QColor _mapWidgetBorderLight[_cThemes][_cColorGroups];
+    static QColor _mapWidgetBorderDark[_cThemes][_cColorGroups];
 
     void _themeChanged(void);
     

--- a/src/QmlControls/DropButton.qml
+++ b/src/QmlControls/DropButton.qml
@@ -15,6 +15,7 @@ Item {
     property int    dropDirection:      dropDown
     property alias  dropDownComponent:  dropDownLoader.sourceComponent
     property real   viewportMargins:    0
+    property alias  lightBorders:       roundButton.lightBorders
 
     width:  radius * 2
     height: radius * 2

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -1,7 +1,31 @@
-import QtQuick 2.4
-import QtQuick.Controls 1.2
-import QtGraphicalEffects 1.0
+/*=====================================================================
 
+QGroundControl Open Source Ground Control Station
+
+(c) 2009, 2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+
+This file is part of the QGROUNDCONTROL project
+
+    QGROUNDCONTROL is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    QGROUNDCONTROL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
+
+======================================================================*/
+
+import QtQuick          2.4
+import QtQuick.Controls 1.2
+
+import QGroundControl.Controls  1.0
+import QGroundControl.Palette   1.0
 
 Item {
     id: _root
@@ -12,28 +36,28 @@ Item {
 
     signal   clicked()
 
+    QGCPalette { id: qgcPal }
+
     onExclusiveGroupChanged: {
         if (exclusiveGroup) {
             exclusiveGroup.bindCheckable(_root)
         }
     }
 
-    Image {
-        id:             icon
-        width:          parent.height * 0.9
-        height:         parent.height * 0.9
-        mipmap:         true
-        fillMode:       Image.PreserveAspectFit
-        visible:        false
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.horizontalCenter: parent.horizontalCenter
+    Rectangle {
+        anchors.fill:   parent
+        color:          qgcPal.buttonHighlight
+        visible:        checked
     }
 
-    ColorOverlay {
-        id:             iconOverlay
-        anchors.fill:   icon
-        source:         icon
-        color:          (checked ? "#e4e428" : "#ffffff")
+    QGCColoredImage {
+        id:         icon
+        width:      parent.height * 0.9
+        height:     parent.height * 0.9
+        fillMode:   Image.PreserveAspectFit
+        color:      checked ? qgcPal.buttonHighlightText : qgcPal.buttonText
+        anchors.verticalCenter:     parent.verticalCenter
+        anchors.horizontalCenter:   parent.horizontalCenter
     }
 
     MouseArea {
@@ -44,62 +68,3 @@ Item {
         }
     }
 }
-
-/*
-QGCButton {
-    id: button
-    property bool repaintChevron: false
-    property var  __qgcPal: QGCPalette { colorGroupEnabled: enabled }
-    property bool showHighlight: __showHighlight
-    style: ButtonStyle {
-        background: Item {
-            anchors.margins: height * 0.1 // 3
-            Canvas {
-                id: chevron
-                anchors.fill: parent
-                antialiasing: true
-                Connections {
-                    target: button
-                    onHoveredChanged: chevron.requestPaint()
-                    onPressedChanged: chevron.requestPaint()
-                    onCheckedChanged: chevron.requestPaint()
-                    onShowHighlightChanged: chevron.requestPaint()
-                    onRepaintChevronChanged: {
-                        if(repaintChevron) {
-                            chevron.requestPaint()
-                            repaintChevron = false;
-                        }
-                    }
-                }
-                onPaint: {
-                    var vMiddle = height / 2;
-                    var context = getContext("2d");
-                    var w12 = button.height * 0.4 // 12
-                    var w3  = button.height * 0.1 // 3
-                    var w15 = w12 + w3
-                    context.reset();
-                    context.beginPath();
-                    context.lineWidth = button.height * 0.2; // 6
-                    context.beginPath();
-                    context.moveTo(0, 0);
-                    context.lineTo(width - w15, 0);
-                    context.lineTo(width - w3,  vMiddle);
-                    context.lineTo(width - w15, height);
-                    context.lineTo(0, height);
-                    context.closePath();
-                    context.strokeStyle = __qgcPal.windowShade
-                    context.fillStyle = showHighlight ? __qgcPal.buttonHighlight : (button.checked ? __qgcPal.buttonHighlight : __qgcPal.button);
-                    context.stroke();
-                    context.fill();
-                }
-            }
-        }
-        label: QGCLabel {
-            text: button.text
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment:   Text.AlignVCenter
-            color: showHighlight ? __qgcPal.buttonHighlightText : (button.checked ? __qgcPal.primaryButtonText : __qgcPal.buttonText)
-        }
-    }
-}
-*/

--- a/src/QmlControls/RoundButton.qml
+++ b/src/QmlControls/RoundButton.qml
@@ -9,9 +9,10 @@ Item {
     id: _root
 
     signal          clicked()
-    property alias  buttonImage:        button.source
-    property real   radius:             ScreenTools.defaultFontPixelHeight * 1.5
-    property bool   rotateImage:        false
+    property alias  buttonImage:    button.source
+    property real   radius:         ScreenTools.defaultFontPixelHeight * 1.5
+    property bool   rotateImage:    false
+    property bool   lightBorders:   true
 
     width:  radius * 2
     height: radius * 2
@@ -40,15 +41,17 @@ Item {
         anchors.fill:   parent
         radius:         width / 2
         border.width:   ScreenTools.defaultFontPixelHeight * 0.0625
-        border.color:   "white"
-        color:          checked ? qgcPal.mapButtonHighlight : qgcPal.mapButton
+        border.color:   lightBorders ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
+        color:          checked ? qgcPal.buttonHighlight : qgcPal.button
 
-        Image {
+        QGCColoredImage {
             id:             button
             anchors.fill:   parent
             fillMode:       Image.PreserveAspectFit
             mipmap:         true
             smooth:         true
+            color:          checked ? qgcPal.buttonHighlightText : qgcPal.buttonText
+
             RotationAnimation on rotation {
                 id: imageRotation
                 loops: Animation.Infinite

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -42,7 +42,7 @@ Item {
     readonly property string _planViewSource:   "MissionEditor.qml"
     readonly property string _setupViewSource:  "SetupView.qml"
 
-    QGCPalette { id: __qgcPal; colorGroupEnabled: true }
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     property real   tbHeight:           ScreenTools.isMobile ? (ScreenTools.isTinyScreen ? (mainWindow.width * 0.0666) : (mainWindow.width * 0.05)) : ScreenTools.defaultFontPixelSize * 4
     property int    tbCellHeight:       tbHeight * 0.75
@@ -381,7 +381,7 @@ Item {
     //-------------------------------------------------------------------------
     //-- Critical Message Area
     Rectangle {
-        id:                 criticalMmessageArea
+        id: criticalMmessageArea
 
         function close() {
             //-- Are there messages in the waiting queue?
@@ -401,7 +401,7 @@ Item {
 
         width:              mainWindow.width  * 0.55
         height:             ScreenTools.defaultFontPixelHeight * ScreenTools.fontHRatio * 6
-        color:              Qt.rgba(0,0,0,0.8)
+        color:              qgcPal.window
         visible:            false
         radius:             ScreenTools.defaultFontPixelHeight * 0.5
         anchors.horizontalCenter:   parent.horizontalCenter
@@ -425,6 +425,7 @@ Item {
             boundsBehavior:     Flickable.StopAtBounds
             pixelAligned:       true
             clip:               true
+
             TextEdit {
                 id:             criticalMessageText
                 width:          criticalMmessageArea.width - criticalClose.width - (ScreenTools.defaultFontPixelHeight * 2)
@@ -433,12 +434,12 @@ Item {
                 textFormat:     TextEdit.RichText
                 font.weight:    Font.DemiBold
                 wrapMode:       TextEdit.WordWrap
-                color:          "#fdfd3b"
+                color:          qgcPal.warningText
             }
         }
 
         //-- Dismiss Critical Message
-        Image {
+        QGCColoredImage {
             id:                 criticalClose
             anchors.margins:    ScreenTools.defaultFontPixelHeight
             anchors.top:        parent.top
@@ -447,8 +448,8 @@ Item {
             height:             ScreenTools.defaultFontPixelHeight * 1.5
             source:             "/res/XDelete.svg"
             fillMode:           Image.PreserveAspectFit
-            mipmap:             true
-            smooth:             true
+            color:              qgcPal.warningText
+
             MouseArea {
                 anchors.fill:   parent
                 onClicked: {
@@ -458,7 +459,7 @@ Item {
         }
 
         //-- More text below indicator
-        Image {
+        QGCColoredImage {
             anchors.margins:    ScreenTools.defaultFontPixelHeight
             anchors.bottom:     parent.bottom
             anchors.right:      parent.right
@@ -466,9 +467,9 @@ Item {
             height:             ScreenTools.defaultFontPixelHeight * 1.5
             source:             "/res/ArrowDown.svg"
             fillMode:           Image.PreserveAspectFit
-            mipmap:             true
-            smooth:             true
             visible:            criticalMessageText.lineCount > 5
+            color:              qgcPal.warningText
+
             MouseArea {
                 anchors.fill:   parent
                 onClicked: {

--- a/src/ui/MainWindowLeftPanel.qml
+++ b/src/ui/MainWindowLeftPanel.qml
@@ -44,6 +44,8 @@ Item {
     readonly property real __closeButtonSize:   ScreenTools.defaultFontPixelHeight * 2
     readonly property real _margins:            ScreenTools.defaultFontPixelHeight / 2
 
+    QGCPalette { id: qgcPal }
+
     onVisibleChanged: {
         //-- Unselect any selected button
         panelActionGroup.current = null
@@ -106,7 +108,7 @@ Item {
         anchors.bottom: parent.bottom
         anchors.left:   parent.left
         opacity:        0.0
-        color:          __qgcPal.window
+        color:          qgcPal.window
         visible:        __rightPanel.source == ""
         // Dismiss if clicked outside menu area
         MouseArea {
@@ -134,7 +136,7 @@ Item {
         anchors.left:   parent.left
         anchors.top:    __topSeparator.bottom
         anchors.bottom: parent.bottom
-        color:          __qgcPal.windowShadeDark
+        color:          qgcPal.windowShadeDark
 
         QGCFlickable {
             anchors.fill:       parent
@@ -270,7 +272,7 @@ Item {
         height:         parent.height - toolBar.height - __topSeparator.height
         anchors.bottom: parent.bottom
         visible:        __rightPanel.source != ""
-        color:          __qgcPal.window
+        color:          qgcPal.window
         //-- Panel Contents
         Loader {
             id:             __rightPanel
@@ -288,7 +290,7 @@ Item {
                 source:       "/res/XDelete.svg"
                 mipmap:       true
                 fillMode:     Image.PreserveAspectFit
-                color:        __qgcPal.text
+                color:        qgcPal.text
                 width:        parent.width  * 0.75
                 height:       parent.height * 0.75
                 anchors.centerIn: parent

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -36,16 +36,13 @@ import QGroundControl.Palette               1.0
 
 Rectangle {
     id:                 _generalRoot
-    color:              __qgcPal.window
+    color:              qgcPal.window
     anchors.fill:       parent
     anchors.margins:    ScreenTools.defaultFontPixelWidth
 
     property Fact _percentRemainingAnnounce: QGroundControl.multiVehicleManager.disconnectedVehicle.battery.percentRemainingAnnounce
 
-    QGCPalette {
-        id:                 qgcPal
-        colorGroupEnabled:  enabled
-    }
+    QGCPalette { id: qgcPal }
 
     QGCFlickable {
         clip:               true
@@ -115,7 +112,7 @@ Rectangle {
                 }
 
                 QGCLabel {
-                    anchors.baseline:   distanceUnitsCombo.baseline
+                    anchors.baseline:   speedUnitsCombo.baseline
                     text:               "(requires reboot to take affect)"
                 }
             }
@@ -250,12 +247,11 @@ Rectangle {
                 QGCComboBox {
                     id: paletteCombo
                     width: ScreenTools.defaultFontPixelWidth * 16
-                    model: [ "Dark", "Light" ]
+                    model: [ "Indoor", "Outdoor" ]
                     currentIndex: QGroundControl.isDarkStyle ? 0 : 1
                     onActivated: {
                         if (index != -1) {
                             currentIndex = index
-                            console.log((index === 0) ? "Now it's Dark" : "Now it's Light")
                             QGroundControl.isDarkStyle = index === 0 ? true : false
                         }
                     }

--- a/src/ui/preferences/MavlinkSettings.qml
+++ b/src/ui/preferences/MavlinkSettings.qml
@@ -35,13 +35,10 @@ import QGroundControl.Palette               1.0
 
 Rectangle {
     id:             __mavlinkRoot
-    color:          __qgcPal.window
+    color:          qgcPal.window
     anchors.fill:   parent
 
-    QGCPalette {
-        id:                 qgcPal
-        colorGroupEnabled:  enabled
-    }
+    QGCPalette { id: qgcPal }
 
     QGCFlickable {
         clip:               true

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -40,8 +40,8 @@ import QGroundControl.ScreenTools           1.0
 import QGroundControl.Controllers           1.0
 
 Rectangle {
-    id:     toolBar
-    color:  opaqueBackground ? "#404040" : Qt.rgba(0,0,0,0.75)
+    id:         toolBar
+    color:      qgcPal.window
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
@@ -197,24 +197,27 @@ Rectangle {
     // GPS Info
     Component {
         id: gpsInfo
+
         Rectangle {
-            color:          Qt.rgba(0,0,0,0.75)
-            width:          gpsCol.width   + ScreenTools.defaultFontPixelWidth  * 3
-            height:         gpsCol.height  + ScreenTools.defaultFontPixelHeight * 2
-            radius:         ScreenTools.defaultFontPixelHeight * 0.5
+            width:  gpsCol.width   + ScreenTools.defaultFontPixelWidth  * 3
+            height: gpsCol.height  + ScreenTools.defaultFontPixelHeight * 2
+            radius: ScreenTools.defaultFontPixelHeight * 0.5
+            color:  qgcPal.window
+
             Column {
                 id:                 gpsCol
                 spacing:            ScreenTools.defaultFontPixelHeight * 0.5
                 width:              Math.max(gpsGrid.width, gpsLabel.width)
                 anchors.margins:    ScreenTools.defaultFontPixelHeight
                 anchors.centerIn:   parent
+
                 QGCLabel {
                     id:         gpsLabel
                     text:       (activeVehicle && activeVehicle.gps.count.value >= 0) ? "GPS Status" : "GPS Data Unavailable"
                     font.weight:Font.DemiBold
-                    color:      colorWhite
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
+
                 GridLayout {
                     id:                 gpsGrid
                     visible:            (activeVehicle && activeVehicle.gps.count.value >= 0)
@@ -222,48 +225,20 @@ Rectangle {
                     columnSpacing:      ScreenTools.defaultFontPixelWidth
                     anchors.horizontalCenter: parent.horizontalCenter
                     columns: 2
-                    QGCLabel {
-                        text:   "GPS Count:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   activeVehicle ? activeVehicle.gps.count.valueString : "N/A"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "GPS Lock:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   activeVehicle ? activeVehicle.gps.lock.enumStringValue : "N/A"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "HDOP:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   activeVehicle ? activeVehicle.gps.hdop.valueString : "--.--"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "VDOP:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   activeVehicle ? activeVehicle.gps.vdop.valueString : "--.--"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "Course Over Ground:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   activeVehicle ? activeVehicle.gps.courseOverGround.valueString : "--.--"
-                        color:  colorWhite
-                    }
+
+                    QGCLabel { text: "GPS Count:" }
+                    QGCLabel { text: activeVehicle ? activeVehicle.gps.count.valueString : "N/A" }
+                    QGCLabel { text: "GPS Lock:" }
+                    QGCLabel { text: activeVehicle ? activeVehicle.gps.lock.enumStringValue : "N/A" }
+                    QGCLabel { text: "HDOP:" }
+                    QGCLabel { text: activeVehicle ? activeVehicle.gps.hdop.valueString : "--.--" }
+                    QGCLabel { text: "VDOP:" }
+                    QGCLabel { text: activeVehicle ? activeVehicle.gps.vdop.valueString : "--.--" }
+                    QGCLabel { text: "Course Over Ground:" }
+                    QGCLabel { text: activeVehicle ? activeVehicle.gps.courseOverGround.valueString : "--.--" }
                 }
             }
+
             Component.onCompleted: {
                 var pos = mapFromItem(toolBar, centerX - (width / 2), toolBar.height)
                 x = pos.x
@@ -278,10 +253,10 @@ Rectangle {
         id: batteryInfo
 
         Rectangle {
-            color:          Qt.rgba(0,0,0,0.75)
-            width:          battCol.width   + ScreenTools.defaultFontPixelWidth  * 3
-            height:         battCol.height  + ScreenTools.defaultFontPixelHeight * 2
-            radius:         ScreenTools.defaultFontPixelHeight * 0.5
+            width:  battCol.width   + ScreenTools.defaultFontPixelWidth  * 3
+            height: battCol.height  + ScreenTools.defaultFontPixelHeight * 2
+            radius: ScreenTools.defaultFontPixelHeight * 0.5
+            color:  qgcPal.window
 
             Column {
                 id:                 battCol
@@ -293,32 +268,21 @@ Rectangle {
                 QGCLabel {
                     id:         battLabel
                     text:       "Battery Status"
-                    color:      colorWhite
                     font.weight:Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
+
                 GridLayout {
                     id:                 battGrid
                     anchors.margins:    ScreenTools.defaultFontPixelHeight
                     columnSpacing:      ScreenTools.defaultFontPixelWidth
+                    columns:            2
                     anchors.horizontalCenter: parent.horizontalCenter
-                    columns: 2
-                    QGCLabel {
-                        text:   "Voltage:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   (activeVehicle && activeVehicle.battery.voltage.value != -1) ? (activeVehicle.battery.voltage.valueString + " " + activeVehicle.battery.voltage.units) : "N/A"
-                        color:  getBatteryColor()
-                    }
-                    QGCLabel {
-                        text:   "Accumulated Consumption:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   (activeVehicle && activeVehicle.battery.mahConsumed.value != -1) ? (activeVehicle.battery.mahConsumed.valueString + " " + activeVehicle.battery.mahConsumed.units) : "N/A"
-                        color:  getBatteryColor()
-                    }
+
+                    QGCLabel { text: "Voltage:" }
+                    QGCLabel { text: (activeVehicle && activeVehicle.battery.voltage.value != -1) ? (activeVehicle.battery.voltage.valueString + " " + activeVehicle.battery.voltage.units) : "N/A" }
+                    QGCLabel { text: "Accumulated Consumption:" }
+                    QGCLabel { text: (activeVehicle && activeVehicle.battery.mahConsumed.value != -1) ? (activeVehicle.battery.mahConsumed.valueString + " " + activeVehicle.battery.mahConsumed.units) : "N/A" }
                 }
             }
 
@@ -334,41 +298,40 @@ Rectangle {
     // RC RSSI Info
     Component {
         id: rcRSSIInfo
+
         Rectangle {
-            color:          Qt.rgba(0,0,0,0.75)
-            width:          rcrssiCol.width   + ScreenTools.defaultFontPixelWidth  * 3
-            height:         rcrssiCol.height  + ScreenTools.defaultFontPixelHeight * 2
-            radius:         ScreenTools.defaultFontPixelHeight * 0.5
+            width:  rcrssiCol.width   + ScreenTools.defaultFontPixelWidth  * 3
+            height: rcrssiCol.height  + ScreenTools.defaultFontPixelHeight * 2
+            radius: ScreenTools.defaultFontPixelHeight * 0.5
+            color:  qgcPal.window
+
             Column {
                 id:                 rcrssiCol
                 spacing:            ScreenTools.defaultFontPixelHeight * 0.5
                 width:              Math.max(rcrssiGrid.width, rssiLabel.width)
                 anchors.margins:    ScreenTools.defaultFontPixelHeight
                 anchors.centerIn:   parent
+
                 QGCLabel {
                     id:         rssiLabel
                     text:       activeVehicle ? (activeVehicle.rcRSSI > 0 ? "RC RSSI Status" : "RC RSSI Data Unavailable") : "N/A"
-                    color:      colorWhite
                     font.weight:Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
+
                 GridLayout {
                     id:                 rcrssiGrid
                     visible:            activeVehicle && activeVehicle.rcRSSI > 0
                     anchors.margins:    ScreenTools.defaultFontPixelHeight
                     columnSpacing:      ScreenTools.defaultFontPixelWidth
+                    columns:            2
                     anchors.horizontalCenter: parent.horizontalCenter
-                    columns: 2
-                    QGCLabel {
-                        text:   "RSSI:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   activeVehicle ? (activeVehicle.rcRSSI + "%") : 0
-                        color:  colorWhite
-                    }
+
+                    QGCLabel { text: "RSSI:" }
+                    QGCLabel { text: activeVehicle ? (activeVehicle.rcRSSI + "%") : 0 }
                 }
             }
+
             Component.onCompleted: {
                 var pos = mapFromItem(toolBar, centerX - (width / 2), toolBar.height)
                 x = pos.x
@@ -381,88 +344,51 @@ Rectangle {
     // Telemetry RSSI Info
     Component {
         id: telemRSSIInfo
+
         Rectangle {
-            color:          Qt.rgba(0,0,0,0.75)
-            width:          telemCol.width   + ScreenTools.defaultFontPixelWidth  * 3
-            height:         telemCol.height  + ScreenTools.defaultFontPixelHeight * 2
-            radius:         ScreenTools.defaultFontPixelHeight * 0.5
+            width:  telemCol.width   + ScreenTools.defaultFontPixelWidth  * 3
+            height: telemCol.height  + ScreenTools.defaultFontPixelHeight * 2
+            radius: ScreenTools.defaultFontPixelHeight * 0.5
+            color:  qgcPal.window
+
             Column {
                 id:                 telemCol
                 spacing:            ScreenTools.defaultFontPixelHeight * 0.5
                 width:              Math.max(telemGrid.width, telemLabel.width)
                 anchors.margins:    ScreenTools.defaultFontPixelHeight
                 anchors.centerIn:   parent
+
                 QGCLabel {
-                    id:         telemLabel
-                    text:       "Telemetry RSSI Status"
-                    color:      colorWhite
-                    font.weight:Font.DemiBold
+                    id:             telemLabel
+                    text:           "Telemetry RSSI Status"
+                    font.weight:    Font.DemiBold
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
+
                 GridLayout {
                     id:                 telemGrid
                     anchors.margins:    ScreenTools.defaultFontPixelHeight
                     columnSpacing:      ScreenTools.defaultFontPixelWidth
+                    columns:            2
                     anchors.horizontalCenter: parent.horizontalCenter
-                    columns: 2
-                    QGCLabel {
-                        text:   "Local RSSI:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   _controller.telemetryLRSSI + " dBm"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "Remote RSSI:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   _controller.telemetryRRSSI + " dBm"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "RX Errors:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   _controller.telemetryRXErrors
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "Errors Fixed:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   _controller.telemetryFixed
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "TX Buffer:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   _controller.telemetryTXBuffer
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "Local Noise:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   _controller.telemetryLNoise
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   "Remote Noise:"
-                        color:  colorWhite
-                    }
-                    QGCLabel {
-                        text:   _controller.telemetryRNoise
-                        color:  colorWhite
-                    }
+
+                    QGCLabel { text: "Local RSSI:" }
+                    QGCLabel { text: _controller.telemetryLRSSI + " dBm" }
+                    QGCLabel { text: "Remote RSSI:" }
+                    QGCLabel { text: _controller.telemetryRRSSI + " dBm" }
+                    QGCLabel { text: "RX Errors:" }
+                    QGCLabel { text: _controller.telemetryRXErrors }
+                    QGCLabel { text: "Errors Fixed:" }
+                    QGCLabel { text: _controller.telemetryFixed }
+                    QGCLabel { text: "TX Buffer:" }
+                    QGCLabel { text: _controller.telemetryTXBuffer }
+                    QGCLabel { text: "Local Noise:" }
+                    QGCLabel { text: _controller.telemetryLNoise }
+                    QGCLabel { text: "Remote Noise:" }
+                    QGCLabel { text: _controller.telemetryRNoise }
                 }
             }
+
             Component.onCompleted: {
                 var pos = mapFromItem(toolBar, centerX - (width / 2), toolBar.height)
                 x = pos.x
@@ -494,12 +420,6 @@ Rectangle {
             }
         }
 
-        Rectangle {
-            height: mainWindow.tbCellHeight
-            width:  1
-            color: Qt.rgba(1,1,1,0.45)
-        }
-
         QGCToolBarButton {
             id:                 setupButton
             width:              mainWindow.tbButtonWidth
@@ -507,12 +427,6 @@ Rectangle {
             exclusiveGroup:     mainActionGroup
             source:             "/qmlimages/Gears.svg"
             onClicked:          toolBar.showSetupView()
-        }
-
-        Rectangle {
-            height: mainWindow.tbCellHeight
-            width:  1
-            color: Qt.rgba(1,1,1,0.45)
         }
 
         QGCToolBarButton {
@@ -524,12 +438,6 @@ Rectangle {
             onClicked:          toolBar.showPlanView()
         }
 
-        Rectangle {
-            height: mainWindow.tbCellHeight
-            width:  1
-            color: Qt.rgba(1,1,1,0.45)
-        }
-
         QGCToolBarButton {
             id:                 flyButton
             width:              mainWindow.tbButtonWidth
@@ -538,13 +446,6 @@ Rectangle {
             source:             "/qmlimages/PaperPlane.svg"
             onClicked:          toolBar.showFlyView()
         }
-
-        Rectangle {
-            height: mainWindow.tbCellHeight
-            width:  1
-            color: Qt.rgba(1,1,1,0.45)
-        }
-
     }
 
     Item {

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -21,18 +21,21 @@ This file is part of the QGROUNDCONTROL project
 
 ======================================================================*/
 
-import QtQuick 2.5
-import QtQuick.Controls 1.2
-import QtGraphicalEffects 1.0
-import QtQuick.Controls.Styles 1.2
-import QtQuick.Dialogs 1.1
+import QtQuick                  2.5
+import QtQuick.Controls         1.2
+import QtGraphicalEffects       1.0
+import QtQuick.Controls.Styles  1.2
+import QtQuick.Dialogs          1.1
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
+import QGroundControl.Palette       1.0
 
 Row {
     spacing:  tbSpacing * 2
+
+    QGCPalette { id: qgcPal }
 
     function getSatStrength(hdop) {
         if (hdop <= 1.0)
@@ -99,23 +102,24 @@ Row {
             id:                 criticalMessage
             anchors.fill:       parent
             visible:            activeVehicle ? (activeVehicle.messageCount > 0 && isMessageImportant) : false
+
             Image {
                 source:         "/qmlimages/Yield.svg"
                 height:         mainWindow.tbCellHeight * 0.75
                 fillMode:       Image.PreserveAspectFit
-                mipmap:         true
-                smooth:         true
                 cache:          false
                 visible:        isMessageImportant
                 anchors.verticalCenter:   parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
             }
+
             SequentialAnimation {
                 id:    loopAnimation
                 loops: Animation.Infinite
                 NumberAnimation { target: criticalMessage; property: "opacity"; duration: 1000; from: 0.25; to: 1 }
                 NumberAnimation { target: criticalMessage; property: "opacity"; duration: 1000; from: 1; to: 0.25 }
             }
+
             onVisibleChanged: {
                 if(messages.visible) {
                     loopAnimation.start()
@@ -128,21 +132,15 @@ Row {
         Item {
             anchors.fill:       parent
             visible:            !criticalMessage.visible
-            Image {
-                id:             messageIcon
-                source:         "/qmlimages/Megaphone.svg"
-                height:         mainWindow.tbCellHeight * 0.5
-                fillMode:       Image.PreserveAspectFit
-                mipmap:         true
-                smooth:         true
-                visible:        false
+
+            QGCColoredImage {
+                id:         messageIcon
+                source:     "/qmlimages/Megaphone.svg"
+                height:     mainWindow.tbCellHeight * 0.5
+                fillMode:   Image.PreserveAspectFit
+                color:      getMessageColor()
                 anchors.verticalCenter:   parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
-            }
-            ColorOverlay {
-                anchors.fill:   messageIcon
-                source:         messageIcon
-                color:          getMessageColor()
             }
         }
 
@@ -163,32 +161,35 @@ Row {
         Row {
             id:     gpsRow
             height: parent.height
-            Image {
+
+            QGCColoredImage {
                 id:             gpsIcon
                 source:         "/qmlimages/Gps.svg"
                 fillMode:       Image.PreserveAspectFit
-                mipmap:         true
-                smooth:         true
                 width:          mainWindow.tbCellHeight * 0.65
                 height:         mainWindow.tbCellHeight * 0.5
                 opacity:        (activeVehicle && activeVehicle.gps.count.value >= 0) ? 1 : 0.5
+                color:          qgcPal.buttonText
                 anchors.verticalCenter: parent.verticalCenter
             }
+
             SignalStrength {
                 size:           mainWindow.tbCellHeight * 0.5
                 percent:        activeVehicle ? getSatStrength(activeVehicle.gps.hdop.value) : ""
                 anchors.verticalCenter: parent.verticalCenter
             }
         }
+
         QGCLabel {
-            text:           activeVehicle ? activeVehicle.gps.hdop.valueString : ""
-            visible:        activeVehicle && !isNaN(activeVehicle.gps.hdop.value)
-            font.pixelSize: tbFontSmall
-            color:          colorWhite
-            anchors.top:    parent.top
+            anchors.top:        parent.top
             anchors.leftMargin: gpsIcon.width
-            anchors.left:   parent.left
+            anchors.left:       parent.left
+            visible:            activeVehicle && !isNaN(activeVehicle.gps.hdop.value)
+            font.pixelSize:     tbFontSmall
+            color:              qgcPal.buttonText
+            text:               activeVehicle ? activeVehicle.gps.hdop.valueString : ""
         }
+
         MouseArea {
             anchors.fill:   parent
             onClicked: {
@@ -204,25 +205,28 @@ Row {
         id:     rcRssi
         width:  rssiRow.width * 1.1
         height: mainWindow.tbCellHeight
+
         Row {
             id:     rssiRow
             height: parent.height
-            Image {
-                source:         "/qmlimages/RC.svg"
-                fillMode:       Image.PreserveAspectFit
-                mipmap:         true
-                smooth:         true
+
+            QGCColoredImage {
                 width:          mainWindow.tbCellHeight * 0.65
                 height:         mainWindow.tbCellHeight * 0.5
+                source:         "/qmlimages/RC.svg"
+                fillMode:       Image.PreserveAspectFit
                 opacity:        activeVehicle ? (activeVehicle.rcRSSI < 1 ? 0.5 : 1) : 0.5
+                color:          qgcPal.buttonText
                 anchors.verticalCenter: parent.verticalCenter
             }
+
             SignalStrength {
-                size:           mainWindow.tbCellHeight * 0.5
-                percent:        activeVehicle ? activeVehicle.rcRSSI : 0
+                size:       mainWindow.tbCellHeight * 0.5
+                percent:    activeVehicle ? activeVehicle.rcRSSI : 0
                 anchors.verticalCenter: parent.verticalCenter
             }
         }
+
         MouseArea {
             anchors.fill:   parent
             onClicked: {
@@ -239,23 +243,17 @@ Row {
         width:      telemIcon.width
         height:     mainWindow.tbCellHeight
         visible:    _controller.telemetryLRSSI < 0
-        Image {
-            id:             telemIcon
-            source:         "/qmlimages/TelemRSSI.svg"
-            fillMode:       Image.PreserveAspectFit
-            mipmap:         true
-            smooth:         true
-            height:         parent.height * 0.5
-            width:          height * 1.5
-            visible:        false
+
+        QGCColoredImage {
+            id:         telemIcon
+            height:     parent.height * 0.5
+            width:      height * 1.5
+            source:     "/qmlimages/TelemRSSI.svg"
+            fillMode:   Image.PreserveAspectFit
+            color:      qgcPal.buttonText
             anchors.verticalCenter: parent.verticalCenter
         }
-        ColorOverlay {
-            id:             telemOverlay
-            anchors.fill:   telemIcon
-            source:         telemIcon
-            color:          getRSSIColor(_controller.telemetryLRSSI)
-        }
+
         MouseArea {
             anchors.fill:   parent
             onClicked: {
@@ -268,22 +266,24 @@ Row {
     //-------------------------------------------------------------------------
     //-- Battery Indicator
     Item {
-        id: batteryStatus
-        width:  battRow.width * 1.1
-        height: mainWindow.tbCellHeight
-        opacity: (activeVehicle && activeVehicle.battery.voltage.value >= 0) ? 1 : 0.5
+        id:         batteryStatus
+        width:      battRow.width * 1.1
+        height:     mainWindow.tbCellHeight
+        opacity:    (activeVehicle && activeVehicle.battery.voltage.value >= 0) ? 1 : 0.5
+
         Row {
-            id:         battRow
-            height:     mainWindow.tbCellHeight
+            id:     battRow
+            height: mainWindow.tbCellHeight
             anchors.horizontalCenter: parent.horizontalCenter
-            Image {
-                source:         "/qmlimages/Battery.svg"
-                fillMode:       Image.PreserveAspectFit
-                mipmap:         true
-                smooth:         true
-                height:         mainWindow.tbCellHeight * 0.65
+
+            QGCColoredImage {
+                height:     mainWindow.tbCellHeight * 0.65
+                source:     "/qmlimages/Battery.svg"
+                fillMode:   Image.PreserveAspectFit
+                color:      qgcPal.buttonText
                 anchors.verticalCenter: parent.verticalCenter
             }
+
             QGCLabel {
                 text:           getBatteryPercentageText()
                 font.pixelSize: tbFontLarge
@@ -291,6 +291,7 @@ Row {
                 anchors.verticalCenter: parent.verticalCenter
             }
         }
+
         MouseArea {
             anchors.fill:   parent
             onClicked: {
@@ -363,24 +364,26 @@ Row {
         width:  selectorRow.width * 1.1
         height: mainWindow.tbCellHeight
         anchors.verticalCenter: parent.verticalCenter
+
         Row {
             id:                 selectorRow
             spacing:            tbSpacing
             anchors.verticalCenter:   parent.verticalCenter
             anchors.horizontalCenter: parent.horizontalCenter
-            Image {
-                width:          mainWindow.tbCellHeight * 0.65
-                height:         mainWindow.tbCellHeight * 0.65
-                fillMode:       Image.PreserveAspectFit
-                mipmap:         true
-                smooth:         true
-                source:         "/qmlimages/Quad.svg"
+
+            QGCColoredImage {
+                width:      mainWindow.tbCellHeight * 0.65
+                height:     mainWindow.tbCellHeight * 0.65
+                fillMode:   Image.PreserveAspectFit
+                source:     "/qmlimages/Quad.svg"
+                color:      qgcPal.buttonText
                 anchors.verticalCenter: parent.verticalCenter
             }
+
             QGCLabel {
                 text:           activeVehicle ? activeVehicle.flightMode : "N/A"
                 font.pixelSize: tbFontLarge
-                color:          colorWhite
+                color:          qgcPal.buttonText
                 anchors.verticalCenter: parent.verticalCenter
             }
         }

--- a/src/ui/toolbar/SignalStrength.qml
+++ b/src/ui/toolbar/SignalStrength.qml
@@ -28,14 +28,20 @@ This file is part of the QGROUNDCONTROL project
  */
 
 import QtQuick 2.4
-import QGroundControl.Controls 1.0
+
+import QGroundControl.Controls  1.0
+import QGroundControl.Palette   1.0
 
 Item {
     id:     signalRoot
-    property real size:     50
-    property real percent:  0
     width:  size
     height: size
+
+    property real size:     50
+    property real percent:  0
+
+    QGCPalette { id: qgcPal }
+
     function getIcon() {
         if (percent < 20)
             return "/qmlimages/Signal0.svg"
@@ -49,11 +55,11 @@ Item {
             return "/qmlimages/Signal80.svg"
         return "/qmlimages/Signal100.svg"
     }
-    Image {
+
+    QGCColoredImage {
         source:         getIcon()
         fillMode:       Image.PreserveAspectFit
-        mipmap:         true
-        smooth:         true
         anchors.fill:   parent
+        color:          qgcPal.buttonText
     }
 }


### PR DESCRIPTION
* Map control use different border color based on map type
* Changed theme names to Indoor/Outdoor

The Issue was that the toolbar and flight display instruments were using hardcoded colors as opposed to the QGC palette. This means that the outdoor color scheme didn't work with these making them hard to see outdoors in sunlight.

The Outdoor palette is still pretty crappy and needs a lot more work. But this change put in place the mechanism such that I can try different palette colors to make things look better.