### PR TITLE
Control sizing on mobile

### DIFF
--- a/src/MissionEditor/MissionSettingsEditor.qml
+++ b/src/MissionEditor/MissionSettingsEditor.qml
@@ -53,10 +53,7 @@ Rectangle {
                     anchors.top:    parent.top
                     spacing:        _margin
 
-                    QGCLabel {
-                        text: qsTr("Planned Home Position")
-                        color: qgcPal.buttonHighlight
-                    }
+                    QGCLabel { text: qsTr("Planned Home Position") }
 
                     Rectangle {
                         anchors.left:   parent.left
@@ -96,7 +93,6 @@ Rectangle {
 
                     QGCLabel {
                         text:           qsTr("Vehicle Info")
-                        color:          qgcPal.buttonHighlight
                         visible:        _multipleFirmware
                     }
 

--- a/src/MissionEditor/SurveyItemEditor.qml
+++ b/src/MissionEditor/SurveyItemEditor.qml
@@ -286,7 +286,7 @@ Rectangle {
             }
         }
 
-        QGCLabel { text: qsTr("Camera"); color: qgcPal.buttonHighlight; visible: gridTypeCombo.currentIndex !== _gridTypeManual}
+        QGCLabel { text: qsTr("Camera"); visible: gridTypeCombo.currentIndex !== _gridTypeManual}
 
         Rectangle {
             anchors.left:   parent.left
@@ -420,7 +420,7 @@ Rectangle {
                 }
             }
 
-            QGCLabel { text: qsTr("Grid"); color: qgcPal.buttonHighlight;}
+            QGCLabel { text: qsTr("Grid") }
 
             Rectangle {
                 anchors.left:   parent.left
@@ -523,7 +523,7 @@ Rectangle {
             spacing:        _margin
             visible:        gridTypeCombo.currentIndex == _gridTypeManual
 
-            QGCLabel { text: qsTr("Grid"); color: qgcPal.buttonHighlight;}
+            QGCLabel { text: qsTr("Grid") }
 
             Rectangle {
                 anchors.left:   parent.left
@@ -547,7 +547,7 @@ Rectangle {
                 onClicked:      missionItem.gridAltitudeRelative = checked
             }
 
-            QGCLabel { text: qsTr("Camera"); color: qgcPal.buttonHighlight;}
+            QGCLabel { text: qsTr("Camera") }
 
             Rectangle {
                 anchors.left:   parent.left
@@ -578,7 +578,7 @@ Rectangle {
             }
         }
 
-        QGCLabel { text: qsTr("Polygon"); color: qgcPal.buttonHighlight;}
+        QGCLabel { text: qsTr("Polygon") }
 
         Rectangle {
             anchors.left:   parent.left
@@ -621,7 +621,7 @@ Rectangle {
             }
         }
 
-        QGCLabel { text: qsTr("Statistics"); color: qgcPal.buttonHighlight;}
+        QGCLabel { text: qsTr("Statistics") }
 
         Rectangle {
             anchors.left:   parent.left

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -19,7 +19,7 @@ ComboBox {
 
         background: Item {
             implicitWidth:      Math.round(ScreenTools.defaultFontPixelWidth * 4.5)
-            implicitHeight:     ScreenTools.isMobile ? Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 2)) : Math.max(25, Math.round(ScreenTools.defaultFontPixelHeight * 1.2))
+            implicitHeight:     Math.round(ScreenTools.defaultFontPixelHeight * (ScreenTools.isMobile ? 2 : 1.2))
 
             Rectangle {
                 anchors.fill:   parent

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -26,7 +26,8 @@ TextField {
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
     textColor:          qgcPal.textFieldText
-    height:             Math.round(Math.max(25, ScreenTools.defaultFontPixelHeight * (ScreenTools.isMobile ? 2.5 : 1.2)))
+
+    implicitHeight: Math.round(ScreenTools.defaultFontPixelHeight * (ScreenTools.isMobile ? 2 : 1.2))
 
     QGCLabel {
         id:             unitsLabelWidthGenerator

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -48,12 +48,13 @@ Rectangle {
     }
 
     MouseArea {
-        x:          -_root.x
-        y:          -_root.y
-        width:      _root.parent.width
-        height:     _root.parent.height
-        visible:    dropPanel.visible
-        onClicked:  dropPanel.hide()
+        x:                  -_root.x
+        y:                  -_root.y
+        width:              _root.parent.width
+        height:             _root.parent.height
+        visible:            dropPanel.visible
+        onClicked:          dropPanel.hide()
+        preventStealing:    true
     }
 
     Column {
@@ -144,11 +145,15 @@ Rectangle {
                     }
 
                     MouseArea {
-                        anchors.left:   parent.left
-                        anchors.right:  parent.right
-                        anchors.top:    parent.top
-                        height:         parent.height + (_showOptionalElements? buttonLabel.height + buttonColumn.spacing : 0)
-                        visible:        _root.buttonEnabled ? _root.buttonEnabled[index] : true
+                        // Size of mouse area is expanded to make touch easier
+                        anchors.leftMargin:     buttonStripColumn.margins
+                        anchors.rightMargin:    buttonStripColumn.margins
+                        anchors.left:           parent.left
+                        anchors.right:          parent.right
+                        anchors.top:            parent.top
+                        height:                 parent.height + (_showOptionalElements? buttonLabel.height + buttonColumn.spacing : 0)
+                        visible:                _root.buttonEnabled ? _root.buttonEnabled[index] : true
+                        preventStealing:        true
 
                         onClicked: {
                             if (modelData.dropPanelComponent === undefined) {


### PR DESCRIPTION
* Increase touch area on ToolStrip buttons
* QGCTextField was setting height instead of implicitHeight which was causing it the be resized smaller when used in a GridLayout
* QGCComboBox and QGCTextField use same height semantics for mobile