### PR TITLE
Paring back OS X travis to installer only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,17 @@ matrix:
           sudo: false
         - os: osx
           osx_image: xcode8
-          env: SPEC=macx-clang CONFIG=debug
-          sudo: required
-        - os: osx
-          osx_image: xcode8
           env: SPEC=macx-clang CONFIG=installer
           sudo: required
-        - os: osx
-          osx_image: xcode8
-          env: SPEC=macx-ios-clang CONFIG=release
-          sudo: false
+# OSX builds pared back to installer only since travis sucks so bad we can't afford more than one'
+#        - os: osx
+#          osx_image: xcode8
+#          env: SPEC=macx-clang CONFIG=debug
+#          sudo: required
+#        - os: osx
+#          osx_image: xcode8
+#          env: SPEC=macx-ios-clang CONFIG=release
+#          sudo: false
 
 android:
   components:


### PR DESCRIPTION
Paring back OS X travis builds to a single installer only build since travis OS X sucks so bad at the moment it's taking 3-6 hours to clear the pull queue.