### PR TITLE
Restoring toolbar transparency.

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -45,9 +45,7 @@ QGCView {
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
-    property var _activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
-
-
+    property var _activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
     property bool _mainIsMap:           _controller.hasVideo ? QGroundControl.loadBoolGlobalSetting(_mainIsMapKey,  true) : true
     property bool _isPipVisible:        _controller.hasVideo ? QGroundControl.loadBoolGlobalSetting(_PIPVisibleKey, true) : false
 
@@ -225,7 +223,10 @@ QGCView {
         Loader {
             id:             widgetsLoader
             z:              _panel.z + 4
-            anchors.fill:   parent
+            height:         ScreenTools.availableHeight
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            anchors.bottom: parent.bottom
             asynchronous:   true
             visible:        status == Loader.Ready
 
@@ -238,11 +239,11 @@ QGCView {
             id:                         multiTouchItem
             z:                          _panel.z + 5
             width:                      parent.width  - (_flightVideoPipControl.width / 2)
-            height:                     Math.min(parent.height * 0.25, ScreenTools.defaultFontPixelWidth * 16)
+            height:                     Math.min(ScreenTools.availableHeight * 0.25, ScreenTools.defaultFontPixelWidth * 16)
             visible:                    QGroundControl.virtualTabletJoystick
             anchors.bottom:             _flightVideoPipControl.top
             anchors.bottomMargin:       ScreenTools.defaultFontPixelHeight * 2
-            anchors.horizontalCenter:   parent.horizontalCenter
+            anchors.horizontalCenter:   widgetsLoader.horizontalCenter
             source:                     "qrc:/qml/VirtualJoystick.qml"
             active:                     QGroundControl.virtualTabletJoystick
         }

--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -23,6 +23,7 @@ This file is part of the QGROUNDCONTROL project
 
 import QtQuick          2.4
 import QtQuick.Dialogs  1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
@@ -52,7 +53,7 @@ QGCFlickable {
     }
 
     function showPicker() {
-        qgcView.showDialog(propertyPicker, qsTr("Value Widget Setup"), qgcView.showDialogDefaultWidth, StandardButton.Ok)
+        qgcView.showDialog(propertyPicker, qsTr("Value Widget Setup"), qgcView.showDialogDefaultWidth, StandardButton.Ok, true /*use available height*/ )
     }
 
     function listContains(list, value) {
@@ -201,7 +202,7 @@ QGCFlickable {
             Repeater {
                 model: factGroup ? factGroup.factNames : 0
 
-                Row {
+                RowLayout {
                     spacing: _margins
 
                     property string propertyName: factGroupName + "." + modelData
@@ -250,11 +251,13 @@ QGCFlickable {
                         text:       factGroup.getFact(modelData).shortDescription
                         checked:    _largeCheckBox.checked || listContains(controller.smallValues, propertyName)
                         onClicked:  updateValues()
+                        Layout.fillWidth:       true
+                        Layout.minimumWidth:    ScreenTools.defaultFontPixelWidth * 20
                     }
 
                     QGCCheckBox {
                         id:         _largeCheckBox
-                        text:       qsTr("large")
+                        text:       qsTr("Large")
                         checked:    listContains(controller.largeValues, propertyName)
                         enabled:    _addCheckBox.checked
                         onClicked:  updateValues()

--- a/src/QmlControls/QGCView.qml
+++ b/src/QmlControls/QGCView.qml
@@ -43,6 +43,8 @@ FactPanel {
 
     property var viewPanel
 
+    property bool __useAvailableHeight: false
+
     /// This is signalled when the top level Item reaches Component.onCompleted. This allows
     /// the view subcomponent to connect to this signal and do work once the full ui is ready
     /// to go.
@@ -134,10 +136,12 @@ FactPanel {
     readonly property int showDialogFullWidth:      -1  ///< Use for full width dialog
     readonly property int showDialogDefaultWidth:   40  ///< Use for default dialog width
 
-    function showDialog(component, title, charWidth, buttons) {
+    function showDialog(component, title, charWidth, buttons, useAvailableHeight) {
         if (__checkForEarlyDialog(title)) {
             return
         }
+
+        __useAvailableHeight = typeof useAvailableHeight !== 'undefined' ? useAvailableHeight : false
 
         __stopAllAnimations()
 
@@ -278,7 +282,7 @@ FactPanel {
         // This covers the parent with an transparent section
         Rectangle {
             id:             __transparentSection
-            anchors.top:    parent.top
+            height:         __useAvailableHeight ? ScreenTools.availableHeight : parent.height
             anchors.bottom: parent.bottom
             anchors.left:   parent.left
             anchors.right:  __dialogPanel.left
@@ -291,7 +295,7 @@ FactPanel {
             id:                 __dialogPanel
             width:              __dialogCharWidth == showDialogFullWidth ? parent.width : defaultTextWidth * __dialogCharWidth
             anchors.topMargin:  topDialogMargin
-            anchors.top:        parent.top
+            height:             __useAvailableHeight ? ScreenTools.availableHeight : parent.height
             anchors.bottom:     parent.bottom
             anchors.right:      parent.right
             color:              __qgcPal.windowShadeDark

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -9,6 +9,8 @@ import QGroundControl.ScreenToolsController 1.0
 Item {
     signal repaintRequested
 
+    property real availableHeight: 0
+
     readonly property real defaultFontPixelSize:    _textMeasure.fontHeight * ScreenToolsController.defaultFontPixelSizeRatio
     readonly property real defaultFontPixelHeight:  defaultFontPixelSize
     readonly property real defaultFontPixelWidth:   _textMeasure.fontWidth

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -55,6 +55,10 @@ Item {
     property var    activeVehicle:      QGroundControl.multiVehicleManager.activeVehicle
     property string formatedMessage:    activeVehicle ? activeVehicle.formatedMessage : ""
 
+    onHeightChanged: {
+        ScreenTools.availableHeight = parent.height - toolBar.height
+    }
+
     function showFlyView() {
         if(currentPopUp) {
             currentPopUp.close()
@@ -276,19 +280,18 @@ Item {
         opaqueBackground:   leftPanel.visible
         isBackgroundDark:   flightView.isBackgroundDark
         z:                  QGroundControl.zOrderTopMost
-
         onShowSetupView:    mainWindow.showSetupView()
         onShowPlanView:     mainWindow.showPlanView()
         onShowFlyView:      mainWindow.showFlyView()
+        Component.onCompleted: {
+            ScreenTools.availableHeight = parent.height - toolBar.height
+        }
     }
 
     FlightDisplayView {
-        id:             flightView
-        anchors.left:   parent.left
-        anchors.right:  parent.right
-        anchors.top:    toolBar.bottom
-        anchors.bottom: parent.bottom
-        visible:        true
+        id:                 flightView
+        anchors.fill:       parent
+        visible:            true
     }
 
     Loader {

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -41,7 +41,7 @@ import QGroundControl.Controllers           1.0
 
 Rectangle {
     id:         toolBar
-    color:      qgcPal.window
+    color:      qgcPal.globalTheme === QGCPalette.Light ? Qt.rgba(1,1,1,0.8) : Qt.rgba(0,0,0,0.75)
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
@@ -424,6 +424,15 @@ Rectangle {
             mipmap:                 true
             antialiasing:           true
         }
+        /* Experimenting with a white/black divider
+        Rectangle {
+            color:      qgcPal.globalTheme === QGCPalette.Light ? Qt.rgba(0,0,0,0.15) : Qt.rgba(1,1,1,0.15)
+            height: parent.height
+            width:  1
+            anchors.right:  parent.right
+            anchors.top:    parent.top
+        }
+        */
         MouseArea {
             anchors.fill: parent
             onClicked: mainWindow.showLeftMenu()


### PR DESCRIPTION
This is in response to issue #3190 

I've restored the main Toolbar transparency. For that to work, the main map/video view has to fill the entire screen. The gadgets, widgets and dialogs have to be aware of the available height (as opposed to using the full height). That is accomplished by querying *ScreenTools*.

![screen shot 2016-04-22 at 5 08 00 am](https://cloud.githubusercontent.com/assets/749243/14737458/1ac0b51c-084a-11e6-9ba1-48795c7bd870.png)

While at it, I've fixed the layout for the *ValueWidget*, making the tabulation work correctly.

![screen shot 2016-04-22 at 5 08 05 am](https://cloud.githubusercontent.com/assets/749243/14737485/421b2048-084a-11e6-9172-89e433d9dfe6.png)

I still think that has a bit of a *Mission Planner* feel to it. All that's missing is an option to display cubits per lunar cycle.
