### PR TITLE
Clicking on the summary titles enter edit mode

### DIFF
--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -38,6 +38,7 @@ import QGroundControl.MultiVehicleManager   1.0
 Rectangle {
     color:  qgcPal.window
     z:      QGroundControl.zOrderTopMost
+    id: setupView
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
@@ -110,6 +111,13 @@ Rectangle {
                 panelLoader.sourceComponent = messagePanelComponent
             } else {
                 panelLoader.source = vehicleComponent.setupSource
+                for(var i = 0; i < componentRepeater.count; i++) {
+                    var obj = componentRepeater.itemAt(i);
+                    if (obj.text === vehicleComponent.name) {
+                        obj.checked = true;
+                        break;
+                    }
+                }
             }
         }
     }

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -36,9 +36,9 @@ import QGroundControl.ScreenTools           1.0
 import QGroundControl.MultiVehicleManager   1.0
 
 Rectangle {
+    id: setupView
     color:  qgcPal.window
     z:      QGroundControl.zOrderTopMost
-    id: setupView
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
@@ -303,7 +303,6 @@ Rectangle {
                     exclusiveGroup: setupButtonGroup
                     text:           modelData.name
                     visible:        modelData.setupSource.toString() != ""
-
 
                     onClicked: showVehicleComponentPanel(modelData)
                 }

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -117,19 +117,11 @@ Rectangle {
                         readonly property real titleHeight: ScreenTools.defaultFontPixelHeight * 2
 
                         // Title bar
-                        Rectangle {
+                        QGCButton {
                             id:     titleBar
                             width:  parent.width
                             height: titleHeight
-                            color:  qgcPal.windowShade
-
-                            // Title text
-                            QGCLabel {
-                                anchors.fill:           parent
-                                verticalAlignment:      TextEdit.AlignVCenter
-                                horizontalAlignment:    TextEdit.AlignHCenter
-                                text:                   capitalizeWords(modelData.name)
-                            }
+                            text:                   capitalizeWords(modelData.name)
 
                             // Setup indicator
                             Rectangle {
@@ -141,6 +133,10 @@ Rectangle {
                                 radius:                 width / 2
                                 color:                  modelData.setupComplete ? "#00d932" : "red"
                                 visible:                modelData.requiresSetup
+                            }
+
+                            onClicked : {
+                                setupView.showVehicleComponentPanel(modelData)
                             }
                         }
 


### PR DESCRIPTION
Clicking on the sumarry titles enters the edit mode
On the tests with users, they always clicked on the
title (because it resembled a button or something) and
nothing happened. it was a bit confusing to have the
same information in two places and only one of them
being clickable.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>