### PR TITLE
Survey: Entry location changes

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -350,17 +350,6 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
     if (_cameraList.size() == 0) {
         CameraMetaData* metaData;
 
-        metaData = new CameraMetaData(tr("Typhoon H CGO3+"),    // Camera name
-                                      6.264,                    // sensorWidth
-                                      4.698,                    // sensorHeight
-                                      4000,                     // imageWidth
-                                      3000,                     // imageHeight
-                                      14,                       // focalLength
-                                      true,                     // landscape orientation
-                                      true,                     // camera orientation is fixed
-                                      this);                    // parent
-        _cameraList.append(QVariant::fromValue(metaData));
-
         metaData = new CameraMetaData(tr("Sony ILCE-QX1"),  //http://www.sony.co.uk/electronics/interchangeable-lens-cameras/ilce-qx1-body-kit/specifications
                                       23.2,                 //http://www.sony.com/electronics/camera-lenses/sel16f28/specifications
                                       15.4,

--- a/src/MissionManager/Survey.SettingsGroup.json
+++ b/src/MissionManager/Survey.SettingsGroup.json
@@ -160,7 +160,7 @@
     "name":             "GridEntryLocation",
     "shortDescription": "Location for entry point into survey area",
     "type":             "uint32",
-    "enumStrings":      "Top Left, Top Right, Bottom Left, Bottom Right",
+    "enumStrings":      "Position 1, Position 2, Position 3, Position 4",
     "enumValues":       "0,1,2,3",
     "defaultValue":     0
 }

--- a/src/MissionManager/SurveyMissionItem.h
+++ b/src/MissionManager/SurveyMissionItem.h
@@ -129,6 +129,14 @@ public:
     void setTurnaroundDist  (double dist) { _turnaroundDistFact.setRawValue(dist); }
     void save               (QJsonArray&  missionItems) final;
 
+    // Must match json spec for GridEntryLocation
+    enum EntryLocation {
+        EntryLocationTopLeft,
+        EntryLocationTopRight,
+        EntryLocationBottomLeft,
+        EntryLocationBottomRight,
+    };
+
     static const char* jsonComplexItemTypeValue;
 
     static const char* settingsGroup;
@@ -176,14 +184,6 @@ private:
         CameraTriggerOn,
         CameraTriggerOff,
         CameraTriggerHoverAndCapture
-    };
-
-    // Must match json spec for GridEntryLocation
-    enum EntryLocation {
-        EntryLocationTopLeft,
-        EntryLocationTopRight,
-        EntryLocationBottomLeft,
-        EntryLocationBottomRight,
     };
 
     void _setExitCoordinate(const QGeoCoordinate& coordinate);

--- a/src/MissionManager/SurveyMissionItemTest.h
+++ b/src/MissionManager/SurveyMissionItemTest.h
@@ -34,8 +34,12 @@ private slots:
     void _testDirty(void);
     void _testCameraValueChanged(void);
     void _testCameraTrigger(void);
+    void _testGridAngle(void);
+    void _testEntryLocation(void);
 
 private:
+    double _clampGridAngle180(double gridAngle);
+
     enum {
         gridPointsChangedIndex = 0,
         cameraShotsChangedIndex,


### PR DESCRIPTION
While writing unit tests for grid angle and entry location (in this pull) I realized that the concept of TopLeft, TopRight, BottomLeft, BottomRight for specifying entry location just didn't make sense when you rotate the grid to say 45 degrees. Although each location did move the the entry location to a unique spot. Relating it to that specific wording wasn't working. So Instead I changes naming to be generic Position 1, Position 2, Position 3, Position 4. Which will allow you to select between the four possible positions.