### PR TITLE
Allow FirmwarePlugin to provide vehicle icons.

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -302,3 +302,21 @@ QString FirmwarePlugin::takeControlFlightMode(void)
 {
     return QString();
 }
+
+QString FirmwarePlugin::vehicleImageOpaque(const Vehicle* vehicle) const
+{
+    Q_UNUSED(vehicle);
+    return QStringLiteral("/qmlimages/vehicleArrowOpaque.svg");
+}
+
+QString FirmwarePlugin::vehicleImageOutline(const Vehicle* vehicle) const
+{
+    Q_UNUSED(vehicle);
+    return QStringLiteral("/qmlimages/vehicleArrowOutline.svg");
+}
+
+QString FirmwarePlugin::vehicleImageCompass(const Vehicle* vehicle) const
+{
+    Q_UNUSED(vehicle);
+    return QStringLiteral("/qmlimages/compassInstrumentArrow.svg");
+}

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -242,6 +242,15 @@ public:
     /// Return the resource file which contains the brand image for the vehicle.
     virtual QString brandImage(const Vehicle* vehicle) const { Q_UNUSED(vehicle) return QString(); }
 
+    /// Return the resource file which contains the vehicle icon used in the flight view when the view is dark (Satellite for instance)
+    virtual QString vehicleImageOpaque(const Vehicle* vehicle) const;
+
+    /// Return the resource file which contains the vehicle icon used in the flight view when the view is light (Map for instance)
+    virtual QString vehicleImageOutline(const Vehicle* vehicle) const;
+
+    /// Return the resource file which contains the vehicle icon used in the compass
+    virtual QString vehicleImageCompass(const Vehicle* vehicle) const;
+
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const char* px4FollowMeFlightMode;
 };

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -81,7 +81,6 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         visible:                !_useAlternateInstruments
         size:                   getGadgetWidth()
-        active:                 _activeVehicle != null
         heading:                _heading
         rollAngle:              _roll
         pitchAngle:             _pitch
