### PR TITLE
fixed uploading of bin files

### DIFF
--- a/src/VehicleSetup/FirmwareImage.cc
+++ b/src/VehicleSetup/FirmwareImage.cc
@@ -51,9 +51,8 @@ bool FirmwareImage::load(const QString& imageFilename, uint32_t boardId)
     _boardId = boardId;
     
     if (imageFilename.endsWith(".bin")) {
-        return _binLoad(imageFilename);
         _binFormat = true;
-        return true;
+        return _binLoad(imageFilename);
     } else if (imageFilename.endsWith(".px4")) {
         _binFormat = true;
         return _px4Load(imageFilename);


### PR DESCRIPTION
`_binFormat` was never set to true, as the function returned before that assignment, resulting in failing uploads of bin fails