### PR TITLE
FTP Fixes

### DIFF
--- a/src/uas/FileManager.cc
+++ b/src/uas/FileManager.cc
@@ -239,6 +239,7 @@ void FileManager::_writeAckResponse(Request* writeAck)
 {
     if(_writeOffset + _writeSize >= _writeFileSize){
         _closeUploadSession(true /* success */);
+        return;
     }
 
     if (writeAck->hdr.session != _activeSession) {

--- a/src/ui/QGCUASFileView.cc
+++ b/src/ui/QGCUASFileView.cc
@@ -198,7 +198,7 @@ void QGCUASFileView::_commandComplete(void)
         _currentCommand = commandNone;
         _setAllButtonsEnabled(true);
         statusText = "Download complete";
-    } else if (_currentCommand == commandDownload) {
+    } else if (_currentCommand == commandUpload) {
         _currentCommand = commandNone;
         _setAllButtonsEnabled(true);
         statusText = "Upload complete";


### PR DESCRIPTION
This adds two fixes for FTP. I tested the full functionality repeatedly in SITL & on a Pixracer via USB and it works well, except when a message is dropped. In that case a transaction is immediately aborted, because of this:
https://github.com/mavlink/qgroundcontrol/blob/9af74e972bec5ec7616248e89c37b247e241ba28/src/uas/FileManager.cc#L326. We need to add retransmission to make this more robust.

Might be worth reverting https://github.com/mavlink/qgroundcontrol/pull/4144.

There are fixes on the vehicle side as well: https://github.com/PX4/Firmware/pull/7665