### PR TITLE
Change Search Field for Parameter List

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -101,11 +101,36 @@ QGCView {
                     anchors.right:  parent.right
                     height: ScreenTools.defaultFontPixelHeight * 1.75
                     onClicked: {
-                        _searchFilter = false
-                        hideDialog()
+                        searchFor.text = ""
                     }
                 }
+
+                QGCLabel {
+                    font.weight: Font.DemiBold
+                    text:   "Filter By:"
+                    anchors.right: searchFor.left
+                    height: ScreenTools.defaultFontPixelHeight * 1.75
+                }
+
+                QGCTextField {
+                    id:                 searchFor
+                    anchors.topMargin:  defaultTextHeight / 3
+                    anchors.right:      toolsButton.left
+                    width:              ScreenTools.defaultFontPixelWidth * 20
+
+                    onTextChanged: {
+                        console.log(text)
+                        if (text.length == 0) {
+                            _searchFilter = false;
+                        } else {
+                            _searchResults = controller.searchParametersForComponent(-1, text, true, true)
+                            _searchFilter = true
+                        }
+                    }
+                }
+
                 QGCButton {
+                    id: toolsButton
                     text:           "Tools"
                     visible:        !_searchFilter
                     anchors.right:  parent.right
@@ -118,10 +143,6 @@ QGCView {
                         MenuItem {
                             text:           "Reset all to defaults"
                             onTriggered:	controller.resetAllToDefaults()
-                        }
-                        MenuItem {
-                            text:           "Search..."
-                            onTriggered:    showDialog(searchDialogComponent, "Parameter Search", qgcView.showDialogDefaultWidth, StandardButton.Reset | StandardButton.Apply)
                         }
                         MenuSeparator { }
                         MenuItem {
@@ -344,44 +365,6 @@ QGCView {
         ParameterEditorDialog {
             fact:           _editorDialogFact
             showRCToParam:  _showRCToParam
-        }
-    }
-
-    Component {
-        id: searchDialogComponent
-
-        QGCViewDialog {
-
-            function accept() {
-                _searchResults = controller.searchParametersForComponent(-1, searchFor.text, true /*searchInName.checked*/, true /*searchInDescriptions.checked*/)
-                _searchFilter = true
-                hideDialog()
-            }
-
-            function reject() {
-                _searchFilter = false
-                hideDialog()
-            }
-
-            QGCLabel {
-                id:     searchForLabel
-                text:   "Search for:"
-            }
-
-            QGCTextField {
-                id:                 searchFor
-                anchors.topMargin:  defaultTextHeight / 3
-                anchors.top:        searchForLabel.bottom
-                width:              ScreenTools.defaultFontPixelWidth * 20
-            }
-
-            QGCLabel {
-                anchors.topMargin:  defaultTextHeight
-                anchors.top:        searchFor.bottom
-                width:              parent.width
-                wrapMode:           Text.WordWrap
-                text:               "Hint: Leave 'Search For' blank and click Apply to list all parameters sorted by name."
-            }
         }
     }
 

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -70,6 +70,7 @@ QGCView {
                 id:     header
                 width:  parent.width
                 height: ScreenTools.defaultFontPixelHeight * 1.75
+
                 QGCLabel {
                     text:           "Search Results"
                     visible:        _searchFilter
@@ -104,18 +105,20 @@ QGCView {
                         searchFor.text = ""
                     }
                 }
-
                 QGCLabel {
                     font.weight: Font.DemiBold
                     text:   "Filter By:"
-                    anchors.right: searchFor.left
-                    height: ScreenTools.defaultFontPixelHeight * 1.75
+                    anchors.right:   searchFor.left
+                    anchors.rightMargin: ScreenTools.defaultFontPixelWidth
+                    anchors.verticalCenter: parent.verticalCenter
                 }
 
                 QGCTextField {
                     id:                 searchFor
                     anchors.topMargin:  defaultTextHeight / 3
                     anchors.right:      toolsButton.left
+                    anchors.rightMargin: ScreenTools.defaultFontPixelWidth
+                    anchors.bottom: toolsButton.bottom
                     width:              ScreenTools.defaultFontPixelWidth * 20
 
                     onTextChanged: {

--- a/src/VehicleSetup/SetupParameterEditor.qml
+++ b/src/VehicleSetup/SetupParameterEditor.qml
@@ -29,5 +29,4 @@ import QGroundControl.ScreenTools 1.0
 import QGroundControl.Palette 1.0
 
 ParameterEditor {
-
 }


### PR DESCRIPTION
This way the search field is always visible, there's no
need to add two buttons ( search / cancel ) to it, it has
live filtering (it will filter while you type) instead of
going to the tools menu (1 click), clicking on the search
(1 click), typing what you whant to filter, clicking on
accept(1 click) for each new letter that you wanna add
to the filter.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>