### PR TITLE
Core/Firmware plugin work

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.qml
@@ -7,18 +7,18 @@
  *
  ****************************************************************************/
 
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
+import QtQuick.Controls.Styles  1.4
+import QtQuick.Dialogs          1.2
 
-import QtQuick 2.3
-import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.4
-import QtQuick.Dialogs 1.2
-
-import QGroundControl.FactSystem 1.0
-import QGroundControl.FactControls 1.0
-import QGroundControl.Palette 1.0
-import QGroundControl.Controls 1.0
-import QGroundControl.ScreenTools 1.0
-import QGroundControl.Controllers 1.0
+import QGroundControl               1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Controllers   1.0
 
 SetupPage {
     id:             sensorsPage
@@ -336,6 +336,7 @@ SetupPage {
                     width:          parent.buttonWidth
                     text:           qsTr("Compass")
                     indicatorGreen: cal_mag0_id.value != 0
+                    visible:        QGroundControl.corePlugin.options.showSensorCalibrationCompass
 
                     onClicked: {
                         preCalibrationDialogType = "compass"
@@ -349,6 +350,7 @@ SetupPage {
                     width:          parent.buttonWidth
                     text:           qsTr("Gyroscope")
                     indicatorGreen: cal_gyro0_id.value != 0
+                    visible:        QGroundControl.corePlugin.options.showSensorCalibrationGyro
 
                     onClicked: {
                         preCalibrationDialogType = "gyro"
@@ -362,6 +364,7 @@ SetupPage {
                     width:          parent.buttonWidth
                     text:           qsTr("Accelerometer")
                     indicatorGreen: cal_acc0_id.value != 0
+                    visible:        QGroundControl.corePlugin.options.showSensorCalibrationAccel
 
                     onClicked: {
                         preCalibrationDialogType = "accel"
@@ -376,6 +379,7 @@ SetupPage {
                     text:           qsTr("Level Horizon")
                     indicatorGreen: sens_board_x_off.value != 0 || sens_board_y_off != 0 | sens_board_z_off != 0
                     enabled:        cal_acc0_id.value != 0 && cal_gyro0_id.value != 0
+                    visible:        QGroundControl.corePlugin.options.showSensorCalibrationLevel
 
                     onClicked: {
                         preCalibrationDialogType = "level"
@@ -388,7 +392,7 @@ SetupPage {
                     id:             airspeedButton
                     width:          parent.buttonWidth
                     text:           qsTr("Airspeed")
-                    visible:        (controller.vehicle.fixedWing || controller.vehicle.vtol) && controller.getParameterFact(-1, "CBRK_AIRSPD_CHK").value != 162128
+                    visible:        (controller.vehicle.fixedWing || controller.vehicle.vtol) && controller.getParameterFact(-1, "CBRK_AIRSPD_CHK").value != 162128 && QGroundControl.corePlugin.options.showSensorCalibrationAirspeed
                     indicatorGreen: sens_dpres_off.value != 0
 
                     onClicked: {
@@ -410,6 +414,8 @@ SetupPage {
                     id:         setOrientationsButton
                     width:      parent.buttonWidth
                     text:       qsTr("Set Orientations")
+                    visible:    QGroundControl.corePlugin.options.showSensorCalibrationOrient
+
                     onClicked:  {
                         setOrientationsDialogShowBoardOrientation = true
                         showDialog(setOrientationsDialogComponent, qsTr("Set Orientations"), sensorsPage.showDialogDefaultWidth, StandardButton.Ok)

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -95,7 +95,8 @@ public:
     QObject*            loadParameterMetaData           (const QString& metaDataFile);
     GeoFenceManager*    newGeoFenceManager              (Vehicle* vehicle) { return new APMGeoFenceManager(vehicle); }
     RallyPointManager*  newRallyPointManager            (Vehicle* vehicle) { return new APMRallyPointManager(vehicle); }
-    QString             brandImage                      (const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImage"); }
+    QString             brandImageIndoor                (const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImage"); }
+    QString             brandImageOutdoor               (const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImage"); }
     QString             missionFlightMode               (void) final;
     QString             rtlFlightMode                   (void) final;
 

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -83,7 +83,8 @@ public:
 
     bool supportsMotorInterference(void);
 
-    QString brandImage(const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImageSub"); }
+    QString brandImageIndoor(const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImageSub"); }
+    QString brandImageOutdoor(const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImageSub"); }
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     int remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const final;
     const QVariantList& toolBarIndicators(const Vehicle* vehicle) final;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -245,8 +245,11 @@ public:
     /// Return the resource file which contains the set of params loaded for offline editing.
     virtual QString offlineEditingParamFile(Vehicle* vehicle) { Q_UNUSED(vehicle); return QString(); }
 
-    /// Return the resource file which contains the brand image for the vehicle.
-    virtual QString brandImage(const Vehicle* vehicle) const { Q_UNUSED(vehicle) return QString(); }
+    /// Return the resource file which contains the brand image for the vehicle for Indoor theme.
+    virtual QString brandImageIndoor(const Vehicle* vehicle) const { Q_UNUSED(vehicle) return QString(); }
+
+    /// Return the resource file which contains the brand image for the vehicle for Outdoor theme.
+    virtual QString brandImageOutdoor(const Vehicle* vehicle) const { Q_UNUSED(vehicle) return QString(); }
 
     /// Return the resource file which contains the vehicle icon used in the flight view when the view is dark (Satellite for instance)
     virtual QString vehicleImageOpaque(const Vehicle* vehicle) const;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -58,7 +58,8 @@ public:
     bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) override;
     GeoFenceManager*    newGeoFenceManager              (Vehicle* vehicle) override { return new PX4GeoFenceManager(vehicle); }
     QString             offlineEditingParamFile(Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral(":/FirmwarePlugin/PX4/PX4.OfflineEditing.params"); }
-    QString             brandImage                      (const Vehicle* vehicle) const override { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/PX4/BrandImage"); }
+    QString             brandImageIndoor                (const Vehicle* vehicle) const override { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/PX4/BrandImage"); }
+    QString             brandImageOutdoor               (const Vehicle* vehicle) const override { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/PX4/BrandImage"); }
     QString             missionFlightMode               (void) override;
     QString             rtlFlightMode                   (void) override;
     QString             takeControlFlightMode           (void) override;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2192,9 +2192,14 @@ void Vehicle::_newGeoFenceAvailable(void)
     }
 }
 
-QString Vehicle::brandImage(void) const
+QString Vehicle::brandImageIndoor(void) const
 {
-    return _firmwarePlugin->brandImage(this);
+    return _firmwarePlugin->brandImageIndoor(this);
+}
+
+QString Vehicle::brandImageOutdoor(void) const
+{
+    return _firmwarePlugin->brandImageOutdoor(this);
 }
 
 QStringList Vehicle::unhealthySensors(void) const

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -290,7 +290,8 @@ public:
     Q_PROPERTY(bool                 coaxialMotors           READ coaxialMotors                                          CONSTANT)
     Q_PROPERTY(bool                 xConfigMotors           READ xConfigMotors                                          CONSTANT)
     Q_PROPERTY(bool                 isOfflineEditingVehicle READ isOfflineEditingVehicle                                CONSTANT)
-    Q_PROPERTY(QString              brandImage              READ brandImage                                             NOTIFY firmwareTypeChanged)
+    Q_PROPERTY(QString              brandImageIndoor        READ brandImageIndoor                                       NOTIFY firmwareTypeChanged)
+    Q_PROPERTY(QString              brandImageOutdoor       READ brandImageOutdoor                                      NOTIFY firmwareTypeChanged)
     Q_PROPERTY(QStringList          unhealthySensors        READ unhealthySensors                                       NOTIFY unhealthySensorsChanged)
     Q_PROPERTY(QString              missionFlightMode       READ missionFlightMode                                      CONSTANT)
     Q_PROPERTY(QString              rtlFlightMode           READ rtlFlightMode                                          CONSTANT)
@@ -567,7 +568,8 @@ public:
     uint8_t         baseMode                () const { return _base_mode; }
     uint32_t        customMode              () const { return _custom_mode; }
     bool            isOfflineEditingVehicle () const { return _offlineEditingVehicle; }
-    QString         brandImage              () const;
+    QString         brandImageIndoor        () const;
+    QString         brandImageOutdoor       () const;
     QStringList     unhealthySensors        () const;
     QString         missionFlightMode       () const;
     QString         rtlFlightMode           () const;

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -37,8 +37,11 @@ public:
     Q_PROPERTY(int          defaultSettings     READ defaultSettings    CONSTANT)
     Q_PROPERTY(QGCOptions*  options             READ options            CONSTANT)
 
-    Q_PROPERTY(bool         showTouchAreas      MEMBER _showTouchAreas NOTIFY showTouchAreasChanged)
-    Q_PROPERTY(bool         showAdvancedUI      MEMBER _showAdvancedUI NOTIFY showAdvancedUIChanged)
+    Q_PROPERTY(bool         showTouchAreas      MEMBER _showTouchAreas  NOTIFY showTouchAreasChanged)
+    Q_PROPERTY(bool         showAdvancedUI      MEMBER _showAdvancedUI  NOTIFY showAdvancedUIChanged)
+
+    Q_PROPERTY(QString      brandImageIndoor    READ brandImageIndoor   CONSTANT)
+    Q_PROPERTY(QString      brandImageOutdoor   READ brandImageIndoor   CONSTANT)
 
     /// The list of settings under the Settings Menu
     /// @return A list of QGCSettings
@@ -61,6 +64,12 @@ public:
     ///     @param metaData - MetaData for setting fact
     /// @return true: Setting should be visible in ui, false: Setting should not be shown in ui
     virtual bool adjustSettingMetaData                  (FactMetaData& metaData);
+
+    /// Return the resource file which contains the brand image for for Indoor theme.
+    virtual QString brandImageIndoor(void) const { return QString(); }
+
+    /// Return the resource file which contains the brand image for for Outdoor theme.
+    virtual QString brandImageOutdoor(void) const { return QString(); }
 
     // Override from QGCTool
     void                            setToolbox          (QGCToolbox *toolbox);

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -24,11 +24,16 @@ class QGCOptions : public QObject
 public:
     QGCOptions(QObject* parent = NULL);
 
-    Q_PROPERTY(bool     combineSettingsAndSetup     READ combineSettingsAndSetup    CONSTANT)
-    Q_PROPERTY(double   toolbarHeightMultiplier     READ toolbarHeightMultiplier    CONSTANT)
-    Q_PROPERTY(bool     enablePlanViewSelector      READ enablePlanViewSelector     CONSTANT)
-    Q_PROPERTY(CustomInstrumentWidget*  instrumentWidget READ instrumentWidget      CONSTANT)
-
+    Q_PROPERTY(bool                     combineSettingsAndSetup         READ combineSettingsAndSetup        CONSTANT)
+    Q_PROPERTY(double                   toolbarHeightMultiplier         READ toolbarHeightMultiplier        CONSTANT)
+    Q_PROPERTY(bool                     enablePlanViewSelector          READ enablePlanViewSelector         CONSTANT)
+    Q_PROPERTY(CustomInstrumentWidget*  instrumentWidget                READ instrumentWidget               CONSTANT)
+    Q_PROPERTY(bool                     showSensorCalibrationCompass    READ showSensorCalibrationCompass   NOTIFY showSensorCalibrationCompassChanged)
+    Q_PROPERTY(bool                     showSensorCalibrationGyro       READ showSensorCalibrationGyro      NOTIFY showSensorCalibrationGyroChanged)
+    Q_PROPERTY(bool                     showSensorCalibrationAccel      READ showSensorCalibrationAccel     NOTIFY showSensorCalibrationAccelChanged)
+    Q_PROPERTY(bool                     showSensorCalibrationLevel      READ showSensorCalibrationLevel     NOTIFY showSensorCalibrationLevelChanged)
+    Q_PROPERTY(bool                     showSensorCalibrationAirspeed   READ showSensorCalibrationAirspeed  NOTIFY showSensorCalibrationAirspeedChanged)
+    Q_PROPERTY(bool                     showSensorCalibrationOrient     READ showSensorCalibrationOrient    NOTIFY showSensorCalibrationOrientChanged)
 
     /// Should QGC hide its settings menu and colapse it into one single menu (Settings and Vehicle Setup)?
     /// @return true if QGC should consolidate both menus into one.
@@ -45,6 +50,22 @@ public:
     /// Provides an alternate instrument widget for the Fly View
     /// @return An alternate widget (see QGCInstrumentWidget.qml, the default widget)
     virtual CustomInstrumentWidget* instrumentWidget();
+
+    /// By returning false you can hide the following sensor calibration pages
+    bool showSensorCalibrationCompass   () const { return true; }
+    bool showSensorCalibrationGyro      () const { return true; }
+    bool showSensorCalibrationAccel     () const { return true; }
+    bool showSensorCalibrationLevel     () const { return true; }
+    bool showSensorCalibrationAirspeed  () const { return true; }
+    bool showSensorCalibrationOrient    () const { return true; }
+
+signals:
+    void showSensorCalibrationCompassChanged    (bool show);
+    void showSensorCalibrationGyroChanged       (bool show);
+    void showSensorCalibrationAccelChanged      (bool show);
+    void showSensorCalibrationLevelChanged      (bool show);
+    void showSensorCalibrationAirspeedChanged   (bool show);
+    void showSensorCalibrationOrientChanged     (bool show);
 
 private:
     CustomInstrumentWidget* _defaultInstrumentWidget;

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -230,17 +230,6 @@ Rectangle {
             anchors.top:        parent.top
             anchors.bottom:     parent.bottom
             Layout.fillWidth:   true
-            visible:            _activeVehicle
-        }
-
-        QGCLabel {
-            id:                     waitForVehicle
-            anchors.verticalCenter: parent.verticalCenter
-            text:                   qsTr("Waiting For Vehicle Connection")
-            font.pointSize:         ScreenTools.mediumFontPointSize
-            font.family:            ScreenTools.demiboldFontFamily
-            color:                  colorRed
-            visible:                !_activeVehicle
         }
     }
 

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -19,19 +19,31 @@ import QGroundControl.ScreenTools           1.0
 import QGroundControl.Palette               1.0
 
 Item {
-    property var  activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
-    property bool communicationLost:    activeVehicle ? activeVehicle.connectionLost : false
+    property var  _activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
+    property bool _communicationLost:    _activeVehicle ? _activeVehicle.connectionLost : false
 
     QGCPalette { id: qgcPal }
+
+
+    QGCLabel {
+        id:                     waitForVehicle
+        anchors.verticalCenter: parent.verticalCenter
+        text:                   qsTr("Waiting For Vehicle Connection")
+        font.pointSize:         ScreenTools.mediumFontPointSize
+        font.family:            ScreenTools.demiboldFontFamily
+        color:                  colorRed
+        visible:                !_activeVehicle
+    }
 
     Row {
         id:             indicatorRow
         anchors.top:    parent.top
         anchors.bottom: parent.bottom
         spacing:        ScreenTools.defaultFontPixelWidth * 1.5
-        visible:        !communicationLost
+        visible:        _activeVehicle && !_communicationLost
+
         Repeater {
-            model:      activeVehicle ? activeVehicle.toolBarIndicators : []
+            model:      _activeVehicle ? _activeVehicle.toolBarIndicators : []
             Loader {
                 anchors.top:    parent.top
                 anchors.bottom: parent.bottom
@@ -44,23 +56,28 @@ Item {
         anchors.right:          parent.right
         anchors.top:            parent.top
         anchors.bottom:         parent.bottom
-        visible:                x > indicatorRow.width && !communicationLost
+        visible:                x > indicatorRow.width && !_communicationLost
         fillMode:               Image.PreserveAspectFit
-        source:                 activeVehicle ? activeVehicle.brandImage : ""
+        source:                 _outdoorPalette ? _brandImageOutdoor : _brandImageIndoor
+
+        property bool   _outdoorPalette:        qgcPal.globalTheme === QGCPalette.Light
+        property bool   _corePluginBranding:    QGroundControl.corePlugin.brandImageIndoor.length != 0
+        property string _brandImageIndoor:      _corePluginBranding ? QGroundControl.corePlugin.brandImageIndoor : (_activeVehicle ? _activeVehicle.brandImageIndoor : "")
+        property string _brandImageOutdoor:     _corePluginBranding ? QGroundControl.corePlugin.brandImageOutdoor : (_activeVehicle ? _activeVehicle.brandImageOutdoor : "")
     }
 
     Row {
         anchors.fill:       parent
         layoutDirection:    Qt.RightToLeft
         spacing:            ScreenTools.defaultFontPixelWidth
-        visible:            communicationLost
+        visible:            _communicationLost
 
         QGCButton {
             id:                     disconnectButton
             anchors.verticalCenter: parent.verticalCenter
             text:                   qsTr("Disconnect")
             primary:                true
-            onClicked:              activeVehicle.disconnectInactiveVehicle()
+            onClicked:              _activeVehicle.disconnectInactiveVehicle()
         }
 
         QGCLabel {


### PR DESCRIPTION
* FirmwarePlugin can now specify indoor and outdoor themed brand images
* QGCCorePlugin can specify which Sensors calibration pages to show/hide
* QGCCorePlugin can specify brand images which show up all the time (not just when vehicle connected)