### PR TITLE
Allow arm with no GPS lock

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -459,7 +459,7 @@ Item {
 
                 QGCButton {
                     text:       (_activeVehicle && _activeVehicle.armed) ? (_activeVehicle.flying ? qsTr("Emergency Stop") : qsTr("Disarm")) :  qsTr("Arm")
-                    visible: (_activeVehicle && _activeVehicle.coordinateValid)
+                    visible:    _activeVehicle
                     onClicked:  _guidedModeBar.confirmAction(_activeVehicle.armed ? (_activeVehicle.flying ? _guidedModeBar.confirmEmergencyStop : _guidedModeBar.confirmDisarm) : _guidedModeBar.confirmArm)
                 }
 


### PR DESCRIPTION
Vehicle should fail arm command if not allowed as opposed to having QGC make the rules for when arm is allowed/disallowed. Otherwise it gets much too complicated as to whether the vehicle even requires a gps. Or if it does whether it has a circuit breaker set for it to allow arm without gps lock.

@LorenzMeier This reverses your change.

Fix for #3391