### PR TITLE
Obligate LinkInterfaces to implement getLinkConfiguration. …

### DIFF
--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -51,10 +51,10 @@ public:
     void setActive(bool active)             { _active = active; emit activeChanged(active); }
 
     /**
-     * @brief Get link configuration (if used)
-     * @return A pointer to the instance of LinkConfiguration if supported. NULL otherwise.
+     * @brief Get link configuration
+     * @return A pointer to the instance of LinkConfiguration
      **/
-    virtual LinkConfiguration* getLinkConfiguration() { return NULL; }
+    virtual LinkConfiguration* getLinkConfiguration() = 0;
 
     /* Connection management */
 

--- a/src/comm/LogReplayLink.h
+++ b/src/comm/LogReplayLink.h
@@ -57,6 +57,8 @@ class LogReplayLink : public LinkInterface
     friend class LinkManager;
 
 public:
+    virtual LinkConfiguration* getLinkConfiguration() { return _config; }
+
     /// @return true: log is currently playing, false: log playback is paused
     bool isPlaying(void) { return _readTickTimer.isActive(); }
 

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -121,6 +121,7 @@ class TCPLink : public LinkInterface
 
 public:
     QTcpSocket* getSocket(void) { return _socket; }
+    virtual LinkConfiguration* getLinkConfiguration() { return _config; }
 
     void signalBytesWritten(void);
 


### PR DESCRIPTION
11ab9aa0311fc0efbb03d3e387480f390f903ea7 introduced a bug where TCP links would cause a crash loading the sensors page.

Found by @dagar 