### PR TITLE
Fix settings clearing and plugin overrides

### DIFF
--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -35,10 +35,17 @@ SettingsFact::SettingsFact(QString settingGroup, FactMetaData* metaData, QObject
     _visible = qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(*metaData);
     setMetaData(metaData);
 
-    QVariant typedValue;
-    QString errorString;
-    metaData->convertAndValidateRaw(settings.value(_name, metaData->rawDefaultValue()), true /* conertOnly */, typedValue, errorString);
-    _rawValue = typedValue;
+    QVariant rawDefaultValue = metaData->rawDefaultValue();
+    if (_visible) {
+        QVariant typedValue;
+        QString errorString;
+        metaData->convertAndValidateRaw(settings.value(_name, rawDefaultValue), true /* conertOnly */, typedValue, errorString);
+        _rawValue = typedValue;
+    } else {
+        // Setting is not visible, force to default value always
+        settings.setValue(_name, rawDefaultValue);
+        _rawValue = rawDefaultValue;
+    }
 
     connect(this, &Fact::rawValueChanged, this, &SettingsFact::_rawValueChanged);
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -283,28 +283,27 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 
     if (fClearSettingsOptions) {
         // User requested settings to be cleared on command line
-
         settings.clear();
-        settings.setValue(_settingsVersionKey, QGC_SETTINGS_VERSION);
 
         // Clear parameter cache
         QDir paramDir(ParameterManager::parameterCacheDir());
         paramDir.removeRecursively();
         paramDir.mkpath(paramDir.absolutePath());
     } else {
-        // Determine if upgrade message for settings version bump is required. Check must happen before toolbox is started since
+        // Determine if upgrade message for settings version bump is required. Check and clear must happen before toolbox is started since
         // that will write some settings.
         if (settings.contains(_settingsVersionKey)) {
             if (settings.value(_settingsVersionKey).toInt() != QGC_SETTINGS_VERSION) {
+                settings.clear();
                 _settingsUpgraded = true;
             }
         } else if (settings.allKeys().count()) {
             // Settings version key is missing and there are settings. This is an upgrade scenario.
+            settings.clear();
             _settingsUpgraded = true;
-        } else {
-            settings.setValue(_settingsVersionKey, QGC_SETTINGS_VERSION);
         }
     }
+    settings.setValue(_settingsVersionKey, QGC_SETTINGS_VERSION);
 
     // Set up our logging filters
     QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(loggingOptions);
@@ -432,8 +431,6 @@ bool QGCApplication::_initForNormalAppBoot(void)
     toolbox()->joystickManager()->init();
 
     if (_settingsUpgraded) {
-        settings.clear();
-        settings.setValue(_settingsVersionKey, QGC_SETTINGS_VERSION);
         showMessage("The format for QGroundControl saved settings has been modified. "
                     "Your saved settings have been reset to defaults.");
     }


### PR DESCRIPTION
* Calls to QSettings.clear() were not in the right place
* New settings versions not alway written out
* Core plugin settings overrides which are hidden are now forced to always come from default value