### PR TITLE
HIL add support for aux controls

### DIFF
--- a/src/comm/QGCFlightGearLink.cc
+++ b/src/comm/QGCFlightGearLink.cc
@@ -208,13 +208,17 @@ void QGCFlightGearLink::setRemoteHost(const QString& host)
 
 }
 
-void QGCFlightGearLink::updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, quint8 systemMode, quint8 navMode)
+void QGCFlightGearLink::updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, float aux1, float aux2, float aux3, float aux4, quint8 systemMode, quint8 navMode)
 {
     // magnetos,aileron,elevator,rudder,throttle\n
 
     //float magnetos = 3.0f;
     Q_UNUSED(time);
     Q_UNUSED(systemMode);
+    Q_UNUSED(aux1);
+    Q_UNUSED(aux2);
+    Q_UNUSED(aux3);
+    Q_UNUSED(aux4);
     Q_UNUSED(navMode);
 
     if(!qIsNaN(rollAilerons) && !qIsNaN(pitchElevator) && !qIsNaN(yawRudder) && !qIsNaN(throttle))

--- a/src/comm/QGCFlightGearLink.h
+++ b/src/comm/QGCFlightGearLink.h
@@ -89,7 +89,7 @@ public slots:
     /** @brief Add a new host to broadcast messages to */
     void setRemoteHost(const QString& host);
     /** @brief Send new control states to the simulation */
-    void updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, quint8 systemMode, quint8 navMode);
+    void updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, float aux1, float aux2, float aux3, float aux4, quint8 systemMode, quint8 navMode);
     /** @brief Set the simulator version as text string */
     void setVersion(const QString& version)
     {

--- a/src/comm/QGCHilLink.h
+++ b/src/comm/QGCHilLink.h
@@ -48,7 +48,7 @@ public slots:
     /** @brief Add a new host to broadcast messages to */
     virtual void setRemoteHost(const QString& host) = 0;
     /** @brief Send new control states to the simulation */
-    virtual void updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, quint8 systemMode, quint8 navMode) = 0;
+    virtual void updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, float aux1, float aux2, float aux3, float aux4, quint8 systemMode, quint8 navMode) = 0;
     virtual void processError(QProcess::ProcessError err) = 0;
     /** @brief Set the simulator version as text string */
     virtual void setVersion(const QString& version) = 0;

--- a/src/comm/QGCJSBSimLink.cc
+++ b/src/comm/QGCJSBSimLink.cc
@@ -220,13 +220,17 @@ void QGCJSBSimLink::setRemoteHost(const QString& host)
 
 }
 
-void QGCJSBSimLink::updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, quint8 systemMode, quint8 navMode)
+void QGCJSBSimLink::updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, float aux1, float aux2, float aux3, float aux4, quint8 systemMode, quint8 navMode)
 {
     // magnetos,aileron,elevator,rudder,throttle\n
 
     //float magnetos = 3.0f;
     Q_UNUSED(time);
     Q_UNUSED(systemMode);
+    Q_UNUSED(aux1);
+    Q_UNUSED(aux2);
+    Q_UNUSED(aux3);
+    Q_UNUSED(aux4);
     Q_UNUSED(navMode);
 
     if(!qIsNaN(rollAilerons) && !qIsNaN(pitchElevator) && !qIsNaN(yawRudder) && !qIsNaN(throttle))

--- a/src/comm/QGCJSBSimLink.h
+++ b/src/comm/QGCJSBSimLink.h
@@ -78,7 +78,7 @@ public slots:
     /** @brief Add a new host to broadcast messages to */
     void setRemoteHost(const QString& host);
     /** @brief Send new control states to the simulation */
-    void updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, quint8 systemMode, quint8 navMode);
+    void updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, float aux1, float aux2, float aux3, float aux4, quint8 systemMode, quint8 navMode);
 //    /** @brief Remove a host from broadcasting messages to */
 //    void removeHost(const QString& host);
     //    void readPendingDatagrams();

