### PR TITLE
Disabling MAVLink 2.0 logging for APM.

### DIFF
--- a/src/ui/preferences/MavlinkSettings.qml
+++ b/src/ui/preferences/MavlinkSettings.qml
@@ -160,7 +160,7 @@ Rectangle {
                 anchors.horizontalCenter: parent.horizontalCenter
                 QGCLabel {
                     id:             mavlogLabel
-                    text:           qsTr("Vehicle MAVLink Logging")
+                    text:           qsTr("MAVLink 2.0 Logging (PX4 Firmware Only)")
                     font.family:    ScreenTools.demiboldFontFamily
                 }
             }
@@ -220,7 +220,7 @@ Rectangle {
                 anchors.horizontalCenter: parent.horizontalCenter
                 QGCLabel {
                     id:             logLabel
-                    text:           qsTr("MAVLink Log Uploads")
+                    text:           qsTr("MAVLink 2.0 Log Uploads (PX4 Firmware Only)")
                     font.family:    ScreenTools.demiboldFontFamily
                 }
             }


### PR DESCRIPTION
In response to #4238 I'm disabling logging for non PX4 firmware and also replacing all `qCCritical` messages with `qCWarning` ones.