### PR TITLE
Support for camera min trigger interval validation

### DIFF
--- a/src/FirmwarePlugin/CameraMetaData.cc
+++ b/src/FirmwarePlugin/CameraMetaData.cc
@@ -17,16 +17,18 @@ CameraMetaData::CameraMetaData(const QString&   name,
                                double           focalLength,
                                bool             landscape,
                                bool             fixedOrientation,
+                               double           minTriggerInterval,
                                QObject*         parent)
-    : QObject(parent)
-    , _name(name)
-    , _sensorWidth(sensorWidth)
-    , _sensorHeight(sensorHeight)
-    , _imageWidth(imageWidth)
-    , _imageHeight(imageHeight)
-    , _focalLength(focalLength)
-    , _landscape(landscape)
-    , _fixedOrientation(fixedOrientation)
+    : QObject               (parent)
+    , _name                 (name)
+    , _sensorWidth          (sensorWidth)
+    , _sensorHeight         (sensorHeight)
+    , _imageWidth           (imageWidth)
+    , _imageHeight          (imageHeight)
+    , _focalLength          (focalLength)
+    , _landscape            (landscape)
+    , _fixedOrientation     (fixedOrientation)
+    , _minTriggerInterval   (minTriggerInterval)
 {
 
 }

--- a/src/FirmwarePlugin/CameraMetaData.h
+++ b/src/FirmwarePlugin/CameraMetaData.h
@@ -26,6 +26,7 @@ public:
                    double           focalLength,
                    bool             landscape,
                    bool             fixedOrientation,
+                   double           minTriggerInterval,
                    QObject*         parent = NULL);
 
     Q_PROPERTY(QString  name                MEMBER _name                CONSTANT)   ///< Camera name
@@ -36,6 +37,7 @@ public:
     Q_PROPERTY(double   focalLength         MEMBER _focalLength         CONSTANT)   ///< Focal length in millimeters
     Q_PROPERTY(bool     landscape           MEMBER _landscape           CONSTANT)   ///< true: camera is in landscape orientation
     Q_PROPERTY(bool     fixedOrientation    MEMBER _fixedOrientation    CONSTANT)   ///< true: camera is in fixed orientation
+    Q_PROPERTY(double   minTriggerInterval  MEMBER _minTriggerInterval  CONSTANT)   ///< Minimum time in seconds between each photo taken, 0 for not specified
 
 private:
     QString _name;
@@ -46,6 +48,7 @@ private:
     double  _focalLength;
     bool    _landscape;
     bool    _fixedOrientation;
+    double  _minTriggerInterval;
 };
 
 #endif

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -354,6 +354,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
                                       16,
                                       true,
                                       false,
+                                      0,
                                       this);
         _cameraList.append(QVariant::fromValue(metaData));
 
@@ -365,6 +366,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
                                       5.2,
                                       true,
                                       false,
+                                      0,
                                       this);
         _cameraList.append(QVariant::fromValue(metaData));
 
@@ -376,6 +378,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
                                       10.2,
                                       true,
                                       false,
+                                      0,
                                       this);
         _cameraList.append(QVariant::fromValue(metaData));
 
@@ -387,6 +390,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
                                       4.5,
                                       true,
                                       false,
+                                      0,
                                       this);
 
         metaData = new CameraMetaData(tr("Canon EOS-M 22mm"),
@@ -397,6 +401,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
                                       22,
                                       true,
                                       false,
+                                      0,
                                       this);
         _cameraList.append(QVariant::fromValue(metaData));
 
@@ -408,6 +413,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
                                       16,
                                       true,
                                       false,
+                                      0,
                                       this);
         _cameraList.append(QVariant::fromValue(metaData));
 
@@ -419,6 +425,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
                                       10.4,
                                       true,
                                       false,
+                                      0,
                                       this);
         _cameraList.append(QVariant::fromValue(metaData));
     }

--- a/src/MissionManager/SurveyMissionItem.cc
+++ b/src/MissionManager/SurveyMissionItem.cc
@@ -39,6 +39,7 @@ const char* SurveyMissionItem::_jsonCameraSensorHeightKey =         "sensorHeigh
 const char* SurveyMissionItem::_jsonCameraResolutionWidthKey =      "resolutionWidth";
 const char* SurveyMissionItem::_jsonCameraResolutionHeightKey =     "resolutionHeight";
 const char* SurveyMissionItem::_jsonCameraFocalLengthKey =          "focalLength";
