### PR TITLE
Link reference bug fix

### DIFF
--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -126,7 +126,8 @@ QGCViewDialog {
 
             QGCComboBox {
                 id:             factCombo
-                width:          valueField.width
+                anchors.left:   parent.left
+                anchors.right:  parent.right
                 visible:        _showCombo
                 model:          fact.enumStrings
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -642,16 +642,15 @@ void LinkManager::_updateAutoConnectLinks(void)
     // Now remove all configs that are gone
     foreach (LinkConfiguration* pDeleteConfig, _confToDelete) {
         qCDebug(LinkManagerLog) << "Removing unused autoconnect config" << pDeleteConfig->name();
+        if (pDeleteConfig->link()) {
+            disconnectLink(pDeleteConfig->link());
+        }
         for (int i=0; i<_sharedAutoconnectConfigurations.count(); i++) {
             if (_sharedAutoconnectConfigurations[i].data() == pDeleteConfig) {
                 _sharedAutoconnectConfigurations.removeAt(i);
                 break;
             }
         }
-        if (pDeleteConfig->link()) {
-            disconnectLink(pDeleteConfig->link());
-        }
-        delete pDeleteConfig;
     }
 #endif
 #endif // NO_SERIAL_LINK


### PR DESCRIPTION
Bad code ordering and remove from list will cause config to delete when last reference goes. The delete pConfig was deleting an already deleted object.