### PR TITLE
Fixing the Mission Editor view to respect the view area

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -90,7 +90,7 @@ QGCView {
 
     function loadFromFile() {
         if (ScreenTools.isMobile) {
-            _root.showDialog(mobileFilePicker, qsTr("Select Mission File"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
+            _root.showDialog(mobileFilePicker, qsTr("Select Mission File"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel, true)
         } else {
             controller.loadMissionFromFilePicker()
             fitViewportToMissionItems()
@@ -99,7 +99,7 @@ QGCView {
 
     function saveToFile() {
         if (ScreenTools.isMobile) {
-            _root.showDialog(mobileFileSaver, qsTr("Save Mission File"), _root.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel)
+            _root.showDialog(mobileFileSaver, qsTr("Save Mission File"), _root.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel, true)
         } else {
             controller.saveMissionToFilePicker()
         }
@@ -252,14 +252,20 @@ QGCView {
 
     QGCViewPanel {
         id:             panel
-        anchors.fill:   parent
+        height:         ScreenTools.availableHeight
+        anchors.bottom: parent.bottom
+        anchors.left:   parent.left
+        anchors.right:  parent.right
 
         Item {
             anchors.fill: parent
 
             FlightMap {
                 id:             editorMap
-                anchors.fill:   parent
+                height:         _root.height
+                anchors.bottom: parent.bottom
+                anchors.left:   parent.left
+                anchors.right:  parent.right
                 mapName:        "MissionEditor"
 
                 signal mapClicked(var coordinate)
@@ -277,19 +283,24 @@ QGCView {
                 }
 
                 MouseArea {
+                    //-- It's a whole lot faster to just fill parent and deal with top offset below
+                    //   than computing the coordinate offset.
                     anchors.fill: parent
-
                     onClicked: {
-                        var coordinate = editorMap.toCoordinate(Qt.point(mouse.x, mouse.y))
-                        coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
-                        coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
-                        coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
-                        if (addMissionItemsButton.checked) {
-                            var sequenceNumber = controller.insertSimpleMissionItem(coordinate, controller.visualItems.count)
-                            setCurrentItem(sequenceNumber)
-                            editorListView.positionViewAtIndex(editorListView.count - 1, ListView.Contain)
-                        } else {
-                            editorMap.mapClicked(coordinate)
+                        //-- Don't pay attention to items beneath the toolbar.
+                        var topLimit = parent.height - ScreenTools.availableHeight
+                        if(mouse.y >= topLimit) {
+                            var coordinate = editorMap.toCoordinate(Qt.point(mouse.x, mouse.y))
+                            coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
+                            coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
+                            coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
+                            if (addMissionItemsButton.checked) {
+                                var sequenceNumber = controller.insertSimpleMissionItem(coordinate, controller.visualItems.count)
+                                setCurrentItem(sequenceNumber)
+                                editorListView.positionViewAtIndex(editorListView.count - 1, ListView.Contain)
+                            } else {
+                                editorMap.mapClicked(coordinate)
+                            }
                         }
                     }
                 }
@@ -399,6 +410,9 @@ QGCView {
                         missionItem:    object
                         sequenceNumber: object.sequenceNumber
 
+                        //-- If you don't want to allow selecting items beneath the
+                        //   toolbar, the code below has to check and see if mouse.y
+                        //   is greater than (map.height - ScreenTools.availableHeight)
                         onClicked: setCurrentItem(object.sequenceNumber)
 
                         function updateItemIndicator() {
@@ -458,7 +472,7 @@ QGCView {
                 // Mission Item Editor
                 Item {
                     id:             missionItemEditor
-                    anchors.top:    parent.top
+                    height:         ScreenTools.availableHeight
                     anchors.bottom: parent.bottom
                     anchors.right:  parent.right
                     width:          _rightPanelWidth
@@ -530,6 +544,7 @@ QGCView {
                 //-- Vertical Tool Buttons
                 Column {
                     id:                 toolColumn
+                    anchors.topMargin:  parent.height - ScreenTools.availableHeight + ScreenTools.defaultFontPixelHeight
                     anchors.margins:    ScreenTools.defaultFontPixelHeight
                     anchors.left:       parent.left
                     anchors.top:        parent.top
@@ -786,7 +801,7 @@ QGCView {
                     onClicked: {
                         syncButton.hideDropDown()
                         if (syncNeeded) {
-                            _root.showDialog(syncLoadFromVehicleOverwrite, qsTr("Mission overwrite"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
+                            _root.showDialog(syncLoadFromVehicleOverwrite, qsTr("Mission overwrite"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel, true)
                         } else {
                             loadFromVehicle()
                         }
@@ -814,7 +829,7 @@ QGCView {
                     onClicked: {
                         syncButton.hideDropDown()
                         if (syncNeeded) {
-                            _root.showDialog(syncLoadFromFileOverwrite, qsTr("Mission overwrite"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
+                            _root.showDialog(syncLoadFromFileOverwrite, qsTr("Mission overwrite"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel, true)
                         } else {
                             loadFromFile()
                         }
@@ -826,7 +841,7 @@ QGCView {
                 text:       qsTr("Remove all")
                 onClicked:  {
                     syncButton.hideDropDown()
-                    _root.showDialog(removeAllPromptDialog, qsTr("Delete all"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
+                    _root.showDialog(removeAllPromptDialog, qsTr("Delete all"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No, true)
                 }
             }
 

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -296,19 +296,16 @@ Item {
 
     Loader {
         id:                 planViewLoader
-        anchors.left:   parent.left
-        anchors.right:  parent.right
-        anchors.top:    toolBar.bottom
-        anchors.bottom: parent.bottom
+        anchors.fill:       parent
         visible:            false
     }
 
     Loader {
         id:                 setupViewLoader
-        anchors.left:   parent.left
-        anchors.right:  parent.right
-        anchors.top:    toolBar.bottom
-        anchors.bottom: parent.bottom
+        anchors.left:       parent.left
+        anchors.right:      parent.right
+        anchors.top:        toolBar.bottom
+        anchors.bottom:     parent.bottom
         visible:            false
     }
 


### PR DESCRIPTION
... so the map extends beneath the toolbar.

When working with the toolbar transparency, I failed to notice the mission editor had its own handling of the map viewing area. It only extended to the bottom of the toolbar (making it look opaque as the map started below it).

This adds the same behavior as the main Flight View.