### PR TITLE
Fixes

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -29,9 +29,11 @@ FlightMap {
     mapName:                    _mapName
     allowGCSLocationCenter:     !userPanned
     allowVehicleLocationCenter: !_keepVehicleCentered
+    planView:                   false
 
     property alias  scaleState: mapScale.state
 
+    // The following properties must be set by the consumer
     property var    missionController
     property var    geoFenceController
     property var    rallyPointController

--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -51,6 +51,7 @@ Rectangle {
             anchors.left:           slider.left
             anchors.right:          slider.right
             horizontalAlignment:    Text.AlignHCenter
+            font.pointSize:         ScreenTools.largeFontPointSize
         }
 
         QGCLabel {

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -38,6 +38,7 @@ Map {
     property bool   allowVehicleLocationCenter:     false   ///< true: map will center/zoom to vehicle location one time
     property bool   firstGCSPositionReceived:       false   ///< true: first gcs position update was responded to
     property bool   firstVehiclePositionReceived:   false   ///< true: first vehicle position update was responded to
+    property bool   planView:                       false   ///< true: map being using for Plan view, items should be draggable
 
     readonly property real  maxZoomLevel: 20
 

--- a/src/MissionManager/MissionSettings.FactMetaData.json
+++ b/src/MissionManager/MissionSettings.FactMetaData.json
@@ -6,13 +6,5 @@
     "units":            "m",
     "decimalPlaces":    1,
     "defaultValue":     0
-},
-{
-    "name":             "MissionEndAction",
-    "shortDescription": "The action to take when the mission completed.",
-    "type":             "uint32",
-    "enumStrings":      "No action on mission end,Loiter after mission end,RTL after mission end",
-    "enumValues":       "0,1,2",
-    "defaultValue":     0
 }
 ]

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -203,7 +203,7 @@ bool MissionSettingsItem::scanForMissionSettings(QmlObjectListModel* visualItems
     if (item) {
         MissionItem& missionItem = item->missionItem();
 
-        if (item->command() == MAV_CMD_NAV_RETURN_TO_LAUNCH &&
+        if (missionItem.command() == MAV_CMD_NAV_RETURN_TO_LAUNCH &&
                 missionItem.param1() == 0 && missionItem.param2() == 0 && missionItem.param3() == 0 && missionItem.param4() == 0 && missionItem.param5() == 0 && missionItem.param6() == 0 && missionItem.param7() == 0) {
             qCDebug(MissionSettingsComplexItemLog) << "Scan: Found end action RTL";
             settingsItem->_missionEndRTL = true;

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -24,18 +24,17 @@ QGC_LOGGING_CATEGORY(MissionSettingsComplexItemLog, "MissionSettingsComplexItemL
 const char* MissionSettingsItem::jsonComplexItemTypeValue = "MissionSettings";
 
 const char* MissionSettingsItem::_plannedHomePositionAltitudeName = "PlannedHomePositionAltitude";
-const char* MissionSettingsItem::_missionEndActionName =            "MissionEndAction";
 
 QMap<QString, FactMetaData*> MissionSettingsItem::_metaDataMap;
 
 MissionSettingsItem::MissionSettingsItem(Vehicle* vehicle, QObject* parent)
-    : ComplexMissionItem(vehicle, parent)
+    : ComplexMissionItem                (vehicle, parent)
     , _plannedHomePositionAltitudeFact  (0, _plannedHomePositionAltitudeName,   FactMetaData::valueTypeDouble)
-    , _missionEndActionFact             (0, _missionEndActionName,              FactMetaData::valueTypeUint32)
-    , _cameraSection(vehicle)
-    , _speedSection(vehicle)
-    , _sequenceNumber(0)
-    , _dirty(false)
+    , _missionEndRTL                    (false)
+    , _cameraSection                    (vehicle)
+    , _speedSection                     (vehicle)
+    , _sequenceNumber                   (0)
+    , _dirty                            (false)
 {
     _editorQml = "qrc:/qml/MissionSettingsEditor.qml";
 
@@ -44,27 +43,25 @@ MissionSettingsItem::MissionSettingsItem(Vehicle* vehicle, QObject* parent)
     }
 
     _plannedHomePositionAltitudeFact.setMetaData    (_metaDataMap[_plannedHomePositionAltitudeName]);
-    _missionEndActionFact.setMetaData               (_metaDataMap[_missionEndActionName]);
 
     _plannedHomePositionAltitudeFact.setRawValue    (_plannedHomePositionAltitudeFact.rawDefaultValue());
-    _missionEndActionFact.setRawValue               (_missionEndActionFact.rawDefaultValue());
 
     setHomePositionSpecialCase(true);
 
     connect(this,               &MissionSettingsItem::specifyMissionFlightSpeedChanged, this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
+    connect(this,               &MissionSettingsItem::missionEndRTLChanged,             this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
     connect(&_cameraSection,    &CameraSection::itemCountChanged,                       this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
     connect(&_speedSection,     &CameraSection::itemCountChanged,                       this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
 
-    connect(&_plannedHomePositionAltitudeFact,  &Fact::valueChanged, this, &MissionSettingsItem::_setDirty);
-    connect(&_plannedHomePositionAltitudeFact,  &Fact::valueChanged, this, &MissionSettingsItem::_updateAltitudeInCoordinate);
+    connect(&_plannedHomePositionAltitudeFact,  &Fact::valueChanged,                        this, &MissionSettingsItem::_setDirty);
 
-    connect(&_missionEndActionFact,             &Fact::valueChanged, this, &MissionSettingsItem::_setDirty);
+    connect(&_plannedHomePositionAltitudeFact,  &Fact::valueChanged, this, &MissionSettingsItem::_updateAltitudeInCoordinate);
 
     connect(&_cameraSection,    &CameraSection::dirtyChanged,   this, &MissionSettingsItem::_sectionDirtyChanged);
     connect(&_speedSection,     &SpeedSection::dirtyChanged,    this, &MissionSettingsItem::_sectionDirtyChanged);
 
-    connect(&_cameraSection,            &CameraSection::specifyGimbalChanged,       this, &MissionSettingsItem::specifiedGimbalYawChanged);
-    connect(&_cameraSection,            &CameraSection::specifiedGimbalYawChanged,  this, &MissionSettingsItem::specifiedGimbalYawChanged);
+    connect(&_cameraSection,    &CameraSection::specifyGimbalChanged,       this, &MissionSettingsItem::specifiedGimbalYawChanged);
+    connect(&_cameraSection,    &CameraSection::specifiedGimbalYawChanged,  this, &MissionSettingsItem::specifiedGimbalYawChanged);
 }
 
 
@@ -184,23 +181,7 @@ bool MissionSettingsItem::addMissionEndAction(QList<MissionItem*>& items, int se
         return false;
     }
 
-    switch(_missionEndActionFact.rawValue().toInt()) {
-    case MissionEndLoiter:
-        qCDebug(MissionSettingsComplexItemLog) << "Appending end action Loiter seqNum" << seqNum;
-        item = new MissionItem(seqNum,
-                               MAV_CMD_NAV_LOITER_UNLIM,
-                               lastWaypointFrame,
-                               0, 0,                        // param 1-2 unused
-                               0,                           // use default loiter radius
-                               0,                           // param 4 not used
-                               lastWaypointCoord.latitude(),
-                               lastWaypointCoord.longitude(),
-                               lastWaypointCoord.altitude(),
-                               true,                        // autoContinue
-                               false,                       // isCurrentItem
-                               missionItemParent);
-        break;
-    case MissionEndRTL:
+    if (_missionEndRTL) {
         qCDebug(MissionSettingsComplexItemLog) << "Appending end action RTL seqNum" << seqNum;
         item = new MissionItem(seqNum,
                                MAV_CMD_NAV_RETURN_TO_LAUNCH,
@@ -209,12 +190,6 @@ bool MissionSettingsItem::addMissionEndAction(QList<MissionItem*>& items, int se
                                true,                       // autoContinue
                                false,                      // isCurrentItem
                                missionItemParent);
-        break;
-    default:
-        break;
-    }
-
-    if (item) {
         items.append(item);
         return true;
     } else {
@@ -248,25 +223,11 @@ bool MissionSettingsItem::scanForMissionSettings(QmlObjectListModel* visualItems
     if (item) {
         MissionItem& missionItem = item->missionItem();
 
-        switch ((MAV_CMD)item->command()) {
-        case MAV_CMD_NAV_LOITER_UNLIM:
-            if (missionItem.param1() == 0 && missionItem.param2() == 0 && missionItem.param3() == 0 && missionItem.param4() == 0) {
-                qCDebug(MissionSettingsComplexItemLog) << "Scan: Found end action Loiter";
-                settingsItem->missionEndAction()->setRawValue(MissionEndLoiter);
-                visualItems->removeAt(lastIndex)->deleteLater();
-            }
-            break;
-
-        case MAV_CMD_NAV_RETURN_TO_LAUNCH:
-            if (missionItem.param1() == 0 && missionItem.param2() == 0 && missionItem.param3() == 0 && missionItem.param4() == 0 && missionItem.param5() == 0 && missionItem.param6() == 0 && missionItem.param7() == 0) {
-                qCDebug(MissionSettingsComplexItemLog) << "Scan: Found end action RTL";
-                settingsItem->missionEndAction()->setRawValue(MissionEndRTL);
-                visualItems->removeAt(lastIndex)->deleteLater();
-            }
-            break;
-
-        default:
-            break;
+        if (item->command() == MAV_CMD_NAV_RETURN_TO_LAUNCH &&
+                missionItem.param1() == 0 && missionItem.param2() == 0 && missionItem.param3() == 0 && missionItem.param4() == 0 && missionItem.param5() == 0 && missionItem.param6() == 0 && missionItem.param7() == 0) {
+            qCDebug(MissionSettingsComplexItemLog) << "Scan: Found end action RTL";
+            settingsItem->_missionEndRTL = true;
+            visualItems->removeAt(lastIndex)->deleteLater();
         }
     }
 

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -161,26 +161,6 @@ bool MissionSettingsItem::addMissionEndAction(QList<MissionItem*>& items, int se
 
     // IMPORTANT NOTE: If anything changes here you must also change MissionSettingsItem::scanForMissionSettings
 
-    // Find last waypoint coordinate information so we have a lat/lon/alt to use
-    QGeoCoordinate  lastWaypointCoord;
-    MAV_FRAME       lastWaypointFrame;
-
-    bool found = false;
-    for (int i=items.count()-1; i>0; i--) {
-        MissionItem* missionItem = items[i];
-
-        const MissionCommandUIInfo* uiInfo = qgcApp()->toolbox()->missionCommandTree()->getUIInfo(_vehicle, (MAV_CMD)missionItem->command());
-        if (uiInfo->specifiesCoordinate() && !uiInfo->isStandaloneCoordinate()) {
-            lastWaypointCoord = missionItem->coordinate();
-            lastWaypointFrame = missionItem->frame();
-            found = true;
-            break;
-        }
-    }
-    if (!found) {
-        return false;
-    }
-
     if (_missionEndRTL) {
         qCDebug(MissionSettingsComplexItemLog) << "Appending end action RTL seqNum" << seqNum;
         item = new MissionItem(seqNum,

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -26,20 +26,12 @@ class MissionSettingsItem : public ComplexMissionItem
 public:
     MissionSettingsItem(Vehicle* vehicle, QObject* parent = NULL);
 
-    enum MissionEndAction {
-        MissionEndNoAction,
-        MissionEndLoiter,
-        MissionEndRTL
-    };
-    Q_ENUMS(MissionEndAction)
-
-    Q_PROPERTY(Fact*    missionEndAction            READ missionEndAction                                                   CONSTANT)
     Q_PROPERTY(Fact*    plannedHomePositionAltitude READ plannedHomePositionAltitude                                        CONSTANT)
+    Q_PROPERTY(bool     missionEndRTL               MEMBER _missionEndRTL                                                   NOTIFY missionEndRTLChanged)
     Q_PROPERTY(QObject* cameraSection               READ cameraSection                                                      CONSTANT)
     Q_PROPERTY(QObject* speedSection                READ speedSection                                                       CONSTANT)
 
     Fact*   plannedHomePositionAltitude (void) { return &_plannedHomePositionAltitudeFact; }
-    Fact*   missionEndAction            (void) { return &_missionEndActionFact; }
 
     QObject* cameraSection(void) { return &_cameraSection; }
     QObject* speedSection(void) { return &_speedSection; }
@@ -92,7 +84,8 @@ public:
     static const char* jsonComplexItemTypeValue;
 
 signals:
-    void specifyMissionFlightSpeedChanged(bool specifyMissionFlightSpeed);
+    void specifyMissionFlightSpeedChanged   (bool specifyMissionFlightSpeed);
+    void missionEndRTLChanged               (bool missionEndRTL);
 
 private slots:
     void _setDirtyAndUpdateLastSequenceNumber   (void);
@@ -101,9 +94,9 @@ private slots:
     void _updateAltitudeInCoordinate            (QVariant value);
 
 private:
-    QGeoCoordinate  _plannedHomePositionCoordinate;     // Does not include altitde
+    QGeoCoordinate  _plannedHomePositionCoordinate;     // Does not include altitude
     Fact            _plannedHomePositionAltitudeFact;
-    Fact            _missionEndActionFact;
+    bool            _missionEndRTL;
     CameraSection   _cameraSection;
     SpeedSection    _speedSection;
 
@@ -113,7 +106,6 @@ private:
     static QMap<QString, FactMetaData*> _metaDataMap;
 
     static const char* _plannedHomePositionAltitudeName;
-    static const char* _missionEndActionName;
 };
 
 #endif

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -124,11 +124,10 @@ Rectangle {
                     }
                 } // GridLayout
 
-                FactComboBox {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    fact:           missionItem.missionEndAction
-                    indexModel:     false
+                QGCCheckBox {
+                    text:       qsTr("RTL after mission end")
+                    checked:    missionItem.missionEndRTL
+                    onClicked:  missionItem.missionEndRTL = checked
                 }
             }
 

--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -62,7 +62,7 @@ Item {
 
     Component.onCompleted: {
         showItemVisuals()
-        if (_missionItem.isCurrentItem) {
+        if (_missionItem.isCurrentItem && map.planView) {
             showDragArea()
         }
     }


### PR DESCRIPTION
* You could get stuck in Plan if you had auto-sync on with a dirty mission while flying a mission
* Waypoints could be dragged in Fly view
* Confirm action dialog usability/readability issues on mobile
* Mission end action supported Loiter which doesn't make sense since the firmware will automatically loiter and end of mission. Now there is only an RTL checkbox.