### PR TITLE
Restoring link change signal.

### DIFF
--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -158,5 +158,8 @@ void LinkConfiguration::setName(const QString name)
 
 void LinkConfiguration::setLink(LinkInterface* link)
 {
-    _link = link;
+    if(_link != link) {
+        _link = link;
+        emit linkChanged(link);
+    }
 }

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -28,7 +28,7 @@ public:
     virtual ~LinkConfiguration() {}
 
     Q_PROPERTY(QString          name                READ name           WRITE setName           NOTIFY nameChanged)
-    Q_PROPERTY(LinkInterface*   link                READ link           WRITE setLink)
+    Q_PROPERTY(LinkInterface*   link                READ link           WRITE setLink           NOTIFY linkChanged)
     Q_PROPERTY(LinkType         linkType            READ type                                   CONSTANT)
     Q_PROPERTY(bool             dynamic             READ isDynamic      WRITE setDynamic        NOTIFY dynamicChanged)
     Q_PROPERTY(bool             autoConnect         READ isAutoConnect  WRITE setAutoConnect    NOTIFY autoConnectChanged)
@@ -180,6 +180,7 @@ signals:
     void nameChanged        (const QString& name);
     void dynamicChanged     ();
     void autoConnectChanged ();
+    void linkChanged        (LinkInterface* link);
 
 protected:
     LinkInterface* _link; ///< Link currently using this configuration (if any)


### PR DESCRIPTION
Restoring link change signal.
Link configuration (QML) relies on the existence of the link (active) configuration to know if the link is active or not. Removing the signal got it confused. I'm restoring the signal but making sure the signal is emitted if the link is truly changed. When a link is disconnected, the link manager resets the link configuration (which causes a signal to be emitted as it changed). When the link itself is deleted, it also sets the link configuration to NULL, which was causing it to emit another signal when no signal was needed (there were no changes as it was already NULL).