### PR TITLE
Fixed wing landing pattern fixes

### DIFF
--- a/src/MissionEditor/FWLandingPatternMapVisual.qml
+++ b/src/MissionEditor/FWLandingPatternMapVisual.qml
@@ -219,7 +219,7 @@ Item {
         MapCircle {
             z:              QGroundControl.zOrderMapItems
             center:         _missionItem.loiterCoordinate
-            radius:         _missionItem.loiterRadius.value
+            radius:         _missionItem.loiterRadius.rawValue
             border.width:   2
             border.color:   "green"
             color:          "transparent"

--- a/src/MissionManager/FWLandingPattern.FactMetaData.json
+++ b/src/MissionManager/FWLandingPattern.FactMetaData.json
@@ -4,6 +4,7 @@
     "shortDescription": "Distance between landing and loiter points.",
     "type":             "double",
     "units":            "m",
+    "min":              10,
     "decimalPlaces":    1,
     "defaultValue":     300.0
 },
@@ -30,7 +31,7 @@
     "shortDescription": "Loiter radius.",
     "type":             "double",
     "decimalPlaces":    1,
-    "min":              0.1,
+    "min":              1,
     "units":            "m",
     "defaultValue":     75.0
 },

--- a/src/MissionManager/FixedWingLandingComplexItem.h
+++ b/src/MissionManager/FixedWingLandingComplexItem.h
@@ -101,6 +101,7 @@ private slots:
     void _updateLandingCoodinateAltitudeFromFact(void);
     double _mathematicAngleToHeading(double angle);
     double _headingToMathematicAngle(double heading);
+    void _setDirty(void);
 
 private:
     QPointF _rotatePoint(const QPointF& point, const QPointF& origin, double angle);


### PR DESCRIPTION
* Fix degenerate case wher landing point is inside loiter radius. Tangent moves to loiter coordinate.
* Correct setting of dirty bit (#4768)
* Loiter radius visualization using wrong value (would use feet incorrectly)