### PR TITLE
Mav command retry work

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -381,6 +381,7 @@ DebugBuild { PX4FirmwarePlugin { PX4FirmwarePluginFactory  { APMFirmwarePlugin {
         src/qgcunittest/TCPLinkTest.h \
         src/qgcunittest/TCPLoopBackServer.h \
         src/qgcunittest/UnitTest.h \
+        src/Vehicle/SendMavCommandTest.h \
 
     SOURCES += \
         src/AnalyzeView/LogDownloadTest.cc \
@@ -409,6 +410,7 @@ DebugBuild { PX4FirmwarePlugin { PX4FirmwarePluginFactory  { APMFirmwarePlugin {
         src/qgcunittest/TCPLoopBackServer.cc \
         src/qgcunittest/UnitTest.cc \
         src/qgcunittest/UnitTestList.cc \
+        src/Vehicle/SendMavCommandTest.cc \
 } } } } } }
 
 # Main QGC Headers and Source files

--- a/src/AutoPilotPlugins/APM/APMCompassCal.cc
+++ b/src/AutoPilotPlugins/APM/APMCompassCal.cc
@@ -145,7 +145,10 @@ CalWorkerThread::calibrate_return CalWorkerThread::calibrate(void)
                     sensorId = 6.0f;
                 }
                 if (sensorId != 0.0f) {
-                    _vehicle->doCommandLong(_vehicle->defaultComponentId(), MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS, sensorId, -sphere_x[cur_mag], -sphere_y[cur_mag], -sphere_z[cur_mag]);
+                    _vehicle->sendMavCommand(_vehicle->defaultComponentId(),
+                                             MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS,
+                                             true, /* showErrors */
+                                             sensorId, -sphere_x[cur_mag], -sphere_y[cur_mag], -sphere_z[cur_mag]);
                 }
             }
         }

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
@@ -381,7 +381,7 @@ ESP8266ComponentController::_processTimeout()
 
 //-----------------------------------------------------------------------------
 void
