### PR TITLE
Allow 2.9.x appimages to run on Ubuntu 16.04. Fixes issue #3615

### DIFF
--- a/deploy/create_linux_appimage.sh
+++ b/deploy/create_linux_appimage.sh
@@ -2,53 +2,89 @@
 
 set +e
 
+if [[ $# -eq 0 ]]; then
+	echo 'create_linux_appimage.sh QGC_SRC_DIR QGC_RELEASE_DIR'
+	exit 1
+fi
+
+QGC_SRC=$1
+if [ ! -f ${QGC_SRC}/qgroundcontrol.pro ]; then
+	echo 'please specify path to qgroundcontrol source as the 1st argument'
+	exit 1
+fi
+
+QGC_RELEASE_DIR=$2
+if [ ! -f ${QGC_RELEASE_DIR}/qgroundcontrol ]; then
+	echo 'please specify path to qgroundcontrol release as the 2nd argument'
+	exit 1
+fi
+
+OUTPUT_DIR=${3-`pwd`}
+echo "Output directory:" ${OUTPUT_DIR}
+
 # Generate AppImage using the binaries currently provided by the project.
 # These require at least GLIBC 2.14, which older distributions might not have. 
 # On the other hand, 2.14 is not that recent so maybe we can just live with it.
 
-APP=qgroundcontrol
+APP=QGroundControl
 
-mkdir -p /tmp/$APP/$APP.AppDir
-cd /tmp/$APP/
-tar xf ${SHADOW_BUILD_DIR}/release/package/qgroundcontrol.tar.bz2
+TMPDIR=`mktemp -d`
+APPDIR=${TMPDIR}/$APP".AppDir"
+mkdir -p ${APPDIR}
 
-wget -c http://ftp.us.debian.org/debian/pool/main/u/udev/udev_175-7.2_amd64.deb
-wget -c http://ftp.us.debian.org/debian/pool/main/e/espeak/espeak_1.46.02-2_amd64.deb
-wget -c http://ftp.us.debian.org/debian/pool/main/libs/libsdl1.2/libsdl1.2debian_1.2.15-5_amd64.deb
+cd ${TMPDIR}
+wget -c --quiet http://ftp.us.debian.org/debian/pool/main/u/udev/udev_175-7.2_amd64.deb
+wget -c --quiet http://ftp.us.debian.org/debian/pool/main/e/espeak/espeak_1.46.02-2_amd64.deb
+wget -c --quiet http://ftp.us.debian.org/debian/pool/main/libs/libsdl1.2/libsdl1.2debian_1.2.15-5_amd64.deb
 
-cd $APP.AppDir/
-
-mv ../qgroundcontrol/* .
-mv qgroundcontrol-start.sh AppRun
+cd ${APPDIR}
 find ../ -name *.deb -exec dpkg -x {} . \;
 
-# Get icon
-cp ${TRAVIS_BUILD_DIR}/resources/icons/qgroundcontrol.png .
+# copy libdirectfb-1.2.so.9
+cd ${TMPDIR}
+wget -c --quiet http://ftp.us.debian.org/debian/pool/main/d/directfb/libdirectfb-1.2-9_1.2.10.0-5.1_amd64.deb
+mkdir libdirectfb
+dpkg -x libdirectfb-1.2-9_1.2.10.0-5.1_amd64.deb libdirectfb
+cp -L libdirectfb/usr/lib/x86_64-linux-gnu/libdirectfb-1.2.so.9 ${APPDIR}/usr/lib/x86_64-linux-gnu/
+cp -L libdirectfb/usr/lib/x86_64-linux-gnu/libfusion-1.2.so.9 ${APPDIR}/usr/lib/x86_64-linux-gnu/
+cp -L libdirectfb/usr/lib/x86_64-linux-gnu/libdirect-1.2.so.9 ${APPDIR}/usr/lib/x86_64-linux-gnu/
 
-cat > ./qgroundcontrol.desktop <<\EOF
+# copy libts-0.0-0
+wget -c --quiet http://ftp.us.debian.org/debian/pool/main/t/tslib/libts-0.0-0_1.0-11_amd64.deb
+mkdir libts
+dpkg -x libts-0.0-0_1.0-11_amd64.deb libts
+cp -L libts/usr/lib/x86_64-linux-gnu/libts-0.0.so.0 ${APPDIR}/usr/lib/x86_64-linux-gnu/
+
+# copy QGroundControl release into appimage
+cp -r ${QGC_RELEASE_DIR}/* ${APPDIR}/
+rm -rf ${APPDIR}/package
+mv ${APPDIR}/qgroundcontrol-start.sh ${APPDIR}/AppRun
+
+# copy icon
+cp ${QGC_SRC}/resources/icons/qgroundcontrol.png ${APPDIR}/
+
+cat > ${APPDIR}/qgroundcontrol.desktop <<\EOF
 [Desktop Entry]
 Type=Application
 Name=QGroundControl
 GenericName=Ground Control Station
 Comment=UAS ground control station
-Icon=qgroundcontrol.png
+Icon=qgroundcontrol
 Exec=AppRun
 Terminal=false
 Categories=Utility;
 Keywords=computer;
 EOF
 
-VERSION=$(strings qgroundcontrol | grep v[0-9*]\.[0-9*]\.[0-9*]-[0-9*] | head -n 1)
+VERSION=$(strings ${APPDIR}/qgroundcontrol | grep '^v[0-9*]\.[0-9*].[0-9*]' | head -n 1)
+echo QGC Version: ${VERSION}
 
 # Go out of AppImage
-cd ..
-
-wget -c "https://github.com/probonopd/AppImageKit/releases/download/5/AppImageAssistant" # (64-bit)
+cd ${TMPDIR}
+wget -c --quiet "https://github.com/probonopd/AppImageKit/releases/download/5/AppImageAssistant" # (64-bit)
 chmod a+x ./AppImageAssistant
-mkdir -p ../out
-rm ../out/$APP".AppImage" || true
-./AppImageAssistant ./$APP.AppDir/ ../out/$APP".AppImage"
 
-# s3 deploys everything in release/package
-cp ../out/$APP".AppImage" ${SHADOW_BUILD_DIR}/release/package/$APP".AppImage"
+./AppImageAssistant ./$APP.AppDir/ ${TMPDIR}/$APP".AppImage"
+
+cp ${TMPDIR}/$APP".AppImage" ${OUTPUT_DIR}/$APP".AppImage"
 


### PR DESCRIPTION
To merge this pull request a new branch Stable_V2.9 is requires.  See the issue #3615