### PR TITLE
Joystick calibration rework

### DIFF
--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -69,6 +69,8 @@ public:
     // Overrides from FirmwarePlugin
     int manualControlReservedButtonCount(void);
 
+    int defaultJoystickTXMode(void) final { return 3; }
+
     bool supportsThrottleModeCenterZero(void);
 
     bool supportsManualControl(void);

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -106,6 +106,11 @@ int FirmwarePlugin::manualControlReservedButtonCount(void)
     return -1;
 }
 
+int FirmwarePlugin::defaultJoystickTXMode(void)
+{
+    return 2;
+}
+
 bool FirmwarePlugin::supportsThrottleModeCenterZero(void)
 {
     // By default, this is supported

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -142,6 +142,10 @@ public:
     /// @return -1: reserver all buttons, >0 number of buttons to reserve
     virtual int manualControlReservedButtonCount(void);
 
+    /// Default tx mode to apply to joystick axes
+    /// TX modes are as outlined here: http://www.rc-airplane-world.com/rc-transmitter-modes.html
+    virtual int defaultJoystickTXMode(void);
+
     /// Returns true if the vehicle and firmware supports the use of a throttle joystick that
     /// is zero when centered. Typically not supported on vehicles that have bidirectional
     /// throttle.

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -577,7 +577,7 @@ Joystick::Calibration_t Joystick::getCalibration(int axis)
     return _rgCalibration[axis];
 }
 
-void Joystick::setFunctionAxis(AxisFunction_t function, int axis)
+void Joystick::setFunctionAxis(AxisFunction_t function, Axis_t axis)
 {
     if (!_validAxis(axis)) {
         qCWarning(JoystickLog) << "Invalid axis index" << axis;
@@ -585,12 +585,12 @@ void Joystick::setFunctionAxis(AxisFunction_t function, int axis)
     }
 
     _calibrated = true;
-    _rgFunctionAxis[function] = (Axis_t)axis;
+    _rgFunctionAxis[function] = axis;
     _saveSettings();
     emit calibratedChanged(_calibrated);
 }
 
