### PR TITLE
Make it possible to run qgroundcontrol-start.sh from outside its directory

### DIFF
--- a/deploy/qgroundcontrol-start.sh
+++ b/deploy/qgroundcontrol-start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-export LD_LIBRARY_PATH=`pwd`/Qt/libs:$LD_LIBRARY_PATH
-export QML2_IMPORT_PATH=`pwd`/Qt/qml
-export QT_PLUGIN_PATH=`pwd`/Qt/plugins
-./qgroundcontrol "$@"
+HERE="$(dirname "$(readlink -f "${0}")")"
+export LD_LIBRARY_PATH="${HERE}/Qt/libs":$LD_LIBRARY_PATH
+export QML2_IMPORT_PATH="${HERE}/Qt/qml"
+export QT_PLUGIN_PATH="${HERE}/Qt/plugins"
+"${HERE}/qgroundcontrol" "$@"


### PR DESCRIPTION
This patch makes it possible to run qgroundcontrol-start.sh from outside its directory, e.g.,
`/qgroundcontrol/qgroundcontrol-start.sh` instead of having to `cd qgroundcontrol/ && ./qgroundcontrol-start.sh`.