### PR TITLE
Default to new Compass Ring style

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -128,6 +128,7 @@
         <file alias="QGroundControl/FlightDisplay/qmldir">src/FlightDisplay/qmldir</file>
         <file alias="QGroundControl/FlightMap/CenterMapDropButton.qml">src/FlightMap/Widgets/CenterMapDropButton.qml</file>
         <file alias="QGroundControl/FlightMap/CenterMapDropPanel.qml">src/FlightMap/Widgets/CenterMapDropPanel.qml</file>
+        <file alias="QGroundControl/FlightMap/CompassRing.qml">src/FlightMap/Widgets/CompassRing.qml</file>
         <file alias="QGroundControl/FlightMap/MapFitFunctions.qml">src/FlightMap/Widgets/MapFitFunctions.qml</file>
         <file alias="QGroundControl/FlightMap/FlightMap.qml">src/FlightMap/FlightMap.qml</file>
         <file alias="QGroundControl/FlightMap/InstrumentSwipeView.qml">src/FlightMap/Widgets/InstrumentSwipeView.qml</file>

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -69,13 +69,18 @@ Item {
                 instrumentsLoader.state  = "topMode"
             } else {
                 instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidget.qml"
-                instrumentsLoader.state  = "centerMode"
+                instrumentsLoader.state  = QGroundControl.settingsManager.appSettings.showLargeCompass.value == 1 ? "centerMode" : "topMode"
             }
         }
     }
 
     Connections {
         target:         QGroundControl.settingsManager.appSettings.virtualJoystick
+        onValueChanged: _setInstrumentWidget()
+    }
+
+    Connections {
+        target:         QGroundControl.settingsManager.appSettings.showLargeCompass
         onValueChanged: _setInstrumentWidget()
     }
 

--- a/src/FlightMap/Widgets/CompassRing.qml
+++ b/src/FlightMap/Widgets/CompassRing.qml
@@ -7,13 +7,6 @@
  *
  ****************************************************************************/
 
-
-/**
- * @file
- *   @brief QGC Compass Widget
- *   @author Gus Grubba <mavlink@grubba.com>
- */
-
 import QtQuick              2.7
 import QtGraphicalEffects   1.0
 
