### PR TITLE
Add support for SettingsFact::visible

### DIFF
--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -23,6 +23,7 @@ SettingsFact::SettingsFact(QObject* parent)
 SettingsFact::SettingsFact(QString settingGroup, FactMetaData* metaData, QObject* parent)
     : Fact(0, metaData->name(), metaData->type(), parent)
     , _settingGroup(settingGroup)
+    , _visible(true)
 {
     QSettings settings;
 
@@ -31,7 +32,7 @@ SettingsFact::SettingsFact(QString settingGroup, FactMetaData* metaData, QObject
     }
 
     // Allow core plugin a chance to override the default value
-    metaData->setRawDefaultValue(qgcApp()->toolbox()->corePlugin()->overrideSettingsDefault(metaData->name(), metaData->rawDefaultValue()));
+    _visible = qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(*metaData);
     setMetaData(metaData);
 
     QVariant typedValue;

--- a/src/FactSystem/SettingsFact.h
+++ b/src/FactSystem/SettingsFact.h
@@ -28,11 +28,14 @@ public:
 
     const SettingsFact& operator=(const SettingsFact& other);
 
+    Q_PROPERTY(bool visible MEMBER _visible CONSTANT)
+
 private slots:
     void _rawValueChanged(QVariant value);
 
 private:
     QString _settingGroup;
+    bool    _visible;
 };
 
 #endif

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -10,6 +10,7 @@
 #include "QGCCorePlugin.h"
 #include "QGCOptions.h"
 #include "QGCSettings.h"
+#include "FactMetaData.h"
 
 #include <QtQml>
 #include <QQmlEngine>
@@ -140,13 +141,6 @@ QGCOptions* QGCCorePlugin::options()
     return _p->defaultOptions;
 }
 
