### PR TITLE
Plan: Support for images in turnaround on/off

### DIFF
--- a/src/MissionManager/CameraSection.FactMetaData.json
+++ b/src/MissionManager/CameraSection.FactMetaData.json
@@ -12,7 +12,7 @@
     "shortDescription": "Specify the distance between each photo",
     "type":             "double",
     "units":            "m",
-    "min":              0,
+    "min":              0.1,
     "decimalPlaces":    1,
     "defaultValue":     1
 },

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -817,11 +817,11 @@
             }
         },
         {
-            "id":           206,
-            "rawName":      "MAV_CMD_DO_SET_CAM_TRIGG_DIST",
-            "friendlyName": "Camera trigger distance",
-            "description":  "Set camera trigger distance.",
-            "category":     "Camera",
+            "id":                   206,
+            "rawName":              "MAV_CMD_DO_SET_CAM_TRIGG_DIST",
+            "friendlyName":         "Camera trigger distance",
+            "description":          "Set camera trigger distance.",
+            "category":             "Camera",
             "param1": {
                 "label":            "Distance",
                 "default":          25,

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1538,10 +1538,8 @@ void MissionController::_scanForAdditionalSettings(QmlObjectListModel* visualIte
         }
 
         SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(visualItem);
-        if (simpleItem && simpleItem->cameraSection()->available()) {
-            scanIndex++;
-            simpleItem->scanForSections(visualItems, scanIndex, vehicle);
-            continue;
+        if (simpleItem) {
+            simpleItem->scanForSections(visualItems, scanIndex + 1, vehicle);
         }
 
         scanIndex++;

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -655,16 +655,17 @@ double SimpleMissionItem::specifiedGimbalYaw(void)
     return _cameraSection->available() ? _cameraSection->specifiedGimbalYaw() : missionItem().specifiedGimbalYaw();
 }
 
-void SimpleMissionItem::scanForSections(QmlObjectListModel* visualItems, int scanIndex, Vehicle* vehicle)
+bool SimpleMissionItem::scanForSections(QmlObjectListModel* visualItems, int scanIndex, Vehicle* vehicle)
 {
+    bool sectionFound = false;
+
     Q_UNUSED(vehicle);
 
-    qDebug() << "SimpleMissionItem::scanForSections" << scanIndex << _cameraSection->available();
-
     if (_cameraSection->available()) {
-        bool sectionFound = _cameraSection->scanForCameraSection(visualItems, scanIndex);
-        qDebug() << sectionFound;
+        sectionFound = _cameraSection->scanForCameraSection(visualItems, scanIndex);
     }
+
+    return sectionFound;
 }
 
 void SimpleMissionItem::_updateCameraSection(void)

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -48,7 +48,8 @@ public:
     ///     @param visualItems List of all visual items
     ///     @param scanIndex Index to start scanning from
     ///     @param vehicle Vehicle associated with this mission
-    void scanForSections(QmlObjectListModel* visualItems, int scanIndex, Vehicle* vehicle);
+    /// @return true: section found
+    bool scanForSections(QmlObjectListModel* visualItems, int scanIndex, Vehicle* vehicle);
 
     // Property accesors
     

--- a/src/MissionManager/Survey.SettingsGroup.json
+++ b/src/MissionManager/Survey.SettingsGroup.json
@@ -131,6 +131,18 @@
     "defaultValue":     25
 },
 {
+    "name":             "CameraTriggerInTurnaround",
+    "shortDescription": "Camera continues taking images in turnarounds.",
+    "type":             "bool",
+    "defaultValue":     false
+},
+{
+    "name":             "HoverAndCapture",
+    "shortDescription": "Hover at each image point and take image",
+    "type":             "bool",
+    "defaultValue":     false
+},
+{
     "name":             "CameraOrientationLandscape",
     "shortDescription": "Camera on vehicle is in landscape orientation.",
     "type":             "bool",
@@ -140,7 +152,7 @@
     "name":             "FixedValueIsAltitude",
     "shortDescription": "The altitude is kep constant while ground resolution changes.",
     "type":             "bool",
-    "defaultValue":     0
+    "defaultValue":     false
 },
 {
     "name":             "Camera",

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -180,39 +180,72 @@ Rectangle {
         spacing:            _margin
 
         SectionHeader {
+            id:         cameraHeader
             text:       qsTr("Camera")
             showSpacer: false
         }
 
-        QGCComboBox {
-            id:             gridTypeCombo
+        Column {
             anchors.left:   parent.left
             anchors.right:  parent.right
-            model:          _cameraList
-            currentIndex:   -1
+            spacing:        _margin
+            visible:        cameraHeader.checked
 
-            onActivated: {
-                if (index == _gridTypeManual) {
-                    missionItem.manualGrid.value = true
-                } else if (index == _gridTypeCustomCamera) {
-                    missionItem.manualGrid.value = false
-                    missionItem.camera.value = gridTypeCombo.textAt(index)
-                    missionItem.cameraOrientationFixed = false
-                } else {
-                    missionItem.manualGrid.value = false
-                    missionItem.camera.value = gridTypeCombo.textAt(index)
-                    _noCameraValueRecalc = true
-                    var listIndex = index - _gridTypeCamera
-                    missionItem.cameraSensorWidth.rawValue          = _vehicleCameraList[listIndex].sensorWidth
-                    missionItem.cameraSensorHeight.rawValue         = _vehicleCameraList[listIndex].sensorHeight
-                    missionItem.cameraResolutionWidth.rawValue      = _vehicleCameraList[listIndex].imageWidth
-                    missionItem.cameraResolutionHeight.rawValue     = _vehicleCameraList[listIndex].imageHeight
-                    missionItem.cameraFocalLength.rawValue          = _vehicleCameraList[listIndex].focalLength
-                    missionItem.cameraOrientationLandscape.rawValue = _vehicleCameraList[listIndex].landscape ? 1 : 0
-                    missionItem.cameraOrientationFixed              = _vehicleCameraList[listIndex].fixedOrientation
-                    _noCameraValueRecalc = false
-                    recalcFromCameraValues()
+            QGCComboBox {
+                id:             gridTypeCombo
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                model:          _cameraList
+                currentIndex:   -1
+
+                onActivated: {
+                    if (index == _gridTypeManual) {
+                        missionItem.manualGrid.value = true
+                    } else if (index == _gridTypeCustomCamera) {
+                        missionItem.manualGrid.value = false
+                        missionItem.camera.value = gridTypeCombo.textAt(index)
+                        missionItem.cameraOrientationFixed = false
+                    } else {
+                        missionItem.manualGrid.value = false
+                        missionItem.camera.value = gridTypeCombo.textAt(index)
+                        _noCameraValueRecalc = true
+                        var listIndex = index - _gridTypeCamera
+                        missionItem.cameraSensorWidth.rawValue          = _vehicleCameraList[listIndex].sensorWidth
+                        missionItem.cameraSensorHeight.rawValue         = _vehicleCameraList[listIndex].sensorHeight
+                        missionItem.cameraResolutionWidth.rawValue      = _vehicleCameraList[listIndex].imageWidth
+                        missionItem.cameraResolutionHeight.rawValue     = _vehicleCameraList[listIndex].imageHeight
+                        missionItem.cameraFocalLength.rawValue          = _vehicleCameraList[listIndex].focalLength
+                        missionItem.cameraOrientationLandscape.rawValue = _vehicleCameraList[listIndex].landscape ? 1 : 0
+                        missionItem.cameraOrientationFixed              = _vehicleCameraList[listIndex].fixedOrientation
+                        _noCameraValueRecalc = false
+                        recalcFromCameraValues()
+                    }
                 }
+            }
+
+            RowLayout {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        _margin
+                visible:        missionItem.manualGrid.value == true
+
+                FactCheckBox {
+                    anchors.baseline:   cameraTriggerDistanceField.baseline
+                    text:               qsTr("Trigger Distance")
+                    fact:               missionItem.cameraTrigger
+                }
+
+                FactTextField {
+                    id:                 cameraTriggerDistanceField
+                    Layout.fillWidth:   true
+                    fact:               missionItem.cameraTriggerDistance
+                    enabled:            missionItem.cameraTrigger.value
+                }
+            }
+
+            FactCheckBox {
+                text:   qsTr("Hover and capture image")
+                fact:   missionItem.hoverAndCapture
             }
         }
 
@@ -343,7 +376,10 @@ Rectangle {
                 }
             }
 
-            SectionHeader { text: qsTr("Grid") }
+            SectionHeader {
+                id:     gridHeader
+                text:   qsTr("Grid")
+            }
 
             GridLayout {
                 anchors.left:   parent.left
@@ -351,6 +387,7 @@ Rectangle {
                 columnSpacing:  _margin
                 rowSpacing:     _margin
                 columns:        2
+                visible:        gridHeader.checked
 
                 QGCLabel { text: qsTr("Angle") }
                 FactTextField {
@@ -403,13 +440,17 @@ Rectangle {
         }
 
         // Manual grid ui
+        SectionHeader {
+            id:         manualGridHeader
+            text:       qsTr("Grid")
+            visible:    gridTypeCombo.currentIndex == _gridTypeManual
+        }
+
         Column {
             anchors.left:   parent.left
             anchors.right:  parent.right
             spacing:        _margin
-            visible:        gridTypeCombo.currentIndex == _gridTypeManual
-
-            SectionHeader { text: qsTr("Grid") }
+            visible:        manualGridHeader.visible && manualGridHeader.checked
 
             FactTextFieldGrid {
                 anchors.left:   parent.left
@@ -420,50 +461,21 @@ Rectangle {
                 factLabels:     [ qsTr("Angle"), qsTr("Spacing"), qsTr("Altitude"), qsTr("Turnaround dist")]
             }
 
-            Item { height: _margin;  width: 1; visible: !ScreenTools.isTinyScreen }
-
             FactCheckBox {
                 anchors.left:   parent.left
                 text:           qsTr("Relative altitude")
                 fact:           missionItem.gridAltitudeRelative
             }
-
-            Item { height: _sectionSpacer;  width: 1; visible: !ScreenTools.isTinyScreen }
-
-            QGCLabel { text: qsTr("Camera") }
-
-            Rectangle {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                height:         1
-                color:          qgcPal.text
-            }
-
-            RowLayout {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                spacing:        _margin
-
-                FactCheckBox {
-                    anchors.baseline:   cameraTriggerDistanceField.baseline
-                    text:               qsTr("Trigger Distance")
-                    fact:               missionItem.cameraTrigger
-                }
-
-                FactTextField {
-                    id:                 cameraTriggerDistanceField
-                    Layout.fillWidth:   true
-                    fact:               missionItem.cameraTriggerDistance
-                    enabled:            missionItem.cameraTrigger.value
-                }
-            }
         }
 
-        SectionHeader { text: qsTr("Statistics") }
+        SectionHeader {
+            id:     statsHeader
+            text:   qsTr("Statistics") }
 
         Grid {
             columns:        2
             columnSpacing:  ScreenTools.defaultFontPixelWidth
+            visible:        statsHeader.checked
 
             QGCLabel { text: qsTr("Survey area") }
             QGCLabel { text: QGroundControl.squareMetersToAppSettingsAreaUnits(missionItem.coveredArea).toFixed(2) + " " + QGroundControl.appSettingsAreaUnitsString }


### PR DESCRIPTION
Although internally there is support to not turn images off in turnaround. It is not exposed in the ui. Mainly because I couldn't think of a good case where this was a good thing.

Also set up scaffolding for Hover and Capture support.