### PR TITLE
Allowing to skip going to the Summary page.

### DIFF
--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -32,6 +32,7 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app)
     , _corePlugin(NULL)
     , _firmwarePluginManager(NULL)
     , _settingsManager(NULL)
+    , _skipSetupPage(false)
 {
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
     setParent(NULL);
@@ -172,4 +173,12 @@ bool QGroundControlQmlGlobal::linesIntersect(QPointF line1A, QPointF line1B, QPo
 
     return QLineF(line1A, line1B).intersect(QLineF(line2A, line2B), &intersectPoint) == QLineF::BoundedIntersection &&
             intersectPoint != line1A && intersectPoint != line1B;
+}
+
+void QGroundControlQmlGlobal::setSkipSetupPage(bool skip)
+{
+    if(_skipSetupPage != skip) {
+        _skipSetupPage = skip;
+        emit skipSetupPageChanged();
+    }
 }

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -48,7 +48,7 @@ public:
     Q_PROPERTY(QGCCorePlugin*       corePlugin          READ corePlugin             CONSTANT)
     Q_PROPERTY(SettingsManager*     settingsManager     READ settingsManager        CONSTANT)
 
-    Q_PROPERTY(int      supportedFirmwareCount          READ supportedFirmwareCount             CONSTANT)
+    Q_PROPERTY(int      supportedFirmwareCount          READ supportedFirmwareCount CONSTANT)
 
     Q_PROPERTY(qreal                zOrderTopMost       READ zOrderTopMost          CONSTANT) ///< z order for top most items, toolbar, main window sub view
     Q_PROPERTY(qreal                zOrderWidgets       READ zOrderWidgets          CONSTANT) ///< z order value to widgets, for example: zoom controls, hud widgetss
@@ -71,7 +71,8 @@ public:
     Q_PROPERTY(QString appSettingsDistanceUnitsString READ appSettingsDistanceUnitsString CONSTANT)
     Q_PROPERTY(QString appSettingsAreaUnitsString READ appSettingsAreaUnitsString CONSTANT)
 
-    Q_PROPERTY(QString qgcVersion READ qgcVersion CONSTANT)
+    Q_PROPERTY(QString qgcVersion       READ qgcVersion         CONSTANT)
+    Q_PROPERTY(bool    skipSetupPage    READ skipSetupPage      WRITE setSkipSetupPage NOTIFY skipSetupPageChanged)
 
     Q_INVOKABLE void    saveGlobalSetting       (const QString& key, const QString& value);
     Q_INVOKABLE QString loadGlobalSetting       (const QString& key, const QString& defaultValue);
@@ -142,7 +143,9 @@ public:
 
     QGeoCoordinate lastKnownHomePosition() { return qgcApp()->lastKnownHomePosition(); }
 
-    int     supportedFirmwareCount      ();
+    int     supportedFirmwareCount  ();
+    bool    skipSetupPage           () { return _skipSetupPage; }
+    void    setSkipSetupPage        (bool skip);
 
     void    setIsVersionCheckEnabled    (bool enable);
     void    setMavlinkSystemID          (int  id);
@@ -153,6 +156,7 @@ public:
 
     QString qgcVersion(void) const { return qgcApp()->applicationVersion(); }
 
+
     // Overrides from QGCTool
     virtual void setToolbox(QGCToolbox* toolbox);
 
@@ -162,6 +166,7 @@ signals:
     void mavlinkSystemIDChanged         (int id);
     void flightMapPositionChanged       (QGeoCoordinate flightMapPosition);
     void flightMapZoomChanged           (double flightMapZoom);
+    void skipSetupPageChanged           ();
 
 private:
     FlightMapSettings*      _flightMapSettings;
@@ -178,6 +183,7 @@ private:
 
     QGeoCoordinate          _flightMapPosition;
     double                  _flightMapZoom;
+    bool                    _skipSetupPage;
 };
 
 #endif

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -114,13 +114,15 @@ Rectangle {
         target: QGroundControl.multiVehicleManager
 
         onParameterReadyVehicleAvailableChanged: {
-            if (parameterReadyVehicleAvailable || summaryButton.checked || setupButtonGroup.current != firmwareButton) {
-                // Show/Reload the Summary panel when:
-                //      A new vehicle shows up
-                //      The summary panel is already showing and the active vehicle goes away
-                //      The active vehicle goes away and we are not on the Firmware panel.
-                summaryButton.checked = true
-                showSummaryPanel()
+            if(!QGroundControl.skipSetupPage) {
+                if (parameterReadyVehicleAvailable || summaryButton.checked || setupButtonGroup.current != firmwareButton) {
+                    // Show/Reload the Summary panel when:
+                    //      A new vehicle shows up
+                    //      The summary panel is already showing and the active vehicle goes away
+                    //      The active vehicle goes away and we are not on the Firmware panel.
+                    summaryButton.checked = true
+                    showSummaryPanel()
+                }
             }
         }
     }


### PR DESCRIPTION
If another panel is controlling vehicle connection/disconnection, we need a way to skip the panel from switching away from underneath you.