### PR TITLE
Plan: Copy coordinate frame from prev waypoint as well

### DIFF
--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -103,7 +103,7 @@ private:
     void _autoSyncSend(void);
     void _setupActiveVehicle(Vehicle* activeVehicle, bool forceLoadFromVehicle);
     static void _calcPrevWaypointValues(double homeAlt, VisualMissionItem* currentItem, VisualMissionItem* prevItem, double* azimuth, double* distance, double* altDifference);
-    bool _findLastAltitude(double* lastAltitude);
+    bool _findLastAltitude(double* lastAltitude, MAV_FRAME* frame);
     bool _findLastAcceptanceRadius(double* lastAcceptanceRadius);
     void _addPlannedHomePosition(QmlObjectListModel* visualItems, bool addToCenter);
     double _normalizeLat(double lat);


### PR DESCRIPTION
Currently adding a new item copies the altitude from the previous waypoint. It also need to copy the coordinate frame, otherwise this could lead to confusion and bad things happening on the mission.