### PR TITLE
Removing forced Mac OS SDK.

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -66,7 +66,8 @@ linux {
         } else {
                 QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.6
         }
-        QMAKE_MAC_SDK = macosx10.12
+        #-- Not forcing anything. Let qmake find the latest, installed SDK.
+        #QMAKE_MAC_SDK = macosx10.12
         QMAKE_CXXFLAGS += -fvisibility=hidden
     } else {
         error("Unsupported Mac toolchain, only 64-bit LLVM+clang is supported")


### PR DESCRIPTION
In response to #4058, I commented off the setting of the Mac OS SDK.

The reason this was being set by hand was due to a bug in qmake, which was not properly assigning the variable and using non-existing SDKs. This has since been fixed.

With this commit, QGC will build using the latest available SDK installed on the system. It doesn't affect the App Store build as that has to be done manually (from an Xcode project) any way.