-ESP8266ComponentController::_mavCommandResult(int vehicleId, int component, MAV_CMD command, MAV_RESULT result, bool noReponseFromVehicle)
+ESP8266ComponentController::_mavCommandResult(int vehicleId, int component, int command, int result, bool noReponseFromVehicle)
 {
     Q_UNUSED(vehicleId);
     Q_UNUSED(noReponseFromVehicle);

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
@@ -83,7 +83,7 @@ signals:
 
 private slots:
     void        _processTimeout     ();
-    void        _mavCommandResult(int vehicleId, int component, MAV_CMD command, MAV_RESULT result, bool noReponseFromVehicle);
+    void        _mavCommandResult(int vehicleId, int component, int command, int result, bool noReponseFromVehicle);
     void        _ssidChanged        (QVariant value);
     void        _passwordChanged    (QVariant value);
     void        _baudChanged        (QVariant value);

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
@@ -83,7 +83,7 @@ signals:
 
 private slots:
     void        _processTimeout     ();
-    void        _commandAck         (uint8_t compID, uint16_t command, uint8_t result);
+    void        _mavCommandResult(int vehicleId, int component, MAV_CMD command, MAV_RESULT result, bool noReponseFromVehicle);
     void        _ssidChanged        (QVariant value);
     void        _passwordChanged    (QVariant value);
     void        _baudChanged        (QVariant value);

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -117,7 +117,7 @@ void AirframeComponentController::_waitParamWriteSignal(QVariant value)
 
 void AirframeComponentController::_rebootAfterStackUnwind(void)
 {    
-    _uas->executeCommand(MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN, 1, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0);
+    _vehicle->sendMavCommand(_vehicle->defaultComponentId(), MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN, true /* showError */, 1.0f);
     qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
     for (unsigned i = 0; i < 2000; i++) {
         QGC::SLEEP::usleep(500);

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -1066,7 +1066,7 @@ void ParameterManager::_initialRequestTimeout(void)
     } else {
         if (!_vehicle->genericFirmware()) {
             // Generic vehicles (like BeBop) may not have any parameters, so don't annoy the user
-            QString errorMsg = tr("Vehicle %1 did not respond to request for parameters"
+            QString errorMsg = tr("Vehicle %1 did not respond to request for parameters. "
                                   "This will cause QGroundControl to be unable to display its full user interface.").arg(_vehicle->id());
             qCDebug(ParameterManagerLog) << errorMsg;
             qgcApp()->showMessage(errorMsg);

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -125,29 +125,11 @@ void ArduCopterFirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double altitu
         return;
     }
 
-    mavlink_message_t msg;
-    mavlink_command_long_t cmd;
-
-    cmd.command = (uint16_t)MAV_CMD_NAV_TAKEOFF;
-    cmd.confirmation = 0;
-    cmd.param1 = 0.0f;
-    cmd.param2 = 0.0f;
-    cmd.param3 = 0.0f;
-    cmd.param4 = 0.0f;
-    cmd.param5 = 0.0f;
-    cmd.param6 = 0.0f;
-    cmd.param7 = vehicle->altitudeAMSL()->rawValue().toFloat() +  altitudeRel; // AMSL meters
-    cmd.target_system = vehicle->id();
-    cmd.target_component = vehicle->defaultComponentId();
-
-    MAVLinkProtocol* mavlink = qgcApp()->toolbox()->mavlinkProtocol();
-    mavlink_msg_command_long_encode_chan(mavlink->getSystemId(),
-                                         mavlink->getComponentId(),
-                                         vehicle->priorityLink()->mavlinkChannel(),
-                                         &msg,
-                                         &cmd);
-
-    vehicle->sendMessageOnLink(vehicle->priorityLink(), msg);
+    vehicle->sendMavCommand(vehicle->defaultComponentId(),
+                            MAV_CMD_NAV_TAKEOFF,
+                            true, // show error
+                            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                            vehicle->altitudeAMSL()->rawValue().toFloat() +  altitudeRel); // AMSL meters
 }
 
 void ArduCopterFirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordinate& gotoCoord)

--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -769,7 +769,7 @@ MAVLinkLogManager::_mavlinkLogData(Vehicle* /*vehicle*/, uint8_t /*target_system
 
 //-----------------------------------------------------------------------------
 void
-MAVLinkLogManager::_mavCommandResult(int vehicleId, int component, MAV_CMD command, MAV_RESULT result, bool noReponseFromVehicle)
+MAVLinkLogManager::_mavCommandResult(int vehicleId, int component, int command, int result, bool noReponseFromVehicle)
 {
     Q_UNUSED(vehicleId);
     Q_UNUSED(component);

--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -19,8 +19,6 @@
 #include <QFile>
 #include <QFileInfo>
 
-#define kTimeOutMilliseconds 1000
-
 QGC_LOGGING_CATEGORY(MAVLinkLogManagerLog, "MAVLinkLogManagerLog")
 
 static const char* kEmailAddressKey         = "MAVLinkLogEmail";
@@ -301,7 +299,6 @@ MAVLinkLogManager::MAVLinkLogManager(QGCApplication* app)
     , _loggingDisabled(false)
     , _logProcessor(NULL)
     , _deleteAfterUpload(false)
-    , _loggingCmdTryCount(0)
 {
     //-- Get saved settings
     QSettings settings;
@@ -347,7 +344,6 @@ MAVLinkLogManager::setToolbox(QGCToolbox* toolbox)
     qmlRegisterUncreatableType<MAVLinkLogManager>("QGroundControl.MAVLinkLogManager", 1, 0, "MAVLinkLogManager", "Reference only");
     if(!_loggingDisabled) {
         connect(toolbox->multiVehicleManager(), &MultiVehicleManager::activeVehicleChanged, this, &MAVLinkLogManager::_activeVehicleChanged);
-        connect(&_ackTimer, &QTimer::timeout, this, &MAVLinkLogManager::_processCmdAck);
     }
 }
 
@@ -540,8 +536,6 @@ MAVLinkLogManager::startLogging()
         if(_createNewLog()) {
             _vehicle->startMavlinkLog();
             _logRunning = true;
-            _loggingCmdTryCount = 0;
-            _ackTimer.start(kTimeOutMilliseconds);
             emit logRunningChanged();
         }
     }
@@ -570,11 +564,6 @@ MAVLinkLogManager::stopLogging()
         delete _logProcessor;
         _logProcessor = NULL;
         _logRunning = false;
-        if(_vehicle) {
-            //-- Setup a timer to make sure vehicle received the command
-            _loggingCmdTryCount = 0;
-            _ackTimer.start(kTimeOutMilliseconds);
-        }
         emit logRunningChanged();
     }
 }
@@ -742,9 +731,9 @@ MAVLinkLogManager::_activeVehicleChanged(Vehicle* vehicle)
     //   For now, we only handle one log download at a time.
     // Disconnect the previous one (if any)
     if(_vehicle) {
-        disconnect(_vehicle, &Vehicle::armedChanged,   this, &MAVLinkLogManager::_armedChanged);
-        disconnect(_vehicle, &Vehicle::mavlinkLogData, this, &MAVLinkLogManager::_mavlinkLogData);
-        disconnect(_vehicle, &Vehicle::commandLongAck, this, &MAVLinkLogManager::_commandLongAck);
+        disconnect(_vehicle, &Vehicle::armedChanged,        this, &MAVLinkLogManager::_armedChanged);
+        disconnect(_vehicle, &Vehicle::mavlinkLogData,      this, &MAVLinkLogManager::_mavlinkLogData);
+        disconnect(_vehicle, &Vehicle::mavCommandResult,    this, &MAVLinkLogManager::_mavCommandResult);
         _vehicle = NULL;
         //-- Stop logging (if that's the case)
         stopLogging();
@@ -753,40 +742,10 @@ MAVLinkLogManager::_activeVehicleChanged(Vehicle* vehicle)
     // Connect new system
     if(vehicle) {
         _vehicle = vehicle;
-        connect(_vehicle, &Vehicle::armedChanged,   this, &MAVLinkLogManager::_armedChanged);
-        connect(_vehicle, &Vehicle::mavlinkLogData, this, &MAVLinkLogManager::_mavlinkLogData);
-        connect(_vehicle, &Vehicle::commandLongAck, this, &MAVLinkLogManager::_commandLongAck);
+        connect(_vehicle, &Vehicle::armedChanged,       this, &MAVLinkLogManager::_armedChanged);
+        connect(_vehicle, &Vehicle::mavlinkLogData,     this, &MAVLinkLogManager::_mavlinkLogData);
+        connect(_vehicle, &Vehicle::mavCommandResult,   this, &MAVLinkLogManager::_mavCommandResult);
         emit canStartLogChanged();
-    }
-}
-
-//-----------------------------------------------------------------------------
-void
-MAVLinkLogManager::_processCmdAck()
-{
-    if(_loggingCmdTryCount++ > 3) {
-        _ackTimer.stop();
-        //-- Give up
-        if(_logRunning) {
-            qCWarning(MAVLinkLogManagerLog) << "Start MAVLink log command had no response.";
-            _discardLog();
-        } else {
-            qCWarning(MAVLinkLogManagerLog) << "Stop MAVLink log command had no response.";
-        }
-    } else {
-        if(_vehicle) {
-            if(_logRunning) {
-                _vehicle->startMavlinkLog();
-                qCWarning(MAVLinkLogManagerLog) << "Start MAVLink log command sent again.";
-            } else {
-                _vehicle->stopMavlinkLog();
-                qCWarning(MAVLinkLogManagerLog) << "Stop MAVLink log command sent again.";
-            }
-            _ackTimer.start(kTimeOutMilliseconds);
-        } else {
-            //-- Vehicle went away on us
-            _ackTimer.stop();
-        }
     }
 }
 
@@ -794,10 +753,6 @@ MAVLinkLogManager::_processCmdAck()
 void
 MAVLinkLogManager::_mavlinkLogData(Vehicle* /*vehicle*/, uint8_t /*target_system*/, uint8_t /*target_component*/, uint16_t sequence, uint8_t first_message, QByteArray data, bool /*acked*/)
 {
-    //-- Disable timer if we got a message before an ACK for the start command
-    if(_logRunning) {
-        _ackTimer.stop();
-    }
     if(_logProcessor && _logProcessor->valid()) {
         if(!_logProcessor->processStreamData(sequence, first_message, data)) {
             qCCritical(MAVLinkLogManagerLog) << "Error writing MAVLink log file:" << _logProcessor->fileName();
@@ -814,12 +769,15 @@ MAVLinkLogManager::_mavlinkLogData(Vehicle* /*vehicle*/, uint8_t /*target_system
 
 //-----------------------------------------------------------------------------
 void
-MAVLinkLogManager::_commandLongAck(uint8_t /*compID*/, uint16_t command, uint8_t result)
+MAVLinkLogManager::_mavCommandResult(int vehicleId, int component, MAV_CMD command, MAV_RESULT result, bool noReponseFromVehicle)
 {
+    Q_UNUSED(vehicleId);
+    Q_UNUSED(component);
+    Q_UNUSED(noReponseFromVehicle)
+
     if(command == MAV_CMD_LOGGING_START || command == MAV_CMD_LOGGING_STOP) {
-        _ackTimer.stop();
         //-- Did it fail?
-        if(result) {
+        if(result != MAV_RESULT_ACCEPTED) {
             if(command == MAV_CMD_LOGGING_STOP) {
                 //-- Not that it could happen but...
                 qCWarning(MAVLinkLogManagerLog) << "Stop MAVLink log command failed.";

--- a/src/Vehicle/MAVLinkLogManager.h
+++ b/src/Vehicle/MAVLinkLogManager.h
@@ -172,8 +172,7 @@ private slots:
     void _activeVehicleChanged      (Vehicle* vehicle);
     void _mavlinkLogData            (Vehicle* vehicle, uint8_t target_system, uint8_t target_component, uint16_t sequence, uint8_t first_message, QByteArray data, bool acked);
     void _armedChanged              (bool armed);
-    void _commandLongAck            (uint8_t compID, uint16_t command, uint8_t result);
-    void _processCmdAck             ();
+    void _mavCommandResult          (int vehicleId, int component, MAV_CMD command, MAV_RESULT result, bool noReponseFromVehicle);
 
 private:
     bool _sendLog                   (const QString& logFile);
@@ -200,8 +199,6 @@ private:
     bool                    _loggingDisabled;
     MAVLinkLogProcessor*    _logProcessor;
     bool                    _deleteAfterUpload;
-    int                     _loggingCmdTryCount;
-    QTimer                  _ackTimer;
 };
 
 #endif

--- a/src/Vehicle/MAVLinkLogManager.h
+++ b/src/Vehicle/MAVLinkLogManager.h
@@ -172,7 +172,7 @@ private slots:
     void _activeVehicleChanged      (Vehicle* vehicle);
     void _mavlinkLogData            (Vehicle* vehicle, uint8_t target_system, uint8_t target_component, uint16_t sequence, uint8_t first_message, QByteArray data, bool acked);
     void _armedChanged              (bool armed);
-    void _mavCommandResult          (int vehicleId, int component, MAV_CMD command, MAV_RESULT result, bool noReponseFromVehicle);
+    void _mavCommandResult          (int vehicleId, int component, int command, int result, bool noReponseFromVehicle);
 
 private:
     bool _sendLog                   (const QString& logFile);

--- a/src/Vehicle/SendMavCommandTest.cc
+++ b/src/Vehicle/SendMavCommandTest.cc
@@ -1,0 +1,151 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+#include "SendMavCommandTest.h"
+#include "MultiVehicleManager.h"
+#include "QGCApplication.h"
+
+void SendMavCommandTest::_noFailure(void)
+{
+    _connectMockLink();
+
+    MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+    Vehicle* vehicle = vehicleMgr->activeVehicle();
+    QVERIFY(vehicle);
+
+    vehicle->sendMavCommand(MAV_COMP_ID_ALL, MAV_CMD_USER_1, true /* showError */);
+
+    QSignalSpy spyResult(vehicle, SIGNAL(mavCommandResult(int, int, int, int, bool)));
+    QCOMPARE(spyResult.wait(10000), true);
+    QList<QVariant> arguments = spyResult.takeFirst();
+    QCOMPARE(arguments.count(), 5);
+    QCOMPARE(arguments.at(0).toInt(), vehicle->id());
+    QCOMPARE(arguments.at(2).toInt(), (int)MAV_CMD_USER_1);
+    QCOMPARE(arguments.at(3).toInt(), (int)MAV_RESULT_ACCEPTED);
+    QCOMPARE(arguments.at(4).toBool(), false);
+}
+
+void SendMavCommandTest::_failureShowError(void)
+{
+    // Will pop error about request failure
+    setExpectedMessageBox(QMessageBox::Ok);
+
+    _connectMockLink();
+
+    MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+    Vehicle* vehicle = vehicleMgr->activeVehicle();
+    QVERIFY(vehicle);
+
+    vehicle->sendMavCommand(MAV_COMP_ID_ALL, MAV_CMD_USER_2, true /* showError */);
+
+    QSignalSpy spyResult(vehicle, SIGNAL(mavCommandResult(int, int, int, int, bool)));
+    QCOMPARE(spyResult.wait(10000), true);
+    QList<QVariant> arguments = spyResult.takeFirst();
+    QCOMPARE(arguments.count(), 5);
+    QCOMPARE(arguments.at(0).toInt(), vehicle->id());
+    QCOMPARE(arguments.at(2).toInt(), (int)MAV_CMD_USER_2);
+    QCOMPARE(arguments.at(3).toInt(), (int)MAV_RESULT_FAILED);
+    QCOMPARE(arguments.at(4).toBool(), false);
+
+    // User should have been notified
+    checkExpectedMessageBox();
+}
+
+void SendMavCommandTest::_failureNoShowError(void)
+{
+    _connectMockLink();
+
+    MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+    Vehicle* vehicle = vehicleMgr->activeVehicle();
+    QVERIFY(vehicle);
+
+    vehicle->sendMavCommand(MAV_COMP_ID_ALL, MAV_CMD_USER_2, false /* showError */);
+
+    QSignalSpy spyResult(vehicle, SIGNAL(mavCommandResult(int, int, int, int, bool)));
+    QCOMPARE(spyResult.wait(10000), true);
+    QList<QVariant> arguments = spyResult.takeFirst();
+    QCOMPARE(arguments.count(), 5);
+    QCOMPARE(arguments.at(0).toInt(), vehicle->id());
+    QCOMPARE(arguments.at(2).toInt(), (int)MAV_CMD_USER_2);
+    QCOMPARE(arguments.at(3).toInt(), (int)MAV_RESULT_FAILED);
+    QCOMPARE(arguments.at(4).toBool(), false);
+}
+
+void SendMavCommandTest::_noFailureAfterRetry(void)
+{
+    _connectMockLink();
+
+    MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+    Vehicle* vehicle = vehicleMgr->activeVehicle();
+    QVERIFY(vehicle);
+
+    vehicle->sendMavCommand(MAV_COMP_ID_ALL, MAV_CMD_USER_3, true /* showError */);
+
+    QSignalSpy spyResult(vehicle, SIGNAL(mavCommandResult(int, int, int, int, bool)));
+    QCOMPARE(spyResult.wait(10000), true);
+    QList<QVariant> arguments = spyResult.takeFirst();
+    QCOMPARE(arguments.count(), 5);
+    QCOMPARE(arguments.at(0).toInt(), vehicle->id());
+    QCOMPARE(arguments.at(2).toInt(), (int)MAV_CMD_USER_3);
+    QCOMPARE(arguments.at(3).toInt(), (int)MAV_RESULT_ACCEPTED);
+    QCOMPARE(arguments.at(4).toBool(), false);
+}
+
+void SendMavCommandTest::_failureAfterRetry(void)
+{
+    // Will pop error about request failure
+    setExpectedMessageBox(QMessageBox::Ok);
+
+    _connectMockLink();
+
+    MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+    Vehicle* vehicle = vehicleMgr->activeVehicle();
+    QVERIFY(vehicle);
+
+    vehicle->sendMavCommand(MAV_COMP_ID_ALL, MAV_CMD_USER_4, true /* showError */);
+
+    QSignalSpy spyResult(vehicle, SIGNAL(mavCommandResult(int, int, int, int, bool)));
+    QCOMPARE(spyResult.wait(10000), true);
+    QList<QVariant> arguments = spyResult.takeFirst();
+    QCOMPARE(arguments.count(), 5);
+    QCOMPARE(arguments.at(0).toInt(), vehicle->id());
+    QCOMPARE(arguments.at(2).toInt(), (int)MAV_CMD_USER_4);
+    QCOMPARE(arguments.at(3).toInt(), (int)MAV_RESULT_FAILED);
+    QCOMPARE(arguments.at(4).toBool(), false);
+
+    // User should have been notified
+    checkExpectedMessageBox();
+}
+
+void SendMavCommandTest::_failureAfterNoReponse(void)
+{
+    // Will pop error about request failure
+    setExpectedMessageBox(QMessageBox::Ok);
+
+    _connectMockLink();
+
+    MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+    Vehicle* vehicle = vehicleMgr->activeVehicle();
+    QVERIFY(vehicle);
+
+    vehicle->sendMavCommand(MAV_COMP_ID_ALL, MAV_CMD_USER_5, true /* showError */);
+
+    QSignalSpy spyResult(vehicle, SIGNAL(mavCommandResult(int, int, int, int, bool)));
+    QCOMPARE(spyResult.wait(10000), true);
+    QList<QVariant> arguments = spyResult.takeFirst();
+    QCOMPARE(arguments.count(), 5);
+    QCOMPARE(arguments.at(0).toInt(), vehicle->id());
+    QCOMPARE(arguments.at(2).toInt(), (int)MAV_CMD_USER_5);
+    QCOMPARE(arguments.at(3).toInt(), (int)MAV_RESULT_FAILED);
+    QCOMPARE(arguments.at(4).toBool(), true);
+
+    // User should have been notified
+    checkExpectedMessageBox();
+}

--- a/src/Vehicle/SendMavCommandTest.h
+++ b/src/Vehicle/SendMavCommandTest.h
@@ -1,0 +1,31 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+#ifndef SendMavCommandTest_H
+#define SendMavCommandTest_H
+
+#include "UnitTest.h"
+
+class SendMavCommandTest : public UnitTest
+{
+    Q_OBJECT
+    
+private slots:
+    void _noFailure(void);
+    void _failureShowError(void);
+    void _failureNoShowError(void);
+    void _noFailureAfterRetry(void);
+    void _failureAfterRetry(void);
+    void _failureAfterNoReponse(void);
+
+private:
+};
+
+#endif

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -564,11 +564,12 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
     mavlink_msg_command_ack_decode(&message, &ack);
 
     if (_mavCommandQueue.count() && ack.command == _mavCommandQueue[0].command) {
+        _mavCommandAckTimer.stop();
         showError = _mavCommandQueue[0].showError;
         _mavCommandQueue.removeFirst();
     }
 
-    emit mavCommandResult(_id, message.compid, (MAV_CMD)ack.command, (MAV_RESULT)ack.result, false /* noResponsefromVehicle */);
+    emit mavCommandResult(_id, message.compid, ack.command, ack.result, false /* noResponsefromVehicle */);
 
     if (showError) {
         QString commandName = qgcApp()->toolbox()->missionCommandTree()->friendlyName((MAV_CMD)ack.command);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -664,7 +664,7 @@ signals:
     ///     @param command MAV_CMD Command which was sent
     ///     @param result MAV_RESULT returned in ack
     ///     @param noResponseFromVehicle true: vehicle did not respond to command, false: vehicle responsed, MAV_RESULT in result
-    void mavCommandResult(int vehicleId, int component, MAV_CMD command, MAV_RESULT result, bool noReponseFromVehicle);
+    void mavCommandResult(int vehicleId, int component, int command, int result, bool noReponseFromVehicle);
 
 private slots:
     void _mavlinkMessageReceived(LinkInterface* link, mavlink_message_t message);

--- a/src/ViewWidgets/CustomCommandWidgetController.cc
+++ b/src/ViewWidgets/CustomCommandWidgetController.cc
@@ -21,10 +21,10 @@
 const char* CustomCommandWidgetController::_settingsKey = "CustomCommand.QmlFile";
 
 CustomCommandWidgetController::CustomCommandWidgetController(void) :
-	_uas(NULL)
+    _vehicle(NULL)
 {
     if(qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()) {
-        _uas = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->uas();
+        _vehicle = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
     }
     QSettings settings;
     _customQmlFile = settings.value(_settingsKey).toString();
@@ -33,15 +33,21 @@ CustomCommandWidgetController::CustomCommandWidgetController(void) :
 
 void CustomCommandWidgetController::sendCommand(int commandId, QVariant componentId, QVariant confirm, QVariant param1, QVariant param2, QVariant param3, QVariant param4, QVariant param5, QVariant param6, QVariant param7)
 {
-    if(_uas) {
-        _uas->executeCommand((MAV_CMD)commandId, confirm.toInt(), param1.toFloat(), param2.toFloat(), param3.toFloat(), param4.toFloat(), param5.toFloat(), param6.toFloat(), param7.toFloat(), componentId.toInt());
+    Q_UNUSED(confirm);
+
+    if(_vehicle) {
+        _vehicle->sendMavCommand(componentId.toInt(),
+                                 (MAV_CMD)commandId,
+                                 true,  // show error if fails
+                                 param1.toFloat(), param2.toFloat(), param3.toFloat(), param4.toFloat(), param5.toFloat(), param6.toFloat(), param7.toFloat());
     }
 }
 
 void CustomCommandWidgetController::_activeVehicleChanged(Vehicle* activeVehicle)
 {
-    if(activeVehicle)
-        _uas = activeVehicle->uas();
+    if (activeVehicle) {
+        _vehicle = activeVehicle;
+    }
 }
 
 void CustomCommandWidgetController::selectQmlFile(void)

--- a/src/ViewWidgets/CustomCommandWidgetController.h
+++ b/src/ViewWidgets/CustomCommandWidgetController.h
@@ -13,7 +13,6 @@
 
 #include <QObject>
 
-#include "UASInterface.h"
 #include "AutoPilotPlugin.h"
 #include "FactPanelController.h"
 
@@ -37,7 +36,7 @@ private slots:
     void _activeVehicleChanged  (Vehicle* activeVehicle);
 
 private:
-	UASInterface*       _uas;
+    Vehicle*            _vehicle;
     QString             _customQmlFile;
     static const char*  _settingsKey;
 };

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -807,6 +807,40 @@ void MockLink::_handleCommandLong(const mavlink_message_t& msg)
         commandResult = MAV_RESULT_ACCEPTED;
         _respondWithAutopilotVersion();
         break;
+    case MAV_CMD_USER_1:
+        // Test command which always returns MAV_RESULT_ACCEPTED
+        commandResult = MAV_RESULT_ACCEPTED;
+        break;
+    case MAV_CMD_USER_2:
+        // Test command which always returns MAV_RESULT_FAILED
+        commandResult = MAV_RESULT_FAILED;
+        break;
+    case MAV_CMD_USER_3:
+        // Test command which returns MAV_RESULT_ACCEPTED on second attempt
+        static bool firstCmdUser3 = true;
+        if (firstCmdUser3) {
+           firstCmdUser3 = false;
+           return;
+        } else {
+            firstCmdUser3 = true;
+            commandResult = MAV_RESULT_ACCEPTED;
+        }
+        break;
+    case MAV_CMD_USER_4:
+        // Test command which returns MAV_RESULT_FAILED on second attempt
+        static bool firstCmdUser4 = true;
+        if (firstCmdUser4) {
+           firstCmdUser4 = false;
+           return;
+        } else {
+            firstCmdUser4 = true;
+            commandResult = MAV_RESULT_FAILED;
+        }
+        break;
+    case MAV_CMD_USER_5:
+        // No response
+        return;
+        break;
     }
 
     mavlink_message_t commandAck;

--- a/src/qgcunittest/UnitTestList.cc
+++ b/src/qgcunittest/UnitTestList.cc
@@ -31,6 +31,7 @@
 #include "ParameterManagerTest.h"
 #include "MissionCommandTreeTest.h"
 #include "LogDownloadTest.h"
+#include "SendMavCommandTest.h"
 
 UT_REGISTER_TEST(FactSystemTestGeneric)
 UT_REGISTER_TEST(FactSystemTestPX4)
@@ -50,6 +51,7 @@ UT_REGISTER_TEST(TCPLinkTest)
 UT_REGISTER_TEST(ParameterManagerTest)
 UT_REGISTER_TEST(MissionCommandTreeTest)
 UT_REGISTER_TEST(LogDownloadTest)
+UT_REGISTER_TEST(SendMavCommandTest)
 
 // List of unit test which are currently disabled.
 // If disabling a new test, include reason in comment.

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1233,33 +1233,6 @@ void UAS::processParamValueMsg(mavlink_message_t& msg, const QString& paramName,
     emit parameterUpdate(uasId, compId, paramName, rawValue.param_count, rawValue.param_index, rawValue.param_type, paramValue);
 }
 
-void UAS::executeCommand(MAV_CMD command, int confirmation, float param1, float param2, float param3, float param4, float param5, float param6, float param7, int component)
-{
-    if (!_vehicle) {
-        return;
-    }
-
-    mavlink_message_t msg;
-    mavlink_command_long_t cmd;
-    cmd.command = (uint16_t)command;
-    cmd.confirmation = confirmation;
-    cmd.param1 = param1;
-    cmd.param2 = param2;
-    cmd.param3 = param3;
-    cmd.param4 = param4;
-    cmd.param5 = param5;
-    cmd.param6 = param6;
-    cmd.param7 = param7;
-    cmd.target_system = uasId;
-    cmd.target_component = component;
-    mavlink_msg_command_long_encode_chan(mavlink->getSystemId(),
-                                         mavlink->getComponentId(),
-                                         _vehicle->priorityLink()->mavlinkChannel(),
-                                         &msg,
-                                         &cmd);
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
-}
-
 /**
 * Set the manual control commands.
 * This can only be done if the system has manual inputs enabled and is armed.

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -472,9 +472,6 @@ public:
     void requestImage();
 
 public slots:
-    /** @brief Executes a command with 7 params */
-    void executeCommand(MAV_CMD command, int confirmation, float param1, float param2, float param3, float param4, float param5, float param6, float param7, int component);
-
     /** @brief Order the robot to pair its receiver **/
     void pairRX(int rxType, int rxSubType);
 

--- a/src/uas/UASInterface.h
+++ b/src/uas/UASInterface.h
@@ -141,10 +141,6 @@ public:
     virtual void stopBusConfig(void) = 0;
 
 public slots:
-
-    /** @brief Executes a command **/
-    virtual void executeCommand(MAV_CMD command, int confirmation, float param1, float param2, float param3, float param4, float param5, float param6, float param7, int component) = 0;
-
     /** @brief Order the robot to pair its receiver **/
     virtual void pairRX(int rxType, int rxSubType) = 0;
 


### PR DESCRIPTION
Support for new Vehicle::sendMavCommand method. This will wait for an ack to come back for the command. If no ack comes back the command will be send again, up to a max number of retries. There is only one command going out to the vehicle at a time in order to verify acts correctly. If a command is already in progress additional commands will be queued.

Converted existing code to use new method and removed old methods which did not verify vehicle reception of command.

Fix for #2975.