### PR TITLE
Fix QGCView.showDialog() when called from FactTextField.

### DIFF
--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -53,7 +53,7 @@ QGCFlickable {
     }
 
     function showPicker() {
-        qgcView.showDialog(propertyPicker, qsTr("Value Widget Setup"), qgcView.showDialogDefaultWidth, StandardButton.Ok, true /*use available height*/ )
+        qgcView.showDialog(propertyPicker, qsTr("Value Widget Setup"), qgcView.showDialogDefaultWidth, StandardButton.Ok)
     }
 
     function listContains(list, value) {

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -90,7 +90,7 @@ QGCView {
 
     function loadFromFile() {
         if (ScreenTools.isMobile) {
-            _root.showDialog(mobileFilePicker, qsTr("Select Mission File"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel, true)
+            _root.showDialog(mobileFilePicker, qsTr("Select Mission File"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
         } else {
             controller.loadMissionFromFilePicker()
             fitViewportToMissionItems()
@@ -99,7 +99,7 @@ QGCView {
 
     function saveToFile() {
         if (ScreenTools.isMobile) {
-            _root.showDialog(mobileFileSaver, qsTr("Save Mission File"), _root.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel, true)
+            _root.showDialog(mobileFileSaver, qsTr("Save Mission File"), _root.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel)
         } else {
             controller.saveMissionToFilePicker()
         }
@@ -801,7 +801,7 @@ QGCView {
                     onClicked: {
                         syncButton.hideDropDown()
                         if (syncNeeded) {
-                            _root.showDialog(syncLoadFromVehicleOverwrite, qsTr("Mission overwrite"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel, true)
+                            _root.showDialog(syncLoadFromVehicleOverwrite, qsTr("Mission overwrite"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
                         } else {
                             loadFromVehicle()
                         }
@@ -829,7 +829,7 @@ QGCView {
                     onClicked: {
                         syncButton.hideDropDown()
                         if (syncNeeded) {
-                            _root.showDialog(syncLoadFromFileOverwrite, qsTr("Mission overwrite"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel, true)
+                            _root.showDialog(syncLoadFromFileOverwrite, qsTr("Mission overwrite"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
                         } else {
                             loadFromFile()
                         }
@@ -841,7 +841,7 @@ QGCView {
                 text:       qsTr("Remove all")
                 onClicked:  {
                     syncButton.hideDropDown()
-                    _root.showDialog(removeAllPromptDialog, qsTr("Delete all"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No, true)
+                    _root.showDialog(removeAllPromptDialog, qsTr("Delete all"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
                 }
             }
 

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -47,6 +47,7 @@ QGCViewDialog {
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     function accept() {
+        /*
         if (bitmaskEditor.visible) {
             var value = 0;
             for (var i = 0; i < fact.bitmaskValues.length; ++i) {
@@ -58,12 +59,12 @@ QGCViewDialog {
             fact.value = value;
             fact.valueChanged(fact.value)
         }
-        else if (factCombo.visible) {
+        else */ if (factCombo.visible) {
             fact.enumIndex = factCombo.currentIndex
             hideDialog()
         } else {
             var errorString = fact.validate(valueField.text, forceSave.checked)
-            if (errorString == "") {
+            if (errorString === "") {
                 fact.value = valueField.text
                 fact.valueChanged(fact.value)
                 hideDialog()
@@ -96,7 +97,7 @@ QGCViewDialog {
             QGCLabel {
                 width:      parent.width
                 wrapMode:   Text.WordWrap
-                text:       fact.shortDescription ? fact.shortDescription : qsTr("Description missing")
+                text:       fact.shortDescription ? fact.shortDescription : qsTr("Parameter Description (not defined)")
             }
 
             QGCLabel {

--- a/src/QmlControls/QGCView.qml
+++ b/src/QmlControls/QGCView.qml
@@ -43,8 +43,6 @@ FactPanel {
 
     property var viewPanel
 
-    property bool __useAvailableHeight: false
-
     /// This is signalled when the top level Item reaches Component.onCompleted. This allows
     /// the view subcomponent to connect to this signal and do work once the full ui is ready
     /// to go.
@@ -136,12 +134,10 @@ FactPanel {
     readonly property int showDialogFullWidth:      -1  ///< Use for full width dialog
     readonly property int showDialogDefaultWidth:   40  ///< Use for default dialog width
 
-    function showDialog(component, title, charWidth, buttons, useAvailableHeight) {
+    function showDialog(component, title, charWidth, buttons) {
         if (__checkForEarlyDialog(title)) {
             return
         }
-
-        __useAvailableHeight = typeof useAvailableHeight !== 'undefined' ? useAvailableHeight : false
 
         __stopAllAnimations()
 
@@ -282,7 +278,7 @@ FactPanel {
         // This covers the parent with an transparent section
         Rectangle {
             id:             __transparentSection
-            height:         __useAvailableHeight ? ScreenTools.availableHeight : parent.height
+            height:         ScreenTools.availableHeight ? ScreenTools.availableHeight : parent.height
             anchors.bottom: parent.bottom
             anchors.left:   parent.left
             anchors.right:  __dialogPanel.left
@@ -295,7 +291,7 @@ FactPanel {
             id:                 __dialogPanel
             width:              __dialogCharWidth == showDialogFullWidth ? parent.width : defaultTextWidth * __dialogCharWidth
             anchors.topMargin:  topDialogMargin
-            height:             __useAvailableHeight ? ScreenTools.availableHeight : parent.height
+            height:             ScreenTools.availableHeight ? ScreenTools.availableHeight : parent.height
             anchors.bottom:     parent.bottom
             anchors.right:      parent.right
             color:              __qgcPal.windowShadeDark
@@ -330,7 +326,9 @@ FactPanel {
                     anchors.right:  parent.right
                     primary:        true
 
-                    onClicked: __dialogComponentLoader.item.accept()
+                    onClicked: {
+                       __dialogComponentLoader.item.accept()
+                    }
                 }
             }
 

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -57,13 +57,17 @@ Item {
     property string formatedMessage:    activeVehicle ? activeVehicle.formatedMessage : ""
 
     onHeightChanged: {
-        ScreenTools.availableHeight = parent.height - toolBar.height
+        //-- We only deal with the available height if within the Fly or Plan view
+        if(!setupViewLoader.visible) {
+            ScreenTools.availableHeight = parent.height - toolBar.height
+        }
     }
 
     function showFlyView() {
         if(currentPopUp) {
             currentPopUp.close()
         }
+        ScreenTools.availableHeight = parent.height - toolBar.height
         flightView.visible          = true
         setupViewLoader.visible     = false
         planViewLoader.visible      = false
@@ -77,6 +81,7 @@ Item {
         if (planViewLoader.source   != _planViewSource) {
             planViewLoader.source   = _planViewSource
         }
+        ScreenTools.availableHeight = parent.height - toolBar.height
         flightView.visible          = false
         setupViewLoader.visible     = false
         planViewLoader.visible      = true
@@ -87,6 +92,8 @@ Item {
         if(currentPopUp) {
             currentPopUp.close()
         }
+        //-- In setup view, the full height is available. Set to 0 so it is ignored.
+        ScreenTools.availableHeight = 0
         if (setupViewLoader.source  != _setupViewSource) {
             setupViewLoader.source  = _setupViewSource
         }


### PR DESCRIPTION
Actually, I changed it so `showDialog` figures out on its own if it should use available height or full parent height. The variable is now set by the main window, which controls which view is being shown.
I commented off some code in `ParameterEditorDialog.qml` as it is not properly handling the dialog and causing it to get "stuck".