### PR TITLE
[Mission stats] Added area translation

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -33,8 +33,14 @@ const FactMetaData::AppSettingsTranslation_s FactMetaData::_rgAppSettingsTransla
     { "m",      "m",        false,  QGroundControlQmlGlobal::DistanceUnitsMeters,           FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "meters", "meters",   false,  QGroundControlQmlGlobal::DistanceUnitsMeters,           FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "m/s",    "m/s",      true,   QGroundControlQmlGlobal::SpeedUnitsMetersPerSecond,     FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "m^2",    "m^2",      false,  QGroundControlQmlGlobal::AreaUnitsSquareMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "m",      "ft",       false,  QGroundControlQmlGlobal::DistanceUnitsFeet,             FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
     { "meters", "ft",       false,  QGroundControlQmlGlobal::DistanceUnitsFeet,             FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
+    { "m^2",    "km^2",     false,  QGroundControlQmlGlobal::AreaUnitsSquareKilometers,         FactMetaData::_squareMetersToSquareKilometers,      FactMetaData::_squareKilometersToSquareMeters },
+    { "m^2",    "ha",       false,  QGroundControlQmlGlobal::AreaUnitsHectares,         FactMetaData::_squareMetersToHectares,               FactMetaData::_hectaresToSquareMeters },
+    { "m^2",    "ft^2",     false,  QGroundControlQmlGlobal::AreaUnitsSquareFeet,         FactMetaData::_squareMetersToSquareFeet,            FactMetaData::_squareFeetToSquareMeters },
+    { "m^2",    "ac",       false,  QGroundControlQmlGlobal::AreaUnitsAcres,         FactMetaData::_squareMetersToAcres,                 FactMetaData::_acresToSquareMeters },
+    { "m^2",    "mi^2",     false,  QGroundControlQmlGlobal::AreaUnitsSquareMiles,         FactMetaData::_squareMetersToSquareMiles,           FactMetaData::_squareMilesToSquareMeters },
     { "m/s",    "ft/s",     true,   QGroundControlQmlGlobal::SpeedUnitsFeetPerSecond,       FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
     { "m/s",    "mph",      true,   QGroundControlQmlGlobal::SpeedUnitsMilesPerHour,        FactMetaData::_metersPerSecondToMilesPerHour,       FactMetaData::_milesPerHourToMetersPerSecond },
     { "m/s",    "km/h",     true,   QGroundControlQmlGlobal::SpeedUnitsKilometersPerHour,   FactMetaData::_metersPerSecondToKilometersPerHour,  FactMetaData::_kilometersPerHourToMetersPerSecond },
@@ -407,6 +413,56 @@ QVariant FactMetaData::_feetToMeters(const QVariant& feet)
     return QVariant(feet.toDouble() * 0.305);
 }
 
+QVariant FactMetaData::_squareMetersToSquareKilometers(const QVariant& squareMeters)
+{
+    return QVariant(squareMeters.toDouble() * 0.000001);
+}
+
+QVariant FactMetaData::_squareKilometersToSquareMeters(const QVariant& squareKilometers)
+{
+    return QVariant(squareKilometers.toDouble() * 1000000.0);
+}
+
+QVariant FactMetaData::_squareMetersToHectares(const QVariant& squareMeters)
+{
+    return QVariant(squareMeters.toDouble() * 0.0001);
+}
+
+QVariant FactMetaData::_hectaresToSquareMeters(const QVariant& hectares)
+{
+    return QVariant(hectares.toDouble() * 1000.0);
+}
+
+QVariant FactMetaData::_squareMetersToSquareFeet(const QVariant& squareMeters)
+{
+    return QVariant(squareMeters.toDouble() * 10.7639);
+}
+
+QVariant FactMetaData::_squareFeetToSquareMeters(const QVariant& squareFeet)
+{
+    return QVariant(squareFeet.toDouble() * 0.0929);
+}
+
+QVariant FactMetaData::_squareMetersToAcres(const QVariant& squareMeters)
+{
+    return QVariant(squareMeters.toDouble() * 0.000247105);
+}
+
+QVariant FactMetaData::_acresToSquareMeters(const QVariant& acres)
+{
+    return QVariant(acres.toDouble() * 4046.86);
+}
+
+QVariant FactMetaData::_squareMetersToSquareMiles(const QVariant& squareMeters)
+{
+    return QVariant(squareMeters.toDouble() * 3.86102e-7);
+}
+
+QVariant FactMetaData::_squareMilesToSquareMeters(const QVariant& squareMiles)
+{
+    return QVariant(squareMiles.toDouble() * 258999039.98855);
+}
+
 QVariant FactMetaData::_metersPerSecondToMilesPerHour(const QVariant& metersPerSecond)
 {
     return QVariant((metersPerSecond.toDouble() * 0.000621371192) * 60.0 * 60.0);
@@ -547,6 +603,21 @@ const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsDist
     return NULL;
 }
 
+const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsAreaUnitsTranslation(const QString& rawUnits)
+{
+    for (size_t i=0; i<sizeof(_rgAppSettingsTranslations)/sizeof(_rgAppSettingsTranslations[0]); i++) {
+        const AppSettingsTranslation_s* pAppSettingsTranslation = &_rgAppSettingsTranslations[i];
+
+        if (pAppSettingsTranslation->rawUnits == rawUnits &&
+                 (!pAppSettingsTranslation->speed && pAppSettingsTranslation->speedOrDistanceUnits == QGroundControlQmlGlobal::areaUnits()->rawValue().toUInt())
+                ) {
+            return pAppSettingsTranslation;
+        }
+    }
+
+    return NULL;
+}
+
 QVariant FactMetaData::metersToAppSettingsDistanceUnits(const QVariant& meters)
 {
     const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsDistanceUnitsTranslation("m");
@@ -574,6 +645,36 @@ QString FactMetaData::appSettingsDistanceUnitsString(void)
         return pAppSettingsTranslation->cookedUnits;
     } else {
         return QStringLiteral("m");
+    }
+}
+
+QVariant FactMetaData::squareMetersToAppSettingsAreaUnits(const QVariant& squareMeters)
+{
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAreaUnitsTranslation("m^2");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->rawTranslator(squareMeters);
+    } else {
+        return squareMeters;
+    }
+}
+
+QVariant FactMetaData::appSettingsAreaUnitsToSquareMeters(const QVariant& area)
+{
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAreaUnitsTranslation("m^2");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->cookedTranslator(area);
+    } else {
+        return area;
+    }
+}
+
+QString FactMetaData::appSettingsAreaUnitsString(void)
+{
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAreaUnitsTranslation("m^2");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->cookedUnits;
+    } else {
+        return QStringLiteral("m^2");
     }
 }
 

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -57,6 +57,15 @@ public:
     /// Returns the string for distance units which has configued by user
     static QString appSettingsDistanceUnitsString(void);
 
