### PR TITLE
Improve deadband

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -431,18 +431,6 @@ void Joystick::run(void)
                 throttle_accu = std::max(static_cast<float>(-1.f), std::min(throttle_accu, static_cast<float>(1.f)));
                 throttle = throttle_accu;
             }
-
-            float roll_limited = std::max(static_cast<float>(-M_PI_4), std::min(roll, static_cast<float>(M_PI_4)));
-            float pitch_limited = std::max(static_cast<float>(-M_PI_4), std::min(pitch, static_cast<float>(M_PI_4)));
-            float yaw_limited = std::max(static_cast<float>(-M_PI_4), std::min(yaw, static_cast<float>(M_PI_4)));
-            float throttle_limited = std::max(static_cast<float>(-M_PI_4), std::min(throttle, static_cast<float>(M_PI_4)));
-
-            // Map from unit circle to linear range and limit
-            roll =      std::max(-1.0f, std::min(tanf(asinf(roll_limited)), 1.0f));
-            pitch =     std::max(-1.0f, std::min(tanf(asinf(pitch_limited)), 1.0f));
-            yaw =       std::max(-1.0f, std::min(tanf(asinf(yaw_limited)), 1.0f));
-            throttle =  std::max(-1.0f, std::min(tanf(asinf(throttle_limited)), 1.0f));
-            
             if ( _exponential ) {
                 // Exponential (0% to -50% range like most RC radios)
                 // 0 for no exponential

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -339,13 +339,16 @@ float Joystick::_adjustRange(int value, Calibration_t calibration, bool withDead
         axisLength =  calibration.center - calibration.min;
     }
 
-    if (withDeadbands) {
-        if (valueNormalized>calibration.deadband) valueNormalized-=calibration.deadband;
-        else if (valueNormalized<-calibration.deadband) valueNormalized+=calibration.deadband;
-        else valueNormalized = 0.f;
-    }
+    float axisPercent;
 
-    float axisPercent = valueNormalized / axisLength;
+    if (withDeadbands) {
+        if (valueNormalized>calibration.deadband) axisPercent = (valueNormalized - calibration.deadband) / (axisLength - calibration.deadband);
+        else if (valueNormalized<-calibration.deadband) axisPercent = (valueNormalized + calibration.deadband) / (axisLength - calibration.deadband);
+        else axisPercent = 0.f;
+    }
+    else {
+        axisPercent = valueNormalized / axisLength;
+    }
 
     float correctedValue = axisBasis * axisPercent;
 

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -438,6 +438,18 @@ void Joystick::run(void)
                 throttle_accu = std::max(static_cast<float>(-1.f), std::min(throttle_accu, static_cast<float>(1.f)));
                 throttle = throttle_accu;
             }
+
+            float roll_limited = std::max(static_cast<float>(-M_PI_4), std::min(roll, static_cast<float>(M_PI_4)));
+            float pitch_limited = std::max(static_cast<float>(-M_PI_4), std::min(pitch, static_cast<float>(M_PI_4)));
+            float yaw_limited = std::max(static_cast<float>(-M_PI_4), std::min(yaw, static_cast<float>(M_PI_4)));
+            float throttle_limited = std::max(static_cast<float>(-M_PI_4), std::min(throttle, static_cast<float>(M_PI_4)));
+
+            // Map from unit circle to linear range and limit
+            roll =      std::max(-1.0f, std::min(tanf(asinf(roll_limited)), 1.0f));
+            pitch =     std::max(-1.0f, std::min(tanf(asinf(pitch_limited)), 1.0f));
+            yaw =       std::max(-1.0f, std::min(tanf(asinf(yaw_limited)), 1.0f));
+            throttle =  std::max(-1.0f, std::min(tanf(asinf(throttle_limited)), 1.0f));
+            
             if ( _exponential ) {
                 // Exponential (0% to -50% range like most RC radios)
                 // 0 for no exponential

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -342,9 +342,13 @@ float Joystick::_adjustRange(int value, Calibration_t calibration, bool withDead
     float axisPercent;
 
     if (withDeadbands) {
-        if (valueNormalized>calibration.deadband) axisPercent = (valueNormalized - calibration.deadband) / (axisLength - calibration.deadband);
-        else if (valueNormalized<-calibration.deadband) axisPercent = (valueNormalized + calibration.deadband) / (axisLength - calibration.deadband);
-        else axisPercent = 0.f;
+        if (valueNormalized>calibration.deadband) {
+            axisPercent = (valueNormalized - calibration.deadband) / (axisLength - calibration.deadband);
+        } else if (valueNormalized<-calibration.deadband) {
+            axisPercent = (valueNormalized + calibration.deadband) / (axisLength - calibration.deadband);
+        } else {
+            axisPercent = 0.f;
+        }
     }
     else {
         axisPercent = valueNormalized / axisLength;


### PR DESCRIPTION
This pull does two things.

1: it removes a section of code that made it so that the output of an axis (manual control signal) reached 100% when the input from that axis was only at ~75%. This means that the last 25% of axis movement was useless. I'm not sure what the intended purpose of this code was.

2: Previously, if an axis had deadband applied then the maximum output on that axis would be 100%-percentDeadband. To give an example, if an axis had 40% deadband then moving the stick all the way over would only result in 60% at the output. This pull causes the sensitivity of each axis to scale with deadband so that 100% input always results in 100% output. 