### PR TITLE
Fix ToolStrip sizing/visability

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -342,7 +342,7 @@ QGCView {
         }
 
         ToolStrip {
-            visible:            _activeVehicle ? _activeVehicle.guidedModeSupported : false
+            visible:            _activeVehicle ? _activeVehicle.guidedModeSupported : true
             id:                 toolStrip
             anchors.leftMargin: ScreenTools.defaultFontPixelWidth
             anchors.left:       _panel.left

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -41,11 +41,8 @@ Rectangle {
     property bool _showOptionalElements:    true
     property bool _needRecalc:              false
 
-    Component.onCompleted: recalcShowOptionalElements()
-
+    Component.onCompleted:  recalcShowOptionalElements()
     onMaxHeightChanged:     recalcShowOptionalElements()
-    onModelChanged:         recalcShowOptionalElements()
-    onButtonVisibleChanged: recalcShowOptionalElements()
 
     Connections {
         target: ScreenTools


### PR DESCRIPTION
@jaxxzer I reversed to initial state of the toolstrip. If there is no vehicle the ToolStrip always shows. It's only after the vehicle shows up that it used guided mode to hide. I don't like that fact that for the majority use case (guided mode supported) it comes and goes which is strange visually. So I've switched the strangeness to the minority use case.e