### PR TITLE
UI Tweaks

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -37,7 +37,7 @@ QGCView {
     readonly property real      _margin:                ScreenTools.defaultFontPixelHeight * 0.5
     readonly property var       _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     readonly property real      _rightPanelWidth:       Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 30)
-    readonly property real      _rightPanelOpacity:     0.8
+    readonly property real      _rightPanelOpacity:     1
     readonly property int       _toolButtonCount:       6
     readonly property real      _toolButtonTopMargin:   parent.height - ScreenTools.availableHeight + (ScreenTools.defaultFontPixelHeight / 2)
     readonly property var       _defaultVehicleCoordinate:   QtPositioning.coordinate(37.803784, -122.462276)

--- a/src/MissionEditor/MissionItemEditor.qml
+++ b/src/MissionEditor/MissionItemEditor.qml
@@ -55,7 +55,7 @@ Rectangle {
         color:                  _outerTextColor
     }
 
-    Image {
+    QGCColoredImage {
         id:                     hamburger
         anchors.rightMargin:    ScreenTools.defaultFontPixelWidth
         anchors.right:          parent.right
@@ -65,6 +65,7 @@ Rectangle {
         sourceSize.height:      _hamburgerSize
         source:                 "qrc:/qmlimages/Hamburger.svg"
         visible:                missionItem.isCurrentItem && missionItem.sequenceNumber != 0
+        color:                  qgcPal.windowShade
 
         MouseArea {
             anchors.fill:   parent

--- a/src/MissionEditor/MissionSettingsEditor.qml
+++ b/src/MissionEditor/MissionSettingsEditor.qml
@@ -37,6 +37,7 @@ Rectangle {
                 property bool   _showOfflineEditingCombos:  _offlineEditing && _noMissionItemsAdded
                 property bool   _showCruiseSpeed:           !_missionVehicle.multiRotor
                 property bool   _showHoverSpeed:            _missionVehicle.multiRotor || missionController.vehicle.vtol
+                property bool   _multipleFirmware:          QGroundControl.supportedFirmwareCount > 2
 
                 readonly property string _firmwareLabel:    qsTr("Firmware:")
                 readonly property string _vehicleLabel:     qsTr("Vehicle:")
@@ -50,7 +51,9 @@ Rectangle {
                     anchors.top:    parent.top
                     spacing:        _margin
 
-                    QGCLabel { text: qsTr("Planned Home Position:") }
+                    QGCLabel {
+                        text: qsTr("Planned Home Position")
+                    }
 
                     Rectangle {
                         anchors.left:   parent.left
@@ -90,27 +93,25 @@ Rectangle {
                         }
                     }
 
-                    QGCButton {
-                        text:       qsTr("Move Home to map center")
-                        visible:    missionItem.homePosition
-                        onClicked:  editorRoot.moveHomeToMapCenter()
-                        anchors.horizontalCenter: parent.horizontalCenter
-                    }
-
                     QGCLabel {
                         width:          parent.width
                         wrapMode:       Text.WordWrap
                         font.pointSize: ScreenTools.smallFontPointSize
-                        text:           qsTr("Note: Planned home position for mission display only. Actual home position set by vehicle at flight time.")
+                        text:           qsTr("Actual position set by vehicle at flight time.")
+                        horizontalAlignment: Text.AlignHCenter
                     }
 
-                    QGCLabel { text: qsTr("Vehicle Info:") }
+                    QGCLabel {
+                        text:           qsTr("Vehicle Info:")
+                        visible:        _multipleFirmware
+                    }
 
                     Rectangle {
                         anchors.left:   parent.left
                         anchors.right:  parent.right
                         height:         1
                         color:          qgcPal.text
+                        visible:        _multipleFirmware
                     }
 
                     GridLayout {
@@ -119,6 +120,7 @@ Rectangle {
                         columnSpacing:  ScreenTools.defaultFontPixelWidth
                         rowSpacing:     columnSpacing
                         columns:        2
+                        visible:        _multipleFirmware
 
                         QGCLabel {
                             text:       _firmwareLabel
@@ -187,8 +189,23 @@ Rectangle {
                         width:          parent.width
                         wrapMode:       Text.WordWrap
                         font.pointSize: ScreenTools.smallFontPointSize
-                        text:           qsTr("Note: Speeds are planned speeds only for time calculations. Actual vehicle will not be affected.")
+                        visible:        _multipleFirmware
+                        text:           qsTr("Speeds are only for time calculations. Actual vehicle will not be affected.")
                     }
+
+                    Rectangle {
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        height:         1
+                        color:          qgcPal.text
+                    }
+
+                    QGCButton {
+                        text:       qsTr("Set Home To Map Center")
+                        onClicked:  editorRoot.moveHomeToMapCenter()
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+
                 } // Column
             } // Item
         } // Component

--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -42,7 +42,7 @@ QColor QGCPalette::_text[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
 
 QColor QGCPalette::_warningText[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
     { QColor("#cc0808"), QColor("#cc0808") },
-    { QColor("#e4e428"), QColor("#e4e428") }
+    { QColor("0xed, 0xd4, 0x69"), QColor("0xed, 0xd4, 0x69") }
 };
 
 QColor QGCPalette::_button[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
@@ -57,7 +57,7 @@ QColor QGCPalette::_buttonText[QGCPalette::_cThemes][QGCPalette::_cColorGroups] 
 
 QColor QGCPalette::_buttonHighlight[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
     { QColor("#e4e4e4"), QColor("#33b5e5") },
-    { QColor(0x58, 0x58, 0x58), QColor(237, 235, 51) },
+    { QColor(0x58, 0x58, 0x58), QColor(0xed, 0xd4, 0x69) },
 };
 
 QColor QGCPalette::_buttonHighlightText[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -50,10 +50,10 @@ Button {
     style: ButtonStyle {
             /*! The padding between the background and the label components. */
             padding {
-                top:    __padding
+                top:    __padding * 0.5
                 left:   __padding
                 right:  control.menu !== null ? Math.round(ScreenTools.defaultFontPixelHeight) : __padding
-                bottom: __padding
+                bottom: __padding * 0.5
             }
 
             /*! This defines the background of the button. */
@@ -66,6 +66,7 @@ Button {
                     anchors.fill:   parent
                     border.width:   _showBorder ? 1: 0
                     border.color:   _qgcPal.buttonText
+                    radius:         3
                     color:          _showHighlight ?
                                         control._qgcPal.buttonHighlight :
                                         (primary ? control._qgcPal.primaryButton : control._qgcPal.button)

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -24,6 +24,7 @@ ComboBox {
             Rectangle {
                 anchors.fill:   parent
                 color:          _showHighlight ? control._qgcPal.buttonHighlight : control._qgcPal.button
+                radius:         3
                 border.width:   _showBorder ? 1: 0
                 border.color:  control._qgcPal.buttonText
             }

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -46,6 +46,7 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
     , _videoManager(NULL)
     , _mavlinkLogManager(NULL)
     , _corePlugin(NULL)
+    , _firmwarePluginManager(NULL)
     , _virtualTabletJoystick(false)
     , _baseFontPointSize(0.0)
 {
@@ -74,6 +75,7 @@ void QGroundControlQmlGlobal::setToolbox(QGCToolbox* toolbox)
     _videoManager           = toolbox->videoManager();
     _mavlinkLogManager      = toolbox->mavlinkLogManager();
     _corePlugin             = toolbox->corePlugin();
+    _firmwarePluginManager  = toolbox->firmwarePluginManager();
 }
 
 void QGroundControlQmlGlobal::saveGlobalSetting (const QString& key, const QString& value)
@@ -336,6 +338,12 @@ Fact* QGroundControlQmlGlobal::batteryPercentRemainingAnnounce(void)
 
     return _batteryPercentRemainingAnnounceFact;
 }
+
+int QGroundControlQmlGlobal::supportedFirmwareCount()
+{
+    return _firmwarePluginManager->knownFirmwareTypes().count();
+}
+
 
 bool QGroundControlQmlGlobal::linesIntersect(QPointF line1A, QPointF line1B, QPointF line2A, QPointF line2B)
 {

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -99,6 +99,7 @@ public:
     Q_PROPERTY(Fact*    areaUnits                       READ areaUnits                          CONSTANT)
     Q_PROPERTY(Fact*    speedUnits                      READ speedUnits                         CONSTANT)
     Q_PROPERTY(Fact*    batteryPercentRemainingAnnounce READ batteryPercentRemainingAnnounce    CONSTANT)
+    Q_PROPERTY(int      supportedFirmwareCount          READ supportedFirmwareCount             CONSTANT)
 
     Q_PROPERTY(QGeoCoordinate lastKnownHomePosition READ lastKnownHomePosition  CONSTANT)
     Q_PROPERTY(QGeoCoordinate flightMapPosition     MEMBER _flightMapPosition   NOTIFY flightMapPositionChanged)
@@ -196,6 +197,8 @@ public:
     static Fact* speedUnits                     (void);
     static Fact* batteryPercentRemainingAnnounce(void);
 
+    int     supportedFirmwareCount      ();
+
     void    setIsDarkStyle              (bool dark);
     void    setIsAudioMuted             (bool muted);
     void    setIsSaveLogPrompt          (bool prompt);
@@ -245,6 +248,7 @@ private:
     VideoManager*           _videoManager;
     MAVLinkLogManager*      _mavlinkLogManager;
     QGCCorePlugin*          _corePlugin;
+    FirmwarePluginManager*  _firmwarePluginManager;
 
     bool                    _virtualTabletJoystick;
     qreal                   _baseFontPointSize;

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -131,7 +131,7 @@ void initializeVideoStreaming(int &argc, char* argv[])
         // Our own plugin
         GST_PLUGIN_STATIC_REGISTER(QGC_VIDEOSINK_PLUGIN);
         // The static plugins we use
-    #if defined(__mobile__)
+    #if defined(__mobile__) && !defined(__macos__)
         GST_PLUGIN_STATIC_REGISTER(coreelements);
         GST_PLUGIN_STATIC_REGISTER(libav);
         GST_PLUGIN_STATIC_REGISTER(rtp);

--- a/src/VideoStreaming/gstqtvideosink/utils/glutils.h
+++ b/src/VideoStreaming/gstqtvideosink/utils/glutils.h
@@ -17,7 +17,7 @@
 #ifndef GLUTILS_H
 #define GLUTILS_H
 
-#ifdef __mobile__
+#if defined(__mobile__) && !defined(__macos__)
 #include <QOpenGLFunctions>
 #define getQOpenGLFunctions() QOpenGLContext::currentContext()->functions()
 #define QOpenGLFunctionsDef QOpenGLFunctions


### PR DESCRIPTION
Several UI tweaks:

 * Subdued the yellow used for the "Active Button", which is also used for other UI elements.
 * Removed the opacity for the Mission Elements as it was only adding to the "noise" those controls already have.
 * Set the color for the "Hamburger" button present in the mission items. It used to be undefined, which was rendering white on light yellow for the *Indoor* theme. It now renders using the appropriate color for the current theme.
 * Tweaked the *Mission Settings* control. It was way too verbose and too large for small, mobile screens. In addition, I've added code to see if QGC was built with support for multiple firmware types. If QGC was built with only one supported firmware, the info related to the firmware is hidden.
 * Tweaked QGCButton and QGCComboBox.
 * Adjusted the VideoStreaming build so you can run a "mobile" build on Desktop (for testing mobile builds on Desktop). This is for Mac OS only and it's only relevant if you have a custom build where you forcefully define *MobileBuild*.
