### PR TITLE
Multicolored polygon

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -345,7 +345,7 @@ Map {
 
                 var clickCoordinate = _map.toCoordinate(Qt.point(mouse.x, mouse.y))
                 var polygonPath = polygonDrawerPolygon.path
-                if(polygonPath.length == 0) {
+                if (polygonPath.length == 0) {
                     // Add first coordinate
                     polygonPath.push(clickCoordinate)
                 } else {
@@ -370,8 +370,6 @@ Map {
 
                 // Update drag line
                 polygonDrawerNextPoint.path = [ polygonDrawerPolygon.path[polygonDrawerPolygon.path.length - 2], dragCoordinate ]
-
-                // Update drag coordinate
 
                 polygonPath[polygonDrawerPolygon.path.length - 1] = dragCoordinate
                 polygonDrawerPolygon.path = polygonPath

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -367,7 +367,9 @@ Map {
                 // Update drag coordinate
                 var polygonPath = polygonDrawerPolygon.path
                 polygonPath[polygonDrawerPolygon.path.length - 1] = dragCoordinate
-                polygonDrawerPolygon.path = polygonPath
+                if (polygonDrawerPolygon.path.length>2){
+                    polygonDrawerPolygon.path = polygonPath
+                }
             }
         }
     }


### PR DESCRIPTION
I originally set out to fix a few minor issues with unwanted black lines being drawn while drawing polygons as mentioned in PR #4142 . I couldn't find a quick and simple way to do this without creating issues so I ended up making a few bigger changes.

In addition to fixing the original issues, this pull request adds a second polygon which indicates what the polygon will look like if you end the drawing, while the original polygon shows what the polygon will look like if you click to add a new point. If you wanted to go back to the original look you could simply set the new polygon to be invisible.