### PR TITLE
ArduSub: Disable radio setup page (Take 2)

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -63,9 +63,11 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
             _airframeComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_airframeComponent));
 
-            _radioComponent = new APMRadioComponent(_vehicle, this);
-            _radioComponent->setupTriggerSignals();
-            _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
+            if ( !_vehicle->sub() ) {
+                _radioComponent = new APMRadioComponent(_vehicle, this);
+                _radioComponent->setupTriggerSignals();
+                _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
+            }
 
             _flightModesComponent = new APMFlightModesComponent(_vehicle, this);
             _flightModesComponent->setupTriggerSignals();

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.cc
@@ -66,8 +66,10 @@ QString APMFlightModesComponent::prerequisiteSetup(void) const
 
     if (!plugin->airframeComponent()->setupComplete()) {
         return plugin->airframeComponent()->name();
-    } else if (!plugin->radioComponent()->setupComplete()) {
-        return plugin->radioComponent()->name();
+    } else if (plugin->radioComponent() != NULL) {
+        if (!plugin->radioComponent()->setupComplete()) {
+            return plugin->radioComponent()->name();
+        }
     }
     
     return QString();

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1474,6 +1474,11 @@ bool Vehicle::rover(void) const
     return vehicleType() == MAV_TYPE_GROUND_ROVER;
 }
 
+bool Vehicle::sub(void) const
+{
+    return vehicleType() == MAV_TYPE_SUBMARINE;
+}
+
 bool Vehicle::multiRotor(void) const
 {
     switch (vehicleType()) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -276,6 +276,7 @@ public:
     Q_PROPERTY(bool                 vtol                    READ vtol                                                   CONSTANT)
     Q_PROPERTY(bool                 rover                   READ rover                                                  CONSTANT)
     Q_PROPERTY(bool                 supportsManualControl   READ supportsManualControl                                  CONSTANT)
+    Q_PROPERTY(bool                 sub                     READ sub                                                    CONSTANT)
     Q_PROPERTY(bool                 autoDisconnect          MEMBER _autoDisconnect                                      NOTIFY autoDisconnectChanged)
     Q_PROPERTY(QString              prearmError             READ prearmError            WRITE setPrearmError            NOTIFY prearmErrorChanged)
     Q_PROPERTY(int                  motorCount              READ motorCount                                             CONSTANT)
@@ -466,6 +467,7 @@ public:
     bool multiRotor(void) const;
     bool vtol(void) const;
     bool rover(void) const;
+    bool sub(void) const;
 
     bool supportsManualControl(void) const;
 


### PR DESCRIPTION
This PR disables the radio setup page when an ArduSub vehicle is connected. The vehicle is detected with MAV_TYPE_SUBMARINE.

The radio page is not needed for ArduSub because it is controlled exclusively through the use of the QGC joystick feature. The radio setup page is confusing for ArduSub users and the calibration process results in settings that are changed to undesirable values.

Please let me know if you have any questions or require any changes. I really appreciate your support!

Thanks!