### PR TITLE
Increase max flightmap zoom level to 22

### DIFF
--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -23,7 +23,7 @@
 #include <QNetworkReply>
 #include <QMutex>
 
-#define MAX_MAP_ZOOM (20.0)
+#define MAX_MAP_ZOOM (22.0)
 
 class UrlFactory : public QObject {
     Q_OBJECT


### PR DESCRIPTION
This approximately doubles the scale of the map at maximum zoom. This helps facilitate flights/missions with particularly small area of operation.