### PR TITLE
Add FirmwarePluginFactory::supportedVehicleTypes support

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
@@ -24,7 +24,7 @@ APMFirmwarePluginFactory::APMFirmwarePluginFactory(void)
 
 }
 
-QList<MAV_AUTOPILOT> APMFirmwarePluginFactory::knownFirmwareTypes(void) const
+QList<MAV_AUTOPILOT> APMFirmwarePluginFactory::supportedFirmwareTypes(void) const
 {
     QList<MAV_AUTOPILOT> list;
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.h
@@ -24,7 +24,7 @@ class APMFirmwarePluginFactory : public FirmwarePluginFactory
 public:
     APMFirmwarePluginFactory(void);
 
-    QList<MAV_AUTOPILOT>    knownFirmwareTypes          (void) const final;
+    QList<MAV_AUTOPILOT>    supportedFirmwareTypes      (void) const final;
     FirmwarePlugin*         firmwarePluginForAutopilot  (MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType) final;
 
 private:

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -24,6 +24,13 @@ FirmwarePluginFactory::FirmwarePluginFactory(void)
     FirmwarePluginFactoryRegister::instance()->registerPluginFactory(this);
 }
 
+QList<MAV_TYPE> FirmwarePluginFactory::supportedVehicleTypes(void) const
+{
+    QList<MAV_TYPE> vehicleTypes;
+    vehicleTypes << MAV_TYPE_FIXED_WING << MAV_TYPE_QUADROTOR << MAV_TYPE_VTOL_QUADROTOR << MAV_TYPE_GROUND_ROVER << MAV_TYPE_SUBMARINE;
+    return vehicleTypes;
+}
+
 FirmwarePluginFactoryRegister* FirmwarePluginFactoryRegister::instance(void)
 {
     if (!_instance) {

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -265,8 +265,11 @@ public:
     /// @return Singleton FirmwarePlugin instance for the specified MAV_AUTOPILOT.
     virtual FirmwarePlugin* firmwarePluginForAutopilot(MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType) = 0;
 
-    /// @return List of autopilot types this plugin supports.
-    virtual QList<MAV_AUTOPILOT> knownFirmwareTypes(void) const = 0;
+    /// @return List of firmware types this plugin supports.
+    virtual QList<MAV_AUTOPILOT> supportedFirmwareTypes(void) const = 0;
+
+    /// @return List of vehicle types this plugin supports.
+    virtual QList<MAV_TYPE> supportedVehicleTypes(void) const;
 };
 
 class FirmwarePluginFactoryRegister : public QObject

--- a/src/FirmwarePlugin/FirmwarePluginManager.cc
+++ b/src/FirmwarePlugin/FirmwarePluginManager.cc
@@ -26,33 +26,68 @@ FirmwarePluginManager::~FirmwarePluginManager()
     delete _genericFirmwarePlugin;
 }
 
