### PR TITLE
Don't let other function mapping lock out usage of those channels for radio cal

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -58,29 +58,17 @@ const char* RadioComponentController::_settingsGroup = "RadioCalibration";
 const char* RadioComponentController::_settingsKeyTransmitterMode = "TransmitterMode";
 
 const struct RadioComponentController::FunctionInfo RadioComponentController::_rgFunctionInfoPX4[RadioComponentController::rcCalFunctionMax] = {
-    //Parameter          required
     { "RC_MAP_ROLL" },
     { "RC_MAP_PITCH" },
     { "RC_MAP_YAW" },
-    { "RC_MAP_THROTTLE" },
-    { "RC_MAP_MODE_SW" },
-    { "RC_MAP_POSCTL_SW" },
-    { "RC_MAP_LOITER_SW" },
-    { "RC_MAP_RETURN_SW" },
-    { "RC_MAP_ACRO_SW" },
+    { "RC_MAP_THROTTLE" }
 };
 
 const struct RadioComponentController::FunctionInfo RadioComponentController::_rgFunctionInfoAPM[RadioComponentController::rcCalFunctionMax] = {
-    //Parameter          required
     { "RCMAP_ROLL" },
     { "RCMAP_PITCH" },
     { "RCMAP_YAW" },
-    { "RCMAP_THROTTLE" },
-    { NULL },
-    { NULL },
-    { NULL },
-    { NULL },
-    { NULL },
+    { "RCMAP_THROTTLE" }
 };
 
 RadioComponentController::RadioComponentController(void) :
@@ -570,38 +558,6 @@ void RadioComponentController::_resetInternalCalibrationValues(void)
     // Initialize attitude function mapping to function channel not set
     for (size_t i=0; i<rcCalFunctionMax; i++) {
         _rgFunctionChannelMapping[i] = _chanMax();
-    }
-    
-    if (_px4Vehicle()) {
-        // Reserve the existing Flight Mode switch settings channels so we don't re-use them
-
-        static const rcCalFunctions rgFlightModeFunctions[] = {
-            rcCalFunctionModeSwitch,
-            rcCalFunctionPosCtlSwitch,
-            rcCalFunctionLoiterSwitch,
-            rcCalFunctionReturnSwitch };
-        static const size_t crgFlightModeFunctions = sizeof(rgFlightModeFunctions) / sizeof(rgFlightModeFunctions[0]);
-
-        for (size_t i=0; i < crgFlightModeFunctions; i++) {
-            QVariant value;
-            enum rcCalFunctions curFunction = rgFlightModeFunctions[i];
-
-            Fact* paramFact = getParameterFact(FactSystem::defaultComponentId, _functionInfo()[curFunction].parameterName);
-            if (paramFact) {
-                bool ok;
-                int switchChannel = paramFact->rawValue().toInt(&ok);
-                Q_ASSERT(ok);
-
-                // Parameter: 1-based channel, 0=not mapped
-                // _rgFunctionChannelMapping: 0-based channel, _chanMax=not mapped
-
-                if (switchChannel != 0) {
-                    qCDebug(RadioComponentControllerLog) << "Reserving 0-based switch channel" << switchChannel - 1;
-                    _rgFunctionChannelMapping[curFunction] = switchChannel - 1;
-                    _rgChannelInfo[switchChannel - 1].function = curFunction;
-                }
-            }
-        }
     }
     
     _signalAllAttiudeValueChanges();

--- a/src/AutoPilotPlugins/Common/RadioComponentController.h
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.h
@@ -149,20 +149,7 @@ private:
         rcCalFunctionPitch,
         rcCalFunctionYaw,
         rcCalFunctionThrottle,
-        rcCalFunctionModeSwitch,
-        rcCalFunctionPosCtlSwitch,
-        rcCalFunctionLoiterSwitch,
-        rcCalFunctionReturnSwitch,
-        rcCalFunctionAcroSwitch,
         rcCalFunctionMax,
-        
-        // Attitude functions are roll/pitch/yaw/throttle
-        rcCalFunctionFirstAttitudeFunction = rcCalFunctionRoll,
-        rcCalFunctionLastAttitudeFunction = rcCalFunctionThrottle,
-        
-        // Non-Attitude functions are everything else
-        rcCalFunctionFirstNonAttitudeFunction = rcCalFunctionModeSwitch,
-        rcCalFunctionLastNonAttitudeFunction = rcCalFunctionAcroSwitch,
     };
     
     /// @brief The states of the calibration state machine.

--- a/src/qgcunittest/RadioConfigTest.cc
+++ b/src/qgcunittest/RadioConfigTest.cc
@@ -332,28 +332,6 @@ void RadioConfigTest::_switchMinMaxStep(void)
     QCOMPARE(_controller->_currentStep, saveStep + 1);
 }
 
