### PR TITLE
Go to location fixes

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -73,6 +73,7 @@
         <file alias="QGroundControl/Controls/MissionItemStatus.qml">src/PlanView/MissionItemStatus.qml</file>
         <file alias="QGroundControl/Controls/ModeSwitchDisplay.qml">src/QmlControls/ModeSwitchDisplay.qml</file>
         <file alias="QGroundControl/Controls/MultiRotorMotorDisplay.qml">src/QmlControls/MultiRotorMotorDisplay.qml</file>
+		<file alias="QGroundControl/Controls/NoMouseThroughRectangle.qml">src/QmlControls/NoMouseThroughRectangle.qml</file>
         <file alias="QGroundControl/Controls/OfflineMapButton.qml">src/QmlControls/OfflineMapButton.qml</file>
         <file alias="QGroundControl/Controls/ParameterEditor.qml">src/QmlControls/ParameterEditor.qml</file>
         <file alias="QGroundControl/Controls/ParameterEditorDialog.qml">src/QmlControls/ParameterEditorDialog.qml</file>

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -540,6 +540,7 @@ QGCView {
             id:                 guidedActionsController
             missionController:  _missionController
             confirmDialog:      guidedActionConfirm
+            actionList:         guidedActionList
             altitudeSlider:     _altitudeSlider
             z:                  _flightVideoPipControl.z + 1
 

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -240,8 +240,9 @@ FlightMap {
         anchorPoint.y:  sourceItem.anchorPointY
 
         sourceItem: MissionItemIndexLabel {
-            checked: true
-            label:   qsTr("G", "Goto here waypoint") // second string is translator's hint.
+            checked:    true
+            index:      -1
+            label:      qsTr("Goto here", "Goto here waypoint")
         }
     }    
 
@@ -260,7 +261,7 @@ FlightMap {
         anchors.fill: parent
 
         onClicked: {
-            if (guidedActionsController.showGotoLocation) {
+            if (guidedActionsController.showGotoLocation && !guidedActionsController.guidedUIVisible) {
                 _gotoHereCoordinate = flightMap.toCoordinate(Qt.point(mouse.x, mouse.y), false /* clipToViewPort */)
                 guidedActionsController.confirmAction(guidedActionsController.actionGoto, _gotoHereCoordinate)
             }

--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -16,7 +16,7 @@ import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0
 
 /// Guided actions confirmation dialog
-Rectangle {
+NoMouseThroughRectangle {
     id:             _root
     border.color:   qgcPal.alertBorder
     border.width:   1

--- a/src/FlightDisplay/GuidedActionList.qml
+++ b/src/FlightDisplay/GuidedActionList.qml
@@ -17,7 +17,7 @@ import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0
 
 /// Dialog showing list of available guided actions
-Rectangle {
+NoMouseThroughRectangle {
     id:         _root
     width:      actionColumn.width  + (_margins * 4)
     height:     actionColumn.height + (_margins * 4)

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -29,6 +29,7 @@ Item {
 
     property var missionController
     property var confirmDialog
+    property var actionList
     property var altitudeSlider
 
     readonly property string emergencyStopTitle:    qsTr("Emergency Stop")
@@ -95,6 +96,8 @@ Item {
     property bool showOrbit:            !_hideOrbit && _activeVehicle && _vehicleFlying && _activeVehicle.orbitModeSupported && _vehicleArmed && !_missionActive
     property bool showLandAbort:        _activeVehicle && _vehicleFlying && _activeVehicle.fixedWing && _vehicleLanding
     property bool showGotoLocation:     _activeVehicle && _activeVehicle.guidedMode && _vehicleFlying
+
+    property bool guidedUIVisible:      guidedActionConfirm.visible || guidedActionList.visible
 
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property string _flightMode:            _activeVehicle ? _activeVehicle.flightMode : ""

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -13,7 +13,7 @@ Canvas {
     signal clicked
 
     property string label                       ///< Label to show to the side of the index indicator
-    property int    index:                  0   ///< Index to show in the indicator, 0 will show label instead
+    property int    index:                  0   ///< Index to show in the indicator, 0 will show single char label instead, -1 first char of label in indicator full label to the side
     property bool   checked:                false
     property bool   small:                  false
     property var    color:                  checked ? "green" : qgcPal.mapButtonHighlight
@@ -33,7 +33,7 @@ Canvas {
     property real   _labelMargin:       2
     property real   _labelRadius:       _indicatorRadius + _labelMargin
     property string _label:             index === 0 ? "" : label
-    property string _index:             index === 0 ? label : index
+    property string _index:             index === 0 || index === -1 ? label.charAt(0) : index
 
     onColorChanged:         requestPaint()
     onShowGimbalYawChanged: requestPaint()

--- a/src/QmlControls/NoMouseThroughRectangle.qml
+++ b/src/QmlControls/NoMouseThroughRectangle.qml
@@ -1,0 +1,14 @@
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
+
+/// This control is used to create a Rectangle control which does not allow mouse events to bleed through to the control
+/// which is beneath it.
+Rectangle {
+    MouseArea {
+        anchors.fill:       parent
+        preventStealing:    true
+        onWheel:            { wheel.accepted = true; }
+        onPressed:          { mouse.accepted = true; }
+        onReleased:         { mouse.accepted = true; }
+    }
+}

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -25,6 +25,7 @@ MissionItemMapVisual    1.0 MissionItemMapVisual.qml
 MissionItemStatus       1.0 MissionItemStatus.qml
 ModeSwitchDisplay       1.0 ModeSwitchDisplay.qml
 MultiRotorMotorDisplay  1.0 MultiRotorMotorDisplay.qml
+NoMouseThroughRectangle 1.0 NoMouseThroughRectangle.qml
 ParameterEditor         1.0 ParameterEditor.qml
 ParameterEditorDialog   1.0 ParameterEditorDialog.qml
 PlanToolBar             1.0 PlanToolBar.qml


### PR DESCRIPTION
* Better GoTo Location indicator visuals on the map
* You can't click in map to go to location is another Guided popup is visible
* Guided popups don't let mouse events bleed through to controls below
* Add new control NoMouseThroughRectangle which is a shortcut to creating a Rectangle which includes a MouseArea which prevents mouse event bleed through
* I did not convert all other various usage of mouse bleed through style usage to NoMouseThroughRectangle. I'll deal with that in 3.3 (#5408)