### PR TITLE
Camera setup sizing/position combo sizes

### DIFF
--- a/src/AutoPilotPlugins/PX4/CameraComponent.qml
+++ b/src/AutoPilotPlugins/PX4/CameraComponent.qml
@@ -20,7 +20,6 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
 
-
 SetupPage {
     id:             cameraPage
     pageComponent:  pageComponent
@@ -28,14 +27,14 @@ SetupPage {
     Component {
         id: pageComponent
 
-        Column {
-            width:  availableWidth
+        Item {
+            width:  Math.max(availableWidth, innerColumn.width)
+            height: innerColumn.height
 
             FactPanelController { id: controller; factPanel: cameraPage.viewPanel }
 
             property real _margins:         ScreenTools.defaultFontPixelHeight
-            property real _middleRowWidth:  ScreenTools.defaultFontPixelWidth * 16
-            property real _editFieldWidth:  ScreenTools.defaultFontPixelWidth * 16
+            property real _editFieldWidth:  ScreenTools.defaultFontPixelWidth * 25
 
             property Fact _camTriggerMode:  controller.getParameterFact(-1, "TRIG_MODE")
             property Fact _camTriggerInterface:  controller.getParameterFact(-1, "TRIG_INTERFACE", false)
@@ -76,215 +75,184 @@ SetupPage {
                 }
             }
 
-            Item {
-                id:                     applyAndRestart
-                visible:                false
-                anchors.left:           parent.left
-                anchors.right:          parent.right
-                anchors.leftMargin:     ScreenTools.defaultFontPixelWidth * 10
-                anchors.rightMargin:    ScreenTools.defaultFontPixelWidth * 10
-                height:                 applyButton.height
-                QGCLabel {
-                    anchors.left:       parent.left
-                    text:               qsTr("Vehicle must be restarted for changes to take effect. ")
-                }
-                QGCButton {
-                    id:                 applyButton
-                    anchors.right:      parent.right
-                    text:               qsTr("Apply and Restart")
-                    onClicked:      {
-                        //-- This will reboot the vehicle! We're set not to allow changes if armed.
-                        QGroundControl.multiVehicleManager.activeVehicle.rebootVehicle()
-                        applyAndRestart.visible = false
-                        _rebooting = true
-                    }
-                }
-            }
+            ColumnLayout {
+                id:                         innerColumn
+                anchors.horizontalCenter:   parent.horizontalCenter
 
-            Column {
-                id:                                     mainCol
-                spacing:                                _margins
-                anchors.horizontalCenter:               parent.horizontalCenter
-                /*
-                   **** Camera Trigger ****
-                */
-                QGCLabel {
-                    text:                               qsTr("Camera Trigger Settings")
-                    font.family:                        ScreenTools.demiboldFontFamily
-                }
-                Rectangle {
-                    id:                                 camTrigRect
-                    color:                              qgcPal.windowShade
-                    width:                              camTrigRow.width  + _margins * 2
-                    height:                             camTrigRow.height + _margins * 2
-                    Row {
-                        id:                             camTrigRow
-                        spacing:                        _margins
-                        anchors.verticalCenter:         parent.verticalCenter
-                        Item { width: _margins * 0.5; height: 1; }
-                        QGCColoredImage {
-                            color:                      qgcPal.text
-                            height:                     ScreenTools.defaultFontPixelWidth * 10
-                            width:                      ScreenTools.defaultFontPixelWidth * 20
-                            sourceSize.width:           width
-                            mipmap:                     true
-                            fillMode:                   Image.PreserveAspectFit
-                            source:                     "/qmlimages/CameraTrigger.svg"
-                            anchors.verticalCenter:     parent.verticalCenter
-                        }
-                        Item { width: _margins * 0.5; height: 1; }
-                        Column {
-                            spacing:                    _margins * 0.5
-                            anchors.verticalCenter:     parent.verticalCenter
-                            Row {
-                                QGCLabel {
-                                    anchors.baseline:   camTrigCombo.baseline
-                                    width:              _middleRowWidth
-                                    text:               qsTr("Trigger mode:")
-                                }
-                                FactComboBox {
-                                    id:                 camTrigCombo
-                                    width:              _editFieldWidth
-                                    fact:               _camTriggerMode
-                                    indexModel:         false
-                                    enabled:            !_rebooting
-                                    onActivated: {
-                                        applyAndRestart.visible = true
-                                    }
-                                }
-                            }
-                            Row {
-                                visible: _camTriggerInterface ? true : false
-                                QGCLabel {
-                                    anchors.baseline:   camInterfaceCombo.baseline
-                                    width:              _middleRowWidth
-                                    text:               qsTr("Trigger interface:")
-                                }
-                                FactComboBox {
-                                    id:                 camInterfaceCombo
-                                    width:              _editFieldWidth
-                                    fact:               _camTriggerInterface
-                                    indexModel:         false
-                                    enabled:            !_rebooting
-                                    onActivated: {
-                                        applyAndRestart.visible = true
-                                    }
-                                }
-                            }
-                            Row {
-                                QGCLabel {
-                                    text:               qsTr("Time Interval")
-                                    width:              _middleRowWidth
-                                    anchors.baseline:   timeIntervalField.baseline
-                                    color:              qgcPal.text
-                                }
-                                FactTextField {
-                                    id:                 timeIntervalField
-                                    fact:               controller.getParameterFact(-1, "TRIG_INTERVAL", false)
-                                    showUnits:          true
-                                    width:              _editFieldWidth
-                                    enabled:            _auxPins && _camTriggerMode.value === 2
-                                }
-                            }
-                            Row {
-                                QGCLabel {
-                                    text:               qsTr("Distance Interval")
-                                    width:              _middleRowWidth
-                                    anchors.baseline:   trigDistField.baseline
-                                    color:              qgcPal.text
-                                }
-                                FactTextField {
-                                    id:                 trigDistField
-                                    fact:               controller.getParameterFact(-1, "TRIG_DISTANCE", false)
-                                    showUnits:          true
-                                    width:              _editFieldWidth
-                                    enabled:            _auxPins && _camTriggerMode.value === 3
-                                }
-                            }
+                RowLayout {
+                    id:         applyAndRestart
+                    spacing:    _margins
+                    visible:    false
+
+                    QGCLabel {
+                        text: qsTr("Vehicle must be restarted for changes to take effect.")
+                    }
+                    QGCButton {
+                        text: qsTr("Apply and Restart")
+                        onClicked:      {
+                            //-- This will reboot the vehicle! We're set not to allow changes if armed.
+                            QGroundControl.multiVehicleManager.activeVehicle.rebootVehicle()
+                            applyAndRestart.visible = false
+                            _rebooting = true
                         }
                     }
                 }
-                /*
-                   **** Camera Hardware ****
-                */
-                Item { width: 1; height: _margins * 0.5; }
-                QGCLabel {
-                    text:                               qsTr("Hardware Settings")
-                    font.family:                        ScreenTools.demiboldFontFamily
-                    visible:                            _auxPins
-                }
-                Rectangle {
-                    color:                              qgcPal.windowShade
-                    width:                              camTrigRect.width
-                    height:                             camHardwareRow.height + _margins * 2
-                    visible:                            _auxPins
-                    Row {
-                        id:                             camHardwareRow
-                        spacing:                        _margins
-                        anchors.verticalCenter:         parent.verticalCenter
-                        Item { width: _margins * 0.5; height: 1; }
-                        Item {
-                            height:                     ScreenTools.defaultFontPixelWidth * 10
-                            width:                      ScreenTools.defaultFontPixelWidth * 20
-                            Column {
-                                spacing:                ScreenTools.defaultFontPixelHeight
-                                anchors.centerIn:       parent
-                                QGCLabel {
-                                    text:               "AUX Pin Assignment"
-                                    anchors.horizontalCenter: parent.horizontalCenter
-                                }
-                                Row {
-                                    spacing:            ScreenTools.defaultFontPixelWidth
-                                    anchors.horizontalCenter: parent.horizontalCenter
+
+                QGCGroupBox {
+                    title:              qsTr("Camera Trigger Settings")
+                    Layout.fillWidth:   true
+
+                    GridLayout {
+                        id:             cameraTrggerGrid
+                        rows:           4
+                        columns:        3
+                        columnSpacing:  ScreenTools.defaultFontPixelWidth
+
+                        QGCColoredImage {
+                            id:                 triggerImage
+                            color:              qgcPal.text
+                            height:             ScreenTools.defaultFontPixelWidth * 10
+                            width:              ScreenTools.defaultFontPixelWidth * 20
+                            sourceSize.width:   width
+                            mipmap:             true
+                            fillMode:           Image.PreserveAspectFit
+                            source:             "/qmlimages/CameraTrigger.svg"
+                            Layout.rowSpan:     4
+                        }
+
+                        QGCLabel {
+                            anchors.baseline:   camTrigCombo.baseline
+                            text:               qsTr("Trigger mode")
+                        }
+                        FactComboBox {
+                            id:                 camTrigCombo
+                            fact:               _camTriggerMode
+                            indexModel:         false
+                            enabled:            !_rebooting
+                            Layout.minimumWidth: _editFieldWidth
+                            onActivated: {
+                                applyAndRestart.visible = true
+                            }
+                        }
+
+                        QGCLabel {
+                            anchors.baseline:   camInterfaceCombo.baseline
+                            text:               qsTr("Trigger interface")
+                        }
+                        FactComboBox {
+                            id:                 camInterfaceCombo
+                            fact:               _camTriggerInterface
+                            indexModel:         false
+                            enabled:            !_rebooting && (_camTriggerInterface ? true : false)
+                            Layout.minimumWidth: _editFieldWidth
+                            onActivated: {
+                                applyAndRestart.visible = true
+                            }
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Time Interval")
+                            anchors.baseline:   timeIntervalField.baseline
+                            color:              qgcPal.text
+                        }
+                        FactTextField {
+                            id:                 timeIntervalField
+                            fact:               controller.getParameterFact(-1, "TRIG_INTERVAL", false)
+                            showUnits:          true
+                            Layout.minimumWidth: _editFieldWidth
+                            enabled:            _camTriggerMode.value === 2
+                        }
+
+                        QGCLabel {
+                            text:               qsTr("Distance Interval")
+                            anchors.baseline:   trigDistField.baseline
+                            color:              qgcPal.text
+                        }
+                        FactTextField {
+                            id:                 trigDistField
+                            fact:               controller.getParameterFact(-1, "TRIG_DISTANCE", false)
+                            showUnits:          true
+                            Layout.minimumWidth: _editFieldWidth
+                            enabled:            _camTriggerMode.value === 3
+                        }
+                    }
+                } // QGCGroupBox - Camera Trigger
+
+                QGCGroupBox {
+                    title:              qsTr("Hardware Settings")
+                    visible:            _auxPins
+                    Layout.fillWidth:   true
+
+                    RowLayout {
+                        spacing: _margins
+
+                        // Aux pin assignment
+                        ColumnLayout {
+                            spacing: _margins
+
+                            QGCLabel {
+                                horizontalAlignment:    Text.AlignHCenter
+                                text:                   qsTr("AUX Pin Assignment")
+                                Layout.minimumWidth:    triggerImage.width
+                            }
+
+                            Row {
+                                spacing:                    _margins
+                                anchors.horizontalCenter:   parent.horizontalCenter
+
+                                GridLayout {
+                                    rows: 2
+                                    columns: 6
+
                                     Repeater {
-                                        model:          _auxChannels
-                                        Column {
-                                            spacing:            ScreenTools.defaultFontPixelWidth * 0.5
-                                            QGCLabel {
-                                                text:           model.index + 1
-                                                color:          qgcPal.text
-                                                anchors.horizontalCenter: parent.horizontalCenter
-                                            }
-                                            Rectangle {
-                                                id:             auxPin
-                                                width:          ScreenTools.defaultFontPixelWidth * 2
-                                                height:         ScreenTools.defaultFontPixelWidth * 2
-                                                border.color:   qgcPal.text
-                                                color:  {
-                                                    if(_auxPins) {
-                                                        var pins = _auxPins.value.toString()
-                                                        var pin  = (model.index + 1).toString()
-                                                        if(pins.indexOf(pin) < 0)
-                                                            return qgcPal.windowShadeDark
-                                                        else
-                                                            return "green"
-                                                    } else {
-                                                        return qgcPal.windowShade
-                                                    }
+                                        model: _auxChannels
+
+                                        QGCLabel {
+                                            horizontalAlignment:    Text.AlignHCenter
+                                            text:                   model.index + 1
+                                        }
+                                    }
+                                    Repeater {
+                                        model: _auxChannels
+
+                                        Rectangle {
+                                            id:             auxPin
+                                            width:          ScreenTools.defaultFontPixelWidth * 2
+                                            height:         ScreenTools.defaultFontPixelWidth * 2
+                                            border.color:   qgcPal.text
+                                            color:  {
+                                                if(_auxPins) {
+                                                    var pins = _auxPins.value.toString()
+                                                    var pin  = (model.index + 1).toString()
+                                                    if(pins.indexOf(pin) < 0)
+                                                        return qgcPal.windowShadeDark
+                                                    else
+                                                        return "green"
+                                                } else {
+                                                    return qgcPal.windowShade
                                                 }
-                                                MouseArea {
-                                                    anchors.fill: parent
-                                                    onClicked: {
-                                                        _auxChannels[model.index] = 1 - _auxChannels[model.index]
-                                                        auxPin.color = _auxChannels[model.index] ? "green" : qgcPal.windowShadeDark
-                                                        setAuxPins()
-                                                    }
+                                            }
+                                            MouseArea {
+                                                anchors.fill: parent
+                                                onClicked: {
+                                                    _auxChannels[model.index] = 1 - _auxChannels[model.index]
+                                                    auxPin.color = _auxChannels[model.index] ? "green" : qgcPal.windowShadeDark
+                                                    setAuxPins()
                                                 }
                                             }
                                         }
                                     }
                                 }
                             }
-                        }
-                        Item { width: _margins * 0.5; height: 1; }
-                        Column {
-                            visible:                    !_camTriggerInterface || (_camTriggerInterface.value === 1)
-                            spacing:                    _margins * 0.5
-                            anchors.verticalCenter:     parent.verticalCenter
-                            QGCLabel {
-                                id:                     returnHomeLabel
-                                text:                   "Trigger Pin Polarity:"
-                            }
+                        } // ColumnLayout - Aux pins
+
+                        // Trigger Pin Setup
+                        ColumnLayout {
+                            visible:    !_camTriggerInterface || (_camTriggerInterface.value === 1)
+                            spacing:    _margins * 0.5
+
+                            QGCLabel { text: qsTr("Trigger Pin Polarity") }
+
                             Row {
                                 Item { height: 1; width: _margins; }
                                 Column {
@@ -312,11 +280,12 @@ SetupPage {
                                     }
                                 }
                             }
-                            Item { width: 1; height: _margins * 0.5; }
+
                             Row {
+                                spacing: ScreenTools.defaultFontPixelWidth
+
                                 QGCLabel {
                                     text:               qsTr("Trigger Period")
-                                    width:              _middleRowWidth
                                     anchors.baseline:   trigPeriodField.baseline
                                     color:              qgcPal.text
                                 }

--- a/src/QmlControls/VehicleSummaryRow.qml
+++ b/src/QmlControls/VehicleSummaryRow.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.3
+import QtQuick          2.3
 import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.4
+import QtQuick.Layouts  1.2
 
-Row {
+RowLayout {
     property string labelText: "Label"
     property string valueText: "value"
 
@@ -13,8 +13,9 @@ Row {
         text:   labelText
     }
     QGCLabel {
-        width:  parent.width - label.contentWidth
-        text:   valueText
-        horizontalAlignment: Text.AlignRight;
+        text:                   valueText
+        elide:                  Text.ElideRight
+        horizontalAlignment:    Text.AlignRight
+        Layout.fillWidth:       true
     }
 }


### PR DESCRIPTION
* Increased width of Combo boxes to prevent most clipping
* Middle column text had fixed width which would not work on all screen size, font combinations
* Because of above middle column change, was unable to maintain trigger period field matching fields in group box above. I may figure out a way to do this when I move to the Safety page and do the same fixups.

![screen shot 2017-03-29 at 12 57 14 pm](https://cloud.githubusercontent.com/assets/5876851/24473944/d91095fe-147f-11e7-86a1-841dfb3299da.png)
