### PR TITLE
Add support for NaN in mission command params

### DIFF
--- a/src/FirmwarePlugin/PX4/MavCmdInfoCommon.json
+++ b/src/FirmwarePlugin/PX4/MavCmdInfoCommon.json
@@ -7,7 +7,7 @@
         {
             "id":           16,
             "comment":      "MAV_CMD_NAV_WAYPOINT",
-            "paramRemove":  "2,3,4"
+            "paramRemove":  "2,3"
         },
         {
             "id":           21,

--- a/src/FirmwarePlugin/PX4/MavCmdInfoMultiRotor.json
+++ b/src/FirmwarePlugin/PX4/MavCmdInfoMultiRotor.json
@@ -14,13 +14,13 @@
             "id":           18,
             "comment":      "MAV_CMD_NAV_LOITER_TURNS",
             "description":  "Travel to a position and Loiter for a number of turns.",
-            "paramRemove":  "3,4"
+            "paramRemove":  "3"
         },
         {
             "id":           19,
             "comment":      "MAV_CMD_NAV_LOITER_TIME",
             "description":  "Travel to a position and Loiter for an amount of time.",
-            "paramRemove":  "3,4"
+            "paramRemove":  "3"
         },
         {
             "id":           22,

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -54,7 +54,7 @@
             "param4": {
                 "label":            "Heading",
                 "units":            "radians",
-                "default":          0.0,
+                "nanUnchanged":     true,
                 "decimalPlaces":    2
             }
         },
@@ -70,6 +70,12 @@
                 "label":            "Radius",
                 "units":            "m",
                 "default":          50.0,
+                "decimalPlaces":    2
+            },
+            "param4": {
+                "label":            "Heading",
+                "units":            "radians",
+                "nanUnchanged":     true,
                 "decimalPlaces":    2
             }
         },
@@ -93,11 +99,10 @@
                 "decimalPlaces":    2
             },
             "param4": {
-                "label":            "Exit loiter from",
-                "enumStrings":      "Center,Tangent",
-                "enumValues":       "0,1",
-                "default":          1,
-                "decimalPlaces":    0
+                "label":            "Heading",
+                "units":            "radians",
+                "nanUnchanged":     true,
+                "decimalPlaces":    2
             }
         },
         {
@@ -121,11 +126,10 @@
                 "decimalPlaces":    2
             },
             "param4": {
-                "label":            "Exit loiter from",
-                "enumStrings":      "Center,Tangent",
-                "enumValues":       "0,1",
-                "default":          1,
-                "decimalPlaces":    0
+                "label":            "Heading",
+                "units":            "radians",
+                "nanUnchanged":     true,
+                "decimalPlaces":    2
             }
         },
         {
@@ -153,7 +157,7 @@
             "param4": {
                 "label":            "Heading",
                 "units":            "radians",
-                "default":          0.0,
+                "nanUnchanged":     true,
                 "decimalPlaces":    2
             }
         },
@@ -174,7 +178,7 @@
             "param4": {
                 "label":            "Heading",
                 "units":            "radians",
-                "default":          0.0,
+                "nanUnchanged":     true,
                 "decimalPlaces":    2
             }
         },
@@ -312,7 +316,7 @@
             "param4": {
                 "label":            "Heading",
                 "units":            "deg",
-                "default":          0.0,
+                "nanUnchanged":     true,
                 "decimalPlaces":    2
             }
         },
@@ -327,7 +331,7 @@
             "param4": {
                 "label":            "Heading",
                 "units":            "deg",
-                "default":          0.0,
+                "nanUnchanged":     true,
                 "decimalPlaces":    2
             }
         },

--- a/src/MissionManager/MavCmdInfoFixedWing.json
+++ b/src/MissionManager/MavCmdInfoFixedWing.json
@@ -8,6 +8,43 @@
             "id":           16,
             "comment":      "MAV_CMD_NAV_WAYPOINT",
             "paramRemove":  "4"
+        },
+        {
+            "id":           17,
+            "comment":      "MAV_CMD_NAV_LOITER_UNLIM",
+            "paramRemove":  "4"
+        },
+        {
+            "id":           18,
+            "comment":      "MAV_CMD_NAV_LOITER_TURNS",
+            "param4": {
+                "label":            "Exit loiter from",
+                "enumStrings":      "Center,Tangent",
+                "enumValues":       "0,1",
+                "default":          1,
+                "decimalPlaces":    0
+            }
+        },
+        {
+            "id":           19,
+            "comment":      "MAV_CMD_NAV_LOITER_TIME",
+            "param4": {
+                "label":            "Exit loiter from",
+                "enumStrings":      "Center,Tangent",
+                "enumValues":       "0,1",
+                "default":          1,
+                "decimalPlaces":    0
+            }
+        },
+        {
+            "id":           21,
+            "comment":      "MAV_CMD_NAV_LAND",
+            "paramRemove":  "4"
+        },
+        {
+            "id":           22,
+            "comment":      "MAV_CMD_NAV_TAKEOFF",
+            "paramRemove":  "4"
         }
     ]
 }

