### PR TITLE
Fix download custom firm file err: no file name specified

### DIFF
--- a/src/VehicleSetup/FirmwareImage.cc
+++ b/src/VehicleSetup/FirmwareImage.cc
@@ -436,5 +436,7 @@ bool FirmwareImage::_binLoad(const QString& imageFilename)
     
     binFile.close();
     
+    _binFilename = imageFilename;
+    
     return true;
 }


### PR DESCRIPTION
down bin file to pixhawk fail,because it do not set value for _binFilename in _binLoad