### PR TITLE
Skip "non compliant" Qt libraries (for Mac OS App Store)

### DIFF
--- a/QGCInstaller.pri
+++ b/QGCInstaller.pri
@@ -37,7 +37,7 @@ installer {
         # qgroundcontrol.app file. If you specify a path to the .app file the symbolic
         # links to plugins will not be created correctly.
         QMAKE_POST_LINK += && mkdir -p $${DESTDIR}/package
-        QMAKE_POST_LINK += && cd $${DESTDIR} && $$dirname(QMAKE_QMAKE)/macdeployqt qgroundcontrol.app -verbose=2 -qmldir=$${BASEDIR}/src
+        QMAKE_POST_LINK += && cd $${DESTDIR} && $$dirname(QMAKE_QMAKE)/macdeployqt qgroundcontrol.app -appstore-compliant -verbose=2 -qmldir=$${BASEDIR}/src
         QMAKE_POST_LINK += && cd $${OUT_PWD}
         QMAKE_POST_LINK += && hdiutil create -layout SPUD -srcfolder $${DESTDIR}/qgroundcontrol.app -volname QGroundControl $${DESTDIR}/package/qgroundcontrol.dmg
     }


### PR DESCRIPTION
These are libraries added by `macdeployqt`, which use non public Mac OS API and are therefore *Non Compliant*. They are not used by QGC any way.

Note that you will still see the warning during the build accompanied with the message these libraries are being skipped:
```
WARNING: Plugin "libqsqlodbc.dylib" uses private API and is not Mac App store compliant.
WARNING: Skip plugin "libqsqlodbc.dylib"
WARNING: Plugin "libqsqlpsql.dylib" uses private API and is not Mac App store compliant.
WARNING: Skip plugin "libqsqlpsql.dylib"
```