### PR TITLE
Add altitde to survey item coordinate

### DIFF
--- a/src/MissionManager/SurveyMissionItem.cc
+++ b/src/MissionManager/SurveyMissionItem.cc
@@ -80,6 +80,7 @@ SurveyMissionItem::SurveyMissionItem(Vehicle* vehicle, QObject* parent)
     connect(&_gridAngleFact,                &Fact::valueChanged, this, &SurveyMissionItem::_generateGrid);
     connect(&_turnaroundDistFact,           &Fact::valueChanged, this, &SurveyMissionItem::_generateGrid);
     connect(&_cameraTriggerDistanceFact,    &Fact::valueChanged, this, &SurveyMissionItem::_generateGrid);
+    connect(&_gridAltitudeFact,             &Fact::valueChanged, this, &SurveyMissionItem::_updateCoordinateAltitude);
 
     connect(this, &SurveyMissionItem::cameraTriggerChanged, this, &SurveyMissionItem::_cameraTriggerChanged);
 }
@@ -397,9 +398,21 @@ void SurveyMissionItem::_generateGrid(void)
     emit lastSequenceNumberChanged(lastSequenceNumber());
 
     if (_gridPoints.count()) {
-        setCoordinate(_gridPoints.first().value<QGeoCoordinate>());
-        _setExitCoordinate(_gridPoints.last().value<QGeoCoordinate>());
+        QGeoCoordinate coordinate = _gridPoints.first().value<QGeoCoordinate>();
+        coordinate.setAltitude(_gridAltitudeFact.rawValue().toDouble());
+        setCoordinate(coordinate);
+        QGeoCoordinate exitCoordinate = _gridPoints.last().value<QGeoCoordinate>();
+        exitCoordinate.setAltitude(_gridAltitudeFact.rawValue().toDouble());
+        _setExitCoordinate(exitCoordinate);
     }
+}
+
+void SurveyMissionItem::_updateCoordinateAltitude(void)
+{
+    _coordinate.setAltitude(_gridAltitudeFact.rawValue().toDouble());
+    _exitCoordinate.setAltitude(_gridAltitudeFact.rawValue().toDouble());
+    emit coordinateChanged(_coordinate);
+    emit exitCoordinateChanged(_exitCoordinate);
 }
 
 QPointF SurveyMissionItem::_rotatePoint(const QPointF& point, const QPointF& origin, double angle)

--- a/src/MissionManager/SurveyMissionItem.h
+++ b/src/MissionManager/SurveyMissionItem.h
@@ -104,6 +104,7 @@ private:
     void _setExitCoordinate(const QGeoCoordinate& coordinate);
     void _clearGrid(void);
     void _generateGrid(void);
+    void _updateCoordinateAltitude(void);
     void _gridGenerator(const QList<QPointF>& polygonPoints, QList<QPointF>& gridPoints);
     QPointF _rotatePoint(const QPointF& point, const QPointF& origin, double angle);
     void _intersectLinesWithRect(const QList<QLineF>& lineList, const QRectF& boundRect, QList<QLineF>& resultLines);


### PR DESCRIPTION
This adds the gridAltitude to the survey item coordinate and exitCoordinate and updates them whenever gridAltitude is changed.
This allows the correct calculation of alt. diff. and gradient for a survey item and shows the correct altitude in the bottom bar.
![screenshot from 2016-09-01 10-43-08](https://cloud.githubusercontent.com/assets/5629242/18161134/ee0c8e8e-7030-11e6-83d2-9430065edefe.png)
