### PR TITLE
CF2 Support

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -806,6 +806,8 @@ HEADERS+= \
     src/AutoPilotPlugins/Common/MixersComponent.h \
     src/AutoPilotPlugins/Common/MotorComponent.h \
     src/AutoPilotPlugins/Common/RadioComponentController.h \
+    src/AutoPilotPlugins/Common/SyslinkComponent.h \
+    src/AutoPilotPlugins/Common/SyslinkComponentController.h \
     src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.h \
     src/FirmwarePlugin/CameraMetaData.h \
     src/FirmwarePlugin/FirmwarePlugin.h \
@@ -829,6 +831,8 @@ SOURCES += \
     src/AutoPilotPlugins/Common/MixersComponent.cc \
     src/AutoPilotPlugins/Common/MotorComponent.cc \
     src/AutoPilotPlugins/Common/RadioComponentController.cc \
+    src/AutoPilotPlugins/Common/SyslinkComponent.cc \
+    src/AutoPilotPlugins/Common/SyslinkComponentController.cc \
     src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.cc \
     src/FirmwarePlugin/CameraMetaData.cc \
     src/FirmwarePlugin/FirmwarePlugin.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -24,6 +24,7 @@
         <file alias="DebugWindow.qml">src/ui/preferences/DebugWindow.qml</file>
         <file alias="ESP8266Component.qml">src/AutoPilotPlugins/Common/ESP8266Component.qml</file>
         <file alias="ESP8266ComponentSummary.qml">src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml</file>
+        <file alias="SyslinkComponent.qml">src/AutoPilotPlugins/Common/SyslinkComponent.qml</file>
         <file alias="FirmwareUpgrade.qml">src/VehicleSetup/FirmwareUpgrade.qml</file>
         <file alias="FlightDisplayViewDummy.qml">src/FlightDisplay/FlightDisplayViewDummy.qml</file>
         <file alias="FlightDisplayViewUVC.qml">src/FlightDisplay/FlightDisplayViewUVC.qml</file>

--- a/src/AutoPilotPlugins/Common/SyslinkComponent.cc
+++ b/src/AutoPilotPlugins/Common/SyslinkComponent.cc
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+#include "SyslinkComponent.h"
+#include "AutoPilotPlugin.h"
+
+SyslinkComponent::SyslinkComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
+    : VehicleComponent(vehicle, autopilot, parent)
+    , _name(tr("Syslink"))
+{
+
+}
+
+QString SyslinkComponent::name(void) const
+{
+    return _name;
+}
+
+QString SyslinkComponent::description(void) const
+{
+    return tr("The Syslink Component is used to setup the radio connection on Crazyflies.");
+}
+
+QString SyslinkComponent::iconResource(void) const
+{
+    return "/qmlimages/wifi.svg";
+}
+
+bool SyslinkComponent::requiresSetup(void) const
+{
+    return false;
+}
+
+bool SyslinkComponent::setupComplete(void) const
+{
+    return true;
+}
+
+QStringList SyslinkComponent::setupCompleteChangedTriggerList(void) const
+{
+    return QStringList();
+}
+
+QUrl SyslinkComponent::setupSource(void) const
+{
+    return QUrl::fromUserInput("qrc:/qml/SyslinkComponent.qml");
+}
+
+QUrl SyslinkComponent::summaryQmlSource(void) const
+{
+    return QUrl();
+}
+
+QString SyslinkComponent::prerequisiteSetup(void) const
+{
+    return QString();
+}

