### PR TITLE
Flight timer

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -270,6 +270,18 @@ QString Fact::_variantToString(const QVariant& variant, int decimalPlaces) const
         }
     }
         break;
+    case FactMetaData::valueTypeElapsedTimeInSeconds:
+    {
+        double dValue = variant.toDouble();
+        if (qIsNaN(dValue)) {
+            valueString = QStringLiteral("--:--:--");
+        } else {
+            QTime time(0, 0, 0, 0);
+            time = time.addSecs(dValue);
+            valueString = time.toString(QStringLiteral("hh:mm:ss"));
+        }
+    }
+        break;
     default:
         valueString = variant.toString();
         break;

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -210,6 +210,8 @@ QVariant FactMetaData::_minForType(void) const
         return QVariant();
     case valueTypeBool:
         return QVariant(0);
+    case valueTypeElapsedTimeInSeconds:
+        return QVariant(0.0);
     }
     
     // Make windows compiler happy, even switch is full cased
@@ -233,6 +235,7 @@ QVariant FactMetaData::_maxForType(void) const
         return QVariant(std::numeric_limits<int>::max());
     case valueTypeFloat:
         return QVariant(std::numeric_limits<float>::max());
+    case valueTypeElapsedTimeInSeconds:
     case valueTypeDouble:
         return QVariant(std::numeric_limits<double>::max());
     case valueTypeString:
@@ -262,7 +265,6 @@ bool FactMetaData::convertAndValidateRaw(const QVariant& rawValue, bool convertO
             }
         }
         break;
-
     case FactMetaData::valueTypeUint8:
     case FactMetaData::valueTypeUint16:
     case FactMetaData::valueTypeUint32:
@@ -273,7 +275,6 @@ bool FactMetaData::convertAndValidateRaw(const QVariant& rawValue, bool convertO
             }
         }
         break;
-
     case FactMetaData::valueTypeFloat:
         typedValue = QVariant(rawValue.toFloat(&convertOk));
         if (!convertOnly && convertOk) {
@@ -282,7 +283,7 @@ bool FactMetaData::convertAndValidateRaw(const QVariant& rawValue, bool convertO
             }
         }
         break;
-
+    case FactMetaData::valueTypeElapsedTimeInSeconds:
     case FactMetaData::valueTypeDouble:
         typedValue = QVariant(rawValue.toDouble(&convertOk));
         if (!convertOnly && convertOk) {
@@ -325,7 +326,6 @@ bool FactMetaData::convertAndValidateCooked(const QVariant& cookedValue, bool co
             }
         }
         break;
-
     case FactMetaData::valueTypeUint8:
     case FactMetaData::valueTypeUint16:
     case FactMetaData::valueTypeUint32:
@@ -336,7 +336,6 @@ bool FactMetaData::convertAndValidateCooked(const QVariant& cookedValue, bool co
             }
         }
         break;
-
     case FactMetaData::valueTypeFloat:
         typedValue = QVariant(cookedValue.toFloat(&convertOk));
         if (!convertOnly && convertOk) {
@@ -345,7 +344,7 @@ bool FactMetaData::convertAndValidateCooked(const QVariant& cookedValue, bool co
             }
         }
         break;
