### PR TITLE
Improve USB Interface detection reliability and support for LibrePilot compatible USB IDs

### DIFF
--- a/android/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/android/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -297,6 +297,13 @@ public class CdcAcmSerialDriver extends CommonUsbSerialDriver {
                     UsbId.DEVICE_UBLOX_7,
                     UsbId.DEVICE_UBLOX_8,
                 });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_OPENPILOT),
+                new int[] {
+                    UsbId.DEVICE_CC3D,
+                    UsbId.DEVICE_REVOLUTION,
+                    UsbId.DEVICE_SPARKY2,
+                    UsbId.DEVICE_OPLINK,
+                });
         return supportedDevices;
     }
 

--- a/android/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/android/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -47,31 +47,75 @@ public class CdcAcmSerialDriver extends CommonUsbSerialDriver {
 
     @Override
     public void open() throws IOException {
-        Log.d(TAG, "claiming interfaces, count=" + mDevice.getInterfaceCount());
+        Log.d(TAG, "device " + mDevice);
+        mControlInterface = null;
+        mDataInterface = null;
+        mWriteEndpoint = null;
+        mReadEndpoint = null;
 
-        Log.d(TAG, "Claiming control interface.");
-        mControlInterface = mDevice.getInterface(0);
-        Log.d(TAG, "Control iface=" + mControlInterface);
-        // class should be USB_CLASS_COMM
+        // locate all needed interfaces
+        for(int i = 0; i < mDevice.getInterfaceCount();i++){
+            UsbInterface iface = mDevice.getInterface(i);
+
+            switch(iface.getInterfaceClass()){
+                case UsbConstants.USB_CLASS_COMM:
+                    mControlInterface = iface;
+                    Log.d(TAG, "control iface=" + iface);
+                    break;
+                case UsbConstants.USB_CLASS_CDC_DATA:
+                    mDataInterface = iface;
+                    Log.d(TAG, "data iface=" + iface);
+                    break;
+                default:
+                    Log.d(TAG, "skipping iface=" + iface);
+                    break;
+            }
+        }
+
+        // failback to the old way
+        if(mControlInterface == null) {
+            mControlInterface = mDevice.getInterface(0);
+            Log.d(TAG, "Failback: Control iface=" + mControlInterface);
+        }
 
         if (!mConnection.claimInterface(mControlInterface, true)) {
             throw new IOException("Could not claim control interface.");
         }
-        mControlEndpoint = mControlInterface.getEndpoint(0);
-        Log.d(TAG, "Control endpoint direction: " + mControlEndpoint.getDirection());
 
-        Log.d(TAG, "Claiming data interface.");
-        mDataInterface = mDevice.getInterface(1);
-        Log.d(TAG, "data iface=" + mDataInterface);
-        // class should be USB_CLASS_CDC_DATA
+        mControlEndpoint = mControlInterface.getEndpoint(0);
+        Log.d(TAG, "Control endpoint: " + mControlEndpoint);
+
+
+        if(mDataInterface == null) {
+            mDataInterface = mDevice.getInterface(1);
+            Log.d(TAG, "Failback: data iface=" + mDataInterface);
+        }
 
         if (!mConnection.claimInterface(mDataInterface, true)) {
             throw new IOException("Could not claim data interface.");
         }
-        mReadEndpoint = mDataInterface.getEndpoint(1);
-        Log.d(TAG, "Read endpoint direction: " + mReadEndpoint.getDirection());
-        mWriteEndpoint = mDataInterface.getEndpoint(0);
-        Log.d(TAG, "Write endpoint direction: " + mWriteEndpoint.getDirection());
+
+        for(int i = 0; i < mDataInterface.getEndpointCount(); i++) {
+            UsbEndpoint endpoint = mDataInterface.getEndpoint(i);
+            switch (endpoint.getDirection()) {
+                case UsbConstants.USB_DIR_OUT:
+                    mWriteEndpoint = endpoint;
+                    Log.d(TAG, "Write endpoint: " + mWriteEndpoint);
+                    break;
+                case UsbConstants.USB_DIR_IN:
+                    mReadEndpoint = endpoint;
+                    Log.d(TAG, "Read endpoint: " + mReadEndpoint);
+                    break;
+            }
+        }
+
+        if(mReadEndpoint == null || mWriteEndpoint == null){
+            // failback to the old method
+            mReadEndpoint = mDataInterface.getEndpoint(0);
+            Log.d(TAG, "Read endpoint direction: " + mReadEndpoint.getDirection());
+            mWriteEndpoint = mDataInterface.getEndpoint(1);
+            Log.d(TAG, "Write endpoint direction: " + mWriteEndpoint.getDirection());
+        }
     }
 
     private int sendAcmControlMessage(int request, int value, byte[] buf) {

--- a/android/src/com/hoho/android/usbserial/driver/UsbId.java
+++ b/android/src/com/hoho/android/usbserial/driver/UsbId.java
@@ -68,6 +68,12 @@ public final class UsbId {
     public static final int DEVICE_UBLOX_7 = 0x01a7;
     public static final int DEVICE_UBLOX_8 = 0x01a8;
 
+    public static final int VENDOR_OPENPILOT = 0x20A0;
+    public static final int DEVICE_REVOLUTION = 0x415E;
+    public static final int DEVICE_OPLINK = 0x415C;
+    public static final int DEVICE_SPARKY2 = 0x41D0;
+    public static final int DEVICE_CC3D = 0x415D;
+
     private UsbId() {
         throw new IllegalAccessError("Non-instantiable class.");
     }

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -40,13 +40,14 @@
 QGC_LOGGING_CATEGORY(LinkManagerLog, "LinkManagerLog")
 QGC_LOGGING_CATEGORY(LinkManagerVerboseLog, "LinkManagerVerboseLog")
 
-const char* LinkManager::_settingsGroup =           "LinkManager";
-const char* LinkManager::_autoconnectUDPKey =       "AutoconnectUDP";
-const char* LinkManager::_autoconnectPixhawkKey =   "AutoconnectPixhawk";
-const char* LinkManager::_autoconnect3DRRadioKey =  "Autoconnect3DRRadio";
-const char* LinkManager::_autoconnectPX4FlowKey =   "AutoconnectPX4Flow";
-const char* LinkManager::_autoconnectRTKGPSKey =    "AutoconnectRTKGPS";
-const char* LinkManager::_defaultUPDLinkName =      "Default UDP Link";
+const char* LinkManager::_settingsGroup =            "LinkManager";
+const char* LinkManager::_autoconnectUDPKey =        "AutoconnectUDP";
+const char* LinkManager::_autoconnectPixhawkKey =    "AutoconnectPixhawk";
+const char* LinkManager::_autoconnect3DRRadioKey =   "Autoconnect3DRRadio";
+const char* LinkManager::_autoconnectPX4FlowKey =    "AutoconnectPX4Flow";
+const char* LinkManager::_autoconnectRTKGPSKey =     "AutoconnectRTKGPS";
+const char* LinkManager::_autoconnectLibrePilotKey = "AutoconnectLibrePilot";
+const char* LinkManager::_defaultUPDLinkName =       "Default UDP Link";
 
 const int LinkManager::_autoconnectUpdateTimerMSecs =   1000;
 #ifdef Q_OS_WIN
@@ -68,6 +69,7 @@ LinkManager::LinkManager(QGCApplication* app)
     , _autoconnect3DRRadio(true)
     , _autoconnectPX4Flow(true)
     , _autoconnectRTKGPS(true)
+    , _autoconnectLibrePilot(true)
 {
     qmlRegisterUncreatableType<LinkManager>         ("QGroundControl", 1, 0, "LinkManager",         "Reference only");
     qmlRegisterUncreatableType<LinkConfiguration>   ("QGroundControl", 1, 0, "LinkConfiguration",   "Reference only");
@@ -76,11 +78,12 @@ LinkManager::LinkManager(QGCApplication* app)
     QSettings settings;
 
     settings.beginGroup(_settingsGroup);
-    _autoconnectUDP =       settings.value(_autoconnectUDPKey, true).toBool();
-    _autoconnectPixhawk =   settings.value(_autoconnectPixhawkKey, true).toBool();
-    _autoconnect3DRRadio =  settings.value(_autoconnect3DRRadioKey, true).toBool();
-    _autoconnectPX4Flow =   settings.value(_autoconnectPX4FlowKey, true).toBool();
-    _autoconnectRTKGPS =    settings.value(_autoconnectRTKGPSKey, true).toBool();
+    _autoconnectUDP =        settings.value(_autoconnectUDPKey, true).toBool();
+    _autoconnectPixhawk =    settings.value(_autoconnectPixhawkKey, true).toBool();
+    _autoconnect3DRRadio =   settings.value(_autoconnect3DRRadioKey, true).toBool();
+    _autoconnectPX4Flow =    settings.value(_autoconnectPX4FlowKey, true).toBool();
+    _autoconnectRTKGPS =     settings.value(_autoconnectRTKGPSKey, true).toBool();
+    _autoconnectLibrePilot = settings.value(_autoconnectLibrePilotKey, true).toBool();
 
 #ifndef __ios__
     _activeLinkCheckTimer.setInterval(_activeLinkCheckTimeoutMSecs);
@@ -564,6 +567,11 @@ void LinkManager::_updateAutoConnectLinks(void)
                         pSerialConfig = new SerialConfiguration(QString("SiK Radio on %1").arg(portInfo.portName().trimmed()));
                     }
                     break;
+                case QGCSerialPortInfo::BoardTypeLibrePilot:
+                    if (_autoconnectLibrePilot) {
+                        pSerialConfig = new SerialConfiguration(QString("LibrePilot on %1").arg(portInfo.portName().trimmed()));
+                    }
+                    break;
 #ifndef __mobile__
                 case QGCSerialPortInfo::BoardTypeRTKGPS:
                     if (_autoconnectRTKGPS && !_toolbox->gpsManager()->connected()) {
@@ -676,6 +684,13 @@ void LinkManager::setAutoconnectRTKGPS(bool autoconnect)
 {
     if (_setAutoconnectWorker(_autoconnectRTKGPS, autoconnect, _autoconnectRTKGPSKey)) {
         emit autoconnectRTKGPSChanged(autoconnect);
+    }
+}
+
+void LinkManager::setAutoconnectLibrePilot(bool autoconnect)
+{
+    if (_setAutoconnectWorker(_autoconnectLibrePilot, autoconnect, _autoconnectLibrePilotKey)) {
+        emit autoconnectLibrePilotChanged(autoconnect);
     }
 }
 

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -66,6 +66,7 @@ public:
     Q_PROPERTY(bool autoconnect3DRRadio                 READ autoconnect3DRRadio                WRITE setAutoconnect3DRRadio    NOTIFY autoconnect3DRRadioChanged)
     Q_PROPERTY(bool autoconnectPX4Flow                  READ autoconnectPX4Flow                 WRITE setAutoconnectPX4Flow     NOTIFY autoconnectPX4FlowChanged)
     Q_PROPERTY(bool autoconnectRTKGPS                   READ autoconnectRTKGPS                  WRITE setAutoconnectRTKGPS      NOTIFY autoconnectRTKGPSChanged)
+    Q_PROPERTY(bool autoconnectLibrePilot               READ autoconnectLibrePilot              WRITE setAutoconnectLibrePilot  NOTIFY autoconnectLibrePilotChanged)
     Q_PROPERTY(bool isBluetoothAvailable                READ isBluetoothAvailable               CONSTANT)
 
     /// LinkInterface Accessor
@@ -96,6 +97,7 @@ public:
     bool autoconnect3DRRadio        (void)  { return _autoconnect3DRRadio; }
     bool autoconnectPX4Flow         (void)  { return _autoconnectPX4Flow; }
     bool autoconnectRTKGPS          (void)  { return _autoconnectRTKGPS; }
+    bool autoconnectLibrePilot      (void)  { return _autoconnectLibrePilot; }
     bool isBluetoothAvailable       (void);
 
     QmlObjectListModel* links               (void) { return &_links; }
@@ -105,11 +107,12 @@ public:
     QStringList         serialPortStrings   (void);
     QStringList         serialPorts         (void);
 
-    void setAutoconnectUDP      (bool autoconnect);
-    void setAutoconnectPixhawk  (bool autoconnect);
-    void setAutoconnect3DRRadio (bool autoconnect);
-    void setAutoconnectPX4Flow  (bool autoconnect);
-    void setAutoconnectRTKGPS   (bool autoconnect);
+    void setAutoconnectUDP        (bool autoconnect);
+    void setAutoconnectPixhawk    (bool autoconnect);
+    void setAutoconnect3DRRadio   (bool autoconnect);
+    void setAutoconnectPX4Flow    (bool autoconnect);
+    void setAutoconnectRTKGPS     (bool autoconnect);
+    void setAutoconnectLibrePilot (bool autoconnect);
 
     /// Load list of link configurations from disk
     void loadLinkConfigurationList();
@@ -163,11 +166,13 @@ public:
     virtual void setToolbox(QGCToolbox *toolbox);
 
 signals:
-    void autoconnectUDPChanged      (bool autoconnect);
-    void autoconnectPixhawkChanged  (bool autoconnect);
-    void autoconnect3DRRadioChanged (bool autoconnect);
-    void autoconnectPX4FlowChanged  (bool autoconnect);
-    void autoconnectRTKGPSChanged   (bool autoconnect);
+    void autoconnectUDPChanged        (bool autoconnect);
+    void autoconnectPixhawkChanged    (bool autoconnect);
+    void autoconnect3DRRadioChanged   (bool autoconnect);
+    void autoconnectPX4FlowChanged    (bool autoconnect);
+    void autoconnectRTKGPSChanged     (bool autoconnect);
+    void autoconnectLibrePilotChanged (bool autoconnect);
+
 
     void newLink(LinkInterface* link);
 
@@ -231,7 +236,7 @@ private:
     bool _autoconnect3DRRadio;
     bool _autoconnectPX4Flow;
     bool _autoconnectRTKGPS;
-
+    bool _autoconnectLibrePilot;
 #ifndef __ios__
     QTimer              _activeLinkCheckTimer;                  ///< Timer which checks for a vehicle showing up on a usb direct link
     QList<SerialLink*>  _activeLinkCheckList;                   ///< List of links we are waiting for a vehicle to show up on
@@ -244,6 +249,7 @@ private:
     static const char*  _autoconnect3DRRadioKey;
     static const char*  _autoconnectPX4FlowKey;
     static const char*  _autoconnectRTKGPSKey;
+    static const char*  _autoconnectLibrePilotKey;
     static const char*  _defaultUPDLinkName;
     static const int    _autoconnectUpdateTimerMSecs;
     static const int    _autoconnectConnectDelayMSecs;

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -30,6 +30,10 @@ static const struct VIDPIDMapInfo_s {
     { QGCSerialPortInfo::threeDRRadioVendorId,  QGCSerialPortInfo::threeDRRadioProductId,               QGCSerialPortInfo::BoardTypeSikRadio,   "Found SiK Radio" },
     { QGCSerialPortInfo::siLabsRadioVendorId,   QGCSerialPortInfo::siLabsRadioProductId,                QGCSerialPortInfo::BoardTypeSikRadio,   "Found SiK Radio" },
     { QGCSerialPortInfo::ubloxRTKVendorId,      QGCSerialPortInfo::ubloxRTKProductId,                   QGCSerialPortInfo::BoardTypeRTKGPS,     "Found RTK GPS" },
+    { QGCSerialPortInfo::openpilotVendorId,     QGCSerialPortInfo::revolutionProductId,                 QGCSerialPortInfo::BoardTypeLibrePilot, "Found OP Revolution" },
+    { QGCSerialPortInfo::openpilotVendorId,     QGCSerialPortInfo::oplinkProductId,                     QGCSerialPortInfo::BoardTypeLibrePilot, "Found OP OPLink" },
+    { QGCSerialPortInfo::openpilotVendorId,     QGCSerialPortInfo::sparky2ProductId,                    QGCSerialPortInfo::BoardTypeLibrePilot, "Found TL Sparky2" },
+    { QGCSerialPortInfo::openpilotVendorId,     QGCSerialPortInfo::CC3DProductId,                       QGCSerialPortInfo::BoardTypeLibrePilot, "Found OP CC3D" },
 };
 
 QGCSerialPortInfo::QGCSerialPortInfo(void) :
@@ -135,6 +139,15 @@ bool QGCSerialPortInfo::isBootloader(void) const
 bool QGCSerialPortInfo::canFlash(void)
 {
     BoardType_t boardType = this->boardType();
+    switch(boardType){
+    case QGCSerialPortInfo::BoardTypeUnknown:
+    case QGCSerialPortInfo::BoardTypeRTKGPS:
+    case QGCSerialPortInfo::BoardTypeLibrePilot:
+        return false;
+    default:
+        return true;
 
-    return boardType != QGCSerialPortInfo::BoardTypeUnknown && boardType != QGCSerialPortInfo::BoardTypeRTKGPS;
+    }
+
+
 }

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -37,6 +37,7 @@ public:
         BoardTypeMINDPXFMUV2,
         BoardTypeTAPV1,
         BoardTypeASCV1,
+        BoardTypeLibrePilot,
         BoardTypeUnknown
     } BoardType_t;
 
@@ -65,6 +66,12 @@ public:
 
     static const int ubloxRTKVendorId =                     5446;   ///< Vendor ID for ublox RTK
     static const int ubloxRTKProductId =                    424;    ///< Product ID for ublox RTK
+
+    static const int openpilotVendorId =                    0x20A0; ///< Vendor ID for OpenPilot
+    static const int revolutionProductId =                  0x415E; ///< Product ID for OpenPilot Revolution
+    static const int oplinkProductId =                      0x415C; ///< Product ID for OpenPilot OPLink
+    static const int sparky2ProductId =                     0x41D0; ///< Product ID for Taulabs Sparky2
+    static const int CC3DProductId =                        0x415D; ///< Product ID for OpenPilot CC3D
 
     QGCSerialPortInfo(void);
     QGCSerialPortInfo(const QSerialPort & port);

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -216,6 +216,8 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
         return false; // couldn't open serial port
     }
 
+    _port->setDataTerminalReady(true);
+
     qCDebug(SerialLinkLog) << "Configuring port";
     _port->setBaudRate     (_config->baud());
     _port->setDataBits     (static_cast<QSerialPort::DataBits>     (_config->dataBits()));

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -472,6 +472,11 @@ QGCView {
                                 onClicked:  QGroundControl.linkManager.autoconnectPX4Flow = checked
                             }
                             QGCCheckBox {
+                                text:       qsTr("LibrePilot")
+                                checked:    QGroundControl.linkManager.autoconnectLibrePilot
+                                onClicked:  QGroundControl.linkManager.autoconnectLibrePilot = checked
+                            }
+                            QGCCheckBox {
                                 text:       qsTr("UDP")
                                 checked:    QGroundControl.linkManager.autoconnectUDP
                                 onClicked:  QGroundControl.linkManager.autoconnectUDP = checked


### PR DESCRIPTION
This PR aim at adding support for several boards compatible with LibrePilot firmware for its upcoming MAVLink interface Implementation.
This is done with the following additions: 
- More robust Interface detection. It is not tied to a specific layout and support composite interfaces;
- USB id for currently supported boards are supplied;
- DTR is asserted when the port is open;
  