-QVariant QGCCorePlugin::overrideSettingsDefault(QString name, QVariant defaultValue)
-{
-    Q_UNUSED(name);
-    // No overrides for base plugin
-    return defaultValue;
-}
-
 QVariantList& QGCCorePlugin::toolBarIndicators()
 {
     if(_p->toolBarIndicatorList.size() == 0) {
@@ -163,7 +157,13 @@ QVariantList& QGCCorePlugin::toolBarIndicators()
 bool QGCCorePlugin::overrideSettingsGroupVisibility(QString name)
 {
     Q_UNUSED(name);
-
+    
     // Always show all
     return true;
+}
+
+bool QGCCorePlugin::adjustSettingMetaData(FactMetaData& metaData)
+{
+    Q_UNUSED(metaData); // No mods to standard meta data
+    return true;        // Show setting in ui
 }

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -24,6 +24,7 @@ class QGCApplication;
 class QGCOptions;
 class QGCSettings;
 class QGCCorePlugin_p;
+class FactMetaData;
 
 class QGCCorePlugin : public QGCTool
 {
@@ -58,11 +59,10 @@ public:
     /// @return true: Show settings ui, false: Hide settings ui
     virtual bool overrideSettingsGroupVisibility        (QString name);
 
-    /// Allows the core plugin to override the default value for the specified setting
-    ///     @param name - Setting name
-    ///     @param defaultValue - Standard default value for setting
-    /// @return New default value for setting, if no override just return passed in defaultValue
-    virtual QVariant overrideSettingsDefault            (QString name, QVariant defaultValue);
+    /// Allows the core plugin to override the setting meta data before the setting fact is created.
+    ///     @param metaData - MetaData for setting fact
+    /// @return true: Setting should be visible in ui, false: Setting should not be shown in ui
+    virtual bool adjustSettingMetaData                  (FactMetaData& metaData);
 
     // Override from QGCTool
     void                            setToolbox          (QGCToolbox *toolbox);

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -54,6 +54,7 @@ QGCView {
                 width:              qgcView.width
                 spacing:            ScreenTools.defaultFontPixelHeight * 0.5
                 anchors.margins:    ScreenTools.defaultFontPixelWidth
+
                 //-----------------------------------------------------------------
                 //-- Units
                 Item {
@@ -79,50 +80,33 @@ QGCView {
                         id:         unitsCol
                         spacing:    ScreenTools.defaultFontPixelWidth
                         anchors.centerIn: parent
-                        Row {
-                            spacing:    ScreenTools.defaultFontPixelWidth
-                            QGCLabel {
-                                width:              _labelWidth
-                                anchors.baseline:   distanceUnitsCombo.baseline
-                                text:               qsTr("Distance:")
-                            }
-                            FactComboBox {
-                                id:                 distanceUnitsCombo
-                                width:              _editFieldWidth
-                                fact:               QGroundControl.settingsManager.unitsSettings.distanceUnits
-                                indexModel:         false
-                            }
-                        }
-                        Row {
-                            spacing:    ScreenTools.defaultFontPixelWidth
-                            QGCLabel {
-                                width:              _labelWidth
-                                anchors.baseline:   areaUnitsCombo.baseline
-                                text:               qsTr("Area:")
-                            }
-                            FactComboBox {
-                                id:                 areaUnitsCombo
-                                width:              _editFieldWidth
-                                fact:               QGroundControl.settingsManager.unitsSettings.areaUnits
-                                indexModel:         false
-                            }
-                        }
-                        Row {
-                            spacing:                ScreenTools.defaultFontPixelWidth
-                            QGCLabel {
-                                width:              _labelWidth
-                                anchors.baseline:   speedUnitsCombo.baseline
-                                text:               qsTr("Speed:")
-                            }
-                            FactComboBox {
-                                id:                 speedUnitsCombo
-                                width:              _editFieldWidth
-                                fact:               QGroundControl.settingsManager.unitsSettings.speedUnits
-                                indexModel:         false
+
+                        Repeater {
+                            id:     unitsRepeater
+                            model:  [ QGroundControl.settingsManager.unitsSettings.distanceUnits, QGroundControl.settingsManager.unitsSettings.areaUnits, QGroundControl.settingsManager.unitsSettings.speedUnits ]
+
+                            property var names: [ qsTr("Distance:"), qsTr("Area:"), qsTr("Speed:") ]
+
+                            Row {
+                                spacing:    ScreenTools.defaultFontPixelWidth
+                                visible:    modelData.visible
+
+                                QGCLabel {
+                                    width:              _labelWidth
+                                    anchors.baseline:   factCombo.baseline
+                                    text:               unitsRepeater.names[index]
+                                }
+                                FactComboBox {
+                                    id:                 factCombo
+                                    width:              _editFieldWidth
+                                    fact:               modelData
+                                    indexModel:         false
+                                }
                             }
                         }
                     }
                 }
+
                 //-----------------------------------------------------------------
                 //-- Miscellanous
                 Item {
@@ -395,6 +379,7 @@ QGCView {
                         }
                     }
                 }
+
                 //-----------------------------------------------------------------
                 //-- Autoconnect settings
                 Item {
@@ -416,44 +401,37 @@ QGCView {
                     anchors.margins:            ScreenTools.defaultFontPixelWidth
                     anchors.horizontalCenter:   parent.horizontalCenter
                     visible:                    QGroundControl.settingsManager.autoConnectSettings.visible
+
                     Column {
                         id:         autoConnectCol
                         spacing:    ScreenTools.defaultFontPixelWidth
                         anchors.centerIn: parent
-                        //-----------------------------------------------------------------
-                        //-- Autoconnect settings
+
                         Row {
                             spacing: ScreenTools.defaultFontPixelWidth * 2
-                            FactCheckBox {
-                                text:       qsTr("Pixhawk")
-                                fact:       QGroundControl.settingsManager.autoConnectSettings.autoConnectPixhawk
-                                visible:    !ScreenTools.isiOS
-                            }
-                            FactCheckBox {
-                                text:       qsTr("SiK Radio")
-                                fact:       QGroundControl.settingsManager.autoConnectSettings.autoConnectSiKRadio
-                                visible:    !ScreenTools.isiOS
-                            }
-                            FactCheckBox {
-                                text:       qsTr("PX4 Flow")
-                                fact:       QGroundControl.settingsManager.autoConnectSettings.autoConnectPX4Flow
-                                visible:    !ScreenTools.isiOS
-                            }
-                            FactCheckBox {
-                                text:       qsTr("LibrePilot")
-                                fact:       QGroundControl.settingsManager.autoConnectSettings.autoConnectLibrePilot
-                            }
-                            FactCheckBox {
-                                text:       qsTr("UDP")
-                                fact:       QGroundControl.settingsManager.autoConnectSettings.autoConnectUDP
-                            }
-                            FactCheckBox {
-                                text:       qsTr("RTK GPS")
-                                fact:       QGroundControl.settingsManager.autoConnectSettings.autoConnectRTKGPS
+
+                            Repeater {
+                                id:     autoConnectRepeater
+                                model:  [ QGroundControl.settingsManager.autoConnectSettings.autoConnectPixhawk,
+                                    QGroundControl.settingsManager.autoConnectSettings.autoConnectSiKRadio,
+                                    QGroundControl.settingsManager.autoConnectSettings.autoConnectPX4Flow,
+                                    QGroundControl.settingsManager.autoConnectSettings.autoConnectLibrePilot,
+                                    QGroundControl.settingsManager.autoConnectSettings.autoConnectUDP,
+                                    QGroundControl.settingsManager.autoConnectSettings.autoConnectRTKGPS
+                                ]
+
+                                property var names: [ qsTr("Pixhawk"), qsTr("SiK Radio"), qsTr("PX4 Flow"), qsTr("LibrePilot"), qsTr("UDP"), qsTr("RTK GPS") ]
+
+                                FactCheckBox {
+                                    text:       autoConnectRepeater.names[index]
+                                    fact:       modelData
+                                    visible:    !ScreenTools.isiOS && modelData.visible
+                                }
                             }
                         }
                     }
                 }
+
                 //-----------------------------------------------------------------
                 //-- Video Source
                 Item {


### PR DESCRIPTION
Modified QCGCorePlugin settings override mechanism to support full modification of setting meta data as well as visibility:
```
    /// Allows the core plugin to override the setting meta data before the setting fact is created.
    ///     @param metaData - MetaData for setting fact
    /// @return true: Setting should be visible in ui, false: Setting should not be shown in ui
    virtual bool adjustSettingMetaData                  (FactMetaData& metaData);
```

Plumbed visibility bits into General Settings page:
* Units, AutoConnect support individual setting visible
* Remainder of visibility on settings is WIP