### PR TITLE
Allow setting the video streaming aspect ratio.

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -23,35 +23,31 @@ import QGroundControl.Controllers   1.0
 
 Item {
     id: root
+    property double _ar: QGroundControl.settingsManager.videoSettings.aspectRatio.rawValue
     Rectangle {
         id:             noVideo
         anchors.fill:   parent
         color:          Qt.rgba(0,0,0,0.75)
         visible:        !QGroundControl.videoManager.videoRunning
         QGCLabel {
-            text:               qsTr("NO VIDEO")
+            text:               qsTr("WAITING FOR VIDEO")
             font.family:        ScreenTools.demiboldFontFamily
             color:              "white"
             font.pointSize:     _mainIsMap ? ScreenTools.smallFontPointSize : ScreenTools.largeFontPointSize
             anchors.centerIn:   parent
         }
     }
-    QGCVideoBackground {
+    Rectangle {
         anchors.fill:   parent
-        display:        QGroundControl.videoManager.videoSurface
-        receiver:       QGroundControl.videoManager.videoReceiver
+        color:          "black"
         visible:        QGroundControl.videoManager.videoRunning
-        /* TODO: Come up with a way to make this an option
-        QGCAttitudeHUD {
-            id:                 attitudeHUD
-            visible:            !_mainIsMap
-            rollAngle:          _activeVehicle ? _activeVehicle.roll.value  : 0
-            pitchAngle:         _activeVehicle ? _activeVehicle.pitch.value : 0
-            width:              ScreenTools.defaultFontPixelHeight * (30)
-            height:             ScreenTools.defaultFontPixelHeight * (30)
-            active:             QGroundControl.multiVehicleManager.activeVehicleAvailable
-            z:                  QGroundControl.zOrderWidgets
+        QGCVideoBackground {
+            height:         parent.height
+            width:          _ar != 0.0 ? height * _ar : parent.width
+            anchors.centerIn: parent
+            display:        QGroundControl.videoManager.videoSurface
+            receiver:       QGroundControl.videoManager.videoReceiver
+            visible:        QGroundControl.videoManager.videoRunning
         }
-        */
     }
 }

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -27,5 +27,13 @@
     "longDescription":  "Directory to save videos to.",
     "type":             "string",
     "defaultValue":     ""
+},
+{
+    "name":             "VideoAspectRatio",
+    "shortDescription": "Video Aspect Ratio",
+    "longDescription":  "Video Aspect Ratio (width / height). Use 0.0 to ignore it.",
+    "type":             "float",
+    "decimalPlaces":    6,
+    "defaultValue":     1.777777
 }
 ]

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -19,10 +19,11 @@
 
 const char* VideoSettings::videoSettingsGroupName = "Video";
 
-const char* VideoSettings::videoSourceName =    "VideoSource";
-const char* VideoSettings::udpPortName =        "VideoUDPPort";
-const char* VideoSettings::rtspUrlName =        "VideoRTSPUrl";
-const char* VideoSettings::videoSavePathName =  "VideoSavePath";
+const char* VideoSettings::videoSourceName =        "VideoSource";
+const char* VideoSettings::udpPortName =            "VideoUDPPort";
+const char* VideoSettings::rtspUrlName =            "VideoRTSPUrl";
+const char* VideoSettings::videoSavePathName =      "VideoSavePath";
+const char* VideoSettings::videoAspectRatioName =   "VideoAspectRatio";
 
 const char* VideoSettings::videoSourceNoVideo = "No Video Available";
 const char* VideoSettings::videoSourceUDP =     "UDP Video Stream";
@@ -34,6 +35,7 @@ VideoSettings::VideoSettings(QObject* parent)
     , _udpPortFact(NULL)
     , _rtspUrlFact(NULL)
     , _videoSavePathFact(NULL)
+    , _videoAspectRatioFact(NULL)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<VideoSettings>("QGroundControl.SettingsManager", 1, 0, "VideoSettings", "Reference only");
@@ -103,4 +105,13 @@ Fact* VideoSettings::videoSavePath(void)
     }
 
     return _videoSavePathFact;
+}
+
+Fact* VideoSettings::aspectRatio(void)
+{
+    if (!_videoAspectRatioFact) {
+        _videoAspectRatioFact = _createSettingsFact(videoAspectRatioName);
+    }
+
+    return _videoAspectRatioFact;
 }

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -15,7 +15,7 @@
 class VideoSettings : public SettingsGroup
 {
     Q_OBJECT
-    
+
 public:
     VideoSettings(QObject* parent = NULL);
 
@@ -23,11 +23,13 @@ public:
     Q_PROPERTY(Fact* udpPort        READ udpPort        CONSTANT)
     Q_PROPERTY(Fact* rtspUrl        READ rtspUrl        CONSTANT)
     Q_PROPERTY(Fact* videoSavePath  READ videoSavePath  CONSTANT)
+    Q_PROPERTY(Fact* aspectRatio    READ aspectRatio    CONSTANT)
 
     Fact* videoSource   (void);
     Fact* udpPort       (void);
     Fact* rtspUrl       (void);
     Fact* videoSavePath (void);
+    Fact* aspectRatio   (void);
 
     static const char* videoSettingsGroupName;
 
@@ -35,6 +37,7 @@ public:
     static const char* udpPortName;
     static const char* rtspUrlName;
     static const char* videoSavePathName;
+    static const char* videoAspectRatioName;
 
     static const char* videoSourceNoVideo;
     static const char* videoSourceUDP;
@@ -45,6 +48,7 @@ private:
     SettingsFact* _udpPortFact;
     SettingsFact* _rtspUrlFact;
     SettingsFact* _videoSavePathFact;
+    SettingsFact* _videoAspectRatioFact;
 };
 
 #endif

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -505,6 +505,20 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
+                            visible:    QGroundControl.videoManager.isGStreamer && QGroundControl.videoManager.isGStreamer && videoSource.currentIndex < 2
+                            QGCLabel {
+                                anchors.baseline:   aspectField.baseline
+                                text:               qsTr("Aspect Ratio:")
+                                width:              _labelWidth
+                            }
+                            FactTextField {
+                                id:                 aspectField
+                                width:              _editFieldWidth
+                                fact:               QGroundControl.settingsManager.videoSettings.aspectRatio
+                            }
+                        }
+                        Row {
+                            spacing:    ScreenTools.defaultFontPixelWidth
                             visible:    QGroundControl.settingsManager.videoSettings.videoSavePath.visible && QGroundControl.videoManager.isGStreamer && QGroundControl.videoManager.recordingEnabled
                             QGCLabel {
                                 anchors.baseline:   pathField.baseline

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -505,7 +505,7 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.videoManager.isGStreamer && QGroundControl.videoManager.isGStreamer && videoSource.currentIndex < 2
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex < 2 && QGroundControl.settingsManager.videoSettings.aspectRatio.visible
                             QGCLabel {
                                 anchors.baseline:   aspectField.baseline
                                 text:               qsTr("Aspect Ratio:")


### PR DESCRIPTION
Up to now, the video display for video streaming would stretch to fit the window. This new setting allows you to set the proper aspect ratio. If the window is wider than the video, you get black bars on the sides. Setting the aspect ratio to 0.0 makes it ignore it and it will stretch the video to fit.

Also changed the "NO VIDEO" message to a more optimistic "WAITING FOR VIDEO" :P