### PR TITLE
Validate/Set decimal places against increment value

### DIFF
--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -70,7 +70,7 @@ public:
     /// Returns the string for distance units which has configued by user
     static QString appSettingsDistanceUnitsString(void);
 
-    int             decimalPlaces           (void) const { return _decimalPlaces; }
+    int             decimalPlaces           (void) const;
     QVariant        rawDefaultValue         (void) const;
     QVariant        cookedDefaultValue      (void) const { return _rawTranslator(rawDefaultValue()); }
     bool            defaultValueAvailable   (void) const { return _defaultValueAvailable; }
@@ -139,7 +139,8 @@ public:
     /// Same as convertAndValidateRaw except for cookedValue input
     bool convertAndValidateCooked(const QVariant& cookedValue, bool convertOnly, QVariant& typedValue, QString& errorString);
 
-    static const int defaultDecimalPlaces = 3;
+    static const int defaultDecimalPlaces = 3;  ///< Default value for decimal places if not specified/known
+    static const int unknownDecimalPlaces = -1; ///< Number of decimal places to specify is not known
 
     static ValueType_t stringToType(const QString& typeString, bool& unknownType);
     static size_t typeToSize(ValueType_t type);

--- a/src/MissionManager/MissionCommandList.cc
+++ b/src/MissionManager/MissionCommandList.cc
@@ -187,7 +187,7 @@ void MissionCommandList::_loadMavCmdInfoJson(const QString& jsonFilename)
 
                 paramInfo->_label =         paramObject.value(_labelJsonKey).toString();
                 paramInfo->_defaultValue =  paramObject.value(_defaultJsonKey).toDouble(0.0);
-                paramInfo->_decimalPlaces = paramObject.value(_decimalPlacesJsonKey).toInt(FactMetaData::defaultDecimalPlaces);
+                paramInfo->_decimalPlaces = paramObject.value(_decimalPlacesJsonKey).toInt(FactMetaData::unknownDecimalPlaces);
                 paramInfo->_enumStrings =   paramObject.value(_enumStringsJsonKey).toString().split(",", QString::SkipEmptyParts);
                 paramInfo->_param =         i;
                 paramInfo->_units =         paramObject.value(_unitsJsonKey).toString();

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -322,16 +322,16 @@ QString SimpleMissionItem::abbreviation() const
 void SimpleMissionItem::_clearParamMetaData(void)
 {
     _param1MetaData.setRawUnits("");
-    _param1MetaData.setDecimalPlaces(FactMetaData::defaultDecimalPlaces);
+    _param1MetaData.setDecimalPlaces(FactMetaData::unknownDecimalPlaces);
     _param1MetaData.setBuiltInTranslator();
     _param2MetaData.setRawUnits("");
-    _param2MetaData.setDecimalPlaces(FactMetaData::defaultDecimalPlaces);
+    _param2MetaData.setDecimalPlaces(FactMetaData::unknownDecimalPlaces);
     _param2MetaData.setBuiltInTranslator();
     _param3MetaData.setRawUnits("");
-    _param3MetaData.setDecimalPlaces(FactMetaData::defaultDecimalPlaces);
+    _param3MetaData.setDecimalPlaces(FactMetaData::unknownDecimalPlaces);
     _param3MetaData.setBuiltInTranslator();
     _param4MetaData.setRawUnits("");
-    _param4MetaData.setDecimalPlaces(FactMetaData::defaultDecimalPlaces);
+    _param4MetaData.setDecimalPlaces(FactMetaData::unknownDecimalPlaces);
     _param4MetaData.setBuiltInTranslator();
 }
 


### PR DESCRIPTION
Fix for Issue #3199

@tridge I agree about using the increment meta data value as both a validation against the decimal place meta data and a default value for decimal places if decimal is not specifically set. But I don't think it works in all cases from a standpoint of never needed to specify decimal places if you also specify an increment. Here is an example:

```
<param humanName="Compass2 offsets in milligauss on the X axis" name="COMPASS_OFS2_X" documentation="Offset to be added to compass2's x-axis values to compensate for metal in the frame">
<field name="Range">-400 400</field>
<field name="Increment">1</field>
<field name="Units">milligauss</field>
</param>
```

Although an increment of 1 here probably makes sense for a ui control like say a spin button on this value. The precision you want when entering/displaying the value manually likely includes some number of decimals places.

Another example would be a parameter which is height in meters. An increment for that would likely be 1 or more so a ui control would bump up/down a meter at a time. But you also would like to have decimal places at 1 as well so you can get precision for the value to be say 10.5 if that is what you want.