### PR TITLE
Add TCP-Mpeg2TS support to available video feeds

### DIFF
--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -59,6 +59,7 @@ VideoManager::setToolbox(QGCToolbox *toolbox)
    connect(_videoSettings->videoSource(),   &Fact::rawValueChanged, this, &VideoManager::_videoSourceChanged);
    connect(_videoSettings->udpPort(),       &Fact::rawValueChanged, this, &VideoManager::_udpPortChanged);
    connect(_videoSettings->rtspUrl(),       &Fact::rawValueChanged, this, &VideoManager::_rtspUrlChanged);
+   connect(_videoSettings->tcpUrl(),        &Fact::rawValueChanged, this, &VideoManager::_tcpUrlChanged);
 
 #if defined(QGC_GST_STREAMING)
 #ifndef QGC_DISABLE_UVC
@@ -111,6 +112,13 @@ VideoManager::_rtspUrlChanged()
 }
 
 //-----------------------------------------------------------------------------
+void
+VideoManager::_tcpUrlChanged()
+{
+    _restartVideo();
+}
+
+//-----------------------------------------------------------------------------
 bool
 VideoManager::hasVideo()
 {
@@ -124,7 +132,7 @@ VideoManager::isGStreamer()
 {
 #if defined(QGC_GST_STREAMING)
     QString videoSource = _videoSettings->videoSource()->rawValue().toString();
-    return videoSource == VideoSettings::videoSourceUDP || videoSource == VideoSettings::videoSourceRTSP;
+    return videoSource == VideoSettings::videoSourceUDP || videoSource == VideoSettings::videoSourceRTSP || videoSource == VideoSettings::videoSourceTCP;
 #else
     return false;
 #endif
@@ -149,6 +157,8 @@ VideoManager::_updateSettings()
         _videoReceiver->setUri(QStringLiteral("udp://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
     else if (_videoSettings->videoSource()->rawValue().toString() == VideoSettings::videoSourceRTSP)
         _videoReceiver->setUri(_videoSettings->rtspUrl()->rawValue().toString());
+    else if (_videoSettings->videoSource()->rawValue().toString() == VideoSettings::videoSourceTCP)
+        _videoReceiver->setUri(QStringLiteral("tcp://%1").arg(_videoSettings->tcpUrl()->rawValue().toString()));
 }
 
 //-----------------------------------------------------------------------------

--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -61,6 +61,7 @@ private slots:
     void _videoSourceChanged        ();
     void _udpPortChanged            ();
     void _rtspUrlChanged            ();
+    void _tcpUrlChanged             ();
 
 private:
     void _updateSettings            ();

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -2,7 +2,7 @@
 {
     "name":             "VideoSource",
     "shortDescription": "Video source",
-    "longDescription":  "Source for video. UDP, RTSP and UVC Cameras may be supported depending on Vehicle and ground station version.",
+    "longDescription":  "Source for video. UDP, TCP, RTSP and UVC Cameras may be supported depending on Vehicle and ground station version.",
     "type":             "string",
     "defaultValue":     ""
 },
@@ -18,6 +18,13 @@
     "name":             "VideoRTSPUrl",
     "shortDescription": "Video RTSP Url",
     "longDescription":  "RTSP url address and port to bind to for video stream. Example: rtsp://192.168.42.1:554/live",
+    "type":             "string",
+    "defaultValue":     ""
+},
+{
+    "name":             "VideoTCPUrl",
+    "shortDescription": "Video TCP Url",
+    "longDescription":  "TCP url address and port to bind to for video stream. Example: 192.168.143.200:3001",
     "type":             "string",
     "defaultValue":     ""
 },

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -22,6 +22,7 @@ const char* VideoSettings::videoSettingsGroupName = "Video";
 const char* VideoSettings::videoSourceName =        "VideoSource";
 const char* VideoSettings::udpPortName =            "VideoUDPPort";
 const char* VideoSettings::rtspUrlName =            "VideoRTSPUrl";
+const char* VideoSettings::tcpUrlName =             "VideoTCPUrl";
 const char* VideoSettings::videoAspectRatioName =   "VideoAspectRatio";
 const char* VideoSettings::videoGridLinesName =     "VideoGridLines";
 const char* VideoSettings::showRecControlName =     "ShowRecControl";
@@ -32,11 +33,13 @@ const char* VideoSettings::videoSourceNoVideo =     "No Video Available";
 const char* VideoSettings::videoDisabled =          "Video Stream Disabled";
 const char* VideoSettings::videoSourceUDP =         "UDP Video Stream";
 const char* VideoSettings::videoSourceRTSP =        "RTSP Video Stream";
+const char* VideoSettings::videoSourceTCP =         "TCP-MPEG2 Video Stream";
 
 VideoSettings::VideoSettings(QObject* parent)
     : SettingsGroup(videoSettingsGroupName, QString() /* root settings group */, parent)
     , _videoSourceFact(NULL)
     , _udpPortFact(NULL)
+    , _tcpUrlFact(NULL)
     , _rtspUrlFact(NULL)
     , _videoAspectRatioFact(NULL)
     , _gridLinesFact(NULL)
@@ -55,6 +58,7 @@ VideoSettings::VideoSettings(QObject* parent)
     videoSourceList.append(videoSourceUDP);
 #endif
     videoSourceList.append(videoSourceRTSP);
+    videoSourceList.append(videoSourceTCP);
 #endif
 #ifndef QGC_DISABLE_UVC
     QList<QCameraInfo> cameras = QCameraInfo::availableCameras();
@@ -107,6 +111,15 @@ Fact* VideoSettings::rtspUrl(void)
     }
 
     return _rtspUrlFact;
+}
+
+Fact* VideoSettings::tcpUrl(void)
+{
+    if (!_tcpUrlFact) {
+        _tcpUrlFact = _createSettingsFact(tcpUrlName);
+    }
+
+    return _tcpUrlFact;
 }
 
 Fact* VideoSettings::aspectRatio(void)

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -59,8 +59,8 @@ public:
 
 private:
     SettingsFact* _videoSourceFact;
