### PR TITLE
[DO NOT MERGE] WIP - Add RTSP video streaming widget

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -414,6 +414,8 @@ HEADERS += \
     src/ViewWidgets/CustomCommandWidgetController.h \
     src/ViewWidgets/LogDownload.h \
     src/ViewWidgets/LogDownloadController.h \
+    src/ViewWidgets/VideoStreamingWidget.h \
+    src/ViewWidgets/VideoStreamingWidgetController.h \
     src/ViewWidgets/ViewWidgetController.h \
 }
 
@@ -559,6 +561,8 @@ SOURCES += \
     src/ViewWidgets/CustomCommandWidgetController.cc \
     src/ViewWidgets/LogDownload.cc \
     src/ViewWidgets/LogDownloadController.cc \
+    src/ViewWidgets/VideoStreamingWidget.cc \
+    src/ViewWidgets/VideoStreamingWidgetController.cc \
     src/ViewWidgets/ViewWidgetController.cc
 }
 
@@ -809,6 +813,7 @@ INCLUDEPATH += \
 HEADERS += \
     src/VideoStreaming/VideoItem.h \
     src/VideoStreaming/VideoReceiver.h \
+    src/VideoStreaming/VideoUtils.h \
     src/VideoStreaming/VideoStreaming.h \
     src/VideoStreaming/VideoSurface.h \
     src/VideoStreaming/VideoSurface_p.h \
@@ -816,6 +821,7 @@ HEADERS += \
 SOURCES += \
     src/VideoStreaming/VideoItem.cc \
     src/VideoStreaming/VideoReceiver.cc \
+    src/VideoStreaming/VideoUtils.cc \
     src/VideoStreaming/VideoStreaming.cc \
     src/VideoStreaming/VideoSurface.cc \
 

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -12,6 +12,7 @@
         <file alias="APMAirframeComponent.qml">src/AutoPilotPlugins/APM/APMAirframeComponent.qml</file>
         <file alias="APMAirframeComponentSummary.qml">src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml</file>
         <file alias="CustomCommandWidget.qml">src/ViewWidgets/CustomCommandWidget.qml</file>
+        <file alias="VideoStreamingWidget.qml">src/ViewWidgets/VideoStreamingWidget.qml</file>
         <file alias="LogDownload.qml">src/ViewWidgets/LogDownload.qml</file>
         <file alias="FirmwareUpgrade.qml">src/VehicleSetup/FirmwareUpgrade.qml</file>
         <file alias="FlightDisplayView.qml">src/FlightDisplay/FlightDisplayView.qml</file>

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -49,6 +49,7 @@
 #include "ViewWidgetController.h"
 #include "ParameterEditorController.h"
 #include "CustomCommandWidgetController.h"
+#include "VideoStreamingWidgetController.h"
 #include "PX4AdvancedFlightModesController.h"
 #include "PX4SimpleFlightModesController.h"
 #include "APMFlightModesComponentController.h"
@@ -406,6 +407,7 @@ void QGCApplication::_initCommon(void)
     qmlRegisterType<CustomCommandWidgetController>  ("QGroundControl.Controllers", 1, 0, "CustomCommandWidgetController");
     qmlRegisterType<FirmwareUpgradeController>      ("QGroundControl.Controllers", 1, 0, "FirmwareUpgradeController");
     qmlRegisterType<LogDownloadController>          ("QGroundControl.Controllers", 1, 0, "LogDownloadController");
+    qmlRegisterType<VideoStreamingWidgetController> ("QGroundControl.Controllers", 1, 0, "VideoStreamingWidgetController");
 #endif
 
     // Register Qml Singletons

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -33,6 +33,8 @@ SettingsFact* QGroundControlQmlGlobal::_speedUnitsFact =                        
 FactMetaData* QGroundControlQmlGlobal::_speedUnitsMetaData =                        NULL;
 SettingsFact* QGroundControlQmlGlobal::_batteryPercentRemainingAnnounceFact =       NULL;
 FactMetaData* QGroundControlQmlGlobal::_batteryPercentRemainingAnnounceMetaData =   NULL;
+SettingsFact* QGroundControlQmlGlobal::_streamingSourcesFact =                      NULL;
+FactMetaData* QGroundControlQmlGlobal::_streamingSourcesMetaData =                  NULL;
 
 const char* QGroundControlQmlGlobal::_virtualTabletJoystickKey  = "VirtualTabletJoystick";
 const char* QGroundControlQmlGlobal::_baseFontPointSizeKey      = "BaseDeviceFontPointSize";
@@ -363,6 +365,25 @@ Fact* QGroundControlQmlGlobal::batteryPercentRemainingAnnounce(void)
     }
 
     return _batteryPercentRemainingAnnounceFact;
