### PR TITLE
Survey settings: Default to 70% overlap as sane default

### DIFF
--- a/src/MissionManager/Survey.SettingsGroup.json
+++ b/src/MissionManager/Survey.SettingsGroup.json
@@ -64,7 +64,7 @@
     "min":              0,
     "max":              85,
     "units":            "%",
-    "defaultValue":     10
+    "defaultValue":     70
 },
 {
     "name":             "SideOverlap",
@@ -74,7 +74,7 @@
     "min":              0,
     "max":              85,
     "units":            "%",
-    "defaultValue":     10
+    "defaultValue":     70
 },
 {
     "name":             "CameraSensorWidth",


### PR DESCRIPTION
10% is really not workable for any stitching engine.