### PR TITLE
Make display of the mission manager optional via firmware plugin

### DIFF
--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -58,6 +58,11 @@ bool ArduSubFirmwarePlugin::supportsThrottleModeCenterZero(void)
     return false;
 }
 
+bool ArduSubFirmwarePlugin::supportsMissionManager(void)
+{
+    return false;
+}
+
 bool ArduSubFirmwarePlugin::supportsManualControl(void)
 {
     return true;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -71,6 +71,8 @@ public:
 
     bool supportsThrottleModeCenterZero(void);
 
+    bool supportsMissionManager(void);
+
     bool supportsManualControl(void);
 
     bool supportsRadio(void);

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -89,6 +89,12 @@ bool FirmwarePlugin::supportsThrottleModeCenterZero(void)
     return true;
 }
 
+bool FirmwarePlugin::supportsMissionManager(void)
+{
+    // By default, this is supported
+    return true;
+}
+
 bool FirmwarePlugin::supportsManualControl(void)
 {
     return false;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -135,6 +135,10 @@ public:
     /// throttle.
     virtual bool supportsThrottleModeCenterZero(void);
 
+    /// Returns true if the vehicle and firmware supports mission planning/manager. Even if turned off,
+    /// it can be enabled in "Advanced Options" for development purposes.
+    virtual bool supportsMissionManager(void);
+
     /// Returns true if the firmware supports the use of the MAVlink "MANUAL_CONTROL" message.
     /// By default, this returns false unless overridden in the firmware plugin.
     virtual bool supportsManualControl(void);

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -32,6 +32,7 @@ SettingsFact* QGroundControlQmlGlobal::_offlineEditingHoverSpeedFact =          
 SettingsFact* QGroundControlQmlGlobal::_batteryPercentRemainingAnnounceFact =       NULL;
 
 const char* QGroundControlQmlGlobal::_virtualTabletJoystickKey  = "VirtualTabletJoystick";
+const char* QGroundControlQmlGlobal::_forceShowMissionManagerKey= "ForceShowMissionManager";
 const char* QGroundControlQmlGlobal::_baseFontPointSizeKey      = "BaseDeviceFontPointSize";
 
 QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
@@ -46,10 +47,12 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
     , _videoManager(NULL)
     , _mavlinkLogManager(NULL)
     , _virtualTabletJoystick(false)
+    , _forceShowMissionManager(false)
     , _baseFontPointSize(0.0)
 {
     QSettings settings;
     _virtualTabletJoystick  = settings.value(_virtualTabletJoystickKey, false).toBool();
+    _forceShowMissionManager= settings.value(_forceShowMissionManagerKey, false).toBool();
     _baseFontPointSize      = settings.value(_baseFontPointSizeKey, 0.0).toDouble();
 
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
@@ -207,6 +210,16 @@ void QGroundControlQmlGlobal::setVirtualTabletJoystick(bool enabled)
         settings.setValue(_virtualTabletJoystickKey, enabled);
         _virtualTabletJoystick = enabled;
         emit virtualTabletJoystickChanged(enabled);
+    }
+}
+
+void QGroundControlQmlGlobal::setForceShowMissionManager(bool enabled)
+{
+    if (_forceShowMissionManager != enabled) {
+        QSettings settings;
+        settings.setValue(_forceShowMissionManagerKey, enabled);
+        _forceShowMissionManager = enabled;
+        emit forceShowMissionManagerChanged(enabled);
     }
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -85,6 +85,7 @@ public:
     Q_PROPERTY(bool     isSaveLogPrompt         READ isSaveLogPrompt            WRITE setIsSaveLogPrompt            NOTIFY isSaveLogPromptChanged)
     Q_PROPERTY(bool     isSaveLogPromptNotArmed READ isSaveLogPromptNotArmed    WRITE setIsSaveLogPromptNotArmed    NOTIFY isSaveLogPromptNotArmedChanged)
     Q_PROPERTY(bool     virtualTabletJoystick   READ virtualTabletJoystick      WRITE setVirtualTabletJoystick      NOTIFY virtualTabletJoystickChanged)
+    Q_PROPERTY(bool     forceShowMissionManager READ forceShowMissionManager    WRITE setForceShowMissionManager    NOTIFY forceShowMissionManagerChanged)
     Q_PROPERTY(qreal    baseFontPointSize       READ baseFontPointSize          WRITE setBaseFontPointSize          NOTIFY baseFontPointSizeChanged)
 
     // MavLink Protocol
@@ -178,6 +179,7 @@ public:
     bool    isSaveLogPrompt         () { return _app->promptFlightDataSave(); }
     bool    isSaveLogPromptNotArmed () { return _app->promptFlightDataSaveNotArmed(); }
     bool    virtualTabletJoystick   () { return _virtualTabletJoystick; }
+    bool    forceShowMissionManager () { return _forceShowMissionManager; }
     qreal   baseFontPointSize       () { return _baseFontPointSize; }
 
     bool    isVersionCheckEnabled   () { return _toolbox->mavlinkProtocol()->versionCheckEnabled(); }
@@ -202,6 +204,7 @@ public:
     void    setIsSaveLogPrompt          (bool prompt);
     void    setIsSaveLogPromptNotArmed  (bool prompt);
     void    setVirtualTabletJoystick    (bool enabled);
+    void    setForceShowMissionManager  (bool enabled);
     void    setBaseFontPointSize        (qreal size);
 
     void    setIsVersionCheckEnabled    (bool enable);
@@ -220,6 +223,7 @@ signals:
     void isSaveLogPromptChanged         (bool prompt);
     void isSaveLogPromptNotArmedChanged (bool prompt);
     void virtualTabletJoystickChanged   (bool enabled);
+    void forceShowMissionManagerChanged (bool enabled);
     void baseFontPointSizeChanged       (qreal size);
     void isMultiplexingEnabledChanged   (bool enabled);
     void isVersionCheckEnabledChanged   (bool enabled);
@@ -242,6 +246,7 @@ private:
     MAVLinkLogManager*      _mavlinkLogManager;
 
     bool                    _virtualTabletJoystick;
+    bool                    _forceShowMissionManager;
     qreal                   _baseFontPointSize;
     QGeoCoordinate          _flightMapPosition;
     double                  _flightMapZoom;
@@ -260,6 +265,7 @@ private:
     static SettingsFact*    _batteryPercentRemainingAnnounceFact;
 
     static const char*  _virtualTabletJoystickKey;
+    static const char*  _forceShowMissionManagerKey;
     static const char*  _baseFontPointSizeKey;
 };
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1618,6 +1618,11 @@ bool Vehicle::supportsThrottleModeCenterZero(void) const
     return _firmwarePlugin->supportsThrottleModeCenterZero();
 }
 
