### PR TITLE
Settings/Console log filter support

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -268,72 +268,8 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 
     ParseCmdLineOptions(argc, argv, rgCmdLineOptions, sizeof(rgCmdLineOptions)/sizeof(rgCmdLineOptions[0]), false);
 
-#ifdef __mobile__
-    QLoggingCategory::setFilterRules(QStringLiteral("*Log.debug=false"));
-#else
-    QString filterRules;
-
-    // Turn off bogus ssl warning
-    filterRules += "qt.network.ssl.warning=false\n";
-
-    if (logging) {
-        QStringList logList = loggingOptions.split(",");
-
-        if (logList[0] == "full") {
-            filterRules += "*Log.debug=true\n";
-            for(int i=1; i<logList.count(); i++) {
-                filterRules += logList[i];
-                filterRules += ".debug=false\n";
-            }
-        } else {
-            foreach(const QString &rule, logList) {
-                filterRules += rule;
-                filterRules += ".debug=true\n";
-            }
-        }
-    } else {
-        // First thing we want to do is set up the qtlogging.ini file. If it doesn't already exist we copy
-        // it to the correct location. This way default debug builds will have logging turned off.
-
-        static const char* qtProjectDir = "QtProject";
-        static const char* qtLoggingFile = "qtlogging.ini";
-        bool loggingDirectoryOk = false;
-
-        QDir iniFileLocation(QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation));
-        if (!iniFileLocation.cd(qtProjectDir)) {
-            if (!iniFileLocation.mkdir(qtProjectDir)) {
-                qDebug() << "Unable to create qtlogging.ini directory" << iniFileLocation.filePath(qtProjectDir);
-            } else {
-                if (!iniFileLocation.cd(qtProjectDir)) {
-                    qDebug() << "Unable to access qtlogging.ini directory" << iniFileLocation.filePath(qtProjectDir);;
-                }
-                loggingDirectoryOk = true;
-            }
-        } else {
-            loggingDirectoryOk = true;
-        }
-
-        if (loggingDirectoryOk) {
-            qDebug () << "Logging ini file directory" << iniFileLocation.absolutePath();
-            if (!iniFileLocation.exists(qtLoggingFile)) {
-                QFile loggingFile(iniFileLocation.filePath(qtLoggingFile));
-                if (loggingFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-                    QTextStream out(&loggingFile);
-                    out << "[Rules]\n";
-                    out << "*Log.debug=false\n";
-                    foreach(const QString &category, QGCLoggingCategoryRegister::instance()->registeredCategories()) {
-                        out << category << ".debug=false\n";
-                    }
-                } else {
-                    qDebug() << "Unable to create logging file" << QString(qtLoggingFile) << "in" << iniFileLocation;
-                }
-            }
-        }
-    }
-
-    qDebug() << "Filter rules" << filterRules;
-    QLoggingCategory::setFilterRules(filterRules);
-#endif
+    // Set up our logging filters
+    QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(loggingOptions);
 
     // Set up timer for delayed missing fact display
     _missingParamsDelayedDisplayTimer.setSingleShot(true);

--- a/src/QGCLoggingCategory.cc
+++ b/src/QGCLoggingCategory.cc
@@ -26,6 +26,8 @@
 
 #include "QGCLoggingCategory.h"
 
+#include <QSettings>
+
 // Add Global logging categories (not class specific) here using QGC_LOGGING_CATEGORY
 QGC_LOGGING_CATEGORY(FirmwareUpgradeLog,        "FirmwareUpgradeLog")
 QGC_LOGGING_CATEGORY(FirmwareUpgradeVerboseLog, "FirmwareUpgradeVerboseLog")
@@ -34,6 +36,7 @@ QGC_LOGGING_CATEGORY(MissionItemLog,            "MissionItemLog")
 QGC_LOGGING_CATEGORY(ParameterLoaderLog,        "ParameterLoaderLog")
 
 QGCLoggingCategoryRegister* _instance = NULL;
+const char* QGCLoggingCategoryRegister::_filterRulesSettingsGroup = "LoggingFilters";
 
 QGCLoggingCategoryRegister* QGCLoggingCategoryRegister::instance(void)
 {
@@ -43,4 +46,67 @@ QGCLoggingCategoryRegister* QGCLoggingCategoryRegister::instance(void)
     }
     
     return _instance;
+}
+
+QStringList QGCLoggingCategoryRegister::registeredCategories(void)
+{
+    _registeredCategories.sort();
+    return _registeredCategories;
+}
+
+void QGCLoggingCategoryRegister::setCategoryLoggingOn(const QString& category, bool enable)
+{
+    QSettings settings;
+
+    settings.beginGroup(_filterRulesSettingsGroup);
+    settings.setValue(category, enable);
+}
+
+bool QGCLoggingCategoryRegister::categoryLoggingOn(const QString& category)
+{
+    QSettings settings;
+
+    settings.beginGroup(_filterRulesSettingsGroup);
+    return settings.value(category, false).toBool();
+}
+
+void QGCLoggingCategoryRegister::setFilterRulesFromSettings(const QString& commandLineLoggingOptions)
+{
+    if (!commandLineLoggingOptions.isEmpty()) {
+        _commandLineLoggingOptions = commandLineLoggingOptions;
+    }
+    QString filterRules;
+
+    // Turn off bogus ssl warning
+    filterRules += "qt.network.ssl.warning=false\n";
+    filterRules += "*Log.debug=false\n";
+
+    // Set up filters defined in settings
+    foreach (QString category, _registeredCategories) {
+        if (categoryLoggingOn(category)) {
+            filterRules += category;
+            filterRules += ".debug=true\n";
+        }
+    }
+
+    // Command line rules take precedence, so they go last in the list
+    if (!_commandLineLoggingOptions.isEmpty()) {
+        QStringList logList = _commandLineLoggingOptions.split(",");
+
+        if (logList[0] == "full") {
+            filterRules += "*Log.debug=true\n";
+            for(int i=1; i<logList.count(); i++) {
+                filterRules += logList[i];
+                filterRules += ".debug=false\n";
+            }
+        } else {
+            foreach(const QString &rule, logList) {
+                filterRules += rule;
+                filterRules += ".debug=true\n";
+            }
+        }
+    }
+
+    qDebug() << "Filter rules" << filterRules;
+    QLoggingCategory::setFilterRules(filterRules);
 }

