### PR TITLE
Dealing with lack of Internet connectivity.

### DIFF
--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -130,11 +130,13 @@ QGCMapEngine::QGCMapEngine()
     , _maxMemCache(0)
     , _prunning(false)
     , _cacheWasReset(false)
+    , _isInternetActive(false)
 {
     qRegisterMetaType<QGCMapTask::TaskType>();
     qRegisterMetaType<QGCTile>();
     qRegisterMetaType<QList<QGCTile*>>();
-    connect(&_worker, &QGCCacheWorker::updateTotals, this, &QGCMapEngine::_updateTotals);
+    connect(&_worker, &QGCCacheWorker::updateTotals,   this, &QGCMapEngine::_updateTotals);
+    connect(&_worker, &QGCCacheWorker::internetStatus, this, &QGCMapEngine::_internetStatus);
 }
 
 //-----------------------------------------------------------------------------
@@ -481,6 +483,20 @@ QGCCreateTileSetTask::~QGCCreateTileSetTask()
     //-- If not sent out, delete it
     if(!_saved && _tileSet)
         delete _tileSet;
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCMapEngine::testInternet()
+{
+    getQGCMapEngine()->addTask(new QGCTestInternetTask());
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCMapEngine::_internetStatus(bool active)
+{
+    _isInternetActive = active;
 }
 
 // Resolution math: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Resolution_and_Scale

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -86,7 +86,9 @@ public:
     void                        setMaxMemCache      (quint32 size);
     const QString               getCachePath        () { return _cachePath; }
     const QString               getCacheFilename    () { return _cacheFile; }
+    void                        testInternet        ();
     bool                        wasCacheReset       () { return _cacheWasReset; }
+    bool                        isInternetActive    () { return _isInternetActive; }
 
     UrlFactory*                 urlFactory          () { return _urlFactory; }
 
@@ -103,6 +105,7 @@ public:
 private slots:
     void _updateTotals          (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
     void _pruned                ();
+    void _internetStatus        (bool active);
 
 signals:
     void updateTotals           (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
@@ -123,6 +126,7 @@ private:
     quint32                 _maxMemCache;
     bool                    _prunning;
     bool                    _cacheWasReset;
+    bool                    _isInternetActive;
 };
 
 extern QGCMapEngine*    getQGCMapEngine();

--- a/src/QtLocationPlugin/QGCMapEngineData.h
+++ b/src/QtLocationPlugin/QGCMapEngineData.h
@@ -110,6 +110,7 @@ public:
 
     enum TaskType {
         taskInit,
+        taskTestInternet,
         taskCacheTile,
         taskFetchTile,
         taskFetchTileSets,
@@ -129,7 +130,7 @@ public:
 
     virtual TaskType    type            () { return _type; }
 
-    void setError(QString errorString)
+    void setError(QString errorString = QString())
     {
         emit error(_type, errorString);
     }
@@ -139,6 +140,16 @@ signals:
 
 private:
     TaskType    _type;
+};
+
+//-----------------------------------------------------------------------------
+class QGCTestInternetTask : public QGCMapTask
+{
+    Q_OBJECT
+public:
+    QGCTestInternetTask()
+        : QGCMapTask(QGCMapTask::taskTestInternet)
+    {}
 };
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -93,20 +93,15 @@ QGCCacheWorker::enqueueTask(QGCMapTask* task)
         task->deleteLater();
         return false;
     }
-    if(!_taskQueue.contains(task))
-    {
-        _mutex.lock();
-        _taskQueue.enqueue(task);
-        _mutex.unlock();
-        if(this->isRunning()) {
-            _waitc.wakeAll();
-        } else {
-            this->start(QThread::NormalPriority);
-        }
-        return true;
+    _mutex.lock();
+    _taskQueue.enqueue(task);
+    _mutex.unlock();
+    if(this->isRunning()) {
+        _waitc.wakeAll();
+    } else {
+        this->start(QThread::HighPriority);
     }
-    //-- Should never happen
-    return false;
+    return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -157,6 +152,9 @@ QGCCacheWorker::run()
                     break;
                 case QGCMapTask::taskReset:
                     _resetCacheDatabase(task);
+                    break;
+                case QGCMapTask::taskTestInternet:
+                    _testInternet();
                     break;
             }
             task->deleteLater();
@@ -662,6 +660,7 @@ QGCCacheWorker::_init()
         qCritical() << "Could not find suitable cache directory.";
         _failed = true;
     }
+    _testInternet();
     return _failed;
 }
 
