### PR TITLE
Turn off touch events for Mac OS

### DIFF
--- a/src/QGCQuickWidget.cc
+++ b/src/QGCQuickWidget.cc
@@ -39,7 +39,12 @@
 QGCQuickWidget::QGCQuickWidget(QWidget* parent) :
     QQuickWidget(parent)
 {
+#ifndef __macos__
+    // The following causes the Map control to hang after doing a pinch gesture on mac trackpads.
+    // By not turning this on for macos we lose pinch gesture, but two finger scroll still zooms the map.
+    // So it's a decent workaround. Qt bug reported: 53634
     setAttribute(Qt::WA_AcceptTouchEvents);
+#endif
     rootContext()->engine()->addImportPath("qrc:/qml");
     rootContext()->setContextProperty("joystickManager", qgcApp()->toolbox()->joystickManager());
 }


### PR DESCRIPTION
This is the workaround around for pinch problems on the Map control with mac trackpads. It disables Pinch zoom support on macos only. This isn't a major issue since on the map since two finger scroll still zooms the map in/out.

The actual issues is a Qt bug: https://bugreports.qt.io/browse/QTBUG-53634

Fix for Issue #3058