### PR TITLE
Handle delayed RTSP video connection.

### DIFF
--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -223,6 +223,15 @@ void VideoManager::_updateTimer()
             _videoRunning = false;
             _videoSurface->setLastFrame(0);
             emit videoRunningChanged();
+            if(_videoReceiver) {
+                if(isGStreamer()) {
+                    //-- Stop it
+                    _videoReceiver->stop();
+                    QThread::msleep(100);
+                    //-- And start over
+                    _videoReceiver->start();
+                }
+            }
         }
     }
     else

--- a/src/VideoStreaming/VideoReceiver.h
+++ b/src/VideoStreaming/VideoReceiver.h
@@ -18,6 +18,9 @@
 #define VIDEORECEIVER_H
 
 #include <QObject>
+#include <QTimer>
+#include <QTcpSocket>
+
 #if defined(QGC_GST_STREAMING)
 #include <gst/gst.h>
 #endif
@@ -33,10 +36,17 @@ public:
     void setVideoSink(GstElement* sink);
 #endif
 
-public Q_SLOTS:
-    void start  ();
-    void stop   ();
-    void setUri (const QString& uri);
+public slots:
+    void start      ();
+    void stop       ();
+    void setUri     (const QString& uri);
+
+private slots:
+#if defined(QGC_GST_STREAMING)
+    void _timeout       ();
+    void _connected     ();
+    void _socketError   (QAbstractSocket::SocketError socketError);
+#endif
 
 private:
 
@@ -52,6 +62,12 @@ private:
     GstElement* _videoSink;
 #endif
 
+    //-- Wait for Video Server to show up before starting
+#if defined(QGC_GST_STREAMING)
+    QTimer      _timer;
+    QTcpSocket* _socket;
+    bool        _serverPresent;
+#endif
 };
 
 #endif // VIDEORECEIVER_H


### PR DESCRIPTION
RTSP will try to connect to the server. If it cannot connect,  it will simply give up and never try again. I added code to keep trying to make a connection to the server first. Only when I get a connection, will I actually start the stream. 

This solves the problem where if QGC was started before it had a network connection, or before the video source had started, it would not connect to the stream.