### PR TITLE
Work around FlightMap weirdness

### DIFF
--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -54,7 +54,7 @@ stQGeoTileCacheQGCMapTypes kMapTypes[] = {
     {"Bing Street Map",         UrlFactory::BingMap},
     {"Bing Satellite Map",      UrlFactory::BingSatellite},
     {"Bing Hybrid Map",         UrlFactory::BingHybrid},
-    {"Statkart Topo2",          UrlFactory::StatkartTopo},
+    {"Statkart Terrain Map",    UrlFactory::StatkartTopo},
     /*
     {"MapQuest Street Map",     UrlFactory::MapQuestMap},
     {"MapQuest Satellite Map",  UrlFactory::MapQuestSat}

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -120,7 +120,7 @@ QGeoTiledMappingManagerEngineQGC::QGeoTiledMappingManagerEngineQGC(const QVarian
     mapTypes << QGCGEOMAPTYPE(QGeoMapType::HybridMap,         "Bing Hybrid Map",          "Bing hybrid map",                  false,  false,  UrlFactory::BingHybrid);
 
     // Statkart
-    mapTypes << QGCGEOMAPTYPE(QGeoMapType::TerrainMap,        "Statkart Topo2",           "Statkart Topo2",                   false,  false,  UrlFactory::StatkartTopo);
+    mapTypes << QGCGEOMAPTYPE(QGeoMapType::TerrainMap,        "Statkart Terrain Map",     "Statkart Terrain Map",             false,  false,  UrlFactory::StatkartTopo);
 
     // Esri
     mapTypes << QGCGEOMAPTYPE(QGeoMapType::StreetMap,         "Esri Street Map",          "ArcGIS Online World Street Map",   true,   false,  UrlFactory::EsriWorldStreet);


### PR DESCRIPTION
It took me quite a while to figure this one out. Even though there is a MapEngine class handling all mapping services, the main map view uses its own, hardcoded set of maps and types, which is a subset of the available maps. The issue with Statkart was that it was named "Statkart Topo2" and the main map view uses hardcoded types (Street, Satellite, Hybrid or Terrain). The "Topo2" part wasn't one of those and therefore, it would not "find" it.

The "Fix" was to rename "Statkart Topo2" to "Statkart Terrain Map".

Note that *Offline Maps* uses MapEngine. That means it will allow you to create map tile sets from any available map source but it also means some of those, specifically those not named "Street Map", "Satellite Map", "Hybrid Map" or "Terrain Map" won't ever match and cannot be used.

Fixes #5372