+}
+
+Fact* QGroundControlQmlGlobal::streamingSources(void)
+{
+    if (!_streamingSourcesFact) {
+        QStringList     enumStrings;
+        QVariantList    enumValues;
+
+        _streamingSourcesFact = new SettingsFact(QString(), "StreamingSources", FactMetaData::valueTypeUint32, StreamingSourcesUDP);
+        _streamingSourcesMetaData = new FactMetaData(FactMetaData::valueTypeUint32);
+
+        enumStrings << "UDP" << "RTSP";
+        enumValues << QVariant::fromValue((uint32_t)StreamingSourcesUDP) << QVariant::fromValue((uint32_t)StreamingSourcesRTSP);
+
+        _streamingSourcesMetaData->setEnumInfo(enumStrings, enumValues);
+        _streamingSourcesFact->setMetaData(_streamingSourcesMetaData);
+    }
+
+    return _streamingSourcesFact;
 }
 
 bool QGroundControlQmlGlobal::linesIntersect(QPointF line1A, QPointF line1B, QPointF line2A, QPointF line2B)

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -60,9 +60,15 @@ public:
         SpeedUnitsKnots,
     };
 
+    enum StreamingSources {
+        StreamingSourcesUDP = 0,
+        StreamingSourcesRTSP
+    };
+
     Q_ENUMS(DistanceUnits)
     Q_ENUMS(AreaUnits)
     Q_ENUMS(SpeedUnits)
+    Q_ENUMS(StreamingSources)
 
     Q_PROPERTY(FlightMapSettings*   flightMapSettings   READ flightMapSettings      CONSTANT)
     Q_PROPERTY(HomePositionManager* homePositionManager READ homePositionManager    CONSTANT)
@@ -99,6 +105,7 @@ public:
     Q_PROPERTY(Fact*    areaUnits                       READ areaUnits                          CONSTANT)
     Q_PROPERTY(Fact*    speedUnits                      READ speedUnits                         CONSTANT)
     Q_PROPERTY(Fact*    batteryPercentRemainingAnnounce READ batteryPercentRemainingAnnounce    CONSTANT)
+    Q_PROPERTY(Fact*    streamingSources                READ streamingSources                   CONSTANT)
 
     Q_PROPERTY(QGeoCoordinate lastKnownHomePosition READ lastKnownHomePosition  CONSTANT)
     Q_PROPERTY(QGeoCoordinate flightMapPosition     MEMBER _flightMapPosition   NOTIFY flightMapPositionChanged)
@@ -193,6 +200,7 @@ public:
     static Fact* areaUnits                      (void);
     static Fact* speedUnits                     (void);
     static Fact* batteryPercentRemainingAnnounce(void);
+    static Fact* streamingSources               (void);
 
     //-- TODO: Make this into an actual preference.
     bool    isAdvancedMode          () { return false; }
@@ -258,6 +266,8 @@ private:
     static FactMetaData*    _speedUnitsMetaData;
     static SettingsFact*    _batteryPercentRemainingAnnounceFact;
     static FactMetaData*    _batteryPercentRemainingAnnounceMetaData;
+    static SettingsFact*    _streamingSourcesFact;
+    static FactMetaData*    _streamingSourcesMetaData;
 
     static const char*  _virtualTabletJoystickKey;
     static const char*  _baseFontPointSizeKey;

--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -15,6 +15,9 @@
  */
 
 #include "VideoReceiver.h"
+
+#include "QGroundControlQmlGlobal.h"
+
 #include <QDebug>
 
 VideoReceiver::VideoReceiver(QObject* parent)
@@ -81,14 +84,13 @@ void VideoReceiver::start()
     stop();
 
     bool running = false;
+    bool isUdp = (QGroundControlQmlGlobal::StreamingSources) QGroundControlQmlGlobal::streamingSources()->rawValue().toUInt() == QGroundControlQmlGlobal::StreamingSources::StreamingSourcesUDP;
 
     GstElement*     dataSource  = NULL;
     GstCaps*        caps        = NULL;
     GstElement*     demux       = NULL;
     GstElement*     parser      = NULL;
     GstElement*     decoder     = NULL;
-
-    bool isUdp = _uri.contains("udp://");
 
     do {
         if ((_pipeline = gst_pipeline_new("receiver")) == NULL) {

--- a/src/VideoStreaming/VideoSurface.cc
+++ b/src/VideoStreaming/VideoSurface.cc
@@ -50,6 +50,7 @@ GstElement* VideoSurface::videoSink()
             qCritical("Failed to create qtquick2videosink. Make sure it is installed correctly");
             return NULL;
         }
+        g_object_set(G_OBJECT(_data->videoSink), "sync", FALSE, NULL);
         g_signal_connect(_data->videoSink, "update", G_CALLBACK(onUpdateThunk), (void* )this);
         _refed = true;
     }

