### PR TITLE
Fix insert functionality after Survey Item

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -672,7 +672,7 @@ QGCView {
                             }
 
                             onInsert: {
-                                var sequenceNumber = missionController.insertSimpleMissionItem(editorMap.center, insertAfterIndex)
+                                var sequenceNumber = missionController.insertSimpleMissionItem(editorMap.center, index)
                                 setCurrentItem(sequenceNumber)
                             }
 

--- a/src/MissionEditor/MissionItemEditor.qml
+++ b/src/MissionEditor/MissionItemEditor.qml
@@ -23,7 +23,7 @@ Rectangle {
 
     signal clicked
     signal remove
-    signal insert(int insertAfterIndex)
+    signal insert
     signal moveHomeToMapCenter
 
     property bool   _currentItem:       missionItem.isCurrentItem
@@ -74,7 +74,7 @@ Rectangle {
 
                 MenuItem {
                     text:           qsTr("Insert")
-                    onTriggered:    insert(missionItem.sequenceNumber)
+                    onTriggered:    insert()
                 }
 
                 MenuItem {


### PR DESCRIPTION
What is happening -

![screen shot 2016-10-05 at 15 57 09](https://cloud.githubusercontent.com/assets/17413192/19116198/e91ab5b4-8b14-11e6-9b90-423c85ec5847.png)

Currently, the insert functionality (as shown in the screenshot) after a Survey Item, doesn't work and if trying to use thus, qgc stops working in the planning view.

This is because, on using the insert functionality, the sequence number set [here](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionEditor/MissionItemEditor.qml#L77) is the actual sequence number allotted to the waypoint after the SurveyItem has been converted to waypoints, i.e., a large number such as 156 as seen above.

This is then passed to function `insertSimpleMissionItem` defined [here](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/MissionController.cc#L159). However, this function sets indices based on "visual items", [(see example)](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/MissionController.cc#L183), which counts the entire survey item as one big item. Thus, there is a mismatch between indices after SurveyItem when using the `insert()` signal via qml  and then you get the message `Index is not valid`.

This PR fixes the issue.