-    SettingsFact* _tcpUrlFact;
     SettingsFact* _udpPortFact;
+    SettingsFact* _tcpUrlFact;
     SettingsFact* _rtspUrlFact;
     SettingsFact* _videoAspectRatioFact;
     SettingsFact* _gridLinesFact;

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -21,6 +21,7 @@ public:
 
     Q_PROPERTY(Fact* videoSource        READ videoSource        CONSTANT)
     Q_PROPERTY(Fact* udpPort            READ udpPort            CONSTANT)
+    Q_PROPERTY(Fact* tcpUrl             READ tcpUrl             CONSTANT)
     Q_PROPERTY(Fact* rtspUrl            READ rtspUrl            CONSTANT)
     Q_PROPERTY(Fact* aspectRatio        READ aspectRatio        CONSTANT)
     Q_PROPERTY(Fact* gridLines          READ gridLines          CONSTANT)
@@ -31,6 +32,7 @@ public:
     Fact* videoSource       (void);
     Fact* udpPort           (void);
     Fact* rtspUrl           (void);
+    Fact* tcpUrl            (void);
     Fact* aspectRatio       (void);
     Fact* gridLines         (void);
     Fact* showRecControl    (void);
@@ -42,6 +44,7 @@ public:
     static const char* videoSourceName;
     static const char* udpPortName;
     static const char* rtspUrlName;
+    static const char* tcpUrlName;
     static const char* videoAspectRatioName;
     static const char* videoGridLinesName;
     static const char* showRecControlName;
@@ -52,9 +55,11 @@ public:
     static const char* videoDisabled;
     static const char* videoSourceUDP;
     static const char* videoSourceRTSP;
+    static const char* videoSourceTCP;
 
 private:
     SettingsFact* _videoSourceFact;
+    SettingsFact* _tcpUrlFact;
     SettingsFact* _udpPortFact;
     SettingsFact* _rtspUrlFact;
     SettingsFact* _videoAspectRatioFact;

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -557,6 +557,20 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
+                            visible:    QGroundControl.settingsManager.videoSettings.tcpUrl.visible && QGroundControl.videoManager.isGStreamer && videoSource.currentIndex === 3
+                            QGCLabel {
+                                text:               qsTr("TCP URL:")
+                                width:              _labelWidth
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                            FactTextField {
+                                width:              _editFieldWidth
+                                fact:               QGroundControl.settingsManager.videoSettings.tcpUrl
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                        }
+                        Row {
+                            spacing:    ScreenTools.defaultFontPixelWidth
                             visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 3 && QGroundControl.settingsManager.videoSettings.aspectRatio.visible
                             QGCLabel {
                                 text:               qsTr("Aspect Ratio:")
@@ -613,7 +627,7 @@ QGCView {
                         anchors.centerIn: parent
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 3 && QGroundControl.settingsManager.videoSettings.maxVideoSize.visible
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 4 && QGroundControl.settingsManager.videoSettings.maxVideoSize.visible
                             QGCLabel {
                                 text:               qsTr("Max Storage Usage:")
                                 width:              _labelWidth
@@ -627,7 +641,7 @@ QGCView {
                         }
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 3 && QGroundControl.settingsManager.videoSettings.recordingFormat.visible
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 4 && QGroundControl.settingsManager.videoSettings.recordingFormat.visible
                             QGCLabel {
                                 text:               qsTr("Video File Format:")
                                 width:              _labelWidth


### PR DESCRIPTION
This adds Mpeg2 Transport stream over TCP support as a possible video feed in the gstreamer pipeline.

This is used in cases where a local ground station receives the video feed from the aircraft, and rebroadcasts it out to multiple ground stations or devices over a wireless link.   Since the network is local and broadcast to more than a single client, occasional packet drops between the ground station and devices occur, which TCP helps to mitigate.

It is not recommended to use TCP/MPEG2_TS as a datalink to directly to the aircraft, since the re transmits that occur over TCP can build up during a loss of link condition causing additional bandwidth overhead and latency issues.