### PR TITLE
Open file and directory dialogs in foreground

### DIFF
--- a/src/AnalyzeView/GeoTagController.cc
+++ b/src/AnalyzeView/GeoTagController.cc
@@ -11,6 +11,7 @@
 #include "ExifParser.h"
 #include "QGCFileDialog.h"
 #include "QGCLoggingCategory.h"
+#include "MainWindow.h"
 #include <math.h>
 #include <QtEndian>
 #include <QMessageBox>
@@ -34,7 +35,7 @@ GeoTagController::~GeoTagController()
 
 void GeoTagController::pickLogFile(void)
 {
-    QString filename = QGCFileDialog::getOpenFileName(NULL, "Select log file load", QString(), "PX4 log file (*.px4log);;All Files (*.*)");
+    QString filename = QGCFileDialog::getOpenFileName(MainWindow::instance(), "Select log file load", QString(), "PX4 log file (*.px4log);;All Files (*.*)");
     if (!filename.isEmpty()) {
         _worker.setLogFile(filename);
         emit logFileChanged(filename);
@@ -43,7 +44,7 @@ void GeoTagController::pickLogFile(void)
 
 void GeoTagController::pickImageDirectory(void)
 {
-    QString dir = QGCFileDialog::getExistingDirectory(NULL, "Select image directory");
+    QString dir = QGCFileDialog::getExistingDirectory(MainWindow::instance(), "Select image directory");
     if (!dir.isEmpty()) {
         _worker.setImageDirectory(dir);
         emit imageDirectoryChanged(dir);
@@ -52,7 +53,7 @@ void GeoTagController::pickImageDirectory(void)
 
 void GeoTagController::pickSaveDirectory(void)
 {
-    QString dir = QGCFileDialog::getExistingDirectory(NULL, "Select save directory");
+    QString dir = QGCFileDialog::getExistingDirectory(MainWindow::instance(), "Select save directory");
     if (!dir.isEmpty()) {
         _worker.setSaveDirectory(dir);
         emit saveDirectoryChanged(dir);

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -20,6 +20,7 @@
 #include "JsonHelper.h"
 
 #ifndef __mobile__
+#include "MainWindow.h"
 #include "QGCFileDialog.h"
 #endif
 
@@ -245,7 +246,7 @@ void GeoFenceController::loadFromFile(const QString& filename)
 void GeoFenceController::loadFromFilePicker(void)
 {
 #ifndef __mobile__
-    QString filename = QGCFileDialog::getOpenFileName(NULL, "Select GeoFence File to load", QString(), "Fence file (*.fence);;All Files (*.*)");
+    QString filename = QGCFileDialog::getOpenFileName(MainWindow::instance(), "Select GeoFence File to load", QString(), "Fence file (*.fence);;All Files (*.*)");
 
     if (filename.isEmpty()) {
         return;
@@ -308,7 +309,7 @@ void GeoFenceController::saveToFile(const QString& filename)
 void GeoFenceController::saveToFilePicker(void)
 {
 #ifndef __mobile__
-    QString filename = QGCFileDialog::getSaveFileName(NULL, "Select file to save GeoFence to", QString(), "Fence file (*.fence);;All Files (*.*)");
+    QString filename = QGCFileDialog::getSaveFileName(MainWindow::instance(), "Select file to save GeoFence to", QString(), "Fence file (*.fence);;All Files (*.*)");
 
     if (filename.isEmpty()) {
         return;

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -21,6 +21,7 @@
 #include "QGroundControlQmlGlobal.h"
 
 #ifndef __mobile__
+#include "MainWindow.h"
 #include "QGCFileDialog.h"
 #endif
 
@@ -469,7 +470,7 @@ void MissionController::loadFromFile(const QString& filename)
 void MissionController::loadFromFilePicker(void)
 {
 #ifndef __mobile__
-    QString filename = QGCFileDialog::getOpenFileName(NULL, "Select Mission File to load", QString(), "Mission file (*.mission);;All Files (*.*)");
+    QString filename = QGCFileDialog::getOpenFileName(MainWindow::instance(), "Select Mission File to load", QString(), "Mission file (*.mission);;All Files (*.*)");
 
     if (filename.isEmpty()) {
         return;
@@ -553,7 +554,7 @@ void MissionController::saveToFile(const QString& filename)
 void MissionController::saveToFilePicker(void)
 {
 #ifndef __mobile__
-    QString filename = QGCFileDialog::getSaveFileName(NULL, "Select file to save mission to", QString(), "Mission file (*.mission);;All Files (*.*)");
+    QString filename = QGCFileDialog::getSaveFileName(MainWindow::instance(), "Select file to save mission to", QString(), "Mission file (*.mission);;All Files (*.*)");
 
     if (filename.isEmpty()) {
         return;

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -113,7 +113,7 @@ void ParameterEditorController::saveToFile(const QString& filename)
 void ParameterEditorController::saveToFilePicker(void)
 {
 #ifndef __mobile__
-    QString fileName = QGCFileDialog::getSaveFileName(NULL,
+    QString fileName = QGCFileDialog::getSaveFileName(MainWindow::instance(),
                                                       "Save Parameters",
                                                       QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
                                                       "Parameter Files (*.params)",
@@ -153,7 +153,7 @@ void ParameterEditorController::loadFromFile(const QString& filename)
 void ParameterEditorController::loadFromFilePicker(void)
 {
 #ifndef __mobile__
-    QString fileName = QGCFileDialog::getOpenFileName(NULL,
+    QString fileName = QGCFileDialog::getOpenFileName(MainWindow::instance(),
                                                       "Load Parameters",
                                                       QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation),
                                                       "Parameter Files (*.params);;All Files (*)");


### PR DESCRIPTION
On ubuntu and mac some of the file dialogs open behind the QGC window. This is fixed in this PR by giving it the main window as parent.