### PR TITLE
Add firmware-specific factgroups

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -102,7 +102,7 @@
         <file alias="QGroundControl/Controls/qmldir">src/QmlControls/QGroundControl.Controls.qmldir</file>
         <file alias="QGroundControl/Controls/RallyPointEditorHeader.qml">src/PlanView/RallyPointEditorHeader.qml</file>
         <file alias="QGroundControl/Controls/RallyPointItemEditor.qml">src/PlanView/RallyPointItemEditor.qml</file>
-		<file alias="QGroundControl/Controls/RallyPointMapVisuals.qml">src/PlanView/RallyPointMapVisuals.qml</file>
+        <file alias="QGroundControl/Controls/RallyPointMapVisuals.qml">src/PlanView/RallyPointMapVisuals.qml</file>
         <file alias="QGroundControl/Controls/RCChannelMonitor.qml">src/QmlControls/RCChannelMonitor.qml</file>
         <file alias="QGroundControl/Controls/RoundButton.qml">src/QmlControls/RoundButton.qml</file>
         <file alias="QGroundControl/Controls/SectionHeader.qml">src/PlanView/SectionHeader.qml</file>
@@ -136,7 +136,7 @@
         <file alias="QGroundControl/FlightDisplay/GuidedAltitudeSlider.qml">src/FlightDisplay/GuidedAltitudeSlider.qml</file>
         <file alias="QGroundControl/FlightDisplay/MultiVehicleList.qml">src/FlightDisplay/MultiVehicleList.qml</file>
         <file alias="QGroundControl/FlightDisplay/qmldir">src/FlightDisplay/qmldir</file>
-		<file alias="QGroundControl/FlightMap/CameraTriggerIndicator.qml">src/FlightMap/MapItems/CameraTriggerIndicator.qml</file>
+        <file alias="QGroundControl/FlightMap/CameraTriggerIndicator.qml">src/FlightMap/MapItems/CameraTriggerIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/CenterMapDropButton.qml">src/FlightMap/Widgets/CenterMapDropButton.qml</file>
         <file alias="QGroundControl/FlightMap/CenterMapDropPanel.qml">src/FlightMap/Widgets/CenterMapDropPanel.qml</file>
         <file alias="QGroundControl/FlightMap/CompassRing.qml">src/FlightMap/Widgets/CompassRing.qml</file>
@@ -212,6 +212,7 @@
         <file alias="Vehicle/WindFact.json">src/Vehicle/WindFact.json</file>
         <file alias="Vehicle/VibrationFact.json">src/Vehicle/VibrationFact.json</file>
         <file alias="Vehicle/TemperatureFact.json">src/Vehicle/TemperatureFact.json</file>
+        <file alias="Vehicle/SubmarineFact.json">src/Vehicle/SubmarineFact.json</file>
     </qresource>
     <qresource prefix="/MockLink">
         <file alias="APMArduCopterMockLink.params">src/comm/APMArduCopterMockLink.params</file>

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -76,27 +76,27 @@ public:
     QList<MAV_CMD> supportedMissionCommands(void) final;
 
     AutoPilotPlugin*    autopilotPlugin                 (Vehicle* vehicle) final;
-    bool                isCapable                       (const Vehicle *vehicle, FirmwareCapabilities capabilities);
+    bool                isCapable                       (const Vehicle *vehicle, FirmwareCapabilities capabilities) override;
     QStringList         flightModes                     (Vehicle* vehicle) final;
     QString             flightMode                      (uint8_t base_mode, uint32_t custom_mode) const final;
     bool                setFlightMode                   (const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) final;
     bool                isGuidedMode                    (const Vehicle* vehicle) const final;
-    void                pauseVehicle                    (Vehicle* vehicle);
-    int                 manualControlReservedButtonCount(void);
+    void                pauseVehicle                    (Vehicle* vehicle) override;
+    int                 manualControlReservedButtonCount(void) override;
     bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) override;
     void                adjustOutgoingMavlinkMessage    (Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message) final;
     void                initializeVehicle               (Vehicle* vehicle) final;
     bool                sendHomePositionToVehicle       (void) final;
     void                addMetaDataToFact               (QObject* parameterMetaData, Fact* fact, MAV_TYPE vehicleType) final;
-    QString             missionCommandOverrides         (MAV_TYPE vehicleType) const;
+    QString             missionCommandOverrides         (MAV_TYPE vehicleType) const override;
     QString             getVersionParam                 (void) final { return QStringLiteral("SYSID_SW_MREV"); }
     QString             internalParameterMetaDataFile   (Vehicle* vehicle) final;
     void                getParameterMetaDataVersionInfo (const QString& metaDataFile, int& majorVersion, int& minorVersion) final { APMParameterMetaData::getParameterMetaDataVersionInfo(metaDataFile, majorVersion, minorVersion); }
-    QObject*            loadParameterMetaData           (const QString& metaDataFile);
-    GeoFenceManager*    newGeoFenceManager              (Vehicle* vehicle) { return new APMGeoFenceManager(vehicle); }
-    RallyPointManager*  newRallyPointManager            (Vehicle* vehicle) { return new APMRallyPointManager(vehicle); }
-    QString             brandImageIndoor                (const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImage"); }
-    QString             brandImageOutdoor               (const Vehicle* vehicle) const { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImage"); }
+    QObject*            loadParameterMetaData           (const QString& metaDataFile) final;
+    GeoFenceManager*    newGeoFenceManager              (Vehicle* vehicle) final { return new APMGeoFenceManager(vehicle); }
+    RallyPointManager*  newRallyPointManager            (Vehicle* vehicle) final { return new APMRallyPointManager(vehicle); }
+    QString             brandImageIndoor                (const Vehicle* vehicle) const override { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImage"); }
+    QString             brandImageOutdoor               (const Vehicle* vehicle) const override { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImage"); }
 
 protected:
     /// All access to singleton is through stack specific implementation

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -83,7 +83,7 @@ public:
     bool                isGuidedMode                    (const Vehicle* vehicle) const final;
     void                pauseVehicle                    (Vehicle* vehicle);
     int                 manualControlReservedButtonCount(void);
-    bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) final;
+    bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) override;
     void                adjustOutgoingMavlinkMessage    (Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message) final;
     void                initializeVehicle               (Vehicle* vehicle) final;
     bool                sendHomePositionToVehicle       (void) final;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -99,6 +99,8 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void)
 
         _remapParamNameIntialized = true;
     }
