### PR TITLE
Show help button on FactTextFields

### DIFF
--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -14,6 +14,7 @@ QGCTextField {
     text:       fact ? fact.valueString : ""
     unitsLabel: fact ? fact.units : ""
     showUnits:  true
+    showHelp:   true
 
     property Fact   fact:           null
     property string _validateString
@@ -31,7 +32,7 @@ QGCTextField {
                 fact.value = text
             } else {
                 _validateString = text
-                qgcView.showDialog(editorDialogComponent, qsTr("Invalid Parameter Value"), qgcView.showDialogDefaultWidth, StandardButton.Save)
+                qgcView.showDialog(validationErrorDialogComponent, qsTr("Invalid Value"), qgcView.showDialogDefaultWidth, StandardButton.Save)
             }
         } else {
             fact.value = text
@@ -39,13 +40,24 @@ QGCTextField {
         }
     }
 
+    onHelpClicked: qgcView.showDialog(helpDialogComponent, qsTr("Value Details"), qgcView.showDialogDefaultWidth, StandardButton.Save)
+
+
     Component {
-        id: editorDialogComponent
+        id: validationErrorDialogComponent
 
         ParameterEditorDialog {
             validate:       true
             validateValue:  _validateString
             fact:           _textField.fact
+        }
+    }
+
+    Component {
+        id: helpDialogComponent
+
+        ParameterEditorDialog {
+            fact: _textField.fact
         }
     }
 }

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -750,7 +750,7 @@ int FactMetaData::decimalPlaces(void) const
     return actualDecimalPlaces;
 }
 
