### PR TITLE
Fix analyze view to work for mavlink 2.0

### DIFF
--- a/src/ui/MAVLinkDecoder.h
+++ b/src/ui/MAVLinkDecoder.h
@@ -2,7 +2,27 @@
 #define MAVLINKDECODER_H
 
 #include <QObject>
+#include <QHash>
+
 #include "MAVLinkProtocol.h"
+
+struct SystemData {
+    /**
+     * @brief Holds mavlink system data
+     */
+    SystemData() :
+        componentID(-1),
+        componentMulti(false),
+        onboardTimeOffset(0),
+        onboardToGCSUnixTimeOffsetAndDelay(0),
+        firstOnboardTime(0) {
+    }
+    int componentID;            ///< Multi component detection
+    bool componentMulti;        ///< Multi components detected
+    quint64 onboardTimeOffset;  ///< Offset of onboard time from Unix epoch (of the receiving GCS)
+    qint64 onboardToGCSUnixTimeOffsetAndDelay; ///< Offset of onboard time and GCS Unix time
+    quint64 firstOnboardTime;   ///< First seen onboard time
+};
 
 class MAVLinkDecoder : public QThread
 {
@@ -26,16 +46,10 @@ protected:
     /** @brief Shift a timestamp in Unix time if necessary */
     quint64 getUnixTimeFromMs(int systemID, quint64 time);
 
-    static const size_t cMessageIds = 256;
-
-    mavlink_message_t receivedMessages[cMessageIds];        ///< Available / known messages
     QMap<uint16_t, bool> messageFilter;                     ///< Message/field names not to emit
     QMap<uint16_t, bool> textMessageFilter;                 ///< Message/field names not to emit in text mode
-    int componentID[cMessageIds];                           ///< Multi component detection
-    bool componentMulti[cMessageIds];                       ///< Multi components detected
-    quint64 onboardTimeOffset[cMessageIds];                 ///< Offset of onboard time from Unix epoch (of the receiving GCS)
-    qint64 onboardToGCSUnixTimeOffsetAndDelay[cMessageIds]; ///< Offset of onboard time and GCS Unix time
-    quint64 firstOnboardTime[cMessageIds];                  ///< First seen onboard time
+    QHash<int, mavlink_message_t> msgDict; ///< dictionary of all mavlink messages
+    QHash<int, SystemData> sysDict; ///< dictionary of all systmes
     QThread* creationThread;                                ///< QThread on which the object is created
 };
 


### PR DESCRIPTION
This fixes integer overflow issues with mavlink 2 msgid's and get the analyze view working for mavlink 2 messages.

Closes https://github.com/mavlink/qgroundcontrol/issues/4479

![image](https://cloud.githubusercontent.com/assets/473772/22396611/c81e8748-e52b-11e6-874c-49f5a6961c44.png)

