### PR TITLE
Save _mainIsMap state persistently

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -66,6 +66,7 @@ QGCView {
     FlightDisplayViewController { id: _controller }
 
     function setStates() {
+        QGroundControl.saveBoolGlobalSetting(_mainIsMapKey, _mainIsMap)
         if(_mainIsMap) {
             //-- Adjust Margins
             _flightMapContainer.state   = "fullMode"


### PR DESCRIPTION
The state of the main map/video window is storable as a global setting. It is currently being loaded from the global settings source, but it is never being saved, so this does not persist. 

This PR is a bugfix to resolve that. With this fix, the map/video window will remain on map or video through restarts instead of always defaulting to the map.

This may have been done intentionally and I don't know about, so please let me know if there are any issues.

-Rusty