@@ -748,4 +747,18 @@ QGCCacheWorker::_createDB()
         file.remove();
     }
     _failed = !_valid;
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCCacheWorker::_testInternet()
+{
+    QTcpSocket socket;
+    socket.connectToHost("8.8.8.8", 53);
+    if (socket.waitForConnected(2500)) {
+        emit internetStatus(true);
+        return;
+    }
+    qWarning() << "No Internet Access";
+    emit internetStatus(false);
 }

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -59,6 +59,7 @@ private:
     void        _deleteTileSet          (QGCMapTask* mtask);
     void        _resetCacheDatabase     (QGCMapTask* mtask);
     void        _pruneCache             (QGCMapTask* mtask);
+    void        _testInternet           ();
 
     quint64     _findTile               (const QString hash);
     bool        _findTileSetID          (const QString name, quint64& setID);
@@ -70,6 +71,7 @@ private:
 
 signals:
     void        updateTotals            (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
+    void        internetStatus          (bool active);
 
 private:
     QQueue<QGCMapTask*>     _taskQueue;

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.h
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.h
@@ -49,6 +49,7 @@
 
 #include <QtNetwork/QNetworkReply>
 #include <QtLocation/private/qgeotiledmapreply_p.h>
+#include <QTimer>
 
 #include "QGCMapEngineData.h"
 
@@ -61,11 +62,15 @@ public:
     void abort();
 
 private slots:
-    void replyDestroyed         ();
     void networkReplyFinished   ();
     void networkReplyError      (QNetworkReply::NetworkError error);
     void cacheReply             (QGCCacheTile* tile);
     void cacheError             (QGCMapTask::TaskType type, QString errorString);
+    void timeout                ();
+
+private:
+    void _clearReply            ();
+    void _returnBadTile         ();
 
 private:
     QNetworkReply*          _reply;
@@ -73,6 +78,8 @@ private:
     QNetworkAccessManager*  _networkManager;
     QByteArray              _badMapBox;
     QByteArray              _badTile;
+    QTimer                  _timer;
+    static int              _requestCount;
 };
 
 #endif // QGEOMAPREPLYQGC_H

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -57,6 +57,10 @@ QGeoTileFetcherQGC::QGeoTileFetcherQGC(QGeoTiledMappingManagerEngine *parent)
     : QGeoTileFetcher(parent)
     , _networkManager(new QNetworkAccessManager(this))
 {
+    //-- Check internet status every 30 seconds or so
+    connect(&_timer, &QTimer::timeout, this, &QGeoTileFetcherQGC::timeout);
+    _timer.setSingleShot(false);
+    _timer.start(30000);
 }
 
 //-----------------------------------------------------------------------------
@@ -72,4 +76,13 @@ QGeoTileFetcherQGC::getTileImage(const QGeoTileSpec &spec)
     //-- Build URL
     QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL((UrlFactory::MapType)spec.mapId(), spec.x(), spec.y(), spec.zoom(), _networkManager);
     return new QGeoTiledMapReplyQGC(_networkManager, request, spec);
+}
+
+//-----------------------------------------------------------------------------
+void
+QGeoTileFetcherQGC::timeout()
+{
+    if(!getQGCMapEngine()->isInternetActive()) {
+        getQGCMapEngine()->testInternet();
+    }
 }

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.h
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.h
@@ -48,6 +48,7 @@
 #define QGEOTILEFETCHERQGC_H
 
 #include <QtLocation/private/qgeotilefetcher_p.h>
+#include <QTimer>
 #include "QGCMapUrlEngine.h"
 
 class QGeoTiledMappingManagerEngine;
@@ -59,10 +60,13 @@ class QGeoTileFetcherQGC : public QGeoTileFetcher
 public:
     explicit QGeoTileFetcherQGC             (QGeoTiledMappingManagerEngine *parent = 0);
     ~QGeoTileFetcherQGC();
+public slots:
+    void                    timeout         ();
 private:
     QGeoTiledMapReply*      getTileImage    (const QGeoTileSpec &spec);
 private:
     QNetworkAccessManager*  _networkManager;
+    QTimer                  _timer;
 };
 
 #endif // QGEOTILEFETCHERQGC_H


### PR DESCRIPTION
When you have no Internet connection (Tablet out in the field), tile downloading can bog the system down. Specially on Android. That's because the system will try to download all and every tile. As each request normally times out in around a minute, you ended up with hundreds of tile requests in the queue.

This change keeps track of the availability of (real) Internet connection. If there is none, QGC won't bother trying to download any tiles. If you have them cached, they will be displayed. Otherwise it will immediately show a "No Tile" tile.
