### PR TITLE
Hide radio rssi icon from toolbar if radio is not supported

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -278,6 +278,7 @@ public:
     Q_PROPERTY(bool                 supportsManualControl   READ supportsManualControl                                  CONSTANT)
     Q_PROPERTY(bool        supportsThrottleModeCenterZero   READ supportsThrottleModeCenterZero                         CONSTANT)
     Q_PROPERTY(bool                 supportsJSButton        READ supportsJSButton                                       CONSTANT)
+    Q_PROPERTY(bool                 supportsRadio           READ supportsRadio                                          CONSTANT)
     Q_PROPERTY(bool                 sub                     READ sub                                                    CONSTANT)
     Q_PROPERTY(bool                 autoDisconnect          MEMBER _autoDisconnect                                      NOTIFY autoDisconnectChanged)
     Q_PROPERTY(QString              prearmError             READ prearmError            WRITE setPrearmError            NOTIFY prearmErrorChanged)

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -168,6 +168,7 @@ Row {
         id:     rcRssi
         width:  rssiRow.width * 1.1
         height: mainWindow.tbCellHeight
+        visible: activeVehicle ? activeVehicle.supportsRadio : true
         Row {
             id:         rssiRow
             height:     parent.height


### PR DESCRIPTION
Optional radio support was added as a plugin feature recently. This PR removes the radio signal strength icon from the top toolbar when the radio is not supported by the firmware plugin.

Please let me know if you have any questions.

-Rusty