### PR TITLE
WIP: Basic video streaming discovery using MAVLink

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1027,6 +1027,7 @@ HEADERS += \
     src/VideoStreaming/VideoItem.h \
     src/VideoStreaming/VideoReceiver.h \
     src/VideoStreaming/VideoStreaming.h \
+    src/VideoStreaming/MAVLinkVideoManager.h \
     src/VideoStreaming/VideoSurface.h \
     src/VideoStreaming/VideoSurface_p.h \
 
@@ -1035,6 +1036,7 @@ SOURCES += \
     src/VideoStreaming/VideoReceiver.cc \
     src/VideoStreaming/VideoStreaming.cc \
     src/VideoStreaming/VideoSurface.cc \
+    src/VideoStreaming/MAVLinkVideoManager.cc \
 
 contains (CONFIG, DISABLE_VIDEOSTREAMING) {
     message("Skipping support for video streaming (manual override from command line)")

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -635,6 +635,7 @@ HEADERS += \
     src/ui/uas/UASQuickViewItem.h \
     src/ui/uas/UASQuickViewItemSelect.h \
     src/ui/uas/UASQuickViewTextItem.h \
+    src/ViewWidgets/VideoStreamingWidget.h \
 }
 
 iOSBuild {
@@ -799,6 +800,7 @@ SOURCES += \
     src/ui/uas/UASQuickViewItem.cc \
     src/ui/uas/UASQuickViewItemSelect.cc \
     src/ui/uas/UASQuickViewTextItem.cc \
+    src/ViewWidgets/VideoStreamingWidget.cc \
 }
 
 # Palette test widget in debug builds

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -24,6 +24,7 @@
         <file alias="DebugWindow.qml">src/ui/preferences/DebugWindow.qml</file>
         <file alias="ESP8266Component.qml">src/AutoPilotPlugins/Common/ESP8266Component.qml</file>
         <file alias="ESP8266ComponentSummary.qml">src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml</file>
+        <file alias="VideoStreamingWidget.qml">src/ViewWidgets/VideoStreamingWidget.qml</file>
         <file alias="SyslinkComponent.qml">src/AutoPilotPlugins/Common/SyslinkComponent.qml</file>
         <file alias="FirmwareUpgrade.qml">src/VehicleSetup/FirmwareUpgrade.qml</file>
         <file alias="FlightDisplayViewDummy.qml">src/FlightDisplay/FlightDisplayViewDummy.qml</file>

--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -38,6 +38,7 @@ VideoManager::VideoManager(QGCApplication* app, QGCToolbox* toolbox)
     , _init(false)
     , _videoSettings(NULL)
     , _showFullScreen(false)
+    , _mavlinkVideoManager(NULL)
 {
 }
 
@@ -94,6 +95,8 @@ VideoManager::setToolbox(QGCToolbox *toolbox)
    connect(&_frameTimer, &QTimer::timeout, this, &VideoManager::_updateTimer);
    _frameTimer.start(1000);
 #endif
+
+   _mavlinkVideoManager = new MAVLinkVideoManager();
 }
 
 void VideoManager::_videoSourceChanged(void)

--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -15,6 +15,7 @@
 #include <QTimer>
 #include <QUrl>
 
+#include "MAVLinkVideoManager.h"
 #include "QGCLoggingCategory.h"
 #include "VideoSurface.h"
 #include "VideoReceiver.h"
@@ -95,6 +96,7 @@ private:
     VideoSettings*  _videoSettings;
     QString         _imageFile;
     bool            _showFullScreen;
+    MAVLinkVideoManager* _mavlinkVideoManager;
 };
 
 #endif

--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -35,6 +35,7 @@ public:
 
     Q_PROPERTY(bool             hasVideo            READ    hasVideo                                    NOTIFY hasVideoChanged)
     Q_PROPERTY(bool             isGStreamer         READ    isGStreamer                                 NOTIFY isGStreamerChanged)
+    Q_PROPERTY(bool             isMAVLinkStream     READ    isMAVLinkStream                        NOTIFY isMAVLinkStreamChanged)
     Q_PROPERTY(QString          videoSourceID       READ    videoSourceID                               NOTIFY videoSourceIDChanged)
     Q_PROPERTY(bool             videoRunning        READ    videoRunning                                NOTIFY videoRunningChanged)
     Q_PROPERTY(bool             uvcEnabled          READ    uvcEnabled                                  CONSTANT)
