### PR TITLE
AutoConnect for UDP links

### DIFF
--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -79,7 +79,7 @@ public:
     /*!
      *
      * Is this an Auto Connect configuration?
-     * @return True if this is an Auto Connect configuration (connects automatically at boot time).
+     * @return True if this is an Auto Connect configuration (connects automatically).
      */
     bool isAutoConnect() { return _autoConnect; }
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -469,6 +469,13 @@ void LinkManager::_updateAutoConnectLinks(void)
         return;
     }
 
+    for (int i=0; i<_linkConfigurations.count(); i++) {
+        LinkConfiguration* conf = _linkConfigurations.value<LinkConfiguration*>(i);
+        if (!conf->link() && conf->isAutoConnect()) {
+            createConnectedLink(conf);
+        }
+    }
+
     // Re-add UDP if we need to
     bool foundUDP = false;
     for (int i=0; i<_links.count(); i++) {

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -117,8 +117,8 @@ public:
     /// Load list of link configurations from disk
     void loadLinkConfigurationList();
 
-    /// Save list of link configurations from disk
-    void saveLinkConfigurationList();
+    /// Save list of link configurations to disk
+    Q_INVOKABLE void saveLinkConfigurationList();
 
     /// Suspend automatic confguration updates (during link maintenance for instance)
     void suspendConfigurationUpdates(bool suspend);

--- a/src/ui/preferences/LinkSettings.qml
+++ b/src/ui/preferences/LinkSettings.qml
@@ -134,6 +134,16 @@ Rectangle {
                 QGroundControl.linkManager.disconnectLink(_currentSelection.link, false)
             }
         }
+        IndicatorButton {
+            text:           qsTr("Autoconnect")
+            width:          ScreenTools.defaultFontPixelWidth * 15
+            enabled:        _currentSelection && _currentSelection.linkType === LinkConfiguration.TypeUdp
+            indicatorGreen: _currentSelection && _currentSelection.autoConnect
+            onClicked:      {
+                _currentSelection.autoConnect = !_currentSelection.autoConnect
+                QGroundControl.linkManager.saveLinkConfigurationList()
+            }
+        }
     }
 
     Loader {


### PR DESCRIPTION
This PR allows to set autoconnect for selected UDP link  that helps if you use QGC for outgoing connection.
Button indicator shows status of autoconnect configuration.