### PR TITLE
Add calibrate pressure button in sensors page, enabled only for ArduSub

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -14,6 +14,7 @@ import QtQuick.Controls.Styles  1.2
 import QtQuick.Dialogs          1.2
 import QtQuick.Layouts          1.2
 
+import QGroundControl               1.0
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0
 import QGroundControl.Palette       1.0
@@ -120,6 +121,7 @@ SetupPage {
                 accelButton:                accelButton
                 compassMotButton:           motorInterferenceButton
                 levelButton:                levelHorizonButton
+                calibratePressureButton:    calibratePressureButton
                 nextButton:                 nextButton
                 cancelButton:               cancelButton
                 setOrientationsButton:      setOrientationsButton
@@ -445,6 +447,26 @@ SetupPage {
                 } // QGCViewDialog
             } // Component - levelHorizonDialogComponent
 
+            Component {
+                id: calibratePressureDialogComponent
+
+                QGCViewDialog {
+                    id: calibratePressureDialog
+
+                    function accept() {
+                        controller.calibratePressure()
+                        calibratePressureDialog.hideDialog()
+                    }
+
+                    QGCLabel {
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        wrapMode:       Text.WordWrap
+                        text:           qsTr("Pressure calibration will set the depth to zero at the current pressure reading.")
+                    }
+                } // QGCViewDialog
+            } // Component - calibratePressureDialogComponent
+
             /// Left button column
             Column {
                 spacing:            ScreenTools.defaultFontPixelHeight / 2
@@ -489,6 +511,20 @@ SetupPage {
                         } else {
                             showDialog(levelHorizonDialogComponent, _levelHorizonText, qgcView.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Ok)
                         }
+                    }
+                }
+
+                QGCButton {
+                    id:     calibratePressureButton
+                    width:  parent.buttonWidth
+                    text:   _calibratePressureText
+                    visible: _activeVehicle ? _activeVehicle.supportsCalibratePressure : false
+
+                    readonly property string _calibratePressureText: qsTr("Calibrate Pressure")
+                    property var  _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+                    onClicked: {
+                        showDialog(calibratePressureDialogComponent, _calibratePressureText, qgcView.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Ok)
                     }
                 }
 

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -30,6 +30,7 @@ APMSensorsComponentController::APMSensorsComponentController(void)
     , _accelButton(NULL)
     , _compassMotButton(NULL)
     , _levelButton(NULL)
+    , _calibratePressureButton(NULL)
     , _nextButton(NULL)
     , _cancelButton(NULL)
     , _setOrientationsButton(NULL)
@@ -101,6 +102,7 @@ void APMSensorsComponentController::_startLogCalibration(void)
     _accelButton->setEnabled(false);
     _compassMotButton->setEnabled(false);
     _levelButton->setEnabled(false);
