### PR TITLE
Deal with macdeployqt relocation issues

### DIFF
--- a/QGCInstaller.pri
+++ b/QGCInstaller.pri
@@ -28,6 +28,9 @@ installer {
         # links to plugins will not be created correctly.
         QMAKE_POST_LINK += && mkdir -p $${DESTDIR}/package
         QMAKE_POST_LINK += && cd $${DESTDIR} && $$dirname(QMAKE_QMAKE)/macdeployqt $${TARGET}.app -appstore-compliant -verbose=2 -qmldir=$${BASEDIR}/src
+        # macdeploy is missing some relocations once in a while. "Fix" it:
+        QMAKE_POST_LINK += && python $$BASEDIR/tools/osxrelocator.py $${TARGET}.app/Contents @rpath @executable_path/../Frameworks -r > /dev/null 2>&1
+        # Create package
         QMAKE_POST_LINK += && cd $${OUT_PWD}
         QMAKE_POST_LINK += && hdiutil create -verbose -stretch 4g -layout SPUD -srcfolder $${DESTDIR}/$${TARGET}.app -volname $${TARGET} $${DESTDIR}/package/$${TARGET}.dmg
     }


### PR DESCRIPTION
Yet another attempt at the macOS relocation issue:

For some unknown reason, `macdeployqt` is messing the relocation of some frameworks during the build phase. This appears to only happen on Travis (I have never been able to reproduce this on a local build).

The "fix" is to let it run (it saves a boatload of work in picking the needed various Qt frameworks and plugins) but run a subsequent, wholesale relocation afterwards. This will guarantee that all frameworks are properly relocated.