### PR TITLE
Add search v2

### DIFF
--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -461,13 +461,7 @@ Fact* ParameterLoader::getFact(int componentId, const QString& name)
 
 QStringList ParameterLoader::parameterNames(int componentId)
 {
-    QStringList names;
-
-    foreach(const QString &paramName, _mapParameterName2Variant[_actualComponentId(componentId)].keys()) {
-        names << paramName;
-    }
-
-    return names;
+    return _mapParameterName2Variant[_actualComponentId(componentId)].keys();
 }
 
 void ParameterLoader::_setupGroupMap(void)

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -101,11 +101,36 @@ QGCView {
                     anchors.right:  parent.right
                     height: ScreenTools.defaultFontPixelHeight * 1.75
                     onClicked: {
-                        _searchFilter = false
-                        hideDialog()
+                        searchFor.text = ""
                     }
                 }
+
+                QGCLabel {
+                    font.weight: Font.DemiBold
+                    text:   "Filter By:"
+                    anchors.right: searchFor.left
+                    height: ScreenTools.defaultFontPixelHeight * 1.75
+                }
+
+                QGCTextField {
+                    id:                 searchFor
+                    anchors.topMargin:  defaultTextHeight / 3
+                    anchors.right:      toolsButton.left
+                    width:              ScreenTools.defaultFontPixelWidth * 20
+
+                    onTextChanged: {
+                        console.log(text)
+                        if (text.length == 0) {
+                            _searchFilter = false;
+                        } else {
+                            _searchResults = controller.searchParametersForComponent(-1, text, true, true)
+                            _searchFilter = true
+                        }
+                    }
+                }
+
                 QGCButton {
+                    id: toolsButton
                     text:           "Tools"
                     visible:        !_searchFilter
                     anchors.right:  parent.right
@@ -118,10 +143,6 @@ QGCView {
                         MenuItem {
                             text:           "Reset all to defaults"
                             onTriggered:	controller.resetAllToDefaults()
-                        }
-                        MenuItem {
-                            text:           "Search..."
-                            onTriggered:    showDialog(searchDialogComponent, "Parameter Search", qgcView.showDialogDefaultWidth, StandardButton.Reset | StandardButton.Apply)
                         }
                         MenuSeparator { }
                         MenuItem {
@@ -344,44 +365,6 @@ QGCView {
         ParameterEditorDialog {
             fact:           _editorDialogFact
             showRCToParam:  _showRCToParam
-        }
-    }
-
-    Component {
-        id: searchDialogComponent
-
-        QGCViewDialog {
-
-            function accept() {
-                _searchResults = controller.searchParametersForComponent(-1, searchFor.text, true /*searchInName.checked*/, true /*searchInDescriptions.checked*/)
-                _searchFilter = true
-                hideDialog()
-            }
-
-            function reject() {
-                _searchFilter = false
-                hideDialog()
-            }
-
-            QGCLabel {
-                id:     searchForLabel
-                text:   "Search for:"
-            }
-
-            QGCTextField {
-                id:                 searchFor
-                anchors.topMargin:  defaultTextHeight / 3
-                anchors.top:        searchForLabel.bottom
-                width:              ScreenTools.defaultFontPixelWidth * 20
-            }
-
-            QGCLabel {
-                anchors.topMargin:  defaultTextHeight
-                anchors.top:        searchFor.bottom
-                width:              parent.width
-                wrapMode:           Text.WordWrap
-                text:               "Hint: Leave 'Search For' blank and click Apply to list all parameters sorted by name."
-            }
         }
     }
 

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -70,6 +70,7 @@ QGCView {
                 id:     header
                 width:  parent.width
                 height: ScreenTools.defaultFontPixelHeight * 1.75
+
                 QGCLabel {
                     text:           "Search Results"
                     visible:        _searchFilter
@@ -104,18 +105,20 @@ QGCView {
                         searchFor.text = ""
                     }
                 }
-
                 QGCLabel {
                     font.weight: Font.DemiBold
                     text:   "Filter By:"
-                    anchors.right: searchFor.left
-                    height: ScreenTools.defaultFontPixelHeight * 1.75
+                    anchors.right:   searchFor.left
+                    anchors.rightMargin: ScreenTools.defaultFontPixelWidth
+                    anchors.verticalCenter: parent.verticalCenter
                 }
 
                 QGCTextField {
                     id:                 searchFor
                     anchors.topMargin:  defaultTextHeight / 3
                     anchors.right:      toolsButton.left
+                    anchors.rightMargin: ScreenTools.defaultFontPixelWidth
+                    anchors.bottom: toolsButton.bottom
                     width:              ScreenTools.defaultFontPixelWidth * 20
 
                     onTextChanged: {

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -122,7 +122,6 @@ QGCView {
                     width:              ScreenTools.defaultFontPixelWidth * 20
 
                     onTextChanged: {
-                        console.log(text)
                         if (text.length == 0) {
                             _searchFilter = false;
                         } else {
@@ -294,13 +293,73 @@ QGCView {
                 clip:           true
                 Loader {
                     id:                 factRowsLoader
-                    sourceComponent:    factRowsComponent
+                    sourceComponent:    filterRowComponent
                     property int    componentId:       -1
-                    property var    parameterNames:    _searchResults
+                    property var    currentModel:    _searchResults
                 }
             }
         }
     }
+
+    //---------------------------------------------
+    // FilterRowComponent
+    Component {
+        id: filterRowComponent
+        Column {
+            spacing: Math.ceil(ScreenTools.defaultFontPixelHeight * 0.25)
+            Repeater {
+                model: currentModel
+                Rectangle {
+                    height: _rowHeight
+                    width:  _rowWidth
+                    color:  Qt.rgba(0,0,0,0)
+                    Row {
+                        id:     factRow
+                        spacing: Math.ceil(ScreenTools.defaultFontPixelWidth * 0.5)
+                        anchors.verticalCenter: parent.verticalCenter
+                        QGCLabel {
+                            id:     nameLabel
+                            width:  ScreenTools.defaultFontPixelWidth  * 20
+                            text:   modelData.name
+                            clip:   true
+                        }
+                        QGCLabel {
+                            id:     valueLabel
+                            width:  ScreenTools.defaultFontPixelWidth  * 20
+                            color:  modelData.defaultValueAvailable ? (modelData.valueEqualsDefault ? __qgcPal.text : __qgcPal.warningText) : __qgcPal.text
+                            text:   modelData.enumStrings.length == 0 ? modelData.valueString + " " + modelData.units : modelData.enumStringValue
+                            clip:   true
+                        }
+                        QGCLabel {
+                            text:   modelData.shortDescription
+                        }
+                        Component.onCompleted: {
+                            if(_rowWidth < factRow.width + ScreenTools.defaultFontPixelWidth) {
+                               _rowWidth = factRow.width + ScreenTools.defaultFontPixelWidth
+                            }
+                        }
+                    }
+                    Rectangle {
+                        width:  _rowWidth
+                        height: 1
+                        color:  __qgcPal.text
+                        opacity: 0.15
+                        anchors.bottom: parent.bottom
+                        anchors.left:   parent.left
+                    }
+                    MouseArea {
+                        anchors.fill:       parent
+                        acceptedButtons:    Qt.LeftButton
+                        onClicked: {
+                            _editorDialogFact = factRow.modelFact
+                            showDialog(editorDialogComponent, "Parameter Editor", qgcView.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Save)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 
     //---------------------------------------------
     // Paremeters view

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -67,28 +67,28 @@ QStringList ParameterEditorController::getParametersForGroup(int componentId, QS
 	return groupMap[componentId][group];
 }
 
-QStringList ParameterEditorController::searchParametersForComponent(int componentId, const QString& searchText, bool searchInName, bool searchInDescriptions)
+QList<QObject*> ParameterEditorController::searchParametersForComponent(int componentId, const QString& searchText, bool searchInName, bool searchInDescriptions)
 {
-    QStringList list;
+    QList<QObject*> list;
 
     if (searchText.isEmpty()) {
-        list = _autopilot->parameterNames(componentId);
-        list.sort();
-        return list;
+        foreach(const QString &paramName, _autopilot->parameterNames(componentId)) {
+            Fact* fact = _autopilot->getParameterFact(componentId, paramName);
+            list.push_back(fact);
+        }
+        goto exit;
     }
 
     foreach(const QString &paramName, _autopilot->parameterNames(componentId)) {
+        Fact* fact = _autopilot->getParameterFact(componentId, paramName);
         if (searchInName && paramName.contains(searchText, Qt::CaseInsensitive)) {
-            list += paramName;
-        } else if (searchInDescriptions) {
-            Fact* fact = _autopilot->getParameterFact(componentId, paramName);
-            if ( fact->shortDescription().contains(searchText, Qt::CaseInsensitive) || fact->longDescription().contains(searchText, Qt::CaseInsensitive)){
-                list += paramName;
-            }
+            list.push_back(fact);
+        } else if (searchInDescriptions && ( fact->shortDescription().contains(searchText, Qt::CaseInsensitive) || fact->longDescription().contains(searchText, Qt::CaseInsensitive))) {
+            list.push_back(fact);
         }
     }
 
-    list.sort();
+    exit:
     return list;
 }
 

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -70,22 +70,25 @@ QStringList ParameterEditorController::getParametersForGroup(int componentId, QS
 QStringList ParameterEditorController::searchParametersForComponent(int componentId, const QString& searchText, bool searchInName, bool searchInDescriptions)
 {
     QStringList list;
-    
+
+    if (searchText.isEmpty()) {
+        list = _autopilot->parameterNames(componentId);
+        list.sort();
+        return list;
+    }
+
     foreach(const QString &paramName, _autopilot->parameterNames(componentId)) {
-        if (searchText.isEmpty()) {
+        if (searchInName && paramName.contains(searchText, Qt::CaseInsensitive)) {
             list += paramName;
-        } else {
+        } else if (searchInDescriptions) {
             Fact* fact = _autopilot->getParameterFact(componentId, paramName);
-            
-            if (searchInName && fact->name().contains(searchText, Qt::CaseInsensitive)) {
-                list += paramName;
-            } else if (searchInDescriptions && (fact->shortDescription().contains(searchText, Qt::CaseInsensitive) || fact->longDescription().contains(searchText, Qt::CaseInsensitive))) {
+            if ( fact->shortDescription().contains(searchText, Qt::CaseInsensitive) || fact->longDescription().contains(searchText, Qt::CaseInsensitive)){
                 list += paramName;
             }
         }
     }
+
     list.sort();
-    
     return list;
 }
 

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -46,7 +46,7 @@ public:
 	
 	Q_INVOKABLE QStringList getGroupsForComponent(int componentId);
 	Q_INVOKABLE QStringList getParametersForGroup(int componentId, QString group);
-    Q_INVOKABLE QStringList searchParametersForComponent(int componentId, const QString& searchText, bool searchInName, bool searchInDescriptions);
+    Q_INVOKABLE QList<QObject*> searchParametersForComponent(int componentId, const QString& searchText, bool searchInName, bool searchInDescriptions);
 	
 	Q_INVOKABLE void clearRCToParam(void);
     Q_INVOKABLE void saveToFilePicker(void);

--- a/src/VehicleSetup/SetupParameterEditor.qml
+++ b/src/VehicleSetup/SetupParameterEditor.qml
@@ -29,5 +29,4 @@ import QGroundControl.ScreenTools 1.0
 import QGroundControl.Palette 1.0
 
 ParameterEditor {
-
 }


### PR DESCRIPTION
    Change the Way Parameter Filtering is done
    
    The old ParameterFiltering worked by retrieving a list of
    QStrings that where the name of the Facts of the vehicle,
    but to search for the names we actually got the Fact*, since
    we needed to check it's name() and other internal methods.
    
    Then we passed the StringList to QML, to again retrieve the
    Facts* that it represented.
    
    getting a Fact* from the controller is a slow operation that
    involves quite a few function calls and conversions, QML
    doesn't really like that, so the minimum calls, the better.
    
    This new way we return a QList<QObject*> instead of a QString
    List, that's filled with the Facts* from the call to the
    search function.
    
    On my tests this speeded up the result into 2, 2.5x because
    it: does less comparissons, create less temporaries and reuse
    the Facts searched.

Didn't tested this on mobile because I don't have a Tablet, but I think this should speed up things on iPad
