### PR TITLE
MissionCmdUIInfo: New support for specifiesAltitudeOnly

### DIFF
--- a/src/FirmwarePlugin/APM/MavCmdInfoFixedWing.json
+++ b/src/FirmwarePlugin/APM/MavCmdInfoFixedWing.json
@@ -15,10 +15,10 @@
             "paramRemove":  "4"
         },
         {
-            "id":                   22,
-            "comment":              "MAV_CMD_NAV_TAKEOFF",
-            "specifiesCoordinate":  false,
-            "paramRemove":          "2,3,4,5,6"
+            "id":                       22,
+            "comment":                  "MAV_CMD_NAV_TAKEOFF",
+            "specifiesCoordinate":      false,
+            "specifiesAltitudeOnly":    true
         },
         {
             "id":           82,

--- a/src/FirmwarePlugin/APM/MavCmdInfoMultiRotor.json
+++ b/src/FirmwarePlugin/APM/MavCmdInfoMultiRotor.json
@@ -30,10 +30,11 @@
             "paramRemove":  "1,4"
         },
         {
-            "id":                   22,
-            "comment":              "MAV_CMD_NAV_TAKEOFF",
-            "specifiesCoordinate":  false,
-            "paramRemove":          "1,2,3,4,5,6"
+            "id":                       22,
+            "comment":                  "MAV_CMD_NAV_TAKEOFF",
+            "specifiesCoordinate":      false,
+            "specifiesAltitudeOnly":    true,
+            "paramRemove":              "1,2,3,4"
         },
         {
             "id":           31,

--- a/src/FirmwarePlugin/PX4/MavCmdInfoFixedWing.json
+++ b/src/FirmwarePlugin/PX4/MavCmdInfoFixedWing.json
@@ -5,20 +5,11 @@
 
     "mavCmdInfo": [
         {
-            "id":           21,
-            "comment":      "MAV_CMD_NAV_LAND",
-            "paramRemove":  "1,4",
-            "param7": {
-                "label":            "Altitude",
-                "units":            "m",
-                "default":          0,
-                "decimalPlaces":    1
-            }
-        },
-        {
-            "id":           22,
-            "comment":      "MAV_CMD_NAV_TAKEOFF",
-            "paramRemove":  "4"
+            "id":                       21,
+            "comment":                  "MAV_CMD_NAV_LAND",
+            "paramRemove":              "1,4",
+            "specifiesCoordinate":      false,
+            "specifiesAltitudeOnly":    true
         }
     ]
 }

--- a/src/MissionManager/FixedWingLandingComplexItem.h
+++ b/src/MissionManager/FixedWingLandingComplexItem.h
@@ -64,6 +64,7 @@ public:
     bool            isSimpleItem            (void) const final { return false; }
     bool            isStandaloneCoordinate  (void) const final { return false; }
     bool            specifiesCoordinate     (void) const final;
+    bool            specifiesAltitudeOnly   (void) const final { return false; }
     QString         commandDescription      (void) const final { return "Landing Pattern"; }
     QString         commandName             (void) const final { return "Landing Pattern"; }
     QString         abbreviation            (void) const final { return "L"; }

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -182,25 +182,20 @@
         { "id": 24, "rawName": "MAV_CMD_NAV_TAKEOFF_LOCAL", "friendlyName": "Takeoff local" },
         { "id": 25, "rawName": "MAV_CMD_NAV_FOLLOW", "friendlyName": "Nav follow" },
         {
-            "id":                    30,
-            "rawName":              "MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT",
-            "friendlyName":         "Change Altitude",
-            "description":          "Continue on the current course and climb/descend to specified altitude. When the altitude is reached continue to the next command.",
-            "specifiesCoordinate":  false,
-            "friendlyEdit":         true,
-            "category":             "Flight control",
+            "id":                       30,
+            "rawName":                  "MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT",
+            "friendlyName":             "Change Altitude",
+            "description":              "Continue on the current course and climb/descend to specified altitude. When the altitude is reached continue to the next command.",
+            "specifiesCoordinate":      false,
+            "specifiesAltitudeOnly":    true,
+            "friendlyEdit":             true,
+            "category":                 "Flight control",
             "param1": {
                 "label":            "Mode",
                 "enumStrings":      "Climb,Neutral,Descend",
                 "enumValues":       "1,0,2",
                 "default":          1,
                 "decimalPlaces":    0
-            },
-            "param7": {
-                "label":            "Altitude",
-                "units":            "m",
-                "default":          55,
-                "decimalPlaces":    2
             }
         },
         {
@@ -391,21 +386,17 @@
             }
         },
         {
-            "id":           113,
-            "rawName":      "MAV_CMD_CONDITION_CHANGE_ALT",
-            "description":  "Delay the mission until the specified altitide is reached.",
-            "friendlyName": "Wait for altitude",
-            "category":     "Conditionals",
+            "id":                           113,
+            "rawName":                  "MAV_CMD_CONDITION_CHANGE_ALT",
+            "description":              "Delay the mission until the specified altitide is reached.",
+            "friendlyName":             "Wait for altitude",
+            "category":                 "Conditionals",
+            "specifiesCoordinate":      false,
+            "specifiesAltitudeOnly":    true,
             "param1": {
                 "label":            "Rate",
                 "units":            "m/s",
                 "default":          5,
-                "decimalPlaces":    2
-            },
-            "param7": {
-                "label":            "Altitude",
-                "units":            "m",
-                "default":          55,
                 "decimalPlaces":    2
             }
         },

