### PR TITLE
FixedWing Landing Pattern fixes

### DIFF
--- a/src/MissionEditor/FWLandingPatternMapVisual.qml
+++ b/src/MissionEditor/FWLandingPatternMapVisual.qml
@@ -92,7 +92,6 @@ Item {
 
     function calcPointTangentToCircleWithCenter() {
         if (_missionItem.landingCoordSet) {
-            console.log("recalc")
             var radius = _missionItem.loiterRadius.value
             var loiterPointPixels = map.fromCoordinate(_missionItem.loiterCoordinate, false /* clipToViewport */)
             var landPointPixels = map.fromCoordinate(_missionItem.landingCoordinate, false /* clipToViewport */)

--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -227,10 +227,15 @@ void FixedWingLandingComplexItem::_recalcLoiterCoordFromFacts(void)
 
         convertGeoToNed(_landingCoordinate, tangentOrigin, &north, &east, &down);
 
+        // Heading is from loiter to land, so we need to rotate angle 180 degrees and go the opposite direction
+        double heading = _landingHeadingFact.rawValue().toDouble();
+        heading += 180.0;
+        heading *= -1.0;
+
         QPointF originPoint(east, north);
         north += _loiterToLandDistanceFact.rawValue().toDouble();
         QPointF loiterPoint(east, north);
-        QPointF rotatedLoiterPoint = _rotatePoint(loiterPoint, originPoint, _landingHeadingFact.rawValue().toDouble());
+        QPointF rotatedLoiterPoint = _rotatePoint(loiterPoint, originPoint, heading);
 
         convertNedToGeo(rotatedLoiterPoint.y(), rotatedLoiterPoint.x(), down, tangentOrigin, &_loiterCoordinate);
 

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -79,8 +79,8 @@ Rectangle {
         dropButtonsExclusiveGroup.current = null
         // Signal all toggles as off
         for (var i=0; i<model.length; i++) {
-            if (model[i].toggleButton === true) {
-                clicked(index, false)
+            if (model[i].toggle === true) {
+                _root.clicked(i, false)
             }
         }
     }
@@ -198,6 +198,7 @@ Rectangle {
                                     dropPanel.hide()    // hide affects checked, so this needs to be duplicated inside not outside if
                                 } else {
                                     dropPanel.hide()    // hide affects checked, so this needs to be duplicated inside not outside if
+                                    uncheckAll()
                                     checked = true
                                     var panelEdgeTopPoint = mapToItem(_root, width, 0)
                                     dropPanel.show(panelEdgeTopPoint, height, modelData.dropPanelComponent)


### PR DESCRIPTION
Fixes for #4706:
* ToolStrip toggle buttons now correctly uncheck themselves when a button with a DropPanel is clicked
* FW Landing Pattern: Fix loiter point rotation when changing landing heading from item editor
