### PR TITLE
Work around using the Clear button while mobile keyboard is up.

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -56,6 +56,17 @@ QGCView {
             anchors.right:  parent.right
             spacing:        ScreenTools.defaultFontPixelWidth
 
+            Timer {
+                id:         clearTimer
+                interval:   100;
+                running:    false;
+                repeat:     false
+                onTriggered: {
+                    searchText.text = ""
+                    controller.searchText = ""
+                }
+            }
+
             QGCLabel {
                 anchors.baseline:   clearButton.baseline
                 text:               qsTr("Search:")
@@ -71,7 +82,12 @@ QGCView {
             QGCButton {
                 id:         clearButton
                 text:       qsTr("Clear")
-                onClicked:  searchText.text = ""
+                onClicked: {
+                    if(ScreenTools.isMobile) {
+                        Qt.inputMethod.hide();
+                    }
+                    clearTimer.start()
+                }
             }
         } // Row - Header
 


### PR DESCRIPTION
On Android, when searching for a parameter you could not use the clear button until you closed the Android Keyboard. I could not quite figured out why the text field would not accept changes from within the button's onClicked signal. It just would not, even if forcing focus, reseting it, whatever. What I did was to trigger a timer than handles the clearing.

While at it, I'm also dismissing the keyboard so you don't have to click in two places (to clear the search field and to dismiss the keyboard).