### PR TITLE
Core plugin changes

### DIFF
--- a/src/AutoPilotPlugins/AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.h
@@ -38,8 +38,8 @@ public:
     AutoPilotPlugin(Vehicle* vehicle, QObject* parent);
     ~AutoPilotPlugin();
 
-    Q_PROPERTY(QVariantList vehicleComponents   READ vehicleComponents  CONSTANT)                       ///< List of VehicleComponent objects
-    Q_PROPERTY(bool         setupComplete       READ setupComplete      NOTIFY setupCompleteChanged)    ///< false: One or more vehicle components require setup
+    Q_PROPERTY(QVariantList vehicleComponents   READ vehicleComponents  NOTIFY vehicleComponentsChanged)    ///< List of VehicleComponent objects
+    Q_PROPERTY(bool         setupComplete       READ setupComplete      NOTIFY setupCompleteChanged)        ///< false: One or more vehicle components require setup
 
     /// Called when parameters are ready for the first time. Note that parameters may still be missing.
     /// Overrides must call base class.
@@ -56,6 +56,7 @@ public:
 
 signals:
     void setupCompleteChanged(bool setupComplete);
+    void vehicleComponentsChanged(void);
 
 protected:
     /// All access to AutoPilotPugin objects is through getInstanceForAutoPilotPlugin

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -718,6 +718,7 @@ QGCView {
                     z:                  QGroundControl.zOrderWidgets
                     showAlternateIcon:  [ false, false, _syncDropDownController.dirty, false, false, false, false ]
                     rotateImage:        [ false, false, _syncDropDownController.syncInProgress, false, false, false, false ]
+                    animateImage:       [ false, false, _syncDropDownController.dirty, false, false, false, false ]
                     buttonEnabled:      [ true, true, !_syncDropDownController.syncInProgress, true, true, true, true ]
                     buttonVisible:      [ true, true, true, true, true, _showZoom, _showZoom ]
                     maxHeight:          mapScale.y - toolStrip.y

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -24,6 +24,7 @@ Rectangle {
     property alias  model:              repeater.model
     property var    showAlternateIcon                   ///< List of bool values, one for each button in strip - true: show alternate icon, false: show normal icon
     property var    rotateImage                         ///< List of bool values, one for each button in strip - true: animation rotation, false: static image
+    property var    animateImage                        ///< List of bool values, one for each button in strip - true: animate image, false: static image
     property var    buttonEnabled                       ///< List of bool values, one for each button in strip - true: button enabled, false: button disabled
     property var    buttonVisible                       ///< List of bool values, one for each button in strip - true: button visible, false: button invisible
     property real   maxHeight                           ///< Maximum height for control, determines whether text is hidden to make control shorter
@@ -123,6 +124,7 @@ Rectangle {
                 property var    _alternateIconSource:   modelData.alternateIconSource
                 property var    _source:                (_root.showAlternateIcon && _root.showAlternateIcon[index]) ? _alternateIconSource : _iconSource
                 property bool   rotateImage:            _root.rotateImage ? _root.rotateImage[index] : false
+                property bool   animateImage:           _root.animateImage ? _root.animateImage[index] : false
 
                 onExclusiveGroupChanged: {
                     if (exclusiveGroup) {
@@ -136,6 +138,15 @@ Rectangle {
                     } else {
                         imageRotation.running = false
                         button.rotation = 0
+                    }
+                }
+
+                onAnimateImageChanged: {
+                    if (animateImage) {
+                        opacityAnimation.running = true
+                    } else {
+                        opacityAnimation.running = false
+                        button.opacity = 1
                     }
                 }
 
@@ -170,6 +181,14 @@ Rectangle {
                             running:        false
                         }
 
+                        NumberAnimation on opacity {
+                            id:         opacityAnimation
+                            running:    false
+                            from:       0
+                            to:         1.0
+                            loops:      Animation.Infinite
+                            duration:   2000
+                        }
                     }
 
                     QGCMouseArea {

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -36,6 +36,7 @@ Rectangle {
 
     property string _messagePanelText:              "missing message panel text"
     property bool   _fullParameterVehicleAvailable: QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable && !QGroundControl.multiVehicleManager.activeVehicle.parameterManager.missingParameters
+    property var    _corePlugin:                    QGroundControl.corePlugin
 
     function showSummaryPanel()
     {
@@ -231,14 +232,14 @@ Rectangle {
             }
 
             Repeater {
-                model:              QGroundControl.corePlugin.settingsPages
-                visible:            QGroundControl.corePlugin.options.combineSettingsAndSetup
+                model:              _corePlugin.settingsPages
+                visible:            _corePlugin.options.combineSettingsAndSetup
                 SubMenuButton {
                     imageResource:      modelData.icon
                     setupIndicator:     false
                     exclusiveGroup:     setupButtonGroup
                     text:               modelData.title
-                    visible:            QGroundControl.corePlugin.options.combineSettingsAndSetup
+                    visible:            _corePlugin.options.combineSettingsAndSetup
                     onClicked:          panelLoader.setSource(modelData.url)
                     Layout.fillWidth:   true
                 }
@@ -261,7 +262,7 @@ Rectangle {
                 imageResource:      "/qmlimages/FirmwareUpgradeIcon.png"
                 setupIndicator:     false
                 exclusiveGroup:     setupButtonGroup
-                visible:            !ScreenTools.isMobile
+                visible:            !ScreenTools.isMobile && _corePlugin.options.showFirmwareUpgrade
                 text:               "Firmware"
                 Layout.fillWidth:   true
 
@@ -311,7 +312,7 @@ Rectangle {
             SubMenuButton {
                 setupIndicator:     false
                 exclusiveGroup:     setupButtonGroup
-                visible:            QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable && QGroundControl.corePlugin.showAdvancedUI
+                visible:            QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable && _corePlugin.showAdvancedUI
                 text:               "Parameters"
                 Layout.fillWidth:   true
 

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -34,6 +34,7 @@ public:
     Q_PROPERTY(bool                     showSensorCalibrationLevel      READ showSensorCalibrationLevel     NOTIFY showSensorCalibrationLevelChanged)
     Q_PROPERTY(bool                     showSensorCalibrationAirspeed   READ showSensorCalibrationAirspeed  NOTIFY showSensorCalibrationAirspeedChanged)
     Q_PROPERTY(bool                     showSensorCalibrationOrient     READ showSensorCalibrationOrient    NOTIFY showSensorCalibrationOrientChanged)
+    Q_PROPERTY(bool                     showFirmwareUpgrade             READ showFirmwareUpgrade            NOTIFY showFirmwareUpgradeChanged)
 
     /// Should QGC hide its settings menu and colapse it into one single menu (Settings and Vehicle Setup)?
     /// @return true if QGC should consolidate both menus into one.
@@ -59,6 +60,8 @@ public:
     virtual bool showSensorCalibrationAirspeed  () const { return true; }
     virtual bool showSensorCalibrationOrient    () const { return true; }
 
+    virtual bool showFirmwareUpgrade            () const { return true; }
+
 signals:
     void showSensorCalibrationCompassChanged    (bool show);
     void showSensorCalibrationGyroChanged       (bool show);
@@ -66,6 +69,7 @@ signals:
     void showSensorCalibrationLevelChanged      (bool show);
     void showSensorCalibrationAirspeedChanged   (bool show);
     void showSensorCalibrationOrientChanged     (bool show);
+    void showFirmwareUpgradeChanged             (bool show);
 
 private:
     CustomInstrumentWidget* _defaultInstrumentWidget;


### PR DESCRIPTION
* Allow QGCOptions to hide Firmware page.
* Allow vehicleComponents to signal change. This allows plugins to changes pages based on advanced mode.
* Plan: Animate opacity of Sync button when dirty