### PR TITLE
Handle single complex mission item case

### DIFF
--- a/custom
+++ b/custom
@@ -1,0 +1,1 @@
+/Users/Don/repos/qgc-typhoon-custom/custom/

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -49,6 +49,7 @@ QGCView {
     property var    activeVehiclePosition:  _activeVehicle ? _activeVehicle.coordinate : QtPositioning.coordinate()
     property bool   _lightWidgetBorders:    editorMap.isSatelliteMap
     property bool   _addWaypointOnClick:    false
+    property bool   _singleComplexItem:     missionController.complexMissionItemNames.length == 1
 
     /// The controller which should be called for load/save, send to/from vehicle calls
     property var _syncDropDownController: missionController
@@ -75,6 +76,14 @@ QGCView {
             _firstVehiclePosition = false
             editorMap.center = _activeVehicle.coordinate
         }
+    }
+
+    function addComplexItem(complexItemName) {
+        var coordinate = editorMap.center
+        coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
+        coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
+        coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
+        var sequenceNumber = missionController.insertComplexMissionItem(complexItemName, coordinate, missionController.visualItems.count)
     }
 
     property bool _firstMissionLoadComplete:    false
@@ -697,7 +706,7 @@ QGCView {
                         {
                             name:               "Pattern",
                             iconSource:         "/qmlimages/MapDrawShape.svg",
-                            dropPanelComponent: patternDropPanel
+                            dropPanelComponent: _singleComplexItem ? undefined : patternDropPanel
                         },
                         {
                             name:                   "Sync",
@@ -729,6 +738,11 @@ QGCView {
                         switch (index) {
                         case 0:
                             _addWaypointOnClick = checked
+                            break
+                        case 1:
+                            if (_singleComplexItem) {
+                                addComplexItem(missionController.complexMissionItemNames[0])
+                            }
                             break
                         case 5:
                             editorMap.zoomLevel += 0.5
@@ -948,12 +962,7 @@ QGCView {
                     Layout.fillWidth:   true
 
                     onClicked: {
-                        var coordinate = editorMap.center
-                        coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
-                        coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
-                        coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
-                        var sequenceNumber = missionController.insertComplexMissionItem(modelData, coordinate, missionController.visualItems.count)
-                        setCurrentItem(sequenceNumber)
+                        addComplexItem(modelData)
                         dropPanel.hide()
                     }
                 }

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -52,6 +52,8 @@ MissionController::MissionController(QObject *parent)
     , _firstItemsFromVehicle(false)
     , _missionItemsRequested(false)
     , _queuedSend(false)
+    , _surveyMissionItemName(tr("Survey"))
+    , _fwLandingMissionItemName(tr("Fixed Wing Landing"))
 {
     _missionFlightStatus.maxTelemetryDistance = 0;
     _missionFlightStatus.totalDistance = 0;
@@ -63,10 +65,6 @@ MissionController::MissionController(QObject *parent)
     _missionFlightStatus.cruiseSpeed = 0;
     _missionFlightStatus.hoverSpeed = 0;
     _missionFlightStatus.gimbalYaw = 0;
-
-    _surveyMissionItemName = tr("Survey");
-    _fwLandingMissionItemName = tr("Fixed Wing Landing");
-    _complexMissionItemNames << _surveyMissionItemName << _fwLandingMissionItemName;
 }
 
 MissionController::~MissionController()
@@ -1287,6 +1285,8 @@ void MissionController::_activeVehicleSet(void)
 
     _activeVehicleHomePositionChanged(_activeVehicle->homePosition());
     _activeVehicleHomePositionAvailableChanged(_activeVehicle->homePositionAvailable());
+
+    emit complexMissionItemNamesChanged();
 }
 
 void MissionController::_activeVehicleHomePositionAvailableChanged(bool homePositionAvailable)
@@ -1569,4 +1569,16 @@ void MissionController::removeAllFromVehicle(void)
 {
     _missionItemsRequested = true;
     _activeVehicle->missionManager()->removeAll();
+}
+
+QStringList MissionController::complexMissionItemNames(void) const
+{
+    QStringList complexItems;
+
+    complexItems.append(_surveyMissionItemName);
+    if (_activeVehicle->fixedWing()) {
+        complexItems.append(_fwLandingMissionItemName);
+    }
+
+    return complexItems;
 }

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -49,18 +49,18 @@ public:
     } MissionFlightStatus_t;
 
     // Mission settings
-    Q_PROPERTY(QGeoCoordinate       plannedHomePosition     READ plannedHomePosition    NOTIFY plannedHomePositionChanged)
-    Q_PROPERTY(QmlObjectListModel*  visualItems             READ visualItems            NOTIFY visualItemsChanged)
-    Q_PROPERTY(QmlObjectListModel*  waypointLines           READ waypointLines          NOTIFY waypointLinesChanged)
-    Q_PROPERTY(QStringList          complexMissionItemNames MEMBER _complexMissionItemNames CONSTANT)
+    Q_PROPERTY(QGeoCoordinate       plannedHomePosition     READ plannedHomePosition        NOTIFY plannedHomePositionChanged)
+    Q_PROPERTY(QmlObjectListModel*  visualItems             READ visualItems                NOTIFY visualItemsChanged)
+    Q_PROPERTY(QmlObjectListModel*  waypointLines           READ waypointLines              NOTIFY waypointLinesChanged)
+    Q_PROPERTY(QStringList          complexMissionItemNames READ complexMissionItemNames    NOTIFY complexMissionItemNamesChanged)
 
-    Q_PROPERTY(double               missionDistance         READ missionDistance        NOTIFY missionDistanceChanged)
-    Q_PROPERTY(double               missionTime             READ missionTime            NOTIFY missionTimeChanged)
-    Q_PROPERTY(double               missionHoverDistance    READ missionHoverDistance   NOTIFY missionHoverDistanceChanged)
-    Q_PROPERTY(double               missionCruiseDistance   READ missionCruiseDistance  NOTIFY missionCruiseDistanceChanged)
-    Q_PROPERTY(double               missionHoverTime        READ missionHoverTime       NOTIFY missionHoverTimeChanged)
-    Q_PROPERTY(double               missionCruiseTime       READ missionCruiseTime      NOTIFY missionCruiseTimeChanged)
-    Q_PROPERTY(double               missionMaxTelemetry     READ missionMaxTelemetry    NOTIFY missionMaxTelemetryChanged)
+    Q_PROPERTY(double               missionDistance         READ missionDistance            NOTIFY missionDistanceChanged)
+    Q_PROPERTY(double               missionTime             READ missionTime                NOTIFY missionTimeChanged)
+    Q_PROPERTY(double               missionHoverDistance    READ missionHoverDistance       NOTIFY missionHoverDistanceChanged)
+    Q_PROPERTY(double               missionCruiseDistance   READ missionCruiseDistance      NOTIFY missionCruiseDistanceChanged)
+    Q_PROPERTY(double               missionHoverTime        READ missionHoverTime           NOTIFY missionHoverTimeChanged)
+    Q_PROPERTY(double               missionCruiseTime       READ missionCruiseTime          NOTIFY missionCruiseTimeChanged)
+    Q_PROPERTY(double               missionMaxTelemetry     READ missionMaxTelemetry        NOTIFY missionMaxTelemetryChanged)
 
     Q_INVOKABLE void removeMissionItem(int index);
 
@@ -106,9 +106,10 @@ public:
 
     // Property accessors
 
-    QGeoCoordinate      plannedHomePosition (void);
-    QmlObjectListModel* visualItems         (void) { return _visualItems; }
-    QmlObjectListModel* waypointLines       (void) { return &_waypointLines; }
+    QGeoCoordinate      plannedHomePosition     (void);
+    QmlObjectListModel* visualItems             (void) { return _visualItems; }
+    QmlObjectListModel* waypointLines           (void) { return &_waypointLines; }
+    QStringList         complexMissionItemNames (void) const;
 
     double  missionDistance         (void) const { return _missionFlightStatus.totalDistance; }
     double  missionTime             (void) const { return _missionFlightStatus.totalTime; }
@@ -130,6 +131,7 @@ signals:
     void missionCruiseDistanceChanged(double missionCruiseDistance);
     void missionCruiseTimeChanged(void);
     void missionMaxTelemetryChanged(double missionMaxTelemetry);
+    void complexMissionItemNamesChanged(void);
 
 private slots:
     void _newMissionItemsAvailableFromVehicle(bool removeAllRequested);
@@ -187,7 +189,6 @@ private:
     MissionFlightStatus_t   _missionFlightStatus;
     QString                 _surveyMissionItemName;
     QString                 _fwLandingMissionItemName;
-    QStringList             _complexMissionItemNames;
 
     static const char*  _settingsGroup;
 


### PR DESCRIPTION
* If there is only one complex item available the Pattern button no longer drops a panel it just adds the one available complex item.
* Also only show FW Landing for fixed wing vehicles.