### PR TITLE
Map Tile Set Import/Export

### DIFF
--- a/src/QtLocationPlugin/QGCMapEngineData.h
+++ b/src/QtLocationPlugin/QGCMapEngineData.h
@@ -389,12 +389,19 @@ public:
         emit exportCompleted();
     }
 
+    void setProgress(int percentage)
+    {
+        emit exportProgress(percentage);
+    }
+
 private:
     QVector<QGCCachedTileSet*>  _sets;
     QString                     _path;
 
 signals:
-    void exportCompleted();
+    void exportCompleted        ();
+    void exportProgress         (int percentage);
+
 };
 
 

--- a/src/QtLocationPlugin/QGCMapEngineData.h
+++ b/src/QtLocationPlugin/QGCMapEngineData.h
@@ -119,7 +119,8 @@ public:
         taskUpdateTileDownloadState,
         taskDeleteTileSet,
         taskPruneCache,
-        taskReset
+        taskReset,
+        taskExport
     };
 
     QGCMapTask(TaskType type)
@@ -363,6 +364,37 @@ public:
 
 signals:
     void resetCompleted();
+};
+
+//-----------------------------------------------------------------------------
+class QGCExportTileTask : public QGCMapTask
+{
+    Q_OBJECT
+public:
+    QGCExportTileTask(QVector<QGCCachedTileSet*> sets, QString path)
+        : QGCMapTask(QGCMapTask::taskExport)
+        , _sets(sets)
+        , _path(path)
+    {}
+
+    ~QGCExportTileTask()
+    {
+    }
+
+    QVector<QGCCachedTileSet*> sets() { return _sets; }
+    QString                    path() { return _path; }
+
+    void setExportCompleted()
+    {
+        emit exportCompleted();
+    }
+
+private:
+    QVector<QGCCachedTileSet*>  _sets;
+    QString                     _path;
+
+signals:
+    void exportCompleted();
 };
 
 

--- a/src/QtLocationPlugin/QGCMapEngineData.h
+++ b/src/QtLocationPlugin/QGCMapEngineData.h
@@ -120,7 +120,8 @@ public:
         taskDeleteTileSet,
         taskPruneCache,
         taskReset,
-        taskExport
+        taskExport,
+        taskImport
     };
 
     QGCMapTask(TaskType type)
@@ -386,12 +387,12 @@ public:
 
     void setExportCompleted()
     {
-        emit exportCompleted();
+        emit actionCompleted();
     }
 
     void setProgress(int percentage)
     {
-        emit exportProgress(percentage);
+        emit actionProgress(percentage);
     }
 
 private:
@@ -399,10 +400,47 @@ private:
     QString                     _path;
 
 signals:
-    void exportCompleted        ();
-    void exportProgress         (int percentage);
+    void actionCompleted        ();
+    void actionProgress         (int percentage);
 
 };
 
+//-----------------------------------------------------------------------------
+class QGCImportTileTask : public QGCMapTask
+{
+    Q_OBJECT
+public:
+    QGCImportTileTask(QString path, bool replace)
+        : QGCMapTask(QGCMapTask::taskImport)
+        , _path(path)
+        , _replace(replace)
+    {}
+
+    ~QGCImportTileTask()
+    {
+    }
+
+    QString                    path     () { return _path; }
+    bool                       replace  () { return _replace; }
+
+    void setImportCompleted()
+    {
+        emit actionCompleted();
+    }
+
+    void setProgress(int percentage)
+    {
+        emit actionProgress(percentage);
+    }
+
+private:
+    QString                     _path;
+    bool                        _replace;
+
+signals:
+    void actionCompleted        ();
+    void actionProgress         (int percentage);
+
+};
 
 #endif // QGC_MAP_ENGINE_DATA_H

--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -52,6 +52,7 @@ QGCCachedTileSet::QGCCachedTileSet(const QString& name)
     , _noMoreTiles(false)
     , _batchRequested(false)
     , _manager(NULL)
+    , _selected(false)
 {
 
 }