--- a/src/VideoStreaming/VideoUtils.cc
+++ b/src/VideoStreaming/VideoUtils.cc
@@ -1,0 +1,181 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "VideoUtils.h"
+
+#include <QDebug>
+
+#include <string.h>
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Utils
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+struct StreamServerData {
+    const char *ip;
+    uint16_t port;
+};
+
+struct StreamData {
+    uint8_t id;
+    uint32_t capabilities;
+    PixelFormat format;
+    PixelFormat availableFormats[20];
+    uint16_t frameSize[2];
+    const char *uri;
+};
+
+static QHash<PixelFormat, FormatPipelineElements> _pixelFormatElementsHash {
+      // RGB formats
+      { PixelFormat::RGB1,  { } },
+      { PixelFormat::R444,  { } },
+      { PixelFormat::RGB0,  { } },
+      { PixelFormat::RGBP,  { } },
+      { PixelFormat::RGBQ,  { } },
+      { PixelFormat::RGBR,  { } },
+      { PixelFormat::BGR3,  { } },
+      { PixelFormat::RGB3,  { } },
+      { PixelFormat::BGR4,  { } },
+      { PixelFormat::RGB4,  { } },
+      // Grey formats
+      { PixelFormat::GREY,  { } },
+      { PixelFormat::Y10,   { } },
+      { PixelFormat::Y16,   { } },
+      // Palette formats
+      { PixelFormat::PAL8,  { } },
+      // Luminance+Chrominance formats
+      { PixelFormat::YVU9,  { } },
+      { PixelFormat::YV12,  { } },
+      { PixelFormat::YUYV,  { } },
+      { PixelFormat::YYUV,  { } },
+      { PixelFormat::YVYU,  { } },
+      { PixelFormat::UYVY,  { } },
+      { PixelFormat::VYUY,  { } },
+      { PixelFormat::F422P, { } },
+      { PixelFormat::F411P, { } },
+      { PixelFormat::Y41P,  { } },
+      { PixelFormat::Y444,  { } },
+      { PixelFormat::YUVO,  { } },
+      { PixelFormat::YUVP,  { } },
+      { PixelFormat::YUV4,  { } },
+      { PixelFormat::YUV9,  { } },
+      { PixelFormat::YU12,  { } },
+      { PixelFormat::HI24,  { } },
+      { PixelFormat::HM12,  { } },
+      // Two planes -- one Y, one Cr + Cb interleaved
+      { PixelFormat::NV12,  { "application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264", "rtph264depay", "h264parse", "avdec_h264" } },
+      { PixelFormat::NV21,  { "application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264", "rtph264depay", "h264parse", "avdec_h264" } },
+      { PixelFormat::NV16,  { "application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264", "rtph264depay", "h264parse", "avdec_h264" } },
+      { PixelFormat::NV61,  { "application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264", "rtph264depay", "h264parse", "avdec_h264" } },
+      // Bayer formats
+      { PixelFormat::BA81,  { } },
+      { PixelFormat::GBRG,  { } },
+      { PixelFormat::GRBG,  { } },
+      { PixelFormat::RGGB,  { } },
+      { PixelFormat::BG10,  { } },
+      { PixelFormat::GB10,  { } },
+      { PixelFormat::BA10,  { } },
+      { PixelFormat::RG10,  { } },
+      { PixelFormat::BD10,  { } },
+      { PixelFormat::BYR2,  { } },
+      // Compressed formats
+      { PixelFormat::MJPG,  { "application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)MJPG", "rtpjpegdepay", NULL, "jpegdec" } },
+      { PixelFormat::JPEG,  { NULL, "rtpjpegdepay", NULL, "jpegdec" } },
+      { PixelFormat::dvsd,  { NULL, "rtpdvdepay", NULL, "dvdec" } },
+      { PixelFormat::MPEG,  { "application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264", "rtph264depay", "h264parse", "avdec_h264" } },
+      // Vendor-specific formats
+      { PixelFormat::CPIA,  { } },
+      { PixelFormat::WNVA,  { } },
+      { PixelFormat::S910,  { } },
+      { PixelFormat::S920,  { } },
+      { PixelFormat::PWC1,  { } },
+      { PixelFormat::PWC2,  { } },
+      { PixelFormat::E625,  { } },
+      { PixelFormat::S501,  { } },
+      { PixelFormat::S505,  { } },
+      { PixelFormat::S508,  { } },
+      { PixelFormat::S561,  { } },
+      { PixelFormat::P207,  { } },
+      { PixelFormat::M310,  { } },
+      { PixelFormat::SONX,  { } },
+      { PixelFormat::F905C, { } },
+      { PixelFormat::PJPG,  { } },
+      { PixelFormat::F0511, { } },
+      { PixelFormat::F0518, { } },
+      { PixelFormat::S680,  { } },
+};
+
+extern QString pixelFormatToFourCC(PixelFormat f)
+{
+    QString fourCC = "";
+
+    fourCC.append((char)(f & 0xFF));
+    fourCC.append((char)((f & 0xFF00) >> 8));
+    fourCC.append((char)((f & 0xFF0000) >> 16));
+    fourCC.append((char)((f & 0xFF000000) >> 24));
+
+    return fourCC;
+}
+
+extern struct StreamServerData getStreamServerData()
+{
+    struct StreamServerData data;
+
+    // TODO: Use custom MAVLink message to get stream server data.
+
+    memset(&data, 0, sizeof(struct StreamServerData));
+
+    data.ip = "0.0.0.0";
+    data.port = 8554;
+
+    return data;
+}
+
+extern struct StreamData getStreamData()
+{
+    struct StreamData data;
+
+    // TODO: Use custom MAVLink message to get stream data.
+
+    memset(&data, 0, sizeof(struct StreamData));
+
+    data.id = 0;
+    data.capabilities = 2216689665;
+    data.format = PixelFormat::MJPG;
+    data.availableFormats[0] = PixelFormat::MJPG;
+    data.availableFormats[1] = PixelFormat::YUYV;
+    data.frameSize[0] = 1280;
+    data.frameSize[1] = 720;
+    data.uri = "rtsp://127.0.0.1:8554/stream0";
+
+    return data;
+}
+
+extern struct FormatPipelineElements getFormatPipelineElements(PixelFormat f)
+{
+    return _pixelFormatElementsHash[f];
+}
+
+extern QStringList getStreams()
+{
+    QStringList list;
+
+    // TODO: Use custom MAVLink message to get streams.
+
+    return list << "rtsp://127.0.0.1:8554/stream0";
+}
+
+extern PixelFormat getStreamFormat()
+{
+    struct StreamData data = getStreamData();
+
+    return data.format;
+}