--- a/src/MissionManager/MissionCommandUIInfo.h
+++ b/src/MissionManager/MissionCommandUIInfo.h
@@ -31,10 +31,11 @@ class MissionCommandTreeTest;
 /// Key             Type    Default     Description
 /// label           string  required    Label for text field
 /// units           string              Units for value, should use FactMetaData units strings in order to get automatic translation
-/// default         double  0.0         Default value for param
+/// default         double  0.0/NaN     Default value for param. If no default value specified and nanUnchanged == true, then defaultVlue is NaN.
 /// decimalPlaces   int     7           Number of decimal places to show for value
 /// enumStrings     string              Strings to show in combo box for selection
 /// enumValues      string              Values assocaited with each enum string
+/// nanUnchanged    bool    false       True: value can be set to NaN to signal unchanged
 ///
 class MissionCmdParamInfo : public QObject {
 
@@ -53,6 +54,7 @@ public:
     Q_PROPERTY(QString      label           READ label          CONSTANT)
     Q_PROPERTY(int          param           READ param          CONSTANT)
     Q_PROPERTY(QString      units           READ units          CONSTANT)
+    Q_PROPERTY(bool         nanUnchanged    READ nanUnchanged   CONSTANT)
 
     int             decimalPlaces   (void) const { return _decimalPlaces; }
     double          defaultValue    (void) const { return _defaultValue; }
@@ -61,6 +63,7 @@ public:
     QString         label           (void) const { return _label; }
     int             param           (void) const { return _param; }
     QString         units           (void) const { return _units; }
+    bool            nanUnchanged    (void) const { return _nanUnchanged; }
 
 private:
     int             _decimalPlaces;
@@ -70,6 +73,7 @@ private:
     QString         _label;
     int             _param;
     QString         _units;
+    bool            _nanUnchanged;
 
     friend class MissionCommandTree;
     friend class MissionCommandUIInfo;
@@ -167,6 +171,7 @@ private:
     static const char* _descriptionJsonKey;
     static const char* _enumStringsJsonKey;
     static const char* _enumValuesJsonKey;
+    static const char* _nanUnchangedJsonKey;
     static const char* _friendlyNameJsonKey;
     static const char* _friendlyEditJsonKey;
     static const char* _idJsonKey;

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -40,9 +40,10 @@ public:
     Q_PROPERTY(QObject*         cameraSection           READ cameraSection                                      NOTIFY cameraSectionChanged)
 
     // These properties are used to display the editing ui
-    Q_PROPERTY(QmlObjectListModel*  checkboxFacts   READ checkboxFacts  NOTIFY uiModelChanged)
-    Q_PROPERTY(QmlObjectListModel*  comboboxFacts   READ comboboxFacts  NOTIFY uiModelChanged)
-    Q_PROPERTY(QmlObjectListModel*  textFieldFacts  READ textFieldFacts NOTIFY uiModelChanged)
+    Q_PROPERTY(QmlObjectListModel*  checkboxFacts   READ checkboxFacts  CONSTANT)
+    Q_PROPERTY(QmlObjectListModel*  comboboxFacts   READ comboboxFacts  CONSTANT)
+    Q_PROPERTY(QmlObjectListModel*  textFieldFacts  READ textFieldFacts CONSTANT)
+    Q_PROPERTY(QmlObjectListModel*  nanFacts        READ nanFacts       CONSTANT)
 
     /// Scans the loaded items for additional section settings
     ///     @param visualItems List of all visual items
@@ -59,9 +60,10 @@ public:
     bool            rawEdit             (void) const;
     CameraSection*  cameraSection       (void) { return _cameraSection; }
 
-    QmlObjectListModel* textFieldFacts  (void);
-    QmlObjectListModel* checkboxFacts   (void);
-    QmlObjectListModel* comboboxFacts   (void);
+    QmlObjectListModel* textFieldFacts  (void) { return &_textFieldFacts; }
+    QmlObjectListModel* nanFacts        (void) { return &_nanFacts; }
+    QmlObjectListModel* checkboxFacts   (void) { return &_checkboxFacts; }
+    QmlObjectListModel* comboboxFacts   (void) { return &_comboboxFacts; }
 
     void setRawEdit(bool rawEdit);
     
@@ -120,28 +122,29 @@ signals:
     void friendlyEditAllowedChanged (bool friendlyEditAllowed);
     void headingDegreesChanged      (double heading);
     void rawEditChanged             (bool rawEdit);
-    void uiModelChanged             (void);
     void cameraSectionChanged       (QObject* cameraSection);
 
 private slots:
-    void _setDirtyFromSignal(void);
-    void _cameraSectionDirtyChanged(bool dirty);
-    void _sendCommandChanged(void);
-    void _sendCoordinateChanged(void);
-    void _sendFrameChanged(void);
-    void _sendFriendlyEditAllowedChanged(void);
-    void _sendUiModelChanged(void);
-    void _syncAltitudeRelativeToHomeToFrame(const QVariant& value);
-    void _syncFrameToAltitudeRelativeToHome(void);
-    void _updateLastSequenceNumber(void);
+    void _setDirtyFromSignal            (void);
+    void _cameraSectionDirtyChanged         (bool dirty);
+    void _sendCommandChanged                (void);
+    void _sendCoordinateChanged             (void);
+    void _sendFrameChanged                  (void);
+    void _sendFriendlyEditAllowedChanged    (void);
+    void _syncAltitudeRelativeToHomeToFrame (const QVariant& value);
+    void _syncFrameToAltitudeRelativeToHome (void);
+    void _updateLastSequenceNumber          (void);
+    void _rebuildFacts                      (void);
 
 private:
-    void _clearParamMetaData(void);
-    void _connectSignals(void);
-    void _setupMetaData(void);
-    void _updateCameraSection(void);
+    void _connectSignals        (void);
+    void _setupMetaData         (void);
+    void _updateCameraSection   (void);
+    void _rebuildTextFieldFacts (void);
+    void _rebuildNaNFacts       (void);
+    void _rebuildCheckboxFacts  (void);
+    void _rebuildComboBoxFacts  (void);
 
-private:
     MissionItem _missionItem;
     bool        _rawEdit;
     bool        _dirty;
@@ -153,6 +156,11 @@ private:
 
     Fact    _altitudeRelativeToHomeFact;
     Fact    _supportedCommandFact;
+
+    QmlObjectListModel  _textFieldFacts;
+    QmlObjectListModel  _nanFacts;
+    QmlObjectListModel  _checkboxFacts;
+    QmlObjectListModel  _comboboxFacts;
     
     static FactMetaData*    _altitudeMetaData;
     static FactMetaData*    _commandMetaData;

--- a/src/MissionManager/SurveyMissionItem.cc
+++ b/src/MissionManager/SurveyMissionItem.cc
@@ -926,12 +926,13 @@ int SurveyMissionItem::_appendWaypointToMission(QList<MissionItem*>& items, int 
                                         MAV_CMD_NAV_WAYPOINT,
                                         altitudeRelative ? MAV_FRAME_GLOBAL_RELATIVE_ALT : MAV_FRAME_GLOBAL,
                                         cameraTrigger == CameraTriggerHoverAndCapture ? 1 : 0,  // Hold time (1 second for hover and capture to settle vehicle before image is taken)
-                                        0.0, 0.0, 0.0,                                          // param 2-4 unused
+                                        0.0, 0.0,
+                                        std::numeric_limits<double>::quiet_NaN(),   // Yaw unchanged
                                         coord.latitude(),
                                         coord.longitude(),
                                         altitude,
-                                        true,                                                   // autoContinue
-                                        false,                                                  // isCurrentItem
+                                        true,                                       // autoContinue
+                                        false,                                      // isCurrentItem
                                         missionItemParent);
     items.append(item);
 

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -107,6 +107,37 @@ Rectangle {
                         }
                     }
 
