### PR TITLE
Fix wrong QColor argument encoding.

### DIFF
--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -42,7 +42,7 @@ QColor QGCPalette::_text[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
 
 QColor QGCPalette::_warningText[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {
     { QColor("#cc0808"), QColor("#cc0808") },
-    { QColor("0xed, 0xd4, 0x69"), QColor("0xed, 0xd4, 0x69") }
+    { QColor("#fd5d13"), QColor("#fd5d13") }
 };
 
 QColor QGCPalette::_button[QGCPalette::_cThemes][QGCPalette::_cColorGroups] = {


### PR DESCRIPTION
Fix for #4500 

It was using a bogus color encoding and QColor was taking is as zero (black). I'm not sure what I did as that wasn't the color I was editing when I got this change in.