### PR TITLE
SDL2: Add missing Info.plist file for SDL2 framework.

### DIFF
--- a/libs/lib/Frameworks/SDL2.framework/Versions/A/Resources/Info.plist
+++ b/libs/lib/Frameworks/SDL2.framework/Versions/A/Resources/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>15C50</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>SDL2</string>
+	<key>CFBundleGetInfoString</key>
+	<string>http://www.libsdl.org</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.libsdl.SDL2</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Simple DirectMedia Layer</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.0.4</string>
+	<key>CFBundleSignature</key>
+	<string>SDLX</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>2.0.4</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>7C68</string>
+	<key>DTPlatformVersion</key>
+	<string>GM</string>
+	<key>DTSDKBuild</key>
+	<string>15C43</string>
+	<key>DTSDKName</key>
+	<string>macosx10.11</string>
+	<key>DTXcode</key>
+	<string>0720</string>
+	<key>DTXcodeBuild</key>
+	<string>7C68</string>
+</dict>
+</plist>


### PR DESCRIPTION
Since this file is in the `.gitignore` file, it was never added to the SDL2 files. On macOS Sierra, this causes code signing issues.

If I download the app and copy this file into the SDL2.framework, then it works just fine. I'm 99% sure this will fix the issue with Sierra.

-Rusty