### PR TITLE
travis-ci remove sed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,7 +180,7 @@ script:
     fi
   - if [[ "${CONFIG}" != "doxygen" && "${SPEC}" != "ios" ]]; then
         cd ${SHADOW_BUILD_DIR} &&
-        make -j4 | sed 's/${TRAVIS_BUILD_DIR}/-/'
+        make -j4
         ;
     fi
   - if [ "${SPEC}" = "ios" ]; then


### PR DESCRIPTION
This might be why a compile failure isn't registered.

#3596