@@ -42,9 +43,11 @@ public:
     Q_PROPERTY(VideoReceiver*   videoReceiver       READ    videoReceiver                               CONSTANT)
     Q_PROPERTY(QString          imageFile           READ    imageFile                                   NOTIFY imageFileChanged)
     Q_PROPERTY(bool             showFullScreen      READ    showFullScreen  WRITE setShowFullScreen     NOTIFY showFullScreenChanged)
+    Q_PROPERTY(MAVLinkVideoManager* mavlinkVideoManager MEMBER  _mavlinkVideoManager CONSTANT)
 
     bool        hasVideo            ();
     bool        isGStreamer         ();
+    bool        isMAVLinkStream();
     bool        videoRunning        () { return _videoRunning; }
     QString     videoSourceID       () { return _videoSourceID; }
     QString     imageFile           () { return _imageFile; }
@@ -69,6 +72,7 @@ signals:
     void hasVideoChanged        ();
     void videoRunningChanged    ();
     void isGStreamerChanged     ();
+    void isMAVLinkStreamChanged ();
     void videoSourceIDChanged   ();
     void imageFileChanged       ();
     void showFullScreenChanged  ();
@@ -77,6 +81,7 @@ private slots:
     void _videoSourceChanged(void);
     void _udpPortChanged(void);
     void _rtspUrlChanged(void);
+    void _mavlinkUriChanged(void);
 
 private:
     void _updateTimer           ();

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -32,6 +32,7 @@ const char* VideoSettings::maxVideoSizeName =       "MaxVideoSize";
 const char* VideoSettings::videoSourceNoVideo =     "No Video Available";
 const char* VideoSettings::videoSourceUDP =         "UDP Video Stream";
 const char* VideoSettings::videoSourceRTSP =        "RTSP Video Stream";
+const char* VideoSettings::videoSourceMAVLink =     "MAVLink Auto Discovery Streams";
 
 VideoSettings::VideoSettings(QObject* parent)
     : SettingsGroup(videoSettingsGroupName, QString() /* root settings group */, parent)
@@ -55,6 +56,7 @@ VideoSettings::VideoSettings(QObject* parent)
     videoSourceList.append(videoSourceUDP);
 #endif
     videoSourceList.append(videoSourceRTSP);
+    videoSourceList.append(videoSourceMAVLink);
 #endif
 #ifndef QGC_DISABLE_UVC
     QList<QCameraInfo> cameras = QCameraInfo::availableCameras();

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -54,6 +54,7 @@ public:
     static const char* videoSourceNoVideo;
     static const char* videoSourceUDP;
     static const char* videoSourceRTSP;
+    static const char* videoSourceMAVLink;
 
 private:
     SettingsFact* _videoSourceFact;

--- a/src/VideoStreaming/MAVLinkVideoManager.cc
+++ b/src/VideoStreaming/MAVLinkVideoManager.cc
@@ -22,8 +22,10 @@
 //-----------------------------------------------------------------------------
 MAVLinkVideoManager::MAVLinkVideoManager()
     : QObject()
-    , _cameraId(0)
+    , _cameraSysid(0)
     , _cameraLink(NULL)
