### PR TITLE
MAVLinkLogManager: fix use of wrong variable

### DIFF
--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -836,7 +836,7 @@ MAVLinkLogManager::_activeVehicleChanged(Vehicle* vehicle)
         emit canStartLogChanged();
     }
     // Connect new system
-    if(_vehicle && _vehicle->px4Firmware()) {
+    if(vehicle && vehicle->px4Firmware()) {
         _vehicle = vehicle;
         connect(_vehicle, &Vehicle::armedChanged,       this, &MAVLinkLogManager::_armedChanged);
         connect(_vehicle, &Vehicle::mavlinkLogData,     this, &MAVLinkLogManager::_mavlinkLogData);


### PR DESCRIPTION
previously the start log button was always disabled, even for PX4.

Fixes regression from 9d413108f8116a5ba049f41d94929789f799a509

@dogmaphobic @ChristophTobler