### PR TITLE
Only accept numbers in FactTextEdit

### DIFF
--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -18,8 +18,8 @@ QGCTextField {
     property Fact   fact:           null
     property string _validateString
 
-
     // At this point all Facts are numeric
+    validator: DoubleValidator {}
     inputMethodHints:   Qt.ImhFormattedNumbersOnly
 
     onEditingFinished: {


### PR DESCRIPTION
All facts are numeric, atm. this means that the input should only
accept numbers. it already had the     inputMethodHints:   Qt.ImhFormattedNumbersOnly
option, but for some reason it still accepted letters and symbols.
by adding a     validator: DoubleValidator {} we limit the characters
to numbers only - and if the value is a integer, it will still work.

Tested by adding waypoints on the map & messing with the GPS coordinates.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>