+    _calibratePressureButton->setEnabled(false);
     _setOrientationsButton->setEnabled(false);
     if (_calTypeInProgress == CalTypeAccel || _calTypeInProgress == CalTypeCompassMot) {
         _nextButton->setEnabled(true);
@@ -114,6 +116,7 @@ void APMSensorsComponentController::_startVisualCalibration(void)
     _accelButton->setEnabled(false);
     _compassMotButton->setEnabled(false);
     _levelButton->setEnabled(false);
+    _calibratePressureButton->setEnabled(false);
     _setOrientationsButton->setEnabled(false);
     _cancelButton->setEnabled(true);
 
@@ -158,6 +161,7 @@ void APMSensorsComponentController::_stopCalibration(APMSensorsComponentControll
     _accelButton->setEnabled(true);
     _compassMotButton->setEnabled(true);
     _levelButton->setEnabled(true);
+    _calibratePressureButton->setEnabled(true);
     _setOrientationsButton->setEnabled(true);
     _nextButton->setEnabled(false);
     _cancelButton->setEnabled(false);
@@ -316,6 +320,15 @@ void APMSensorsComponentController::levelHorizon(void)
     _startLogCalibration();
     _appendStatusLog(tr("Hold the vehicle in its level flight position."));
     _uas->startCalibration(UASInterface::StartCalibrationLevel);
+}
+
+void APMSensorsComponentController::calibratePressure(void)
+{
+    _calTypeInProgress = CalTypePressure;
+    _vehicle->setConnectionLostEnabled(false);
+    _startLogCalibration();
+    _appendStatusLog(tr("Requesting pressure calibration..."));
+    _uas->startCalibration(UASInterface::StartCalibrationPressure);
 }
 
 void APMSensorsComponentController::_handleUASTextMessage(int uasId, int compId, int severity, QString text)
@@ -623,6 +636,24 @@ void APMSensorsComponentController::_handleCommandAck(mavlink_message_t& message
                 break;
             default:
                 _appendStatusLog(tr("Level horizon failed"));
+                _stopCalibration(StopCalibrationFailed);
+                break;
+            }
+        }
+    }
+
+    if (_calTypeInProgress == CalTypePressure) {
+        mavlink_command_ack_t commandAck;
+        mavlink_msg_command_ack_decode(&message, &commandAck);
+
+        if (commandAck.command == MAV_CMD_PREFLIGHT_CALIBRATION) {
+            switch (commandAck.result) {
+            case MAV_RESULT_ACCEPTED:
+                _appendStatusLog(tr("Pressure calibration success"));
+                _stopCalibration(StopCalibrationSuccessShowLog);
+                break;
+            default:
+                _appendStatusLog(tr("Pressure calibration fail"));
                 _stopCalibration(StopCalibrationFailed);
                 break;
             }

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
@@ -38,6 +38,7 @@ public:
     Q_PROPERTY(QQuickItem* accelButton MEMBER _accelButton)
     Q_PROPERTY(QQuickItem* compassMotButton MEMBER _compassMotButton)
     Q_PROPERTY(QQuickItem* levelButton MEMBER _levelButton)
+    Q_PROPERTY(QQuickItem* calibratePressureButton MEMBER _calibratePressureButton)
     Q_PROPERTY(QQuickItem* nextButton MEMBER _nextButton)
     Q_PROPERTY(QQuickItem* cancelButton MEMBER _cancelButton)
     Q_PROPERTY(QQuickItem* setOrientationsButton MEMBER _setOrientationsButton)
@@ -90,6 +91,7 @@ public:
     Q_INVOKABLE void calibrateAccel(void);
     Q_INVOKABLE void calibrateMotorInterference(void);
     Q_INVOKABLE void levelHorizon(void);
+    Q_INVOKABLE void calibratePressure(void);
     Q_INVOKABLE void cancelCalibration(void);
     Q_INVOKABLE void nextClicked(void);
     Q_INVOKABLE bool usingUDPLink(void);
@@ -103,6 +105,7 @@ public:
         CalTypeOffboardCompass,
         CalTypeLevelHorizon,
         CalTypeCompassMot,
+        CalTypePressure,
         CalTypeNone
     } CalType_t;
     Q_ENUM(CalType_t)
@@ -169,6 +172,7 @@ private:
     QQuickItem* _accelButton;
     QQuickItem* _compassMotButton;
     QQuickItem* _levelButton;
+    QQuickItem* _calibratePressureButton;
     QQuickItem* _nextButton;
     QQuickItem* _cancelButton;
     QQuickItem* _setOrientationsButton;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -72,3 +72,8 @@ bool ArduSubFirmwarePlugin::supportsJSButton(void)
 {
     return true;
 }
+
+bool ArduSubFirmwarePlugin::supportsCalibratePressure(void)
+{
+    return true;
+}

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -79,6 +79,8 @@ public:
 
     bool supportsJSButton(void);
 
+    bool supportsCalibratePressure(void);
+
     QString brandImage(const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImageSub"); }
 };
 

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -127,6 +127,11 @@ bool FirmwarePlugin::supportsRadio(void)
     return true;
 }
 
