### PR TITLE
Plan fixes: RTL waypoint line, Mission End dialog

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -148,7 +148,10 @@ QGCView {
             }
         } else {
             if (promptForMissionRemove && (_missionController.containsItems || _geoFenceController.containsItems || _rallyPointController.containsItems)) {
-                root.showDialog(missionCompleteDialogComponent, qsTr("Flight Plan complete"), showDialogDefaultWidth, StandardButton.Close)
+                // ArduPilot has a strange bug which prevents mission clear from working at certain times, so we can't show this dialog
+                if (!_activeVehicle.apmFirmware) {
+                    root.showDialog(missionCompleteDialogComponent, qsTr("Flight Plan complete"), showDialogDefaultWidth, StandardButton.Close)
+                }
             }
             promptForMissionRemove = false
         }
@@ -168,7 +171,7 @@ QGCView {
                 anchors.fill:   parent
                 contentHeight:  column.height
 
-                Column {
+                ColumnLayout {
                     id:                 column
                     anchors.margins:    _margins
                     anchors.left:       parent.left
@@ -176,18 +179,26 @@ QGCView {
                     spacing:            ScreenTools.defaultFontPixelHeight
 
                     QGCLabel {
-                        text:                       qsTr("%1 Images Taken").arg(_activeVehicle.cameraTriggerPoints.count)
-                        anchors.horizontalCenter:   parent.horizontalCenter
-                        visible:                    _activeVehicle.cameraTriggerPoints.count != 0
+                        Layout.fillWidth:       true
+                        text:                   qsTr("%1 Images Taken").arg(_activeVehicle.cameraTriggerPoints.count)
+                        horizontalAlignment:    Text.AlignHCenter
+                        visible:                _activeVehicle.cameraTriggerPoints.count != 0
                     }
 
                     QGCButton {
-                        text:                       qsTr("Remove plan from vehicle")
-                        anchors.horizontalCenter:   parent.horizontalCenter
+                        Layout.fillWidth:   true
+                        text:               qsTr("Remove plan from vehicle")
                         onClicked: {
                             _planMasterController.removeAllFromVehicle()
                             hideDialog()
                         }
+                    }
+
+                    QGCButton {
+                        Layout.fillWidth:   true
+                        text:               qsTr("Leave plan on vehicle")
+                        anchors.horizontalCenter:   parent.horizontalCenter
+                        onClicked:                  hideDialog()
                     }
                 }
             }

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -209,6 +209,7 @@ private:
     void _updateBatteryInfo(int waypointIndex);
     bool _loadItemsFromJson(const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString);
     void _initLoadedVisualItems(QmlObjectListModel* loadedVisualItems);
+    void _addWaypointLineSegment(CoordVectHashTable& prevItemPairHashTable, VisualItemPair& pair);
 
 private:
     MissionManager*         _missionManager;

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -273,3 +273,11 @@ double MissionSettingsItem::specifiedFlightSpeed(void)
         return std::numeric_limits<double>::quiet_NaN();
     }
 }
+
+void MissionSettingsItem::setMissionEndRTL(bool missionEndRTL)
+{
+    if (missionEndRTL != _missionEndRTL) {
+        _missionEndRTL = missionEndRTL;
+        emit missionEndRTLChanged(missionEndRTL);
+    }
+}

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -26,15 +26,17 @@ class MissionSettingsItem : public ComplexMissionItem
 public:
     MissionSettingsItem(Vehicle* vehicle, QObject* parent = NULL);
 
-    Q_PROPERTY(Fact*    plannedHomePositionAltitude READ plannedHomePositionAltitude                                        CONSTANT)
-    Q_PROPERTY(bool     missionEndRTL               MEMBER _missionEndRTL                                                   NOTIFY missionEndRTLChanged)
-    Q_PROPERTY(QObject* cameraSection               READ cameraSection                                                      CONSTANT)
-    Q_PROPERTY(QObject* speedSection                READ speedSection                                                       CONSTANT)
+    Q_PROPERTY(Fact*    plannedHomePositionAltitude READ plannedHomePositionAltitude                            CONSTANT)
+    Q_PROPERTY(bool     missionEndRTL               READ missionEndRTL                  WRITE setMissionEndRTL  NOTIFY missionEndRTLChanged)
+    Q_PROPERTY(QObject* cameraSection               READ cameraSection                                          CONSTANT)
+    Q_PROPERTY(QObject* speedSection                READ speedSection                                           CONSTANT)
 
-    Fact*   plannedHomePositionAltitude (void) { return &_plannedHomePositionAltitudeFact; }
+    Fact*           plannedHomePositionAltitude (void) { return &_plannedHomePositionAltitudeFact; }
+    bool            missionEndRTL               (void) const { return _missionEndRTL; }
+    CameraSection*  cameraSection               (void) { return &_cameraSection; }
+    SpeedSection*   speedSection                (void) { return &_speedSection; }
 
-    CameraSection* cameraSection(void) { return &_cameraSection; }
-    SpeedSection* speedSection(void) { return &_speedSection; }
+    void setMissionEndRTL(bool missionEndRTL);
 
     /// Scans the loaded items for settings items
     bool scanForMissionSettings(QmlObjectListModel* visualItems, int scanIndex);


### PR DESCRIPTION
* If the mission ends in an RTL then there will be a waypoint line which links back to home
* The Mission End dialog now have a "Leave mission on vehicle" button to reduce confusion that you don't need to remove the mission from the vehicle
* The Mission End dialog doesn't show for ArduPilot vehicles since the ability to remove a mission from the vehicle is flaky