### PR TITLE
Allow core plugin to override palette

### DIFF
--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -16,7 +16,7 @@ import QGroundControl.Palette       1.0
 Rectangle {
     id:     _root
     height: editorLoader.y + editorLoader.height + (_margin * 2)
-    color:  _currentItem ? qgcPal.primaryButton : qgcPal.windowShade
+    color:  _currentItem ? qgcPal.missionItemEditor : qgcPal.windowShade
     radius: _radius
 
     property var    map                 ///< Map control

--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -12,6 +12,8 @@
 ///     @author Don Gagne <don@thegagnes.com>
 
 #include "QGCPalette.h"
+#include "QGCApplication.h"
+#include "QGCCorePlugin.h"
 
 #include <QApplication>
 #include <QPalette>
@@ -20,42 +22,16 @@ QList<QGCPalette*>   QGCPalette::_paletteObjects;
 
 QGCPalette::Theme QGCPalette::_theme = QGCPalette::Dark;
 
-//                                      Light                 Dark
-//                                      Disabled   Enabled    Disabled   Enabled
-DECLARE_QGC_COLOR(window,               "#ffffff", "#ffffff", "#222222", "#222222")
-DECLARE_QGC_COLOR(windowShade,          "#d9d9d9", "#d9d9d9", "#333333", "#333333")
-DECLARE_QGC_COLOR(windowShadeDark,      "#bdbdbd", "#bdbdbd", "#282828", "#282828")
-DECLARE_QGC_COLOR(text,                 "#9d9d9d", "#000000", "#a0a0a0", "#ffffff")
-DECLARE_QGC_COLOR(warningText,          "#cc0808", "#cc0808", "#f85761", "#f85761")
-DECLARE_QGC_COLOR(button,               "#ffffff", "#ffffff", "#707070", "#626270")
-DECLARE_QGC_COLOR(buttonText,           "#9d9d9d", "#000000", "#202020", "#ffffff")
-DECLARE_QGC_COLOR(buttonHighlight,      "#e4e4e4", "#946120", "#3a3a3a", "#fff291")
-DECLARE_QGC_COLOR(buttonHighlightText,  "#2c2c2c", "#ffffff", "#2c2c2c", "#000000")
-DECLARE_QGC_COLOR(primaryButton,        "#585858", "#8cb3be", "#585858", "#8cb3be")
-DECLARE_QGC_COLOR(primaryButtonText,    "#2c2c2c", "#000000", "#2c2c2c", "#000000")
-DECLARE_QGC_COLOR(textField,            "#ffffff", "#ffffff", "#585858", "#ffffff")
-DECLARE_QGC_COLOR(textFieldText,        "#dedede", "#000000", "#2c2c2c", "#000000")
-DECLARE_QGC_COLOR(mapButton,            "#585858", "#000000", "#585858", "#000000")
-DECLARE_QGC_COLOR(mapButtonHighlight,   "#585858", "#be781c", "#585858", "#be781c")
-DECLARE_QGC_COLOR(colorGreen,           "#009431", "#009431", "#00e04b", "#00e04b")
-DECLARE_QGC_COLOR(colorOrange,          "#b95604", "#b95604", "#de8500", "#de8500")
-DECLARE_QGC_COLOR(colorRed,             "#ed3939", "#ed3939", "#f32836", "#f32836")
-DECLARE_QGC_COLOR(colorGrey,            "#808080", "#808080", "#bfbfbf", "#bfbfbf")
-DECLARE_QGC_COLOR(colorBlue,            "#1a72ff", "#1a72ff", "#536dff", "#536dff")
-DECLARE_QGC_COLOR(alertBackground,      "#eecc44", "#eecc44", "#eecc44", "#eecc44")
-DECLARE_QGC_COLOR(alertBorder,          "#808080", "#808080", "#808080", "#808080")
-DECLARE_QGC_COLOR(alertText,            "#000000", "#000000", "#000000", "#000000")
-
-// Colors are not affecting by theming
-DECLARE_QGC_COLOR(mapWidgetBorderLight, "#ffffff", "#ffffff", "#ffffff", "#ffffff")
-DECLARE_QGC_COLOR(mapWidgetBorderDark,  "#000000", "#000000", "#000000", "#000000")
-DECLARE_QGC_COLOR(brandingPurple,       "#4A2C6D", "#4A2C6D", "#4A2C6D", "#4A2C6D")
-DECLARE_QGC_COLOR(brandingBlue,         "#48D6FF", "#48D6FF", "#48D6FF", "#48D6FF")
+QMap<int, QMap<int, QMap<QString, QColor>>> QGCPalette::_colorInfoMap;
 
 QGCPalette::QGCPalette(QObject* parent) :
     QObject(parent),
     _colorGroupEnabled(true)
 {
+    if (_colorInfoMap.isEmpty()) {
+        _buildMap();
+    }
+
     // We have to keep track of all QGCPalette objects in the system so we can signal theme change to all of them
     _paletteObjects += this;
 }
@@ -65,6 +41,42 @@ QGCPalette::~QGCPalette()
     bool fSuccess = _paletteObjects.removeOne(this);
     Q_ASSERT(fSuccess);
     Q_UNUSED(fSuccess);
+}
+
+void QGCPalette::_buildMap(void)
+{
+    //                                      Light                 Dark
+    //                                      Disabled   Enabled    Disabled   Enabled
+    DECLARE_QGC_COLOR(window,               "#ffffff", "#ffffff", "#222222", "#222222")
+    DECLARE_QGC_COLOR(windowShade,          "#d9d9d9", "#d9d9d9", "#333333", "#333333")
+    DECLARE_QGC_COLOR(windowShadeDark,      "#bdbdbd", "#bdbdbd", "#282828", "#282828")
+    DECLARE_QGC_COLOR(text,                 "#9d9d9d", "#000000", "#a0a0a0", "#ffffff")
+    DECLARE_QGC_COLOR(warningText,          "#cc0808", "#cc0808", "#f85761", "#f85761")
+    DECLARE_QGC_COLOR(button,               "#ffffff", "#ffffff", "#707070", "#626270")
+    DECLARE_QGC_COLOR(buttonText,           "#9d9d9d", "#000000", "#202020", "#ffffff")
+    DECLARE_QGC_COLOR(buttonHighlight,      "#e4e4e4", "#946120", "#3a3a3a", "#fff291")
+    DECLARE_QGC_COLOR(buttonHighlightText,  "#2c2c2c", "#ffffff", "#2c2c2c", "#000000")
+    DECLARE_QGC_COLOR(primaryButton,        "#585858", "#8cb3be", "#585858", "#8cb3be")
+    DECLARE_QGC_COLOR(primaryButtonText,    "#2c2c2c", "#000000", "#2c2c2c", "#000000")
+    DECLARE_QGC_COLOR(textField,            "#ffffff", "#ffffff", "#585858", "#ffffff")
+    DECLARE_QGC_COLOR(textFieldText,        "#dedede", "#000000", "#2c2c2c", "#000000")
+    DECLARE_QGC_COLOR(mapButton,            "#585858", "#000000", "#585858", "#000000")
+    DECLARE_QGC_COLOR(mapButtonHighlight,   "#585858", "#be781c", "#585858", "#be781c")
+    DECLARE_QGC_COLOR(colorGreen,           "#009431", "#009431", "#00e04b", "#00e04b")
+    DECLARE_QGC_COLOR(colorOrange,          "#b95604", "#b95604", "#de8500", "#de8500")
+    DECLARE_QGC_COLOR(colorRed,             "#ed3939", "#ed3939", "#f32836", "#f32836")
+    DECLARE_QGC_COLOR(colorGrey,            "#808080", "#808080", "#bfbfbf", "#bfbfbf")
+    DECLARE_QGC_COLOR(colorBlue,            "#1a72ff", "#1a72ff", "#536dff", "#536dff")
+    DECLARE_QGC_COLOR(alertBackground,      "#eecc44", "#eecc44", "#eecc44", "#eecc44")
+    DECLARE_QGC_COLOR(alertBorder,          "#808080", "#808080", "#808080", "#808080")
+    DECLARE_QGC_COLOR(alertText,            "#000000", "#000000", "#000000", "#000000")
+    DECLARE_QGC_COLOR(missionItemEditor,    "#585858", "#8cb3be", "#585858", "#8cb3be")
+
+    // Colors are not affecting by theming
+    DECLARE_QGC_COLOR(mapWidgetBorderLight, "#ffffff", "#ffffff", "#ffffff", "#ffffff")
+    DECLARE_QGC_COLOR(mapWidgetBorderDark,  "#000000", "#000000", "#000000", "#000000")
+    DECLARE_QGC_COLOR(brandingPurple,       "#4A2C6D", "#4A2C6D", "#4A2C6D", "#4A2C6D")
+    DECLARE_QGC_COLOR(brandingBlue,         "#48D6FF", "#48D6FF", "#48D6FF", "#48D6FF")
 }
 
 void QGCPalette::setColorGroupEnabled(bool enabled)

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -26,9 +26,9 @@ Item {
     property bool           logo:           false
     property ExclusiveGroup exclusiveGroup:  null
 
-    readonly property real _topBottomMargins: ScreenTools.defaultFontPixelHeight / 2
-
     signal clicked()
+
+    readonly property real _topBottomMargins: ScreenTools.defaultFontPixelHeight / 2
 
     onExclusiveGroupChanged: {
         if (exclusiveGroup) {
@@ -41,7 +41,7 @@ Item {
     Rectangle {
         anchors.fill:   parent
         visible:        logo
-        color:          "#4A2C6D"
+        color:          qgcPal.brandingPurple
     }
 
     QGCColoredImage {

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -184,3 +184,9 @@ void QGCCorePlugin::setShowAdvancedUI(bool show)
         emit showAdvancedUIChanged(show);
     }
 }
+
+void QGCCorePlugin::paletteOverride(QString colorName, QGCPalette::PaletteColorInfo_t& colorInfo)
+{
+    Q_UNUSED(colorName);
+    Q_UNUSED(colorInfo);
+}

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "QGCToolbox.h"
+#include "QGCPalette.h"
 
 #include <QObject>
 #include <QVariantList>
@@ -78,7 +79,10 @@ public:
                                                                   "You should do so only if instructed by customer support. Are you sure you want to enable Advanced Mode?"); }
 
     /// @return An instance of an alternate postion source (or NULL if not available)
-    virtual QGeoPositionInfoSource* createPositionSource    (QObject* parent) { Q_UNUSED(parent); return NULL; }
+    virtual QGeoPositionInfoSource* createPositionSource(QObject* parent) { Q_UNUSED(parent); return NULL; }
+
+    /// Allows a plugin to override the specified color name from the palette
+    virtual void paletteOverride(QString colorName, QGCPalette::PaletteColorInfo_t& colorInfo);
 
     bool showTouchAreas(void) const { return _showTouchAreas; }
     bool showAdvancedUI(void) const { return _showAdvancedUI; }


### PR DESCRIPTION
* QGCCorePlugin can now override the color palette on a case by case basis. ```QGCCorePlugin::paletteOverride(QString colorName, QGCPalette::PaletteColorInfo_t& colorInfo)```
* Added a new palette entry for the misison item editor backgrounds