### PR TITLE
Put back correct app name

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -76,7 +76,7 @@ WindowsBuild {
 # Branding
 #
 
-QGC_APP_NAME        = "QGroundControl Foo"
+QGC_APP_NAME        = "QGroundControl"
 QGC_ORG_NAME        = "QGroundControl.org"
 QGC_ORG_DOMAIN      = "org.qgroundcontrol"
 QGC_APP_DESCRIPTION = "Open source ground control app provided by QGroundControl dev team"


### PR DESCRIPTION
While testing custom installed changed I changed app name to "QGroundControl Foo" for testing. Then I left that in and merged it!