### PR TITLE
Map polygon drawing tool

### DIFF
--- a/src/MissionEditor/SurveyItemEditor.qml
+++ b/src/MissionEditor/SurveyItemEditor.qml
@@ -19,8 +19,7 @@ Rectangle {
     //property real   availableWidth    ///< Width for control
     //property var    missionItem       ///< Mission Item for editor
 
-    property bool _addPointsMode:   false
-    property real _margin:          ScreenTools.defaultFontPixelWidth / 2
+    property real _margin: ScreenTools.defaultFontPixelWidth / 2
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
@@ -31,16 +30,6 @@ Rectangle {
         anchors.left:       parent.left
         anchors.right:      parent.right
         spacing:            _margin
-
-        Connections {
-            target: editorMap
-
-            onMapClicked: {
-                if (_addPointsMode) {
-                    missionItem.addPolygonCoordinate(coordinate)
-                }
-            }
-        }
 
         QGCLabel {
             text:       qsTr("Fly a grid pattern over a defined area.")
@@ -108,14 +97,29 @@ Rectangle {
             }
         }
 
+        Connections {
+            target: editorMap.polygonDraw
+
+            onPolygonStarted: {
+                missionItem.clearPolygon()
+            }
+
+            onPolygonFinished: {
+                for (var i=0; i<coordinates.length; i++) {
+                    missionItem.addPolygonCoordinate(coordinates[i])
+                }
+            }
+        }
+
         QGCButton {
-            text: _addPointsMode ? qsTr("Finish Polygon") : qsTr("Draw Polygon")
+            text:       editorMap.polygonDraw.drawingPolygon ? qsTr("Finish Polygon") : qsTr("Draw Polygon")
+            enabled:    (editorMap.polygonDraw.drawingPolygon && editorMap.polygonDraw.polygonReady) || !editorMap.polygonDraw.drawingPolygon
+
             onClicked: {
-                if (_addPointsMode) {
-                    _addPointsMode = false
+                if (editorMap.polygonDraw.drawingPolygon) {
+                    editorMap.polygonDraw.finishPolygon()
                 } else {
-                    missionItem.clearPolygon()
-                    _addPointsMode = true
+                    editorMap.polygonDraw.startPolygon()
                 }
             }
         }

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -279,3 +279,11 @@ Fact* QGroundControlQmlGlobal::speedUnits(void)
 
     return _speedUnitsFact;
 }
+
+bool QGroundControlQmlGlobal::linesIntersect(QPointF line1A, QPointF line1B, QPointF line2A, QPointF line2B)
+{
+    QPointF intersectPoint;
+
+    return QLineF(line1A, line1B).intersect(QLineF(line2A, line2B), &intersectPoint) == QLineF::BoundedIntersection &&
+            intersectPoint != line1A && intersectPoint != line1B;
+}

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -14,6 +14,8 @@
 #include "QGroundControlQmlGlobal.h"
 
 #include <QSettings>
+#include <QLineF>
+#include <QPointF>
 
 static const char* kQmlGlobalKeyName = "QGCQml";
 

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -133,6 +133,8 @@ public:
     /// Updates the logging filter rules after settings have changed
     Q_INVOKABLE void updateLoggingFilterRules(void) { QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(QString()); }
 
+    Q_INVOKABLE bool linesIntersect(QPointF xLine1, QPointF yLine1, QPointF xLine2, QPointF yLine2);
+
     // Property accesors
 
     FlightMapSettings*      flightMapSettings   ()      { return _flightMapSettings; }


### PR DESCRIPTION
FlightMap control nows support a generic polygon drawing tool. Reusable by Survey (already converted), GeoFence (coming soon) and so forth. Will also add polygon re-editing at a later time.

```
    //
    // Usage:
    //
    // Connections {
    //     target: map.polygonDraw
    //
    //    onPolygonStarted: {
    //      // Polygon creation has started
    //    }
    //
    //    onPolygonFinished: {
    //      // Polygon capture complete, coordinates signal variable contains the polygon points
    //    }
    // }
    //
    // map.polygonDraqw.startPolgyon() - begin capturing a new polygon
    // map.polygonDraqw.endPolygon() - end capture (right-click will also end capture)
```

Example usage in SurveyItemEditor:
```
        Connections {
            target: editorMap.polygonDraw

            onPolygonStarted: {
                missionItem.clearPolygon()
            }

            onPolygonFinished: {
                for (var i=0; i<coordinates.length; i++) {
                    missionItem.addPolygonCoordinate(coordinates[i])
                }
            }
        }

        QGCButton {
            text:       editorMap.polygonDraw.drawingPolygon ? qsTr("Finish Polygon") : qsTr("Draw Polygon")
            enabled:    (editorMap.polygonDraw.drawingPolygon && editorMap.polygonDraw.polygonReady) || !editorMap.polygonDraw.drawingPolygon

            onClicked: {
                if (editorMap.polygonDraw.drawingPolygon) {
                    editorMap.polygonDraw.finishPolygon()
                } else {
                    editorMap.polygonDraw.startPolygon()
                }
            }
        }
 ```