### PR TITLE
Disable scrolling on QGCComboBox

### DIFF
--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -39,4 +39,24 @@ ComboBox {
             }
         }
     }
+
+    // Capture Wheel events to disable scrolling options in ComboBox.
+    // As a side effect, this also prevents scrolling the page when
+    // mouse is over a ComboBox, but this would also the case when
+    // scrolling items in the ComboBox is enabled.
+    MouseArea {
+        anchors.fill: parent
+        onWheel: {
+            // do nothing
+            wheel.accepted = true;
+        }
+        onPressed: {
+            // propogate to ComboBox
+            mouse.accepted = false;
+        }
+        onReleased: {
+            // propogate to ComboBox
+            mouse.accepted = false;
+        }
+    }
 }


### PR DESCRIPTION
Currently, settings are easily changed by accident when scrolling a page, when the mouse passes over a combobox while scrolling. It is also easy to not notice this when it occurs. This patch will disable changing the options on comboboxes via scrolling, by handling the event (do nothing) with a mousearea over the combobox.