### PR TITLE
ArduSub: Disable joystick warning message

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -91,7 +91,7 @@ QGCView {
     }
 
     function px4JoystickCheck() {
-        if (_activeVehicle && !_activeVehicle.px4Firmware && (QGroundControl.virtualTabletJoystick || _activeVehicle.joystickEnabled)) {
+        if ( _activeVehicle && !_activeVehicle.supportsManualControl && (QGroundControl.virtualTabletJoystick || _activeVehicle.joystickEnabled)) {
             px4JoystickSupport.open()
         }
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1505,6 +1505,19 @@ bool Vehicle::vtol(void) const
     }
 }
 
+bool Vehicle::supportsManualControl(void) const
+{
+    // PX4 Firmware supports manual control message
+    if ( px4Firmware() ) {
+        return true;
+    }
+    // ArduSub supports manual control message (identified by APM + Submarine type)
+    if ( apmFirmware() && vehicleType() == MAV_TYPE_SUBMARINE ) {
+        return true;
+    }
+    return false;
+}
+
 void Vehicle::_setCoordinateValid(bool coordinateValid)
 {
     if (coordinateValid != _coordinateValid) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -275,6 +275,7 @@ public:
     Q_PROPERTY(bool                 multiRotor              READ multiRotor                                             CONSTANT)
     Q_PROPERTY(bool                 vtol                    READ vtol                                                   CONSTANT)
     Q_PROPERTY(bool                 rover                   READ rover                                                  CONSTANT)
+    Q_PROPERTY(bool                 supportsManualControl   READ supportsManualControl                                  CONSTANT)
     Q_PROPERTY(bool                 autoDisconnect          MEMBER _autoDisconnect                                      NOTIFY autoDisconnectChanged)
     Q_PROPERTY(QString              prearmError             READ prearmError            WRITE setPrearmError            NOTIFY prearmErrorChanged)
     Q_PROPERTY(int                  motorCount              READ motorCount                                             CONSTANT)
@@ -465,6 +466,8 @@ public:
     bool multiRotor(void) const;
     bool vtol(void) const;
     bool rover(void) const;
+
+    bool supportsManualControl(void) const;
 
     void setFlying(bool flying);
     void setGuidedMode(bool guidedMode);


### PR DESCRIPTION
When an APM vehicle is connected and a joystick is enabled, QGC currently pops up a dialog warning the user that the vehicle must support the `MANUAL_CONTROL` message to be used with the joystick. That is appropriate for most APM vehicles, which don't support `MANUAL_CONTROL`. 

This PR disables this message for ArduSub firmware, which does support the `MANUAL_CONTROL` message. The message is still shown for all other APM firmware types.

ArduSub is detected with `MAV_TYPE_SUBMARINE`.

Please let me know if you have any questions or concerns.

Thanks!