### PR TITLE
Survey: Corrected EOS-M focal length

### DIFF
--- a/src/MissionEditor/SurveyItemEditor.qml
+++ b/src/MissionEditor/SurveyItemEditor.qml
@@ -61,8 +61,8 @@ Rectangle {
            }
            ListElement {
                text:           qsTr("Canon EOS-M 22mm")
-               sensorWidth:    23.5
-               sensorHeight:   15.6
+               sensorWidth:    22.3
+               sensorHeight:   14.9
                imageWidth:     5184
                imageHeight:    3456
                focalLength:    22

--- a/src/MissionEditor/SurveyItemEditor.qml
+++ b/src/MissionEditor/SurveyItemEditor.qml
@@ -65,7 +65,7 @@ Rectangle {
                sensorHeight:   15.6
                imageWidth:     5184
                imageHeight:    3456
-               focalLength:    14.36
+               focalLength:    22
            }
    }
 


### PR DESCRIPTION
The 22mm as stated on the lens is actual, not 35mm equvalent as on smaller
cameras.  - So it was wrong to reverse calculate for crop factor.