### PR TITLE
Use either A or mA for the current, but not centiAmps

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -903,6 +903,10 @@ void Vehicle::_handleSysStatus(mavlink_message_t& message)
         _batteryFactGroup.current()->setRawValue(VehicleBatteryFactGroup::_currentUnavailable);
     } else {
         // Current is in Amps, current_battery is 10 * milliamperes (1 = 10 milliampere)
+        // To reduce confusion and misunderstandings, suggest not to work in units of centiAmperes. 
+        // Consider either Amps or milliAmps. Note that at some point, this is converted into UINT16. 
+        // If people prefer A, then suggest FLOAT for _batteryFactGroup.current(); 
+        // If people prefer mA, suggest UINT32 large drones with large current draws > 65,535 mA are happy, too. 
         _batteryFactGroup.current()->setRawValue((float)sysStatus.current_battery / 100.0f);
     }
     if (sysStatus.voltage_battery == UINT16_MAX) {


### PR DESCRIPTION
At present, part of qgroundcontrl uses centiAmps as the units of the current. For first time users, and for most people in general, thinking in centiAmps (100 centiAmps = 1 Amp) is confusing. How about using either Amps or milliAmps? Using Amps might be best? In that case, some variables will need to go from UINT16 to FLOAT. (Presumably centiAmps where chosen to accommodate very large drones, since 200A = 20,000 centiAmps, whereas 200,000 milliAmps would exceed the UINT16).