### PR TITLE
Better Plan view map viewport handling

### DIFF
--- a/src/FirmwarePlugin/APM/APMGeoFenceManager.h
+++ b/src/FirmwarePlugin/APM/APMGeoFenceManager.h
@@ -49,6 +49,8 @@ private:
 private:
     bool _fenceSupported;
     bool _breachReturnSupported;
+    bool _circleSupported;
+    bool _polygonSupported;
     bool _firstParamLoadComplete;
 
     QVariantList    _params;
@@ -63,7 +65,6 @@ private:
     uint8_t _cWriteFencePoints;
     uint8_t _currentFencePoint;
 
-    Fact* _fenceEnableFact;
     Fact* _fenceTypeFact;
 
     static const char* _fenceTotalParam;

--- a/src/FirmwarePlugin/APM/APMRallyPointManager.cc
+++ b/src/FirmwarePlugin/APM/APMRallyPointManager.cc
@@ -90,7 +90,7 @@ void APMRallyPointManager::_mavlinkMessageReceived(const mavlink_message_t& mess
 
         QGeoCoordinate point((float)rallyPoint.lat / 1e7, (float)rallyPoint.lng / 1e7, rallyPoint.alt);
         _rgPoints.append(point);
-        if (rallyPoint.idx < _cReadRallyPoints - 2) {
+        if (rallyPoint.idx < _cReadRallyPoints - 1) {
             // Still more points to request
             _requestRallyPoint(++_currentRallyPoint);
         } else {

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -562,66 +562,27 @@ QGCView {
                         }
                     }
 
-                    RoundButton {
+                    QGCRadioButton {
                         id:             planElementMission
-                        radius:         parent._buttonRadius
-                        buttonImage:    "/qmlimages/Plan.svg"
-                        lightBorders:   _lightWidgetBorders
                         exclusiveGroup: planElementSelectorGroup
+                        text:           qsTr("Mission")
                         checked:        true
                     }
 
-                    QGCLabel {
-                        text:                   qsTr("Mission")
-                        color:                  mapPal.text
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        MouseArea {
-                            anchors.fill:   parent
-                            onClicked:      planElementMission.checked = true
-                        }
-                    }
-
                     Item { height: 1; width: 1 }
 
-                    RoundButton {
+                    QGCRadioButton {
                         id:             planElementGeoFence
-                        radius:         parent._buttonRadius
-                        buttonImage:    "/qmlimages/Plan.svg"
-                        lightBorders:   _lightWidgetBorders
                         exclusiveGroup: planElementSelectorGroup
-                    }
-
-                    QGCLabel {
-                        text:                   qsTr("Fence")
-                        color:                  mapPal.text
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        MouseArea {
-                            anchors.fill:   parent
-                            onClicked:      planElementGeoFence.checked = true
-                        }
+                        text:           qsTr("Fence")
                     }
 
                     Item { height: 1; width: 1 }
 
-                    RoundButton {
+                    QGCRadioButton {
                         id:             planElementRallyPoints
-                        radius:         parent._buttonRadius
-                        buttonImage:    "/qmlimages/Plan.svg"
-                        lightBorders:   _lightWidgetBorders
                         exclusiveGroup: planElementSelectorGroup
-                    }
-
-                    QGCLabel {
-                        text:                   qsTr("Rally")
-                        color:                  mapPal.text
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        MouseArea {
-                            anchors.fill:   parent
-                            onClicked:      planElementRallyPoints.checked = true
-                        }
+                        text:           qsTr("Rally")
                     }
                 } // Row - Plan Element Selector
 

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -333,9 +333,9 @@ void GeoFenceController::loadFromVehicle(void)
 void GeoFenceController::sendToVehicle(void)
 {
     if (_activeVehicle->parameterManager()->parametersReady() && !syncInProgress()) {
-        setDirty(false);
-        _polygon.setDirty(false);
         _activeVehicle->geoFenceManager()->sendToVehicle(_breachReturnPoint, _polygon.coordinateList());
+        _polygon.setDirty(false);
+        setDirty(false);
     } else {
         qCWarning(GeoFenceControllerLog) << "GeoFenceController::loadFromVehicle call at wrong time" << _activeVehicle->parameterManager()->parametersReady() << syncInProgress();
     }
@@ -433,6 +433,7 @@ void GeoFenceController::_loadComplete(const QGeoCoordinate& breachReturn, const
     _setReturnPointFromManager(breachReturn);
     _setPolygonFromManager(polygon);
     setDirty(false);
+    emit loadComplete();
 }
 
 QString GeoFenceController::fileExtension(void) const

--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -78,6 +78,7 @@ signals:
     void paramsChanged                  (QVariantList params);
     void paramLabelsChanged             (QStringList paramLabels);
     void editorQmlChanged               (QString editorQml);
+    void loadComplete                   (void);
 
 private slots:
     void _polygonDirtyChanged(bool dirty);

--- a/src/MissionManager/GeoFenceManager.cc
+++ b/src/MissionManager/GeoFenceManager.cc
@@ -34,7 +34,7 @@ void GeoFenceManager::_sendError(ErrorCode_t errorCode, const QString& errorMsg)
 void GeoFenceManager::loadFromVehicle(void)
 {
     // No geofence support in unknown vehicle
-    loadComplete(QGeoCoordinate(), QList<QGeoCoordinate>());
+    emit loadComplete(QGeoCoordinate(), QList<QGeoCoordinate>());
 }
 
 void GeoFenceManager::sendToVehicle(const QGeoCoordinate& breachReturn, const QList<QGeoCoordinate>& polygon)

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -254,6 +254,7 @@ void RallyPointController::_loadComplete(const QList<QGeoCoordinate> rgPoints)
     _points.swapObjectList(pointList);
     setDirty(false);
     _setFirstPointCurrent();
+    emit loadComplete();
 }
 
 QString RallyPointController::fileExtension(void) const

--- a/src/MissionManager/RallyPointController.h
+++ b/src/MissionManager/RallyPointController.h
@@ -61,6 +61,7 @@ public:
 signals:
     void rallyPointsSupportedChanged(bool rallyPointsSupported);
     void currentRallyPointChanged(QObject* rallyPoint);
+    void loadComplete(void);
 
 private slots:
     void _loadComplete(const QList<QGeoCoordinate> rgPoints);

--- a/src/MissionManager/RallyPointManager.cc
+++ b/src/MissionManager/RallyPointManager.cc
@@ -34,7 +34,7 @@ void RallyPointManager::_sendError(ErrorCode_t errorCode, const QString& errorMs
 void RallyPointManager::loadFromVehicle(void)
 {
     // No support in generic vehicle
-    loadComplete(QList<QGeoCoordinate>());
+    emit loadComplete(QList<QGeoCoordinate>());
 }
 
 void RallyPointManager::sendToVehicle(const QList<QGeoCoordinate>& rgPoints)


### PR DESCRIPTION
* When the Plan view first comes up it will adjust the viewport on the map to include all items: Mission, Fence, Rally
* When you load items back from the vehicle (Mission, Fence, Rally) the map viewport will adjust to show those items
* New Center map: All Items support to fit all items (mission/fence/rally) into view
* Also fixed a number of fence and rally point bugs

Fix for #4051