### PR TITLE
Mission Settings: Work on usability

### DIFF
--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -63,8 +63,8 @@ public:
     bool            isStandaloneCoordinate  (void) const final { return false; }
     bool            specifiesCoordinate     (void) const final;
     bool            specifiesAltitudeOnly   (void) const final { return false; }
-    QString         commandDescription      (void) const final { return "Mission Settings"; }
-    QString         commandName             (void) const final { return "Mission Settings"; }
+    QString         commandDescription      (void) const final { return "Mission Start"; }
+    QString         commandName             (void) const final { return "Mission Start"; }
     QString         abbreviation            (void) const final { return "H"; }
     QGeoCoordinate  coordinate              (void) const final { return _plannedHomePositionCoordinate; }
     QGeoCoordinate  exitCoordinate          (void) const final { return _plannedHomePositionCoordinate; }

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -235,11 +235,25 @@ Rectangle {
                 } // GridLayout
             }
 
+            CameraSection {
+                id:         cameraSection
+                checked:    true
+            }
+
+            QGCLabel {
+                anchors.left:           parent.left
+                anchors.right:          parent.right
+                text:                   qsTr("Above camera commands will take affect immediately upon mission start.")
+                wrapMode:               Text.WordWrap
+                horizontalAlignment:    Text.AlignHCenter
+                font.pointSize:         ScreenTools.smallFontPointSize
+                visible:                cameraSection.checked
+            }
+
             SectionHeader {
                 id:         missionEndHeader
                 text:       qsTr("Mission End")
                 checked:    true
-                showSpacer: false
             }
 
             Column {
@@ -254,20 +268,6 @@ Rectangle {
                 }
             }
 