+    /// Converts from meters to the user specified distance unit
+    static QVariant squareMetersToAppSettingsAreaUnits(const QVariant& squareMeters);
+
+    /// Converts from user specified distance unit to meters
+    static QVariant appSettingsAreaUnitsToSquareMeters(const QVariant& area);
+
+    /// Returns the string for distance units which has configued by user
+    static QString appSettingsAreaUnitsString(void);
+
     int             decimalPlaces           (void) const;
     QVariant        rawDefaultValue         (void) const;
     QVariant        cookedDefaultValue      (void) const { return _rawTranslator(rawDefaultValue()); }
@@ -144,6 +153,16 @@ private:
     static QVariant _degreesToCentiDegrees(const QVariant& degrees);
     static QVariant _metersToFeet(const QVariant& meters);
     static QVariant _feetToMeters(const QVariant& feet);
+    static QVariant _squareMetersToSquareKilometers(const QVariant& squareMeters);
+    static QVariant _squareKilometersToSquareMeters(const QVariant& squareKilometers);
+    static QVariant _squareMetersToHectares(const QVariant& squareMeters);
+    static QVariant _hectaresToSquareMeters(const QVariant& hectares);
+    static QVariant _squareMetersToSquareFeet(const QVariant& squareMeters);
+    static QVariant _squareFeetToSquareMeters(const QVariant& squareFeet);
+    static QVariant _squareMetersToAcres(const QVariant& squareMeters);
+    static QVariant _acresToSquareMeters(const QVariant& acres);
+    static QVariant _squareMetersToSquareMiles(const QVariant& squareMeters);
+    static QVariant _squareMilesToSquareMeters(const QVariant& squareMiles);
     static QVariant _metersPerSecondToMilesPerHour(const QVariant& metersPerSecond);
     static QVariant _milesPerHourToMetersPerSecond(const QVariant& milesPerHour);
     static QVariant _metersPerSecondToKilometersPerHour(const QVariant& metersPerSecond);
