### PR TITLE
Removing unused signal.

### DIFF
--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -159,5 +159,4 @@ void LinkConfiguration::setName(const QString name)
 void LinkConfiguration::setLink(LinkInterface* link)
 {
     _link = link;
-    emit linkChanged(link);
 }

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -28,7 +28,7 @@ public:
     virtual ~LinkConfiguration() {}
 
     Q_PROPERTY(QString          name                READ name           WRITE setName           NOTIFY nameChanged)
-    Q_PROPERTY(LinkInterface*   link                READ link           WRITE setLink           NOTIFY linkChanged)
+    Q_PROPERTY(LinkInterface*   link                READ link           WRITE setLink)
     Q_PROPERTY(LinkType         linkType            READ type                                   CONSTANT)
     Q_PROPERTY(bool             dynamic             READ isDynamic      WRITE setDynamic        NOTIFY dynamicChanged)
     Q_PROPERTY(bool             autoConnect         READ isAutoConnect  WRITE setAutoConnect    NOTIFY autoConnectChanged)
@@ -178,7 +178,6 @@ public:
 
 signals:
     void nameChanged        (const QString& name);
-    void linkChanged        (LinkInterface* link);
     void dynamicChanged     ();
     void autoConnectChanged ();
 


### PR DESCRIPTION
According to #2641, the link change signal was causing a crash on shutdown. Since this signal is not used anywhere, I removed it.