+
+    fwFactGroup = new APMSubmarineFactGroup(this);
 }
 
 int ArduSubFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const
@@ -154,4 +156,60 @@ const QVariantList& ArduSubFirmwarePlugin::toolBarIndicators(const Vehicle* vehi
         _toolBarIndicators.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ArmedIndicator.qml")));
     }
     return _toolBarIndicators;
+}
+
+void ArduSubFirmwarePlugin::_handleNamedValueFloat(mavlink_message_t* message)
+{
+    mavlink_named_value_float_t value;
+    mavlink_msg_named_value_float_decode(message, &value);
+
+    QString name = QString(value.name);
+
+    if (name == "CamTilt") {
+        fwFactGroup->getFact("camera tilt")->setRawValue(value.value * 100);
+    } else if (name == "TetherTrn") {
+        fwFactGroup->getFact("tether turns")->setRawValue(value.value);
+    } else if (name == "Lights1") {
+        fwFactGroup->getFact("lights 1")->setRawValue(value.value * 100);
+    } else if (name == "Lights2") {
+        fwFactGroup->getFact("lights 2")->setRawValue(value.value * 100);
+    }
+}
+
+void ArduSubFirmwarePlugin::_handleMavlinkMessage(mavlink_message_t* message)
+{
+    switch (message->msgid) {
+    case (MAVLINK_MSG_ID_NAMED_VALUE_FLOAT):
+        _handleNamedValueFloat(message);
+    }
+}
+
+bool ArduSubFirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message)
+{
+    _handleMavlinkMessage(message);
+    return APMFirmwarePlugin::adjustIncomingMavlinkMessage(vehicle, message);
+}
+
+const char* APMSubmarineFactGroup::_camTiltFactName = "camera tilt";
+const char* APMSubmarineFactGroup::_tetherTurnsFactName = "tether turns";
+const char* APMSubmarineFactGroup::_lightsLevel1FactName = "lights 1";
+const char* APMSubmarineFactGroup::_lightsLevel2FactName = "lights 2";
+
+APMSubmarineFactGroup::APMSubmarineFactGroup(QObject* parent)
+    : FactGroup(300, ":/json/Vehicle/SubmarineFact.json", parent)
+    , _camTiltFact       (0, _camTiltFactName,       FactMetaData::valueTypeDouble)
+    , _tetherTurnsFact   (0, _tetherTurnsFactName,   FactMetaData::valueTypeDouble)
+    , _lightsLevel1Fact  (0, _lightsLevel1FactName,  FactMetaData::valueTypeDouble)
+    , _lightsLevel2Fact  (0, _lightsLevel2FactName,  FactMetaData::valueTypeDouble)
+{
+    _addFact(&_camTiltFact,       _camTiltFactName);
+    _addFact(&_tetherTurnsFact,   _tetherTurnsFactName);
+    _addFact(&_lightsLevel1Fact,  _lightsLevel1FactName);
+    _addFact(&_lightsLevel2Fact,  _lightsLevel2FactName);
+
+    // Start out as not available "--.--"
+    _camTiltFact.setRawValue       (std::numeric_limits<float>::quiet_NaN());
+    _tetherTurnsFact.setRawValue   (std::numeric_limits<float>::quiet_NaN());
+    _lightsLevel1Fact.setRawValue  (std::numeric_limits<float>::quiet_NaN());
+    _lightsLevel2Fact.setRawValue  (std::numeric_limits<float>::quiet_NaN());
 }

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -193,6 +193,10 @@ bool ArduSubFirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavli
     return APMFirmwarePlugin::adjustIncomingMavlinkMessage(vehicle, message);
 }
 
+QMap<QString, FactGroup*>* ArduSubFirmwarePlugin::factGroups(void) {
+    return &_nameToFactGroupMap;
+}
+
 const char* APMSubmarineFactGroup::_camTiltFactName = "camera tilt";
 const char* APMSubmarineFactGroup::_tetherTurnsFactName = "tether turns";
 const char* APMSubmarineFactGroup::_lightsLevel1FactName = "lights 1";

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -173,6 +173,8 @@ void ArduSubFirmwarePlugin::_handleNamedValueFloat(mavlink_message_t* message)
         fwFactGroup->getFact("lights 1")->setRawValue(value.value * 100);
     } else if (name == "Lights2") {
         fwFactGroup->getFact("lights 2")->setRawValue(value.value * 100);
+    } else if (name == "PilotGain") {
+        fwFactGroup->getFact("pilot gain")->setRawValue(value.value * 100);
     }
 }
 
@@ -194,6 +196,7 @@ const char* APMSubmarineFactGroup::_camTiltFactName = "camera tilt";
 const char* APMSubmarineFactGroup::_tetherTurnsFactName = "tether turns";
 const char* APMSubmarineFactGroup::_lightsLevel1FactName = "lights 1";
 const char* APMSubmarineFactGroup::_lightsLevel2FactName = "lights 2";
+const char* APMSubmarineFactGroup::_pilotGainFactName = "pilot gain";
 
 APMSubmarineFactGroup::APMSubmarineFactGroup(QObject* parent)
     : FactGroup(300, ":/json/Vehicle/SubmarineFact.json", parent)
@@ -201,15 +204,18 @@ APMSubmarineFactGroup::APMSubmarineFactGroup(QObject* parent)
     , _tetherTurnsFact   (0, _tetherTurnsFactName,   FactMetaData::valueTypeDouble)
     , _lightsLevel1Fact  (0, _lightsLevel1FactName,  FactMetaData::valueTypeDouble)
     , _lightsLevel2Fact  (0, _lightsLevel2FactName,  FactMetaData::valueTypeDouble)
