### PR TITLE
Optional camera mode support

### DIFF
--- a/src/MissionManager/CameraSection.cc
+++ b/src/MissionManager/CameraSection.cc
@@ -9,6 +9,7 @@
 
 #include "CameraSection.h"
 #include "SimpleMissionItem.h"
+#include "FirmwarePlugin.h"
 
 QGC_LOGGING_CATEGORY(CameraSectionLog, "CameraSectionLog")
 
@@ -401,4 +402,9 @@ void CameraSection::_cameraActionChanged(void)
 {
     _setDirtyAndUpdateItemCount();
     _updateSettingsSpecified();
+}
+
+bool CameraSection::cameraModeSupported(void) const
+{
+    return _vehicle->firmwarePlugin()->supportedMissionCommands().contains(MAV_CMD_SET_CAMERA_MODE);
 }

--- a/src/MissionManager/CameraSection.h
+++ b/src/MissionManager/CameraSection.h
@@ -38,8 +38,9 @@ public:
     Q_PROPERTY(Fact*    cameraAction                    READ cameraAction                                                       CONSTANT)
     Q_PROPERTY(Fact*    cameraPhotoIntervalTime         READ cameraPhotoIntervalTime                                            CONSTANT)
     Q_PROPERTY(Fact*    cameraPhotoIntervalDistance     READ cameraPhotoIntervalDistance                                        CONSTANT)
+    Q_PROPERTY(bool     cameraModeSupported             READ cameraModeSupported                                                CONSTANT)   ///< true: cameraMode is supported by this vehicle
     Q_PROPERTY(bool     specifyCameraMode               READ specifyCameraMode              WRITE setSpecifyCameraMode          NOTIFY specifyCameraModeChanged)
-    Q_PROPERTY(Fact*    cameraMode                      READ cameraMode                                                         CONSTANT)
+    Q_PROPERTY(Fact*    cameraMode                      READ cameraMode                                                         CONSTANT)   ///< MAV_CMD_SET_CAMERA_MODE.param2
 
     bool    specifyGimbal               (void) const { return _specifyGimbal; }
     Fact*   gimbalYaw                   (void) { return &_gimbalYawFact; }
@@ -47,6 +48,7 @@ public:
     Fact*   cameraAction                (void) { return &_cameraActionFact; }
     Fact*   cameraPhotoIntervalTime     (void) { return &_cameraPhotoIntervalTimeFact; }
     Fact*   cameraPhotoIntervalDistance (void) { return &_cameraPhotoIntervalDistanceFact; }
+    bool    cameraModeSupported         (void) const;
     bool    specifyCameraMode           (void) const { return _specifyCameraMode; }
     Fact*   cameraMode                  (void) { return &_cameraModeFact; }
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -319,7 +319,7 @@ int MissionController::insertComplexMissionItem(QString itemName, QGeoCoordinate
         MissionSettingsItem* settingsItem = _visualItems->value<MissionSettingsItem*>(0);
         CameraSection* cameraSection = settingsItem->cameraSection();
         // Set camera to photo mode (leave alone if user already specified)
-        if (!cameraSection->specifyCameraMode()) {
+        if (cameraSection->cameraModeSupported() && !cameraSection->specifyCameraMode()) {
             cameraSection->setSpecifyCameraMode(true);
             cameraSection->cameraMode()->setRawValue(0);
         }
@@ -382,7 +382,7 @@ void MissionController::removeMissionItem(int index)
                     cameraSection->setSpecifyGimbal(false);
                 }
             }
-            if (cameraSection->specifyCameraMode() && cameraSection->cameraMode()->rawValue().toInt() == 0) {
+            if (cameraSection->cameraModeSupported() && cameraSection->specifyCameraMode() && cameraSection->cameraMode()->rawValue().toInt() == 0) {
                 cameraSection->setSpecifyCameraMode(false);
             }
         }

--- a/src/PlanView/CameraSection.qml
+++ b/src/PlanView/CameraSection.qml
@@ -109,6 +109,7 @@ Column {
             anchors.left:   parent.left
             anchors.right:  parent.right
             spacing:        ScreenTools.defaultFontPixelWidth
+            visible:        _camera.cameraModeSupported
 
             QGCCheckBox {
                 id:                 modeCheckBox


### PR DESCRIPTION
* Camera section only includes Mode if FirmwarePlugin reports support for MAV_CMD_SET_CAMERA_MODE
* Plan - Mission Settings: Photo mode only set automatically for Survey is FirmwarePlugin reports support for MAV_CMD_SET_CAMERA_MODE

Fix for #5120