### PR TITLE
ADS-B vehicle timeout and stacked callsign

### DIFF
--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -57,6 +57,7 @@ MapQuickItem {
         }
 
         QGCMapLabel {
+            id:                         vehicleLabel
             anchors.top:                parent.bottom
             anchors.horizontalCenter:   parent.horizontalCenter
             map:                        _map
@@ -66,10 +67,21 @@ MapQuickItem {
 
             property string vehicleLabelText: visible ?
                                                   (_adsbVehicle ?
-                                                       callsign + " " + QGroundControl.metersToAppSettingsDistanceUnits(altitude).toFixed(0) + " " + QGroundControl.appSettingsDistanceUnitsString :
+                                                       QGroundControl.metersToAppSettingsDistanceUnits(altitude).toFixed(0) + " " + QGroundControl.appSettingsDistanceUnitsString :
                                                        (_multiVehicle ? qsTr("Vehicle %1").arg(vehicle.id) : "")) :
                                                   ""
 
+        }
+
+        QGCMapLabel {
+            anchors.top:                vehicleLabel.bottom
+            anchors.horizontalCenter:   parent.horizontalCenter
+            map:                        _map
+            text:                       vehicleLabelText
+            font.pointSize:             ScreenTools.smallFontPointSize
+            visible:                    _adsbVehicle ? !isNaN(altitude) : _multiVehicle
+
+            property string vehicleLabelText: visible && _adsbVehicle ? callsign : ""
         }
     }
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2631,7 +2631,7 @@ bool Vehicle::autoDisarm(void)
 void Vehicle::_handleADSBVehicle(const mavlink_message_t& message)
 {
     mavlink_adsb_vehicle_t adsbVehicle;
-    static const int maxTimeSinceLastSeen = 10;
+    static const int maxTimeSinceLastSeen = 15;
 
     mavlink_msg_adsb_vehicle_decode(&message, &adsbVehicle);
     if (adsbVehicle.flags | ADSB_FLAGS_VALID_COORDS) {
@@ -2642,11 +2642,9 @@ void Vehicle::_handleADSBVehicle(const mavlink_message_t& message)
                 _adsbICAOMap.remove(adsbVehicle.ICAO_address);
                 vehicle->deleteLater();
             } else {
-                if (adsbVehicle.tslc <= maxTimeSinceLastSeen) {
-                    _adsbICAOMap[adsbVehicle.ICAO_address]->update(adsbVehicle);
-                }
+                _adsbICAOMap[adsbVehicle.ICAO_address]->update(adsbVehicle);
             }
-        } else {
+        } else if (adsbVehicle.tslc <= maxTimeSinceLastSeen) {
             ADSBVehicle* vehicle = new ADSBVehicle(adsbVehicle, this);
             _adsbICAOMap[adsbVehicle.ICAO_address] = vehicle;
             _adsbVehicles.append(vehicle);

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -1278,8 +1278,8 @@ void MockLink::_sendADSBVehicles(void)
                                        _mavlinkChannel,
                                        &responseMsg,
                                        12345,                           // ICAO address
-                                       (_vehicleLatitude + 0.001) * qPow(10.0, 7.0),
-                                       (_vehicleLongitude + 0.001) * qPow(10.0, 7.0),
+                                       (_vehicleLatitude + 0.001) * 1e7,
+                                       (_vehicleLongitude + 0.001) * 1e7,
                                        ADSB_ALTITUDE_TYPE_GEOMETRIC,
                                        100 * 1000,                      // Altitude in millimeters
                                        10 * 100,                        // Heading in centidegress


### PR DESCRIPTION
* ADS-B Vehicles will be remove from display are they are no longer heard from
* Altitude and callsign are stacked visually
<img width="77" alt="screen shot 2017-07-21 at 9 34 14 am" src="https://user-images.githubusercontent.com/5876851/28472984-cc2d3ec4-6df7-11e7-92d1-d819a1f61cd9.png">
