### PR TITLE
Mission settings: No max altitude

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -52,7 +52,6 @@
     "type":             "double",
     "defaultValue":     50.0,
     "min":              0.0,
-    "max":              121.92,
     "units":            "meters",
     "decimalPlaces":    2
 },


### PR DESCRIPTION
Decided to back to the max altitude of 400ft. Instead third parties can set as they like in their versions using settings override.