### PR TITLE
Joystick button function selector for ArduSub

### DIFF
--- a/src/FactSystem/FactControls/FactComboBox.qml
+++ b/src/FactSystem/FactControls/FactComboBox.qml
@@ -10,7 +10,7 @@ QGCComboBox {
     property Fact fact: Fact { }
     property bool indexModel: true  ///< true: model must be specifed, selected index is fact value, false: use enum meta data
 
-    model: fact.enumStrings
+    model: fact ? fact.enumStrings : null
 
     currentIndex: indexModel ? fact.value : fact.enumIndex
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -79,7 +79,7 @@ public:
     bool        setFlightMode(const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) final;
     bool        isGuidedMode(const Vehicle* vehicle) const final;
     void        pauseVehicle(Vehicle* vehicle);
-    int         manualControlReservedButtonCount(void) final;
+    int         manualControlReservedButtonCount(void);
     bool        adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message) final;
     void        adjustOutgoingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message) final;
     void        initializeVehicle(Vehicle* vehicle) final;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -47,3 +47,8 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void)
     supportedFlightModes << APMSubMode(APMSubMode::ALT_HOLD  ,true);
     setSupportedModes(supportedFlightModes);
 }
+
+int ArduSubFirmwarePlugin::manualControlReservedButtonCount(void)
+{
+    return 0;
+}

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -67,6 +67,7 @@ public:
     ArduSubFirmwarePlugin(void);
 
     // Overrides from FirmwarePlugin
+    int manualControlReservedButtonCount(void);
 
 };
 

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -284,7 +284,7 @@ void Joystick::run(void)
             throttle =  std::max(-1.0f, std::min(tanf(asinf(throttle_limited)), 1.0f));
 
             // Adjust throttle to 0:1 range
-            if (_throttleMode == ThrottleModeCenterZero) {
+            if (_throttleMode == ThrottleModeCenterZero && !_activeVehicle->sub()) {
                 throttle = std::max(0.0f, throttle);
             } else {
                 throttle = (throttle + 1.0f) / 2.0f;

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -380,6 +380,7 @@ QGCView {
 
                         Column {
                             spacing: ScreenTools.defaultFontPixelHeight / 3
+                            visible: !_activeVehicle.sub
 
                             ExclusiveGroup { id: throttleModeExclusiveGroup }
 

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -18,6 +18,7 @@ import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controllers   1.0
 import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
 
 /// Joystick Config
 QGCView {
@@ -448,6 +449,9 @@ QGCView {
                             if (buttonActionRepeater.itemAt(index)) {
                                 buttonActionRepeater.itemAt(index).pressed = pressed
                             }
+                            if (subButtonActionRepeater.itemAt(index)) {
+                                subButtonActionRepeater.itemAt(index).pressed = pressed
+                            }
                         }
                     }
 
@@ -470,7 +474,7 @@ QGCView {
 
                             Row {
                                 spacing: ScreenTools.defaultFontPixelWidth
-                                visible: _activeVehicle.manualControlReservedButtonCount == -1 ? false : modelData >= _activeVehicle.manualControlReservedButtonCount
+                                visible: (_activeVehicle.manualControlReservedButtonCount == -1 ? false : modelData >= _activeVehicle.manualControlReservedButtonCount) && !_activeVehicle.sub
 
                                 property bool pressed
 
@@ -508,6 +512,71 @@ QGCView {
                                     Component.onCompleted:  currentIndex = find(_activeJoystick.buttonActions[modelData])
                                 }
                             }
+                        } // Repeater
+
+                        Row {
+                            spacing: ScreenTools.defaultFontPixelWidth
+                            visible: _activeVehicle.sub
+
+                            QGCLabel {
+                                horizontalAlignment:    Text.AlignHCenter
+                                width:                  ScreenTools.defaultFontPixelHeight * 1.5
+                                text:                   qsTr("#")
+                            }
+
+                            QGCLabel {
+                                width:                  ScreenTools.defaultFontPixelWidth * 15
+                                text:                   qsTr("Function: ")
+                            }
+
+                            QGCLabel {
+                                width:                  ScreenTools.defaultFontPixelWidth * 15
+                                text:                   qsTr("Shift Function: ")
+                            }
+                        } // Row
+
+                        Repeater {
+                            id:     subButtonActionRepeater
+                            model:  _activeJoystick.totalButtonCount
+
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                visible: _activeVehicle.sub
+
+                                property bool pressed
+
+                                Rectangle {
+                                    anchors.verticalCenter:     parent.verticalCenter
+                                    width:                      ScreenTools.defaultFontPixelHeight * 1.5
+                                    height:                     width
+                                    border.width:               1
+                                    border.color:               qgcPal.text
+                                    color:                      pressed ? qgcPal.buttonHighlight : qgcPal.button
+
+
+                                    QGCLabel {
+                                        anchors.fill:           parent
+                                        color:                  pressed ? qgcPal.buttonHighlightText : qgcPal.buttonText
+                                        horizontalAlignment:    Text.AlignHCenter
+                                        verticalAlignment:      Text.AlignVCenter
+                                        text:                   modelData
+                                    }
+                                }
+
+                                FactComboBox {
+                                    id:         mainSubButtonActionCombo
+                                    width:      ScreenTools.defaultFontPixelWidth * 15
+                                    fact:       controller.parameterExists(-1, "BTN"+index+"_FUNCTION") ? controller.getParameterFact(-1, "BTN" + index + "_FUNCTION") : null;
+                                    indexModel: false
+                                }
+
+                                FactComboBox {
+                                    id:         shiftSubButtonActionCombo
+                                    width:      ScreenTools.defaultFontPixelWidth * 15
+                                    fact:       controller.parameterExists(-1, "BTN"+index+"_SFUNCTION") ? controller.getParameterFact(-1, "BTN" + index + "_SFUNCTION") : null;
+                                    indexModel: false
+                                }
+                            } // Row
                         } // Repeater
                     } // Column
                 } // Column - right setting column


### PR DESCRIPTION
This PR contains changes for a joystick button function selector specifically to support ArduSub. It is integrated so that it does not have any affect whatsoever on existing features and appearance. The button function selector allows selection of the button "function" and the "shift function" directly from the joystick page, greatly increasing usability for ArduSub users.

Additionally, there are some minor changes along the way:

- The `throttleMode` radio buttons on the joystick page are now hidden for ArduSub and forced to use "full down stick is zero throttle" to avoid issues during use.
- The FactComboBox implementation was fixed to allow for null Facts
- The `manualControlReservedButtonCount` function in `APMFirmwarePlugin` was made non-final so it could be overridden by the ArduSub plugin.

I've tested this with a Pixhawk with ArduSub and with the ArduCopter mock link and it works well. Please feel free to test and let me know if there are any issues, comments, changes, etc. 

Thanks!