### PR TITLE
New Plan a mission sync/save user model

### DIFF
--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -88,6 +88,9 @@ public:
     /// Sends the mission items to the specified vehicle
     static void sendItemsToVehicle(Vehicle* vehicle, QmlObjectListModel* visualMissionItems);
 
+    Q_INVOKABLE void save(void);
+    Q_INVOKABLE void clearMission(void);
+
     // Overrides from PlanElementController
     void start                      (bool editMode) final;
     void startStaticActiveVehicle   (Vehicle* vehicle) final;

--- a/src/MissionManager/MissionSettings.FactMetaData.json
+++ b/src/MissionManager/MissionSettings.FactMetaData.json
@@ -19,8 +19,14 @@
     "name":             "MissionEndAction",
     "shortDescription": "The action to take when the mission completed.",
     "type":             "uint32",
-    "enumStrings":      "No action on mission completion,Loiter after mission completes,RTL after mission completes,Land after mission completes",
-    "enumValues":       "0,1,2,3",
+    "enumStrings":      "No action on mission end,Loiter after mission end,RTL after mission end",
+    "enumValues":       "0,1,2",
     "defaultValue":     0
+},
+{
+    "name":             "MissionName",
+    "shortDescription": "Name for the mission.",
+    "type":             "string",
+    "defaultValue":     ""
 }
 ]

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -28,23 +28,29 @@ public:
     enum MissionEndAction {
         MissionEndNoAction,
         MissionEndLoiter,
-        MissionEndRTL,
-        MissionEndLand
+        MissionEndRTL
     };
     Q_ENUMS(MissionEndAction)
 
-    Q_PROPERTY(bool     specifyMissionFlightSpeed       READ specifyMissionFlightSpeed      WRITE setSpecifyMissionFlightSpeed  NOTIFY specifyMissionFlightSpeedChanged)
-    Q_PROPERTY(Fact*    missionFlightSpeed              READ missionFlightSpeed                                                 CONSTANT)
-    Q_PROPERTY(Fact*    missionEndAction                READ missionEndAction                                                   CONSTANT)
-    Q_PROPERTY(Fact*    plannedHomePositionAltitude     READ plannedHomePositionAltitude                                        CONSTANT)
-    Q_PROPERTY(QObject* cameraSection                   READ cameraSection                                                      CONSTANT)
+    Q_PROPERTY(Fact*    missionName                 READ missionName                                                        CONSTANT)
+    Q_PROPERTY(Fact*    missionFullPath             READ missionFullPath                                                    CONSTANT)
+    Q_PROPERTY(bool     existingMission             READ existingMission                WRITE setExistingMission            NOTIFY existingMissionChanged)
+    Q_PROPERTY(bool     specifyMissionFlightSpeed   READ specifyMissionFlightSpeed      WRITE setSpecifyMissionFlightSpeed  NOTIFY specifyMissionFlightSpeedChanged)
+    Q_PROPERTY(Fact*    missionFlightSpeed          READ missionFlightSpeed                                                 CONSTANT)
+    Q_PROPERTY(Fact*    missionEndAction            READ missionEndAction                                                   CONSTANT)
+    Q_PROPERTY(Fact*    plannedHomePositionAltitude READ plannedHomePositionAltitude                                        CONSTANT)
+    Q_PROPERTY(QObject* cameraSection               READ cameraSection                                                      CONSTANT)
 
-    bool    specifyMissionFlightSpeed   (void) const { return _specifyMissionFlightSpeed; }
+    Fact*   missionName                 (void) { return &_missionNameFact; }
+    Fact*   missionFullPath             (void) { return &_missionFullPathFact; }
     Fact*   plannedHomePositionAltitude (void) { return &_plannedHomePositionAltitudeFact; }
     Fact*   missionFlightSpeed          (void) { return &_missionFlightSpeedFact; }
     Fact*   missionEndAction            (void) { return &_missionEndActionFact; }
+    bool    specifyMissionFlightSpeed   (void) const { return _specifyMissionFlightSpeed; }
+    bool    existingMission             (void) const { return _existingMission; }
 
     void setSpecifyMissionFlightSpeed(bool specifyMissionFlightSpeed);
