### PR TITLE
Set default video streaming to Disabled.

### DIFF
--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -114,11 +114,8 @@ VideoManager::_rtspUrlChanged()
 bool
 VideoManager::hasVideo()
 {
-#if defined(QGC_GST_STREAMING)
-    return true;
-#endif
     QString videoSource = _videoSettings->videoSource()->rawValue().toString();
-    return !videoSource.isEmpty() && videoSource != VideoSettings::videoSourceNoVideo;
+    return !videoSource.isEmpty() && videoSource != VideoSettings::videoSourceNoVideo && videoSource != VideoSettings::videoDisabled;
 }
 
 //-----------------------------------------------------------------------------
@@ -150,7 +147,7 @@ VideoManager::_updateSettings()
         return;
     if (_videoSettings->videoSource()->rawValue().toString() == VideoSettings::videoSourceUDP)
         _videoReceiver->setUri(QStringLiteral("udp://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
-    else
+    else if (_videoSettings->videoSource()->rawValue().toString() == VideoSettings::videoSourceRTSP)
         _videoReceiver->setUri(_videoSettings->rtspUrl()->rawValue().toString());
 }
 

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -29,6 +29,7 @@ const char* VideoSettings::recordingFormatName =    "RecordingFormat";
 const char* VideoSettings::maxVideoSizeName =       "MaxVideoSize";
 
 const char* VideoSettings::videoSourceNoVideo =     "No Video Available";
+const char* VideoSettings::videoDisabled =          "Video Stream Disabled";
 const char* VideoSettings::videoSourceUDP =         "UDP Video Stream";
 const char* VideoSettings::videoSourceRTSP =        "RTSP Video Stream";
 
@@ -47,6 +48,7 @@ VideoSettings::VideoSettings(QObject* parent)
     qmlRegisterUncreatableType<VideoSettings>("QGroundControl.SettingsManager", 1, 0, "VideoSettings", "Reference only");
 
     // Setup enum values for videoSource settings into meta data
+    bool noVideo = false;
     QStringList videoSourceList;
 #ifdef QGC_GST_STREAMING
 #ifndef NO_UDP_VIDEO
@@ -61,7 +63,10 @@ VideoSettings::VideoSettings(QObject* parent)
     }
 #endif
     if (videoSourceList.count() == 0) {
+        noVideo = true;
         videoSourceList.append(videoSourceNoVideo);
+    } else {
+        videoSourceList.insert(0, videoDisabled);
     }
     QVariantList videoSourceVarList;
     foreach (const QString& videoSource, videoSourceList) {
@@ -70,11 +75,11 @@ VideoSettings::VideoSettings(QObject* parent)
     _nameToMetaDataMap[videoSourceName]->setEnumInfo(videoSourceList, videoSourceVarList);
 
     // Set default value for videoSource
-#if defined(NO_UDP_VIDEO)
-    _nameToMetaDataMap[videoSourceName]->setRawDefaultValue(videoSourceRTSP);
-#else
-    _nameToMetaDataMap[videoSourceName]->setRawDefaultValue(videoSourceUDP);
-#endif
+    if (noVideo) {
+        _nameToMetaDataMap[videoSourceName]->setRawDefaultValue(videoSourceNoVideo);
+    } else {
+        _nameToMetaDataMap[videoSourceName]->setRawDefaultValue(videoDisabled);
+    }
 }
 
 Fact* VideoSettings::videoSource(void)

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -49,6 +49,7 @@ public:
     static const char* maxVideoSizeName;
 
     static const char* videoSourceNoVideo;
+    static const char* videoDisabled;
     static const char* videoSourceUDP;
     static const char* videoSourceRTSP;
 

--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -220,10 +220,11 @@ VideoReceiver::start()
 
     _starting = true;
 
-    bool isUdp = _uri.contains("udp://");
+    bool isUdp  = _uri.contains("udp://");
+    bool isRtsp = _uri.contains("rtsp://");
 
     //-- For RTSP, check to see if server is there first
-    if(!_serverPresent && !isUdp) {
+    if(!_serverPresent && isRtsp) {
         _timer.start(100);
         return;
     }
@@ -776,7 +777,7 @@ VideoReceiver::_updateTimer()
                 stop();
             }
         } else {
-            if(!running()) {
+            if(!running() && !_uri.isEmpty()) {
                 start();
             }
         }

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -529,7 +529,7 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.settingsManager.videoSettings.udpPort.visible && QGroundControl.videoManager.isGStreamer && videoSource.currentIndex === 0
+                            visible:    QGroundControl.settingsManager.videoSettings.udpPort.visible && QGroundControl.videoManager.isGStreamer && videoSource.currentIndex === 1
                             QGCLabel {
                                 text:               qsTr("UDP Port:")
                                 width:              _labelWidth
@@ -543,7 +543,7 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.settingsManager.videoSettings.rtspUrl.visible && QGroundControl.videoManager.isGStreamer && videoSource.currentIndex === 1
+                            visible:    QGroundControl.settingsManager.videoSettings.rtspUrl.visible && QGroundControl.videoManager.isGStreamer && videoSource.currentIndex === 2
                             QGCLabel {
                                 anchors.verticalCenter: parent.verticalCenter
                                 text:               qsTr("RTSP URL:")
@@ -557,7 +557,7 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex < 2 && QGroundControl.settingsManager.videoSettings.aspectRatio.visible
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 3 && QGroundControl.settingsManager.videoSettings.aspectRatio.visible
                             QGCLabel {
                                 text:               qsTr("Aspect Ratio:")
                                 width:              _labelWidth
@@ -571,7 +571,7 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex < 2 && QGroundControl.settingsManager.videoSettings.gridLines.visible
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 3 && QGroundControl.settingsManager.videoSettings.gridLines.visible
                             QGCLabel {
                                 text:               qsTr("Grid Lines:")
                                 width:              _labelWidth
@@ -613,7 +613,7 @@ QGCView {
                         anchors.centerIn: parent
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex < 2 && QGroundControl.settingsManager.videoSettings.maxVideoSize.visible
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 3 && QGroundControl.settingsManager.videoSettings.maxVideoSize.visible
                             QGCLabel {
                                 text:               qsTr("Max Storage Usage:")
                                 width:              _labelWidth
@@ -627,7 +627,7 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex < 2 && QGroundControl.settingsManager.videoSettings.recordingFormat.visible
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 3 && QGroundControl.settingsManager.videoSettings.recordingFormat.visible
                             QGCLabel {
                                 text:               qsTr("Video File Format:")
                                 width:              _labelWidth


### PR DESCRIPTION
Video streaming source now defaults to *Disabled*. This is just the default, initial source option. Once set to something else, it will persist.

Having a default to anything doesn't really make much sense as there is nothing _standard_ about video streaming to default to.

Note that this will only be noticeable for new installations. If you already have QGC installed, it will pick up whatever source you had defined last. You can always select *Video Stream Disabled*, under General Settings, to disable video streaming.

Fixes #5380 
