### PR TITLE
[Mission stats] Offline planning settings

### DIFF
--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -19,6 +19,10 @@ static const char* kQmlGlobalKeyName = "QGCQml";
 
 SettingsFact* QGroundControlQmlGlobal::_offlineEditingFirmwareTypeFact =        NULL;
 FactMetaData* QGroundControlQmlGlobal::_offlineEditingFirmwareTypeMetaData =    NULL;
+SettingsFact* QGroundControlQmlGlobal::_offlineEditingVehicleTypeFact =         NULL;
+FactMetaData* QGroundControlQmlGlobal::_offlineEditingVehicleTypeMetaData =     NULL;
+SettingsFact* QGroundControlQmlGlobal::_offlineEditingCruiseSpeedFact =         NULL;
+SettingsFact* QGroundControlQmlGlobal::_offlineEditingHoverSpeedFact =          NULL;
 SettingsFact* QGroundControlQmlGlobal::_distanceUnitsFact =                     NULL;
 FactMetaData* QGroundControlQmlGlobal::_distanceUnitsMetaData =                 NULL;
 SettingsFact* QGroundControlQmlGlobal::_speedUnitsFact =                        NULL;
@@ -224,6 +228,41 @@ Fact* QGroundControlQmlGlobal::offlineEditingFirmwareType(void)
     }
 
     return _offlineEditingFirmwareTypeFact;
+}
+
+Fact* QGroundControlQmlGlobal::offlineEditingVehicleType(void)
+{
+    if (!_offlineEditingVehicleTypeFact) {
+        QStringList     enumStrings;
+        QVariantList    enumValues;
+
+        _offlineEditingVehicleTypeFact = new SettingsFact(QString(), "OfflineEditingVehicleType", FactMetaData::valueTypeUint32, (uint32_t)MAV_TYPE_FIXED_WING);
+        _offlineEditingVehicleTypeMetaData = new FactMetaData(FactMetaData::valueTypeUint32);
+
+        enumStrings << "Fixedwing" << "Multicopter" << "VTOL";
+        enumValues << QVariant::fromValue((uint32_t)MAV_TYPE_FIXED_WING) << QVariant::fromValue((uint32_t)MAV_TYPE_QUADROTOR) << QVariant::fromValue((uint32_t)MAV_TYPE_VTOL_DUOROTOR);
+
+        _offlineEditingVehicleTypeMetaData->setEnumInfo(enumStrings, enumValues);
+        _offlineEditingVehicleTypeFact->setMetaData(_offlineEditingVehicleTypeMetaData);
+    }
+
+    return _offlineEditingVehicleTypeFact;
+}
+
+Fact* QGroundControlQmlGlobal::offlineEditingCruiseSpeed(void)
+{
+    if (!_offlineEditingCruiseSpeedFact) {
+        _offlineEditingCruiseSpeedFact = new SettingsFact(QString(), "OfflineEditingCruiseSpeed", FactMetaData::valueTypeDouble, 16.0);
+    }
+    return _offlineEditingCruiseSpeedFact;
+}
+
+Fact* QGroundControlQmlGlobal::offlineEditingHoverSpeed(void)
+{
+    if (!_offlineEditingHoverSpeedFact) {
+        _offlineEditingHoverSpeedFact = new SettingsFact(QString(), "OfflineEditingHoverSpeed", FactMetaData::valueTypeDouble, 4.0);
+    }
+    return _offlineEditingHoverSpeedFact;
 }
 
 Fact* QGroundControlQmlGlobal::distanceUnits(void)

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -82,6 +82,9 @@ public:
     Q_PROPERTY(int      mavlinkSystemID         READ mavlinkSystemID            WRITE setMavlinkSystemID            NOTIFY mavlinkSystemIDChanged)
 
     Q_PROPERTY(Fact*    offlineEditingFirmwareType  READ offlineEditingFirmwareType CONSTANT)
+    Q_PROPERTY(Fact*    offlineEditingVehicleType   READ offlineEditingVehicleType  CONSTANT)
+    Q_PROPERTY(Fact*    offlineEditingCruiseSpeed   READ offlineEditingCruiseSpeed  CONSTANT)
+    Q_PROPERTY(Fact*    offlineEditingHoverSpeed    READ offlineEditingHoverSpeed   CONSTANT)
     Q_PROPERTY(Fact*    distanceUnits               READ distanceUnits              CONSTANT)
     Q_PROPERTY(Fact*    speedUnits                  READ speedUnits                 CONSTANT)
 
