### PR TITLE
Complex item visual dynamically added to map

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -41,6 +41,7 @@
         <file alias="PX4FlowSensor.qml">src/VehicleSetup/PX4FlowSensor.qml</file>
         <file alias="QGroundControl/Controls/AnalyzePage.qml">src/AnalyzeView/AnalyzePage.qml</file>
         <file alias="QGroundControl/Controls/AppMessages.qml">src/QmlControls/AppMessages.qml</file>
+        <file alias="QGroundControl/Controls/ComplexMissionItem.qml">src/MissionEditor/ComplexMissionItem.qml</file>
         <file alias="QGroundControl/Controls/ClickableColor.qml">src/QmlControls/ClickableColor.qml</file>
         <file alias="QGroundControl/Controls/DropButton.qml">src/QmlControls/DropButton.qml</file>
         <file alias="QGroundControl/Controls/ExclusiveGroupItem.qml">src/QmlControls/ExclusiveGroupItem.qml</file>
@@ -92,6 +93,7 @@
         <file alias="QGroundControl/Controls/SignalStrength.qml">src/ui/toolbar/SignalStrength.qml</file>
         <file alias="QGroundControl/Controls/SliderSwitch.qml">src/QmlControls/SliderSwitch.qml</file>
         <file alias="QGroundControl/Controls/SubMenuButton.qml">src/QmlControls/SubMenuButton.qml</file>
+        <file alias="QGroundControl/Controls/SurveyComplexItem.qml">src/MissionEditor/SurveyComplexItem.qml</file>
         <file alias="QGroundControl/Controls/VehicleRotationCal.qml">src/QmlControls/VehicleRotationCal.qml</file>
         <file alias="QGroundControl/Controls/VehicleSummaryRow.qml">src/QmlControls/VehicleSummaryRow.qml</file>
         <file alias="QGroundControl/Controls/ToolStrip.qml">src/QmlControls/ToolStrip.qml</file>

--- a/src/MissionEditor/ComplexMissionItem.qml
+++ b/src/MissionEditor/ComplexMissionItem.qml
@@ -1,0 +1,43 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.2
+import QtQuick.Controls 1.2
+import QtLocation       5.3
+import QtPositioning    5.2
+
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.Controls      1.0
+
+
+/// Mission item edit control
+Item {
+    id: _root
+
+    property var map    ///< Map control to place item in
+
+    property var _complexItem
+
+    Component.onCompleted: {
+        if (object.mapVisualQML) {
+            var component = Qt.createComponent(object.mapVisualQML)
+            if (component.status === Component.Error) {
+                console.log("Error loading Qml: ", object.mapVisualQML, component.errorString())
+            }
+            _complexItem = component.createObject(map, { "map": _root.map })
+        }
+    }
+
+    Component.onDestruction: {
+        if (_complexItem) {
+            _complexItem.destroy()
+        }
+    }
+}

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -445,25 +445,12 @@ QGCView {
                     }
                 }
 
