### PR TITLE
Rework vehicle sensors_health alert

### DIFF
--- a/src/FlightMap/Widgets/InstrumentSwipeView.qml
+++ b/src/FlightMap/Widgets/InstrumentSwipeView.qml
@@ -41,6 +41,10 @@ Item {
         showPage(_currentPage)
     }
 
+    function currentPage() {
+        return _currentPage
+    }
+
     MouseArea {
         anchors.fill:   parent
         onClicked:      showNextPage()

--- a/src/FlightMap/Widgets/QGCInstrumentWidget.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidget.qml
@@ -92,6 +92,37 @@ Rectangle {
                     onClicked:      _valuesWidget.showPicker()
                 }
             }
+
+            Image {
+                id:                 healthWarning
+                anchors.bottom:     outerCompass.bottom
+                anchors.left:       outerCompass.left
+                source:             "/qmlimages/Yield.svg"
+                mipmap:             true
+                visible:            _activeVehicle ? !_warningsViewed && _activeVehicle.unhealthySensors.length > 0 && _valuesWidget.currentPage() != 2 : false
+                opacity:            0.8
+                width:              outerCompass.width * 0.15
+                sourceSize.width:   width
+                fillMode:           Image.PreserveAspectFit
+
+                property bool _warningsViewed: false
+
+                MouseArea {
+                    anchors.fill:   parent
+                    hoverEnabled:   true
+                    onEntered:      healthWarning.opacity = 1
+                    onExited:       healthWarning.opacity = 0.8
+                    onClicked:      {
+                        _valuesWidget.showPage(2)
+                        healthWarning._warningsViewed = true
+                    }
+                }
+
+                Connections {
+                    target: _activeVehicle
+                    onUnhealthySensorsChanged: healthWarning._warningsViewed = false
+                }
+            }
         }
 
         Rectangle {

--- a/src/FlightMap/Widgets/VehicleHealthWidget.qml
+++ b/src/FlightMap/Widgets/VehicleHealthWidget.qml
@@ -27,13 +27,6 @@ QGCFlickable {
 
     property var    unhealthySensors:   QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle.unhealthySensors : [ ]
 
-    // Any time the unhealthy sensors list changes, switch to the health page
-    onUnhealthySensorsChanged: {
-        if (unhealthySensors.length != 0) {
-            showPage(2)
-        }
-    }
-
     MouseArea {
         anchors.fill:   parent
         onClicked:      showNextPage()

--- a/src/FlightMap/Widgets/VibrationWidget.qml
+++ b/src/FlightMap/Widgets/VibrationWidget.qml
@@ -153,7 +153,7 @@ QGCFlickable {
             }
 
             QGCLabel {
-                text: qsTr("Accel 2: ") + (_activeVehicle ? _activeVehicle.vibration.clipCount3.valueString : "")
+                text: qsTr("Accel 3: ") + (_activeVehicle ? _activeVehicle.vibration.clipCount3.valueString : "")
                 color: textColor
             }
         }


### PR DESCRIPTION
I think that automatically switching the page in the instrument panel every time the sensors_health flag changes is heavy-handed and obnoxious.

This pr changes the behavior to show a warning icon opposite the gearthingy beneath the attitude indicator. Click the warning icon to quickly switch to the sensors health page. The warning icon goes away until another sensors_health bit changes.

![screenshot 2017-05-12 12 03 17](https://cloud.githubusercontent.com/assets/8315108/26006606/0be2a6ea-370b-11e7-8f7f-c96cb2c402e1.png)

