### PR TITLE
Allow users to change base UI font point size.

### DIFF
--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -37,7 +37,8 @@ FactMetaData* QGroundControlQmlGlobal::_distanceUnitsMetaData =                 
 SettingsFact* QGroundControlQmlGlobal::_speedUnitsFact =                        NULL;
 FactMetaData* QGroundControlQmlGlobal::_speedUnitsMetaData =                    NULL;
 
-const char* QGroundControlQmlGlobal::_virtualTabletJoystickKey = "VirtualTabletJoystick";
+const char* QGroundControlQmlGlobal::_virtualTabletJoystickKey  = "VirtualTabletJoystick";
+const char* QGroundControlQmlGlobal::_baseFontPointSizeKey      = "BaseFontPointSize";
 
 QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
     : QGCTool(app)
@@ -48,9 +49,11 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
     , _multiVehicleManager(NULL)
     , _mapEngineManager(NULL)
     , _virtualTabletJoystick(false)
+    , _baseFontPointSize(0.0)
 {
     QSettings settings;
-    _virtualTabletJoystick = settings.value(_virtualTabletJoystickKey, false). toBool();
+    _virtualTabletJoystick  = settings.value(_virtualTabletJoystickKey, false).toBool();
+    _baseFontPointSize      = settings.value(_baseFontPointSizeKey, 0.0).toDouble();
 
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
     setParent(NULL);
@@ -204,6 +207,16 @@ void QGroundControlQmlGlobal::setVirtualTabletJoystick(bool enabled)
         settings.setValue(_virtualTabletJoystickKey, enabled);
         _virtualTabletJoystick = enabled;
         emit virtualTabletJoystickChanged(enabled);
+    }
+}
+
+void QGroundControlQmlGlobal::setBaseFontPointSize(qreal size)
+{
+    if (size >= 6.0 && size <= 48.0) {
+        QSettings settings;
+        settings.setValue(_baseFontPointSizeKey, size);
+        _baseFontPointSize = size;
+        emit baseFontPointSizeChanged(size);
     }
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -86,6 +86,7 @@ public:
     Q_PROPERTY(bool     isSaveLogPrompt         READ isSaveLogPrompt            WRITE setIsSaveLogPrompt            NOTIFY isSaveLogPromptChanged)
     Q_PROPERTY(bool     isSaveLogPromptNotArmed READ isSaveLogPromptNotArmed    WRITE setIsSaveLogPromptNotArmed    NOTIFY isSaveLogPromptNotArmedChanged)
     Q_PROPERTY(bool     virtualTabletJoystick   READ virtualTabletJoystick      WRITE setVirtualTabletJoystick      NOTIFY virtualTabletJoystickChanged)
+    Q_PROPERTY(qreal    baseFontPointSize       READ baseFontPointSize          WRITE setBaseFontPointSize          NOTIFY baseFontPointSizeChanged)
 
     // MavLink Protocol
     Q_PROPERTY(bool     isMultiplexingEnabled   READ isMultiplexingEnabled      WRITE setIsMultiplexingEnabled      NOTIFY isMultiplexingEnabledChanged)
@@ -151,6 +152,7 @@ public:
     bool    isSaveLogPrompt         () { return _app->promptFlightDataSave(); }
     bool    isSaveLogPromptNotArmed () { return _app->promptFlightDataSaveNotArmed(); }
     bool    virtualTabletJoystick   () { return _virtualTabletJoystick; }
+    qreal   baseFontPointSize       () { return _baseFontPointSize; }
 
     bool    isMultiplexingEnabled   () { return _toolbox->mavlinkProtocol()->multiplexingEnabled(); }
     bool    isVersionCheckEnabled   () { return _toolbox->mavlinkProtocol()->versionCheckEnabled(); }
@@ -170,6 +172,7 @@ public:
     void    setIsSaveLogPrompt          (bool prompt);
     void    setIsSaveLogPromptNotArmed  (bool prompt);
     void    setVirtualTabletJoystick    (bool enabled);
+    void    setBaseFontPointSize        (qreal size);
 
     void    setIsMultiplexingEnabled    (bool enable);
     void    setIsVersionCheckEnabled    (bool enable);
@@ -191,6 +194,7 @@ signals:
     void isSaveLogPromptChanged         (bool prompt);
     void isSaveLogPromptNotArmedChanged (bool prompt);
     void virtualTabletJoystickChanged   (bool enabled);
+    void baseFontPointSizeChanged       (qreal size);
     void isMultiplexingEnabledChanged   (bool enabled);
     void isVersionCheckEnabledChanged   (bool enabled);
     void mavlinkSystemIDChanged         (int id);
@@ -207,10 +211,10 @@ private:
     QGCMapEngineManager*    _mapEngineManager;
     QGCPositionManager*     _qgcPositionManager;
 
-    bool _virtualTabletJoystick;
-
-    QGeoCoordinate  _flightMapPosition;
-    double          _flightMapZoom;
+    bool                    _virtualTabletJoystick;
+    qreal                   _baseFontPointSize;
+    QGeoCoordinate          _flightMapPosition;
+    double                  _flightMapZoom;
 
     // These are static so they are available to C++ code as well as Qml
     static SettingsFact*    _offlineEditingFirmwareTypeFact;
@@ -221,6 +225,7 @@ private:
     static FactMetaData*    _speedUnitsMetaData;
 
     static const char*  _virtualTabletJoystickKey;
+    static const char*  _baseFontPointSizeKey;
 };
 
 #endif

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -238,16 +238,22 @@ Rectangle {
 
             Connections {
                 target: componentRepeater
-
                 onModelChanged: buttonColumn.reflowWidths()
             }
 
+            // I don't know why this does not work
+            Connections {
+                target: QGroundControl
+                onBaseFontPointSizeChanged: buttonColumn.reflowWidths()
+            }
+
             function reflowWidths() {
-                for (var i=0; i<children.length; i++) {
-                    _maxButtonWidth = Math.max(_maxButtonWidth, children[i].width)
+                buttonColumn._maxButtonWidth = 0
+                for (var i = 0; i < children.length; i++) {
+                    buttonColumn._maxButtonWidth = Math.max(buttonColumn._maxButtonWidth, children[i].width)
                 }
-                for (var i=0; i<children.length; i++) {
-                    children[i].width = _maxButtonWidth
+                for (var j = 0; j < children.length; j++) {
+                    children[j].width = buttonColumn._maxButtonWidth
                 }
             }
 

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -72,6 +72,70 @@ Rectangle {
             }
 
             //-----------------------------------------------------------------
+            //-- Base UI Font Point Size
+            Row {
+                spacing:    ScreenTools.defaultFontPixelWidth
+                QGCLabel {
+                    width:              _firstLabelWidth
+                    text:               qsTr("Base UI font size:")
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+                Row {
+                    anchors.verticalCenter: parent.verticalCenter
+                    Rectangle {
+                        width:              baseFontEdit.height
+                        height:             width
+                        color:              qgcPal.button
+                        QGCLabel {
+                            text:           "-"
+                            anchors.centerIn: parent
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                if(ScreenTools.defaultFontPointSize > 6)
+                                    QGroundControl.baseFontPointSize = QGroundControl.baseFontPointSize - 1
+                            }
+                        }
+                    }
+                    QGCTextField {
+                        id:                 baseFontEdit
+                        width:              _editFieldWidth - (height * 2)
+                        text:               QGroundControl.baseFontPointSize
+                        showUnits:          true
+                        unitsLabel:         "pt"
+                        maximumLength:      6
+                        validator:          DoubleValidator {bottom: 6.0; top: 48.0; decimals: 2;}
+                        onEditingFinished: {
+                            var point = parseFloat(text)
+                            if(point >= 6.0 && point <= 48.0)
+                                QGroundControl.baseFontPointSize = point;
+                        }
+                    }
+                    Rectangle {
+                        width:              baseFontEdit.height
+                        height:             width
+                        color:              qgcPal.button
+                        QGCLabel {
+                            text:           "+"
+                            anchors.centerIn: parent
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                if(ScreenTools.defaultFontPointSize < 49)
+                                    QGroundControl.baseFontPointSize = QGroundControl.baseFontPointSize + 1
+                            }
+                        }
+                    }
+                }
+                QGCLabel {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text:               qsTr("(requires reboot to take affect)")
+                }
+            }
+
+            //-----------------------------------------------------------------
             //-- Units
 
             Row {


### PR DESCRIPTION
I've added a setting under *General Settings* allowing users to set the base UI font point size. This is used throughout QGroundControl to size almost all UI controls (in addition to fonts). You can now fine tune the UI size to your liking.

![screen shot 2016-05-06 at 9 50 37 am](https://cloud.githubusercontent.com/assets/749243/15075114/ab59bf52-1370-11e6-93a0-4ba33ac6a236.png)
