### PR TITLE
ExternalLibs: Fix compilation on windows 64bit

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -80,11 +80,14 @@ MacBuild {
 } else:LinuxBuild {
     PKGCONFIG = sdl2
 } else:WindowsBuild {
-    INCLUDEPATH += \
-        $$BASEDIR/libs/lib/sdl2/msvc/include \
+    INCLUDEPATH += $$BASEDIR/libs/lib/sdl2/msvc/include
 
+    contains(QT_ARCH, i386) {
+        LIBS += -L$$BASEDIR/libs/lib/sdl2/msvc/lib/x86
+    } else {
+        LIBS += -L$$BASEDIR/libs/lib/sdl2/msvc/lib/x64
+    }
     LIBS += \
-        -L$$BASEDIR/libs/lib/sdl2/msvc/lib/x86 \
         -lSDL2main \
         -lSDL2
 }


### PR DESCRIPTION
Add switch to QGCExternalLibs.pri to check whether 32bit or 64bit version of SDL should be used on windows