### PR TITLE
Fixed crash when switching to the Flight Modes panel.

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
@@ -1,24 +1,24 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 /// @file
@@ -107,8 +107,10 @@ QString FlightModesComponent::prerequisiteSetup(void) const
             return plugin->airframeComponent()->name();
         } else if (!plugin->radioComponent()->setupComplete()) {
             return plugin->radioComponent()->name();
+        } else if (!plugin->sensorsComponent()->setupComplete()) {
+            return plugin->sensorsComponent()->name();
         }
     }
-    
+
     return QString();
 }

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -1,24 +1,24 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009 - 2014 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 #include "PX4AutoPilotPlugin.h"
@@ -44,7 +44,7 @@ enum PX4_CUSTOM_MAIN_MODE {
     PX4_CUSTOM_MAIN_MODE_OFFBOARD,
     PX4_CUSTOM_MAIN_MODE_STABILIZED,
     PX4_CUSTOM_MAIN_MODE_RATTITUDE
-    
+
 };
 
 enum PX4_CUSTOM_SUB_MODE_AUTO {
@@ -80,10 +80,10 @@ PX4AutoPilotPlugin::PX4AutoPilotPlugin(Vehicle* vehicle, QObject* parent) :
     _incorrectParameterVersion(false)
 {
     Q_ASSERT(vehicle);
-    
+
     _airframeFacts = new PX4AirframeLoader(this, _vehicle->uas(), this);
     Q_CHECK_PTR(_airframeFacts);
-    
+
     PX4AirframeLoader::loadAirframeMetaData();
 }
 
@@ -96,28 +96,28 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
 {
     if (_components.count() == 0 && !_incorrectParameterVersion) {
         Q_ASSERT(_vehicle);
-        
+
         if (parametersReady()) {
             _airframeComponent = new AirframeComponent(_vehicle, this);
             _airframeComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_airframeComponent));
-            
+
             _radioComponent = new PX4RadioComponent(_vehicle, this);
             _radioComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
 
-            _flightModesComponent = new FlightModesComponent(_vehicle, this);
-            _flightModesComponent->setupTriggerSignals();
-            _components.append(QVariant::fromValue((VehicleComponent*)_flightModesComponent));
-            
             _sensorsComponent = new SensorsComponent(_vehicle, this);
             _sensorsComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_sensorsComponent));
-            
+
+            _flightModesComponent = new FlightModesComponent(_vehicle, this);
+            _flightModesComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue((VehicleComponent*)_flightModesComponent));
+
             _powerComponent = new PowerComponent(_vehicle, this);
             _powerComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_powerComponent));
-            
+
             _safetyComponent = new SafetyComponent(_vehicle, this);
             _safetyComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_safetyComponent));
@@ -136,7 +136,7 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
             qWarning() << "Call to vehicleCompenents prior to parametersReady";
         }
     }
-    
+
     return _components;
 }
 
@@ -150,8 +150,8 @@ void PX4AutoPilotPlugin::_parametersReadyPreChecks(bool missingParameters)
         _incorrectParameterVersion = true;
         qgcApp()->showMessage("This version of GroundControl can only perform vehicle setup on a newer version of firmware. "
                               "Please perform a Firmware Upgrade if you wish to use Vehicle Setup.");
-	}
-	
+    }
+
     _parametersReady = true;
     _missingParameters = missingParameters;
     emit missingParametersChanged(_missingParameters);

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
@@ -55,7 +55,11 @@ void PX4SimpleFlightModesController::_rcChannelsChanged(int channelCount, int pw
 
     Fact* pFact = getParameterFact(-1, "RC_MAP_FLTMODE");
     if(!pFact) {
+#if defined _MSC_VER
+        qCritical() << "RC_MAP_FLTMODE Fact is NULL in" << __FILE__ << __LINE__;
+#else
         qCritical() << "RC_MAP_FLTMODE Fact is NULL in" << __func__ << __FILE__ << __LINE__;
+#endif
         return;
     }
 
@@ -63,7 +67,11 @@ void PX4SimpleFlightModesController::_rcChannelsChanged(int channelCount, int pw
 
     pFact = getParameterFact(-1, QString("RC%1_REV").arg(flightModeChannel + 1));
     if(!pFact) {
-        qCritical() << QString("RC%1_REV").arg(flightModeChannel + 1) << "is NULL in" << __func__ << __FILE__ << __LINE__;
+#if defined _MSC_VER
+        qCritical() << QString("RC%1_REV").arg(flightModeChannel + 1) << "Fact is NULL in" << __FILE__ << __LINE__;
+#else
+        qCritical() << QString("RC%1_REV").arg(flightModeChannel + 1) << " Fact is NULL in" << __func__ << __FILE__ << __LINE__;
+#endif
         return;
     }
 

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
@@ -1,24 +1,24 @@
 /*=====================================================================
- 
+
  QGroundControl Open Source Ground Control Station
- 
+
  (c) 2009, 2015 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- 
+
  This file is part of the QGROUNDCONTROL project
- 
+
  QGROUNDCONTROL is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  QGROUNDCONTROL is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with QGROUNDCONTROL. If not, see <http://www.gnu.org/licenses/>.
- 
+
  ======================================================================*/
 
 #include "PX4SimpleFlightModesController.h"
@@ -53,9 +53,21 @@ void PX4SimpleFlightModesController::_rcChannelsChanged(int channelCount, int pw
     }
     emit rcChannelValuesChanged();
 
-    int flightModeChannel = getParameterFact(-1, "RC_MAP_FLTMODE")->rawValue().toInt() - 1;
+    Fact* pFact = getParameterFact(-1, "RC_MAP_FLTMODE");
+    if(!pFact) {
+        qCritical() << "RC_MAP_FLTMODE Fact is NULL in" << __func__ << __FILE__ << __LINE__;
+        return;
+    }
 
-    int flightModeReversed = getParameterFact(1, QString("RC%1_REV").arg(flightModeChannel + 1))->rawValue().toInt();
+    int flightModeChannel = pFact->rawValue().toInt() - 1;
+
+    pFact = getParameterFact(-1, QString("RC%1_REV").arg(flightModeChannel + 1));
+    if(!pFact) {
+        qCritical() << QString("RC%1_REV").arg(flightModeChannel + 1) << "is NULL in" << __func__ << __FILE__ << __LINE__;
+        return;
+    }
+
+    int flightModeReversed = pFact->rawValue().toInt();
 
     if (flightModeChannel < 0 || flightModeChannel > channelCount) {
         return;


### PR DESCRIPTION
This was reported by @sn0west and @jcooper21 in #3262. If you were to select the *Flight Modes* panel before running the calibrations (*Sensors*), QGC would crash while plowing through non existing *Facts*.

This "*fix*" prevents you from attempting to run the Flight Modes before running the calibrations. I've also added some NULL pointer checks as the original code was making indirect calls without any checks.

To be consistent with the above, I've moved *Flight Modes* below *Sensors* in the setup list.

@DonLakeFlyer If indeed you need to run the calibration before assigning Flight Modes (weird), I guess this is all that was needed. If not, this is the code that was causing the crash:

https://github.com/mavlink/qgroundcontrol/blob/master/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc#L48

The original line was:

`int flightModeReversed = getParameterFact(1, QString("RC%1_REV").arg(flightModeChannel + 1))->rawValue().toInt();`

Where `getParameter()` was returning NULL and proceeding to call `rawValue()` on a NULL pointer. The parameter in question above was `RC0_REV`.