+    void setExistingMission(bool existingMission);
     QObject* cameraSection(void) { return &_cameraSection; }
 
     /// Scans the loaded items for settings items
@@ -94,17 +100,22 @@ public:
     static const char* jsonComplexItemTypeValue;
 
 signals:
-    bool specifyMissionFlightSpeedChanged(bool specifyMissionFlightSpeed);
+    void specifyMissionFlightSpeedChanged(bool specifyMissionFlightSpeed);
+    void existingMissionChanged(bool existingMission);
 
 private slots:
     void _setDirtyAndUpdateLastSequenceNumber   (void);
     void _setDirty                              (void);
     void _cameraSectionDirtyChanged             (bool dirty);
     void _updateAltitudeInCoordinate            (QVariant value);
+    void _missionNameChanged                    (QVariant value);
 
 private:
+    bool            _existingMission;
     bool            _specifyMissionFlightSpeed;
     QGeoCoordinate  _plannedHomePositionCoordinate;     // Does not include altitde
+    Fact            _missionNameFact;
+    Fact            _missionFullPathFact;
     Fact            _plannedHomePositionAltitudeFact;
     Fact            _missionFlightSpeedFact;
     Fact            _missionEndActionFact;
@@ -115,6 +126,8 @@ private:
 
     static QMap<QString, FactMetaData*> _metaDataMap;
 
