### PR TITLE
move continuous s3 builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,7 +73,7 @@ deploy:
       secure: RiYqaR+3T2PMNz2j5ur8LCA6H/Zfd4jTX33CZE5iBxm+zaz4QLs25p0B7prpaoNN
     bucket: qgroundcontrol
     set_public: true
-    folder: $(APPVEYOR_REPO_BRANCH)
+    folder: builds/$(APPVEYOR_REPO_BRANCH)
     artifact: qgcinstaller
     on:
       CONFIG: installer

--- a/.travis.yml
+++ b/.travis.yml
@@ -225,7 +225,7 @@ deploy:
       secure: BsLXeXUPsCJdX4tawrDnO8OFK5Hk4kzlDTiyH93En6TbjUargVAWDMcHVj7TUhr7+3Tao1W1zb0G4SJe9kHv+jrky0yE72KvoG3YAON0VXWKizxBAKkgHE2RxSTNAwDeKbi2G6YJfNDescBBfX7zEohShdXglQu7CGaUQKRaiI4=
     bucket: qgroundcontrol
     local_dir: ${SHADOW_BUILD_DIR}/release/package
-    upload-dir: ${TRAVIS_BRANCH}
+    upload-dir: builds/${TRAVIS_BRANCH}
     acl: public_read
     region: us-west-2
     skip_cleanup: true


### PR DESCRIPTION
I'm moving the continuous builds from the top level of the qgc bucket to builds/$branch to enable auto expire.