### PR TITLE
Quickly handle downloading scattered gaps

### DIFF
--- a/src/ViewWidgets/LogDownloadController.cc
+++ b/src/ViewWidgets/LogDownloadController.cc
@@ -365,6 +365,9 @@ LogDownloadController::_logData(UASInterface* uas, uint32_t ofs, uint16_t id, ui
                 _requestLogData(_downloadData->ID,
                                 _downloadData->current_chunk*kChunkSize,
                                 _downloadData->chunk_table.size()*MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN);
+            } else if (bin < _downloadData->chunk_table.size() - 1 && _downloadData->chunk_table.at(bin+1)) {
+                // Likely to be grabbing fragments and got to the end of a gap
+                _findMissingData();
             }
         } else {
             qWarning() << "Error while writing log file chunk";


### PR DESCRIPTION
Without this change we need 500ms to elapse so the [timer](https://github.com/NaterGator/qgroundcontrol/blob/b4afd5283bff3291f1bfabfc06d99e8af9c63e84/src/ViewWidgets/LogDownloadController.cc#L117) fires for each missing bin in a chunk (dropped / corrupted packets, or whatever else may cause it). 

This checks if a LOG_DATA packet is being received at the end of a gap in the downloaded data to continue searching for other gaps of missing data to request immediately. 