### PR TITLE
Limit max memory cache for offline maps.

### DIFF
--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -362,6 +362,9 @@ QGCMapEngine::getMaxMemCache()
         _maxMemCache = settings.value(kMaxMemCacheKey, 128).toUInt();
 #endif
     }
+    //-- Size in MB
+    if(_maxMemCache > 1024)
+        _maxMemCache = 1024;
     return _maxMemCache;
 }
 
@@ -369,6 +372,9 @@ QGCMapEngine::getMaxMemCache()
 void
 QGCMapEngine::setMaxMemCache(quint32 size)
 {
+    //-- Size in MB
+    if(size > 1024)
+        size = 1024;
     QSettings settings;
     settings.setValue(kMaxMemCacheKey, size);
     _maxMemCache = size;

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -230,7 +230,10 @@ QGeoTiledMappingManagerEngineQGC::_setCache(const QVariantMap &parameters)
     //-- It won't work with less than 1M of memory cache
     if(memLimit < 1024 * 1024)
         memLimit = 1024 * 1024;
-    //-- Disable Qt's disk cache (set memory cache otherwise Qtlocation won't work)
+    //-- On the other hand, Qt uses signed 32-bit integers. Limit to 1G to round it down (you don't need more than that).
+    if(memLimit > 1024 * 1024 * 1024)
+        memLimit = 1024 * 1024 * 1024;
+    //-- Disable Qt's disk cache (sort of)
 #if QT_VERSION >= 0x050600
     QAbstractGeoTileCache *pTileCache = new QGeoFileTileCache(cacheDir);
     setTileCache(pTileCache);
@@ -241,6 +244,7 @@ QGeoTiledMappingManagerEngineQGC::_setCache(const QVariantMap &parameters)
     {
         //-- We're basically telling it to use 100k of disk for cache. It doesn't like
         //   values smaller than that and I could not find a way to make it NOT cache.
+        //   We handle our own disk caching elsewhere.
         pTileCache->setMaxDiskUsage(1024 * 100);
         pTileCache->setMaxMemoryUsage(memLimit);
     }

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -246,7 +246,7 @@ QGCView {
                         id:                 maxCacheMemSize
                         maximumLength:      4
                         inputMethodHints:   Qt.ImhDigitsOnly
-                        validator:          IntValidator {bottom: 1; top: 4096;}
+                        validator:          IntValidator {bottom: 1; top: 1024;}
                         text:               QGroundControl.mapEngineManager.maxMemCache
                     }
 


### PR DESCRIPTION
In response to #3676.

Qt is using a 32-bit signed integer for setting the max memory cache (which limits it to < 2G). I'm limiting it to 1G, rounding down as there is no good reason to use more than that.