-FactMetaData* FactMetaData::_createFromJsonObject(const QJsonObject& json, QObject* metaDataParent)
+FactMetaData* FactMetaData::createFromJsonObject(const QJsonObject& json, QObject* metaDataParent)
 {
     QString         errorString;
 
@@ -855,7 +855,7 @@ QMap<QString, FactMetaData*> FactMetaData::createMapFromJsonFile(const QString& 
             continue;
         }
         QJsonObject jsonObject = jsonValue.toObject();
-        FactMetaData* metaData = _createFromJsonObject(jsonObject, metaDataParent);
+        FactMetaData* metaData = createFromJsonObject(jsonObject, metaDataParent);
 
         if (metaDataMap.contains(metaData->name())) {
             qWarning() << QStringLiteral("Duplicate fact name:") << metaData->name();

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -48,6 +48,8 @@ public:
 
     static QMap<QString, FactMetaData*> createMapFromJsonFile(const QString& jsonFilename, QObject* metaDataParent);
 
+    static FactMetaData* createFromJsonObject(const QJsonObject& json, QObject* metaDataParent);
+
     const FactMetaData& operator=(const FactMetaData& other);
 
     /// Converts from meters to the user specified distance unit
@@ -144,7 +146,6 @@ private:
     QVariant _minForType(void) const;
     QVariant _maxForType(void) const;
     void _setAppSettingsTranslators(void);
-    static FactMetaData* _createFromJsonObject(const QJsonObject& json, QObject* metaDataParent);
 
     // Built in translators
     static QVariant _defaultTranslator(const QVariant& from) { return from; }

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -85,7 +85,8 @@ QGCViewDialog {
             QGCLabel {
                 width:      parent.width
                 wrapMode:   Text.WordWrap
-                text:       fact.shortDescription ? fact.shortDescription : qsTr("Parameter Description (not defined)")
+                visible:    fact.shortDescription
+                text:       fact.shortDescription
             }
 
             QGCLabel {
@@ -156,7 +157,10 @@ QGCViewDialog {
                 }
             }
 
-            QGCLabel { text: fact.name }
+            QGCLabel {
+                text:       fact.name
+                visible:    fact.componentId > 0 // > 0 means it's a parameter fact
+            }
 
             Column {
                 spacing:        defaultTextHeight / 2
@@ -202,7 +206,7 @@ QGCViewDialog {
             QGCLabel {
                 width:      parent.width
                 wrapMode:   Text.WordWrap
-                text:       qsTr("Warning: Modifying parameters while vehicle is in flight can lead to vehicle instability and possible vehicle loss. ") +
+                text:       qsTr("Warning: Modifying values while vehicle is in flight can lead to vehicle instability and possible vehicle loss. ") +
                             qsTr("Make sure you know what you are doing and double-check your values before Save!")
             }
 

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -1,15 +1,21 @@
-import QtQuick 2.2
-import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.2
+import QtQuick                  2.2
+import QtQuick.Controls         1.2
+import QtQuick.Controls.Styles  1.2
+import QtQuick.Layouts          1.2
 
-import QGroundControl.Palette 1.0
-import QGroundControl.ScreenTools 1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
 
 TextField {
     id: root
 
-    property bool showUnits: false
+    property bool   showUnits:  false
+    property bool   showHelp:   false
     property string unitsLabel: ""
+
+    signal helpClicked
+
+    property real _helpLayoutWidth: 0
 
     Component.onCompleted: {
         if (typeof qgcTextFieldforwardKeysTo !== 'undefined') {
@@ -17,9 +23,9 @@ TextField {
         }
     }
 
-    property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
-    textColor:          __qgcPal.textFieldText
+    textColor:          qgcPal.textFieldText
     height:             Math.round(Math.max(25, ScreenTools.defaultFontPixelHeight * (ScreenTools.isMobile ? 2.5 : 1.2)))
 
     QGCLabel {
@@ -35,6 +41,8 @@ TextField {
         background: Item {
             id: backgroundItem
 
+            property bool showHelp: control.showHelp && control.activeFocus
+
             Rectangle {
                 anchors.fill:           parent
                 anchors.bottomMargin:   -1
@@ -44,32 +52,58 @@ TextField {
             Rectangle {
                 anchors.fill:           parent
                 border.color:           control.activeFocus ? "#47b" : "#999"
-                color:                  __qgcPal.textField
+                color:                  qgcPal.textField
             }
 
-            Text {
-                id: unitsLabel
+            RowLayout {
+                id:                     unitsHelpLayout
+                anchors.top:            parent.top
+                anchors.bottom:         parent.bottom
+                anchors.rightMargin:    backgroundItem.showHelp ? 0 : control.__contentHeight * 0.333
+                anchors.right:          parent.right
+                spacing:                4
 
-                anchors.top:    parent.top
-                anchors.bottom: parent.bottom
+                Component.onCompleted:  control._helpLayoutWidth = unitsHelpLayout.width
+                onWidthChanged:         control._helpLayoutWidth = unitsHelpLayout.width
 
-                verticalAlignment:  Text.AlignVCenter
-                horizontalAlignment:Text.AlignHCenter
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text:                   control.unitsLabel
+                    font.pointSize:         backgroundItem.showHelp ? ScreenTools.smallFontPointSize : ScreenTools.defaultFontPointSize
+                    font.family:            ScreenTools.normalFontFamily
+                    antialiasing:           true
+                    color:                  control.textColor
+                    visible:                control.showUnits
+                }
 
-                x:              parent.width - width
-                width:          unitsLabelWidthGenerator.width
+                Rectangle {
+                    anchors.margins:    2
+                    anchors.top:        parent.top
+                    anchors.bottom:     parent.bottom
+                    anchors.right:      parent.right
+                    width:              height * 0.75
+                    color:              control.textColor
+                    radius:             2
+                    visible:            backgroundItem.showHelp
 
-                text:           control.unitsLabel
-                font.pointSize: ScreenTools.defaultFontPointSize
-                font.family:    ScreenTools.normalFontFamily
-                antialiasing:   true
+                    QGCLabel {
+                        anchors.fill:           parent
+                        verticalAlignment:      Text.AlignVCenter
+                        horizontalAlignment:    Text.AlignHCenter
+                        color:                  qgcPal.textField
+                        text:                   "?"
+                    }
+                }
+            }
 
-                color:          control.textColor
-                visible:        control.showUnits
+            MouseArea {
+                anchors.fill:   unitsHelpLayout
+                enabled:        control.activeFocus
+                onClicked:      root.helpClicked()
             }
         }
 
-        padding.right: control.showUnits ? unitsLabelWidthGenerator.width : control.__contentHeight * 0.333
+        padding.right: control._helpLayoutWidth //control.showUnits ? unitsLabelWidthGenerator.width : control.__contentHeight * 0.333
     }
 
     onActiveFocusChanged: {


### PR DESCRIPTION
Any place you use a FactTextField you now automatically get detailed help associated with the value. Here is an example using it on a settings (offline edit cruise speed) that may be unclear to the user. Also an example for a param on a mission item.
![screen shot 2016-09-19 at 1 52 21 pm](https://cloud.githubusercontent.com/assets/5876851/18655325/bf70dcea-7e9c-11e6-9079-77fdf653def0.png)
![screen shot 2016-09-19 at 1 52 58 pm](https://cloud.githubusercontent.com/assets/5876851/18655352/f7dfc3a2-7e9c-11e6-87a6-a213d47fc510.png)
![screen shot 2016-09-19 at 1 53 03 pm](https://cloud.githubusercontent.com/assets/5876851/18655398/5dd417f8-7e9d-11e6-92f6-f1aff590ae83.png)
![screen shot 2016-09-19 at 1 53 20 pm](https://cloud.githubusercontent.com/assets/5876851/18655323/bf6e73f6-7e9c-11e6-9f04-fb890b6b30f4.png)

Note: Mission Items params don't have good meta data yet. I'm working on that.
