### PR TITLE
Add RC-radio-like exponential to joystick RPY axes

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -286,7 +286,7 @@ void Joystick::run(void)
             // Exponential (0% to -50% range like most RC radios)
             // 0 for no exponential
             // -0.5 for strong exponential
-            float expo = -0.35;
+            float expo = -0.35f;
 
             // Calculate new RPY with exponential applied
             roll =      -expo*powf(roll,3) + (1+expo)*roll;

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -282,6 +282,16 @@ void Joystick::run(void)
             pitch =     std::max(-1.0f, std::min(tanf(asinf(pitch_limited)), 1.0f));
             yaw =       std::max(-1.0f, std::min(tanf(asinf(yaw_limited)), 1.0f));
             throttle =  std::max(-1.0f, std::min(tanf(asinf(throttle_limited)), 1.0f));
+            
+            // Exponential (0% to -50% range like most RC radios)
+            // 0 for no exponential
+            // -0.5 for strong exponential
+            float expo = -0.35;
+
+            // Calculate new RPY with exponential applied
+            roll =      -expo*powf(roll,3) + (1+expo)*roll;
+            pitch =     -expo*powf(pitch,3) + (1+expo)*pitch;
+            yaw =       -expo*powf(yaw,3) + (1+expo)*yaw;
 
             // Adjust throttle to 0:1 range
             if (_throttleMode == ThrottleModeCenterZero) {

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -65,6 +65,7 @@ public:
     Q_INVOKABLE QString getButtonAction(int button);
 
     Q_PROPERTY(int throttleMode READ throttleMode WRITE setThrottleMode NOTIFY throttleModeChanged)
+    Q_PROPERTY(int exponential READ exponential WRITE setExponential NOTIFY exponentialChanged)
 
     // Property accessors
 
@@ -89,6 +90,9 @@ public:
     int throttleMode(void);
     void setThrottleMode(int mode);
 
+    bool exponential(void);
+    void setExponential(bool expo);
+
     typedef enum {
         CalibrationModeOff,         // Not calibrating
         CalibrationModeMonitor,     // Monitors are active, continue to send to vehicle if already polling
@@ -111,6 +115,8 @@ signals:
     void buttonActionsChanged(QVariantList actions);
 
     void throttleModeChanged(int mode);
+
+    void exponentialChanged(bool exponential);
 
     void enabledChanged(bool enabled);
 
@@ -168,6 +174,8 @@ protected:
 
     ThrottleMode_t      _throttleMode;
 
+    bool                _exponential;
+
     Vehicle*            _activeVehicle;
     bool                _pollingStartedForCalibration;
 
@@ -180,6 +188,7 @@ private:
     static const char* _calibratedSettingsKey;
     static const char* _buttonActionSettingsKey;
     static const char* _throttleModeSettingsKey;
+    static const char* _exponentialSettingsKey;
 };
 
 #endif

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -400,6 +400,18 @@ QGCView {
                             }
                         }
 
+                        Column {
+                            spacing: ScreenTools.defaultFontPixelHeight / 3
+
+                            QGCCheckBox {
+                                id:         exponential
+                                checked:    _activeJoystick.exponential
+                                text:       qsTr("Use exponential curve on roll, pitch, yaw")
+
+                                onClicked:  _activeJoystick.exponential = checked
+                            }
+                        }
+
                         QGCCheckBox {
                             id:         advancedSettings
                             checked:    _activeVehicle.joystickMode != 0


### PR DESCRIPTION
This adds an exponential response to the joystick roll, pitch, yaw axes for better usability and better similarity to an actual RC radio.

The exponential equation is:

```
float expo = -0.35;

roll = -expo*powf(roll,3) + (1+expo)*roll;
[etc..]
```
The exponential factor is very similar to RC radio expo settings, which usually go from 0% to -50% or so. The output remains normalized regardless of the exponential factor. The default is hardcoded at -35%, which gives a good response for joystick axes.

I made a quick illustration of what this looks like from 0% (linear) to -50% (strong exponential):

https://www.dropbox.com/s/86l66vb2tl7syjv/expo-qgc-20160528.mov?dl=0

Note: This only applies to the physical joysticks and not to the virtual joysticks. I can fix that if you'd like.