@@ -22,8 +15,6 @@ import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 
 Item {
-    id:                     root
-
     property real size:     _defaultSize
     property var  vehicle:  null
 
@@ -48,47 +39,32 @@ Item {
         visible:        false
 
         Image {
-            id:                 pointer
-            source:             vehicle ? vehicle.vehicleImageCompass : ""
-            mipmap:             true
-            width:              size * 0.75
-            sourceSize.width:   width
-            fillMode:           Image.PreserveAspectFit
-            anchors.centerIn:   parent
+            id:                     pointer
+            source:                 "/qmlimages/attitudePointer.svg"
+            mipmap:                 true
+            fillMode:               Image.PreserveAspectFit
+            anchors.leftMargin:     _pointerMargin
+            anchors.rightMargin:    _pointerMargin
+            anchors.topMargin:      _pointerMargin
+            anchors.bottomMargin:   _pointerMargin
+            anchors.fill:           parent
+            sourceSize.height:      parent.height
+
             transform: Rotation {
                 origin.x:       pointer.width  / 2
                 origin.y:       pointer.height / 2
                 angle:          _heading
             }
+
+            readonly property real _pointerMargin: -10
         }
 
         Image {
-            id:                 compassDial
             source:             "/qmlimages/compassInstrumentDial.svg"
             mipmap:             true
             fillMode:           Image.PreserveAspectFit
             anchors.fill:       parent
             sourceSize.height:  parent.height
-        }
-
-        Rectangle {
-            anchors.centerIn:   parent
-            width:              size * 0.35
-            height:             size * 0.2
-            border.color:       Qt.rgba(1,1,1,0.15)
-            color:              Qt.rgba(0,0,0,0.65)
-
-            QGCLabel {
-                text:           _headingString3
-                font.family:    vehicle ? ScreenTools.demiboldFontFamily : ScreenTools.normalFontFamily
-                font.pointSize: _fontSize < 8 ? 8 : _fontSize;
-                color:          "white"
-                anchors.centerIn: parent
-
-                property string _headingString: vehicle ? _heading.toFixed(0) : "OFF"
-                property string _headingString2: _headingString.length === 1 ? "0" + _headingString : _headingString
-                property string _headingString3: _headingString2.length === 2 ? "0" + _headingString2 : _headingString2
-            }
         }
     }
 

--- a/src/FlightMap/Widgets/QGCAttitudeWidget.qml
+++ b/src/FlightMap/Widgets/QGCAttitudeWidget.qml
@@ -14,11 +14,12 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick 2.7
-import QtGraphicalEffects 1.0
+import QtQuick              2.7
+import QtGraphicalEffects   1.0
 
-import QGroundControl          1.0
-import QGroundControl.Controls 1.0
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
 
 Item {
     id: root
@@ -26,6 +27,7 @@ Item {
     property bool showPitch:    true
     property var  vehicle:      null
     property real size
+    property bool showHeading:  false
 
     property real _rollAngle:   vehicle ? vehicle.roll.rawValue  : 0
     property real _pitchAngle:  vehicle ? vehicle.pitch.rawValue : 0
@@ -117,4 +119,16 @@ Item {
         border.width:   2
     }
 
+    QGCLabel {
+        anchors.bottomMargin:       Math.round(ScreenTools.defaultFontPixelHeight * .75)
+        anchors.bottom:             parent.bottom
+        anchors.horizontalCenter:   parent.horizontalCenter
+        text:                       _headingString3
+        color:                      "white"
+        visible:                    showHeading
+
+        property string _headingString: vehicle ? vehicle.heading.rawValue.toFixed(0) : "OFF"
+        property string _headingString2: _headingString.length === 1 ? "0" + _headingString : _headingString
+        property string _headingString3: _headingString2.length === 2 ? "0" + _headingString2 : _headingString2
+    }
 }

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -7,13 +7,6 @@
  *
  ****************************************************************************/
 
-
-/**
- * @file
- *   @brief QGC Fly View Widgets
- *   @author Gus Grubba <mavlink@grubba.com>
- */
-
 import QtQuick 2.7
 
 import QGroundControl               1.0
@@ -23,33 +16,29 @@ import QGroundControl.FactSystem    1.0
 import QGroundControl.FlightMap     1.0
 import QGroundControl.Palette       1.0
 
-Item {
-    id:     instrumentPanel
-    height: instrumentColumn.y + instrumentColumn.height + _topBottomMargin
-    width:  getPreferredInstrumentWidth()
+Rectangle {
+    id:             instrumentPanel
+    height:         instrumentColumn.height + (_topBottomMargin * 2)
+    width:          getPreferredInstrumentWidth()
+    radius:         _showLargeCompass ? width / 2 :  ScreenTools.defaultFontPixelWidth / 2
+    color:          _backgroundColor
+    border.width:   _showLargeCompass ? 1 : 0
+    border.color:   _isSatellite ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
 
-    property var    _qgcView:           qgcView
-    property real   _maxHeight:         maxHeight
-    property real   _defaultSize:       ScreenTools.defaultFontPixelHeight * (9)
-    property color  _backgroundColor:   qgcPal.window
-    property real   _spacing:           ScreenTools.defaultFontPixelHeight * 0.33
-    property real   _topBottomMargin:   (width * 0.05) / 2
-    property real   _availableValueHeight: _maxHeight - (attitudeWidget.height + _spacer1.height + _spacer2.height + (_spacing * 4)) - (_showCompass ? compass.height : 0)
-    property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
+    property var    _qgcView:               qgcView
+    property real   _maxHeight:             maxHeight
+    property real   _defaultSize:           ScreenTools.defaultFontPixelHeight * (9)
+    property color  _backgroundColor:       qgcPal.window
+    property real   _spacing:               ScreenTools.defaultFontPixelHeight * 0.33
+    property real   _topBottomMargin:       (width * 0.05) / 2
+    property real   _availableValueHeight:  _maxHeight - (outerCompass.height + _spacer1.height + _spacer2.height + (_spacing * 4)) - (_showLargeCompass ? compass.height : 0)
+    property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _showLargeCompass:      QGroundControl.settingsManager.appSettings.showLargeCompass.value
 
-    readonly property bool _showCompass:    true // !ScreenTools.isShortScreen
+    readonly property real _outerRingRatio: 0.95
+    readonly property real _innerRingRatio: 0.80
 
     QGCPalette { id: qgcPal }
-
-    Rectangle {
-        anchors.left:   parent.left
-        anchors.right:  parent.right
-        height:         (_showCompass ? instrumentColumn.height : attitudeWidget.height) + (_topBottomMargin * 2)
-        radius:         width / 2
-        color:          _backgroundColor
-        border.width:   1
-        border.color:   _isSatellite ? qgcPal.mapWidgetBorderLight : qgcPal.mapWidgetBorderDark
-    }
 
     MouseArea {
         anchors.fill: parent
@@ -66,23 +55,33 @@ Item {
 
         Item {
             width:  parent.width
-            height: attitudeWidget.height
+            height: outerCompass.height
+
+            CompassRing {
+                id:                 outerCompass
+                size:               parent.width * _outerRingRatio
+                vehicle:            _activeVehicle
+                anchors.horizontalCenter: parent.horizontalCenter
+                visible:            !_showLargeCompass
+
+            }
 
             QGCAttitudeWidget {
-                id:             attitudeWidget
-                size:           parent.width * 0.95
-                vehicle:        _activeVehicle
-                anchors.horizontalCenter: parent.horizontalCenter
+                id:                 attitudeWidget
+                size:               parent.width * (_showLargeCompass ? _outerRingRatio : _innerRingRatio)
+                vehicle:            _activeVehicle
+                anchors.centerIn:   outerCompass
+                showHeading:        !_showLargeCompass
             }
 
             Image {
                 id:                 gearThingy
-                anchors.bottom:     attitudeWidget.bottom
-                anchors.right:      attitudeWidget.right
+                anchors.bottom:     outerCompass.bottom
+                anchors.right:      outerCompass.right
                 source:             qgcPal.globalTheme == QGCPalette.Light ? "/res/gear-black.svg" : "/res/gear-white.svg"
                 mipmap:             true
                 opacity:            0.5
-                width:              attitudeWidget.width * 0.15
+                width:              outerCompass.width * 0.15
                 sourceSize.width:   width
                 fillMode:           Image.PreserveAspectFit
                 MouseArea {
@@ -96,11 +95,11 @@ Item {
         }
 
         Rectangle {
-            id:                 _spacer1
-            height:             1
-            width:              parent.width * 0.9
-            color:              qgcPal.text
-            anchors.horizontalCenter: parent.horizontalCenter
+            id:                         _spacer1
+            anchors.horizontalCenter:   parent.horizontalCenter
+            height:                     1
+            width:                      parent.width * 0.9
+            color:                      qgcPal.text
         }
 
         Item {
@@ -110,8 +109,8 @@ Item {
             Rectangle {
                 anchors.fill:   _valuesWidget
                 color:          _backgroundColor
-                visible:        !_showCompass
                 radius:         _spacing
+                visible:        !_showLargeCompass
             }
 
             InstrumentSwipeView {
@@ -127,20 +126,20 @@ Item {
         }
 
         Rectangle {
-            id:                 _spacer2
-            height:             1
-            width:              parent.width * 0.9
-            color:              qgcPal.text
-            visible:            _showCompass
-            anchors.horizontalCenter: parent.horizontalCenter
+            id:                         _spacer2
+            anchors.horizontalCenter:   parent.horizontalCenter
+            height:                     1
+            width:                      parent.width * 0.9
+            color:                      qgcPal.text
+            visible:                    _showLargeCompass
         }
 
         QGCCompassWidget {
-            id:                 compass
-            size:               parent.width * 0.95
-            visible:            _showCompass
-            vehicle:            _activeVehicle
-            anchors.horizontalCenter: parent.horizontalCenter
+            id:                         compass
+            anchors.horizontalCenter:   parent.horizontalCenter
+            size:                       parent.width * 0.95
+            vehicle:                    _activeVehicle
+            visible:                    _showLargeCompass
         }
     }
 }

--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -15,6 +15,7 @@ import QtQuick.Layouts  1.3
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
 import QGroundControl.Controllers   1.0
 import QGroundControl.Palette       1.0
 import QGroundControl               1.0
@@ -147,21 +148,42 @@ QGCFlickable {
                 flickableDirection: Flickable.VerticalFlick
                 clip:               true
 
-                QGCLabel {
-                    id:     _label
-                    text:   qsTr("Select the values you want to display:")
-                }
+                Column {
+                    id:             column
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    spacing:        _margins
 
-                Loader {
-                    id:                 _loader
-                    anchors.left:       parent.left
-                    anchors.right:      parent.right
-                    anchors.topMargin:  _margins
-                    anchors.top:        _label.bottom
-                    sourceComponent:    factGroupList
+                    FactCheckBox {
+                        text:       qsTr("Show large compass")
+                        fact:       _showLargeCompass
+                        visible:    _showLargeCompass.visible
 
-                    property var factGroup:     _activeVehicle
-                    property var factGroupName: "Vehicle"
+                        property Fact _showLargeCompass: QGroundControl.settingsManager.appSettings.showLargeCompass
+                    }
+
+                    Item {
+                        width:  1
+                        height: _margins
+                    }
+
+                    QGCLabel {
+                        id:     _label
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        wrapMode:       Text.WordWrap
+                        text:   qsTr("Select the values you want to display:")
+                    }
+
+                    Loader {
+                        id:                 _loader
+                        anchors.left:       parent.left
+                        anchors.right:      parent.right
+                        sourceComponent:    factGroupList
+
+                        property var factGroup:     _activeVehicle
+                        property var factGroupName: "Vehicle"
+                    }
                 }
             }
         }

--- a/src/FlightMap/qmldir
+++ b/src/FlightMap/qmldir
@@ -8,6 +8,7 @@ QGCVideoBackground  1.0 QGCVideoBackground.qml
 CameraWidget            1.0 CameraWidget.qml
 CenterMapDropButton     1.0 CenterMapDropButton.qml
 CenterMapDropPanel      1.0 CenterMapDropPanel.qml
+CompassRing             1.0 CompassRing.qml
 InstrumentSwipeView     1.0 InstrumentSwipeView.qml
 MapFitFunctions         1.0 MapFitFunctions.qml
 MapScale                1.0 MapScale.qml

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -107,5 +107,12 @@
     "type":             "uint32",
     "enumStrings":      "Indoor,Outdoor",
     "enumValues":       "1,0"
+},
+{
+    "name":             "ShowLargeCompass",
+    "shortDescription": "Show large compass",
+    "longDescription":  "Show large compass on instrument panel",
+    "type":             "bool",
+    "defaultValue":     false
 }
 ]

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -28,6 +28,7 @@ const char* AppSettings::audioMutedName =                               "AudioMu
 const char* AppSettings::virtualJoystickName =                          "VirtualTabletJoystick";
 const char* AppSettings::appFontPointSizeName =                         "BaseDeviceFontPointSize";
 const char* AppSettings::indoorPaletteName =                            "StyleIsDark";
+const char* AppSettings::showLargeCompassName =                         "ShowLargeCompass";
 
 AppSettings::AppSettings(QObject* parent)
     : SettingsGroup(appSettingsGroupName, QString() /* root settings group */, parent)
@@ -44,6 +45,7 @@ AppSettings::AppSettings(QObject* parent)
     , _virtualJoystickFact(NULL)
     , _appFontPointSizeFact(NULL)
     , _indoorPaletteFact(NULL)
+    , _showLargeCompassFact(NULL)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<AppSettings>("QGroundControl.SettingsManager", 1, 0, "AppSettings", "Reference only");        
@@ -171,3 +173,13 @@ void AppSettings::_indoorPaletteChanged(void)
     qgcApp()->_loadCurrentStyleSheet();
     QGCPalette::setGlobalTheme(indoorPalette()->rawValue().toBool() ? QGCPalette::Dark : QGCPalette::Light);
 }
+
+Fact* AppSettings::showLargeCompass(void)
+{
+    if (!_showLargeCompassFact) {
+        _showLargeCompassFact = _createSettingsFact(showLargeCompassName);
+    }
+
+    return _showLargeCompassFact;
+}
+

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -32,6 +32,7 @@ public:
     Q_PROPERTY(Fact* virtualJoystick                    READ virtualJoystick                    CONSTANT)
     Q_PROPERTY(Fact* appFontPointSize                   READ appFontPointSize                   CONSTANT)
     Q_PROPERTY(Fact* indoorPalette                      READ indoorPalette                      CONSTANT)
+    Q_PROPERTY(Fact* showLargeCompass                   READ showLargeCompass                   CONSTANT)
 
     Fact* offlineEditingFirmwareType        (void);
     Fact* offlineEditingVehicleType         (void);
@@ -46,6 +47,7 @@ public:
     Fact* virtualJoystick                   (void);
     Fact* appFontPointSize                  (void);
     Fact* indoorPalette                     (void);
+    Fact* showLargeCompass                  (void);
 
     static const char* appSettingsGroupName;
 
@@ -62,6 +64,7 @@ public:
     static const char* virtualJoystickName;
     static const char* appFontPointSizeName;
     static const char* indoorPaletteName;
+    static const char* showLargeCompassName;
 
 private slots:
     void _indoorPaletteChanged(void);
@@ -80,6 +83,7 @@ private:
     SettingsFact* _virtualJoystickFact;
     SettingsFact* _appFontPointSizeFact;
     SettingsFact* _indoorPaletteFact;
+    SettingsFact* _showLargeCompassFact;
 };
 
 #endif


### PR DESCRIPTION
* New style combined compass and attitude instrument. Reason is to take less space, leaving more for instrument values if wanted.
* Controlled by setting available from Gear thingy. Defaults to new visuals. Check Show large compass to go back to old style.
* Also changed heading display in new and old style to always 3 digits.

Consider this a WIP. 

![screen shot 2017-03-03 at 11 38 27 am](https://cloud.githubusercontent.com/assets/5876851/23566385/7ba4e5b0-0006-11e7-85ff-aeaba6127017.png)

Fix for #4691