### PR TITLE
PX4 misc

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
@@ -107,7 +107,7 @@ QString FlightModesComponent::prerequisiteSetup(void) const
             return plugin->airframeComponent()->name();
         } else if (!plugin->radioComponent()->setupComplete()) {
             return plugin->radioComponent()->name();
-        } else if (!plugin->sensorsComponent()->setupComplete()) {
+        } else if (!plugin->vehicle()->hilMode() && !plugin->sensorsComponent()->setupComplete()) {
             return plugin->sensorsComponent()->name();
         }
     }

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -73,9 +73,11 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
             _radioComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
 
-            _sensorsComponent = new SensorsComponent(_vehicle, this);
-            _sensorsComponent->setupTriggerSignals();
-            _components.append(QVariant::fromValue((VehicleComponent*)_sensorsComponent));
+            if (!_vehicle->hilMode()) {
+                _sensorsComponent = new SensorsComponent(_vehicle, this);
+                _sensorsComponent->setupTriggerSignals();
+                _components.append(QVariant::fromValue((VehicleComponent*)_sensorsComponent));
+            }
 
             _flightModesComponent = new FlightModesComponent(_vehicle, this);
             _flightModesComponent->setupTriggerSignals();

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -490,7 +490,7 @@ QGCView {
                             spacing:                    _margins * 0.5
                             anchors.verticalCenter:     parent.verticalCenter
                             Row {
-                                visible:                _landSpeedMC !== -1
+                                visible:                !controller.vehicle.fixedWing && (_landSpeedMC !== -1)
                                 QGCLabel {
                                     anchors.baseline:   landVelField.baseline
                                     width:              _middleRowWidth

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -167,8 +167,9 @@ QList<VehicleComponent*> APMFirmwarePlugin::componentsForVehicle(AutoPilotPlugin
     return QList<VehicleComponent*>();
 }
 
-QStringList APMFirmwarePlugin::flightModes(void)
+QStringList APMFirmwarePlugin::flightModes(Vehicle* vehicle)
 {
+    Q_UNUSED(vehicle)
     QStringList flightModesList;
     foreach (const APMCustomMode& customMode, _supportedModes) {
         if (customMode.canBeSet()) {

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -87,7 +87,7 @@ public:
     QList<MAV_CMD> supportedMissionCommands(void) final;
 
     bool        isCapable(FirmwareCapabilities capabilities);
-    QStringList flightModes(void) final;
+    QStringList flightModes(Vehicle* vehicle) final;
     QString     flightMode(uint8_t base_mode, uint32_t custom_mode) const final;
     bool        setFlightMode(const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) final;
     bool        isGuidedMode(const Vehicle* vehicle) const final;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -84,7 +84,10 @@ public:
     virtual QList<VehicleComponent*> componentsForVehicle(AutoPilotPlugin* vehicle);
     
     /// Returns the list of available flight modes
-    virtual QStringList flightModes(void) { return QStringList(); }
+    virtual QStringList flightModes(Vehicle* vehicle) {
+		Q_UNUSED(vehicle);
+		return QStringList();
+	}
     
     /// Returns the name for this flight mode. Flight mode names must be human readable as well as audio speakable.
     ///     @param base_mode Base mode from mavlink HEARTBEAT message

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -42,7 +42,7 @@ public:
     QList<MAV_CMD> supportedMissionCommands(void) final;
 
     bool        isCapable                       (FirmwareCapabilities capabilities) final;
-    QStringList flightModes                     (void) final;
+    QStringList flightModes                     (Vehicle* vehicle) final;
     QString     flightMode                      (uint8_t base_mode, uint32_t custom_mode) const final;
     bool        setFlightMode                   (const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) final;
     void        setGuidedMode(Vehicle* vehicle, bool guidedMode) final;

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -181,7 +181,7 @@ QGCView {
                             readonly property int componentId: parseInt(modelData)
                             spacing: Math.ceil(ScreenTools.defaultFontPixelHeight * 0.25)
                             QGCLabel {
-                                text: qsTr("Component #: %1)").arg(componentId.toString())
+                                text: qsTr("Component #: %1").arg(componentId.toString())
                                 font.family: ScreenTools.demiboldFontFamily
                                 anchors.horizontalCenter: parent.horizontalCenter
                             }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1193,7 +1193,7 @@ bool Vehicle::flightModeSetAvailable(void)
 
 QStringList Vehicle::flightModes(void)
 {
-    return _firmwarePlugin->flightModes();
+    return _firmwarePlugin->flightModes(this);
 }
 
 QString Vehicle::flightMode(void) const


### PR DESCRIPTION
- safety setup hide land speed setting (MC only)
- only show appropriate modes for FW/MC (is there a better way to do this?)
- don't require calibrated sensors in HIL mode