-QList<MAV_AUTOPILOT> FirmwarePluginManager::knownFirmwareTypes(void)
+QList<MAV_AUTOPILOT> FirmwarePluginManager::supportedFirmwareTypes(void)
 {
-    if (_knownFirmwareTypes.isEmpty()) {
+    if (_supportedFirmwareTypes.isEmpty()) {
         QList<FirmwarePluginFactory*> factoryList = FirmwarePluginFactoryRegister::instance()->pluginFactories();
         for (int i = 0; i < factoryList.count(); i++) {
-            _knownFirmwareTypes.append(factoryList[i]->knownFirmwareTypes());
+            _supportedFirmwareTypes.append(factoryList[i]->supportedFirmwareTypes());
         }
-        _knownFirmwareTypes.append(MAV_AUTOPILOT_GENERIC);
+        _supportedFirmwareTypes.append(MAV_AUTOPILOT_GENERIC);
     }
-    return _knownFirmwareTypes;
+    return _supportedFirmwareTypes;
 }
 
-FirmwarePlugin* FirmwarePluginManager::firmwarePluginForAutopilot(MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType)
+QList<MAV_TYPE> FirmwarePluginManager::supportedVehicleTypes(MAV_AUTOPILOT firmwareType)
 {
-    FirmwarePlugin* _plugin = NULL;
+    QList<MAV_TYPE> vehicleTypes;
+
+    FirmwarePluginFactory* factory = _findPluginFactory(firmwareType);
+
+    if (factory) {
+        vehicleTypes = factory->supportedVehicleTypes();
+    } else if (firmwareType == MAV_AUTOPILOT_GENERIC) {
+        vehicleTypes << MAV_TYPE_FIXED_WING << MAV_TYPE_QUADROTOR << MAV_TYPE_VTOL_QUADROTOR << MAV_TYPE_GROUND_ROVER << MAV_TYPE_SUBMARINE;
+    } else {
+        qWarning() << "Request for unknown firmware plugin factory" << firmwareType;
+    }
+
+    return vehicleTypes;
+}
+
+FirmwarePlugin* FirmwarePluginManager::firmwarePluginForAutopilot(MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType)
+{
+    FirmwarePluginFactory*  factory = _findPluginFactory(firmwareType);
+    FirmwarePlugin*         plugin = NULL;
+
+    if (factory) {
+        plugin = factory->firmwarePluginForAutopilot(firmwareType, vehicleType);
+    } else if (firmwareType != MAV_AUTOPILOT_GENERIC) {
+        qWarning() << "Request for unknown firmware plugin factory" << firmwareType;
+    }
+
+    if (!plugin) {
+        // Default plugin fallback
+        if (!_genericFirmwarePlugin) {
+            _genericFirmwarePlugin = new FirmwarePlugin;
+        }
+        plugin = _genericFirmwarePlugin;
+    }
+
+    return plugin;
+}
+
+FirmwarePluginFactory* FirmwarePluginManager::_findPluginFactory(MAV_AUTOPILOT firmwareType)
+{
     QList<FirmwarePluginFactory*> factoryList = FirmwarePluginFactoryRegister::instance()->pluginFactories();
 
     // Find the plugin which supports this vehicle
     for (int i=0; i<factoryList.count(); i++) {
-        if ((_plugin = factoryList[i]->firmwarePluginForAutopilot(autopilotType, vehicleType))) {
-            return _plugin;
+        FirmwarePluginFactory* factory = factoryList[i];
+        if (factory->supportedFirmwareTypes().contains(firmwareType)) {
+            return factory;
         }
     }
 
-    // Default plugin fallback
-    if (!_genericFirmwarePlugin) {
-        _genericFirmwarePlugin = new FirmwarePlugin;
-    }
-    return _genericFirmwarePlugin;
+    return NULL;
 }

--- a/src/FirmwarePlugin/FirmwarePluginManager.h
+++ b/src/FirmwarePlugin/FirmwarePluginManager.h
@@ -32,17 +32,23 @@ public:
     FirmwarePluginManager(QGCApplication* app);
     ~FirmwarePluginManager();
 
-    QList<MAV_AUTOPILOT> knownFirmwareTypes(void);
+    /// Returns list of firmwares which are supported by the system
+    QList<MAV_AUTOPILOT> supportedFirmwareTypes(void);
+
+    /// Returns the list of supported vehicle types for the specified firmware
+    QList<MAV_TYPE> supportedVehicleTypes(MAV_AUTOPILOT firmwareType);
 
     /// Returns appropriate plugin for autopilot type.
-    ///     @param autopilotType Type of autopilot to return plugin for.
-    ///     @param vehicleType Vehicle type of autopilot to return plugin for.
+    ///     @param firmwareType Type of firmwware to return plugin for.
+    ///     @param vehicleType Vehicle type to return plugin for.
     /// @return Singleton FirmwarePlugin instance for the specified MAV_AUTOPILOT.
-    FirmwarePlugin* firmwarePluginForAutopilot(MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType);
+    FirmwarePlugin* firmwarePluginForAutopilot(MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType);
 
 private:
+    FirmwarePluginFactory* _findPluginFactory(MAV_AUTOPILOT firmwareType);
+
     FirmwarePlugin*         _genericFirmwarePlugin;
-    QList<MAV_AUTOPILOT>    _knownFirmwareTypes;
+    QList<MAV_AUTOPILOT>    _supportedFirmwareTypes;
 };
 
 #endif

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -256,7 +256,7 @@ QString PX4FirmwarePlugin::missionCommandOverrides(MAV_TYPE vehicleType) const
         return QStringLiteral(":/json/PX4/MavCmdInfoMultiRotor.json");
         break;
     case MAV_TYPE_VTOL_QUADROTOR:
-        return QStringLiteral(":/json/APM/MavCmdInfoVTOL.json");
+        return QStringLiteral(":/json/PX4/MavCmdInfoVTOL.json");
         break;
     case MAV_TYPE_SUBMARINE:
         return QStringLiteral(":/json/PX4/MavCmdInfoSub.json");

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
@@ -21,7 +21,7 @@ PX4FirmwarePluginFactory::PX4FirmwarePluginFactory(void)
 
 }
 
