### PR TITLE
Initial localization work.

### DIFF
--- a/localization/README.md
+++ b/localization/README.md
@@ -1,0 +1,25 @@
+To generate (or update) a source translation file, use the "lupdate" command line tool. It can be found in the Qt distribution.
+
+(Easiest to just run the `gen_translation_source.sh` script, or get the commands from within the script and run them manually)
+
+This will parse all the source files and generate a language translation file called qgc.ts. This file should be copied into whatever language it is to be translated to and sent to translation. The translation can either be done directly within the (XML) file, using Qt's "Linguist" tool, or uploaded to crowdin.
+
+For instance, to localize to Germany German as an example you first copy the original source:
+```
+cp qgc.ts qgc_de-DE.ts
+```
+The German localization is then performed in qgc_de-DE.ts
+
+Once localization is complete, you "compile" it using the "lrelease" command line tool.
+```
+lrelease qgc_de-DE.ts
+```
+This will generate the ("compiled") localization file `qgc_de-DE.qm`, which should be shipped with QGroundControl.
+
+Further documentation can be found at:
+
+http://doc.qt.io/qt-5/qtlinguist-index.html
+
+Note about crowdin:
+
+If you build the project and download the resulting ZIP file, the translated (.ts) files all come with the same name "qgc.ts". They each reside in a different directory named after the language for which it was translated into. Care must be taken to rename these files before moving them to the locale directory so you don't override the original, English source file.

--- a/localization/gen_translation_source.sh
+++ b/localization/gen_translation_source.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This is set to find lupdate in my particular installation. You will need to set the path
+# where you have Qt installed.
+QT_PATH=~/Applications/Qt/5.7/clang_64/bin
+$QT_PATH/lupdate ../src -ts qgc.ts

