### PR TITLE
Show firmware version if the vehicle is connected

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
@@ -35,5 +35,10 @@ FactPanel {
                      : /* Fact.value == 10 */  "New Y6");
 
         }
+
+        VehicleSummaryRow {
+            labelText: qsTr("Firmware Version:")
+            valueText: activeVehicle.firmwareMajorVersion() + "." + activeVehicle.firmwareMinorVersion() + "." + activeVehicle.firmwarePatchVersion()
+        }
     }
 }

--- a/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
@@ -38,5 +38,10 @@ FactPanel {
             labelText: qsTr("Vehicle:")
             valueText: autoStartSet ? controller.currentVehicleName : qsTr("Setup required")
         }
+
+        VehicleSummaryRow {
+            labelText: qsTr("Firmware Version:")
+            valueText: activeVehicle.firmwareMajorVersion() + "." + activeVehicle.firmwareMinorVersion() + "." + activeVehicle.firmwarePatchVersion()
+        }
     }
 }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -521,9 +521,9 @@ public:
     bool containsLink(LinkInterface* link) { return _links.contains(link); }
     void doCommandLong(int component, MAV_CMD command, float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
 
-    int firmwareMajorVersion(void) const { return _firmwareMajorVersion; }
-    int firmwareMinorVersion(void) const { return _firmwareMinorVersion; }
-    int firmwarePatchVersion(void) const { return _firmwarePatchVersion; }
+    Q_INVOKABLE int firmwareMajorVersion(void) const { return _firmwareMajorVersion; }
+    Q_INVOKABLE int firmwareMinorVersion(void) const { return _firmwareMinorVersion; }
+    Q_INVOKABLE int firmwarePatchVersion(void) const { return _firmwarePatchVersion; }
     void setFirmwareVersion(int majorVersion, int minorVersion, int patchVersion);
     static const int versionNotSetValue = -1;
 

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -106,6 +106,7 @@ QGCView {
                 // Board was found right away, so something is already plugged in before we've started upgrade
                 statusTextArea.append(qgcUnplugText1)
                 statusTextArea.append(qgcUnplugText2)
+                statusTextArea.append(qsTr("Current Firmware: ") + activeVehicle.firmwareMajorVersion() + "." + activeVehicle.firmwareMinorVersion() + "." + activeVehicle.firmwarePatchVersion())
                 QGroundControl.multiVehicleManager.activeVehicle.autoDisconnect = true
             } else {
                 // We end up here when we detect a board plugged in after we've started upgrade

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -706,7 +706,6 @@ void FirmwareUpgradeController::_loadAPMVersions(QGCSerialPortInfo::BoardType_t 
     }
 }
 
-
 void FirmwareUpgradeController::_apmVersionDownloadFinished(QString remoteFile, QString localFile)
 {
     qCDebug(FirmwareUpgradeLog) << "Download complete" << remoteFile << localFile;


### PR DESCRIPTION

![screenshot_20160427_163523](https://cloud.githubusercontent.com/assets/4027216/14866526/87828398-0c9a-11e6-8623-ee4cf153e1a6.png)
Display the firmware version if the vehicle is already connected
and the user clicks on Firmware Upgrade.

Signed-off-by: Tomaz Canabrava <tomaz.canabrava@intel.com>