### PR TITLE
Add video streaming dependency

### DIFF
--- a/src/VideoStreaming/README.md
+++ b/src/VideoStreaming/README.md
@@ -31,7 +31,7 @@ gst-launch-1.0 udpsrc port=5600 caps='application/x-rtp, media=(string)video, cl
 
 Use apt-get to install GStreamer 1.0
 ```
-sudo apt-get install libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev
+sudo apt-get install libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev libgstreamer-plugins-bad1.0
 ```
 
 The build system is setup to use pkgconfig and it will find the necessary headers and libraries automatically.


### PR DESCRIPTION
libgstreamer-plugins-bad1.0 is not installed if 3rd party plugins are opted-out during OS install