### PR TITLE
Tweaks to mission editor model views. Helps to address #3456

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -285,7 +285,6 @@ QGCView {
                             if (addMissionItemsButton.checked) {
                                 var sequenceNumber = controller.insertSimpleMissionItem(coordinate, controller.visualItems.count)
                                 setCurrentItem(sequenceNumber)
-                                editorListView.positionViewAtIndex(editorListView.count - 1, ListView.Contain)
                             } else {
                                 editorMap.mapClicked(coordinate)
                             }
@@ -485,6 +484,8 @@ QGCView {
                         model:          controller.visualItems
                         cacheBuffer:    height * 2
                         clip:           true
+                        highlightMoveDuration: 250
+
 
                         delegate: MissionItemEditor {
                             missionItem:    object
@@ -499,11 +500,6 @@ QGCView {
                                 controller.removeMissionItem(index)
                             }
 
-                            onInsert: {
-                                var sequenceNumber = controller.insertSimpleMissionItem(editorMap.center, i)
-                                setCurrentItem(sequenceNumber)
-                            }
-
                             onMoveHomeToMapCenter: controller.visualItems.get(0).coordinate = editorMap.center
 
                             Connections {
@@ -511,7 +507,7 @@ QGCView {
 
                                 onIsCurrentItemChanged: {
                                     if (object.isCurrentItem) {
-                                        editorListView.positionViewAtIndex(index, ListView.Contain)
+                                        editorListView.currentIndex = index
                                     }
                                 }
                             }

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -74,53 +74,43 @@ Rectangle {
             QGCLabel { text: _azimuthText }
         }
 
-        QGCFlickable {
+        ListView {
+            id:    statusListView
+            model: missionItems
+            highlightMoveDuration:  250
             anchors.leftMargin:     _margins
             anchors.rightMargin:    _margins
             anchors.top:            parent.top
             anchors.bottom:         parent.bottom
-            width:                  parent.width - valueGrid.width - (_margins * 2)
-            contentWidth:           graphRow.width
+            orientation:            ListView.Horizontal
+            spacing:                ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
             visible:                _expanded
+            width:                  parent.width - valueGrid.width - (_margins * 2)
             clip:                   true
+            delegate: Item {
+                height:     statusListView.height
+                width:      indicator.width
+                visible:    object.specifiesCoordinate && !object.isStandaloneCoordinate
 
-            Row {
-                id:                 graphRow
-                anchors.top:        parent.top
-                anchors.bottom:     parent.bottom
-                //anchors.margins:    ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
-                spacing:            ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
+                property real availableHeight:  height - indicator.height
+                property bool graphAbsolute:    true
 
-                Repeater {
-                    model: missionItems
+                MissionItemIndexLabel {
+                    id:                         indicator
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                    y:                          availableHeight - (availableHeight * object.altPercent)
+                    small:                      true
+                    isCurrentItem:              object.isCurrentItem
+                    label:                      object.abbreviation
+                    visible:                    object.relativeAltitude ? true : (object.homePosition || graphAbsolute)
+                }
+                Connections {
+                    target: object
 
-                    Item {
-                        height:     graphRow.height
-                        width:      indicator.width
-                        visible:    object.specifiesCoordinate && !object.isStandaloneCoordinate
-
-                        property real availableHeight:  height - indicator.height
-                        property bool graphAbsolute:    true
-
-                        MissionItemIndexLabel {
-                            id:                         indicator
-                            anchors.horizontalCenter:   parent.horizontalCenter
-                            y:                          availableHeight - (availableHeight * object.altPercent)
-                            small:                      true
-                            isCurrentItem:              object.isCurrentItem
-                            label:                      object.abbreviation
-                            visible:                    object.relativeAltitude ? true : (object.homePosition || graphAbsolute)
+                    onIsCurrentItemChanged: {
+                        if (object.isCurrentItem) {
+                            statusListView.currentIndex = index
                         }
-
-                        /*
-                          Taking these off for now since there really isn't room for the numbers
-                        QGCLabel {
-                            anchors.bottom:             parent.bottom
-                            anchors.horizontalCenter:   parent.horizontalCenter
-                            font.pointSize:             ScreenTools.smallFontPointSize
-                            text:                       (object.relativeAltitude ? "" : "=") + object.coordinate.altitude.toFixed(0)
-                        }
-                        */
                     }
                 }
             }

--- a/src/MissionEditor/SimpleItemEditor.qml
+++ b/src/MissionEditor/SimpleItemEditor.qml
@@ -13,7 +13,7 @@ import QGroundControl.Palette       1.0
 Rectangle {
     id:                 valuesRect
     width:              availableWidth
-    height:             valuesItem.height
+    height:             visible ? valuesItem.height : 0
     color:              qgcPal.windowShadeDark
     visible:            missionItem.isCurrentItem
     radius:             _radius

--- a/src/MissionEditor/SurveyItemEditor.qml
+++ b/src/MissionEditor/SurveyItemEditor.qml
@@ -10,7 +10,7 @@ import QGroundControl.Palette       1.0
 // Editor for Survery mission items
 Rectangle {
     id:         _root
-    height:     editorColumn.height + (_margin * 2)
+    height:     visible ? (editorColumn.height + (_margin * 2)) : 0
     width:      availableWidth
     color:      qgcPal.windowShadeDark
     radius:     _radius

--- a/src/QmlControls/MissionItemEditor.qml
+++ b/src/QmlControls/MissionItemEditor.qml
@@ -151,9 +151,9 @@ Rectangle {
         anchors.topMargin:  _margin
         anchors.left:       parent.left
         anchors.top:        commandPicker.bottom
-        height:             _currentItem && item ? item.height : 0
-        source:             _currentItem ? (missionItem.isSimpleItem ? "qrc:/qml/SimpleItemEditor.qml" : "qrc:/qml/SurveyItemEditor.qml") : ""
-
+        height:             item ? item.height : 0
+        source:             missionItem.isSimpleItem ? "qrc:/qml/SimpleItemEditor.qml" : "qrc:/qml/SurveyItemEditor.qml"
+        onLoaded:         { item.visible = Qt.binding(function() { return _currentItem; }) }
         property real   availableWidth: _root.width - (_margin * 2) ///< How wide the editor should be
         property var    editorRoot:     _root
     }


### PR DESCRIPTION
Let Qt manage scrolling the respective views to the right spot. It actually seems to do a decent job. There is still a bit of raciness with the MissionItemStatus view positioning when adding new items, but it is infrequent. 