### PR TITLE
Update OpenGL buglist to blacklist rotation on Intel HD graphics adapters

### DIFF
--- a/resources/opengl/buglist.json
+++ b/resources/opengl/buglist.json
@@ -44,6 +44,18 @@
             "features": [
                 "disable_desktopgl"
             ]
+        },
+        {
+           "id": 6,
+           "description": "Intel(R) HD Graphics 4000 / 5500 cause crashes on orientation changes in fullscreen mode (QTBUG-49541)",
+           "vendor_id": "0x8086",
+           "device_id": [ "0x0166", "0x1616" ],
+           "os": {
+               "type": "win"
+           },
+           "features": [
+               "disable_rotation"
+           ]
         }
     ]
 }


### PR DESCRIPTION
Upstream: https://bugreports.qt.io/browse/QTBUG-49541
Report: https://groups.google.com/forum/#!topic/qgroundcontrol/1BjN5M4f7Tg

This may make a strong case for reading the current Qt blacklist from memory and making whatever modifications we feel necessary on the fly. Granted we haven't upgraded to 5.6.0 so we wouldn't have gotten the fix yet, but we were dependent on users to report something that was already fixed upstream. 