### PR TITLE
Log download fixes.

### DIFF
--- a/src/ViewWidgets/LogDownloadController.h
+++ b/src/ViewWidgets/LogDownloadController.h
@@ -152,10 +152,11 @@ private:
     void _receivedAllData   ();
     void _resetSelection    (bool canceled = false);
     void _findMissingData   ();
-    void _requestLogList    (uint32_t start = 0, uint32_t end = 0xFFFF);
+    void _requestLogList    (uint32_t start, uint32_t end);
     void _requestLogData    (uint8_t id, uint32_t offset = 0, uint32_t count = 0xFFFFFFFF);
     bool _prepareLogDownload();
     void _setDownloading    (bool active);
+    void _setListing        (bool active);
 
     QGCLogEntry* _getNextSelected();
 


### PR DESCRIPTION
In response to #3763 

Increased the timeout for log listing to accommodate the time it takes for the firmware to build the list before sending it.

Disabled heartbeat timeout during log listing as it is done with log downloading. For long listings (where you have a lot of log files to list), QGC was timing out and issuing "Connection Lost" during the list download.

There is a corresponding firmware change (https://github.com/PX4/Firmware/pull/5133), which handles the deletion of the "msgs_*" files along with the log files.