### PR TITLE
Changes imports back to v5.5 level

### DIFF
--- a/src/AnalyzeView/AnalyzePage.qml
+++ b/src/AnalyzeView/AnalyzePage.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl               1.0
 import QGroundControl.Palette       1.0

--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -12,8 +12,8 @@
 ///     @brief Setup View
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl               1.0
 import QGroundControl.Palette       1.0

--- a/src/AnalyzeView/GeoTagPage.qml
+++ b/src/AnalyzeView/GeoTagPage.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/AnalyzeView/LogDownloadPage.qml
+++ b/src/AnalyzeView/LogDownloadPage.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 import QtQuick.Dialogs      1.2
-import QtQuick.Layouts      1.3
+import QtQuick.Layouts      1.2
 
 import QGroundControl               1.0
 import QGroundControl.Palette       1.0

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/APM/APMCameraComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMCameraComponent.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/APM/APMCameraComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMCameraComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/APM/APMLightsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMLightsComponent.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/APM/APMNotSupported.qml
+++ b/src/AutoPilotPlugins/APM/APMNotSupported.qml
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.Controls 1.0
 

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 import QtGraphicalEffects   1.0
 
 import QGroundControl.FactSystem    1.0

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 import QtGraphicalEffects   1.0
 
 import QGroundControl.FactSystem    1.0

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentRover.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentRover.qml
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.Controls 1.0
 

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 import QtGraphicalEffects   1.0
 
 import QGroundControl.FactSystem    1.0

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryRover.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryRover.qml
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.Controls 1.0
 

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -8,11 +8,11 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtQuick.Layouts          1.3
+import QtQuick.Layouts          1.2
 
 import QGroundControl               1.0
 import QGroundControl.FactSystem    1.0

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl.FactSystem    1.0

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/Common/ESP8266Component.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266Component.qml
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.FactSystem    1.0

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/Common/MixersComponent.qml
+++ b/src/AutoPilotPlugins/Common/MixersComponent.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/Common/MotorComponent.qml
+++ b/src/AutoPilotPlugins/Common/MotorComponent.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/AutoPilotPlugins/Common/RadioComponent.qml
+++ b/src/AutoPilotPlugins/Common/RadioComponent.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Dialogs 1.2
 

--- a/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/PX4/CameraComponent.qml
+++ b/src/AutoPilotPlugins/PX4/CameraComponent.qml
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 
-import QtQuick                      2.7
-import QtQuick.Controls             1.4
+import QtQuick                      2.3
+import QtQuick.Controls             1.2
 import QtQuick.Controls.Styles      1.4
-import QtQuick.Layouts              1.3
+import QtQuick.Layouts              1.2
 import QtGraphicalEffects           1.0
 
 import QGroundControl               1.0

--- a/src/AutoPilotPlugins/PX4/CameraComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/CameraComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml
+++ b/src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml
@@ -8,11 +8,11 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtQuick.Layouts          1.3
+import QtQuick.Layouts          1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/PX4/PX4FlightModes.qml
+++ b/src/AutoPilotPlugins/PX4/PX4FlightModes.qml
@@ -8,11 +8,11 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtQuick.Layouts          1.3
+import QtQuick.Layouts          1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.Controls  1.0
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.Controls  1.0
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.Controls  1.0
 

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
@@ -12,8 +12,8 @@
 ///     @brief Battery, propeller and magnetometer summary
 ///     @author Gus Grubba <mavlink@grubba.com>
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
-import QtQuick.Layouts          1.3
+import QtQuick.Layouts          1.2
 import QtGraphicalEffects       1.0
 
 import QGroundControl.FactSystem    1.0

--- a/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Dialogs 1.2
 

--- a/src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.FactSystem 1.0

--- a/src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0

--- a/src/FactSystem/FactControls/FactBitmask.qml
+++ b/src/FactSystem/FactControls/FactBitmask.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.Palette       1.0

--- a/src/FactSystem/FactControls/FactCheckBox.qml
+++ b/src/FactSystem/FactControls/FactCheckBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.FactSystem 1.0

