### PR TITLE
Fixes

### DIFF
--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -83,10 +83,10 @@ public:
     QString         group                   (void) const { return _group; }
     QString         longDescription         (void) const { return _longDescription;}
     QVariant        rawMax                  (void) const { return _rawMax; }
-    QVariant        cookedMax               (void) const { return _rawTranslator(_rawMax); }
+    QVariant        cookedMax               (void) const;
     bool            maxIsDefaultForType     (void) const { return _maxIsDefaultForType; }
     QVariant        rawMin                  (void) const { return _rawMin; }
-    QVariant        cookedMin               (void) const { return _rawTranslator(_rawMin); }
+    QVariant        cookedMin               (void) const;
     bool            minIsDefaultForType     (void) const { return _minIsDefaultForType; }
     QString         name                    (void) const { return _name; }
     QString         shortDescription        (void) const { return _shortDescription; }
@@ -155,6 +155,8 @@ private:
     static QVariant _radiansToDegrees(const QVariant& radians);
     static QVariant _centiDegreesToDegrees(const QVariant& centiDegrees);
     static QVariant _degreesToCentiDegrees(const QVariant& degrees);
+    static QVariant _userGimbalDegreesToMavlinkGimbalDegrees(const QVariant& userGimbalDegrees);
+    static QVariant _mavlinkGimbalDegreesToUserGimbalDegrees(const QVariant& mavlinkGimbalDegrees);
     static QVariant _metersToFeet(const QVariant& meters);
     static QVariant _feetToMeters(const QVariant& feet);
     static QVariant _squareMetersToSquareKilometers(const QVariant& squareMeters);

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -139,7 +139,7 @@ void ArduCopterFirmwarePlugin::guidedModeLand(Vehicle* vehicle)
 
 void ArduCopterFirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle)
 {
-    if (!_armVehicle(vehicle)) {
+    if (!_armVehicleAndValidate(vehicle)) {
         qgcApp()->showMessage(tr("Unable to takeoff: Vehicle failed to arm."));
         return;
     }

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -435,7 +435,7 @@ bool FirmwarePlugin::vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) 
     return vehicle->multiRotor() ? false : true;
 }
 
-bool FirmwarePlugin::_armVehicle(Vehicle* vehicle)
+bool FirmwarePlugin::_armVehicleAndValidate(Vehicle* vehicle)
 {
     if (!vehicle->armed()) {
         vehicle->setArmed(true);

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -303,7 +303,7 @@ public:
 protected:
     // Arms the vehicle, waiting for the arm state to change.
     // @return: true - vehicle armed, false - vehicle failed to arm
-    bool _armVehicle(Vehicle* vehicle);
+    bool _armVehicleAndValidate(Vehicle* vehicle);
 
 private:
     QVariantList _toolBarIndicatorList;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -103,6 +103,9 @@ protected:
     QString _followMeFlightMode;
     QString _simpleFlightMode;
 
+private slots:
+    void _mavCommandResult(int vehicleId, int component, int command, int result, bool noReponseFromVehicle);
+
 private:
     void _handleAutopilotVersion(Vehicle* vehicle, mavlink_message_t* message);
 

--- a/src/MissionManager/CameraSection.FactMetaData.json
+++ b/src/MissionManager/CameraSection.FactMetaData.json
@@ -29,7 +29,7 @@
     "name":             "GimbalPitch",
     "shortDescription": "Gimbal pitch rotation.",
     "type":             "double",
-    "units":            "deg",
+    "units":            "gimbal-degrees",
     "min":              -90,
     "max":              0,
     "decimalPlaces":    0,

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -138,7 +138,9 @@ QGCViewDialog {
                 }
 
                 onCurrentIndexChanged: {
-                    valueField.text = fact.enumValues[currentIndex]
+                    if (currentIndex >=0 && currentIndex < model.length) {
+                        valueField.text = fact.enumValues[currentIndex]
+                    }
                 }
             }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -621,6 +621,7 @@ public:
     ///     @param component Component to send to
     ///     @param command MAV_CMD to send
     ///     @param showError true: Display error to user if command failed, false:  no error shown
+    /// Signals: mavCommandResult on success or failure
     void sendMavCommand(int component, MAV_CMD command, bool showError, float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
 
     int firmwareMajorVersion(void) const { return _firmwareMajorVersion; }


### PR DESCRIPTION
* User facing gimbal pitch values are 0=level, 90=straight down
* Change sequence for PX4 Takeoff. This prevents a case where the user can't manually cancel a takeoff command when the initial Ack back is lost over the wire.