### PR TITLE
travis-ci deploy tagged Android builds to google play production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,6 @@ script:
         ./tools/update_android_version.sh
         ;
     fi
-  - echo 'Building QGroundControl'
   - if [[ "${CONFIG}" != "doxygen" && "${SPEC}" != "ios" ]]; then
         cd ${SHADOW_BUILD_DIR} &&
         make -j4 | sed 's/${TRAVIS_BUILD_DIR}/-/'
@@ -199,15 +198,16 @@ script:
 
 after_success:
   - if [[ "${TRAVIS_OS_NAME}" = "linux" && "${CONFIG}" = "installer" ]]; then
-        ${TRAVIS_BUILD_DIR}/deploy/create_linux_appimage.sh ${TRAVIS_BUILD_DIR} ${SHADOW_BUILD_DIR}/release ${SHADOW_BUILD_DIR}/release/package
-        ;
+        ${TRAVIS_BUILD_DIR}/deploy/create_linux_appimage.sh ${TRAVIS_BUILD_DIR} ${SHADOW_BUILD_DIR}/release ${SHADOW_BUILD_DIR}/release/package;
     fi
   - if [ "${TRAVIS_TAG}" ]; then
         export GOOGLE_PLAY_TRACK=production;
-    else
+    elif [ "${TRAVIS_BRANCH}" = "master" ]; then
         export GOOGLE_PLAY_TRACK=beta;
+    else
+        export GOOGLE_PLAY_TRACK=none;
     fi
-  - if [[ "${TRAVIS_OS_NAME}" = "android" && "${TRAVIS_PULL_REQUEST}" = "false" && "${TRAVIS_BRANCH}" = "master" ]]; then
+  - if [[ "${TRAVIS_OS_NAME}" = "android" && "${TRAVIS_PULL_REQUEST}" = "false" && "${GOOGLE_PLAY_TRACK}" != "none" ]]; then
         pip install --user google-api-python-client PyOpenSSL &&
         cd ${TRAVIS_BUILD_DIR} &&
         openssl aes-256-cbc -K $encrypted_25db6eb7c3fd_key -iv $encrypted_25db6eb7c3fd_iv -in ${TRAVIS_BUILD_DIR}/android/Google_Play_Android_Developer-4432a3c4f5d1.json.enc -out android/Google_Play_Android_Developer-4432a3c4f5d1.json -d &&


### PR DESCRIPTION
-closes #3479

This is hard to test without dropping a tag and accidentally pushing something to production.