### PR TITLE
Root loader

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -264,7 +264,7 @@ QGCView {
                 anchors.top:        parent.top
                 anchors.bottom:     parent.bottom
                 width:              height
-                radius:             QGroundControl.videoManager.videoReceiver && QGroundControl.videoManager.videoReceiver.recording ? 0 : height
+                radius:             QGroundControl.videoManager && QGroundControl.videoManager.videoReceiver && QGroundControl.videoManager.videoReceiver.recording ? 0 : height
                 color:              "red"
             }
 

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -530,5 +530,14 @@ Item {
             }
         }
     }
+
+    //-------------------------------------------------------------------------
+    //-- Loader helper for any child, no matter how deep can display an element
+    //   in the middle of the main window.
+    Loader {
+        id: rootLoader
+        anchors.centerIn: parent
+    }
+
 }
 


### PR DESCRIPTION
Added a root loader to help deep nested children to show an element in the middle of the root Window.
While at it, fixed annoying QML error that would show when QGroundControl.videoManager would go out of scope.