### PR TITLE
Add message telling QGC is waiting for a vehicle

### DIFF
--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -212,6 +212,16 @@ Rectangle {
             Layout.fillWidth:   true
             visible:            _activeVehicle
         }
+
+        QGCLabel {
+            id:                     waitForVehicle
+            anchors.verticalCenter: parent.verticalCenter
+            text:                   qsTr("Waiting For Vehicle Connection")
+            font.pointSize:         ScreenTools.mediumFontPointSize
+            font.family:            ScreenTools.demiboldFontFamily
+            color:                  colorRed
+            visible:                !_activeVehicle
+        }
     }
 
     // Progress bar


### PR DESCRIPTION
When you first launch QGC and nothing is connected, the tool bar has a large blank space where the toolbar items are displayed once a vehicle is connected. This adds a message telling you QGC is waiting for a vehicle to connect.