### PR TITLE
Show firmware version in Vehicle summary

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
@@ -32,5 +32,10 @@ FactPanel {
                      : /* Fact.value == 10 */  "New Y6");
 
         }
+
+        VehicleSummaryRow {
+            labelText: qsTr("Firmware Version:")
+            valueText: activeVehicle.firmwareMajorVersion == -1 ? qsTr("Unknown") : activeVehicle.firmwareMajorVersion + "." + activeVehicle.firmwareMinorVersion + "." + activeVehicle.firmwarePatchVersion + activeVehicle.firmwareVersionTypeString
+        }
     }
 }

--- a/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
@@ -34,5 +34,10 @@ FactPanel {
             labelText: qsTr("Vehicle:")
             valueText: autoStartSet ? controller.currentVehicleName : qsTr("Setup required")
         }
+
+        VehicleSummaryRow {
+            labelText: qsTr("Firmware Version:")
+            valueText: activeVehicle.firmwareMajorVersion == -1 ? qsTr("Unknown") : activeVehicle.firmwareMajorVersion + "." + activeVehicle.firmwareMinorVersion + "." + activeVehicle.firmwarePatchVersion + activeVehicle.firmwareVersionTypeString
+        }
     }
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -470,7 +470,7 @@ void Vehicle::_handleAutopilotVersion(mavlink_message_t& message)
         minorVersion = (autopilotVersion.flight_sw_version >> (8*2)) & 0xFF;
         patchVersion = (autopilotVersion.flight_sw_version >> (8*1)) & 0xFF;
         versionType = (FIRMWARE_VERSION_TYPE)((autopilotVersion.flight_sw_version >> (8*0)) & 0xFF);
-        setFirmwareVersion(majorVersion, minorVersion, patchVersion);
+        setFirmwareVersion(majorVersion, minorVersion, patchVersion, versionType);
     }
 }
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -126,6 +126,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _firmwareMajorVersion(versionNotSetValue)
     , _firmwareMinorVersion(versionNotSetValue)
     , _firmwarePatchVersion(versionNotSetValue)
+    , _firmwareVersionType(FIRMWARE_VERSION_TYPE_OFFICIAL)
     , _rollFact             (0, _rollFactName,              FactMetaData::valueTypeDouble)
     , _pitchFact            (0, _pitchFactName,             FactMetaData::valueTypeDouble)
     , _headingFact          (0, _headingFactName,           FactMetaData::valueTypeDouble)
@@ -207,6 +208,9 @@ Vehicle::Vehicle(LinkInterface*             link,
     _parameterLoader = new ParameterLoader(this);
     connect(_parameterLoader, &ParameterLoader::parametersReady, _autopilotPlugin, &AutoPilotPlugin::_parametersReadyPreChecks);
     connect(_parameterLoader, &ParameterLoader::parameterListProgress, _autopilotPlugin, &AutoPilotPlugin::parameterListProgress);
+
+    // Ask the vehicle for firmware version info
+    doCommandLong(MAV_COMP_ID_ALL, MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES, 1 /* request firmware version */);
 
     _firmwarePlugin->initializeVehicle(this);
 
@@ -437,6 +441,9 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_COMMAND_ACK:
         _handleCommandAck(message);
         break;
+    case MAVLINK_MSG_ID_AUTOPILOT_VERSION:
+        _handleAutopilotVersion(message);
+        break;
 
     // Following are ArduPilot dialect messages
 
@@ -448,6 +455,23 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     emit mavlinkMessageReceived(message);
 
     _uas->receiveMessage(message);
+}
+
+void Vehicle::_handleAutopilotVersion(mavlink_message_t& message)
+{
+    mavlink_autopilot_version_t autopilotVersion;
+    mavlink_msg_autopilot_version_decode(&message, &autopilotVersion);
+
+    if (autopilotVersion.flight_sw_version != 0) {
+        int majorVersion, minorVersion, patchVersion;
+        FIRMWARE_VERSION_TYPE versionType;
+
+        majorVersion = (autopilotVersion.flight_sw_version >> (8*3)) & 0xFF;
+        minorVersion = (autopilotVersion.flight_sw_version >> (8*2)) & 0xFF;
+        patchVersion = (autopilotVersion.flight_sw_version >> (8*1)) & 0xFF;
+        versionType = (FIRMWARE_VERSION_TYPE)((autopilotVersion.flight_sw_version >> (8*0)) & 0xFF);
+        setFirmwareVersion(majorVersion, minorVersion, patchVersion);
+    }
 }
 
 void Vehicle::_handleCommandAck(mavlink_message_t& message)
