### PR TITLE
Fix mode switching

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -485,7 +485,7 @@ bool FirmwarePlugin::_setFlightModeAndValidate(Vehicle* vehicle, const QString& 
         vehicle->setFlightMode(flightMode);
 
         // Wait for vehicle to return flight mode
-        for (int i=0; i<30; i++) {
+        for (int i=0; i<22; i++) {
             if (vehicle->flightMode() == flightMode) {
                 flightModeChanged = true;
                 break;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -452,12 +452,15 @@ void PX4FirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
 
 void PX4FirmwarePlugin::startMission(Vehicle* vehicle)
 {
-    if (!_armVehicleAndValidate(vehicle)) {
-        qgcApp()->showMessage(tr("Unable to start mission: Vehicle failed to arm."));
-        return;
-    }
 
-    _setFlightModeAndValidate(vehicle, missionFlightMode());
+    if (_setFlightModeAndValidate(vehicle, missionFlightMode())) {
+        if (!_armVehicleAndValidate(vehicle)) {
+            qgcApp()->showMessage(tr("Unable to start mission: Vehicle rejected arming."));
+            return;
+        }
+    } else {
+        qgcApp()->showMessage(tr("Unable to start mission: Vehicle not ready."));
+    }
 }
 
 void PX4FirmwarePlugin::setGuidedMode(Vehicle* vehicle, bool guidedMode)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -789,7 +789,7 @@ void Vehicle::_handleHilActuatorControls(mavlink_message_t &message)
 
 void Vehicle::_handleCommandAck(mavlink_message_t& message)
 {
-    bool showError = true;
+    bool showError = false;
 
     mavlink_command_ack_t ack;
     mavlink_msg_command_ack_decode(&message, &ack);


### PR DESCRIPTION
The mode switching for PX4 was generating excessive feedback hiding the user-facing error message and was leaving the vehicle potentially in an unintended armed state.