### PR TITLE
Plan: Extra paranoia around clearing indices

### DIFF
--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -55,6 +55,7 @@ void MissionManager::_writeMissionItemsWorker(void)
     qCDebug(MissionManagerLog) << "writeMissionItems count:" << _writeMissionItems.count();
 
     // Prime write list
+    _itemIndicesToWrite.clear();
     for (int i=0; i<_writeMissionItems.count(); i++) {
         _itemIndicesToWrite << i;
     }


### PR DESCRIPTION
Getting some reports of vehicle not requesting all mission items. Did some visual inspection and there seems to be a remote possibility of the index list not clearing correctly (although I can't find the code path). So although this may not really be needed it will make it clear that the QGC side is doing the right thing.