-
+    case FactMetaData::valueTypeElapsedTimeInSeconds:
     case FactMetaData::valueTypeDouble:
         typedValue = QVariant(cookedValue.toDouble(&convertOk));
         if (!convertOnly && convertOk) {
@@ -604,7 +603,8 @@ FactMetaData::ValueType_t FactMetaData::stringToType(const QString& typeString, 
                      << QStringLiteral("Float")
                      << QStringLiteral("Double")
                      << QStringLiteral("String")
-                     << QStringLiteral("Bool");
+                     << QStringLiteral("Bool")
+                     << QStringLiteral("ElapsedSeconds");
 
     knownTypes << valueTypeUint8
                << valueTypeInt8
@@ -615,7 +615,8 @@ FactMetaData::ValueType_t FactMetaData::stringToType(const QString& typeString, 
                << valueTypeFloat
                << valueTypeDouble
                << valueTypeString
-               << valueTypeBool;
+               << valueTypeBool
+               << valueTypeElapsedTimeInSeconds;
 
     for (int i=0; i<knownTypeStrings.count(); i++) {
         if (knownTypeStrings[i].compare(typeString, Qt::CaseInsensitive) == 0) {

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -39,7 +39,8 @@ public:
         valueTypeFloat,
         valueTypeDouble,
         valueTypeString,
-        valueTypeBool
+        valueTypeBool,
+        valueTypeElapsedTimeInSeconds,  // Internally stored as double, valueString displays as HH:MM:SS
     } ValueType_t;
 
     typedef QVariant (*Translator)(const QVariant& from);

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.cc
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.cc
@@ -52,6 +52,7 @@ QVariant APMParameterMetaData::_stringToTypedVariant(const QString& string,
     case FactMetaData::valueTypeFloat:
         convertTo = QMetaType::Float;
         break;
+    case FactMetaData::valueTypeElapsedTimeInSeconds:
     case FactMetaData::valueTypeDouble:
         convertTo = QVariant::Double;
         break;

--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
@@ -52,6 +52,7 @@ QVariant PX4ParameterMetaData::_stringToTypedVariant(const QString& string, Fact
     case FactMetaData::valueTypeFloat:
         convertTo = QMetaType::Float;
         break;
+    case FactMetaData::valueTypeElapsedTimeInSeconds:
     case FactMetaData::valueTypeDouble:
         convertTo = QVariant::Double;
         break;

--- a/src/FlightMap/Widgets/ValuesWidgetController.cc
+++ b/src/FlightMap/Widgets/ValuesWidgetController.cc
@@ -9,6 +9,8 @@
 
 
 #include "ValuesWidgetController.h"
+#include "QGCApplication.h"
+#include "QGCCorePlugin.h"
 
 #include <QSettings>
 
@@ -19,13 +21,14 @@ const char* ValuesWidgetController::_smallValuesKey =   "small";
 ValuesWidgetController::ValuesWidgetController(void)
 {
     QSettings settings;
-    QStringList largeDefaults;
 
     settings.beginGroup(_groupKey);
 
-    largeDefaults << "Vehicle.altitudeRelative" << "Vehicle.groundSpeed";
+    QStringList largeDefaults, smallDefaults;
+    qgcApp()->toolbox()->corePlugin()->valuesWidgetDefaultSettings(largeDefaults, smallDefaults);
+
     _largeValues = settings.value(_largeValuesKey, largeDefaults).toStringList();
-    _smallValues = settings.value(_smallValuesKey, QStringList()).toStringList();
+    _smallValues = settings.value(_smallValuesKey, smallDefaults).toStringList();
 
     _altitudeProperties << "altitudeRelative" << "altitudeAMSL";
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -52,6 +52,7 @@ const char* Vehicle::_climbRateFactName =           "climbRate";
 const char* Vehicle::_altitudeRelativeFactName =    "altitudeRelative";
 const char* Vehicle::_altitudeAMSLFactName =        "altitudeAMSL";
 const char* Vehicle::_flightDistanceFactName =      "flightDistance";
+const char* Vehicle::_flightTimeFactName =          "flightTime";
 
 const char* Vehicle::_gpsFactGroupName =        "gps";
 const char* Vehicle::_batteryFactGroupName =    "battery";
@@ -150,6 +151,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _altitudeRelativeFact (0, _altitudeRelativeFactName,  FactMetaData::valueTypeDouble)
     , _altitudeAMSLFact     (0, _altitudeAMSLFactName,      FactMetaData::valueTypeDouble)
     , _flightDistanceFact   (0, _flightDistanceFactName,    FactMetaData::valueTypeDouble)
+    , _flightTimeFact       (0, _flightTimeFactName,        FactMetaData::valueTypeElapsedTimeInSeconds)
     , _gpsFactGroup(this)
     , _batteryFactGroup(this)
     , _windFactGroup(this)
@@ -303,6 +305,8 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _climbRateFact        (0, _climbRateFactName,         FactMetaData::valueTypeDouble)
     , _altitudeRelativeFact (0, _altitudeRelativeFactName,  FactMetaData::valueTypeDouble)
     , _altitudeAMSLFact     (0, _altitudeAMSLFactName,      FactMetaData::valueTypeDouble)
+    , _flightDistanceFact   (0, _flightDistanceFactName,    FactMetaData::valueTypeDouble)
+    , _flightTimeFact       (0, _flightTimeFactName,        FactMetaData::valueTypeElapsedTimeInSeconds)
     , _gpsFactGroup(this)
     , _batteryFactGroup(this)
     , _windFactGroup(this)
@@ -353,6 +357,7 @@ void Vehicle::_commonInit(void)
     _addFact(&_altitudeRelativeFact,    _altitudeRelativeFactName);
     _addFact(&_altitudeAMSLFact,        _altitudeAMSLFactName);
     _addFact(&_flightDistanceFact,      _flightDistanceFactName);
+    _addFact(&_flightTimeFact,          _flightTimeFactName);
 
     _addFactGroup(&_gpsFactGroup,       _gpsFactGroupName);
     _addFactGroup(&_batteryFactGroup,   _batteryFactGroupName);
@@ -361,6 +366,7 @@ void Vehicle::_commonInit(void)
     _addFactGroup(&_temperatureFactGroup, _temperatureFactGroupName);
 
     _flightDistanceFact.setRawValue(0);
+    _flightTimeFact.setRawValue(0);
 }
 
 Vehicle::~Vehicle()
@@ -1674,6 +1680,7 @@ void Vehicle::_addNewMapTrajectoryPoint(void)
     }
     _mapTrajectoryHaveFirstCoordinate = true;
     _mapTrajectoryLastCoordinate = _coordinate;
+    _flightTimeFact.setRawValue((double)_flightTimer.elapsed() / 1000.0);
 }
 
 void Vehicle::_clearTrajectoryPoints(void)
@@ -1691,7 +1698,9 @@ void Vehicle::_mapTrajectoryStart(void)
     _mapTrajectoryHaveFirstCoordinate = false;
     _clearTrajectoryPoints();
     _mapTrajectoryTimer.start();
+    _flightTimer.start();
     _flightDistanceFact.setRawValue(0);
+    _flightTimeFact.setRawValue(0);
 }
 
 void Vehicle::_mapTrajectoryStop()

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -959,6 +959,7 @@ private:
     QTimer  _sendMultipleTimer;
     int     _nextSendMessageMultipleIndex;
 
+    QTime               _flightTimer;
     QTimer              _mapTrajectoryTimer;
     QmlObjectListModel  _mapTrajectoryList;
     QGeoCoordinate      _mapTrajectoryLastCoordinate;
@@ -1004,6 +1005,7 @@ private:
     Fact _altitudeRelativeFact;
     Fact _altitudeAMSLFact;
     Fact _flightDistanceFact;
+    Fact _flightTimeFact;
 
     VehicleGPSFactGroup         _gpsFactGroup;
     VehicleBatteryFactGroup     _batteryFactGroup;
@@ -1020,6 +1022,7 @@ private:
     static const char* _altitudeRelativeFactName;
     static const char* _altitudeAMSLFactName;
     static const char* _flightDistanceFactName;
+    static const char* _flightTimeFactName;
 
     static const char* _gpsFactGroupName;
     static const char* _batteryFactGroupName;

--- a/src/Vehicle/VehicleFact.json
+++ b/src/Vehicle/VehicleFact.json
@@ -61,5 +61,11 @@
     "type":             "double",
     "decimalPlaces":    1,
     "units":            "m"
+},
+{
+    "name":             "flightTime",
+    "shortDescription": "Flight Time",
+    "type":             "elapsedSeconds",
+    "decimalPlaces":    1
 }
 ]

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -198,3 +198,9 @@ QString QGCCorePlugin::showAdvancedUIMessage(void) const
               "You should do so only if instructed by customer support. "
               "Are you sure you want to enable Advanced Mode?");
 }