@@ -1638,12 +1662,35 @@ void Vehicle::_prearmErrorTimeout(void)
     setPrearmError(QString());
 }
 
-void Vehicle::setFirmwareVersion(int majorVersion, int minorVersion, int patchVersion)
+void Vehicle::setFirmwareVersion(int majorVersion, int minorVersion, int patchVersion, FIRMWARE_VERSION_TYPE versionType)
 {
     _firmwareMajorVersion = majorVersion;
     _firmwareMinorVersion = minorVersion;
     _firmwarePatchVersion = patchVersion;
+    _firmwareVersionType = versionType;
+    emit firmwareMajorVersionChanged(_firmwareMajorVersion);
+    emit firmwareMinorVersionChanged(_firmwareMinorVersion);
+    emit firmwarePatchVersionChanged(_firmwarePatchVersion);
+    emit firmwareVersionTypeChanged(_firmwareVersionType);
 }
+
+QString Vehicle::firmwareVersionTypeString(void) const
+{
+    switch (_firmwareVersionType) {
+    case FIRMWARE_VERSION_TYPE_DEV:
+        return QStringLiteral("dev");
+    case FIRMWARE_VERSION_TYPE_ALPHA:
+        return QStringLiteral("alpha");
+    case FIRMWARE_VERSION_TYPE_BETA:
+        return QStringLiteral("beta");
+    case FIRMWARE_VERSION_TYPE_RC:
+        return QStringLiteral("rc");
+    case FIRMWARE_VERSION_TYPE_OFFICIAL:
+    default:
+        return QStringLiteral("");
+    }
+}
+
 
 void Vehicle::rebootVehicle()
 {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -316,6 +316,12 @@ public:
     Q_PROPERTY(FactGroup* wind      READ windFactGroup      CONSTANT)
     Q_PROPERTY(FactGroup* vibration READ vibrationFactGroup CONSTANT)
 
+    Q_PROPERTY(int firmwareMajorVersion READ firmwareMajorVersion NOTIFY firmwareMajorVersionChanged)
+    Q_PROPERTY(int firmwareMinorVersion READ firmwareMinorVersion NOTIFY firmwareMinorVersionChanged)
+    Q_PROPERTY(int firmwarePatchVersion READ firmwarePatchVersion NOTIFY firmwarePatchVersionChanged)
+    Q_PROPERTY(int firmwareVersionType READ firmwareVersionType NOTIFY firmwareVersionTypeChanged)
+    Q_PROPERTY(QString firmwareVersionTypeString READ firmwareVersionTypeString NOTIFY firmwareVersionTypeChanged)
+
     /// Resets link status counters
     Q_INVOKABLE void resetCounters  ();
 
@@ -530,7 +536,9 @@ public:
     int firmwareMajorVersion(void) const { return _firmwareMajorVersion; }
     int firmwareMinorVersion(void) const { return _firmwareMinorVersion; }
     int firmwarePatchVersion(void) const { return _firmwarePatchVersion; }
-    void setFirmwareVersion(int majorVersion, int minorVersion, int patchVersion);
+    int firmwareVersionType(void) const { return _firmwareVersionType; }
+    QString firmwareVersionTypeString(void) const;
+    void setFirmwareVersion(int majorVersion, int minorVersion, int patchVersion, FIRMWARE_VERSION_TYPE versionType = FIRMWARE_VERSION_TYPE_OFFICIAL);
     static const int versionNotSetValue = -1;
 
 public slots:
@@ -578,6 +586,11 @@ signals:
     void currentStateChanged    ();
     void flowImageIndexChanged  ();
     void rcRSSIChanged          (int rcRSSI);
+
+    void firmwareMajorVersionChanged(int major);
+    void firmwareMinorVersionChanged(int minor);
+    void firmwarePatchVersionChanged(int patch);
+    void firmwareVersionTypeChanged(int type);
 
     /// New RC channel values
     ///     @param channelCount Number of available channels, cMaxRcChannels max
@@ -637,6 +650,7 @@ private:
     void _handleVibration(mavlink_message_t& message);
     void _handleExtendedSysState(mavlink_message_t& message);
     void _handleCommandAck(mavlink_message_t& message);
+    void _handleAutopilotVersion(mavlink_message_t& message);
     void _missionManagerError(int errorCode, const QString& errorMsg);
     void _mapTrajectoryStart(void);
     void _mapTrajectoryStop(void);
@@ -747,6 +761,7 @@ private:
     int _firmwareMajorVersion;
     int _firmwareMinorVersion;
     int _firmwarePatchVersion;
+    FIRMWARE_VERSION_TYPE _firmwareVersionType;
 
     static const int    _lowBatteryAnnounceRepeatMSecs; // Amount of time in between each low battery announcement
     QElapsedTimer       _lowBatteryAnnounceTimer;

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -727,7 +727,6 @@ void FirmwareUpgradeController::_loadAPMVersions(QGCSerialPortInfo::BoardType_t 
     }
 }
 
