### PR TITLE
Fix GStreamer relocation for Mac OS release (installer) builds.

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -65,7 +65,15 @@ LinuxBuild {
 CONFIG += qt \
     thread \
     c++11 \
+
+contains(DEFINES, ENABLE_VERBOSE_OUTPUT) {
+    message("Enable verbose compiler output (manual override from command line)")
+} else:exists(user_config.pri):infile(user_config.pri, DEFINES, ENABLE_VERBOSE_OUTPUT) {
+    message("Enable verbose compiler output (manual override from user_config.pri)")
+} else {
+CONFIG += \
     silent
+}
 
 QT += \
     concurrent \

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -69,41 +69,35 @@ static void qgcputenv(const QString& key, const QString& root, const QString& pa
 void initializeVideoStreaming(int &argc, char* argv[])
 {
 #if defined(QGC_GST_STREAMING)
-    // Initialize GStreamer
-    GError* error = NULL;
-    if (!gst_init_check(&argc, &argv, &error)) {
-        qCritical() << "gst_init_check() failed: " << error->message;
-        g_error_free(error);
-    }
-    // Our own plugin
-    GST_PLUGIN_STATIC_REGISTER(QGC_VIDEOSINK_PLUGIN);
-    // The static plugins we use
-#if defined(__mobile__)
-    GST_PLUGIN_STATIC_REGISTER(coreelements);
-    GST_PLUGIN_STATIC_REGISTER(libav);
-    GST_PLUGIN_STATIC_REGISTER(rtp);
-    GST_PLUGIN_STATIC_REGISTER(udp);
-    GST_PLUGIN_STATIC_REGISTER(videoparsersbad);
-    GST_PLUGIN_STATIC_REGISTER(x264);
-#endif
-
-#ifdef __macos__
-#ifdef QGC_INSTALL_RELEASE
-    QString currentDir = QCoreApplication::applicationDirPath();
-    qgcputenv("GST_PLUGIN_SCANNER",           currentDir, "/gst-plugin-scanner");
-    qgcputenv("GTK_PATH",                     currentDir, "/../Frameworks/GStreamer.framework/Versions/Current");
-    qgcputenv("GIO_EXTRA_MODULES",            currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gio/modules");
-    qgcputenv("GST_PLUGIN_SYSTEM_PATH_1_0",   currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
-    qgcputenv("GST_PLUGIN_SYSTEM_PATH",       currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
-    qgcputenv("GST_PLUGIN_PATH_1_0",          currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
-    qgcputenv("GST_PLUGIN_PATH",              currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
-//    QStringList env = QProcessEnvironment::systemEnvironment().keys();
-//    foreach(const QString &key, env) {
-//        qDebug() << key << QProcessEnvironment::systemEnvironment().value(key);
-//    }
-#endif
-#endif
-
+    #ifdef __macos__
+        #ifdef QGC_INSTALL_RELEASE
+            QString currentDir = QCoreApplication::applicationDirPath();
+            qgcputenv("GST_PLUGIN_SCANNER",           currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/libexec/gstreamer-1.0/gst-plugin-scanner");
+            qgcputenv("GTK_PATH",                     currentDir, "/../Frameworks/GStreamer.framework/Versions/Current");
+            qgcputenv("GIO_EXTRA_MODULES",            currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gio/modules");
+            qgcputenv("GST_PLUGIN_SYSTEM_PATH_1_0",   currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+            qgcputenv("GST_PLUGIN_SYSTEM_PATH",       currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+            qgcputenv("GST_PLUGIN_PATH_1_0",          currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+            qgcputenv("GST_PLUGIN_PATH",              currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+        #endif
+    #endif
+        // Initialize GStreamer
+        GError* error = NULL;
+        if (!gst_init_check(&argc, &argv, &error)) {
+            qCritical() << "gst_init_check() failed: " << error->message;
+            g_error_free(error);
+        }
+        // Our own plugin
+        GST_PLUGIN_STATIC_REGISTER(QGC_VIDEOSINK_PLUGIN);
+        // The static plugins we use
+    #if defined(__mobile__)
+        GST_PLUGIN_STATIC_REGISTER(coreelements);
+        GST_PLUGIN_STATIC_REGISTER(libav);
+        GST_PLUGIN_STATIC_REGISTER(rtp);
+        GST_PLUGIN_STATIC_REGISTER(udp);
+        GST_PLUGIN_STATIC_REGISTER(videoparsersbad);
+        GST_PLUGIN_STATIC_REGISTER(x264);
+    #endif
 #else
     Q_UNUSED(argc);
     Q_UNUSED(argv);

--- a/tools/osxrelocator.py
+++ b/tools/osxrelocator.py
@@ -26,7 +26,7 @@ OTOOL_CMD = 'otool'
 
 
 def shell_call(cmd, cmd_dir='.', fail=True):
-    print "call", cmd
+    #print("call", cmd)
     try:
         ret = subprocess.check_call(
                 cmd, cwd=cmd_dir,
@@ -40,7 +40,7 @@ def shell_call(cmd, cmd_dir='.', fail=True):
 
 
 def shell_check_call(cmd):
-    print "ccall", cmd
+    #print("ccall", cmd)
     try:
         process = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE)
@@ -54,6 +54,7 @@ class OSXRelocator(object):
     '''
     Wrapper for OS X's install_name_tool and otool commands to help
     relocating shared libraries.
+
     It parses lib/ /libexec and bin/ directories, changes the prefix path of
     the shared libraries that an object file uses and changes it's library
     ID if the file is a shared library.
@@ -61,19 +62,19 @@ class OSXRelocator(object):
 
     def __init__(self, root, lib_prefix, new_lib_prefix, recursive):
         self.root = root
-        self.lib_prefix = self._fix_path(lib_prefix)
-        self.new_lib_prefix = self._fix_path(new_lib_prefix)
+        self.lib_prefix = self._fix_path(lib_prefix).encode('utf-8')
+        self.new_lib_prefix = self._fix_path(new_lib_prefix).encode('utf-8')
         self.recursive = recursive
 
     def relocate(self):
-        self.parse_dir(self.root, filters=['', '.dylib', '.so', '0'])
+        self.parse_dir(self.root, filters=['', '.dylib', '.so'])
 
     def relocate_file(self, object_file, id=None):
         self.change_libs_path(object_file)
         self.change_id(object_file, id)
 
     def change_id(self, object_file, id=None):
-        id = id or object_file.replace(self.lib_prefix, self.new_lib_prefix)
+        id = id or object_file.replace(self.lib_prefix.decode('utf-8'), self.new_lib_prefix.decode('utf-8'))
         filename = os.path.basename(object_file)
         if not (filename.endswith('so') or filename.endswith('dylib')):
             return
@@ -105,13 +106,13 @@ class OSXRelocator(object):
     @staticmethod
     def list_shared_libraries(object_file):
         cmd = [OTOOL_CMD, "-L", object_file]
-        res = shell_check_call(cmd).split('\n')
+        res = shell_check_call(cmd).split(b'\n')
         # We don't use the first line
         libs = res[1:]
         # Remove the first character tabulation
         libs = [x[1:] for x in libs]
         # Remove the version info
-        libs = [x.split(' ', 1)[0] for x in libs]
+        libs = [x.split(b' ', 1)[0] for x in libs]
         return libs
 
     @staticmethod
@@ -157,4 +158,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
While at it, I also defined a new `DEFINES`. If you add `ENABLE_VERBOSE_OUTPUT` to your `user_config.pri`, you get “noise” compiler output.