### PR TITLE
Fix plugin semantics for ArduSub additions

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -66,7 +66,7 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
             _airframeComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_airframeComponent));
 
-            if ( !_vehicle->sub() ) {
+            if ( _vehicle->supportsRadio() ) {
                 _radioComponent = new APMRadioComponent(_vehicle, this);
                 _radioComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -52,3 +52,8 @@ int ArduSubFirmwarePlugin::manualControlReservedButtonCount(void)
 {
     return 0;
 }
+
+bool ArduSubFirmwarePlugin::supportsThrottleModeCenterZero(void)
+{
+    return false;
+}

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -67,3 +67,8 @@ bool ArduSubFirmwarePlugin::supportsRadio(void)
 {
     return false;
 }
+
+bool ArduSubFirmwarePlugin::supportsJSButton(void)
+{
+    return true;
+}

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -57,3 +57,8 @@ bool ArduSubFirmwarePlugin::supportsThrottleModeCenterZero(void)
 {
     return false;
 }
+
+bool ArduSubFirmwarePlugin::supportsManualControl(void)
+{
+    return true;
+}

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -62,3 +62,8 @@ bool ArduSubFirmwarePlugin::supportsManualControl(void)
 {
     return true;
 }
+
+bool ArduSubFirmwarePlugin::supportsRadio(void)
+{
+    return false;
+}

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -72,6 +72,8 @@ public:
     bool supportsThrottleModeCenterZero(void);
 
     bool supportsManualControl(void);
+
+    bool supportsRadio(void);
 };
 
 #endif

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -74,6 +74,8 @@ public:
     bool supportsManualControl(void);
 
     bool supportsRadio(void);
+
+    bool supportsJSButton(void);
 };
 
 #endif

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -69,6 +69,8 @@ public:
     // Overrides from FirmwarePlugin
     int manualControlReservedButtonCount(void);
 
+    bool supportsThrottleModeCenterZero(void);
+
 };
 
 #endif

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -71,6 +71,7 @@ public:
 
     bool supportsThrottleModeCenterZero(void);
 
+    bool supportsManualControl(void);
 };
 
 #endif

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -94,6 +94,11 @@ bool FirmwarePlugin::supportsManualControl(void)
     return false;
 }
 
+bool FirmwarePlugin::supportsRadio(void)
+{
+    return true;
+}
+
 bool FirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message)
 {
     Q_UNUSED(vehicle);

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -99,6 +99,11 @@ bool FirmwarePlugin::supportsRadio(void)
     return true;
 }
 
+bool FirmwarePlugin::supportsJSButton(void)
+{
+    return false;
+}
+
 bool FirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message)
 {
     Q_UNUSED(vehicle);

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -89,6 +89,11 @@ bool FirmwarePlugin::supportsThrottleModeCenterZero(void)
     return true;
 }
 
+bool FirmwarePlugin::supportsManualControl(void)
+{
+    return false;
+}
+
 bool FirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message)
 {
     Q_UNUSED(vehicle);

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -83,6 +83,12 @@ int FirmwarePlugin::manualControlReservedButtonCount(void)
     return -1;
 }
 
+bool FirmwarePlugin::supportsThrottleModeCenterZero(void)
+{
+    // By default, this is supported
+    return true;
+}
+
 bool FirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message)
 {
     Q_UNUSED(vehicle);

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -133,6 +133,10 @@ public:
     /// throttle.
     virtual bool supportsThrottleModeCenterZero(void);
 
+    /// Returns true if the firmware supports the use of the MAVlink "MANUAL_CONTROL" message.
+    /// By default, this returns false unless overridden in the firmware plugin.
+    virtual bool supportsManualControl(void);
+
     /// Called before any mavlink message is processed by Vehicle such that the firmwre plugin
     /// can adjust any message characteristics. This is handy to adjust or differences in mavlink
     /// spec implementations such that the base code can remain mavlink generic.

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -128,6 +128,11 @@ public:
     /// @return -1: reserver all buttons, >0 number of buttons to reserve
     virtual int manualControlReservedButtonCount(void);
 
+    /// Returns true if the vehicle and firmware supports the use of a throttle joystick that
+    /// is zero when centered. Typically not supported on vehicles that have bidirectional
+    /// throttle.
+    virtual bool supportsThrottleModeCenterZero(void);
+
     /// Called before any mavlink message is processed by Vehicle such that the firmwre plugin
     /// can adjust any message characteristics. This is handy to adjust or differences in mavlink
     /// spec implementations such that the base code can remain mavlink generic.

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -137,6 +137,10 @@ public:
     /// By default, this returns false unless overridden in the firmware plugin.
     virtual bool supportsManualControl(void);
 
+    /// Returns true if the firmware supports the use of the RC radio and requires the RC radio
+    /// setup page. Returns true by default.
+    virtual bool supportsRadio(void);
+
     /// Called before any mavlink message is processed by Vehicle such that the firmwre plugin
     /// can adjust any message characteristics. This is handy to adjust or differences in mavlink
     /// spec implementations such that the base code can remain mavlink generic.

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -141,6 +141,10 @@ public:
     /// setup page. Returns true by default.
     virtual bool supportsRadio(void);
 
+    /// Returns true if the firmware supports the AP_JSButton library, which allows joystick buttons
+    /// to be assigned via parameters in firmware. Default is false.
+    virtual bool supportsJSButton(void);
+
     /// Called before any mavlink message is processed by Vehicle such that the firmwre plugin
     /// can adjust any message characteristics. This is handy to adjust or differences in mavlink
     /// spec implementations such that the base code can remain mavlink generic.

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -170,6 +170,11 @@ int PX4FirmwarePlugin::manualControlReservedButtonCount(void)
     return 0;   // 0 buttons reserved for rc switch simulation
 }
 