-
 void FirmwareUpgradeController::_apmVersionDownloadFinished(QString remoteFile, QString localFile)
 {
     qCDebug(FirmwareUpgradeLog) << "Download complete" << remoteFile << localFile;

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -803,6 +803,10 @@ void MockLink::_handleCommandLong(const mavlink_message_t& msg)
     case MAV_CMD_PREFLIGHT_STORAGE:
         commandResult = MAV_RESULT_ACCEPTED;
         break;
+    case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES:
+        commandResult = MAV_RESULT_ACCEPTED;
+        _respondWithAutopilotVersion();
+        break;
     }
 
     mavlink_message_t commandAck;
@@ -812,6 +816,31 @@ void MockLink::_handleCommandLong(const mavlink_message_t& msg)
                                  request.command,
                                  commandResult);
     respondWithMavlinkMessage(commandAck);
+}
+
+void MockLink::_respondWithAutopilotVersion(void)
+{
+    mavlink_message_t msg;
+
+    uint8_t customVersion[8];
+    memset(customVersion, 0, sizeof(customVersion));
+
+    // Only flight_sw_version is supported a this point
+    mavlink_msg_autopilot_version_pack(_vehicleSystemId,
+                                       _vehicleComponentId,
+                                       &msg,
+                                       0,                                           // capabilities,
+                                       (1 << (8*3)) | FIRMWARE_VERSION_TYPE_DEV,    // flight_sw_version,
+                                       0,                                           // middleware_sw_version,
+                                       0,                                           // os_sw_version,
+                                       0,                                           // board_version,
+                                       (uint8_t *)&customVersion,                   // flight_custom_version,
+                                       (uint8_t *)&customVersion,                   // middleware_custom_version,
+                                       (uint8_t *)&customVersion,                   // os_custom_version,
+                                       0,                                           // vendor_id,
+                                       0,                                           // product_id,
+                                       0);                                          // uid
+    respondWithMavlinkMessage(msg);
 }
 
 void MockLink::setMissionItemFailureMode(MockLinkMissionItemHandler::FailureMode_t failureMode)

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -185,6 +185,7 @@ private:
     void _sendGpsRawInt(void);
     void _sendVibration(void);
     void _sendStatusTextMessages(void);
+    void _respondWithAutopilotVersion(void);
 
     static MockLink* _startMockLink(MockConfiguration* mockConfig);
 


### PR DESCRIPTION
@LorenzMeier This pull assumes PX4 stack will begin returning AUTOPILOT_VERSION.flight_sw_version using the following semantics. This mechanism is already supported by ArduPilot. PX4 stack is currently returning 0 in AUTOPILOT_VERSION.flight_sw_version.

```
void Vehicle::_handleAutopilotVersion(mavlink_message_t& message)
{
    mavlink_autopilot_version_t autopilotVersion;
    mavlink_msg_autopilot_version_decode(&message, &autopilotVersion);

    if (autopilotVersion.flight_sw_version != 0) {
        int majorVersion, minorVersion, patchVersion;
        FIRMWARE_VERSION_TYPE versionType;

        majorVersion = (autopilotVersion.flight_sw_version >> (8*3)) & 0xFF;
        minorVersion = (autopilotVersion.flight_sw_version >> (8*2)) & 0xFF;
        patchVersion = (autopilotVersion.flight_sw_version >> (8*1)) & 0xFF;
        versionType = (FIRMWARE_VERSION_TYPE)((autopilotVersion.flight_sw_version >> (8*0)) & 0xFF);
        setFirmwareVersion(majorVersion, minorVersion, patchVersion, versionType);
    }
}
```

Example ArduPilot run:
![screen shot 2016-05-23 at 8 27 26 pm](https://cloud.githubusercontent.com/assets/5876851/15491392/db94ee82-2124-11e6-9c9c-63262e75d698.png)