-                // Add the complex mission item polygon to the map
-                MapItemView {
+                // Add the complex mission item to the map
+                Repeater {
                     model: missionController.complexVisualItems
 
-                    delegate: MapPolygon {
-                        color:      'green'
-                        path:       object.polygonPath
-                        opacity:    0.5
-                    }
-                }
-
-                // Add the complex mission item grid to the map
-                MapItemView {
-                    model: missionController.complexVisualItems
-
-                    delegate: MapPolyline {
-                        line.color: "white"
-                        line.width: 2
-                        path:       object.gridPoints
+                    delegate: ComplexMissionItem {
+                        map: editorMap
                     }
                 }
 

--- a/src/MissionEditor/SurveyComplexItem.qml
+++ b/src/MissionEditor/SurveyComplexItem.qml
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.2
+import QtQuick.Controls 1.2
+import QtLocation       5.3
+import QtPositioning    5.2
+
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.Controls      1.0
+
+/// Survey Complex Mission Item visuals
+Item {
+    property var map    ///< Map control to place item in
+
+    property var _polygon
+    property var _grid
+
+    Component.onCompleted: {
+        _polygon = polygonComponent.createObject(map)
+        _grid = gridComponent.createObject(map)
+        map.addMapItem(_polygon)
+        map.addMapItem(_grid)
+    }
+
+    Component.onDestruction: {
+        _polygon.destroy()
+        _grid.destroy()
+    }
+
+    // Survey area polygon
+    Component {
+        id: polygonComponent
+
+        MapPolygon {
+            color: "green"
+            opacity:    0.5
+            path:       object.polygonPath
+        }
+    }
+
+    // Survey grid lines
+    Component {
+        id: gridComponent
+
+        MapPolyline {
+            line.color: "white"
+            line.width: 2
+            path:       object.gridPoints
+        }
+    }
+}

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -21,6 +21,7 @@ public:
 
     const ComplexMissionItem& operator=(const ComplexMissionItem& other);
 
+    Q_PROPERTY(QString  mapVisualQML        READ mapVisualQML       CONSTANT)
     Q_PROPERTY(int      lastSequenceNumber  READ lastSequenceNumber NOTIFY lastSequenceNumberChanged)
     Q_PROPERTY(double   complexDistance     READ complexDistance    NOTIFY complexDistanceChanged)
 
@@ -51,6 +52,9 @@ public:
 
     /// This mission item attribute specifies the type of the complex item.
     static const char* jsonComplexItemTypeKey;
+
+    /// @return The QML resource file which contains the control which visualizes the item on the map.
+    virtual QString mapVisualQML(void) const = 0;
 
 signals:
     void lastSequenceNumberChanged  (int lastSequenceNumber);

--- a/src/MissionManager/FixedWingLandingComplexItem.h
+++ b/src/MissionManager/FixedWingLandingComplexItem.h
@@ -32,6 +32,7 @@ public:
     bool                load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
     double              greatestDistanceTo  (const QGeoCoordinate &other) const final;
     void                setCruiseSpeed      (double cruiseSpeed) final;
+    QString             mapVisualQML        (void) const final { return QString(); }
 
     // Overrides from VisualMissionItem
 

--- a/src/MissionManager/SurveyMissionItem.h
+++ b/src/MissionManager/SurveyMissionItem.h
@@ -83,6 +83,7 @@ public:
     bool                load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
     double              greatestDistanceTo  (const QGeoCoordinate &other) const final;
     void                setCruiseSpeed      (double cruiseSpeed) final;
+    QString             mapVisualQML        (void) const final { return QStringLiteral("SurveyComplexItem.qml"); }
 
 
     // Overrides from VisualMissionItem

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -3,6 +3,7 @@ Module QGroundControl.Controls
 AnalyzePage             1.0 AnalyzePage.qml
 AppMessages             1.0 AppMessages.qml
 ClickableColor          1.0 ClickableColor.qml
+ComplexMissionItem      1.0 ComplexMissionItem.qml
 DropButton              1.0 DropButton.qml
 DropPanel               1.0 DropPanel.qml
 ExclusiveGroupItem      1.0 ExclusiveGroupItem.qml
@@ -50,6 +51,7 @@ SetupPage               1.0 SetupPage.qml
 SignalStrength          1.0 SignalStrength.qml
 SliderSwitch            1.0 SliderSwitch.qml
 SubMenuButton           1.0 SubMenuButton.qml
+SurveyComplexItem       1.0 SurveyComplexItem.qml
 ToolStrip               1.0 ToolStrip.qml
 VehicleRotationCal      1.0 VehicleRotationCal.qml
 VehicleSummaryRow       1.0 VehicleSummaryRow.qml


### PR DESCRIPTION
Previously the visuals for the Survey complex mission item where hardwired into the MissionEditor (Plan View) Map control. Up until now I hadn't figured out how to dynamically add the needed controls to the Map since the Map controls work differently than the rest of QML controls. Now that I know how to do that I changed it such that the Qml for complex item visuals is now specified by ComplexMissionItem. Then the map loads a ComplexMissionItem control for each complex item, which then dynamically loads the control(s) for the complex item visuals.

Basically all of that means new complex mission items can be added to the system without modifying the MissionEditor control.