### PR TITLE
Allow UDP auto connect to be controlled through settings

### DIFF
--- a/src/Settings/AutoConnect.SettingsGroup.json
+++ b/src/Settings/AutoConnect.SettingsGroup.json
@@ -40,5 +40,23 @@
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a LibrePilot board which is connected via USB.",
     "type":             "bool",
     "defaultValue":     true
+},
+{
+    "name":             "AutoconnectUDPListenPort",
+    "shortDescription": "UDP port for autoconnect",
+    "type":             "uint32",
+    "defaultValue":     14550
+},
+{
+    "name":             "AutoconnectUDPTargetHostIP",
+    "shortDescription": "UDP target host IP for autoconnect",
+    "type":             "string",
+    "defaultValue":     ""
+},
+{
+    "name":             "AutoconnectUDPTargetHostPort",
+    "shortDescription": "UDP target host port for autoconnect",
+    "type":             "uint32",
+    "defaultValue":     14550
 }
 ]

--- a/src/Settings/AutoConnectSettings.cc
+++ b/src/Settings/AutoConnectSettings.cc
@@ -21,17 +21,23 @@ const char* AutoConnectSettings:: autoConnectSiKRadioSettingsName =     "Autocon
 const char* AutoConnectSettings:: autoConnectPX4FlowSettingsName =      "AutoconnectPX4Flow";
 const char* AutoConnectSettings:: autoConnectRTKGPSSettingsName =       "AutoconnectRTKGPS";
 const char* AutoConnectSettings:: autoConnectLibrePilotSettingsName =   "AutoconnectLibrePilot";
+const char* AutoConnectSettings:: udpListenPortName =                   "AutoconnectUDPListenPort";
+const char* AutoConnectSettings:: udpTargetHostIPName =                 "AutoconnectUDPTargetHostIP";
+const char* AutoConnectSettings:: udpTargetHostPortName =               "AutoconnectUDPTargetHostPort";
 
 const char* AutoConnectSettings::autoConnectSettingsGroupName = "AutoConnect";
 
 AutoConnectSettings::AutoConnectSettings(QObject* parent)
-    : SettingsGroup(autoConnectSettingsGroupName, _settingsGroup, parent)
-    , _autoConnectUDPFact(NULL)
-    , _autoConnectPixhawkFact(NULL)
-    , _autoConnectSiKRadioFact(NULL)
-    , _autoConnectPX4FlowFact(NULL)
-    , _autoConnectRTKGPSFact(NULL)
+    : SettingsGroup             (autoConnectSettingsGroupName, _settingsGroup, parent)
+    , _autoConnectUDPFact       (NULL)
+    , _autoConnectPixhawkFact   (NULL)
+    , _autoConnectSiKRadioFact  (NULL)
+    , _autoConnectPX4FlowFact   (NULL)
+    , _autoConnectRTKGPSFact    (NULL)
     , _autoConnectLibrePilotFact(NULL)
+    , _udpListenPortFact        (NULL)
+    , _udpTargetHostIPFact      (NULL)
+    , _udpTargetHostPortFact    (NULL)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<AutoConnectSettings>("QGroundControl.SettingsManager", 1, 0, "AutoConnectSettings", "Reference only");
@@ -89,4 +95,31 @@ Fact* AutoConnectSettings::autoConnectLibrePilot(void)
     }
 
     return _autoConnectLibrePilotFact;
+}
+
+Fact* AutoConnectSettings::udpListenPort(void)
+{
+    if (!_udpListenPortFact) {
+        _udpListenPortFact = _createSettingsFact(udpListenPortName);
+    }
+
+    return _udpListenPortFact;
+}
+
+Fact* AutoConnectSettings::udpTargetHostIP(void)
+{
+    if (!_udpTargetHostIPFact) {
+        _udpTargetHostIPFact = _createSettingsFact(udpTargetHostIPName);
+    }
+
+    return _udpTargetHostIPFact;
+}
+
+Fact* AutoConnectSettings::udpTargetHostPort(void)
+{
+    if (!_udpTargetHostPortFact) {
+        _udpTargetHostPortFact = _createSettingsFact(udpTargetHostPortName);
+    }
+
+    return _udpTargetHostPortFact;
 }

--- a/src/Settings/AutoConnectSettings.h
+++ b/src/Settings/AutoConnectSettings.h
@@ -25,6 +25,9 @@ public:
     Q_PROPERTY(Fact* autoConnectPX4Flow     READ autoConnectPX4Flow     CONSTANT)
     Q_PROPERTY(Fact* autoConnectRTKGPS      READ autoConnectRTKGPS      CONSTANT)
     Q_PROPERTY(Fact* autoConnectLibrePilot  READ autoConnectLibrePilot  CONSTANT)
+    Q_PROPERTY(Fact* udpListenPort          READ udpListenPort          CONSTANT)   ///< Port to listen on for UDP autoconnect
+    Q_PROPERTY(Fact* udpTargetHostIP        READ udpTargetHostIP        CONSTANT)   ///< Target host IP for UDP autoconnect, empty string for none
+    Q_PROPERTY(Fact* udpTargetHostPort      READ udpTargetHostPort      CONSTANT)   ///< Target host post for UDP autoconnect
 
     Fact* autoConnectUDP        (void);
     Fact* autoConnectPixhawk    (void);
@@ -32,6 +35,9 @@ public:
     Fact* autoConnectPX4Flow    (void);
     Fact* autoConnectRTKGPS     (void);
     Fact* autoConnectLibrePilot (void);
+    Fact* udpListenPort         (void);
+    Fact* udpTargetHostIP       (void);
+    Fact* udpTargetHostPort     (void);
 
     static const char* autoConnectSettingsGroupName;
 
@@ -41,6 +47,9 @@ public:
     static const char* autoConnectPX4FlowSettingsName;
     static const char* autoConnectRTKGPSSettingsName;
     static const char* autoConnectLibrePilotSettingsName;
+    static const char* udpListenPortName;
+    static const char* udpTargetHostIPName;
+    static const char* udpTargetHostPortName;
 
 private:
     SettingsFact* _autoConnectUDPFact;
@@ -49,6 +58,9 @@ private:
     SettingsFact* _autoConnectPX4FlowFact;
     SettingsFact* _autoConnectRTKGPSFact;
     SettingsFact* _autoConnectLibrePilotFact;
+    SettingsFact* _udpListenPortFact;
+    SettingsFact* _udpTargetHostIPFact;
+    SettingsFact* _udpTargetHostPortFact;
 
     static const char* _settingsGroup;
 };

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -459,8 +459,8 @@ void LinkManager::_updateAutoConnectLinks(void)
     }
     if (!foundUDP && _autoConnectSettings->autoConnectUDP()->rawValue().toBool()) {
         qCDebug(LinkManagerLog) << "New auto-connect UDP port added";
+        // Default UDPConfiguration is set up for autoconnect
         UDPConfiguration* udpConfig = new UDPConfiguration(_defaultUPDLinkName);
-        udpConfig->setLocalPort(QGC_UDP_LOCAL_PORT);
         udpConfig->setDynamic(true);
         SharedLinkConfigurationPointer config = addConfiguration(udpConfig);
         createConnectedLink(config);

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -34,9 +34,6 @@
 #include "QGCConfig.h"
 #include "LinkManager.h"
 
-#define QGC_UDP_LOCAL_PORT  14550
-#define QGC_UDP_TARGET_PORT 14555
-
 class UDPConfiguration : public LinkConfiguration
 {
     Q_OBJECT


### PR DESCRIPTION
This is to allow core plugin to be able to override the autoconnect udp port as well as set a single target host.