### PR TITLE
Handle network availability transitions.

### DIFF
--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -1039,6 +1039,7 @@ QGCCacheWorker::_testInternet()
     QTcpSocket socket;
     socket.connectToHost("8.8.8.8", 53);
     if (socket.waitForConnected(2500)) {
+        qCDebug(QGCTileCacheLog) << "Yes Internet Access";
         emit internetStatus(true);
         return;
     }

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.h
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.h
@@ -70,7 +70,6 @@ private slots:
 
 private:
     void _clearReply            ();
-    void _returnBadTile         ();
 
 private:
     QNetworkReply*          _reply;

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -82,7 +82,5 @@ QGeoTileFetcherQGC::getTileImage(const QGeoTileSpec &spec)
 void
 QGeoTileFetcherQGC::timeout()
 {
-    if(!getQGCMapEngine()->isInternetActive()) {
-        getQGCMapEngine()->testInternet();
-    }
+    getQGCMapEngine()->testInternet();
 }


### PR DESCRIPTION
QGC's QtLocation plugin monitors Internet availability and only actually makes requests if Internet is available. This is to avoid Qt flooding us with requests, which make take up to 30 seconds to timeout if the network is active but no WAN access exists.

This fixes the case where there is a transition from available to NOT available. The code would only work if you started off with no Internet and later gained access. Now it handles any case.

In addition, the plugin would return a fake tile (*No Tile Found*) to fulfill the request so you would have something other than just a white nothingness on the screen. Well, even though we handle the cache ourselves, Qt will still cache a little bit. Enough to "cache" those fake tiles and never ask for them again, even if the Internet connection is enabled/resumed. You would end up with a patch work of permanent fake tiles on the screen. As that is now off, we're back to whiteness when no tiles are found.