### PR TITLE
Restore critical messages in the main window.

### DIFF
--- a/src/FactSystem/ParameterLoader.cc
+++ b/src/FactSystem/ParameterLoader.cc
@@ -953,35 +953,6 @@ void ParameterLoader::_checkInitialLoadComplete(bool failIfNoDefaultComponent)
     // We aren't waiting for any more initial parameter updates, initial parameter loading is complete
     _initialLoadComplete = true;
 
-    // Check for any errors during vehicle boot
-
-    UASMessageHandler* msgHandler = qgcApp()->toolbox()->uasMessageHandler();
-    if (msgHandler->getErrorCountTotal()) {
-        QString errors;
-        bool firstError = true;
-        bool errorsFound = false;
-
-        msgHandler->lockAccess();
-        foreach (UASMessage* msg, msgHandler->messages()) {
-            if (msg->severityIsError()) {
-                if (!firstError) {
-                    errors += "<br>";
-                }
-                errors += " - ";
-                errors += msg->getText();
-                firstError = false;
-                errorsFound = true;
-            }
-        }
-        msgHandler->showErrorsInToolbar();
-        msgHandler->unlockAccess();
-
-        if (errorsFound) {
-            QString errorMsg = QString("<b>Critical safety issue detected:</b><br>%1").arg(errors);
-            qgcApp()->showMessage(errorMsg);
-        }
-    }
-
     // Check for index based load failures
     QString indexList;
     bool initialLoadFailures = false;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -1,30 +1,32 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 #include "FirmwarePlugin.h"
 #include "QGCApplication.h"
 
 #include <QDebug>
+
+const char* guided_mode_not_supported_by_vehicle = "Guided mode not supported by Vehicle.";
 
 bool FirmwarePlugin::isCapable(FirmwareCapabilities capabilities)
 {
@@ -35,14 +37,14 @@ bool FirmwarePlugin::isCapable(FirmwareCapabilities capabilities)
 QList<VehicleComponent*> FirmwarePlugin::componentsForVehicle(AutoPilotPlugin* vehicle)
 {
     Q_UNUSED(vehicle);
-    
+
     return QList<VehicleComponent*>();
 }
 
 QString FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) const
 {
     QString flightMode;
-    
+
     struct Bit2Name {
         uint8_t     baseModeBit;
         const char* name;
@@ -54,9 +56,9 @@ QString FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) cons
         { MAV_MODE_FLAG_AUTO_ENABLED,           "Auto" },
         { MAV_MODE_FLAG_TEST_ENABLED,           "Test" },
     };
-    
+
     Q_UNUSED(custom_mode);
-    
+
     if (base_mode == 0) {
         flightMode = "PreFlight";
     } else if (base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
@@ -71,7 +73,7 @@ QString FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) cons
             }
         }
     }
-    
+
     return flightMode;
 }
 
@@ -80,9 +82,9 @@ bool FirmwarePlugin::setFlightMode(const QString& flightMode, uint8_t* base_mode
     Q_UNUSED(flightMode);
     Q_UNUSED(base_mode);
     Q_UNUSED(custom_mode);
-    
+
     qWarning() << "FirmwarePlugin::setFlightMode called on base class, not supported";
-    
+
     return false;
 }
 
@@ -96,7 +98,7 @@ int FirmwarePlugin::manualControlReservedButtonCount(void)
 bool FirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message)
 {
     Q_UNUSED(vehicle);
-    Q_UNUSED(message);    
+    Q_UNUSED(message);
     // Generic plugin does no message adjustment
     return true;
 }
@@ -111,7 +113,7 @@ void FirmwarePlugin::adjustOutgoingMavlinkMessage(Vehicle* vehicle, mavlink_mess
 void FirmwarePlugin::initializeVehicle(Vehicle* vehicle)
 {
     Q_UNUSED(vehicle);
-    
+
     // Generic Flight Stack is by definition "generic", so no extra work
 }
 
@@ -155,7 +157,7 @@ void FirmwarePlugin::setGuidedMode(Vehicle* vehicle, bool guidedMode)
 {
     Q_UNUSED(vehicle);
     Q_UNUSED(guidedMode);
-    qgcApp()->showMessage(QStringLiteral("Guided mode not supported by Vehicle."));
+    qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
 }
 
 bool FirmwarePlugin::isPaused(const Vehicle* vehicle) const
@@ -169,21 +171,21 @@ void FirmwarePlugin::pauseVehicle(Vehicle* vehicle)
 {
     // Not supported by generic vehicle
     Q_UNUSED(vehicle);
-    qgcApp()->showMessage(QStringLiteral("Guided mode not supported by Vehicle."));
+    qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
 }
 
 void FirmwarePlugin::guidedModeRTL(Vehicle* vehicle)
 {
     // Not supported by generic vehicle
     Q_UNUSED(vehicle);
-    qgcApp()->showMessage(QStringLiteral("Guided mode not supported by Vehicle."));
+    qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
 }
 
 void FirmwarePlugin::guidedModeLand(Vehicle* vehicle)
 {
     // Not supported by generic vehicle
     Q_UNUSED(vehicle);
-    qgcApp()->showMessage(QStringLiteral("Guided mode not supported by Vehicle."));
+    qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
 }
 
 void FirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double altitudeRel)
