### PR TITLE
Moving Add New Set as a sibling of Map rather than a child.

### DIFF
--- a/src/FlightMap/Widgets/CenterMapDropButton.qml
+++ b/src/FlightMap/Widgets/CenterMapDropButton.qml
@@ -200,7 +200,7 @@ DropButton {
             QGCButton {
                 text:               qsTr("Current Location")
                 Layout.fillWidth:   true
-                enabled:            mainWindow.gcsPosition.isValid && !followVehicleCheckBox.checked
+                enabled:            mainWindow.gcsPosition && mainWindow.gcsPosition.isValid && !followVehicleCheckBox.checked
 
                 onClicked: {
                     dropButton.hideDropDown()

--- a/src/PlanView/PlanToolBar.qml
+++ b/src/PlanView/PlanToolBar.qml
@@ -178,7 +178,7 @@ Rectangle {
         anchors.rightMargin:    _margins
         anchors.right:          parent.right
         anchors.verticalCenter: parent.verticalCenter
-        text:                   missionController.dirty ? qsTr("Upload Required") : qsTr("Upload")
+        text:                   missionController ? (missionController.dirty ? qsTr("Upload Required") : qsTr("Upload")) : ""
         enabled:                _activeVehicle
         visible:                _manualUpload
         onClicked:              missionController.upload()


### PR DESCRIPTION
If the Rectangle containing the Add New Set options is a child of Map, mouse commands bleed through to the map.
Aldo made the slider button slightly larger for mobile (but not Tiny Screens as these have a proper larger font size)
Also cleared up a couple of JavaScript exceptions.