--- a/src/AutoPilotPlugins/Common/SyslinkComponent.h
+++ b/src/AutoPilotPlugins/Common/SyslinkComponent.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+#ifndef SyslinkComponent_H
+#define SyslinkComponent_H
+
+#include "VehicleComponent.h"
+
+class SyslinkComponent : public VehicleComponent
+{
+    Q_OBJECT
+public:
+    SyslinkComponent            (Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
+    
+    // Virtuals from VehicleComponent
+    QStringList setupCompleteChangedTriggerList() const;
+    
+    // Virtuals from VehicleComponent
+    QString name                () const;
+    QString description         () const;
+    QString iconResource        () const;
+    bool    requiresSetup       () const;
+    bool    setupComplete       () const;
+    QUrl    setupSource         () const;
+    QUrl    summaryQmlSource    () const;
+    QString prerequisiteSetup   () const;
+    
+private:
+    const QString   _name;
+    QVariantList    _summaryItems;
+};
+
+#endif

--- a/src/AutoPilotPlugins/Common/SyslinkComponent.qml
+++ b/src/AutoPilotPlugins/Common/SyslinkComponent.qml
@@ -1,0 +1,152 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+import QtQuick          2.5
+import QtQuick.Controls 1.2
+import QtQuick.Dialogs  1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Controllers   1.0
+
+QGCView {
+    id:         qgcView
+    viewPanel:  panel
+
+    QGCPalette { id: palette; colorGroupEnabled: panel.enabled }
+
+    property real _margins:         ScreenTools.defaultFontPixelHeight
+    property real _editFieldWidth:  ScreenTools.defaultFontPixelWidth * 16
+    property real _labelWidth:      ScreenTools.defaultFontPixelWidth * 18
+
+    SyslinkComponentController {
+        id:             controller
+        factPanel:      panel
+    }
+
+    QGCViewPanel {
+        id:             panel
+        anchors.fill:   parent
+
+        Flickable {
+            clip:                                       true
+            anchors.fill:                               parent
+            contentHeight:                              mainCol.height
+            flickableDirection:                         Flickable.VerticalFlick
+            Column {
+                id:                                     mainCol
+                spacing:                                _margins
+                anchors.horizontalCenter:               parent.horizontalCenter
+                Item { width: 1; height: _margins * 0.5; }
+
+                Rectangle {
+                    color:                              palette.windowShade
+                    height:                             settingsRow.height  + _margins * 2
+                    Row {
+                        id:                             settingsRow
+                        spacing:                        _margins * 4
+                        anchors.centerIn:               parent
+                        Column {
+                            spacing:                        _margins * 0.5
+                            anchors.verticalCenter:         parent.verticalCenter
+                            Row {
+                                QGCLabel {
+                                    text:                               qsTr("NRF Radio Settings")
+                                    font.family:                        ScreenTools.demiboldFontFamily
+                                }
+                            }
+                            Row {
+                                QGCLabel {
+                                    text:                   qsTr("Channel")
+                                    width:                  _labelWidth
+                                    anchors.baseline:       channelField.baseline
+                                }
+                                QGCTextField {
+                                    id:                     channelField
+                                    width:                  _editFieldWidth
+                                    text:                   controller.radioChannel
+                                    validator:              IntValidator {bottom: 0; top: 125;}
+                                    inputMethodHints:       Qt.ImhDigitsOnly
+                                    onEditingFinished: {
+                                        controller.radioChannel = text
+                                    }
+                                }
+                            }
+                            Row {
+                                anchors.right:   parent.right
+                                QGCLabel {
+                                    wrapMode:       Text.WordWrap
+                                    text:           qsTr("Channel can be between 0 and 125")
+                                }
+
+                            }
+                            Row {
+                                QGCLabel {
+                                    text:                   qsTr("Address")
+                                    width:                  _labelWidth
+                                    anchors.baseline:       addressField.baseline
+                                }
+                                QGCTextField {
+                                    id:                     addressField
+                                    width:                  _editFieldWidth
+                                    text:                   controller.radioAddress
+                                    maximumLength:          10
+                                    validator:              RegExpValidator { regExp: /^[0-9A-Fa-f]*$/ }
+                                    onEditingFinished: {
+                                        controller.radioAddress = text
+                                    }
+                                }
+                            }
+                            Row {
+                                anchors.right:  parent.right
+                                QGCLabel {
+                                    wrapMode:       Text.WordWrap
+                                    text:           qsTr("Address in hex. Default E7E7E7E7E7")
+                                }
+
+                            }
+                            Row {
+                                QGCLabel {
+                                    text:                   qsTr("Data Rate")
+                                    width:                  _labelWidth
+                                    anchors.baseline:       rateField.baseline
+                                }
+                                QGCComboBox {
+                                    id:                     rateField
+                                    width:                  _editFieldWidth
+                                    model:                  controller.radioRates
+                                    currentIndex:           controller.radioRate
+                                    onActivated: {
+                                        controller.radioRate = index
+                                    }
+                                }
+                            }
+                            Row {
+                                spacing:                            _margins
+                                anchors.horizontalCenter:           parent.horizontalCenter
+                                QGCButton {
+                                    text:                           qsTr("Restore Defaults")
+                                    width:                          _editFieldWidth
+                                    onClicked: {
+                                        controller.resetDefaults()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/src/AutoPilotPlugins/Common/SyslinkComponent.qml
+++ b/src/AutoPilotPlugins/Common/SyslinkComponent.qml
@@ -8,145 +8,133 @@
  ****************************************************************************/
 
 
-import QtQuick          2.5
+
+import QtQuick          2.2
 import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 import QtQuick.Layouts  1.2
 
-import QGroundControl               1.0
-import QGroundControl.Palette       1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controllers   1.0
 
-QGCView {
-    id:         qgcView
-    viewPanel:  panel
+SetupPage {
+    id:             syslinkPage
+    pageComponent:  pageComponent
 
-    QGCPalette { id: palette; colorGroupEnabled: panel.enabled }
+    Component {
+        id: pageComponent
 
-    property real _margins:         ScreenTools.defaultFontPixelHeight
-    property real _editFieldWidth:  ScreenTools.defaultFontPixelWidth * 16
-    property real _labelWidth:      ScreenTools.defaultFontPixelWidth * 18
+        Column {
+            id:         innerColumn
+            width:      availableWidth
+            spacing:    ScreenTools.defaultFontPixelHeight * 0.5
 
-    SyslinkComponentController {
-        id:             controller
-        factPanel:      panel
-    }
+            property int textEditWidth:    ScreenTools.defaultFontPixelWidth * 12
 
-    QGCViewPanel {
-        id:             panel
-        anchors.fill:   parent
 
-        Flickable {
-            clip:                                       true
-            anchors.fill:                               parent
-            contentHeight:                              mainCol.height
-            flickableDirection:                         Flickable.VerticalFlick
-            Column {
-                id:                                     mainCol
-                spacing:                                _margins
-                anchors.horizontalCenter:               parent.horizontalCenter
-                Item { width: 1; height: _margins * 0.5; }
+            SyslinkComponentController {
+                id:         controller
+                factPanel:  syslinkPage.viewPanel
+            }
 
-                Rectangle {
-                    color:                              palette.windowShade
-                    height:                             settingsRow.height  + _margins * 2
-                    Row {
-                        id:                             settingsRow
-                        spacing:                        _margins * 4
-                        anchors.centerIn:               parent
-                        Column {
-                            spacing:                        _margins * 0.5
-                            anchors.verticalCenter:         parent.verticalCenter
-                            Row {
-                                QGCLabel {
-                                    text:                               qsTr("NRF Radio Settings")
-                                    font.family:                        ScreenTools.demiboldFontFamily
-                                }
-                            }
-                            Row {
-                                QGCLabel {
-                                    text:                   qsTr("Channel")
-                                    width:                  _labelWidth
-                                    anchors.baseline:       channelField.baseline
-                                }
-                                QGCTextField {
-                                    id:                     channelField
-                                    width:                  _editFieldWidth
-                                    text:                   controller.radioChannel
-                                    validator:              IntValidator {bottom: 0; top: 125;}
-                                    inputMethodHints:       Qt.ImhDigitsOnly
-                                    onEditingFinished: {
-                                        controller.radioChannel = text
-                                    }
-                                }
-                            }
-                            Row {
-                                anchors.right:   parent.right
-                                QGCLabel {
-                                    wrapMode:       Text.WordWrap
-                                    text:           qsTr("Channel can be between 0 and 125")
-                                }
+            QGCLabel {
+                text: qsTr("Radio Settings")
+                font.family: ScreenTools.demiboldFontFamily
+            }
 
-                            }
-                            Row {
-                                QGCLabel {
-                                    text:                   qsTr("Address")
-                                    width:                  _labelWidth
-                                    anchors.baseline:       addressField.baseline
-                                }
-                                QGCTextField {
-                                    id:                     addressField
-                                    width:                  _editFieldWidth
-                                    text:                   controller.radioAddress
-                                    maximumLength:          10
-                                    validator:              RegExpValidator { regExp: /^[0-9A-Fa-f]*$/ }
-                                    onEditingFinished: {
-                                        controller.radioAddress = text
-                                    }
-                                }
-                            }
-                            Row {
-                                anchors.right:  parent.right
-                                QGCLabel {
-                                    wrapMode:       Text.WordWrap
-                                    text:           qsTr("Address in hex. Default E7E7E7E7E7")
-                                }
+            Rectangle {
+                width:  parent.width
+                height: radioGrid.height + ScreenTools.defaultFontPixelHeight
+                color:  qgcPal.windowShade
 
-                            }
-                            Row {
-                                QGCLabel {
-                                    text:                   qsTr("Data Rate")
-                                    width:                  _labelWidth
-                                    anchors.baseline:       rateField.baseline
-                                }
-                                QGCComboBox {
-                                    id:                     rateField
-                                    width:                  _editFieldWidth
-                                    model:                  controller.radioRates
-                                    currentIndex:           controller.radioRate
-                                    onActivated: {
-                                        controller.radioRate = index
-                                    }
-                                }
-                            }
-                            Row {
-                                spacing:                            _margins
-                                anchors.horizontalCenter:           parent.horizontalCenter
-                                QGCButton {
-                                    text:                           qsTr("Restore Defaults")
-                                    width:                          _editFieldWidth
-                                    onClicked: {
-                                        controller.resetDefaults()
-                                    }
-                                }
-                            }
+                GridLayout {
+                    id:                 radioGrid
+                    anchors.margins:    ScreenTools.defaultFontPixelHeight / 2
+                    anchors.left:       parent.left
+                    anchors.top:        parent.top
+                    columns:            2
+                    columnSpacing:      ScreenTools.defaultFontPixelWidth
+
+                    QGCLabel {
+                        text:               qsTr("Channel")
+                    }
+
+                    QGCTextField {
+                        id:                     channelField
+                        width:                  textEditWidth
+                        text:                   controller.radioChannel
+                        validator:              IntValidator {bottom: 0; top: 125;}
+                        inputMethodHints:       Qt.ImhDigitsOnly
+                        onEditingFinished: {
+                            controller.radioChannel = text
                         }
                     }
-                }
 
-            }
+                    QGCLabel {
+                        id:                 channelHelp
+                        Layout.columnSpan:  radioGrid.columns
+                        Layout.fillWidth:   true
+                        font.pointSize:     ScreenTools.smallFontPointSize
+                        wrapMode:           Text.WordWrap
+                        text:               "Channel can be between 0 and 125"
+                    }
+
+                    QGCLabel {
+                        id:                 addressLabel
+                        text:               qsTr("Address")
+                    }
+
+                    QGCTextField {
+                        id:                     addressField
+                        width:                  textEditWidth
+                        text:                   controller.radioAddress
+                        maximumLength:          10
+                        validator:              RegExpValidator { regExp: /^[0-9A-Fa-f]*$/ }
+                        onEditingFinished: {
+                            controller.radioAddress = text
+                        }
+                    }
+
+                    QGCLabel {
+                        id:                 addressHelp
+                        Layout.columnSpan:  radioGrid.columns
+                        Layout.fillWidth:   true
+                        font.pointSize:     ScreenTools.smallFontPointSize
+                        wrapMode:           Text.WordWrap
+                        text:               "Address in hex. Default is E7E7E7E7E7."
+                    }
+
+
+                    QGCLabel {
+                        id:                 rateLabel
+                        text:               qsTr("Data Rate")
+                    }
+
+                    QGCComboBox {
+                        id:                     rateField
+                        Layout.fillWidth:       true
+                        model:                  controller.radioRates
+                        currentIndex:           controller.radioRate
+                        onActivated: {
+                            controller.radioRate = index
+                        }
+                    }
+
+                    QGCButton {
+                        text:                           "Restore Defaults"
+                        width:                          textEditWidth
+                        onClicked: {
+                            controller.resetDefaults()
+                        }
+                    }
+
+                } // Grid
+            } // Rectangle - Radio Settings
+
+
         }
     }
 }

--- a/src/AutoPilotPlugins/Common/SyslinkComponentController.cc
+++ b/src/AutoPilotPlugins/Common/SyslinkComponentController.cc
@@ -1,0 +1,137 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "SyslinkComponentController.h"
+#include "QGCApplication.h"
+#include "UAS.h"
+#include "ParameterManager.h"
+
+#include <QHostAddress>
+#include <QtEndian>
+
+QGC_LOGGING_CATEGORY(SyslinkComponentControllerLog, "SyslinkComponentControllerLog")
+
+//-----------------------------------------------------------------------------
+SyslinkComponentController::SyslinkComponentController()
+{
+    _dataRates.append("750Kb/s");
+    _dataRates.append("1Mb/s");
+    _dataRates.append("2Mb/s");
+
+    Fact* chan = getParameterFact(_vehicle->id(), "SLNK_RADIO_CHAN");
+    connect(chan, &Fact::valueChanged, this, &SyslinkComponentController::_channelChanged);
+    Fact* rate = getParameterFact(_vehicle->id(), "SLNK_RADIO_RATE");
+    connect(rate, &Fact::valueChanged, this, &SyslinkComponentController::_rateChanged);
+    Fact* addr1 = getParameterFact(_vehicle->id(), "SLNK_RADIO_ADDR1");
+    connect(addr1, &Fact::valueChanged, this, &SyslinkComponentController::_addressChanged);
+    Fact* addr2 = getParameterFact(_vehicle->id(), "SLNK_RADIO_ADDR2");
+    connect(addr2, &Fact::valueChanged, this, &SyslinkComponentController::_addressChanged);
+}
+
+//-----------------------------------------------------------------------------
+SyslinkComponentController::~SyslinkComponentController()
+{
+
+}
+
+//-----------------------------------------------------------------------------
+int
+SyslinkComponentController::radioChannel()
+{
+    return getParameterFact(_vehicle->id(), "SLNK_RADIO_CHAN")->rawValue().toUInt();
+}
+
+//-----------------------------------------------------------------------------
+void
+SyslinkComponentController::setRadioChannel(int num)
+{
+    Fact* f = getParameterFact(_vehicle->id(), "SLNK_RADIO_CHAN");
+    f->setRawValue(QVariant(num));
+}
+
+//-----------------------------------------------------------------------------
+QString
+SyslinkComponentController::radioAddress()
+{
+    uint32_t val_uh = getParameterFact(_vehicle->id(), "SLNK_RADIO_ADDR1")->rawValue().toUInt();
+    uint32_t val_lh = getParameterFact(_vehicle->id(), "SLNK_RADIO_ADDR2")->rawValue().toUInt();
+    uint64_t val = (((uint64_t) val_uh) << 32) | ((uint64_t) val_lh);
+
+    return QString().number(val, 16);
+}
+
+//-----------------------------------------------------------------------------
+void
+SyslinkComponentController::setRadioAddress(QString str)
+{
+    Fact *uh = getParameterFact(_vehicle->id(), "SLNK_RADIO_ADDR1");
+    Fact *lh = getParameterFact(_vehicle->id(), "SLNK_RADIO_ADDR2");
+
+    uint64_t val = str.toULongLong(0, 16);
+
+    uint32_t val_uh = val >> 32;
+    uint32_t val_lh = val & 0xFFFFFFFF;
+
+    uh->setRawValue(QVariant(val_uh));
+    lh->setRawValue(QVariant(val_lh));
+}
+
+//-----------------------------------------------------------------------------
+int
+SyslinkComponentController::radioRate()
+{
+    return getParameterFact(_vehicle->id(), "SLNK_RADIO_RATE")->rawValue().toInt();
+}
+
+//-----------------------------------------------------------------------------
+void
+SyslinkComponentController::setRadioRate(int idx)
+{
+    if(idx >= 0 && idx <= 2 && idx != radioRate()) {
+        Fact* r = getParameterFact(_vehicle->id(), "SLNK_RADIO_RATE");
+        r->setRawValue(idx);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+SyslinkComponentController::resetDefaults()
+{
+    Fact* chan = getParameterFact(_vehicle->id(), "SLNK_RADIO_CHAN");
+    Fact* rate = getParameterFact(_vehicle->id(), "SLNK_RADIO_RATE");
+    Fact* addr1 = getParameterFact(_vehicle->id(), "SLNK_RADIO_ADDR1");
+    Fact* addr2 = getParameterFact(_vehicle->id(), "SLNK_RADIO_ADDR2");
+
+    chan->setRawValue(chan->rawDefaultValue());
+    rate->setRawValue(rate->rawDefaultValue());
+    addr1->setRawValue(addr1->rawDefaultValue());
+    addr2->setRawValue(addr2->rawDefaultValue());
+}
+
+//-----------------------------------------------------------------------------
+void
+SyslinkComponentController::_channelChanged(QVariant)
+{
+    emit radioChannelChanged();
+}
+
+//-----------------------------------------------------------------------------
+void
+SyslinkComponentController::_addressChanged(QVariant)
+{
+    emit radioAddressChanged();
+}
+
+//-----------------------------------------------------------------------------
+void
+SyslinkComponentController::_rateChanged(QVariant)
+{
+    emit radioRateChanged();
+}
+

--- a/src/AutoPilotPlugins/Common/SyslinkComponentController.h
+++ b/src/AutoPilotPlugins/Common/SyslinkComponentController.h
@@ -1,0 +1,66 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#ifndef SyslinkComponentController_H
+#define SyslinkComponentController_H
+
+#include "FactPanelController.h"
+#include "UASInterface.h"
+#include "QGCLoggingCategory.h"
+#include "AutoPilotPlugin.h"
+
+Q_DECLARE_LOGGING_CATEGORY(SyslinkComponentControllerLog)
+
+namespace Ui {
+    class SyslinkComponentController;
+}
+
+class SyslinkComponentController : public FactPanelController
+{
+    Q_OBJECT
+
+public:
+    SyslinkComponentController      ();
+    ~SyslinkComponentController     ();
+
+    Q_PROPERTY(int              radioChannel    READ radioChannel       WRITE setRadioChannel       NOTIFY radioChannelChanged)
+    Q_PROPERTY(QString          radioAddress    READ radioAddress       WRITE setRadioAddress       NOTIFY radioAddressChanged)
+    Q_PROPERTY(int              radioRate       READ radioRate          WRITE setRadioRate          NOTIFY radioRateChanged)
+    Q_PROPERTY(QStringList      radioRates      READ radioRates                                     CONSTANT)
+    Q_PROPERTY(Vehicle*         vehicle         READ vehicle                                        CONSTANT)
+
+    Q_INVOKABLE void resetDefaults();
+
+    int             radioChannel    ();
+    QString         radioAddress    ();
+    int             radioRate       ();
+    QStringList     radioRates      () { return _dataRates; }
+    Vehicle*        vehicle         () { return _vehicle; }
+
+    void        setRadioChannel     (int num);
+    void        setRadioAddress     (QString str);
+    void        setRadioRate        (int idx);
+
+
+signals:
+    void        radioChannelChanged     ();
+    void        radioAddressChanged     ();
+    void        radioRateChanged        ();
+
+private slots:
+    void        _channelChanged     (QVariant value);
+    void        _addressChanged     (QVariant value);
+    void        _rateChanged        (QVariant value);
+
+private:
+    QStringList _dataRates;
+
+};
+
+#endif // SyslinkComponentController_H

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -40,6 +40,7 @@ PX4AutoPilotPlugin::PX4AutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     , _motorComponent(NULL)
     , _tuningComponent(NULL)
     , _mixersComponent(NULL)
+    , _syslinkComponent(NULL)
 {
     if (!vehicle) {
         qWarning() << "Internal error";
@@ -121,6 +122,12 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
                 }
             } else {
                 qWarning() << "Call to vehicleCompenents prior to parametersReady";
+            }
+
+            if(_vehicle->parameterManager()->parameterExists(_vehicle->id(), "SLNK_RADIO_CHAN")) {
+                _syslinkComponent = new SyslinkComponent(_vehicle, this);
+                _syslinkComponent->setupTriggerSignals();
+                _components.append(QVariant::fromValue((VehicleComponent*)_syslinkComponent));
             }
         } else {
             qWarning() << "Internal error";

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
@@ -24,6 +24,7 @@
 #include "MotorComponent.h"
 #include "PX4TuningComponent.h"
 #include "MixersComponent.h"
+#include "SyslinkComponent.h"
 #include "Vehicle.h"
 
 #include <QImage>
@@ -44,7 +45,6 @@ public:
     const QVariantList& vehicleComponents(void) override;
     void parametersReadyPreChecks(void) override;
     QString prerequisiteSetup(VehicleComponent* component) const override;
-
 protected:
     bool                    _incorrectParameterVersion; ///< true: parameter version incorrect, setup not allowed
     PX4AirframeLoader*      _airframeFacts;
@@ -59,7 +59,7 @@ protected:
     MotorComponent*         _motorComponent;
     PX4TuningComponent*     _tuningComponent;
     MixersComponent*        _mixersComponent;
-
+    SyslinkComponent*       _syslinkComponent;
 private:
     QVariantList            _components;
 };

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -51,6 +51,7 @@
 #include "ScreenToolsController.h"
 #include "QFileDialogController.h"
 #include "RCChannelMonitorController.h"
+#include "SyslinkComponentController.h"
 #include "AutoPilotPlugin.h"
 #include "VehicleComponent.h"
 #include "FirmwarePluginManager.h"
@@ -390,6 +391,7 @@ void QGCApplication::_initCommon(void)
     qmlRegisterType<RCChannelMonitorController>         ("QGroundControl.Controllers", 1, 0, "RCChannelMonitorController");
     qmlRegisterType<JoystickConfigController>           ("QGroundControl.Controllers", 1, 0, "JoystickConfigController");
     qmlRegisterType<LogDownloadController>              ("QGroundControl.Controllers", 1, 0, "LogDownloadController");
+    qmlRegisterType<SyslinkComponentController>         ("QGroundControl.Controllers", 1, 0, "SyslinkComponentController");
 #ifndef __mobile__
     qmlRegisterType<ViewWidgetController>           ("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
     qmlRegisterType<CustomCommandWidgetController>  ("QGroundControl.Controllers", 1, 0, "CustomCommandWidgetController");

--- a/src/VehicleSetup/Bootloader.h
+++ b/src/VehicleSetup/Bootloader.h
@@ -73,7 +73,7 @@ public:
     static const int boardIDMINDPXFMUV2 = 88;   ///< MindPX V2 board, as from USB PID
     static const int boardIDTAPV1 = 64;         ///< TAP V1 board, as from USB PID
     static const int boardIDASCV1 = 65;         ///< ASC V1 board, as from USB PID
-    
+    static const int boardIDCrazyflie2 = 12;    ///< Crazyflie 2.0 board, as from USB PID
 signals:
     /// @brief Signals progress indicator for long running bootloader utility routines
     void updateProgress(int curr, int total);

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -335,6 +335,14 @@ void FirmwareUpgradeController::_initFirmwareHash()
         { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/asc-v1_default.px4"},
         { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/asc-v1_default.px4"},
     };
+
+    //////////////////////////////////// Crazyflie 2.0 firmwares //////////////////////////////////////////////////
+    FirmwareToUrlElement_t rgCrazyflie2FirmwareArray[] = {
+        { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/crazyflie_default.px4"},
+        { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/crazyflie_default.px4"},
+        { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/crazyflie_default.px4"},
+    };
+
     /////////////////////////////// px4flow firmwares ///////////////////////////////////////
     FirmwareToUrlElement_t rgPX4FLowFirmwareArray[] = {
         { PX4Flow, StableFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Flow/master/px4flow.px4" },
@@ -406,6 +414,12 @@ void FirmwareUpgradeController::_initFirmwareHash()
         _rgASCV1Firmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
     }
 
+    size = sizeof(rgCrazyflie2FirmwareArray)/sizeof(rgCrazyflie2FirmwareArray[0]);
+    for (int i = 0; i < size; i++) {
+        const FirmwareToUrlElement_t& element = rgCrazyflie2FirmwareArray[i];
+        _rgCrazyflie2Firmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
+    }
+
     size = sizeof(rgPX4FLowFirmwareArray)/sizeof(rgPX4FLowFirmwareArray[0]);
     for (int i = 0; i < size; i++) {
         const FirmwareToUrlElement_t& element = rgPX4FLowFirmwareArray[i];
@@ -457,6 +471,8 @@ QHash<FirmwareUpgradeController::FirmwareIdentifier, QString>* FirmwareUpgradeCo
         return &_rgTAPV1Firmware;
     case Bootloader::boardIDASCV1:
         return &_rgASCV1Firmware;
+    case Bootloader::boardIDCrazyflie2:
+        return &_rgCrazyflie2Firmware;
     case Bootloader::boardID3DRRadio:
         return &_rg3DRRadioFirmware;
     default:

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -211,6 +211,7 @@ private:
     QHash<FirmwareIdentifier, QString> _rgMindPXFMUV2Firmware;
     QHash<FirmwareIdentifier, QString> _rgTAPV1Firmware;
     QHash<FirmwareIdentifier, QString> _rgASCV1Firmware;
+    QHash<FirmwareIdentifier, QString> _rgCrazyflie2Firmware;
     QHash<FirmwareIdentifier, QString> _rgPX4FLowFirmware;
     QHash<FirmwareIdentifier, QString> _rg3DRRadioFirmware;
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -526,12 +526,6 @@ void LinkManager::_updateAutoConnectLinks(void)
                         pSerialConfig->setUsbDirect(true);
                     }
                     break;
-                case QGCSerialPortInfo::BoardTypeCrazyflie2:
-                    if (_autoconnectPixhawk) {
-                        pSerialConfig = new SerialConfiguration(QString("Crazyflie on %1").arg(portInfo.portName().trimmed()));
-                        pSerialConfig->setUsbDirect(true);
-                    }
-                    break;
                 case QGCSerialPortInfo::BoardTypePX4Flow:
                     if (_autoConnectSettings->autoConnectPX4Flow()->rawValue().toBool()) {
                         pSerialConfig = new SerialConfiguration(tr("%1 on %2 (AutoConnect)").arg(boardName).arg(portInfo.portName().trimmed()));

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -526,6 +526,12 @@ void LinkManager::_updateAutoConnectLinks(void)
                         pSerialConfig->setUsbDirect(true);
                     }
                     break;
+                case QGCSerialPortInfo::BoardTypeCrazyflie2:
+                    if (_autoconnectPixhawk) {
+                        pSerialConfig = new SerialConfiguration(QString("Crazyflie on %1").arg(portInfo.portName().trimmed()));
+                        pSerialConfig->setUsbDirect(true);
+                    }
+                    break;
                 case QGCSerialPortInfo::BoardTypePX4Flow:
                     if (_autoConnectSettings->autoConnectPX4Flow()->rawValue().toBool()) {
                         pSerialConfig = new SerialConfiguration(tr("%1 on %2 (AutoConnect)").arg(boardName).arg(portInfo.portName().trimmed()));

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -204,8 +204,6 @@ bool QGCSerialPortInfo::getBoardInfo(QGCSerialPortInfo::BoardType_t& boardType, 
     if (boardType == BoardTypeUnknown) {
         // Fall back to port name matching which could lead to incorrect board mapping. But in some cases the
         // vendor and product id do not come through correctly so this is used as a last chance detection method.
-<<<<<<< c4da69536e067addfbf394609e9369c1c2d00129
-
         for (int i=0; i<_boardFallbackList.count(); i++) {
             const BoardFallback_t& boardFallback = _boardFallbackList[i];
 
@@ -214,44 +212,6 @@ bool QGCSerialPortInfo::getBoardInfo(QGCSerialPortInfo::BoardType_t& boardType, 
                 if (boardFallback.androidOnly) {
                     continue;
                 }
-=======
-        if (description() == "PX4 FMU v4.x" || description() == "PX4 BL FMU v4.x") {
-            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V4 (by name matching fallback)";
-            boardType = BoardTypePX4FMUV4;
-        } else if (description() == "PX4 FMU v2.x" || description() == "PX4 BL FMU v2.x") {
-            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V2 (by name matching fallback)";
-            boardType = BoardTypePX4FMUV2;
-        } else if (description() == "PX4 FMU v1.x" || description() == "PX4 BL FMU v1.x") {
-            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V1 (by name matching fallback)";
-            boardType = BoardTypePX4FMUV1;
-        } else if (description().startsWith("PX4 FMU")) {
-            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU, assuming V2 (by name matching fallback)";
-            boardType = BoardTypePX4FMUV2;
-        } else if (description().contains(QRegExp("PX4.*Flow", Qt::CaseInsensitive))) {
-            qCDebug(QGCSerialPortInfoLog) << "Found possible px4 flow camera (by name matching fallback)";
-            boardType = BoardTypePX4Flow;
-        } else if (description() == "MindPX FMU v2.x" || description() == "MindPX BL FMU v2.x") {
-            qCDebug(QGCSerialPortInfoLog) << "Found MindPX FMU V2 (by name matching fallback)";
-            boardType = BoardTypeMINDPXFMUV2;
-        } else if (description() == "PX4 TAP v1.x" || description() == "PX4 BL TAP v1.x") {
-            qCDebug(QGCSerialPortInfoLog) << "Found TAP V1 (by name matching fallback)";
-            boardType = BoardTypeTAPV1;
-        } else if (description() == "PX4 ASC v1.x" || description() == "PX4 BL ASC v1.x") {
-            qCDebug(QGCSerialPortInfoLog) << "Found ASC V1 (by name matching fallback)";
-            boardType = BoardTypeASCV1;
-        } else if (description() == "PX4 Crazyflie v2.0" || description() == "Crazyflie BL") {
-            qCDebug(QGCSerialPortInfoLog) << "Found Crazyflie 2.0 (by name matching fallback)";
-            boardType = BoardTypeCrazyflie2;
-        } else if (description() == "FT231X USB UART") {
-            qCDebug(QGCSerialPortInfoLog) << "Found possible Radio (by name matching fallback)";
-            boardType = BoardTypeSikRadio;
-#ifdef __android__
-        } else if (description().endsWith("USB UART")) {
-            // This is a fairly broad fallbacks for radios which will also catch most FTDI devices. That would
-            // cause problems on desktop due to incorrect connections. Since mobile is more anal about connecting
-            // it will work fine here.
-            boardType = BoardTypeSikRadio;
->>>>>>> Add firmware upgrade support for CF2
 #endif
                 boardType = boardFallback.boardType;
                 name = _boardTypeToString(boardType);
@@ -298,19 +258,6 @@ QList<QGCSerialPortInfo> QGCSerialPortInfo::availablePorts(void)
     return list;
 }
 
-<<<<<<< c4da69536e067addfbf394609e9369c1c2d00129
-=======
-bool QGCSerialPortInfo::boardTypePixhawk(void) const
-{
-    BoardType_t boardType = this->boardType();
-
-    return boardType == BoardTypePX4FMUV1 || boardType == BoardTypePX4FMUV2
-            || boardType == BoardTypePX4FMUV4 || boardType == BoardTypeAeroCore
-            || boardType == BoardTypeMINDPXFMUV2 || boardType == BoardTypeTAPV1
-            || boardType == BoardTypeASCV1 || boardType == BoardTypeCrazyflie2;
-}
-
->>>>>>> Add firmware upgrade support for CF2
 bool QGCSerialPortInfo::isBootloader(void) const
 {
     BoardType_t boardType;

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -204,6 +204,7 @@ bool QGCSerialPortInfo::getBoardInfo(QGCSerialPortInfo::BoardType_t& boardType, 
     if (boardType == BoardTypeUnknown) {
         // Fall back to port name matching which could lead to incorrect board mapping. But in some cases the
         // vendor and product id do not come through correctly so this is used as a last chance detection method.
+<<<<<<< c4da69536e067addfbf394609e9369c1c2d00129
 
         for (int i=0; i<_boardFallbackList.count(); i++) {
             const BoardFallback_t& boardFallback = _boardFallbackList[i];
@@ -213,6 +214,44 @@ bool QGCSerialPortInfo::getBoardInfo(QGCSerialPortInfo::BoardType_t& boardType, 
                 if (boardFallback.androidOnly) {
                     continue;
                 }
+=======
+        if (description() == "PX4 FMU v4.x" || description() == "PX4 BL FMU v4.x") {
+            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V4 (by name matching fallback)";
+            boardType = BoardTypePX4FMUV4;
+        } else if (description() == "PX4 FMU v2.x" || description() == "PX4 BL FMU v2.x") {
+            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V2 (by name matching fallback)";
+            boardType = BoardTypePX4FMUV2;
+        } else if (description() == "PX4 FMU v1.x" || description() == "PX4 BL FMU v1.x") {
+            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU V1 (by name matching fallback)";
+            boardType = BoardTypePX4FMUV1;
+        } else if (description().startsWith("PX4 FMU")) {
+            qCDebug(QGCSerialPortInfoLog) << "Found PX4 FMU, assuming V2 (by name matching fallback)";
+            boardType = BoardTypePX4FMUV2;
+        } else if (description().contains(QRegExp("PX4.*Flow", Qt::CaseInsensitive))) {
+            qCDebug(QGCSerialPortInfoLog) << "Found possible px4 flow camera (by name matching fallback)";
+            boardType = BoardTypePX4Flow;
+        } else if (description() == "MindPX FMU v2.x" || description() == "MindPX BL FMU v2.x") {
+            qCDebug(QGCSerialPortInfoLog) << "Found MindPX FMU V2 (by name matching fallback)";
+            boardType = BoardTypeMINDPXFMUV2;
+        } else if (description() == "PX4 TAP v1.x" || description() == "PX4 BL TAP v1.x") {
+            qCDebug(QGCSerialPortInfoLog) << "Found TAP V1 (by name matching fallback)";
+            boardType = BoardTypeTAPV1;
+        } else if (description() == "PX4 ASC v1.x" || description() == "PX4 BL ASC v1.x") {
+            qCDebug(QGCSerialPortInfoLog) << "Found ASC V1 (by name matching fallback)";
+            boardType = BoardTypeASCV1;
+        } else if (description() == "PX4 Crazyflie v2.0" || description() == "Crazyflie BL") {
+            qCDebug(QGCSerialPortInfoLog) << "Found Crazyflie 2.0 (by name matching fallback)";
+            boardType = BoardTypeCrazyflie2;
+        } else if (description() == "FT231X USB UART") {
+            qCDebug(QGCSerialPortInfoLog) << "Found possible Radio (by name matching fallback)";
+            boardType = BoardTypeSikRadio;
+#ifdef __android__
+        } else if (description().endsWith("USB UART")) {
+            // This is a fairly broad fallbacks for radios which will also catch most FTDI devices. That would
+            // cause problems on desktop due to incorrect connections. Since mobile is more anal about connecting
+            // it will work fine here.
+            boardType = BoardTypeSikRadio;
+>>>>>>> Add firmware upgrade support for CF2
 #endif
                 boardType = boardFallback.boardType;
                 name = _boardTypeToString(boardType);
@@ -259,6 +298,19 @@ QList<QGCSerialPortInfo> QGCSerialPortInfo::availablePorts(void)
     return list;
 }
 
+<<<<<<< c4da69536e067addfbf394609e9369c1c2d00129
+=======
+bool QGCSerialPortInfo::boardTypePixhawk(void) const
+{
+    BoardType_t boardType = this->boardType();
+
+    return boardType == BoardTypePX4FMUV1 || boardType == BoardTypePX4FMUV2
+            || boardType == BoardTypePX4FMUV4 || boardType == BoardTypeAeroCore
+            || boardType == BoardTypeMINDPXFMUV2 || boardType == BoardTypeTAPV1
+            || boardType == BoardTypeASCV1 || boardType == BoardTypeCrazyflie2;
+}
+
+>>>>>>> Add firmware upgrade support for CF2
 bool QGCSerialPortInfo::isBootloader(void) const
 {
     BoardType_t boardType;

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -17,6 +17,7 @@
         { "vendorID": 9900, "productID": 50,        "boardClass": "Pixhawk",    "name": "PX4 FMU V5" },
         { "vendorID": 9900, "productID": 64,        "boardClass": "Pixhawk",    "name": "TAP V1" },
         { "vendorID": 9900, "productID": 65,        "boardClass": "Pixhawk",    "name": "ASC V1" },
+        { "vendorID": 9900, "productID": 22,        "boardClass": "Pixhawk",    "name": "Crazyflie 2" },
 
         { "vendorID": 9900, "productID": 21,        "boardClass": "PX4 Flow",   "name": "PX4 Flow" },
 
@@ -49,6 +50,8 @@
         { "regExp": "^PX4 ASC v1.x$",       "boardClass": "Pixhawk" },
         { "regExp": "^PX4 BL ASC v1.x$",    "boardClass": "Pixhawk" },
         { "regExp": "^PX4 FMU",             "boardClass": "Pixhawk" },
+        { "regExp": "^PX4 Crazyflie v2.0",  "boardClass": "Pixhawk" },
+        { "regExp": "^Crazyflie BL",        "boardClass": "Pixhawk" },
         { "regExp": "PX4.*Flow",            "boardClass": "PX4 Flow" },
         { "regExp": "^FT231X USB UART$",    "boardClass": "SiK Radio" },
         { "regExp": "USB UART$",            "boardClass": "SiK Radio",  "androidOnly": true, "comment": "Very broad fallback, too dangerous for non-android" }


### PR DESCRIPTION
- Adding support for flashing the Crazyflie 2
- Also adds a basic GUI for reconfiguring the radio on it
- So far supported via reflashing with PX4 (http://dev.px4.io/hardware-crazyflie2.html)

@dagar  I set up the firmware paths to point to px4-travis. Can you set it up to upload the build for the `crazyflie_default` target?