### PR TITLE
travis-ci install gstreamer for linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ addons:
     - graphviz
     - libc6-i386
     - libespeak-dev
+    - libgstreamer-plugins-base1.0-dev
+    - libgstreamer1.0-0:amd64
+    - libgstreamer1.0-dev
     - libopenscenegraph-dev
     - libsdl1.2-dev
     - libudev-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ matrix:
           sudo: false
         - os: linux
           env: CONFIG=doxygen
-          sudo: false
+          sudo: required
+          dist: trusty
 
 android:
   components:

--- a/src/VideoStreaming/README.md
+++ b/src/VideoStreaming/README.md
@@ -31,8 +31,7 @@ gst-launch-1.0 udpsrc port=5600 caps='application/x-rtp, media=(string)video, cl
 
 Use apt-get to install GStreamer 1.0
 ```
-sudo apt-get install gstreamer1.0*
-sudo apt-get install libgstreamer1.0*
+sudo apt-get install libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev
 ```
 
 The build system is setup to use pkgconfig and it will find the necessary headers and libraries automatically.

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -184,8 +184,7 @@ VideoEnabled {
         }
         LinuxBuild {
             message("  You can install it using apt-get")
-            message("  sudo apt-get install gstreamer1.0*")
-            message("  sudo apt-get install libgstreamer1.0*")
+            message("  sudo apt-get install libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev")
         }
         WindowsBuild {
             message("  You can download it from http://gstreamer.freedesktop.org/data/pkg/windows/")


### PR DESCRIPTION
This was lost on travis-ci when switching to their newer infrastructure with the apt add-on instead of just using the command line to install packages.