@@ -100,7 +99,6 @@ Item {
         anchors.right:          altitudeSlider.visible ? altitudeSlider.left : parent.right
         visible:                _useAlternateInstruments
         width:                  ScreenTools.isTinyScreen ? getGadgetWidth() * 1.5 : getGadgetWidth()
-        active:                 _activeVehicle != null
         heading:                _heading
         rollAngle:              _roll
         pitchAngle:             _pitch

--- a/src/FlightDisplay/MultiVehicleList.qml
+++ b/src/FlightDisplay/MultiVehicleList.qml
@@ -52,8 +52,8 @@ QGCListView {
 
             QGCCompassWidget {
                 size:       _widgetHeight
-                active:     true
                 heading:    _vehicle.heading.rawValue
+                vehicle:    _vehicle
             }
 
             QGCAttitudeWidget {

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -30,7 +30,7 @@ MapQuickItem {
 
     sourceItem: Image {
         id:                 vehicleIcon
-        source:             isSatellite ? "/qmlimages/vehicleArrowOpaque.svg" : "/qmlimages/vehicleArrowOutline.svg"
+        source:             isSatellite ? vehicle.vehicleImageOpaque : vehicle.vehicleImageOutline
         mipmap:             true
         width:              size
         sourceSize.width:   size

--- a/src/FlightMap/Widgets/QGCCompassWidget.qml
+++ b/src/FlightMap/Widgets/QGCCompassWidget.qml
@@ -17,15 +17,16 @@
 import QtQuick 2.4
 import QtGraphicalEffects 1.0
 
-import QGroundControl.Controls 1.0
-import QGroundControl.ScreenTools 1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
 
 Item {
     id:                     root
 
-    property bool active:   false  ///< true: actively connected to data provider, false: show inactive control
-    property real heading:  0
     property real size:     _defaultSize
+    property real heading:  0
+    property var  vehicle:  null
 
     property real _defaultSize: ScreenTools.defaultFontPixelHeight * (10)
     property real _sizeRatio:   ScreenTools.isTinyScreen ? (size / _defaultSize) * 0.5 : size / _defaultSize
@@ -48,7 +49,7 @@ Item {
 
         Image {
             id:                 pointer
-            source:             "/qmlimages/compassInstrumentArrow.svg"
+            source:             vehicle ? vehicle.vehicleImageCompass : ""
             mipmap:             true
             width:              size * 0.75
             sourceSize.width:   width
@@ -78,8 +79,8 @@ Item {
             color:              Qt.rgba(0,0,0,0.65)
 
             QGCLabel {
-                text:           active ? heading.toFixed(0) : qsTr("OFF")
-                font.family:    active ? ScreenTools.demiboldFontFamily : ScreenTools.normalFontFamily
+                text:           vehicle ? heading.toFixed(0) : qsTr("OFF")
+                font.family:    vehicle ? ScreenTools.demiboldFontFamily : ScreenTools.normalFontFamily
                 font.pointSize: _fontSize < 8 ? 8 : _fontSize;
                 color:          "white"
                 anchors.centerIn: parent

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -150,8 +150,8 @@ Item {
         QGCCompassWidget {
             id:                 compass
             size:               parent.width * 0.95
-            active:             instrumentPanel.active
             visible:            _showCompass
+            vehicle:            _activeVehicle
             anchors.horizontalCenter: parent.horizontalCenter
         }
     }

--- a/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
@@ -10,6 +10,7 @@
 
 import QtQuick 2.4
 
+import QGroundControl               1.0
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.FactSystem    1.0
@@ -68,7 +69,7 @@ Rectangle {
         anchors.leftMargin: _spacing
         anchors.left:       attitude.right
         size:               _innerRadius * 2
-        active:             root.active
+        vehicle:            QGroundControl.multiVehicleManager.activeVehicle
         anchors.verticalCenter: parent.verticalCenter
     }
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2203,6 +2203,30 @@ QString Vehicle::takeControlFlightMode(void) const
     return _firmwarePlugin->takeControlFlightMode();
 }
 
+QString Vehicle::vehicleImageOpaque() const
+{
+    if(_firmwarePlugin)
+        return _firmwarePlugin->vehicleImageOpaque(this);
+    else
+        return QString();
+}
+
+QString Vehicle::vehicleImageOutline() const
+{
+    if(_firmwarePlugin)
+        return _firmwarePlugin->vehicleImageOutline(this);
+    else
+        return QString();
+}
+
+QString Vehicle::vehicleImageCompass() const
+{
+    if(_firmwarePlugin)
+        return _firmwarePlugin->vehicleImageCompass(this);
+    else
+        return QString();
+}
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -264,6 +264,9 @@ public:
     Q_PROPERTY(QString              takeControlFlightMode   READ takeControlFlightMode                                  CONSTANT)
     Q_PROPERTY(QString              firmwareTypeString      READ firmwareTypeString                                     NOTIFY firmwareTypeChanged)
     Q_PROPERTY(QString              vehicleTypeString       READ vehicleTypeString                                      NOTIFY vehicleTypeChanged)
+    Q_PROPERTY(QString              vehicleImageOpaque      READ vehicleImageOpaque                                     CONSTANT)
+    Q_PROPERTY(QString              vehicleImageOutline     READ vehicleImageOutline                                    CONSTANT)
+    Q_PROPERTY(QString              vehicleImageCompass     READ vehicleImageCompass                                    CONSTANT)
 
     /// true: Vehicle is flying, false: Vehicle is on ground
     Q_PROPERTY(bool flying      READ flying     WRITE setFlying     NOTIFY flyingChanged)
@@ -581,6 +584,10 @@ public:
     /// Sets the firmware plugin instance data associated with this Vehicle. This object will be parented to the Vehicle
     /// and destroyed when the vehicle goes away.
     void setFirmwarePluginInstanceData(QObject* firmwarePluginInstanceData);
+
+    QString vehicleImageOpaque  () const;
+    QString vehicleImageOutline () const;
+    QString vehicleImageCompass () const;
 
 public slots:
     void setLatitude(double latitude);


### PR DESCRIPTION
These are for the icons shown over the map and the one used in the Compass widget. If nothing is defined, the defaults (current icons) are used.