### PR TITLE
Auto connect on start for UDP links

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -439,6 +439,9 @@ bool QGCApplication::_initForNormalAppBoot(void)
                     "Your saved settings have been reset to defaults.");
     }
 
+    // Connect links with flag AutoconnectLink
+    toolbox()->linkManager()->startAutoConnectedLinks();
+
     if (getQGCMapEngine()->wasCacheReset()) {
         showMessage("The Offline Map Cache database has been upgraded. "
                     "Your old map cache sets have been reset.");

--- a/src/comm/BluetoothLink.h
+++ b/src/comm/BluetoothLink.h
@@ -104,7 +104,6 @@ public:
     void        loadSettings            (QSettings& settings, const QString& root);
     void        saveSettings            (QSettings& settings, const QString& root);
     void        updateSettings          ();
-    bool        isAutoConnectAllowed    () { return false; }
     QString     settingsURL             () { return "BluetoothSettings.qml"; }
 
 public slots:

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -93,7 +93,7 @@ public:
      * Is Auto Connect allowed for this type?
      * @return True if this type can be set as an Auto Connect configuration
      */
-    virtual bool isAutoConnectAllowed() { return true; }
+    virtual bool isAutoConnectAllowed() { return false; }
 
     /*!
      * @brief Connection type

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -990,3 +990,14 @@ QList<LinkInterface*> LinkManager::links(void)
 
     return rawLinks;
 }
+
+void LinkManager::startAutoConnectedLinks(void)
+{
+    SharedLinkConfigurationPointer conf;
+
+    for(int i = 0; i < _sharedConfigurations.count(); i++) {
+        conf = _sharedConfigurations[i];
+        if (conf->isAutoConnect())
+            createConnectedLink(conf);
+    }
+}

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -171,6 +171,8 @@ public:
 
     SharedLinkConfigurationPointer addConfiguration(LinkConfiguration* config);
 
+    void startAutoConnectedLinks(void);
+
 signals:
     void autoconnectUDPChanged        (bool autoconnect);
     void autoconnectPixhawkChanged    (bool autoconnect);

--- a/src/comm/LogReplayLink.h
+++ b/src/comm/LogReplayLink.h
@@ -40,7 +40,6 @@ public:
     void        loadSettings            (QSettings& settings, const QString& root);
     void        saveSettings            (QSettings& settings, const QString& root);
     void        updateSettings          ();
-    bool        isAutoConnectAllowed    () { return false; }
     QString     settingsURL             () { return "LogReplaySettings.qml"; }
 signals:
     void fileNameChanged();

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -131,12 +131,13 @@ public:
     QStringList hostList    () { return _hostList; }
 
     /// From LinkConfiguration
-    LinkType    type            () { return LinkConfiguration::TypeUdp; }
-    void        copyFrom        (LinkConfiguration* source);
-    void        loadSettings    (QSettings& settings, const QString& root);
-    void        saveSettings    (QSettings& settings, const QString& root);
-    void        updateSettings  ();
-    QString     settingsURL     () { return "UdpSettings.qml"; }
+    LinkType    type                 () { return LinkConfiguration::TypeUdp; }
+    void        copyFrom             (LinkConfiguration* source);
+    void        loadSettings         (QSettings& settings, const QString& root);
+    void        saveSettings         (QSettings& settings, const QString& root);
+    void        updateSettings       ();
+    bool        isAutoConnectAllowed () { return true; }
+    QString     settingsURL          () { return "UdpSettings.qml"; }
 
 signals:
     void localPortChanged   ();

--- a/src/ui/preferences/LinkSettings.qml
+++ b/src/ui/preferences/LinkSettings.qml
@@ -271,12 +271,11 @@ Rectangle {
                         height: ScreenTools.defaultFontPixelHeight * 0.5
                         width:  parent.width
                     }
-                    /*
-                    //-- Auto Connect
+                    //-- Auto Connect on Start
                     QGCCheckBox {
                         text:       "Automatically Connect on Start"
                         checked:    false
-                        enabled:    editConfig ? editConfig.autoConnectAllowed : false
+                        visible:    editConfig ? editConfig.autoConnectAllowed : false
                         onCheckedChanged: {
                             if(editConfig) {
                                 editConfig.autoConnect = checked
@@ -287,7 +286,6 @@ Rectangle {
                                 checked = editConfig.autoConnect
                         }
                     }
-                    */
                     Item {
                         height: ScreenTools.defaultFontPixelHeight
                         width:  parent.width


### PR DESCRIPTION
This PR
- sets autoconnect flag on start for selected UDP link that helps if you use QGC for outgoing connection and for links with another listening port (not only for 14550). To use this feature set checkbox in the link configuration:
![screenshot from 2017-01-24 16-15-33](https://cloud.githubusercontent.com/assets/14868794/22249625/357d1f42-e25d-11e6-9031-4cbea2f78178.png)
-  changes return code of virtual method ```isAutoConnectAllowed``` from true to false. This way allowing to autoconnect only for UDP links and prohibiting for all other link types.