### PR TITLE
Change airplane compass icon to generic arrow icon

### DIFF
--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -109,6 +109,8 @@
         <file alias="scale_endLight.png">src/FlightMap/Images/scale_endLight.png</file>
         <file alias="airplaneOutline.svg">src/FlightMap/Images/airplaneOutline.svg</file>
         <file alias="airplaneOpaque.svg">src/FlightMap/Images/airplaneOpaque.svg</file>
+        <file alias="vehicleArrowOutline.svg">src/FlightMap/Images/vehicleArrowOutline.svg</file>
+        <file alias="vehicleArrowOpaque.svg">src/FlightMap/Images/vehicleArrowOpaque.svg</file>
         <file alias="ZoomPlus.svg">src/FlightMap/Images/ZoomPlus.svg</file>
         <file alias="ZoomMinus.svg">src/FlightMap/Images/ZoomMinus.svg</file>
         <file alias="ArrowHead.svg">src/FlightMap/Images/ArrowHead.svg</file>

--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -97,6 +97,7 @@
         <file alias="buttonHome.svg">src/FlightMap/Images/buttonHome.svg</file>
         <file alias="buttonMore.svg">src/FlightMap/Images/buttonMore.svg</file>
         <file alias="compassInstrumentAirplane.svg">src/FlightMap/Images/compassInstrumentAirplane.svg</file>
+        <file alias="compassInstrumentArrow.svg">src/FlightMap/Images/compassInstrumentArrow.svg</file>
         <file alias="compassInstrumentDial.svg">src/FlightMap/Images/compassInstrumentDial.svg</file>
         <file alias="crossHair.svg">src/FlightMap/Images/crossHair.svg</file>
         <file alias="PiP.svg">src/FlightMap/Images/PiP.svg</file>

--- a/src/FlightMap/Images/compassInstrumentArrow.svg
+++ b/src/FlightMap/Images/compassInstrumentArrow.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 288 288" style="enable-background:new 0 0 288 288;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#231F20;stroke:#D23528;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<polygon class="st0" points="144,173.6 137.1,240.2 76.9,252 144,36 144,36 211,252 151,240.2 "/>
+</svg>

--- a/src/FlightMap/Images/compassInstrumentArrow.svg
+++ b/src/FlightMap/Images/compassInstrumentArrow.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 288 288" style="enable-background:new 0 0 288 288;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#231F20;stroke:#D23528;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;}
+	.st0{fill:#231F20;stroke:#D23528;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;}
 </style>
 <polygon class="st0" points="144,173.6 137.1,240.2 76.9,252 144,36 144,36 211,252 151,240.2 "/>
 </svg>

--- a/src/FlightMap/Images/vehicleArrowOpaque.svg
+++ b/src/FlightMap/Images/vehicleArrowOpaque.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 288 288" style="enable-background:new 0 0 288 288;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FF460A;stroke:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<polygon class="st0" points="144,173.6 137.1,240.2 76.9,252 144,36 144,36 211,252 151,240.2 "/>
+</svg>

--- a/src/FlightMap/Images/vehicleArrowOutline.svg
+++ b/src/FlightMap/Images/vehicleArrowOutline.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 288 288" style="enable-background:new 0 0 288 288;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<polygon class="st0" points="144,173.6 137.1,240.2 76.9,252 144,36 144,36 211,252 151,240.2 "/>
+</svg>

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -30,7 +30,7 @@ MapQuickItem {
 
     sourceItem: Image {
         id:                 vehicleIcon
-        source:             isSatellite ? "/qmlimages/airplaneOpaque.svg" : "/qmlimages/airplaneOutline.svg"
+        source:             isSatellite ? "/qmlimages/vehicleArrowOpaque.svg" : "/qmlimages/vehicleArrowOutline.svg"
         mipmap:             true
         width:              size
         sourceSize.width:   size

--- a/src/FlightMap/Widgets/QGCCompassWidget.qml
+++ b/src/FlightMap/Widgets/QGCCompassWidget.qml
@@ -48,7 +48,7 @@ Item {
 
         Image {
             id:                 pointer
-            source:             "/qmlimages/compassInstrumentAirplane.svg"
+            source:             "/qmlimages/compassInstrumentArrow.svg"
             mipmap:             true
             width:              size * 0.75
             sourceSize.width:   width


### PR DESCRIPTION
This PR changes the compass icon to an arrow instead of an airplane. This shape better suites the other firmware types besides plane including Copter, Rover, and Sub. The arrow design is loosely based on the compass icon from other digital compasses, such as Garmin watches.

Here are a few screenshots of how it looks at various angles:

<img width="249" alt="screen shot 2016-12-19 at 8 12 42 am" src="https://cloud.githubusercontent.com/assets/968100/21319682/1197465e-c5c3-11e6-95aa-97881cf65914.png">

<img width="251" alt="screen shot 2016-12-19 at 8 13 05 am" src="https://cloud.githubusercontent.com/assets/968100/21319687/13a25e16-c5c3-11e6-87f2-30015a401a7b.png">

This is currently implemented across all firmware types, however we can make it a firmware plugin feature if desired. Please let me know if you'd like me to do that!
