### PR TITLE
Remove animation to save perf

### DIFF
--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -102,19 +102,6 @@ Row {
                 anchors.verticalCenter:   parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
             }
-            SequentialAnimation {
-                id:    loopAnimation
-                loops: Animation.Infinite
-                NumberAnimation { target: criticalMessage; property: "opacity"; duration: 1000; from: 0.25; to: 1 }
-                NumberAnimation { target: criticalMessage; property: "opacity"; duration: 1000; from: 1; to: 0.25 }
-            }
-            onVisibleChanged: {
-                if(messages.visible) {
-                    loopAnimation.start()
-                } else {
-                    loopAnimation.stop()
-                }
-            }
         }
         Item {
             anchors.fill:       parent


### PR DESCRIPTION
This is the Yield button for messages on the toolbar. When the animation for that starts it chews a ridiculous amount of CPU on iOS. I get it more often on my Solo since it's always complaining about the GPS pre-arm state. Which cause the animation to go off.

Related to #3576