### PR TITLE
Recognize joystick hats and append to the button list (rev 2)

### DIFF
--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -26,7 +26,8 @@ class Joystick : public QThread
     Q_OBJECT
     
 public:
-    Joystick(const QString& name, int axisCount, int buttonCount, MultiVehicleManager* multiVehicleManager);
+    Joystick(const QString& name, int axisCount, int buttonCount, int hatCount, MultiVehicleManager* multiVehicleManager);
+
     ~Joystick();
 
     typedef struct {
@@ -54,7 +55,7 @@ public:
     
     Q_PROPERTY(bool calibrated MEMBER _calibrated NOTIFY calibratedChanged)
     
-    Q_PROPERTY(int buttonCount  READ buttonCount    CONSTANT)
+    Q_PROPERTY(int totalButtonCount  READ totalButtonCount    CONSTANT)
     Q_PROPERTY(int axisCount    READ axisCount      CONSTANT)
     
     Q_PROPERTY(QStringList actions READ actions CONSTANT)
@@ -68,7 +69,7 @@ public:
     // Property accessors
 
     int axisCount(void) { return _axisCount; }
-    int buttonCount(void) { return _buttonCount; }
+    int totalButtonCount(void) { return _totalButtonCount; }
     
     /// Start the polling thread which will in turn emit joystick signals
     void startPolling(Vehicle* vehicle);
@@ -138,6 +139,7 @@ private:
 
     virtual bool _getButton(int i) = 0;
     virtual int _getAxis(int i) = 0;
+    virtual uint8_t _getHat(int hat,int i) = 0;
 
     // Override from QThread
     virtual void run(void);
@@ -150,6 +152,9 @@ protected:
     bool    _calibrated;
     int     _axisCount;
     int     _buttonCount;
+    int     _hatCount;
+    int     _hatButtonCount;
+    int     _totalButtonCount;
     
     CalibrationMode_t   _calibrationMode;
     

--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -4,8 +4,8 @@
 
 #include <QQmlEngine>
 
-JoystickSDL::JoystickSDL(const QString& name, int axisCount, int buttonCount, int index, MultiVehicleManager* multiVehicleManager)
-    : Joystick(name,axisCount,buttonCount,multiVehicleManager)
+JoystickSDL::JoystickSDL(const QString& name, int axisCount, int buttonCount, int hatCount, int index, MultiVehicleManager* multiVehicleManager)
+    : Joystick(name,axisCount,buttonCount,hatCount,multiVehicleManager)
     , _index(index)
 {
 }
@@ -26,15 +26,16 @@ QMap<QString, Joystick*> JoystickSDL::discover(MultiVehicleManager* _multiVehicl
         QString name = SDL_JoystickName(i);
 
         if (!ret.contains(name)) {
-            int axisCount, buttonCount;
+            int axisCount, buttonCount, hatCount;
 
             SDL_Joystick* sdlJoystick = SDL_JoystickOpen(i);
             axisCount = SDL_JoystickNumAxes(sdlJoystick);
             buttonCount = SDL_JoystickNumButtons(sdlJoystick);
+            hatCount = SDL_JoystickNumHats(sdlJoystick);
             SDL_JoystickClose(sdlJoystick);
 
-            qCDebug(JoystickLog) << "\t" << name << "axes:" << axisCount << "buttons:" << buttonCount;
-            ret[name] = new JoystickSDL(name, axisCount, buttonCount, i, _multiVehicleManager);
+            qCDebug(JoystickLog) << "\t" << name << "axes:" << axisCount << "buttons:" << buttonCount << "hats:" << hatCount;
+            ret[name] = new JoystickSDL(name, axisCount, buttonCount, hatCount, i, _multiVehicleManager);
         } else {
             qCDebug(JoystickLog) << "\tSkipping duplicate" << name;
         }
@@ -69,5 +70,14 @@ bool JoystickSDL::_getButton(int i) {
 
 int JoystickSDL::_getAxis(int i) {
     return SDL_JoystickGetAxis(sdlJoystick, i);
+}
+
+uint8_t JoystickSDL::_getHat(int hat,int i) {
+    uint8_t hatButtons[] = {SDL_HAT_UP,SDL_HAT_DOWN,SDL_HAT_LEFT,SDL_HAT_RIGHT};
+
+    if ( i < int(sizeof(hatButtons)) ) {
+        return !!(SDL_JoystickGetHat(sdlJoystick, hat) & hatButtons[i]);
+    }
+    return 0;
 }
 

--- a/src/Joystick/JoystickSDL.h
+++ b/src/Joystick/JoystickSDL.h
@@ -15,7 +15,7 @@
 class JoystickSDL : public Joystick
 {
 public:
-    JoystickSDL(const QString& name, int axisCount, int buttonCount, int index, MultiVehicleManager* multiVehicleManager);
+    JoystickSDL(const QString& name, int axisCount, int buttonCount, int hatCount, int index, MultiVehicleManager* multiVehicleManager);
 
     static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager); 
 
@@ -26,6 +26,7 @@ private:
 
     bool _getButton(int i) final;
     int _getAxis(int i) final;
+    uint8_t _getHat(int hat,int i) final;
 
     SDL_Joystick *sdlJoystick;
     int     _index;      ///< Index for SDL_JoystickOpen

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -460,7 +460,7 @@ QGCView {
                             visible: _activeVehicle.manualControlReservedButtonCount != 0
                             text: qsTr("Buttons 0-%1 reserved for firmware use").arg(reservedButtonCount)
 
-                            property int reservedButtonCount: _activeVehicle.manualControlReservedButtonCount == -1 ? _activeJoystick.buttonCount : _activeVehicle.manualControlReservedButtonCount
+                            property int reservedButtonCount: _activeVehicle.manualControlReservedButtonCount == -1 ? _activeJoystick.totalButtonCount : _activeVehicle.manualControlReservedButtonCount
                         }
 
                         Repeater {
@@ -599,10 +599,10 @@ QGCView {
 
                     Repeater {
                         id:     buttonMonitorRepeater
-                        model:  _activeJoystick.buttonCount
+                        model:  _activeJoystick.totalButtonCount
 
                         Rectangle {
-                            width:          ScreenTools.defaultFontPixelHeight * 1.5
+                            width:          ScreenTools.defaultFontPixelHeight * 1.2
                             height:         width
                             border.width:   1
                             border.color:   qgcPal.text


### PR DESCRIPTION
(Note: This is a new version of PR #3455 that has been updated for the new joystick code.)

This PR addresses the issue that joystick/gamepad hats are considered to be "hats" in Windows but "buttons" on Mac and Linux. This causes inconsistent numbers of joystick buttons between OSes.

This PR causes joystick hats to be detected and appended to the normal button list. Only the up, down, left, right buttons are recognized and appear in the same order that they are detect on Mac/Linux.

A few things worth mentioning:

- The other buttons are still detected in different orders on different OSes so this doesn't provide complete consistency
- The center button (like the "X" on the Xbox controller) is not detected on Windows. This will be fixed in SDL2
- This does not affect the indices of any buttons so it should not affect any existing joystick performance or setup
- This has been tested on Mac and Windows with Xbox 360 and Logitech 310 controllers
- My motivation for doing this was to provide additional buttons to ArduSub software but it should be broadly useful

Let me know if you have any thoughts or questions. I'm happy to discuss.

Also, I committed this before the repo was switched to the new dual licenses and I'm fine with the new license.
