### PR TITLE
MAVLink decoder: Run at lowest priority

### DIFF
--- a/src/ui/MAVLinkDecoder.cc
+++ b/src/ui/MAVLinkDecoder.cc
@@ -43,7 +43,7 @@ MAVLinkDecoder::MAVLinkDecoder(MAVLinkProtocol* protocol) :
     connect(protocol, &MAVLinkProtocol::messageReceived, this, &MAVLinkDecoder::receiveMessage);
     connect(this, &MAVLinkDecoder::finish, this, &QThread::quit);
 
-    start(LowPriority);
+    start(LowestPriority);
 }
 
 /**


### PR DESCRIPTION
There is no reason to run it at any other priority, since its only for UI / inspection.