### PR TITLE
Adding missing library to Linux build.

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -121,7 +121,8 @@ LinuxBuild {
 
         !contains (DEFINES, QGC_DISABLE_UVC) {
             QT_LIB_LIST += \
-                libQt5Multimedia.so.5
+                libQt5Multimedia.so.5 \
+                libQt5MultimediaQuick_p.so.5
         }
 
         !contains(DEFINES, __rasp_pi2__) {


### PR DESCRIPTION
I had added `libQt5Multimedia.so.5` but I missed `libQt5MultimediaQuick_p.so.5`. It will be a trial-and-error until we get it all there as I don't have a way to fully test what libraries are needed. Let's see if this is all it takes.