### PR TITLE
Decouple VideoReceiver from VideoManager.

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -370,7 +370,7 @@ QGCView {
             anchors.right:      _flightVideo.right
             height:             ScreenTools.defaultFontPixelHeight * 2
             width:              height
-            visible:            QGroundControl.videoManager.videoRunning && QGroundControl.settingsManager.videoSettings.showRecControl.rawValue
+            visible:            QGroundControl.videoManager.videoReceiver.videoRunning && QGroundControl.settingsManager.videoSettings.showRecControl.rawValue
             opacity:            0.75
 
             Rectangle {

--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -29,7 +29,7 @@ Item {
         id:             noVideo
         anchors.fill:   parent
         color:          Qt.rgba(0,0,0,0.75)
-        visible:        !QGroundControl.videoManager.videoRunning
+        visible:        !QGroundControl.videoManager.videoReceiver.videoRunning
         QGCLabel {
             text:               qsTr("WAITING FOR VIDEO")
             font.family:        ScreenTools.demiboldFontFamily
@@ -41,20 +41,20 @@ Item {
     Rectangle {
         anchors.fill:   parent
         color:          "black"
-        visible:        QGroundControl.videoManager.videoRunning
+        visible:        QGroundControl.videoManager.videoReceiver.videoRunning
         QGCVideoBackground {
             id:             videoContent
             height:         parent.height
             width:          _ar != 0.0 ? height * _ar : parent.width
             anchors.centerIn: parent
-            display:        QGroundControl.videoManager.videoSurface
             receiver:       QGroundControl.videoManager.videoReceiver
-            visible:        QGroundControl.videoManager.videoRunning
+            display:        QGroundControl.videoManager.videoReceiver.videoSurface
+            visible:        QGroundControl.videoManager.videoReceiver.videoRunning
             Connections {
-                target:         QGroundControl.videoManager
+                target:         QGroundControl.videoManager.videoReceiver
                 onImageFileChanged: {
                     videoContent.grabToImage(function(result) {
-                        if (!result.saveToFile(QGroundControl.videoManager.imageFile)) {
+                        if (!result.saveToFile(QGroundControl.videoManager.videoReceiver.imageFile)) {
                             console.error('Error capturing video frame');
                         }
                     });

--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -16,7 +16,6 @@
 #include <QUrl>
 
 #include "QGCLoggingCategory.h"
-#include "VideoSurface.h"
 #include "VideoReceiver.h"
 #include "QGCToolbox.h"
 
@@ -35,21 +34,13 @@ public:
     Q_PROPERTY(bool             hasVideo            READ    hasVideo                                    NOTIFY hasVideoChanged)
     Q_PROPERTY(bool             isGStreamer         READ    isGStreamer                                 NOTIFY isGStreamerChanged)
     Q_PROPERTY(QString          videoSourceID       READ    videoSourceID                               NOTIFY videoSourceIDChanged)
-    Q_PROPERTY(bool             videoRunning        READ    videoRunning                                NOTIFY videoRunningChanged)
     Q_PROPERTY(bool             uvcEnabled          READ    uvcEnabled                                  CONSTANT)
-    Q_PROPERTY(VideoSurface*    videoSurface        READ    videoSurface                                CONSTANT)
     Q_PROPERTY(VideoReceiver*   videoReceiver       READ    videoReceiver                               CONSTANT)
-    Q_PROPERTY(QString          imageFile           READ    imageFile                                   NOTIFY imageFileChanged)
-    Q_PROPERTY(bool             showFullScreen      READ    showFullScreen  WRITE setShowFullScreen     NOTIFY showFullScreenChanged)
 
     bool        hasVideo            ();
     bool        isGStreamer         ();
-    bool        videoRunning        () { return _videoRunning; }
     QString     videoSourceID       () { return _videoSourceID; }
-    QString     imageFile           () { return _imageFile; }
-    bool        showFullScreen      () { return _showFullScreen; }
 
-    VideoSurface*   videoSurface    () { return _videoSurface; }
     VideoReceiver*  videoReceiver   () { return _videoReceiver; }
 
 #if defined(QGC_DISABLE_UVC)
@@ -58,43 +49,26 @@ public:
     bool        uvcEnabled          ();
 #endif
 
-    void        grabImage           (QString imageFile);
-    void        setShowFullScreen   (bool show) { _showFullScreen = show; emit showFullScreenChanged(); }
-
     // Override from QGCTool
     void        setToolbox          (QGCToolbox *toolbox);
 
 signals:
-    void hasVideoChanged        ();
-    void videoRunningChanged    ();
-    void isGStreamerChanged     ();
-    void videoSourceIDChanged   ();
-    void imageFileChanged       ();
-    void showFullScreenChanged  ();
+    void hasVideoChanged            ();
+    void isGStreamerChanged         ();
+    void videoSourceIDChanged       ();
 
 private slots:
-    void _videoSourceChanged(void);
-    void _udpPortChanged(void);
-    void _rtspUrlChanged(void);
+    void _videoSourceChanged        ();
+    void _udpPortChanged            ();
+    void _rtspUrlChanged            ();
 
 private:
-    void _updateTimer           ();
-    void _updateSettings        ();
-    void _updateVideo           ();
-    void _restartVideo          ();
+    void _updateSettings            ();
+    void _restartVideo              ();
 
-
-    VideoSurface*   _videoSurface;
     VideoReceiver*  _videoReceiver;
-    bool            _videoRunning;
-#if defined(QGC_GST_STREAMING)
-    QTimer          _frameTimer;
-#endif
-    QString         _videoSourceID;
-    bool            _init;
     VideoSettings*  _videoSettings;
-    QString         _imageFile;
-    bool            _showFullScreen;
+    QString         _videoSourceID;
 };
 
 #endif

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -345,8 +345,6 @@ void QGCApplication::_initCommon(void)
 
     qmlRegisterUncreatableType<CoordinateVector>    ("QGroundControl",                  1, 0, "CoordinateVector",       "Reference only");
     qmlRegisterUncreatableType<QmlObjectListModel>  ("QGroundControl",                  1, 0, "QmlObjectListModel",     "Reference only");
-    qmlRegisterUncreatableType<VideoReceiver>       ("QGroundControl",                  1, 0, "VideoReceiver",          "Reference only");
-    qmlRegisterUncreatableType<VideoSurface>        ("QGroundControl",                  1, 0, "VideoSurface",           "Reference only");
     qmlRegisterUncreatableType<MissionCommandTree>  ("QGroundControl",                  1, 0, "MissionCommandTree",     "Reference only");
 
     qmlRegisterUncreatableType<AutoPilotPlugin>     ("QGroundControl.AutoPilotPlugin",      1, 0, "AutoPilotPlugin",        "Reference only");

--- a/src/VideoStreaming/VideoReceiver.h
+++ b/src/VideoStreaming/VideoReceiver.h
@@ -22,6 +22,8 @@
 #include <QTimer>
 #include <QTcpSocket>
 
+#include "VideoSurface.h"
+
 #if defined(QGC_GST_STREAMING)
 #include <gst/gst.h>
 #endif
@@ -33,51 +35,64 @@ class VideoReceiver : public QObject
     Q_OBJECT
 public:
 #if defined(QGC_GST_STREAMING)
-    Q_PROPERTY(bool recording READ recording NOTIFY recordingChanged)
+    Q_PROPERTY(bool             recording           READ    recording           NOTIFY recordingChanged)
 #endif
+    Q_PROPERTY(VideoSurface*    videoSurface        READ    videoSurface        CONSTANT)
+    Q_PROPERTY(bool             videoRunning        READ    videoRunning        NOTIFY videoRunningChanged)
+    Q_PROPERTY(QString          imageFile           READ    imageFile           NOTIFY imageFileChanged)
+    Q_PROPERTY(bool             showFullScreen      READ    showFullScreen      WRITE setShowFullScreen     NOTIFY showFullScreenChanged)
 
     explicit VideoReceiver(QObject* parent = 0);
     ~VideoReceiver();
 
 #if defined(QGC_GST_STREAMING)
-    void setVideoSink(GstElement* sink);
-
-    bool running()   { return _running;   }
-    bool recording() { return _recording; }
-    bool streaming() { return _streaming; }
-    bool starting()  { return _starting;  }
-    bool stopping()  { return _stopping;  }
+    bool            running         () { return _running;   }
+    bool            recording       () { return _recording; }
+    bool            streaming       () { return _streaming; }
+    bool            starting        () { return _starting;  }
+    bool            stopping        () { return _stopping;  }
 #endif
 
+    VideoSurface*   videoSurface    () { return _videoSurface; }
+    bool            videoRunning    () { return _videoRunning; }
+    QString         imageFile       () { return _imageFile; }
+    bool            showFullScreen  () { return _showFullScreen; }
+    void            grabImage       (QString imageFile);
+
+    void        setShowFullScreen   (bool show) { _showFullScreen = show; emit showFullScreenChanged(); }
 
 signals:
+    void videoRunningChanged        ();
+    void imageFileChanged           ();
+    void showFullScreenChanged      ();
 #if defined(QGC_GST_STREAMING)
-    void recordingChanged();
-    void msgErrorReceived();
-    void msgEOSReceived();
-    void msgStateChangedReceived();
+    void recordingChanged           ();
+    void msgErrorReceived           ();
+    void msgEOSReceived             ();
+    void msgStateChangedReceived    ();
 #endif
 
 public slots:
-    void start              ();
-    void stop               ();
-    void setUri             (const QString& uri);
-    void stopRecording      ();
-    void startRecording     ();
-
+    void start                      ();
+    void stop                       ();
+    void setUri                     (const QString& uri);
+    void stopRecording              ();
+    void startRecording             ();
 
 private slots:
+    void _updateTimer               ();
 #if defined(QGC_GST_STREAMING)
-    void _timeout       ();
-    void _connected     ();
-    void _socketError   (QAbstractSocket::SocketError socketError);
-    void _handleError();
-    void _handleEOS();
-    void _handleStateChanged();
+    void _timeout                   ();
+    void _connected                 ();
+    void _socketError               (QAbstractSocket::SocketError socketError);
+    void _handleError               ();
+    void _handleEOS                 ();
+    void _handleStateChanged        ();
 #endif
 
 private:
 #if defined(QGC_GST_STREAMING)
+
     typedef struct
     {
         GstPad*         teepad;
@@ -96,29 +111,32 @@ private:
     Sink*               _sink;
     GstElement*         _tee;
 
-    static gboolean             _onBusMessage(GstBus* bus, GstMessage* message, gpointer user_data);
-    static GstPadProbeReturn    _unlinkCallBack(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
-    void                        _detachRecordingBranch(GstPadProbeInfo* info);
+    static gboolean             _onBusMessage           (GstBus* bus, GstMessage* message, gpointer user_data);
+    static GstPadProbeReturn    _unlinkCallBack         (GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
+    void                        _detachRecordingBranch  (GstPadProbeInfo* info);
     void                        _shutdownRecordingBranch();
-    void                        _shutdownPipeline();
-    void                        _cleanupOldVideos();
+    void                        _shutdownPipeline       ();
+    void                        _cleanupOldVideos       ();
+    void                        _setVideoSink           (GstElement* sink);
 
-#endif
-
-    QString     _uri;
-
-#if defined(QGC_GST_STREAMING)
-    GstElement*         _pipeline;
-    GstElement*         _pipelineStopRec;
-    GstElement*         _videoSink;
-#endif
+    GstElement*     _pipeline;
+    GstElement*     _pipelineStopRec;
+    GstElement*     _videoSink;
 
     //-- Wait for Video Server to show up before starting
-#if defined(QGC_GST_STREAMING)
-    QTimer      _timer;
-    QTcpSocket* _socket;
-    bool        _serverPresent;
+    QTimer          _frameTimer;
+    QTimer          _timer;
+    QTcpSocket*     _socket;
+    bool            _serverPresent;
+
 #endif
+
+    QString         _uri;
+    QString         _imageFile;
+    VideoSurface*   _videoSurface;
+    bool            _videoRunning;
+    bool            _showFullScreen;
+
 };
 
 #endif // VIDEORECEIVER_H

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -345,6 +345,13 @@ Item {
         id:                 flightView
         anchors.fill:       parent
         visible:            true
+        //-------------------------------------------------------------------------
+        //-- Loader helper for any child, no matter how deep can display an element
+        //   on top of the video window.
+        Loader {
+            id:             rootVideoLoader
+            anchors.centerIn: parent
+        }
     }
 
     Loader {


### PR DESCRIPTION
When video streaming was first added to QGC, it was all based on the assumption one single stream was ever in use. The `VideoManager` class provided all the methods for controlling this one single stream.

This PR decouples `VideoReceiver` from `VideoManager`. Now, all the properties, methods and ancillary classes needed for a video stream are built solely within `VideoReceiver`.

The original video stream, the one that existed until now, will continue to exist and work in the exact same way. That's the video stream exposed by `VideoManager`. What is different is that now you can create separate instances of `VideoReceiver` for additional video streams.
