### PR TITLE
Default case for RADIO_STATUS

### DIFF
--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -270,6 +270,9 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                      */
                     rssi    = qMin(qMax(qRound(static_cast<qreal>(rssi)    / 1.9 - 127.0), - 120), 0);
                     remrssi = qMin(qMax(qRound(static_cast<qreal>(remrssi) / 1.9 - 127.0), - 120), 0);
+                } else {
+                    rssi = (int8_t) rstatus.rssi;
+                    remrssi = (int8_t) rstatus.remrssi;
                 }
 
                 emit radioStatusChanged(link, rstatus.rxerrors, rstatus.fixed, rssi, remrssi,


### PR DESCRIPTION
https://github.com/mavlink/qgroundcontrol/issues/3151

Adding default case for RADIO_STATUS. This means it is now possible to send a RADIO_STATUS message with the actual, negative rssi and remrssi (i.e. using mavlink_msg_radio_status_pack) and this will correctly displayed in the QGC telemetry.