+const char* SurveyMissionItem::_jsonCameraMinTriggerIntervalKey =   "minTriggerInterval";
 const char* SurveyMissionItem::_jsonCameraObjectKey =               "camera";
 const char* SurveyMissionItem::_jsonCameraNameKey =                 "name";
 const char* SurveyMissionItem::_jsonManualGridKey =                 "manualGrid";
@@ -79,6 +80,7 @@ SurveyMissionItem::SurveyMissionItem(Vehicle* vehicle, QObject* parent)
     , _missionCommandCount(0)
     , _refly90Degrees(false)
     , _additionalFlightDelaySeconds(0)
+    , _cameraMinTriggerInterval(0)
     , _ignoreRecalc(false)
     , _surveyDistance(0.0)
     , _cameraShots(0)
@@ -240,6 +242,7 @@ void SurveyMissionItem::save(QJsonArray&  missionItems)
         cameraObject[_jsonCameraResolutionWidthKey] =       _cameraResolutionWidthFact.rawValue().toDouble();
         cameraObject[_jsonCameraResolutionHeightKey] =      _cameraResolutionHeightFact.rawValue().toDouble();
         cameraObject[_jsonCameraFocalLengthKey] =           _cameraFocalLengthFact.rawValue().toDouble();
+        cameraObject[_jsonCameraMinTriggerIntervalKey] =    _cameraMinTriggerInterval;
         cameraObject[_jsonGroundResolutionKey] =            _groundResolutionFact.rawValue().toDouble();
         cameraObject[_jsonFrontalOverlapKey] =              _frontalOverlapFact.rawValue().toInt();
         cameraObject[_jsonSideOverlapKey] =                 _sideOverlapFact.rawValue().toInt();
@@ -373,6 +376,7 @@ bool SurveyMissionItem::load(const QJsonObject& complexObject, int sequenceNumbe
             { _jsonCameraFocalLengthKey,            QJsonValue::Double, true },
             { _jsonCameraNameKey,                   QJsonValue::String, true },
             { _jsonCameraOrientationLandscapeKey,   QJsonValue::Bool,   true },
+            { _jsonCameraMinTriggerIntervalKey,     QJsonValue::Double, false },
         };
         if (!JsonHelper::validateKeys(cameraObject, cameraKeyInfoList, errorString)) {
             return false;
@@ -389,6 +393,7 @@ bool SurveyMissionItem::load(const QJsonObject& complexObject, int sequenceNumbe
         _cameraResolutionWidthFact.setRawValue  (cameraObject[_jsonCameraResolutionWidthKey].toDouble());
         _cameraResolutionHeightFact.setRawValue (cameraObject[_jsonCameraResolutionHeightKey].toDouble());
         _cameraFocalLengthFact.setRawValue      (cameraObject[_jsonCameraFocalLengthKey].toDouble());
+        _cameraMinTriggerInterval =             cameraObject[_jsonCameraMinTriggerIntervalKey].toDouble(0);
     }
 
     // Polygon shape

--- a/src/MissionManager/SurveyMissionItem.h
+++ b/src/MissionManager/SurveyMissionItem.h
@@ -43,14 +43,15 @@ public:
     Q_PROPERTY(Fact*                cameraResolutionWidth       READ cameraResolutionWidth          CONSTANT)
     Q_PROPERTY(Fact*                cameraResolutionHeight      READ cameraResolutionHeight         CONSTANT)
     Q_PROPERTY(Fact*                cameraFocalLength           READ cameraFocalLength              CONSTANT)
-    Q_PROPERTY(Fact*                fixedValueIsAltitude        READ fixedValueIsAltitude           CONSTANT)
     Q_PROPERTY(Fact*                cameraOrientationLandscape  READ cameraOrientationLandscape     CONSTANT)
+    Q_PROPERTY(Fact*                fixedValueIsAltitude        READ fixedValueIsAltitude           CONSTANT)
     Q_PROPERTY(Fact*                manualGrid                  READ manualGrid                     CONSTANT)
     Q_PROPERTY(Fact*                camera                      READ camera                         CONSTANT)
 
     Q_PROPERTY(bool                 cameraOrientationFixed      MEMBER _cameraOrientationFixed      NOTIFY cameraOrientationFixedChanged)
     Q_PROPERTY(bool                 hoverAndCaptureAllowed      READ hoverAndCaptureAllowed         CONSTANT)
     Q_PROPERTY(bool                 refly90Degrees              READ refly90Degrees WRITE setRefly90Degrees NOTIFY refly90DegreesChanged)
+    Q_PROPERTY(double               cameraMinTriggerInterval    MEMBER _cameraMinTriggerInterval    NOTIFY cameraMinTriggerIntervalChanged)
 
     Q_PROPERTY(double               timeBetweenShots            READ timeBetweenShots               NOTIFY timeBetweenShotsChanged)
     Q_PROPERTY(QVariantList         gridPoints                  READ gridPoints                     NOTIFY gridPointsChanged)
@@ -165,14 +166,15 @@ public:
     static const char* cameraName;
 
 signals:
-    void gridPointsChanged              (void);
-    void cameraShotsChanged             (int cameraShots);
-    void coveredAreaChanged             (double coveredArea);
-    void cameraValueChanged             (void);
-    void gridTypeChanged                (QString gridType);
-    void timeBetweenShotsChanged        (void);
-    void cameraOrientationFixedChanged  (bool cameraOrientationFixed);
-    void refly90DegreesChanged          (bool refly90Degrees);
+    void gridPointsChanged                  (void);
+    void cameraShotsChanged                 (int cameraShots);
+    void coveredAreaChanged                 (double coveredArea);
+    void cameraValueChanged                 (void);
+    void gridTypeChanged                    (QString gridType);
+    void timeBetweenShotsChanged            (void);
+    void cameraOrientationFixedChanged      (bool cameraOrientationFixed);
+    void refly90DegreesChanged              (bool refly90Degrees);
+    void cameraMinTriggerIntervalChanged    (double cameraMinTriggerInterval);
 
 private slots:
     void _setDirty(void);
@@ -233,6 +235,7 @@ private:
     int                             _missionCommandCount;
     bool                            _refly90Degrees;
     double                          _additionalFlightDelaySeconds;
+    double                          _cameraMinTriggerInterval;
 
     bool            _ignoreRecalc;
     double          _surveyDistance;
@@ -283,6 +286,7 @@ private:
     static const char* _jsonCameraResolutionWidthKey;
     static const char* _jsonCameraResolutionHeightKey;
     static const char* _jsonCameraFocalLengthKey;
+    static const char* _jsonCameraMinTriggerIntervalKey;
     static const char* _jsonManualGridKey;
     static const char* _jsonCameraObjectKey;
     static const char* _jsonCameraNameKey;

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -57,7 +57,9 @@ Rectangle {
                 gridTypeCombo.currentIndex = index
                 if (index != 1) {
                     // Specific camera is selected
-                    missionItem.cameraOrientationFixed = _vehicleCameraList[index - _gridTypeCamera].fixedOrientation
+                    var camera = _vehicleCameraList[index - _gridTypeCamera]
+                    missionItem.cameraOrientationFixed = camera.fixedOrientation
+                    missionItem.cameraMinTriggerInterval = camera.minTriggerInterval
                 }
             }
         }