+    , _selectedStream(-1)
+
 
 {
     _mavlink = qgcApp()->toolbox()->mavlinkProtocol();
@@ -45,21 +47,33 @@ MAVLinkVideoManager::~MAVLinkVideoManager()
  */
 void MAVLinkVideoManager::_videoHeartbeatInfo(LinkInterface *link, int systemId)
 {
-    if (systemId == _cameraId)
+    if (systemId == _cameraSysid)
         return;
 
     qDebug() << "MAVLinkVideoManager: First camera heartbeat info received";
-    _cameraId = systemId;
+    _cameraSysid = systemId;
     _cameraLink = link;
+    link->setActive(true);
 
     mavlink_message_t msg;
-    mavlink_msg_command_long_pack(_mavlink->getSystemId(), _mavlink->getComponentId(), &msg, _cameraId, MAV_COMP_ID_CAMERA, MAV_CMD_REQUEST_CAMERA_INFORMATION, 0, 0, 1, 0, 0, 0, 0, 0);
+    mavlink_msg_command_long_pack(_mavlink->getSystemId(), _mavlink->getComponentId(), &msg, _cameraSysid, MAV_COMP_ID_CAMERA, MAV_CMD_REQUEST_CAMERA_INFORMATION, 0, 0, 1, 0, 0, 0, 0, 0);
 
     uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
     int len = mavlink_msg_to_send_buffer(buffer, &msg);
 
     _cameraLink->writeBytesSafe((const char*)buffer, len);
-    qDebug() << "Request camera information sent:"<<msg.msgid;
+    qDebug() << "Request camera information sent:" << msg.msgid;
+}
+
+Stream *MAVLinkVideoManager::_find_camera_by_id(int cameraId)
+{
+    QObject *s;
+    foreach(s, _streamList) {
+        if (((Stream *)s)->cameraId == cameraId)
+            return (Stream *)s;
+    }
+
+    return NULL;
 }
 
 /**
@@ -69,14 +83,73 @@ void MAVLinkVideoManager::_videoHeartbeatInfo(LinkInterface *link, int systemId)
  */
 void MAVLinkVideoManager::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t message)
 {
-    if(message.msgid != MAVLINK_MSG_ID_HEARTBEAT) {
-        qDebug() << "Message received" << message.msgid;
-        if (message.sysid != _cameraId)
-            return;
+    Q_UNUSED(link);
 
+    if(message.msgid == MAVLINK_MSG_ID_HEARTBEAT || message.sysid != _cameraSysid)
+        return;
+
+    qDebug() << "Camera message received" << message.msgid;
+    switch(message.msgid) {
+    case MAVLINK_MSG_ID_CAMERA_INFORMATION: {
         mavlink_camera_information_t info;
         mavlink_msg_camera_information_decode(&message, &info);
+
+        Stream *s = _find_camera_by_id(info.camera_id);
+        if (s) {
+            //Camera already added to stream list. Droping duplicate.
+            break;
+        }
+        _streamList.append(new Stream(info.camera_id, (const char *)info.model_name));
+        if (_selectedStream < 0)
+            setSelectedStream(0);
+
+        emit streamListChanged();
+
         qDebug() << "Camera found:@ id:" << info.camera_id;
         qDebug() << "model:" << (const char *)info.model_name;
-     }
+        break;
+    }
+    case MAVLINK_MSG_ID_VIDEO_STREAM_INFORMATION: {
+        mavlink_video_stream_information_t info;
+        mavlink_msg_video_stream_information_decode(&message, &info);
+
+        Stream *s = _find_camera_by_id(info.camera_id);
+        if (!s) {
+            qDebug() << "Camera " << info.camera_id << " removed. Ignoring message.";
+            break;
+        }
+        s->uri = info.uri;
+
+        emit currentUriChanged();
+        break;
+    }
+    }
+}
+
+QString MAVLinkVideoManager::getVideoURI()
+{
+    if (_selectedStream < 0 || _selectedStream >= _streamList.size())
+        return QString("");
+
+    return ((Stream *)_streamList[_selectedStream])->uri;
+}
+
+void MAVLinkVideoManager::setSelectedStream(int index)
+{
+    if (index >= _streamList.size())
+        index = -1;
+    _selectedStream = index;
+
+    if (index >= 0) {
+        Stream *s = (Stream *)_streamList[index];
+        uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+        mavlink_message_t msg;
+
+        mavlink_msg_command_long_pack(_mavlink->getSystemId(), _mavlink->getComponentId(), &msg, _cameraSysid, MAV_COMP_ID_CAMERA, MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION, 0, s->cameraId, 1, 0, 0, 0, 0, 0);
+
+        int len = mavlink_msg_to_send_buffer(buffer, &msg);
+        _cameraLink->writeBytesSafe((const char*)buffer, len);
+
+        emit currentUriChanged();
+    }
 }

--- a/src/VideoStreaming/MAVLinkVideoManager.cc
+++ b/src/VideoStreaming/MAVLinkVideoManager.cc
@@ -200,3 +200,17 @@ void MAVLinkVideoManager::setCurrentResolution(int resolution)
     _cameraLink->writeBytesSafe((const char*)buffer, len);
     _updateStream();
 }
+
+void MAVLinkVideoManager::refreshVideoProvider()
+{
+    _selectedStream = -1;
+    _currentResolution = 0;
+    _cameraSysid = 0;
+
+    _streamList.clear();
+
+    emit currentUriChanged();
+    emit currentResolutionChanged();
+    emit currentUriChanged();
+    emit resolutionListChanged();
+}

