### PR TITLE
Small Screen and Touch usability changes

### DIFF
--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -26,6 +26,10 @@ QGCTextField {
                           Qt.ImhFormattedNumbersOnly  // Forces use of virtual numeric keyboard
 
     onEditingFinished: {
+        if (ScreenTools.isMobile) {
+            // Toss focus on mobile after Done on virtual keyboard. Prevent strange interactions.
+            focus = false
+        }
         if (typeof qgcView !== 'undefined' && qgcView) {
             var errorString = fact.validate(text, false /* convertOnly */)
             if (errorString == "") {

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -85,6 +85,7 @@ FlightMap {
         title:              qsTr("Fly")
         z:                  QGroundControl.zOrderWidgets
         buttonVisible:      [ true, true, _showZoom, _showZoom ]
+        maxHeight:          (_flightVideo.visible ? _flightVideo.y : parent.height) - toolStrip.y   // Massive reach across hack
 
         property bool _showZoom: !ScreenTools.isShortScreen
 

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -777,6 +777,7 @@ QGCView {
                     rotateImage:        [ false, false, _syncDropDownController.syncInProgress, false, false, false, false ]
                     buttonEnabled:      [ true, true, !_syncDropDownController.syncInProgress, true, true, true, true ]
                     buttonVisible:      [ true, true, true, true, true, _showZoom, _showZoom ]
+                    maxHeight:          mapScale.y - toolStrip.y
 
                     property bool _showZoom: !ScreenTools.isShortScreen
 
@@ -839,6 +840,7 @@ QGCView {
                 }
 
                 MapScale {
+                    id:                 mapScale
                     anchors.margins:    ScreenTools.defaultFontPixelHeight * (0.66)
                     anchors.bottom:     waypointValuesDisplay.visible ? waypointValuesDisplay.top : parent.bottom
                     anchors.left:       parent.left

--- a/src/MissionEditor/MissionItemEditor.qml
+++ b/src/MissionEditor/MissionItemEditor.qml
@@ -66,50 +66,57 @@ Rectangle {
         visible:                missionItem.isCurrentItem && missionItem.sequenceNumber != 0
         color:                  qgcPal.windowShade
 
-        MouseArea {
-            anchors.fill:   parent
-            onClicked:      hamburgerMenu.popup()
+    }
 
-            Menu {
-                id: hamburgerMenu
+    MouseArea {
+        // The MouseArea for the hamburger is larger than the hamburger image itself in order to provide a larger
+        // touch area on mobile
+        anchors.top:        parent.top
+        anchors.bottom:     editorLoader.top
+        anchors.leftMargin: -hamburger.anchors.rightMargin
+        anchors.left:       hamburger.left
+        anchors.right:      parent.right
+        onClicked:          hamburgerMenu.popup()
 
-                MenuItem {
-                    text:           qsTr("Insert")
-                    onTriggered:    insert()
-                }
+        Menu {
+            id: hamburgerMenu
 
-                MenuItem {
-                    text:           qsTr("Delete")
-                    onTriggered:    remove()
-                }
+            MenuItem {
+                text:           qsTr("Insert")
+                onTriggered:    insert()
+            }
 
-                MenuItem {
-                    text:           "Change command..."
-                    onTriggered:    commandPicker.clicked()
-                }
+            MenuItem {
+                text:           qsTr("Delete")
+                onTriggered:    remove()
+            }
 
-                MenuSeparator {
-                    visible: missionItem.isSimpleItem
-                }
+            MenuItem {
+                text:           "Change command..."
+                onTriggered:    commandPicker.clicked()
+            }
 
-                MenuItem {
-                    text:       qsTr("Show all values")
-                    checkable:  true
-                    checked:    missionItem.isSimpleItem ? missionItem.rawEdit : false
-                    visible:    missionItem.isSimpleItem
+            MenuSeparator {
+                visible: missionItem.isSimpleItem
+            }
 
-                    onTriggered:    {
-                        if (missionItem.rawEdit) {
-                            if (missionItem.friendlyEditAllowed) {
-                                missionItem.rawEdit = false
-                            } else {
-                                qgcView.showMessage(qsTr("Mission Edit"), qsTr("You have made changes to the mission item which cannot be shown in Simple Mode"), StandardButton.Ok)
-                            }
+            MenuItem {
+                text:       qsTr("Show all values")
+                checkable:  true
+                checked:    missionItem.isSimpleItem ? missionItem.rawEdit : false
+                visible:    missionItem.isSimpleItem
+
+                onTriggered:    {
+                    if (missionItem.rawEdit) {
+                        if (missionItem.friendlyEditAllowed) {
+                            missionItem.rawEdit = false
                         } else {
-                            missionItem.rawEdit = true
+                            qgcView.showMessage(qsTr("Mission Edit"), qsTr("You have made changes to the mission item which cannot be shown in Simple Mode"), StandardButton.Ok)
                         }
-                        checked = missionItem.rawEdit
+                    } else {
+                        missionItem.rawEdit = true
                     }
+                    checked = missionItem.rawEdit
                 }
             }
         }

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -29,6 +29,13 @@ TextField {
 
     implicitHeight: ScreenTools.implicitTextFieldHeight
 
+    onEditingFinished: {
+        if (ScreenTools.isMobile) {
+            // Toss focus on mobile after Done on virtual keyboard. Prevent strange interactions.
+            focus = false
+        }
+    }
+
     QGCLabel {
         id:             unitsLabelWidthGenerator
         text:           unitsLabel

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -22,17 +22,55 @@ Rectangle {
 
     property string title:              "Title"
     property alias  model:              repeater.model
-    property var    showAlternateIcon
-    property var    rotateImage
-    property var    buttonEnabled
-    property var    buttonVisible
+    property var    showAlternateIcon                   ///< List of bool values, one for each button in strip - true: show alternate icon, false: show normal icon
+    property var    rotateImage                         ///< List of bool values, one for each button in strip - true: animation rotation, false: static image
+    property var    buttonEnabled                       ///< List of bool values, one for each button in strip - true: button enabled, false: button disabled
+    property var    buttonVisible                       ///< List of bool values, one for each button in strip - true: button visible, false: button invisible
+    property real   maxHeight                           ///< Maximum height for control, determines whether text is hidden to make control shorter
 
     signal clicked(int index, bool checked)
 
     readonly property real  _radius:                ScreenTools.defaultFontPixelWidth / 2
     readonly property real  _margin:                ScreenTools.defaultFontPixelWidth / 2
     readonly property real  _buttonSpacing:         ScreenTools.defaultFontPixelWidth
-    readonly property bool  _showOptionalElements:  !ScreenTools.isShortScreen
+
+    // All of the following values, connections and function are to support the ability to determine
+    // whether to show or hide the optional elements on the fly.
+
+    property bool _showOptionalElements:    true
+    property bool _needRecalc:              true
+
+    Component.onCompleted: recalcShowOptionalElements()
+
+    onMaxHeightChanged: recalcShowOptionalElements()
+
+    Connections {
+        target: ScreenTools
+
+        onDefaultFontPixelWidthChanged:     recalcShowOptionalElements()
+        onDefaultFontPixelHeightChanged:    recalcShowOptionalElements()
+    }
+
+    onHeightChanged: {
+        if (_needRecalc) {
+            _needRecalc = false
+            if (maxHeight && height > maxHeight) {
+                _showOptionalElements = false
+            }
+        }
+    }
+
+    function recalcShowOptionalElements() {
+        if (_showOptionalElements) {
+            if (maxHeight && height > maxHeight) {
+                _showOptionalElements = false
+            }
+        } else {
+            _needRecalc = true
+            _showOptionalElements = true
+        }
+
+    }
 
     QGCPalette { id: qgcPal }
     ExclusiveGroup { id: dropButtonsExclusiveGroup }


### PR DESCRIPTION
* FactTextField/QGCTextField: Drop focus after done on Virtual Keyboard. This is because some versions of android show a big IP arrow when a control has focus. This gets really annoying if you just entered a new value.
* Increase touch area on mission item editor hamburger
* ToolStrip control now automatically determine if it should show/hide text base on available screen real estate. it will adjust as you resize window as well. Previously it based this on ScreenTools.isSmallScreen but that was turning off text too early. This new way it's always just right.