### PR TITLE
Mission Settings: Fix section dirty bit handling

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -398,6 +398,7 @@ DebugBuild { PX4FirmwarePlugin { PX4FirmwarePluginFactory  { APMFirmwarePlugin {
         src/MissionManager/MissionControllerTest.h \
         src/MissionManager/MissionItemTest.h \
         src/MissionManager/MissionManagerTest.h \
+        src/MissionManager/MissionSettingsTest.h \
         src/MissionManager/PlanMasterControllerTest.h \
         src/MissionManager/SectionTest.h \
         src/MissionManager/SimpleMissionItemTest.h \
@@ -431,6 +432,7 @@ DebugBuild { PX4FirmwarePlugin { PX4FirmwarePluginFactory  { APMFirmwarePlugin {
         src/MissionManager/MissionControllerTest.cc \
         src/MissionManager/MissionItemTest.cc \
         src/MissionManager/MissionManagerTest.cc \
+        src/MissionManager/MissionSettingsTest.cc \
         src/MissionManager/PlanMasterControllerTest.cc \
         src/MissionManager/SectionTest.cc \
         src/MissionManager/SimpleMissionItemTest.cc \

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -80,6 +80,10 @@ void MissionSettingsItem::setDirty(bool dirty)
 {
     if (_dirty != dirty) {
         _dirty = dirty;
+        if (!dirty) {
+            _cameraSection.setDirty(false);
+            _speedSection.setDirty(false);
+        }
         emit dirtyChanged(_dirty);
     }
 }

--- a/src/MissionManager/MissionSettingsTest.cc
+++ b/src/MissionManager/MissionSettingsTest.cc
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "MissionSettingsTest.h"
+#include "QGCApplication.h"
+#include "QGroundControlQmlGlobal.h"
+#include "SettingsManager.h"
+
+MissionSettingsTest::MissionSettingsTest(void)
+    : _settingsItem(NULL)
+{
+    
+}
+
+void MissionSettingsTest::init(void)
+{
+    VisualMissionItemTest::init();
+
+    _settingsItem = new MissionSettingsItem(_offlineVehicle, this);
+}
+
+void MissionSettingsTest::cleanup(void)
+{
+    delete _settingsItem;
+    VisualMissionItemTest::cleanup();
+}
+
+void MissionSettingsTest::_testCameraSectionDirty(void)
+{
+    CameraSection* cameraSection = _settingsItem->cameraSection();
+
+    QVERIFY(!cameraSection->dirty());
+    QVERIFY(!_settingsItem->dirty());
+
+    // Dirtying the camera section should also dirty the item
+    cameraSection->setDirty(true);
+    QVERIFY(_settingsItem->dirty());
+
+    // Clearing the dirty bit from the item should also clear the dirty bit on the camera section
+    _settingsItem->setDirty(false);
+    QVERIFY(!cameraSection->dirty());
+}
+
+void MissionSettingsTest::_testSpeedSectionDirty(void)
+{
+    SpeedSection* speedSection = _settingsItem->speedSection();
+
+    QVERIFY(!speedSection->dirty());
+    QVERIFY(!_settingsItem->dirty());
+
+    // Dirtying the speed section should also dirty the item
+    speedSection->setDirty(true);
+    QVERIFY(_settingsItem->dirty());
+
+    // Clearing the dirty bit from the item should also clear the dirty bit on the camera section
+    _settingsItem->setDirty(false);
+    QVERIFY(!speedSection->dirty());
+}

--- a/src/MissionManager/MissionSettingsTest.h
+++ b/src/MissionManager/MissionSettingsTest.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "VisualMissionItemTest.h"
+#include "MissionSettingsItem.h"
+
+/// Unit test for SimpleMissionItem
+class MissionSettingsTest : public VisualMissionItemTest
+{
+    Q_OBJECT
+    
+public:
+    MissionSettingsTest(void);
+
+    void init(void) override;
+    void cleanup(void) override;
+
+private slots:
+    void _testCameraSectionDirty(void);
+    void _testSpeedSectionDirty(void);
+
+private:
+    MissionSettingsItem* _settingsItem;
+};

--- a/src/MissionManager/SimpleMissionItemTest.cc
+++ b/src/MissionManager/SimpleMissionItemTest.cc
@@ -256,6 +256,38 @@ void SimpleMissionItemTest::_testSignals(void)
     QVERIFY(_spyVisualItem->checkSignalsByMask(commandNameChangedMask | dirtyChangedMask | coordinateChangedMask));
 }
 
+void SimpleMissionItemTest::_testCameraSectionDirty(void)
+{
+    CameraSection* cameraSection = _simpleItem->cameraSection();
+
+    QVERIFY(!cameraSection->dirty());
+    QVERIFY(!_simpleItem->dirty());
+
+    // Dirtying the camera section should also dirty the item
+    cameraSection->setDirty(true);
+    QVERIFY(_simpleItem->dirty());
+
+    // Clearing the dirty bit from the item should also clear the dirty bit on the camera section
+    _simpleItem->setDirty(false);
+    QVERIFY(!cameraSection->dirty());
+}
+
+void SimpleMissionItemTest::_testSpeedSectionDirty(void)
+{
+    SpeedSection* speedSection = _simpleItem->speedSection();
+
+    QVERIFY(!speedSection->dirty());
+    QVERIFY(!_simpleItem->dirty());
+
+    // Dirtying the speed section should also dirty the item
+    speedSection->setDirty(true);
+    QVERIFY(_simpleItem->dirty());
+
+    // Clearing the dirty bit from the item should also clear the dirty bit on the camera section
+    _simpleItem->setDirty(false);
+    QVERIFY(!speedSection->dirty());
+}
+
 void SimpleMissionItemTest::_testCameraSection(void)
 {
     // No gimbal yaw to start with

--- a/src/MissionManager/SimpleMissionItemTest.h
+++ b/src/MissionManager/SimpleMissionItemTest.h
@@ -27,6 +27,8 @@ private slots:
     void _testSignals(void);
     void _testEditorFacts(void);
     void _testDefaultValues(void);
+    void _testCameraSectionDirty(void);
+    void _testSpeedSectionDirty(void);
     void _testCameraSection(void);
     void _testSpeedSection(void);
 

--- a/src/qgcunittest/UnitTestList.cc
+++ b/src/qgcunittest/UnitTestList.cc
@@ -36,6 +36,7 @@
 #include "CameraSectionTest.h"
 #include "SpeedSectionTest.h"
 #include "PlanMasterControllerTest.h"
+#include "MissionSettingsTest.h"
 
 UT_REGISTER_TEST(FactSystemTestGeneric)
 UT_REGISTER_TEST(FactSystemTestPX4)
@@ -58,6 +59,7 @@ UT_REGISTER_TEST(SurveyMissionItemTest)
 UT_REGISTER_TEST(CameraSectionTest)
 UT_REGISTER_TEST(SpeedSectionTest)
 UT_REGISTER_TEST(PlanMasterControllerTest)
+UT_REGISTER_TEST(MissionSettingsTest)
 
 // List of unit test which are currently disabled.
 // If disabling a new test, include reason in comment.


### PR DESCRIPTION
Dirty bits for Camera and Flight Speed sections not being cleared when parent item cleared dirty bit. This was causing incorrect Upload Required state.