+
+void QGCCorePlugin::valuesWidgetDefaultSettings(QStringList& largeValues, QStringList& smallValues)
+{
+    Q_UNUSED(smallValues);
+    largeValues << "Vehicle.altitudeRelative" << "Vehicle.groundSpeed" << "Vehicle.flightTime";
+}

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -48,25 +48,25 @@ public:
 
     /// The list of settings under the Settings Menu
     /// @return A list of QGCSettings
-    virtual QVariantList&           settingsPages       ();
+    virtual QVariantList& settingsPages(void);
 
     /// The default settings panel to show
     /// @return The settings index
-    virtual int                     defaultSettings     ();
+    virtual int defaultSettings(void);
 
     /// Global options
     /// @return An instance of QGCOptions
-    virtual QGCOptions*             options             ();
+    virtual QGCOptions* options(void);
 
     /// Allows the core plugin to override the visibility for a settings group
     ///     @param name - Setting group name
     /// @return true: Show settings ui, false: Hide settings ui
-    virtual bool overrideSettingsGroupVisibility        (QString name);
+    virtual bool overrideSettingsGroupVisibility(QString name);
 
     /// Allows the core plugin to override the setting meta data before the setting fact is created.
     ///     @param metaData - MetaData for setting fact
     /// @return true: Setting should be visible in ui, false: Setting should not be shown in ui
-    virtual bool adjustSettingMetaData                  (FactMetaData& metaData);
+    virtual bool adjustSettingMetaData(FactMetaData& metaData);
 
     /// Return the resource file which contains the brand image for for Indoor theme.
     virtual QString brandImageIndoor(void) const { return QString(); }
@@ -82,6 +82,9 @@ public:
 
     /// Allows a plugin to override the specified color name from the palette
     virtual void paletteOverride(QString colorName, QGCPalette::PaletteColorInfo_t& colorInfo);
+
+    /// Allows the plugin the override the default settings for the Values Widget large and small values
+    virtual void valuesWidgetDefaultSettings(QStringList& largeValues, QStringList& smallValues);
 
     bool showTouchAreas(void) const { return _showTouchAreas; }
     bool showAdvancedUI(void) const { return _showAdvancedUI; }


### PR DESCRIPTION
* Flight Time is now available from the Values Widget: Vehicle.flightTime
* Default Values Widget setup includes Flight Time

Existing QGC users who have already modified the Values Widget will need to add Flight Time manually if they want it.

![screen shot 2017-05-06 at 2 57 19 pm](https://cloud.githubusercontent.com/assets/5876851/25776197/e1d360da-326c-11e7-94e2-d22f2e0008a1.png)
