### PR TITLE
Single map type setting for all maps

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -26,7 +26,6 @@ FlightMap {
     id:             flightMap
     anchors.fill:   parent
     mapName:        _mapName
-    showScale:      QGroundControl.flightMapSettings.showScaleOnFlyView
 
     property alias  missionController: _missionController
     property var    flightWidgets
@@ -109,6 +108,16 @@ FlightMap {
             isCurrentItem:  true
             label:          qsTr("G", "Goto here waypoint") // second string is translator's hint.
         }
+    }    
+
+    MapScale {
+        anchors.bottomMargin:   ScreenTools.defaultFontPixelHeight * (0.66)
+        anchors.rightMargin:    ScreenTools.defaultFontPixelHeight * (0.33)
+        anchors.bottom:         parent.bottom
+        anchors.right:          parent.right
+        z:                      QGroundControl.zOrderWidgets
+        mapControl:             flightMap
+        visible:                !ScreenTools.isTinyScreen
     }
 
     // Handle guided mode clicks

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -209,12 +209,13 @@ Item {
 
                             QGCButton {
                                 checkable:      true
-                                checked:        _flightMap ? _flightMap.mapType === text : false
-                                text:               modelData
+                                checked:        QGroundControl.flightMapSettings.mapType === text
+                                text:           modelData
                                 width:          clearButton.width
                                 exclusiveGroup: _mapTypeButtonsExclusiveGroup
+
                                 onClicked: {
-                                    _flightMap.mapType = text
+                                    QGroundControl.flightMapSettings.mapType = text
                                     checked = true
                                     _dropButtonsExclusiveGroup.current = null
                                 }

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -32,10 +32,7 @@ Map {
     id: _map
 
     property string mapName:            'defaultMap'
-    property string mapType:            QGroundControl.flightMapSettings.mapTypeForMapName(mapName)
-//  property alias  mapWidgets:         controlWidgets
-    property bool   isSatelliteMap:     mapType == "Satellite Map" || mapType == "Hybrid Map"
-    property bool   showScale:          false
+    property bool   isSatelliteMap:     QGroundControl.flightMapSettings.mapType == "Satellite" || QGroundControl.flightMapSettings.mapType == "Hybrid"
 
     readonly property real  maxZoomLevel: 20
     property variant        scaleLengths: [5, 10, 25, 50, 100, 150, 250, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000, 2000000]
@@ -93,8 +90,6 @@ Map {
 
     ExclusiveGroup { id: mapTypeGroup }
 
-    Component.onCompleted: onMapTypeChanged
-
     property bool _initialMapPositionSet: false
 
     Connections {
@@ -107,15 +102,21 @@ Map {
         }
     }
 
-    onMapTypeChanged: {
-        QGroundControl.flightMapSettings.setMapTypeForMapName(mapName, mapType)
-        var fullMapName = QGroundControl.flightMapSettings.mapProvider + " " + mapType
+    function updateActiveMapType() {
+        var fullMapName = QGroundControl.flightMapSettings.mapProvider + " " + QGroundControl.flightMapSettings.mapType
         for (var i = 0; i < _map.supportedMapTypes.length; i++) {
             if (fullMapName === _map.supportedMapTypes[i].name) {
                 _map.activeMapType = _map.supportedMapTypes[i]
                 return
             }
         }
+    }
+
+    Component.onCompleted: updateActiveMapType()
+
+    Connections {
+        target:             QGroundControl.flightMapSettings
+        onMapTypeChanged:   updateActiveMapType()
     }
 
     MapQuickItem {
@@ -127,180 +128,4 @@ Map {
             label: "Q"
         }
     }
-
-    onWidthChanged: {
-        if(_map.showScale)
-            scaleTimer.restart()
-    }
-
-    onHeightChanged: {
-        if(_map.showScale)
-            scaleTimer.restart()
-    }
-
-    onZoomLevelChanged:{
-        if(_map.showScale)
-            scaleTimer.restart()
-    }
-
-    Timer {
-        id:         scaleTimer
-        interval:   100
-        running:    false
-        repeat:     false
-        onTriggered: {
-            _map.calculateScale()
-        }
-    }
-    /*
-        Scale
-    */
-    Item {
-        id:                         scale
-        visible:                    !ScreenTools.isTinyScreen && _map.showScale && scaleText.text !== "0 m"
-        z:                          _map.z + 20
-        width:                      scaleImageLeft.width + scaleImage.width + scaleImageRight.width
-        anchors {
-            bottom:                 parent.bottom
-            bottomMargin:           ScreenTools.defaultFontPixelHeight * (0.66)
-            right:                  parent.right
-            rightMargin:            ScreenTools.defaultFontPixelHeight * (0.33)
-        }
-        Image {
-            id:                     scaleImageLeft
-            source:                 isSatelliteMap ? "/qmlimages/scale_end.png" : "/qmlimages/scale_endLight.png"
-            anchors.bottom:         parent.bottom
-            anchors.left:           parent.left
-        }
-        Image {
-            id:                     scaleImage
-            source:                 isSatelliteMap ? "/qmlimages/scale.png" : "/qmlimages/scaleLight.png"
-            anchors.bottom:         parent.bottom
-            anchors.left:           scaleImageLeft.right
-        }
-        Image {
-            id:                     scaleImageRight
-            source:                 isSatelliteMap ? "/qmlimages/scale_end.png" : "/qmlimages/scale_endLight.png"
-            anchors.bottom:         parent.bottom
-            anchors.left:           scaleImage.right
-        }
-        QGCLabel {
-            id: scaleText
-            color:                  isSatelliteMap ? "white" : "black"
-            font.family:            ScreenTools.demiboldFontFamily
-            horizontalAlignment:    Text.AlignHCenter
-            anchors.bottom:         parent.bottom
-            anchors.right:          parent.right
-            anchors.bottomMargin:   ScreenTools.defaultFontPixelHeight * (0.83)
-            text: "0 m"
-        }
-        Component.onCompleted: {
-            if(_map.showScale)
-                _map.calculateScale();
-        }
-    }
-
-    /*********************************************
-    /// Map control widgets
-    Column {
-        id:                 controlWidgets
-        anchors.margins:    ScreenTools.defaultFontPixelWidth
-        anchors.right:      parent.right
-        anchors.bottom:     parent.bottom
-        spacing:            ScreenTools.defaultFontPixelWidth / 2
-        z:                  1000    // Must be on top for clicking
-        // Pinch zoom doesn't seem to be working, so zoom buttons in mobile on for now
-        //visible:            !ScreenTools.isMobile
-
-        Row {
-            layoutDirection:    Qt.RightToLeft
-            spacing:            ScreenTools.defaultFontPixelWidth / 2
-
-            readonly property real _zoomIncrement: 1.0
-            property real _buttonWidth: ScreenTools.defaultFontPixelWidth * 5
-
-            NumberAnimation {
-                id: animateZoom
-
-                property real startZoom
-                property real endZoom
-
-                target:     _map
-                properties: "zoomLevel"
-                from:       startZoom
-                to:         endZoom
-                duration:   500
-
-                easing {
-                    type: Easing.OutExpo
-                }
-            }
-
-
-            QGCButton {
-                width:  parent._buttonWidth
-                z:      QGroundControl.zOrderWidgets
-                //iconSource: "/qmlimages/ZoomPlus.svg"
-                text:   "+"
-
-                onClicked: {
-                    var endZoomLevel = _map.zoomLevel + parent._zoomIncrement
-                    if (endZoomLevel > _map.maximumZoomLevel) {
-                        endZoomLevel = _map.maximumZoomLevel
-                    }
-                    animateZoom.startZoom = _map.zoomLevel
-                    animateZoom.endZoom = endZoomLevel
-                    animateZoom.start()
-                }
-            }
-
-            QGCButton {
-                width:  parent._buttonWidth
-                z:      QGroundControl.zOrderWidgets
-                //iconSource: "/qmlimages/ZoomMinus.svg"
-                text:   "-"
-
-                onClicked: {
-                    var endZoomLevel = _map.zoomLevel - parent._zoomIncrement
-                    if (endZoomLevel < _map.minimumZoomLevel) {
-                        endZoomLevel = _map.minimumZoomLevel
-                    }
-                    animateZoom.startZoom = _map.zoomLevel
-                    animateZoom.endZoom = endZoomLevel
-                    animateZoom.start()
-                }
-            }
-        } // Row - +/- buttons
-    } // Column - Map control widgets
-*********************************************/
-
-/*
- The slider and scale display are commented out for now to try to save real estate - DonLakeFlyer
- Not sure if I'll bring them back or not. Need room for waypoint list at bottom
-
-    QGCSlider {
-        id: zoomSlider;
-        minimum: map.minimumZoomLevel;
-        maximum: map.maximumZoomLevel;
-        opacity: 1
-        visible: parent.visible
-        z: 1000
-        anchors {
-            bottom: parent.bottom;
-            bottomMargin:   ScreenTools.defaultFontPixelHeight * (1.25)
-            rightMargin:    ScreenTools.defaultFontPixelHeight * (1.66)
-            leftMargin:     ScreenTools.defaultFontPixelHeight * (1.66)
-            left: parent.left
-        }
-        width: parent.width - anchors.rightMargin - anchors.leftMargin
-        value: map.zoomLevel
-        Binding {
-            target: zoomSlider; property: "value"; value: map.zoomLevel
-        }
-        onValueChanged: {
-            map.zoomLevel = value
-        }
-    }
-*/
-
 } // Map

--- a/src/FlightMap/FlightMapSettings.cc
+++ b/src/FlightMap/FlightMapSettings.cc
@@ -17,7 +17,6 @@ const char* FlightMapSettings::_defaultMapProvider      = "Bing";               
 const char* FlightMapSettings::_settingsGroup           = "FlightMapSettings";
 const char* FlightMapSettings::_mapProviderKey          = "MapProvider";
 const char* FlightMapSettings::_mapTypeKey              = "MapType";
-const char* FlightMapSettings::_showScaleOnFlyViewKey   = "ShowScaleOnFlyView";
 
 FlightMapSettings::FlightMapSettings(QGCApplication* app)
     : QGCTool(app)
@@ -90,24 +89,24 @@ void FlightMapSettings::_setMapTypesForCurrentProvider(void)
     emit mapTypesChanged(_mapTypes);
 }
 
-QString FlightMapSettings::mapTypeForMapName(const QString& mapName)
+QString FlightMapSettings::mapType(void)
 {
     QSettings settings;
 
     settings.beginGroup(_settingsGroup);
-    settings.beginGroup(mapName);
     settings.beginGroup(_mapProvider);
     return settings.value(_mapTypeKey, "Satellite Map").toString();
 }
 
-void FlightMapSettings::setMapTypeForMapName(const QString& mapName, const QString& mapType)
+void FlightMapSettings::setMapType(const QString& mapType)
 {
     QSettings settings;
 
     settings.beginGroup(_settingsGroup);
-    settings.beginGroup(mapName);
     settings.beginGroup(_mapProvider);
     settings.setValue(_mapTypeKey, mapType);
+
+    emit mapTypeChanged(mapType);
 }
 
 void FlightMapSettings::saveMapSetting (const QString &mapName, const QString& key, const QString& value)
@@ -144,20 +143,4 @@ bool FlightMapSettings::loadBoolMapSetting (const QString &mapName, const QStrin
     settings.beginGroup(_settingsGroup);
     settings.beginGroup(mapName);
     return settings.value(key, defaultValue).toBool();
-}
-
-bool FlightMapSettings::showScaleOnFlyView()
-{
-    QSettings settings;
-    settings.beginGroup(_settingsGroup);
-    bool show = settings.value(_showScaleOnFlyViewKey, true).toBool();
-    return show;
-}
-
-void FlightMapSettings::setShowScaleOnFlyView(bool show)
-{
-    QSettings settings;
-    settings.beginGroup(_settingsGroup);
-    settings.setValue(_showScaleOnFlyViewKey, show);
-    emit showScaleOnFlyViewChanged();
 }

--- a/src/FlightMap/FlightMapSettings.h
+++ b/src/FlightMap/FlightMapSettings.h
@@ -24,18 +24,16 @@ public:
     FlightMapSettings(QGCApplication* app);
 
     /// mapProvider is either Bing, Google or Open to specify to set of maps available
-    Q_PROPERTY(QString      mapProvider         READ mapProvider    WRITE setMapProvider NOTIFY mapProviderChanged)
+    Q_PROPERTY(QString      mapProvider     READ mapProvider    WRITE setMapProvider    NOTIFY mapProviderChanged)
 
     /// Map providers
-    Q_PROPERTY(QStringList  mapProviders        READ mapProviders   CONSTANT)
+    Q_PROPERTY(QStringList  mapProviders    READ mapProviders                           CONSTANT)
 
     /// Map types associated with current map provider
-    Q_PROPERTY(QStringList  mapTypes            MEMBER _mapTypes    NOTIFY mapTypesChanged)
+    Q_PROPERTY(QStringList  mapTypes        MEMBER _mapTypes                            NOTIFY mapTypesChanged)
 
-    Q_PROPERTY(bool         showScaleOnFlyView  READ showScaleOnFlyView WRITE setShowScaleOnFlyView NOTIFY showScaleOnFlyViewChanged)
-
-    Q_INVOKABLE QString     mapTypeForMapName   (const QString& mapName);
-    Q_INVOKABLE void        setMapTypeForMapName(const QString& mapName, const QString& mapType);
+    /// Map type to be used for all maps
+    Q_PROPERTY(QString      mapType         READ mapType        WRITE setMapType        NOTIFY mapTypeChanged)
 
     Q_INVOKABLE void        saveMapSetting      (const QString &mapName, const QString& key, const QString& value);
     Q_INVOKABLE QString     loadMapSetting      (const QString &mapName, const QString& key, const QString& defaultValue);
@@ -47,18 +45,18 @@ public:
     QString mapProvider(void);
     void setMapProvider(const QString& mapProvider);
 
+    QString mapType(void);
+    void setMapType(const QString& mapType);
+
     // Override from QGCTool
     virtual void setToolbox(QGCToolbox *toolbox);
 
     QStringList mapProviders() { return _supportedMapProviders; }
 
-    bool    showScaleOnFlyView          ();
-    void    setShowScaleOnFlyView       (bool show);
-
 signals:
-    void    mapProviderChanged          (const QString& mapProvider);
-    void    mapTypesChanged             (const QStringList& mapTypes);
-    void    showScaleOnFlyViewChanged   ();
+    void mapProviderChanged (const QString& mapProvider);
+    void mapTypesChanged    (const QStringList& mapTypes);
+    void mapTypeChanged     (const QString& mapType);
 
 private:
     void    _storeSettings              (void);
@@ -74,7 +72,6 @@ private:
     static const char* _settingsGroup;
     static const char* _mapProviderKey;
     static const char* _mapTypeKey;
-    static const char* _showScaleOnFlyViewKey;
 };
 
 #endif

--- a/src/FlightMap/MapScale.qml
+++ b/src/FlightMap/MapScale.qml
@@ -24,7 +24,7 @@ Item {
 
     property variant _scaleLengths: [5, 10, 25, 50, 100, 150, 250, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000, 2000000]
 
-    property bool   _isSatelliteMap:    mapControl.activeMapType.name.indexOf(qsTr("Street")) == -1    ///< Scale control being displayed over satellite map
+    property bool   _isSatelliteMap:    mapControl.activeMapType.name.indexOf("Satellite") > -1 || mapControl.activeMapType.name.indexOf("Hybrid") > -1
     property var    _color:             _isSatelliteMap ? "white" : "black"
 
     function formatDistance(meters)

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -631,13 +631,14 @@ QGCView {
                                     spacing: ScreenTools.defaultFontPixelWidth
                                     Repeater {
                                         model: QGroundControl.flightMapSettings.mapTypes
+
                                         QGCButton {
                                             checkable:      true
-                                            checked:        editorMap.mapType === text
+                                            checked:        QGroundControl.flightMapSettings.mapType === text
                                             text:           modelData
                                             exclusiveGroup: _mapTypeButtonsExclusiveGroup
                                             onClicked: {
-                                                editorMap.mapType = text
+                                                QGroundControl.flightMapSettings.mapType = text
                                                 checked = true
                                                 mapTypeButton.hideDropDown()
                                             }
@@ -674,6 +675,15 @@ QGCView {
                             checked = false
                         }
                     }
+                }
+
+                MapScale {
+                    anchors.margins:    ScreenTools.defaultFontPixelHeight * (0.66)
+                    anchors.bottom:     waypointValuesDisplay.visible ? waypointValuesDisplay.top : parent.bottom
+                    anchors.left:       parent.left
+                    z:                  QGroundControl.zOrderWidgets
+                    mapControl:         editorMap
+                    visible:            !ScreenTools.isTinyScreen
                 }
 
                 MissionItemStatus {

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -31,7 +31,7 @@ QGCView {
 
     property string mapKey:             "lastMapType"
 
-    property string mapType:            QGroundControl.mapEngineManager.loadSetting(mapKey, "Google Street Map")
+    property string mapType:            QGroundControl.flightMapSettings.mapProvider + " " + QGroundControl.flightMapSettings.mapType
     property bool   isMapInteractive:   true
     property var    savedCenter:        undefined
     property real   savedZoom:          3
@@ -106,6 +106,7 @@ QGCView {
     }
 
     function addNewSet() {
+        mapType = QGroundControl.flightMapSettings.mapProvider + " " + QGroundControl.flightMapSettings.mapType
         _map.visible = true
         _tileSetList.visible = false
         infoView.visible = false
@@ -700,8 +701,8 @@ QGCView {
                                 id:             mapCombo
                                 anchors.left:   parent.left
                                 anchors.right:  parent.right
+                                model:          QGroundControl.mapEngineManager.mapList
 
-                                model:      QGroundControl.mapEngineManager.mapList
                                 onActivated: {
                                     mapType = textAt(index)
                                     if(_dropButtonsExclusiveGroup.current)
@@ -712,7 +713,7 @@ QGCView {
                                 Component.onCompleted: {
                                     var index = mapCombo.find(mapType)
                                     if (index === -1) {
-                                        console.warn(qsTr("Active map name not in combo"), mapType)
+                                        console.warn("Active map name not in combo", mapType)
                                     } else {
                                         mapCombo.currentIndex = index
                                     }

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -177,17 +177,6 @@ Rectangle {
             }
 
             //-----------------------------------------------------------------
-            //-- Scale on Flight View
-            QGCCheckBox {
-                text:       qsTr("Show scale on Fly View")
-                onClicked: {
-                    QGroundControl.flightMapSettings.showScaleOnFlyView = checked
-                }
-                Component.onCompleted: {
-                    checked = QGroundControl.flightMapSettings.showScaleOnFlyView
-                }
-            }
-            //-----------------------------------------------------------------
             //-- Audio preferences
             QGCCheckBox {
                 text:       qsTr("Mute all audio output")
@@ -284,7 +273,7 @@ Rectangle {
                 QGCLabel {
                     id:                 mapProvidersLabel
                     anchors.baseline:   mapProviders.baseline
-                    text:               qsTr("Map Providers:")
+                    text:               qsTr("Map Provider:")
                 }
 
                 QGCComboBox {


### PR DESCRIPTION
- Offline maps now set defaults to default map type
- Plan/Fly views uses new MapScale control
- Remove map scale on/off option from settings. 1) Due to less is more 2) Added complexity of scale showing up on all maps and also not showing up on small screens

Fix for #3517, #3518