-int Joystick::getFunctionAxis(AxisFunction_t function)
+Joystick::Axis_t Joystick::getFunctionAxis(AxisFunction_t function)
 {
     if (function < 0 || function >= maxFunction) {
         qCWarning(JoystickLog) << "Invalid function" << function;
@@ -653,14 +653,12 @@ void Joystick::setMode(int mode, bool save)
 
     switch(Joystick::_mode) {
     case 1:
-        qCDebug(JoystickLog) << "Setting Mode:" << Joystick::_mode;
         _rgFunctionAxis[rollFunction] = stickRightX;
         _rgFunctionAxis[pitchFunction] = stickLeftY;
         _rgFunctionAxis[yawFunction] = stickLeftX;
         _rgFunctionAxis[throttleFunction] = stickRightY;
         break;
     case 2:
-        qCDebug(JoystickLog) << "Setting Mode:" << Joystick::_mode;
         _rgFunctionAxis[rollFunction] = stickRightX;
         _rgFunctionAxis[pitchFunction] = stickRightY;
         _rgFunctionAxis[yawFunction] = stickLeftX;

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -92,6 +92,7 @@ void Joystick::_setDefaultCalibration(void) {
     settings.beginGroup(_name);
     _calibrated = settings.value(_calibratedSettingsKey, false).toBool();
 
+    // Only set default calibrations if we do not have a calibration for this gamecontroller
     if(_calibrated) return;
 
     for (int axis=0; axis<_axisCount; axis++) {

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -203,7 +203,7 @@ void Joystick::_loadSettings(void)
 
     for (int axis=0; axis<maxAxis; axis++) {
         int mappedAxis;
-        mappedAxis = settings.value(_rgAxisMappingKey[axis], -1).toInt(&convertOk);
+        mappedAxis = settings.value(_rgAxisMappingKey[axis], maxAxis).toInt(&convertOk);
         badSettings |= !convertOk || (mappedAxis == -1);
 
         _rgAxisMapping[axis] = mappedAxis;

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -147,7 +147,7 @@ void Joystick::_activeVehicleChanged(Vehicle *activeVehicle)
         settings.beginGroup(_settingsGroup);
         int mode = settings.value(_modeSettingsKey, activeVehicle->firmwarePlugin()->defaultJoystickTXMode()).toInt();
 
-        setMode(mode);
+        setMode(mode, false);
     }
 }
 
@@ -562,6 +562,12 @@ void Joystick::setCalibration(int axis, Calibration_t& calibration)
     emit calibratedChanged(_calibrated);
 }
 
+void Joystick::setAxisMapping(Axis_t axis, int map)
+{
+    _rgAxisMapping[axis] = map;
+    _saveSettings();
+}
+
 Joystick::Calibration_t Joystick::getCalibration(int axis)
 {
     if (!_validAxis(axis)) {
@@ -592,10 +598,6 @@ int Joystick::getFunctionAxis(AxisFunction_t function)
 
     return _rgFunctionAxis[function];
 }
-
-//int Joystick::getAxisFunction(Axis_t axis) {
-//    return
-//}
 
 QStringList Joystick::actions(void)
 {

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -111,8 +111,11 @@ public:
     void setCalibration(int axis, Calibration_t& calibration);
     Calibration_t getCalibration(int axis);
 
-    void setFunctionAxis(AxisFunction_t function, int axis);
-    int getFunctionAxis(AxisFunction_t function);
+    void setFunctionAxis(AxisFunction_t function, Axis_t axis); // Unused, set via mode signal
+    Axis_t getFunctionAxis(AxisFunction_t function);
+
+    void setAxisMapping(Axis_t axis, int map);
+    int getMappedAxis(Axis_t axis) { return _rgAxisMapping[axis]; }
 
     QStringList actions(void);
     QVariantList buttonActions(void);
@@ -123,9 +126,6 @@ public:
     int  mode(void) { return Joystick::_mode; }
 
     virtual bool requiresCalibration(void) { return true; }
-
-    void setAxisMapping(Axis_t axis, int map);
-    int getMappedAxis(Axis_t axis) { return _rgAxisMapping[axis]; }
 
     int throttleMode(void);
     void setThrottleMode(int mode);
@@ -246,13 +246,12 @@ private:
     static const char* _exponentialSettingsKey;
     static const char* _accumulatorSettingsKey;
     static const char* _deadbandSettingsKey;
-    //static const char* _modeSettingsKey;
+    static const char* _modeSettingsKey;
     static const char* _fixedWingModeSettingsKey;
     static const char* _multiRotorModeSettingsKey;
     static const char* _roverModeSettingsKey;
     static const char* _vtolModeSettingsKey;
     static const char* _submarineModeSettingsKey;
-    static const char* _modeSettingsKey;
 
 private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -31,14 +31,6 @@ public:
 
     ~Joystick();
 
-    typedef enum {
-        stickLeftX,
-        stickLeftY,
-        stickRightX,
-        stickRightY,
-        maxAxis
-    } Axis_t;
-
     typedef struct Calibration_t {
         int     min;
         int     max;
@@ -46,12 +38,20 @@ public:
         int     deadband;
         bool    reversed;
         Calibration_t()
-            : min(-32768)
-            , max(32768)
+            : min(-32767)
+            , max(32767)
             , center(0)
             , deadband(0)
             , reversed(false) {}
     } Calibration_t;
+
+    typedef enum {
+        stickLeftX,
+        stickLeftY,
+        stickRightX,
+        stickRightY,
+        maxAxis
+    } Axis_t;
 
     typedef enum {
         rollFunction,
@@ -124,7 +124,7 @@ public:
 
     virtual bool requiresCalibration(void) { return true; }
 
-    void setAxisMapping(Axis_t axis, int map) { _rgAxisMapping[axis] = map; }
+    void setAxisMapping(Axis_t axis, int map);
     int getMappedAxis(Axis_t axis) { return _rgAxisMapping[axis]; }
 
     int throttleMode(void);

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -62,6 +62,14 @@ public:
     } AxisFunction_t;
 
     typedef enum {
+        Mode1,
+        Mode2,
+        Mode3,
+        Mode4,
+        maxMode
+    } JoystickTXMode_t;
+
+    typedef enum {
         ThrottleModeCenterZero,
         ThrottleModeDownZero,
         ThrottleModeMax
@@ -85,11 +93,11 @@ public:
     Q_INVOKABLE void setButtonAction(int button, const QString& action);
     Q_INVOKABLE QString getButtonAction(int button);
 
-    Q_PROPERTY(int throttleMode READ throttleMode WRITE setThrottleMode NOTIFY throttleModeChanged)
-    Q_PROPERTY(bool exponential READ exponential WRITE setExponential NOTIFY exponentialChanged)
-    Q_PROPERTY(bool accumulator READ accumulator WRITE setAccumulator NOTIFY accumulatorChanged)
-    Q_PROPERTY(int mode         READ mode        WRITE setMode           NOTIFY modeChanged)
-    Q_PROPERTY(bool requiresCalibration READ requiresCalibration CONSTANT)
+    Q_PROPERTY(int  throttleMode        READ throttleMode       WRITE setThrottleMode   NOTIFY throttleModeChanged)
+    Q_PROPERTY(bool exponential         READ exponential        WRITE setExponential    NOTIFY exponentialChanged)
+    Q_PROPERTY(bool accumulator         READ accumulator        WRITE setAccumulator    NOTIFY accumulatorChanged)
+    Q_PROPERTY(int  mode                READ mode               WRITE setMode           NOTIFY modeChanged)
+    Q_PROPERTY(bool requiresCalibration READ requiresCalibration                        CONSTANT)
 
     // Property accessors
 
@@ -111,7 +119,7 @@ public:
 
     QString name(void) { return _name; }
 
-    void setMode(int mode);
+    void setMode(int mode, bool save=true);
     int  mode(void) { return Joystick::_mode; }
 
     virtual bool requiresCalibration(void) { return true; }
@@ -238,7 +246,16 @@ private:
     static const char* _exponentialSettingsKey;
     static const char* _accumulatorSettingsKey;
     static const char* _deadbandSettingsKey;
+    //static const char* _modeSettingsKey;
+    static const char* _fixedWingModeSettingsKey;
+    static const char* _multiRotorModeSettingsKey;
+    static const char* _roverModeSettingsKey;
+    static const char* _vtolModeSettingsKey;
+    static const char* _submarineModeSettingsKey;
     static const char* _modeSettingsKey;
+
+private slots:
+    void _activeVehicleChanged(Vehicle* activeVehicle);
 };
 
 #endif

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -19,7 +19,6 @@
 #include "MultiVehicleManager.h"
 
 Q_DECLARE_LOGGING_CATEGORY(JoystickLog)
-Q_DECLARE_LOGGING_CATEGORY(JoystickVerboseLog)
 Q_DECLARE_LOGGING_CATEGORY(JoystickValuesLog)
 
 class Joystick : public QThread
@@ -62,23 +61,10 @@ public:
     } AxisFunction_t;
 
     typedef enum {
-        Mode1,
-        Mode2,
-        Mode3,
-        Mode4,
-        maxMode
-    } JoystickTXMode_t;
-
-    typedef enum {
         ThrottleModeCenterZero,
         ThrottleModeDownZero,
         ThrottleModeMax
     } ThrottleMode_t;
-
-    AxisFunction_t modes[2][maxAxis] = {
-    { rollFunction, pitchFunction, yawFunction, throttleFunction },
-    { rollFunction, throttleFunction, yawFunction, pitchFunction }
-    };
 
     Q_PROPERTY(QString name READ name CONSTANT)
 
@@ -111,7 +97,7 @@ public:
     void setCalibration(int axis, Calibration_t& calibration);
     Calibration_t getCalibration(int axis);
 
-    void setFunctionAxis(AxisFunction_t function, Axis_t axis); // Unused, set via mode signal
+    void setFunctionAxis(AxisFunction_t function, Axis_t axis); // Unused, always determined internally via TXmode
     Axis_t getFunctionAxis(AxisFunction_t function);
 
     void setAxisMapping(Axis_t axis, int map);
@@ -237,7 +223,6 @@ protected:
     MultiVehicleManager*    _multiVehicleManager;
 
 private:
-//    static const char*  _rgFunctionSettingsKey[maxFunction];
     static const char* _rgAxisMappingKey[maxAxis];
     static const char* _settingsGroup;
     static const char* _calibratedSettingsKey;

--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -10,6 +10,7 @@ JoystickSDL::JoystickSDL(const QString& name, int axisCount, int buttonCount, in
     , _isGameController(isGameController)
     , _index(index)
 {
+    if(_isGameController) _setDefaultCalibration();
 }
 
 QMap<QString, Joystick*> JoystickSDL::discover(MultiVehicleManager* _multiVehicleManager) {

--- a/src/Joystick/JoystickSDL.h
+++ b/src/Joystick/JoystickSDL.h
@@ -14,7 +14,8 @@ public:
 
     static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager);
 
-    bool requiresCalibration(void) final { return !_isGameController; }
+    // This can be uncommented to hide the calibration buttons for gamecontrollers in the future
+    //bool requiresCalibration(void) final { return !_isGameController; }
 
 private:
     static void _loadGameControllerMappings();

--- a/src/Joystick/JoystickSDL.h
+++ b/src/Joystick/JoystickSDL.h
@@ -12,7 +12,9 @@ class JoystickSDL : public Joystick
 public:
     JoystickSDL(const QString& name, int axisCount, int buttonCount, int hatCount, int index, bool isGameController, MultiVehicleManager* multiVehicleManager);
 
-    static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager); 
+    static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager);
+
+    bool requiresCalibration(void) final { return !_isGameController; }
 
 private:
     static void _loadGameControllerMappings();

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -176,7 +176,7 @@ SetupPage {
                         QGCLabel {
                             id:     rollLabel
                             width:  defaultTextWidth * 10
-                            text:   qsTr("Roll")
+                            text:   _activeVehicle.sub ? qsTr("Lateral") : qsTr("Roll")
                         }
 
                         Loader {
@@ -208,7 +208,7 @@ SetupPage {
                         QGCLabel {
                             id:     pitchLabel
                             width:  defaultTextWidth * 10
-                            text:   qsTr("Pitch")
+                            text:   _activeVehicle.sub ? qsTr("Forward") : qsTr("Pitch")
                         }
 
                         Loader {

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -371,44 +371,6 @@ SetupPage {
                                 spacing:    ScreenTools.defaultFontPixelWidth
 
                                 QGCLabel {
-                                    id:                 modeLabel
-                                    text:               qsTr("Mode:")
-                                }
-
-                                Row {
-                                    ExclusiveGroup { id: modeGroup }
-                                    RadioButton {
-                                        text: "1"
-                                        checked: _activeJoystick.mode == 1
-                                        exclusiveGroup: modeGroup
-                                        onClicked: _activeJoystick.mode = 1
-                                    }
-                                    RadioButton {
-                                        text: "2"
-                                        checked: _activeJoystick.mode == 2
-                                        exclusiveGroup: modeGroup
-                                        onClicked: _activeJoystick.mode = 2
-                                    }
-                                    RadioButton {
-                                        text: "3"
-                                        checked: _activeJoystick.mode == 3
-                                        exclusiveGroup: modeGroup
-                                        onClicked: _activeJoystick.mode = 3
-                                    }
-                                    RadioButton {
-                                        text: "4"
-                                        checked: _activeJoystick.mode == 4
-                                        exclusiveGroup: modeGroup
-                                        onClicked: _activeJoystick.mode = 4
-                                    }
-                                }
-                            }
-
-                            Row {
-                                width:      parent.width
-                                spacing:    ScreenTools.defaultFontPixelWidth
-
-                                QGCLabel {
                                     id:                 activeJoystickLabel
                                     anchors.baseline:   joystickCombo.baseline
                                     text:               qsTr("Active joystick:")
@@ -490,6 +452,45 @@ SetupPage {
                                 onClicked: {
                                     if (!checked) {
                                         _activeVehicle.joystickMode = 0
+                                    }
+                                }
+                            }
+
+                            Row {
+                                width:      parent.width
+                                spacing:    ScreenTools.defaultFontPixelWidth
+                                visible:    advancedSettings.checked
+
+                                QGCLabel {
+                                    id:                 modeLabel
+                                    text:               qsTr("Stick Layout (Transmitter Mode):")
+                                }
+
+                                Row {
+                                    ExclusiveGroup { id: modeGroup }
+                                    RadioButton {
+                                        text: "1"
+                                        checked: _activeJoystick.mode == 1
+                                        exclusiveGroup: modeGroup
+                                        onClicked: _activeJoystick.mode = 1
+                                    }
+                                    RadioButton {
+                                        text: "2"
+                                        checked: _activeJoystick.mode == 2
+                                        exclusiveGroup: modeGroup
+                                        onClicked: _activeJoystick.mode = 2
+                                    }
+                                    RadioButton {
+                                        text: "3"
+                                        checked: _activeJoystick.mode == 3
+                                        exclusiveGroup: modeGroup
+                                        onClicked: _activeJoystick.mode = 3
+                                    }
+                                    RadioButton {
+                                        text: "4"
+                                        checked: _activeJoystick.mode == 4
+                                        exclusiveGroup: modeGroup
+                                        onClicked: _activeJoystick.mode = 4
                                     }
                                 }
                             }

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -302,6 +302,7 @@ SetupPage {
                 // Command Buttons
                 Row {
                     spacing: 10
+                    visible: _activeJoystick.requiresCalibration
 
                     QGCButton {
                         id:     skipButton
@@ -363,6 +364,44 @@ SetupPage {
                                 checked:    _activeVehicle.joystickEnabled
 
                                 onClicked:  _activeVehicle.joystickEnabled = checked
+                            }
+
+                            Row {
+                                width:      parent.width
+                                spacing:    ScreenTools.defaultFontPixelWidth
+
+                                QGCLabel {
+                                    id:                 modeLabel
+                                    text:               qsTr("Mode:")
+                                }
+
+                                Row {
+                                    ExclusiveGroup { id: modeGroup }
+                                    RadioButton {
+                                        text: "1"
+                                        checked: _activeJoystick.mode == 1
+                                        exclusiveGroup: modeGroup
+                                        onClicked: _activeJoystick.mode = 1
+                                    }
+                                    RadioButton {
+                                        text: "2"
+                                        checked: _activeJoystick.mode == 2
+                                        exclusiveGroup: modeGroup
+                                        onClicked: _activeJoystick.mode = 2
+                                    }
+                                    RadioButton {
+                                        text: "3"
+                                        checked: _activeJoystick.mode == 3
+                                        exclusiveGroup: modeGroup
+                                        onClicked: _activeJoystick.mode = 3
+                                    }
+                                    RadioButton {
+                                        text: "4"
+                                        checked: _activeJoystick.mode == 4
+                                        exclusiveGroup: modeGroup
+                                        onClicked: _activeJoystick.mode = 4
+                                    }
+                                }
                             }
 
                             Row {

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -123,7 +123,7 @@ void JoystickConfigController::_setupCurrentState(void)
     
     _setHelpImage(state->image);
     
-    _stickDetectAxis = _axisNoAxis;
+    _stickDetectAxis = Joystick::maxAxis;
     _stickDetectSettleStarted = false;
     
     _calSaveCurrentValues();
@@ -314,7 +314,7 @@ void JoystickConfigController::_inputStickDetect(Joystick::Axis_t axis, int mapp
         return;
     }
     
-    if (_stickDetectAxis == _axisNoAxis) {
+    if (_stickDetectAxis == Joystick::maxAxis) {
         // We have not detected enough movement on a axis yet
         
         if (abs(_axisValueSave[mappedAxis] - value) > _calMoveDelta) {
@@ -377,7 +377,7 @@ void JoystickConfigController::_inputStickMin(Joystick::Axis_t axis, int mappedA
         return;
     }
 
-    if (_stickDetectAxis == _axisNoAxis) {
+    if (_stickDetectAxis == Joystick::maxAxis) {
         // Setup up to detect stick being pegged to extreme position
         if (_rgAxisInfo[mappedAxis].reversed) {
             if (value > _calCenterPoint + _calMoveDelta) {
@@ -428,7 +428,7 @@ void JoystickConfigController::_inputCenterWait(Joystick::Axis_t axis, int mappe
         return;
     }
     
-    if (_stickDetectAxis == _axisNoAxis) {
+    if (_stickDetectAxis == Joystick::maxAxis) {
         // Sticks have not yet moved close enough to center
         
         if (abs(_calCenterPoint - value) < _calRoughCenterDelta) {
@@ -469,7 +469,7 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
     }
 
     for (size_t i=0; i<Joystick::maxAxis; i++) {
-        _rgAxisMapping[i] = _axisNoAxis;
+        _rgAxisMapping[i] = Joystick::maxAxis;
     }
     
     _signalAllAttiudeValueChanges();
@@ -489,11 +489,11 @@ void JoystickConfigController::_setInternalCalibrationValuesFromSettings(void)
     }
 
     for (size_t i=0; i<Joystick::maxFunction; i++) {
-        _rgFunctionAxisMapping[i] = (Joystick::Axis_t)_axisNoAxis;
+        _rgFunctionAxisMapping[i] = (Joystick::Axis_t)Joystick::maxAxis;
     }
 
     for (size_t i=0; i<Joystick::maxAxis; i++) {
-        _rgAxisMapping[i] = _axisNoAxis;
+        _rgAxisMapping[i] = Joystick::maxAxis;
     }
     
     for (int axis=0; axis<_axisCount; axis++) {
@@ -694,7 +694,7 @@ int JoystickConfigController::axisCount(void)
 
 int JoystickConfigController::rollAxisValue(void)
 {    
-    if (_rgFunctionAxisMapping[Joystick::rollFunction] != _axisNoAxis) {
+    if (_rgFunctionAxisMapping[Joystick::rollFunction] != Joystick::maxAxis) {
         return _axisRawValue[Joystick::rollFunction];
     } else {
         return 1500;
@@ -703,7 +703,7 @@ int JoystickConfigController::rollAxisValue(void)
 
 int JoystickConfigController::pitchAxisValue(void)
 {
-    if (_rgFunctionAxisMapping[Joystick::pitchFunction] != _axisNoAxis) {
+    if (_rgFunctionAxisMapping[Joystick::pitchFunction] != Joystick::maxAxis) {
         return _axisRawValue[Joystick::pitchFunction];
     } else {
         return 1500;
@@ -712,7 +712,7 @@ int JoystickConfigController::pitchAxisValue(void)
 
 int JoystickConfigController::yawAxisValue(void)
 {
-    if (_rgFunctionAxisMapping[Joystick::yawFunction] != _axisNoAxis) {
+    if (_rgFunctionAxisMapping[Joystick::yawFunction] != Joystick::maxAxis) {
         return _axisRawValue[Joystick::yawFunction];
     } else {
         return 1500;
@@ -721,7 +721,7 @@ int JoystickConfigController::yawAxisValue(void)
 
 int JoystickConfigController::throttleAxisValue(void)
 {
-    if (_rgFunctionAxisMapping[Joystick::throttleFunction] != _axisNoAxis) {
+    if (_rgFunctionAxisMapping[Joystick::throttleFunction] != Joystick::maxAxis) {
         return _axisRawValue[Joystick::throttleFunction];
     } else {
         return 1500;
@@ -730,7 +730,7 @@ int JoystickConfigController::throttleAxisValue(void)
 
 int JoystickConfigController::rollAxisDeadband(void)
 {
-    if ((_rgFunctionAxisMapping[Joystick::rollFunction] != _axisNoAxis) && (_activeJoystick->deadband())) {
+    if ((_rgFunctionAxisMapping[Joystick::rollFunction] != Joystick::maxAxis) && (_activeJoystick->deadband())) {
         return _rgAxisInfo[_rgFunctionAxisMapping[Joystick::rollFunction]].deadband;
     } else {
         return 0;
@@ -739,7 +739,7 @@ int JoystickConfigController::rollAxisDeadband(void)
 
 int JoystickConfigController::pitchAxisDeadband(void)
 {
-    if ((_rgFunctionAxisMapping[Joystick::pitchFunction] != _axisNoAxis) && (_activeJoystick->deadband())) {
+    if ((_rgFunctionAxisMapping[Joystick::pitchFunction] != Joystick::maxAxis) && (_activeJoystick->deadband())) {
         return _rgAxisInfo[_rgFunctionAxisMapping[Joystick::pitchFunction]].deadband;
     } else {
         return 0;
@@ -748,7 +748,7 @@ int JoystickConfigController::pitchAxisDeadband(void)
 
 int JoystickConfigController::yawAxisDeadband(void)
 {
-    if ((_rgFunctionAxisMapping[Joystick::yawFunction] != _axisNoAxis) && (_activeJoystick->deadband())) {
+    if ((_rgFunctionAxisMapping[Joystick::yawFunction] != Joystick::maxAxis) && (_activeJoystick->deadband())) {
         return _rgAxisInfo[_rgFunctionAxisMapping[Joystick::yawFunction]].deadband;
     } else {
         return 0;
@@ -757,7 +757,7 @@ int JoystickConfigController::yawAxisDeadband(void)
 
 int JoystickConfigController::throttleAxisDeadband(void)
 {
-    if ((_rgFunctionAxisMapping[Joystick::throttleFunction] != _axisNoAxis) && (_activeJoystick->deadband())) {
+    if ((_rgFunctionAxisMapping[Joystick::throttleFunction] != Joystick::maxAxis) && (_activeJoystick->deadband())) {
         return _rgAxisInfo[_rgFunctionAxisMapping[Joystick::throttleFunction]].deadband;
     } else {
         return 0;
@@ -768,7 +768,7 @@ bool JoystickConfigController::rollAxisMapped(void)
 {
     int axis = _rgFunctionAxisMapping[Joystick::rollFunction];
     int mappedAxis = _rgAxisMapping[axis];
-    if (mappedAxis == _axisNoAxis) {
+    if (mappedAxis == Joystick::maxAxis) {
         return false;
     }
     return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
@@ -778,7 +778,7 @@ bool JoystickConfigController::pitchAxisMapped(void)
 {
     int axis = _rgFunctionAxisMapping[Joystick::pitchFunction];
     int mappedAxis = _rgAxisMapping[axis];
-    if (mappedAxis == _axisNoAxis) {
+    if (mappedAxis == Joystick::maxAxis) {
         return false;
     }
     return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
@@ -788,7 +788,7 @@ bool JoystickConfigController::yawAxisMapped(void)
 {
     int axis = _rgFunctionAxisMapping[Joystick::yawFunction];
     int mappedAxis = _rgAxisMapping[axis];
-    if (mappedAxis == _axisNoAxis) {
+    if (mappedAxis == Joystick::maxAxis) {
         return false;
     }
     return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
@@ -798,7 +798,7 @@ bool JoystickConfigController::throttleAxisMapped(void)
 {
     int axis = _rgFunctionAxisMapping[Joystick::throttleFunction];
     int mappedAxis = _rgAxisMapping[axis];
-    if (mappedAxis == _axisNoAxis) {
+    if (mappedAxis == Joystick::maxAxis) {
         return false;
     }
     return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
@@ -806,7 +806,7 @@ bool JoystickConfigController::throttleAxisMapped(void)
 
 bool JoystickConfigController::rollAxisReversed(void)
 {
-    if (_rgFunctionAxisMapping[Joystick::rollFunction] != _axisNoAxis) {
+    if (_rgFunctionAxisMapping[Joystick::rollFunction] != Joystick::maxAxis) {
         return _rgAxisInfo[_rgAxisMapping[_rgFunctionAxisMapping[Joystick::rollFunction]]].reversed;
     } else {
         return false;
@@ -815,7 +815,7 @@ bool JoystickConfigController::rollAxisReversed(void)
 
 bool JoystickConfigController::pitchAxisReversed(void)
 {
-    if (_rgFunctionAxisMapping[Joystick::pitchFunction] != _axisNoAxis) {
+    if (_rgFunctionAxisMapping[Joystick::pitchFunction] != Joystick::maxAxis) {
         return _rgAxisInfo[_rgAxisMapping[_rgFunctionAxisMapping[Joystick::pitchFunction]]].reversed;
     } else {
         return false;
@@ -824,7 +824,7 @@ bool JoystickConfigController::pitchAxisReversed(void)
 
 bool JoystickConfigController::yawAxisReversed(void)
 {
-    if (_rgFunctionAxisMapping[Joystick::yawFunction] != _axisNoAxis) {
+    if (_rgFunctionAxisMapping[Joystick::yawFunction] != Joystick::maxAxis) {
         return _rgAxisInfo[_rgAxisMapping[_rgFunctionAxisMapping[Joystick::yawFunction]]].reversed;
     } else {
         return false;
@@ -833,7 +833,7 @@ bool JoystickConfigController::yawAxisReversed(void)
 
 bool JoystickConfigController::throttleAxisReversed(void)
 {
-    if (_rgFunctionAxisMapping[Joystick::throttleFunction] != _axisNoAxis) {
+    if (_rgFunctionAxisMapping[Joystick::throttleFunction] != Joystick::maxAxis) {
         return _rgAxisInfo[_rgAxisMapping[_rgFunctionAxisMapping[Joystick::throttleFunction]]].reversed;
     } else {
         return false;

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -15,6 +15,7 @@
 #include <QSettings>
 
 QGC_LOGGING_CATEGORY(JoystickConfigControllerLog, "JoystickConfigControllerLog")
+QGC_LOGGING_CATEGORY(JoystickConfigControllerVerboseLog, "JoystickConfigControllerVerboseLog")
 
 const int JoystickConfigController::_updateInterval =       150;        ///< Interval for timer which updates radio channel widgets
 const int JoystickConfigController::_calCenterPoint =       0;
@@ -76,30 +77,30 @@ JoystickConfigController::~JoystickConfigController()
 const JoystickConfigController::stateMachineEntry* JoystickConfigController::_getStateMachineEntry(int step)
 {
     static const char* msgBegin =           "Allow all sticks to center as shown in diagram.\n\nClick Next to continue";
-    static const char* msgThrottleUp =      "Move the Throttle stick all the way up and hold it there...";
-    static const char* msgThrottleDown =    "Move the Throttle stick all the way down and hold it there...";
-    static const char* msgYawLeft =         "Move the Yaw stick all the way to the left and hold it there...";
-    static const char* msgYawRight =        "Move the Yaw stick all the way to the right and hold it there...";
-    static const char* msgRollLeft =        "Move the Roll stick all the way to the left and hold it there...";
-    static const char* msgRollRight =       "Move the Roll stick all the way to the right and hold it there...";
-    static const char* msgPitchDown =       "Move the Pitch stick all the way down and hold it there...";
-    static const char* msgPitchUp =         "Move the Pitch stick all the way up and hold it there...";
-    static const char* msgPitchCenter =     "Allow the Pitch stick to move back to center...";
+    static const char* msgLStickUp =      "Move the LEFT stick all the way up and hold it there...";
+    static const char* msgLStickDown =    "Move the LEFT stick all the way down and hold it there...";
+    static const char* msgLStickLeft =         "Move the LEFT stick all the way to the left and hold it there...";
+    static const char* msgLStickRight =        "Move the LEFT stick all the way to the right and hold it there...";
+    static const char* msgRStickLeft =        "Move the RIGHT stick all the way to the left and hold it there...";
+    static const char* msgRStickRight =       "Move the RIGHT stick all the way to the right and hold it there...";
+    static const char* msgRStickDown =       "Move the RIGHT stick all the way down and hold it there...";
+    static const char* msgRStickUp =         "Move the RIGHT stick all the way up and hold it there...";
+    static const char* msgRStickCenter =     "Allow the RIGHT stick to move back to center...";
     static const char* msgComplete =        "All settings have been captured. Click Next to enable the joystick.";
     
     static const stateMachineEntry rgStateMachine[] = {
-        //Function
-        { Joystick::maxFunction,       msgBegin,           _imageCenter,       &JoystickConfigController::_inputCenterWaitBegin,   &JoystickConfigController::_saveAllTrims,       NULL },
-        { Joystick::throttleFunction,  msgThrottleUp,      _imageThrottleUp,   &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
-        { Joystick::throttleFunction,  msgThrottleDown,    _imageThrottleDown, &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
-        { Joystick::yawFunction,       msgYawRight,        _imageYawRight,     &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
-        { Joystick::yawFunction,       msgYawLeft,         _imageYawLeft,      &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
-        { Joystick::rollFunction,      msgRollRight,       _imageRollRight,    &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
-        { Joystick::rollFunction,      msgRollLeft,        _imageRollLeft,     &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
-        { Joystick::pitchFunction,     msgPitchUp,         _imagePitchUp,      &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
-        { Joystick::pitchFunction,     msgPitchDown,       _imagePitchDown,    &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
-        { Joystick::pitchFunction,     msgPitchCenter,     _imageCenter,       &JoystickConfigController::_inputCenterWait,        NULL,                                           NULL },
-        { Joystick::maxFunction,       msgComplete,        _imageCenter,       NULL,                                               &JoystickConfigController::_writeCalibration,   NULL },
+        //Axis                   Message           Image               RCInputFunction                                     NextFunction                                    SkipFunction
+        { Joystick::maxAxis,     msgBegin,         _imageCenter,       &JoystickConfigController::_inputCenterWaitBegin,   &JoystickConfigController::_saveAllTrims,       NULL },
+        { Joystick::stickLeftY,  msgLStickUp,      _imageThrottleUp,   &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
+        { Joystick::stickLeftY,  msgLStickDown,    _imageThrottleDown, &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
+        { Joystick::stickLeftX,  msgLStickRight,   _imageYawRight,     &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
+        { Joystick::stickLeftX,  msgLStickLeft,    _imageYawLeft,      &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
+        { Joystick::stickRightX, msgRStickRight,   _imageRollRight,    &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
+        { Joystick::stickRightX, msgRStickLeft,    _imageRollLeft,     &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
+        { Joystick::stickRightY, msgRStickUp,      _imagePitchUp,      &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
+        { Joystick::stickRightY, msgRStickDown,    _imagePitchDown,    &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
+        { Joystick::stickRightY, msgRStickCenter,  _imageCenter,       &JoystickConfigController::_inputCenterWait,        NULL,                                           NULL },
+        { Joystick::maxAxis,     msgComplete,      _imageCenter,       NULL,                                               &JoystickConfigController::_writeCalibration,   NULL },
     };
     
     Q_ASSERT(step >=0 && step < (int)(sizeof(rgStateMachine) / sizeof(rgStateMachine[0])));
@@ -140,7 +141,7 @@ void JoystickConfigController::_axisValueChanged(int axis, int value)
         emit axisValueChanged(axis, _axisRawValue[axis]);
         
         // Signal attitude axis values to Qml if mapped
-        if (_rgAxisInfo[axis].function != Joystick::maxFunction) {
+        if (_rgAxisInfo[axis].axis != Joystick::maxAxis) {
             switch (_rgAxisInfo[axis].function) {
                 case Joystick::rollFunction:
                     emit rollAxisValueChanged(_axisRawValue[axis]);
@@ -172,7 +173,7 @@ void JoystickConfigController::_axisValueChanged(int axis, int value)
             const stateMachineEntry* state = _getStateMachineEntry(_currentStep);
             Q_ASSERT(state);
             if (state->rcInputFn) {
-                (this->*state->rcInputFn)(state->function, axis, value);
+                (this->*state->rcInputFn)(state->axis, axis, value);
             }
         }
     }
@@ -228,9 +229,9 @@ void JoystickConfigController::_saveAllTrims(void)
     // allow us to get good trims for the roll/pitch/yaw/throttle even though we don't know which
     // axis they are yet. As we continue through the process the other axes will get their
     // trims reset to correct values.
-    
+    qCDebug(JoystickConfigControllerLog) << "_saveAllTrims";
     for (int i=0; i<_axisCount; i++) {
-        qCDebug(JoystickConfigControllerLog) << "_saveAllTrims trim" << _axisRawValue[i];
+        qCDebug(JoystickConfigControllerVerboseLog) << "\taxis:" << i << "\ttrim:" << _axisRawValue[i];
         _rgAxisInfo[i].axisTrim = _axisRawValue[i];
     }
     _advanceState();
@@ -242,17 +243,17 @@ void JoystickConfigController::_axisDeadbandChanged(int axis, int value)
 
     _rgAxisInfo[axis].deadband = value;
 
-    qCDebug(JoystickConfigControllerLog) << "Axis:" << axis << "Deadband:" << _rgAxisInfo[axis].deadband;
+    //qCDebug(JoystickConfigControllerLog) << "Axis:" << axis << "Deadband:" << _rgAxisInfo[axis].deadband;
 }
 
 /// @brief Waits for the sticks to be centered, enabling Next when done.
-void JoystickConfigController::_inputCenterWaitBegin(Joystick::AxisFunction_t function, int axis, int value)
+void JoystickConfigController::_inputCenterWaitBegin(Joystick::Axis_t axis, int map, int value)
 {
-    Q_UNUSED(function);
+    Q_UNUSED(axis);
 
     //sensing deadband
-    if (abs(value)*1.1f>_rgAxisInfo[axis].deadband) {   //add 10% on top of existing deadband
-        _axisDeadbandChanged(axis,abs(value)*1.1f);
+    if (abs(value)*1.1f>_rgAxisInfo[map].deadband) {   //add 10% on top of existing deadband
+        _axisDeadbandChanged(map,abs(value)*1.1f);
     }
 
     _nextButton->setEnabled(true);
@@ -272,7 +273,7 @@ bool JoystickConfigController::_stickSettleComplete(int axis, int value)
     if (abs(_stickDetectValue - value) > _calSettleDelta) {
         // Stick is moving too much to consider stopped
         
-        qCDebug(JoystickConfigControllerLog) << "_stickSettleComplete still moving, axis:_stickDetectValue:value" << axis << _stickDetectValue << value;
+        qCDebug(JoystickConfigControllerVerboseLog) << "_stickSettleComplete still moving, axis:_stickDetectValue:value" << axis << _stickDetectValue << value;
 
         _stickDetectValue = value;
         _stickDetectSettleStarted = false;
@@ -300,52 +301,54 @@ bool JoystickConfigController::_stickSettleComplete(int axis, int value)
     return false;
 }
 
-void JoystickConfigController::_inputStickDetect(Joystick::AxisFunction_t function, int axis, int value)
-{
-    qCDebug(JoystickConfigControllerLog) << "_inputStickDetect function:axis:value" << function << axis << value;
-    
-    if (!_validAxis(axis)) {
-        qCWarning(JoystickConfigControllerLog) << "Invalid axis axis:_axisCount" << axis << _axisCount;
+void JoystickConfigController::_inputStickDetect(Joystick::Axis_t axis, int map, int value)
+{    
+    if (!_validAxis(map)) {
+        qCWarning(JoystickConfigControllerLog) << "Invalid axis map:_axisCount" << map << _axisCount;
         return;
     }
 
     // If this axis is already used in a mapping we can't use it again
-    if (_rgAxisInfo[axis].function != Joystick::maxFunction) {
+    if (_rgAxisInfo[map].axis != Joystick::maxAxis) {
         return;
     }
-    
+
     if (_stickDetectAxis == _axisNoAxis) {
         // We have not detected enough movement on a axis yet
         
-        if (abs(_axisValueSave[axis] - value) > _calMoveDelta) {
+        if (abs(_axisValueSave[map] - value) > _calMoveDelta) {
             // Stick has moved far enough to consider it as being selected for the function
             
-            qCDebug(JoystickConfigControllerLog) << "_inputStickDetect starting settle wait, function:axis:value" << function << axis << value;
+            qCDebug(JoystickConfigControllerLog) << "_inputStickDetect starting settle wait, axis:map:value" << axis << map << value;
             
             // Setup up to detect stick being pegged to min or max value
-            _stickDetectAxis = axis;
+            _stickDetectAxis = map;
             _stickDetectInitialValue = value;
             _stickDetectValue = value;
         }
-    } else if (axis == _stickDetectAxis) {
-        if (_stickSettleComplete(axis, value)) {
-            AxisInfo* info = &_rgAxisInfo[axis];
+    } else if (map == _stickDetectAxis) {
+        if (_stickSettleComplete(map, value)) {
+            AxisInfo* info = &_rgAxisInfo[map];
             
             // Stick detection is complete. Stick should be at max position.
             // Map the axis to the function
-            _rgFunctionAxisMapping[function] = axis;
-            info->function = function;
+            //_rgFunctionAxisMapping[axis] = map;
+            info->axis = axis;
+            //info->function = joystick->
+
+            _rgAxisMapping[axis] = map;
+//            _rgFunctionAxisMapping = joystick->get
             
             // Axis should be at max value, if it is below initial set point the the axis is reversed.
-            info->reversed = value < _axisValueSave[axis];
+            info->reversed = value < _axisValueSave[map];
             
             if (info->reversed) {
-                _rgAxisInfo[axis].axisMin = value;
+                _rgAxisInfo[map].axisMin = value;
             } else {
-                _rgAxisInfo[axis].axisMax = value;
+                _rgAxisInfo[map].axisMax = value;
             }
             
-            qCDebug(JoystickConfigControllerLog) << "_inputStickDetect saving values, function:axis:value:reversed:_axisValueSave" << function << axis << value << info->reversed << _axisValueSave[axis];
+            qCDebug(JoystickConfigControllerLog) << "_inputStickDetect saving values, axis:map:value:reversed:_axisValueSave" << axis << map << value << info->reversed << _axisValueSave[map];
             
             _signalAllAttiudeValueChanges();
             
@@ -354,32 +357,30 @@ void JoystickConfigController::_inputStickDetect(Joystick::AxisFunction_t functi
     }
 }
 
-void JoystickConfigController::_inputStickMin(Joystick::AxisFunction_t function, int axis, int value)
-{
-    qCDebug(JoystickConfigControllerLog) << "_inputStickMin function:axis:value" << function << axis << value;
-    
-    if (!_validAxis(axis)) {
-        qCWarning(JoystickConfigControllerLog) << "Invalid axis axis:_axisCount" << axis << _axisCount;
+void JoystickConfigController::_inputStickMin(Joystick::Axis_t axis, int map, int value)
+{    
+    if (!_validAxis(map)) {
+        qCWarning(JoystickConfigControllerLog) << "Invalid axis map:_axisCount" << map << _axisCount;
         return;
     }
 
     // We only care about the axis mapped to the function we are working on
-    if (_rgFunctionAxisMapping[function] != axis) {
+    if (_rgAxisMapping[axis] != map) {
         return;
     }
 
     if (_stickDetectAxis == _axisNoAxis) {
         // Setup up to detect stick being pegged to extreme position
-        if (_rgAxisInfo[axis].reversed) {
+        if (_rgAxisInfo[map].reversed) {
             if (value > _calCenterPoint + _calMoveDelta) {
-                _stickDetectAxis = axis;
+                _stickDetectAxis = map;
                 _stickDetectInitialValue = value;
                 _stickDetectValue = value;
                 qCDebug(JoystickConfigControllerLog) << "_inputStickMin detected movement _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
             }
         } else {
             if (value < _calCenterPoint - _calMoveDelta) {
-                _stickDetectAxis = axis;
+                _stickDetectAxis = map;
                 _stickDetectInitialValue = value;
                 _stickDetectValue = value;
                 qCDebug(JoystickConfigControllerLog) << "_inputStickMin detected movement _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
@@ -388,34 +389,32 @@ void JoystickConfigController::_inputStickMin(Joystick::AxisFunction_t function,
     } else {
         // We are waiting for the selected axis to settle out
         
-        if (_stickSettleComplete(axis, value)) {
-            AxisInfo* info = &_rgAxisInfo[axis];
+        if (_stickSettleComplete(map, value)) {
+            AxisInfo* info = &_rgAxisInfo[map];
             
             // Stick detection is complete. Stick should be at min position.
             if (info->reversed) {
-                _rgAxisInfo[axis].axisMax = value;
+                _rgAxisInfo[map].axisMax = value;
             } else {
-                _rgAxisInfo[axis].axisMin = value;
+                _rgAxisInfo[map].axisMin = value;
             }
             
-            qCDebug(JoystickConfigControllerLog) << "_inputStickMin saving values, function:axis:value:reversed" << function << axis << value << info->reversed;
+            qCDebug(JoystickConfigControllerLog) << "_inputStickMin saving values, axis:map:value:reversed" << axis << map << value << info->reversed;
             
             _advanceState();
         }
     }
 }
 
-void JoystickConfigController::_inputCenterWait(Joystick::AxisFunction_t function, int axis, int value)
-{
-    qCDebug(JoystickConfigControllerLog) << "_inputCenterWait function:axis:value" << function << axis << value;
-    
-    if (!_validAxis(axis)) {
-        qCWarning(JoystickConfigControllerLog) << "Invalid axis axis:_axisCount" << axis << _axisCount;
+void JoystickConfigController::_inputCenterWait(Joystick::Axis_t axis, int map, int value)
+{    
+    if (!_validAxis(map)) {
+        qCWarning(JoystickConfigControllerLog) << "Invalid axis map:_axisCount" << map << _axisCount;
         return;
     }
 
     // We only care about the axis mapped to the function we are working on
-    if (_rgFunctionAxisMapping[function] != axis) {
+    if (_rgAxisMapping[axis] != map) {
         return;
     }
     
@@ -424,13 +423,13 @@ void JoystickConfigController::_inputCenterWait(Joystick::AxisFunction_t functio
         
         if (abs(_calCenterPoint - value) < _calRoughCenterDelta) {
             // Stick has moved close enough to center that we can start waiting for it to settle
-            _stickDetectAxis = axis;
+            _stickDetectAxis = map;
             _stickDetectInitialValue = value;
             _stickDetectValue = value;
             qCDebug(JoystickConfigControllerLog) << "_inputStickMin detected possible center _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
         }
     } else {
-        if (_stickSettleComplete(axis, value)) {
+        if (_stickSettleComplete(map, value)) {
             _advanceState();
         }
     }
@@ -439,10 +438,12 @@ void JoystickConfigController::_inputCenterWait(Joystick::AxisFunction_t functio
 /// @brief Resets internal calibration values to their initial state in preparation for a new calibration sequence.
 void JoystickConfigController::_resetInternalCalibrationValues(void)
 {
-    // Set all raw axiss to not reversed and center point values
+    qCDebug(JoystickConfigControllerLog) << "Internal calibrations reset";
+    // Set all raw axes to not reversed and center point values
     for (int i=0; i<_axisCount; i++) {
         struct AxisInfo* info = &_rgAxisInfo[i];
-        info->function = Joystick::maxFunction;
+        //info->function = Joystick::maxFunction;
+        info->axis = Joystick::maxAxis;
         info->reversed = false;
         info->deadband = 0;
         info->axisMin = JoystickConfigController::_calCenterPoint;
@@ -452,7 +453,11 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
     
     // Initialize attitude function mapping to function axis not set
     for (size_t i=0; i<Joystick::maxFunction; i++) {
-        _rgFunctionAxisMapping[i] = _axisNoAxis;
+        //_rgFunctionAxisMapping[i] = _axisNoAxis;
+    }
+
+    for (size_t i=0; i<Joystick::maxAxis; i++) {
+        _rgAxisMapping[i] = _axisNoAxis;
     }
     
     _signalAllAttiudeValueChanges();
@@ -468,10 +473,16 @@ void JoystickConfigController::_setInternalCalibrationValuesFromSettings(void)
     for (int i=0; i<_axisCount; i++) {
         struct AxisInfo* info = &_rgAxisInfo[i];
         info->function = Joystick::maxFunction;
+        info->axis = Joystick::maxAxis;
     }
-    
+    qCDebug(JoystickConfigControllerLog) << "_setInternalCalibrationValuesFromSettings: Axes and function mappings cleared";
+
     for (size_t i=0; i<Joystick::maxFunction; i++) {
         _rgFunctionAxisMapping[i] = _axisNoAxis;
+    }
+
+    for (size_t i=0; i<Joystick::maxAxis; i++) {
+        _rgAxisMapping[i] = _axisNoAxis;
     }
     
     for (int axis=0; axis<_axisCount; axis++) {
@@ -484,7 +495,7 @@ void JoystickConfigController::_setInternalCalibrationValuesFromSettings(void)
         info->reversed = calibration.reversed;
         info->deadband = calibration.deadband;
 
-        qCDebug(JoystickConfigControllerLog) << "Read settings name:axis:min:max:trim:reversed" << joystick->name() << axis << info->axisMin << info->axisMax << info->axisTrim << info->reversed;
+        qCDebug(JoystickConfigControllerVerboseLog) << "Read settings name:axis:min:max:trim:reversed" << joystick->name() << axis << info->axisMin << info->axisMax << info->axisTrim << info->reversed;
     }
     
     for (int function=0; function<Joystick::maxFunction; function++) {
@@ -494,6 +505,14 @@ void JoystickConfigController::_setInternalCalibrationValuesFromSettings(void)
         
         _rgFunctionAxisMapping[function] = paramAxis;
         _rgAxisInfo[paramAxis].function = (Joystick::AxisFunction_t)function;
+
+        qCDebug(JoystickConfigControllerLog) << "paramAxis:" << paramAxis << "function:" << function;
+    }
+
+    for (int axis=0; axis<Joystick::maxAxis; axis++) {
+        int mappedAxis = joystick->getMappedAxis((Joystick::Axis_t)axis);
+        _rgAxisMapping[axis] = mappedAxis;
+        _rgAxisInfo[mappedAxis].axis = (Joystick::Axis_t)axis;
     }
     
     _signalAllAttiudeValueChanges();
@@ -533,7 +552,7 @@ void JoystickConfigController::_validateCalibration(void)
                     break;
             }
         } else {
-            // Unavailable axiss are set to defaults
+            // Unavailable axes are set to defaults
             qCDebug(JoystickConfigControllerLog) << "_validateCalibration resetting unavailable axis" << chan;
             info->axisMin = _calDefaultMinValue;
             info->axisMax = _calDefaultMaxValue;
@@ -566,9 +585,13 @@ void JoystickConfigController::_writeCalibration(void)
         joystick->setCalibration(axis, calibration);
     }
     
-    // Write function mapping parameters
-    for (int function=0; function<Joystick::maxFunction; function++) {
-        joystick->setFunctionAxis((Joystick::AxisFunction_t)function, _rgFunctionAxisMapping[function]);
+    // Write axis mapping parameters
+//    for (int function=0; function<Joystick::maxFunction; function++) {
+//        joystick->setFunctionAxis((Joystick::AxisFunction_t)function, _rgFunctionAxisMapping[function]);
+//    }
+
+    for (int axis=0; axis<Joystick::maxAxis; axis++) {
+        joystick->setAxisMapping((Joystick::Axis_t)axis, _rgAxisMapping[axis]);
     }
     
     _stopCalibration();
@@ -611,10 +634,10 @@ void JoystickConfigController::_stopCalibration(void)
     _setHelpImage(_imageCenter);
 }
 
-/// @brief Saves the current axis values, so that we can detect when the use moves an input.
+/// @brief Saves the current axis values, so that we can detect when the user moves an input.
 void JoystickConfigController::_calSaveCurrentValues(void)
 {
-	qCDebug(JoystickConfigControllerLog) << "_calSaveCurrentValues";
+    //qCDebug(JoystickConfigControllerLog) << "_calSaveCurrentValues";
     for (int i = 0; i < _axisCount; i++) {
         _axisValueSave[i] = _axisRawValue[i];
     }
@@ -730,22 +753,46 @@ int JoystickConfigController::throttleAxisDeadband(void)
 
 bool JoystickConfigController::rollAxisMapped(void)
 {
-    return _rgFunctionAxisMapping[Joystick::rollFunction] != _axisNoAxis;
+    int axis = _rgFunctionAxisMapping[Joystick::rollFunction];
+    int mappedAxis = _rgAxisMapping[axis];
+    if (mappedAxis == _axisNoAxis) {
+        return false;
+    }
+    qCDebug(JoystickConfigControllerLog) << "axis:mappedAxis:rollAxisMapped:" << axis << mappedAxis << _rgAxisInfo[mappedAxis].axis;
+    return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
 }
 
 bool JoystickConfigController::pitchAxisMapped(void)
 {
-    return _rgFunctionAxisMapping[Joystick::pitchFunction] != _axisNoAxis;
+    int axis = _rgFunctionAxisMapping[Joystick::pitchFunction];
+    int mappedAxis = _rgAxisMapping[axis];
+    if (mappedAxis == _axisNoAxis) {
+        return false;
+    }
+    qCDebug(JoystickConfigControllerLog) << "axis:mappedAxis:pitchAxisMapped:" << axis << mappedAxis << _rgAxisInfo[mappedAxis].axis;
+    return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
 }
 
 bool JoystickConfigController::yawAxisMapped(void)
 {
-    return _rgFunctionAxisMapping[Joystick::yawFunction] != _axisNoAxis;
+    int axis = _rgFunctionAxisMapping[Joystick::yawFunction];
+    int mappedAxis = _rgAxisMapping[axis];
+    if (mappedAxis == _axisNoAxis) {
+        return false;
+    }
+    qCDebug(JoystickConfigControllerLog) << "axis:mappedAxis:yawAxisMapped:" << axis << mappedAxis << _rgAxisInfo[mappedAxis].axis;
+    return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
 }
 
 bool JoystickConfigController::throttleAxisMapped(void)
 {
-    return _rgFunctionAxisMapping[Joystick::throttleFunction] != _axisNoAxis;
+    int axis = _rgFunctionAxisMapping[Joystick::throttleFunction];
+    int mappedAxis = _rgAxisMapping[axis];
+    if (mappedAxis == _axisNoAxis) {
+        return false;
+    }
+    qCDebug(JoystickConfigControllerLog) << "axis:mappedAxis:throttleAxisMapped:" << axis << mappedAxis << _rgAxisInfo[mappedAxis].axis;
+    return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
 }
 
 bool JoystickConfigController::rollAxisReversed(void)
@@ -786,6 +833,7 @@ bool JoystickConfigController::throttleAxisReversed(void)
 
 void JoystickConfigController::_signalAllAttiudeValueChanges(void)
 {
+    qCDebug(JoystickConfigControllerLog) << "_signalAllAttitudeValueChanges";
     emit rollAxisMappedChanged(rollAxisMapped());
     emit pitchAxisMappedChanged(pitchAxisMapped());
     emit yawAxisMappedChanged(yawAxisMapped());
@@ -809,6 +857,7 @@ void JoystickConfigController::_activeJoystickChanged(Joystick* joystick)
     if (_activeJoystick) {
         joystickTransition = true;
         disconnect(_activeJoystick, &Joystick::rawAxisValueChanged, this, &JoystickConfigController::_axisValueChanged);
+        disconnect(_activeJoystick, &Joystick::modeChanged, this, &JoystickConfigController::_modeChanged);
         delete _rgAxisInfo;
         delete _axisValueSave;
         delete _axisRawValue;
@@ -827,7 +876,24 @@ void JoystickConfigController::_activeJoystickChanged(Joystick* joystick)
         _axisValueSave = new int[_axisCount];
         _axisRawValue = new int[_axisCount];
         connect(_activeJoystick, &Joystick::rawAxisValueChanged, this, &JoystickConfigController::_axisValueChanged);
+        connect(_activeJoystick, &Joystick::modeChanged, this, &JoystickConfigController::_modeChanged);
     }
+}
+
+void JoystickConfigController::_modeChanged(int mode)
+{
+    qCDebug(JoystickConfigControllerLog) << "Mode changed:" << mode;
+    for (int function=0; function<Joystick::maxFunction; function++) {
+        int paramAxis;
+
+        paramAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
+
+        _rgFunctionAxisMapping[function] = paramAxis;
+        _rgAxisInfo[paramAxis].function = (Joystick::AxisFunction_t)function;
+
+        qCDebug(JoystickConfigControllerLog) << "paramAxis:" << paramAxis << "function:" << function;
+    }
+    _signalAllAttiudeValueChanges();
 }
 
 bool JoystickConfigController::_validAxis(int axis)

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -451,7 +451,7 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
     // Set all raw axes to not reversed and center point values
     for (int i=0; i<_axisCount; i++) {
         struct AxisInfo* info = &_rgAxisInfo[i];
-        //info->function = Joystick::maxFunction;
+        info->function = Joystick::maxFunction;
         info->axis = Joystick::maxAxis;
         info->reversed = false;
         info->deadband = 0;

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -139,11 +139,8 @@ void JoystickConfigController::_axisValueChanged(int axis, int value)
         // We always update raw values
         _axisRawValue[axis] = value;
         emit axisValueChanged(axis, _axisRawValue[axis]);
-        //int mappedAxis = _rgAxisMapping[axis];
         // Signal attitude axis values to Qml if mapped
         if (_rgAxisInfo[axis].axis != Joystick::maxAxis) {
-//            _rgAxisMapping[_]
-//            _rgFunctionAxisMapping[]
             switch (_rgAxisInfo[axis].function) {
                 case Joystick::rollFunction:
                     emit rollAxisValueChanged(_axisRawValue[axis]);
@@ -471,12 +468,12 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
 //    }
 
     for (int function=0; function<Joystick::maxFunction; function++) {
-        int paramAxis;
+        Joystick::Axis_t realAxis;
 
-        paramAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
+        realAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
 
-        _rgFunctionAxisMapping[function] = paramAxis;
-        _rgAxisInfo[paramAxis].function = (Joystick::AxisFunction_t)function;
+        _rgFunctionAxisMapping[function] = realAxis;
+        _rgAxisInfo[_rgAxisMapping[realAxis]].function = (Joystick::AxisFunction_t)function;
 
         //qCDebug(JoystickConfigControllerLog) << "paramAxis:" << paramAxis << "function:" << function;
     }
@@ -507,7 +504,7 @@ void JoystickConfigController::_setInternalCalibrationValuesFromSettings(void)
     qCDebug(JoystickConfigControllerLog) << "_setInternalCalibrationValuesFromSettings: Axes and function mappings cleared";
 
     for (size_t i=0; i<Joystick::maxFunction; i++) {
-        _rgFunctionAxisMapping[i] = _axisNoAxis;
+        _rgFunctionAxisMapping[i] = (Joystick::Axis_t)_axisNoAxis;
     }
 
     for (size_t i=0; i<Joystick::maxAxis; i++) {
@@ -535,12 +532,14 @@ void JoystickConfigController::_setInternalCalibrationValuesFromSettings(void)
     }
 
     for (int function=0; function<Joystick::maxFunction; function++) {
-        int paramAxis;
+        Joystick::Axis_t realAxis;
 
-        paramAxis = joystick->getFunctionAxis((Joystick::AxisFunction_t)function);
+        realAxis = joystick->getFunctionAxis((Joystick::AxisFunction_t)function);
 
-        _rgFunctionAxisMapping[function] = paramAxis;
-        _rgAxisInfo[_rgAxisMapping[paramAxis]].function = (Joystick::AxisFunction_t)function;
+        _rgFunctionAxisMapping[function] = realAxis;
+
+        int mappedAxis = _rgAxisMapping[realAxis];
+        _rgAxisInfo[mappedAxis].function = (Joystick::AxisFunction_t)function;
     }
 
 
@@ -920,14 +919,15 @@ void JoystickConfigController::_modeChanged(int mode)
 {
     qCDebug(JoystickConfigControllerLog) << "Mode changed:" << mode;
     for (int function=0; function<Joystick::maxFunction; function++) {
-        int functionAxis;
+        Joystick::Axis_t realAxis;
 
         // Get axis for this function (stickRightX etc.)
-        functionAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
-        _rgFunctionAxisMapping[function] = functionAxis;
-        _rgAxisInfo[_rgAxisMapping[functionAxis]].function = (Joystick::AxisFunction_t)function;
-        // unnecessary, calibration hasn't changed
-        //_rgAxisInfo[_rgAxisMapping[functionAxis]].reversed = _activeJoystick->getCalibration(_rgAxisMapping[functionAxis]).reversed;
+        realAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
+
+        _rgFunctionAxisMapping[function] = realAxis;
+
+        int mappedAxis = _rgAxisMapping[realAxis];
+        _rgAxisInfo[mappedAxis].function = (Joystick::AxisFunction_t)function;
     }
     _signalAllAttiudeValueChanges();
 }

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -76,17 +76,17 @@ JoystickConfigController::~JoystickConfigController()
 /// @brief Returns the state machine entry for the specified state.
 const JoystickConfigController::stateMachineEntry* JoystickConfigController::_getStateMachineEntry(int step)
 {
-    static const char* msgBegin =           "Allow all sticks to center as shown in diagram.\n\nClick Next to continue";
+    static const char* msgBegin =         "Allow all sticks to center as shown in diagram.\n\nClick Next to continue";
     static const char* msgLStickUp =      "Move the LEFT stick all the way up and hold it there...";
     static const char* msgLStickDown =    "Move the LEFT stick all the way down and hold it there...";
-    static const char* msgLStickLeft =         "Move the LEFT stick all the way to the left and hold it there...";
-    static const char* msgLStickRight =        "Move the LEFT stick all the way to the right and hold it there...";
-    static const char* msgRStickLeft =        "Move the RIGHT stick all the way to the left and hold it there...";
-    static const char* msgRStickRight =       "Move the RIGHT stick all the way to the right and hold it there...";
-    static const char* msgRStickDown =       "Move the RIGHT stick all the way down and hold it there...";
-    static const char* msgRStickUp =         "Move the RIGHT stick all the way up and hold it there...";
-    static const char* msgRStickCenter =     "Allow the RIGHT stick to move back to center...";
-    static const char* msgComplete =        "All settings have been captured. Click Next to enable the joystick.";
+    static const char* msgLStickLeft =    "Move the LEFT stick all the way to the left and hold it there...";
+    static const char* msgLStickRight =   "Move the LEFT stick all the way to the right and hold it there...";
+    static const char* msgRStickLeft =    "Move the RIGHT stick all the way to the left and hold it there...";
+    static const char* msgRStickRight =   "Move the RIGHT stick all the way to the right and hold it there...";
+    static const char* msgRStickDown =    "Move the RIGHT stick all the way down and hold it there...";
+    static const char* msgRStickUp =      "Move the RIGHT stick all the way up and hold it there...";
+    static const char* msgRStickCenter =  "Allow the RIGHT stick to move back to center...";
+    static const char* msgComplete =      "All settings have been captured. Click Next to enable the joystick.";
     
     static const stateMachineEntry rgStateMachine[] = {
         //Axis                   Message           Image               RCInputFunction                                     NextFunction                                    SkipFunction
@@ -139,9 +139,11 @@ void JoystickConfigController::_axisValueChanged(int axis, int value)
         // We always update raw values
         _axisRawValue[axis] = value;
         emit axisValueChanged(axis, _axisRawValue[axis]);
-        
+        //int mappedAxis = _rgAxisMapping[axis];
         // Signal attitude axis values to Qml if mapped
         if (_rgAxisInfo[axis].axis != Joystick::maxAxis) {
+//            _rgAxisMapping[_]
+//            _rgFunctionAxisMapping[]
             switch (_rgAxisInfo[axis].function) {
                 case Joystick::rollFunction:
                     emit rollAxisValueChanged(_axisRawValue[axis]);
@@ -285,13 +287,13 @@ bool JoystickConfigController::_stickSettleComplete(int axis, int value)
             
             if (_stickDetectSettleElapsed.elapsed() > _stickDetectSettleMSecs) {
                 // Stick has stayed positioned in one place long enough, detection is complete.
-                qCDebug(JoystickConfigControllerLog) << "_stickSettleComplete detection complete, axis:_stickDetectValue:value" << axis << _stickDetectValue << value;
+                qCDebug(JoystickConfigControllerVerboseLog) << "_stickSettleComplete detection complete, axis:_stickDetectValue:value" << axis << _stickDetectValue << value;
                 return true;
             }
         } else {
             // Start waiting for the stick to stay settled for _stickDetectSettleWaitMSecs msecs
             
-            qCDebug(JoystickConfigControllerLog) << "_stickSettleComplete starting settle timer, axis:_stickDetectValue:value" << axis << _stickDetectValue << value;
+            qCDebug(JoystickConfigControllerVerboseLog) << "_stickSettleComplete starting settle timer, axis:_stickDetectValue:value" << axis << _stickDetectValue << value;
             
             _stickDetectSettleStarted = true;
             _stickDetectSettleElapsed.start();
@@ -319,7 +321,7 @@ void JoystickConfigController::_inputStickDetect(Joystick::Axis_t axis, int map,
         if (abs(_axisValueSave[map] - value) > _calMoveDelta) {
             // Stick has moved far enough to consider it as being selected for the function
             
-            qCDebug(JoystickConfigControllerLog) << "_inputStickDetect starting settle wait, axis:map:value" << axis << map << value;
+            qCDebug(JoystickConfigControllerVerboseLog) << "_inputStickDetect starting settle wait, axis:map:value" << axis << map << value;
             
             // Setup up to detect stick being pegged to min or max value
             _stickDetectAxis = map;
@@ -331,13 +333,24 @@ void JoystickConfigController::_inputStickDetect(Joystick::Axis_t axis, int map,
             AxisInfo* info = &_rgAxisInfo[map];
             
             // Stick detection is complete. Stick should be at max position.
-            // Map the axis to the function
-            //_rgFunctionAxisMapping[axis] = map;
-            info->axis = axis;
-            //info->function = joystick->
+            for(int i = 0; i < Joystick::maxFunction; i++) {
+                if(_rgFunctionAxisMapping[i] == axis)
+                    info->function = (Joystick::AxisFunction_t)i;
+            }
 
+            info->axis = axis;
             _rgAxisMapping[axis] = map;
-//            _rgFunctionAxisMapping = joystick->get
+
+            qDebug() << "\nstickLeftX is mapped to raw axis:" << _rgAxisMapping[Joystick::stickLeftX];
+            qDebug() << "stickLeftY is mapped to raw axis:" << _rgAxisMapping[Joystick::stickLeftY];
+            qDebug() << "stickRightX is mapped to raw axis:" << _rgAxisMapping[Joystick::stickRightX];
+            qDebug() << "stickRightY is mapped to raw axis:" << _rgAxisMapping[Joystick::stickRightY];
+
+            qDebug() << "Raw axis 0 is mapped to stickAxis:" << _rgAxisInfo[0].axis << "and has function:" << _rgAxisInfo[0].function;
+            qDebug() << "Raw axis 1 is mapped to stickAxis:" << _rgAxisInfo[1].axis << "and has function:" << _rgAxisInfo[1].function;
+            qDebug() << "Raw axis 2 is mapped to stickAxis:" << _rgAxisInfo[2].axis << "and has function:" << _rgAxisInfo[2].function;
+            qDebug() << "Raw axis 3 is mapped to stickAxis:" << _rgAxisInfo[3].axis << "and has function:" << _rgAxisInfo[3].function;
+
             
             // Axis should be at max value, if it is below initial set point the the axis is reversed.
             info->reversed = value < _axisValueSave[map];
@@ -348,7 +361,7 @@ void JoystickConfigController::_inputStickDetect(Joystick::Axis_t axis, int map,
                 _rgAxisInfo[map].axisMax = value;
             }
             
-            qCDebug(JoystickConfigControllerLog) << "_inputStickDetect saving values, axis:map:value:reversed:_axisValueSave" << axis << map << value << info->reversed << _axisValueSave[map];
+            qCDebug(JoystickConfigControllerVerboseLog) << "_inputStickDetect saving values, axis:map:value:reversed:_axisValueSave" << axis << map << value << info->reversed << _axisValueSave[map];
             
             _signalAllAttiudeValueChanges();
             
@@ -376,14 +389,14 @@ void JoystickConfigController::_inputStickMin(Joystick::Axis_t axis, int map, in
                 _stickDetectAxis = map;
                 _stickDetectInitialValue = value;
                 _stickDetectValue = value;
-                qCDebug(JoystickConfigControllerLog) << "_inputStickMin detected movement _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
+                qCDebug(JoystickConfigControllerVerboseLog) << "_inputStickMin detected movement _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
             }
         } else {
             if (value < _calCenterPoint - _calMoveDelta) {
                 _stickDetectAxis = map;
                 _stickDetectInitialValue = value;
                 _stickDetectValue = value;
-                qCDebug(JoystickConfigControllerLog) << "_inputStickMin detected movement _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
+                qCDebug(JoystickConfigControllerVerboseLog) << "_inputStickMin detected movement _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
             }
         }
     } else {
@@ -399,7 +412,7 @@ void JoystickConfigController::_inputStickMin(Joystick::Axis_t axis, int map, in
                 _rgAxisInfo[map].axisMin = value;
             }
             
-            qCDebug(JoystickConfigControllerLog) << "_inputStickMin saving values, axis:map:value:reversed" << axis << map << value << info->reversed;
+            qCDebug(JoystickConfigControllerVerboseLog) << "_inputStickMin saving values, axis:map:value:reversed" << axis << map << value << info->reversed;
             
             _advanceState();
         }
@@ -426,7 +439,7 @@ void JoystickConfigController::_inputCenterWait(Joystick::Axis_t axis, int map, 
             _stickDetectAxis = map;
             _stickDetectInitialValue = value;
             _stickDetectValue = value;
-            qCDebug(JoystickConfigControllerLog) << "_inputStickMin detected possible center _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
+            qCDebug(JoystickConfigControllerVerboseLog) << "_inputStickMin detected possible center _stickDetectAxis:_stickDetectInitialValue" << _stickDetectAxis << _stickDetectInitialValue;
         }
     } else {
         if (_stickSettleComplete(map, value)) {
@@ -452,10 +465,25 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
     }
     
     // Initialize attitude function mapping to function axis not set
-    for (size_t i=0; i<Joystick::maxFunction; i++) {
-        // I had commented this..
-        _rgFunctionAxisMapping[i] = _axisNoAxis;
+//    for (size_t i=0; i<Joystick::maxFunction; i++) {
+//        // I had commented this..
+//        //_rgFunctionAxisMapping[i] = _axisNoAxis;
+//    }
+
+    for (int function=0; function<Joystick::maxFunction; function++) {
+        int paramAxis;
+
+        paramAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
+
+        _rgFunctionAxisMapping[function] = paramAxis;
+        _rgAxisInfo[paramAxis].function = (Joystick::AxisFunction_t)function;
+
+        //qCDebug(JoystickConfigControllerLog) << "paramAxis:" << paramAxis << "function:" << function;
     }
+
+//    for (int axis=0; axis<Joystick::maxAxis; axis++) {
+//        _activeJoystick->setAxisMapping((Joystick::Axis_t)axis, _axisNoAxis);
+//    }
 
     for (size_t i=0; i<Joystick::maxAxis; i++) {
         _rgAxisMapping[i] = _axisNoAxis;
@@ -499,22 +527,32 @@ void JoystickConfigController::_setInternalCalibrationValuesFromSettings(void)
         qCDebug(JoystickConfigControllerVerboseLog) << "Read settings name:axis:min:max:trim:reversed" << joystick->name() << axis << info->axisMin << info->axisMax << info->axisTrim << info->reversed;
     }
     
-    for (int function=0; function<Joystick::maxFunction; function++) {
-        int paramAxis;
-        
-        paramAxis = joystick->getFunctionAxis((Joystick::AxisFunction_t)function);
-        
-        _rgFunctionAxisMapping[function] = paramAxis;
-        _rgAxisInfo[paramAxis].function = (Joystick::AxisFunction_t)function;
-
-        qCDebug(JoystickConfigControllerLog) << "paramAxis:" << paramAxis << "function:" << function;
-    }
 
     for (int axis=0; axis<Joystick::maxAxis; axis++) {
         int mappedAxis = joystick->getMappedAxis((Joystick::Axis_t)axis);
         _rgAxisMapping[axis] = mappedAxis;
         _rgAxisInfo[mappedAxis].axis = (Joystick::Axis_t)axis;
     }
+
+    for (int function=0; function<Joystick::maxFunction; function++) {
+        int paramAxis;
+
+        paramAxis = joystick->getFunctionAxis((Joystick::AxisFunction_t)function);
+
+        _rgFunctionAxisMapping[function] = paramAxis;
+        _rgAxisInfo[_rgAxisMapping[paramAxis]].function = (Joystick::AxisFunction_t)function;
+    }
+
+
+    qDebug() << "\nstickLeftX is mapped to raw axis:" << _rgAxisMapping[Joystick::stickLeftX];
+    qDebug() << "stickLeftY is mapped to raw axis:" << _rgAxisMapping[Joystick::stickLeftY];
+    qDebug() << "stickRightX is mapped to raw axis:" << _rgAxisMapping[Joystick::stickRightX];
+    qDebug() << "stickRightY is mapped to raw axis:" << _rgAxisMapping[Joystick::stickRightY];
+
+    qDebug() << "Raw axis 0 is mapped to stickAxis:" << _rgAxisInfo[0].axis << "and has function:" << _rgAxisInfo[0].function;
+    qDebug() << "Raw axis 1 is mapped to stickAxis:" << _rgAxisInfo[1].axis << "and has function:" << _rgAxisInfo[1].function;
+    qDebug() << "Raw axis 2 is mapped to stickAxis:" << _rgAxisInfo[2].axis << "and has function:" << _rgAxisInfo[2].function;
+    qDebug() << "Raw axis 3 is mapped to stickAxis:" << _rgAxisInfo[3].axis << "and has function:" << _rgAxisInfo[3].function;
     
     _signalAllAttiudeValueChanges();
 }
@@ -568,6 +606,12 @@ void JoystickConfigController::_validateCalibration(void)
 /// @brief Saves the rc calibration values to the board parameters.
 void JoystickConfigController::_writeCalibration(void)
 {
+    qDebug() << "_writeCalibration";
+
+    for(int i = 0 ; i < Joystick::maxAxis; i++) {
+        qDebug() << "axis" << i << ":" << _rgAxisMapping[i];
+        qDebug() << "info axis:" << _rgAxisInfo[i].axis << "function:" << _rgAxisInfo[i].function;
+    }
     Joystick* joystick = _joystickManager->activeJoystick();
 
     _validateCalibration();
@@ -585,11 +629,6 @@ void JoystickConfigController::_writeCalibration(void)
         
         joystick->setCalibration(axis, calibration);
     }
-    
-    // Write axis mapping parameters
-//    for (int function=0; function<Joystick::maxFunction; function++) {
-//        joystick->setFunctionAxis((Joystick::AxisFunction_t)function, _rgFunctionAxisMapping[function]);
-//    }
 
     for (int axis=0; axis<Joystick::maxAxis; axis++) {
         joystick->setAxisMapping((Joystick::Axis_t)axis, _rgAxisMapping[axis]);
@@ -669,7 +708,7 @@ void JoystickConfigController::_setHelpImage(const char* imageFile)
     file += _imageFileMode2Dir;
     file += imageFile;
     
-    qCDebug(JoystickConfigControllerLog) << "_setHelpImage" << file;
+    qCDebug(JoystickConfigControllerVerboseLog) << "_setHelpImage" << file;
     
     _imageHelp = file;
     emit imageHelpChanged(file);
@@ -759,7 +798,6 @@ bool JoystickConfigController::rollAxisMapped(void)
     if (mappedAxis == _axisNoAxis) {
         return false;
     }
-    qCDebug(JoystickConfigControllerLog) << "axis:mappedAxis:rollAxisMapped:" << axis << mappedAxis << _rgAxisInfo[mappedAxis].axis;
     return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
 }
 
@@ -770,7 +808,6 @@ bool JoystickConfigController::pitchAxisMapped(void)
     if (mappedAxis == _axisNoAxis) {
         return false;
     }
-    qCDebug(JoystickConfigControllerLog) << "axis:mappedAxis:pitchAxisMapped:" << axis << mappedAxis << _rgAxisInfo[mappedAxis].axis;
     return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
 }
 
@@ -781,7 +818,6 @@ bool JoystickConfigController::yawAxisMapped(void)
     if (mappedAxis == _axisNoAxis) {
         return false;
     }
-    qCDebug(JoystickConfigControllerLog) << "axis:mappedAxis:yawAxisMapped:" << axis << mappedAxis << _rgAxisInfo[mappedAxis].axis;
     return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
 }
 
@@ -792,14 +828,13 @@ bool JoystickConfigController::throttleAxisMapped(void)
     if (mappedAxis == _axisNoAxis) {
         return false;
     }
-    qCDebug(JoystickConfigControllerLog) << "axis:mappedAxis:throttleAxisMapped:" << axis << mappedAxis << _rgAxisInfo[mappedAxis].axis;
     return _rgAxisInfo[mappedAxis].axis != Joystick::maxAxis;
 }
 
 bool JoystickConfigController::rollAxisReversed(void)
 {
     if (_rgFunctionAxisMapping[Joystick::rollFunction] != _axisNoAxis) {
-        return _rgAxisInfo[_rgFunctionAxisMapping[Joystick::rollFunction]].reversed;
+        return _rgAxisInfo[_rgAxisMapping[_rgFunctionAxisMapping[Joystick::rollFunction]]].reversed;
     } else {
         return false;
     }
@@ -808,7 +843,7 @@ bool JoystickConfigController::rollAxisReversed(void)
 bool JoystickConfigController::pitchAxisReversed(void)
 {
     if (_rgFunctionAxisMapping[Joystick::pitchFunction] != _axisNoAxis) {
-        return _rgAxisInfo[_rgFunctionAxisMapping[Joystick::pitchFunction]].reversed;
+        return _rgAxisInfo[_rgAxisMapping[_rgFunctionAxisMapping[Joystick::pitchFunction]]].reversed;
     } else {
         return false;
     }
@@ -817,7 +852,7 @@ bool JoystickConfigController::pitchAxisReversed(void)
 bool JoystickConfigController::yawAxisReversed(void)
 {
     if (_rgFunctionAxisMapping[Joystick::yawFunction] != _axisNoAxis) {
-        return _rgAxisInfo[_rgFunctionAxisMapping[Joystick::yawFunction]].reversed;
+        return _rgAxisInfo[_rgAxisMapping[_rgFunctionAxisMapping[Joystick::yawFunction]]].reversed;
     } else {
         return false;
     }
@@ -826,7 +861,7 @@ bool JoystickConfigController::yawAxisReversed(void)
 bool JoystickConfigController::throttleAxisReversed(void)
 {
     if (_rgFunctionAxisMapping[Joystick::throttleFunction] != _axisNoAxis) {
-        return _rgAxisInfo[_rgFunctionAxisMapping[Joystick::throttleFunction]].reversed;
+        return _rgAxisInfo[_rgAxisMapping[_rgFunctionAxisMapping[Joystick::throttleFunction]]].reversed;
     } else {
         return false;
     }
@@ -885,14 +920,14 @@ void JoystickConfigController::_modeChanged(int mode)
 {
     qCDebug(JoystickConfigControllerLog) << "Mode changed:" << mode;
     for (int function=0; function<Joystick::maxFunction; function++) {
-        int paramAxis;
+        int functionAxis;
 
-        paramAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
-
-        _rgFunctionAxisMapping[function] = paramAxis;
-        _rgAxisInfo[paramAxis].function = (Joystick::AxisFunction_t)function;
-
-        qCDebug(JoystickConfigControllerLog) << "paramAxis:" << paramAxis << "function:" << function;
+        // Get axis for this function (stickRightX etc.)
+        functionAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
+        _rgFunctionAxisMapping[function] = functionAxis;
+        _rgAxisInfo[_rgAxisMapping[functionAxis]].function = (Joystick::AxisFunction_t)function;
+        // unnecessary, calibration hasn't changed
+        //_rgAxisInfo[_rgAxisMapping[functionAxis]].reversed = _activeJoystick->getCalibration(_rgAxisMapping[functionAxis]).reversed;
     }
     _signalAllAttiudeValueChanges();
 }

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -30,17 +30,17 @@ const int JoystickConfigController::_calMinDelta =          1000;       ///< Amo
 
 const int JoystickConfigController::_stickDetectSettleMSecs = 500;
 
-const char*  JoystickConfigController::_imageFilePrefix =   "calibration/";
-const char*  JoystickConfigController::_imageFileMode2Dir = "joystick/";
-const char*  JoystickConfigController::_imageCenter =       "joystickCenter.png";
-const char*  JoystickConfigController::_imageThrottleUp =   "joystickThrottleUp.png";
-const char*  JoystickConfigController::_imageThrottleDown = "joystickThrottleDown.png";
-const char*  JoystickConfigController::_imageYawLeft =      "joystickYawLeft.png";
-const char*  JoystickConfigController::_imageYawRight =     "joystickYawRight.png";
-const char*  JoystickConfigController::_imageRollLeft =     "joystickRollLeft.png";
-const char*  JoystickConfigController::_imageRollRight =    "joystickRollRight.png";
-const char*  JoystickConfigController::_imagePitchUp =      "joystickPitchUp.png";
-const char*  JoystickConfigController::_imagePitchDown =    "joystickPitchDown.png";
+const char*  JoystickConfigController::_imageFilePrefix =       "calibration/";
+const char*  JoystickConfigController::_imageFileMode2Dir =     "joystick/";
+const char*  JoystickConfigController::_imageCenter =           "joystickCenter.png";
+const char*  JoystickConfigController::_imageLeftStickUp =      "joystickThrottleUp.png";
+const char*  JoystickConfigController::_imageLeftStickDown =    "joystickThrottleDown.png";
+const char*  JoystickConfigController::_imageLeftStickLeft =    "joystickYawLeft.png";
+const char*  JoystickConfigController::_imageLeftStickRight =   "joystickYawRight.png";
+const char*  JoystickConfigController::_imageRightStickLeft =   "joystickRollLeft.png";
+const char*  JoystickConfigController::_imageRightStickRight =  "joystickRollRight.png";
+const char*  JoystickConfigController::_imageRightStickUp =     "joystickPitchUp.png";
+const char*  JoystickConfigController::_imageRightStickDown =   "joystickPitchDown.png";
 
 JoystickConfigController::JoystickConfigController(void)
     : _activeJoystick(NULL)
@@ -89,18 +89,18 @@ const JoystickConfigController::stateMachineEntry* JoystickConfigController::_ge
     static const char* msgComplete =      "All settings have been captured. Click Next to enable the joystick.";
     
     static const stateMachineEntry rgStateMachine[] = {
-        //Axis                   Message           Image               RCInputFunction                                     NextFunction                                    SkipFunction
-        { Joystick::maxAxis,     msgBegin,         _imageCenter,       &JoystickConfigController::_inputCenterWaitBegin,   &JoystickConfigController::_saveAllTrims,       NULL },
-        { Joystick::stickLeftY,  msgLStickUp,      _imageThrottleUp,   &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
-        { Joystick::stickLeftY,  msgLStickDown,    _imageThrottleDown, &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
-        { Joystick::stickLeftX,  msgLStickRight,   _imageYawRight,     &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
-        { Joystick::stickLeftX,  msgLStickLeft,    _imageYawLeft,      &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
-        { Joystick::stickRightX, msgRStickRight,   _imageRollRight,    &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
-        { Joystick::stickRightX, msgRStickLeft,    _imageRollLeft,     &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
-        { Joystick::stickRightY, msgRStickUp,      _imagePitchUp,      &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
-        { Joystick::stickRightY, msgRStickDown,    _imagePitchDown,    &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
-        { Joystick::stickRightY, msgRStickCenter,  _imageCenter,       &JoystickConfigController::_inputCenterWait,        NULL,                                           NULL },
-        { Joystick::maxAxis,     msgComplete,      _imageCenter,       NULL,                                               &JoystickConfigController::_writeCalibration,   NULL },
+        //Axis                   Message           Image                    RCInputFunction                                     NextFunction                                    SkipFunction
+        { Joystick::maxAxis,     msgBegin,         _imageCenter,            &JoystickConfigController::_inputCenterWaitBegin,   &JoystickConfigController::_saveAllTrims,       NULL },
+        { Joystick::stickLeftY,  msgLStickUp,      _imageLeftStickUp,       &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
+        { Joystick::stickLeftY,  msgLStickDown,    _imageLeftStickDown,     &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
+        { Joystick::stickLeftX,  msgLStickRight,   _imageLeftStickRight,    &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
+        { Joystick::stickLeftX,  msgLStickLeft,    _imageLeftStickLeft,     &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
+        { Joystick::stickRightX, msgRStickRight,   _imageRightStickRight,   &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
+        { Joystick::stickRightX, msgRStickLeft,    _imageRightStickLeft,    &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
+        { Joystick::stickRightY, msgRStickUp,      _imageRightStickUp,      &JoystickConfigController::_inputStickDetect,       NULL,                                           NULL },
+        { Joystick::stickRightY, msgRStickDown,    _imageRightStickDown,    &JoystickConfigController::_inputStickMin,          NULL,                                           NULL },
+        { Joystick::stickRightY, msgRStickCenter,  _imageCenter,            &JoystickConfigController::_inputCenterWait,        NULL,                                           NULL },
+        { Joystick::maxAxis,     msgComplete,      _imageCenter,            NULL,                                               &JoystickConfigController::_writeCalibration,   NULL },
     };
     
     Q_ASSERT(step >=0 && step < (int)(sizeof(rgStateMachine) / sizeof(rgStateMachine[0])));
@@ -338,17 +338,16 @@ void JoystickConfigController::_inputStickDetect(Joystick::Axis_t axis, int map,
             info->axis = axis;
             _rgAxisMapping[axis] = map;
 
-            qDebug() << "\nstickLeftX is mapped to raw axis:" << _rgAxisMapping[Joystick::stickLeftX];
-            qDebug() << "stickLeftY is mapped to raw axis:" << _rgAxisMapping[Joystick::stickLeftY];
-            qDebug() << "stickRightX is mapped to raw axis:" << _rgAxisMapping[Joystick::stickRightX];
-            qDebug() << "stickRightY is mapped to raw axis:" << _rgAxisMapping[Joystick::stickRightY];
+            qDebug(JoystickConfigControllerLog) << "\nstickLeftX is mapped to raw axis:" << _rgAxisMapping[Joystick::stickLeftX];
+            qDebug(JoystickConfigControllerLog) << "stickLeftY is mapped to raw axis:" << _rgAxisMapping[Joystick::stickLeftY];
+            qDebug(JoystickConfigControllerLog) << "stickRightX is mapped to raw axis:" << _rgAxisMapping[Joystick::stickRightX];
+            qDebug(JoystickConfigControllerLog) << "stickRightY is mapped to raw axis:" << _rgAxisMapping[Joystick::stickRightY];
 
-            qDebug() << "Raw axis 0 is mapped to stickAxis:" << _rgAxisInfo[0].axis << "and has function:" << _rgAxisInfo[0].function;
-            qDebug() << "Raw axis 1 is mapped to stickAxis:" << _rgAxisInfo[1].axis << "and has function:" << _rgAxisInfo[1].function;
-            qDebug() << "Raw axis 2 is mapped to stickAxis:" << _rgAxisInfo[2].axis << "and has function:" << _rgAxisInfo[2].function;
-            qDebug() << "Raw axis 3 is mapped to stickAxis:" << _rgAxisInfo[3].axis << "and has function:" << _rgAxisInfo[3].function;
+            qDebug(JoystickConfigControllerLog) << "Raw axis 0 is mapped to stickAxis:" << _rgAxisInfo[0].axis << "and has function:" << _rgAxisInfo[0].function;
+            qDebug(JoystickConfigControllerLog) << "Raw axis 1 is mapped to stickAxis:" << _rgAxisInfo[1].axis << "and has function:" << _rgAxisInfo[1].function;
+            qDebug(JoystickConfigControllerLog) << "Raw axis 2 is mapped to stickAxis:" << _rgAxisInfo[2].axis << "and has function:" << _rgAxisInfo[2].function;
+            qDebug(JoystickConfigControllerLog) << "Raw axis 3 is mapped to stickAxis:" << _rgAxisInfo[3].axis << "and has function:" << _rgAxisInfo[3].function;
 
-            
             // Axis should be at max value, if it is below initial set point the the axis is reversed.
             info->reversed = value < _axisValueSave[map];
             
@@ -408,7 +407,7 @@ void JoystickConfigController::_inputStickMin(Joystick::Axis_t axis, int map, in
             } else {
                 _rgAxisInfo[map].axisMin = value;
             }
-            
+
             qCDebug(JoystickConfigControllerVerboseLog) << "_inputStickMin saving values, axis:map:value:reversed" << axis << map << value << info->reversed;
             
             _advanceState();
@@ -461,12 +460,6 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
         info->axisTrim = JoystickConfigController::_calCenterPoint;
     }
     
-    // Initialize attitude function mapping to function axis not set
-//    for (size_t i=0; i<Joystick::maxFunction; i++) {
-//        // I had commented this..
-//        //_rgFunctionAxisMapping[i] = _axisNoAxis;
-//    }
-
     for (int function=0; function<Joystick::maxFunction; function++) {
         Joystick::Axis_t realAxis;
 
@@ -474,13 +467,7 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
 
         _rgFunctionAxisMapping[function] = realAxis;
         _rgAxisInfo[_rgAxisMapping[realAxis]].function = (Joystick::AxisFunction_t)function;
-
-        //qCDebug(JoystickConfigControllerLog) << "paramAxis:" << paramAxis << "function:" << function;
     }
-
-//    for (int axis=0; axis<Joystick::maxAxis; axis++) {
-//        _activeJoystick->setAxisMapping((Joystick::Axis_t)axis, _axisNoAxis);
-//    }
 
     for (size_t i=0; i<Joystick::maxAxis; i++) {
         _rgAxisMapping[i] = _axisNoAxis;

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -453,7 +453,8 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
     
     // Initialize attitude function mapping to function axis not set
     for (size_t i=0; i<Joystick::maxFunction; i++) {
-        //_rgFunctionAxisMapping[i] = _axisNoAxis;
+        // I had commented this..
+        _rgFunctionAxisMapping[i] = _axisNoAxis;
     }
 
     for (size_t i=0; i<Joystick::maxAxis; i++) {

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -466,7 +466,6 @@ void JoystickConfigController::_resetInternalCalibrationValues(void)
         realAxis = _activeJoystick->getFunctionAxis((Joystick::AxisFunction_t)function);
 
         _rgFunctionAxisMapping[function] = realAxis;
-        _rgAxisInfo[_rgAxisMapping[realAxis]].function = (Joystick::AxisFunction_t)function;
     }
 
     for (size_t i=0; i<Joystick::maxAxis; i++) {

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -229,18 +229,17 @@ private:
 
     /// Get the real life axis mapped to a function (roll->stickRightX).
     /// This mapping is determined by the current JoystickTXMode
-    /// _axisNoAxis (-1) indicates axis not set for this function.
+    /// Joystick::maxAxis indicates axis not set for this function.
     Joystick::Axis_t _rgFunctionAxisMapping[Joystick::maxFunction];
 
     /// Get the raw joystick axis mapped to a real life axis (stickRightX->n).
     /// This mapping is determined through the calibration process
-    /// _axisNoAxis (-1) indicates axis not mapped
+    /// Joystick::maxAxis indicates axis not mapped
     int _rgAxisMapping[Joystick::maxAxis];
 
     static const int _attitudeControls = 5; // Unused.. and should be 4?
     
     int                 _axisCount;         ///< Number of actual joystick axes available
-    static const int    _axisNoAxis = -1;   ///< Signals no axis set
     static const int    _axisMinimum = 4;   ///< Minimum numner of joystick axes required to run PX4
     struct AxisInfo*    _rgAxisInfo;        ///< Information associated with each axis
     int*                _axisValueSave;     ///< Saved values prior to detecting axis movement

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -23,6 +23,7 @@
 #include "Joystick.h"
 
 Q_DECLARE_LOGGING_CATEGORY(JoystickConfigControllerLog)
+Q_DECLARE_LOGGING_CATEGORY(JoystickConfigControllerVerboseLog)
 
 class RadioConfigest;
 class JoystickManager;
@@ -135,6 +136,7 @@ private slots:
     void _activeJoystickChanged(Joystick* joystick);
     void _axisValueChanged(int axis, int value);
     void _axisDeadbandChanged(int axis, int value);
+    void _modeChanged(int mode);
    
 private:
     /// @brief The states of the calibration state machine.
@@ -149,10 +151,10 @@ private:
         calStateSave
     };
     
-    typedef void (JoystickConfigController::*inputFn)(Joystick::AxisFunction_t function, int axis, int value);
+    typedef void (JoystickConfigController::*inputFn)(Joystick::Axis_t axis, int map, int value);
     typedef void (JoystickConfigController::*buttonFn)(void);
     struct stateMachineEntry {
-        Joystick::AxisFunction_t    function;
+        Joystick::Axis_t            axis;
         const char*                 instructions;
         const char*                 image;
         inputFn                     rcInputFn;
@@ -162,7 +164,8 @@ private:
     
     /// @brief A set of information associated with a radio axis.
     struct AxisInfo {
-        Joystick::AxisFunction_t    function;   ///< Function mapped to this axis, Joystick::maxFunction for none
+        Joystick::Axis_t            axis;       ///< Physical axis mapped to the arbitrary axis index reported by joystick, Joystick::maxAxis for none
+        Joystick::AxisFunction_t    function;
         bool                        reversed;   ///< true: axis is reverse, false: not reversed
         int                         axisMin;    ///< Minimum axis value
         int                         axisMax;    ///< Maximum axis value
@@ -181,15 +184,15 @@ private:
     
     bool _validAxis(int axis);
 
-    void _inputCenterWaitBegin  (Joystick::AxisFunction_t function, int axis, int value);
-    void _inputStickDetect      (Joystick::AxisFunction_t function, int axis, int value);
-    void _inputStickMin         (Joystick::AxisFunction_t function, int axis, int value);
-    void _inputCenterWait       (Joystick::AxisFunction_t function, int axis, int value);
+    void _inputCenterWaitBegin  (Joystick::Axis_t axis, int map, int value);
+    void _inputStickDetect      (Joystick::Axis_t axis, int map, int value);
+    void _inputStickMin         (Joystick::Axis_t axis, int map, int value);
+    void _inputCenterWait       (Joystick::Axis_t axis, int map, int value);
     
-    void _switchDetect(Joystick::AxisFunction_t function, int axis, int value, bool moveToNextStep);
-    
-    void _saveFlapsDown(void);
-    void _skipFlaps(void);
+    void _switchDetect(Joystick::AxisFunction_t function, int axis, int value, bool moveToNextStep); // Undefined
+
+    void _saveFlapsDown(void); // Undefined
+    void _skipFlaps(void); // Undefined
     void _saveAllTrims(void);
     
     bool _stickSettleComplete(int axis, int value);
@@ -226,8 +229,9 @@ private:
     static const int _updateInterval;   ///< Interval for ui update timer
     
     int _rgFunctionAxisMapping[Joystick::maxFunction]; ///< Maps from joystick function to axis index. _axisMax indicates axis not set for this function.
+    int _rgAxisMapping[Joystick::maxAxis];
 
-    static const int _attitudeControls = 5;
+    static const int _attitudeControls = 5; // Unused.. and should be 4?
     
     int                 _axisCount;         ///< Number of actual joystick axes available
     static const int    _axisNoAxis = -1;   ///< Signals no axis set

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -164,8 +164,8 @@ private:
     
     /// @brief A set of information associated with a radio axis.
     struct AxisInfo {
-        Joystick::Axis_t            axis;       ///< Physical axis mapped to the arbitrary axis index reported by joystick, Joystick::maxAxis for none
-        Joystick::AxisFunction_t    function;
+        Joystick::Axis_t            axis;       ///< Physical real-life axis (stickLeft/Right/X/Y) mapped to this arbitrary raw axis index. _axisNoAxis (-1) for none.
+        Joystick::AxisFunction_t    function;   ///< Function mapped to this raw axis
         bool                        reversed;   ///< true: axis is reverse, false: not reversed
         int                         axisMin;    ///< Minimum axis value
         int                         axisMax;    ///< Maximum axis value
@@ -227,8 +227,15 @@ private:
     static const char* _imagePitchDown;
     
     static const int _updateInterval;   ///< Interval for ui update timer
-    
-    int _rgFunctionAxisMapping[Joystick::maxFunction]; ///< Maps from joystick function to axis index. _axisMax indicates axis not set for this function.
+
+    /// Get the real life axis mapped to a function (roll->stickRightX).
+    /// This mapping is determined by the current JoystickTXMode
+    /// _axisNoAxis (-1) indicates axis not set for this function.
+    Joystick::Axis_t _rgFunctionAxisMapping[Joystick::maxFunction];
+
+    /// Get the raw joystick axis mapped to a real life axis (stickRightX->n).
+    /// This mapping is determined through the calibration process
+    /// _axisNoAxis (-1) indicates axis not mapped
     int _rgAxisMapping[Joystick::maxAxis];
 
     static const int _attitudeControls = 5; // Unused.. and should be 4?

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -164,8 +164,8 @@ private:
     
     /// @brief A set of information associated with a radio axis.
     struct AxisInfo {
-        Joystick::Axis_t            axis;       ///< Physical real-life axis (stickLeft/Right/X/Y) mapped to this arbitrary raw axis index. _axisNoAxis (-1) for none.
-        Joystick::AxisFunction_t    function;   ///< Function mapped to this raw axis
+        Joystick::Axis_t            axis;       ///< Physical real-life axis (stickLeft/Right/X/Y) mapped to this arbitrary raw axis index. Joystick::maxAxis for none.
+        Joystick::AxisFunction_t    function;   ///< Function mapped to this raw axis. Joystick::maxFunction for none.
         bool                        reversed;   ///< true: axis is reverse, false: not reversed
         int                         axisMin;    ///< Minimum axis value
         int                         axisMax;    ///< Maximum axis value

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -217,14 +217,14 @@ private:
     static const char* _imageFileMode2Dir;
     static const char* _imageFilePrefix;
     static const char* _imageCenter;
-    static const char* _imageThrottleUp;
-    static const char* _imageThrottleDown;
-    static const char* _imageYawLeft;
-    static const char* _imageYawRight;
-    static const char* _imageRollLeft;
-    static const char* _imageRollRight;
-    static const char* _imagePitchUp;
-    static const char* _imagePitchDown;
+    static const char* _imageLeftStickUp;
+    static const char* _imageLeftStickDown;
+    static const char* _imageLeftStickLeft;
+    static const char* _imageLeftStickRight;
+    static const char* _imageRightStickLeft;
+    static const char* _imageRightStickRight;
+    static const char* _imageRightStickUp;
+    static const char* _imageRightStickDown;
     
     static const int _updateInterval;   ///< Interval for ui update timer
 

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -23,7 +23,6 @@
 #include "Joystick.h"
 
 Q_DECLARE_LOGGING_CATEGORY(JoystickConfigControllerLog)
-Q_DECLARE_LOGGING_CATEGORY(JoystickConfigControllerVerboseLog)
 
 class RadioConfigest;
 class JoystickManager;
@@ -151,7 +150,7 @@ private:
         calStateSave
     };
     
-    typedef void (JoystickConfigController::*inputFn)(Joystick::Axis_t axis, int map, int value);
+    typedef void (JoystickConfigController::*inputFn)(Joystick::Axis_t axis, int mappedAxis, int value);
     typedef void (JoystickConfigController::*buttonFn)(void);
     struct stateMachineEntry {
         Joystick::Axis_t            axis;
@@ -184,10 +183,10 @@ private:
     
     bool _validAxis(int axis);
 
-    void _inputCenterWaitBegin  (Joystick::Axis_t axis, int map, int value);
-    void _inputStickDetect      (Joystick::Axis_t axis, int map, int value);
-    void _inputStickMin         (Joystick::Axis_t axis, int map, int value);
-    void _inputCenterWait       (Joystick::Axis_t axis, int map, int value);
+    void _inputCenterWaitBegin  (Joystick::Axis_t axis, int mappedAxis, int value);
+    void _inputStickDetect      (Joystick::Axis_t axis, int mappedAxis, int value);
+    void _inputStickMin         (Joystick::Axis_t axis, int mappedAxis, int value);
+    void _inputCenterWait       (Joystick::Axis_t axis, int mappedAxis, int value);
     
     void _switchDetect(Joystick::AxisFunction_t function, int axis, int value, bool moveToNextStep); // Undefined
 


### PR DESCRIPTION
This is a rework of the joystick calibration process to allow selecting a transmitter mode (TX mode) for the joystick input. The mode options are 1-4 as described [here](http://www.rc-airplane-world.com/rc-transmitter-modes.html). This option is placed under the Advanced Settings in the joystick configuration page.

Instead of mapping functions to raw axis indices, functions are mapped to real-life axes (stickLeftX, stickLeftY, stickRightX, stickRightY). This mapping is changed by selecting the joystick TX mode. The joystick TX mode setting is firmware-specific, so a user can use different TX modes for copter and sub, for example. The default TX mode is 2 for all firmwares except sub, whose default is 3.

The functionAxis saved settings have been replaced with real-life axis mappings, and firmware specific TX mode settings.

The attitude controls in the joystick configuration page will always reflect the current TX mode, and the text has been changed for Sub to show Forward/Lateral instead of Pitch/Roll.

![screenshot 2017-01-23 15 41 01](https://cloud.githubusercontent.com/assets/8315108/22221819/8020c296-e182-11e6-8b8f-a0388a424789.png)
![screenshot 2017-01-23 15 41 17](https://cloud.githubusercontent.com/assets/8315108/22221822/81f9e52a-e182-11e6-9743-b99987c1d6ca.png)

The calibration process has changed by prompting the user to move the left/right sticks on the joystick instead of the throttle/pitch sticks. The real life axes are mapped to raw axis indices reported by the joystick in this step.

![screenshot 2017-01-23 15 43 11](https://cloud.githubusercontent.com/assets/8315108/22221871/ac9d427c-e182-11e6-98a5-40d865957f37.png)

SDL2 provides a gamecontroller subclass of joysticks in which the real-life axis mappings are already done by SDL2, and all game controller axis mappings will be consistent. For this reason, game controllers will have a default calibration loaded, and won't require calibration. The option to (re)calibrate a gamecontroller joystick is still available, but the joystick will be enabled automatically without requiring an initial calibration.