### PR TITLE
Fixed issue with artificial horizon

### DIFF
--- a/src/FlightMap/Widgets/QGCArtificialHorizon.qml
+++ b/src/FlightMap/Widgets/QGCArtificialHorizon.qml
@@ -28,7 +28,7 @@ Item {
     Item {
         id: artificialHorizon
         width:  root.width  * 4
-        height: root.height * 4
+        height: root.height * 8
         anchors.centerIn: parent
         Rectangle {
             id: sky


### PR DESCRIPTION
In response to #3974

It was not working right when pointing straight up or down. Important for rocketry or ICBMs :P

In reality, something changed that caused the angle to end at 270/-270 instead of 180/-180. That in turn would make the display go past its end.