### PR TITLE
Tweaks for small screens on iOS.

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -38,7 +38,7 @@ Item {
 
     function getGadgetWidth() {
         if(ScreenTools.isMobile) {
-            return mainWindow.width * 0.15
+            return ScreenTools.isTinyScreen ? mainWindow.width * 0.2 : mainWindow.width * 0.15
         }
         var w = mainWindow.width * 0.15
         return Math.min(w, 200)

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -157,7 +157,7 @@ Map {
     */
     Item {
         id:                         scale
-        visible:                    _map.showScale && scaleText.text !== "0 m"
+        visible:                    !ScreenTools.isTinyScreen && _map.showScale && scaleText.text !== "0 m"
         z:                          _map.z + 20
         width:                      scaleImageLeft.width + scaleImage.width + scaleImageRight.width
         anchors {

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -25,7 +25,7 @@ SettingsFact* QGroundControlQmlGlobal::_speedUnitsFact =                        
 FactMetaData* QGroundControlQmlGlobal::_speedUnitsMetaData =                    NULL;
 
 const char* QGroundControlQmlGlobal::_virtualTabletJoystickKey  = "VirtualTabletJoystick";
-const char* QGroundControlQmlGlobal::_baseFontPointSizeKey      = "BaseFontPointSize";
+const char* QGroundControlQmlGlobal::_baseFontPointSizeKey      = "BaseDeviceFontPointSize";
 
 QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
     : QGCTool(app)

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -83,13 +83,19 @@ Item {
             if(baseSize < 6 || baseSize > 48) {
                 //-- Init base size base on the platform
                 if(ScreenToolsController.isMobile) {
-                    // Small Devices
-                    if((Screen.width / Screen.pixelDensity) < 120)
-                        baseSize = 11;
-                    // iOS
+                    //-- Check iOS really tiny screens (iPhone 4s/5/5s)
+                    if(ScreenToolsController.isiOS && Screen.width < 570)
+                        baseSize = 9;
+                    //-- iPhone 6/6s)
+                    else if(ScreenToolsController.isiOS && Screen.width < 670)
+                        baseSize = 10;
+                    // Larger iOS (6/6s Plus or iPad)
                     else if(ScreenToolsController.isiOS)
                         baseSize = 13;
-                    // Android
+                    // Small Android Devices
+                    else if((Screen.width / Screen.pixelDensity) < 120)
+                        baseSize = 11;
+                    // Other Android
                     else
                         baseSize = 14;
                 } else {

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -13,8 +13,23 @@
 
 #include "ScreenToolsController.h"
 #include <QScreen>
+#if defined(__ios__)
+#include <sys/utsname.h>
+#endif
 
 ScreenToolsController::ScreenToolsController()
 {
 
+}
+
+QString
+ScreenToolsController::iOSDevice()
+{
+#if defined(__ios__)
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    return QString(systemInfo.machine);
+#else
+    return QString();
+#endif
 }

--- a/src/QmlControls/ScreenToolsController.h
+++ b/src/QmlControls/ScreenToolsController.h
@@ -36,6 +36,7 @@ public:
     Q_PROPERTY(bool     isDebug             READ isDebug        CONSTANT)
     Q_PROPERTY(bool     isMacOS             READ isMacOS        CONSTANT)
     Q_PROPERTY(bool     isLinux             READ isLinux        CONSTANT)
+    Q_PROPERTY(QString  iOSDevice           READ iOSDevice      CONSTANT)
 
     // Returns current mouse position
     Q_INVOKABLE int mouseX(void) { return QCursor::pos().x(); }
@@ -80,6 +81,8 @@ public:
     bool isDebug                () { return false; }
     bool testHighDPI            () { return false; }
 #endif
+
+    QString  iOSDevice          ();
 
 };
 


### PR DESCRIPTION
Very small iOS screens have a different density and need and appropriate default font point size, which in turn defines the overall UI scale.

The code now identifies iOS very small screens (4s, 5 and 5s), medium (6 and 6s) and larger screens (6/6s Plus and all iPads).

In addition, I am hiding the map scale on tiny screens. It just doesn't fit as the Fly Widget overlaps it.

This handles most, if not all problems defined in #3483