+    static const char* _missionNameName;
+    static const char* _missionFullPathName;
     static const char* _plannedHomePositionAltitudeName;
     static const char* _missionFlightSpeedName;
     static const char* _missionEndActionName;

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -28,7 +28,7 @@ Rectangle {
 
     property bool   _currentItem:           missionItem.isCurrentItem
     property color  _outerTextColor:        _currentItem ? "black" : qgcPal.text
-    property bool   _noMissionItemsAdded:   ListView.view.model.count == 1
+    property bool   _noMissionItemsAdded:   ListView.view.model.count === 1
     property real   _sectionSpacer:         ScreenTools.defaultFontPixelWidth / 2  // spacing between section headings
 
     readonly property real  _editFieldWidth:    Math.min(width - _margin * 2, ScreenTools.defaultFontPixelWidth * 12)

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -9,6 +9,7 @@ import QGroundControl.Controls          1.0
 import QGroundControl.FactControls      1.0
 import QGroundControl.Palette           1.0
 import QGroundControl.SettingsManager   1.0
+import QGroundControl.Controllers       1.0
 
 // Editor for Mission Settings
 Rectangle {
@@ -18,6 +19,38 @@ Rectangle {
     color:              qgcPal.windowShadeDark
     visible:            missionItem.isCurrentItem
     radius:             _radius
+
+    property var    _missionVehicle:            missionController.vehicle
+    property bool   _vehicleHasHomePosition:    _missionVehicle.homePosition.isValid
+    property bool   _offlineEditing:            _missionVehicle.isOfflineEditingVehicle
+    property bool   _showOfflineVehicleCombos:  _offlineEditing && _multipleFirmware && _noMissionItemsAdded
+    property bool   _showCruiseSpeed:           !_missionVehicle.multiRotor
+    property bool   _showHoverSpeed:            _missionVehicle.multiRotor || _missionVehicle.vtol
+    property bool   _multipleFirmware:          QGroundControl.supportedFirmwareCount > 2
+    property real   _fieldWidth:                ScreenTools.defaultFontPixelWidth * 16
+    property bool   _mobile:                    ScreenTools.isMobile
+    property var    _savePath:                  QGroundControl.settingsManager.appSettings.missionSavePath
+    property var    _fileExtension:             QGroundControl.settingsManager.appSettings.missionFileExtension
+    property bool   _newMissionAlreadyExists:   false
+    property bool   _noMissionName:             missionItem.missionName.valueString === ""
+    property bool   _showMissionList:           _noMissionItemsAdded && (_noMissionName || _newMissionAlreadyExists)
+    property bool   _existingMissionLoaded:     missionItem.existingMission
+
+    readonly property string _firmwareLabel:    qsTr("Firmware")
+    readonly property string _vehicleLabel:     qsTr("Vehicle")
+
+    QGCPalette { id: qgcPal }
+    QFileDialogController { id: fileController }
+
+    Connections {
+        target:             missionItem.missionName
+
+        onRawValueChanged: {
+            if (!_existingMissionLoaded) {
+                _newMissionAlreadyExists = !_noMissionName && fileController.fileExists(_savePath + "/" + missionItem.missionName.valueString + "." + _fileExtension)
+            }
+        }
+    }
 
     Loader {
         id:              deferedload
@@ -33,21 +66,6 @@ Rectangle {
                 id:                 valuesItem
                 height:             valuesColumn.height + (_margin * 2)
 
-                property var    _missionVehicle:            missionController.vehicle
-                property bool   _vehicleHasHomePosition:    _missionVehicle.homePosition.isValid
-                property bool   _offlineEditing:            _missionVehicle.isOfflineEditingVehicle
-                property bool   _showOfflineVehicleCombos:  _offlineEditing && _multipleFirmware && _noMissionItemsAdded
-                property bool   _showCruiseSpeed:           !_missionVehicle.multiRotor
-                property bool   _showHoverSpeed:            _missionVehicle.multiRotor || _missionVehicle.vtol
-                property bool   _multipleFirmware:          QGroundControl.supportedFirmwareCount > 2
-                property real   _fieldWidth:                ScreenTools.defaultFontPixelWidth * 16
-                property bool   _mobile:                    ScreenTools.isMobile
-
-                readonly property string _firmwareLabel:    qsTr("Firmware")
-                readonly property string _vehicleLabel:     qsTr("Vehicle")
-
-                QGCPalette { id: qgcPal }
-
                 Column {
                     id:             valuesColumn
                     anchors.left:   parent.left
@@ -55,176 +73,269 @@ Rectangle {
                     anchors.top:    parent.top
                     spacing:        _margin
 
-                    SectionHeader {
-                        id:             plannedHomePositionSection
-                        text:           qsTr("Planned Home Position")
-                        showSpacer:     false
-                        visible:        !_vehicleHasHomePosition
+                    QGCLabel {
+                        text:           qsTr("Mission name")
+                        font.pointSize: ScreenTools.smallFontPointSize
                     }
 
-                    Column {
+                    FactTextField {
                         anchors.left:   parent.left
                         anchors.right:  parent.right
-                        spacing:        _margin
-                        visible:        plannedHomePositionSection.checked && !_vehicleHasHomePosition
-
-                        GridLayout {
-                            anchors.left:   parent.left
-                            anchors.right:  parent.right
-                            columnSpacing:  ScreenTools.defaultFontPixelWidth
-                            rowSpacing:     columnSpacing
-                            columns:        2
-
-                            QGCLabel {
-                                text: qsTr("Altitude")
-                            }
-                            FactTextField {
-                                fact:               missionItem.plannedHomePositionAltitude
-                                Layout.fillWidth:   true
-                            }
-                        }
-
-                        QGCLabel {
-                            width:                  parent.width
-                            wrapMode:               Text.WordWrap
-                            font.pointSize:         ScreenTools.smallFontPointSize
-                            text:                   qsTr("Actual position set by vehicle at flight time.")
-                            horizontalAlignment:    Text.AlignHCenter
-                        }
-
-                        QGCButton {
-                            text:                       qsTr("Set Home To Map Center")
-                            onClicked:                  missionItem.coordinate = map.center
-                            anchors.horizontalCenter:   parent.horizontalCenter
-                        }
-                    }
-
-                    SectionHeader {
-                        id:             vehicleInfoSectionHeader
-                        text:           qsTr("Vehicle Info")
-                        visible:        _offlineEditing
-                        checked:        false
-                    }
-
-                    GridLayout {
-                        anchors.left:   parent.left
-                        anchors.right:  parent.right
-                        columnSpacing:  ScreenTools.defaultFontPixelWidth
-                        rowSpacing:     columnSpacing
-                        columns:        2
-                        visible:        vehicleInfoSectionHeader.visible && vehicleInfoSectionHeader.checked
-
-                        QGCLabel {
-                            text:               _firmwareLabel
-                            Layout.fillWidth:   true
-                            visible:            _showOfflineVehicleCombos
-                        }
-                        FactComboBox {
-                            fact:                   QGroundControl.settingsManager.appSettings.offlineEditingFirmwareType
-                            indexModel:             false
-                            Layout.preferredWidth:  _fieldWidth
-                            visible:                _showOfflineVehicleCombos
-                        }
-
-                        QGCLabel {
-                            text:               _vehicleLabel
-                            Layout.fillWidth:   true
-                            visible:            _showOfflineVehicleCombos
-                        }
-                        FactComboBox {
-                            fact:                   QGroundControl.settingsManager.appSettings.offlineEditingVehicleType
-                            indexModel:             false
-                            Layout.preferredWidth:  _fieldWidth
-                            visible:                _showOfflineVehicleCombos
-                        }
-
-                        QGCLabel {
-                            text:               qsTr("Cruise speed")
-                            visible:            _showCruiseSpeed
-                            Layout.fillWidth:   true
-                        }
-                        FactTextField {
-                            fact:                   QGroundControl.settingsManager.appSettings.offlineEditingCruiseSpeed
-                            visible:                _showCruiseSpeed
-                            Layout.preferredWidth:  _fieldWidth
-                        }
-
-                        QGCLabel {
-                            text:               qsTr("Hover speed")
-                            visible:            _showHoverSpeed
-                            Layout.fillWidth:   true
-                        }
-                        FactTextField {
-                            fact:                   QGroundControl.settingsManager.appSettings.offlineEditingHoverSpeed
-                            visible:                _showHoverSpeed
-                            Layout.preferredWidth:  _fieldWidth
-                        }
-                    } // GridLayout
-
-                    SectionHeader {
-                        id:             missionDefaultsSectionHeader
-                        text:           qsTr("Mission Defaults")
-                        checked:        true
-                    }
-
-                    Column {
-                        anchors.left:   parent.left
-                        anchors.right:  parent.right
-                        spacing:        _margin
-                        visible:        missionDefaultsSectionHeader.checked
-
-                        GridLayout {
-                            anchors.left:   parent.left
-                            anchors.right:  parent.right
-                            columnSpacing:  ScreenTools.defaultFontPixelWidth
-                            rowSpacing:     columnSpacing
-                            columns:        2
-
-                            QGCLabel {
-                                text:       qsTr("Altitude")
-                            }
-                            FactTextField {
-                                fact:               QGroundControl.settingsManager.appSettings.defaultMissionItemAltitude
-                                Layout.fillWidth:   true
-                            }
-
-                            QGCCheckBox {
-                                id:         flightSpeedCheckBox
-                                text:       qsTr("Flight speed")
-                                visible:    !_missionVehicle.vtol
-                                checked:    missionItem.specifyMissionFlightSpeed
-                                onClicked:  missionItem.specifyMissionFlightSpeed = checked
-                            }
-                            FactTextField {
-                                Layout.fillWidth:   true
-                                fact:               missionItem.missionFlightSpeed
-                                visible:            flightSpeedCheckBox.visible
-                                enabled:            flightSpeedCheckBox.checked
-                            }
-                        } // GridLayout
-
-                        FactComboBox {
-                            anchors.left:   parent.left
-                            anchors.right:  parent.right
-                            fact:           missionItem.missionEndAction
-                            indexModel:     false
-                        }
-                    }
-
-                    CameraSection {
-                        checked: missionItem.cameraSection.settingsSpecified
+                        fact:           missionItem.missionName
+                        visible:        !_existingMissionLoaded
                     }
 
                     QGCLabel {
-                        width:                  parent.width
-                        wrapMode:               Text.WordWrap
-                        font.pointSize:         ScreenTools.smallFontPointSize
-                        text:                   qsTr("Speeds are only used for time calculations. Actual vehicle speed will not be affected.")
-                        horizontalAlignment:    Text.AlignHCenter
-                        visible:                _offlineEditing && _missionVehicle.vtol
+                        text:       missionItem.missionName.valueString
+                        visible:    _existingMissionLoaded
+                    }
+
+                    QGCLabel {
+                        text:           qsTr("Mission already exists")
+                        font.pointSize: ScreenTools.smallFontPointSize
+                        color:          qgcPal.warningText
+                        visible:        !_existingMissionLoaded && _newMissionAlreadyExists
+                    }
+
+                    QGCButton {
+                        text:       qsTr("Clear mission")
+                        visible:    !_noMissionItemsAdded
+                        onClicked:  missionController.clearMission()
+                    }
+
+                    Loader {
+                        anchors.left:       parent.left
+                        anchors.right:      parent.right
+                        sourceComponent:    _showMissionList ? missionList : missionSettings
                     }
                 } // Column
             } // Item
         } // Component
     } // Loader
+
+    Component {
+        id: missionList
+
+        QGCFlickable {
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            height:         missionColumn.height
+
+            Column {
+                id:             missionColumn
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        _margin
+
+                SectionHeader {
+                    text:       qsTr("Load Mission")
+                    showSpacer: false
+                }
+
+                QGCButton {
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    text:           qsTr("Load from Vehicle")
+                    visible:        !_offlineEditing
+
+                    onClicked: {
+                        missionController.loadFromVehicle()
+                    }
+                }
+
+                QGCLabel {
+                    text:       qsTr("No mission files")
+                    visible:    missionRepeater.model.length === 0
+                }
+
+                Repeater {
+                    id:     missionRepeater
+                    model:  fileController.getFiles(_savePath, _fileExtension);
+
+                    QGCButton {
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        text:           modelData
+
+                        onClicked: {
+                            missionController.loadFromFile(fileController.fullyQualifiedFilename(_savePath, modelData, _fileExtension))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: missionSettings
+
+        Column {
+            id:             valuesColumn
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            anchors.top:    parent.top
+            spacing:        _margin
+
+            SectionHeader {
+                id:         missionDefaultsSectionHeader
+                text:       qsTr("Mission Defaults")
+                checked:    true
+                showSpacer: false
+            }
+
+            Column {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        _margin
+                visible:        missionDefaultsSectionHeader.checked
+
+                GridLayout {
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    columnSpacing:  ScreenTools.defaultFontPixelWidth
+                    rowSpacing:     columnSpacing
+                    columns:        2
+
+                    QGCLabel {
+                        text:       qsTr("Waypoint alt")
+                    }
+                    FactTextField {
+                        fact:               QGroundControl.settingsManager.appSettings.defaultMissionItemAltitude
+                        Layout.fillWidth:   true
+                    }
+
+                    QGCCheckBox {
+                        id:         flightSpeedCheckBox
+                        text:       qsTr("Flight speed")
+                        visible:    !_missionVehicle.vtol
+                        checked:    missionItem.specifyMissionFlightSpeed
+                        onClicked:  missionItem.specifyMissionFlightSpeed = checked
+                    }
+                    FactTextField {
+                        Layout.fillWidth:   true
+                        fact:               missionItem.missionFlightSpeed
+                        visible:            flightSpeedCheckBox.visible
+                        enabled:            flightSpeedCheckBox.checked
+                    }
+                } // GridLayout
+
+                FactComboBox {
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    fact:           missionItem.missionEndAction
+                    indexModel:     false
+                }
+            }
+
+            CameraSection {
+                checked: missionItem.cameraSection.settingsSpecified
+            }
+
+            SectionHeader {
+                id:         vehicleInfoSectionHeader
+                text:       qsTr("Vehicle Info")
+                visible:    _offlineEditing
+                checked:    false
+            }
+
+            GridLayout {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                columnSpacing:  ScreenTools.defaultFontPixelWidth
+                rowSpacing:     columnSpacing
+                columns:        2
+                visible:        vehicleInfoSectionHeader.visible && vehicleInfoSectionHeader.checked
+
+                QGCLabel {
+                    text:               _firmwareLabel
+                    Layout.fillWidth:   true
+                    visible:            _showOfflineVehicleCombos
+                }
+                FactComboBox {
+                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingFirmwareType
+                    indexModel:             false
+                    Layout.preferredWidth:  _fieldWidth
+                    visible:                _showOfflineVehicleCombos
+                }
+
+                QGCLabel {
+                    text:               _vehicleLabel
+                    Layout.fillWidth:   true
+                    visible:            _showOfflineVehicleCombos
+                }
+                FactComboBox {
+                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingVehicleType
+                    indexModel:             false
+                    Layout.preferredWidth:  _fieldWidth
+                    visible:                _showOfflineVehicleCombos
+                }
+
+                QGCLabel {
+                    text:               qsTr("Cruise speed")
+                    visible:            _showCruiseSpeed
+                    Layout.fillWidth:   true
+                }
+                FactTextField {
+                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingCruiseSpeed
+                    visible:                _showCruiseSpeed
+                    Layout.preferredWidth:  _fieldWidth
+                }
+
+                QGCLabel {
+                    text:               qsTr("Hover speed")
+                    visible:            _showHoverSpeed
+                    Layout.fillWidth:   true
+                }
+                FactTextField {
+                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingHoverSpeed
+                    visible:                _showHoverSpeed
+                    Layout.preferredWidth:  _fieldWidth
+                }
+            } // GridLayout
+
+            SectionHeader {
+                id:         plannedHomePositionSection
+                text:       qsTr("Planned Home Position")
+                visible:    !_vehicleHasHomePosition
+                checked:    false
+            }
+
+            Column {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        _margin
+                visible:        plannedHomePositionSection.checked && !_vehicleHasHomePosition
+
+                GridLayout {
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    columnSpacing:  ScreenTools.defaultFontPixelWidth
+                    rowSpacing:     columnSpacing
+                    columns:        2
+
+                    QGCLabel {
+                        text: qsTr("Altitude")
+                    }
+                    FactTextField {
+                        fact:               missionItem.plannedHomePositionAltitude
+                        Layout.fillWidth:   true
+                    }
+                }
+
+                QGCLabel {
+                    width:                  parent.width
+                    wrapMode:               Text.WordWrap
+                    font.pointSize:         ScreenTools.smallFontPointSize
+                    text:                   qsTr("Actual position set by vehicle at flight time.")
+                    horizontalAlignment:    Text.AlignHCenter
+                }
+
+                QGCButton {
+                    text:                       qsTr("Set Home To Map Center")
+                    onClicked:                  missionItem.coordinate = map.center
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                }
+            }
+        } // Column
+    }
 } // Rectangle

--- a/src/PlanView/PlanToolBar.qml
+++ b/src/PlanView/PlanToolBar.qml
@@ -80,26 +80,10 @@ Rectangle {
             checked:            false
 
             onClicked: {
+                console.log("Leave plan clicked")
                 checked = false
-                if (missionController.dirty) {
-                    uploadPrompt.visible = true
-                } else {
-                    showFlyView()
-                }
-            }
-
-            MessageDialog {
-                id:                 uploadPrompt
-                title:              _activeVehicle ? qsTr("Unsent changes") : qsTr("Unsaved changes")
-                text:               qsTr("You have %1 changes to your mission. Are you sure you want to leave before you %2?").arg(_activeVehicle ? qsTr("unsent") : qsTr("unsaved")).arg(_activeVehicle ? qsTr("send the mission to the vehicle") : qsTr("save the mission to a file"))
-                standardButtons:    StandardButton.Yes | StandardButton.No
-
-                onNo: visible = false
-
-                onYes: {
-                    visible = false
-                    showFlyView()
-                }
+                missionController.saveOnSwitch()
+                showFlyView()
             }
         }
 
@@ -178,32 +162,6 @@ Rectangle {
 
             QGCLabel { text: qsTr("Swap waypoint:") }
             QGCLabel { text: "--" }
-        }
-    }
-
-    QGCButton {
-        anchors.rightMargin:    _margins
-        anchors.right:          parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        text:                   _activeVehicle ? qsTr("Upload") : qsTr("Save")
-        visible:                missionDirty
-        primary:                true
-
-        onClicked: {
-            if (_activeVehicle) {
-                missionController.sendToVehicle()
-            } else {
-                missionController.saveToSelectedFile()
-            }
-        }
-
-        NumberAnimation on opacity {
-            id:         opacityAnimation
-            running:    missionDirty
-            from:       0.5
-            to:         1.0
-            loops:      Animation.Infinite
-            duration:   2000
         }
     }
 }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -103,15 +103,16 @@ QGCView {
             setCurrentItem(0)
         }
 
+        // Users is switching away from Plan View
+        function saveOnSwitch() {
+            save()
+        }
+
         function loadFromSelectedFile() {
             fileDialog.title =          qsTr("Select Mission File")
             fileDialog.selectExisting = true
             fileDialog.nameFilters =    missionController.nameFilters
             fileDialog.openForLoad()
-
-            // FIXME: Hmm
-            //mapFitFunctions.fitMapViewportToMissionItems()
-            //_currentMissionItem = _visualItems.get(0)
         }
 
         function saveToSelectedFile() {
@@ -464,13 +465,12 @@ QGCView {
                 // Plan Element selector (Mission/Fence/Rally)
                 Row {
                     id:                 planElementSelectorRow
-                    anchors.topMargin:  parent.height - ScreenTools.availableHeight + _margin
-                    anchors.top:        parent.top
+                    anchors.top:        toolStrip.top
                     anchors.leftMargin: parent.width - _rightPanelWidth
                     anchors.left:       parent.left
                     z:                  QGroundControl.zOrderWidgets
                     spacing:            _horizontalMargin
-                    visible:            QGroundControl.corePlugin.options.enablePlanViewSelector
+                    visible:            false // WIP: Temporarily remove - QGroundControl.corePlugin.options.enablePlanViewSelector
 
                     readonly property real _buttonRadius: ScreenTools.defaultFontPixelHeight * 0.75
 
@@ -531,7 +531,7 @@ QGCView {
                 // Mission Item Editor
                 Item {
                     id:                 missionItemEditor
-                    anchors.topMargin:  _margin
+                    anchors.topMargin:  planElementSelectorRow.visible ? _margin : 0
                     anchors.top:        planElementSelectorRow.visible ? planElementSelectorRow.bottom : planElementSelectorRow.top
                     anchors.bottom:     parent.bottom
                     anchors.right:      parent.right
@@ -673,18 +673,16 @@ QGCView {
                     color:              qgcPal.window
                     title:              qsTr("Plan")
                     z:                  QGroundControl.zOrderWidgets
-                    showAlternateIcon:  [ false, false, _syncDropDownController.dirty, false, false, false ]
-                    rotateImage:        [ false, false, _syncDropDownController.syncInProgress, false, false, false ]
-                    animateImage:       [ false, false, _syncDropDownController.dirty, false, false, false ]
-                    buttonEnabled:      [ true, true, !_syncDropDownController.syncInProgress, true, true, true ]
+                    showAlternateIcon:  [ false, false, false, false, false ]
+                    rotateImage:        [ false, false, false, false, false ]
+                    animateImage:       [ false, false, false, false, false ]
+                    buttonEnabled:      [ true, true, true, true, true ]
                     buttonVisible:      [ true, true, true, true, _showZoom, _showZoom ]
                     maxHeight:          mapScale.y - toolStrip.y
 
                     property bool _showZoom: !ScreenTools.isMobile
 
                     property bool mySingleComplexItem: _singleComplexItem
-
-                    onMySingleComplexItemChanged: console.log(model[1].dropPanelComponent)
 
                     model: [
                         {
@@ -696,12 +694,6 @@ QGCView {
                             name:               "Pattern",
                             iconSource:         "/qmlimages/MapDrawShape.svg",
                             dropPanelComponent: _singleComplexItem ? undefined : patternDropPanel
-                        },
-                        {
-                            name:                   "Sync",
-                            iconSource:             "/qmlimages/MapSync.svg",
-                            alternateIconSource:    "/qmlimages/MapSyncChanged.svg",
-                            dropPanelComponent:     syncDropPanel
                         },
                         {
                             name:               "Center",
@@ -728,16 +720,10 @@ QGCView {
                                 addComplexItem(missionController.complexMissionItemNames[0])
                             }
                             break
-                        case 5:
+                        case 3:
                             editorMap.zoomLevel += 0.5
                             break
-                        case 6:
-                            editorMap.zoomLevel -= 0.5
-                            break
-                        case 5:
-                            editorMap.zoomLevel += 0.5
-                            break
-                        case 6:
+                        case 4:
                             editorMap.zoomLevel -= 0.5
                             break
                         }
@@ -834,12 +820,12 @@ QGCView {
                 columnSpacing:      ScreenTools.defaultFontPixelWidth
 
                 QGCButton {
-                    text:               qsTr("Send To Vehicle")
+                    text:               qsTr("Save")
                     Layout.fillWidth:   true
-                    enabled:            _activeVehicle && !_syncDropDownController.syncInProgress
+                    enabled:            !_syncDropDownController.syncInProgress
                     onClicked: {
                         dropPanel.hide()
-                        _syncDropDownController.sendToVehicle()
+                        _syncDropDownController.save()
                     }
                 }
 

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -200,6 +200,7 @@ QGCViewDialog {
                 wrapMode:   Text.WordWrap
                 text:       qsTr("Warning: Modifying values while vehicle is in flight can lead to vehicle instability and possible vehicle loss. ") +
                             qsTr("Make sure you know what you are doing and double-check your values before Save!")
+                visible:    fact.componentId != -1
             }
 
             QGCCheckBox {

--- a/src/QmlControls/QFileDialogController.cc
+++ b/src/QmlControls/QFileDialogController.cc
@@ -27,7 +27,7 @@ QStringList QFileDialogController::getFiles(const QString& directoryPath, const 
 
     foreach (const QFileInfo& fileInfo, fileInfoList) {
         qCDebug(QFileDialogControllerLog) << "getFiles found" << fileInfo.baseName();
-        files << fileInfo.baseName() + QStringLiteral(".") + fileExtension;
+        files << fileInfo.baseName();
     }
 
     return files;


### PR DESCRIPTION
The way you work with missions in QGC has changed massively. There is no longer the concept of "Sync". In fact there is no Sync button at all any more. Let me walk you through it. Let's walk through and example where you are connected to a vehicle which has no current mission on it. It starts out with the mission editor looking like this:
![screen shot 2017-03-26 at 8 30 09 pm](https://cloud.githubusercontent.com/assets/5876851/24339904/7cc20ae4-1263-11e7-8d48-284a572b110d.png)

You can either load an existing mission or create a new one. When you load an existing mission by clicking one of the mission files, the mission will be loaded and also sent automatically to the vehicle.

You can create a new mission by just started to add way points. New missions can be named as well. In this example I've named my mission. You can see that the list of mission to load is now gone.
![screen shot 2017-03-26 at 8 30 33 pm](https://cloud.githubusercontent.com/assets/5876851/24339949/bbbdca44-1263-11e7-8715-3cc8e1b0129b.png)

Here I've added a bunch of waypoints. That's all the same.
![screen shot 2017-03-26 at 8 30 46 pm](https://cloud.githubusercontent.com/assets/5876851/24339964/ddac99f0-1263-11e7-9796-3d132e49791e.png)

I now switch back to the Fly view and the mission is automatically sent to the vehicle. Since I named the mission the mission is also save to file automatically.

Here you can see the mission in the Fly View:
![screen shot 2017-03-26 at 8 30 55 pm](https://cloud.githubusercontent.com/assets/5876851/24339994/014be24e-1264-11e7-8a1a-da737f6419e0.png)

Then if you go back to Plan view again you will see that there is now a Clear Mission button. Clicking this will clear the mission from Plan and the vehicle.
![screen shot 2017-03-26 at 8 31 05 pm](https://cloud.githubusercontent.com/assets/5876851/24340004/1b8968de-1264-11e7-8dfd-029bff314a41.png)
