### PR TITLE
fix for MAVLinkLogManager

### DIFF
--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -223,7 +223,6 @@ MAVLinkLogProcessor::_writeUlogMessage(QByteArray& data)
             break;
         _writeData(data.data(), message_length);
         data.remove(0, message_length);
-        return data;
     }
     return data;
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2090,8 +2090,8 @@ Vehicle::_handleMavlinkLoggingData(mavlink_message_t& message)
 void
 Vehicle::_handleMavlinkLoggingDataAcked(mavlink_message_t& message)
 {
-    mavlink_logging_data_t log;
-    mavlink_msg_logging_data_decode(&message, &log);
+    mavlink_logging_data_acked_t log;
+    mavlink_msg_logging_data_acked_decode(&message, &log);
     _ackMavlinkLogData(log.sequence);
     emit mavlinkLogData(this, log.target_system, log.target_component, log.sequence,
         log.first_message_offset, QByteArray((const char*)log.data, log.length), true);


### PR DESCRIPTION
The early return lead to data being dropped. Some of this data could have been
part of the ulog header, which lead to corrupt files.

@dogmaphobic with this ulog streaming seems to work well now. Thanks for your efforts.