-QList<MAV_AUTOPILOT> PX4FirmwarePluginFactory::knownFirmwareTypes(void) const
+QList<MAV_AUTOPILOT> PX4FirmwarePluginFactory::supportedFirmwareTypes(void) const
 {
     QList<MAV_AUTOPILOT> list;
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.h
@@ -21,7 +21,7 @@ class PX4FirmwarePluginFactory : public FirmwarePluginFactory
 public:
     PX4FirmwarePluginFactory(void);
 
-    QList<MAV_AUTOPILOT>    knownFirmwareTypes          (void) const final;
+    QList<MAV_AUTOPILOT>    supportedFirmwareTypes      (void) const final;
     FirmwarePlugin*         firmwarePluginForAutopilot  (MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType) final;
 
 private:

--- a/src/MissionManager/MissionCommandTree.cc
+++ b/src/MissionManager/MissionCommandTree.cc
@@ -46,7 +46,7 @@ void MissionCommandTree::setToolbox(QGCToolbox* toolbox)
     } else {
 #endif
         // Load all levels of hierarchy
-        foreach (MAV_AUTOPILOT firmwareType, _toolbox->firmwarePluginManager()->knownFirmwareTypes()) {
+        foreach (MAV_AUTOPILOT firmwareType, _toolbox->firmwarePluginManager()->supportedFirmwareTypes()) {
             FirmwarePlugin* plugin = _toolbox->firmwarePluginManager()->firmwarePluginForAutopilot(firmwareType, MAV_TYPE_QUADROTOR);
 
             QList<MAV_TYPE> vehicleTypes;
@@ -66,7 +66,7 @@ void MissionCommandTree::setToolbox(QGCToolbox* toolbox)
 
 MAV_AUTOPILOT MissionCommandTree::_baseFirmwareType(MAV_AUTOPILOT firmwareType) const
 {
-    if (qgcApp()->toolbox()->firmwarePluginManager()->knownFirmwareTypes().contains(firmwareType)) {
+    if (qgcApp()->toolbox()->firmwarePluginManager()->supportedFirmwareTypes().contains(firmwareType)) {
         return firmwareType;
     } else {
         return MAV_AUTOPILOT_GENERIC;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -197,7 +197,7 @@ void QGroundControlQmlGlobal::setBaseFontPointSize(qreal size)
 
 int QGroundControlQmlGlobal::supportedFirmwareCount()
 {
-    return _firmwarePluginManager->knownFirmwareTypes().count();
+    return _firmwarePluginManager->supportedFirmwareTypes().count();
 }
 
 


### PR DESCRIPTION
This allows a plugin to override the list of available vehicle types.