### PR TITLE
Fix regression bug with Bluetooth.

### DIFF
--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -31,6 +31,7 @@
 
 BluetoothLink::BluetoothLink(SharedLinkConfigurationPointer& config)
     : LinkInterface(config)
+    , _config(qobject_cast<BluetoothConfiguration*>(config.data()))
     , _connectState(false)
     , _targetSocket(NULL)
 #ifdef __ios__


### PR DESCRIPTION
This is in response to #2910.
It fixes a bug introduced by #4349.
The Bluetooth configuration was not being set and the code would crash when using it.