### PR TITLE
Survey: Option to take images in turnarounds

### DIFF
--- a/src/MissionManager/Survey.SettingsGroup.json
+++ b/src/MissionManager/Survey.SettingsGroup.json
@@ -132,7 +132,7 @@
     "name":             "CameraTriggerInTurnaround",
     "shortDescription": "Camera continues taking images in turnarounds.",
     "type":             "bool",
-    "defaultValue":     false
+    "defaultValue":     true
 },
 {
     "name":             "HoverAndCapture",

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -252,12 +252,6 @@ Rectangle {
                     enabled:            cameraTriggerDistanceCheckBox.checked
                 }
             }
-
-            FactCheckBox {
-                text:       qsTr("Hover and capture image")
-                fact:       missionItem.hoverAndCapture
-                visible:    missionItem.hoverAndCaptureAllowed
-            }
         }
 
         // Camera based grid ui
@@ -385,6 +379,23 @@ Rectangle {
                     Layout.preferredWidth:  _root._fieldWidth
                     fact:                   missionItem.sideOverlap
                 }
+            }
+
+            FactCheckBox {
+                text:       qsTr("Hover and capture image")
+                fact:       missionItem.hoverAndCapture
+                visible:    missionItem.hoverAndCaptureAllowed
+                onClicked: {
+                    if (checked) {
+                        missionItem.cameraTriggerInTurnaround.rawValue = false
+                    }
+                }
+            }
+
+            FactCheckBox {
+                text:       qsTr("Take images in turnarounds")
+                fact:       missionItem.cameraTriggerInTurnaround
+                enabled:    !missionItem.hoverAndCapture.rawValue
             }
 
             SectionHeader {


### PR DESCRIPTION
Getting correct coverage over a survey polygon is a bit of black magic due to waypoint acceptance causing trigerring to start/stop too early. Due to this I'm adding back to option in Survey to take images throughout the entire survey. This gets better coverage, but you need to deal with possibly tilted images in the turnaround on fixed wing.