### PR TITLE
Plan: Load plan file while connect, update home positon from vehicle

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1372,7 +1372,7 @@ void MissionController::_initAllVisualItems(void)
         _settingsItem->setIsCurrentItem(true);
     }
 
-    if (!_editMode && _managerVehicle->homePosition().isValid()) {
+    if (_managerVehicle->homePosition().isValid()) {
         _settingsItem->setCoordinate(_managerVehicle->homePosition());
     }
 


### PR DESCRIPTION
Plan view wasn't updating home position of plan if it was loaded while already connected to a vehicle.