### PR TITLE
New mechanism for better "touch-ability" of controls on mobile

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -85,6 +85,7 @@
         <file alias="QGroundControl/Controls/QGCMapLabel.qml">src/QmlControls/QGCMapLabel.qml</file>
         <file alias="QGroundControl/Controls/QGCMobileFileOpenDialog.qml">src/QmlControls/QGCMobileFileOpenDialog.qml</file>
         <file alias="QGroundControl/Controls/QGCMobileFileSaveDialog.qml">src/QmlControls/QGCMobileFileSaveDialog.qml</file>
+        <file alias="QGroundControl/Controls/QGCMouseArea.qml">src/QmlControls/QGCMouseArea.qml</file>
         <file alias="QGroundControl/Controls/QGCMovableItem.qml">src/QmlControls/QGCMovableItem.qml</file>
         <file alias="QGroundControl/Controls/QGCPipable.qml">src/QmlControls/QGCPipable.qml</file>
         <file alias="QGroundControl/Controls/QGCRadioButton.qml">src/QmlControls/QGCRadioButton.qml</file>

--- a/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
@@ -17,30 +17,31 @@ import QGroundControl.Controls      1.0
 /// Use the drag a MissionItemIndicator
 Rectangle {
     id:             itemDragger
-    x:              itemIndicator.x - _expandMargin
-    y:              itemIndicator.y - _expandMargin
-    width:          itemIndicator.width + (_expandMargin * 2)
-    height:         itemIndicator.height + (_expandMargin * 2)
+    x:              itemIndicator.x - _touchMarginHorizontal
+    y:              itemIndicator.y - _touchMarginVertical
+    width:          itemIndicator.width + (_touchMarginHorizontal * 2)
+    height:         itemIndicator.height + (_touchMarginVertical * 2)
     color:          "transparent"
     z:              QGroundControl.zOrderMapItems + 1    // Above item icons
-
-    // These are handy for debugging so left in for now
-    //border.width:   1
-    //border.color:   "white"
 
     // Properties which must be specific by consumer
     property var itemIndicator  ///< The mission item indicator to drag around
     property var itemCoordinate ///< Coordinate we are updating during drag
 
     property bool   _preventCoordinateBindingLoop:  false
-    property real   _expandMargin:                  ScreenTools.isMobile ? ScreenTools.defaultFontPixelWidth : 0
+
+    property bool _mobile:                  true//ScreenTools.isMobile
+    property real _touchWidth:              Math.max(itemIndicator.width, ScreenTools.minTouchPixels)
+    property real _touchHeight:             Math.max(itemIndicator.height, ScreenTools.minTouchPixels)
+    property real _touchMarginHorizontal:   _mobile ? (_touchWidth - itemIndicator.width) / 2 : 0
+    property real _touchMarginVertical:     _mobile ? (_touchHeight - itemIndicator.height) / 2 : 0
 
     onXChanged: liveDrag()
     onYChanged: liveDrag()
 
     function liveDrag() {
         if (!itemDragger._preventCoordinateBindingLoop && Drag.active) {
-            var point = Qt.point(itemDragger.x + _expandMargin + itemIndicator.anchorPoint.x, itemDragger.y + _expandMargin + itemIndicator.anchorPoint.y)
+            var point = Qt.point(itemDragger.x + _touchMarginHorizontal + itemIndicator.anchorPoint.x, itemDragger.y + _touchMarginVertical + itemIndicator.anchorPoint.y)
             var coordinate = map.toCoordinate(point)
             itemDragger._preventCoordinateBindingLoop = true
             coordinate.altitude = itemCoordinate.altitude
@@ -51,13 +52,14 @@ Rectangle {
 
     Drag.active: itemDrag.drag.active
 
-    MouseArea {
-        id:             itemDrag
-        anchors.fill:   parent
-        drag.target:    parent
-        drag.minimumX:  0
-        drag.minimumY:  0
-        drag.maximumX:  itemDragger.parent.width - parent.width
-        drag.maximumY:  itemDragger.parent.height - parent.height
+    QGCMouseArea {
+        id:                 itemDrag
+        anchors.fill:       parent
+        drag.target:        parent
+        drag.minimumX:      0
+        drag.minimumY:      0
+        drag.maximumX:      itemDragger.parent.width - parent.width
+        drag.maximumY:      itemDragger.parent.height - parent.height
+        preventStealing:    true
     }
 }

--- a/src/MissionEditor/MissionItemEditor.qml
+++ b/src/MissionEditor/MissionItemEditor.qml
@@ -68,15 +68,21 @@ Rectangle {
 
     }
 
-    MouseArea {
+    QGCMouseArea {
         // The MouseArea for the hamburger is larger than the hamburger image itself in order to provide a larger
         // touch area on mobile
-        anchors.top:        parent.top
-        anchors.bottom:     editorLoader.top
-        anchors.leftMargin: -hamburger.anchors.rightMargin
-        anchors.left:       hamburger.left
-        anchors.right:      parent.right
-        onClicked:          hamburgerMenu.popup()
+        anchors.leftMargin:     -_touchMarginHorizontal
+        anchors.rightMargin:    -_touchMarginHorizontal
+        anchors.topMargin:      -_touchMarginVertical
+        anchors.bottomMargin:   -_touchMarginVertical
+        anchors.fill:           hamburger
+        visible:                hamburger.visible
+        onClicked:              hamburgerMenu.popup()
+
+        property real _touchWidth:              Math.max(hamburger.width, ScreenTools.minTouchPixels)
+        property real _touchHeight:             Math.max(hamburger.height, ScreenTools.minTouchPixels)
+        property real _touchMarginHorizontal:   ScreenTools.isMobile ? (_touchWidth - hamburger.width) / 2 : 0
+        property real _touchMarginVertical:     ScreenTools.isMobile ? (_touchHeight - hamburger.height) / 2 : 0
 
         Menu {
             id: hamburgerMenu

--- a/src/QmlControls/QGCMouseArea.qml
+++ b/src/QmlControls/QGCMouseArea.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.3
+
+import QGroundControl 1.0
+
+MouseArea {
+    Rectangle {
+        anchors.fill:   parent
+        border.color:   "red"
+        border.width:   QGroundControl.showTouchAreas ? 1 : 0
+        color:          "transparent"
+    }
+}

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -37,6 +37,7 @@ QGCListView             1.0 QGCListView.qml
 QGCMapLabel             1.0 QGCMapLabel.qml
 QGCMobileFileOpenDialog 1.0 QGCMobileFileOpenDialog.qml
 QGCMobileFileSaveDialog 1.0 QGCMobileFileSaveDialog.qml
+QGCMouseArea            1.0 QGCMouseArea.qml
 QGCMovableItem          1.0 QGCMovableItem.qml
 QGCPipable              1.0 QGCPipable.qml
 QGCRadioButton          1.0 QGCRadioButton.qml

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -32,6 +32,8 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
     , _corePlugin(NULL)
     , _firmwarePluginManager(NULL)
     , _settingsManager(NULL)
+    , _showTouchAreas(false)
+    , _showAdvancedUI(false)
 {
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
     setParent(NULL);

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -73,6 +73,9 @@ public:
 
     Q_PROPERTY(QString qgcVersion READ qgcVersion CONSTANT)
 
+    Q_PROPERTY(bool showTouchAreas MEMBER _showTouchAreas NOTIFY showTouchAreasChanged)
+    Q_PROPERTY(bool showAdvancedUI MEMBER _showAdvancedUI NOTIFY showAdvancedUIChanged)
+
     Q_INVOKABLE void    saveGlobalSetting       (const QString& key, const QString& value);
     Q_INVOKABLE QString loadGlobalSetting       (const QString& key, const QString& defaultValue);
     Q_INVOKABLE void    saveBoolGlobalSetting   (const QString& key, bool value);
@@ -153,6 +156,9 @@ public:
 
     QString qgcVersion(void) const { return qgcApp()->applicationVersion(); }
 
+    bool showTouchAreas(void) const { return _showTouchAreas; } ///< Show visible extents of touch areas
+    bool showAdvancedUI(void) const { return _showAdvancedUI; } ///< Show hidden advanced UI
+
     // Overrides from QGCTool
     virtual void setToolbox(QGCToolbox* toolbox);
 
@@ -162,6 +168,8 @@ signals:
     void mavlinkSystemIDChanged         (int id);
     void flightMapPositionChanged       (QGeoCoordinate flightMapPosition);
     void flightMapZoomChanged           (double flightMapZoom);
+    void showTouchAreasChanged          (bool showTouchAreas);
+    void showAdvancedUIChanged          (bool showAdvancedUI);
 
 private:
     FlightMapSettings*      _flightMapSettings;
@@ -178,6 +186,9 @@ private:
 
     QGeoCoordinate          _flightMapPosition;
     double                  _flightMapZoom;
+
+    bool                    _showTouchAreas;
+    bool                    _showAdvancedUI;
 };
 
 #endif

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -60,6 +60,9 @@ Item {
     property bool isTinyScreen:     (Screen.width / Screen.pixelDensity) < 120 // 120mm
     property bool isShortScreen:    ScreenToolsController.isMobile && ((Screen.height / Screen.width) < 0.6) // Nexus 7 for example
 
+    readonly property real minTouchMillimeters: 10      ///< Minimum touch size in millimeters
+    property real minTouchPixels:               0       ///< Minimum touch size in pixels
+
     // The implicit heights/widths for our custom control set
     property real implicitButtonWidth:      Math.round(defaultFontPixelWidth *  (isMobile ? 7.0 : 5.0))
     property real implicitButtonHeight:     Math.round(defaultFontPixelHeight * (isMobile ? 2.0 : 1.6))
@@ -101,7 +104,8 @@ Item {
         smallFontPointSize      = defaultFontPointSize  * _screenTools.smallFontPointRatio
         mediumFontPointSize     = defaultFontPointSize  * _screenTools.mediumFontPointRatio
         largeFontPointSize      = defaultFontPointSize  * _screenTools.largeFontPointRatio
-        toolbarHeight           = defaultFontPixelHeight * 3 * QGroundControl.corePlugin.options.toolbarHeightMultiplier
+        minTouchPixels          = Math.round(minTouchMillimeters * Screen.pixelDensity)
+        toolbarHeight           = isMobile ? minTouchPixels : defaultFontPixelHeight * 3
     }
 
     Text {

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -16,7 +16,7 @@ import QGroundControl.Palette       1.0
 Rectangle {
     id:         _root
     color:      qgcPal.window
-    width:      ScreenTools.defaultFontPixelWidth * 6
+    width:      ScreenTools.isMobile ? ScreenTools.minTouchPixels : ScreenTools.defaultFontPixelWidth * 6
     height:     buttonStripColumn.height + (buttonStripColumn.anchors.margins * 2)
     radius:     _radius
 
@@ -172,10 +172,10 @@ Rectangle {
 
                     }
 
-                    MouseArea {
+                    QGCMouseArea {
                         // Size of mouse area is expanded to make touch easier
-                        anchors.leftMargin:     buttonStripColumn.margins
-                        anchors.rightMargin:    buttonStripColumn.margins
+                        anchors.leftMargin:     -buttonStripColumn.anchors.margins
+                        anchors.rightMargin:    -buttonStripColumn.anchors.margins
                         anchors.left:           parent.left
                         anchors.right:          parent.right
                         anchors.top:            parent.top

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -67,6 +67,28 @@ Rectangle {
         flyButton.checked = true
     }
 
+    // Easter egg mechanism
+    MouseArea {
+        anchors.fill: parent
+        onClicked: {
+            console.log("easter egg click", ++_clickCount)
+            eggTimer.restart()
+            if (_clickCount == 5) {
+                QGroundControl.showAdvancedUI = true
+            } else if (_clickCount == 7) {
+                QGroundControl.showTouchAreas = true
+            }
+        }
+
+        property int _clickCount: 0
+
+        Timer {
+            id:             eggTimer
+            interval:       1000
+            onTriggered:    parent._clickCount = 0
+        }
+    }
+
     /// Bottom single pixel divider
     Rectangle {
         anchors.left:   parent.left


### PR DESCRIPTION
To Recap: The QGC UI is almost completely based on using ratios of default font pixel width/height for sizing and positioning. This all works fine on desktop builds where you are using a mouse to click on things. The problem is on mobile touch screen all you have is your finger. Which is way less accurate and requires larger touch areas to be usable. The touch areas which work on desktop don't work on mobile.

Before these changes:
* The font sizing on mobile devices was bumped up such that the whole UI got larger which in turn provided larger touch areas.
* The QGC set of controls adjust their sizing to be larger on mobile to provide larger touch areas.
* Things like drag areas were also increased in size when running on mobile to improve touch areas.

All of the above sort of works but in reality it works poorly. Which I'm sure anyone spending a lot of time with a tablet builds can attest to.

The new user model:
* Depending on what the user is doing sometimes they need really easy targets to touch and sometimes it's ok for the targets to require a little more precise touching. 
* The decision point between those two states is related to whether the user is interacting with UI which is meant to be used while flying. When you are flying you don't want to spend a lot of time trying to find the right place to click. For these things you want larger targets for touch.
* Whereas for example when you are planning a mission you can focus more on the task at hand as far as looking at the screen and touching things. For these things you can get away with slightly smaller touch areas (within reason).
* There a couple cases which break this rule somewhat:
  * Dragging things on the screen. Since when you drag something the touch area you have to start the drag with is in essence invisible you want it to be large enough to touch without missing.
  * Custom controls whose visuals are small. An example of this is the hamburger on mission item editors. In this case you want to expand that touch area on mobile.
* Using minTouchPixels for sizing should be used appropriately using the model above. In general most sizing should still be done using font ratios. If you are not sure, ask.

You may ask why not just expand touch areas to large sizes everywhere. The reason is that there are certain actitivies withing QGC which require quite of a bit information entry. Planning a missing is a great example of this. If you blew up sizing of touch areas for entering values for planning mission there would be no room left on the screen to see anything.

In order to do this I've created the following new things:
* ScreenTools.minTouchPixels - This represent the minimum rectangular region size for cases where you want the largest possible touch area. The default for this is the the number of pixels it takes for a 10mm square.
* QGCMouseArea - This is exactly the same as MouseArea except it has a secret mode hidden behind and easter egg. If you turn on that mode that extents of the tough area will be shown on the screen.
* Toolbar Easter Egg - If you click quickly multiple times in the blank space of the tool bar you can turn on various easter egg functionality. 5 clicks will turn on advanced ui for core plugins. 7 clicks will turn on visible touch areas extents.

If you look at the pull you see that I've modified the following more problematic places to use these new mechanisms rules:
* ToolStrip uses minTouchPixel and QGCMouseArea for sizing
* Mission Item Editor hamburger uses minTouchPixels/QGCMouseArea for sizing
* Waypoint drag area using minTouchPixels/QGCMouseArea for better touch dragging

This is just the beginning of using this new mechanism. There are a number of additional places which need conversion which will be coming soon.