--- a/src/VideoStreaming/MAVLinkVideoManager.cc
+++ b/src/VideoStreaming/MAVLinkVideoManager.cc
@@ -1,0 +1,63 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include <QDebug>
+
+#include "MAVLinkVideoManager.h"
+#include "LinkInterface.h"
+#include "QGCApplication.h"
+
+/**
+ * @file
+ *   @brief QGC MAVLink video streaming Manager
+ */
+
+
+//-----------------------------------------------------------------------------
+MAVLinkVideoManager::MAVLinkVideoManager()
+    : QObject()
+    , _cameraId(0)
+    , _cameraLink(NULL)
+
+{
+    _mavlink = qgcApp()->toolbox()->mavlinkProtocol();
+    connect(_mavlink, &MAVLinkProtocol::videoHeartbeatInfo, this, &MAVLinkVideoManager::_videoHeartbeatInfo);
+    connect(_mavlink, &MAVLinkProtocol::messageReceived, this, &MAVLinkVideoManager::_mavlinkMessageReceived);
+}
+
+//-----------------------------------------------------------------------------
+MAVLinkVideoManager::~MAVLinkVideoManager()
+{
+}
+
+//-----------------------------------------------------------------------------
+void
+MAVLinkVideoManager::_videoHeartbeatInfo(LinkInterface *link, int systemId)
+{
+    if (systemId == _cameraId)
+        return;
+
+    qDebug() << "MAVLinkVideoManager: First camera heartbeat info received";
+    _cameraId = systemId;
+    _cameraLink = link;
+
+    //TODO: Send message requesting cameras (MAV_CMD_REQUEST_CAMERA_INFORMATION)
+}
+
+//-----------------------------------------------------------------------------
+void
+MAVLinkVideoManager::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t message)
+{
+    if (message.sysid != _cameraId)
+        return;
+
+    qDebug() << "Message received";
+
+    //TODO: Handle received messages like CAMERA_INFORMATION and VIDEO_STREAM_INFORMATION
+}

--- a/src/VideoStreaming/MAVLinkVideoManager.h
+++ b/src/VideoStreaming/MAVLinkVideoManager.h
@@ -88,6 +88,9 @@ public:
     QString videoResolution();
     void setCurrentResolution(int resolution);
 
+public slots:
+    void refreshVideoProvider();
+
 signals:
     void streamListChanged();
     void selectedStreamChanged();

--- a/src/VideoStreaming/MAVLinkVideoManager.h
+++ b/src/VideoStreaming/MAVLinkVideoManager.h
@@ -21,21 +21,64 @@
 
 #include "MAVLinkProtocol.h"
 
+class Stream : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString text MEMBER name NOTIFY nameChanged)
+public:
+    Stream(int _cameraId, QString _name)
+        : cameraId(_cameraId)
+        , name(_name)
+        , uri("") {}
+
+    ~Stream() { }
+    int cameraId;
+    QString name;
+    QString uri;
+    signals:
+        void nameChanged();
+};
+
 class MAVLinkVideoManager : public QObject
 {
     Q_OBJECT
+
+    Q_PROPERTY(QList<QObject*>  streamList              READ streamList             NOTIFY streamListChanged)
+    Q_PROPERTY(int              selectedStream          READ selectedStream         WRITE  setSelectedStream        NOTIFY selectedStreamChanged)
+    Q_PROPERTY(QString          currentUri              READ getVideoURI  NOTIFY currentUriChanged)
+
 public:
     MAVLinkVideoManager();
     ~MAVLinkVideoManager();
+
+    QList<QObject *> streamList() {
+        return _streamList;
+    }
+
+    int selectedStream() {
+        return _selectedStream;
+    }
+
+    QString getVideoURI();
+    void setSelectedStream(int index);
+
+signals:
+    void streamListChanged();
+    void selectedStreamChanged();
+    void currentUriChanged();
 
 private slots:
     void _mavlinkMessageReceived(LinkInterface *link, mavlink_message_t message);
     void _videoHeartbeatInfo(LinkInterface *link, int systemId);
 
 private:
-    int _cameraId;
+    int _cameraSysid;
     MAVLinkProtocol *_mavlink;
     LinkInterface *_cameraLink;
+    QList<QObject*> _streamList;
+    int _selectedStream;
+
+    Stream *_find_camera_by_id(int cameraId);
 };
 
 #endif // MAVLINK_VIDEO_MANAGER_H

