### PR TITLE
[Mission stats] Compute distance & time

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -693,6 +693,10 @@ QGCView {
                     currentMissionItem: _currentMissionItem
                     missionItems:       controller.visualItems
                     expandedWidth:      missionItemEditor.x - (ScreenTools.defaultFontPixelWidth * 2)
+                    missionDistance:    controller.missionDistance
+                    missionMaxTelemetry: controller.missionMaxTelemetry
+                    cruiseDistance:    controller.cruiseDistance
+                    hoverDistance:    controller.hoverDistance
                     visible:            !ScreenTools.isShortScreen
                 }
             } // FlightMap

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -15,13 +15,23 @@ import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0
 import QGroundControl               1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
 
 Rectangle {
     readonly property var       _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
 
+    property Fact   _offlineEditingVehicleType:     QGroundControl.offlineEditingVehicleType
+    property Fact   _offlineEditingCruiseSpeed:     QGroundControl.offlineEditingCruiseSpeed
+    property Fact   _offlineEditingHoverSpeed:      QGroundControl.offlineEditingHoverSpeed
+
     property var    currentMissionItem          ///< Mission item to display status for
     property var    missionItems                ///< List of all available mission items
     property real   expandedWidth               ///< Width of control when expanded
+    property real   missionDistance
+    property real   missionMaxTelemetry
+    property real   cruiseDistance
+    property real   hoverDistance
 
     width:      _expanded ? expandedWidth : _collapsedWidth
     height:     Math.max(valueGrid.height, valueMissionGrid.height) + (_margins * 2)
@@ -37,17 +47,25 @@ Rectangle {
 
     property real   _distance:          _statusValid ? _currentMissionItem.distance : 0
     property real   _altDifference:     _statusValid ? _currentMissionItem.altDifference : 0
-    property real   _gradient:          _statusValid || _currentMissionItem.distance == 0 ? Math.atan(_currentMissionItem.altDifference / _currentMissionItem.distance) : 0
+    property real   _gradient:          _statusValid && _currentMissionItem.distance > 0 ? Math.atan(_currentMissionItem.altDifference / _currentMissionItem.distance) : 0
     property real   _gradientPercent:   isNaN(_gradient) ? 0 : _gradient * 100
     property real   _azimuth:           _statusValid ? _currentMissionItem.azimuth : -1
     property int    _numberShots:       _currentSurvey ? _currentMissionItem.cameraShots : 0
     property real   _coveredArea:       _currentSurvey ? _currentMissionItem.coveredArea : 0
+    property real   _missionDistance:   _missionValid ? missionDistance : 0
+    property real   _missionMaxTelemetry: _missionValid ? missionMaxTelemetry : 0
+    property real   _missionTime:       _missionValid && _missionSpeed > 0 ?  (_isVTOL ? _hoverTime + _cruiseTime : _missionDistance / _missionSpeed) : 0
+    property real   _hoverDistance:    _missionValid ? hoverDistance : 0
+    property real   _cruiseDistance:    _missionValid ? cruiseDistance : 0
+    property real   _hoverTime:         _missionValid && _offlineEditingHoverSpeed.value > 0 ? _hoverDistance / _offlineEditingHoverSpeed.value : 0
+    property real   _cruiseTime:        _missionValid && _offlineEditingCruiseSpeed.value > 0 ? _cruiseDistance / _offlineEditingCruiseSpeed.value : 0
 
     property bool   _statusValid:       currentMissionItem != undefined
     property bool   _vehicleValid:      _activeVehicle != undefined
     property bool   _missionValid:      missionItems != undefined
-    property bool   _currentSurvey:     _statusValid ? currentMissionItem.commandName == "Survey" : false
-    property bool   _isVTOL:            _vehicleValid ? _activeVehicle.vtol : false
+    property bool   _currentSurvey:     _statusValid ? _currentMissionItem.commandName == "Survey" : false
+    property bool   _isVTOL:            _vehicleValid ? _activeVehicle.vtol : _offlineEditingVehicleType.enumStringValue == "VTOL" //hardcoded
+    property real   _missionSpeed:      _offlineEditingVehicleType.enumStringValue == "Fixedwing" ? _offlineEditingCruiseSpeed.value : _offlineEditingHoverSpeed.value
 
     property string _distanceText:      _statusValid ? QGroundControl.metersToAppSettingsDistanceUnits(_distance).toFixed(2) + " " + QGroundControl.appSettingsDistanceUnitsString : " "
     property string _altText:           _statusValid ? QGroundControl.metersToAppSettingsDistanceUnits(_altDifference).toFixed(2) + " " + QGroundControl.appSettingsDistanceUnitsString : " "
@@ -55,13 +73,13 @@ Rectangle {
     property string _azimuthText:       _statusValid ? Math.round(_azimuth) : " "
     property string _numberShotsText:   _currentSurvey ? _numberShots.toFixed(0) : " "
     property string _coveredAreaText:   _currentSurvey ? QGroundControl.squareMetersToAppSettingsAreaUnits(_coveredArea).toFixed(2) + " " + QGroundControl.appSettingsAreaUnitsString : " "
-    property string _totalDistanceText: _missionValid ? "30.91" + " " + QGroundControl.appSettingsDistanceUnitsString : " "
-    property string _totalTimeText:     _missionValid ? "34min 23s" : " "
-    property string _maxTelemDistText:  _missionValid ? "5.23" + " " + QGroundControl.appSettingsDistanceUnitsString : " "
-    property string _hoverDistanceText: _missionValid ? "0.47" + " " + QGroundControl.appSettingsDistanceUnitsString : " "
-    property string _cruiseDistanceText: _missionValid ? "30.44" + " " + QGroundControl.appSettingsDistanceUnitsString : " "
-    property string _hoverTimeText:     _missionValid ? "4min 02s" : " "
-    property string _cruiseTimeText:    _missionValid ? "34min 21s" : " "
+    property string _missionDistanceText: _missionValid ? QGroundControl.metersToAppSettingsDistanceUnits(_missionDistance).toFixed(2) + " " + QGroundControl.appSettingsDistanceUnitsString : " "
+    property string _missionTimeText:     _missionValid ? _missionTime.toFixed(0) + "s" : " "
+    property string _missionMaxTelemetryText:  _missionValid ? QGroundControl.metersToAppSettingsDistanceUnits(_missionMaxTelemetry).toFixed(2) + " " + QGroundControl.appSettingsDistanceUnitsString : " "
+    property string _hoverDistanceText: _missionValid ? QGroundControl.metersToAppSettingsDistanceUnits(_hoverDistance).toFixed(2) + " " + QGroundControl.appSettingsDistanceUnitsString : " "
+    property string _cruiseDistanceText: _missionValid ? QGroundControl.metersToAppSettingsDistanceUnits(_cruiseDistance).toFixed(2) + " " + QGroundControl.appSettingsDistanceUnitsString : " "
+    property string _hoverTimeText:     _missionValid ? _hoverTime.toFixed(0) + "s" : " "
+    property string _cruiseTimeText:    _missionValid ? _cruiseTime.toFixed(0) + "s" : " "
 
     readonly property real _margins:    ScreenTools.defaultFontPixelWidth
 
@@ -158,17 +176,17 @@ Rectangle {
             columnSpacing:      _margins
             anchors.verticalCenter: parent.verticalCenter
 
-            QGCLabel { text: qsTr("Total mission [WIP]") }
+            QGCLabel { text: qsTr("Total mission") }
             QGCLabel { text: qsTr(" ") }
 
             QGCLabel { text: qsTr("Distance:") }
-            QGCLabel { text: _totalDistanceText }
+            QGCLabel { text: _missionDistanceText }
 
             QGCLabel { text: qsTr("Time:") }
-            QGCLabel { text: _totalTimeText }
+            QGCLabel { text: _missionTimeText }
 
             QGCLabel { text: qsTr("Max telem dist:") }
-            QGCLabel { text: _maxTelemDistText }
+            QGCLabel { text: _missionMaxTelemetryText }
 
             QGCLabel {
                 text: qsTr("Hover distance:")

--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -36,6 +36,7 @@ ComplexMissionItem::ComplexMissionItem(Vehicle* vehicle, QObject* parent)
     , _dirty(false)
     , _cameraTrigger(false)
     , _gridAltitudeRelative(true)
+    , _surveyDistance(0.0)
     , _cameraShots(0)
     , _coveredArea(0.0)
     , _gridAltitudeFact (0, "Altitude:",        FactMetaData::valueTypeDouble)
@@ -64,10 +65,19 @@ const ComplexMissionItem& ComplexMissionItem::operator=(const ComplexMissionItem
     setAltPercent(other._altPercent);
     setAzimuth(other._azimuth);
     setDistance(other._distance);
+    setSurveyDistance(other._surveyDistance);
     setCameraShots(other._cameraShots);
     setCoveredArea(other._coveredArea);
 
     return *this;
+}
+
+void ComplexMissionItem::setSurveyDistance(double surveyDistance)
+{
+    if (!qFuzzyCompare(_surveyDistance, surveyDistance)) {
+        _surveyDistance = surveyDistance;
+        emit surveyDistanceChanged(_surveyDistance);
+    }
 }
 
 void ComplexMissionItem::setCameraShots(int cameraShots)
@@ -271,6 +281,19 @@ bool ComplexMissionItem::load(const QJsonObject& complexObject, QString& errorSt
     return true;
 }
 
+double ComplexMissionItem::greatestDistanceTo(const QGeoCoordinate &other) const
+{
+    double greatestDistance = 0.0;
+    for (int i=0; i<_gridPoints.count(); i++) {
+        QGeoCoordinate currentCoord = _gridPoints[i].value<QGeoCoordinate>();
+        double distance = currentCoord.distanceTo(other);
+        if (distance > greatestDistance) {
+            greatestDistance = distance;
+        }
+    }
+    return greatestDistance;
+}
+
 void ComplexMissionItem::_setExitCoordinate(const QGeoCoordinate& coordinate)
 {
     if (_exitCoordinate != coordinate) {
@@ -342,6 +365,7 @@ void ComplexMissionItem::_generateGrid(void)
         convertNedToGeo(-point.y(), point.x(), 0, tangentOrigin, &geoCoord);
         _gridPoints += QVariant::fromValue(geoCoord);
     }
+    setSurveyDistance(surveyDistance);
     setCameraShots((int)floor(surveyDistance / _cameraTriggerDistanceFact.rawValue().toDouble()));
 
     emit gridPointsChanged();

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -37,6 +37,7 @@ public:
     Q_PROPERTY(int                  lastSequenceNumber      READ lastSequenceNumber         NOTIFY lastSequenceNumberChanged)
     Q_PROPERTY(QVariantList         gridPoints              READ gridPoints                 NOTIFY gridPointsChanged)
 
+    Q_PROPERTY(double               surveyDistance          READ surveyDistance             NOTIFY surveyDistanceChanged)
     Q_PROPERTY(int                  cameraShots             READ cameraShots                NOTIFY cameraShotsChanged)
     Q_PROPERTY(double               coveredArea             READ coveredArea                NOTIFY coveredAreaChanged)
 
@@ -52,9 +53,11 @@ public:
     Fact* gridSpacing(void)     { return &_gridSpacingFact; }
     Fact* cameraTriggerDistance(void) { return &_cameraTriggerDistanceFact; }
 
+    double  surveyDistance      (void) const { return _surveyDistance; }
     int     cameraShots         (void) const { return _cameraShots; }
     double  coveredArea         (void) const { return _coveredArea; }
 
+    void setSurveyDistance      (double surveyDistance);
     void setCameraShots         (int cameraShots);
     void setCoveredArea         (double coveredArea);
 
@@ -70,6 +73,11 @@ public:
     ///     @param[out] errorString Error if load fails
     /// @return true: load success, false: load failed, errorString set
     bool load(const QJsonObject& complexObject, QString& errorString);
+
+    /// Get the point of complex mission item furthest away from a coordinate
+    ///     @param other QGeoCoordinate to which distance is calculated
+    /// @return the greatest distance from any point of the complex item to some coordinate
+    double greatestDistanceTo(const QGeoCoordinate &other) const;
 
     // Overrides from VisualMissionItem
 
@@ -102,6 +110,7 @@ signals:
     void cameraTriggerChanged           (bool cameraTrigger);
     void gridAltitudeRelativeChanged    (bool gridAltitudeRelative);
 
+    void surveyDistanceChanged          (double surveyDistance);
     void cameraShotsChanged             (int cameraShots);
     void coveredAreaChanged             (double coveredArea);
 
@@ -130,6 +139,7 @@ private:
     bool                _cameraTrigger;
     bool                _gridAltitudeRelative;
 
+    double              _surveyDistance;
     int                 _cameraShots;
     double              _coveredArea;
 

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -40,6 +40,12 @@ public:
     Q_PROPERTY(bool                 autoSync            READ autoSync               WRITE setAutoSync   NOTIFY autoSyncChanged)
     Q_PROPERTY(bool                 syncInProgress      READ syncInProgress                             NOTIFY syncInProgressChanged)
 
+    Q_PROPERTY(double               missionDistance     READ missionDistance                            NOTIFY missionDistanceChanged)
+    Q_PROPERTY(double               missionMaxTelemetry READ missionMaxTelemetry                        NOTIFY missionMaxTelemetryChanged)
+    Q_PROPERTY(double               cruiseDistance      READ cruiseDistance                             NOTIFY cruiseDistanceChanged)
+    Q_PROPERTY(double               hoverDistance       READ hoverDistance                              NOTIFY hoverDistanceChanged)
+
+
     Q_INVOKABLE void start(bool editMode);
     Q_INVOKABLE void getMissionItems(void);
     Q_INVOKABLE void sendMissionItems(void);
@@ -70,6 +76,17 @@ public:
     void setAutoSync(bool autoSync);
     bool syncInProgress(void);
 
+    double  missionDistance         (void) const { return _missionDistance; }
+    double  missionMaxTelemetry     (void) const { return _missionMaxTelemetry; }
+    double  cruiseDistance          (void) const { return _cruiseDistance; }
+    double  hoverDistance           (void) const { return _hoverDistance; }
+
+
+    void setMissionDistance         (double missionDistance );
+    void setMissionMaxTelemetry     (double missionMaxTelemetry);
+    void setCruiseDistance          (double cruiseDistance );
+    void setHoverDistance           (double hoverDistance );
+
     static const char* jsonSimpleItemsKey;  ///< Key for simple items in a json file
 
 signals:
@@ -79,6 +96,10 @@ signals:
     void autoSyncChanged(bool autoSync);
     void newItemsFromVehicle(void);
     void syncInProgressChanged(bool syncInProgress);
+    void missionDistanceChanged(double missionDistance);
+    void missionMaxTelemetryChanged(double missionMaxTelemetry);
+    void cruiseDistanceChanged(double cruiseDistance);
+    void hoverDistanceChanged(double hoverDistance);
 
 private slots:
     void _newMissionItemsAvailableFromVehicle();
@@ -103,6 +124,7 @@ private:
     void _autoSyncSend(void);
     void _setupActiveVehicle(Vehicle* activeVehicle, bool forceLoadFromVehicle);
     static void _calcPrevWaypointValues(double homeAlt, VisualMissionItem* currentItem, VisualMissionItem* prevItem, double* azimuth, double* distance, double* altDifference);
+    static void _calcHomeDist(VisualMissionItem* currentItem, VisualMissionItem* homeItem, double* distance);
     bool _findLastAltitude(double* lastAltitude, MAV_FRAME* frame);
     bool _findLastAcceptanceRadius(double* lastAcceptanceRadius);
     void _addPlannedHomePosition(QmlObjectListModel* visualItems, bool addToCenter);
@@ -123,6 +145,10 @@ private:
     bool                _firstItemsFromVehicle;
     bool                _missionItemsRequested;
     bool                _queuedSend;
+    double              _missionDistance;
+    double              _missionMaxTelemetry;
+    double              _cruiseDistance;
+    double              _hoverDistance;
 
     static const char*  _settingsGroup;
     static const char*  _jsonVersionKey;

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -31,7 +31,7 @@
 class VisualMissionItem : public QObject
 {
     Q_OBJECT
-    
+
 public:
     VisualMissionItem(Vehicle* vehicle, QObject* parent = NULL);
     VisualMissionItem(const VisualMissionItem& other, QObject* parent = NULL);
@@ -73,7 +73,7 @@ public:
     Q_PROPERTY(bool     isCurrentItem           READ isCurrentItem          WRITE setIsCurrentItem      NOTIFY isCurrentItemChanged)
     Q_PROPERTY(int      sequenceNumber          READ sequenceNumber         WRITE setSequenceNumber     NOTIFY sequenceNumberChanged)
     Q_PROPERTY(bool     specifiesCoordinate     READ specifiesCoordinate                                NOTIFY specifiesCoordinateChanged)      ///< Item is associated with a coordinate position
-    Q_PROPERTY(bool     isStandaloneCoordinate  READ isStandaloneCoordinate                             NOTIFY isStandaloneCoordinateChanged)   ///< Wayoint line does not go through item
+    Q_PROPERTY(bool     isStandaloneCoordinate  READ isStandaloneCoordinate                             NOTIFY isStandaloneCoordinateChanged)   ///< Waypoint line does not go through item
     Q_PROPERTY(bool     isSimpleItem            READ isSimpleItem                                       NOTIFY isSimpleItemChanged)             ///< Simple or Complex MissionItem
 
     /// List of child mission items. Child mission item are subsequent mision items which do not specify a coordinate. They
@@ -81,7 +81,7 @@ public:
     Q_PROPERTY(QmlObjectListModel*  childItems      READ childItems     CONSTANT)
 
     // Property accesors
-    
+
     double altDifference    (void) const { return _altDifference; }
     double altPercent       (void) const { return _altPercent; }
     double azimuth          (void) const { return _azimuth; }


### PR DESCRIPTION
This PR is part of the new [mission stats](https://github.com/mavlink/qgroundcontrol/issues/3802) feature.

This PR will require a rebase once https://github.com/mavlink/qgroundcontrol/pull/3852 and https://github.com/mavlink/qgroundcontrol/pull/3830 are merged.

The following is computed:
* Mission distance
* Mission time
* Maximum telemetry distance

For the case of a VTOL the code added also computes
* distance estimate for hover and cruise individually
* time estimate for hover and cruise individually

and outputs them all in the previously established mission statistics display.