@@ -348,4 +349,15 @@ void
 QGCCachedTileSet::setManager(QGCMapEngineManager* mgr)
 {
     _manager = mgr;
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCCachedTileSet::setSelected(bool sel)
+{
+    _selected = sel;
+    emit selectedChanged();
+    if(_manager) {
+        emit _manager->selectedCountChanged();
+    }
 }

--- a/src/QtLocationPlugin/QGCMapTileSet.h
+++ b/src/QtLocationPlugin/QGCMapTileSet.h
@@ -72,6 +72,8 @@ public:
     Q_PROPERTY(quint32      errorCount          READ    errorCount          NOTIFY errorCountChanged)
     Q_PROPERTY(QString      errorCountStr       READ    errorCountStr       NOTIFY errorCountChanged)
 
+    Q_PROPERTY(bool         selected            READ    selected            WRITE  setSelected  NOTIFY selectedChanged)
+
     Q_INVOKABLE void createDownloadTask ();
     Q_INVOKABLE void resumeDownloadTask ();
     Q_INVOKABLE void cancelDownloadTask ();
@@ -109,7 +111,9 @@ public:
     bool        downloading             () { return _downloading; }
     quint32     errorCount              () { return _errorCount; }
     QString     errorCountStr           ();
+    bool        selected                () { return _selected; }
 
+    void        setSelected             (bool sel);
     void        setName                 (QString name)              { _name = name; }
     void        setMapTypeStr           (QString typeStr)           { _mapTypeStr = typeStr; }
     void        setTopleftLat           (double lat)                { _topleftLat = lat; }
@@ -142,6 +146,7 @@ signals:
     void        savedTileSizeChanged    ();
     void        completeChanged         ();
     void        errorCountChanged       ();
+    void        selectedChanged         ();
 
 private slots:
     void _tileListFetched               (QList<QGCTile*> tiles);
@@ -181,6 +186,7 @@ private:
     bool        _noMoreTiles;
     bool        _batchRequested;
     QGCMapEngineManager* _manager;
+    bool        _selected;
 };
 
 #endif // QGC_MAP_TILE_SET_H

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -157,6 +157,9 @@ QGCCacheWorker::run()
                 case QGCMapTask::taskExport:
                     _exportSets(task);
                     break;
+                case QGCMapTask::taskImport:
+                    _importSets(task);
+                    break;
                 case QGCMapTask::taskTestInternet:
                     _testInternet();
                     break;