--- a/src/MissionManager/MissionSettingsComplexItem.h
+++ b/src/MissionManager/MissionSettingsComplexItem.h
@@ -69,6 +69,7 @@ public:
     bool            isSimpleItem            (void) const final { return false; }
     bool            isStandaloneCoordinate  (void) const final { return false; }
     bool            specifiesCoordinate     (void) const final;
+    bool            specifiesAltitudeOnly   (void) const final { return false; }
     QString         commandDescription      (void) const final { return "Mission Settings"; }
     QString         commandName             (void) const final { return "Mission Settings"; }
     QString         abbreviation            (void) const final { return "H"; }

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -185,6 +185,7 @@ void SimpleMissionItem::_connectSignals(void)
     connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::commandDescriptionChanged);
     connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::abbreviationChanged);
     connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::specifiesCoordinateChanged);
+    connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::specifiesAltitudeOnlyChanged);
     connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::isStandaloneCoordinateChanged);
 
     // Whenever these properties change the ui model changes as well
@@ -296,6 +297,16 @@ bool SimpleMissionItem::specifiesCoordinate(void) const
     }
 }
 
+bool SimpleMissionItem::specifiesAltitudeOnly(void) const
+{
+    const MissionCommandUIInfo* uiInfo = _commandTree->getUIInfo(_vehicle, (MAV_CMD)command());
+    if (uiInfo) {
+        return uiInfo->specifiesAltitudeOnly();
+    } else {
+        return false;
+    }
+}
+
 QString SimpleMissionItem::commandDescription(void) const
 {
     const MissionCommandUIInfo* uiInfo = _commandTree->getUIInfo(_vehicle, (MAV_CMD)command());
@@ -392,9 +403,10 @@ QmlObjectListModel* SimpleMissionItem::textFieldFacts(void)
         Fact*           rgParamFacts[7] =       { &_missionItem._param1Fact, &_missionItem._param2Fact, &_missionItem._param3Fact, &_missionItem._param4Fact, &_missionItem._param5Fact, &_missionItem._param6Fact, &_missionItem._param7Fact };
         FactMetaData*   rgParamMetaData[7] =    { &_param1MetaData, &_param2MetaData, &_param3MetaData, &_param4MetaData, &_param5MetaData, &_param6MetaData, &_param7MetaData };
 
-        bool altitudeAdded = false;
+        const MissionCommandUIInfo* uiInfo = _commandTree->getUIInfo(_vehicle, command);
+
         for (int i=1; i<=7; i++) {
-            const MissionCmdParamInfo* paramInfo = _commandTree->getUIInfo(_vehicle, command)->getParamInfo(i);
+            const MissionCmdParamInfo* paramInfo = uiInfo->getParamInfo(i);
 
             if (paramInfo && paramInfo->enumStrings().count() == 0) {
                 Fact*               paramFact =     rgParamFacts[i-1];
@@ -406,14 +418,10 @@ QmlObjectListModel* SimpleMissionItem::textFieldFacts(void)
                 paramMetaData->setRawUnits(paramInfo->units());
                 paramFact->setMetaData(paramMetaData);
                 model->append(paramFact);
-
-                if (i == 7) {
-                    altitudeAdded = true;
-                }
             }
         }
 
-        if (specifiesCoordinate() && !altitudeAdded) {
+        if (uiInfo->specifiesCoordinate() || uiInfo->specifiesAltitudeOnly()) {
             _missionItem._param7Fact._setName("Altitude");
             _missionItem._param7Fact.setMetaData(_altitudeMetaData);
             model->append(&_missionItem._param7Fact);
@@ -430,7 +438,7 @@ QmlObjectListModel* SimpleMissionItem::checkboxFacts(void)
 
     if (rawEdit()) {
         model->append(&_missionItem._autoContinueFact);
-    } else if (specifiesCoordinate() && !_homePositionSpecialCase) {
+    } else if ((specifiesCoordinate() || specifiesAltitudeOnly()) && !_homePositionSpecialCase) {
         model->append(&_altitudeRelativeToHomeFact);
     }
 
@@ -483,7 +491,7 @@ bool SimpleMissionItem::friendlyEditAllowed(void) const
             return false;
         }
 
-        if (specifiesCoordinate()) {
+        if (specifiesCoordinate() || specifiesAltitudeOnly()) {
             return _missionItem.frame() == MAV_FRAME_GLOBAL || _missionItem.frame() == MAV_FRAME_GLOBAL_RELATIVE_ALT;
         }
 
@@ -560,14 +568,20 @@ void SimpleMissionItem::setDefaultsForCommand(void)
         }
     }
 
-    if (command == MAV_CMD_NAV_WAYPOINT) {
+    switch (command) {
+    case MAV_CMD_NAV_WAYPOINT:
         // We default all acceptance radius to 0. This allows flight controller to be in control of
         // accept radius.
         _missionItem.setParam2(0);
+        break;
+
+    case MAV_CMD_NAV_LAND:
+        _missionItem.setParam7(0);
+        break;
     }
 
     _missionItem.setAutoContinue(true);
-    _missionItem.setFrame(specifiesCoordinate() ? MAV_FRAME_GLOBAL_RELATIVE_ALT : MAV_FRAME_MISSION);
+    _missionItem.setFrame((specifiesCoordinate() || specifiesAltitudeOnly()) ? MAV_FRAME_GLOBAL_RELATIVE_ALT : MAV_FRAME_MISSION);
     setRawEdit(false);
 }
 

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -578,6 +578,8 @@ void SimpleMissionItem::setDefaultsForCommand(void)
     case MAV_CMD_NAV_LAND:
         _missionItem.setParam7(0);
         break;
+    default:
+        break;
     }
 
     _missionItem.setAutoContinue(true);

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -87,6 +87,7 @@ public:
     bool            isSimpleItem            (void) const final { return true; }
     bool            isStandaloneCoordinate  (void) const final;
     bool            specifiesCoordinate     (void) const final;
