### PR TITLE
[Mission stats] Computing number of shots and covered area

### DIFF
--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -34,25 +34,30 @@ Rectangle {
 
     property real   _collapsedWidth:    valueGrid.width + (margins * 2)
     property bool   _expanded:          true
+
     property real   _distance:          _statusValid ? _currentMissionItem.distance : 0
     property real   _altDifference:     _statusValid ? _currentMissionItem.altDifference : 0
     property real   _gradient:          _statusValid || _currentMissionItem.distance == 0 ? Math.atan(_currentMissionItem.altDifference / _currentMissionItem.distance) : 0
     property real   _gradientPercent:   isNaN(_gradient) ? 0 : _gradient * 100
     property real   _azimuth:           _statusValid ? _currentMissionItem.azimuth : -1
+    property int    _numberShots:       _currentSurvey ? _currentMissionItem.cameraShots : 0
+    property real   _coveredArea:       _currentSurvey ? _currentMissionItem.coveredArea : 0
+
     property bool   _statusValid:       currentMissionItem != undefined
     property bool   _vehicleValid:      _activeVehicle != undefined
     property bool   _missionValid:      missionItems != undefined
     property bool   _currentSurvey:     _statusValid ? currentMissionItem.commandName == "Survey" : false
+    property bool   _isVTOL:            _vehicleValid ? _activeVehicle.vtol : false
+
     property string _distanceText:      _statusValid ? QGroundControl.metersToAppSettingsDistanceUnits(_distance).toFixed(2) + " " + QGroundControl.appSettingsDistanceUnitsString : " "
     property string _altText:           _statusValid ? QGroundControl.metersToAppSettingsDistanceUnits(_altDifference).toFixed(2) + " " + QGroundControl.appSettingsDistanceUnitsString : " "
     property string _gradientText:      _statusValid ? _gradientPercent.toFixed(0) + "%" : " "
     property string _azimuthText:       _statusValid ? Math.round(_azimuth) : " "
-    property string _numberShotsText:   _currentSurvey ? "783" : " "
-    property string _coveredAreaText:   _currentSurvey ? "87ha / 217acr" : " "
+    property string _numberShotsText:   _currentSurvey ? _numberShots.toFixed(0) : " "
+    property string _coveredAreaText:   _currentSurvey ? QGroundControl.squareMetersToAppSettingsAreaUnits(_coveredArea).toFixed(2) + " " + QGroundControl.appSettingsAreaUnitsString : " "
     property string _totalDistanceText: _missionValid ? "30.91" + " " + QGroundControl.appSettingsDistanceUnitsString : " "
     property string _totalTimeText:     _missionValid ? "34min 23s" : " "
     property string _maxTelemDistText:  _missionValid ? "5.23" + " " + QGroundControl.appSettingsDistanceUnitsString : " "
-    property bool   _isVTOL:            _vehicleValid ? _activeVehicle.vtol : false
     property string _hoverDistanceText: _missionValid ? "0.47" + " " + QGroundControl.appSettingsDistanceUnitsString : " "
     property string _cruiseDistanceText: _missionValid ? "30.44" + " " + QGroundControl.appSettingsDistanceUnitsString : " "
     property string _hoverTimeText:     _missionValid ? "4min 02s" : " "

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -25,6 +25,8 @@ class ComplexMissionItem : public VisualMissionItem
 public:
     ComplexMissionItem(Vehicle* vehicle, QObject* parent = NULL);
 
+    const ComplexMissionItem& operator=(const ComplexMissionItem& other);
+
     Q_PROPERTY(Fact*                gridAltitude            READ gridAltitude               CONSTANT)
     Q_PROPERTY(bool                 gridAltitudeRelative    MEMBER _gridAltitudeRelative    NOTIFY gridAltitudeRelativeChanged)
     Q_PROPERTY(Fact*                gridAngle               READ gridAngle                  CONSTANT)
@@ -34,6 +36,9 @@ public:
     Q_PROPERTY(QVariantList         polygonPath             READ polygonPath                NOTIFY polygonPathChanged)
     Q_PROPERTY(int                  lastSequenceNumber      READ lastSequenceNumber         NOTIFY lastSequenceNumberChanged)
     Q_PROPERTY(QVariantList         gridPoints              READ gridPoints                 NOTIFY gridPointsChanged)
+
+    Q_PROPERTY(int                  cameraShots             READ cameraShots                NOTIFY cameraShotsChanged)
+    Q_PROPERTY(double               coveredArea             READ coveredArea                NOTIFY coveredAreaChanged)
 
     Q_INVOKABLE void clearPolygon(void);
     Q_INVOKABLE void addPolygonCoordinate(const QGeoCoordinate coordinate);
@@ -46,6 +51,12 @@ public:
     Fact* gridAngle(void)       { return &_gridAngleFact; }
     Fact* gridSpacing(void)     { return &_gridSpacingFact; }
     Fact* cameraTriggerDistance(void) { return &_cameraTriggerDistanceFact; }
+
+    int     cameraShots         (void) const { return _cameraShots; }
+    double  coveredArea         (void) const { return _coveredArea; }
+
+    void setCameraShots         (int cameraShots);
+    void setCoveredArea         (double coveredArea);
 
     /// @return The last sequence number used by this item. Takes into account child items of the complex item
     int lastSequenceNumber(void) const;
@@ -91,6 +102,9 @@ signals:
     void cameraTriggerChanged           (bool cameraTrigger);
     void gridAltitudeRelativeChanged    (bool gridAltitudeRelative);
 
+    void cameraShotsChanged             (int cameraShots);
+    void coveredAreaChanged             (double coveredArea);
+
 private slots:
     void _cameraTriggerChanged(void);
 
@@ -114,6 +128,9 @@ private:
     double              _gridAngle;
     bool                _cameraTrigger;
     bool                _gridAltitudeRelative;
+
+    int                 _cameraShots;
+    double              _coveredArea;
 
     Fact    _gridAltitudeFact;
     Fact    _gridAngleFact;


### PR DESCRIPTION
This PR is part of the new [mission stats](https://github.com/mavlink/qgroundcontrol/issues/3802) feature.

This PR requires merging of https://github.com/mavlink/qgroundcontrol/pull/3828 and https://github.com/mavlink/qgroundcontrol/pull/3829 first.

* Computes the number of shots of a survey item, based on the distance and the selected triggering distance.
* Computes the area of the drawn polygon in the survey item and displays it as Covered area.