### PR TITLE
Use single mavlink_status_t array

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -143,6 +143,9 @@ const char* QGCApplication::_lastKnownHomePositionAltKey    = "LastKnownHomePosi
 const char* QGCApplication::_darkStyleFile          = ":/res/styles/style-dark.css";
 const char* QGCApplication::_lightStyleFile         = ":/res/styles/style-light.css";
 
+// Mavlink status structures for entire app
+mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
+
 // Qml Singleton factories
 
 static QObject* screenToolsControllerSingletonFactory(QQmlEngine*, QJSEngine*)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -877,6 +877,12 @@ void Vehicle::_sendMessageOnLink(LinkInterface* link, mavlink_message_t message)
         return;
     }
 
+#if 0
+    // Leaving in for ease in Mav 2.0 testing
+    mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(link->mavlinkChannel());
+    qDebug() << "_sendMessageOnLink" << mavlinkStatus << link->mavlinkChannel() << mavlinkStatus->flags << message.magic;
+#endif
+
     // Give the plugin a chance to adjust
     _firmwarePlugin->adjustOutgoingMavlinkMessage(this, link, &message);
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -192,7 +192,9 @@ void LinkManager::_addLink(LinkInterface* link)
                 mavlink_reset_channel_status(i);
                 link->_setMavlinkChannel(i);
                 // Start the channel on Mav 1 protocol
-                mavlink_get_channel_status(i)->flags = mavlink_get_channel_status(i)->flags | MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+                mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(i);
+                mavlinkStatus->flags = mavlink_get_channel_status(i)->flags | MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+                qDebug() << "LinkManager mavlinkStatus" << mavlinkStatus << i << mavlinkStatus->flags;
                 _mavlinkChannelsUsedBitMask |= 1 << i;
                 channelSet = true;
                 break;

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -216,10 +216,10 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
 
             mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(mavlinkChannel);
             if (!(mavlinkStatus->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) && (mavlinkStatus->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)) {
-                qDebug() << "switch to mavlink 2.0" << mavlinkStatus->flags;
+                qDebug() << "switch to mavlink 2.0" << mavlinkStatus << mavlinkChannel << mavlinkStatus->flags;
                 mavlinkStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
             } else if ((mavlinkStatus->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) && !(mavlinkStatus->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)) {
-                qDebug() << "switch to mavlink 1.0" << mavlinkStatus->flags;
+                qDebug() << "switch to mavlink 1.0" << mavlinkStatus << mavlinkChannel << mavlinkStatus->flags;
                 mavlinkStatus->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
             }
 

--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -17,6 +17,11 @@
 #ifndef QGCMAVLINK_H
 #define QGCMAVLINK_H
 
+#define MAVLINK_USE_MESSAGE_INFO
+#define MAVLINK_EXTERNAL_RX_STATUS  // Single m_mavlink_status instance is in QGCApplication.cc
+#include <stddef.h>                 // Hack workaround for Mav 2.0 header problem with respect to offsetof usage
+#include <mavlink_types.h>
+extern mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
 #include <mavlink.h>
 
 class QGCMAVLink {

--- a/src/ui/MAVLinkDecoder.cc
+++ b/src/ui/MAVLinkDecoder.cc
@@ -1,5 +1,3 @@
-#define MAVLINK_USE_MESSAGE_INFO
-#include <stddef.h>         // Hack workaround for Mav 2.0 header problem with respect to offsetof usage
 #include "QGCMAVLink.h"
 #include "MAVLinkDecoder.h"
 

--- a/src/ui/QGCMAVLinkInspector.cc
+++ b/src/ui/QGCMAVLinkInspector.cc
@@ -1,5 +1,3 @@
-#define MAVLINK_USE_MESSAGE_INFO
-#include <stddef.h>         // Hack workaround for Mav 2.0 header problem with respect to offsetof usage
 #include "QGCMAVLink.h"
 #include "QGCMAVLinkInspector.h"
 #include "MultiVehicleManager.h"


### PR DESCRIPTION
Using generic mavlink header support was causing mavlink_status_t to be created for each source file. Which in turn caused the mavlink 2.0 flags to be out of whack.