### PR TITLE
Fix inverted logic when disabling UVC.

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -119,6 +119,11 @@ LinuxBuild {
             libQt5Widgets.so.5 \
             libQt5XcbQpa.so.5
 
+        !contains (DEFINES, QGC_DISABLE_UVC) {
+            QT_LIB_LIST += \
+                libQt5Multimedia.so.5
+        }
+
         !contains(DEFINES, __rasp_pi2__) {
             QT_LIB_LIST += \
                 libicudata.so.54 \

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -49,10 +49,10 @@ contains (DEFINES, QGC_DISABLE_BLUETOOTH) {
 # USB Camera and UVC Video Sources
 contains (DEFINES, QGC_DISABLE_UVC) {
     message("Skipping support for UVC devices (manual override from command line)")
-    DEFINES -= QGC_DISABLE_UVC
+    DEFINES += QGC_DISABLE_UVC
 } else:exists(user_config.pri):infile(user_config.pri, DEFINES, QGC_DISABLE_UVC) {
     message("Skipping support for UVC devices (manual override from user_config.pri)")
-    DEFINES -= QGC_DISABLE_UVC
+    DEFINES += QGC_DISABLE_UVC
 }
 
 LinuxBuild {
@@ -87,8 +87,13 @@ QT += \
     sql \
     svg \
     widgets \
-    xml \
-    multimedia
+    xml
+
+# Multimedia only used if QVC is enabled
+!contains (DEFINES, QGC_DISABLE_UVC) {
+    QT += \
+        multimedia
+}
 
 !MobileBuild {
 QT += \

--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -11,7 +11,10 @@
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QSettings>
+
+#ifndef QGC_DISABLE_UVC
 #include <QCameraInfo>
+#endif
 
 #include <VideoItem.h>
 


### PR DESCRIPTION
I'm also including `multimedia` to QT only when UVC is enabled.
In addition, I've added `libQt5Multimedia.so.5` to the Linux setup in hopes that's all that is needed. I don't have a system to try it on.