### PR TITLE
Set flying flag regardless of armed status

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2013,7 +2013,7 @@ void Vehicle::_announceArmedChanged(bool armed)
 
 void Vehicle::_setFlying(bool flying)
 {
-    if (armed() && _flying != flying) {
+    if (_flying != flying) {
         _flying = flying;
         emit flyingChanged(flying);
     }


### PR DESCRIPTION
This is a bug. Why not be able to change the flying flag to false when we are disarmed?

I think the intention was to not set the flag to true when we are disarmed, but that is [handled by the caller](https://github.com/mavlink/qgroundcontrol/blob/master/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc#L437).


