### PR TITLE
Mission item fixes

### DIFF
--- a/src/MissionManager/MissionItem.cc
+++ b/src/MissionManager/MissionItem.cc
@@ -203,6 +203,10 @@ bool MissionItem::load(const QJsonObject& json, QString& errorString)
         return false;
     }
 
+    // Make sure to set these first since they can signal other changes
+    setFrame((MAV_FRAME)json[_jsonFrameKey].toInt());
+    setCommand((MAV_CMD)json[_jsonCommandKey].toInt());
+
     QGeoCoordinate coordinate;
     if (!JsonHelper::toQGeoCoordinate(json[_jsonCoordinateKey], coordinate, true /* altitudeRequired */, errorString)) {
         return false;
@@ -213,8 +217,6 @@ bool MissionItem::load(const QJsonObject& json, QString& errorString)
 
     setIsCurrentItem(false);
     setSequenceNumber(json[_jsonIdKey].toInt());
-    setFrame((MAV_FRAME)json[_jsonFrameKey].toInt());
-    setCommand((MAV_CMD)json[_jsonCommandKey].toInt());
     setParam1(json[_jsonParam1Key].toDouble());
     setParam2(json[_jsonParam2Key].toDouble());
     setParam3(json[_jsonParam3Key].toDouble());

--- a/src/MissionManager/MissionItemTest.h
+++ b/src/MissionManager/MissionItemTest.h
@@ -26,6 +26,7 @@
 
 #include "UnitTest.h"
 #include "MultiSignalSpy.h"
+#include "MissionItem.h"
 
 /// Unit test for the MissionItem Object
 class MissionItemTest : public UnitTest
@@ -40,8 +41,13 @@ private slots:
     void _testSignals(void);
     void _testFactSignals(void);
     void _testLoadFromStream(void);
+    void _testSimpleLoadFromStream(void);
     void _testLoadFromJson(void);
+    void _testSimpleLoadFromJson(void);
     void _testSaveToJson(void);
+
+private:
+    void _checkExpectedMissionItem(const MissionItem& missionItem);
 };
 
 #endif


### PR DESCRIPTION
* SimpleMissionItem resets default values when command changes (correct behavior). MissionItem::loadFromJson was setting command after coordinate was loaded. This was causing coordinate to be modified after correct value was loaded.
* Update unit tests to catch this case.

Fix for Issue #3117.