--- a/src/FactSystem/FactControls/FactComboBox.qml
+++ b/src/FactSystem/FactControls/FactComboBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.FactSystem 1.0

--- a/src/FactSystem/FactControls/FactLabel.qml
+++ b/src/FactSystem/FactControls/FactLabel.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.FactSystem 1.0

--- a/src/FactSystem/FactControls/FactPanel.qml
+++ b/src/FactSystem/FactControls/FactPanel.qml
@@ -11,8 +11,8 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.FactSystem 1.0
 import QGroundControl.Controls 1.0

--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
 

--- a/src/FactSystem/FactControls/FactTextFieldGrid.qml
+++ b/src/FactSystem/FactControls/FactTextFieldGrid.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.Controls      1.0

--- a/src/FactSystem/FactControls/FactTextFieldRow.qml
+++ b/src/FactSystem/FactControls/FactTextFieldRow.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.Controls      1.0

--- a/src/FactSystem/FactSystemTest.qml
+++ b/src/FactSystem/FactSystemTest.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QGroundControl.FactSystem 1.0
 import QGroundControl.FactControls 1.0
 

--- a/src/FirmwarePlugin/APM/APMSensorParams.qml
+++ b/src/FirmwarePlugin/APM/APMSensorParams.qml
@@ -7,7 +7,7 @@
  *
  ****************************************************************************/
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.FactSystem 1.0
 

--- a/src/FirmwarePlugin/APM/CopterGeoFenceEditor.qml
+++ b/src/FirmwarePlugin/APM/CopterGeoFenceEditor.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FirmwarePlugin/APM/PlaneGeoFenceEditor.qml
+++ b/src/FirmwarePlugin/APM/PlaneGeoFenceEditor.qml
@@ -1,6 +1,6 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FirmwarePlugin/NoGeoFenceEditor.qml
+++ b/src/FirmwarePlugin/NoGeoFenceEditor.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FirmwarePlugin/PX4/PX4GeoFenceEditor.qml
+++ b/src/FirmwarePlugin/PX4/PX4GeoFenceEditor.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -8,13 +8,13 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtLocation               5.6
-import QtPositioning            5.5
-import QtMultimedia             5.8
+import QtLocation               5.3
+import QtPositioning            5.3
+import QtMultimedia             5.5
 
 import QGroundControl               1.0
 import QGroundControl.FlightDisplay 1.0

--- a/src/FlightDisplay/FlightDisplayViewDummy.qml
+++ b/src/FlightDisplay/FlightDisplayViewDummy.qml
@@ -7,7 +7,7 @@
  *
  ****************************************************************************/
 
