### PR TITLE
Xcode 8.3 has issues on how MAVLink accesses message structure members.

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -199,6 +199,8 @@ MacBuild | LinuxBuild {
     MacBuild {
         # Latest clang version has a buggy check for this which cause Qt headers to throw warnings on qmap.h
         QMAKE_CXXFLAGS_WARN_ON += -Wno-return-stack-address
+        # Xcode 8.3 has issues on how MAVLink accesses (packed) message structure members.
+        QMAKE_CXXFLAGS_WARN_ON += -Wno-address-of-packed-member
     }
 }
 

--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -200,7 +200,9 @@ MacBuild | LinuxBuild {
         # Latest clang version has a buggy check for this which cause Qt headers to throw warnings on qmap.h
         QMAKE_CXXFLAGS_WARN_ON += -Wno-return-stack-address
         # Xcode 8.3 has issues on how MAVLink accesses (packed) message structure members.
-        QMAKE_CXXFLAGS_WARN_ON += -Wno-address-of-packed-member
+        # Note that this will fail when Xcode version reaches 10.x.x
+        XCODE_VERSION = $$system($$PWD/tools/get_xcode_version.sh)
+        greaterThan(XCODE_VERSION, 8.2.0): QMAKE_CXXFLAGS_WARN_ON += -Wno-address-of-packed-member
     }
 }
 

--- a/tools/get_xcode_version.sh
+++ b/tools/get_xcode_version.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+xcodebuild -version 2>&1 | (head -n1) | awk  '{print $2}'
+


### PR DESCRIPTION
For example:
```
crc_accumulate(crc_extra, &msg->checksum);
```
in https://github.com/mavlink/c_library_v2/blob/fb411385d5f00300ab5d04c5adb08e7e17670d58/mavlink_helpers.h#L245

You would end up with a warning:
```
<...>/qgroundcontrol/libs/mavlink/include/mavlink/v2.0/mavlink_helpers.h:467:21: warning: taking
address of packed member 'checksum' of class or structure '__mavlink_message' may result in an
unaligned pointer value [-Waddress-of-packed-member]
        crc_accumulate(c, &msg->checksum);
                           ^~~~~~~~~~~~~
```