+    bool            specifiesAltitudeOnly   (void) const final;
     QString         commandDescription      (void) const final;
     QString         commandName             (void) const final;
     QString         abbreviation            (void) const final;

--- a/src/MissionManager/SurveyMissionItem.h
+++ b/src/MissionManager/SurveyMissionItem.h
@@ -110,6 +110,7 @@ public:
     bool            isSimpleItem            (void) const final { return false; }
     bool            isStandaloneCoordinate  (void) const final { return false; }
     bool            specifiesCoordinate     (void) const final;
+    bool            specifiesAltitudeOnly   (void) const final { return false; }
     QString         commandDescription      (void) const final { return "Survey"; }
     QString         commandName             (void) const final { return "Survey"; }
     QString         abbreviation            (void) const final { return "S"; }

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -80,8 +80,9 @@ public:
     Q_PROPERTY(bool     dirty                   READ dirty                  WRITE setDirty              NOTIFY dirtyChanged)                    ///< Item is dirty and requires save/send
     Q_PROPERTY(bool     isCurrentItem           READ isCurrentItem          WRITE setIsCurrentItem      NOTIFY isCurrentItemChanged)
     Q_PROPERTY(int      sequenceNumber          READ sequenceNumber         WRITE setSequenceNumber     NOTIFY sequenceNumberChanged)
-    Q_PROPERTY(bool     specifiesCoordinate     READ specifiesCoordinate                                NOTIFY specifiesCoordinateChanged)      ///< Item is associated with a coordinate position
-    Q_PROPERTY(bool     isStandaloneCoordinate  READ isStandaloneCoordinate                             NOTIFY isStandaloneCoordinateChanged)   ///< Waypoint line does not go through item
+    Q_PROPERTY(bool     specifiesCoordinate     READ specifiesCoordinate                                NOTIFY specifiesCoordinateChanged)      ///< true: Item is associated with a coordinate position
+    Q_PROPERTY(bool     isStandaloneCoordinate  READ isStandaloneCoordinate                             NOTIFY isStandaloneCoordinateChanged)   ///< true: Waypoint line does not go through item
+    Q_PROPERTY(bool     specifiesAltitudeOnly   READ specifiesAltitudeOnly                              NOTIFY specifiesAltitudeOnlyChanged)    ///< true: Item has altitude only, no full coordinate
     Q_PROPERTY(bool     isSimpleItem            READ isSimpleItem                                       NOTIFY isSimpleItemChanged)             ///< Simple or Complex MissionItem
     Q_PROPERTY(QString  editorQml               MEMBER _editorQml                                       CONSTANT)                               ///< Qml code for editing this item
     Q_PROPERTY(QString  mapVisualQML            READ mapVisualQML                                       CONSTANT)                               ///< QMl code for map visuals
@@ -119,6 +120,7 @@ public:
     virtual bool            isSimpleItem            (void) const = 0;
     virtual bool            isStandaloneCoordinate  (void) const = 0;
     virtual bool            specifiesCoordinate     (void) const = 0;
+    virtual bool            specifiesAltitudeOnly   (void) const = 0;;
     virtual QString         commandDescription      (void) const = 0;
     virtual QString         commandName             (void) const = 0;
     virtual QString         abbreviation            (void) const = 0;
@@ -169,6 +171,7 @@ signals:
     void isSimpleItemChanged            (bool isSimpleItem);
     void specifiesCoordinateChanged     (void);
     void isStandaloneCoordinateChanged  (void);
+    void specifiesAltitudeOnlyChanged     (void);
     void flightSpeedChanged             (double flightSpeed);
     void lastSequenceNumberChanged      (int sequenceNumber);
 


### PR DESCRIPTION
Mission items which do not specify a coordinate, but do specify an altitude now handled correctly.

Fix for #4787.