-            CameraSection {
-                id:         cameraSection
-                checked:    missionItem.cameraSection.settingsSpecified
-            }
-
-            QGCLabel {
-                anchors.left:           parent.left
-                anchors.right:          parent.right
-                text:                   qsTr("Above camera commands will take affect immediately upon mission start.")
-                wrapMode:               Text.WordWrap
-                horizontalAlignment:    Text.AlignHCenter
-                font.pointSize:         ScreenTools.smallFontPointSize
-                visible:                cameraSection.checked
-            }
         } // Column
     } // Deferred loader
 } // Rectangle

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -85,60 +85,6 @@ Rectangle {
             spacing:        _margin
 
             SectionHeader {
-                id:         missionDefaultsSectionHeader
-                text:       qsTr("Mission Defaults")
-                checked:    true
-                showSpacer: false
-            }
-
-            Column {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                spacing:        _margin
-                visible:        missionDefaultsSectionHeader.checked
-
-                GridLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    columnSpacing:  ScreenTools.defaultFontPixelWidth
-                    rowSpacing:     columnSpacing
-                    columns:        2
-
-                    QGCLabel {
-                        text:       qsTr("Waypoint alt")
-                    }
-                    FactTextField {
-                        fact:               QGroundControl.settingsManager.appSettings.defaultMissionItemAltitude
-                        Layout.fillWidth:   true
-                    }
-
-                    QGCCheckBox {
-                        id:         flightSpeedCheckBox
-                        text:       qsTr("Flight speed")
-                        visible:    !_missionVehicle.vtol
-                        checked:    missionItem.speedSection.specifyFlightSpeed
-                        onClicked:   missionItem.speedSection.specifyFlightSpeed = checked
-                    }
-                    FactTextField {
-                        Layout.fillWidth:   true
-                        fact:               missionItem.speedSection.flightSpeed
-                        visible:            flightSpeedCheckBox.visible
-                        enabled:            flightSpeedCheckBox.checked
-                    }
-                } // GridLayout
-
-                QGCCheckBox {
-                    text:       qsTr("RTL after mission end")
-                    checked:    missionItem.missionEndRTL
-                    onClicked:  missionItem.missionEndRTL = checked
-                }
-            }
-
-            CameraSection {
-                checked: missionItem.cameraSection.settingsSpecified
-            }
-
-            SectionHeader {
                 id:         vehicleInfoSectionHeader
                 text:       qsTr("Vehicle Info")
                 visible:    _offlineEditing && !_waypointsOnlyMode
@@ -244,6 +190,83 @@ Rectangle {
                     onClicked:                  missionItem.coordinate = map.center
                     anchors.horizontalCenter:   parent.horizontalCenter
                 }
+            }
+
+            SectionHeader {
+                id:         missionDefaultsSectionHeader
+                text:       qsTr("Mission Defaults")
+                checked:    true
+            }
+
+            Column {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        _margin
+                visible:        missionDefaultsSectionHeader.checked
+
+                GridLayout {
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    columnSpacing:  ScreenTools.defaultFontPixelWidth
+                    rowSpacing:     columnSpacing
+                    columns:        2
+
+                    QGCLabel {
+                        text:       qsTr("Waypoint alt")
+                    }
+                    FactTextField {
+                        fact:               QGroundControl.settingsManager.appSettings.defaultMissionItemAltitude
+                        Layout.fillWidth:   true
+                    }
+
+                    QGCCheckBox {
+                        id:         flightSpeedCheckBox
+                        text:       qsTr("Flight speed")
+                        visible:    !_missionVehicle.vtol
+                        checked:    missionItem.speedSection.specifyFlightSpeed
+                        onClicked:   missionItem.speedSection.specifyFlightSpeed = checked
+                    }
+                    FactTextField {
+                        Layout.fillWidth:   true
+                        fact:               missionItem.speedSection.flightSpeed
+                        visible:            flightSpeedCheckBox.visible
+                        enabled:            flightSpeedCheckBox.checked
+                    }
+                } // GridLayout
+            }
+
+            SectionHeader {
+                id:         missionEndHeader
+                text:       qsTr("Mission End")
+                checked:    true
+                showSpacer: false
+            }
+
+            Column {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        _margin
+                visible:        missionEndHeader.checked
+
+                FactCheckBox {
+                    text:   qsTr("Return To Launch")
+                    fact:   missionItem.missionEndRTL
+                }
+            }
+
+            CameraSection {
+                id:         cameraSection
+                checked:    missionItem.cameraSection.settingsSpecified
+            }
+
+            QGCLabel {
+                anchors.left:           parent.left
+                anchors.right:          parent.right
+                text:                   qsTr("Above camera commands will take effect immediately upon mission start.")
+                wrapMode:               Text.WordWrap
+                horizontalAlignment:    Text.AlignHCenter
+                font.pointSize:         ScreenTools.smallFontPointSize
+                visible:                cameraSection.checked
             }
         } // Column
     } // Deferred loader

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -262,7 +262,7 @@ Rectangle {
             QGCLabel {
                 anchors.left:           parent.left
                 anchors.right:          parent.right
-                text:                   qsTr("Above camera commands will take effect immediately upon mission start.")
+                text:                   qsTr("Above camera commands will take affect immediately upon mission start.")
                 wrapMode:               Text.WordWrap
                 horizontalAlignment:    Text.AlignHCenter
                 font.pointSize:         ScreenTools.smallFontPointSize

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -83,6 +83,82 @@ Rectangle {
             anchors.right:  parent ? parent.right : undefined
             anchors.top:    parent ? parent.top   : undefined
             spacing:        _margin
+            SectionHeader {
+                id:         missionDefaultsSectionHeader
+                text:       qsTr("Mission Defaults")
+                checked:    true
+            }
+
+            Column {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        _margin
+                visible:        missionDefaultsSectionHeader.checked
+
+                GridLayout {
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    columnSpacing:  ScreenTools.defaultFontPixelWidth
+                    rowSpacing:     columnSpacing
+                    columns:        2
+
+                    QGCLabel {
+                        text:       qsTr("Waypoint alt")
+                    }
+                    FactTextField {
+                        fact:               QGroundControl.settingsManager.appSettings.defaultMissionItemAltitude
+                        Layout.fillWidth:   true
+                    }
+
+                    QGCCheckBox {
+                        id:         flightSpeedCheckBox
+                        text:       qsTr("Flight speed")
+                        visible:    !_missionVehicle.vtol
+                        checked:    missionItem.speedSection.specifyFlightSpeed
+                        onClicked:   missionItem.speedSection.specifyFlightSpeed = checked
+                    }
+                    FactTextField {
+                        Layout.fillWidth:   true
+                        fact:               missionItem.speedSection.flightSpeed
+                        visible:            flightSpeedCheckBox.visible
+                        enabled:            flightSpeedCheckBox.checked
+                    }
+                } // GridLayout
+            }
+
+            CameraSection {
+                id:         cameraSection
+                checked:    true
+            }
+
+            QGCLabel {
+                anchors.left:           parent.left
+                anchors.right:          parent.right
+                text:                   qsTr("Above camera commands will take affect immediately upon mission start.")
+                wrapMode:               Text.WordWrap
+                horizontalAlignment:    Text.AlignHCenter
+                font.pointSize:         ScreenTools.smallFontPointSize
+                visible:                cameraSection.checked
+            }
+
+            SectionHeader {
+                id:         missionEndHeader
+                text:       qsTr("Mission End")
+                checked:    true
+            }
+
+            Column {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        _margin
+                visible:        missionEndHeader.checked
+
+                FactCheckBox {
+                    text:   qsTr("Return To Launch")
+                    fact:   missionItem.missionEndRTL
+                }
+            }
+
 
             SectionHeader {
                 id:         vehicleInfoSectionHeader
@@ -191,83 +267,6 @@ Rectangle {
                     anchors.horizontalCenter:   parent.horizontalCenter
                 }
             }
-
-            SectionHeader {
-                id:         missionDefaultsSectionHeader
-                text:       qsTr("Mission Defaults")
-                checked:    true
-            }
-
-            Column {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                spacing:        _margin
-                visible:        missionDefaultsSectionHeader.checked
-
-                GridLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    columnSpacing:  ScreenTools.defaultFontPixelWidth
-                    rowSpacing:     columnSpacing
-                    columns:        2
-
-                    QGCLabel {
-                        text:       qsTr("Waypoint alt")
-                    }
-                    FactTextField {
-                        fact:               QGroundControl.settingsManager.appSettings.defaultMissionItemAltitude
-                        Layout.fillWidth:   true
-                    }
-
-                    QGCCheckBox {
-                        id:         flightSpeedCheckBox
-                        text:       qsTr("Flight speed")
-                        visible:    !_missionVehicle.vtol
-                        checked:    missionItem.speedSection.specifyFlightSpeed
-                        onClicked:   missionItem.speedSection.specifyFlightSpeed = checked
-                    }
-                    FactTextField {
-                        Layout.fillWidth:   true
-                        fact:               missionItem.speedSection.flightSpeed
-                        visible:            flightSpeedCheckBox.visible
-                        enabled:            flightSpeedCheckBox.checked
-                    }
-                } // GridLayout
-            }
-
-            CameraSection {
-                id:         cameraSection
-                checked:    true
-            }
-
-            QGCLabel {
-                anchors.left:           parent.left
-                anchors.right:          parent.right
-                text:                   qsTr("Above camera commands will take affect immediately upon mission start.")
-                wrapMode:               Text.WordWrap
-                horizontalAlignment:    Text.AlignHCenter
-                font.pointSize:         ScreenTools.smallFontPointSize
-                visible:                cameraSection.checked
-            }
-
-            SectionHeader {
-                id:         missionEndHeader
-                text:       qsTr("Mission End")
-                checked:    true
-            }
-
-            Column {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                spacing:        _margin
-                visible:        missionEndHeader.checked
-
-                FactCheckBox {
-                    text:   qsTr("Return To Launch")
-                    fact:   missionItem.missionEndRTL
-                }
-            }
-
         } // Column
     } // Deferred loader
 } // Rectangle


### PR DESCRIPTION
There is confusion around what the camera commands do in Mission Settings. The key is that they take affect immediately. So if you turn on the camera you are going to get photos/video from the ground on up.

Default visuals:
![screen shot 2017-06-16 at 2 40 09 pm](https://user-images.githubusercontent.com/5876851/27245742-3d84ff74-52a2-11e7-887d-7fde79aa0bf5.png)

Camera section manually opened:
![screen shot 2017-06-16 at 2 40 17 pm](https://user-images.githubusercontent.com/5876851/27245750-452150d4-52a2-11e7-8713-5d46f6b0bb17.png)
