### PR TITLE
Null pointer issue

### DIFF
--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -979,6 +979,10 @@ void UAS::setExternalControlSetpoint(float roll, float pitch, float yaw, float t
         return;
     }
 
+    if (!_vehicle->priorityLink()) {
+        return;
+    }
+
     // Store the previous manual commands
     static float manualRollAngle = 0.0;
     static float manualPitchAngle = 0.0;


### PR DESCRIPTION
This PR fixes an issue that causes QGC to crash when exiting when a joystick is connected. I'm not confident on the series of events when QGC shuts down, but somehow the function to send a MANUAL_CONTROL message is being called after the vehicle's MAVlink connection ceases to exist. This causes a null point exception and a crash.

This code adds one line to check to see if the pointer in question is null.

I'm open to other fixes if there's a better way to do this.

This addresses ArduSub Issue: https://github.com/bluerobotics/ardusub/issues/56