### PR TITLE
Fix logic to handle decimal places not specified in meta data

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -614,8 +614,8 @@ int FactMetaData::decimalPlaces(void) const
     if (incrementDecimalPlaces != unknownDecimalPlaces && _decimalPlaces == unknownDecimalPlaces) {
         actualDecimalPlaces = incrementDecimalPlaces;
     } else {
-
-        int settingsDecimalPlaces = _decimalPlaces;
+        // Adjust decimal places for cooked translation
+        int settingsDecimalPlaces = _decimalPlaces == unknownDecimalPlaces ? defaultDecimalPlaces : _decimalPlaces;
         double ctest = _rawTranslator(1.0).toDouble();
 
         settingsDecimalPlaces += -log10(ctest);


### PR DESCRIPTION
Decimal places adjustment for cooked values wasn't handling the case wher decimal places is not specified in meta data.