--- a/src/VideoStreaming/MAVLinkVideoManager.h
+++ b/src/VideoStreaming/MAVLinkVideoManager.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC MAVLink video streaming Manager
+ */
+
+#ifndef MAVLINK_VIDEO_MANAGER_H
+#define MAVLINK_VIDEO_MANAGER_H
+
+#include <QObject>
+#include <QStringList>
+
+#include "MAVLinkProtocol.h"
+
+class MAVLinkVideoManager : public QObject
+{
+    Q_OBJECT
+public:
+    MAVLinkVideoManager();
+    ~MAVLinkVideoManager();
+
+private slots:
+    void _mavlinkMessageReceived(LinkInterface *link, mavlink_message_t message);
+    void _videoHeartbeatInfo(LinkInterface *link, int systemId);
+
+private:
+    int _cameraId;
+    MAVLinkProtocol *_mavlink;
+    LinkInterface *_cameraLink;
+};
+
+#endif // MAVLINK_VIDEO_MANAGER_H

--- a/src/VideoStreaming/MAVLinkVideoManager.h
+++ b/src/VideoStreaming/MAVLinkVideoManager.h
@@ -39,13 +39,32 @@ public:
         void nameChanged();
 };
 
+class Resolution : public QObject {
+    Q_OBJECT
+
+    Q_PROPERTY(QString text MEMBER name NOTIFY nameChanged)
+public:
+    Resolution(QString _name, int _h, int _v)
+        : name(_name)
+        , h(_h)
+        , v(_v) { }
+    ~Resolution() { }
+    QString name;
+    int h, v;
+    signals:
+        void nameChanged();
+};
+
 class MAVLinkVideoManager : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY(QList<QObject*>  streamList              READ streamList             NOTIFY streamListChanged)
+    Q_PROPERTY(QList<QObject*>  streamList              READ streamList                                             NOTIFY streamListChanged)
     Q_PROPERTY(int              selectedStream          READ selectedStream         WRITE  setSelectedStream        NOTIFY selectedStreamChanged)
-    Q_PROPERTY(QString          currentUri              READ getVideoURI  NOTIFY currentUriChanged)
+    Q_PROPERTY(QList<QObject *> resolutionList          READ resolutionList                                         NOTIFY resolutionListChanged)
+    Q_PROPERTY(QString          currentUri              READ getVideoURI                                            NOTIFY currentUriChanged)
+    Q_PROPERTY(int              currentResolution       READ currentResolution       WRITE  setCurrentResolution    NOTIFY currentResolutionChanged)
+    Q_PROPERTY(QString          videoResolution         READ videoResolution                                        NOTIFY videoResolutionChanged)
 
 public:
     MAVLinkVideoManager();
@@ -59,13 +78,23 @@ public:
         return _selectedStream;
     }
 
+    QList<QObject *> resolutionList() {
+        return _resolutionList;
+    }
+
     QString getVideoURI();
     void setSelectedStream(int index);
+    int currentResolution();
+    QString videoResolution();
+    void setCurrentResolution(int resolution);
 
 signals:
     void streamListChanged();
     void selectedStreamChanged();
+    void resolutionListChanged();
     void currentUriChanged();
+    void currentResolutionChanged();
+    void videoResolutionChanged();
 
 private slots:
     void _mavlinkMessageReceived(LinkInterface *link, mavlink_message_t message);
@@ -76,9 +105,13 @@ private:
     MAVLinkProtocol *_mavlink;
     LinkInterface *_cameraLink;
     QList<QObject*> _streamList;
+    QList<QObject*> _resolutionList;
     int _selectedStream;
+    int _currentResolution;
+    QString _videoResolution;
 
     Stream *_find_camera_by_id(int cameraId);
+    void _updateStream();
 };
 
 #endif // MAVLINK_VIDEO_MANAGER_H

--- a/src/ViewWidgets/VideoStreamingWidget.cc
+++ b/src/ViewWidgets/VideoStreamingWidget.cc
@@ -1,0 +1,30 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Widget
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+#include "VideoStreamingWidget.h"
+
+VideoStreamingWidget::VideoStreamingWidget(const QString& title, QAction* action, QWidget *parent) :
+    QGCQmlWidgetHolder(title, action, parent)
+{
+    Q_UNUSED(title)
+    Q_UNUSED(action);
+
+    resize(320, 200);
+
+    setSource(QUrl::fromUserInput("qrc:/qml/VideoStreamingWidget.qml"));
+
+    loadSettings();
+}