+    , _pilotGainFact     (0, _pilotGainFactName,     FactMetaData::valueTypeDouble)
 {
     _addFact(&_camTiltFact,       _camTiltFactName);
     _addFact(&_tetherTurnsFact,   _tetherTurnsFactName);
     _addFact(&_lightsLevel1Fact,  _lightsLevel1FactName);
     _addFact(&_lightsLevel2Fact,  _lightsLevel2FactName);
+    _addFact(&_pilotGainFact,     _pilotGainFactName);
 
     // Start out as not available "--.--"
     _camTiltFact.setRawValue       (std::numeric_limits<float>::quiet_NaN());
     _tetherTurnsFact.setRawValue   (std::numeric_limits<float>::quiet_NaN());
     _lightsLevel1Fact.setRawValue  (std::numeric_limits<float>::quiet_NaN());
     _lightsLevel2Fact.setRawValue  (std::numeric_limits<float>::quiet_NaN());
+    _pilotGainFact.setRawValue     (std::numeric_limits<float>::quiet_NaN());
 }

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -40,7 +40,8 @@ APMSubMode::APMSubMode(uint32_t mode, bool settable) :
     setEnumToStringMapping(enumToString);
 }
 
-ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void)
+ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void):
+    _infoFactGroup(this)
 {
     QList<APMCustomMode> supportedFlightModes;
     supportedFlightModes << APMSubMode(APMSubMode::MANUAL ,true);
@@ -100,7 +101,7 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void)
         _remapParamNameIntialized = true;
     }
 
-    fwFactGroup = new APMSubmarineFactGroup(this);
+    _factGroups.append(&_infoFactGroup);
 }
 
 int ArduSubFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const
@@ -166,15 +167,15 @@ void ArduSubFirmwarePlugin::_handleNamedValueFloat(mavlink_message_t* message)
     QString name = QString(value.name);
 
     if (name == "CamTilt") {
-        fwFactGroup->getFact("camera tilt")->setRawValue(value.value * 100);
+        _infoFactGroup.getFact("camera tilt")->setRawValue(value.value * 100);
     } else if (name == "TetherTrn") {
-        fwFactGroup->getFact("tether turns")->setRawValue(value.value);
+        _infoFactGroup.getFact("tether turns")->setRawValue(value.value);
     } else if (name == "Lights1") {
-        fwFactGroup->getFact("lights 1")->setRawValue(value.value * 100);
+        _infoFactGroup.getFact("lights 1")->setRawValue(value.value * 100);
     } else if (name == "Lights2") {
-        fwFactGroup->getFact("lights 2")->setRawValue(value.value * 100);
+        _infoFactGroup.getFact("lights 2")->setRawValue(value.value * 100);
     } else if (name == "PilotGain") {
-        fwFactGroup->getFact("pilot gain")->setRawValue(value.value * 100);
+        _infoFactGroup.getFact("pilot gain")->setRawValue(value.value * 100);
     }
 }
 

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -101,7 +101,7 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void):
         _remapParamNameIntialized = true;
     }
 
-    _factGroups.append(&_infoFactGroup);
+    _nameToFactGroupMap.insert("APMSubInfo", &_infoFactGroup);
 }
 
 int ArduSubFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -28,6 +28,40 @@
 #define ArduSubFirmwarePlugin_H
 
 #include "APMFirmwarePlugin.h"
+class APMSubmarineFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+public:
+    APMSubmarineFactGroup(QObject* parent = NULL);
+
+    Q_PROPERTY(Fact* camTilt       READ camTilt       CONSTANT)
+    Q_PROPERTY(Fact* tetherTurns   READ tetherTurns   CONSTANT)
+    Q_PROPERTY(Fact* lightsLevel1  READ lightsLevel1  CONSTANT)
+    Q_PROPERTY(Fact* lightsLevel2  READ lightsLevel2  CONSTANT)
+    Q_PROPERTY(Fact* pilotGain     READ pilotGain     CONSTANT)
+
+    Fact* camTilt       (void) { return &_camTiltFact; }
+    Fact* tetherTurns   (void) { return &_tetherTurnsFact; }
+    Fact* lightsLevel1  (void) { return &_lightsLevel1Fact; }
+    Fact* lightsLevel2  (void) { return &_lightsLevel2Fact; }
+    Fact* pilotGain     (void) { return &_pilotGainFact; }
+
+    static const char* _camTiltFactName;
+    static const char* _tetherTurnsFactName;
+    static const char* _lightsLevel1FactName;
+    static const char* _lightsLevel2FactName;
+    static const char* _pilotGainFactName;
+
+    static const char* _settingsGroup;
+
+private:
+    Fact            _camTiltFact;
+    Fact            _tetherTurnsFact;
+    Fact            _lightsLevel1Fact;
+    Fact            _lightsLevel2Fact;
+    Fact            _pilotGainFact;
+};
 
 class APMSubMode : public APMCustomMode
 {
@@ -97,40 +131,7 @@ private:
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;
     void _handleNamedValueFloat(mavlink_message_t* message);
     void _handleMavlinkMessage(mavlink_message_t* message);
-};
 
-class APMSubmarineFactGroup : public FactGroup
-{
-    Q_OBJECT
-
-public:
-    APMSubmarineFactGroup(QObject* parent = NULL);
-
-    Q_PROPERTY(Fact* camTilt       READ camTilt       CONSTANT)
-    Q_PROPERTY(Fact* tetherTurns   READ tetherTurns   CONSTANT)
-    Q_PROPERTY(Fact* lightsLevel1  READ lightsLevel1  CONSTANT)
-    Q_PROPERTY(Fact* lightsLevel2  READ lightsLevel2  CONSTANT)
-    Q_PROPERTY(Fact* pilotGain     READ pilotGain     CONSTANT)
-
-    Fact* camTilt       (void) { return &_camTiltFact; }
-    Fact* tetherTurns   (void) { return &_tetherTurnsFact; }
-    Fact* lightsLevel1  (void) { return &_lightsLevel1Fact; }
-    Fact* lightsLevel2  (void) { return &_lightsLevel2Fact; }
-    Fact* pilotGain     (void) { return &_pilotGainFact; }
-
-    static const char* _camTiltFactName;
-    static const char* _tetherTurnsFactName;
-    static const char* _lightsLevel1FactName;
-    static const char* _lightsLevel2FactName;
-    static const char* _pilotGainFactName;
-
-    static const char* _settingsGroup;
-
-private:
-    Fact            _camTiltFact;
-    Fact            _tetherTurnsFact;
-    Fact            _lightsLevel1Fact;
-    Fact            _lightsLevel2Fact;
-    Fact            _pilotGainFact;
+    APMSubmarineFactGroup _infoFactGroup;
 };
 #endif

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -123,6 +123,7 @@ public:
     int remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const final;
     const QVariantList& toolBarIndicators(const Vehicle* vehicle) final;
     bool  adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message);
