### PR TITLE
Plan toolbar tweaks

### DIFF
--- a/src/MissionEditor/PlanToolBar.qml
+++ b/src/MissionEditor/PlanToolBar.qml
@@ -17,7 +17,7 @@ Rectangle {
     anchors.right:      parent.right
     anchors.top:        parent.top
     z:                  toolBar.z + 1
-    color:              qgcPal.window
+    color:              qgcPal.globalTheme === QGCPalette.Light ? Qt.rgba(1,1,1,0.8) : Qt.rgba(0,0,0,0.75)
     visible:            false
 
     signal showFlyView
@@ -55,6 +55,14 @@ Rectangle {
     readonly property real _margins: ScreenTools.defaultFontPixelWidth
 
     QGCPalette { id: qgcPal }
+
+    //-- Eat mouse events, preventing them from reaching toolbar, which is underneath us.
+    MouseArea {
+        anchors.fill:   parent
+        onWheel:        { wheel.accepted = true; }
+        onPressed:      { mouse.accepted = true; }
+        onReleased:     { mouse.accepted = true; }
+    }
 
     Row {
         anchors.top:    parent.top

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -259,6 +259,7 @@ Item {
         anchors.left:       parent.left
         anchors.right:      parent.right
         anchors.top:        parent.top
+        opacity:            planToolBar.visible ? 0 : 1
         z:                  QGroundControl.zOrderTopMost
 
         Component.onCompleted:  ScreenTools.availableHeight = parent.height - toolBar.height


### PR DESCRIPTION
- Eat mouse events within the plan toolbar, preventing them from reaching the main toolbar, which is underneath it.
- Making the main toolbar transparent when the plan toolbar is visible.
- Using the same translucent color as the main toolbar.