### PR TITLE
New Arm/Disarm toolbar indicator

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -3,6 +3,7 @@
         <file alias="FactSystemTest.qml">src/FactSystem/FactSystemTest.qml</file>
     </qresource>
     <qresource prefix="/toolbar">
+        <file alias="ArmedIndicator.qml">src/ui/toolbar/ArmedIndicator.qml</file>
         <file alias="BatteryIndicator.qml">src/ui/toolbar/BatteryIndicator.qml</file>
         <file alias="GPSIndicator.qml">src/ui/toolbar/GPSIndicator.qml</file>
         <file alias="MessageIndicator.qml">src/ui/toolbar/MessageIndicator.qml</file>

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
@@ -76,6 +76,7 @@ public:
     QString landFlightMode(void) const override { return QString("Land"); }
     QString takeControlFlightMode(void) const override { return QString("Stablize"); }
     bool vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) const final;
+    QString autoDisarmParameter(Vehicle* vehicle) final { Q_UNUSED(vehicle); return QStringLiteral("DISARM_DELAY"); }
 
 private:
     static bool _remapParamNameIntialized;

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
@@ -59,6 +59,7 @@ public:
     QString offlineEditingParamFile(Vehicle* vehicle) final { Q_UNUSED(vehicle); return QStringLiteral(":/FirmwarePlugin/APM/Plane.OfflineEditing.params"); }
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     int remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const final;
+    QString autoDisarmParameter(Vehicle* vehicle) final { Q_UNUSED(vehicle); return QStringLiteral("LAND_DISARMDELAY"); }
 
 private:
     static bool _remapParamNameIntialized;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -336,6 +336,7 @@ const QVariantList &FirmwarePlugin::toolBarIndicators(const Vehicle* vehicle)
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")));
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")));
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ModeIndicator.qml")));
+        _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ArmedIndicator.qml")));
     }
     return _toolBarIndicatorList;
 }
@@ -444,4 +445,10 @@ void FirmwarePlugin::batteryConsumptionData(Vehicle* vehicle, int& mAhBattery, d
     mAhBattery = 0;
     hoverAmps = 0;
     cruiseAmps = 0;
+}
+
+QString FirmwarePlugin::autoDisarmParameter(Vehicle* vehicle)
+{
+    Q_UNUSED(vehicle);
+    return QString();
 }

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -282,6 +282,9 @@ public:
     ///     @param[out] cruiseAmps Current draw in amps during cruise
     virtual void batteryConsumptionData(Vehicle* vehicle, int& mAhBattery, double& hoverAmps, double& cruiseAmps) const;
 
