### PR TITLE
ParameterManager: make sure there is progress even on connection loss

### DIFF
--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -543,10 +543,6 @@ void ParameterManager::_waitingParamTimeout(void)
         }
 
         foreach(int paramIndex, _waitingReadParamIndexMap[componentId].keys()) {            
-            if (++batchCount > _maxBatchSize) {
-                goto Out;
-            }
-
             _waitingReadParamIndexMap[componentId][paramIndex]++;   // Bump retry count
             if (_disableAllRetries || _waitingReadParamIndexMap[componentId][paramIndex] > _maxInitialLoadRetrySingleParam) {
                 // Give up on this index
@@ -558,6 +554,9 @@ void ParameterManager::_waitingParamTimeout(void)
                 paramsRequested = true;
                 _readParameterRaw(componentId, "", paramIndex);
                 qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "Read re-request for (paramIndex:" << paramIndex << "retryCount:" << _waitingReadParamIndexMap[componentId][paramIndex] << ")";
+                if (++batchCount > _maxBatchSize) {
+                    goto Out;
+                }
             }
         }
     }


### PR DESCRIPTION
What could happen before on connection loss:
- a full batch of params reached the retry limit
- goto Out; was executed, but actually no new params got requested
- retry timer did not get restarted

The result was no progress anymore.

There's still the problem that when we lose connection during param load, some params will time out, reach the maximum retry count and thus QGC will show the error that it could not retrieve all params.

What we could do is:
- stop the retry timer on connection loss
- on connection regain:
  - if (!_initialLoadComplete) { add all failedReadParamIndexMap to waitingReadParamIndexMap}
  - start the retry timer

This will not work when a connection stops, all retries fail (and qgc will already show the error), and only then a connection loss is triggered. Increasing the maximum number of retries would help with that.

@DonLakeFlyer @dogmaphobic does that sound reasonable? I don't want to make things more complicated than necessary.