+    virtual QMap<QString, FactGroup*>* factGroups(void);
 
 
 private:
@@ -132,6 +133,7 @@ private:
     void _handleNamedValueFloat(mavlink_message_t* message);
     void _handleMavlinkMessage(mavlink_message_t* message);
 
+    QMap<QString, FactGroup*> _nameToFactGroupMap;
     APMSubmarineFactGroup _infoFactGroup;
 };
 #endif

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -110,16 +110,19 @@ public:
     Q_PROPERTY(Fact* tetherTurns   READ tetherTurns   CONSTANT)
     Q_PROPERTY(Fact* lightsLevel1  READ lightsLevel1  CONSTANT)
     Q_PROPERTY(Fact* lightsLevel2  READ lightsLevel2  CONSTANT)
+    Q_PROPERTY(Fact* pilotGain     READ pilotGain     CONSTANT)
 
     Fact* camTilt       (void) { return &_camTiltFact; }
     Fact* tetherTurns   (void) { return &_tetherTurnsFact; }
     Fact* lightsLevel1  (void) { return &_lightsLevel1Fact; }
     Fact* lightsLevel2  (void) { return &_lightsLevel2Fact; }
+    Fact* pilotGain     (void) { return &_pilotGainFact; }
 
     static const char* _camTiltFactName;
     static const char* _tetherTurnsFactName;
     static const char* _lightsLevel1FactName;
     static const char* _lightsLevel2FactName;
+    static const char* _pilotGainFactName;
 
     static const char* _settingsGroup;
 
@@ -128,5 +131,6 @@ private:
     Fact            _tetherTurnsFact;
     Fact            _lightsLevel1Fact;
     Fact            _lightsLevel2Fact;
+    Fact            _pilotGainFact;
 };
 #endif

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -88,11 +88,45 @@ public:
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     int remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const final;
     const QVariantList& toolBarIndicators(const Vehicle* vehicle) final;
+    bool  adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message);
+
 
 private:
     QVariantList _toolBarIndicators;
     static bool _remapParamNameIntialized;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;
+    void _handleNamedValueFloat(mavlink_message_t* message);
+    void _handleMavlinkMessage(mavlink_message_t* message);
 };
 
+class APMSubmarineFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+public:
+    APMSubmarineFactGroup(QObject* parent = NULL);
+
+    Q_PROPERTY(Fact* camTilt       READ camTilt       CONSTANT)
+    Q_PROPERTY(Fact* tetherTurns   READ tetherTurns   CONSTANT)
+    Q_PROPERTY(Fact* lightsLevel1  READ lightsLevel1  CONSTANT)
+    Q_PROPERTY(Fact* lightsLevel2  READ lightsLevel2  CONSTANT)
+
+    Fact* camTilt       (void) { return &_camTiltFact; }
+    Fact* tetherTurns   (void) { return &_tetherTurnsFact; }
+    Fact* lightsLevel1  (void) { return &_lightsLevel1Fact; }
+    Fact* lightsLevel2  (void) { return &_lightsLevel2Fact; }
+
+    static const char* _camTiltFactName;
+    static const char* _tetherTurnsFactName;
+    static const char* _lightsLevel1FactName;
+    static const char* _lightsLevel2FactName;
+
+    static const char* _settingsGroup;
+
+private:
+    Fact            _camTiltFact;
+    Fact            _tetherTurnsFact;
+    Fact            _lightsLevel1Fact;
+    Fact            _lightsLevel2Fact;
+};
 #endif

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -419,8 +419,9 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
     return _cameraList;
 }
 
-const QMap<QString, FactGroup*>& FirmwarePlugin::factGroups(void) {
-    return _nameToFactGroupMap;
+QMap<QString, FactGroup*>* FirmwarePlugin::factGroups(void) {
+    // Generic plugin has no FactGroups
+    return NULL;
 }
 
 bool FirmwarePlugin::vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) const

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -419,6 +419,10 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
     return _cameraList;
 }
 
+QList<FactGroup*> FirmwarePlugin::factGroups(void) {
+    return _factGroups;
+}
+
 bool FirmwarePlugin::vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) const
 {
     return vehicle->multiRotor() ? false : true;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -419,8 +419,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
     return _cameraList;
 }
 
-QList<FactGroup*> FirmwarePlugin::factGroups(void) {
-    return _factGroups;
+const QMap<QString, FactGroup*>& FirmwarePlugin::factGroups(void) {
+    return _nameToFactGroupMap;
 }
 
 bool FirmwarePlugin::vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) const

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -273,7 +273,8 @@ public:
     /// Returns a list of CameraMetaData objects for available cameras on the vehicle.
     virtual const QVariantList& cameraList(const Vehicle* vehicle);
 
-    virtual const QMap<QString, FactGroup*>& factGroups(void);
+    /// Returns a pointer to a dictionary of firmware-specific FactGroups
+    virtual QMap<QString, FactGroup*>* factGroups(void);
 
     /// @true: When flying a mission the vehicle is always facing towards the next waypoint
     virtual bool vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) const;
@@ -301,7 +302,6 @@ protected:
     // Arms the vehicle with validation and retries
     // @return: true - vehicle armed, false - vehicle failed to arm
     bool _armVehicleAndValidate(Vehicle* vehicle);
-    QMap<QString, FactGroup*> _nameToFactGroupMap;
 
     // Sets the vehicle to the specified flight mode with validation and retries
     // @return: true - vehicle in specified flight mode, false - flight mode change failed

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -273,7 +273,7 @@ public:
     /// Returns a list of CameraMetaData objects for available cameras on the vehicle.
     virtual const QVariantList& cameraList(const Vehicle* vehicle);
 