+    // Returns the parameter which control auto-dismar. Assume == 0 means no auto disarm
+    virtual QString autoDisarmParameter(Vehicle* vehicle);
+
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const char* px4FollowMeFlightMode;
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -67,6 +67,7 @@ public:
     QString             brandImageIndoor                (const Vehicle* vehicle) const override { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/PX4/BrandImage"); }
     QString             brandImageOutdoor               (const Vehicle* vehicle) const override { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/PX4/BrandImage"); }
     bool                vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) const override;
+    QString             autoDisarmParameter             (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral("COM_DISARM_LAND"); }
 
 protected:
     typedef struct {

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -34,6 +34,8 @@ QGCView {
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
+    property alias guidedController: guidedActionsController
+
     property bool activeVehicleJoystickEnabled: _activeVehicle ? _activeVehicle.joystickEnabled : false
 
     property var _activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
@@ -444,7 +446,7 @@ QGCView {
         }
 
         GuidedActionsController {
-            id:                 guidedController
+            id:                 guidedActionsController
             missionController:  flyMissionController
             z:                  _flightVideoPipControl.z + 1
 

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -46,8 +46,8 @@ Item {
     readonly property string setWaypointTitle:      qsTr("Set Waypoint")
     readonly property string gotoTitle:             qsTr("Goto Location")
 
-    readonly property string armMessage:                qsTr("arm")
-    readonly property string disarmMessage:             qsTr("disarm")
+    readonly property string armMessage:                qsTr("Arm the vehicle.")
+    readonly property string disarmMessage:             qsTr("Disarm the vehicle")
     readonly property string emergencyStopMessage:      qsTr("WARNING: This still stop all motors. If vehicle is currently in air it will crash.")
     readonly property string takeoffMessage:            qsTr("Takeoff from ground and hold position.")
     readonly property string startMissionMessage:       qsTr("Start the mission which is currently displayed above. If the vehicle is on the ground it will takeoff.")
@@ -109,10 +109,16 @@ Item {
         _actionData = actionData
         switch (actionCode) {
         case actionArm:
+            if (_activeVehicle.flying) {
+                return
+            }
             title = armTitle
             message = armMessage
             break;
         case actionDisarm:
+            if (_activeVehicle.flying) {
+                return
+            }
             title = disarmTitle
             message = disarmMessage
             break;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1647,10 +1647,8 @@ void Vehicle::_startMissionRequest(void)
 void Vehicle::_parametersReady(bool parametersReady)
 {
     if (parametersReady) {
+        _setupAutoDisarmSignalling();
         _startMissionRequest();
-    }
-
-    if (parametersReady) {
         setJoystickEnabled(_joystickEnabled);
     }
 }
@@ -2411,6 +2409,29 @@ const QVariantList& Vehicle::cameraList(void) const
 bool Vehicle::vehicleYawsToNextWaypointInMission(void) const
 {
     return _firmwarePlugin->vehicleYawsToNextWaypointInMission(this);
+}
+
+void Vehicle::_setupAutoDisarmSignalling(void)
+{
+    QString param = _firmwarePlugin->autoDisarmParameter(this);
+
+    if (!param.isEmpty() && _parameterManager->parameterExists(FactSystem::defaultComponentId, param)) {
+        Fact* fact = _parameterManager->getParameter(FactSystem::defaultComponentId,param);
+        connect(fact, &Fact::rawValueChanged, this, &Vehicle::autoDisarmChanged);
+        emit autoDisarmChanged();
+    }
+}
+
+bool Vehicle::autoDisarm(void)
+{
+    QString param = _firmwarePlugin->autoDisarmParameter(this);
+
+    if (!param.isEmpty() && _parameterManager->parameterExists(FactSystem::defaultComponentId, param)) {
+        Fact* fact = _parameterManager->getParameter(FactSystem::defaultComponentId,param);
+        return fact->rawValue().toDouble() > 0;
+    }
+
+    return false;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -240,6 +240,7 @@ public:
     Q_PROPERTY(QGeoCoordinate       coordinate              READ coordinate                                             NOTIFY coordinateChanged)
     Q_PROPERTY(QGeoCoordinate       homePosition            READ homePosition                                           NOTIFY homePositionChanged)
     Q_PROPERTY(bool                 armed                   READ armed                  WRITE setArmed                  NOTIFY armedChanged)
+    Q_PROPERTY(bool                 autoDisarm              READ autoDisarm                                             NOTIFY autoDisarmChanged)
     Q_PROPERTY(bool                 flightModeSetAvailable  READ flightModeSetAvailable                                 CONSTANT)
     Q_PROPERTY(QStringList          flightModes             READ flightModes                                            CONSTANT)
     Q_PROPERTY(QString              flightMode              READ flightMode             WRITE setFlightMode             NOTIFY flightModeChanged)
@@ -588,6 +589,7 @@ public:
     unsigned int    telemetryTXBuffer       () { return _telemetryTXBuffer; }
     unsigned int    telemetryLNoise         () { return _telemetryLNoise; }
     unsigned int    telemetryRNoise         () { return _telemetryRNoise; }
+    bool            autoDisarm              ();
 
     Fact* roll              (void) { return &_rollFact; }
     Fact* heading           (void) { return &_headingFact; }
@@ -717,6 +719,7 @@ signals:
     void telemetryTXBufferChanged   (unsigned int value);
     void telemetryLNoiseChanged     (unsigned int value);
     void telemetryRNoiseChanged     (unsigned int value);
+    void autoDisarmChanged          (void);
 
     void firmwareMajorVersionChanged(int major);
     void firmwareMinorVersionChanged(int minor);
@@ -825,6 +828,7 @@ private:
     void _updatePriorityLink(void);
     void _commonInit(void);
     void _startMissionRequest(void);
+    void _setupAutoDisarmSignalling(void);
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -265,12 +265,16 @@ Item {
         anchors.top:        parent.top
         opacity:            planToolBar.visible ? 0 : 1
         z:                  QGroundControl.zOrderTopMost
+
         Component.onCompleted:  ScreenTools.availableHeight = parent.height - toolBar.height
         onShowSettingsView:     mainWindow.showSettingsView()
         onShowSetupView:        mainWindow.showSetupView()
         onShowPlanView:         mainWindow.showPlanView()
         onShowFlyView:          mainWindow.showFlyView()
         onShowAnalyzeView:      mainWindow.showAnalyzeView()
+        onArmVehicle:           flightView.guidedController.confirmAction(flightView.guidedController.actionArm)
+        onDisarmVehicle:        flightView.guidedController.confirmAction(flightView.guidedController.actionDisarm)
+
         //-- Entire tool bar area disable on cammand
         MouseArea {
             id:             toolbarBlocker

--- a/src/ui/toolbar/ArmedIndicator.qml
+++ b/src/ui/toolbar/ArmedIndicator.qml
@@ -1,0 +1,42 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl                       1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.MultiVehicleManager   1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.Palette               1.0
+
+//-------------------------------------------------------------------------
+//-- Armed Indicator
+QGCLabel {
+    anchors.top:        parent.top
+    anchors.bottom:     parent.bottom
+    verticalAlignment:  Text.AlignVCenter
+    text:               _armed ? qsTr("Armed") : qsTr("Disarmed")
+    font.pointSize:     ScreenTools.mediumFontPointSize
+    color:              qgcPal.buttonText
+    visible:            !_autoDisarm || _fixedWing
+
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _autoDisarm:    _activeVehicle ? _activeVehicle.autoDisarm : false
+    property bool   _fixedWing:     _activeVehicle ? _activeVehicle.fixedWing : false
+    property bool   _armed:         _activeVehicle ? _activeVehicle.armed : false
+
+    QGCPalette { id: qgcPal }
+
+    QGCMouseArea {
+        fillItem: parent
+        onClicked: _armed ? toolBar.disarmVehicle() : toolBar.armVehicle()
+    }
+}

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -31,6 +31,8 @@ Rectangle {
     signal showPlanView
     signal showFlyView
     signal showAnalyzeView
+    signal armVehicle
+    signal disarmVehicle
 
     function checkSettingsButton() {
         settingsButton.checked = true


### PR DESCRIPTION
It's not very pretty but functionally it works:
* This shows up in the toolbar if a vehicle has auto-disarm turned off or if the vehicle is a fixed wing. Still discussing whether this should always be there. The reason for fixed wing is that a fixed wing vehicle doesn't spin props like multi-rotor so it isn't very clear whether the vehicle is armed or not.
* If you click on it you can arm/dismarm with a confirmation. Clicking does nothing if you are flying (still thinking about what to do here).

![screen shot 2017-04-07 at 12 07 29 pm](https://cloud.githubusercontent.com/assets/5876851/24815673/d6091d6a-1b8a-11e7-9459-39d942c40974.png)