+bool PX4FirmwarePlugin::supportsManualControl(void)
+{
+    return true;
+}
+
 bool PX4FirmwarePlugin::isCapable(const Vehicle *vehicle, FirmwareCapabilities capabilities)
 {
     if(vehicle->multiRotor()) {

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -44,6 +44,7 @@ public:
     void        guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeRel) final;
     bool        isGuidedMode                    (const Vehicle* vehicle) const;
     int         manualControlReservedButtonCount(void) final;
+    bool        supportsManualControl           (void) final;
     void        initializeVehicle               (Vehicle* vehicle) final;
     bool        sendHomePositionToVehicle       (void) final;
     void        addMetaDataToFact               (QObject* parameterMetaData, Fact* fact, MAV_TYPE vehicleType) final;

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -284,7 +284,7 @@ void Joystick::run(void)
             throttle =  std::max(-1.0f, std::min(tanf(asinf(throttle_limited)), 1.0f));
 
             // Adjust throttle to 0:1 range
-            if (_throttleMode == ThrottleModeCenterZero && !_activeVehicle->sub()) {
+            if (_throttleMode == ThrottleModeCenterZero && _activeVehicle->supportsThrottleModeCenterZero()) {
                 throttle = std::max(0.0f, throttle);
             } else {
                 throttle = (throttle + 1.0f) / 2.0f;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1530,6 +1530,11 @@ bool Vehicle::supportsRadio(void) const
     return _firmwarePlugin->supportsRadio();
 }
 
+bool Vehicle::supportsJSButton(void) const
+{
+    return _firmwarePlugin->supportsJSButton();
+}
+
 void Vehicle::_setCoordinateValid(bool coordinateValid)
 {
     if (coordinateValid != _coordinateValid) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1525,6 +1525,11 @@ bool Vehicle::supportsThrottleModeCenterZero(void) const
     return _firmwarePlugin->supportsThrottleModeCenterZero();
 }
 
+bool Vehicle::supportsRadio(void) const
+{
+    return _firmwarePlugin->supportsRadio();
+}
+
 void Vehicle::_setCoordinateValid(bool coordinateValid)
 {
     if (coordinateValid != _coordinateValid) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1517,15 +1517,7 @@ bool Vehicle::vtol(void) const
 
 bool Vehicle::supportsManualControl(void) const
 {
-    // PX4 Firmware supports manual control message
-    if ( px4Firmware() ) {
-        return true;
-    }
-    // ArduSub supports manual control message (identified by APM + Submarine type)
-    if ( apmFirmware() && vehicleType() == MAV_TYPE_SUBMARINE ) {
-        return true;
-    }
-    return false;
+    return _firmwarePlugin->supportsManualControl();
 }
 
 bool Vehicle::supportsThrottleModeCenterZero(void) const

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1528,6 +1528,11 @@ bool Vehicle::supportsManualControl(void) const
     return false;
 }
 
+bool Vehicle::supportsThrottleModeCenterZero(void) const
+{
+    return _firmwarePlugin->supportsThrottleModeCenterZero();
+}
+
 void Vehicle::_setCoordinateValid(bool coordinateValid)
 {
     if (coordinateValid != _coordinateValid) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -276,6 +276,7 @@ public:
     Q_PROPERTY(bool                 vtol                    READ vtol                                                   CONSTANT)
     Q_PROPERTY(bool                 rover                   READ rover                                                  CONSTANT)
     Q_PROPERTY(bool                 supportsManualControl   READ supportsManualControl                                  CONSTANT)
+    Q_PROPERTY(bool        supportsThrottleModeCenterZero   READ supportsThrottleModeCenterZero                         CONSTANT)
     Q_PROPERTY(bool                 sub                     READ sub                                                    CONSTANT)
     Q_PROPERTY(bool                 autoDisconnect          MEMBER _autoDisconnect                                      NOTIFY autoDisconnectChanged)
     Q_PROPERTY(QString              prearmError             READ prearmError            WRITE setPrearmError            NOTIFY prearmErrorChanged)
@@ -473,6 +474,7 @@ public:
     bool sub(void) const;
 
     bool supportsManualControl(void) const;
+    bool supportsThrottleModeCenterZero(void) const;
 
     void setFlying(bool flying);
     void setGuidedMode(bool guidedMode);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -475,6 +475,7 @@ public:
 
     bool supportsManualControl(void) const;
     bool supportsThrottleModeCenterZero(void) const;
+    bool supportsRadio(void) const;
 
     void setFlying(bool flying);
     void setGuidedMode(bool guidedMode);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -277,6 +277,7 @@ public:
     Q_PROPERTY(bool                 rover                   READ rover                                                  CONSTANT)
     Q_PROPERTY(bool                 supportsManualControl   READ supportsManualControl                                  CONSTANT)
     Q_PROPERTY(bool        supportsThrottleModeCenterZero   READ supportsThrottleModeCenterZero                         CONSTANT)
+    Q_PROPERTY(bool                 supportsJSButton        READ supportsJSButton                                       CONSTANT)
     Q_PROPERTY(bool                 sub                     READ sub                                                    CONSTANT)
     Q_PROPERTY(bool                 autoDisconnect          MEMBER _autoDisconnect                                      NOTIFY autoDisconnectChanged)
     Q_PROPERTY(QString              prearmError             READ prearmError            WRITE setPrearmError            NOTIFY prearmErrorChanged)
@@ -476,6 +477,7 @@ public:
     bool supportsManualControl(void) const;
     bool supportsThrottleModeCenterZero(void) const;
     bool supportsRadio(void) const;
+    bool supportsJSButton(void) const;
 
     void setFlying(bool flying);
     void setGuidedMode(bool guidedMode);

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -381,7 +381,7 @@ QGCView {
 
                         Column {
                             spacing: ScreenTools.defaultFontPixelHeight / 3
-                            visible: !_activeVehicle.sub
+                            visible: _activeVehicle.supportsThrottleModeCenterZero
 
                             ExclusiveGroup { id: throttleModeExclusiveGroup }
 
@@ -449,8 +449,8 @@ QGCView {
                             if (buttonActionRepeater.itemAt(index)) {
                                 buttonActionRepeater.itemAt(index).pressed = pressed
                             }
-                            if (subButtonActionRepeater.itemAt(index)) {
-                                subButtonActionRepeater.itemAt(index).pressed = pressed
+                            if (jsButtonActionRepeater.itemAt(index)) {
+                                jsButtonActionRepeater.itemAt(index).pressed = pressed
                             }
                         }
                     }
@@ -474,7 +474,7 @@ QGCView {
 
                             Row {
                                 spacing: ScreenTools.defaultFontPixelWidth
-                                visible: (_activeVehicle.manualControlReservedButtonCount == -1 ? false : modelData >= _activeVehicle.manualControlReservedButtonCount) && !_activeVehicle.sub
+                                visible: (_activeVehicle.manualControlReservedButtonCount == -1 ? false : modelData >= _activeVehicle.manualControlReservedButtonCount) && !_activeVehicle.supportsJSButton
 
                                 property bool pressed
 
@@ -516,7 +516,7 @@ QGCView {
 
                         Row {
                             spacing: ScreenTools.defaultFontPixelWidth
-                            visible: _activeVehicle.sub
+                            visible: _activeVehicle.supportsJSButton
 
                             QGCLabel {
                                 horizontalAlignment:    Text.AlignHCenter
@@ -536,12 +536,12 @@ QGCView {
                         } // Row
 
                         Repeater {
-                            id:     subButtonActionRepeater
+                            id:     jsButtonActionRepeater
                             model:  _activeJoystick.totalButtonCount
 
                             Row {
                                 spacing: ScreenTools.defaultFontPixelWidth
-                                visible: _activeVehicle.sub
+                                visible: _activeVehicle.supportsJSButton
 
                                 property bool pressed
 
@@ -564,14 +564,14 @@ QGCView {
                                 }
 
                                 FactComboBox {
-                                    id:         mainSubButtonActionCombo
+                                    id:         mainJSButtonActionCombo
                                     width:      ScreenTools.defaultFontPixelWidth * 15
                                     fact:       controller.parameterExists(-1, "BTN"+index+"_FUNCTION") ? controller.getParameterFact(-1, "BTN" + index + "_FUNCTION") : null;
                                     indexModel: false
                                 }
 
                                 FactComboBox {
-                                    id:         shiftSubButtonActionCombo
+                                    id:         shiftJSButtonActionCombo
                                     width:      ScreenTools.defaultFontPixelWidth * 15
                                     fact:       controller.parameterExists(-1, "BTN"+index+"_SFUNCTION") ? controller.getParameterFact(-1, "BTN" + index + "_SFUNCTION") : null;
                                     indexModel: false


### PR DESCRIPTION
Per Issue #3894, this fixes the way various UI options are detected using a plugin based method instead of direct detection by vehicle type. This fixes this in a number of places beyond those mentioned in #3894.

Specifically, the following methods are now part of `Vehicle` and `FirmwarePlugin`:

- `supportsManualControl`
- `supportsThrottleModeCenterZero`
- `supportsRadio`
- `supportsJSButton`

Please let me know if there are any questions or required changes.

-Rusty