### PR TITLE
Fix memory leak during dragging waypoint

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -629,7 +629,7 @@ void MissionController::_recalcWaypointLines(void)
     double homePositionAltitude = homeItem->coordinate().altitude();
     minAltSeen = maxAltSeen = homeItem->coordinate().altitude();
 
-    _waypointLines.clear();
+    _waypointLines.clearAndDeleteContents();
 
     bool linkBackToHome = false;
     for (int i=1; i<_visualItems->count(); i++) {


### PR DESCRIPTION
This function is creating the objects on the heap... hence it is owned by the MissionController. If we don't delete them they are leaked. 