### PR TITLE
Add joystick indicator to show actual output

### DIFF
--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -81,7 +81,7 @@ JoystickConfigController::~JoystickConfigController()
 /// @brief Returns the state machine entry for the specified state.
 const JoystickConfigController::stateMachineEntry* JoystickConfigController::_getStateMachineEntry(int step)
 {
-    static const char* msgBegin =           "Allow all sticks to center as shown in diagram.\n\nClick Next to continue";
+    static const char* msgBegin =           "Allow all sticks to center as shown in diagram.\nIf using deadband, move all axes through extent of deadzone before continuing\n\nClick Next to continue";
     static const char* msgThrottleUp =      "Move the Throttle stick all the way up and hold it there...";
     static const char* msgThrottleDown =    "Move the Throttle stick all the way down and hold it there...";
     static const char* msgYawLeft =         "Move the Yaw stick all the way to the left and hold it there...";

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -81,7 +81,7 @@ JoystickConfigController::~JoystickConfigController()
 /// @brief Returns the state machine entry for the specified state.
 const JoystickConfigController::stateMachineEntry* JoystickConfigController::_getStateMachineEntry(int step)
 {
-    static const char* msgBegin =           "Allow all sticks to center as shown in diagram.\nIf using deadband, move all axes through extent of deadzone before continuing\n\nClick Next to continue";
+    static const char* msgBegin =           "Allow all sticks to center as shown in diagram.\nIf using deadband, move all axes through extent of deadzone before proceeding.\nClick Next to continue";
     static const char* msgThrottleUp =      "Move the Throttle stick all the way up and hold it there...";
     static const char* msgThrottleDown =    "Move the Throttle stick all the way down and hold it there...";
     static const char* msgYawLeft =         "Move the Yaw stick all the way to the left and hold it there...";


### PR DESCRIPTION
This adds a second indicator dot to the roll, pitch, yaw, and throttle bars to show what is actually being output by the manualControl signal after the exponential and deadband is applied.

I have also changed the message that is displayed when you start joystick calibration so that the user knows that the deadzone is being measured at this time.

While working on this I noticed that the extremes of joystick movement don't actually change the output, I believe this may be a bug.