### PR TITLE
ArduSub: Disable radio setup page and component

### DIFF
--- a/src/AutoPilotPlugins/APM/APMRadioComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMRadioComponent.cc
@@ -87,12 +87,34 @@ QStringList APMRadioComponent::setupCompleteChangedTriggerList(void) const
 
 QUrl APMRadioComponent::setupSource(void) const
 {
-    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/RadioComponent.qml"));
+    QString qmlFile;
+
+    switch (_vehicle->vehicleType()) {
+        case MAV_TYPE_SUBMARINE:
+            qmlFile = QStringLiteral("qrc:/qml/APMNotSupported.qml");
+            break;
+        default:
+            qmlFile = QStringLiteral("qrc:/qml/RadioComponent.qml");
+            break;
+    }
+
+    return QUrl::fromUserInput(qmlFile);
 }
 
 QUrl APMRadioComponent::summaryQmlSource(void) const
 {
-    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMRadioComponentSummary.qml"));
+    QString qmlFile;
+
+    switch (_vehicle->vehicleType()) {
+        case MAV_TYPE_SUBMARINE:
+            qmlFile = QStringLiteral("qrc:/qml/APMNotSupported.qml");
+            break;
+        default:
+            qmlFile = QStringLiteral("qrc:/qml/APMRadioComponentSummary.qml");
+            break;
+    }
+
+    return QUrl::fromUserInput(qmlFile);
 }
 
 QString APMRadioComponent::prerequisiteSetup(void) const


### PR DESCRIPTION
This PR disables the radio setup page when an ArduSub vehicle is connected. The vehicle is detected with MAV_TYPE_SUBMARINE.

The radio page is not needed for ArduSub because it is controlled exclusively through the use of the QGC joystick feature. The radio setup page is confusing for ArduSub users and the calibration process results in settings that are changed to undesirable values.

Please let me know if you have any questions or require any changes. I really appreciate your support!

Thanks!