+                    GridLayout {
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        columns:        2
+
+                        Repeater {
+                            model: missionItem.nanFacts
+
+                            QGCCheckBox {
+                                text:           object.name
+                                Layout.column:  0
+                                Layout.row:     index
+                                checked:        isNaN(object.rawValue)
+                                onClicked:      object.rawValue = checked ? NaN : 0
+                            }
+                        }
+
+                        Repeater {
+                            model: missionItem.nanFacts
+
+                            FactTextField {
+                                showUnits:          true
+                                fact:               object
+                                Layout.column:      1
+                                Layout.row:         index
+                                Layout.fillWidth:   true
+                                enabled:            !isNaN(object.rawValue)
+                            }
+                        }
+                    }
+
                     Repeater {
                         model: missionItem.checkboxFacts
 

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -119,8 +119,8 @@ Rectangle {
                                 text:           object.name
                                 Layout.column:  0
                                 Layout.row:     index
-                                checked:        isNaN(object.rawValue)
-                                onClicked:      object.rawValue = checked ? NaN : 0
+                                checked:        !isNaN(object.rawValue)
+                                onClicked:      object.rawValue = checked ? 0 : NaN
                             }
                         }
 


### PR DESCRIPTION
* Added new setting for MissionCmdParamInfo: nanUnchanged. This indicates that this CMD_LONG parameter supports NaN to signal the value is unchanged.
* Use this new settings on the heading params for the appropriate commands. Also fixed up a bunch of problems with PX4 MavCmdInfo capabilities being out of date.
* Update SimpleItemEditor to support NaN fields.

Here is what it looks like:
<img width="247" alt="screen shot 2017-04-07 at 8 52 05 pm" src="https://cloud.githubusercontent.com/assets/5876851/24825489/1b1abad2-1bd4-11e7-901e-b6572274b3b2.png">

* Check the box for Heading to specify a heading
* Leave unchecked to set as NaN which means leave heading alone

Fixes for: #4905, #4902