### PR TITLE
[Mission stats in Survey Feature]: check when survey item is first mission item

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -844,6 +844,14 @@ void MissionController::_recalcAltitudeRangeBearing()
                         missionMaxTelemetry = telemetryDistance;
                     }
                 }
+                else if (lastCoordinateItem == homeItem && !item->isSimpleItem()){
+                    missionDistance += qobject_cast<ComplexMissionItem*>(item)->surveyDistance();
+                    missionMaxTelemetry = qobject_cast<ComplexMissionItem*>(item)->greatestDistanceTo(homeItem->exitCoordinate());
+
+                    if (vtolCalc){
+                        cruiseDistance += qobject_cast<ComplexMissionItem*>(item)->surveyDistance(); //assume all survey missions undertaken in cruise
+                    }
+                }
                 lastCoordinateItem = item;
             }
         }


### PR DESCRIPTION
As pointed out [here](https://github.com/mavlink/qgroundcontrol/pull/3863#discussion_r73190742) in PR #3863, while calculating mission distance, we fail to take into account the case when survey mission item is the first waypoint after home. This PR takes care of that.