### PR TITLE
Added altitude to the Vehicle coordinate (QGeoCoordinate)

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -605,8 +605,11 @@ void Vehicle::_handleGpsRawInt(mavlink_message_t& message)
 
     if (gpsRawInt.fix_type >= GPS_FIX_TYPE_3D_FIX) {
         if (!_globalPositionIntMessageAvailable) {
-            setLatitude(gpsRawInt.lat / (double)1E7);
-            setLongitude(gpsRawInt.lon / (double)1E7);
+            //-- Set these here and emit a single signal instead of 3 for the same variable (_coordinate)
+            _coordinate.setLatitude(gpsRawInt.lat  / (double)1E7);
+            _coordinate.setLongitude(gpsRawInt.lon / (double)1E7);
+            _coordinate.setAltitude(gpsRawInt.alt  / 1000.0);
+            emit coordinateChanged(_coordinate);
             _altitudeAMSLFact.setRawValue(gpsRawInt.alt / 1000.0);
         }
     }
@@ -628,9 +631,11 @@ void Vehicle::_handleGlobalPositionInt(mavlink_message_t& message)
     mavlink_msg_global_position_int_decode(&message, &globalPositionInt);
 
     _globalPositionIntMessageAvailable = true;
-
-    setLatitude(globalPositionInt.lat / (double)1E7);
-    setLongitude(globalPositionInt.lon / (double)1E7);
+    //-- Set these here and emit a single signal instead of 3 for the same variable (_coordinate)
+    _coordinate.setLatitude(globalPositionInt.lat  / (double)1E7);
+    _coordinate.setLongitude(globalPositionInt.lon / (double)1E7);
+    _coordinate.setAltitude(globalPositionInt.alt  / 1000.0);
+    emit coordinateChanged(_coordinate);
     _altitudeRelativeFact.setRawValue(globalPositionInt.relative_alt / 1000.0);
     _altitudeAMSLFact.setRawValue(globalPositionInt.alt / 1000.0);
 }
@@ -1133,6 +1138,11 @@ void Vehicle::setLatitude(double latitude)
 
 void Vehicle::setLongitude(double longitude){
     _coordinate.setLongitude(longitude);
+    emit coordinateChanged(_coordinate);
+}
+
+void Vehicle::setAltitude(double altitude){
+    _coordinate.setAltitude(altitude);
     emit coordinateChanged(_coordinate);
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -645,8 +645,11 @@ public:
     QString vehicleImageCompass () const;
 
 public slots:
-    void setLatitude(double latitude);
-    void setLongitude(double longitude);
+    /// Sets the firmware plugin instance data associated with this Vehicle. This object will be parented to the Vehicle
+    /// and destroyed when the vehicle goes away.
+    void setLatitude    (double latitude);
+    void setLongitude   (double longitude);
+    void setAltitude    (double altitude);
 
 signals:
     void allLinksInactive(Vehicle* vehicle);


### PR DESCRIPTION
QGeoCoordinate has 3 components: latitude, longitude and altitude. Up to now, only lat/lon were set, leaving the altitude fixed at 0. I'm now adding the altitude so I can compute an accurate distance between QGC and the vehicle.

In addition, instead of using functions to set lat/lon/alt, I'm setting them all at once and generating a single signal instead of multiple signals for the same variable as it was the case.