### PR TITLE
Improve release logging, deal with MAVLinkDecoder shutdown

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -221,7 +221,7 @@ WindowsBuild {
 #
 
 ReleaseBuild {
-    DEFINES += QT_NO_DEBUG
+    DEFINES += QT_NO_DEBUG QT_MESSAGELOGCONTEXT
     CONFIG += force_debug_info  # Enable debugging symbols on release builds
     !iOSBuild {
         CONFIG += ltcg              # Turn on link time code generation

--- a/src/ui/MAVLinkDecoder.h
+++ b/src/ui/MAVLinkDecoder.h
@@ -8,13 +8,14 @@ class MAVLinkDecoder : public QThread
 {
     Q_OBJECT
 public:
-    MAVLinkDecoder(MAVLinkProtocol* protocol, QObject *parent = 0);
+    MAVLinkDecoder(MAVLinkProtocol* protocol);
 
     void run();
 
 signals:
     void textMessageReceived(int uasid, int componentid, int severity, const QString& text);
     void valueChanged(const int uasId, const QString& name, const QString& unit, const QVariant& value, const quint64 msec);
+    void finish(); ///< Trigger a thread safe shutdown
 
 public slots:
     /** @brief Receive one message from the protocol and decode it */
@@ -35,6 +36,7 @@ protected:
     quint64 onboardTimeOffset[cMessageIds];                 ///< Offset of onboard time from Unix epoch (of the receiving GCS)
     qint64 onboardToGCSUnixTimeOffsetAndDelay[cMessageIds]; ///< Offset of onboard time and GCS Unix time
     quint64 firstOnboardTime[cMessageIds];                  ///< First seen onboard time
+    QThread* creationThread;                                ///< QThread on which the object is created
 };
 
 #endif // MAVLINKDECODER_H

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -274,6 +274,11 @@ MainWindow::MainWindow()
 
 MainWindow::~MainWindow()
 {
+    // Enforce thread-safe shutdown of the mavlink decoder
+    mavlinkDecoder->finish();
+    mavlinkDecoder->wait(1000);
+    mavlinkDecoder->deleteLater();
+
     // This needs to happen before we get into the QWidget dtor
     // otherwise  the QML engine reads freed data and tries to
     // destroy MainWindow a second time.
@@ -290,8 +295,7 @@ QString MainWindow::_getWindowGeometryKey()
 void MainWindow::_buildCommonWidgets(void)
 {
     // Add generic MAVLink decoder
-    // TODO: This is never deleted
-    mavlinkDecoder = new MAVLinkDecoder(qgcApp()->toolbox()->mavlinkProtocol(), this);
+    mavlinkDecoder = new MAVLinkDecoder(qgcApp()->toolbox()->mavlinkProtocol());
     connect(mavlinkDecoder.data(), &MAVLinkDecoder::valueChanged, this, &MainWindow::valueChanged);
 
     // Log player


### PR DESCRIPTION
Just a few simple tweaks to improve things. MAVLinkDecoder was not properly parented (the whole threading the right way can of worms) so this PR removes the parent pointer we aren't using (false sense of proper QObject parenting) and uses a signal to quit the thread and move the object back to the creating thread context. MainWindow waits 1s for the thread to finish and then invokes deleteLater on it so the object is destroyed when the event loop returns.

Also turned on contextual information for release builds in the message logger so we have a trace back in source files when users submit logs. 