### PR TITLE
More size adjustments.

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -218,9 +218,9 @@ Item {
 
                             QGCButton {
                                 checkable:  true
-                                checked:    _flightMap ? _flightMap.mapType == text : false
+                                checked:    _flightMap ? _flightMap.mapType === text : false
                                 text:       modelData
-
+                                width:      clearButton.width
                                 onClicked: {
                                     _flightMap.mapType = text
                                     _dropButtonsExclusiveGroup.current = null
@@ -230,9 +230,9 @@ Item {
                     }
 
                     QGCButton {
-                        text:       qsTr("Clear flight trails")
+                        id:         clearButton
+                        text:       qsTr("Clear Flight Trails")
                         enabled:    QGroundControl.multiVehicleManager.activeVehicle
-
                         onClicked: {
                             QGroundControl.multiVehicleManager.activeVehicle.clearTrajectoryPoints()
                             _dropButtonsExclusiveGroup.current = null

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -26,6 +26,7 @@ import QtQuick.Controls 1.3
 import QtQuick.Dialogs  1.2
 import QtLocation       5.3
 import QtPositioning    5.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.FlightMap     1.0
@@ -49,7 +50,7 @@ QGCView {
 
     readonly property int       _decimalPlaces:     8
     readonly property real      _horizontalMargin:  ScreenTools.defaultFontPixelWidth  / 2
-    readonly property real      _margin:            ScreenTools.defaultFontPixelHeight / 2
+    readonly property real      _margin:            ScreenTools.defaultFontPixelHeight * 0.5
     readonly property var       _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     readonly property real      _editFieldWidth:    ScreenTools.defaultFontPixelWidth * 16
     readonly property real      _rightPanelWidth:   Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 30)
@@ -601,35 +602,31 @@ QGCView {
 
                         dropDownComponent: Component {
                             Column {
+                                spacing: ScreenTools.defaultFontPixelWidth * 0.5
                                 QGCLabel { text: qsTr("Center map:") }
-
                                 Row {
                                     spacing: ScreenTools.defaultFontPixelWidth
-
                                     QGCButton {
                                         text: qsTr("Home")
-
+                                        width:  ScreenTools.defaultFontPixelWidth * 10
                                         onClicked: {
                                             centerMapButton.hideDropDown()
                                             editorMap.center = controller.visualItems.get(0).coordinate
                                         }
                                     }
-
                                     QGCButton {
                                         text: qsTr("Mission")
-
+                                        width:  ScreenTools.defaultFontPixelWidth * 10
                                         onClicked: {
                                             centerMapButton.hideDropDown()
                                             fitViewportToMissionItems()
                                         }
                                     }
-
                                     QGCButton {
                                         text:       qsTr("Vehicle")
+                                        width:      ScreenTools.defaultFontPixelWidth * 10
                                         enabled:    activeVehicle && activeVehicle.latitude != 0 && activeVehicle.longitude != 0
-
                                         property var activeVehicle: _activeVehicle
-
                                         onClicked: {
                                             centerMapButton.hideDropDown()
                                             editorMap.center = activeVehicle.coordinate
@@ -651,20 +648,17 @@ QGCView {
 
                         dropDownComponent: Component {
                             Column {
+                                spacing: _margin
                                 QGCLabel { text: qsTr("Map type:") }
-
                                 Row {
                                     spacing: ScreenTools.defaultFontPixelWidth
-
                                     Repeater {
                                         model: QGroundControl.flightMapSettings.mapTypes
-
                                         QGCButton {
                                             checkable:      true
-                                            checked:        editorMap.mapType == text
+                                            checked:        editorMap.mapType === text
                                             text:           modelData
                                             exclusiveGroup: _mapTypeButtonsExclusiveGroup
-
                                             onClicked: {
                                                 editorMap.mapType = text
                                                 checked = true
@@ -724,11 +718,9 @@ QGCView {
 
     Component {
         id: syncLoadFromVehicleOverwrite
-
         QGCViewMessage {
             id:         syncLoadFromVehicleCheck
             message:   qsTr("You have unsaved/unsent mission changes. Loading the mission from the Vehicle will lose these changes. Are you sure you want to load the mission from the Vehicle?")
-
             function accept() {
                 hideDialog()
                 loadFromVehicle()
@@ -738,11 +730,9 @@ QGCView {
 
     Component {
         id: syncLoadFromFileOverwrite
-
         QGCViewMessage {
             id:         syncLoadFromVehicleCheck
             message:   qsTr("You have unsaved/unsent mission changes. Loading a mission from a file will lose these changes. Are you sure you want to load a mission from a file?")
-
             function accept() {
                 hideDialog()
                 loadFromFile()
@@ -752,10 +742,8 @@ QGCView {
 
     Component {
         id: removeAllPromptDialog
-
         QGCViewMessage {
             message: qsTr("Are you sure you want to delete all mission items?")
-
             function accept() {
                 itemDragger.clearItem()
                 controller.removeAllMissionItems()
@@ -766,38 +754,36 @@ QGCView {
 
     Component {
         id: syncDropDownComponent
-
         Column {
             id:         columnHolder
             spacing:    _margin
-
             QGCLabel {
-                width:      sendSaveRow.width
+                width:      sendSaveGrid.width
                 wrapMode:   Text.WordWrap
                 text:       syncNeeded && !controller.autoSync ?
                                 qsTr("You have unsaved changed to you mission. You should send to your vehicle, or save to a file:") :
                                 qsTr("Sync:")
             }
-
-            Row {
-                id:         sendSaveRow
-                visible:    true //autoSyncCheckBox.enabled && autoSyncCheckBox.checked
-                spacing:    ScreenTools.defaultFontPixelWidth
-
+            GridLayout {
+                id:                 sendSaveGrid
+                columns:            2
+                anchors.margins:    _margin
+                rowSpacing:         _margin
+                columnSpacing:      ScreenTools.defaultFontPixelWidth
+                visible:            true //autoSyncCheckBox.enabled && autoSyncCheckBox.checked
                 QGCButton {
-                    text:       qsTr("Send to vehicle")
-                    enabled:    _activeVehicle && !controller.syncInProgress
-
+                    text:               qsTr("Send To Vehicle")
+                    Layout.fillWidth:   true
+                    enabled:            _activeVehicle && !controller.syncInProgress
                     onClicked: {
                         syncButton.hideDropDown()
                         controller.sendMissionItems()
                     }
                 }
-
                 QGCButton {
-                    text:       qsTr("Load from vehicle")
-                    enabled:    _activeVehicle && !controller.syncInProgress
-
+                    text:               qsTr("Load From Vehicle")
+                    Layout.fillWidth:   true
+                    enabled:            _activeVehicle && !controller.syncInProgress
                     onClicked: {
                         syncButton.hideDropDown()
                         if (syncNeeded) {
@@ -807,25 +793,19 @@ QGCView {
                         }
                     }
                 }
-            }
-
-            Row {
-                spacing: ScreenTools.defaultFontPixelWidth
-
                 QGCButton {
-                    text:       qsTr("Save to file...")
-                    enabled:    !controller.syncInProgress
-
+                    text:               qsTr("Save To File...")
+                    Layout.fillWidth:   true
+                    enabled:            !controller.syncInProgress
                     onClicked: {
                         syncButton.hideDropDown()
                         saveToFile()
                     }
                 }
-
                 QGCButton {
-                    text:       qsTr("Load from file...")
-                    enabled:    !controller.syncInProgress
-
+                    text:               qsTr("Load From File...")
+                    Layout.fillWidth:   true
+                    enabled:            !controller.syncInProgress
                     onClicked: {
                         syncButton.hideDropDown()
                         if (syncNeeded) {
@@ -835,15 +815,16 @@ QGCView {
                         }
                     }
                 }
-            }
-
-            QGCButton {
-                text:       qsTr("Remove all")
-                onClicked:  {
-                    syncButton.hideDropDown()
-                    _root.showDialog(removeAllPromptDialog, qsTr("Delete all"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
+                QGCButton {
+                    text:               qsTr("Remove All")
+                    Layout.fillWidth:   true
+                    onClicked:  {
+                        syncButton.hideDropDown()
+                        _root.showDialog(removeAllPromptDialog, qsTr("Delete all"), _root.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
+                    }
                 }
             }
+
 
 /*
         FIXME: autoSync is temporarily disconnected since it's still buggy

--- a/src/QmlControls/DropButton.qml
+++ b/src/QmlControls/DropButton.qml
@@ -11,7 +11,7 @@ Item {
     signal          clicked()
     property alias  buttonImage:        roundButton.buttonImage
     property alias  rotateImage:        roundButton.rotateImage
-    property real   radius:             ScreenTools.defaultFontPixelHeight * 1.25
+    property real   radius:             ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.75 : ScreenTools.defaultFontPixelHeight * 1.25
     property int    dropDirection:      dropDown
     property alias  dropDownComponent:  dropDownLoader.sourceComponent
     property real   viewportMargins:    0
@@ -26,15 +26,15 @@ Item {
     readonly property int dropUp:       3
     readonly property int dropDown:     4
 
-    readonly property real _arrowBaseWidth:     (radius * 2) / 2    // Width of long side of arrow
-    readonly property real _arrowPointHeight:   (radius * 2) / 3    // Height is long side to point
-    readonly property real _dropCornerRadius:   ScreenTools.defaultFontPixelWidth / 2
+    readonly property real _arrowBaseWidth:     radius             // Width of long side of arrow
+    readonly property real _arrowPointHeight:   radius * 0.666     // Height is long side to point
+    readonly property real _dropCornerRadius:   ScreenTools.defaultFontPixelWidth * 0.5
     readonly property real _dropCornerRadiusX2: _dropCornerRadius * 2
     readonly property real _dropMargin:         _dropCornerRadius
     readonly property real _dropMarginX2:       _dropMargin * 2
 
     property real   _viewportMaxLeft:   -x + viewportMargins
-    property real   _viewportMaxRight:  parent.width - (viewportMargins * 2) - x
+    property real   _viewportMaxRight:  parent.width  - (viewportMargins * 2) - x
     property real   _viewportMaxTop:    -y + viewportMargins
     property real   _viewportMaxBottom: parent.height - (viewportMargins * 2) - y
 

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -20,8 +20,9 @@ Button {
 
     property bool __forceHoverOff: false
 
-    property int __lastGlobalMouseX: 0
-    property int __lastGlobalMouseY: 0
+    property int __lastGlobalMouseX:    0
+    property int __lastGlobalMouseY:    0
+    property int __padding:             Math.round(ScreenTools.defaultFontPixelHeight * 0.5)
 
     Connections {
         target: __behavior
@@ -41,7 +42,6 @@ Button {
         id:         hoverTimer
         interval:   250
         repeat:     true
-
         onTriggered: {
             __forceHoverOff = (__lastGlobalMouseX !== ScreenTools.mouseX() || __lastGlobalMouseY !== ScreenTools.mouseY());
         }
@@ -50,17 +50,17 @@ Button {
     style: ButtonStyle {
             /*! The padding between the background and the label components. */
             padding {
-                top:    4
-                left:   4
-                right:  control.menu !== null ? Math.round(ScreenTools.defaultFontPixelHeight * 0.5) : 4
-                bottom: 4
+                top:    __padding
+                left:   __padding
+                right:  control.menu !== null ? Math.round(ScreenTools.defaultFontPixelHeight) : __padding
+                bottom: __padding
             }
 
             /*! This defines the background of the button. */
             background: Item {
                 property bool down: control.pressed || (control.checkable && control.checked)
                 implicitWidth:      Math.round(ScreenTools.defaultFontPixelWidth * 4.5)
-                implicitHeight:     Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 1.2))
+                implicitHeight:     ScreenTools.isMobile ? Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 2)) : Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 1.2))
 
                 Rectangle {
                     anchors.fill:   parent
@@ -72,26 +72,26 @@ Button {
                 }
 
                 Image {
-                    id: imageItem
-                    visible: control.menu !== null
-                    source: "/qmlimages/arrow-down.png"
+                    id:                     imageItem
+                    visible:                control.menu !== null
+                    source:                 "/qmlimages/arrow-down.png"
                     anchors.verticalCenter: parent.verticalCenter
-                    anchors.right: parent.right
-                    anchors.rightMargin: padding.right
-                    opacity: control.enabled ? 0.6 : 0.5
+                    anchors.right:          parent.right
+                    anchors.rightMargin:    __padding
+                    opacity:                control.enabled ? 0.6 : 0.5
                 }
             }
 
             /*! This defines the label of the button.  */
             label: Item {
-                implicitWidth:  row.implicitWidth
-                implicitHeight: row.implicitHeight
-                baselineOffset: row.y + text.y + text.baselineOffset
+                implicitWidth:          control.menu === null ? row.implicitWidth : row.implicitWidth + ScreenTools.defaultFontPixelWidth
+                implicitHeight:         row.implicitHeight
+                baselineOffset:         row.y + text.y + text.baselineOffset
 
                 Row {
-                    id: row
-                    anchors.centerIn: parent
-                    spacing: 2
+                    id:                 row
+                    anchors.centerIn:   parent
+                    spacing:            ScreenTools.defaultFontPixelWidth * 0.25
 
                     Image {
                         source: control.iconSource

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -18,8 +18,8 @@ ComboBox {
                     control._qgcPal.buttonText
 
         background: Item {
-            implicitWidth:  Math.round(ScreenTools.defaultFontPixelWidth * 4.5)
-            implicitHeight: Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 1.2))
+            implicitWidth:      Math.round(ScreenTools.defaultFontPixelWidth * 4.5)
+            implicitHeight:     ScreenTools.isMobile ? Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 2)) : Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 1.2))
 
             Rectangle {
                 anchors.fill:   parent

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -10,29 +10,29 @@ RadioButton {
 
     style: RadioButtonStyle {
         label: Item {
-            implicitWidth: text.implicitWidth + 2
-            implicitHeight: text.implicitHeight
-            baselineOffset: text.y + text.baselineOffset
+            implicitWidth:          text.implicitWidth + ScreenTools.defaultFontPixelWidth * 0.25
+            implicitHeight:         text.implicitHeight
+            baselineOffset:         text.y + text.baselineOffset
             Rectangle {
-                anchors.fill: text
-                anchors.margins: -1
+                anchors.fill:       text
+                anchors.margins:    -1
                 anchors.leftMargin: -3
-                anchors.rightMargin: -3
-                visible: control.activeFocus
-                height: 6
-                radius: 3
-                color: "#224f9fef"
-                border.color: "#47b"
-                opacity: 0.6
+                anchors.rightMargin:-3
+                visible:            control.activeFocus
+                height:             ScreenTools.defaultFontPixelWidth * 0.25
+                radius:             height * 0.5
+                color:              "#224f9fef"
+                border.color:       "#47b"
+                opacity:            0.6
             }
             Text {
-                id:             text
-                text:           control.text
-                font.pointSize: ScreenTools.defaultFontPointSize
-                font.family:    ScreenTools.normalFontFamily
-                antialiasing:   true
-                color:          control.__qgcPal.text
-                anchors.centerIn: parent
+                id:                 text
+                text:               control.text
+                font.pointSize:     ScreenTools.defaultFontPointSize
+                font.family:        ScreenTools.normalFontFamily
+                antialiasing:       true
+                color:              control.__qgcPal.text
+                anchors.centerIn:   parent
             }
         }
     }

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -20,12 +20,12 @@ TextField {
     property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
 
     textColor:          __qgcPal.textFieldText
-    height:             Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 1.2))
+    height:             ScreenTools.isMobile ? Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 2)) : Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 1.2))
 
     Label {
         id:             unitsLabelWidthGenerator
         text:           unitsLabel
-        width:          contentWidth + ((parent.__contentHeight/3)*2)
+        width:          contentWidth + parent.__contentHeight * 0.666
         visible:        false
         antialiasing:   true
         font.family:    ScreenTools.normalFontFamily
@@ -37,15 +37,15 @@ TextField {
             id: backgroundItem
 
             Rectangle {
-                anchors.fill: parent
-                anchors.bottomMargin: -1
-                color: "#44ffffff"
+                anchors.fill:           parent
+                anchors.bottomMargin:   -1
+                color:                  "#44ffffff"
             }
 
             Rectangle {
-                anchors.fill: parent
-                border.color: control.activeFocus ? "#47b" : "#999"
-                color: __qgcPal.textField
+                anchors.fill:           parent
+                border.color:           control.activeFocus ? "#47b" : "#999"
+                color:                  __qgcPal.textField
             }
 
             Text {
@@ -70,7 +70,7 @@ TextField {
             }
         }
 
-        padding.right: control.showUnits ? unitsLabelWidthGenerator.width : control.__contentHeight/3
+        padding.right: control.showUnits ? unitsLabelWidthGenerator.width : control.__contentHeight * 0.333
     }
 
     onActiveFocusChanged: {

--- a/src/QmlControls/RoundButton.qml
+++ b/src/QmlControls/RoundButton.qml
@@ -10,7 +10,7 @@ Item {
 
     signal          clicked()
     property alias  buttonImage:    button.source
-    property real   radius:         ScreenTools.defaultFontPixelHeight * 1.25
+    property real   radius:         ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.75 : ScreenTools.defaultFontPixelHeight * 1.25
     property bool   rotateImage:    false
     property bool   lightBorders:   true
 
@@ -54,12 +54,12 @@ Item {
             color:              checked ? qgcPal.buttonHighlightText : qgcPal.buttonText
 
             RotationAnimation on rotation {
-                id: imageRotation
-                loops: Animation.Infinite
-                from: 0
-                to: 360
-                duration: 500
-                running: false
+                id:             imageRotation
+                loops:          Animation.Infinite
+                from:           0
+                to:             360
+                duration:       500
+                running:        false
             }
 
             MouseArea {

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -391,7 +391,7 @@ Item {
             anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.5
             anchors.top:        parent.top
             anchors.right:      parent.right
-            width:              ScreenTools.isTinyScreen ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
+            width:              ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
             height:             width
             sourceSize.height:  width
             source:             "/res/XDelete.svg"
@@ -399,7 +399,8 @@ Item {
             mipmap:             true
             smooth:             true
             MouseArea {
-                anchors.fill:   parent
+                anchors.fill:       parent
+                anchors.margins:    ScreenTools.isMobile ? -ScreenTools.defaultFontPixelHeight : 0
                 onClicked: {
                     messageArea.close()
                 }
@@ -410,7 +411,7 @@ Item {
             anchors.bottom:     parent.bottom
             anchors.right:      parent.right
             anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.5
-            height:             ScreenTools.isTinyScreen ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
+            height:             ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
             width:              height
             sourceSize.height:   height
             source:             "/res/TrashDelete.svg"
@@ -499,14 +500,15 @@ Item {
             anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.5
             anchors.top:        parent.top
             anchors.right:      parent.right
-            width:              ScreenTools.isTinyScreen ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
+            width:              ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
             height:             width
             sourceSize.height:  width
             source:             "/res/XDelete.svg"
             fillMode:           Image.PreserveAspectFit
             color:              "black"
             MouseArea {
-                anchors.fill:   parent
+                anchors.fill:       parent
+                anchors.margins:    ScreenTools.isMobile ? -ScreenTools.defaultFontPixelHeight : 0
                 onClicked: {
                     criticalMmessageArea.close()
                 }
@@ -518,14 +520,13 @@ Item {
             anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.5
             anchors.bottom:     parent.bottom
             anchors.right:      parent.right
-            width:              ScreenTools.isTinyScreen ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
+            width:              ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
             height:             width
             sourceSize.height:  width
             source:             "/res/ArrowDown.svg"
             fillMode:           Image.PreserveAspectFit
             visible:            criticalMessageText.lineCount > 5
             color:              "black"
-
             MouseArea {
                 anchors.fill:   parent
                 onClicked: {


### PR DESCRIPTION
In response to #3349 

Made quite a few UI adjustments:

* Larger button sizes for all mobile devices. It used to be only for *Tiny Screens*
* Made touch sensitive area for the "X" to close both the Critical Message Area and the Message Window larger for mobile devices. Normally, only the "X" is touch sensitive, which works fine on desktop platforms with a mouse but quite tricky to hit it using touch.
* Made the DropDown buttons (and the RoundButtons) slightly larger on all mobile devices.
* Fixed the Down Arrow icon on buttons with menus (#3352). The padding and overall width were being computed incorrectly. In addition, several dimensions were hardcoded with small numbers, which become irrelevant on high density devices.
* Made all QGCButtons, QGCRadioButton and QGCTextField slightly larger on all mobile devices. It used to be larger only on *Tiny Screens*

More cosmetics:
* Capitalized several buttons in both Plan View and Fly View to make them all consistent. Some where first word only, others, such as the map types, which come from the map engine, were fully capitalized.
* Adjusted the width of the buttons within the DropDown buttons so they all match instead of each having a different size based on its content. It makes for a cleaner look. Go ahead, just call me OCD :P


