### PR TITLE
UDP join multicast group for windows client

### DIFF
--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -245,6 +245,7 @@ bool UDPLink::_hardwareConnect()
     _socket->setProxy(QNetworkProxy::NoProxy);
     _connectState = _socket->bind(host, _udpConfig->localPort(), QAbstractSocket::ReuseAddressHint | QUdpSocket::ShareAddress);
     if (_connectState) {
+        _socket->joinMulticastGroup(QHostAddress("224.0.0.1"));
         //-- Make sure we have a large enough IO buffers
 #ifdef __mobile__
         _socket->setSocketOption(QAbstractSocket::SendBufferSizeSocketOption,     64 * 1024);


### PR DESCRIPTION
Explicitly join the default multicast address seems to be required on windows when multicasting telemetry over vpn.