### PR TITLE
Offline map

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -60,7 +60,7 @@ Button {
             background: Item {
                 property bool down: control.pressed || (control.checkable && control.checked)
                 implicitWidth: Math.round(TextSingleton.implicitHeight * 4.5)
-                implicitHeight: ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 3 * 0.75 : Math.max(25, Math.round(TextSingleton.implicitHeight * 1.2))
+                implicitHeight: ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 2.5 : Math.max(25, Math.round(TextSingleton.implicitHeight * 1.2))
 
                 Rectangle {
                     anchors.fill:   parent

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -31,6 +31,7 @@ TextField {
     }
 
     style: TextFieldStyle {
+        font.pixelSize: ScreenTools.defaultFontPixelSize
         background: Item {
             id: backgroundItem
 

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -31,7 +31,7 @@ const double ScreenToolsController::_defaultFontPixelSizeRatio  = 1.0;
 #elif __android__
 const double ScreenToolsController::_defaultFontPixelSizeRatio  = 1.0;
 #elif __ios__
-const double ScreenToolsController::_defaultFontPixelSizeRatio  = 0.8;
+const double ScreenToolsController::_defaultFontPixelSizeRatio  = 0.6;
 #else
 const double ScreenToolsController::_defaultFontPixelSizeRatio  = 0.8;
 #endif

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -266,7 +266,7 @@ QGCTileSet
 QGCMapEngine::getTileCount(int zoom, double topleftLon, double topleftLat, double bottomRightLon, double bottomRightLat, UrlFactory::MapType mapType)
 {
     if(zoom <  1) zoom = 1;
-    if(zoom > 18) zoom = 18;
+    if(zoom > MAX_MAP_ZOOM) zoom = MAX_MAP_ZOOM;
     QGCTileSet set;
     set.tileX0 = long2tileX(topleftLon,     zoom);
     set.tileY0 = lat2tileY(topleftLat,      zoom);

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -579,27 +579,27 @@ Rectangle {
                             Label {
                                 text:   qsTr("Tile Count")
                                 color:  "black"
-                                width:  ScreenTools.defaultFontPixelWidth * 12
+                                width:  ScreenTools.defaultFontPixelWidth * 8
                                 font.pixelSize: ScreenTools.smallFontPixelSize
                                 horizontalAlignment: Text.AlignHCenter
                             }
                             Label {
                                 text:  QGroundControl.mapEngineManager.tileCountStr
                                 color: "black"
-                                width: ScreenTools.defaultFontPixelWidth * 12
+                                width: ScreenTools.defaultFontPixelWidth * 8
                                 horizontalAlignment: Text.AlignHCenter
                             }
                             Label {
                                 text:   qsTr("Set Size (Est)")
                                 color:  "black"
-                                width:  ScreenTools.defaultFontPixelWidth * 12
+                                width:  ScreenTools.defaultFontPixelWidth * 8
                                 font.pixelSize: ScreenTools.smallFontPixelSize
                                 horizontalAlignment: Text.AlignHCenter
                             }
                             Label {
                                 text:  QGroundControl.mapEngineManager.tileSizeStr
                                 color: "black"
-                                width: ScreenTools.defaultFontPixelWidth * 12
+                                width: ScreenTools.defaultFontPixelWidth * 8
                                 horizontalAlignment: Text.AlignHCenter
                             }
                         }
@@ -618,7 +618,7 @@ Rectangle {
                         }
                         QGCTextField {
                             id:     setName
-                            width:  ScreenTools.defaultFontPixelWidth * 24
+                            width:  ScreenTools.defaultFontPixelWidth * 20
                             anchors.verticalCenter: parent.verticalCenter
                         }
                     }
@@ -633,7 +633,7 @@ Rectangle {
                         QGCTextField {
                             id:     setDescription
                             text:   qsTr("Description")
-                            width:  ScreenTools.defaultFontPixelWidth * 24
+                            width:  ScreenTools.defaultFontPixelWidth * 20
                             anchors.verticalCenter: parent.verticalCenter
                         }
                     }
@@ -647,7 +647,7 @@ Rectangle {
                         }
                         QGCComboBox {
                             id:         mapCombo
-                            width:      ScreenTools.defaultFontPixelWidth * 24
+                            width:      ScreenTools.defaultFontPixelWidth * 20
                             model:      QGroundControl.mapEngineManager.mapList
                             onActivated: {
                                 mapType = textAt(index)
@@ -668,7 +668,7 @@ Rectangle {
                 }
                 Item {
                     height: 1
-                    width:  ScreenTools.defaultFontPixelWidth * 1.5
+                    width:  ScreenTools.defaultFontPixelWidth
                 }
                 Column {
                     anchors.verticalCenter: parent.verticalCenter

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -26,8 +26,8 @@ import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.2
 import QtQuick.Dialogs          1.1
 import QtQuick.Layouts          1.2
-import QtLocation               5.3
-import QtPositioning            5.3
+import QtLocation               5.5
+import QtPositioning            5.5
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0
@@ -174,14 +174,15 @@ Rectangle {
             _map.visible = true
             mapType = _offlineMapRoot._currentSelection.mapTypeStr
             _map.center = midPoint(_offlineMapRoot._currentSelection.topleftLat, _offlineMapRoot._currentSelection.bottomRightLat, _offlineMapRoot._currentSelection.topleftLon, _offlineMapRoot._currentSelection.bottomRightLon)
-            _map.zoomLevel = _offlineMapRoot._currentSelection.minZoom
-            var p = _map.fromCoordinate(QtPositioning.coordinate(_offlineMapRoot._currentSelection.topleftLat, _offlineMapRoot._currentSelection.topleftLon), false)
-            console.log(_map.zoomLevel + " " + p)
-            while ((isNaN(p.x) || isNaN(p.y) || (p.x > 25 && p.y > 25)) && _map.zoomLevel < _offlineMapRoot._currentSelection.maxZoom) {
-                _map.zoomLevel = _map.zoomLevel + 1
-                p = _map.fromCoordinate(QtPositioning.coordinate(_offlineMapRoot._currentSelection.topleftLat, _offlineMapRoot._currentSelection.topleftLon), false)
-                console.log(_map.zoomLevel + " " + p)
-            }
+            //-- Delineate Set Region
+            var x0 = _offlineMapRoot._currentSelection.topleftLon
+            var x1 = _offlineMapRoot._currentSelection.bottomRightLon
+            var y0 = _offlineMapRoot._currentSelection.topleftLat
+            var y1 = _offlineMapRoot._currentSelection.bottomRightLat
+            mapBoundary.topLeft     = QtPositioning.coordinate(y0, x0)
+            mapBoundary.bottomRight = QtPositioning.coordinate(y1, x1)
+            mapBoundary.visible = true
+            _map.fitViewportToMapItems()
         }
         _tileSetList.visible = false
         _mapView.visible = false
@@ -199,6 +200,7 @@ Rectangle {
     }
 
     function leaveInfoView() {
+        mapBoundary.visible = false
         _map.center = savedCenter
         _map.zoomLevel = savedZoom
         mapType = savedMapType
@@ -271,6 +273,15 @@ Rectangle {
             border.color: "black"
             border.width: 1
             anchors.fill: parent
+        }
+
+        MapRectangle {
+            id:             mapBoundary
+            border.width:   2
+            border.color:   "red"
+            color:          Qt.rgba(1,0,0,0.05)
+            smooth:         true
+            antialiasing:   true
         }
 
         Component.onCompleted: {

--- a/src/ui/MainWindowLeftPanel.qml
+++ b/src/ui/MainWindowLeftPanel.qml
@@ -193,6 +193,7 @@ Item {
                     anchors.right:  parent.right
                     text:           qsTr("Offline Maps")
                     exclusiveGroup: panelActionGroup
+                    visible:        !ScreenTools.isTinyScreen
                     onClicked: {
                         if(__rightPanel.source != "OfflineMap.qml") {
                             __rightPanel.source = "OfflineMap.qml"

--- a/src/ui/MainWindowLeftPanel.qml
+++ b/src/ui/MainWindowLeftPanel.qml
@@ -282,6 +282,7 @@ Item {
 
     //-- Main Setting Display Area
     Rectangle {
+        id:             settingDisplayArea
         anchors.left:   __verticalSeparator.right
         width:          mainWindow.width - __leftMenu.width - __verticalSeparator.width
         height:         parent.height - toolBar.height - __topSeparator.height


### PR DESCRIPTION
Work on the *Offline Tile Cache* UI

* Made the map a lot larger during the definition of a set, making better use of the screen real estate.
* When viewing an existing tile set, the UI now shows the map and delineates the cached region.

![screen shot 2016-04-19 at 2 11 17 pm](https://cloud.githubusercontent.com/assets/749243/14650292/2ba7f10a-0639-11e6-9df0-6a2b9fdc8a28.png)

![screen shot 2016-04-19 at 2 09 58 pm](https://cloud.githubusercontent.com/assets/749243/14650284/22689bb2-0639-11e6-9f22-2081fd03b8bb.png)
