### PR TITLE
Testing Android issues with WiFi and no Internet.

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -48,7 +48,7 @@
             <!-- Background running -->
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="22"/>
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="19"/>
 
     <!-- Needed to keep working while 'asleep' -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>


### PR DESCRIPTION
In response to #3128 (and others), it seems that by targeting KITKAT instead of LOLIPOP, we should be able to have both Cellular and WiFi communications even when WiFi has no Internet. This is based on what I found here:

https://developer.android.com/reference/android/net/wifi/WifiManager.html#enableNetwork%28int,%20boolean%29

I can't test this as I don't have any Android phone (or an Android tablet with Cellular data). Could someone running Android 5.x or 6.x test and see if this is indeed true? Android 7.x has an additional issue of not connecting to WiFi at all if it doesn't find google.com (no internet access -- issue #4355).

QGC was (arbitrarily) targeting LOLLIPOP_MR1 (API level 22). We don't use anything special to justify that.