### PR TITLE
Defer loading and binding of mission editing QML components

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -46,8 +46,9 @@ QGCView {
     readonly property int       _addMissionItemsButtonAutoOffTimeout:   10000
     readonly property var       _defaultVehicleCoordinate:   QtPositioning.coordinate(37.803784, -122.462276)
 
-    property var    _visualItems:          controller.visualItems
+    property var    _visualItems:           controller.visualItems
     property var    _currentMissionItem
+    property int    _currentMissionIndex:   0
     property bool   _firstVehiclePosition:  true
     property var    activeVehiclePosition:  _activeVehicle ? _activeVehicle.coordinate : QtPositioning.coordinate()
     property bool   _lightWidgetBorders:    editorMap.isSatelliteMap
@@ -168,6 +169,7 @@ QGCView {
             if (visualItem.sequenceNumber == sequenceNumber) {
                 _currentMissionItem = visualItem
                 _currentMissionItem.isCurrentItem = true
+                _currentMissionIndex = i
             } else {
                 visualItem.isCurrentItem = false
             }
@@ -485,6 +487,7 @@ QGCView {
                         model:          controller.visualItems
                         cacheBuffer:    height * 2
                         clip:           true
+                        currentIndex:   _currentMissionIndex
                         highlightMoveDuration: 250
 
                         delegate: MissionItemEditor {
@@ -506,16 +509,6 @@ QGCView {
                             }
 
                             onMoveHomeToMapCenter: controller.visualItems.get(0).coordinate = editorMap.center
-
-                            Connections {
-                                target: object
-
-                                onIsCurrentItemChanged: {
-                                    if (object.isCurrentItem) {
-                                        editorListView.currentIndex = index
-                                    }
-                                }
-                            }
                         }
                     } // ListView
                 } // Item - Mission Item editor

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -87,6 +87,7 @@ Rectangle {
             visible:                _expanded
             width:                  parent.width - valueGrid.width - (_margins * 2)
             clip:                   true
+            currentIndex:           _currentMissionIndex
 
             delegate: Item {
                 height:     statusListView.height
@@ -106,16 +107,6 @@ Rectangle {
                     isCurrentItem:              object.isCurrentItem
                     label:                      object.abbreviation
                     visible:                    object.relativeAltitude ? true : (object.homePosition || graphAbsolute)
-                }
-
-                Connections {
-                    target: object
-
-                    onIsCurrentItemChanged: {
-                        if (object.isCurrentItem) {
-                            statusListView.currentIndex = index
-                        }
-                    }
                 }
             }
         }

--- a/src/MissionEditor/SimpleItemEditor.qml
+++ b/src/MissionEditor/SimpleItemEditor.qml
@@ -1,4 +1,4 @@
-import QtQuick                  2.2
+import QtQuick                  2.5
 import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.2
 import QtQuick.Dialogs          1.2
@@ -13,112 +13,115 @@ import QGroundControl.Palette       1.0
 Rectangle {
     id:                 valuesRect
     width:              availableWidth
-    height:             visible ? valuesItem.height : 0
+    height:             deferedload.status == Loader.Ready ? (visible ? deferedload.item.height : 0) : 0
     color:              qgcPal.windowShadeDark
     visible:            missionItem.isCurrentItem
     radius:             _radius
 
-    // The following properties must be available up the hierachy chain
-    //property real   availableWidth    ///< Width for control
-    //property var    missionItem       ///< Mission Item for editor
+    Loader {
+        id:              deferedload
+        active:          valuesRect.visible
+        asynchronous:    true
+        anchors.margins: _margin
+        anchors.left:    valuesRect.left
+        anchors.right:   valuesRect.right
+        anchors.top:     valuesRect.top
+        sourceComponent: Component {
+            Item {
+                id:                 valuesItem
+                height:             valuesColumn.height + (_margin * 2)
 
-    Item {
-        id:                 valuesItem
-        anchors.margins:    _margin
-        anchors.left:       parent.left
-        anchors.right:      parent.right
-        anchors.top:        parent.top
-        height:             valuesColumn.height + (_margin * 2)
-
-        Column {
-            id:             valuesColumn
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            anchors.top:    parent.top
-            spacing:        _margin
-
-            QGCLabel {
-                width:          parent.width
-                wrapMode:       Text.WordWrap
-                font.pointSize: ScreenTools.smallFontPointSize
-                text:           missionItem.sequenceNumber == 0 ?
-                                    qsTr("Planned home position. Actual home position set by Vehicle.") :
-                                    (missionItem.rawEdit ?
-                                        qsTr("Provides advanced access to all commands/parameters. Be very careful!") :
-                                        missionItem.commandDescription)
-            }
-
-            Repeater {
-                model: missionItem.comboboxFacts
-
-                Item {
-                    width:  valuesColumn.width
-                    height: comboBoxFact.height
+                Column {
+                    id:             valuesColumn
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    anchors.top:    parent.top
+                    spacing:        _margin
 
                     QGCLabel {
-                        id:                 comboBoxLabel
-                        anchors.baseline:   comboBoxFact.baseline
-                        text:               object.name
-                        visible:            object.name != ""
+                        width:          parent.width
+                        wrapMode:       Text.WordWrap
+                        font.pointSize: ScreenTools.smallFontPointSize
+                        text:           missionItem.sequenceNumber == 0 ?
+                                            qsTr("Planned home position. Actual home position set by Vehicle.") :
+                                            (missionItem.rawEdit ?
+                                                qsTr("Provides advanced access to all commands/parameters. Be very careful!") :
+                                                missionItem.commandDescription)
                     }
 
-                    FactComboBox {
-                        id:             comboBoxFact
-                        anchors.right:  parent.right
-                        width:          comboBoxLabel.visible ? _editFieldWidth : parent.width
-                        indexModel:     false
-                        model:          object.enumStrings
-                        fact:           object
-                    }
-                }
-            }
+                    Repeater {
+                        model: missionItem.comboboxFacts
 
-            Repeater {
-                model: missionItem.textFieldFacts
+                        Item {
+                            width:  valuesColumn.width
+                            height: comboBoxFact.height
 
-                Item {
-                    width:  valuesColumn.width
-                    height: textField.height
+                            QGCLabel {
+                                id:                 comboBoxLabel
+                                anchors.baseline:   comboBoxFact.baseline
+                                text:               object.name
+                                visible:            object.name != ""
+                            }
 
-                    QGCLabel {
-                        id:                 textFieldLabel
-                        anchors.baseline:   textField.baseline
-                        text:               object.name
-                    }
-
-                    FactTextField {
-                        id:             textField
-                        anchors.right:  parent.right
-                        width:          _editFieldWidth
-                        showUnits:      true
-                        fact:           object
-                        visible:        !_root.readOnly
+                            FactComboBox {
+                                id:             comboBoxFact
+                                anchors.right:  parent.right
+                                width:          comboBoxLabel.visible ? _editFieldWidth : parent.width
+                                indexModel:     false
+                                model:          object.enumStrings
+                                fact:           object
+                            }
+                        }
                     }
 
-                    FactLabel {
-                        anchors.baseline:   textFieldLabel.baseline
-                        anchors.right:      parent.right
-                        fact:               object
-                        visible:            _root.readOnly
+                    Repeater {
+                        model: missionItem.textFieldFacts
+
+                        Item {
+                            width:  valuesColumn.width
+                            height: textField.height
+
+                            QGCLabel {
+                                id:                 textFieldLabel
+                                anchors.baseline:   textField.baseline
+                                text:               object.name
+                            }
+
+                            FactTextField {
+                                id:             textField
+                                anchors.right:  parent.right
+                                width:          _editFieldWidth
+                                showUnits:      true
+                                fact:           object
+                                visible:        !_root.readOnly
+                            }
+
+                            FactLabel {
+                                anchors.baseline:   textFieldLabel.baseline
+                                anchors.right:      parent.right
+                                fact:               object
+                                visible:            _root.readOnly
+                            }
+                        }
                     }
-                }
-            }
 
-            Repeater {
-                model: missionItem.checkboxFacts
+                    Repeater {
+                        model: missionItem.checkboxFacts
 
-                FactCheckBox {
-                    text:   object.name
-                    fact:   object
-                }
-            }
+                        FactCheckBox {
+                            text:   object.name
+                            fact:   object
+                        }
+                    }
 
-            QGCButton {
-                text:       qsTr("Move Home to map center")
-                visible:    missionItem.homePosition
-                onClicked:  editorRoot.moveHomeToMapCenter()
-                anchors.horizontalCenter: parent.horizontalCenter
-            }
-        } // Column
-    } // Item
+                    QGCButton {
+                        text:       qsTr("Move Home to map center")
+                        visible:    missionItem.homePosition
+                        onClicked:  editorRoot.moveHomeToMapCenter()
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                } // Column
+            } // Item
+        } // Component
+    } // Loader
 } // Rectangle


### PR DESCRIPTION
Also should finally fix mission editor view sync when changing current waypoint.


During creation of a very large mission with 100s of points I noticed the mission editor was getting really laggy. QML profiler showed the editor bindings for the simple mission item delegate were extremely expensive and slow.

Instead, load them only for each point when it is selected. This makes the ListView scroll smoothly with a ton of points too. 