### PR TITLE
Fix sizing within MissionItemStatus

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -496,6 +496,7 @@ QGCView {
                         orientation:    ListView.Vertical
                         model:          controller.visualItems
                         cacheBuffer:    height * 2
+                        clip:           true
 
                         delegate: MissionItemEditor {
                             missionItem:    object

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -35,8 +35,8 @@ Rectangle {
     property real   expandedWidth               ///< Width of control when expanded
 
     width:      _expanded ? expandedWidth : _collapsedWidth
-    height:     valueGrid.height + _margins
-    radius:     ScreenTools.defaultFontPixelWidth
+    height:     valueGrid.height + (_margins * 2)
+    radius:     ScreenTools.defaultFontPixelWidth * 0.5
     color:      qgcPal.window
     opacity:    0.80
     clip:       true
@@ -63,75 +63,78 @@ Rectangle {
         onClicked:      _expanded = !_expanded
     }
 
-    Grid {
-        id:                 valueGrid
+    Row {
+        anchors.fill:       parent
         anchors.margins:    _margins
-        anchors.left:       parent.left
-        anchors.top:        parent.top
-        columns:            2
-        columnSpacing:      _margins
+        spacing:            _margins
 
-        QGCLabel { text: qsTr("Distance:") }
-        QGCLabel { text: _distanceText }
+        Grid {
+            id:                 valueGrid
+            columns:            2
+            columnSpacing:      _margins
+            anchors.verticalCenter: parent.verticalCenter
 
-        QGCLabel { text: qsTr("Alt diff:") }
-        QGCLabel { text: _altText }
+            QGCLabel { text: qsTr("Distance:") }
+            QGCLabel { text: _distanceText }
 
-        QGCLabel { text: qsTr("Gradient:") }
-        QGCLabel { text: _gradientText }
+            QGCLabel { text: qsTr("Alt diff:") }
+            QGCLabel { text: _altText }
 
-        QGCLabel { text: qsTr("Azimuth:") }
-        QGCLabel { text: _azimuthText }
-    }
+            QGCLabel { text: qsTr("Gradient:") }
+            QGCLabel { text: _gradientText }
 
-    QGCFlickable {
-        anchors.leftMargin:     _margins
-        anchors.rightMargin:    _margins
-        anchors.left:           valueGrid.right
-        anchors.right:          parent.right
-        anchors.top:            parent.top
-        anchors.bottom:         parent.bottom
-        contentWidth:           graphRow.width
-        clip:                   true
+            QGCLabel { text: qsTr("Azimuth:") }
+            QGCLabel { text: _azimuthText }
+        }
 
-        Row {
-            id:             graphRow
-            anchors.top:    parent.top
-            anchors.bottom: parent.bottom
-            spacing:        ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
+        QGCFlickable {
+            anchors.leftMargin:     _margins
+            anchors.rightMargin:    _margins
+            anchors.top:            parent.top
+            anchors.bottom:         parent.bottom
+            width:                  parent.width - valueGrid.width - (_margins * 2)
+            contentWidth:           graphRow.width
+            visible:                _expanded
+            clip:                   true
 
-            Repeater {
-                model: missionItems
+            Row {
+                id:                 graphRow
+                anchors.top:        parent.top
+                anchors.bottom:     parent.bottom
+                //anchors.margins:    ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
+                spacing:            ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
 
-                Item {
-                    height:     graphRow.height
-                    width:      ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio * 2
-                    visible:    object.specifiesCoordinate && !object.isStandaloneCoordinate
+                Repeater {
+                    model: missionItems
 
+                    Item {
+                        height:     graphRow.height
+                        width:      indicator.width
+                        visible:    object.specifiesCoordinate && !object.isStandaloneCoordinate
 
-                    property real availableHeight: height - (ScreenTools.defaultFontPixelHeight * ScreenTools.smallFontPointRatio) - indicator.height
+                        property real availableHeight:  height - indicator.height
+                        property bool graphAbsolute:    true
 
-                    property bool graphAbsolute:    true
+                        MissionItemIndexLabel {
+                            id:                         indicator
+                            anchors.horizontalCenter:   parent.horizontalCenter
+                            y:                          availableHeight - (availableHeight * object.altPercent)
+                            small:                      true
+                            isCurrentItem:              object.isCurrentItem
+                            label:                      object.abbreviation
+                            visible:                    object.relativeAltitude ? true : (object.homePosition || graphAbsolute)
+                        }
 
-                    MissionItemIndexLabel {
-                        id:                         indicator
-                        anchors.horizontalCenter:   parent.horizontalCenter
-                        y:                          availableHeight - (availableHeight * object.altPercent)
-                        small:                      true
-                        isCurrentItem:              object.isCurrentItem
-                        label:                      object.abbreviation
-                        visible:                    object.relativeAltitude ? true : (object.homePosition || graphAbsolute)
+                        /*
+                          Taking these off for now since there really isn't room for the numbers
+                        QGCLabel {
+                            anchors.bottom:             parent.bottom
+                            anchors.horizontalCenter:   parent.horizontalCenter
+                            font.pointSize:             ScreenTools.smallFontPointSize
+                            text:                       (object.relativeAltitude ? "" : "=") + object.coordinate.altitude.toFixed(0)
+                        }
+                        */
                     }
-
-                    /*
-                      Taking these off for now since there really isn't room for the numbers
-                    QGCLabel {
-                        anchors.bottom:             parent.bottom
-                        anchors.horizontalCenter:   parent.horizontalCenter
-                        font.pointSize:             ScreenTools.smallFontPointSize
-                        text:                       (object.relativeAltitude ? "" : "=") + object.coordinate.altitude.toFixed(0)
-                    }
-                    */
                 }
             }
         }

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -19,15 +19,9 @@ Rectangle {
     border.color:   "white"
     color:          isCurrentItem ? "green" : qgcPal.mapButtonHighlight
 
-    property real _width: small ? ScreenTools.smallFontPointSize * 1.5 : ScreenTools.mediumFontPointSize * 1.5
+    property real _width: small ? ScreenTools.defaultFontPixelHeight * ScreenTools.smallFontPointRatio * 1.75 : ScreenTools.defaultFontPixelHeight * 1.75
 
     QGCPalette { id: qgcPal }
-
-    MouseArea {
-        anchors.fill: parent
-
-        onClicked: parent.clicked()
-    }
 
     QGCLabel {
         id:                     _label
@@ -35,6 +29,12 @@ Rectangle {
         horizontalAlignment:    Text.AlignHCenter
         verticalAlignment:      Text.AlignVCenter
         color:                  "white"
-        font.pointSize:         small ? ScreenTools.smallFontPointSize : ScreenTools.mediumFontPointSize
+        font.pointSize:         small ? ScreenTools.smallFontPointSize : ScreenTools.defaultFontPointSize
     }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: parent.clicked()
+    }
+
 }


### PR DESCRIPTION
The Mission Item Status was using the font *pixel* size to compute dimensions (instead of its height or width in pixels). With the change to point size, the computations were all over the place.

While at it, fixed some clipping errors in both the mission list within the Plan View and the Mission Item Status view as well.

![screen shot 2016-05-05 at 4 44 52 pm](https://cloud.githubusercontent.com/assets/749243/15056760/64cb5f3a-12e1-11e6-8b1b-fb82e7878608.png)