--- a/src/ViewWidgets/VideoStreamingWidget.cc
+++ b/src/ViewWidgets/VideoStreamingWidget.cc
@@ -22,7 +22,7 @@ VideoStreamingWidget::VideoStreamingWidget(const QString& title, QAction* action
     Q_UNUSED(title)
     Q_UNUSED(action);
 
-    resize(320, 200);
+    resize(420, 200);
 
     setSource(QUrl::fromUserInput("qrc:/qml/VideoStreamingWidget.qml"));
 

--- a/src/ViewWidgets/VideoStreamingWidget.h
+++ b/src/ViewWidgets/VideoStreamingWidget.h
@@ -1,0 +1,30 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Widget
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ */
+
+#ifndef VideoStreamingWidget_H
+#define VideoStreamingWidget_H
+
+#include "QGCQmlWidgetHolder.h"
+
+class VideoStreamingWidget : public QGCQmlWidgetHolder
+{
+    Q_OBJECT
+
+public:
+    VideoStreamingWidget(const QString& title, QAction* action, QWidget *parent = 0);
+};
+
+#endif // VideoStreamingWidget_H

--- a/src/ViewWidgets/VideoStreamingWidget.qml
+++ b/src/ViewWidgets/VideoStreamingWidget.qml
@@ -30,7 +30,7 @@ QGCView {
     viewPanel:    panel
 
     property real _margins:             ScreenTools.defaultFontPixelWidth
-    property real _labelsWidth:         ScreenTools.defaultFontPixelWidth * 7
+    property real _labelsWidth:         ScreenTools.defaultFontPixelWidth * 20
     property real _elementsHeight:      ScreenTools.defaultFontPixelWidth * 3
     property real _elementsWidth:       ScreenTools.defaultFontPixelWidth * 28
     property real _buttonWidth:         ScreenTools.defaultFontPixelWidth * 15
@@ -94,12 +94,72 @@ QGCView {
             }
 
             Row {
-                id:                         uriRow
+                id:                         resolutionRow
                 spacing:                    ScreenTools.defaultFontPixelWidth
                 anchors.margins:            _margins
                 anchors.left:               parent.left
                 anchors.right:              parent.right
                 anchors.top:                streamsRow.bottom
+
+                QGCLabel {
+                    id:                     resolutionLabel
+                    width:                  _labelsWidth
+                    height:                 _elementsHeight
+                    wrapMode:               Text.WordWrap
+                    textFormat:             Text.RichText
+                    text:                   "Desired Resolution: "
+                }
+
+                QGCComboBox {
+                    id:                     resolutionComboBox
+                    model:                  QGroundControl.videoManager.mavlinkVideoManager.resolutionList
+                    width:                  _elementsWidth
+                    height:                 _elementsHeight
+                    onModelChanged: {
+                        currentIndex = QGroundControl.videoManager.mavlinkVideoManager.currentResolution
+                    }
+                    onActivated: {
+                        QGroundControl.videoManager.mavlinkVideoManager.currentResolution = index
+                    }
+                    textRole: 'text'
+                }
+            }
+
+            Row {
+                id:                         videoResolutionRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                resolutionRow.bottom
+
+                QGCLabel {
+                    id:                     videoResolutionLabel
+                    width:                  _labelsWidth
+                    height:                 _elementsHeight
+                    wrapMode:               Text.WordWrap
+                    textFormat:             Text.RichText
+                    text:                   "Real Video Resolution: "
+                }
+
+                QGCLabel {
+                    id:                     videoResolutionValueLabel
+                    width:                  _labelsWidth
+                    height:                 _elementsHeight
+                    wrapMode:               Text.WordWrap
+                    textFormat:             Text.RichText
+                    text:                   QGroundControl.videoManager.mavlinkVideoManager.videoResolution
+                }
+
+            }
+
+            Row {
+                id:                         uriRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                videoResolutionRow.bottom
 
                 QGCLabel {
                     id:                     uriLabel

--- a/src/ViewWidgets/VideoStreamingWidget.qml
+++ b/src/ViewWidgets/VideoStreamingWidget.qml
@@ -1,0 +1,124 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Widget
+ *   @author Ricardo de Almeida Gonzaga <ricardo.gonzaga@intel.com>
+ *   @author Otavio Pontes <otavio.pontes@intel.com>
+ */
+
+import QtQuick                    2.5
+import QtQuick.Controls           1.2
+import QtQuick.Controls.Styles    1.2
+import QtQuick.Dialogs            1.2
+
+import QGroundControl             1.0
+import QGroundControl.Palette     1.0
+import QGroundControl.Controls    1.0
+import QGroundControl.Controllers 1.0
+import QGroundControl.ScreenTools 1.0
+
+QGCView {
+    viewPanel:    panel
+
+    property real _margins:             ScreenTools.defaultFontPixelWidth
+    property real _labelsWidth:         ScreenTools.defaultFontPixelWidth * 7
+    property real _elementsHeight:      ScreenTools.defaultFontPixelWidth * 3
+    property real _elementsWidth:       ScreenTools.defaultFontPixelWidth * 28
+    property real _buttonWidth:         ScreenTools.defaultFontPixelWidth * 15
+
+    QGCPalette {
+        id:                qgcPal
+        colorGroupEnabled: enabled
+    }
+
+    QGCViewPanel {
+        id:                panel
+        anchors.fill:      parent
+        enabled:           QGroundControl.videoManager.isMAVLinkStream
+
+        Rectangle {
+            anchors.fill:                   parent
+            color:                          qgcPal.window
+
+            QGCLabel {
+                id:                         title
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                parent.top
+                horizontalAlignment:        Text.AlignHCenter
+                wrapMode:                   Text.WordWrap
+                textFormat:                 Text.RichText
+                text:                       "Mavlink Stream Configuration"
+            }
+
+            Row {
+                id:                         streamsRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                title.bottom
+
+                QGCLabel {
+                    id:                     streamsLabel
+                    width:                  _labelsWidth
+                    height:                 _elementsHeight
+                    wrapMode:               Text.WordWrap
+                    textFormat:             Text.RichText
+                    text:                   "Stream: "
+                }
+
+                QGCComboBox {
+                    id:                     streamsComboBox
+                    width:                  _elementsWidth
+                    height:                 _elementsHeight
+                    model:                  QGroundControl.videoManager.mavlinkVideoManager.streamList
+                    onModelChanged: {
+                        currentIndex = QGroundControl.videoManager.mavlinkVideoManager.selectedStream
+                    }
+                    onActivated: {
+                        QGroundControl.videoManager.mavlinkVideoManager.selectedStream = index;
+                    }
+                    textRole: 'text'
+                }
+            }
+
+            Row {
+                id:                         uriRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                streamsRow.bottom
+
+                QGCLabel {
+                    id:                     uriLabel
+                    width:                  _labelsWidth
+                    height:                 _elementsHeight
+                    wrapMode:               Text.WordWrap
+                    textFormat:             Text.RichText
+                    text:                   "Uri: "
+                }
+
+                QGCTextField {
+                    id:                     uriField
+                    width:                  _elementsWidth
+                    height:                 _elementsHeight
+                    anchors.verticalCenter: parent.verticalCenter
+                    readOnly:               true
+                    text:                   QGroundControl.videoManager.mavlinkVideoManager.currentUri
+                }
+            }
+        }
+    }
+}

--- a/src/ViewWidgets/VideoStreamingWidget.qml
+++ b/src/ViewWidgets/VideoStreamingWidget.qml
@@ -179,6 +179,24 @@ QGCView {
                     text:                   QGroundControl.videoManager.mavlinkVideoManager.currentUri
                 }
             }
+
+            Row {
+                id:                         refreshRow
+                spacing:                    ScreenTools.defaultFontPixelWidth
+                anchors.margins:            _margins
+                anchors.left:               parent.left
+                anchors.right:              parent.right
+                anchors.top:                uriRow.bottom
+
+                QGCButton {
+                    text:       qsTr("Refresh")
+                    width:      ScreenTools.defaultFontPixelWidth * 22
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    onClicked: {
+                        QGroundControl.videoManager.mavlinkVideoManager.refreshVideoProvider()
+                    }
+                }
+            }
         }
     }
 }

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -242,7 +242,11 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                 _startLogging();
                 mavlink_heartbeat_t heartbeat;
                 mavlink_msg_heartbeat_decode(&message, &heartbeat);
