### PR TITLE
Fix most (all?) QML font rendering glitches on Windows

### DIFF
--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -87,8 +87,8 @@ Item {
     function _setBasePointSize(pointSize) {
         _textMeasure.font.pointSize = pointSize
         defaultFontPointSize    = pointSize
-        defaultFontPixelHeight  = _textMeasure.fontHeight
-        defaultFontPixelWidth   = _textMeasure.fontWidth
+        defaultFontPixelHeight  = Math.round(_textMeasure.fontHeight/2.0)*2
+        defaultFontPixelWidth   = Math.round(_textMeasure.fontWidth/2.0)*2
         smallFontPointSize      = defaultFontPointSize  * _screenTools.smallFontPointRatio
         mediumFontPointSize     = defaultFontPointSize  * _screenTools.mediumFontPointRatio
         largeFontPointSize      = defaultFontPointSize  * _screenTools.largeFontPointRatio


### PR DESCRIPTION
This has always driven me crazy. This seems to be a general-case app-wide fix of the font rendering problems no matter what base font size is selected. Presumably this is because the defaultFontPixelWidth/defaultFontPixelHeight are used throughout the QML codebase to define margins (usually divided by 2). Just ensuring that those numbers are even and hence divide by two into an integer prevents the transforms applied to QML views from corrupting Windows font rendering. 

Before:
![image](https://cloud.githubusercontent.com/assets/2575/21032043/d5d284b8-bd74-11e6-88de-e72b2d29134a.png)

After:
![image](https://cloud.githubusercontent.com/assets/2575/21032073/002a2932-bd75-11e6-9dac-b6b5899b1488.png)