--- a/localization/qgc.ts
+++ b/localization/qgc.ts
@@ -1,0 +1,9388 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>APMAirframeComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="129"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="172"/>
+        <source>Select your drone to load the default parameters for it. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="219"/>
+        <source>Please select your airframe type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="224"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="225"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="277"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="278"/>
+        <source>Load common parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="257"/>
+        <source>Frame Class:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.qml" line="267"/>
+        <source>Frame Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponent.cc" line="46"/>
+        <source>Airframe Setup is used to select the airframe which matches your vehicle. You can also the load default parameter values associated with known vehicle types.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMAirframeComponentController</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponentController.cc" line="242"/>
+        <source>Param file github json download failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponentController.cc" line="255"/>
+        <source>Param file download failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMAirframeComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml" line="30"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml" line="43"/>
+        <source>Frame Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml" line="36"/>
+        <source>Frame Class:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml" line="50"/>
+        <source>Firmware Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml" line="51"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMCameraComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="173"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="174"/>
+        <source>Channel 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="175"/>
+        <source>Channel 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="176"/>
+        <source>Channel 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="177"/>
+        <source>Channel 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="178"/>
+        <source>Channel 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="179"/>
+        <source>Channel 10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="180"/>
+        <source>Channel 11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="181"/>
+        <source>Channel 12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="182"/>
+        <source>Channel 13</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="183"/>
+        <source>Channel 14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="209"/>
+        <source>Gimbal </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="227"/>
+        <source>Stabilize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="239"/>
+        <source>Servo reverse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="253"/>
+        <source>Output channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="273"/>
+        <source>Input channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="293"/>
+        <source>Gimbal angle limits:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="302"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="346"/>
+        <source>min</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="320"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="365"/>
+        <source>max</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="338"/>
+        <source>Servo PWM limits:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="393"/>
+        <source>Gimbal Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="410"/>
+        <source>Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="432"/>
+        <source>Gimbal Type changes takes affect next reboot of autopilot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="440"/>
+        <source>Default Mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="460"/>
+        <source>Tilt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="478"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.qml" line="496"/>
+        <source>Pan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.cc" line="21"/>
+        <source>Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponent.cc" line="32"/>
+        <source>Camera setup is used to adjust camera and gimbal settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMCameraComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponentSummary.qml" line="30"/>
+        <source>Gimbal type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponentSummary.qml" line="35"/>
+        <source>Tilt input channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponentSummary.qml" line="40"/>
+        <source>Pan input channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMCameraComponentSummary.qml" line="45"/>
+        <source>Roll input channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMFirmwarePlugin</name>
+    <message>
+        <location filename="../src/FirmwarePlugin/APM/APMFirmwarePlugin.cc" line="746"/>
+        <source>Error during Solo video link setup: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMFlightModesComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="56"/>
+        <source>Flight Mode Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="56"/>
+        <source> (Channel 5)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="80"/>
+        <source>Flight mode channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="86"/>
+        <source>Not assigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="86"/>
+        <source>Channel 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="86"/>
+        <source>Channel 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="87"/>
+        <source>Channel 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="87"/>
+        <source>Channel 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="87"/>
+        <source>Channel 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="88"/>
+        <source>Channel 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="88"/>
+        <source>Channel 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="88"/>
+        <source>Channel 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="106"/>
+        <source>Flight Mode </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="133"/>
+        <source>Channel Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.qml" line="161"/>
+        <source>Channel option %1 :</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.cc" line="18"/>
+        <source>Flight Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponent.cc" line="29"/>
+        <source>Flight Modes Setup is used to configure the transmitter switches associated with Flight Modes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMFlightModesComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml" line="30"/>
+        <source>Flight Mode 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml" line="35"/>
+        <source>Flight Mode 2:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml" line="40"/>
+        <source>Flight Mode 3:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml" line="45"/>
+        <source>Flight Mode 4:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml" line="50"/>
+        <source>Flight Mode 5:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml" line="55"/>
+        <source>Flight Mode 6:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMLightsComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="123"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="124"/>
+        <source>Channel 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="125"/>
+        <source>Channel 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="126"/>
+        <source>Channel 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="127"/>
+        <source>Channel 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="128"/>
+        <source>Channel 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="129"/>
+        <source>Channel 10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="130"/>
+        <source>Channel 11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="131"/>
+        <source>Channel 12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="132"/>
+        <source>Channel 13</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="133"/>
+        <source>Channel 14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="145"/>
+        <source>Light Output Channels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="162"/>
+        <source>Lights 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="182"/>
+        <source>Lights 2:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.qml" line="202"/>
+        <source>Brightness Steps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.cc" line="22"/>
+        <source>Lights</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponent.cc" line="33"/>
+        <source>Lights setup is used to adjust light output channels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMLightsComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="66"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="67"/>
+        <source>Channel 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="68"/>
+        <source>Channel 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="69"/>
+        <source>Channel 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="70"/>
+        <source>Channel 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="71"/>
+        <source>Channel 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="72"/>
+        <source>Channel 10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="73"/>
+        <source>Channel 11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="74"/>
+        <source>Channel 12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="75"/>
+        <source>Channel 13</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="76"/>
+        <source>Channel 14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="92"/>
+        <source>Lights Output 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml" line="97"/>
+        <source>Lights Output 2:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMNotSupported</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMNotSupported.qml" line="17"/>
+        <source>Not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMPowerComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="69"/>
+        <source>Power Module 90A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="77"/>
+        <source>Power Module HV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="93"/>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="218"/>
+        <source>Battery monitor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="230"/>
+        <source>Battery capacity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="242"/>
+        <source>Power sensor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="265"/>
+        <source>Current pin:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="278"/>
+        <source>Voltage pin:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="292"/>
+        <source>Voltage multiplier:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="303"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="329"/>
+        <source>Calculate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="304"/>
+        <source>Calculate Voltage Multiplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="313"/>
+        <source>If the battery voltage reported by the vehicle is largely different than the voltage read externally using a voltmeter you can adjust the voltage multiplier value to correct this. Click the Calculate button for help with calculating a new value.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="318"/>
+        <source>Amps per volt:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="330"/>
+        <source>Calculate Amps per Volt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.qml" line="339"/>
+        <source>If the current draw reported by the vehicle is largely different than the current read externally using a current meter you can adjust the amps per volt value to correct this. Click the Calculate button for help with calculating a new value.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponent.cc" line="29"/>
+        <source>The Power Component is used to setup battery parameters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMPowerComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml" line="34"/>
+        <source>Battery monitor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml" line="39"/>
+        <source>Battery capacity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMRadioComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponent.cc" line="18"/>
+        <source>Radio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponent.cc" line="37"/>
+        <source>The Radio Component is used to setup which channels on your RC Transmitter you will use for each vehicle control such as Roll, Pitch, Yaw and Throttle. It also allows you to assign switches and dials to the various flight modes. Prior to flight you must also calibrate the extents for all of your channels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMRadioComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="26"/>
+        <source>Roll:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="27"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="32"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="37"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="42"/>
+        <source>Setup required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="27"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="32"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="37"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="42"/>
+        <source>Channel %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="31"/>
+        <source>Pitch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="36"/>
+        <source>Yaw:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml" line="41"/>
+        <source>Throttle:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponent.cc" line="21"/>
+        <source>Safety</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponent.cc" line="34"/>
+        <source>Safety Setup is used to setup failsafe actions, geofence limits, leak detection, and arming checks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponent.cc" line="45"/>
+        <source>Safety Setup is used to setup triggers for Return to Land as well as the settings for Return to Land itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponentCopter</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="70"/>
+        <source>Failsafe Triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="85"/>
+        <source>Ground Station failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="104"/>
+        <source>Throttle failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="113"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="151"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="113"/>
+        <source>Always RTL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="114"/>
+        <source>Continue with Mission in Auto Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="114"/>
+        <source>Always Land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="125"/>
+        <source>PWM threshold:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="142"/>
+        <source>Battery failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="151"/>
+        <source>Land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="151"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="328"/>
+        <source>Return to Launch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="162"/>
+        <source>Voltage threshold:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="182"/>
+        <source>MAH threshold:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="204"/>
+        <source>GeoFence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="219"/>
+        <source>Circle GeoFence enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="244"/>
+        <source>Altitude GeoFence enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="269"/>
+        <source>Report only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="281"/>
+        <source>RTL or Land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="292"/>
+        <source>Max radius:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="308"/>
+        <source>Max altitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="364"/>
+        <source>Return at current altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="376"/>
+        <source>Return at specified altitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="398"/>
+        <source>Loiter above Home for:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="417"/>
+        <source>Land with descent speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="438"/>
+        <source>Final loiter altitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="460"/>
+        <source>Arming Checks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml" line="491"/>
+        <source>Warning: Turning off arming checks can lead to loss of Vehicle control.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponentPlane</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml" line="53"/>
+        <source>Failsafe Triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml" line="67"/>
+        <source>Throttle PWM threshold:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml" line="88"/>
+        <source>Voltage threshold:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml" line="109"/>
+        <source>MAH threshold:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml" line="130"/>
+        <source>GCS failsafe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml" line="142"/>
+        <source>Return to Launch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml" line="156"/>
+        <source>Return at current altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml" line="168"/>
+        <source>Return at specified altitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponentRover</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentRover.qml" line="17"/>
+        <source>Not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponentSub</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="65"/>
+        <source>Failsafe Actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="80"/>
+        <source>Ground Station failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="98"/>
+        <source>Leak failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="118"/>
+        <source>GeoFence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="133"/>
+        <source>Depth GeoFence enabled
+(report only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="155"/>
+        <source>Max depth:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="175"/>
+        <source>Leak Detector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="190"/>
+        <source>Pin:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="208"/>
+        <source>Logic (when dry):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="227"/>
+        <source>Arming Checks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml" line="258"/>
+        <source>Warning: Turning off arming checks can lead to loss of Vehicle control.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponentSummaryCopter</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="54"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="73"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="107"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="57"/>
+        <source>Always RTL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="60"/>
+        <source>Continue with Mission in Auto Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="63"/>
+        <source>Always Land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="66"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="82"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="117"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="76"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="133"/>
+        <source>Land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="79"/>
+        <source>Return to Launch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="90"/>
+        <source>Arming Checks:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="91"/>
+        <source>Enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="91"/>
+        <source>Some disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="95"/>
+        <source>Throttle failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="100"/>
+        <source>Battery failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="105"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="114"/>
+        <source>GeoFence:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="109"/>
+        <source>Altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="110"/>
+        <source>Circle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="110"/>
+        <source>Altitude,Circle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="116"/>
+        <source>Report only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="117"/>
+        <source>RTL or Land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="122"/>
+        <source>RTL min alt:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="123"/>
+        <source>current</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="127"/>
+        <source>RTL loiter time:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="132"/>
+        <source>RTL final alt:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryCopter.qml" line="137"/>
+        <source>Descent speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponentSummaryPlane</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml" line="29"/>
+        <source>Throttle failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml" line="30"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml" line="35"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml" line="40"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml" line="34"/>
+        <source>Voltage failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml" line="39"/>
+        <source>mAh failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml" line="44"/>
+        <source>RTL min alt:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml" line="45"/>
+        <source>current</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponentSummaryRover</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummaryRover.qml" line="17"/>
+        <source>Not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSafetyComponentSummarySub</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="32"/>
+        <source>Arming Checks:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="33"/>
+        <source>Enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="33"/>
+        <source>Some disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="37"/>
+        <source>GCS failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="42"/>
+        <source>Leak failsafe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="47"/>
+        <source>Leak detector:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="52"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="61"/>
+        <source>GeoFence:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="54"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="56"/>
+        <source>Depth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="57"/>
+        <source>Circle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="57"/>
+        <source>Depth,Circle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml" line="62"/>
+        <source>Report only</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSensorsComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="91"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="494"/>
+        <source>Calibrate Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="97"/>
+        <source>Calibrate Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="103"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="561"/>
+        <source>Sensor Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="136"/>
+        <source>Calibration Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="136"/>
+        <source>Waiting for Vehicle to response to Cancel. This may take a few seconds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="145"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="148"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="151"/>
+        <source>Calibration complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="145"/>
+        <source>Accelerometer calibration complete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="148"/>
+        <source>Compass calibration complete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="259"/>
+        <source>Shown in the indicator bars is the quality of the calibration for each compass.
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="260"/>
+        <source>- Green indicates a well functioning compass.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="261"/>
+        <source>- Yellow indicates a questionable compass or calibration.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="262"/>
+        <source>- Red indicates a compass which should not be used.
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="263"/>
+        <source>YOU MUST REBOOT YOUR VEHICLE AFTER EACH CALIBRATION.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="299"/>
+        <source>Orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="346"/>
+        <source>Autopilot Orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="445"/>
+        <source>To level the horizon you need to place the vehicle in its level flight position and press Ok.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="465"/>
+        <source>Pressure calibration will set the depth to zero at the current pressure reading.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="480"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="489"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="494"/>
+        <source>Accelerometer must be calibrated prior to Compass.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="506"/>
+        <source>Level Horizon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="510"/>
+        <source>Accelerometer must be calibrated prior to Level Horizon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="523"/>
+        <source>Calibrate Pressure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="534"/>
+        <source>CompassMot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="539"/>
+        <source>CompassMot - Compass Motor Interference Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="545"/>
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="553"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="631"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="640"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="649"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="658"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="667"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="676"/>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="631"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="640"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="649"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="658"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="667"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.qml" line="676"/>
+        <source>Hold Still</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.cc" line="21"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponent.cc" line="33"/>
+        <source>Sensors Setup is used to calibrate the sensors within your vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSensorsComponentController</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="280"/>
+        <source>Rotate the vehicle randomly around all axes until the progress bar fills all the way to the right .</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="322"/>
+        <source>Raise the throttle slowly to between 50% ~ 75% (the props will spin!) for 5 ~ 10 seconds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="323"/>
+        <source>Quickly bring the throttle back down to zero</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="324"/>
+        <source>Press the Next button to complete the calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="333"/>
+        <source>Hold the vehicle in its level flight position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="342"/>
+        <source>Requesting pressure calibration...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="644"/>
+        <source>Level horizon complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="648"/>
+        <source>Level horizon failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="662"/>
+        <source>Pressure calibration success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="666"/>
+        <source>Pressure calibration fail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="714"/>
+        <source>Compass %1 calibration complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="716"/>
+        <source>Compass %1 calibration below quality threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="735"/>
+        <source>All compasses calibrated successfully</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="736"/>
+        <source>YOU MUST REBOOT YOUR VEHICLE NOW FOR NEW SETTINGS TO TAKE AFFECT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="739"/>
+        <source>Compass calibration failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="740"/>
+        <source>YOU MUST REBOOT YOUR VEHICLE NOW AND RETRY COMPASS CALIBRATION PRIOR TO FLIGHT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentController.cc" line="744"/>
+        <source>Continue rotating...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSensorsComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml" line="37"/>
+        <source>Compass </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml" line="44"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml" line="51"/>
+        <source>Setup required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml" line="45"/>
+        <source>Not installed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml" line="50"/>
+        <source>Accelerometer(s):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml" line="51"/>
+        <source>Ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSubFrameComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSubFrameComponent.cc" line="22"/>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSubFrameComponent.cc" line="33"/>
+        <source>Frame setup allows you to choose your vehicle&apos;s motor configuration. Install clockwise
+propellers on the green thrusters and counter-clockwise propellers on the blue thrusters
+(or vice-versa). The flight controller will need to be rebooted to apply changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMSubFrameComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml" line="48"/>
+        <source>Frame Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml" line="53"/>
+        <source>Firmware Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml" line="54"/>
+        <location filename="../src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml" line="59"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml" line="58"/>
+        <source>Git Revision:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMTuningComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponent.cc" line="29"/>
+        <source>Tuning Setup is used to tune the flight characteristics of the Vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>APMTuningComponentCopter</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="126"/>
+        <source>Basic Tuning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="150"/>
+        <source>Throttle Hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="155"/>
+        <source>How much throttle is needed to maintain a steady hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="180"/>
+        <source>Roll/Pitch Sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="185"/>
+        <source>Slide to the right if the copter is sluggish or slide to the left if the copter is twitchy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="213"/>
+        <source>Climb Sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="218"/>
+        <source>Slide to the right to climb more aggressively or slide to the left to climb more gently</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="245"/>
+        <source>RC Roll/Pitch Feel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="250"/>
+        <source>Slide to the left for soft control, slide to the right for crisp control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="285"/>
+        <source>AutoTune</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="306"/>
+        <source>Axes to AutoTune:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="315"/>
+        <source>Channel for AutoTune switch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="321"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="321"/>
+        <source>Channel 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="321"/>
+        <source>Channel 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="321"/>
+        <source>Channel 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="321"/>
+        <source>Channel 10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="321"/>
+        <source>Channel 11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="321"/>
+        <source>Channel 12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="345"/>
+        <source>In Flight Tuning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="369"/>
+        <source>Channel Option 6 (Tuning):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="387"/>
+        <source>Min:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml" line="399"/>
+        <source>Max:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AirframeComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="70"/>
+        <source>Custom Airframe Config</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="80"/>
+        <source>Your vehicle is using a custom airframe configuration. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="81"/>
+        <source>This configuration can only be modified through the Parameter Editor.
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="82"/>
+        <source>If you want to reset your airframe configuration and select a standard configuration, click &apos;Reset&apos; above.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="107"/>
+        <source>Clicking “Apply” will save the changes you have made to your airframe configuration.&lt;br&gt;&lt;br&gt;All vehicle parameters other than Radio Calibration will be reset.&lt;br&gt;&lt;br&gt;Your vehicle will also be restarted in order to complete the process.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="124"/>
+        <source>You&apos;ve connected a %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="125"/>
+        <source>Airframe is not set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="126"/>
+        <source>To change this configuration, select the desired airframe below then click “Apply and Restart”.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="134"/>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.qml" line="136"/>
+        <source>Apply and Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.cc" line="20"/>
+        <source>Airframe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponent.cc" line="32"/>
+        <source>Airframe Setup is used to select the airframe which matches your vehicle. This will in turn set up the various tuning values for flight parameters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AirframeComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml" line="26"/>
+        <source>System ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml" line="30"/>
+        <source>Airframe type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml" line="31"/>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml" line="35"/>
+        <source>Setup required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml" line="34"/>
+        <source>Vehicle:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml" line="39"/>
+        <source>Firmware Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml" line="40"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AnalyzeView</name>
+    <message>
+        <location filename="../src/AnalyzeView/AnalyzeView.qml" line="91"/>
+        <source>Analyze</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/AnalyzeView.qml" line="103"/>
+        <source>Log Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/AnalyzeView.qml" line="108"/>
+        <source>GeoTag Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/AnalyzeView.qml" line="113"/>
+        <source>Mavlink Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AppMessages</name>
+    <message>
+        <location filename="../src/QmlControls/AppMessages.qml" line="117"/>
+        <source>Log files (*.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/AppMessages.qml" line="117"/>
+        <source>All Files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/AppMessages.qml" line="119"/>
+        <source>Select log save file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/AppMessages.qml" line="138"/>
+        <source>Save App Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/AppMessages.qml" line="154"/>
+        <source>Show Latest</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/AppMessages.qml" line="169"/>
+        <source>Set logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/AppMessages.qml" line="170"/>
+        <source>Turn on logging categories</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AppSettings</name>
+    <message>
+        <location filename="../src/ui/AppSettings.qml" line="63"/>
+        <source>Application Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ArduCopterFirmwarePlugin</name>
+    <message>
+        <location filename="../src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc" line="176"/>
+        <source>Unable to takeoff: Vehicle failed to arm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ArmedIndicator</name>
+    <message>
+        <location filename="../src/ui/toolbar/ArmedIndicator.qml" line="26"/>
+        <source>Armed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/ArmedIndicator.qml" line="26"/>
+        <source>Disarmed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BatteryIndicator</name>
+    <message>
+        <location filename="../src/ui/toolbar/BatteryIndicator.qml" line="79"/>
+        <source>Battery Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/BatteryIndicator.qml" line="91"/>
+        <source>Voltage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/BatteryIndicator.qml" line="93"/>
+        <source>Accumulated Consumption:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BluetoothSettings</name>
+    <message>
+        <location filename="../src/ui/preferences/BluetoothSettings.qml" line="30"/>
+        <source>Bluetooth Not Available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/BluetoothSettings.qml" line="49"/>
+        <source>Bluetooth Link Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/BluetoothSettings.qml" line="63"/>
+        <source>Device:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/BluetoothSettings.qml" line="75"/>
+        <source>Address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/BluetoothSettings.qml" line="88"/>
+        <source>Bluetooth Devices:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/BluetoothSettings.qml" line="142"/>
+        <source>Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/BluetoothSettings.qml" line="151"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Bootloader</name>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="35"/>
+        <source>Write failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="40"/>
+        <source>Incorrect number of bytes returned for write: actual(%1) expected(%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="63"/>
+        <source>Timeout waiting for bytes to be available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="73"/>
+        <source>Read failed: error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="97"/>
+        <source>Invalid sync response: 0x%1 0x%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="100"/>
+        <source>This board is using a microcontroller with faulty silicon and an incorrect configuration and should be put out of service.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="103"/>
+        <source>Unknown response code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="109"/>
+        <source>Command failed: 0x%1 (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="167"/>
+        <source>Board erase failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="187"/>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="357"/>
+        <source>Unable to open firmware file %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="208"/>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="382"/>
+        <source>Firmware file read failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="228"/>
+        <source>Flash failed: %1 at address 0x%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="400"/>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="485"/>
+        <source>Read failed: %1 at address: 0x%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="406"/>
+        <source>Compare failed: expected(0x%1) actual(0x%2) at address: 0x%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="529"/>
+        <source>CRC mismatch: board(0x%1) file(0x%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="548"/>
+        <source>Open failed on port %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/Bootloader.cc" line="573"/>
+        <source>Found unsupported bootloader version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CameraComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="88"/>
+        <source>Vehicle must be restarted for changes to take effect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="91"/>
+        <source>Apply and Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="102"/>
+        <source>Camera Trigger Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="125"/>
+        <source>Trigger mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="140"/>
+        <source>Trigger interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="154"/>
+        <source>Time Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="167"/>
+        <source>Distance Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="182"/>
+        <source>Hardware Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="195"/>
+        <source>AUX Pin Assignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="254"/>
+        <source>Trigger Pin Polarity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.qml" line="288"/>
+        <source>Trigger Period</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.cc" line="21"/>
+        <source>Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponent.cc" line="32"/>
+        <source>Camera setup is used to adjust camera and gimbal settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CameraComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponentSummary.qml" line="28"/>
+        <source>Trigger interface:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponentSummary.qml" line="33"/>
+        <source>Trigger mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponentSummary.qml" line="39"/>
+        <source>Time interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponentSummary.qml" line="45"/>
+        <source>Distance interval:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponentSummary.qml" line="51"/>
+        <source>AUX pins:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/CameraComponentSummary.qml" line="57"/>
+        <source>AUX pin polarity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CameraSection</name>
+    <message>
+        <location filename="../src/PlanView/CameraSection.qml" line="27"/>
+        <source>Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/CameraSection.qml" line="52"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/CameraSection.qml" line="68"/>
+        <source>Distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/CameraSection.qml" line="85"/>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/CameraSection.qml" line="86"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/CameraSection.qml" line="90"/>
+        <source>Gimbal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/CameraSection.qml" line="116"/>
+        <source>Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CameraWidget</name>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CameraWidget.qml" line="44"/>
+        <source>Camera Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CameraWidget.qml" line="49"/>
+        <source>Trigger Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CenterMapDropButton</name>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropButton.qml" line="163"/>
+        <source>Center map on:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropButton.qml" line="166"/>
+        <source>Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropButton.qml" line="178"/>
+        <source>All items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropButton.qml" line="190"/>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropButton.qml" line="201"/>
+        <source>Current Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropButton.qml" line="212"/>
+        <source>Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropButton.qml" line="224"/>
+        <source>Follow Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CenterMapDropPanel</name>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropPanel.qml" line="31"/>
+        <source>Center map on:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropPanel.qml" line="34"/>
+        <source>Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropPanel.qml" line="45"/>
+        <source>All items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropPanel.qml" line="56"/>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropPanel.qml" line="66"/>
+        <source>Current Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/CenterMapDropPanel.qml" line="77"/>
+        <source>Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CustomCommandWidget</name>
+    <message>
+        <location filename="../src/ViewWidgets/CustomCommandWidget.qml" line="86"/>
+        <source>Load Custom Qml file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ViewWidgets/CustomCommandWidget.qml" line="91"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DebugWindow</name>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="46"/>
+        <source>Qt Platform:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="56"/>
+        <source>Font Point Size 10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="62"/>
+        <source>Default font width:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="72"/>
+        <source>Font Point Size 10.5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="78"/>
+        <source>Default font height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="88"/>
+        <source>Font Point Size 11</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="94"/>
+        <source>Default font pixel size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="104"/>
+        <source>Font Point Size 11.5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="110"/>
+        <source>Default font point size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="120"/>
+        <source>Font Point Size 12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="126"/>
+        <source>QML Screen Desktop:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="136"/>
+        <source>Font Point Size 12.5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="142"/>
+        <source>QML Screen Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="152"/>
+        <source>Font Point Size 13</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="158"/>
+        <source>QML Pixel Density:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="168"/>
+        <source>Font Point Size 13.5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="174"/>
+        <source>QML Pixel Ratio:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="184"/>
+        <source>Font Point Size 14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="190"/>
+        <source>Default Point:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="200"/>
+        <source>Font Point Size 14.5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="206"/>
+        <source>Computed Font Height:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/DebugWindow.qml" line="216"/>
+        <source>Font Point Size 15</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ESP8266Component</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="37"/>
+        <source>controller WiFi Bridge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="71"/>
+        <source>Error fetching WiFi Bridge Status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="121"/>
+        <source>ESP WiFi Bridge Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="148"/>
+        <source>WiFi Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="164"/>
+        <source>WiFi Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="181"/>
+        <source>WiFi AP SSID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="197"/>
+        <source>WiFi AP Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="213"/>
+        <source>WiFi STA SSID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="230"/>
+        <source>WiFi STA Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="247"/>
+        <source>UART Baud Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="263"/>
+        <source>QGC UDP Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="282"/>
+        <source>ESP WiFi Bridge Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="295"/>
+        <source>Bridge/Vehicle Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="299"/>
+        <source>Bridge/QGC Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="303"/>
+        <source>QGC/Bridge Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="309"/>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="324"/>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="338"/>
+        <source>Messages Received</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="351"/>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="365"/>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="379"/>
+        <source>Messages Lost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="393"/>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="407"/>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="421"/>
+        <source>Messages Sent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="438"/>
+        <source>Restore Defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="445"/>
+        <source>Restart WiFi Bridge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="456"/>
+        <source>Reboot WiFi Bridge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="457"/>
+        <source>This will restart the WiFi Bridge so the settings you&apos;ve changed can take effect. Note that you may have to change your computer WiFi settings and QGroundControl link settings to match these changes. Are you sure you want to restart it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.qml" line="468"/>
+        <source>Reset Counters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.cc" line="16"/>
+        <source>WiFi Bridge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266Component.cc" line="28"/>
+        <source>The ESP8266 WiFi Bridge Component is used to setup the WiFi link.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ESP8266ComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml" line="33"/>
+        <source>Firmware Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml" line="37"/>
+        <source>WiFi Mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml" line="41"/>
+        <source>WiFi Channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml" line="46"/>
+        <source>WiFi AP SSID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml" line="50"/>
+        <source>WiFi AP Password:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml" line="64"/>
+        <source>UART Baud Rate:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FWLandingPatternEditor</name>
+    <message>
+        <location filename="../src/PlanView/FWLandingPatternEditor.qml" line="45"/>
+        <source>Loiter point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/FWLandingPatternEditor.qml" line="61"/>
+        <location filename="../src/PlanView/FWLandingPatternEditor.qml" line="89"/>
+        <source>Altitude relative to home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/FWLandingPatternEditor.qml" line="70"/>
+        <source>Loiter clockwise</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/FWLandingPatternEditor.qml" line="75"/>
+        <source>Landing point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/FWLandingPatternEditor.qml" line="108"/>
+        <source>WIP (NOT FOR REAL FLIGHT!)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/FWLandingPatternEditor.qml" line="115"/>
+        <source>Click in map to set landing point.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FactCheckBox</name>
+    <message>
+        <location filename="../src/FactSystem/FactControls/FactCheckBox.qml" line="20"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FactPanel</name>
+    <message>
+        <location filename="../src/FactSystem/FactControls/FactPanel.qml" line="57"/>
+        <source>Parameters(s) missing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FactTextField</name>
+    <message>
+        <location filename="../src/FactSystem/FactControls/FactTextField.qml" line="39"/>
+        <source>Invalid Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FactSystem/FactControls/FactTextField.qml" line="47"/>
+        <source>Value Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileManager</name>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="82"/>
+        <source>Unable to open local file for writing (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="89"/>
+        <source>Unable to write data to local file (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="127"/>
+        <source>Download: Incorrect session returned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="133"/>
+        <source>Download: Offset returned (%1) differs from offset requested/expected (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="167"/>
+        <source>List: Offset returned (%1) differs from offset requested (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="184"/>
+        <source>Incorrectly formed list entry: &apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="188"/>
+        <source>Missing NULL termination in list entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="246"/>
+        <source>Write: Incorrect session returned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="252"/>
+        <source>Write: Offset returned (%1) differs from offset requested (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="258"/>
+        <source>Write: Returned invalid size of write size data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="265"/>
+        <source>Write: Size returned (%1) differs from size requested (%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="350"/>
+        <source>Bad sequence number on received message: expected(%1) received(%2)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="406"/>
+        <source>Nak received creating file, error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="417"/>
+        <source>Nak received, error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="422"/>
+        <source>Unknown opcode returned from server: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="429"/>
+        <location filename="../src/uas/FileManager.cc" line="473"/>
+        <location filename="../src/uas/FileManager.cc" line="490"/>
+        <source>Command not sent. Waiting for previous command to complete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="435"/>
+        <location filename="../src/uas/FileManager.cc" line="479"/>
+        <location filename="../src/uas/FileManager.cc" line="496"/>
+        <location filename="../src/uas/FileManager.cc" line="546"/>
+        <source>Command not sent. No Vehicle links.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="540"/>
+        <source>UAS File manager busy.  Try again later</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="555"/>
+        <source>File (%1) is not readable for upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="561"/>
+        <source>Unable to open local file for upload (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="571"/>
+        <source>Unable to read data from local file (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="669"/>
+        <location filename="../src/uas/FileManager.cc" line="675"/>
+        <source>Timeout waiting for ack: Download failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/FileManager.cc" line="681"/>
+        <location filename="../src/uas/FileManager.cc" line="687"/>
+        <source>Timeout waiting for ack: Upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FirmwarePlugin</name>
+    <message>
+        <location filename="../src/FirmwarePlugin/FirmwarePlugin.cc" line="353"/>
+        <source>Typhoon H CGO3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/FirmwarePlugin.cc" line="364"/>
+        <source>Sony ILCE-QX1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/FirmwarePlugin.cc" line="375"/>
+        <source>Canon S100 PowerShot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/FirmwarePlugin.cc" line="386"/>
+        <source>Canon G9 X PowerShot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/FirmwarePlugin.cc" line="397"/>
+        <source>Canon SX260 HS PowerShot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/FirmwarePlugin.cc" line="407"/>
+        <source>Canon EOS-M 22mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/FirmwarePlugin.cc" line="418"/>
+        <source>Sony a6000 16mm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FirmwareUpgrade</name>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="36"/>
+        <source>%1 can upgrade the firmware on Pixhawk devices, SiK Radios and PX4 Flow Smart Cameras.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="40"/>
+        <source>All %1 connections to vehicles must be </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="51"/>
+        <source>Upgrade cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="101"/>
+        <source>Found device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="145"/>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="254"/>
+        <source>PX4 Flight Stack </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="182"/>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="203"/>
+        <source>Standard Version (stable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="186"/>
+        <source>Beta Testing (beta)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="190"/>
+        <source>Developer Build (master)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="194"/>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="207"/>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="220"/>
+        <source>Custom firmware file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="216"/>
+        <source>Standard Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="234"/>
+        <source>Detected PX4 Flow board. You can select from the following firmware:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="235"/>
+        <source>Detected Pixhawk board. You can select from the following flight stacks:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="236"/>
+        <source>Press Ok to upgrade your vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="263"/>
+        <source>ArduPilot Flight Stack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="291"/>
+        <source>Advanced settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="313"/>
+        <source>Select which version of the firmware you would like to install:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="313"/>
+        <source>Select which version of the above flight stack you would like to install:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="328"/>
+        <source>WARNING: BETA FIRMWARE. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="329"/>
+        <source>This firmware version is ONLY intended for beta testers. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="330"/>
+        <source>Although it has received FLIGHT TESTING, it represents actively changed code. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="331"/>
+        <source>Do NOT use for normal operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="334"/>
+        <source>WARNING: CONTINUOUS BUILD FIRMWARE. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="335"/>
+        <source>This firmware has NOT BEEN FLIGHT TESTED. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="336"/>
+        <source>It is only intended for DEVELOPERS. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="337"/>
+        <source>Run bench tests without props first. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="338"/>
+        <source>Do NOT fly this without additional safety precautions. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgrade.qml" line="339"/>
+        <source>Follow the mailing list actively when using it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FirmwareUpgradeController</name>
+    <message>
+        <location filename="../src/VehicleSetup/FirmwareUpgradeController.cc" line="85"/>
+        <source>Connect not allowed during Firmware Upgrade.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FixedWingLandingComplexItem</name>
+    <message>
+        <location filename="../src/MissionManager/FixedWingLandingComplexItem.cc" line="170"/>
+        <source>%1 does not support loading this complex mission item type: %2:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlightDisplayView</name>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="111"/>
+        <source>Joystick support requires MAVLink MANUAL_CONTROL support. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="112"/>
+        <source>The firmware you are running does not normally support this. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="113"/>
+        <source>It will only work if you have modified the firmware to add MANUAL_CONTROL support.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="151"/>
+        <source>Flight complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="167"/>
+        <source>Do you want to remove the mission from the vehicle?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="295"/>
+        <source>Single</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="302"/>
+        <source>Multi-Vehicle (WIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="406"/>
+        <source>Fly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayView.qml" line="476"/>
+        <source>Action</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlightDisplayViewMap</name>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayViewMap.qml" line="229"/>
+        <source>R</source>
+        <comment>rally point map item label</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayViewMap.qml" line="244"/>
+        <source>G</source>
+        <comment>Goto here waypoint</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlightDisplayViewVideo</name>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayViewVideo.qml" line="35"/>
+        <source>WAITING FOR VIDEO</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlightDisplayViewWidgets</name>
+    <message>
+        <location filename="../src/FlightDisplay/FlightDisplayViewWidgets.qml" line="106"/>
+        <source>No GPS Lock for Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlightModeDropdown</name>
+    <message>
+        <location filename="../src/QmlControls/FlightModeDropdown.qml" line="22"/>
+        <source>N/A</source>
+        <comment>No data to display</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlightModeMenu</name>
+    <message>
+        <location filename="../src/QmlControls/FlightModeMenu.qml" line="20"/>
+        <source>N/A</source>
+        <comment>No data to display</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlightModesComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponent.cc" line="25"/>
+        <source>Flight Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponent.cc" line="36"/>
+        <source>Flight Modes Setup is used to configure the transmitter switches associated with Flight Modes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FlightModesComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="32"/>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="52"/>
+        <source>Mode switch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="33"/>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="53"/>
+        <source>Setup required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="38"/>
+        <source>Flight Mode %1 :</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="56"/>
+        <source>Position Ctl switch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="57"/>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="61"/>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="65"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="60"/>
+        <source>Loiter switch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml" line="64"/>
+        <source>Return switch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Form</name>
+    <message>
+        <location filename="../src/ui/uas/UASQuickView.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GPSIndicator</name>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="48"/>
+        <source>GPS Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="48"/>
+        <source>GPS Data Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="61"/>
+        <source>GPS Count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="62"/>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="64"/>
+        <source>N/A</source>
+        <comment>No data to display</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="63"/>
+        <source>GPS Lock:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="65"/>
+        <source>HDOP:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="66"/>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="68"/>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="70"/>
+        <source>--.--</source>
+        <comment>No data to display</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="67"/>
+        <source>VDOP:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/GPSIndicator.qml" line="69"/>
+        <source>Course Over Ground:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeneralSettings</name>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="44"/>
+        <source>(Requires Restart)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="72"/>
+        <source>Units (Requires Restart)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="92"/>
+        <source>Distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="92"/>
+        <source>Area:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="92"/>
+        <source>Speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="124"/>
+        <source>Miscellaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="146"/>
+        <source>Font size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="191"/>
+        <source>Color scheme:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="208"/>
+        <source>Map Provider:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="225"/>
+        <source>Map Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="246"/>
+        <source>Mute all audio output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="255"/>
+        <source>Save telemetry log after each flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="263"/>
+        <source>Save telemetry log even if vehicle was not armed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="273"/>
+        <source>Clear all settings on next start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="283"/>
+        <source>Clear Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="284"/>
+        <source>All saved settings will be reset the next time you start %1. Is this really what you want?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="301"/>
+        <source>Announce battery lower than:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="324"/>
+        <source>Virtual Joystick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="338"/>
+        <source>Default mission altitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="351"/>
+        <source>AutoLoad missions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="366"/>
+        <source>File save path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="370"/>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="598"/>
+        <source>&lt;not set&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="380"/>
+        <source>Choose the location to save files:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="402"/>
+        <source>RTK GPS (Requires Restart)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="421"/>
+        <source>Survey in accuracy:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="428"/>
+        <source>Minimum observation duration:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="446"/>
+        <source>AutoConnect to the following devices:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="476"/>
+        <source>Pixhawk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="476"/>
+        <source>SiK Radio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="476"/>
+        <source>PX4 Flow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="476"/>
+        <source>LibrePilot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="476"/>
+        <source>UDP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="476"/>
+        <source>RTK GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="498"/>
+        <source>Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="521"/>
+        <source>Video Source:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="536"/>
+        <source>UDP Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="550"/>
+        <source>RTSP URL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="564"/>
+        <source>Aspect Ratio:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="578"/>
+        <source>Grid Lines:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="593"/>
+        <source>Save path:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/GeneralSettings.qml" line="622"/>
+        <source>%1 Version: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoFenceController</name>
+    <message>
+        <location filename="../src/MissionManager/GeoFenceController.cc" line="120"/>
+        <source>GeoFence: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoFenceEditor</name>
+    <message>
+        <location filename="../src/PlanView/GeoFenceEditor.qml" line="40"/>
+        <source>GeoFence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/GeoFenceEditor.qml" line="67"/>
+        <source>GeoFencing allows you to set a virtual ‘fence’ around the area you want to fly in.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/GeoFenceEditor.qml" line="108"/>
+        <source>Add fence polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/GeoFenceEditor.qml" line="114"/>
+        <source>Remove fence polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoTagController</name>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="41"/>
+        <source>Select log file load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="41"/>
+        <source>ULog file (*.ulg);;PX4 log file (*.px4log);;All Files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="50"/>
+        <source>Select image directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="59"/>
+        <source>Select save directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="73"/>
+        <source>Cannot find the image directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="80"/>
+        <source>Images have alreay been tagged.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="81"/>
+        <source>The images have already been tagged. Do you want to replace the previously tagged images?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="84"/>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="116"/>
+        <source>Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="86"/>
+        <source>Images have already been tagged</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="93"/>
+        <source>Couldn&apos;t replace the previously tagged images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="101"/>
+        <source>Cannot find the save directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="112"/>
+        <source>Save folder not empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="113"/>
+        <source>The save folder already contains images. Do you want to replace them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="118"/>
+        <source>Save folder not empty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="125"/>
+        <source>Couldn&apos;t replace the existing images</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoTagPage</name>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagPage.qml" line="25"/>
+        <source>GeoTag Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagPage.qml" line="26"/>
+        <source>GeoTag Images is used to tag a set of images from a survey mission with gps coordinates. You must provide the binary log from the flight as well as the directory which contains the images to tag.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagPage.qml" line="74"/>
+        <source>Select log file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagPage.qml" line="90"/>
+        <source>Select image directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagPage.qml" line="106"/>
+        <source>(Optionally) Select save directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagPage.qml" line="127"/>
+        <source>Cancel Tagging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagPage.qml" line="127"/>
+        <source>Start Tagging</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GeoTagWorker</name>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="172"/>
+        <source>The image directory doesn&apos;t contain images, make sure your images are of the JPG format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="183"/>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="264"/>
+        <source>Geotagging failed. Couldn&apos;t open an image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="195"/>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="226"/>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="240"/>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="254"/>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="291"/>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="298"/>
+        <source>Tagging cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="204"/>
+        <source>Geotagging failed. Couldn&apos;t open log file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="230"/>
+        <source>Log parsing failed - tagging cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="247"/>
+        <source>Geotagging failed in trigger filtering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="271"/>
+        <source>Geotagging failed. Couldn&apos;t write to image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/GeoTagController.cc" line="281"/>
+        <source>Geotagging failed. Couldn&apos;t write to an image.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GuidedActionConfirm</name>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionConfirm.qml" line="78"/>
+        <source>Slide to confirm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GuidedActionList</name>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionList.qml" line="45"/>
+        <source>Select Action</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GuidedActionsController</name>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="34"/>
+        <source>Emergency Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="35"/>
+        <source>Arm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="36"/>
+        <source>Disarm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="37"/>
+        <source>RTL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="38"/>
+        <source>Takeoff</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="39"/>
+        <source>Land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="40"/>
+        <source>Start Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="41"/>
+        <source>Continue Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="42"/>
+        <source>Resume Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="43"/>
+        <source>Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="44"/>
+        <source>Change Altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="45"/>
+        <source>Orbit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="46"/>
+        <source>Land Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="47"/>
+        <source>Set Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="48"/>
+        <source>Goto Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="50"/>
+        <source>Arm the vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="51"/>
+        <source>Disarm the vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="52"/>
+        <source>WARNING: This will stop all motors. If vehicle is currently in air it will crash.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="53"/>
+        <source>Takeoff from ground and hold position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="54"/>
+        <source>Takeoff from ground and start the current mission.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="55"/>
+        <source>Continue the mission from the current waypoint.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="56"/>
+        <source>Resume the current mission. This will re-generate the mission from waypoint %1, takeoff and continue the mission.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="57"/>
+        <source>Review the modified mission. Confirm if you want to takeoff and begin mission.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="58"/>
+        <source>Land the vehicle at the current position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="59"/>
+        <source>Return to the home position of the vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="60"/>
+        <source>Change the altitude of the vehicle up or down.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="61"/>
+        <source>Move the vehicle to the location clicked on the map.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="62"/>
+        <source>Adjust current waypoint to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="63"/>
+        <source>Orbit the vehicle around the current location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="64"/>
+        <source>Abort the landing sequence.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="65"/>
+        <source>Pause the vehicle at it&apos;s current position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedActionsController.qml" line="276"/>
+        <source>Internal error: unknown actionCode</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GuidedAltitudeSlider</name>
+    <message>
+        <location filename="../src/FlightDisplay/GuidedAltitudeSlider.qml" line="50"/>
+        <source>New Alt(rel)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>JoystickConfig</name>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="27"/>
+        <source>Joystick</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="28"/>
+        <source>Joystick Setup is used to configure a calibrate joysticks.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="139"/>
+        <source>Not Mapped</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="179"/>
+        <source>Attitude Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="188"/>
+        <source>Lateral</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="188"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="218"/>
+        <source>Forward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="218"/>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="248"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="278"/>
+        <source>Throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="309"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="316"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="324"/>
+        <source>Calibrate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="354"/>
+        <source>Additional Joystick settings:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="364"/>
+        <source>Enable joystick input</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="364"/>
+        <source>Enable not allowed (Calibrate First)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="387"/>
+        <source>Active joystick:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="400"/>
+        <source>Active joystick name not in combo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="426"/>
+        <source>Center stick is zero throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="441"/>
+        <source>Spring loaded throttle smoothing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="449"/>
+        <source>Full down stick is zero throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="461"/>
+        <source>Exponential:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="484"/>
+        <source>Advanced settings (careful!)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="501"/>
+        <source>Joystick mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="522"/>
+        <source>Deadbands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="548"/>
+        <source>Button actions:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="556"/>
+        <source>Buttons 0-%1 reserved for firmware use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="614"/>
+        <source>#</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="619"/>
+        <source>Function: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="624"/>
+        <source>Shift Function: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="742"/>
+        <source>Axis Monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/JoystickConfig.qml" line="796"/>
+        <source>Button Monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>JoystickIndicator</name>
+    <message>
+        <location filename="../src/ui/toolbar/JoystickIndicator.qml" line="48"/>
+        <source>Joystick Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/JoystickIndicator.qml" line="60"/>
+        <source>Connected:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/JoystickIndicator.qml" line="65"/>
+        <source>Enabled:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LinechartWidget</name>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="106"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="107"/>
+        <source>Val</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="109"/>
+        <source>Unit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="112"/>
+        <source>Mean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="113"/>
+        <source>Variance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="210"/>
+        <source>LOG</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="212"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="213"/>
+        <source>Set logarithmic scale for Y axis</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="218"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="219"/>
+        <source>Sliding window size to calculate mean and variance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="229"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="230"/>
+        <source>Start to log curve data into a CSV or TXT file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="231"/>
+        <source>Start Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="237"/>
+        <source>Ground Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="238"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="239"/>
+        <source>Overwrite timestamp of data from vehicle with ground receive time. Helps if the plots are not visible because of missing or invalid onboard time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="428"/>
+        <source>No curves selected for logging.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="429"/>
+        <source>Please check all curves you want to log. Currently no data would be logged. Aborting the logging.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="437"/>
+        <source>Save Log File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="439"/>
+        <source>Log Files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="451"/>
+        <source>Stop logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="470"/>
+        <source>Starting Log Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="471"/>
+        <source>Should empty fields (e.g. due to packet drops) be filled with the previous value of the same variable (zero order hold)?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="478"/>
+        <source>Start logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="515"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="516"/>
+        <source>Enable the curve in the graph window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="537"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="538"/>
+        <source>Current value of %1 in %2 units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="545"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="546"/>
+        <source>Unit of </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="556"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="557"/>
+        <source>Arithmetic mean of %1 in %2 units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="571"/>
+        <location filename="../src/ui/linechart/LinechartWidget.cc" line="572"/>
+        <source>Variance of %1 in (%2)^2 units</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LinkManager</name>
+    <message>
+        <location filename="../src/comm/LinkManager.cc" line="525"/>
+        <location filename="../src/comm/LinkManager.cc" line="531"/>
+        <location filename="../src/comm/LinkManager.cc" line="536"/>
+        <location filename="../src/comm/LinkManager.cc" line="541"/>
+        <source>%1 on %2 (AutoConnect)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/LinkManager.cc" line="879"/>
+        <source>Please check to make sure you have an SD Card inserted in your Vehicle and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/LinkManager.cc" line="880"/>
+        <source>Your Vehicle is not responding. If this continues, shutdown %1, restart the Vehicle letting it boot completely, then start %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LinkSettings</name>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="88"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="99"/>
+        <source>Remove Link Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="100"/>
+        <source>Remove %1. Is this really what you want?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="112"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="119"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="125"/>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="132"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="190"/>
+        <source>Edit Link Configuration Settings (WIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="190"/>
+        <source>Create New Link Configuration (WIP)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="205"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="219"/>
+        <source>Type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="309"/>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LinkSettings.qml" line="329"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogCompressor</name>
+    <message>
+        <location filename="../src/LogCompressor.cc" line="50"/>
+        <source>Log Compressor: Cannot start/compress log file, since input file %1 is not readable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/LogCompressor.cc" line="67"/>
+        <source>Log Compressor: Cannot start/compress log file, since output file %1 is not writable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/LogCompressor.cc" line="105"/>
+        <source>Log compressor: Dataset contains dimensions: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/LogCompressor.cc" line="213"/>
+        <source>Log Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogDownloadController</name>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="183"/>
+        <source>Available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="230"/>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="691"/>
+        <source>Canceled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="277"/>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="382"/>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="637"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="363"/>
+        <source>Downloaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="428"/>
+        <source>Timed Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="519"/>
+        <source>Log Download Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="546"/>
+        <source>Waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogDownloadPage</name>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="24"/>
+        <source>Log Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="25"/>
+        <source>Log Download allows you to download binary log files from your vehicle. Click Refresh to get list of available logs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="61"/>
+        <source>Id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="74"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="85"/>
+        <source>Date Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="96"/>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="109"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="128"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="133"/>
+        <source>Log Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="133"/>
+        <source>You must be connected to a vehicle in order to download logs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="142"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="156"/>
+        <source>Select save directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="175"/>
+        <source>Erase All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="178"/>
+        <source>Delete All Log Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="186"/>
+        <source>All log files will be erased permanently. Is this really what you want?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadPage.qml" line="197"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogReplayLink</name>
+    <message>
+        <location filename="../src/comm/LogReplayLink.cc" line="355"/>
+        <source>Connect not allowed during Flight Data replay.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogReplaySettings</name>
+    <message>
+        <location filename="../src/ui/preferences/LogReplaySettings.qml" line="35"/>
+        <source>Log Replay Link Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LogReplaySettings.qml" line="44"/>
+        <source>Log File:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LogReplaySettings.qml" line="55"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/LogReplaySettings.qml" line="63"/>
+        <source>Please choose a file</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MAVLinkProtocol</name>
+    <message>
+        <location filename="../src/comm/MAVLinkProtocol.cc" line="195"/>
+        <location filename="../src/comm/MAVLinkProtocol.cc" line="234"/>
+        <location filename="../src/comm/MAVLinkProtocol.cc" line="383"/>
+        <source>MAVLink Protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/MAVLinkProtocol.cc" line="195"/>
+        <source>There is a MAVLink Version or Baud Rate Mismatch. Please check if the baud rates of %1 and your autopilot are the same.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/MAVLinkProtocol.cc" line="234"/>
+        <source>MAVLink Logging failed. Could not write to file %1, logging disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/MAVLinkProtocol.cc" line="317"/>
+        <source>MAVLink protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/MAVLinkProtocol.cc" line="383"/>
+        <source>Opening Flight Data file for writing failed. Unable to write to %1. Please choose a different file location.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainToolBarIndicators</name>
+    <message>
+        <location filename="../src/ui/toolbar/MainToolBarIndicators.qml" line="50"/>
+        <source>Advanced Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/MainToolBarIndicators.qml" line="64"/>
+        <source>Waiting For Vehicle Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/MainToolBarIndicators.qml" line="111"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/MainToolBarIndicators.qml" line="119"/>
+        <source>COMMUNICATION LOST</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/ui/MainWindow.ui" line="29"/>
+        <source>MGMainWindow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.ui" line="59"/>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.ui" line="68"/>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.ui" line="77"/>
+        <source>Exit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.ui" line="80"/>
+        <source>Ctrl+Q</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.ui" line="85"/>
+        <source>Manage Communication Links</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.ui" line="93"/>
+        <source>Advanced Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.ui" line="101"/>
+        <source>Replay Flight Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.cc" line="134"/>
+        <source>Setting up user interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.cc" line="183"/>
+        <source>Building common widgets.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.cc" line="185"/>
+        <source>Building common actions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.cc" line="192"/>
+        <location filename="../src/ui/MainWindow.cc" line="198"/>
+        <source>Initializing 3D mouse interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.cc" line="206"/>
+        <source>Restoring last view state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.cc" line="211"/>
+        <source>Restoring last window size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindow.cc" line="239"/>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindowInner</name>
+    <message>
+        <location filename="../src/ui/MainWindowInner.qml" line="149"/>
+        <location filename="../src/ui/MainWindowInner.qml" line="168"/>
+        <source>%1 close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindowInner.qml" line="150"/>
+        <source>You have a mission edit in progress which has not been saved/sent. If you close you will lose changes. Are you sure you want to close?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindowInner.qml" line="169"/>
+        <source>There are still active connections to vehicles. Do you want to disconnect these before closing?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/MainWindowInner.qml" line="235"/>
+        <source>No Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MapScale</name>
+    <message>
+        <location filename="../src/FlightMap/MapScale.qml" line="40"/>
+        <source> km</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/MapScale.qml" line="42"/>
+        <source> m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/MapScale.qml" line="53"/>
+        <source> mile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/MapScale.qml" line="55"/>
+        <source> miles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/MapScale.qml" line="58"/>
+        <source> ft</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MavlinkConsolePage</name>
+    <message>
+        <location filename="../src/AnalyzeView/MavlinkConsolePage.qml" line="26"/>
+        <source>Mavlink Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AnalyzeView/MavlinkConsolePage.qml" line="27"/>
+        <source>Mavlink Console provides a connection to the vehicle&apos;s system shell.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MavlinkSettings</name>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="76"/>
+        <source>MAVLink Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="77"/>
+        <source>Please enter an email address before uploading MAVLink log files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="102"/>
+        <source>Ground Station</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="121"/>
+        <source>MAVLink System ID:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="137"/>
+        <source>Emit heartbeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="146"/>
+        <source>Only accept MAVs with same protocol version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="163"/>
+        <source>MAVLink 2.0 Logging (PX4 Firmware Only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="185"/>
+        <source>Manual Start/Stop:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="189"/>
+        <source>Start Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="196"/>
+        <source>Stop Logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="206"/>
+        <source>Enable automatic logging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="223"/>
+        <source>MAVLink 2.0 Log Uploads (PX4 Firmware Only)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="244"/>
+        <source>Email address for Log Upload:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="264"/>
+        <source>Default Description:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="283"/>
+        <source>Default Upload URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="303"/>
+        <source>Video URL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="320"/>
+        <source>Wind Speed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="356"/>
+        <source>Flight Rating:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="392"/>
+        <source>Additional Feedback:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="410"/>
+        <source>Make this log publicly available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="420"/>
+        <source>Enable automatic log uploads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="431"/>
+        <source>Delete log file after uploading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="449"/>
+        <source>Saved Log Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="511"/>
+        <source>Uploaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="534"/>
+        <source>Check All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="544"/>
+        <source>Check None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="554"/>
+        <source>Delete Selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="562"/>
+        <source>Delete Selected Log Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="563"/>
+        <source>Confirm deleting selected log files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="570"/>
+        <source>Upload Selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="585"/>
+        <source>Upload Selected Log Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="586"/>
+        <source>Confirm uploading selected log files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="593"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="602"/>
+        <source>Cancel Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MavlinkSettings.qml" line="603"/>
+        <source>Confirm canceling the upload process?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MissionCommandDialog</name>
+    <message>
+        <location filename="../src/QmlControls/MissionCommandDialog.qml" line="31"/>
+        <source>Category:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MissionCommandTree</name>
+    <message>
+        <location filename="../src/MissionManager/MissionCommandTree.cc" line="26"/>
+        <source>All commands</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MissionController</name>
+    <message>
+        <location filename="../src/MissionManager/MissionController.cc" line="59"/>
+        <source>Survey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/MissionController.cc" line="60"/>
+        <source>Fixed Wing Landing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/MissionController.cc" line="557"/>
+        <source>Mission item %1 is not an object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/MissionController.cc" line="618"/>
+        <source>Unsupported complex item type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/MissionController.cc" line="621"/>
+        <source>Unknown item type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/MissionController.cc" line="644"/>
+        <source>Could not find doJumpId: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/MissionController.cc" line="757"/>
+        <location filename="../src/MissionManager/MissionController.cc" line="772"/>
+        <location filename="../src/MissionManager/MissionController.cc" line="796"/>
+        <source>Mission: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MissionItem</name>
+    <message>
+        <location filename="../src/MissionManager/MissionItem.cc" line="253"/>
+        <source>Type found: %1 must be: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/MissionItem.cc" line="259"/>
+        <source>%1 key must contains 4 values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/MissionItem.cc" line="265"/>
+        <source>Param %1 incorrect type %2, must be double or null</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MissionItemEditor</name>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="100"/>
+        <source>Insert waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="106"/>
+        <source>Insert pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="123"/>
+        <source>Insert </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="129"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="134"/>
+        <source>Change command...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="144"/>
+        <source>Show all values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="154"/>
+        <source>Mission Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="154"/>
+        <source>You have made changes to the mission item which cannot be shown in Simple Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionItemEditor.qml" line="183"/>
+        <source>Select Mission Command</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MissionItemStatus</name>
+    <message>
+        <location filename="../src/PlanView/MissionItemStatus.qml" line="38"/>
+        <source>Altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MissionManager</name>
+    <message>
+        <location filename="../src/MissionManager/MissionManager.cc" line="982"/>
+        <source>Unable to generate resume mission due to MAV_CMD_DO_JUMP command.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MissionSettingsEditor</name>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="39"/>
+        <source>Firmware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="40"/>
+        <source>Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="88"/>
+        <source>Mission Defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="107"/>
+        <source>Waypoint alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="116"/>
+        <source>Flight speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="130"/>
+        <source>RTL after mission end</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="142"/>
+        <source>Vehicle Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="180"/>
+        <source>Cruise speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="191"/>
+        <source>Hover speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="204"/>
+        <source>Planned Home Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="223"/>
+        <source>Altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="235"/>
+        <source>Actual position set by vehicle at flight time.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/MissionSettingsEditor.qml" line="240"/>
+        <source>Set Home To Map Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MixersComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/MixersComponent.qml" line="35"/>
+        <source>Lot of Qml code goes here...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/MixersComponent.cc" line="15"/>
+        <source>Mixers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/MixersComponent.cc" line="26"/>
+        <source>Mixers tuning is used to blah, blah, blah... [WIP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MockLink</name>
+    <message>
+        <location filename="../src/ui/preferences/MockLink.qml" line="40"/>
+        <source>PX4 Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLink.qml" line="44"/>
+        <source>APM ArduCopter Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLink.qml" line="48"/>
+        <source>APM ArduPlane Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLink.qml" line="52"/>
+        <source>APM ArduSub Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLink.qml" line="56"/>
+        <source>Generic Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLink.qml" line="61"/>
+        <source>Send status text + voice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLink.qml" line="64"/>
+        <source>Stop All MockLinks</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MockLinkSettings</name>
+    <message>
+        <location filename="../src/ui/preferences/MockLinkSettings.qml" line="59"/>
+        <source>Mock Link Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLinkSettings.qml" line="67"/>
+        <source>Send Status Text and Voice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLinkSettings.qml" line="78"/>
+        <source>PX4 Firmware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLinkSettings.qml" line="84"/>
+        <source>APM Firmware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLinkSettings.qml" line="90"/>
+        <source>Generic Firmware</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLinkSettings.qml" line="100"/>
+        <source>APM Vehicle Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLinkSettings.qml" line="108"/>
+        <source>ArduCopter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/MockLinkSettings.qml" line="114"/>
+        <source>ArduPlane</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ModeIndicator</name>
+    <message>
+        <location filename="../src/ui/toolbar/ModeIndicator.qml" line="31"/>
+        <source>N/A</source>
+        <comment>No data to display</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ModeSwitchDisplay</name>
+    <message>
+        <location filename="../src/QmlControls/ModeSwitchDisplay.qml" line="95"/>
+        <source>Monitor:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ModeSwitchDisplay.qml" line="135"/>
+        <source>Threshold:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MotorComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/MotorComponent.qml" line="82"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/MotorComponent.qml" line="115"/>
+        <source>Moving the sliders will causes the motors to spin. Make sure you remove all props.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/MotorComponent.qml" line="135"/>
+        <source>Propellers are removed - Enable motor sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/MotorComponent.cc" line="14"/>
+        <source>Motors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/MotorComponent.cc" line="26"/>
+        <source>Motors Setup is used to manually test motor control and direction.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Mouse6dofInput</name>
+    <message>
+        <location filename="../src/input/Mouse6dofInput.cpp" line="90"/>
+        <source>No 3DxWare driver is running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/input/Mouse6dofInput.cpp" line="91"/>
+        <source>Enter in Terminal &apos;sudo /etc/3DxWare/daemon/3dxsrv -d usb&apos; and then restart QGroundControl.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultiVehicleDockWidget</name>
+    <message>
+        <location filename="../src/ui/MultiVehicleDockWidget.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MultiVehicleManager</name>
+    <message>
+        <location filename="../src/Vehicle/MultiVehicleManager.cc" line="130"/>
+        <source>Connected to Vehicle %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OfflineMap</name>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="217"/>
+        <source>Error Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="249"/>
+        <source>Max Cache Disk Size (MB):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="261"/>
+        <source>Max Cache Memory Size (MB):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="273"/>
+        <source>Memory cache changes require a restart to take effect.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="278"/>
+        <source>MapBox Access Token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="288"/>
+        <source>With an access token, you can use MapBox Maps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="294"/>
+        <source>Esri Access Token</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="304"/>
+        <source>With an access token, you can use Esri Maps.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="318"/>
+        <source>This will delete all tiles INCLUDING the tile sets you have created yourself.
+
+Is this really what you want?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="320"/>
+        <source>Delete %1 and all its tiles.
+
+Is this really what you want?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="417"/>
+        <source>System Wide Tile Cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="430"/>
+        <source>Zoom Levels:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="437"/>
+        <source>Total:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="444"/>
+        <source>Unique:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="452"/>
+        <source>Downloaded:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="459"/>
+        <source>Error Count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="467"/>
+        <source>Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="474"/>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="829"/>
+        <source>Tile Count:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="481"/>
+        <source>Resume Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="490"/>
+        <source>Cancel Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="499"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="501"/>
+        <source>Confirm Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="504"/>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1073"/>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1155"/>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1231"/>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1276"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="564"/>
+        <source>Min Zoom: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="603"/>
+        <source>Max Zoom: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="651"/>
+        <source>Add New Set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="679"/>
+        <source>Name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="692"/>
+        <source>Map type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="734"/>
+        <source>Min/Max Zoom Levels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="838"/>
+        <source>Est Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="850"/>
+        <source>Too many tiles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="861"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="874"/>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1025"/>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1186"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="903"/>
+        <source>Add new set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="936"/>
+        <source>Import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="942"/>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="949"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="951"/>
+        <source>Offline Maps Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="972"/>
+        <source>Select Tile Sets to Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="996"/>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1001"/>
+        <source>Select None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1006"/>
+        <source>Export to Disk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1017"/>
+        <source>Export to Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1052"/>
+        <source>Tile Set Export Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1052"/>
+        <source>Tile Set Export Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1108"/>
+        <source>Map Tile Set Import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1110"/>
+        <source>Map Tile Set Import Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1112"/>
+        <source>Map Tile Set Import Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1141"/>
+        <source>Append to existing set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1148"/>
+        <source>Replace existing set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1169"/>
+        <source>Import From Disk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1179"/>
+        <source>Import From Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1219"/>
+        <source>Map Tile Set Import From Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1225"/>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1270"/>
+        <source>NOT YET IMPLEMENTED</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QtLocationPlugin/QMLControl/OfflineMap.qml" line="1264"/>
+        <source>Map Tile Set Export To Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4AdvancedFlightModes</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="36"/>
+        <source>FLIGHT MODES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="39"/>
+        <source>Assign Flight Modes to radio control channels and adjust the thresholds for triggering them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="40"/>
+        <source>Assign Flight Modes to radio control channels and adjust the thresholds for triggering them. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="41"/>
+        <source>You can assign multiple flight modes to a single channel. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="42"/>
+        <source>Turn your radio control on to test switch settings. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="43"/>
+        <source>The following channels: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="44"/>
+        <source> are not available for Flight Modes since they are already in use for other functions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="46"/>
+        <source>Manual/Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="47"/>
+        <source>Stabilized/Main</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="48"/>
+        <source>The pilot has full control of the aircraft, no assistance is provided. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="49"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="51"/>
+        <source>The Main mode switch must always be assigned to a channel in order to fly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="50"/>
+        <source>The pilot has full control of the aircraft, only attitude is stabilized. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="53"/>
+        <source>Assist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="54"/>
+        <source>If Position Control is placed on a separate channel from the Main mode channel, an additional &apos;Assist&apos; mode is added to the Main switch. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="55"/>
+        <source>In order for the Attitude Control/Position Control switch to be active, the Main switch must be in Assist mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="57"/>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="58"/>
+        <source>If Loiter is placed on a separate channel from the Main mode channel, an additional &apos;Auto&apos; mode is added to the Main switch. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="59"/>
+        <source>In order for the Mission/Loiter switch to be active, the Main switch must be in Auto mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="61"/>
+        <source>Stabilized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="62"/>
+        <source>Acro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="63"/>
+        <source>Roll/pitch angles and rudder deflection are controlled. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="64"/>
+        <source>The angular rates are controlled, but not the attitude. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="66"/>
+        <source>Altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="67"/>
+        <source>Roll stick controls banking, pitch stick altitude </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="68"/>
+        <source>Throttle stick controls speed. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="69"/>
+        <source>With no stick inputs the plane holds heading, but drifts off in wind. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="70"/>
+        <source>Same as Stablized mode except that Throttle controls climb/sink rate. Centered Throttle holds altitude steady. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="72"/>
+        <source>Position Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="73"/>
+        <source>Roll stick controls banking, pitch stick controls altitude. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="74"/>
+        <source>Throttle stick controls speed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="75"/>
+        <source>With no stick inputs the plane flies a straight line, even in wind. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="76"/>
+        <source>Roll and Pitch sticks control sideways and forward speed </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="77"/>
+        <source>Throttle stick controls climb / sink rade. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="79"/>
+        <source>Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="80"/>
+        <source>The aircraft obeys the programmed mission sent by QGroundControl. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="82"/>
+        <source>Hold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="83"/>
+        <source>The aircraft flies in a circle around the current position at the current altitude. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="84"/>
+        <source>The multirotor hovers at the current position and altitude. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="86"/>
+        <source>Return</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="87"/>
+        <source>The vehicle returns to the home position, loiters and then lands. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="89"/>
+        <source>Offboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="90"/>
+        <source>All flight control aspects are controlled by an offboard system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="165"/>
+        <source>Flight Mode Config is disabled since you have a Joystick enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="200"/>
+        <source>Use Single Channel Mode Selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml" line="210"/>
+        <source>Generate Thresholds</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4FirmwarePlugin</name>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="37"/>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="38"/>
+        <source>Acro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="39"/>
+        <source>Stabilized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="40"/>
+        <source>Rattitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="41"/>
+        <source>Altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="42"/>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="43"/>
+        <source>Offboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="44"/>
+        <source>Ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="45"/>
+        <source>Takeoff</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="46"/>
+        <source>Hold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="47"/>
+        <source>Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="48"/>
+        <source>Return</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="49"/>
+        <source>Land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="50"/>
+        <source>Return to Groundstation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="51"/>
+        <source>Follow Me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="52"/>
+        <source>Simple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="179"/>
+        <source>Unknown %1:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="388"/>
+        <source>Unable to takeoff, vehicle position not known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="393"/>
+        <source>Unable to takeoff, MIS_TAKEOFF_ALT parameter missing.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="411"/>
+        <source>Unable to go to location, vehicle position not known.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="430"/>
+        <source>Unable to change altitude, home position unknown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="434"/>
+        <source>Unable to change altitude, home position altitude unknown.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc" line="464"/>
+        <source>Unable to start mission: Vehicle failed to arm.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4FlowSensor</name>
+    <message>
+        <location filename="../src/VehicleSetup/PX4FlowSensor.qml" line="38"/>
+        <source>PX4Flow Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4ParameterMetaData</name>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc" line="313"/>
+        <source>Enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc" line="315"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4RadioComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponent.cc" line="16"/>
+        <source>Radio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponent.cc" line="27"/>
+        <source>Radio Setup is used to calibrate your transmitter. It also assign channels for Roll, Pitch, Yaw and Throttle vehicle control as well as determining whether they are reversed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4RadioComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="29"/>
+        <source>Roll:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="30"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="35"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="40"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="45"/>
+        <source>Setup required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="34"/>
+        <source>Pitch:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="39"/>
+        <source>Yaw:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="44"/>
+        <source>Throttle:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="49"/>
+        <source>Flaps:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="50"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="56"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="61"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="55"/>
+        <source>Aux1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml" line="60"/>
+        <source>Aux2:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4SimpleFlightModes</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml" line="58"/>
+        <source>Flight Mode Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml" line="81"/>
+        <source>Mode channel:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml" line="102"/>
+        <source>Flight Mode %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml" line="123"/>
+        <source>Switch Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4TuningComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponent.cc" line="28"/>
+        <source>Tuning Setup is used to tune the flight characteristics of the Vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4TuningComponentCopter</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="29"/>
+        <source>Hover Throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="30"/>
+        <source>Adjust throttle so hover is at mid-throttle. Slide to the left if hover is lower than throttle center. Slide to the right if hover is higher than throttle center.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="38"/>
+        <source>Manual minimum throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="39"/>
+        <source>Slide to the left to start the motors with less idle power. Slide to the right if descending in manual flight becomes unstable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="47"/>
+        <source>Roll sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="48"/>
+        <source>Slide to the left to make roll control faster and more accurate. Slide to the right if roll oscillates or is too twitchy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="56"/>
+        <source>Pitch sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="57"/>
+        <source>Slide to the left to make pitch control faster and more accurate. Slide to the right if pitch oscillates or is too twitchy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="65"/>
+        <source>Altitude control sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="66"/>
+        <source>Slide to the left to make altitude control smoother and less twitchy. Slide to the right to make altitude control more accurate and more aggressive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="74"/>
+        <source>Position control sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml" line="75"/>
+        <source>Slide to the left to make flight in position control mode smoother and less twitchy. Slide to the right to make position control more accurate and more aggressive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PX4TuningComponentVTOL</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="30"/>
+        <source>Hover Roll sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="31"/>
+        <source>Slide to the left to make roll control during hover faster and more accurate. Slide to the right if roll oscillates or is too twitchy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="39"/>
+        <source>Hover Pitch sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="40"/>
+        <source>Slide to the left to make pitch control during hover faster and more accurate. Slide to the right if pitch oscillates or is too twitchy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="48"/>
+        <source>Hover Altitude control sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="49"/>
+        <source>Slide to the left to make altitude control during hover smoother and less twitchy. Slide to the right to make altitude control more accurate and more aggressive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="57"/>
+        <source>Hover Position control sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="58"/>
+        <source>Slide to the left to make flight during hover in position control mode smoother and less twitchy. Slide to the right to make position control more accurate and more aggressive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="65"/>
+        <source>Plane Roll sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="66"/>
+        <source>Slide to the left to make roll control faster and more accurate. Slide to the right if roll oscillates or is too twitchy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="74"/>
+        <source>Plane Pitch sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="75"/>
+        <source>Slide to the left to make pitch control faster and more accurate. Slide to the right if pitch oscillates or is too twitchy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="83"/>
+        <source>Plane Cruise throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="84"/>
+        <source>This is the throttle setting required to achieve the desired cruise speed. Most planes need 50-60%.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="92"/>
+        <source>Hover Throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="93"/>
+        <source>Adjust throttle so hover is at mid-throttle. Slide to the left if hover is lower than throttle center. Slide to the right if hover is higher than throttle center.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="101"/>
+        <source>Hoever manual minimum throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="102"/>
+        <source>Slide to the left to start the motors with less idle power. Slide to the right if descending in manual flight becomes unstable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="110"/>
+        <source>Plane Mission mode sensitivity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml" line="111"/>
+        <source>Slide to the left to make position control more accurate and more aggressive. Slide to the right to make flight in mission mode smoother and less twitchy.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ParameterEditor</name>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="43"/>
+        <source>Parameter Load Errors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="72"/>
+        <source>Search:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="84"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="98"/>
+        <source>Tools</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="103"/>
+        <source>Refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="107"/>
+        <source>Reset all to defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="108"/>
+        <source>Reset All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="112"/>
+        <source>Load from file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="117"/>
+        <source>Select Parameter File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="121"/>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="135"/>
+        <source>Parameter Files (*.%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="121"/>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="135"/>
+        <source>All Files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="126"/>
+        <source>Save to file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="131"/>
+        <source>Save Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="141"/>
+        <source>Clear RC to Param</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="147"/>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="148"/>
+        <source>Reboot Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="180"/>
+        <source>Component #: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="276"/>
+        <source>Parameter Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="318"/>
+        <source>Select Reset to reset all parameters to their defaults.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditor.qml" line="335"/>
+        <source>Select Ok to reboot vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ParameterEditorDialog</name>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="113"/>
+        <source>Reset to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="187"/>
+        <source>Min: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="192"/>
+        <source>Max: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="197"/>
+        <source>Default: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="203"/>
+        <source>Parameter name: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="215"/>
+        <source>Warning: Modifying values while vehicle is in flight can lead to vehicle instability and possible vehicle loss. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="216"/>
+        <source>Make sure you know what you are doing and double-check your values before Save!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="223"/>
+        <source>Force save (dangerous!)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="240"/>
+        <source>Advanced settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="255"/>
+        <source>Manual Entry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/ParameterEditorDialog.qml" line="263"/>
+        <source>Set RC to Param...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ParameterManager</name>
+    <message>
+        <location filename="../src/FactSystem/ParameterManager.cc" line="619"/>
+        <source>Parameter write failed: veh:%1 comp:%2 param:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FactSystem/ParameterManager.cc" line="641"/>
+        <source>Parameter read failed: veh:%1 comp:%2 param:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FactSystem/ParameterManager.cc" line="1053"/>
+        <source>%1 was unable to retrieve the full set of parameters from vehicle %2. This will cause %1 to be unable to display its full user interface. If you are using modified firmware, you may need to resolve any vehicle startup errors to resolve the issue. If you are using standard firmware, you may need to upgrade to a newer version to resolve the issue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FactSystem/ParameterManager.cc" line="1079"/>
+        <source>Vehicle %1 did not respond to request for parameters. This will cause %2 to be unable to display its full user interface.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FactSystem/ParameterManager.cc" line="1424"/>
+        <source>%1 key is not a json object</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PlanMasterController</name>
+    <message>
+        <location filename="../src/MissionManager/PlanMasterController.cc" line="235"/>
+        <source>Error reading Plan file (%1). %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/PlanMasterController.cc" line="310"/>
+        <source>Plan save error %1 : %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/PlanMasterController.cc" line="379"/>
+        <source>Supported types (*.%1 *.%2 *.%3 *.%4)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/PlanMasterController.cc" line="380"/>
+        <location filename="../src/MissionManager/PlanMasterController.cc" line="389"/>
+        <source>All Files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/PlanMasterController.cc" line="389"/>
+        <source>Plan Files (*.%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PlanToolBar</name>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="159"/>
+        <source>Selected Waypoint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="164"/>
+        <source>Alt diff:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="173"/>
+        <source>Azimuth:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="182"/>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="219"/>
+        <source>Distance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="189"/>
+        <source>Gradient:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="198"/>
+        <source>Heading:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="214"/>
+        <source>Total Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="228"/>
+        <source>Max telem dist:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="235"/>
+        <source>Time:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="251"/>
+        <source>Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="256"/>
+        <source>Batteries required:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="265"/>
+        <source>Swap waypoint:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="279"/>
+        <source>Upload Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanToolBar.qml" line="279"/>
+        <source>Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PlanView</name>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="61"/>
+        <source>Vehicle is currently armed. Do you want to upload the mission to the vehicle?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="98"/>
+        <source>Apply new alititude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="107"/>
+        <source>You have changed the default altitude for mission items. Would you like to apply that altitude to all the items in the current mission?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="128"/>
+        <source>Your vehicle is currently flying a mission. In order to upload a new or modified mission the current mission will be paused.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="134"/>
+        <source>After the mission is uploaded you can adjust the current waypoint and start the mission.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="138"/>
+        <source>Pause and Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="159"/>
+        <source>Plan Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="166"/>
+        <source>Select Plan File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="173"/>
+        <source>Save Plan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="273"/>
+        <source>Move the selected mission item to the be after following mission item:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="399"/>
+        <source>Plan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="509"/>
+        <source>Mission</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="521"/>
+        <source>Fence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="532"/>
+        <source>Rally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="646"/>
+        <source>You have unsaved/unsent changes. Loading from the Vehicle will lose these changes. Are you sure you want to load from the Vehicle?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="658"/>
+        <source>You have unsaved/unsent changes. Loading from a file will lose these changes. Are you sure you want to load from a file?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="669"/>
+        <source>Are you sure you want to remove all items? </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="670"/>
+        <source>This will also remove all items from the vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="699"/>
+        <source>Create complex pattern:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="724"/>
+        <source>Mission overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="724"/>
+        <source>GeoFence overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="724"/>
+        <source>Rally Points overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="730"/>
+        <source>You have unsaved changes. You should upload to your vehicle, or save to a file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="731"/>
+        <source>Sync:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="742"/>
+        <source>Upload</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="752"/>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="766"/>
+        <source>Save To File...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="776"/>
+        <source>Load From File...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="790"/>
+        <source>Remove All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/PlanView.qml" line="794"/>
+        <source>Remove all</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PolygonEditor</name>
+    <message>
+        <location filename="../src/FlightMap/MapItems/PolygonEditor.qml" line="178"/>
+        <source>Click to add point %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/MapItems/PolygonEditor.qml" line="178"/>
+        <source>- Right Click to end polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/MapItems/PolygonEditor.qml" line="185"/>
+        <source>Click to add point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/MapItems/PolygonEditor.qml" line="192"/>
+        <source>Click to add point - Right Click to end polygon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/MapItems/PolygonEditor.qml" line="198"/>
+        <source>Adjust polygon by dragging corners</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PowerComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="93"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="94"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="95"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="97"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="98"/>
+        <source>ESC Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="93"/>
+        <source>%1 cannot perform ESC Calibration with this version of firmware. You will need to upgrade to a newer firmware.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="94"/>
+        <source>%1 cannot perform ESC Calibration with this version of firmware. You will need to upgrade %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="95"/>
+        <source>Performing calibration. This will take a few seconds..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="96"/>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="99"/>
+        <source>ESC Calibration failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="97"/>
+        <source>Calibration complete. You can disconnect your battery now if you like.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="98"/>
+        <source>WARNING: Props must be removed from vehicle prior to performing ESC calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="98"/>
+        <source> Connect the battery now and calibration will begin.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="99"/>
+        <source>You must disconnect the battery prior to performing ESC Calibration. Disconnect your battery and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="220"/>
+        <source>Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="228"/>
+        <source>Number of Cells (in Series)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="255"/>
+        <source>Full Voltage (per cell)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="266"/>
+        <source>Battery Max:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="275"/>
+        <source>Empty Voltage (per cell)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="286"/>
+        <source>Battery Min:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="294"/>
+        <source>Voltage divider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="305"/>
+        <source>Calculate Voltage Divider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="322"/>
+        <source>Amps per volt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="333"/>
+        <source>Calculate Amps per Volt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="353"/>
+        <source>ESC PWM Minimum and Maximum Calibration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="363"/>
+        <source>WARNING: Propellers must be removed from vehicle prior to performing ESC calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="368"/>
+        <source>You must use USB connection for this operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="372"/>
+        <source>Calibrate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="381"/>
+        <source>Show UAVCAN Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="388"/>
+        <source>UAVCAN Bus Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="404"/>
+        <source>Change required restart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="412"/>
+        <source>UAVCAN Motor Index and Direction Assignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="423"/>
+        <source>WARNING: Propellers must be removed from vehicle prior to performing UAVCAN ESC configuration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="429"/>
+        <source>ESC parameters will only be accessible in the editor after assignment.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="435"/>
+        <source>Start the process, then turn each motor into its turn direction, in the order of their motor indices.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="440"/>
+        <source>Start Assignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="446"/>
+        <source>Stop Assignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="455"/>
+        <source>Show Advanced Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="461"/>
+        <source>Advanced Power Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="473"/>
+        <source>Voltage Drop on Full Load (per cell)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="487"/>
+        <source>Batteries show less voltage at high throttle. Enter the difference in Volts between idle throttle and full </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="488"/>
+        <source>throttle, divided by the number of battery cells. Leave at the default if unsure. </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="489"/>
+        <source>If this value is set too high, the battery might be deep discharged and damaged.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="497"/>
+        <source>Compensated Minimum Voltage:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.qml" line="501"/>
+        <source> V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.cc" line="20"/>
+        <source>Power</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponent.cc" line="31"/>
+        <source>Power Setup is used to setup battery parameters as well as advanced settings for propellers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PowerComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponentSummary.qml" line="39"/>
+        <source>Battery Full:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponentSummary.qml" line="44"/>
+        <source>Battery Empty:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/PowerComponentSummary.qml" line="49"/>
+        <source>Number of Cells:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCApplication</name>
+    <message>
+        <location filename="../src/QGCApplication.cc" line="195"/>
+        <source>You are running %1 as root. You should not do this since it will cause other issues with %1. %1 will now exit. If you are having serial port issues on Ubuntu, execute the following commands to fix most issues:
+sudo usermod -a -G dialout $USER
+sudo apt-get remove modemmanager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QGCApplication.cc" line="527"/>
+        <location filename="../src/QGCApplication.cc" line="542"/>
+        <source>Telemetry save error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QGCApplication.cc" line="527"/>
+        <source>Unable to save telemetry log. Error copying telemetry to &apos;%1&apos;: &apos;%2&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QGCApplication.cc" line="546"/>
+        <source>Unable to save telemetry log. Application save directory is not set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QGCApplication.cc" line="557"/>
+        <source>Unable to save telemetry log. Telemetry save directory &quot;%1&quot; does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCCorePlugin</name>
+    <message>
+        <location filename="../src/api/QGCCorePlugin.cc" line="103"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/api/QGCCorePlugin.cc" line="107"/>
+        <source>Comm Links</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/api/QGCCorePlugin.cc" line="111"/>
+        <source>Offline Maps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/api/QGCCorePlugin.cc" line="115"/>
+        <source>MAVLink</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/api/QGCCorePlugin.cc" line="119"/>
+        <source>Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/api/QGCCorePlugin.cc" line="124"/>
+        <source>Mock Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/api/QGCCorePlugin.cc" line="127"/>
+        <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/api/QGCCorePlugin.cc" line="196"/>
+        <source>WARNING: You are about to enter Advanced Mode. If used incorrectly, this may cause your vehicle to malfunction thus voiding your warranty. You should do so only if instructed by customer support. Are you sure you want to enable Advanced Mode?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCFileDialog</name>
+    <message>
+        <location filename="../src/QmlControls/QGCFileDialog.qml" line="126"/>
+        <source>No files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCFileDialog.qml" line="167"/>
+        <source>New file name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCFileDialog.qml" line="180"/>
+        <source>File names must end with .%1 file extension. If missing it will be added.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCFileDialog.qml" line="188"/>
+        <source>The file %1 exists. Click Save again to replace it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCFileDialog.qml" line="196"/>
+        <source>Save to existing file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCFlightGearLink</name>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="61"/>
+        <source>FlightGear 3.0+ Link (port:%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="150"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="892"/>
+        <source>FlightGear Failed to Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="153"/>
+        <source>FlightGear Crashed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="153"/>
+        <source>This is a FlightGear-related problem. Please upgrade FlightGear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="156"/>
+        <source>FlightGear Start Timed Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="156"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="159"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="162"/>
+        <source>Please check if the path and command is correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="159"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="162"/>
+        <source>Could not Communicate with FlightGear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="166"/>
+        <source>FlightGear Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="166"/>
+        <source>Please check if the path and command is correct.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="291"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="535"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="625"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="786"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="814"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="824"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="838"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="845"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="853"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="870"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="882"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="884"/>
+        <source>FlightGear HIL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="292"/>
+        <source>Flight Gear protocol file &apos;%1&apos; is out of date. Quit %2. Delete the file and restart %2 to fix.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="535"/>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="625"/>
+        <source>FlightGear failed to start. There are mismatched quotes in specified command line options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="736"/>
+        <source>FlightGear application not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="737"/>
+        <source>FlightGear application not found at: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="741"/>
+        <source>I&apos;ll specify directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="747"/>
+        <source>Please select directory of FlightGear application : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="782"/>
+        <source>--fg-root directory specified from ui option not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="784"/>
+        <source>Unable to automatically determine --fg-root directory location. You will need to specify --fg-root=&lt;directory&gt; as an additional command line parameter from ui.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="810"/>
+        <source>--fg-scenery directory specified from ui option not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="812"/>
+        <source>Unable to automatically determine --fg-scenery directory location. You will need to specify --fg-scenery=directory as an additional command line parameter from ui.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="824"/>
+        <source>Incorrect %1 installation. Aircraft directory is missing: &apos;%2&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="838"/>
+        <source>Incorrect FlightGear setup. Protocol directory is missing: &apos;%1&apos;. Command line parameter for --fg-root may be set incorrectly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="845"/>
+        <source>Incorrect installation. Protocol directory is missing (%1).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="853"/>
+        <source>Incorrect installation. FlightGear protocol file missing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="870"/>
+        <source>Unable to verify that protocol file %1 is current. If file is out of date, you may experience problems. Safest approach is to delete the file manually and allow %2 install the latest file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="882"/>
+        <source>FlightGear protocol file %1 is out of date. It will be deleted, which will cause %2 to install the latest version of the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="884"/>
+        <source>Delete of protocol file failed. You will have to manually delete the file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="893"/>
+        <source>FlightGear Failed to Start. %1 protocol (%2) not installed to FlightGear Protocol directory (%3)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="897"/>
+        <source>Fix it for me</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="913"/>
+        <source>Copy failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="915"/>
+        <source>Copy from (%1) to (%2) failed, possibly due to permissions issue. You will need to perform manually. Try pasting the following command into a Command Prompt which was started with Run as Administrator:
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="917"/>
+        <source>Copy from (%1) to (%2) failed, possibly due to permissions issue. You will need to perform manually. Try pasting the following command into a shell:
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCFlightGearLink.cc" line="922"/>
+        <source>Copy to Clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCHilConfiguration</name>
+    <message>
+        <location filename="../src/ui/QGCHilConfiguration.ui" line="20"/>
+        <source>HIL Config</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilConfiguration.ui" line="26"/>
+        <source>Simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilConfiguration.ui" line="42"/>
+        <source>FlightGear 3.0+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilConfiguration.ui" line="47"/>
+        <source>X-Plane 10</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilConfiguration.ui" line="52"/>
+        <source>X-Plane 9</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCHilFlightGearConfiguration</name>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.ui" line="51"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Additional Options:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.ui" line="58"/>
+        <source>Airframe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.ui" line="84"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.ui" line="91"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.ui" line="98"/>
+        <source>Sensor HIL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.ui" line="108"/>
+        <source>Barometer Offset [kPa]:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.ui" line="115"/>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilFlightGearConfiguration.cc" line="24"/>
+        <source>Reset to default options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCHilJSBSimConfiguration</name>
+    <message>
+        <location filename="../src/ui/QGCHilJSBSimConfiguration.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilJSBSimConfiguration.ui" line="38"/>
+        <source>Airframe:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilJSBSimConfiguration.ui" line="58"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Additional Options:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilJSBSimConfiguration.ui" line="71"/>
+        <source>--in-air --roll=0 --pitch=0 --vc=90 --heading=300 --timeofday=noon --disable-hud-3d --disable-fullscreen --geometry=400x300 --disable-anti-alias-hud --wind=0@0 --turbulence=0.0 --prop:/sim/frame-rate-throttle-hz=30 --control=mouse --disable-intro-music --disable-sound --disable-random-objects --disable-ai-models --shading-flat --fog-disable --disable-specular-highlight --disable-random-objects --disable-panel --disable-clouds --fdm=jsb --units-meters --prop:/engines/engine/running=true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilJSBSimConfiguration.ui" line="84"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilJSBSimConfiguration.ui" line="91"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCHilXPlaneConfiguration</name>
+    <message>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.ui" line="32"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.ui" line="39"/>
+        <source>Host</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.ui" line="59"/>
+        <source>Enable sensor level HIL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.ui" line="70"/>
+        <source>127.0.0.1:49000</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.ui" line="84"/>
+        <source>Use newer actuator format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.cc" line="24"/>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.cc" line="75"/>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCHilXPlaneConfiguration.cc" line="70"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCJSBSimLink</name>
+    <message>
+        <location filename="../src/comm/QGCJSBSimLink.cc" line="45"/>
+        <source>JSBSim Link (port:%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCJSBSimLink.cc" line="109"/>
+        <source>JSBSim failed to start. JSBSim was not found at %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCJSBSimLink.cc" line="116"/>
+        <source>JSBSim failed to start. JSBSim data directory was not found at %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCJSBSimLink.cc" line="158"/>
+        <source>JSBSim Failed to start. Please check if the path and command is correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCJSBSimLink.cc" line="162"/>
+        <source>JSBSim crashed. This is a JSBSim-related problem, check for JSBSim upgrade.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCJSBSimLink.cc" line="166"/>
+        <source>JSBSim start timed out. Please check if the path and command is correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCJSBSimLink.cc" line="171"/>
+        <source>Could not communicate with JSBSim. Please check if the path and command are correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCJSBSimLink.cc" line="176"/>
+        <source>JSBSim error occurred. Please check if the path and command is correct.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCLogEntry</name>
+    <message>
+        <location filename="../src/AnalyzeView/LogDownloadController.cc" line="98"/>
+        <source>Pending</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCMAVLinkInspector</name>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkInspector.ui" line="14"/>
+        <source>MAVLink Inspector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkInspector.ui" line="38"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkInspector.ui" line="51"/>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkInspector.ui" line="58"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkInspector.cc" line="25"/>
+        <location filename="../src/ui/QGCMAVLinkInspector.cc" line="26"/>
+        <location filename="../src/ui/QGCMAVLinkInspector.cc" line="78"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkInspector.cc" line="30"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkInspector.cc" line="31"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkInspector.cc" line="32"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCMAVLinkLogPlayer</name>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="39"/>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="42"/>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="45"/>
+        <source>Start to replay Flight Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="48"/>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="65"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="88"/>
+        <source>No Flight Data selected..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="95"/>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="98"/>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="101"/>
+        <source>Select the Flight Data to replay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.ui" line="104"/>
+        <source>Replay Flight Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.cc" line="70"/>
+        <source>Log Replay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.cc" line="70"/>
+        <source>You must close all connections prior to replaying a log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.cc" line="76"/>
+        <source>Load Telemetry Log File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMAVLinkLogPlayer.cc" line="78"/>
+        <source>MAVLink Log Files (*.tlog);;All Files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCMapRCToParamDialog</name>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="14"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="25"/>
+        <source>Bind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="32"/>
+        <source>Parameter Tuning ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="42"/>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="46"/>
+        <source>1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="51"/>
+        <source>2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="56"/>
+        <source>3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="64"/>
+        <source>Parameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="71"/>
+        <source>TextLabel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="78"/>
+        <source>with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="85"/>
+        <source>Scale (keep default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="99"/>
+        <source>Center value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="122"/>
+        <source>Minimum Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="142"/>
+        <source>Maximum Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="168"/>
+        <source>Waiting for parameter refresh,,,</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCMapRCToParamDialog.ui" line="188"/>
+        <source>Tuning IDs can be mapped to channels in the RC settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCPluginHost</name>
+    <message>
+        <location filename="../src/ui/QGCPluginHost.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCPluginHost.ui" line="49"/>
+        <source>Loaded Plugins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCPluginHost.ui" line="62"/>
+        <source>Plugin Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCQFileDialog</name>
+    <message>
+        <location filename="../src/QGCQFileDialog.cc" line="141"/>
+        <source>File Exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QGCQFileDialog.cc" line="142"/>
+        <source>%1 already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QGCQFileDialog.cc" line="146"/>
+        <source>Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCQmlWidgetHolder</name>
+    <message>
+        <location filename="../src/QGCQmlWidgetHolder.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCTabbedInfoView</name>
+    <message>
+        <location filename="../src/ui/QGCTabbedInfoView.ui" line="14"/>
+        <source>Info View</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCUASFileView</name>
+    <message>
+        <location filename="../src/ui/QGCUASFileView.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCUASFileView.ui" line="20"/>
+        <source>List Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCUASFileView.ui" line="55"/>
+        <source>Download File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCUASFileView.ui" line="78"/>
+        <source>Upload File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCUASFileViewMulti</name>
+    <message>
+        <location filename="../src/ui/QGCUASFileViewMulti.ui" line="14"/>
+        <source>Onboard Files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCUnconnectedInfoWidget</name>
+    <message>
+        <location filename="../src/ui/uas/QGCUnconnectedInfoWidget.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCView</name>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="43"/>
+        <source>Ok</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="46"/>
+        <location filename="../src/QmlControls/QGCView.qml" line="55"/>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="49"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="52"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="58"/>
+        <source>Save All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="61"/>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="64"/>
+        <source>Yes to All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="67"/>
+        <source>Retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="70"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="73"/>
+        <source>Restore to Defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="76"/>
+        <source>Ignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="82"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="85"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="88"/>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="91"/>
+        <source>No to All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="94"/>
+        <source>Abort</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QGCView.qml" line="101"/>
+        <source>showDialog called before QGCView.completed signalled</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCWebView</name>
+    <message>
+        <location filename="../src/ui/QGCWebView.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QGCWebView.ui" line="21"/>
+        <source>about:blank</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGCXPlaneLink</name>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="64"/>
+        <source>X-Plane Link (localPort:%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="187"/>
+        <source>Waiting for XPlane..</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="282"/>
+        <source>X-Plane Failed to start. Please check if the path and command is correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="286"/>
+        <source>X-Plane crashed. This is an X-Plane-related problem, check for X-Plane upgrade.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="290"/>
+        <source>X-Plane start timed out. Please check if the path and command is correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="295"/>
+        <source>Could not communicate with X-Plane. Please check if the path and command are correct</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="300"/>
+        <source>X-Plane error occurred. Please check if the path and command is correct.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="305"/>
+        <source>X-Plane HIL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="850"/>
+        <source>Receiving from XPlane at %1 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCXPlaneLink.cc" line="919"/>
+        <source>Receiving from XPlane.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QMap3D</name>
+    <message>
+        <location filename="../src/ui/QMap3D.ui" line="14"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QMap3D.ui" line="20"/>
+        <source>Map</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/QMap3D.ui" line="30"/>
+        <source>Vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/comm/QGCSerialPortInfo.cc" line="229"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCSerialPortInfo.cc" line="233"/>
+        <source>Pixhawk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCSerialPortInfo.cc" line="235"/>
+        <source>SiK Radio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCSerialPortInfo.cc" line="237"/>
+        <source>PX4 Flow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCSerialPortInfo.cc" line="239"/>
+        <source>OpenPilot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/QGCSerialPortInfo.cc" line="241"/>
+        <source>RTK GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="41"/>
+        <source>The following required keys are missing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="54"/>
+        <source>value for coordinate is not array</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="61"/>
+        <source>Coordinate array must contain %1 values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="67"/>
+        <source>Coordinate array may only contain double values, found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="78"/>
+        <source>Coordinate is invalid: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="110"/>
+        <source>Incorrect value type - key:type:expected %1:%2:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="125"/>
+        <source>enum strings/values count mismatch strings:values %1:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="168"/>
+        <source>Incorrect file type key expected:%1 actual:%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="179"/>
+        <source>Incorrect type for version value, must be integer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="185"/>
+        <source>File version %1 is no longer supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="189"/>
+        <source>File version %1 is newer than current supported version %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="211"/>
+        <source>value for coordinate array is not array</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/JsonHelper.cc" line="320"/>
+        <source>Unknown type: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QmlTest</name>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="93"/>
+        <source>Window Color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="104"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="110"/>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="148"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="885"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="155"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="878"/>
+        <source>Enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="162"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="169"/>
+        <source>Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="896"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="901"/>
+        <source>Label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="913"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="918"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="931"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="936"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="961"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="967"/>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="949"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1031"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1036"/>
+        <source>Item 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="952"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1031"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1036"/>
+        <source>Item 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="955"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1031"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1036"/>
+        <source>Item 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="980"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="985"/>
+        <source>Radio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="997"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1002"/>
+        <source>Check Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1048"/>
+        <location filename="../src/QmlControls/QmlTest.qml" line="1053"/>
+        <source>SUB MENU</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RCRSSIIndicator</name>
+    <message>
+        <location filename="../src/ui/toolbar/RCRSSIIndicator.qml" line="50"/>
+        <source>RC RSSI Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/RCRSSIIndicator.qml" line="50"/>
+        <source>RC RSSI Data Unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/RCRSSIIndicator.qml" line="50"/>
+        <source>N/A</source>
+        <comment>No data available</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/RCRSSIIndicator.qml" line="63"/>
+        <source>RSSI:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RadioComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="34"/>
+        <source>Radio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="72"/>
+        <source>Reboot required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="72"/>
+        <source>Your stick mappings have changed, you must reboot the vehicle for correct operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="73"/>
+        <source>Throttle channel reversed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="73"/>
+        <source>Calibration failed. The throttle channel on your transmitter is reversed. You must correct this on your transmitter in order to complete calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="80"/>
+        <source>Center your sticks and move throttle all the way down, then press Ok to copy trims. After pressing Ok, reset the trims on your radio back to zero.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="93"/>
+        <source>Before calibrating you should zero all your trims and subtrims. Click Ok to start Calibration.
+
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="94"/>
+        <source>Please ensure all motor power is disconnected AND all props are removed from the vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="107"/>
+        <source>Please turn on transmitter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="107"/>
+        <source>%1 channels or more are needed to fly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="132"/>
+        <source>Click Ok to place your Spektrum receiver in the bind mode. Select the specific receiver type below:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="139"/>
+        <source>DSM2 Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="146"/>
+        <source>DSMX (7 channels or less)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="154"/>
+        <source>DSMX (8 channels or more)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="210"/>
+        <source>Not Mapped</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="236"/>
+        <source>Attitude Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="244"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="274"/>
+        <source>Pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="304"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="334"/>
+        <source>Throttle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="364"/>
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="371"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="379"/>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="382"/>
+        <source>Calibrate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="410"/>
+        <source>Additional Radio setup:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="414"/>
+        <source>Spektrum Bind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="420"/>
+        <source>Copy Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="472"/>
+        <source>Mode 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/RadioComponent.qml" line="480"/>
+        <source>Mode 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RallyPointController</name>
+    <message>
+        <location filename="../src/MissionManager/RallyPointController.cc" line="83"/>
+        <source>Rally: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RallyPointEditorHeader</name>
+    <message>
+        <location filename="../src/PlanView/RallyPointEditorHeader.qml" line="30"/>
+        <source>Rally Points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/RallyPointEditorHeader.qml" line="52"/>
+        <source>Rally Points provide alternate landing points when performing a Return to Launch (RTL).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/RallyPointEditorHeader.qml" line="63"/>
+        <source>Click in the map to add new rally points.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/RallyPointEditorHeader.qml" line="64"/>
+        <source>This vehicle does not support Rally Points.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RallyPointItemEditor</name>
+    <message>
+        <location filename="../src/PlanView/RallyPointItemEditor.qml" line="49"/>
+        <source>Rally Point</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/RallyPointItemEditor.qml" line="71"/>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RallyPointMapVisuals</name>
+    <message>
+        <location filename="../src/PlanView/RallyPointMapVisuals.qml" line="69"/>
+        <source>R</source>
+        <comment>rally point map item label</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SafetyComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="109"/>
+        <source>Low Battery Failsafe Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="132"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="186"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="231"/>
+        <source>Failsafe Action:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="142"/>
+        <source>Battery Warn Level:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="151"/>
+        <source>Battery Failsafe Level:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="163"/>
+        <source>RC Loss Failsafe Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="196"/>
+        <source>RC Loss Timeout:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="208"/>
+        <source>Data Link Loss Failsafe Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="241"/>
+        <source>Data Link Loss Timeout:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="253"/>
+        <source>Geofence Failsafe Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="276"/>
+        <source>Action on breach:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="287"/>
+        <source>Max radius:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="300"/>
+        <source>Max altitude:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="315"/>
+        <source>Return Home Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="339"/>
+        <source>Climb to altitude of:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="348"/>
+        <source>Return home, then:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="358"/>
+        <source>Land immediately</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="369"/>
+        <source>Loiter and do not land</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="380"/>
+        <source>Loiter and land after specified time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="386"/>
+        <source>Loiter Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="396"/>
+        <source>Loiter Altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="409"/>
+        <source>Land Mode Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="434"/>
+        <source>Landing Descent Rate:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.qml" line="446"/>
+        <source>Disarm After:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.cc" line="19"/>
+        <source>Safety</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponent.cc" line="30"/>
+        <source>Safety Setup is used to setup triggers for Return to Land as well as the settings for Return to Land itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SafetyComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml" line="29"/>
+        <source>RTL min alt:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml" line="34"/>
+        <source>RTL home alt:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml" line="39"/>
+        <source>RC loss RTL:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml" line="44"/>
+        <source>RC loss action:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml" line="49"/>
+        <source>Link loss action:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml" line="54"/>
+        <source>Low battery action:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SensorsComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="37"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="38"/>
+        <source>If the orientation is in the direction of flight, select ROTATION_NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="40"/>
+        <source>For Compass calibration you will need to rotate your vehicle through a number of positions. Click Ok to start calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="41"/>
+        <source>For Gyroscope calibration you will need to place your vehicle on a surface and leave it still. Click Ok to start calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="42"/>
+        <source>For Accelerometer calibration you will need to place your vehicle on all six sides on a perfectly level surface and hold it still in each orientation for a few seconds. Click Ok to start calibration.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="43"/>
+        <source>To level the horizon you need to place the vehicle in its level flight position and press OK.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="44"/>
+        <source>For Airspeed calibration you will need to keep your airspeed sensor out of any wind and then blow across the sensor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="46"/>
+        <source>Start the individual calibration steps by clicking one of the buttons to the left.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="131"/>
+        <source>Set Compass Rotation(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="137"/>
+        <source>Calibration Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="137"/>
+        <source>Waiting for Vehicle to response to Cancel. This may take a few seconds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="198"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="244"/>
+        <source>Autopilot Orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="261"/>
+        <source>External Compass Orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="286"/>
+        <source>External Compass 1 Orientation:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="313"/>
+        <source>Compass 2 Orientation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="344"/>
+        <source>Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="351"/>
+        <source>Calibrate Compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="358"/>
+        <source>Gyroscope</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="365"/>
+        <source>Calibrate Gyro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="372"/>
+        <source>Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="379"/>
+        <source>Calibrate Accelerometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="386"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="394"/>
+        <source>Level Horizon</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="401"/>
+        <source>Airspeed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="408"/>
+        <source>Calibrate Airspeed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="415"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="423"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="428"/>
+        <source>Set Orientations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="502"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="511"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="520"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="529"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="538"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="547"/>
+        <source>Rotate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="502"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="511"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="520"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="529"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="538"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.qml" line="547"/>
+        <source>Hold Still</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.cc" line="24"/>
+        <source>Sensors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponent.cc" line="36"/>
+        <source>Sensors Setup is used to calibrate the sensors within your vehicle.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SensorsComponentSummary</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="32"/>
+        <source>Compass 0:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="33"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="50"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="55"/>
+        <source>Setup required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="33"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="39"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="45"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="50"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="55"/>
+        <source>Ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="37"/>
+        <source>Compass 1:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="43"/>
+        <source>Compass 2:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="49"/>
+        <source>Gyro:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml" line="54"/>
+        <source>Accelerometer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SensorsComponentSummaryFixedWing</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="30"/>
+        <source>Compass:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="31"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="36"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="41"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="46"/>
+        <source>Setup required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="31"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="36"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="41"/>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="46"/>
+        <source>Ready</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="35"/>
+        <source>Gyro:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="40"/>
+        <source>Accelerometer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml" line="45"/>
+        <source>Airspeed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SerialLink</name>
+    <message>
+        <location filename="../src/comm/SerialLink.cc" line="95"/>
+        <source>Could not send data - link %1 is disconnected!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/SerialLink.cc" line="352"/>
+        <source>Link Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SerialSettings</name>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="35"/>
+        <source>Serial Link Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="49"/>
+        <source>Serial Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="54"/>
+        <source>No serial ports available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="75"/>
+        <source>Serial Port not present</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="88"/>
+        <source>Baud Rate:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="109"/>
+        <source>Baud rate name not in combo box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="124"/>
+        <source>Show Advanced Serial Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="132"/>
+        <source>Enable Flow Control</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="146"/>
+        <source>Parity:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="153"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="153"/>
+        <source>Even</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="153"/>
+        <source>Odd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/SerialSettings.qml" line="213"/>
+        <source>Stop Bits:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SetupPage</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/SetupPage.qml" line="54"/>
+        <source>Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SetupView</name>
+    <message>
+        <location filename="../src/VehicleSetup/SetupView.qml" line="35"/>
+        <source>This operation cannot be performed while vehicle is armed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/SetupView.qml" line="165"/>
+        <source>Connect vehicle to your device and %1 will automatically detect it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/SetupView.qml" line="228"/>
+        <source>Vehicle Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SimpleItemEditor</name>
+    <message>
+        <location filename="../src/PlanView/SimpleItemEditor.qml" line="33"/>
+        <source>Provides advanced access to all commands/parameters. Be very careful!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SimpleItemEditor.qml" line="92"/>
+        <source>Flight Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SimpleMissionItem</name>
+    <message>
+        <location filename="../src/MissionManager/SimpleMissionItem.cc" line="337"/>
+        <source>Unknown: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SurveyItemEditor</name>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="31"/>
+        <source>Manual Grid (no camera specs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="31"/>
+        <source>Custom Camera Grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="186"/>
+        <source>Camera</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="237"/>
+        <source>Trigger Distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="257"/>
+        <source>Hover and capture image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="306"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="310"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="318"/>
+        <source>Sensor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="333"/>
+        <source>Image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="349"/>
+        <source>Focal length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="367"/>
+        <source>Frontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="371"/>
+        <source>Side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="379"/>
+        <source>Overlap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="392"/>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="492"/>
+        <source>Grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="413"/>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="512"/>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="439"/>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="544"/>
+        <source>Turnaround dist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="446"/>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="548"/>
+        <source>Refly at 90 degree offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="454"/>
+        <source>Select one:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="461"/>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="544"/>
+        <source>Altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="475"/>
+        <source>Ground res</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="544"/>
+        <source>Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="555"/>
+        <source>Relative altitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="562"/>
+        <source>Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="569"/>
+        <source>Survey area</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="572"/>
+        <source>Photo count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="575"/>
+        <source>Photo interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="580"/>
+        <source>N/A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/PlanView/SurveyItemEditor.qml" line="582"/>
+        <source>secs</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SurveyMissionItem</name>
+    <message>
+        <location filename="../src/MissionManager/SurveyMissionItem.cc" line="272"/>
+        <source>%1 does not support this version of survey items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/SurveyMissionItem.cc" line="303"/>
+        <source>%1 does not support loading this complex mission item type: %2:%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/MissionManager/SurveyMissionItem.cc" line="339"/>
+        <source>%1 but %2 object is missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SyslinkComponent</name>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/SyslinkComponent.qml" line="44"/>
+        <source>Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/SyslinkComponent.qml" line="62"/>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/SyslinkComponent.qml" line="87"/>
+        <source>Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/SyslinkComponent.qml" line="113"/>
+        <source>Data Rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/SyslinkComponent.cc" line="16"/>
+        <source>Syslink</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/AutoPilotPlugins/Common/SyslinkComponent.cc" line="28"/>
+        <source>The Syslink Component is used to setup the radio connection on Crazyflies.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TCPLink</name>
+    <message>
+        <location filename="../src/comm/TCPLink.cc" line="161"/>
+        <location filename="../src/comm/TCPLink.cc" line="175"/>
+        <source>Link Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TcpSettings</name>
+    <message>
+        <location filename="../src/ui/preferences/TcpSettings.qml" line="38"/>
+        <source>TCP Link Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/TcpSettings.qml" line="52"/>
+        <source>Host Address:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/TcpSettings.qml" line="66"/>
+        <source>TCP Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryRSSIIndicator</name>
+    <message>
+        <location filename="../src/ui/toolbar/TelemetryRSSIIndicator.qml" line="48"/>
+        <source>Telemetry RSSI Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/TelemetryRSSIIndicator.qml" line="58"/>
+        <source>Local RSSI:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/TelemetryRSSIIndicator.qml" line="60"/>
+        <source>Remote RSSI:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/TelemetryRSSIIndicator.qml" line="62"/>
+        <source>RX Errors:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/TelemetryRSSIIndicator.qml" line="64"/>
+        <source>Errors Fixed:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/TelemetryRSSIIndicator.qml" line="66"/>
+        <source>TX Buffer:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/TelemetryRSSIIndicator.qml" line="68"/>
+        <source>Local Noise:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/toolbar/TelemetryRSSIIndicator.qml" line="70"/>
+        <source>Remote Noise:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UAS</name>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="784"/>
+        <source>UNINIT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="785"/>
+        <source>Unitialized, booting up.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="788"/>
+        <source>BOOT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="789"/>
+        <source>Booting system, please wait.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="792"/>
+        <source>CALIBRATING</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="793"/>
+        <source>Calibrating sensors, please wait.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="796"/>
+        <source>ACTIVE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="797"/>
+        <source>Active, normal operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="800"/>
+        <source>STANDBY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="801"/>
+        <source>Standby mode, ready for launch.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="804"/>
+        <source>CRITICAL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="805"/>
+        <source>FAILURE: Continuing operation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="808"/>
+        <source>EMERGENCY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="809"/>
+        <source>EMERGENCY: Land Immediately!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="817"/>
+        <source>SHUTDOWN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="818"/>
+        <source>Powering off system.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="822"/>
+        <source>UNKNOWN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UAS.cc" line="823"/>
+        <source>Unknown system state</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UASMessageHandler</name>
+    <message>
+        <location filename="../src/uas/UASMessageHandler.cc" line="156"/>
+        <source> EMERGENCY:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UASMessageHandler.cc" line="159"/>
+        <source> ALERT:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UASMessageHandler.cc" line="162"/>
+        <source> Critical:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UASMessageHandler.cc" line="165"/>
+        <source> Error:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UASMessageHandler.cc" line="168"/>
+        <source> Warning:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UASMessageHandler.cc" line="171"/>
+        <source> Notice:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UASMessageHandler.cc" line="174"/>
+        <source> Info:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/uas/UASMessageHandler.cc" line="177"/>
+        <source> Debug:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UASMessageView</name>
+    <message>
+        <location filename="../src/ui/uas/UASMessageView.ui" line="23"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UASMessageViewWidget</name>
+    <message>
+        <location filename="../src/ui/uas/UASMessageView.cc" line="49"/>
+        <source>Clear Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UASQuickViewItemSelect</name>
+    <message>
+        <location filename="../src/ui/uas/UASQuickViewItemSelect.ui" line="14"/>
+        <source>Select Item</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UDPLink</name>
+    <message>
+        <location filename="../src/comm/UDPLink.cc" line="263"/>
+        <source>UDP Link Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/comm/UDPLink.cc" line="263"/>
+        <source>Error binding UDP port: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UdpSettings</name>
+    <message>
+        <location filename="../src/ui/preferences/UdpSettings.qml" line="44"/>
+        <source>UDP Link Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/UdpSettings.qml" line="58"/>
+        <source>Listening Port:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/UdpSettings.qml" line="81"/>
+        <source>Target Hosts:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/UdpSettings.qml" line="155"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/preferences/UdpSettings.qml" line="168"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ValuesWidget</name>
+    <message>
+        <location filename="../src/FlightMap/Widgets/ValuesWidget.qml" line="44"/>
+        <source>Value Widget Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/ValuesWidget.qml" line="158"/>
+        <source>Show large compass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/ValuesWidget.qml" line="175"/>
+        <source>Select the values you want to display:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/ValuesWidget.qml" line="206"/>
+        <source>Vehicle must be connected to assign values.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/ValuesWidget.qml" line="267"/>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Vehicle</name>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="417"/>
+        <source>MAVLink Generic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="424"/>
+        <source>Fixed Wing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="426"/>
+        <source>Multi-Rotor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="428"/>
+        <source>VTOL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="430"/>
+        <source>Rover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="432"/>
+        <source>Sub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="434"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="787"/>
+        <source>%1 command temporarily rejected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="790"/>
+        <source>%1 command denied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="793"/>
+        <source>%1 command not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="796"/>
+        <source>%1 command failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1755"/>
+        <source>AutoLoad%1.%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1961"/>
+        <source>Generic micro air vehicle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1962"/>
+        <source>Fixed wing aircraft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1963"/>
+        <source>Quadrotor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1964"/>
+        <source>Coaxial helicopter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1965"/>
+        <source>Normal helicopter with tail rotor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1966"/>
+        <source>Ground installation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1967"/>
+        <source>Operator control unit / ground control station</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1968"/>
+        <source>Airship, controlled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1969"/>
+        <source>Free balloon, uncontrolled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1970"/>
+        <source>Rocket</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1971"/>
+        <source>Ground rover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1972"/>
+        <source>Surface vessel, boat, ship</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1973"/>
+        <source>Submarine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1974"/>
+        <source>Hexarotor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1975"/>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1976"/>
+        <source>Octorotor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1977"/>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1978"/>
+        <source>Flapping wing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1979"/>
+        <source>Onboard companion controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1980"/>
+        <source>Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1981"/>
+        <source>Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1982"/>
+        <source>Tiltrotor VTOL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1983"/>
+        <source>VTOL reserved 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1984"/>
+        <source>VTOL reserved 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1985"/>
+        <source>VTOL reserved 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1986"/>
+        <source>VTOL reserved 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1987"/>
+        <source>Onboard gimbal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="1988"/>
+        <source>Onboard ADSB peripheral</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/Vehicle/Vehicle.cc" line="2207"/>
+        <source>Vehicle did not respond to command: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VehicleHealthWidget</name>
+    <message>
+        <location filename="../src/FlightMap/Widgets/VehicleHealthWidget.qml" line="50"/>
+        <source>Vehicle Health</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/VehicleHealthWidget.qml" line="57"/>
+        <source>All systems healthy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VehicleRotationCal</name>
+    <message>
+        <location filename="../src/QmlControls/VehicleRotationCal.qml" line="26"/>
+        <source>Hold Still</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/VehicleRotationCal.qml" line="58"/>
+        <source>Completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/QmlControls/VehicleRotationCal.qml" line="58"/>
+        <source>Incomplete</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VehicleSummary</name>
+    <message>
+        <location filename="../src/VehicleSetup/VehicleSummary.qml" line="87"/>
+        <source>Below you will find a summary of the settings for your vehicle. To the left are the setup menus for each component.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/VehicleSetup/VehicleSummary.qml" line="88"/>
+        <source>WARNING: Your vehicle requires setup prior to flight. Please resolve the items marked in red using the menu on the left.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VibrationWidget</name>
+    <message>
+        <location filename="../src/FlightMap/Widgets/VibrationWidget.qml" line="55"/>
+        <source>Vibe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/VibrationWidget.qml" line="136"/>
+        <source>Clip count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/VibrationWidget.qml" line="146"/>
+        <source>Accel 1: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/VibrationWidget.qml" line="151"/>
+        <location filename="../src/FlightMap/Widgets/VibrationWidget.qml" line="156"/>
+        <source>Accel 2: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/FlightMap/Widgets/VibrationWidget.qml" line="170"/>
+        <source>Not Available</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ViewWidget</name>
+    <message>
+        <location filename="../src/ViewWidgets/ViewWidget.qml" line="59"/>
+        <source>missing connected implementation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ViewWidgets/ViewWidget.qml" line="79"/>
+        <source>no vehicle connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>linechart</name>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="26"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="130"/>
+        <source>Filter... (Ctrl+F)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="138"/>
+        <source>All MAVs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="156"/>
+        <source>Display only variable names in curve list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="159"/>
+        <source>Short names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="166"/>
+        <location filename="../src/ui/Linechart.ui" line="169"/>
+        <source>Display variable units in curve list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="172"/>
+        <source>Show units</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="208"/>
+        <source>Rotate color scheme for all curves</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/ui/Linechart.ui" line="211"/>
+        <source>Recolor</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/src/AnalyzeView/GeoTagController.cc
+++ b/src/AnalyzeView/GeoTagController.cc
@@ -38,7 +38,7 @@ GeoTagController::~GeoTagController()
 
 void GeoTagController::pickLogFile(void)
 {
-    QString filename = QGCQFileDialog::getOpenFileName(MainWindow::instance(), "Select log file load", QString(), "ULog file (*.ulg);;PX4 log file (*.px4log);;All Files (*.*)");
+    QString filename = QGCQFileDialog::getOpenFileName(MainWindow::instance(), tr("Select log file load"), QString(), tr("ULog file (*.ulg);;PX4 log file (*.px4log);;All Files (*.*)"));
     if (!filename.isEmpty()) {
         _worker.setLogFile(filename);
         emit logFileChanged(filename);
@@ -47,7 +47,7 @@ void GeoTagController::pickLogFile(void)
 
 void GeoTagController::pickImageDirectory(void)
 {
-    QString dir = QGCQFileDialog::getExistingDirectory(MainWindow::instance(), "Select image directory");
+    QString dir = QGCQFileDialog::getExistingDirectory(MainWindow::instance(), tr("Select image directory"));
     if (!dir.isEmpty()) {
         _worker.setImageDirectory(dir);
         emit imageDirectoryChanged(dir);
@@ -56,7 +56,7 @@ void GeoTagController::pickImageDirectory(void)
 
 void GeoTagController::pickSaveDirectory(void)
 {
-    QString dir = QGCQFileDialog::getExistingDirectory(MainWindow::instance(), "Select save directory");
+    QString dir = QGCQFileDialog::getExistingDirectory(MainWindow::instance(), tr("Select save directory"));
     if (!dir.isEmpty()) {
         _worker.setSaveDirectory(dir);
         emit saveDirectoryChanged(dir);

--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -95,7 +95,7 @@ QGCLogEntry::QGCLogEntry(uint logId, const QDateTime& dateTime, uint logSize, bo
     , _received(received)
     , _selected(false)
 {
-    _status = "Pending";
+    _status = tr("Pending");
 }
 
 //----------------------------------------------------------------------------------------
@@ -180,7 +180,7 @@ LogDownloadController::_logEntry(UASInterface* uas, uint32_t time_utc, uint32_t 
                 entry->setSize(size);
                 entry->setTime(QDateTime::fromTime_t(time_utc));
                 entry->setReceived(true);
-                entry->setStatus(QString("Available"));
+                entry->setStatus(QString(tr("Available")));
             } else {
                 qWarning() << "Received log entry for out-of-bound index:" << id;
             }
@@ -227,7 +227,7 @@ LogDownloadController::_resetSelection(bool canceled)
         if(entry) {
             if(entry->selected()) {
                 if(canceled) {
-                    entry->setStatus(QString("Canceled"));
+                    entry->setStatus(QString(tr("Canceled")));
                 }
                 entry->setSelected(false);
             }
@@ -274,7 +274,7 @@ LogDownloadController::_findMissingEntries()
             for(int i = 0; i < num_logs; i++) {
                 QGCLogEntry* entry = _logEntriesModel[i];
                 if(entry && !entry->received()) {
-                    entry->setStatus(QString("Error"));
+                    entry->setStatus(QString(tr("Error")));
                 }
             }
             //-- Give up
@@ -360,7 +360,7 @@ LogDownloadController::_logData(UASInterface* uas, uint32_t ofs, uint16_t id, ui
             _timer.start(timeout_time);
             //-- Do we have it all?
             if(_logComplete()) {
-                _downloadData->entry->setStatus(QString("Downloaded"));
+                _downloadData->entry->setStatus(QString(tr("Downloaded")));
                 //-- Check for more
                 _receivedAllData();
             } else if (_chunkComplete()) {
@@ -379,7 +379,7 @@ LogDownloadController::_logData(UASInterface* uas, uint32_t ofs, uint16_t id, ui
         qWarning() << "Received log offset greater than expected";
     }
     if(!result) {
-        _downloadData->entry->setStatus(QString("Error"));
+        _downloadData->entry->setStatus(QString(tr("Error")));
     }
 }
 
@@ -425,7 +425,7 @@ LogDownloadController::_findMissingData()
     }
 
     if(_retries++ > 2) {
-        _downloadData->entry->setStatus(QString("Timed Out"));
+        _downloadData->entry->setStatus(QString(tr("Timed Out")));
         //-- Give up
         qWarning() << "Too many errors retreiving log data. Giving up.";
         _receivedAllData();
@@ -516,7 +516,7 @@ LogDownloadController::download(QString path)
     if(dir.isEmpty()) {
         dir = QGCQFileDialog::getExistingDirectory(
                 MainWindow::instance(),
-                "Log Download Directory",
+                tr("Log Download Directory"),
                 QDir::homePath(),
                 QGCQFileDialog::ShowDirsOnly | QGCQFileDialog::DontResolveSymlinks);
     }
@@ -543,7 +543,7 @@ void LogDownloadController::downloadToDirectory(const QString& dir)
             QGCLogEntry* entry = _logEntriesModel[i];
             if(entry) {
                 if(entry->selected()) {
-                   entry->setStatus(QString("Waiting"));
+                   entry->setStatus(QString(tr("Waiting")));
                 }
             }
         }
@@ -634,7 +634,7 @@ LogDownloadController::_prepareLogDownload()
         if (_downloadData->file.exists()) {
             _downloadData->file.remove();
         }
-        _downloadData->entry->setStatus(QString("Error"));
+        _downloadData->entry->setStatus(QString(tr("Error")));
         delete _downloadData;
         _downloadData = NULL;
     }
@@ -688,7 +688,7 @@ LogDownloadController::cancel(void)
         _receivedAllEntries();
     }
     if(_downloadData) {
-        _downloadData->entry->setStatus(QString("Canceled"));
+        _downloadData->entry->setStatus(QString(tr("Canceled")));
         if (_downloadData->file.exists()) {
             _downloadData->file.remove();
         }

--- a/src/AnalyzeView/ULogParser.cc
+++ b/src/AnalyzeView/ULogParser.cc
@@ -1,4 +1,4 @@
- #include "ULogParser.h"
+#include "ULogParser.h"
 #include <math.h>
 #include <QDateTime>
 

--- a/src/QGCQFileDialog.h
+++ b/src/QGCQFileDialog.h
@@ -15,6 +15,7 @@
 #error Should not be included in mobile builds
 #endif
 
+#include <QCoreApplication>
 #include <QFileDialog>
 
 /// @file
@@ -40,7 +41,7 @@
 */
 
 class QGCQFileDialog : public QFileDialog {
-    
+    Q_DECLARE_TR_FUNCTIONS(QGCQFileDialog)
 public:
 
     //! Static helper that will return an existing directory selected by the user.


### PR DESCRIPTION
This is an initial, token start of localizing QGC.

I've added a script that collects all the strings that are set to be localized and creates the localization source file to be sent to crowding for translation. This is just the beginning of the work. There is a great deal of work to be done before all strings used throughout QGC are ready for exporting by that script. 

Localization is a complex task. It's not just a matter of translating every instance of a string, but things need to be in context. In addition, strings that are built from parts or used for comparison, need special handling as well and this is the case in several places throughout the code.

For instance, take this [example](https://github.com/mavlink/qgroundcontrol/blob/master/src/AutoPilotPlugins/APM/APMPowerComponentController.cc#L106-L109):

```
if (text == "Connect battery now") {
      emit connectBattery();
      return;
}
```

Whatever __*Connect battery now*__ gets translated to, it has to match exactly whatever that source is otherwise the code above won't work. This should not be comparing a string but rather a constant that corresponds to the string.

String constants also don't work directly. There are various [instances](https://github.com/mavlink/qgroundcontrol/blob/master/src/AutoPilotPlugins/APM/APMCompassCal.cc#L385-L398) of them as well:

```
    static const char* rgOrientationStrs[] = {
        "back",		// tail down
        "front",	// nose down
        "left",
        "right",
        "up",		// upside-down
        "down",		// right-side up
        "error"
    };
```

Here is a starting point for what needs to be done:

http://doc.qt.io/qt-5/i18n-source-translation.html
http://doc.qt.io/qt-5/qtlinguist-index.html

In summary, this gets the ball rolling but there is a tremendous amount of work to be done before QGC can be properly localized. The code was not built with localization in mind and retroactively making it so will not be an easy task.

The localization source file included in this PR (qgc.ts) is ready to start. It can already be sent to crowdin as the `lupdate` tool is smart enough to append new strings added to the code. With that said, it would be best to minimize drastic changes to existing strings already set for translation.

The actual code that loads the *compiled*, translated files will come in a new PR after this one.