### PR TITLE
Fix persistency of joystickEnable setting

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1119,7 +1119,12 @@ void Vehicle::_saveSettings(void)
     settings.beginGroup(QString(_settingsGroup).arg(_id));
 
     settings.setValue(_joystickModeSettingsKey, _joystickMode);
-    settings.setValue(_joystickEnabledSettingsKey, _joystickEnabled);
+
+    // The joystick enabled setting should only be changed if a joystick is present
+    // since the checkbox can only be clicked if one is present
+    if (qgcApp()->toolbox()->joystickManager()->joysticks().count()) {
+        settings.setValue(_joystickEnabledSettingsKey, _joystickEnabled);
+    }
 }
 
 int Vehicle::joystickMode(void)


### PR DESCRIPTION
As discussed with Don, this prevents the "joystick enabled" setting from being disabled every time QGC opens without a joystick attached. The "joystick enabled" setting will only be loaded and saved if a joystick is attached, otherwise, it will always be `false`.