### PR TITLE
Show GPS error message only on map view

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -71,7 +71,7 @@ Item {
 
         QGCLabel {
             anchors.horizontalCenter:   parent.horizontalCenter
-            visible:                    _activeVehicle && !_activeVehicle.coordinateValid
+            visible:                    _activeVehicle && !_activeVehicle.coordinateValid && _mainIsMap
             z:                          QGroundControl.zOrderTopMost
             color:                      mapPal.text
             font.pixelSize:             ScreenTools.largeFontPixelSize


### PR DESCRIPTION
This hides the "No GPS Lock on Vehicle" message when the video stream is full screen.

I'm doing this for ArduSub, since ROVs don't have GPS but do use the video stream. This would also be helpful for people flying FPV with no GPS. 

If you disagree that the error should be hidden, then I would ask that we put it in a less conspicuous place.