@@ -191,7 +193,7 @@ void FirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double altitudeRel)
     // Not supported by generic vehicle
     Q_UNUSED(vehicle);
     Q_UNUSED(altitudeRel);
-    qgcApp()->showMessage(QStringLiteral("Guided mode not supported by Vehicle."));
+    qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
 }
 
 void FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordinate& gotoCoord)
@@ -199,7 +201,7 @@ void FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordina
     // Not supported by generic vehicle
     Q_UNUSED(vehicle);
     Q_UNUSED(gotoCoord);
-    qgcApp()->showMessage(QStringLiteral("Guided mode not supported by Vehicle."));
+    qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
 }
 
 void FirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitudeRel)
@@ -207,7 +209,7 @@ void FirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitudeR
     // Not supported by generic vehicle
     Q_UNUSED(vehicle);
     Q_UNUSED(altitudeRel);
-    qgcApp()->showMessage(QStringLiteral("Guided mode not supported by Vehicle."));
+    qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
 }
 
 const FirmwarePlugin::remapParamNameMajorVersionMap_t& FirmwarePlugin::paramNameRemapMajorVersionMap(void) const

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -43,6 +43,8 @@ QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
 #define DEFAULT_LAT  38.965767f
 #define DEFAULT_LON -120.083923f
 
+extern const char* guided_mode_not_supported_by_vehicle;
+
 const char* Vehicle::_settingsGroup =               "Vehicle%1";        // %1 replaced with mavlink system id
 const char* Vehicle::_joystickModeSettingsKey =     "JoystickMode";
 const char* Vehicle::_joystickEnabledSettingsKey =  "JoystickEnabled";
@@ -1465,7 +1467,7 @@ bool Vehicle::pauseVehicleSupported(void) const
 void Vehicle::guidedModeRTL(void)
 {
     if (!guidedModeSupported()) {
-        qgcApp()->showMessage(QStringLiteral("Guided mode not supported by vehicle."));
+        qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
     _firmwarePlugin->guidedModeRTL(this);
@@ -1474,7 +1476,7 @@ void Vehicle::guidedModeRTL(void)
 void Vehicle::guidedModeLand(void)
 {
     if (!guidedModeSupported()) {
-        qgcApp()->showMessage(QStringLiteral("Guided mode not supported by vehicle."));
+        qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
     _firmwarePlugin->guidedModeLand(this);
@@ -1483,7 +1485,7 @@ void Vehicle::guidedModeLand(void)
 void Vehicle::guidedModeTakeoff(double altitudeRel)
 {
     if (!guidedModeSupported()) {
-        qgcApp()->showMessage(QStringLiteral("Guided mode not supported by vehicle."));
+        qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
     setGuidedMode(true);
@@ -1493,7 +1495,7 @@ void Vehicle::guidedModeTakeoff(double altitudeRel)
 void Vehicle::guidedModeGotoLocation(const QGeoCoordinate& gotoCoord)
 {
     if (!guidedModeSupported()) {
-        qgcApp()->showMessage(QStringLiteral("Guided mode not supported by vehicle."));
+        qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
     _firmwarePlugin->guidedModeGotoLocation(this, gotoCoord);
@@ -1502,7 +1504,7 @@ void Vehicle::guidedModeGotoLocation(const QGeoCoordinate& gotoCoord)
 void Vehicle::guidedModeChangeAltitude(double altitudeRel)
 {
     if (!guidedModeSupported()) {
-        qgcApp()->showMessage(QStringLiteral("Guided mode not supported by vehicle."));
+        qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
     _firmwarePlugin->guidedModeChangeAltitude(this, altitudeRel);

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -278,6 +278,11 @@ MainWindow::MainWindow()
 #ifndef __mobile__
     _loadVisibleWidgetsSettings();
 #endif
+    //-- Enable message handler display of messages in main window
+    UASMessageHandler* msgHandler = qgcApp()->toolbox()->uasMessageHandler();
+    if(msgHandler) {
+        msgHandler->showErrorsInToolbar();
+    }
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
In response to #2829:

A boolean was added to the message handler preventing it from sending critical messages to the main window until told otherwise. The call to enable these messages was within the parameter handler and it would only get called once the parameters were received (`msgHandler->showErrorsInToolbar();`). That code in turn would send whatever error messages the handler had accumulated so far and enabled the handler. This was also causing these messages to be sent twice. Once by the parameter handler and another by the normal behavior of the message handler, which was now enabled to send messages to the main window.

On a minor note I noticed that the error message *"Guided mode not supported by Vehicle."* was issued 12 times from different places (repeating the entire message each time). I converted it to a constant so we don't store 12 copies of the same message in memory.