-void RadioConfigTest::_switchSelectAutoStep(const char* functionStr, RadioComponentController::rcCalFunctions function)
-{
-    Q_UNUSED(functionStr);
-    ////qCDebug(RadioConfigTestLog)() << "_switchSelectAutoStep" << functionStr << "function:" << function;
-    
-    int buttonMask = cancelButtonMask;
-    if (function != RadioComponentController::rcCalFunctionModeSwitch) {
-        buttonMask |= skipButtonMask;
-    }
-    
-    CHK_BUTTONS(buttonMask);
-    
-    int saveStep = _controller->_currentStep;
-    
-    // Wiggle stick for channel
-    int channel = _rgFunctionChannelMap[function];
-    _mockLink->emitRemoteControlChannelRawChanged(channel, _testMinValue);
-    _mockLink->emitRemoteControlChannelRawChanged(channel, _testMaxValue);
-    
-    QCOMPARE(_controller->_currentStep, saveStep + 1);
-}
-
 void RadioConfigTest::_fullCalibrationWorker(MAV_AUTOPILOT firmwareType)
 {
     _init(firmwareType);
@@ -409,15 +387,15 @@ void RadioConfigTest::_fullCalibrationWorker(MAV_AUTOPILOT firmwareType)
     _channelHomePosition();
     _controller->nextButtonClicked();
     _beginCalibration();
-    _stickMoveAutoStep("Throttle", RadioComponentController::rcCalFunctionThrottle, moveToMax, true /* identify step */);
-    _stickMoveAutoStep("Throttle", RadioComponentController::rcCalFunctionThrottle, moveToMin, false /* not identify step */);
-    _stickMoveAutoStep("Yaw", RadioComponentController::rcCalFunctionYaw, moveToMax, true /* identify step */);
-    _stickMoveAutoStep("Yaw", RadioComponentController::rcCalFunctionYaw, moveToMin, false /* not identify step */);
-    _stickMoveAutoStep("Roll", RadioComponentController::rcCalFunctionRoll, moveToMax, true /* identify step */);
-    _stickMoveAutoStep("Roll", RadioComponentController::rcCalFunctionRoll, moveToMin, false /* not identify step */);
-    _stickMoveAutoStep("Pitch", RadioComponentController::rcCalFunctionPitch, moveToMax, true /* identify step */);
-    _stickMoveAutoStep("Pitch", RadioComponentController::rcCalFunctionPitch, moveToMin, false /* not identify step */);
-    _stickMoveAutoStep("Pitch", RadioComponentController::rcCalFunctionPitch, moveToCenter, false /* not identify step */);
+    _stickMoveAutoStep("Throttle",  RadioComponentController::rcCalFunctionThrottle,    moveToMax,      true /* identify step */);
+    _stickMoveAutoStep("Throttle",  RadioComponentController::rcCalFunctionThrottle,    moveToMin,      false /* not identify step */);
+    _stickMoveAutoStep("Yaw",       RadioComponentController::rcCalFunctionYaw,         moveToMax,      true /* identify step */);
+    _stickMoveAutoStep("Yaw",       RadioComponentController::rcCalFunctionYaw,         moveToMin,      false /* not identify step */);
+    _stickMoveAutoStep("Roll",      RadioComponentController::rcCalFunctionRoll,        moveToMax,      true /* identify step */);
+    _stickMoveAutoStep("Roll",      RadioComponentController::rcCalFunctionRoll,        moveToMin,      false /* not identify step */);
+    _stickMoveAutoStep("Pitch",     RadioComponentController::rcCalFunctionPitch,       moveToMax,      true /* identify step */);
+    _stickMoveAutoStep("Pitch",     RadioComponentController::rcCalFunctionPitch,       moveToMin,      false /* not identify step */);
+    _stickMoveAutoStep("Pitch",     RadioComponentController::rcCalFunctionPitch,       moveToCenter,   false /* not identify step */);
     _switchMinMaxStep();
 
     // One more click and the parameters should get saved

--- a/src/qgcunittest/RadioConfigTest.h
+++ b/src/qgcunittest/RadioConfigTest.h
@@ -76,7 +76,6 @@ private:
     void _stickMoveWaitForSettle(int channel, int value);
     void _stickMoveAutoStep(const char* functionStr, enum RadioComponentController::rcCalFunctions function, enum MoveToDirection direction, bool identifyStep);
     void _switchMinMaxStep(void);
-    void _switchSelectAutoStep(const char* functionStr, RadioComponentController::rcCalFunctions function);
     bool _px4Vehicle(void) const;
     const struct RadioComponentController::FunctionInfo* _functionInfo(void) const;
     const struct ChannelSettings* _channelSettings(void) const;


### PR DESCRIPTION
Fix for #3228

This code was a hold over from when the flight mode setup was in rc cal.