### PR TITLE
Fix crash by invalid socket deletion

### DIFF
--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -80,7 +80,7 @@ void VideoReceiver::_connected()
 {
     //-- Server showed up. Now we start the stream.
     _timer.stop();
-    delete _socket;
+    _socket->deleteLater();
     _socket = NULL;
     _serverPresent = true;
     start();
@@ -91,7 +91,7 @@ void VideoReceiver::_connected()
 void VideoReceiver::_socketError(QAbstractSocket::SocketError socketError)
 {
     Q_UNUSED(socketError);
-    delete _socket;
+    _socket->deleteLater();
     _socket = NULL;
     //-- Try again in 5 seconds
     _timer.start(5000);


### PR DESCRIPTION
Calling delete on a socket callback is not safe and this can crash
QGroundControl. Using deleteLater method from socket to perform deletion.