@@ -158,6 +161,9 @@ public:
     QGeoCoordinate lastKnownHomePosition() { return qgcApp()->lastKnownHomePosition(); }
 
     static Fact* offlineEditingFirmwareType (void);
+    static Fact* offlineEditingVehicleType  (void);
+    static Fact* offlineEditingCruiseSpeed  (void);
+    static Fact* offlineEditingHoverSpeed   (void);
     static Fact* distanceUnits              (void);
     static Fact* speedUnits                 (void);
 
@@ -212,6 +218,10 @@ private:
     // These are static so they are available to C++ code as well as Qml
     static SettingsFact*    _offlineEditingFirmwareTypeFact;
     static FactMetaData*    _offlineEditingFirmwareTypeMetaData;
+    static SettingsFact*    _offlineEditingVehicleTypeFact;
+    static FactMetaData*    _offlineEditingVehicleTypeMetaData;
+    static SettingsFact*    _offlineEditingCruiseSpeedFact;
+    static SettingsFact*    _offlineEditingHoverSpeedFact;
     static SettingsFact*    _distanceUnitsFact;
     static FactMetaData*    _distanceUnitsMetaData;
     static SettingsFact*    _speedUnitsFact;

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -378,11 +378,15 @@ QGCView {
 
                 //-----------------------------------------------------------------
                 //-- Offline mission editing settings
+
+                QGCLabel { text: "Offline mission editing" }
+
                 Row {
                     spacing: ScreenTools.defaultFontPixelWidth
 
                     QGCLabel {
-                        text:               qsTr("Offline mission editing:")
+                        text:               qsTr("Firmware:")
+                        width:              hoverSpeedLabel.width
                         anchors.baseline:   offlineTypeCombo.baseline
                     }
 
@@ -391,6 +395,62 @@ QGCView {
                         width:      ScreenTools.defaultFontPixelWidth * 18
                         fact:       QGroundControl.offlineEditingFirmwareType
                         indexModel: false
+                    }
+                }
+
+                Row {
+                    spacing: ScreenTools.defaultFontPixelWidth
+
+                    QGCLabel {
+                        text:               qsTr("Vehicle:")
+                        width:              hoverSpeedLabel.width
+                        anchors.baseline:   offlineVehicleCombo.baseline
+                    }
+
+                    FactComboBox {
+                        id:         offlineVehicleCombo
+                        width:      offlineTypeCombo.width
+                        fact:       QGroundControl.offlineEditingVehicleType
+                        indexModel: false
+                    }
+                }
+
+                Row {
+                    spacing: ScreenTools.defaultFontPixelWidth
+                    visible:  offlineVehicleCombo.currentText != "Multicopter"
+
+                    QGCLabel {
+                        text:               qsTr("Cruise speed:")
+                        width:              hoverSpeedLabel.width
+                        anchors.baseline:   cruiseSpeedField.baseline
+                    }
+
+
+                    FactTextField {
+                        id:                 cruiseSpeedField
+                        width:              offlineTypeCombo.width
+                        fact:               QGroundControl.offlineEditingCruiseSpeed
+                        enabled:            true
+                    }
+                }
+
+                Row {
+                    spacing: ScreenTools.defaultFontPixelWidth
+                    visible:  offlineVehicleCombo.currentText != "Fixedwing"
+
+                    QGCLabel {
+                        id:                 hoverSpeedLabel
+                        text:               qsTr("Hover speed:")
+                        width:              baseFontLabel.width
+                        anchors.baseline:   hoverSpeedField.baseline
+                    }
+
+
+                    FactTextField {
+                        id:                 hoverSpeedField
+                        width:              offlineTypeCombo.width
+                        fact:               QGroundControl.offlineEditingHoverSpeed
+                        enabled:            true
                     }
                 }
 


### PR DESCRIPTION
This PR is part of the new [mission stats](https://github.com/mavlink/qgroundcontrol/issues/3802) feature.

It gives the user the option to select in general settings:
* Vehicle type: {Fixedwing, Multicopter, VTOL}
* Nominal cruise speed (only visible if not selected multicopter)
* Nominal hover speed (only visible if not selected fixedwing)

These values will be used to calculated a flight duration estimate while planning missions.