--- a/src/QGCLoggingCategory.h
+++ b/src/QGCLoggingCategory.h
@@ -44,18 +44,36 @@ Q_DECLARE_LOGGING_CATEGORY(ParameterLoaderLog)
     static QGCLoggingCategory qgcCategory ## name (__VA_ARGS__); \
     Q_LOGGING_CATEGORY(name, __VA_ARGS__)
 
-class QGCLoggingCategoryRegister
+class QGCLoggingCategoryRegister : public QObject
 {
+    Q_OBJECT
+
 public:
     static QGCLoggingCategoryRegister* instance(void);
-    
+
+    /// Registers the specified logging category to the system.
     void registerCategory(const char* category) { _registeredCategories << category; }
-    const QStringList& registeredCategories(void) { return _registeredCategories; }
-    
+
+    /// Returns the list of available logging category names.
+    Q_INVOKABLE QStringList registeredCategories(void);
+
+    /// Turns on/off logging for the specified category. State is saved in app settings.
+    Q_INVOKABLE void setCategoryLoggingOn(const QString& category, bool enable);
+
+    /// Returns true if logging is turned on for the specified category.
+    Q_INVOKABLE bool categoryLoggingOn(const QString& category);
+
+    /// Sets the logging filters rules from saved settings.
+    ///     @param commandLineLogggingOptions Logging options which were specified on the command line
+    void setFilterRulesFromSettings(const QString& commandLineLoggingOptions);
+
 private:
     QGCLoggingCategoryRegister(void) { }
     
     QStringList _registeredCategories;
+    QString     _commandLineLoggingOptions;
+
+    static const char* _filterRulesSettingsGroup;
 };
         
 class QGCLoggingCategory

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -36,6 +36,7 @@
 #include "SettingsFact.h"
 #include "FactMetaData.h"
 #include "SimulatedPosition.h"
+#include "QGCLoggingCategory.h"
 
 #ifdef QT_DEBUG
 #include "MockLink.h"
@@ -132,6 +133,18 @@ public:
     Q_INVOKABLE QVariant appSettingsDistanceUnitsToMeters(const QVariant& distance) const { return FactMetaData::appSettingsDistanceUnitsToMeters(distance); }
 
     QString appSettingsDistanceUnitsString(void) const { return FactMetaData::appSettingsDistanceUnitsString(); }
+
+    /// Returns the list of available logging category names.
+    Q_INVOKABLE QStringList loggingCategories(void) const { return QGCLoggingCategoryRegister::instance()->registeredCategories(); }
+
+    /// Turns on/off logging for the specified category. State is saved in app settings.
+    Q_INVOKABLE void setCategoryLoggingOn(const QString& category, bool enable) { QGCLoggingCategoryRegister::instance()->setCategoryLoggingOn(category, enable); };
+
+    /// Returns true if logging is turned on for the specified category.
+    Q_INVOKABLE bool categoryLoggingOn(const QString& category) { return QGCLoggingCategoryRegister::instance()->categoryLoggingOn(category); };
+
+    /// Updates the logging filter rules after settings have changed
+    Q_INVOKABLE void updateLoggingFilterRules(void) { QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(QString()); }
 
     // Property accesors
 

--- a/src/ui/MainWindowLeftPanel.qml
+++ b/src/ui/MainWindowLeftPanel.qml
@@ -302,34 +302,5 @@ Item {
             id:             __rightPanel
             anchors.fill:   parent
         }
-        //-- Dismiss it all
-        Item {
-            id:              closeButton
-            width:           __closeButtonSize
-            height:          __closeButtonSize
-            anchors.right:   parent.right
-            anchors.top:     parent.top
-            anchors.margins: ScreenTools.defaultFontPixelHeight * 0.5
-            QGCColoredImage {
-                source:       "/res/XDelete.svg"
-                mipmap:       true
-                fillMode:     Image.PreserveAspectFit
-                color:        qgcPal.text
-                width:        parent.width  * 0.75
-                height:       parent.height * 0.75
-                sourceSize.height: height
-                anchors.centerIn: parent
-            }
-            MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                    if (!__animateShowDialog.running) {
-                        __rightPanel.source = ""
-                        mainWindow.hideLeftMenu()
-                    }
-                }
-            }
-
-        }
     }
 }


### PR DESCRIPTION
- Turning logging on/off can now be done from Settings/Console
- Log options are saved in app settings
- Log options coming in from the command line take precedence over the ones set in Console
- Remove "X" to close in Settings panel since it was conflicting with QGCViewDialogs

This change is important since we can now set logging options and capture logs from mobile devices. Fix for Issue #2520.