@@ -164,6 +183,7 @@ private:
     };
 
     static const AppSettingsTranslation_s* _findAppSettingsDistanceUnitsTranslation(const QString& rawUnits);
+    static const AppSettingsTranslation_s* _findAppSettingsAreaUnitsTranslation(const QString& rawUnits);
 
     ValueType_t     _type;                  // must be first for correct constructor init
     int             _decimalPlaces;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -21,6 +21,8 @@ SettingsFact* QGroundControlQmlGlobal::_offlineEditingFirmwareTypeFact =        
 FactMetaData* QGroundControlQmlGlobal::_offlineEditingFirmwareTypeMetaData =    NULL;
 SettingsFact* QGroundControlQmlGlobal::_distanceUnitsFact =                     NULL;
 FactMetaData* QGroundControlQmlGlobal::_distanceUnitsMetaData =                 NULL;
+SettingsFact* QGroundControlQmlGlobal::_areaUnitsFact =                         NULL;
+FactMetaData* QGroundControlQmlGlobal::_areaUnitsMetaData =                     NULL;
 SettingsFact* QGroundControlQmlGlobal::_speedUnitsFact =                        NULL;
 FactMetaData* QGroundControlQmlGlobal::_speedUnitsMetaData =                    NULL;
 
@@ -243,6 +245,26 @@ Fact* QGroundControlQmlGlobal::distanceUnits(void)
     }
 
     return _distanceUnitsFact;
+
+}
+
+Fact* QGroundControlQmlGlobal::areaUnits(void)
+{
+    if (!_areaUnitsFact) {
+        QStringList     enumStrings;
+        QVariantList    enumValues;
+
+        _areaUnitsFact = new SettingsFact(QString(), "AreaUnits", FactMetaData::valueTypeUint32, AreaUnitsSquareMeters);
+        _areaUnitsMetaData = new FactMetaData(FactMetaData::valueTypeUint32);
+
+        enumStrings << "SquareFeet" << "SquareMeters" << "SquareKilometers" << "Hectares" << "Acres" << "SquareMiles";
+        enumValues << QVariant::fromValue((uint32_t)AreaUnitsSquareFeet) << QVariant::fromValue((uint32_t)AreaUnitsSquareMeters) << QVariant::fromValue((uint32_t)AreaUnitsSquareKilometers) << QVariant::fromValue((uint32_t)AreaUnitsHectares) << QVariant::fromValue((uint32_t)AreaUnitsAcres) << QVariant::fromValue((uint32_t)AreaUnitsSquareMiles);
+
+        _areaUnitsMetaData->setEnumInfo(enumStrings, enumValues);
+        _areaUnitsFact->setMetaData(_areaUnitsMetaData);
+    }
+
+    return _areaUnitsFact;
 
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -44,6 +44,15 @@ public:
         DistanceUnitsMeters
     };
 
+    enum AreaUnits {
+        AreaUnitsSquareFeet = 0,
+        AreaUnitsSquareMeters,
+        AreaUnitsSquareKilometers,
+        AreaUnitsHectares,
+        AreaUnitsAcres,
+        AreaUnitsSquareMiles,
+    };
+
     enum SpeedUnits {
         SpeedUnitsFeetPerSecond = 0,
         SpeedUnitsMetersPerSecond,
@@ -53,6 +62,7 @@ public:
     };
 
     Q_ENUMS(DistanceUnits)
+    Q_ENUMS(AreaUnits)
     Q_ENUMS(SpeedUnits)
 
     Q_PROPERTY(FlightMapSettings*   flightMapSettings   READ flightMapSettings      CONSTANT)