+bool FirmwarePlugin::supportsCalibratePressure(void)
+{
+    return false;
+}
+
 bool FirmwarePlugin::supportsJSButton(void)
 {
     return false;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -163,6 +163,10 @@ public:
     /// to be assigned via parameters in firmware. Default is false.
     virtual bool supportsJSButton(void);
 
+    /// Returns true if the firmware supports calibrating the pressure sensor so the altitude will read
+    /// zero at the current pressure. Default is false.
+    virtual bool supportsCalibratePressure(void);
+
     /// Called before any mavlink message is processed by Vehicle such that the firmwre plugin
     /// can adjust any message characteristics. This is handy to adjust or differences in mavlink
     /// spec implementations such that the base code can remain mavlink generic.

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1742,6 +1742,11 @@ bool Vehicle::supportsJSButton(void) const
     return _firmwarePlugin->supportsJSButton();
 }
 
+bool Vehicle::supportsCalibratePressure(void) const
+{
+    return _firmwarePlugin->supportsCalibratePressure();
+}
+
 void Vehicle::_setCoordinateValid(bool coordinateValid)
 {
     if (coordinateValid != _coordinateValid) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -253,6 +253,7 @@ public:
     Q_PROPERTY(bool        supportsThrottleModeCenterZero   READ supportsThrottleModeCenterZero                         CONSTANT)
     Q_PROPERTY(bool                 supportsJSButton        READ supportsJSButton                                       CONSTANT)
     Q_PROPERTY(bool                 supportsRadio           READ supportsRadio                                          CONSTANT)
+    Q_PROPERTY(bool               supportsCalibratePressure READ supportsCalibratePressure                                  CONSTANT)
     Q_PROPERTY(bool                 autoDisconnect          MEMBER _autoDisconnect                                      NOTIFY autoDisconnectChanged)
     Q_PROPERTY(QString              prearmError             READ prearmError            WRITE setPrearmError            NOTIFY prearmErrorChanged)
     Q_PROPERTY(int                  motorCount              READ motorCount                                             CONSTANT)
@@ -474,6 +475,7 @@ public:
     bool supportsThrottleModeCenterZero(void) const;
     bool supportsRadio(void) const;
     bool supportsJSButton(void) const;
+    bool supportsCalibratePressure(void) const;
 
     void setFlying(bool flying);
     void setGuidedMode(bool guidedMode);

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -528,6 +528,7 @@ void UAS::startCalibration(UASInterface::StartCalibrationType calType)
     int airspeedCal = 0;
     int radioCal = 0;
     int accelCal = 0;
+    int pressureCal = 0;
     int escCal = 0;
 
     switch (calType) {
@@ -551,6 +552,9 @@ void UAS::startCalibration(UASInterface::StartCalibrationType calType)
         break;
     case StartCalibrationLevel:
         accelCal = 2;
+        break;
+    case StartCalibrationPressure:
+        pressureCal = 1;
         break;
     case StartCalibrationEsc:
         escCal = 1;
@@ -576,7 +580,7 @@ void UAS::startCalibration(UASInterface::StartCalibrationType calType)
                                        0,                                // 0=first transmission of command
                                        gyroCal,                          // gyro cal
                                        magCal,                           // mag cal
-                                       0,                                // ground pressure
+                                       pressureCal,                      // ground pressure
                                        radioCal,                         // radio cal
                                        accelCal,                         // accel cal
                                        airspeedCal,                      // PX4: airspeed cal, ArduPilot: compass mot

--- a/src/uas/UASInterface.h
+++ b/src/uas/UASInterface.h
@@ -111,6 +111,7 @@ public:
         StartCalibrationAirspeed,
         StartCalibrationAccel,
         StartCalibrationLevel,
+        StartCalibrationPressure,
         StartCalibrationEsc,
         StartCalibrationCopyTrims,
         StartCalibrationUavcanEsc,


### PR DESCRIPTION
This could be used for the other vehicle types, but I was not sure if it is supported or handled on APM side, so it is only available for Sub.

![screenshot 2017-02-22 12 50 29](https://cloud.githubusercontent.com/assets/8315108/23224755/9482d570-f8fd-11e6-99dc-02cd53cafa03.png)