-    virtual QList<FactGroup*> factGroups(void);
+    virtual const QMap<QString, FactGroup*>& factGroups(void);
 
     /// @true: When flying a mission the vehicle is always facing towards the next waypoint
     virtual bool vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) const;
@@ -301,7 +301,7 @@ protected:
     // Arms the vehicle with validation and retries
     // @return: true - vehicle armed, false - vehicle failed to arm
     bool _armVehicleAndValidate(Vehicle* vehicle);
-    QList<FactGroup*> _factGroups;
+    QMap<QString, FactGroup*> _nameToFactGroupMap;
 
     // Sets the vehicle to the specified flight mode with validation and retries
     // @return: true - vehicle in specified flight mode, false - flight mode change failed

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -273,6 +273,8 @@ public:
     /// Returns a list of CameraMetaData objects for available cameras on the vehicle.
     virtual const QVariantList& cameraList(const Vehicle* vehicle);
 
+    virtual QList<FactGroup*> factGroups(void);
+
     /// @true: When flying a mission the vehicle is always facing towards the next waypoint
     virtual bool vehicleYawsToNextWaypointInMission(const Vehicle* vehicle) const;
 
@@ -295,13 +297,11 @@ public:
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const char* px4FollowMeFlightMode;
 
-    /// Used to add additional firmware-specific facts to the vehicle values widget
-    FactGroup* fwFactGroup = NULL;
-
 protected:
     // Arms the vehicle with validation and retries
     // @return: true - vehicle armed, false - vehicle failed to arm
     bool _armVehicleAndValidate(Vehicle* vehicle);
+    QList<FactGroup*> _factGroups;
 
     // Sets the vehicle to the specified flight mode with validation and retries
     // @return: true - vehicle in specified flight mode, false - flight mode change failed

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -295,6 +295,9 @@ public:
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const char* px4FollowMeFlightMode;
 
+    /// Used to add additional firmware-specific facts to the vehicle values widget
+    FactGroup* fwFactGroup = NULL;
+
 protected:
     // Arms the vehicle with validation and retries
     // @return: true - vehicle armed, false - vehicle failed to arm
@@ -307,7 +310,6 @@ protected:
 private:
     QVariantList _toolBarIndicatorList;
     static QVariantList _cameraList;    ///< Standard QGC camera list
-
 };
 
 class FirmwarePluginFactory : public QObject

