### PR TITLE
Add joystick button limit

### DIFF
--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -27,6 +27,8 @@ SetupPage {
     pageName:           qsTr("Joystick")
     pageDescription:    qsTr("Joystick Setup is used to configure a calibrate joysticks.")
 
+    readonly property real _maxButtons: 16
+
     Connections {
         target: joystickManager
         onAvailableJoysticksChanged: {
@@ -560,7 +562,7 @@ SetupPage {
 
                             Repeater {
                                 id:     buttonActionRepeater
-                                model:  _activeJoystick ? _activeJoystick.totalButtonCount : 0
+                                model:  _activeJoystick ? Math.min(_activeJoystick.totalButtonCount, _maxButtons) : 0
 
                                 Row {
                                     spacing: ScreenTools.defaultFontPixelWidth
@@ -627,7 +629,7 @@ SetupPage {
 
                             Repeater {
                                 id:     jsButtonActionRepeater
-                                model:  _activeJoystick ? _activeJoystick.totalButtonCount : 0
+                                model:  _activeJoystick ? Math.min(_activeJoystick.totalButtonCount, _maxButtons) : 0
 
                                 Row {
                                     spacing: ScreenTools.defaultFontPixelWidth


### PR DESCRIPTION
Limits the maximum number of joystick buttons for which functions can be added on vehicle settings, joystick setup page, to 16.

Prevents issues of unconfigurable buttons outside the range 0~15 from appearing to be configurable, such as: https://cdn-business2.discourse.org/uploads/bluerobotics/original/2X/8/886612ffc44d2d46447e44976e857bec158ec7f3.png

Closes bluerobotics/qgroundcontrol#21