@@ -181,6 +183,15 @@ Rectangle {
         anchors.right:      parent.right
         spacing:            _margin
 
+        QGCLabel {
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            text:           qsTr("WARNING: Photo interval is below minimum interval (%1 secs) supported by camera.").arg(missionItem.cameraMinTriggerInterval.toFixed(1))
+            wrapMode:       Text.WordWrap
+            color:          qgcPal.warningText
+            visible:        missionItem.manualGrid.value !== true && missionItem.cameraShots > 0 && missionItem.cameraMinTriggerInterval !== 0 && missionItem.cameraMinTriggerInterval > missionItem.timeBetweenShots
+        }
+
         SectionHeader {
             id:         cameraHeader
             text:       qsTr("Camera")
@@ -207,6 +218,7 @@ Rectangle {
                         missionItem.manualGrid.value = false
                         missionItem.camera.value = gridTypeCombo.textAt(index)
                         missionItem.cameraOrientationFixed = false
+                        missionItem.cameraMinTriggerInterval = 0
                     } else {
                         missionItem.manualGrid.value = false
                         missionItem.camera.value = gridTypeCombo.textAt(index)
@@ -219,6 +231,7 @@ Rectangle {
                         missionItem.cameraFocalLength.rawValue          = _vehicleCameraList[listIndex].focalLength
                         missionItem.cameraOrientationLandscape.rawValue = _vehicleCameraList[listIndex].landscape ? 1 : 0
                         missionItem.cameraOrientationFixed              = _vehicleCameraList[listIndex].fixedOrientation
+                        missionItem.cameraMinTriggerInterval            = _vehicleCameraList[listIndex].minTriggerInterval
                         _noCameraValueRecalc = false
                         recalcFromCameraValues()
                     }


### PR DESCRIPTION
Camera meta data now includes minimum trigger interval. If the survey goes below this minimum a warning will be displayed to the user.