### PR TITLE
Parameter Edit: Handle bitfields as ComboBoxes

### DIFF
--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -47,7 +47,18 @@ QGCViewDialog {
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     function accept() {
-        if (factCombo.visible) {
+        if (bitmaskEditor.visible) {
+            var value = 0;
+            for (var i = 0; i < fact.bitmaskValues.length; ++i) {
+                var checkbox = bitmaskEditor.itemAt(i)
+                if (checkbox.checked) {
+                    value |= fact.bitmaskValues[i];
+                }
+            }
+            fact.value = value;
+            fact.valueChanged(fact.value)
+        }
+        else if (factCombo.visible) {
             fact.enumIndex = factCombo.currentIndex
             hideDialog()
         } else {
@@ -127,13 +138,24 @@ QGCViewDialog {
                 visible:        _showCombo
                 model:          fact.enumStrings
 
-                property bool _showCombo: fact.enumStrings.length != 0 && !validate
+                property bool _showCombo: fact.enumStrings.length != 0 && fact.bitmaskStrings.length == 0 && !validate
 
                 Component.onCompleted: {
                     // We can't bind directly to fact.enumIndex since that would add an unknown value
                     // if there are no enum strings.
                     if (_showCombo) {
                         currentIndex = fact.enumIndex
+                    }
+                }
+            }
+
+            Column {
+                Repeater {
+                    id: bitmaskEditor
+                    model: fact.bitmaskStrings
+                    delegate : QGCCheckBox {
+                        text : modelData
+                        checked : fact.value & fact.bitmaskValues[index]
                     }
                 }
             }

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -150,6 +150,8 @@ QGCViewDialog {
             }
 
             Column {
+                spacing: ScreenTools.defaultFontPixelHeight / 2
+
                 Repeater {
                     id: bitmaskEditor
                     model: fact.bitmaskStrings


### PR DESCRIPTION
This makes it possible to select more than one value
to be used in the parameter configuration, and since
the parameter is actually a bitfield - this is the
correct thing to do.

one of the drawbacks is that in the parameter listing
the value of the Fact will not be displayed as string
anymore, but with 'undefined: numerical-value', that is
the OR combination of the applied values.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>