### PR TITLE
the message handleAltitude

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -560,8 +560,8 @@ void Vehicle::_handleAltitude(mavlink_message_t& message)
 
     _useAltitudeForAltitude = true;
     _useGpsRawIntForAltitude = false;
-    _altitudeRelativeFact.setRawValue(altitude.altitude_relative / 1000.0);
-    _altitudeAMSLFact.setRawValue(altitude.altitude_amsl / 1000.0);
+    _altitudeRelativeFact.setRawValue(altitude.altitude_relative);
+    _altitudeAMSLFact.setRawValue(altitude.altitude_amsl);
 
 }
 


### PR DESCRIPTION
altitudeAMSL and altitudeRelative do not need divide 1000，the unit is meter and float format。 can you use _handleGlobalPositionInt message for altitudeAMSL and altitudeRelative？ because _handleGlobalPositionInt is default 5Hz and _handleAltitude is 1Hz.