-import QtQuick                  2.7
+import QtQuick                  2.3
 
 Rectangle {
     anchors.fill:               parent

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 
-import QtQuick                      2.7
-import QtQuick.Controls             1.4
-import QtLocation                   5.6
-import QtPositioning                5.5
+import QtQuick                      2.3
+import QtQuick.Controls             1.2
+import QtLocation                   5.3
+import QtPositioning                5.3
 
 import QGroundControl               1.0
 import QGroundControl.FlightDisplay 1.0

--- a/src/FlightDisplay/FlightDisplayViewUVC.qml
+++ b/src/FlightDisplay/FlightDisplayViewUVC.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick                  2.7
-import QtMultimedia             5.8
+import QtQuick                  2.3
+import QtMultimedia             5.5
 
 import QGroundControl           1.0
 

--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick                      2.7
-import QtQuick.Controls             1.4
+import QtQuick                      2.3
+import QtQuick.Controls             1.2
 
 import QGroundControl               1.0
 import QGroundControl.FlightDisplay 1.0

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -8,12 +8,12 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtLocation               5.6
-import QtPositioning            5.5
+import QtLocation               5.3
+import QtPositioning            5.3
 
 import QGroundControl                           1.0
 import QGroundControl.ScreenTools               1.0

--- a/src/FlightDisplay/MultiVehicleList.qml
+++ b/src/FlightDisplay/MultiVehicleList.qml
@@ -7,9 +7,9 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FlightDisplay/VirtualJoystick.qml
+++ b/src/FlightDisplay/VirtualJoystick.qml
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -14,10 +14,10 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtLocation       5.6
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtLocation       5.3
+import QtPositioning    5.3
 
 import QGroundControl                       1.0
 import QGroundControl.FactSystem            1.0

--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick      2.7
-import QtLocation   5.6
+import QtQuick      2.3
+import QtLocation   5.3
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0

--- a/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick      2.7
-import QtLocation   5.6
+import QtQuick      2.3
+import QtLocation   5.3
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FlightMap/MapItems/MissionItemView.qml
+++ b/src/FlightMap/MapItems/MissionItemView.qml
@@ -8,11 +8,11 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtLocation       5.6
-import QtPositioning    5.5
+import QtLocation       5.3
+import QtPositioning    5.3
 
 import QGroundControl               1.0
 import QGroundControl.FlightMap     1.0

--- a/src/FlightMap/MapItems/MissionLineView.qml
+++ b/src/FlightMap/MapItems/MissionLineView.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtLocation       5.6
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtLocation       5.3
+import QtPositioning    5.3
 
 import QGroundControl           1.0
 import QGroundControl.Palette   1.0

--- a/src/FlightMap/MapItems/PolygonEditor.qml
+++ b/src/FlightMap/MapItems/PolygonEditor.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick      2.7
-import QtLocation   5.6
+import QtQuick      2.3
+import QtLocation   5.3
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0
@@ -69,8 +69,8 @@ Item {
         adjustingPolygon = true
         for (var i=0; i<vertexCoordinates.length; i++) {
             var dragItem = Qt.createQmlObject(
-                        "import QtQuick                     2.7; " +
-                        "import QtLocation                  5.6; " +
+                        "import QtQuick                     2.3; " +
+                        "import QtLocation                  5.3; " +
                         "import QGroundControl.ScreenTools  1.0; " +
                         "" +
                         "Rectangle {" +

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -11,9 +11,9 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick          2.7
-import QtLocation       5.6
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtLocation       5.3
+import QtPositioning    5.3
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0

--- a/src/FlightMap/MapScale.qml
+++ b/src/FlightMap/MapScale.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl                   1.0
 import QGroundControl.Controls          1.0

--- a/src/FlightMap/QGCVideoBackground.qml
+++ b/src/FlightMap/QGCVideoBackground.qml
@@ -14,8 +14,8 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QGroundControl.QgcQtGStreamer 1.0
 
 VideoItem {

--- a/src/FlightMap/Widgets/CameraWidget.qml
+++ b/src/FlightMap/Widgets/CameraWidget.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/FlightMap/Widgets/CenterMapDropButton.qml
+++ b/src/FlightMap/Widgets/CenterMapDropButton.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+import QtPositioning    5.3
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FlightMap/Widgets/CenterMapDropPanel.qml
+++ b/src/FlightMap/Widgets/CenterMapDropPanel.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+import QtPositioning    5.3
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FlightMap/Widgets/CompassRing.qml
+++ b/src/FlightMap/Widgets/CompassRing.qml
@@ -7,7 +7,7 @@
  *
  ****************************************************************************/
 
-import QtQuick              2.7
+import QtQuick              2.3
 import QtGraphicalEffects   1.0
 
 import QGroundControl.Controls      1.0

--- a/src/FlightMap/Widgets/InstrumentSwipeView.qml
+++ b/src/FlightMap/Widgets/InstrumentSwipeView.qml
@@ -1,6 +1,6 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
-import QtQuick.Layouts          1.3
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
+import QtQuick.Layouts          1.2
 
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FlightMap/Widgets/MapFitFunctions.qml
+++ b/src/FlightMap/Widgets/MapFitFunctions.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtPositioning    5.3
 
 import QGroundControl 1.0
 

--- a/src/FlightMap/Widgets/QGCArtificialHorizon.qml
+++ b/src/FlightMap/Widgets/QGCArtificialHorizon.qml
@@ -14,7 +14,7 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 Item {
     id: root

--- a/src/FlightMap/Widgets/QGCAttitudeHUD.qml
+++ b/src/FlightMap/Widgets/QGCAttitudeHUD.qml
@@ -14,7 +14,7 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick 2.7
+import QtQuick 2.3
 import QGroundControl.ScreenTools 1.0
 
 Item {

--- a/src/FlightMap/Widgets/QGCAttitudeWidget.qml
+++ b/src/FlightMap/Widgets/QGCAttitudeWidget.qml
@@ -14,7 +14,7 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick              2.7
+import QtQuick              2.3
 import QtGraphicalEffects   1.0
 
 import QGroundControl               1.0

--- a/src/FlightMap/Widgets/QGCCompassWidget.qml
+++ b/src/FlightMap/Widgets/QGCCompassWidget.qml
@@ -14,7 +14,7 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick              2.7
+import QtQuick              2.3
 import QtGraphicalEffects   1.0
 
 import QGroundControl.Controls      1.0

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -7,7 +7,7 @@
  *
  ****************************************************************************/
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/FlightMap/Widgets/QGCPitchIndicator.qml
+++ b/src/FlightMap/Widgets/QGCPitchIndicator.qml
@@ -14,7 +14,7 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick 2.7
+import QtQuick 2.3
 import QGroundControl.ScreenTools 1.0
 import QGroundControl.Controls 1.0
 

--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
+import QtQuick          2.3
 import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/FlightMap/Widgets/VehicleHealthWidget.qml
+++ b/src/FlightMap/Widgets/VehicleHealthWidget.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/FlightMap/Widgets/VibrationWidget.qml
+++ b/src/FlightMap/Widgets/VibrationWidget.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/MissionEditor/FWLandingPatternEditor.qml
+++ b/src/MissionEditor/FWLandingPatternEditor.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/MissionEditor/FWLandingPatternMapVisual.qml
+++ b/src/MissionEditor/FWLandingPatternMapVisual.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtLocation       5.6
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtLocation       5.3
+import QtPositioning    5.3
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/MissionEditor/GeoFenceEditor.qml
+++ b/src/MissionEditor/GeoFenceEditor.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -8,12 +8,12 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtLocation       5.6
-import QtPositioning    5.5
-import QtQuick.Layouts  1.3
+import QtLocation       5.3
+import QtPositioning    5.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.FlightMap     1.0

--- a/src/MissionEditor/MissionItemEditor.qml
+++ b/src/MissionEditor/MissionItemEditor.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
 

--- a/src/MissionEditor/MissionItemMapVisual.qml
+++ b/src/MissionEditor/MissionItemMapVisual.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtLocation       5.6
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtLocation       5.3
+import QtPositioning    5.3
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Palette       1.0

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0

--- a/src/MissionEditor/MissionSettingsEditor.qml
+++ b/src/MissionEditor/MissionSettingsEditor.qml
@@ -1,6 +1,6 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl                   1.0
 import QGroundControl.ScreenTools       1.0

--- a/src/MissionEditor/QGCMapPolygonControls.qml
+++ b/src/MissionEditor/QGCMapPolygonControls.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0

--- a/src/MissionEditor/RallyPointEditorHeader.qml
+++ b/src/MissionEditor/RallyPointEditorHeader.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/MissionEditor/RallyPointItemEditor.qml
+++ b/src/MissionEditor/RallyPointItemEditor.qml
@@ -1,6 +1,6 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0

--- a/src/MissionEditor/SimpleItemEditor.qml
+++ b/src/MissionEditor/SimpleItemEditor.qml
@@ -1,8 +1,8 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtQuick.Layouts          1.3
+import QtQuick.Layouts          1.2
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0

--- a/src/MissionEditor/SimpleItemMapVisual.qml
+++ b/src/MissionEditor/SimpleItemMapVisual.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtLocation       5.6
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtLocation       5.3
+import QtPositioning    5.3
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/MissionEditor/SurveyItemEditor.qml
+++ b/src/MissionEditor/SurveyItemEditor.qml
@@ -1,7 +1,7 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/MissionEditor/SurveyMapVisual.qml
+++ b/src/MissionEditor/SurveyMapVisual.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtLocation       5.6
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtLocation       5.3
+import QtPositioning    5.3
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/MultiVehicle/MultiVehicleView.qml
+++ b/src/MultiVehicle/MultiVehicleView.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.3
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/AppMessages.qml
+++ b/src/QmlControls/AppMessages.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
 

--- a/src/QmlControls/ClickableColor.qml
+++ b/src/QmlControls/ClickableColor.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs 1.2
 
 Rectangle {

--- a/src/QmlControls/DropButton.qml
+++ b/src/QmlControls/DropButton.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl               1.0

--- a/src/QmlControls/DropPanel.qml
+++ b/src/QmlControls/DropPanel.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl               1.0

--- a/src/QmlControls/ExclusiveGroupItem.qml
+++ b/src/QmlControls/ExclusiveGroupItem.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 
 
 /// The ExclusiveGroupItem control can be used as a base class for a control which

--- a/src/QmlControls/FactSliderPanel.qml
+++ b/src/QmlControls/FactSliderPanel.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick              2.7
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Controls     1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0

--- a/src/QmlControls/FlightModeDropdown.qml
+++ b/src/QmlControls/FlightModeDropdown.qml
@@ -7,7 +7,7 @@
  *
  ****************************************************************************/
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/FlightModeMenu.qml
+++ b/src/QmlControls/FlightModeMenu.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/QmlControls/GuidedBar.qml
+++ b/src/QmlControls/GuidedBar.qml
@@ -7,7 +7,7 @@
  *
  ****************************************************************************/
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/QmlControls/IndicatorButton.qml
+++ b/src/QmlControls/IndicatorButton.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0

--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/MissionCommandDialog.qml
+++ b/src/QmlControls/MissionCommandDialog.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl.ScreenTools 1.0

--- a/src/QmlControls/ModeSwitchDisplay.qml
+++ b/src/QmlControls/ModeSwitchDisplay.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.Palette 1.0

--- a/src/QmlControls/MultiRotorMotorDisplay.qml
+++ b/src/QmlControls/MultiRotorMotorDisplay.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/OfflineMapButton.qml
+++ b/src/QmlControls/OfflineMapButton.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -11,8 +11,8 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Dialogs          1.2
 
 import QGroundControl               1.0

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -7,9 +7,9 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.Palette 1.0

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl.Palette       1.0

--- a/src/QmlControls/QGCColoredImage.qml
+++ b/src/QmlControls/QGCColoredImage.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 import QtGraphicalEffects 1.0
 

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.Palette 1.0

--- a/src/QmlControls/QGCFlickable.qml
+++ b/src/QmlControls/QGCFlickable.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.Palette 1.0
 

--- a/src/QmlControls/QGCFlickableHorizontalIndicator.qml
+++ b/src/QmlControls/QGCFlickableHorizontalIndicator.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.3
 
 Rectangle {
     id:                    horizontalIndicator

--- a/src/QmlControls/QGCFlickableVerticalIndicator.qml
+++ b/src/QmlControls/QGCFlickableVerticalIndicator.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.3
 
 Rectangle {
     id:                    verticalIndicator

--- a/src/QmlControls/QGCGroupBox.qml
+++ b/src/QmlControls/QGCGroupBox.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools 1.0

--- a/src/QmlControls/QGCLabel.qml
+++ b/src/QmlControls/QGCLabel.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.Palette 1.0

--- a/src/QmlControls/QGCListView.qml
+++ b/src/QmlControls/QGCListView.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.Palette 1.0
 

--- a/src/QmlControls/QGCMapLabel.qml
+++ b/src/QmlControls/QGCMapLabel.qml
@@ -1,5 +1,5 @@
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Controls  1.0
 import QGroundControl.Palette   1.0

--- a/src/QmlControls/QGCMobileFileOpenDialog.qml
+++ b/src/QmlControls/QGCMobileFileOpenDialog.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/QmlControls/QGCMobileFileSaveDialog.qml
+++ b/src/QmlControls/QGCMobileFileSaveDialog.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/QmlControls/QGCMovableItem.qml
+++ b/src/QmlControls/QGCMovableItem.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QGroundControl.ScreenTools 1.0
 
 // This item can be dragged around within its parent.

--- a/src/QmlControls/QGCPipable.qml
+++ b/src/QmlControls/QGCPipable.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick                      2.7
-import QtQuick.Controls             1.4
+import QtQuick                      2.3
+import QtQuick.Controls             1.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl.Palette       1.0

--- a/src/QmlControls/QGCSlider.qml
+++ b/src/QmlControls/QGCSlider.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl.Palette       1.0

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -1,7 +1,7 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
-import QtQuick.Layouts          1.3
+import QtQuick.Layouts          1.2
 
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0

--- a/src/QmlControls/QGCView.qml
+++ b/src/QmlControls/QGCView.qml
@@ -11,8 +11,8 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs 1.2
 
 import QGroundControl.Controls 1.0

--- a/src/QmlControls/QGCViewDialog.qml
+++ b/src/QmlControls/QGCViewDialog.qml
@@ -11,8 +11,8 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Controls 1.0
 import QGroundControl.Palette 1.0

--- a/src/QmlControls/QGCViewMessage.qml
+++ b/src/QmlControls/QGCViewMessage.qml
@@ -11,8 +11,8 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Controls 1.0
 import QGroundControl.Palette 1.0

--- a/src/QmlControls/QGCViewPanel.qml
+++ b/src/QmlControls/QGCViewPanel.qml
@@ -11,8 +11,8 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Palette 1.0
 import QGroundControl.Controls 1.0

--- a/src/QmlControls/QmlTest.qml
+++ b/src/QmlControls/QmlTest.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.Palette 1.0

--- a/src/QmlControls/RCChannelMonitor.qml
+++ b/src/QmlControls/RCChannelMonitor.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/QmlControls/RoundButton.qml
+++ b/src/QmlControls/RoundButton.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -1,7 +1,7 @@
 pragma Singleton
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Window 2.2
 
 import QGroundControl                       1.0

--- a/src/QmlControls/SliderSwitch.qml
+++ b/src/QmlControls/SliderSwitch.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Palette       1.0

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -1,5 +1,5 @@
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtGraphicalEffects       1.0
 

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Palette       1.0

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.Palette 1.0

--- a/src/QmlControls/VehicleSummaryRow.qml
+++ b/src/QmlControls/VehicleSummaryRow.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 Row {

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -7,13 +7,13 @@
  *
  ****************************************************************************/
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtQuick.Layouts          1.3
-import QtLocation               5.6
-import QtPositioning            5.5
+import QtQuick.Layouts          1.2
+import QtLocation               5.3
+import QtPositioning            5.3
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Dialogs 1.2
 

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl               1.0

--- a/src/VehicleSetup/PX4FlowSensor.qml
+++ b/src/VehicleSetup/PX4FlowSensor.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
 

--- a/src/VehicleSetup/SetupParameterEditor.qml
+++ b/src/VehicleSetup/SetupParameterEditor.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl.Controls 1.0
 import QGroundControl.ScreenTools 1.0

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -12,8 +12,8 @@
 ///     @brief Setup View
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl                       1.0
 import QGroundControl.AutoPilotPlugin       1.0

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 
 import QGroundControl                       1.0

--- a/src/ViewWidgets/CustomCommandWidget.qml
+++ b/src/ViewWidgets/CustomCommandWidget.qml
@@ -11,8 +11,8 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
 

--- a/src/ViewWidgets/ViewWidget.qml
+++ b/src/ViewWidgets/ViewWidget.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.Palette 1.0

--- a/src/test.qml
+++ b/src/test.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 
 import QGroundControl.FactControls 1.0

--- a/src/ui/AppSettings.qml
+++ b/src/ui/AppSettings.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtPositioning    5.5
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtPositioning    5.3
 
 import QGroundControl               1.0
 import QGroundControl.Palette       1.0

--- a/src/ui/MainWindowHybrid.qml
+++ b/src/ui/MainWindowHybrid.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl           1.0

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
-import QtPositioning    5.5
+import QtPositioning    5.3
 
 import QGroundControl                       1.0
 import QGroundControl.Palette               1.0

--- a/src/ui/MainWindowNative.qml
+++ b/src/ui/MainWindowNative.qml
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
+import QtQuick          2.3
 import QtQuick.Window   2.2
 import QtQuick.Dialogs  1.2
 

--- a/src/ui/preferences/BluetoothSettings.qml
+++ b/src/ui/preferences/BluetoothSettings.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl                       1.0

--- a/src/ui/preferences/DebugWindow.qml
+++ b/src/ui/preferences/DebugWindow.qml
@@ -8,11 +8,11 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
-import QtQuick.Controls 1.4
+import QtQuick 2.3
+import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Dialogs 1.2
-import QtQuick.Layouts 1.3
+import QtQuick.Layouts 1.2
 import QtQuick.Window 2.2
 
 import QGroundControl.Controls 1.0

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -8,12 +8,12 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtMultimedia             5.8
-import QtQuick.Layouts          1.3
+import QtMultimedia             5.5
+import QtQuick.Layouts          1.2
 
 import QGroundControl                       1.0
 import QGroundControl.FactSystem            1.0

--- a/src/ui/preferences/LinkSettings.qml
+++ b/src/ui/preferences/LinkSettings.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl                       1.0

--- a/src/ui/preferences/LogReplaySettings.qml
+++ b/src/ui/preferences/LogReplaySettings.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl                       1.0

--- a/src/ui/preferences/MavlinkSettings.qml
+++ b/src/ui/preferences/MavlinkSettings.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick                  2.7
-import QtQuick.Controls         1.4
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
 

--- a/src/ui/preferences/MockLink.qml
+++ b/src/ui/preferences/MockLink.qml
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/ui/preferences/MockLinkSettings.qml
+++ b/src/ui/preferences/MockLinkSettings.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/preferences/SerialSettings.qml
+++ b/src/ui/preferences/SerialSettings.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl                       1.0

--- a/src/ui/preferences/TcpSettings.qml
+++ b/src/ui/preferences/TcpSettings.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl                       1.0

--- a/src/ui/preferences/UdpSettings.qml
+++ b/src/ui/preferences/UdpSettings.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
 
 import QGroundControl                       1.0

--- a/src/ui/toolbar/BatteryIndicator.qml
+++ b/src/ui/toolbar/BatteryIndicator.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/GPSIndicator.qml
+++ b/src/ui/toolbar/GPSIndicator.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -7,9 +7,9 @@
  *
  ****************************************************************************/
 
-import QtQuick              2.7
-import QtQuick.Layouts      1.3
-import QtQuick.Controls     1.4
+import QtQuick              2.3
+import QtQuick.Layouts      1.2
+import QtQuick.Controls     1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/MessageIndicator.qml
+++ b/src/ui/toolbar/MessageIndicator.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/ModeIndicator.qml
+++ b/src/ui/toolbar/ModeIndicator.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
+import QtQuick          2.3
+import QtQuick.Controls 1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/RCRSSIIndicator.qml
+++ b/src/ui/toolbar/RCRSSIIndicator.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/SignalStrength.qml
+++ b/src/ui/toolbar/SignalStrength.qml
@@ -14,7 +14,7 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  */
 
-import QtQuick 2.7
+import QtQuick 2.3
 
 import QGroundControl.Controls  1.0
 import QGroundControl.Palette   1.0

--- a/src/ui/toolbar/TelemetryRSSIIndicator.qml
+++ b/src/ui/toolbar/TelemetryRSSIIndicator.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 
-import QtQuick          2.7
-import QtQuick.Controls 1.4
-import QtQuick.Layouts  1.3
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0


### PR DESCRIPTION
We are going to move to Qt 5.7 since 5.8 has an android showstopper in it (#4705). Just to be safe for now I'm backing imports back to 5.5 level in case we find more problems with 5.7 and need to move back again.