### PR TITLE
Adding Sony a6000 to camera list

### DIFF
--- a/src/MissionEditor/SurveyItemEditor.qml
+++ b/src/MissionEditor/SurveyItemEditor.qml
@@ -67,6 +67,14 @@ Rectangle {
                imageHeight:    3456
                focalLength:    22
            }
+           ListElement {
+               text:           qsTr("Sony a6000 16mm") //http://www.sony.co.uk/electronics/interchangeable-lens-cameras/ilce-6000-body-kit#product_details_default
+               sensorWidth:    23.5
+               sensorHeight:   15.6
+               imageWidth:     6000
+               imageHeight:    4000
+               focalLength:    16
+           }
    }
 
     function recalcFromCameraValues() {


### PR DESCRIPTION
Sony a6000 ILCE-6000 with 16mm lens.
Source : 
http://www.sony.co.uk/electronics/interchangeable-lens-cameras/ilce-6000-body-kit#product_details_default