### PR TITLE
Scale increment and decimal fields according to cooked unit, so that …

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -596,7 +596,8 @@ int FactMetaData::decimalPlaces(void) const
     int incrementDecimalPlaces = unknownDecimalPlaces;
 
     // First determine decimal places from increment
-    double increment = this->increment();
+    double increment = _rawTranslator(this->increment()).toDouble();
+    qDebug() << "increment:" << increment;
     if (!qIsNaN(increment)) {
         double integralPart;
 
@@ -614,7 +615,18 @@ int FactMetaData::decimalPlaces(void) const
     if (incrementDecimalPlaces != unknownDecimalPlaces && _decimalPlaces == unknownDecimalPlaces) {
         actualDecimalPlaces = incrementDecimalPlaces;
     } else {
-        actualDecimalPlaces = qMax(_decimalPlaces, incrementDecimalPlaces);
+
+        int settingsDecimalPlaces = _decimalPlaces;
+        double ctest = _rawTranslator(1.0).toDouble();
+
+        settingsDecimalPlaces += -log10(ctest);
+
+        qDebug() << "Decimal" << settingsDecimalPlaces;
+
+        settingsDecimalPlaces = qMin(25, settingsDecimalPlaces);
+        settingsDecimalPlaces = qMax(0, settingsDecimalPlaces);
+
+        actualDecimalPlaces = qMax(settingsDecimalPlaces, incrementDecimalPlaces);
     }
 
     return actualDecimalPlaces;


### PR DESCRIPTION
…the decimal and increments provided by meta data still work in the cooked display.

@dagar This is what you need. Note that a lot of the fixed wing meta for angles doesn't contain increment or meta and thus the angles here only allow natural numbers. We should re-test this against updated meta data.

<img width="1241" alt="screen shot 2016-05-08 at 11 26 59" src="https://cloud.githubusercontent.com/assets/1208119/15097047/1b785cf8-1510-11e6-9eda-3e5ec5996ec2.png">

Slider increment also makes sense:

<img width="1241" alt="screen shot 2016-05-08 at 11 30 12" src="https://cloud.githubusercontent.com/assets/1208119/15097052/49c3278c-1510-11e6-8401-44e84f2b6d13.png">
