### PR TITLE
Instrument widgets

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -21,6 +21,7 @@ include(QGCCommon.pri)
 
 TARGET   = QGroundControl
 TEMPLATE = app
+QGCROOT  = $$PWD
 
 DebugBuild {
     DESTDIR  = $${OUT_PWD}/debug

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -125,8 +125,8 @@
         <file alias="QGroundControl/FlightMap/QGCAttitudeHUD.qml">src/FlightMap/Widgets/QGCAttitudeHUD.qml</file>
         <file alias="QGroundControl/FlightMap/QGCAttitudeWidget.qml">src/FlightMap/Widgets/QGCAttitudeWidget.qml</file>
         <file alias="QGroundControl/FlightMap/QGCCompassWidget.qml">src/FlightMap/Widgets/QGCCompassWidget.qml</file>
-        <file alias="QGroundControl/FlightMap/QGCInstrumentWidget.qml">src/FlightMap/Widgets/QGCInstrumentWidget.qml</file>
-        <file alias="QGroundControl/FlightMap/QGCInstrumentWidgetAlternate.qml">src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml</file>
+        <file alias="QGCInstrumentWidget.qml">src/FlightMap/Widgets/QGCInstrumentWidget.qml</file>
+        <file alias="QGCInstrumentWidgetAlternate.qml">src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml</file>
         <file alias="QGroundControl/FlightMap/QGCMapPolygonControls.qml">src/MissionEditor/QGCMapPolygonControls.qml</file>
         <file alias="QGroundControl/FlightMap/QGCPitchIndicator.qml">src/FlightMap/Widgets/QGCPitchIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/QGCVideoBackground.qml">src/FlightMap/QGCVideoBackground.qml</file>

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -33,25 +33,14 @@ QGCView {
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
+    property bool activeVehicleJoystickEnabled: _activeVehicle ? _activeVehicle.joystickEnabled : false
+
     property var _activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
     property bool _mainIsMap:           QGroundControl.videoManager.hasVideo ? QGroundControl.loadBoolGlobalSetting(_mainIsMapKey,  true) : true
     property bool _isPipVisible:        QGroundControl.videoManager.hasVideo ? QGroundControl.loadBoolGlobalSetting(_PIPVisibleKey, true) : false
-
-    property real _roll:                _activeVehicle ? _activeVehicle.roll.value    : _defaultRoll
-    property real _pitch:               _activeVehicle ? _activeVehicle.pitch.value   : _defaultPitch
-    property real _heading:             _activeVehicle ? _activeVehicle.heading.value : _defaultHeading
-
-    property Fact _emptyFact:               Fact { }
-    property Fact _groundSpeedFact:         _activeVehicle ? _activeVehicle.groundSpeed      : _emptyFact
-    property Fact _airSpeedFact:            _activeVehicle ? _activeVehicle.airSpeed         : _emptyFact
-
-    property bool activeVehicleJoystickEnabled: _activeVehicle ? _activeVehicle.joystickEnabled : false
-
-    property real _savedZoomLevel:  0
-    property real _margins:         ScreenTools.defaultFontPixelWidth / 2
-
-
-    property real pipSize:              mainWindow.width * 0.2
+    property real _savedZoomLevel:      0
+    property real _margins:             ScreenTools.defaultFontPixelWidth / 2
+    property real _pipSize:             mainWindow.width * 0.2
 
     readonly property bool      isBackgroundDark:       _mainIsMap ? (_flightMap ? _flightMap.isSatelliteMap : true) : true
     readonly property real      _defaultRoll:           0
@@ -136,8 +125,8 @@ QGCView {
             anchors.left:   _panel.left
             anchors.bottom: _panel.bottom
             visible:        _mainIsMap || _isPipVisible
-            width:          _mainIsMap ? _panel.width  : pipSize
-            height:         _mainIsMap ? _panel.height : pipSize * (9/16)
+            width:          _mainIsMap ? _panel.width  : _pipSize
+            height:         _mainIsMap ? _panel.height : _pipSize * (9/16)
             states: [
                 State {
                     name:   "pipMode"
@@ -166,8 +155,8 @@ QGCView {
         Item {
             id:             _flightVideo
             z:              _mainIsMap ? _panel.z + 2 : _panel.z + 1
-            width:          !_mainIsMap ? _panel.width  : pipSize
-            height:         !_mainIsMap ? _panel.height : pipSize * (9/16)
+            width:          !_mainIsMap ? _panel.width  : _pipSize
+            height:         !_mainIsMap ? _panel.height : _pipSize * (9/16)
             anchors.left:   _panel.left
             anchors.bottom: _panel.bottom
             visible:        QGroundControl.videoManager.hasVideo && (!_mainIsMap || _isPipVisible)
@@ -204,8 +193,8 @@ QGCView {
         QGCPipable {
             id:                 _flightVideoPipControl
             z:                  _flightVideo.z + 3
-            width:              pipSize
-            height:             pipSize * (9/16)
+            width:              _pipSize
+            height:             _pipSize * (9/16)
             anchors.left:       _panel.left
             anchors.bottom:     _panel.bottom
             anchors.margins:    ScreenTools.defaultFontPixelHeight

--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -45,8 +45,8 @@ Item {
         QGCAttitudeHUD {
             id:                 attitudeHUD
             visible:            !_mainIsMap
-            rollAngle:          _roll
-            pitchAngle:         _pitch
+            rollAngle:          _activeVehicle ? _activeVehicle.roll.value  : 0
+            pitchAngle:         _activeVehicle ? _activeVehicle.pitch.value : 0
             width:              ScreenTools.defaultFontPixelHeight * (30)
             height:             ScreenTools.defaultFontPixelHeight * (30)
             active:             QGroundControl.multiVehicleManager.activeVehicleAvailable

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -25,27 +25,48 @@ import QGroundControl.FlightMap     1.0
 Item {
     id: _root
 
-    property alias  guidedModeBar:      _guidedModeBar
-    property bool   gotoEnabled:        _activeVehicle && _activeVehicle.guidedMode && _activeVehicle.flying
+    property alias  guidedModeBar:          _guidedModeBar
+    property bool   gotoEnabled:            _activeVehicle && _activeVehicle.guidedMode && _activeVehicle.flying
     property var    qgcView
     property bool   isBackgroundDark
 
-    property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
-    property bool   _isSatellite:               _mainIsMap ? (_flightMap ? _flightMap.isSatelliteMap : true) : true
-    property bool   _lightWidgetBorders:        _isSatellite
-    property bool   _useAlternateInstruments:   QGroundControl.virtualTabletJoystick || ScreenTools.isTinyScreen
+    property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _isSatellite:           _mainIsMap ? (_flightMap ? _flightMap.isSatelliteMap : true) : true
+    property bool   _lightWidgetBorders:    _isSatellite
 
-    readonly property real _margins:                ScreenTools.defaultFontPixelHeight / 2
+    readonly property real _margins:        ScreenTools.defaultFontPixelHeight * 0.5
 
     QGCMapPalette { id: mapPal; lightColors: isBackgroundDark }
-    QGCPalette { id: qgcPal }
+    QGCPalette    { id: qgcPal }
 
-    function getGadgetWidth() {
+    function getPreferredInstrumentWidth() {
         if(ScreenTools.isMobile) {
             return ScreenTools.isTinyScreen ? mainWindow.width * 0.2 : mainWindow.width * 0.15
         }
         var w = mainWindow.width * 0.15
         return Math.min(w, 200)
+    }
+
+    function _setInstrumentWidget() {
+        var useAlternateInstruments = QGroundControl.virtualTabletJoystick || ScreenTools.isTinyScreen
+        if(useAlternateInstruments) {
+            instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidgetAlternate.qml"
+            instrumentsLoader.state  = "topMode"
+        } else {
+            instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidget.qml"
+            instrumentsLoader.state  = "centerMode"
+        }
+    }
+
+    Connections {
+        target: QGroundControl
+        onVirtualTabletJoystickChanged: {
+            _setInstrumentWidget()
+        }
+    }
+
+    Component.onCompleted: {
+        _setInstrumentWidget()
     }
 
     //-- Map warnings
@@ -74,53 +95,32 @@ Item {
     }
 
     //-- Instrument Panel
-    QGCInstrumentWidget {
-        id:                     instrumentGadget
+    Loader {
+        id:                     instrumentsLoader
         anchors.margins:        ScreenTools.defaultFontPixelHeight / 2
         anchors.right:          altitudeSlider.visible ? altitudeSlider.left : parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        visible:                !_useAlternateInstruments
-        size:                   getGadgetWidth()
-        heading:                _heading
-        rollAngle:              _roll
-        pitchAngle:             _pitch
-        groundSpeedFact:        _groundSpeedFact
-        airSpeedFact:           _airSpeedFact
-        lightBorders:           _lightWidgetBorders
         z:                      QGroundControl.zOrderWidgets
-        qgcView:                _root.qgcView
-        maxHeight:              parent.height - (anchors.margins * 2)
+        property var  qgcView:  _root.qgcView
+        property real maxHeight:parent.height - (anchors.margins * 2)
+        states: [
+            State {
+                name:   "topMode"
+                AnchorChanges {
+                    target:                 instrumentsLoader
+                    anchors.verticalCenter: undefined
+                    anchors.top:            _root ? _root.top : undefined
+                }
+            },
+            State {
+                name:   "centerMode"
+                AnchorChanges {
+                    target:                 instrumentsLoader
+                    anchors.top:            undefined
+                    anchors.verticalCenter: _root ? _root.verticalCenter : undefined
+                }
+            }
+        ]
     }
-
-    QGCInstrumentWidgetAlternate {
-        id:                     instrumentGadgetAlternate
-        anchors.margins:        ScreenTools.defaultFontPixelHeight / 2
-        anchors.top:            parent.top
-        anchors.right:          altitudeSlider.visible ? altitudeSlider.left : parent.right
-        visible:                _useAlternateInstruments
-        width:                  ScreenTools.isTinyScreen ? getGadgetWidth() * 1.5 : getGadgetWidth()
-        heading:                _heading
-        rollAngle:              _roll
-        pitchAngle:             _pitch
-        groundSpeedFact:        _groundSpeedFact
-        airSpeedFact:           _airSpeedFact
-        lightBorders:           _lightWidgetBorders
-        qgcView:                _root.qgcView
-        maxHeight:              parent.height - (anchors.margins * 2)
-        z:                      QGroundControl.zOrderWidgets
-    }
-
-    /*
-    ValuesWidget {
-        anchors.topMargin:          ScreenTools.defaultFontPixelHeight
-        anchors.top:                instrumentGadgetAlternate.bottom
-        anchors.horizontalCenter:   instrumentGadgetAlternate.horizontalCenter
-        width:                      getGadgetWidth()
-        qgcView:                    _root.qgcView
-        textColor:                  _isSatellite ? "white" : "black"
-        visible:                    _useAlternateInstruments
-        maxHeight:                  virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.y - y : parent.height - anchors.margins - y
-    }*/
 
     //-- Guided mode buttons
     Rectangle {
@@ -131,7 +131,7 @@ Item {
         width:                      guidedModeColumn.width  + (_margins * 2)
         height:                     guidedModeColumn.height + (_margins * 2)
         radius:                     ScreenTools.defaultFontPixelHeight * 0.25
-        color:                      _lightWidgetBorders ? Qt.rgba(qgcPal.mapWidgetBorderLight.r, qgcPal.mapWidgetBorderLight.g, qgcPal.mapWidgetBorderLight.b, 0.8) : Qt.rgba(qgcPal.mapWidgetBorderDark.r, qgcPal.mapWidgetBorderDark.g, qgcPal.mapWidgetBorderDark.b, 0.75)
+        color:                      _isSatellite ? Qt.rgba(qgcPal.mapWidgetBorderLight.r, qgcPal.mapWidgetBorderLight.g, qgcPal.mapWidgetBorderLight.b, 0.8) : Qt.rgba(qgcPal.mapWidgetBorderDark.r, qgcPal.mapWidgetBorderDark.g, qgcPal.mapWidgetBorderDark.b, 0.75)
         visible:                    _activeVehicle
         z:                          QGroundControl.zOrderWidgets
         state:                      "Shown"
@@ -303,7 +303,7 @@ Item {
 
             QGCLabel {
                 anchors.horizontalCenter: parent.horizontalCenter
-                color:      _lightWidgetBorders ? qgcPal.mapWidgetBorderDark : qgcPal.mapWidgetBorderLight
+                color:      _isSatellite ? qgcPal.mapWidgetBorderDark : qgcPal.mapWidgetBorderLight
                 text:       "Click in map to move vehicle"
                 visible:    gotoEnabled
             }

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -15,12 +15,12 @@ import QtQuick.Dialogs          1.2
 import QtLocation               5.3
 import QtPositioning            5.2
 
-import QGroundControl               1.0
-import QGroundControl.ScreenTools   1.0
-import QGroundControl.Controls      1.0
-import QGroundControl.Palette       1.0
-import QGroundControl.Vehicle       1.0
-import QGroundControl.FlightMap     1.0
+import QGroundControl                           1.0
+import QGroundControl.ScreenTools               1.0
+import QGroundControl.Controls                  1.0
+import QGroundControl.Palette                   1.0
+import QGroundControl.Vehicle                   1.0
+import QGroundControl.FlightMap                 1.0
 
 Item {
     id: _root
@@ -48,13 +48,29 @@ Item {
     }
 
     function _setInstrumentWidget() {
-        var useAlternateInstruments = QGroundControl.virtualTabletJoystick || ScreenTools.isTinyScreen
-        if(useAlternateInstruments) {
-            instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidgetAlternate.qml"
-            instrumentsLoader.state  = "topMode"
+        if(QGroundControl.corePlugin.options.instrumentWidget.source.toString().length) {
+            instrumentsLoader.source = QGroundControl.corePlugin.options.instrumentWidget.source
+            switch(QGroundControl.corePlugin.options.instrumentWidget.widgetPosition) {
+            case CustomInstrumentWidget.POS_TOP_RIGHT:
+                instrumentsLoader.state  = "topMode"
+                break;
+            case CustomInstrumentWidget.POS_BOTTOM_RIGHT:
+                instrumentsLoader.state  = "bottomMode"
+                break;
+            case CustomInstrumentWidget.POS_CENTER_RIGHT:
+            default:
+                instrumentsLoader.state  = "centerMode"
+                break;
+            }
         } else {
-            instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidget.qml"
-            instrumentsLoader.state  = "centerMode"
+            var useAlternateInstruments = QGroundControl.virtualTabletJoystick || ScreenTools.isTinyScreen
+            if(useAlternateInstruments) {
+                instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidgetAlternate.qml"
+                instrumentsLoader.state  = "topMode"
+            } else {
+                instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidget.qml"
+                instrumentsLoader.state  = "centerMode"
+            }
         }
     }
 
@@ -108,6 +124,7 @@ Item {
                 AnchorChanges {
                     target:                 instrumentsLoader
                     anchors.verticalCenter: undefined
+                    anchors.bottom:         undefined
                     anchors.top:            _root ? _root.top : undefined
                 }
             },
@@ -116,7 +133,17 @@ Item {
                 AnchorChanges {
                     target:                 instrumentsLoader
                     anchors.top:            undefined
+                    anchors.bottom:         undefined
                     anchors.verticalCenter: _root ? _root.verticalCenter : undefined
+                }
+            },
+            State {
+                name:   "bottomMode"
+                AnchorChanges {
+                    target:                 instrumentsLoader
+                    anchors.top:            undefined
+                    anchors.verticalCenter: undefined
+                    anchors.bottom:         _root ? _root.bottom : undefined
                 }
             }
         ]

--- a/src/FlightDisplay/MultiVehicleList.qml
+++ b/src/FlightDisplay/MultiVehicleList.qml
@@ -52,15 +52,12 @@ QGCListView {
 
             QGCCompassWidget {
                 size:       _widgetHeight
-                heading:    _vehicle.heading.rawValue
                 vehicle:    _vehicle
             }
 
             QGCAttitudeWidget {
                 size:       _widgetHeight
-                active:     true
-                rollAngle:  _vehicle.roll.rawValue
-                pitchAngle: _vehicle.pitch.rawValue
+                vehicle:    _vehicle
             }
         }
 

--- a/src/FlightMap/Widgets/QGCAttitudeWidget.qml
+++ b/src/FlightMap/Widgets/QGCAttitudeWidget.qml
@@ -17,22 +17,18 @@
 import QtQuick 2.4
 import QtGraphicalEffects 1.0
 
+import QGroundControl          1.0
 import QGroundControl.Controls 1.0
 
 Item {
     id: root
 
-    property bool active:       false  ///< true: actively connected to data provider, false: show inactive control
-    property real rollAngle :   _defaultRollAngle
-    property real pitchAngle:   _defaultPitchAngle
     property bool showPitch:    true
+    property var  vehicle:      null
     property real size
 
-    readonly property real _defaultRollAngle:   0
-    readonly property real _defaultPitchAngle:  0
-
-    property real _rollAngle:   active ? rollAngle  : _defaultRollAngle
-    property real _pitchAngle:  active ? pitchAngle : _defaultPitchAngle
+    property real _rollAngle:   vehicle ? vehicle.roll.rawValue  : 0
+    property real _pitchAngle:  vehicle ? vehicle.pitch.rawValue : 0
 
     width:  size
     height: size

--- a/src/FlightMap/Widgets/QGCCompassWidget.qml
+++ b/src/FlightMap/Widgets/QGCCompassWidget.qml
@@ -25,12 +25,12 @@ Item {
     id:                     root
 
     property real size:     _defaultSize
-    property real heading:  0
     property var  vehicle:  null
 
     property real _defaultSize: ScreenTools.defaultFontPixelHeight * (10)
     property real _sizeRatio:   ScreenTools.isTinyScreen ? (size / _defaultSize) * 0.5 : size / _defaultSize
     property int  _fontSize:    ScreenTools.defaultFontPointSize * _sizeRatio
+    property real _heading:     vehicle ? vehicle.heading.rawValue : 0
 
     width:                  size
     height:                 size
@@ -58,7 +58,7 @@ Item {
             transform: Rotation {
                 origin.x:       pointer.width  / 2
                 origin.y:       pointer.height / 2
-                angle:          heading
+                angle:          _heading
             }
         }
 
@@ -79,7 +79,7 @@ Item {
             color:              Qt.rgba(0,0,0,0.65)
 
             QGCLabel {
-                text:           vehicle ? heading.toFixed(0) : qsTr("OFF")
+                text:           vehicle ? _heading.toFixed(0) : qsTr("OFF")
                 font.family:    vehicle ? ScreenTools.demiboldFontFamily : ScreenTools.normalFontFamily
                 font.pointSize: _fontSize < 8 ? 8 : _fontSize;
                 color:          "white"

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -26,27 +26,15 @@ import QGroundControl.Palette       1.0
 Item {
     id:     instrumentPanel
     height: instrumentColumn.y + instrumentColumn.height + _topBottomMargin
-    width:  size
+    width:  getPreferredInstrumentWidth()
 
-    property alias  heading:        compass.heading
-    property alias  rollAngle:      attitudeWidget.rollAngle
-    property alias  pitchAngle:     attitudeWidget.pitchAngle
-    property real   size:           _defaultSize
-    property bool   lightBorders:   true
-    property bool   active:         false
-    property var    qgcView
-    property real   maxHeight
-
-    property Fact   _emptyFact:         Fact { }
-    property Fact   groundSpeedFact:    _emptyFact
-    property Fact   airSpeedFact:       _emptyFact
-
-    property real   _defaultSize:   ScreenTools.defaultFontPixelHeight * (9)
-
+    property var    _qgcView:           qgcView
+    property real   _maxHeight:         maxHeight
+    property real   _defaultSize:       ScreenTools.defaultFontPixelHeight * (9)
     property color  _backgroundColor:   qgcPal.window
     property real   _spacing:           ScreenTools.defaultFontPixelHeight * 0.33
-    property real   _topBottomMargin:   (size * 0.05) / 2
-    property real   _availableValueHeight: maxHeight - (attitudeWidget.height + _spacer1.height + _spacer2.height + (_spacing * 4)) - (_showCompass ? compass.height : 0)
+    property real   _topBottomMargin:   (width * 0.05) / 2
+    property real   _availableValueHeight: _maxHeight - (attitudeWidget.height + _spacer1.height + _spacer2.height + (_spacing * 4)) - (_showCompass ? compass.height : 0)
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
 
     readonly property bool _showCompass:    true // !ScreenTools.isShortScreen
@@ -57,10 +45,10 @@ Item {
         anchors.left:   parent.left
         anchors.right:  parent.right
         height:         (_showCompass ? instrumentColumn.height : attitudeWidget.height) + (_topBottomMargin * 2)
-        radius:         size / 2
+        radius:         width / 2
         color:          _backgroundColor
         border.width:   1
-        border.color:   lightBorders ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
+        border.color:   _isSatellite ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
     }
 
     MouseArea {
@@ -83,7 +71,7 @@ Item {
             QGCAttitudeWidget {
                 id:             attitudeWidget
                 size:           parent.width * 0.95
-                active:         instrumentPanel.active
+                vehicle:        _activeVehicle
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
@@ -131,7 +119,7 @@ Item {
                 anchors.margins:    1
                 anchors.left:       parent.left
                 anchors.right:      parent.right
-                qgcView:            instrumentPanel.qgcView
+                qgcView:            instrumentPanel._qgcView
                 textColor:          qgcPal.text
                 backgroundColor:    _backgroundColor
                 maxHeight:          _availableValueHeight

--- a/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
@@ -20,38 +20,24 @@ import QGroundControl.Palette       1.0
 /// Instrument panel shown when virtual thumbsticks are visible
 Rectangle {
     id:             root
+    width:          ScreenTools.isTinyScreen ? getPreferredInstrumentWidth() * 1.5 : getPreferredInstrumentWidth()
     height:         _outerRadius * 2
     radius:         _outerRadius
     color:          qgcPal.window
     border.width:   1
-    border.color:   lightBorders ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
+    border.color:   _isSatellite ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
 
-    property alias  heading:        compass.heading
-    property alias  rollAngle:      attitude.rollAngle
-    property alias  pitchAngle:     attitude.pitchAngle
-    property real   size:           _defaultSize
-    property bool   active:         false
-    property bool   lightBorders:   true
-    property var    qgcView
-    property real   maxHeight
-
-    property Fact   _emptyFact:         Fact { }
-    property Fact   groundSpeedFact:    _emptyFact
-    property Fact   airSpeedFact:       _emptyFact
-    property Fact   altitudeFact:       _emptyFact
-
-    property real   _innerRadius: (width - (_topBottomMargin * 3)) / 4
-    property real   _outerRadius: _innerRadius + _topBottomMargin
-
-    property real   _defaultSize:   ScreenTools.defaultFontPixelHeight * (9)
-
-    property real   _sizeRatio:     ScreenTools.isTinyScreen ? (size / _defaultSize) * 0.5 : size / _defaultSize
-    property real   _bigFontSize:   ScreenTools.defaultFontPointSize * 2.5  * _sizeRatio
-    property real   _normalFontSize:ScreenTools.defaultFontPointSize * 1.5  * _sizeRatio
-    property real   _labelFontSize: ScreenTools.defaultFontPointSize * 0.75 * _sizeRatio
-    property real   _spacing:       ScreenTools.defaultFontPixelHeight * 0.33
-    property real   _topBottomMargin: (size * 0.05) / 2
+    property real   _innerRadius:       (width - (_topBottomMargin * 3)) / 4
+    property real   _outerRadius:       _innerRadius + _topBottomMargin
+    property real   _defaultSize:       ScreenTools.defaultFontPixelHeight * (9)
+    property real   _sizeRatio:         ScreenTools.isTinyScreen ? (width / _defaultSize) * 0.5 : width / _defaultSize
+    property real   _bigFontSize:       ScreenTools.defaultFontPointSize * 2.5  * _sizeRatio
+    property real   _normalFontSize:    ScreenTools.defaultFontPointSize * 1.5  * _sizeRatio
+    property real   _labelFontSize:     ScreenTools.defaultFontPointSize * 0.75 * _sizeRatio
+    property real   _spacing:           ScreenTools.defaultFontPixelHeight * 0.33
+    property real   _topBottomMargin:   (width * 0.05) / 2
     property real   _availableValueHeight: maxHeight - (root.height + _valuesItem.anchors.topMargin)
+    property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
 
     QGCPalette { id: qgcPal }
 
@@ -60,7 +46,7 @@ Rectangle {
         anchors.leftMargin: _topBottomMargin
         anchors.left:       parent.left
         size:               _innerRadius * 2
-        active:             root.active
+        vehicle:            _activeVehicle
         anchors.verticalCenter: parent.verticalCenter
     }
 
@@ -69,7 +55,7 @@ Rectangle {
         anchors.leftMargin: _spacing
         anchors.left:       attitude.right
         size:               _innerRadius * 2
-        vehicle:            QGroundControl.multiVehicleManager.activeVehicle
+        vehicle:            _activeVehicle
         anchors.verticalCenter: parent.verticalCenter
     }
 

--- a/src/FlightMap/qmldir
+++ b/src/FlightMap/qmldir
@@ -14,8 +14,6 @@ QGCArtificialHorizon            1.0 QGCArtificialHorizon.qml
 QGCAttitudeHUD                  1.0 QGCAttitudeHUD.qml
 QGCAttitudeWidget               1.0 QGCAttitudeWidget.qml
 QGCCompassWidget                1.0 QGCCompassWidget.qml
-QGCInstrumentWidget             1.0 QGCInstrumentWidget.qml
-QGCInstrumentWidgetAlternate    1.0 QGCInstrumentWidgetAlternate.qml
 QGCPitchIndicator               1.0 QGCPitchIndicator.qml
 QGCSlider                       1.0 QGCSlider.qml
 ValuesWidget                    1.0 ValuesWidget.qml

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -126,6 +126,11 @@ QVariantList &QGCCorePlugin::settings()
     return _p->settingsList;
 }
 
+int QGCCorePlugin::defaltSettings()
+{
+    return 0;
+}
+
 QGCOptions* QGCCorePlugin::options()
 {
     if(!_p->defaultOptions) {

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -32,20 +32,27 @@ public:
     QGCCorePlugin(QGCApplication* app);
     ~QGCCorePlugin();
 
-    Q_PROPERTY(QVariantList settings READ settings CONSTANT)
-    Q_PROPERTY(QGCOptions*  options  READ options  CONSTANT)
+    Q_PROPERTY(QVariantList settings        READ settings       CONSTANT)
+    Q_PROPERTY(int          defaltSettings  READ defaltSettings CONSTANT)
+    Q_PROPERTY(QGCOptions*  options         READ options        CONSTANT)
 
     //! The list of settings under the Settings Menu
     /*!
         @return A list of QGCSettings
     */
-    virtual QVariantList&           settings    ();
+    virtual QVariantList&           settings        ();
+
+    //! The default settings panel to show
+    /*!
+        @return The settings index
+    */
+    virtual int                     defaltSettings  ();
 
     //! Global options
     /*!
         @return An instance of QGCOptions
     */
-    virtual QGCOptions*             options     ();
+    virtual QGCOptions*             options         ();
 
     // Override from QGCTool
     void                            setToolbox  (QGCToolbox *toolbox);

--- a/src/api/QGCOptions.cc
+++ b/src/api/QGCOptions.cc
@@ -8,6 +8,7 @@
  ****************************************************************************/
 
 #include "QGCOptions.h"
+#include <QtQml>
 
 /// @file
 ///     @brief Core Plugin Interface for QGroundControl - Application Options
@@ -15,5 +16,23 @@
 
 QGCOptions::QGCOptions(QObject* parent)
     : QObject(parent)
+    , _defaultInstrumentWidget(NULL)
+{
+    qmlRegisterUncreatableType<CustomInstrumentWidget>("QGroundControl", 1, 0, "CustomInstrumentWidget", "Reference only");
+}
+
+CustomInstrumentWidget*
+QGCOptions::instrumentWidget()
+{
+    if(!_defaultInstrumentWidget) {
+        _defaultInstrumentWidget = new CustomInstrumentWidget(this);
+    }
+    return _defaultInstrumentWidget;
+}
+
+CustomInstrumentWidget::CustomInstrumentWidget(QObject* parent)
+    : QObject(parent)
 {
 }
+
+

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -11,11 +11,13 @@
 
 #include <QObject>
 #include <QString>
+#include <QUrl>
 
 /// @file
 ///     @brief Core Plugin Interface for QGroundControl - Application Options
 ///     @author Gus Grubba <mavlink@grubba.com>
 
+class CustomInstrumentWidget;
 class QGCOptions : public QObject
 {
     Q_OBJECT
@@ -32,6 +34,8 @@ public:
     Q_PROPERTY(double   toolbarHeightMultiplier     READ toolbarHeightMultiplier    CONSTANT)
     Q_PROPERTY(double   defaultFontPointSize        READ defaultFontPointSize       CONSTANT)
     Q_PROPERTY(bool     enablePlanViewSelector      READ enablePlanViewSelector     CONSTANT)
+    Q_PROPERTY(CustomInstrumentWidget*  instrumentWidget READ instrumentWidget      CONSTANT)
+
 
     //! Should QGC hide its settings menu and colapse it into one single menu (Settings and Vehicle Setup)?
     /*!
@@ -83,4 +87,32 @@ public:
         @return True or false
     */
     virtual bool        enablePlanViewSelector      () { return true; }
+    //! Provides an alternate instrument widget for the Fly View
+    /*!
+        @return An alternate widget (see QGCInstrumentWidget.qml, the default widget)
+    */
+    virtual CustomInstrumentWidget* instrumentWidget();
+private:
+    CustomInstrumentWidget* _defaultInstrumentWidget;
+};
+
+//-----------------------------------------------------------------------------
+class CustomInstrumentWidget : public QObject
+{
+    Q_OBJECT
+public:
+    //-- Widget Position
+    enum Pos {
+        POS_TOP_RIGHT           = 0,
+        POS_CENTER_RIGHT        = 1,
+        POS_BOTTOM_RIGHT        = 2,
+    };
+    Q_ENUMS(Pos)
+    CustomInstrumentWidget(QObject* parent = NULL);
+    Q_PROPERTY(QUrl     source  READ source CONSTANT)
+    Q_PROPERTY(Pos      widgetPosition              READ widgetPosition             NOTIFY widgetPositionChanged)
+    virtual QUrl        source                      () { return QUrl(); }
+    virtual Pos         widgetPosition              () { return POS_CENTER_RIGHT; }
+signals:
+    void widgetPositionChanged  ();
 };

--- a/src/ui/AppSettings.qml
+++ b/src/ui/AppSettings.qml
@@ -35,8 +35,8 @@ Rectangle {
     QGCPalette { id: qgcPal }
 
     Component.onCompleted: {
-        //-- Default to General Settings
-        __rightPanel.source = "GeneralSettings.qml"
+        //-- Default Settings
+        __rightPanel.source = QGroundControl.corePlugin.settings[QGroundControl.corePlugin.defaltSettings].url
     }
 
     QGCFlickable {

--- a/src/ui/toolbar/MainToolBarController.h
+++ b/src/ui/toolbar/MainToolBarController.h
@@ -22,13 +22,6 @@
 #include "Vehicle.h"
 #include "UASMessageView.h"
 
-#define TOOL_BAR_SETTINGS_GROUP "TOOLBAR_SETTINGS_GROUP"
-#define TOOL_BAR_SHOW_BATTERY   "ShowBattery"
-#define TOOL_BAR_SHOW_GPS       "ShowGPS"
-#define TOOL_BAR_SHOW_MAV       "ShowMav"
-#define TOOL_BAR_SHOW_MESSAGES  "ShowMessages"
-#define TOOL_BAR_SHOW_RSSI      "ShowRSSI"
-
 class MainToolBarController : public QObject
 {
     Q_OBJECT
@@ -45,8 +38,6 @@ public:
     Q_PROPERTY(unsigned int telemetryLNoise     READ telemetryLNoise            NOTIFY telemetryLNoiseChanged)
     Q_PROPERTY(unsigned int telemetryRNoise     READ telemetryRNoise            NOTIFY telemetryRNoiseChanged)
 
-    void        viewStateChanged        (const QString& key, bool value);
-
     int         telemetryRRSSI          () { return _telemetryRRSSI; }
     int         telemetryLRSSI          () { return _telemetryLRSSI; }
     unsigned int telemetryRXErrors      () { return _telemetryRXErrors; }
@@ -58,7 +49,6 @@ public:
 signals:
     void telemetryRRSSIChanged          (int value);
     void telemetryLRSSIChanged          (int value);
-    void heightChanged                  (double height);
     void telemetryRXErrorsChanged       (unsigned int value);
     void telemetryFixedChanged          (unsigned int value);
     void telemetryTXBufferChanged       (unsigned int value);
@@ -81,8 +71,6 @@ private:
     uint32_t        _telemetryLNoise;
     uint32_t        _telemetryRNoise;
 
-    QStringList     _toolbarMessageQueue;
-    QMutex          _toolbarMessageQueueMutex;
 };
 
 #endif // MainToolBarController_H


### PR DESCRIPTION
Move instrument widget off to a loader.
This allows a custom plugin the option to replace the entire widget with its own.
In the process of working with the instrument widget, I've removed a hole pile of unnecessary *properties*, which where passed around and around. Things like *active*, which would indicate if there was an active vehicle. And others such as *heading*, *roll*, *pitch*, etc., which are all properties of Vehicle, which is accessible globally.
While at it, removed some unused cruft from the toolbar controller. I'm looking into eventually removing the toolbar controller and move its functionality to Vehicle where it truly belongs. The toolbar was the very first QML code added to QGC, long before the Vehicle controller came into existence.