--- a/src/FlightMap/Widgets/ValuesWidget.qml
+++ b/src/FlightMap/Widgets/ValuesWidget.qml
@@ -65,32 +65,38 @@ QGCFlickable {
 
         Repeater {
             model: _activeVehicle ? controller.largeValues : 0
-
-            Column {
-                width:  _largeColumn.width
-
+            Loader {
+                sourceComponent: fact ? largeValue : undefined
                 property Fact fact: _activeVehicle.getFact(modelData.replace("Vehicle.", ""))
-                property bool largeValue: _root.listContains(controller.altitudeProperties, fact.name)
-
-                QGCLabel {
-                    width:                  parent.width
-                    horizontalAlignment:    Text.AlignHCenter
-                    color:                  textColor
-                    fontSizeMode:           Text.HorizontalFit
-                    text:                   fact.shortDescription + (fact.units ? " (" + fact.units + ")" : "")
-                }
-                QGCLabel {
-                    width:                  parent.width
-                    horizontalAlignment:    Text.AlignHCenter
-                    font.pointSize:         ScreenTools.mediumFontPointSize * (largeValue ? 1.3 : 1.0)
-                    font.family:            largeValue ? ScreenTools.demiboldFontFamily : ScreenTools.normalFontFamily
-                    fontSizeMode:           Text.HorizontalFit
-                    color:                  textColor
-                    text:                   fact.valueString
-                }
             }
         } // Repeater - Large
     } // Column - Large
+
+    Component {
+        id: largeValue
+
+        Column {
+            width:  _largeColumn.width
+            property bool largeValue: _root.listContains(controller.altitudeProperties, fact.name)
+
+            QGCLabel {
+                width:                  parent.width
+                horizontalAlignment:    Text.AlignHCenter
+                color:                  textColor
+                fontSizeMode:           Text.HorizontalFit
+                text:                   fact.shortDescription + (fact.units ? " (" + fact.units + ")" : "")
+            }
+            QGCLabel {
+                width:                  parent.width
+                horizontalAlignment:    Text.AlignHCenter
+                font.pointSize:         ScreenTools.mediumFontPointSize * (largeValue ? 1.3 : 1.0)
+                font.family:            largeValue ? ScreenTools.demiboldFontFamily : ScreenTools.normalFontFamily
+                fontSizeMode:           Text.HorizontalFit
+                color:                  textColor
+                text:                   fact.valueString
+            }
+        }
+    }
 
     Flow {
         id:                 _smallFlow
@@ -102,39 +108,45 @@ QGCFlickable {
 
         Repeater {
             model: _activeVehicle ? controller.smallValues : 0
-
-            Column {
-                width:  (_root.width / 2) - (_margins / 2) - 0.1
-                clip:   true
-
+            Loader {
+                sourceComponent: fact ? smallValue : undefined
                 property Fact fact: _activeVehicle.getFact(modelData.replace("Vehicle.", ""))
-
-                QGCLabel {
-                    width:                  parent.width
-                    horizontalAlignment:    Text.AlignHCenter
-                    font.pointSize:         ScreenTools.isTinyScreen ? ScreenTools.smallFontPointSize * 0.75 : ScreenTools.smallFontPointSize
-                    fontSizeMode:           Text.HorizontalFit
-                    color:                  textColor
-                    text:                   fact.shortDescription
-                }
-                QGCLabel {
-                    width:                  parent.width
-                    horizontalAlignment:    Text.AlignHCenter
-                    color:                  textColor
-                    fontSizeMode:           Text.HorizontalFit
-                    text:                   fact.enumOrValueString
-                }
-                QGCLabel {
-                    width:                  parent.width
-                    horizontalAlignment:    Text.AlignHCenter
-                    font.pointSize:         ScreenTools.isTinyScreen ? ScreenTools.smallFontPointSize * 0.75 : ScreenTools.smallFontPointSize
-                    fontSizeMode:           Text.HorizontalFit
-                    color:                  textColor
-                    text:                   fact.units
-                }
             }
         } // Repeater - Small
     } // Flow
+
+    Component {
+        id: smallValue
+
+        Column {
+            width:  (_root.width / 2) - (_margins / 2) - 0.1
+            clip:   true
+
+            QGCLabel {
+                width:                  parent.width
+                horizontalAlignment:    Text.AlignHCenter
+                font.pointSize:         ScreenTools.isTinyScreen ? ScreenTools.smallFontPointSize * 0.75 : ScreenTools.smallFontPointSize
+                fontSizeMode:           Text.HorizontalFit
+                color:                  textColor
+                text:                   fact.shortDescription
+            }
+            QGCLabel {
+                width:                  parent.width
+                horizontalAlignment:    Text.AlignHCenter
+                color:                  textColor
+                fontSizeMode:           Text.HorizontalFit
+                text:                   fact.enumOrValueString
+            }
+            QGCLabel {
+                width:                  parent.width
+                horizontalAlignment:    Text.AlignHCenter
+                font.pointSize:         ScreenTools.isTinyScreen ? ScreenTools.smallFontPointSize * 0.75 : ScreenTools.smallFontPointSize
+                fontSizeMode:           Text.HorizontalFit
+                color:                  textColor
+                text:                   fact.units
+            }
+        }
+    }
 
     Component {
         id: propertyPicker

--- a/src/Vehicle/SubmarineFact.json
+++ b/src/Vehicle/SubmarineFact.json
@@ -22,5 +22,11 @@
     "shortDescription": "Lights 2 level",
     "type":             "int16",
     "units":            "%"
+},
+{
+    "name":             "pilot gain",
+    "shortDescription": "Pilot Gain",
+    "type":             "int16",
+    "units":            "%"
 }
 ]

--- a/src/Vehicle/SubmarineFact.json
+++ b/src/Vehicle/SubmarineFact.json
@@ -1,0 +1,26 @@
+[
+{
+    "name":             "camera tilt",
+    "shortDescription": "Camera Tilt",
+    "type":             "int16",
+    "units":            "%"
+},
+{
+    "name":             "tether turns",
+    "shortDescription": "Tether Turns",
+    "type":             "int16",
+    "units":            "clockwise"
+},
+{
+    "name":             "lights 1",
+    "shortDescription": "Lights 1 level",
+    "type":             "int16",
+    "units":            "%"
+},
+{
+    "name":             "lights 2",
+    "shortDescription": "Lights 2 level",
+    "type":             "int16",
+    "units":            "%"
+}
+]

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -373,8 +373,9 @@ void Vehicle::_commonInit(void)
     _addFactGroup(&_temperatureFactGroup, _temperatureFactGroupName);
 
     // Add firmware-specific fact group, if provided
-    if (_firmwarePlugin->fwFactGroup) {
-        _addFactGroup(_firmwarePlugin->fwFactGroup, "FWPlugin");
+    QList<FactGroup*> fwFactGroups = _firmwarePlugin->factGroups();
+    for (int i = 0; i < fwFactGroups.count(); i++) {
+        _addFactGroup(fwFactGroups[i], QString("FWPlugin%1").arg(i));
     }
 
     _flightDistanceFact.setRawValue(0);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -373,11 +373,13 @@ void Vehicle::_commonInit(void)
     _addFactGroup(&_temperatureFactGroup, _temperatureFactGroupName);
 
     // Add firmware-specific fact groups, if provided
-    QMap<QString, FactGroup*> fwFactGroups = _firmwarePlugin->factGroups();
-    QMapIterator<QString, FactGroup*> i(fwFactGroups);
-    while(i.hasNext()) {
-        i.next();
-        _addFactGroup(i.value(), i.key());
+    QMap<QString, FactGroup*>* fwFactGroups = _firmwarePlugin->factGroups();
+    if (fwFactGroups) {
+        QMapIterator<QString, FactGroup*> i(*fwFactGroups);
+        while(i.hasNext()) {
+            i.next();
+            _addFactGroup(i.value(), i.key());
+        }
     }
 
     _flightDistanceFact.setRawValue(0);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -372,10 +372,12 @@ void Vehicle::_commonInit(void)
     _addFactGroup(&_vibrationFactGroup, _vibrationFactGroupName);
     _addFactGroup(&_temperatureFactGroup, _temperatureFactGroupName);
 
-    // Add firmware-specific fact group, if provided
-    QList<FactGroup*> fwFactGroups = _firmwarePlugin->factGroups();
-    for (int i = 0; i < fwFactGroups.count(); i++) {
-        _addFactGroup(fwFactGroups[i], QString("FWPlugin%1").arg(i));
+    // Add firmware-specific fact groups, if provided
+    QMap<QString, FactGroup*> fwFactGroups = _firmwarePlugin->factGroups();
+    QMapIterator<QString, FactGroup*> i(fwFactGroups);
+    while(i.hasNext()) {
+        i.next();
+        _addFactGroup(i.value(), i.key());
     }
 
     _flightDistanceFact.setRawValue(0);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -59,7 +59,6 @@ const char* Vehicle::_batteryFactGroupName =    "battery";
 const char* Vehicle::_windFactGroupName =       "wind";
 const char* Vehicle::_vibrationFactGroupName =  "vibration";
 const char* Vehicle::_temperatureFactGroupName = "temperature";
-const char* Vehicle::_submarineFactGroupName = "sub";
 
 Vehicle::Vehicle(LinkInterface*             link,
                  int                        vehicleId,
@@ -373,9 +372,9 @@ void Vehicle::_commonInit(void)
     _addFactGroup(&_vibrationFactGroup, _vibrationFactGroupName);
     _addFactGroup(&_temperatureFactGroup, _temperatureFactGroupName);
 
-    if (_vehicleType == MAV_TYPE_SUBMARINE) {
-        _submarineFactGroup = new VehicleSubmarineFactGroup(this);
-        _addFactGroup(_submarineFactGroup, _submarineFactGroupName);
+    // Add firmware-specific fact group, if provided
+    if (_firmwarePlugin->fwFactGroup) {
+        _addFactGroup(_firmwarePlugin->fwFactGroup, "FWPlugin");
     }
 
     _flightDistanceFact.setRawValue(0);
@@ -602,10 +601,6 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
 
     case MAVLINK_MSG_ID_WIND:
         _handleWind(message);
-        break;
-
-    case MAVLINK_MSG_ID_NAMED_VALUE_FLOAT:
-        _handleNamedValueFloat(message);
         break;
     }
 
@@ -1172,27 +1167,6 @@ void Vehicle::_handleScaledPressure3(mavlink_message_t& message) {
     mavlink_scaled_pressure3_t pressure;
     mavlink_msg_scaled_pressure3_decode(&message, &pressure);
     _temperatureFactGroup.temperature3()->setRawValue(pressure.temperature / 100.0);
-}
-
-void Vehicle::_handleNamedValueFloat(mavlink_message_t &message) {
-    if (!_submarineFactGroup) {
-        return;
-    }
-
-    mavlink_named_value_float_t value;
-    mavlink_msg_named_value_float_decode(&message, &value);
-
-    QString name = QString(value.name);
-
-    if (name == "CamTilt") {
-        _submarineFactGroup->camTilt()->setRawValue(value.value * 100);
-    } else if (name == "TetherTrn") {
-        _submarineFactGroup->tetherTurns()->setRawValue(value.value);
-    } else if (name == "Lights1") {
-        _submarineFactGroup->lightsLevel1()->setRawValue(value.value * 100);
-    } else if (name == "Lights2") {
-        _submarineFactGroup->lightsLevel2()->setRawValue(value.value * 100);
-    }
 }
 
 bool Vehicle::_containsLink(LinkInterface* link)
@@ -2742,28 +2716,4 @@ VehicleTemperatureFactGroup::VehicleTemperatureFactGroup(QObject* parent)
     _temperature1Fact.setRawValue      (std::numeric_limits<float>::quiet_NaN());
     _temperature2Fact.setRawValue      (std::numeric_limits<float>::quiet_NaN());
     _temperature3Fact.setRawValue      (std::numeric_limits<float>::quiet_NaN());
-}
-
-const char* VehicleSubmarineFactGroup::_camTiltFactName = "camera tilt";
-const char* VehicleSubmarineFactGroup::_tetherTurnsFactName = "tether turns";
-const char* VehicleSubmarineFactGroup::_lightsLevel1FactName = "lights 1";
-const char* VehicleSubmarineFactGroup::_lightsLevel2FactName = "lights 2";
-
-VehicleSubmarineFactGroup::VehicleSubmarineFactGroup(QObject* parent)
-    : FactGroup(300, ":/json/Vehicle/SubmarineFact.json", parent)
-    , _camTiltFact       (0, _camTiltFactName,       FactMetaData::valueTypeDouble)
-    , _tetherTurnsFact   (0, _tetherTurnsFactName,   FactMetaData::valueTypeDouble)
-    , _lightsLevel1Fact  (0, _lightsLevel1FactName,  FactMetaData::valueTypeDouble)
-    , _lightsLevel2Fact  (0, _lightsLevel2FactName,  FactMetaData::valueTypeDouble)
-{
-    _addFact(&_camTiltFact,       _camTiltFactName);
-    _addFact(&_tetherTurnsFact,   _tetherTurnsFactName);
-    _addFact(&_lightsLevel1Fact,  _lightsLevel1FactName);
-    _addFact(&_lightsLevel2Fact,  _lightsLevel2FactName);
-
-    // Start out as not available "--.--"
-    _camTiltFact.setRawValue       (std::numeric_limits<float>::quiet_NaN());
-    _tetherTurnsFact.setRawValue   (std::numeric_limits<float>::quiet_NaN());
-    _lightsLevel1Fact.setRawValue  (std::numeric_limits<float>::quiet_NaN());
-    _lightsLevel2Fact.setRawValue  (std::numeric_limits<float>::quiet_NaN());
 }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -214,6 +214,37 @@ private:
     Fact            _temperature3Fact;
 };
 
+class VehicleSubmarineFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+public:
+    VehicleSubmarineFactGroup(QObject* parent = NULL);
+
+    Q_PROPERTY(Fact* camTilt       READ camTilt       CONSTANT)
+    Q_PROPERTY(Fact* tetherTurns   READ tetherTurns   CONSTANT)
+    Q_PROPERTY(Fact* lightsLevel1  READ lightsLevel1  CONSTANT)
+    Q_PROPERTY(Fact* lightsLevel2  READ lightsLevel2  CONSTANT)
+
+    Fact* camTilt       (void) { return &_camTiltFact; }
+    Fact* tetherTurns   (void) { return &_tetherTurnsFact; }
+    Fact* lightsLevel1  (void) { return &_lightsLevel1Fact; }
+    Fact* lightsLevel2  (void) { return &_lightsLevel2Fact; }
+
+    static const char* _camTiltFactName;
+    static const char* _tetherTurnsFactName;
+    static const char* _lightsLevel1FactName;
+    static const char* _lightsLevel2FactName;
+
+    static const char* _settingsGroup;
+
+private:
+    Fact            _camTiltFact;
+    Fact            _tetherTurnsFact;
+    Fact            _lightsLevel1Fact;
+    Fact            _lightsLevel2Fact;
+};
+
 class Vehicle : public FactGroup
 {
     Q_OBJECT
@@ -350,6 +381,7 @@ public:
     Q_PROPERTY(FactGroup* wind        READ windFactGroup        CONSTANT)
     Q_PROPERTY(FactGroup* vibration   READ vibrationFactGroup   CONSTANT)
     Q_PROPERTY(FactGroup* temperature READ temperatureFactGroup CONSTANT)
+    Q_PROPERTY(FactGroup* submarineFactGroup   READ submarineFactGroup   CONSTANT)
 
     Q_PROPERTY(int      firmwareMajorVersion        READ firmwareMajorVersion       NOTIFY firmwareVersionChanged)
     Q_PROPERTY(int      firmwareMinorVersion        READ firmwareMinorVersion       NOTIFY firmwareVersionChanged)
@@ -612,6 +644,7 @@ public:
     FactGroup* windFactGroup        (void) { return &_windFactGroup; }
     FactGroup* vibrationFactGroup   (void) { return &_vibrationFactGroup; }
     FactGroup* temperatureFactGroup (void) { return &_temperatureFactGroup; }
+    FactGroup* submarineFactGroup   (void) { return _submarineFactGroup; }
 
     void setConnectionLostEnabled(bool connectionLostEnabled);
 
@@ -832,6 +865,7 @@ private:
     void _handleScaledPressure(mavlink_message_t& message);
     void _handleScaledPressure2(mavlink_message_t& message);
     void _handleScaledPressure3(mavlink_message_t& message);
+    void _handleNamedValueFloat(mavlink_message_t& message);
     void _handleCameraFeedback(const mavlink_message_t& message);
     void _handleCameraImageCaptured(const mavlink_message_t& message);
     void _missionManagerError(int errorCode, const QString& errorMsg);
@@ -1019,6 +1053,7 @@ private:
     VehicleWindFactGroup        _windFactGroup;
     VehicleVibrationFactGroup   _vibrationFactGroup;
     VehicleTemperatureFactGroup _temperatureFactGroup;
+    VehicleSubmarineFactGroup*  _submarineFactGroup;
 
     static const char* _rollFactName;
     static const char* _pitchFactName;
@@ -1036,6 +1071,7 @@ private:
     static const char* _windFactGroupName;
     static const char* _vibrationFactGroupName;
     static const char* _temperatureFactGroupName;
+    static const char* _submarineFactGroupName;
 
     static const int _vehicleUIUpdateRateMSecs = 100;
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -214,37 +214,6 @@ private:
     Fact            _temperature3Fact;
 };
 
-class VehicleSubmarineFactGroup : public FactGroup
-{
-    Q_OBJECT
-
-public:
-    VehicleSubmarineFactGroup(QObject* parent = NULL);
-
-    Q_PROPERTY(Fact* camTilt       READ camTilt       CONSTANT)
-    Q_PROPERTY(Fact* tetherTurns   READ tetherTurns   CONSTANT)
-    Q_PROPERTY(Fact* lightsLevel1  READ lightsLevel1  CONSTANT)
-    Q_PROPERTY(Fact* lightsLevel2  READ lightsLevel2  CONSTANT)
-
-    Fact* camTilt       (void) { return &_camTiltFact; }
-    Fact* tetherTurns   (void) { return &_tetherTurnsFact; }
-    Fact* lightsLevel1  (void) { return &_lightsLevel1Fact; }
-    Fact* lightsLevel2  (void) { return &_lightsLevel2Fact; }
-
-    static const char* _camTiltFactName;
-    static const char* _tetherTurnsFactName;
-    static const char* _lightsLevel1FactName;
-    static const char* _lightsLevel2FactName;
-
-    static const char* _settingsGroup;
-
-private:
-    Fact            _camTiltFact;
-    Fact            _tetherTurnsFact;
-    Fact            _lightsLevel1Fact;
-    Fact            _lightsLevel2Fact;
-};
-
 class Vehicle : public FactGroup
 {
     Q_OBJECT
@@ -381,7 +350,6 @@ public:
     Q_PROPERTY(FactGroup* wind        READ windFactGroup        CONSTANT)
     Q_PROPERTY(FactGroup* vibration   READ vibrationFactGroup   CONSTANT)
     Q_PROPERTY(FactGroup* temperature READ temperatureFactGroup CONSTANT)
-    Q_PROPERTY(FactGroup* submarineFactGroup   READ submarineFactGroup   CONSTANT)
 
     Q_PROPERTY(int      firmwareMajorVersion        READ firmwareMajorVersion       NOTIFY firmwareVersionChanged)
     Q_PROPERTY(int      firmwareMinorVersion        READ firmwareMinorVersion       NOTIFY firmwareVersionChanged)
@@ -644,7 +612,6 @@ public:
     FactGroup* windFactGroup        (void) { return &_windFactGroup; }
     FactGroup* vibrationFactGroup   (void) { return &_vibrationFactGroup; }
     FactGroup* temperatureFactGroup (void) { return &_temperatureFactGroup; }
-    FactGroup* submarineFactGroup   (void) { return _submarineFactGroup; }
 
     void setConnectionLostEnabled(bool connectionLostEnabled);
 
@@ -865,7 +832,6 @@ private:
     void _handleScaledPressure(mavlink_message_t& message);
     void _handleScaledPressure2(mavlink_message_t& message);
     void _handleScaledPressure3(mavlink_message_t& message);
-    void _handleNamedValueFloat(mavlink_message_t& message);
     void _handleCameraFeedback(const mavlink_message_t& message);
     void _handleCameraImageCaptured(const mavlink_message_t& message);
     void _missionManagerError(int errorCode, const QString& errorMsg);
@@ -1053,7 +1019,6 @@ private:
     VehicleWindFactGroup        _windFactGroup;
     VehicleVibrationFactGroup   _vibrationFactGroup;
     VehicleTemperatureFactGroup _temperatureFactGroup;
-    VehicleSubmarineFactGroup*  _submarineFactGroup;
 
     static const char* _rollFactName;
     static const char* _pitchFactName;
@@ -1071,7 +1036,6 @@ private:
     static const char* _windFactGroupName;
     static const char* _vibrationFactGroupName;
     static const char* _temperatureFactGroupName;
-    static const char* _submarineFactGroupName;
 
     static const int _vehicleUIUpdateRateMSecs = 100;
 


### PR DESCRIPTION
This will add some valuable information for Sub operation in the vehicle values widget. Because these options are sub-specific, they are allocated at runtime if the vehicle is MAV_TYPE_SUBMARINE.

I think the way the options are created could use a rework in general to be firmware-specific, but maybe that should wait till after 3.2. In the meantime, I can rework the implementation in this PR if it is not appropriate; I am open to alternative approaches.