@@ -632,6 +635,22 @@ QGCCacheWorker::_resetCacheDatabase(QGCMapTask* mtask)
     query.exec(s);
     _valid = _createDB(_db);
     task->setResetCompleted();
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCCacheWorker::_importSets(QGCMapTask* mtask)
+{
+    if(!_testTask(mtask)) {
+        return;
+    }
+    QGCImportTileTask* task = static_cast<QGCImportTileTask*>(mtask);
+
+
+
+
+
+    task->setImportCompleted();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -60,6 +60,7 @@ private:
     void        _resetCacheDatabase     (QGCMapTask* mtask);
     void        _pruneCache             (QGCMapTask* mtask);
     void        _exportSets             (QGCMapTask* mtask);
+    void        _importSets             (QGCMapTask* mtask);
     bool        _testTask               (QGCMapTask* mtask);
     void        _testInternet           ();
 

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -59,13 +59,15 @@ private:
     void        _deleteTileSet          (QGCMapTask* mtask);
     void        _resetCacheDatabase     (QGCMapTask* mtask);
     void        _pruneCache             (QGCMapTask* mtask);
+    void        _exportSets             (QGCMapTask* mtask);
+    bool        _testTask               (QGCMapTask* mtask);
     void        _testInternet           ();
 
     quint64     _findTile               (const QString hash);
     bool        _findTileSetID          (const QString name, quint64& setID);
     void        _updateSetTotals        (QGCCachedTileSet* set);
     bool        _init                   ();
-    void        _createDB               ();
+    bool        _createDB               (QSqlDatabase *db, bool createDefault = true);
     quint64     _getDefaultTileSet      ();
     void        _updateTotals           ();
 

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -858,11 +858,13 @@ QGCView {
             QGCButton {
                 text:           qsTr("Import")
                 width:          _buttonSize
+                visible:        !ScreenTools.isMobile
                 onClicked:      rootLoader.sourceComponent = importDialog
             }
             QGCButton {
                 text:           qsTr("Export")
                 width:          _buttonSize
+                visible:        !ScreenTools.isMobile
                 enabled:        QGroundControl.mapEngineManager.tileSets.count > 1
                 onClicked:      showExport()
             }
@@ -939,7 +941,7 @@ QGCView {
                 width:          _bigButtonSize
                 enabled:        QGroundControl.mapEngineManager.selectedCount > 0
                 onClicked: {
-                    showList()
+                    rootLoader.sourceComponent = exportToDevice
                 }
             }
             QGCButton {
@@ -1100,8 +1102,7 @@ QGCView {
                             text:           qsTr("Import From Device")
                             width:          _bigButtonSize * 1.25
                             onClicked: {
-                                showList();
-                                rootLoader.sourceComponent = null
+                                rootLoader.sourceComponent = importFromDevice
                             }
                         }
                         QGCButton {
@@ -1111,6 +1112,96 @@ QGCView {
                                 showList();
                                 rootLoader.sourceComponent = null
                             }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: importFromDevice
+        Rectangle {
+            width:      mainWindow.width
+            height:     mainWindow.height
+            color:      "black"
+            anchors.centerIn: parent
+            Rectangle {
+                width:  parent.width  * 0.45
+                height: importCol.height * 1.5
+                radius: ScreenTools.defaultFontPixelWidth
+                color:  qgcPal.windowShadeDark
+                border.color: qgcPal.text
+                anchors.centerIn: parent
+                Column {
+                    id:                 importCol
+                    spacing:            ScreenTools.defaultFontPixelHeight
+                    width:              parent.width
+                    anchors.centerIn:   parent
+                    QGCLabel {
+                        text:           qsTr("Map Tile Set Import From Device");
+                        font.family:        ScreenTools.demiboldFontFamily
+                        font.pointSize:     ScreenTools.mediumFontPointSize
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    QGCLabel {
+                        text:           qsTr("NOT YET IMPLEMENTED");
+                        font.family:        ScreenTools.demiboldFontFamily
+                        font.pointSize:     ScreenTools.mediumFontPointSize
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    QGCButton {
+                        text:           qsTr("Close")
+                        width:          _bigButtonSize * 1.25
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        onClicked: {
+                            showList();
+                            rootLoader.sourceComponent = null
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: exportToDevice
+        Rectangle {
+            width:      mainWindow.width
+            height:     mainWindow.height
+            color:      "black"
+            anchors.centerIn: parent
+            Rectangle {
+                width:  parent.width  * 0.45
+                height: importCol.height * 1.5
+                radius: ScreenTools.defaultFontPixelWidth
+                color:  qgcPal.windowShadeDark
+                border.color: qgcPal.text
+                anchors.centerIn: parent
+                Column {
+                    id:                 importCol
+                    spacing:            ScreenTools.defaultFontPixelHeight
+                    width:              parent.width
+                    anchors.centerIn:   parent
+                    QGCLabel {
+                        text:           qsTr("Map Tile Set Export To Device");
+                        font.family:        ScreenTools.demiboldFontFamily
+                        font.pointSize:     ScreenTools.mediumFontPointSize
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    QGCLabel {
+                        text:           qsTr("NOT YET IMPLEMENTED");
+                        font.family:        ScreenTools.demiboldFontFamily
+                        font.pointSize:     ScreenTools.mediumFontPointSize
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    QGCButton {
+                        text:           qsTr("Close")
+                        width:          _bigButtonSize * 1.25
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        onClicked: {
+                            showList();
+                            rootLoader.sourceComponent = null
                         }
                     }
                 }

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -39,6 +39,7 @@ QGCView {
     property bool   _defaultSet:        offlineMapView && offlineMapView._currentSelection && offlineMapView._currentSelection.defaultSet
     property real   _margins:           ScreenTools.defaultFontPixelWidth * 0.5
     property real   _buttonSize:        ScreenTools.defaultFontPixelWidth * 12
+    property real   _bigButtonSize:     ScreenTools.defaultFontPixelWidth * 16
 
     property bool   _saveRealEstate:          ScreenTools.isTinyScreen || ScreenTools.isShortScreen
     property real   _adjustableFontPointSize: _saveRealEstate ? ScreenTools.smallFontPointSize : ScreenTools.defaultFontPointSize
@@ -850,8 +851,8 @@ QGCView {
             visible:            _tileSetList.visible
             spacing:            _margins
             anchors.bottom:     parent.bottom
-            anchors.right:      parent.right
             anchors.margins:    ScreenTools.defaultFontPixelWidth
+            anchors.horizontalCenter: parent.horizontalCenter
             QGCButton {
                 text:           qsTr("Import")
                 width:          _buttonSize
@@ -907,21 +908,31 @@ QGCView {
             visible:            _exporTiles.visible
             spacing:            _margins
             anchors.bottom:     parent.bottom
-            anchors.right:      parent.right
             anchors.margins:    ScreenTools.defaultFontPixelWidth
+            anchors.horizontalCenter: parent.horizontalCenter
             QGCButton {
-                text:           qsTr("All")
-                width:          _buttonSize
+                text:           qsTr("Select All")
+                width:          _bigButtonSize
                 onClicked:      QGroundControl.mapEngineManager.selectAll()
             }
             QGCButton {
-                text:           qsTr("None")
-                width:          _buttonSize
+                text:           qsTr("Select None")
+                width:          _bigButtonSize
                 onClicked:      QGroundControl.mapEngineManager.selectNone()
             }
             QGCButton {
-                text:           qsTr("Export")
-                width:          _buttonSize
+                text:           qsTr("Export to Disk")
+                width:          _bigButtonSize
+                enabled:        QGroundControl.mapEngineManager.selectedCount > 0
+                onClicked: {
+                    showList();
+                    QGroundControl.mapEngineManager.exportSets()
+                    rootLoader.sourceComponent = exportToDiskProgress
+                }
+            }
+            QGCButton {
+                text:           qsTr("Export to Device")
+                width:          _bigButtonSize
                 enabled:        QGroundControl.mapEngineManager.selectedCount > 0
                 onClicked: {
                     QGroundControl.mapEngineManager.exportSets()
@@ -930,9 +941,64 @@ QGCView {
             }
             QGCButton {
                 text:           qsTr("Cancel")
-                width:          _buttonSize
+                width:          _bigButtonSize
                 onClicked:       showList()
             }
         }
     } // QGCViewPanel
+
+    Component {
+        id: exportToDiskProgress
+        Rectangle {
+            width:      mainWindow.width
+            height:     mainWindow.height
+            color:      "black"
+            anchors.centerIn: parent
+            Rectangle {
+                width:  parent.width  * 0.5
+                height: cameraSettingsCol.height * 1.25
+                radius: ScreenTools.defaultFontPixelWidth
+                color:  qgcPal.windowShadeDark
+                border.color: qgcPal.text
+                anchors.centerIn: parent
+                Column {
+                    id:                 cameraSettingsCol
+                    spacing:            ScreenTools.defaultFontPixelHeight
+                    width:              parent.width
+                    anchors.centerIn:   parent
+                    QGCLabel {
+                        text:               QGroundControl.mapEngineManager.exporting ? qsTr("Tile Set Export Progress") : qsTr("Tile Set Export Completed")
+                        font.family:        ScreenTools.demiboldFontFamily
+                        font.pointSize:     ScreenTools.mediumFontPointSize
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    ProgressBar {
+                        id:             progressBar
+                        width:          parent.width * 0.45
+                        maximumValue:   100
+                        value:          QGroundControl.mapEngineManager.exportProgress
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    BusyIndicator {
+                        visible:        QGroundControl.mapEngineManager.exporting
+                        running:        QGroundControl.mapEngineManager.exporting
+                        width:          exportCloseButton.height
+                        height:         exportCloseButton.height
+                        anchors.horizontalCenter: parent.horizontalCenter
+                    }
+                    QGCButton {
+                        id:             exportCloseButton
+                        text:           qsTr("Close")
+                        width:          _buttonSize
+                        visible:        !QGroundControl.mapEngineManager.exporting
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        onClicked: {
+                            rootLoader.sourceComponent = null
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 } // QGCView

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -114,6 +114,7 @@ QGCView {
         _tileSetList.visible = true
         infoView.visible = false
         addNewSetView.visible = false
+        QGroundControl.mapEngineManager.resetAction();
     }
 
     function showExport() {
@@ -1047,8 +1048,8 @@ QGCView {
                     BusyIndicator {
                         visible:        QGroundControl.mapEngineManager.importAction === QGCMapEngineManager.ActionImporting
                         running:        QGroundControl.mapEngineManager.importAction === QGCMapEngineManager.ActionImporting
-                        width:          ScreenTools.defaultFontPixelWidth
-                        height:         ScreenTools.defaultFontPixelWidth
+                        width:          ScreenTools.defaultFontPixelWidth * 2
+                        height:         width
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
                     ExclusiveGroup { id: radioGroup }
@@ -1077,7 +1078,7 @@ QGCView {
                         visible:        QGroundControl.mapEngineManager.importAction === QGCMapEngineManager.ActionDone
                         anchors.horizontalCenter: parent.horizontalCenter
                         onClicked: {
-                            showList()
+                            showList();
                             rootLoader.sourceComponent = null
                         }
                     }
@@ -1107,7 +1108,7 @@ QGCView {
                             text:           qsTr("Cancel")
                             width:          _bigButtonSize * 1.25
                             onClicked: {
-                                showList()
+                                showList();
                                 rootLoader.sourceComponent = null
                             }
                         }

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -481,7 +481,20 @@ QGCMapEngineManager::_actionProgressHandler(int percentage)
 void
 QGCMapEngineManager::_actionCompleted()
 {
+    ImportAction oldState = _importAction;
     _importAction = ActionDone;
+    emit importActionChanged();
+    //-- If we just imported, reload it all
+    if(oldState == ActionImporting) {
+        loadTileSets();
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCMapEngineManager::resetAction()
+{
+    _importAction = ActionNone;
     emit importActionChanged();
 }
 

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -46,7 +46,10 @@ public:
     //-- Disk Space in MB
     Q_PROPERTY(quint32              freeDiskSpace   READ    freeDiskSpace   NOTIFY  freeDiskSpaceChanged)
     Q_PROPERTY(quint32              diskSpace       READ    diskSpace       CONSTANT)
+    //-- Tile set export
     Q_PROPERTY(int                  selectedCount   READ    selectedCount   NOTIFY selectedCountChanged)
+    Q_PROPERTY(int                  exportProgress  READ    exportProgress  NOTIFY exportProgressChanged)
+    Q_PROPERTY(bool                 exporting       READ    exporting       NOTIFY exportingChanged)
 
     Q_INVOKABLE void                loadTileSets            ();
     Q_INVOKABLE void                updateForCurrentView    (double lon0, double lat0, double lon1, double lat1, int minZoom, int maxZoom, const QString& mapName);
@@ -58,7 +61,7 @@ public:
     Q_INVOKABLE bool                findName                (const QString& name);
     Q_INVOKABLE void                selectAll               ();
     Q_INVOKABLE void                selectNone              ();
-    Q_INVOKABLE void                exportSets              (QString path = QString());
+    Q_INVOKABLE bool                exportSets              (QString path = QString());
 
     int                             tileX0                  () { return _totalSet.tileX0; }
     int                             tileX1                  () { return _totalSet.tileX1; }
@@ -77,6 +80,8 @@ public:
     quint64                         freeDiskSpace           () { return _freeDiskSpace; }
     quint64                         diskSpace               () { return _diskSpace; }
     int                             selectedCount           ();
+    int                             exportProgress          () { return _exportProgress; }
+    bool                            exporting               () { return _exporting; }
 
     void                            setMapboxToken          (QString token);
     void                            setMaxMemCache          (quint32 size);
@@ -101,6 +106,8 @@ signals:
     void errorMessageChanged    ();
     void freeDiskSpaceChanged   ();
     void selectedCountChanged   ();
+    void exportProgressChanged  ();
+    void exportingChanged       ();
 
 public slots:
     void taskError              (QGCMapTask::TaskType type, QString error);
@@ -112,6 +119,7 @@ private slots:
     void _updateTotals          (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
     void _resetCompleted        ();
     void _exportCompleted       ();
+    void _exportProgressHandler (int percentage);
 
 private:
     void _updateDiskFreeSpace   ();
@@ -129,6 +137,8 @@ private:
     quint32     _diskSpace;
     QmlObjectListModel _tileSets;
     QString     _errorMessage;
+    int         _exportProgress;
+    bool        _exporting;
 };
 
 #endif

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -29,6 +29,14 @@ public:
     QGCMapEngineManager(QGCApplication* app);
     ~QGCMapEngineManager();
 
+    enum ImportAction {
+        ActionNone,
+        ActionImporting,
+        ActionExporting,
+        ActionDone,
+    };
+    Q_ENUMS(ImportAction)
+
     Q_PROPERTY(int                  tileX0          READ    tileX0          NOTIFY tileX0Changed)
     Q_PROPERTY(int                  tileX1          READ    tileX1          NOTIFY tileX1Changed)
     Q_PROPERTY(int                  tileY0          READ    tileY0          NOTIFY tileY0Changed)
@@ -48,8 +56,10 @@ public:
     Q_PROPERTY(quint32              diskSpace       READ    diskSpace       CONSTANT)
     //-- Tile set export
     Q_PROPERTY(int                  selectedCount   READ    selectedCount   NOTIFY selectedCountChanged)
-    Q_PROPERTY(int                  exportProgress  READ    exportProgress  NOTIFY exportProgressChanged)
-    Q_PROPERTY(bool                 exporting       READ    exporting       NOTIFY exportingChanged)
+    Q_PROPERTY(int                  actionProgress  READ    actionProgress  NOTIFY actionProgressChanged)
+    Q_PROPERTY(ImportAction         importAction    READ    importAction    NOTIFY importActionChanged)
+
+    Q_PROPERTY(bool                 importReplace   READ    importReplace   WRITE   setImportReplace   NOTIFY importReplaceChanged)
 
     Q_INVOKABLE void                loadTileSets            ();
     Q_INVOKABLE void                updateForCurrentView    (double lon0, double lat0, double lon1, double lat1, int minZoom, int maxZoom, const QString& mapName);
@@ -62,6 +72,7 @@ public:
     Q_INVOKABLE void                selectAll               ();
     Q_INVOKABLE void                selectNone              ();
     Q_INVOKABLE bool                exportSets              (QString path = QString());
+    Q_INVOKABLE bool                importSets              (QString path = QString());
 
     int                             tileX0                  () { return _totalSet.tileX0; }
     int                             tileX1                  () { return _totalSet.tileX1; }
@@ -80,12 +91,14 @@ public:
     quint64                         freeDiskSpace           () { return _freeDiskSpace; }
     quint64                         diskSpace               () { return _diskSpace; }
     int                             selectedCount           ();
-    int                             exportProgress          () { return _exportProgress; }
-    bool                            exporting               () { return _exporting; }
+    int                             actionProgress          () { return _actionProgress; }
+    ImportAction                    importAction            () { return _importAction; }
+    bool                            importReplace           () { return _importReplace; }
 
     void                            setMapboxToken          (QString token);
     void                            setMaxMemCache          (quint32 size);
     void                            setMaxDiskCache         (quint32 size);
+    void                            setImportReplace        (bool replace) { _importReplace = replace; emit importReplaceChanged(); }
 
     void                            setErrorMessage         (const QString& error) { _errorMessage = error; emit errorMessageChanged(); }
 
@@ -106,8 +119,9 @@ signals:
     void errorMessageChanged    ();
     void freeDiskSpaceChanged   ();
     void selectedCountChanged   ();
-    void exportProgressChanged  ();
-    void exportingChanged       ();
+    void actionProgressChanged  ();
+    void importActionChanged    ();
+    void importReplaceChanged   ();
 
 public slots:
     void taskError              (QGCMapTask::TaskType type, QString error);
@@ -118,8 +132,8 @@ private slots:
     void _tileSetDeleted        (quint64 setID);
     void _updateTotals          (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
     void _resetCompleted        ();
-    void _exportCompleted       ();
-    void _exportProgressHandler (int percentage);
+    void _actionCompleted       ();
+    void _actionProgressHandler (int percentage);
 
 private:
     void _updateDiskFreeSpace   ();
@@ -137,8 +151,9 @@ private:
     quint32     _diskSpace;
     QmlObjectListModel _tileSets;
     QString     _errorMessage;
-    int         _exportProgress;
-    bool        _exporting;
+    int         _actionProgress;
+    ImportAction _importAction;
+    bool        _importReplace;
 };
 
 #endif

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -46,6 +46,7 @@ public:
     //-- Disk Space in MB
     Q_PROPERTY(quint32              freeDiskSpace   READ    freeDiskSpace   NOTIFY  freeDiskSpaceChanged)
     Q_PROPERTY(quint32              diskSpace       READ    diskSpace       CONSTANT)
+    Q_PROPERTY(int                  selectedCount   READ    selectedCount   NOTIFY selectedCountChanged)
 
     Q_INVOKABLE void                loadTileSets            ();
     Q_INVOKABLE void                updateForCurrentView    (double lon0, double lat0, double lon1, double lat1, int minZoom, int maxZoom, const QString& mapName);
@@ -55,6 +56,9 @@ public:
     Q_INVOKABLE void                deleteTileSet           (QGCCachedTileSet* tileSet);
     Q_INVOKABLE QString             getUniqueName           ();
     Q_INVOKABLE bool                findName                (const QString& name);
+    Q_INVOKABLE void                selectAll               ();
+    Q_INVOKABLE void                selectNone              ();
+    Q_INVOKABLE void                exportSets              (QString path = QString());
 
     int                             tileX0                  () { return _totalSet.tileX0; }
     int                             tileX1                  () { return _totalSet.tileX1; }
@@ -72,6 +76,7 @@ public:
     QString                         errorMessage            () { return _errorMessage; }
     quint64                         freeDiskSpace           () { return _freeDiskSpace; }
     quint64                         diskSpace               () { return _diskSpace; }
+    int                             selectedCount           ();
 
     void                            setMapboxToken          (QString token);
     void                            setMaxMemCache          (quint32 size);
@@ -95,6 +100,7 @@ signals:
     void maxDiskCacheChanged    ();
     void errorMessageChanged    ();
     void freeDiskSpaceChanged   ();
+    void selectedCountChanged   ();
 
 public slots:
     void taskError              (QGCMapTask::TaskType type, QString error);
@@ -105,6 +111,7 @@ private slots:
     void _tileSetDeleted        (quint64 setID);
     void _updateTotals          (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
     void _resetCompleted        ();
+    void _exportCompleted       ();
 
 private:
     void _updateDiskFreeSpace   ();

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -73,6 +73,7 @@ public:
     Q_INVOKABLE void                selectNone              ();
     Q_INVOKABLE bool                exportSets              (QString path = QString());
     Q_INVOKABLE bool                importSets              (QString path = QString());
+    Q_INVOKABLE void                resetAction             ();
 
     int                             tileX0                  () { return _totalSet.tileX0; }
     int                             tileX1                  () { return _totalSet.tileX1; }

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -232,14 +232,14 @@ Rectangle {
             }
 
             Repeater {
-                model:              _corePlugin.settingsPages
-                visible:            _corePlugin.options.combineSettingsAndSetup
+                model:                  _corePlugin ? _corePlugin.settingsPages : []
+                visible:                _corePlugin && _corePlugin.options.combineSettingsAndSetup
                 SubMenuButton {
                     imageResource:      modelData.icon
                     setupIndicator:     false
                     exclusiveGroup:     setupButtonGroup
                     text:               modelData.title
-                    visible:            _corePlugin.options.combineSettingsAndSetup
+                    visible:            _corePlugin && _corePlugin.options.combineSettingsAndSetup
                     onClicked:          panelLoader.setSource(modelData.url)
                     Layout.fillWidth:   true
                 }
@@ -312,7 +312,7 @@ Rectangle {
             SubMenuButton {
                 setupIndicator:     false
                 exclusiveGroup:     setupButtonGroup
-                visible:            QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable && _corePlugin.showAdvancedUI
+                visible:            QGroundControl.multiVehicleManager && QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable && _corePlugin.showAdvancedUI
                 text:               "Parameters"
                 Layout.fillWidth:   true
 


### PR DESCRIPTION
This is the fist part of Import/Export of map tiles sets.

This PR implements export and import from disk. You can select what sets you want to export and these will be saved into a file. You can then "import" this file into another instance of QGC.