### PR TITLE
Support survey polygon drag

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -384,7 +384,7 @@ DebugBuild { PX4FirmwarePlugin { PX4FirmwarePluginFactory  { APMFirmwarePlugin {
         src/FactSystem/FactSystemTestGeneric.h \
         src/FactSystem/FactSystemTestPX4.h \
         src/FactSystem/ParameterManagerTest.h \
-        src/MissionManager/ComplexMissionItemTest.h \
+        src/MissionManager/SurveyMissionItemTest.h \
         src/MissionManager/MissionCommandTreeTest.h \
         src/MissionManager/MissionControllerManagerTest.h \
         src/MissionManager/MissionControllerTest.h \
@@ -412,7 +412,7 @@ DebugBuild { PX4FirmwarePlugin { PX4FirmwarePluginFactory  { APMFirmwarePlugin {
         src/FactSystem/FactSystemTestGeneric.cc \
         src/FactSystem/FactSystemTestPX4.cc \
         src/FactSystem/ParameterManagerTest.cc \
-        src/MissionManager/ComplexMissionItemTest.cc \
+        src/MissionManager/SurveyMissionItemTest.cc \
         src/MissionManager/MissionCommandTreeTest.cc \
         src/MissionManager/MissionControllerManagerTest.cc \
         src/MissionManager/MissionControllerTest.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -85,6 +85,7 @@
         <file alias="QGroundControl/Controls/QGCLabel.qml">src/QmlControls/QGCLabel.qml</file>
         <file alias="QGroundControl/Controls/QGCListView.qml">src/QmlControls/QGCListView.qml</file>
         <file alias="QGroundControl/Controls/QGCMapLabel.qml">src/QmlControls/QGCMapLabel.qml</file>
+        <file alias="QGroundControl/Controls/QGCMapPolygonVisuals.qml">src/MissionManager/QGCMapPolygonVisuals.qml</file>
         <file alias="QGroundControl/Controls/QGCMouseArea.qml">src/QmlControls/QGCMouseArea.qml</file>
         <file alias="QGroundControl/Controls/QGCMovableItem.qml">src/QmlControls/QGCMovableItem.qml</file>
         <file alias="QGroundControl/Controls/QGCPipable.qml">src/QmlControls/QGCPipable.qml</file>

--- a/src/MissionManager/QGCMapPolygon.h
+++ b/src/MissionManager/QGCMapPolygon.h
@@ -26,10 +26,11 @@ class QGCMapPolygon : public QObject
 public:
     QGCMapPolygon(QObject* newCoordParent, QObject* parent = NULL);
 
-    Q_PROPERTY(int                  count       READ count                      NOTIFY countChanged)
-    Q_PROPERTY(QVariantList         path        READ path                       NOTIFY pathChanged)
-    Q_PROPERTY(QmlObjectListModel*  pathModel   READ qmlPathModel               CONSTANT)
-    Q_PROPERTY(bool                 dirty       READ dirty      WRITE setDirty  NOTIFY dirtyChanged)
+    Q_PROPERTY(int                  count       READ count                          NOTIFY countChanged)
+    Q_PROPERTY(QVariantList         path        READ path                           NOTIFY pathChanged)
+    Q_PROPERTY(QmlObjectListModel*  pathModel   READ qmlPathModel                   CONSTANT)
+    Q_PROPERTY(bool                 dirty       READ dirty          WRITE setDirty  NOTIFY dirtyChanged)
+    Q_PROPERTY(QGeoCoordinate       center      READ center         WRITE setCenter NOTIFY centerChanged)
 
     Q_INVOKABLE void clear(void);
     Q_INVOKABLE void appendVertex(const QGeoCoordinate& coordinate);
@@ -42,9 +43,6 @@ public:
 
     /// Splits the segment comprised of vertextIndex -> vertexIndex + 1
     Q_INVOKABLE void splitPolygonSegment(int vertexIndex);
-
-    /// Returns the center point coordinate for the polygon
-    Q_INVOKABLE QGeoCoordinate center(void) const;
 
     /// Returns true if the specified coordinate is within the polygon
     Q_INVOKABLE bool containsCoordinate(const QGeoCoordinate& coordinate) const;
@@ -65,9 +63,11 @@ public:
 
     // Property methods
 
-    int     count   (void) const { return _polygonPath.count(); }
-    bool    dirty   (void) const { return _dirty; }
-    void    setDirty(bool dirty);
+    int             count   (void) const { return _polygonPath.count(); }
+    bool            dirty   (void) const { return _dirty; }
+    void            setDirty(bool dirty);
+    QGeoCoordinate  center  (void) const { return _center; }
+
 
     QVariantList        path        (void) const { return _polygonPath; }
     QmlObjectListModel* qmlPathModel(void) { return &_polygonModel; }
@@ -75,15 +75,21 @@ public:
 
     void setPath(const QList<QGeoCoordinate>& path);
     void setPath(const QVariantList& path);
+    void setCenter(QGeoCoordinate newCenter);
+
+    static const char* jsonPolygonKey;
 
 signals:
-    void countChanged(int count);
-    void pathChanged(void);
-    void dirtyChanged(bool dirty);
+    void countChanged   (int count);
+    void pathChanged    (void);
+    void dirtyChanged   (bool dirty);
+    void cleared        (void);
+    void centerChanged  (QGeoCoordinate center);
 
 private slots:
     void _polygonModelCountChanged(int count);
     void _polygonModelDirtyChanged(bool dirty);
+    void _updateCenter(void);
 
 private:
     QPolygonF _toPolygonF(void) const;
@@ -94,8 +100,8 @@ private:
     QVariantList        _polygonPath;
     QmlObjectListModel  _polygonModel;
     bool                _dirty;
-
-    static const char* _jsonPolygonKey;
+    QGeoCoordinate      _center;
+    bool                _ignoreCenterUpdates;
 };
 
 #endif

--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -1,0 +1,251 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtLocation       5.3
+import QtPositioning    5.3
+
+import QGroundControl               1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FlightMap     1.0
+
+/// QGCMapPolygon map visuals
+Item {
+    id: _root
+
+    property var mapControl     ///< Map control to place item in
+    property var mapPolygon     ///< QGCMapPolygon object
+
+    property var _polygonComponent
+    property var _dragHandlesComponent
+    property var _splitHandlesComponent
+    property var _centerDragHandleComponent
+
+    function addVisuals() {
+        _polygonComponent = polygonComponent.createObject(mapControl)
+        mapControl.addMapItem(_polygonComponent)
+    }
+
+    function removeVisuals() {
+        _polygonComponent.destroy()
+    }
+
+    function addHandles() {
+        _dragHandlesComponent = dragHandlesComponent.createObject(mapControl)
+        _splitHandlesComponent = splitHandlesComponent.createObject(mapControl)
+        _centerDragHandleComponent = centerDragHandleComponent.createObject(mapControl)
+    }
+
+    function removeHandles() {
+        if (_dragHandlesComponent) {
+            _dragHandlesComponent.destroy()
+            _dragHandlesComponent = undefined
+        }
+        if (_splitHandlesComponent) {
+            _splitHandlesComponent.destroy()
+            _splitHandlesComponent = undefined
+        }
+        if (_centerDragHandleComponent) {
+            _centerDragHandleComponent.destroy()
+            _centerDragHandleComponent = undefined
+        }
+    }
+
+    Component.onDestruction: {
+        removeVisuals()
+        removeHandles()
+    }
+
+    Component {
+        id: polygonComponent
+
+        MapPolygon {
+            color: "green"
+            opacity:    0.5
+            path:       mapPolygon.path
+        }
+    }
+
+    Component {
+        id: splitHandleComponent
+
+        MapQuickItem {
+            id:             mapQuickItem
+            anchorPoint.x:  dragHandle.width / 2
+            anchorPoint.y:  dragHandle.height / 2
+            z:              QGroundControl.zOrderMapItems + 1
+
+            property int vertexIndex
+
+            sourceItem: Rectangle {
+                id:         dragHandle
+                width:      ScreenTools.defaultFontPixelHeight * 1.5
+                height:     width
+                radius:     width / 2
+                color:      "white"
+                opacity:    .50
+
+                QGCLabel {
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                    anchors.verticalCenter:     parent.verticalCenter
+                    text:                       "+"
+                }
+
+                QGCMouseArea {
+                    fillItem:   parent
+                    onClicked:  mapPolygon.splitPolygonSegment(mapQuickItem.vertexIndex)
+                }
+            }
+        }
+    }
+
+    Component {
+        id: splitHandlesComponent
+
+        Repeater {
+            model: mapPolygon.path
+
+            delegate: Item {
+                property var _splitHandle
+                property var _vertices:     mapPolygon.path
+
+                function _setHandlePosition() {
+                    var nextIndex = index + 1
+                    if (nextIndex > _vertices.length - 1) {
+                        nextIndex = 0
+                    }
+                    var distance = _vertices[index].distanceTo(_vertices[nextIndex])
+                    var azimuth = _vertices[index].azimuthTo(_vertices[nextIndex])
+                    _splitHandle.coordinate = _vertices[index].atDistanceAndAzimuth(distance / 2, azimuth)
+                }
+
+                Component.onCompleted: {
+                    _splitHandle = splitHandleComponent.createObject(mapControl)
+                    _splitHandle.vertexIndex = index
+                    _setHandlePosition()
+                    mapControl.addMapItem(_splitHandle)
+                }
+
+                Component.onDestruction: {
+                    if (_splitHandle) {
+                        _splitHandle.destroy()
+                    }
+                }
+            }
+        }
+    }
+
+    // Control which is used to drag polygon vertices
+    Component {
+        id: dragAreaComponent
+
+        MissionItemIndicatorDrag {
+            id: dragArea
+
+            property int polygonVertex
+
+            property bool _creationComplete: false
+
+            Component.onCompleted: _creationComplete = true
+
+            onItemCoordinateChanged: {
+                if (_creationComplete) {
+                    // During component creation some bad coordinate values got through which screws up polygon draw
+                    mapPolygon.adjustVertex(polygonVertex, itemCoordinate)
+                }
+            }
+
+            onClicked: mapPolygon.removeVertex(polygonVertex)
+        }
+    }
+
+    Component {
+        id: dragHandleComponent
+
+        MapQuickItem {
+            id:             mapQuickItem
+            anchorPoint.x:  dragHandle.width / 2
+            anchorPoint.y:  dragHandle.height / 2
+            z:              QGroundControl.zOrderMapItems + 2
+
+            sourceItem: Rectangle {
+                id:         dragHandle
+                width:      ScreenTools.defaultFontPixelHeight * 1.5
+                height:     width
+                radius:     width / 2
+                color:      "white"
+                opacity:    .90
+            }
+        }
+    }
+
+    // Add all polygon vertex drag handles to the map
+    Component {
+        id: dragHandlesComponent
+
+        Repeater {
+            model: mapPolygon.pathModel
+
+            delegate: Item {
+                property var _visuals: [ ]
+
+                Component.onCompleted: {
+                    var dragHandle = dragHandleComponent.createObject(mapControl)
+                    dragHandle.coordinate = Qt.binding(function() { return object.coordinate })
+                    mapControl.addMapItem(dragHandle)
+                    var dragArea = dragAreaComponent.createObject(mapControl, { "itemIndicator": dragHandle, "itemCoordinate": object.coordinate })
+                    dragArea.polygonVertex = Qt.binding(function() { return index })
+                    _visuals.push(dragHandle)
+                    _visuals.push(dragArea)
+                }
+
+                Component.onDestruction: {
+                    for (var i=0; i<_visuals.length; i++) {
+                        _visuals[i].destroy()
+                    }
+                    _visuals = [ ]
+                }
+            }
+        }
+    }
+
+    Component {
+        id: centerDragAreaComponent
+
+        MissionItemIndicatorDrag {
+            onItemCoordinateChanged: mapPolygon.center = itemCoordinate
+        }
+    }
+
+    Component {
+        id: centerDragHandleComponent
+
+        Item {
+            property var dragHandle
+            property var dragArea
+
+            Component.onCompleted: {
+                dragHandle = dragHandleComponent.createObject(mapControl)
+                dragHandle.coordinate = Qt.binding(function() { return mapPolygon.center })
+                mapControl.addMapItem(dragHandle)
+                dragArea = centerDragAreaComponent.createObject(mapControl, { "itemIndicator": dragHandle, "itemCoordinate": mapPolygon.center })
+            }
+
+            Component.onDestruction: {
+                dragHandle.destroy()
+                dragArea.destroy()
+            }
+        }
+    }
+}
+
+

--- a/src/MissionManager/SurveyMissionItemTest.h
+++ b/src/MissionManager/SurveyMissionItemTest.h
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-#ifndef ComplexMissionItemTest_H
-#define ComplexMissionItemTest_H
+#ifndef SurveyMissionItemTest_H
+#define SurveyMissionItemTest_H
 
 #include "UnitTest.h"
 #include "TCPLink.h"
@@ -19,12 +19,12 @@
 #include <QGeoCoordinate>
 
 /// Unit test for SimpleMissionItem
-class ComplexMissionItemTest : public UnitTest
+class SurveyMissionItemTest : public UnitTest
 {
     Q_OBJECT
     
 public:
-    ComplexMissionItemTest(void);
+    SurveyMissionItemTest(void);
 
 protected:
     void init(void) final;
@@ -95,7 +95,8 @@ private:
     const char*         _rgComplexMissionItemSignals[_cComplexMissionItemSignals];
 
     MultiSignalSpy*         _multiSpy;
-    SurveyMissionItem*     _complexItem;
+    SurveyMissionItem*      _surveyItem;
+    QGCMapPolygon*          _mapPolygon;
     QList<QGeoCoordinate>   _polyPoints;
 };
 

--- a/src/PlanView/SurveyMapVisual.qml
+++ b/src/PlanView/SurveyMapVisual.qml
@@ -25,56 +25,31 @@ Item {
     property var map    ///< Map control to place item in
 
     property var _missionItem:      object
-    property var _polygon
-    property var _grid
+    property var _mapPolygon:       object.mapPolygon
+    property var _gridComponent
     property var _entryCoordinate
     property var _exitCoordinate
-    property var _dragHandles
-    property var _splitHandles
 
     signal clicked(int sequenceNumber)
 
     function _addVisualElements() {
-        _polygon = polygonComponent.createObject(map)
-        _grid = gridComponent.createObject(map)
+        _gridComponent = gridComponent.createObject(map)
         _entryCoordinate = entryPointComponent.createObject(map)
         _exitCoordinate = exitPointComponent.createObject(map)
-        map.addMapItem(_polygon)
-        map.addMapItem(_grid)
+        map.addMapItem(_gridComponent)
         map.addMapItem(_entryCoordinate)
         map.addMapItem(_exitCoordinate)
     }
 
     function _destroyVisualElements() {
-        _polygon.destroy()
-        _grid.destroy()
+        _gridComponent.destroy()
         _entryCoordinate.destroy()
         _exitCoordinate.destroy()
     }
 
-    function _addDragHandles() {
-        if (!_dragHandles) {
-            _dragHandles = dragHandlesComponent.createObject(map)
-        }
-        if (!_splitHandles) {
-            _splitHandles = splitHandlesComponent.createObject(map)
-        }
-    }
-
-    function _destroyDragHandles() {
-        if (_dragHandles) {
-            _dragHandles.destroy()
-            _dragHandles = undefined
-        }
-        if (_splitHandles) {
-            _splitHandles.destroy()
-            _splitHandles = undefined
-        }
-    }
-
     /// Add an initial 4 sided polygon if there is none
     function _addInitialPolygon() {
-        if (_missionItem.polygonPath.length < 3) {
+        if (_mapPolygon.count < 3) {
             // Initial polygon is inset to take 2/3rds space
             var rect = Qt.rect(map.centerViewport.x, map.centerViewport.y, map.centerViewport.width, map.centerViewport.height)
             console.log(map.centerViewport)
@@ -87,46 +62,44 @@ Item {
             var topRight = Qt.point(rect.x + rect.width, rect.y)
             var bottomLeft = Qt.point(rect.x, rect.y + rect.height)
             var bottomRight = Qt.point(rect.x + rect.width, rect.y + rect.height)
-            _missionItem.addPolygonCoordinate(map.toCoordinate(topLeft, false /* clipToViewPort */))
-            _missionItem.addPolygonCoordinate(map.toCoordinate(topRight, false /* clipToViewPort */))
-            _missionItem.addPolygonCoordinate(map.toCoordinate(bottomRight, false /* clipToViewPort */))
-            _missionItem.addPolygonCoordinate(map.toCoordinate(bottomLeft, false /* clipToViewPort */))
+            _mapPolygon.appendVertex(map.toCoordinate(topLeft, false /* clipToViewPort */))
+            _mapPolygon.appendVertex(map.toCoordinate(topRight, false /* clipToViewPort */))
+            _mapPolygon.appendVertex(map.toCoordinate(bottomRight, false /* clipToViewPort */))
+            _mapPolygon.appendVertex(map.toCoordinate(bottomLeft, false /* clipToViewPort */))
         }
     }
 
     Component.onCompleted: {
         _addInitialPolygon()
         _addVisualElements()
-        if (_missionItem.isCurrentItem) {
-            _addDragHandles()
-        }
     }
 
     Component.onDestruction: {
         _destroyVisualElements()
-        _destroyDragHandles()
     }
 
-    Connections {
-        target: _missionItem
+    QGCMapPolygonVisuals {
+        id:         mapPolygonVisuals
+        mapControl: map
+        mapPolygon: _mapPolygon
 
-        onIsCurrentItemChanged: {
+        Component.onCompleted: {
+            mapPolygonVisuals.addVisuals()
             if (_missionItem.isCurrentItem) {
-                _addDragHandles()
-            } else {
-                _destroyDragHandles()
+                mapPolygonVisuals.addHandles()
             }
         }
-    }
 
-    // Survey area polygon
-    Component {
-        id: polygonComponent
+        Connections {
+            target: _missionItem
 
-        MapPolygon {
-            color: "green"
-            opacity:    0.5
-            path:       _missionItem.polygonPath
+            onIsCurrentItemChanged: {
+                if (_missionItem.isCurrentItem) {
+                    mapPolygonVisuals.addHandles()
+                } else {
+                    mapPolygonVisuals.removeHandles()
+                }
+            }
         }
     }
 
@@ -180,148 +153,4 @@ Item {
             }
         }
     }
-
-    Component {
-        id: splitHandleComponent
-
-        MapQuickItem {
-            id:             mapQuickItem
-            anchorPoint.x:  dragHandle.width / 2
-            anchorPoint.y:  dragHandle.height / 2
-            z:              QGroundControl.zOrderMapItems + 1
-
-            property int vertexIndex
-
-            sourceItem: Rectangle {
-                id:         dragHandle
-                width:      ScreenTools.defaultFontPixelHeight * 1.5
-                height:     width
-                radius:     width / 2
-                color:      "white"
-                opacity:    .50
-
-                QGCLabel {
-                    anchors.horizontalCenter:   parent.horizontalCenter
-                    anchors.verticalCenter:     parent.verticalCenter
-                    text:                       "+"
-                }
-
-                QGCMouseArea {
-                    fillItem:   parent
-                    onClicked:  _missionItem.splitPolygonSegment(mapQuickItem.vertexIndex)
-                }
-            }
-        }
-    }
-
-    Component {
-        id: splitHandlesComponent
-
-        Repeater {
-            model: _missionItem.polygonPath
-
-            delegate: Item {
-                property var _splitHandle
-                property var _vertices:     _missionItem.polygonPath
-
-                function _setHandlePosition() {
-                    var nextIndex = index + 1
-                    if (nextIndex > _vertices.length - 1) {
-                        nextIndex = 0
-                    }
-                    var distance = _vertices[index].distanceTo(_vertices[nextIndex])
-                    var azimuth = _vertices[index].azimuthTo(_vertices[nextIndex])
-                    _splitHandle.coordinate = _vertices[index].atDistanceAndAzimuth(distance / 2, azimuth)
-                }
-
-                Component.onCompleted: {
-                    _splitHandle = splitHandleComponent.createObject(map)
-                    _splitHandle.vertexIndex = index
-                    _setHandlePosition()
-                    map.addMapItem(_splitHandle)
-                }
-
-                Component.onDestruction: {
-                    if (_splitHandle) {
-                        _splitHandle.destroy()
-                    }
-                }
-            }
-        }
-    }
-
-    // Control which is used to drag polygon vertices
-    Component {
-        id: dragAreaComponent
-
-        MissionItemIndicatorDrag {
-            id: dragArea
-
-            property int polygonVertex
-
-            property bool _creationComplete: false
-
-            Component.onCompleted: _creationComplete = true
-
-            onItemCoordinateChanged: {
-                if (_creationComplete) {
-                    // During component creation some bad coordinate values got through which screws up polygon draw
-                    _missionItem.adjustPolygonCoordinate(polygonVertex, itemCoordinate)
-                }
-            }
-
-            onClicked: _missionItem.removePolygonVertex(polygonVertex)
-        }
-    }
-
-    Component {
-        id: dragHandleComponent
-
-        MapQuickItem {
-            id:             mapQuickItem
-            anchorPoint.x:  dragHandle.width / 2
-            anchorPoint.y:  dragHandle.height / 2
-            z:              QGroundControl.zOrderMapItems + 2
-
-            sourceItem: Rectangle {
-                id:         dragHandle
-                width:      ScreenTools.defaultFontPixelHeight * 1.5
-                height:     width
-                radius:     width / 2
-                color:      "white"
-                opacity:    .90
-            }
-        }
-    }
-
-    // Add all polygon vertex drag handles to the map
-    Component {
-        id: dragHandlesComponent
-
-        Repeater {
-            model: _missionItem.polygonModel
-
-            delegate: Item {
-                property var _visuals: [ ]
-
-                Component.onCompleted: {
-                    var dragHandle = dragHandleComponent.createObject(map)
-                    dragHandle.coordinate = Qt.binding(function() { return object.coordinate })
-                    map.addMapItem(dragHandle)
-                    var dragArea = dragAreaComponent.createObject(map, { "itemIndicator": dragHandle, "itemCoordinate": object.coordinate })
-                    dragArea.polygonVertex = Qt.binding(function() { return index })
-                    _visuals.push(dragHandle)
-                    _visuals.push(dragArea)
-                }
-
-                Component.onDestruction: {
-                    for (var i=0; i<_visuals.length; i++) {
-                        _visuals[i].destroy()
-                    }
-                    _visuals = [ ]
-                }
-            }
-        }
-    }
 }
-

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -39,6 +39,7 @@ QGCGroupBox             1.0 QGCGroupBox.qml
 QGCLabel                1.0 QGCLabel.qml
 QGCListView             1.0 QGCListView.qml
 QGCMapLabel             1.0 QGCMapLabel.qml
+QGCMapPolygonVisuals    1.0 QGCMapPolygonVisuals.qml
 QGCMouseArea            1.0 QGCMouseArea.qml
 QGCMovableItem          1.0 QGCMovableItem.qml
 QGCPipable              1.0 QGCPipable.qml

--- a/src/qgcunittest/UnitTestList.cc
+++ b/src/qgcunittest/UnitTestList.cc
@@ -20,7 +20,7 @@
 #include "MessageBoxTest.h"
 #include "MissionItemTest.h"
 #include "SimpleMissionItemTest.h"
-#include "ComplexMissionItemTest.h"
+#include "SurveyMissionItemTest.h"
 #include "MissionControllerTest.h"
 #include "MissionManagerTest.h"
 #include "RadioConfigTest.h"
@@ -61,5 +61,5 @@ UT_REGISTER_TEST(SendMavCommandTest)
 //UT_REGISTER_TEST(FileManagerTest)
 
 // Needs to be update for latest changes
-//UT_REGISTER_TEST(ComplexMissionItemTest)
+//UT_REGISTER_TEST(SurveyMissionItemTest)
 //UT_REGISTER_TEST(MavlinkLogTest)


### PR DESCRIPTION
* QGCMapPolygon now supports map visuals for dragging. So this is now a fullt reusable polygon manipulation control.
* Moved Survey to QGCMapPolygon.
* QGCMapPolygon support dragging the center of the polygon to a new location

Still somewhat flaky but about 75% working. Still lots of testing, visual glitch cleanup to do.

![screen shot 2017-04-07 at 3 04 38 pm](https://cloud.githubusercontent.com/assets/5876851/24821526/fb09bc32-1ba3-11e7-81bc-6d24b5fc2f17.png)
