### PR TITLE
Add battery capacity field

### DIFF
--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -289,7 +289,7 @@ SetupPage {
                         QGCLabel {
                             text:   (battNumCells.value * battLowVolt.value).toFixed(1) + ' V'
                         }
-/*
+
                         QGCLabel {
                             text: qsTr("Battery Capacity:")
                         }
@@ -300,7 +300,9 @@ SetupPage {
                             fact:       battCap
                             showUnits:  true
                         }
-*/
+
+                        Item { width: 1; height: 1; Layout.columnSpan: 3 }
+
                         QGCLabel {
                             text:               qsTr("Voltage divider")
                         }

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -38,6 +38,7 @@ SetupPage {
             property Fact battVoltageDivider:   controller.getParameterFact(-1, "BAT_V_DIV")
             property Fact battAmpsPerVolt:      controller.getParameterFact(-1, "BAT_A_PER_V")
             property Fact uavcanEnable:         controller.getParameterFact(-1, "UAVCAN_ENABLE", false)
+            property Fact battCap:              controller.getParameterFact(-1, "BAT_CAPACITY")
 
             readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
             readonly property string highlightSuffix:   "</font>"
@@ -288,7 +289,18 @@ SetupPage {
                         QGCLabel {
                             text:   (battNumCells.value * battLowVolt.value).toFixed(1) + ' V'
                         }
+/*
+                        QGCLabel {
+                            text: qsTr("Battery Capacity:")
+                        }
 
+                        FactTextField {
+                            id:         battCapField
+                            width:      textEditWidth
+                            fact:       battCap
+                            showUnits:  true
+                        }
+*/
                         QGCLabel {
                             text:               qsTr("Voltage divider")
                         }


### PR DESCRIPTION
From what I understand from here: https://pixhawk.org/users/battery_config
the battery capacity is important in order for the battery life estimation to function well. Since it is important it should appear in the battery configuration page and not just in the parameters page. This pull request adds a field to the "Power" page that allows the user to change the BAT_CAPACITY parameter