### PR TITLE
Show a more educative airframe configuration

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -188,6 +188,11 @@ APMAirframeType *APMAirframeComponentController::currentAirframeType() const
     return _currentAirframeType;
 }
 
+QString APMAirframeComponentController::currentAirframeTypeName() const
+{
+    return _vehicle->vehicleTypeName();
+}
+
 APMAirframe *APMAirframeComponentController::currentAirframe() const
 {
     return _currentAirframe;

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.h
@@ -70,6 +70,7 @@ signals:
 
 public slots:
     APMAirframeType *currentAirframeType() const;
+    Q_INVOKABLE QString currentAirframeTypeName() const;
     APMAirframe *currentAirframe() const;
     void setCurrentAirframeType(APMAirframeType *t);
     void setCurrentAirframe(APMAirframe *t);

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
@@ -28,11 +28,11 @@ FactPanel {
         VehicleSummaryRow {
             id: nameRow;
             labelText: qsTr("Frame Type:")
-            valueText: sysIdFact.valueString === "0" ? "Plus"
+            valueText: controller.currentAirframeTypeName() + " " + (sysIdFact.valueString === "0" ? "Plus"
                      : sysIdFact.valueString === "1" ? "X"
                      : sysIdFact.valueString === "2" ? "V"
                      : sysIdFact.valueString == "3" ? "H"
-                     :/* Fact.value == 10 */ "New Y6";
+                     : /* Fact.value == 10 */  "New Y6");
 
         }
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1420,6 +1420,40 @@ void Vehicle::_setCoordinateValid(bool coordinateValid)
     }
 }
 
+QString Vehicle::vehicleTypeName() const {
+    static QMap<int, QString> typeNames = {
+        { MAV_TYPE_GENERIC,         tr("Generic micro air vehicle" )},
+        { MAV_TYPE_FIXED_WING,      tr("Fixed wing aircraft")},
+        { MAV_TYPE_QUADROTOR,       tr("Quadrotor")},
+        { MAV_TYPE_COAXIAL,         tr("Coaxial helicopter")},
+        { MAV_TYPE_HELICOPTER,      tr("Normal helicopter with tail rotor.")},
+        { MAV_TYPE_ANTENNA_TRACKER, tr("Ground installation")},
+        { MAV_TYPE_GCS,             tr("Operator control unit / ground control station")},
+        { MAV_TYPE_AIRSHIP,         tr("Airship, controlled")},
+        { MAV_TYPE_FREE_BALLOON,    tr("Free balloon, uncontrolled")},
+        { MAV_TYPE_ROCKET,          tr("Rocket")},
+        { MAV_TYPE_GROUND_ROVER,    tr("Ground rover")},
+        { MAV_TYPE_SURFACE_BOAT,    tr("Surface vessel, boat, ship")},
+        { MAV_TYPE_SUBMARINE,       tr("Submarine")},
+        { MAV_TYPE_HEXAROTOR,       tr("Hexarotor")},
+        { MAV_TYPE_OCTOROTOR,       tr("Octorotor")},
+        { MAV_TYPE_TRICOPTER,       tr("Octorotor")},
+        { MAV_TYPE_FLAPPING_WING,   tr("Flapping wing")},
+        { MAV_TYPE_KITE,            tr("Flapping wing")},
+        { MAV_TYPE_ONBOARD_CONTROLLER, tr("Onboard companion controller")},
+        { MAV_TYPE_VTOL_DUOROTOR,   tr("Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter")},
+        { MAV_TYPE_VTOL_QUADROTOR,  tr("Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter")},
+        { MAV_TYPE_VTOL_TILTROTOR,  tr("Tiltrotor VTOL")},
+        { MAV_TYPE_VTOL_RESERVED2,  tr("VTOL reserved 2")},
+        { MAV_TYPE_VTOL_RESERVED3,  tr("VTOL reserved 3")},
+        { MAV_TYPE_VTOL_RESERVED4,  tr("VTOL reserved 4")},
+        { MAV_TYPE_VTOL_RESERVED5,  tr("VTOL reserved 5")},
+        { MAV_TYPE_GIMBAL,          tr("Onboard gimbal")},
+        { MAV_TYPE_ADSB,            tr("Onboard ADSB peripheral")},
+    };
+    return typeNames[_vehicleType];
+}
+
 /// Returns the string to speak to identify the vehicle
 QString Vehicle::_vehicleIdSpeech(void)
 {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -395,6 +395,7 @@ public:
     int id(void) { return _id; }
     MAV_AUTOPILOT firmwareType(void) const { return _firmwareType; }
     MAV_TYPE vehicleType(void) const { return _vehicleType; }
+    Q_INVOKABLE QString vehicleTypeName(void) const;
 
     /// Returns the highest quality link available to the Vehicle
     LinkInterface* priorityLink(void);


### PR DESCRIPTION
During tests, if the airframe was configured to be an 'X' type
we showed just 'X' on the airframe type. It's correct but a
single letter - specially an X - made users think that it was
a error code, not the airframe name. So, because of that, also
show the vehicle type plus the airframe type - a wrong value, but elucidative for users.

![screenshot_20160420_151317](https://cloud.githubusercontent.com/assets/4027216/14686224/20780d08-070e-11e6-8351-ccfd5ce0596f.png)


Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>