+bool Vehicle::supportsMissionManager(void) const
+{
+    return _firmwarePlugin->supportsMissionManager();
+}
+
 bool Vehicle::supportsRadio(void) const
 {
     return _firmwarePlugin->supportsRadio();

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -270,6 +270,7 @@ public:
     Q_PROPERTY(bool                 rover                   READ rover                                                  CONSTANT)
     Q_PROPERTY(bool                 supportsManualControl   READ supportsManualControl                                  CONSTANT)
     Q_PROPERTY(bool        supportsThrottleModeCenterZero   READ supportsThrottleModeCenterZero                         CONSTANT)
+    Q_PROPERTY(bool                 supportsMissionManager  READ supportsMissionManager                                 CONSTANT)
     Q_PROPERTY(bool                 supportsJSButton        READ supportsJSButton                                       CONSTANT)
     Q_PROPERTY(bool                 supportsRadio           READ supportsRadio                                          CONSTANT)
     Q_PROPERTY(bool                 sub                     READ sub                                                    CONSTANT)
@@ -472,6 +473,7 @@ public:
 
     bool supportsManualControl(void) const;
     bool supportsThrottleModeCenterZero(void) const;
+    bool supportsMissionManager(void) const;
     bool supportsRadio(void) const;
     bool supportsJSButton(void) const;
 

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -198,10 +198,19 @@ QGCView {
                                 enabled:            true
                             }
                         }
+                        Row {
+                            spacing: ScreenTools.defaultFontPixelWidth
+                            visible: offlineVehicleCombo.currentText == "Sub"
+                            QGCCheckBox {
+                                text:       qsTr("Show mission manager even if not supported by firmware")
+                                checked:    QGroundControl.forceShowMissionManager
+                                onClicked:  QGroundControl.forceShowMissionManager = checked
+                            }
+                        }
                     }
                 }
                 //-----------------------------------------------------------------
-                //-- Miscelanous
+                //-- Miscellanous
                 Item {
                     width:              qgcView.width * 0.8
                     height:             miscLabel.height
@@ -209,7 +218,7 @@ QGCView {
                     anchors.horizontalCenter: parent.horizontalCenter
                     QGCLabel {
                         id:             miscLabel
-                        text:           qsTr("Miscelaneous")
+                        text:           qsTr("Miscellaneous")
                         font.family:    ScreenTools.demiboldFontFamily
                     }
                 }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -356,6 +356,7 @@ Rectangle {
             anchors.top:        parent.top
             anchors.bottom:     parent.bottom
             exclusiveGroup:     mainActionGroup
+            visible:            activeVehicle ? activeVehicle.supportsMissionManager || QGroundControl.forceShowMissionManager : true
             source:             "/qmlimages/Plan.svg"
             onClicked:          toolBar.showPlanView()
         }


### PR DESCRIPTION
This PR makes it optional to display the Mission Manager (planning map) via a firmware plugin feature. This is primarily intended for ArduSub, which does not support planned missions yet. It could also be used for FPV-only drones.

This is implemented by hiding the icon from the top bar if the Mission Manager is not supported. It does not remove any of the backend and is therefore a minimal change.

Since support for auto missions is slowly being developed in ArduSub, there is an added option to allow the mission manager to be displayed anyways. That's on the general settings page and only appears if offline mission editing is set to "Sub".

<img width="514" alt="screen shot 2016-10-30 at 7 49 45 pm" src="https://cloud.githubusercontent.com/assets/968100/19842842/0b17374a-9eda-11e6-9ed3-117fbf76fdd3.png">

There's also a "bug" in this, where you can select the mission manager page, then connect a vehicle that does not support it, but it will not kick you off of the page, however the icon will disappear from the top bar.

This PR should result in better usability and less confusion for ArduSub users. Please let me know if you have any questions or comments.

-Rusty
