### PR TITLE
Moved toolbar indicator list from QGCCorePlugin to FirmwarePlugin.

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -104,7 +104,7 @@ protected:
     APMFirmwarePlugin(void);
     void setSupportedModes(QList<APMCustomMode> supportedModes);
 
-    bool _coaxialMotors;
+    bool                _coaxialMotors;
 
 private slots:
     void _artooSocketError(QAbstractSocket::SocketError socketError);
@@ -125,8 +125,8 @@ private:
     QList<APMCustomMode>    _supportedModes;
     QMap<QString, QTime>    _noisyPrearmMap;
 
-    static const char*  _artooIP;
-    static const int    _artooVideoHandshakePort;
+    static const char*      _artooIP;
+    static const int        _artooVideoHandshakePort;
 
 };
 

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -106,3 +106,17 @@ bool ArduSubFirmwarePlugin::supportsMotorInterference(void)
 {
     return false;
 }
+
+QVariantList& ArduSubFirmwarePlugin::toolBarIndicators(const Vehicle* vehicle)
+{
+    Q_UNUSED(vehicle);
+    //-- Sub specific list of indicators (Enter your modified list here)
+    if(_toolBarIndicatorList.size() == 0) {
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ModeIndicator.qml")));
+    }
+    return _toolBarIndicatorList;
+}

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -86,6 +86,7 @@ public:
     QString brandImage(const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImageSub"); }
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     int remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const final;
+    QVariantList& toolBarIndicators(const Vehicle* vehicle) final;
 
 private:
     static bool _remapParamNameIntialized;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -337,3 +337,18 @@ QString FirmwarePlugin::vehicleImageCompass(const Vehicle* vehicle) const
     Q_UNUSED(vehicle);
     return QStringLiteral("/qmlimages/compassInstrumentArrow.svg");
 }
+
+QVariantList& FirmwarePlugin::toolBarIndicators(const Vehicle* vehicle)
+{
+    Q_UNUSED(vehicle);
+    //-- Default list of indicators for all vehicles.
+    if(_toolBarIndicatorList.size() == 0) {
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ModeIndicator.qml")));
+    }
+    return _toolBarIndicatorList;
+}

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -22,6 +22,7 @@
 
 #include <QList>
 #include <QString>
+#include <QVariantList>
 
 class Vehicle;
 
@@ -256,8 +257,16 @@ public:
     /// Return the resource file which contains the vehicle icon used in the compass
     virtual QString vehicleImageCompass(const Vehicle* vehicle) const;
 
+    /// Allows the core plugin to override the toolbar indicators
+    /// @return A list of QUrl with the indicators (see MainToolBarIndicators.qml)
+    virtual QVariantList& toolBarIndicators(const Vehicle* vehicle);
+
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const char* px4FollowMeFlightMode;
+
+protected:
+    QVariantList _toolBarIndicatorList;
+
 };
 
 class FirmwarePluginFactory : public QObject

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2375,6 +2375,15 @@ QString Vehicle::vehicleImageCompass() const
         return QString();
 }
 
+QVariantList& Vehicle::toolBarIndicators()
+{
+    if(_firmwarePlugin) {
+        return _firmwarePlugin->toolBarIndicators(this);
+    }
+    static QVariantList emptyList;
+    return emptyList;
+}
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -307,6 +307,7 @@ public:
     Q_PROPERTY(unsigned int         telemetryTXBuffer       READ telemetryTXBuffer                                      NOTIFY telemetryTXBufferChanged)
     Q_PROPERTY(unsigned int         telemetryLNoise         READ telemetryLNoise                                        NOTIFY telemetryLNoiseChanged)
     Q_PROPERTY(unsigned int         telemetryRNoise         READ telemetryRNoise                                        NOTIFY telemetryRNoiseChanged)
+    Q_PROPERTY(QVariantList         toolBarIndicators       READ toolBarIndicators                                      CONSTANT)
 
     /// true: Vehicle is flying, false: Vehicle is on ground
     Q_PROPERTY(bool flying      READ flying     WRITE setFlying     NOTIFY flyingChanged)
@@ -650,6 +651,8 @@ public:
     QString vehicleImageOpaque  () const;
     QString vehicleImageOutline () const;
     QString vehicleImageCompass () const;
+
+    QVariantList& toolBarIndicators();
 
 public slots:
     /// Sets the firmware plugin instance data associated with this Vehicle. This object will be parented to the Vehicle

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -67,7 +67,6 @@ public:
     QGCSettings* pDebug;
 #endif
     QVariantList settingsList;
-    QVariantList toolBarIndicatorList;
     QGCOptions*  defaultOptions;
 };
 
@@ -142,23 +141,10 @@ QGCOptions* QGCCorePlugin::options()
     return _p->defaultOptions;
 }
 
-QVariantList& QGCCorePlugin::toolBarIndicators()
-{
-    if(_p->toolBarIndicatorList.size() == 0) {
-        _p->toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")));
-        _p->toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")));
-        _p->toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")));
-        _p->toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")));
-        _p->toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")));
-        _p->toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ModeIndicator.qml")));
-    }
-    return _p->toolBarIndicatorList;
-}
-
 bool QGCCorePlugin::overrideSettingsGroupVisibility(QString name)
 {
     Q_UNUSED(name);
-    
+
     // Always show all
     return true;
 }

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -36,15 +36,10 @@ public:
     Q_PROPERTY(QVariantList settings            READ settings           CONSTANT)
     Q_PROPERTY(int          defaultSettings     READ defaultSettings    CONSTANT)
     Q_PROPERTY(QGCOptions*  options             READ options            CONSTANT)
-    Q_PROPERTY(QVariantList toolBarIndicators   READ toolBarIndicators  CONSTANT)
 
     /// The list of settings under the Settings Menu
     /// @return A list of QGCSettings
     virtual QVariantList&           settings            ();
-
-    /// Allows the core plugin to override the toolbar indicators
-    /// @return A list of QUrl with the indicators (see MainToolBarIndicators.qml)
-    virtual QVariantList&           toolBarIndicators   ();
 
     /// The default settings panel to show
     /// @return The settings index

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -31,7 +31,7 @@ Item {
         spacing:        ScreenTools.defaultFontPixelWidth * 1.5
         visible:        !communicationLost
         Repeater {
-            model:  QGroundControl.corePlugin.toolBarIndicators
+            model:      activeVehicle ? activeVehicle.toolBarIndicators : []
             Loader {
                 anchors.top:    parent.top
                 anchors.bottom: parent.bottom


### PR DESCRIPTION
In response to #4701 

The list of indicators is now provided by the FirmwarePlugin. The base class defines the default list of indicators. I went ahead and implemented a "specialized" implementation for the ArduSub plugin. I only removed the GPS, just to show where to add/change/remove indicators for a specific firmware/vehicle.

See ArduSubFirmwarePlugin.cc/h for how to implement your own list.