### PR TITLE
QGCOptions changes

### DIFF
--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -19,6 +19,7 @@ import QGroundControl               1.0
 import QGroundControl.FlightMap     1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.Mavlink       1.0
@@ -615,7 +616,11 @@ QGCView {
             height:             ScreenTools.availableHeight
             width:              _rightPanelWidth
             color:              qgcPal.window
-            opacity:            0.95
+            opacity:            0.2
+        }
+
+        Item {
+            anchors.fill:   rightPanel
 
             // Plan Element selector (Mission/Fence/Rally)
             Row {
@@ -928,8 +933,11 @@ QGCView {
             }
 
             FactCheckBox {
-                text:   qsTr("Automatic upload to vehicle")
-                fact:   QGroundControl.settingsManager.appSettings.automaticMissionUpload
+                text:       qsTr("Automatic upload to vehicle")
+                fact:       autoSyncFact
+                visible:    autoSyncFact.visible
+
+                property Fact autoSyncFact: QGroundControl.settingsManager.appSettings.automaticMissionUpload
             }
         }
     }

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -33,7 +33,8 @@ public:
     Q_PROPERTY(bool                     showSensorCalibrationAccel      READ showSensorCalibrationAccel     NOTIFY showSensorCalibrationAccelChanged)
     Q_PROPERTY(bool                     showSensorCalibrationLevel      READ showSensorCalibrationLevel     NOTIFY showSensorCalibrationLevelChanged)
     Q_PROPERTY(bool                     showSensorCalibrationAirspeed   READ showSensorCalibrationAirspeed  NOTIFY showSensorCalibrationAirspeedChanged)
-    Q_PROPERTY(bool                     showSensorCalibrationOrient     READ showSensorCalibrationOrient    NOTIFY showSensorCalibrationOrientChanged)
+    Q_PROPERTY(bool                     sensorsHaveFixedOrientation     READ sensorsHaveFixedOrientation    CONSTANT)
+    Q_PROPERTY(bool                     wifiReliableForCalibration      READ wifiReliableForCalibration     CONSTANT)
     Q_PROPERTY(bool                     showFirmwareUpgrade             READ showFirmwareUpgrade            NOTIFY showFirmwareUpgradeChanged)
     Q_PROPERTY(QString                  firmwareUpgradeSingleURL        READ firmwareUpgradeSingleURL       CONSTANT)
     Q_PROPERTY(bool                     guidedBarShowEmergencyStop      READ guidedBarShowEmergencyStop     NOTIFY guidedBarShowEmergencyStopChanged)
@@ -61,7 +62,8 @@ public:
     virtual bool    showSensorCalibrationAccel      () const { return true; }
     virtual bool    showSensorCalibrationLevel      () const { return true; }
     virtual bool    showSensorCalibrationAirspeed   () const { return true; }
-    virtual bool    showSensorCalibrationOrient     () const { return true; }
+    virtual bool    wifiReliableForCalibration      () const { return false; }
+    virtual bool    sensorsHaveFixedOrientation     () const { return false; }
 
     virtual bool    showFirmwareUpgrade             () const { return true; }
 
@@ -79,7 +81,6 @@ signals:
     void showSensorCalibrationAccelChanged      (bool show);
     void showSensorCalibrationLevelChanged      (bool show);
     void showSensorCalibrationAirspeedChanged   (bool show);
-    void showSensorCalibrationOrientChanged     (bool show);
     void showFirmwareUpgradeChanged             (bool show);
     void guidedBarShowEmergencyStopChanged       (bool show);
     void guidedBarShowOrbitChanged              (bool show);


### PR DESCRIPTION
* sensorsHaveFixedOrientation - true: don't show orientation ui diring calibration, false: default
* wifiReliableForCalibration - true: don't warn abot flaky wifi calibration, false: default
* removed showSensorCalibrationOrient

Made code changes to use these new values.