### PR TITLE
Add firmware information to parameter file header

### DIFF
--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -843,6 +843,17 @@ void ParameterManager::writeParametersToStream(QTextStream &stream)
 {
     stream << "# Onboard parameters for Vehicle " << _vehicle->id() << "\n";
     stream << "#\n";
+
+    stream << "# Stack: " << _vehicle->firmwareTypeString() << "\n";
+    stream << "# Vehicle: " << _vehicle->vehicleTypeString() << "\n";
+    stream << "# Version: "
+           << _vehicle->firmwareMajorVersion() << "."
+           << _vehicle->firmwareMinorVersion() << "."
+           << _vehicle->firmwarePatchVersion() << " "
+           << _vehicle->firmwareVersionTypeString() << "\n";
+    stream << "# Git Revision: " << _vehicle->gitHash() << "\n";
+
+    stream << "#\n";
     stream << "# Vehicle-Id Component-Id Name Value Type\n";
 
     foreach (int componentId, _mapParameterName2Variant.keys()) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -675,7 +675,17 @@ void Vehicle::_handleAutopilotVersion(LinkInterface *link, mavlink_message_t& me
 
     // Git hash
     if (autopilotVersion.flight_custom_version[0] != 0) {
-        _gitHash = QString::fromUtf8((char*)autopilotVersion.flight_custom_version, 8);
+        // PX4 Firmware stores the first 16 characters of the git hash as binary, with the individual bytes in reverse order
+        if (px4Firmware()) {
+            _gitHash = "";
+            QByteArray array((char*)autopilotVersion.flight_custom_version, 8);
+            for (int i = 7; i >= 0; i--) {
+                _gitHash.append(QString("%1").arg(autopilotVersion.flight_custom_version[i], 2, 16, QChar('0')));
+            }
+        } else {
+            // APM Firmware stores the first 8 characters of the git hash as an ASCII character string
+            _gitHash = QString::fromUtf8((char*)autopilotVersion.flight_custom_version, 8);
+        }
         emit gitHashChanged(_gitHash);
     }
 }


### PR DESCRIPTION
This adds some information about the autopilot firmware that would be useful in troubleshooting issues on user forums, among other things.

Here are some examples of what the parameter file header looks like:
APM:
```
# Onboard parameters for Vehicle 1
#
# Stack: ArduPilot
# Vehicle: Fixed Wing
# Version: 3.7.1 
# Git Revision: 22b5c415
#
# Vehicle-Id Component-Id Name Value Type
```

PX4:
```
# Onboard parameters for Vehicle 1
#
# Stack: PX4 Pro
# Vehicle: Multi-Rotor
# Version: 1.6.0 dev
# Git Revision: e892a51afb597632
#
# Vehicle-Id Component-Id Name Value Type
```