### PR TITLE
dynamic param load timeout

### DIFF
--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -63,6 +63,8 @@ ParameterManager::ParameterManager(Vehicle* vehicle)
 {
     _versionParam = vehicle->firmwarePlugin()->getVersionParam();
 
+    _intervalUpdateTimer.invalidate();
+
     if (_vehicle->isOfflineEditingVehicle()) {
         _loadOfflineEditingParams();
         return;
@@ -221,6 +223,21 @@ void ParameterManager::_parameterUpdate(int vehicleId, int componentId, QString 
 
     int readWaitingParamCount = waitingReadParamIndexCount + waitingReadParamNameCount;
     int totalWaitingParamCount = readWaitingParamCount + waitingWriteParamNameCount;
+
+    // dynamically adjust the retry timeout according to the measured incoming parameter rate
+    if (_intervalUpdateTimer.isValid()) {
+        int numParamRead = _totalParamCount - readWaitingParamCount;
+        if (numParamRead > 10) {
+            const int multiplier = 5; // increase the timeout by this factor to account for jitter
+            const int timeout_ms = qMin(3000, (int)(_intervalUpdateTimer.nsecsElapsed() * _maxBatchSize * multiplier / numParamRead / 1000000));
+            qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix() << "Setting _waitingParamTimeoutTimer interval:" << timeout_ms;
+            _waitingParamTimeoutTimer.setInterval(timeout_ms);
+        }
+        if (totalWaitingParamCount == 0) {
+            _intervalUpdateTimer.invalidate(); // all params loaded, so don't update the interval anymore
+        }
+    }
+
     if (totalWaitingParamCount) {
         // More params to wait for, restart timer
         _waitingParamTimeoutTimer.start();
@@ -389,6 +406,8 @@ void ParameterManager::refreshAllParameters(uint8_t componentId)
 
     _dataMutex.unlock();
 
+    _intervalUpdateTimer.start();
+
     MAVLinkProtocol* mavlink = qgcApp()->toolbox()->mavlinkProtocol();
     Q_ASSERT(mavlink);
 
@@ -510,8 +529,9 @@ const QMap<int, QMap<QString, QStringList> >& ParameterManager::getGroupMap(void
 void ParameterManager::_waitingParamTimeout(void)
 {
     bool paramsRequested = false;
-    const int maxBatchSize = 10;
     int batchCount = 0;
+
+    _intervalUpdateTimer.invalidate(); // don't update the interval anymore
 
     qCDebug(ParameterManagerLog) << _logVehiclePrefix() << "_waitingParamTimeout";
 
@@ -524,7 +544,7 @@ void ParameterManager::_waitingParamTimeout(void)
         }
 
         foreach(int paramIndex, _waitingReadParamIndexMap[componentId].keys()) {            
-            if (++batchCount > maxBatchSize) {
+            if (++batchCount > _maxBatchSize) {
                 goto Out;
             }
 
@@ -563,7 +583,7 @@ void ParameterManager::_waitingParamTimeout(void)
                 if (_waitingWriteParamNameMap[componentId][paramName] <= _maxReadWriteRetry) {
                     _writeParameterRaw(componentId, paramName, getParameter(componentId, paramName)->rawValue());
                     qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "Write resend for (paramName:" << paramName << "retryCount:" << _waitingWriteParamNameMap[componentId][paramName] << ")";
-                    if (++batchCount > maxBatchSize) {
+                    if (++batchCount > _maxBatchSize) {
                         goto Out;
                     }
                 } else {
@@ -585,7 +605,7 @@ void ParameterManager::_waitingParamTimeout(void)
                 if (_waitingReadParamNameMap[componentId][paramName] <= _maxReadWriteRetry) {
                     _readParameterRaw(componentId, paramName, -1);
                     qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "Read re-request for (paramName:" << paramName << "retryCount:" << _waitingReadParamNameMap[componentId][paramName] << ")";
-                    if (++batchCount > maxBatchSize) {
+                    if (++batchCount > _maxBatchSize) {
                         goto Out;
                     }
                 } else {
@@ -781,6 +801,8 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, QVarian
         });
 
         ani->start(QAbstractAnimation::DeleteWhenStopped);
+
+        _intervalUpdateTimer.invalidate(); // don't change the interval since we loaded the params from cache
     }
 }
 

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -140,7 +140,6 @@ void ParameterManager::_parameterUpdate(int vehicleId, int componentId, QString 
         return;
     }
 
-    _initialRequestTimeoutTimer.stop();
     _waitingParamTimeoutTimer.stop();
 
     _dataMutex.lock();

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -18,6 +18,7 @@
 #include <QMutex>
 #include <QDir>
 #include <QJsonObject>
+#include <QElapsedTimer>
 
 #include "FactSystem.h"
 #include "MAVLinkProtocol.h"
@@ -196,6 +197,9 @@ private:
     QTimer _initialRequestTimeoutTimer;
     QTimer _waitingParamTimeoutTimer;
     
+    QElapsedTimer _intervalUpdateTimer;        ///< measures the time since refreshAllParameters() was called
+    static constexpr int _maxBatchSize = 10;   ///< maximum number of parameters retry requests at once
+
     QMutex _dataMutex;
     
     static Fact _defaultFact;   ///< Used to return default fact, when parameter not found


### PR DESCRIPTION
This dynamically sets the param load retry timeout based on the measured param receiving rate. The previous fixed timeout did not account for different link speeds, resulting in unnecessary high waiting times.

I tested with different HW (SITL, Pixracer, Pixhawk), different connections (UDP, USB, Pixracer WiFi), and various param drop scenarios (none, single, burst of 50, every second param).
Even with 50% drops, I still got an acceptable param load time.

Results: the timeout is large enough so that it never triggered too early. For a usb connection I got 60ms, for a pixracer via WiFi 200ms timer timeout.

@DonLakeFlyer The default timeout of 30s is incredibly high. I see that it has been recently changed due to some problems with APM (https://github.com/mavlink/qgroundcontrol/pull/4687). Maybe it needs different handling for APM vs PX4?

TODO:
- test using a telemetry link
- test with APM