--- a/src/VideoStreaming/VideoUtils.h
+++ b/src/VideoStreaming/VideoUtils.h
@@ -1,0 +1,120 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Utils
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+#include <QHash>
+#include <QStringList>
+
+#ifndef VIDEO_UTILS_H
+#define VIDEO_UTILS_H
+
+#define fourcc(a,b,c,d) ((uint32_t)(a) << 0) | ((uint32_t)(b) << 8) | ((uint32_t)(c) << 16) | ((uint32_t)(d) << 24)
+
+enum PixelFormat {
+    // RGB formats
+    RGB1  = fourcc('R', 'G', 'B', '1'),
+    R444  = fourcc('R', '4', '4', '4'),
+    RGB0  = fourcc('R', 'G', 'B', '0'),
+    RGBP  = fourcc('R', 'G', 'B', 'P'),
+    RGBQ  = fourcc('R', 'G', 'B', 'Q'),
+    RGBR  = fourcc('R', 'G', 'B', 'R'),
+    BGR3  = fourcc('B', 'G', 'R', '3'),
+    RGB3  = fourcc('R', 'G', 'B', '3'),
+    BGR4  = fourcc('B', 'G', 'R', '4'),
+    RGB4  = fourcc('R', 'G', 'B', '4'),
+    // Grey formats
+    GREY  = fourcc('G', 'R', 'E', 'Y'),
+    Y10   = fourcc('Y', '1', '0', ' '),
+    Y16   = fourcc('Y', '1', '6', ' '),
+    // Palette formats
+    PAL8  = fourcc('P', 'A', 'L', '8'),
+    // Luminance+Chrominance formats
+    YVU9  = fourcc('Y', 'V', 'U', '9'),
+    YV12  = fourcc('Y', 'V', '1', '2'),
+    YUYV  = fourcc('Y', 'U', 'Y', 'V'),
+    YYUV  = fourcc('Y', 'Y', 'U', 'V'),
+    YVYU  = fourcc('Y', 'V', 'Y', 'U'),
+    UYVY  = fourcc('U', 'Y', 'V', 'Y'),
+    VYUY  = fourcc('V', 'Y', 'U', 'Y'),
+    F422P = fourcc('4', '2', '2', 'P'),
+    F411P = fourcc('4', '1', '1', 'P'),
+    Y41P  = fourcc('Y', '4', '1', 'P'),
+    Y444  = fourcc('Y', '4', '4', '4'),
+    YUVO  = fourcc('Y', 'U', 'V', 'O'),
+    YUVP  = fourcc('Y', 'U', 'V', 'P'),
+    YUV4  = fourcc('Y', 'U', 'V', '4'),
+    YUV9  = fourcc('Y', 'U', 'V', '9'),
+    YU12  = fourcc('Y', 'U', '1', '2'),
+    HI24  = fourcc('H', 'I', '2', '4'),
+    HM12  = fourcc('H', 'M', '1', '2'),
+    // Two planes -- one Y, one Cr + Cb interleaved
+    NV12  = fourcc('N', 'V', '1', '2'),
+    NV21  = fourcc('N', 'V', '2', '1'),
+    NV16  = fourcc('N', 'V', '1', '6'),
+    NV61  = fourcc('N', 'V', '6', '1'),
+    // Bayer formats
+    BA81  = fourcc('B', 'A', '8', '1'),
+    GBRG  = fourcc('G', 'B', 'R', 'G'),
+    GRBG  = fourcc('G', 'R', 'B', 'G'),
+    RGGB  = fourcc('R', 'G', 'G', 'B'),
+    BG10  = fourcc('B', 'G', '1', '0'),
+    GB10  = fourcc('G', 'B', '1', '0'),
+    BA10  = fourcc('B', 'A', '1', '0'),
+    RG10  = fourcc('R', 'G', '1', '0'),
+    BD10  = fourcc('B', 'D', '1', '0'),
+    BYR2  = fourcc('B', 'Y', 'R', '2'),
+    // Compressed formats
+    MJPG  = fourcc('M', 'J', 'P', 'G'),
+    JPEG  = fourcc('J', 'P', 'E', 'G'),
+    dvsd  = fourcc('d', 'v', 's', 'd'),
+    MPEG  = fourcc('M', 'P', 'E', 'G'),
+    // Vendor-specific formats
+    CPIA  = fourcc('C', 'P', 'I', 'A'),
+    WNVA  = fourcc('W', 'N', 'V', 'A'),
+    S910  = fourcc('S', '9', '1', '0'),
+    S920  = fourcc('S', '9', '2', '0'),
+    PWC1  = fourcc('P', 'W', 'C', '1'),
+    PWC2  = fourcc('P', 'W', 'C', '2'),
+    E625  = fourcc('E', '6', '2', '5'),
+    S501  = fourcc('S', '5', '0', '1'),
+    S505  = fourcc('S', '5', '0', '5'),
+    S508  = fourcc('S', '5', '0', '8'),
+    S561  = fourcc('S', '5', '6', '1'),
+    P207  = fourcc('P', '2', '0', '7'),
+    M310  = fourcc('M', '3', '1', '0'),
+    SONX  = fourcc('S', 'O', 'N', 'X'),
+    F905C = fourcc('9', '0', '5', 'C'),
+    PJPG  = fourcc('P', 'J', 'P', 'G'),
+    F0511 = fourcc('0', '5', '1', '1'),
+    F0518 = fourcc('0', '5', '1', '8'),
+    S680  = fourcc('S', '6', '8', '0'),
+};
+
+#undef fourcc
+
+struct FormatPipelineElements {
+    const char *caps;
+    const char *demux;
+    const char *parser;
+    const char *decoder;
+};
+
+extern QString pixelFormatToFourCC(PixelFormat f);
+
+extern struct FormatPipelineElements getFormatPipelineElements(PixelFormat f);
+extern QStringList getStreams();
+extern PixelFormat getStreamFormat();
+
+#endif // VIDEO_UTILS_H

