### PR TITLE
Make recording status more obvious

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -44,6 +44,7 @@ QGCView {
     property var    _rallyPointController:  _planMasterController.rallyPointController
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property var    _videoReceiver:         QGroundControl.videoManager.videoReceiver
+    property bool   _recordingVideo:        _videoReceiver && _videoReceiver.recording
     property bool   _mainIsMap:             QGroundControl.videoManager.hasVideo ? QGroundControl.loadBoolGlobalSetting(_mainIsMapKey,  true) : true
     property bool   _isPipVisible:          QGroundControl.videoManager.hasVideo ? QGroundControl.loadBoolGlobalSetting(_PIPVisibleKey, true) : false
     property real   _savedZoomLevel:        0
@@ -381,11 +382,11 @@ QGCView {
                 anchors.top:        parent.top
                 anchors.bottom:     parent.bottom
                 width:              height
-                radius:             QGroundControl.videoManager && _videoReceiver && _videoReceiver.recording ? 0 : height
+                radius:             _recordingVideo ? 0 : height
                 color:              "red"
 
                 SequentialAnimation on visible {
-                    running:        QGroundControl.videoManager && QGroundControl.videoManager.videoReceiver && QGroundControl.videoManager.videoReceiver.recording
+                    running:        _recordingVideo
                     loops:          Animation.Infinite
                     PropertyAnimation { to: false; duration: 1000 }
                     PropertyAnimation { to: true;  duration: 1000 }
@@ -407,12 +408,13 @@ QGCView {
             MouseArea {
                 anchors.fill:   parent
                 onClicked: {
-                    if (QGroundControl.videoManager && QGroundControl.videoManager.videoReceiver) {
-                        if (QGroundControl.videoManager.videoReceiver.recording) {
-                            QGroundControl.videoManager.videoReceiver.stopRecording()
+                    if (_videoReceiver) {
+                        if (_recordingVideo) {
+                            _videoReceiver.stopRecording()
+                            // reset blinking animation
                             recordBtnBackground.visible = true
                         } else {
-                            QGroundControl.videoManager.videoReceiver.startRecording()
+                            _videoReceiver.startRecording()
                         }
                     }
                 }

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -374,12 +374,22 @@ QGCView {
             visible:            _videoReceiver && _videoReceiver.videoRunning && QGroundControl.settingsManager.videoSettings.showRecControl.rawValue
             opacity:            0.75
 
+            readonly property string recordBtnBackground: "BackgroundName"
+
             Rectangle {
+                id:                 recordBtnBackground
                 anchors.top:        parent.top
                 anchors.bottom:     parent.bottom
                 width:              height
                 radius:             QGroundControl.videoManager && _videoReceiver && _videoReceiver.recording ? 0 : height
                 color:              "red"
+
+                SequentialAnimation on visible {
+                    running:        QGroundControl.videoManager && QGroundControl.videoManager.videoReceiver && QGroundControl.videoManager.videoReceiver.recording
+                    loops:          Animation.Infinite
+                    PropertyAnimation { to: false; duration: 1000 }
+                    PropertyAnimation { to: true;  duration: 1000 }
+                }
             }
 
             QGCColoredImage {
@@ -389,13 +399,23 @@ QGCView {
                 width:                      height * 0.625
                 sourceSize.width:           width
                 source:                     "/qmlimages/CameraIcon.svg"
+                visible:                    recordBtnBackground.visible
                 fillMode:                   Image.PreserveAspectFit
                 color:                      "white"
             }
 
             MouseArea {
                 anchors.fill:   parent
-                onClicked:      _videoReceiver && _videoReceiver.recording ? _videoReceiver.stopRecording() : _videoReceiver.startRecording()
+                onClicked: {
+                    if (QGroundControl.videoManager && QGroundControl.videoManager.videoReceiver) {
+                        if (QGroundControl.videoManager.videoReceiver.recording) {
+                            QGroundControl.videoManager.videoReceiver.stopRecording()
+                            recordBtnBackground.visible = true
+                        } else {
+                            QGroundControl.videoManager.videoReceiver.startRecording()
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
We had a disappointing report of someone loosing a lot of footage they thought they were recording because they had accidentally set their hand on the touchpad or something and didn't notice they turned it off. In an effort to prevent these types of happenings, we are trying to make it more obvious when recording is active/inactive. This makes the recording button visibility toggle at 1Hz. I thought it might be distracting to do it this way, but I don't think it is after seeing it.