### PR TITLE
Hide plan toolbar when switching views

### DIFF
--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -53,6 +53,7 @@ Item {
         for (var i=0; i<_viewList.length; i++) {
             _viewList[i].visible = false
         }
+        planToolBar.visible = false
     }
 
     function showSettingsView() {


### PR DESCRIPTION
There was a bug where you went to plan and then a vehicle connected which required setup. This then automatically took you to Setup. But the plan toolbar was still there.