--- a/src/ViewWidgets/VideoStreamingWidget.cc
+++ b/src/ViewWidgets/VideoStreamingWidget.cc
@@ -1,0 +1,30 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Widget
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+#include "VideoStreamingWidget.h"
+
+VideoStreamingWidget::VideoStreamingWidget(const QString& title, QAction* action, QWidget *parent) :
+    QGCQmlWidgetHolder(title, action, parent)
+{
+    Q_UNUSED(title)
+    Q_UNUSED(action);
+
+    resize(460, 328);
+
+    setSource(QUrl::fromUserInput("qrc:/qml/VideoStreamingWidget.qml"));
+
+    loadSettings();
+}

--- a/src/ViewWidgets/VideoStreamingWidget.h
+++ b/src/ViewWidgets/VideoStreamingWidget.h
@@ -1,0 +1,30 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Widget
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+#ifndef VideoStreamingWidget_H
+#define VideoStreamingWidget_H
+
+#include "QGCQmlWidgetHolder.h"
+
+class VideoStreamingWidget : public QGCQmlWidgetHolder
+{
+    Q_OBJECT
+
+public:
+    VideoStreamingWidget(const QString& title, QAction* action, QWidget *parent = 0);
+};
+
+#endif // VideoStreamingWidget_H

--- a/src/ViewWidgets/VideoStreamingWidget.qml
+++ b/src/ViewWidgets/VideoStreamingWidget.qml
@@ -1,0 +1,264 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Widget
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+import QtQuick                    2.5
+import QtQuick.Controls           1.2
+import QtQuick.Controls.Styles    1.2
+import QtQuick.Dialogs            1.2
+
+import QGroundControl.Palette     1.0
+import QGroundControl.Controls    1.0
+import QGroundControl.Controllers 1.0
+import QGroundControl.ScreenTools 1.0
+
+QGCView {
+    viewPanel:    panel
+
+    property real _margins:             ScreenTools.defaultFontPixelWidth
+    property real _elementsHeight:      ScreenTools.defaultFontPixelWidth * 3
+    property real _elementsWidth:       ScreenTools.defaultFontPixelWidth * 28
+    property real _buttonWidth:         ScreenTools.defaultFontPixelWidth * 15
+    property real _frameSizeFieldWidth: ScreenTools.defaultFontPixelWidth * 12
+
+    QGCPalette {
+        id:                qgcPal
+        colorGroupEnabled: enabled
+    }
+
+    VideoStreamingWidgetController {
+        id:                   controller
+        factPanel:            panel
+        serverLabel:          serverLabel
+        ipField:              ipField
+        portField:            portField
+        streamsComboBox:      streamsComboBox
+        formatComboBox:       formatComboBox
+        frameSizeWidthField:  frameSizeWidthField
+        frameSizeHeightField: frameSizeHeightField
+        nameField:            nameField
+    }
+
+    QGCViewPanel {
+        id:                panel
+        anchors.fill:      parent
+        enabled:           controller.rtspEnabled
+
+        Rectangle {
+            anchors.fill:                   parent
+            color:                          qgcPal.window
+
+            QGCLabel {
+                id:                         title
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                parent.top
+                horizontalAlignment:        Text.AlignHCenter
+                wrapMode:                   Text.WordWrap
+                textFormat:                 Text.RichText
+                text:                       "RTSP Stream Configuration"
+            }
+
+            Row {
+                id:                         serverRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                title.bottom
+
+                QGCLabel {
+                    id:                     serverLabel
+                    width:                  _elementsWidth
+                    height:                 _elementsHeight
+                    wrapMode:               Text.WordWrap
+                    textFormat:             Text.RichText
+                    text:                   "Server:"
+                }
+
+
+                QGCButton {
+                    id:                     refreshButton
+                    text:                   "Refresh"
+                    width:                  _buttonWidth
+                    height:                 _elementsHeight
+                    onClicked:              controller.refresh()
+                }
+            }
+
+            Row {
+                id:                         ipRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                serverRow.bottom
+
+                QGCTextField {
+                    id:                     ipField
+                    width:                  _elementsWidth
+                    height:                 _elementsHeight
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                QGCButton {
+                    id:                     ipButton
+                    text:                   "Set IP"
+                    width:                  _buttonWidth
+                    height:                 _elementsHeight
+                    onClicked:              controller.setIp()
+                }
+            }
+
+            Row {
+                id:                         portRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                ipRow.bottom
+
+                QGCTextField {
+                    id:                     portField
+                    width:                  _elementsWidth
+                    height:                 _elementsHeight
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                QGCButton {
+                    id:                     portButton
+                    text:                   "Set Port"
+                    width:                  _buttonWidth
+                    height:                 _elementsHeight
+                    onClicked:              controller.setPort()
+                }
+            }
+
+            Row {
+                id:                         streamsRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                portRow.bottom
+
+                QGCLabel {
+                    id:                     streamsLabel
+                    width:                  ScreenTools.defaultFontPixelWidth * 7
+                    height:                 _elementsHeight
+                    wrapMode:               Text.WordWrap
+                    textFormat:             Text.RichText
+                    text:                   "Stream: "
+                }
+
+                QGCComboBox {
+                    id:                     streamsComboBox
+                    width:                  ScreenTools.defaultFontPixelWidth * 36
+                    height:                 _elementsHeight
+                    onActivated:            controller.setActiveStream()
+                }
+            }
+
+            Row {
+                id:                         formatRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                streamsRow.bottom
+
+                QGCComboBox {
+                    id:                     formatComboBox
+                    width:                  _elementsWidth
+                    height:                 _elementsHeight
+                }
+
+                QGCButton {
+                    id:                     formatButton
+                    text:                   "Set Format"
+                    width:                  _buttonWidth
+                    height:                 _elementsHeight
+                    onClicked:              controller.setFormat()
+                }
+            }
+
+            Row {
+                id:                         frameSizeRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                formatRow.bottom
+
+                QGCTextField {
+                    id:                     frameSizeWidthField
+                    width:                  _frameSizeFieldWidth
+                    height:                 _elementsHeight
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                QGCLabel {
+                    id:                     frameSizeLabel
+                    width:                  ScreenTools.defaultFontPixelWidth * 2
+                    height:                 _elementsHeight
+                    horizontalAlignment:    Text.AlignHCenter
+                    wrapMode:               Text.WordWrap
+                    textFormat:             Text.RichText
+                    text:                   "x"
+                }
+
+                QGCTextField {
+                    id:                     frameSizeHeightField
+                    width:                  _frameSizeFieldWidth
+                    height:                 _elementsHeight
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                QGCButton {
+                    id:                     frameSizeButton
+                    text:                   "Set Frame Size"
+                    width:                  _buttonWidth
+                    height:                 _elementsHeight
+                    onClicked:              controller.setFrameSize()
+                }
+            }
+
+            Row {
+                id:                         nameRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                frameSizeRow.bottom
+
+                QGCTextField {
+                    id:                     nameField
+                    width:                  _elementsWidth
+                    height:                 _elementsHeight
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                QGCButton {
+                    id:                     nameButton
+                    text:                   "Set Name"
+                    width:                  _buttonWidth
+                    height:                 _elementsHeight
+                    onClicked:              controller.setName()
+                }
+            }
+        }
+    }
+}

--- a/src/ViewWidgets/VideoStreamingWidgetController.cc
+++ b/src/ViewWidgets/VideoStreamingWidgetController.cc
@@ -1,0 +1,139 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Widget Controller
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+#include "VideoStreamingWidgetController.h"
+
+#include "QGroundControlQmlGlobal.h"
+
+VideoStreamingWidgetController::VideoStreamingWidgetController(void)
+    : _rtspEnabled(false)
+    , _serverLabel(NULL)
+    , _ipField(NULL)
+    , _portField(NULL)
+    , _streamsComboBox(NULL)
+    , _formatComboBox(NULL)
+    , _frameSizeWidthField(NULL)
+    , _frameSizeHeightField(NULL)
+    , _nameField(NULL)
+{
+    if (QGroundControlQmlGlobal::streamingSources()->rawValue().toUInt() == QGroundControlQmlGlobal::StreamingSources::StreamingSourcesRTSP)
+        _rtspEnabled = true;
+}
+
+VideoStreamingWidgetController::~VideoStreamingWidgetController(void)
+{
+
+}
+
+void VideoStreamingWidgetController::getServerInfo(void)
+{
+    Q_ASSERT(_serverLabel);
+    Q_ASSERT(_ipField);
+    Q_ASSERT(_portField);
+    Q_ASSERT(_streamsComboBox);
+
+    // TODO: Use custom MAVLink message to get server information.
+
+    QStringList streams;
+    streams << "rtsp://0.0.0.0:8554/stream0" << "rtsp://0.0.0.0:8554/stream1";
+
+    _serverLabel->setProperty("text", "Server: 0.0.0.0:8554");
+    _ipField->setProperty("text", "0.0.0.0");
+    _portField->setProperty("text", "8554");
+    _streamsComboBox->setProperty("model", streams);
+}
+
+void VideoStreamingWidgetController::getStreamInfo(void)
+{
+    Q_ASSERT(_streamsComboBox);
+    Q_ASSERT(_formatComboBox);
+    Q_ASSERT(_frameSizeWidthField);
+    Q_ASSERT(_frameSizeHeightField);
+    Q_ASSERT(_nameField);
+
+    // TODO: Use custom MAVLink message to get stream information.
+
+    QStringList formats;
+    formats << "YUYV" << "MJPG";
+
+    _formatComboBox->setProperty("model", formats);
+    _formatComboBox->setProperty("currentIndex", 0);
+    _frameSizeWidthField->setProperty("text", "1280");
+    _frameSizeHeightField->setProperty("text", "720");
+    _nameField->setProperty("text", "stream0");
+}
+
+void VideoStreamingWidgetController::refresh(void)
+{
+    getServerInfo();
+    getStreamInfo();
+}
+
+void VideoStreamingWidgetController::setIp(void)
+{
+    Q_ASSERT(_ipField);
+
+    // TODO: Use custom MAVLink message to set ip.
+
+    _ipField->setProperty("text", "0.0.0.0");
+}
+
+void VideoStreamingWidgetController::setPort(void)
+{
+    Q_ASSERT(_portField);
+
+    // TODO: Use custom MAVLink message to set port.
+
+    _portField->setProperty("text", "8554");
+}
+
+void VideoStreamingWidgetController::setActiveStream(void)
+{
+    getStreamInfo();
+}
+
+void VideoStreamingWidgetController::setFormat(void)
+{
+    Q_ASSERT(_formatComboBox);
+
+    // TODO: Use custom MAVLink message to set format.
+
+    QStringList formats;
+    formats << "YUYV" << "MJPG";
+
+    _formatComboBox->setProperty("model", formats);
+    _formatComboBox->setProperty("currentIndex", 0);
+}
+
+void VideoStreamingWidgetController::setFrameSize(void)
+{
+    Q_ASSERT(_frameSizeWidthField);
+    Q_ASSERT(_frameSizeHeightField);
+
+    // TODO: Use custom MAVLink message to set frame size.
+
+    _frameSizeWidthField->setProperty("text", "1280");
+    _frameSizeHeightField->setProperty("text", "720");
+}
+
+void VideoStreamingWidgetController::setName(void)
+{
+    Q_ASSERT(_nameField);
+
+    // TODO: Use custom MAVLink message to set name.
+
+    _nameField->setProperty("text", "stream0");
+}

--- a/src/ViewWidgets/VideoStreamingWidgetController.h
+++ b/src/ViewWidgets/VideoStreamingWidgetController.h
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Widget Controller
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+#ifndef VideoStreamingWidgetController_H
+#define VideoStreamingWidgetController_H
+
+#include "FactPanelController.h"
+
+class VideoStreamingWidgetController : public FactPanelController
+{
+    Q_OBJECT
+
+public:
+    VideoStreamingWidgetController(void);
+    ~VideoStreamingWidgetController();
+
+    void getServerInfo(void);
+    void getStreamInfo(void);
+
+    Q_INVOKABLE void refresh(void);
+    Q_INVOKABLE void setIp(void);
+    Q_INVOKABLE void setPort(void);
+    Q_INVOKABLE void setActiveStream(void);
+    Q_INVOKABLE void setFormat(void);
+    Q_INVOKABLE void setFrameSize(void);
+    Q_INVOKABLE void setName(void);
+
+    Q_PROPERTY(bool        rtspEnabled          READ rtspEnabled          CONSTANT)
+    Q_PROPERTY(QQuickItem* serverLabel          READ serverLabel          WRITE setServerLabel)
+    Q_PROPERTY(QQuickItem* ipField              READ ipField              WRITE setIpField)
+    Q_PROPERTY(QQuickItem* portField            READ portField            WRITE setPortField)
+    Q_PROPERTY(QQuickItem* streamsComboBox      READ streamsComboBox      WRITE setStreamsComboBox)
+    Q_PROPERTY(QQuickItem* formatComboBox       READ formatComboBox       WRITE setFormatComboBox)
+    Q_PROPERTY(QQuickItem* frameSizeWidthField  READ frameSizeWidthField  WRITE setFrameSizeWidthField)
+    Q_PROPERTY(QQuickItem* frameSizeHeightField READ frameSizeHeightField WRITE setFrameSizeHeightField)
+    Q_PROPERTY(QQuickItem* nameField            READ nameField            WRITE setNameField)
+
+    bool        rtspEnabled(void) {          return _rtspEnabled; }
+    QQuickItem* serverLabel(void) {          return _serverLabel; }
+    QQuickItem* ipField(void) {              return _ipField; }
+    QQuickItem* portField(void) {            return _portField; }
+    QQuickItem* streamsComboBox(void) {      return _streamsComboBox; }
+    QQuickItem* formatComboBox(void) {       return _formatComboBox; }
+    QQuickItem* frameSizeWidthField(void) {  return _frameSizeWidthField; }
+    QQuickItem* frameSizeHeightField(void) { return _frameSizeHeightField; }
+    QQuickItem* nameField(void) {            return _nameField; }
+
+    void setServerLabel(QQuickItem* serverLabel)                   { _serverLabel = serverLabel; }
+    void setIpField(QQuickItem* ipField)                           { _ipField = ipField; }
+    void setPortField(QQuickItem* portField)                       { _portField = portField; }
+    void setStreamsComboBox(QQuickItem* streamsComboBox)           { _streamsComboBox = streamsComboBox; }
+    void setFormatComboBox(QQuickItem* formatComboBox)             { _formatComboBox = formatComboBox; }
+    void setFrameSizeWidthField(QQuickItem* frameSizeWidthField)   { _frameSizeWidthField = frameSizeWidthField; }
+    void setFrameSizeHeightField(QQuickItem* frameSizeHeightField) { _frameSizeHeightField = frameSizeHeightField; }
+    void setNameField(QQuickItem* nameField)                       { _nameField = nameField; }
+
+private:
+    bool        _rtspEnabled;
+    QQuickItem* _serverLabel;
+    QQuickItem* _ipField;
+    QQuickItem* _portField;
+    QQuickItem* _streamsComboBox;
+    QQuickItem* _formatComboBox;
+    QQuickItem* _frameSizeWidthField;
+    QQuickItem* _frameSizeHeightField;
+    QQuickItem* _nameField;
+};
+
+#endif // VideoStreamingWidgetController_H

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -53,6 +53,7 @@
 #include "HILDockWidget.h"
 #include "LogDownload.h"
 #include "AppMessages.h"
+#include "VideoStreamingWidget.h"
 #endif
 
 #ifndef __ios__
@@ -74,7 +75,8 @@ enum DockWidgetTypes {
     INFO_VIEW,
     HIL_CONFIG,
     ANALYZE,
-    LOG_DOWNLOAD
+    LOG_DOWNLOAD,
+    VIDEO_STREAMING,
 };
 
 static const char *rgDockWidgetNames[] = {
@@ -84,7 +86,8 @@ static const char *rgDockWidgetNames[] = {
     "Info View",
     "HIL Config",
     "Analyze",
-    "Log Download"
+    "Log Download",
+    "Video Streaming",
 };
 
 #define ARRAY_SIZE(ARRAY) (sizeof(ARRAY) / sizeof(ARRAY[0]))
@@ -363,6 +366,9 @@ bool MainWindow::_createInnerDockWidget(const QString& widgetName)
                 break;
             case INFO_VIEW:
                 widget= new QGCTabbedInfoView(widgetName, action, this);
+                break;
+            case VIDEO_STREAMING:
+                widget = new VideoStreamingWidget(widgetName, action, this);
                 break;
         }
         if(action->data().toInt() == INFO_VIEW) {

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -514,22 +514,11 @@ QGCView {
                                 text:               qsTr("Video Source:")
                                 width:              _labelWidth
                             }
-                            QGCComboBox {
+                            FactComboBox {
                                 id:                 videoSource
                                 width:              _editFieldWidth
-                                model:              QGroundControl.videoManager.videoSourceList
-                                Component.onCompleted: {
-                                    var index = videoSource.find(QGroundControl.videoManager.videoSource)
-                                    if (index >= 0) {
-                                        videoSource.currentIndex = index
-                                    }
-                                }
-                                onActivated: {
-                                    if (index != -1) {
-                                        currentIndex = index
-                                        QGroundControl.videoManager.videoSource = model[index]
-                                    }
-                                }
+                                fact:               QGroundControl.streamingSources
+                                indexModel:         false
                             }
                         }
                         Row {


### PR DESCRIPTION
The idea of this PR is to give you guys a brief of the solution we're planning to video streaming, which includes some patches in qgroundcontrol as well.

This commit is still work in progress but adds an RTSP video streaming widget which will be used to set RTSP streaming configurations such as query streams URIs, formats, capabilities, framesizes and so on.

In order to control these configurations we need the support for a custom MAVLink message which is still being reviewed by the Ardupilot team.

http://discuss.ardupilot.org/t/review-camera-streaming-custom-mavlink-message/11132/5

I would like to ask you guys for a review of what you think of it as well as review the commit itself.

Thanks!

This commit is above #4026, which can be merged to upstream.