### PR TITLE
iOS fixes

### DIFF
--- a/ios/iOSForAppStore-Info-Source.plist
+++ b/ios/iOSForAppStore-Info-Source.plist
@@ -85,6 +85,8 @@
 	<string>Ground Station Location</string>
 	<key>UILaunchStoryboardName</key>
 	<string>QGCLaunchScreen</string>
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>QGroundControl would like to use bluetooth.</string>    
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -55,6 +55,8 @@ iOSBuild {
         count(APP_ERROR, 1) {
             error("Error building .plist file. 'ForAppStore' builds are only possible through the official build system.")
         }
+        QT               += qml-private
+        CONFIG           += qtquickcompiler
         QMAKE_INFO_PLIST  = $${BASEDIR}/ios/iOSForAppStore-Info.plist
         OTHER_FILES      += $${BASEDIR}/ios/iOSForAppStore-Info.plist
     } else {

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -176,6 +176,13 @@ bool QGCCorePlugin::adjustSettingMetaData(FactMetaData& metaData)
         metaData.setRawDefaultValue(true);
         return true;
 #endif
+#if defined(__ios__)
+    } else if (metaData.name() == AppSettings::savePathName) {
+        QString appName = qgcApp()->applicationName();
+        QDir rootDir = QDir(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
+        metaData.setRawDefaultValue(rootDir.filePath(appName));
+        return false;
+#endif
     }
     return true; // Show setting in ui
 }


### PR DESCRIPTION
I made these fixes for the iOS app store

 * New, required NSBluetoothPeripheralUsageDescription
 * Enabled QtQuick compiler
 * Hide _Save Path_ from the General Settings. The path was huge, breaking the whole UI as it was accommodating the size. I think there is no point setting that path on iOS anyway as you can only save it within the app's own data directory.