-                emit vehicleHeartbeatInfo(link, message.sysid, message.compid, heartbeat.mavlink_version, heartbeat.autopilot, heartbeat.type);
+
+                if (message.compid == MAV_COMP_ID_CAMERA) {
+                    emit videoHeartbeatInfo(link, message.sysid);
+                } else
+                    emit vehicleHeartbeatInfo(link, message.sysid, message.compid, heartbeat.mavlink_version, heartbeat.autopilot, heartbeat.type);
             }
 
             // Increase receive counter

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -129,6 +129,7 @@ protected:
 signals:
     /// Heartbeat received on link
     void vehicleHeartbeatInfo(LinkInterface* link, int vehicleId, int componentId, int vehicleMavlinkVersion, int vehicleFirmwareType, int vehicleType);
+    void videoHeartbeatInfo(LinkInterface* link, int systemId);
 
     /** @brief Message received and directly copied via signal */
     void messageReceived(LinkInterface* link, mavlink_message_t message);

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -51,6 +51,7 @@
 #include "QGCDockWidget.h"
 #include "HILDockWidget.h"
 #include "AppMessages.h"
+#include "VideoStreamingWidget.h"
 #endif
 
 #ifndef NO_SERIAL_LINK
@@ -71,7 +72,8 @@ enum DockWidgetTypes {
     ONBOARD_FILES,
     INFO_VIEW,
     HIL_CONFIG,
-    ANALYZE
+    ANALYZE,
+    VIDEO_STREAMING,
 };
 
 static const char *rgDockWidgetNames[] = {
@@ -80,7 +82,8 @@ static const char *rgDockWidgetNames[] = {
     "Onboard Files",
     "Info View",
     "HIL Config",
-    "Analyze"
+    "Analyze",
+    "Video Streaming",
 };
 
 #define ARRAY_SIZE(ARRAY) (sizeof(ARRAY) / sizeof(ARRAY[0]))
@@ -369,6 +372,9 @@ bool MainWindow::_createInnerDockWidget(const QString& widgetName)
                 break;
             case INFO_VIEW:
                 widget= new QGCTabbedInfoView(widgetName, action, this);
+                break;
+            case VIDEO_STREAMING:
+                widget = new VideoStreamingWidget(widgetName, action, this);
                 break;
         }
         if(action->data().toInt() == INFO_VIEW) {


### PR DESCRIPTION
TL;DR: Adding Basic video streams discovery on QGC using MAVLink messages merged on https://github.com/mavlink/mavlink/pull/677.

Justification:
Following the discussions on previous QGroundControl and mavlink repositories pull requests, as well as in the px4 discuss page and conversation with other developers interested in extending camera support in MAVLink, we concluded that we will need an extended way to send all information related to cameras  from the vehicle to the Ground Station, in order to have a nice and custom UI. As @dogmaphobic commented in other pull request, the suggestions on how to do it are being held on this page: http://discuss.px4.io/t/mavlink-camera-api-discussion/3278/21.

But, we have also discussed that it would be important to have a basic video camera support using only MAVLink messages, to be used as a fallback. And this is what I am proposing in this PR: To use MAVLink messages already merged in mavlink repository to discover video streams and present some available options to the user.

How to test it:
We have an implementation of a camera daemon that runs in a drone's companion board and it is used to advertise available cameras and stream videos using RTSP. It is available at https://github.com/01org/camera-streaming-daemon and all MAVLink messages used by this PR are implemented in that daemon. An easy way to test it is to run it on any system that have V4L2 compatible cameras, that will be advertised and streamed by the daemon. If you are running this on a drone you will also need a proxy to redirect camera specific MAVLink messages to the drone. I have tested that with https://github.com/01org/mavlink-router.

Video Support:
So far only RTSP video is supported. It is easy to add support for UDP video streaming though.

Why adding a new Widget:
Instead of adding the streams discovered using MAVLink to the video source ComboBox in General Settings page, I added a new option called "MAVLink Auto Discovery Streams" and created a new Widget to display the discovered streams and other stream settings. Why did I take this approach? Because I think it is important for the user to be able to change the video source and settings and watch the video at the same time and this is not possible if I used the General Settings for this. When you have multiple cameras in a drone, it is not practical to have the video selection in a different screen. Anyway, I accept suggestions regarding the proposed UI.