### PR TITLE
Re-enable FTP in menu

### DIFF
--- a/src/qgcunittest/UnitTestList.cc
+++ b/src/qgcunittest/UnitTestList.cc
@@ -52,6 +52,7 @@ UT_REGISTER_TEST(MissionControllerTest)
 UT_REGISTER_TEST(MissionManagerTest)
 UT_REGISTER_TEST(RadioConfigTest)
 UT_REGISTER_TEST(TCPLinkTest)
+UT_REGISTER_TEST(FileManagerTest)
 UT_REGISTER_TEST(ParameterManagerTest)
 UT_REGISTER_TEST(MissionCommandTreeTest)
 UT_REGISTER_TEST(LogDownloadTest)
@@ -68,9 +69,6 @@ UT_REGISTER_TEST(QGCMapPolygonTest)
 
 // FIXME: Temporarily disabled until this can be stabilized
 //UT_REGISTER_TEST(MainWindowTest)
-
-// Onboard file support has been removed until it can be make to work correctly
-//UT_REGISTER_TEST(FileManagerTest)
 
 // Needs to be update for latest updates
 //UT_REGISTER_TEST(MavlinkLogTest)

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -313,10 +313,6 @@ void MainWindow::_buildCommonWidgets(void)
 
     // Populate widget menu
     for (int i = 0, end = ARRAY_SIZE(rgDockWidgetNames); i < end; i++) {
-        if (i == ONBOARD_FILES) {
-            // Temporarily removed until twe can fix all the problems with it
-            continue;
-        }
 
         const char* pDockWidgetName = rgDockWidgetNames[i];
 
@@ -333,11 +329,6 @@ void MainWindow::_buildCommonWidgets(void)
 /// Shows or hides the specified dock widget, creating if necessary
 void MainWindow::_showDockWidget(const QString& name, bool show)
 {
-    if (name == rgDockWidgetNames[ONBOARD_FILES]) {
-        // Temporarily disabled due to bugs
-        return;
-    }
-
     // Create the inner widget if we need to
     if (!_mapName2DockWidget.contains(name)) {
         if(!_createInnerDockWidget(name)) {


### PR DESCRIPTION
This re-enables FTP now that Beat has fixed some underlying issues. The main motivation for it is that even high-bandwidth data links tend to only support UDP or even just a single data channel. Having a tunnelled, packetised file transfer is actually appropriate. MAVLink also ensures data integrity (via authentication in MAVLink 2) and therefore offers a viable solution.

The only caveat we need to add (@bkueng) is immediate re-transmission when something drops. It has to work on an unreliable link.

There are a number of use cases where having the ability to get / set files is powerful. This includes:

  * Terrain data
  * Camera meta data (we should reconsider going to JSON instead of XML @dogmaphobic)
  * Vehicle meta data (would avoid the common issue we're having right now with param meta)

It makes no sense to handle these one-off like with the log download tool.