@@ -83,6 +93,7 @@ public:
 
     Q_PROPERTY(Fact*    offlineEditingFirmwareType  READ offlineEditingFirmwareType CONSTANT)
     Q_PROPERTY(Fact*    distanceUnits               READ distanceUnits              CONSTANT)
+    Q_PROPERTY(Fact*    areaUnits                   READ areaUnits                  CONSTANT)
     Q_PROPERTY(Fact*    speedUnits                  READ speedUnits                 CONSTANT)
 
     Q_PROPERTY(QGeoCoordinate lastKnownHomePosition READ lastKnownHomePosition  CONSTANT)
@@ -95,6 +106,7 @@ public:
 
     /// Returns the string for distance units which has configued by user
     Q_PROPERTY(QString appSettingsDistanceUnitsString READ appSettingsDistanceUnitsString CONSTANT)
+    Q_PROPERTY(QString appSettingsAreaUnitsString READ appSettingsAreaUnitsString CONSTANT)
 
     Q_INVOKABLE void    saveGlobalSetting       (const QString& key, const QString& value);
     Q_INVOKABLE QString loadGlobalSetting       (const QString& key, const QString& defaultValue);
@@ -117,6 +129,14 @@ public:
     Q_INVOKABLE QVariant appSettingsDistanceUnitsToMeters(const QVariant& distance) const { return FactMetaData::appSettingsDistanceUnitsToMeters(distance); }
 
     QString appSettingsDistanceUnitsString(void) const { return FactMetaData::appSettingsDistanceUnitsString(); }
+
+    /// Converts from square meters to the user specified area unit
+    Q_INVOKABLE QVariant squareMetersToAppSettingsAreaUnits(const QVariant& meters) const { return FactMetaData::squareMetersToAppSettingsAreaUnits(meters); }
+
+    /// Converts from user specified area unit to square meters
+    Q_INVOKABLE QVariant appSettingsAreaUnitsToSquareMeters(const QVariant& area) const { return FactMetaData::appSettingsAreaUnitsToSquareMeters(area); }
+
+    QString appSettingsAreaUnitsString(void) const { return FactMetaData::appSettingsAreaUnitsString(); }
 
     /// Returns the list of available logging category names.
     Q_INVOKABLE QStringList loggingCategories(void) const { return QGCLoggingCategoryRegister::instance()->registeredCategories(); }
@@ -159,6 +179,7 @@ public:
 
     static Fact* offlineEditingFirmwareType (void);
     static Fact* distanceUnits              (void);
+    static Fact* areaUnits                  (void);
     static Fact* speedUnits                 (void);
 
     //-- TODO: Make this into an actual preference.
@@ -214,6 +235,8 @@ private:
     static FactMetaData*    _offlineEditingFirmwareTypeMetaData;
     static SettingsFact*    _distanceUnitsFact;
     static FactMetaData*    _distanceUnitsMetaData;
+    static SettingsFact*    _areaUnitsFact;
+    static FactMetaData*    _areaUnitsMetaData;
     static SettingsFact*    _speedUnitsFact;
     static FactMetaData*    _speedUnitsMetaData;
 

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -139,6 +139,29 @@ QGCView {
                 }
 
                 Row {
+                    spacing:    ScreenTools.defaultFontPixelWidth
+
+                    QGCLabel {
+                        width:              baseFontLabel.width
+                        anchors.baseline:   areaUnitsCombo.baseline
+                        text:               qsTr("Area units:")
+                    }
+
+                    FactComboBox {
+                        id:                 areaUnitsCombo
+                        width:              _editFieldWidth
+                        fact:               QGroundControl.areaUnits
+                        indexModel:         false
+                    }
+
+                    QGCLabel {
+                        anchors.baseline:   areaUnitsCombo.baseline
+                        text:               qsTr("(requires app restart)")
+                    }
+
+                }
+
+                Row {
                     spacing:                ScreenTools.defaultFontPixelWidth
 
                     QGCLabel {


### PR DESCRIPTION
This PR is part of the new [mission stats](https://github.com/mavlink/qgroundcontrol/issues/3802) feature.

It adds a choice for area unit, which will then later be used to display the area of a survey mission.

It supports:
* Square meters
* Square kilometers
* Hectares
* Square feet
* Acres
* Square miles