### PR TITLE
Offline map Tokens

### DIFF
--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -15,6 +15,9 @@
  *   @author Gus Grubba <mavlink@grubba.com>
  *
  */
+#include "QGCApplication.h"
+#include "AppSettings.h"
+#include "SettingsManager.h"
 
 #include <math.h>
 #include <QSettings>
@@ -88,8 +91,6 @@ stQGeoTileCacheQGCMapTypes kEsriTypes[] = {
 
 #define NUM_ESRIMAPS (sizeof(kEsriTypes) / sizeof(stQGeoTileCacheQGCMapTypes))
 
-static const char* kMapBoxTokenKey  = "MapBoxToken";
-static const char* kEsriTokenKey    = "EsriToken";
 static const char* kMaxDiskCacheKey = "MaxDiskCache";
 static const char* kMaxMemCacheKey  = "MaxMemoryCache";
 
@@ -346,57 +347,17 @@ QGCMapEngine::getMapNameList()
     for(size_t i = 0; i < NUM_MAPS; i++) {
         mapList << kMapTypes[i].name;
     }
-    if(!getMapBoxToken().isEmpty()) {
+    if(!qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxToken()->rawValue().toString().isEmpty()) {
         for(size_t i = 0; i < NUM_MAPBOXMAPS; i++) {
             mapList << kMapBoxTypes[i].name;
         }
     }
-    if(!getEsriToken().isEmpty()) {
+    if(!qgcApp()->toolbox()->settingsManager()->appSettings()->esriToken()->rawValue().toString().isEmpty()) {
         for(size_t i = 0; i < NUM_ESRIMAPS; i++) {
             mapList << kEsriTypes[i].name;
         }
     }
     return mapList;
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::setMapBoxToken(const QString& token)
-{
-    QSettings settings;
-    settings.setValue(kMapBoxTokenKey, token);
-    _mapBoxToken = token;
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::setEsriToken(const QString& token)
-{
-    QSettings settings;
-    settings.setValue(kEsriTokenKey, token);
-    _esriToken = token;
-}
-
-//-----------------------------------------------------------------------------
-QString
-QGCMapEngine::getMapBoxToken()
-{
-    if(_mapBoxToken.isEmpty()) {
-        QSettings settings;
-        _mapBoxToken = settings.value(kMapBoxTokenKey).toString();
-    }
-    return _mapBoxToken;
-}
-
-//-----------------------------------------------------------------------------
-QString
-QGCMapEngine::getEsriToken()
-{
-    if(_esriToken.isEmpty()) {
-        QSettings settings;
-        _esriToken = settings.value(kEsriTokenKey).toString();
-    }
-    return _esriToken;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -78,10 +78,6 @@ public:
     const QString               userAgent           () { return _userAgent; }
     void                        setUserAgent        (const QString& ua) { _userAgent = ua; }
     UrlFactory::MapType         hashToType          (const QString& hash);
-    QString                     getMapBoxToken      ();
-    QString                     getEsriToken        ();
-    void                        setMapBoxToken      (const QString& token);
-    void                        setEsriToken        (const QString& token);
     quint32                     getMaxDiskCache     ();
     void                        setMaxDiskCache     (quint32 size);
     quint32                     getMaxMemCache      ();
@@ -121,8 +117,6 @@ private:
     QGCCacheWorker          _worker;
     QString                 _cachePath;
     QString                 _cacheFile;
-    QString                 _mapBoxToken;
-    QString                 _esriToken;
     UrlFactory*             _urlFactory;
     QString                 _userAgent;
     quint32                 _maxDiskCache;

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -16,7 +16,10 @@
 
 //#define DEBUG_GOOGLE_MAPS
 
+#include "QGCApplication.h"
 #include "QGCMapEngine.h"
+#include "AppSettings.h"
+#include "SettingsManager.h"
 
 #include <QRegExp>
 #include <QNetworkReply>
@@ -168,7 +171,7 @@ UrlFactory::getTileURL(MapType type, int x, int y, int zoom, QNetworkAccessManag
         case EsriWorldStreet:
         case EsriWorldSatellite:
         case EsriTerrain: {
-                QByteArray token = getQGCMapEngine()->getEsriToken().toLatin1();
+                QByteArray token = qgcApp()->toolbox()->settingsManager()->appSettings()->esriToken()->rawValue().toString().toLatin1();
                 request.setRawHeader("User-Agent", QByteArrayLiteral("Qt Location based application"));
                 request.setRawHeader("User-Token", token);
             }
@@ -335,7 +338,7 @@ UrlFactory::_getURL(MapType type, int x, int y, int zoom, QNetworkAccessManager*
     case MapBoxEmerald:
     case MapBoxHighContrast:
     {
-        QString mapBoxToken = getQGCMapEngine()->getMapBoxToken();
+        QString mapBoxToken = qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxToken()->rawValue().toString();
         if(!mapBoxToken.isEmpty()) {
             QString server = "https://api.mapbox.com/v4/";
             switch(type) {

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -21,6 +21,8 @@ import QGroundControl.ScreenTools           1.0
 import QGroundControl.Palette               1.0
 import QGroundControl.FlightMap             1.0
 import QGroundControl.QGCMapEngineManager   1.0
+import QGroundControl.FactSystem            1.0
+import QGroundControl.FactControls          1.0
 
 QGCView {
     id:             offlineMapView
@@ -30,6 +32,9 @@ QGCView {
     property var    _currentSelection:  null
 
     property string mapKey:             "lastMapType"
+
+    property Fact   _mapboxFact:        QGroundControl.settingsManager.appSettings.mapboxToken
+    property Fact   _esriFact:          QGroundControl.settingsManager.appSettings.esriToken
 
     property string mapType:            _settings.mapProvider.enumStringValue + " " + _settings.mapType.enumStringValue
     property bool   isMapInteractive:   false
@@ -227,8 +232,6 @@ QGCView {
             id: optionDialog
 
             function accept() {
-                QGroundControl.mapEngineManager.mapboxToken  = mapBoxToken.text
-                QGroundControl.mapEngineManager.esriToken    = esriToken.text
                 QGroundControl.mapEngineManager.maxDiskCache = parseInt(maxCacheSize.text)
                 QGroundControl.mapEngineManager.maxMemCache  = parseInt(maxCacheMemSize.text)
                 optionDialog.hideDialog()
@@ -277,11 +280,10 @@ QGCView {
 
                     QGCLabel { text: qsTr("MapBox Access Token") }
 
-                    QGCTextField {
-                        id:             mapBoxToken
-                        maximumLength:  256
-                        width:          ScreenTools.defaultFontPixelWidth * 30
-                        text:           QGroundControl.mapEngineManager.mapboxToken
+                    FactTextField {
+                        fact:               _mapboxFact
+                        maximumLength:      256
+                        width:              ScreenTools.defaultFontPixelWidth * 30
                     }
 
                     QGCLabel {
@@ -293,11 +295,10 @@ QGCView {
 
                     QGCLabel { text: qsTr("Esri Access Token") }
 
-                    QGCTextField {
-                        id:             esriToken
-                        maximumLength:  256
-                        width:          ScreenTools.defaultFontPixelWidth * 30
-                        text:           QGroundControl.mapEngineManager.esriToken
+                    FactTextField {
+                        fact:               _esriFact
+                        maximumLength:      256
+                        width:              ScreenTools.defaultFontPixelWidth * 30
                     }
 
                     QGCLabel {

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -276,33 +276,31 @@ QGCView {
                         text:           qsTr("Memory cache changes require a restart to take effect.")
                     }
 
-                    Item { width: 1; height: 1 }
-
-                    QGCLabel { text: qsTr("MapBox Access Token") }
-
+                    Item { width: 1; height: 1; visible: _mapboxFact ? _mapboxFact.visible : false }
+                    QGCLabel { text: qsTr("MapBox Access Token"); visible: _mapboxFact ? _mapboxFact.visible : false }
                     FactTextField {
                         fact:               _mapboxFact
+                        visible:            _mapboxFact ? _mapboxFact.visible : false
                         maximumLength:      256
                         width:              ScreenTools.defaultFontPixelWidth * 30
                     }
-
                     QGCLabel {
                         text:           qsTr("With an access token, you can use MapBox Maps.")
+                        visible:        _mapboxFact ? _mapboxFact.visible : false
                         font.pointSize: _adjustableFontPointSize
                     }
 
-                    Item { width: 1; height: 1 }
-
-                    QGCLabel { text: qsTr("Esri Access Token") }
-
+                    Item { width: 1; height: 1; visible: _esriFact ? _esriFact.visible : false }
+                    QGCLabel { text: qsTr("Esri Access Token"); visible: _esriFact ? _esriFact.visible : false }
                     FactTextField {
                         fact:               _esriFact
+                        visible:            _esriFact ? _esriFact.visible : false
                         maximumLength:      256
                         width:              ScreenTools.defaultFontPixelWidth * 30
                     }
-
                     QGCLabel {
                         text:           qsTr("With an access token, you can use Esri Maps.")
+                        visible:        _esriFact ? _esriFact.visible : false
                         font.pointSize: _adjustableFontPointSize
                     }
                 } // GridLayout

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -196,34 +196,6 @@ QGCMapEngineManager::mapList()
 }
 
 //-----------------------------------------------------------------------------
-QString
-QGCMapEngineManager::mapboxToken()
-{
-    return getQGCMapEngine()->getMapBoxToken();
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngineManager::setMapboxToken(QString token)
-{
-    getQGCMapEngine()->setMapBoxToken(token);
-}
-
-//-----------------------------------------------------------------------------
-QString
-QGCMapEngineManager::esriToken()
-{
-    return getQGCMapEngine()->getEsriToken();
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngineManager::setEsriToken(QString token)
-{
-    getQGCMapEngine()->setEsriToken(token);
-}
-
-//-----------------------------------------------------------------------------
 quint32
 QGCMapEngineManager::maxMemCache()
 {

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -47,8 +47,6 @@ public:
     Q_PROPERTY(QString              tileSizeStr     READ    tileSizeStr     NOTIFY tileSizeChanged)
     Q_PROPERTY(QmlObjectListModel*  tileSets        READ    tileSets        NOTIFY tileSetsChanged)
     Q_PROPERTY(QStringList          mapList         READ    mapList         CONSTANT)
-    Q_PROPERTY(QString              mapboxToken     READ    mapboxToken     WRITE   setMapboxToken  NOTIFY  mapboxTokenChanged)
-    Q_PROPERTY(QString              esriToken       READ    esriToken       WRITE   setEsriToken    NOTIFY  esriTokenChanged)
     Q_PROPERTY(quint32              maxMemCache     READ    maxMemCache     WRITE   setMaxMemCache  NOTIFY  maxMemCacheChanged)
     Q_PROPERTY(quint32              maxDiskCache    READ    maxDiskCache    WRITE   setMaxDiskCache NOTIFY  maxDiskCacheChanged)
     Q_PROPERTY(QString              errorMessage    READ    errorMessage    NOTIFY  errorMessageChanged)
@@ -85,8 +83,6 @@ public:
     quint64                         tileSize                () { return _totalSet.tileSize; }
     QString                         tileSizeStr             ();
     QStringList                     mapList                 ();
-    QString                         mapboxToken             ();
-    QString                         esriToken               ();
     QmlObjectListModel*             tileSets                () { return &_tileSets; }
     quint32                         maxMemCache             ();
     quint32                         maxDiskCache            ();
@@ -98,8 +94,6 @@ public:
     ImportAction                    importAction            () { return _importAction; }
     bool                            importReplace           () { return _importReplace; }
 
-    void                            setMapboxToken          (QString token);
-    void                            setEsriToken            (QString token);
     void                            setMaxMemCache          (quint32 size);
     void                            setMaxDiskCache         (quint32 size);
     void                            setImportReplace        (bool replace) { _importReplace = replace; emit importReplaceChanged(); }
@@ -116,8 +110,6 @@ signals:
     void tileY1Changed          ();
     void tileCountChanged       ();
     void tileSizeChanged        ();
-    void mapboxTokenChanged     ();
-    void esriTokenChanged       ();
     void tileSetsChanged        ();
     void maxMemCacheChanged     ();
     void maxDiskCacheChanged    ();

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -122,5 +122,19 @@
     "longDescription":  "Directory to which all data files  are saved/loaded from",
     "type":             "string",
     "defaultValue":     ""
+},
+{
+    "name":             "MapBoxToken",
+    "shortDescription": "Access token to MapBox maps",
+    "longDescription":  "Your personal access token for MapBox maps",
+    "type":             "string",
+    "defaultValue":     ""
+},
+{
+    "name":             "EsriToken",
+    "shortDescription": "Access token to Esri maps",
+    "longDescription":  "Your personal access token for Esri maps",
+    "type":             "string",
+    "defaultValue":     ""
 }
 ]

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -31,6 +31,8 @@ const char* AppSettings::indoorPaletteName =                            "StyleIs
 const char* AppSettings::showLargeCompassName =                         "ShowLargeCompass";
 const char* AppSettings::savePathName =                                 "SavePath";
 const char* AppSettings::autoLoadMissionsName =                         "AutoLoadMissions";
+const char* AppSettings::mapboxTokenName =                              "MapBoxToken";
+const char* AppSettings::esriTokenName =                                "EsriToken";
 
 const char* AppSettings::parameterFileExtension =   "params";
 const char* AppSettings::planFileExtension =        "plan";
@@ -61,6 +63,8 @@ AppSettings::AppSettings(QObject* parent)
     , _showLargeCompassFact(NULL)
     , _savePathFact(NULL)
     , _autoLoadMissionsFact(NULL)
+    , _mapboxTokenFact(NULL)
+    , _esriTokenFact(NULL)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<AppSettings>("QGroundControl.SettingsManager", 1, 0, "AppSettings", "Reference only");
@@ -276,6 +280,24 @@ Fact* AppSettings::autoLoadMissions(void)
     }
 
     return _autoLoadMissionsFact;
+}
+
+Fact* AppSettings::mapboxToken(void)
+{
+    if (!_mapboxTokenFact) {
+        _mapboxTokenFact = _createSettingsFact(mapboxTokenName);
+    }
+
+    return _mapboxTokenFact;
+}
+
+Fact* AppSettings::esriToken(void)
+{
+    if (!_esriTokenFact) {
+        _esriTokenFact = _createSettingsFact(esriTokenName);
+    }
+
+    return _esriTokenFact;
 }
 
 MAV_AUTOPILOT AppSettings::offlineEditingFirmwareTypeFromFirmwareType(MAV_AUTOPILOT firmwareType)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -35,12 +35,14 @@ public:
     Q_PROPERTY(Fact* showLargeCompass                   READ showLargeCompass                   CONSTANT)
     Q_PROPERTY(Fact* savePath                           READ savePath                           CONSTANT)
     Q_PROPERTY(Fact* autoLoadMissions                   READ autoLoadMissions                   CONSTANT)
+    Q_PROPERTY(Fact* mapboxToken                        READ mapboxToken                        CONSTANT)
+    Q_PROPERTY(Fact* esriToken                          READ esriToken                          CONSTANT)
 
     Q_PROPERTY(QString missionSavePath      READ missionSavePath    NOTIFY savePathsChanged)
     Q_PROPERTY(QString parameterSavePath    READ parameterSavePath  NOTIFY savePathsChanged)
     Q_PROPERTY(QString telemetrySavePath    READ telemetrySavePath  NOTIFY savePathsChanged)
 
-    Q_PROPERTY(QString planFileExtension        MEMBER planFileExtension     CONSTANT)
+    Q_PROPERTY(QString planFileExtension        MEMBER planFileExtension        CONSTANT)
     Q_PROPERTY(QString missionFileExtension     MEMBER missionFileExtension     CONSTANT)
     Q_PROPERTY(QString waypointsFileExtension   MEMBER waypointsFileExtension   CONSTANT)
     Q_PROPERTY(QString parameterFileExtension   MEMBER parameterFileExtension   CONSTANT)
@@ -61,6 +63,8 @@ public:
     Fact* showLargeCompass                  (void);
     Fact* savePath                          (void);
     Fact* autoLoadMissions                  (void);
+    Fact* mapboxToken                       (void);
+    Fact* esriToken                         (void);
 
     QString missionSavePath     (void);
     QString parameterSavePath   (void);
@@ -86,6 +90,8 @@ public:
     static const char* showLargeCompassName;
     static const char* savePathName;
     static const char* autoLoadMissionsName;
+    static const char* mapboxTokenName;
+    static const char* esriTokenName;
 
     // Application wide file extensions
     static const char* parameterFileExtension;
@@ -124,6 +130,8 @@ private:
     SettingsFact* _showLargeCompassFact;
     SettingsFact* _savePathFact;
     SettingsFact* _autoLoadMissionsFact;
+    SettingsFact* _mapboxTokenFact;
+    SettingsFact* _esriTokenFact;
 };
 
 #endif

--- a/src/Settings/FlightMapSettings.cc
+++ b/src/Settings/FlightMapSettings.cc
@@ -110,6 +110,9 @@ void FlightMapSettings::_newMapProvider(QVariant value)
         _removeEnumValue(mapTypeSatellite, enumStrings, enumValues);
         _removeEnumValue(mapTypeHybrid, enumStrings, enumValues);
         break;
+    case mapProviderEsri:
+        _removeEnumValue(mapTypeHybrid, enumStrings, enumValues);
+        break;
     }
     metaData->setEnumInfo(enumStrings, enumValues);
     emit mapTypeChanged();

--- a/src/Settings/FlightMapSettings.cc
+++ b/src/Settings/FlightMapSettings.cc
@@ -7,8 +7,11 @@
  *
  ****************************************************************************/
 
+#include "QGCApplication.h"
 #include "FlightMapSettings.h"
 #include "QGCMapEngine.h"
+#include "AppSettings.h"
+#include "SettingsManager.h"
 
 #include <QQmlEngine>
 #include <QtQml>
@@ -34,10 +37,10 @@ FlightMapSettings::FlightMapSettings(QObject* parent)
     //-- Remove Google
     _excludeProvider(mapProviderGoogle);
 #endif
-    if(getQGCMapEngine()->getMapBoxToken().isEmpty()) {
+    if(qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxToken()->rawValue().toString().isEmpty()) {
         _excludeProvider(mapProviderMapBox);
     }
-    if(getQGCMapEngine()->getEsriToken().isEmpty()) {
+    if(qgcApp()->toolbox()->settingsManager()->appSettings()->esriToken()->rawValue().toString().isEmpty()) {
         _excludeProvider(mapProviderEsri);
     }
     _newMapProvider(mapProvider()->rawValue());


### PR DESCRIPTION
Moved offline map tokens to AppSettings.

Before you ask, it won't work for them to be part of FlightMapSettings because the tokens are used within the FlightMapSettings constructor, at which point things are not yet ready :P

What really needs to be done is to consolidate QGCMapEngine with FlightMapSettings. That's what QGCMapEngine was written for when I first added map management.