--- a/src/comm/QGCXPlaneLink.cc
+++ b/src/comm/QGCXPlaneLink.cc
@@ -336,7 +336,7 @@ void QGCXPlaneLink::setRemoteHost(const QString& newHost)
     emit remoteChanged(QString("%1:%2").arg(remoteHost.toString()).arg(remotePort));
 }
 
-void QGCXPlaneLink::updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, quint8 systemMode, quint8 navMode)
+void QGCXPlaneLink::updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, float aux1, float aux2, float aux3, float aux4, quint8 systemMode, quint8 navMode)
 {
     #pragma pack(push, 1)
     struct payload {
@@ -354,6 +354,10 @@ void QGCXPlaneLink::updateControls(quint64 time, float rollAilerons, float pitch
 
     Q_UNUSED(time);
     Q_UNUSED(systemMode);
+    Q_UNUSED(aux1);
+    Q_UNUSED(aux2);
+    Q_UNUSED(aux3);
+    Q_UNUSED(aux4);
     Q_UNUSED(navMode);
 
     if (_vehicle->vehicleType() == MAV_TYPE_QUADROTOR

--- a/src/comm/QGCXPlaneLink.h
+++ b/src/comm/QGCXPlaneLink.h
@@ -98,7 +98,7 @@ public slots:
     /** @brief Add a new host to broadcast messages to */
     void setRemoteHost(const QString& host);
     /** @brief Send new control states to the simulation */
-    void updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, quint8 systemMode, quint8 navMode);
+    void updateControls(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, float aux1, float aux2, float aux3, float aux4, quint8 systemMode, quint8 navMode);
     /** @brief Set the simulator version as text string */
     void setVersion(const QString& version);
     /** @brief Set the simulator version as integer */

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -426,7 +426,7 @@ void UAS::receiveMessage(mavlink_message_t message)
         {
             mavlink_hil_controls_t hil;
             mavlink_msg_hil_controls_decode(&message, &hil);
-            emit hilControlsChanged(hil.time_usec, hil.roll_ailerons, hil.pitch_elevator, hil.yaw_rudder, hil.throttle, hil.mode, hil.nav_mode);
+	    emit hilControlsChanged(hil.time_usec, hil.roll_ailerons, hil.pitch_elevator, hil.yaw_rudder, hil.throttle, hil.aux1, hil.aux2, hil.aux3, hil.aux4, hil.mode, hil.nav_mode);
         }
             break;
         case MAVLINK_MSG_ID_VFR_HUD:

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -426,7 +426,7 @@ void UAS::receiveMessage(mavlink_message_t message)
         {
             mavlink_hil_controls_t hil;
             mavlink_msg_hil_controls_decode(&message, &hil);
-	    emit hilControlsChanged(hil.time_usec, hil.roll_ailerons, hil.pitch_elevator, hil.yaw_rudder, hil.throttle, hil.aux1, hil.aux2, hil.aux3, hil.aux4, hil.mode, hil.nav_mode);
+            emit hilControlsChanged(hil.time_usec, hil.roll_ailerons, hil.pitch_elevator, hil.yaw_rudder, hil.throttle, hil.aux1, hil.aux2, hil.aux3, hil.aux4, hil.mode, hil.nav_mode);
         }
             break;
         case MAVLINK_MSG_ID_VFR_HUD:

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -553,7 +553,7 @@ signals:
     /** @brief A new camera image has arrived */
     void imageReady(UASInterface* uas);
     /** @brief HIL controls have changed */
-    void hilControlsChanged(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, quint8 systemMode, quint8 navMode);
+    void hilControlsChanged(quint64 time, float rollAilerons, float pitchElevator, float yawRudder, float throttle, float aux1, float aux2, float aux3, float aux4, quint8 systemMode, quint8 navMode);
 
     void localXChanged(double val,QString name);
     void localYChanged(double val,QString name);


### PR DESCRIPTION
The HIL_CONTROLS message in mavlink has four aux values which are not used. This PR adds support for aux1-4 so that they can be used for future developments.