### PR TITLE
Use stored QMetaObject::Connections to disconnect deactivated vehicles

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -938,16 +938,10 @@ void MissionController::_activeVehicleChanged(Vehicle* activeVehicle)
 {
     qCDebug(MissionControllerLog) << "_activeVehicleChanged activeVehicle" << activeVehicle;
 
-    if (_activeVehicle) {
-        MissionManager* missionManager = _activeVehicle->missionManager();
-
-        disconnect(missionManager, &MissionManager::newMissionItemsAvailable,   this, &MissionController::_newMissionItemsAvailableFromVehicle);
-        disconnect(missionManager, &MissionManager::inProgressChanged,          this, &MissionController::_inProgressChanged);
-        disconnect(missionManager, &MissionManager::currentItemChanged,         this, &MissionController::_currentMissionItemChanged);
-        disconnect(_activeVehicle, &Vehicle::homePositionAvailableChanged,      this, &MissionController::_activeVehicleHomePositionAvailableChanged);
-        disconnect(_activeVehicle, &Vehicle::homePositionChanged,               this, &MissionController::_activeVehicleHomePositionChanged);
-        _activeVehicle = NULL;
+    for(auto con : _vehicleConnections) {
+        disconnect(con);
     }
+    _activeVehicle = nullptr;
 
     // We always remove all items on vehicle change. This leaves a user model hole:
     //      If the user has unsaved changes in the Plan view they will lose them
@@ -958,11 +952,11 @@ void MissionController::_activeVehicleChanged(Vehicle* activeVehicle)
     if (_activeVehicle) {
         MissionManager* missionManager = activeVehicle->missionManager();
 
-        connect(missionManager, &MissionManager::newMissionItemsAvailable,  this, &MissionController::_newMissionItemsAvailableFromVehicle);
-        connect(missionManager, &MissionManager::inProgressChanged,         this, &MissionController::_inProgressChanged);
-        connect(missionManager, &MissionManager::currentItemChanged,        this, &MissionController::_currentMissionItemChanged);
-        connect(_activeVehicle, &Vehicle::homePositionAvailableChanged,     this, &MissionController::_activeVehicleHomePositionAvailableChanged);
-        connect(_activeVehicle, &Vehicle::homePositionChanged,              this, &MissionController::_activeVehicleHomePositionChanged);
+        _vehicleConnections << connect(missionManager, &MissionManager::newMissionItemsAvailable,  this, &MissionController::_newMissionItemsAvailableFromVehicle);
+        _vehicleConnections << connect(missionManager, &MissionManager::inProgressChanged,         this, &MissionController::_inProgressChanged);
+        _vehicleConnections << connect(missionManager, &MissionManager::currentItemChanged,        this, &MissionController::_currentMissionItemChanged);
+        _vehicleConnections << connect(_activeVehicle, &Vehicle::homePositionAvailableChanged,     this, &MissionController::_activeVehicleHomePositionAvailableChanged);
+        _vehicleConnections << connect(_activeVehicle, &Vehicle::homePositionChanged,              this, &MissionController::_activeVehicleHomePositionChanged);
 
         if (_activeVehicle->getParameterLoader()->parametersAreReady() && !syncInProgress()) {
             // We are switching between two previously existing vehicles. We have to manually ask for the items from the Vehicle.

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -123,6 +123,7 @@ private:
     bool                _firstItemsFromVehicle;
     bool                _missionItemsRequested;
     bool                _queuedSend;
+    QList<QMetaObject::Connection> _vehicleConnections;
 
     static const char*  _settingsGroup;
     static const char*  _jsonVersionKey;

--- a/src/ViewWidgets/LogDownloadController.cc
+++ b/src/ViewWidgets/LogDownloadController.cc
@@ -129,17 +129,17 @@ LogDownloadController::_processDownload()
 void
 LogDownloadController::_setActiveVehicle(Vehicle* vehicle)
 {
-    if(_uas) {
-        _logEntriesModel.clear();
-        disconnect(_uas, &UASInterface::logEntry, this, &LogDownloadController::_logEntry);
-        disconnect(_uas, &UASInterface::logData,  this, &LogDownloadController::_logData);
-        _uas = NULL;
+    for(auto con : _vehicleConnections) {
+        disconnect(con);
     }
+    _logEntriesModel.clear();
+    _uas = NULL;
+
     _vehicle = vehicle;
     if(_vehicle) {
         _uas = vehicle->uas();
-        connect(_uas, &UASInterface::logEntry, this, &LogDownloadController::_logEntry);
-        connect(_uas, &UASInterface::logData,  this, &LogDownloadController::_logData);
+        _vehicleConnections << connect(_uas, &UASInterface::logEntry, this, &LogDownloadController::_logEntry);
+        _vehicleConnections << connect(_uas, &UASInterface::logData,  this, &LogDownloadController::_logData);
     }
 }
 

--- a/src/ViewWidgets/LogDownloadController.h
+++ b/src/ViewWidgets/LogDownloadController.h
@@ -169,6 +169,7 @@ private:
     int                 _retries;
     int                 _apmOneBased;
     QString             _downloadPath;
+    QList<QMetaObject::Connection> _vehicleConnections;
 };
 
 #endif

--- a/src/ui/toolbar/MainToolBarController.cc
+++ b/src/ui/toolbar/MainToolBarController.cc
@@ -45,19 +45,17 @@ MainToolBarController::~MainToolBarController()
 
 void MainToolBarController::_activeVehicleChanged(Vehicle* vehicle)
 {
-    // Disconnect the previous one (if any)
-    if (_vehicle) {
-        disconnect(_vehicle->autopilotPlugin(), &AutoPilotPlugin::parameterListProgress, this, &MainToolBarController::_setProgressBarValue);
-        _mav = NULL;
-        _vehicle = NULL;
+    for(auto con : _vehicleConnections) {
+        disconnect(con);
     }
+    _mav = nullptr;
+    _vehicle = nullptr;
 
     // Connect new system
-    if (vehicle)
-    {
+    if (vehicle) {
         _vehicle = vehicle;
         _mav = vehicle->uas();
-        connect(_vehicle->autopilotPlugin(), &AutoPilotPlugin::parameterListProgress, this, &MainToolBarController::_setProgressBarValue);
+        _vehicleConnections << connect(_vehicle->autopilotPlugin(), &AutoPilotPlugin::parameterListProgress, this, &MainToolBarController::_setProgressBarValue);
     }
 }
 

--- a/src/ui/toolbar/MainToolBarController.h
+++ b/src/ui/toolbar/MainToolBarController.h
@@ -90,6 +90,7 @@ private:
 
     QStringList     _toolbarMessageQueue;
     QMutex          _toolbarMessageQueueMutex;
+    QList<QMetaObject::Connection> _vehicleConnections;
 };
 
 #endif // MainToolBarController_H


### PR DESCRIPTION
@DonLakeFlyer this is what I was talking about [here](https://github.com/mavlink/qgroundcontrol/issues/3364#issuecomment-231251274)