### PR TITLE
Switch Bluetooth connection from a generic Rfcomm protocol...

### DIFF
--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -150,7 +150,7 @@ bool BluetoothLink::_hardwareConnect()
     _discoveryAgent->start();
 #else
     _createSocket();
-    _targetSocket->connectToService(QBluetoothAddress(_config->device().address), QBluetoothUuid(QBluetoothUuid::Rfcomm));
+    _targetSocket->connectToService(QBluetoothAddress(_config->device().address), QBluetoothUuid(QBluetoothUuid::SerialPort));
 #endif
     return true;
 }
@@ -352,9 +352,17 @@ void BluetoothConfiguration::startScan()
 
 void BluetoothConfiguration::deviceDiscovered(QBluetoothDeviceInfo info)
 {
-    //print_device_info(info);
     if(!info.name().isEmpty() && info.isValid())
     {
+#if 0
+        qDebug() << "Name:           " << info.name();
+        qDebug() << "Address:        " << info.address().toString();
+        qDebug() << "Service Classes:" << info.serviceClasses();
+        QList<QBluetoothUuid> uuids = info.serviceUuids();
+        foreach (QBluetoothUuid uuid, uuids) {
+            qDebug() << "Service UUID:   " << uuid.toString();
+        }
+#endif
         BluetoothData data;
         data.name    = info.name();
 #ifdef __ios__


### PR DESCRIPTION
... to a specfic SerialPort service.

This is a fix for Android Bluetooth links.

When the Bluetooth link was first implemented, the only way I got a comm link to work with the TBS Crossfire was setting the socket as a generic *Rfcomm* protocol. Something changed after Android 6.x that made this no longer work. Switching to a specific *SerialPort* protocol now enables a socket connection.

Note that I could only test this with Android 6.x and 7.x. Android 5.x no longer pairs with the Crossfire neither does Mac OS. I do not have anything else with Bluetooth so it would be good to know how it behaves with other Bluetooth devices (other than the Crossfire) and other platforms.

Testing was done using Crossfire firmware version 1.44.