### PR TITLE
Plan: Change semantics for pulling altitude from mission items for new items

### DIFF
--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -851,7 +851,7 @@ QGCView {
                     ]
 
                     onClicked: {
-                        switch (index == 0) {
+                        switch (index) {
                         case 0:
                             _addWaypointOnClick = checked
                             break

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -148,8 +148,7 @@ private:
     void _setupActiveVehicle(Vehicle* activeVehicle, bool forceLoadFromVehicle);
     static void _calcPrevWaypointValues(double homeAlt, VisualMissionItem* currentItem, VisualMissionItem* prevItem, double* azimuth, double* distance, double* altDifference);
     static double _calcDistanceToHome(VisualMissionItem* currentItem, VisualMissionItem* homeItem);
-    bool _findLastAltitude(double* lastAltitude, MAV_FRAME* frame);
-    bool _findLastAcceptanceRadius(double* lastAcceptanceRadius);
+    bool _findPreviousAltitude(int newIndex, double* prevAltitude, MAV_FRAME* prevFrame);
     static double _normalizeLat(double lat);
     static double _normalizeLon(double lon);
     static void _addPlannedHomePosition(Vehicle* vehicle, QmlObjectListModel* visualItems, bool addToCenter);


### PR DESCRIPTION
New semantics:
* When a new item is inserted we look backwards from that item for a previous MAV_CMD_NAV_WAYPOINT and use the altitude and frame from that item as the defaults for the new item.
* The semantics above only apply to newly added MAV_CMD_NAV_WAYPOINT items
* Removed support for look back/set on new items for acceptance radius. Since acceptance radius is not normally shown on new items it's dangerous to override the default (which is 0) on something that isn't shown.

This differs from previous support which would find the last mission item which specified a coordinate and was not a land item. The issue with that method were:
* If you inserted a new item in the middle of a mission it would still use the value from the last mission item. This just didn't make any sense.
* I tried to exclude special case items to avoid pulling  previous altitude from them (MAV_CMD_NAV_TAKEOFF for example). This special casing mechanism wasn't feasible movinf forward as new items are added. The special casing will most likely fall out of date from new items being supported which would be a bad thing.

Fix for #4572