### PR TITLE
Use exact conversion factor for feetToMeters translation

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -404,7 +404,7 @@ QVariant FactMetaData::_metersToFeet(const QVariant& meters)
 
 QVariant FactMetaData::_feetToMeters(const QVariant& feet)
 {
-    return QVariant(feet.toDouble() * 0.305);
+    return QVariant(feet.toDouble() * 0.3048);
 }
 
 QVariant FactMetaData::_metersPerSecondToMilesPerHour(const QVariant& metersPerSecond)


### PR DESCRIPTION
Found this when converting between feet/meters frequently on an experimental draggable waypoint fact editor. Doing so causes the value to tend to grow continuously. 