### PR TITLE
New toolbar and user model for plan view

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -74,6 +74,7 @@
         <file alias="QGroundControl/Controls/OfflineMapButton.qml">src/QmlControls/OfflineMapButton.qml</file>
         <file alias="QGroundControl/Controls/ParameterEditor.qml">src/QmlControls/ParameterEditor.qml</file>
         <file alias="QGroundControl/Controls/ParameterEditorDialog.qml">src/QmlControls/ParameterEditorDialog.qml</file>
+        <file alias="QGroundControl/Controls/PlanToolBar.qml">src/MissionEditor/PlanToolBar.qml</file>
         <file alias="QGroundControl/Controls/QGCButton.qml">src/QmlControls/QGCButton.qml</file>
         <file alias="QGroundControl/Controls/QGCCheckBox.qml">src/QmlControls/QGCCheckBox.qml</file>
         <file alias="QGroundControl/Controls/QGCColoredImage.qml">src/QmlControls/QGCColoredImage.qml</file>

--- a/src/MissionEditor/MissionEditor.qml
+++ b/src/MissionEditor/MissionEditor.qml
@@ -59,6 +59,11 @@ QGCView {
     readonly property int _layerRallyPoints:    3
     property int _editingLayer: _layerMission
 
+    Component.onCompleted: {
+        toolbar.missionController =     Qt.binding(function () { return missionController })
+        toolbar.currentMissionItem =    Qt.binding(function () { return _currentMissionItem })
+    }
+
     onActiveVehiclePositionChanged: updateMapToVehiclePosition()
 
     Connections {

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -64,7 +64,7 @@ Rectangle {
         highlightMoveDuration:  250
         orientation:            ListView.Horizontal
         spacing:                0
-        width:                  parent.width - valueGrid.width - valueMissionGrid.width - (_margins * 2)
+        width:                  parent.width -  (_margins * 2)
         clip:                   true
         currentIndex:           _currentMissionIndex
 

--- a/src/MissionEditor/MissionItemStatus.qml
+++ b/src/MissionEditor/MissionItemStatus.qml
@@ -20,8 +20,8 @@ import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0
 
 Rectangle {
-    width:      _expanded ? expandedWidth : _collapsedWidth
-    height:     Math.max(valueGrid.height, valueMissionGrid.height) + (_margins * 2)
+    width:      expandedWidth
+    height:     ScreenTools.defaultFontPixelHeight * 7
     radius:     ScreenTools.defaultFontPixelWidth * 0.5
     color:      qgcPal.window
     opacity:    0.80
@@ -33,9 +33,6 @@ Rectangle {
     property real   missionDistance             ///< Total mission distance
     property real   missionTime                 ///< Total mission time
     property real   missionMaxTelemetry
-
-    property real   _collapsedWidth:            valueGrid.width + (_margins * 2)
-    property bool   _expanded:                  true
 
     property bool   _statusValid:               currentMissionItem != undefined
     property bool   _missionValid:              missionItems != undefined
@@ -59,92 +56,38 @@ Rectangle {
 
     readonly property real _margins:    ScreenTools.defaultFontPixelWidth
 
-    MouseArea {
-        anchors.fill:   parent
-        onClicked:      _expanded = !_expanded
-    }
+    QGCListView {
+        id:                     statusListView
+        anchors.fill:           parent
+        anchors.margins:        _margins
+        model:                  missionItems
+        highlightMoveDuration:  250
+        orientation:            ListView.Horizontal
+        spacing:                0
+        width:                  parent.width - valueGrid.width - valueMissionGrid.width - (_margins * 2)
+        clip:                   true
+        currentIndex:           _currentMissionIndex
 
-    Row {
-        anchors.fill:       parent
-        anchors.margins:    _margins
-        spacing:            _margins
+        delegate: Item {
+            height:     statusListView.height
+            width:      display ? (indicator.width + spacing)  : 0
+            visible:    display
 
-        GridLayout {
-            id:                     valueGrid
-            columns:                2
-            rowSpacing:             0
-            columnSpacing:          _margins
-            anchors.verticalCenter: parent.verticalCenter
+            property real availableHeight:  height - indicator.height
+            property bool graphAbsolute:    true
+            readonly property bool display: object.specifiesCoordinate && !object.isStandaloneCoordinate
+            readonly property real spacing: ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
 
-            QGCLabel { text: qsTr("Selected waypoint"); Layout.columnSpan: 2 }
-
-            QGCLabel { text: qsTr("Distance:") }
-            QGCLabel { text: _distanceText }
-
-            QGCLabel { text: qsTr("Alt diff:") }
-            QGCLabel { text: _altDifferenceText }
-
-            QGCLabel { text: qsTr("Gradient:") }
-            QGCLabel { text: _gradientText }
-
-            QGCLabel { text: qsTr("Azimuth:") }
-            QGCLabel { text: _azimuthText }
-        }
-
-        QGCListView {
-            id:                     statusListView
-            model:                  missionItems
-            highlightMoveDuration:  250
-            anchors.leftMargin:     _margins
-            anchors.rightMargin:    _margins
-            anchors.top:            parent.top
-            anchors.bottom:         parent.bottom
-            orientation:            ListView.Horizontal
-            spacing:                0
-            visible:                _expanded
-            width:                  parent.width - valueGrid.width - valueMissionGrid.width - (_margins * 2)
-            clip:                   true
-            currentIndex:           _currentMissionIndex
-
-            delegate: Item {
-                height:     statusListView.height
-                width:      display ? (indicator.width + spacing)  : 0
-                visible:    display
-
-                property real availableHeight:  height - indicator.height
-                property bool graphAbsolute:    true
-                readonly property bool display: object.specifiesCoordinate && !object.isStandaloneCoordinate
-                readonly property real spacing: ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
-
-                MissionItemIndexLabel {
-                    id:                         indicator
-                    anchors.horizontalCenter:   parent.horizontalCenter
-                    y:                          availableHeight - (availableHeight * object.altPercent)
-                    small:                      true
-                    checked:                    object.isCurrentItem
-                    label:                      object.abbreviation
-                    visible:                    object.relativeAltitude ? true : (object.homePosition || graphAbsolute)
-                }
+            MissionItemIndexLabel {
+                id:                         indicator
+                anchors.horizontalCenter:   parent.horizontalCenter
+                y:                          availableHeight - (availableHeight * object.altPercent)
+                small:                      true
+                checked:                    object.isCurrentItem
+                label:                      object.abbreviation
+                visible:                    object.relativeAltitude ? true : (object.homePosition || graphAbsolute)
             }
-        }
-
-        Grid {
-            id:                 valueMissionGrid
-            columns:            2
-            columnSpacing:      _margins
-            anchors.verticalCenter: parent.verticalCenter
-
-            QGCLabel { text: qsTr("Total mission") }
-            QGCLabel { text: qsTr(" ") }
-
-            QGCLabel { text: qsTr("Distance:") }
-            QGCLabel { text: _missionDistanceText }
-
-            QGCLabel { text: qsTr("Time:") }
-            QGCLabel { text: _missionTimeText }
-
-            QGCLabel { text: qsTr("Max telem dist:") }
-            QGCLabel { text: _missionMaxTelemetryText }
         }
     }
 }
+

--- a/src/MissionEditor/PlanToolBar.qml
+++ b/src/MissionEditor/PlanToolBar.qml
@@ -1,0 +1,172 @@
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+import QtQuick.Dialogs  1.2
+
+import QGroundControl                   1.0
+import QGroundControl.ScreenTools       1.0
+import QGroundControl.Controls          1.0
+import QGroundControl.FactControls      1.0
+import QGroundControl.Palette           1.0
+
+// Toolbar for Plan View
+Rectangle {
+    id:                 _root
+    height:             ScreenTools.toolbarHeight
+    anchors.left:       parent.left
+    anchors.right:      parent.right
+    anchors.top:        parent.top
+    z:                  toolBar.z + 1
+    color:              qgcPal.window
+    visible:            false
+
+    signal showFlyView
+
+    property var    missionController
+    property var    currentMissionItem          ///< Mission item to display status for
+
+    property var    missionItems:               missionController.visualItems
+    property real   missionDistance:            missionController.missionDistance
+    property real   missionTime:                missionController.missionTime
+    property real   missionMaxTelemetry:        missionController.missionMaxTelemetry
+
+    property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
+
+    property bool   _statusValid:               currentMissionItem != undefined
+    property bool   _missionValid:              missionItems != undefined
+
+    property real   _distance:                  _statusValid ? currentMissionItem.distance : NaN
+    property real   _altDifference:             _statusValid ? currentMissionItem.altDifference : NaN
+    property real   _gradient:                  _statusValid && currentMissionItem.distance > 0 ? Math.atan(currentMissionItem.altDifference / currentMissionItem.distance) : NaN
+    property real   _gradientPercent:           isNaN(_gradient) ? NaN : _gradient * 100
+    property real   _azimuth:                   _statusValid ? currentMissionItem.azimuth : NaN
+    property real   _missionDistance:           _missionValid ? missionDistance : NaN
+    property real   _missionMaxTelemetry:       _missionValid ? missionMaxTelemetry : NaN
+    property real   _missionTime:               _missionValid ? missionTime : NaN
+
+    property string _distanceText:              isNaN(_distance) ? "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_distance).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
+    property string _altDifferenceText:         isNaN(_altDifference) ? "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_altDifference).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
+    property string _gradientText:              isNaN(_gradient) ? "-.-" : _gradientPercent.toFixed(0) + "%"
+    property string _azimuthText:               isNaN(_azimuth) ? "-.-" : Math.round(_azimuth)
+    property string _missionDistanceText:       isNaN(_missionDistance) ? "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_missionDistance).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
+    property string _missionTimeText:           isNaN(_missionTime) ? "-.-" : Number(_missionTime / 60).toFixed(1) + " min"
+    property string _missionMaxTelemetryText:   isNaN(_missionMaxTelemetry) ? "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_missionMaxTelemetry).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
+
+    readonly property real _margins:    ScreenTools.defaultFontPixelWidth
+
+    QGCPalette { id: qgcPal }
+
+    Row {
+        anchors.top:    parent.top
+        anchors.bottom: parent.bottom
+        spacing:        ScreenTools.defaultFontPixelWidth * 2
+
+        QGCToolBarButton {
+            id:                 settingsButton
+            anchors.top:        parent.top
+            anchors.bottom:     parent.bottom
+            source:             "/qmlimages/PaperPlane.svg"
+            logo:               true
+            checked:            false
+
+            onClicked: {
+                checked = false
+                if (missionController.dirty) {
+                    uploadPrompt.visible = true
+                } else {
+                    showFlyView()
+                }
+            }
+
+            MessageDialog {
+                id:                 uploadPrompt
+                title:              _activeVehicle ? qsTr("Unsent changes") : qsTr("Unsaved changes")
+                text:               qsTr("You have %1 changes to your mission. Are you sure you want to leave before you %2?").arg(_activeVehicle ? qsTr("unsent") : qsTr("unsaved")).arg(_activeVehicle ? qsTr("send the missoin to the vehicle") : qsTr("save the mission to a file"))
+                standardButtons:    StandardButton.Yes | StandardButton.No
+
+                onNo: visible = false
+
+                onYes: {
+                    visible = false
+                    showFlyView()
+                }
+            }
+        }
+
+        GridLayout {
+            anchors.top:            parent.top
+            anchors.bottom:         parent.bottom
+            columns:                4
+            rowSpacing:             0
+            columnSpacing:          _margins
+
+            QGCLabel {
+                text: qsTr("Selected waypoint")
+                Layout.columnSpan: 4
+                font.pointSize: ScreenTools.smallFontPointSize
+            }
+
+            QGCLabel { text: qsTr("Distance:") }
+            QGCLabel { text: _distanceText }
+
+            QGCLabel { text: qsTr("Gradient:") }
+            QGCLabel { text: _gradientText }
+
+            QGCLabel { text: qsTr("Alt diff:") }
+            QGCLabel { text: _altDifferenceText }
+
+            QGCLabel { text: qsTr("Azimuth:") }
+            QGCLabel { text: _azimuthText }
+        }
+
+        GridLayout {
+            anchors.top:            parent.top
+            anchors.bottom:         parent.bottom
+            columns:                4
+            rowSpacing:             0
+            columnSpacing:          _margins
+
+            QGCLabel {
+                text: qsTr("Total mission")
+                Layout.columnSpan: 4
+                font.pointSize: ScreenTools.smallFontPointSize
+            }
+
+            QGCLabel { text: qsTr("Distance:") }
+            QGCLabel { text: _missionDistanceText }
+
+            QGCLabel { text: qsTr("Max telem dist:") }
+            QGCLabel { text: _missionMaxTelemetryText }
+
+            QGCLabel { text: qsTr("Time:") }
+            QGCLabel { text: _missionTimeText }
+        }
+    }
+
+    QGCButton {
+        anchors.rightMargin:    _margins
+        anchors.right:          parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        text:                   _activeVehicle ? qsTr("Upload") : qsTr("Save")
+        visible:                missionController.dirty
+        primary:                true
+
+        onClicked: {
+            if (_activeVehicle) {
+                missionController.sendToVehicle()
+            } else {
+                missionController.saveToSelectedFile()
+            }
+        }
+
+        NumberAnimation on opacity {
+            id:         opacityAnimation
+            running:    missionController.dirty
+            from:       0.5
+            to:         1.0
+            loops:      Animation.Infinite
+            duration:   2000
+        }
+    }
+}
+

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -26,6 +26,7 @@ ModeSwitchDisplay       1.0 ModeSwitchDisplay.qml
 MultiRotorMotorDisplay  1.0 MultiRotorMotorDisplay.qml
 ParameterEditor         1.0 ParameterEditor.qml
 ParameterEditorDialog   1.0 ParameterEditorDialog.qml
+PlanToolBar             1.0 PlanToolBar.qml
 RallyPointEditorHeader  1.0 RallyPointEditorHeader.qml
 RallyPointItemEditor    1.0 RallyPointItemEditor.qml
 RCChannelMonitor        1.0 RCChannelMonitor.qml

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -93,7 +93,7 @@ Item {
         ScreenTools.availableHeight = parent.height - toolBar.height
         hideAllViews()
         planViewLoader.visible = true
-        toolBar.checkPlanButton()
+        planToolBar.visible = true
     }
 
     function showFlyView() {
@@ -269,6 +269,20 @@ Item {
         onShowAnalyzeView:      mainWindow.showAnalyzeView()
     }
 
+    PlanToolBar {
+        id:                 planToolBar
+        height:             ScreenTools.toolbarHeight
+        anchors.left:       parent.left
+        anchors.right:      parent.right
+        anchors.top:        parent.top
+        z:                  toolBar.z + 1
+
+        onShowFlyView: {
+            planToolBar.visible = false
+            mainWindow.showFlyView()
+        }
+    }
+
     Loader {
         id:                 settingsViewLoader
         anchors.left:       parent.left
@@ -292,12 +306,16 @@ Item {
         anchors.top:        toolBar.bottom
         anchors.bottom:     parent.bottom
         visible:            false
+
+        property var planToolBar: planToolBar
     }
 
     Loader {
         id:                 planViewLoader
         anchors.fill:       parent
         visible:            false
+
+        property var toolbar: planToolBar
     }
 
     FlightDisplayView {


### PR DESCRIPTION
Now when you go to plan view you see this:
![screen shot 2017-03-23 at 4 04 04 pm](https://cloud.githubusercontent.com/assets/5876851/24273944/78e46cf6-0fe2-11e7-9077-c4b34748a791.png)

@dogmaphobic  Had the fantastic idea to do this. I just implemented it:
* Reuses toolbar real estate to show mission stats
* If the mission is dirty a button will show up on the right saying either "Upload" or "Save" depending on whether you are connected to a vehicle.
* When you click the Fly button to go back to Fly view you will be prompted to Upload/Save if your mission is dirty before you leave.

Hoping this makes the user model of needing to send the vehicel to the vehicle a little more understanable. It's work in progress from a standpoint of user model but everything there is working.