### PR TITLE
Enable only the gestures we're interested in.

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -27,6 +27,8 @@ Map {
 
     zoomLevel:                  QGroundControl.flightMapZoom
     center:                     QGroundControl.flightMapPosition
+    //-- Qt 5.9 has rotation gesture enabled by default. Here we limit the possible gestures.
+    gesture.acceptedGestures:   MapGestureArea.PinchGesture | MapGestureArea.PanGesture | MapGestureArea.FlickGesture
     gesture.flickDeceleration:  3000
     plugin:                     Plugin { name: "QGroundControl" }
 


### PR DESCRIPTION
Qt 5.9 has added a few more map gestures, some of which QGC doesn't yet handle (rotation, tilt, etc.) To avoid these, I'm now explicitly defining the desired (enabled) gestures for maps.