### PR TITLE
Better handle disabling AP channel number for WiFi parameters.

### DIFF
--- a/src/AutoPilotPlugins/Common/ESP8266Component.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266Component.qml
@@ -168,7 +168,7 @@ QGCView {
                                 QGCComboBox {
                                     id:                     channelField
                                     width:                  _editFieldWidth
-                                    enabled:                wifiMode && wifiMode.value === 0
+                                    enabled:                wifiMode ? wifiMode.value === 0 : true
                                     model:                  controller.wifiChannels
                                     currentIndex:           wifiChannel ? wifiChannel.value - 1 : 0
                                     onActivated: {

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
@@ -38,8 +38,9 @@ FactPanel {
             valueText: wifiMode ? (wifiMode.value === 0 ? "AP Mode" : "Station Mode") : "AP Mode"
         }
         VehicleSummaryRow {
-            labelText: qsTr("WiFi Channel:")
-            valueText: wifiChannel ? wifiChannel.valueString : ""
+            labelText:  qsTr("WiFi Channel:")
+            valueText:  wifiChannel ? wifiChannel.valueString : ""
+            visible:    wifiMode ? wifiMode.value === 0 : true
         }
         VehicleSummaryRow {
             labelText: qsTr("WiFi AP SSID:")


### PR DESCRIPTION
In response to #3453

QGC disables the (WiFi) channel assignment if the module is set to *Station Mode*. The problem was that with it, it was also disabling it if you were running older Firmware that did not support changing WiFi modes.