### PR TITLE
Rework disabling of setup pages

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
@@ -22,6 +22,7 @@ import QGroundControl.ScreenTools   1.0
 SetupPage {
     id:                 safetyPage
     pageComponent:      safetyPageComponent
+    visibleWhileArmed:   true
 
     Component {
         id: safetyPageComponent

--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -66,7 +66,7 @@ QGCView {
         }
 
         QGCLabel {
-            anchors.margins:        _defaultTextWidth * 2
+            anchors.margins:        defaultTextWidth * 2
             anchors.fill:           parent
             verticalAlignment:      Text.AlignVCenter
             horizontalAlignment:    Text.AlignHCenter

--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -32,7 +32,50 @@ QGCView {
 
     property real _margins: ScreenTools.defaultFontPixelHeight / 2
 
+    property bool visibleWhileArmed: false
+
+    property bool vehicleArmed: QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle.armed : false
+
+    onVehicleArmedChanged: {
+        if (visibleWhileArmed) {
+            return
+        }
+
+        if (vehicleArmed) {
+            disabledWhileArmed.visible = true
+            setupView.viewPanel.enabled = false
+        } else {
+            disabledWhileArmed.visible = false
+            setupView.viewPanel.enabled = true
+        }
+    }
+
     QGCPalette { id: qgcPal; colorGroupEnabled: setupPanel.enabled }
+
+    // Overlay to display when vehicle is armed and the setup page needs
+    // to be disabled
+    Item {
+        id: disabledWhileArmed
+        visible: false
+        z: 9999
+        anchors.fill: parent
+        Rectangle {
+            anchors.fill: parent
+            color: "black"
+            opacity: 0.5
+        }
+
+        QGCLabel {
+            anchors.margins:        _defaultTextWidth * 2
+            anchors.fill:           parent
+            verticalAlignment:      Text.AlignVCenter
+            horizontalAlignment:    Text.AlignHCenter
+            wrapMode:               Text.WordWrap
+            font.pointSize:         ScreenTools.largeFontPointSize
+            color:                  "red"
+            text:                   "Setup disabled while the vehicle is armed"
+        }
+    }
 
     QGCViewPanel {
         id:             setupPanel
@@ -68,7 +111,6 @@ QGCView {
                 id:                 pageLoader
                 anchors.topMargin:  _margins
                 anchors.top:        headingColumn.bottom
-
             }
         }
     }

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -12,6 +12,7 @@ import QtQuick 2.3
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.3
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0
@@ -22,404 +23,400 @@ import QGroundControl.Controllers   1.0
 import QGroundControl.ScreenTools   1.0
 
 SetupPage {
-    id:         qgcView
-    viewPanel:  panel
-
-    // Those user visible strings are hard to translate because we can't send the
-    // HTML strings to translation as this can create a security risk. we need to find
-    // a better way to hightlight them, or use less hightlights.
-
-    // User visible strings
-    pageName:                                   "Firmware"
-
-    readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
-    readonly property string highlightSuffix:   "</font>"
-    readonly property string welcomeText:       qsTr("%1 can upgrade the firmware on Pixhawk devices, SiK Radios and PX4 Flow Smart Cameras.").arg(QGroundControl.appName)
-    readonly property string plugInText:        "<big>" + highlightPrefix + "Plug in your device" + highlightSuffix + " via USB to " + highlightPrefix + "start" + highlightSuffix + " firmware upgrade.</big>"
-    readonly property string flashFailText:     "If upgrade failed, make sure to connect " + highlightPrefix + "directly" + highlightSuffix + " to a powered USB port on your computer, not through a USB hub. " +
-                                                "Also make sure you are only powered via USB " + highlightPrefix + "not battery" + highlightSuffix + "."
-    readonly property string qgcUnplugText1:    qsTr("All %1 connections to vehicles must be ").arg(QGroundControl.appName) + highlightPrefix + " disconnected " + highlightSuffix + "prior to firmware upgrade."
-    readonly property string qgcUnplugText2:    highlightPrefix + "<big>Please unplug your Pixhawk and/or Radio from USB.</big>" + highlightSuffix
-
-    readonly property int _defaultFimwareTypePX4:   12
-    readonly property int _defaultFimwareTypeAPM:   3
-
-    property var    _defaultFirmwareFact:   QGroundControl.settingsManager.appSettings.defaultFirmwareType
-    property bool   _defaultFirmwareIsPX4:  _defaultFirmwareFact.rawValue == _defaultFimwareTypePX4
-
-    property string firmwareWarningMessage
-    property bool   controllerCompleted:      false
-    property bool   initialBoardSearch:       true
-    property string firmwareName
-
-    property bool _singleFirmwareMode: QGroundControl.corePlugin.options.firmwareUpgradeSingleURL.length != 0   ///< true: running in special single firmware download mode
-
-    function cancelFlash() {
-        statusTextArea.append(highlightPrefix + qsTr("Upgrade cancelled") + highlightSuffix)
-        statusTextArea.append("------------------------------------------")
-        controller.cancel()
-    }
-
-    QGCPalette { id: qgcPal; colorGroupEnabled: true }
-
-    FirmwareUpgradeController {
-        id:             controller
-        progressBar:    progressBar
-        statusLog:      statusTextArea
-
-        property var activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
-
-        Component.onCompleted: {
-            controllerCompleted = true
-            if (qgcView.completedSignalled) {
-                // We can only start the board search when the Qml and Controller are completely done loading
-                controller.startBoardSearch()
-            }
-        }
-
-        onActiveVehicleChanged: {
-            if (!activeVehicle) {
-                statusTextArea.append(plugInText)
-            }
-        }
-
-        onNoBoardFound: {
-            initialBoardSearch = false
-            if (!QGroundControl.multiVehicleManager.activeVehicleAvailable) {
-                statusTextArea.append(plugInText)
-            }
-        }
-
-        onBoardGone: {
-            initialBoardSearch = false
-            if (!QGroundControl.multiVehicleManager.activeVehicleAvailable) {
-                statusTextArea.append(plugInText)
-            }
-        }
-
-        onBoardFound: {
-            if (initialBoardSearch) {
-                // Board was found right away, so something is already plugged in before we've started upgrade
-                statusTextArea.append(qgcUnplugText1)
-                statusTextArea.append(qgcUnplugText2)
-                QGroundControl.multiVehicleManager.activeVehicle.autoDisconnect = true
-            } else {
-                // We end up here when we detect a board plugged in after we've started upgrade
-                statusTextArea.append(highlightPrefix + qsTr("Found device") + highlightSuffix + ": " + controller.boardType)
-                if (controller.pixhawkBoard || controller.px4FlowBoard) {
-                    showDialog(pixhawkFirmwareSelectDialogComponent, title, qgcView.showDialogDefaultWidth, StandardButton.Ok | StandardButton.Cancel)
-                }
-            }
-        }
-
-        onError: {
-            hideDialog()
-            statusTextArea.append(flashFailText)
-        }
-    }
-
-    onCompleted: {
-        if (controllerCompleted) {
-            // We can only start the board search when the Qml and Controller are completely done loading
-            controller.startBoardSearch()
-        }
-    }
+    id:            firmwarePage
+    pageComponent: firmwarePageComponent
+    pageName:      "Firmware" // For building setup page title: 'Firmware Setup'
 
     Component {
-        id: pixhawkFirmwareSelectDialogComponent
+        id: firmwarePageComponent
 
-        QGCViewDialog {
-            id:             pixhawkFirmwareSelectDialog
-            anchors.fill:   parent
+        ColumnLayout {
+            width:   availableWidth
+            height:  availableHeight
+            spacing: ScreenTools.defaultFontPixelHeight
 
-            property bool showFirmwareTypeSelection:    _advanced.checked
-            property bool px4Flow:                      controller.px4FlowBoard
+            // Those user visible strings are hard to translate because we can't send the
+            // HTML strings to translation as this can create a security risk. we need to find
+            // a better way to hightlight them, or use less highlights.
 
-            function updatePX4VersionDisplay() {
-                var versionString = ""
-                if (_advanced.checked) {
-                    switch (controller.selectedFirmwareType) {
-                    case FirmwareUpgradeController.StableFirmware:
-                        versionString = controller.px4StableVersion
-                        break
-                    case FirmwareUpgradeController.BetaFirmware:
-                        versionString = controller.px4BetaVersion
-                        break
-                    }
-                } else {
-                    versionString = controller.px4StableVersion
-                }
-                px4FlightStack.text = qsTr("PX4 Flight Stack ") + versionString
+            // User visible strings
+            readonly property string title:   "Firmware Setup" // Popup dialog title
+
+            readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
+            readonly property string highlightSuffix:   "</font>"
+            readonly property string welcomeText:       qsTr("%1 can upgrade the firmware on Pixhawk devices, SiK Radios and PX4 Flow Smart Cameras.").arg(QGroundControl.appName)
+            readonly property string plugInText:        "<big>" + highlightPrefix + "Plug in your device" + highlightSuffix + " via USB to " + highlightPrefix + "start" + highlightSuffix + " firmware upgrade.</big>"
+            readonly property string flashFailText:     "If upgrade failed, make sure to connect " + highlightPrefix + "directly" + highlightSuffix + " to a powered USB port on your computer, not through a USB hub. " +
+                                                        "Also make sure you are only powered via USB " + highlightPrefix + "not battery" + highlightSuffix + "."
+            readonly property string qgcUnplugText1:    qsTr("All %1 connections to vehicles must be ").arg(QGroundControl.appName) + highlightPrefix + " disconnected " + highlightSuffix + "prior to firmware upgrade."
+            readonly property string qgcUnplugText2:    highlightPrefix + "<big>Please unplug your Pixhawk and/or Radio from USB.</big>" + highlightSuffix
+
+            readonly property int _defaultFimwareTypePX4:   12
+            readonly property int _defaultFimwareTypeAPM:   3
+
+            property var    _defaultFirmwareFact:   QGroundControl.settingsManager.appSettings.defaultFirmwareType
+            property bool   _defaultFirmwareIsPX4:  _defaultFirmwareFact.rawValue == _defaultFimwareTypePX4
+
+            property string firmwareWarningMessage
+            property bool   controllerCompleted:      false
+            property bool   initialBoardSearch:       true
+            property string firmwareName
+
+            property bool _singleFirmwareMode: QGroundControl.corePlugin.options.firmwareUpgradeSingleURL.length != 0   ///< true: running in special single firmware download mode
+
+            function cancelFlash() {
+                statusTextArea.append(highlightPrefix + qsTr("Upgrade cancelled") + highlightSuffix)
+                statusTextArea.append("------------------------------------------")
+                controller.cancel()
             }
 
-            Component.onCompleted: updatePX4VersionDisplay()
+            QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
-            function accept() {
-                hideDialog()
-                if (_singleFirmwareMode) {
-                    controller.flashSingleFirmwareMode()
-                } else {
-                    var stack = apmFlightStack.checked ? FirmwareUpgradeController.AutoPilotStackAPM : FirmwareUpgradeController.AutoPilotStackPX4
-                    if (px4Flow) {
-                        stack = FirmwareUpgradeController.PX4Flow
-                    }
+            FirmwareUpgradeController {
+                id:             controller
+                progressBar:    progressBar
+                statusLog:      statusTextArea
 
-                    var firmwareType = firmwareVersionCombo.model.get(firmwareVersionCombo.currentIndex).firmwareType
-                    var vehicleType = FirmwareUpgradeController.DefaultVehicleFirmware
-                    if (apmFlightStack.checked) {
-                        vehicleType = controller.vehicleTypeFromVersionIndex(vehicleTypeSelectionCombo.currentIndex)
-                    }
-                    controller.flash(stack, firmwareType, vehicleType)
-                }
-            }
-
-            function reject() {
-                hideDialog()
-                cancelFlash()
-            }
-
-            ExclusiveGroup {
-                id: firmwareGroup
-            }
-
-            ListModel {
-                id: firmwareTypeList
-
-                ListElement {
-                    text:           qsTr("Standard Version (stable)")
-                    firmwareType:   FirmwareUpgradeController.StableFirmware
-                }
-                ListElement {
-                    text:           qsTr("Beta Testing (beta)")
-                    firmwareType:   FirmwareUpgradeController.BetaFirmware
-                }
-                ListElement {
-                    text:           qsTr("Developer Build (master)")
-                    firmwareType:   FirmwareUpgradeController.DeveloperFirmware
-                }
-                ListElement {
-                    text:           qsTr("Custom firmware file...")
-                    firmwareType:   FirmwareUpgradeController.CustomFirmware
-                }
-            }
-
-            ListModel {
-                id: px4FlowTypeList
-
-                ListElement {
-                    text:           qsTr("Standard Version (stable)")
-                    firmwareType:   FirmwareUpgradeController.StableFirmware
-                }
-                ListElement {
-                    text:           qsTr("Custom firmware file...")
-                    firmwareType:   FirmwareUpgradeController.CustomFirmware
-                }
-            }
-
-            ListModel {
-                id: singleFirmwareModeTypeList
-
-                ListElement {
-                    text:           qsTr("Standard Version")
-                    firmwareType:   FirmwareUpgradeController.StableFirmware
-                }
-                ListElement {
-                    text:           qsTr("Custom firmware file...")
-                    firmwareType:   FirmwareUpgradeController.CustomFirmware
-                }
-            }
-
-            Column {
-                anchors.fill:   parent
-                spacing:        defaultTextHeight
-
-                QGCLabel {
-                    width:      parent.width
-                    wrapMode:   Text.WordWrap
-                    text:       _singleFirmwareMode ? _singleFirmwareLabel : (px4Flow ? _px4FlowLabel : _pixhawkLabel)
-
-                    readonly property string _px4FlowLabel:          qsTr("Detected PX4 Flow board. You can select from the following firmware:")
-                    readonly property string _pixhawkLabel:          qsTr("Detected Pixhawk board. You can select from the following flight stacks:")
-                    readonly property string _singleFirmwareLabel:   qsTr("Press Ok to upgrade your vehicle.")
-                }
-
-                function firmwareVersionChanged(model) {
-                    firmwareVersionWarningLabel.visible = false
-                    // All of this bizarre, setting model to null and index to 1 and then to 0 is to work around
-                    // strangeness in the combo box implementation. This sequence of steps correctly changes the combo model
-                    // without generating any warnings and correctly updates the combo text with the new selection.
-                    firmwareVersionCombo.model = null
-                    firmwareVersionCombo.model = model
-                    firmwareVersionCombo.currentIndex = 1
-                    firmwareVersionCombo.currentIndex = 0
-                }
+                property var activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
 
                 Component.onCompleted: {
-                    if (_defaultFirmwareIsPX4) {
-                        px4FlightStack.checked = true
+                    controllerCompleted = true
+                    if (qgcView.completedSignalled) {
+                        // We can only start the board search when the Qml and Controller are completely done loading
+                        controller.startBoardSearch()
+                    }
+                }
+
+                onActiveVehicleChanged: {
+                    if (!activeVehicle) {
+                        statusTextArea.append(plugInText)
+                    }
+                }
+
+                onNoBoardFound: {
+                    initialBoardSearch = false
+                    if (!QGroundControl.multiVehicleManager.activeVehicleAvailable) {
+                        statusTextArea.append(plugInText)
+                    }
+                }
+
+                onBoardGone: {
+                    initialBoardSearch = false
+                    if (!QGroundControl.multiVehicleManager.activeVehicleAvailable) {
+                        statusTextArea.append(plugInText)
+                    }
+                }
+
+                onBoardFound: {
+                    if (initialBoardSearch) {
+                        // Board was found right away, so something is already plugged in before we've started upgrade
+                        statusTextArea.append(qgcUnplugText1)
+                        statusTextArea.append(qgcUnplugText2)
+                        QGroundControl.multiVehicleManager.activeVehicle.autoDisconnect = true
                     } else {
-                        apmFlightStack.checked = true
-                    }
-                }
-
-                QGCRadioButton {
-                    id:             px4FlightStack
-                    exclusiveGroup: firmwareGroup
-                    text:           qsTr("PX4 Flight Stack ")
-                    visible:        !_singleFirmwareMode && !px4Flow
-
-                    onClicked: {
-                        _defaultFirmwareFact.rawValue = _defaultFimwareTypePX4
-                        parent.firmwareVersionChanged(firmwareTypeList)
-                    }
-                }
-
-                QGCRadioButton {
-                    id:             apmFlightStack
-                    exclusiveGroup: firmwareGroup
-                    text:           qsTr("ArduPilot Flight Stack")
-                    visible:        !_singleFirmwareMode && !px4Flow
-
-                    onClicked: {
-                        _defaultFirmwareFact.rawValue = _defaultFimwareTypeAPM
-                        parent.firmwareVersionChanged(firmwareTypeList)
-                    }
-                }
-
-                QGCComboBox {
-                    id:             vehicleTypeSelectionCombo
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    visible:        apmFlightStack.checked
-                    model:          controller.apmAvailableVersions
-                }
-
-                Row {
-                    width:      parent.width
-                    spacing:    ScreenTools.defaultFontPixelWidth / 2
-                    visible:    !px4Flow
-
-                    Rectangle {
-                        height: 1
-                        width:      ScreenTools.defaultFontPixelWidth * 5
-                        color:      qgcPal.text
-                        anchors.verticalCenter: _advanced.verticalCenter
-                    }
-
-                    QGCCheckBox {
-                        id:         _advanced
-                        text:       qsTr("Advanced settings")
-                        checked:    px4Flow ? true : false
-
-                        onClicked: {
-                            firmwareVersionCombo.currentIndex = 0
-                            firmwareVersionWarningLabel.visible = false
-                            updatePX4VersionDisplay()
+                        // We end up here when we detect a board plugged in after we've started upgrade
+                        statusTextArea.append(highlightPrefix + qsTr("Found device") + highlightSuffix + ": " + controller.boardType)
+                        if (controller.pixhawkBoard || controller.px4FlowBoard) {
+                            showDialog(pixhawkFirmwareSelectDialogComponent, title, qgcView.showDialogDefaultWidth, StandardButton.Ok | StandardButton.Cancel)
                         }
                     }
-
-                    Rectangle {
-                        height:     1
-                        width:      ScreenTools.defaultFontPixelWidth * 5
-                        color:      qgcPal.text
-                        anchors.verticalCenter: _advanced.verticalCenter
-                    }
                 }
 
-                QGCLabel {
-                    width:      parent.width
-                    wrapMode:   Text.WordWrap
-                    visible:    showFirmwareTypeSelection
-                    text:       px4Flow ? qsTr("Select which version of the firmware you would like to install:") : qsTr("Select which version of the above flight stack you would like to install:")
+                onError: {
+                    hideDialog()
+                    statusTextArea.append(flashFailText)
                 }
+            }
 
-                QGCComboBox {
-                    id:             firmwareVersionCombo
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    visible:        showFirmwareTypeSelection
-                    model:          _singleFirmwareMode ? singleFirmwareModeTypeList: (px4Flow ? px4FlowTypeList : firmwareTypeList)
-                    currentIndex:   controller.selectedFirmwareType
+            Component.onCompleted: {
+                if (controllerCompleted) {
+                    // We can only start the board search when the Qml and Controller are completely done loading
+                    controller.startBoardSearch()
+                }
+            }
 
-                    onActivated: {
-                        controller.selectedFirmwareType = index
-                        if (model.get(index).firmwareType == FirmwareUpgradeController.BetaFirmware) {
-                            firmwareVersionWarningLabel.visible = true
-                            firmwareVersionWarningLabel.text = qsTr("WARNING: BETA FIRMWARE. ") +
-                                    qsTr("This firmware version is ONLY intended for beta testers. ") +
-                                    qsTr("Although it has received FLIGHT TESTING, it represents actively changed code. ") +
-                                    qsTr("Do NOT use for normal operation.")
-                        } else if (model.get(index).firmwareType == FirmwareUpgradeController.DeveloperFirmware) {
-                            firmwareVersionWarningLabel.visible = true
-                            firmwareVersionWarningLabel.text = qsTr("WARNING: CONTINUOUS BUILD FIRMWARE. ") +
-                                    qsTr("This firmware has NOT BEEN FLIGHT TESTED. ") +
-                                    qsTr("It is only intended for DEVELOPERS. ") +
-                                    qsTr("Run bench tests without props first. ") +
-                                    qsTr("Do NOT fly this without additional safety precautions. ") +
-                                    qsTr("Follow the mailing list actively when using it.")
+            Component {
+                id: pixhawkFirmwareSelectDialogComponent
+
+                QGCViewDialog {
+                    id:             pixhawkFirmwareSelectDialog
+                    anchors.fill:   parent
+
+                    property bool showFirmwareTypeSelection:    _advanced.checked
+                    property bool px4Flow:                      controller.px4FlowBoard
+
+                    function updatePX4VersionDisplay() {
+                        var versionString = ""
+                        if (_advanced.checked) {
+                            switch (controller.selectedFirmwareType) {
+                            case FirmwareUpgradeController.StableFirmware:
+                                versionString = controller.px4StableVersion
+                                break
+                            case FirmwareUpgradeController.BetaFirmware:
+                                versionString = controller.px4BetaVersion
+                                break
+                            }
                         } else {
-                            firmwareVersionWarningLabel.visible = false
+                            versionString = controller.px4StableVersion
                         }
-                        updatePX4VersionDisplay()
+                        px4FlightStack.text = qsTr("PX4 Flight Stack ") + versionString
+                    }
+
+                    Component.onCompleted: updatePX4VersionDisplay()
+
+                    function accept() {
+                        hideDialog()
+                        if (_singleFirmwareMode) {
+                            controller.flashSingleFirmwareMode()
+                        } else {
+                            var stack = apmFlightStack.checked ? FirmwareUpgradeController.AutoPilotStackAPM : FirmwareUpgradeController.AutoPilotStackPX4
+                            if (px4Flow) {
+                                stack = FirmwareUpgradeController.PX4Flow
+                            }
+
+                            var firmwareType = firmwareVersionCombo.model.get(firmwareVersionCombo.currentIndex).firmwareType
+                            var vehicleType = FirmwareUpgradeController.DefaultVehicleFirmware
+                            if (apmFlightStack.checked) {
+                                vehicleType = controller.vehicleTypeFromVersionIndex(vehicleTypeSelectionCombo.currentIndex)
+                            }
+                            controller.flash(stack, firmwareType, vehicleType)
+                        }
+                    }
+
+                    function reject() {
+                        hideDialog()
+                        cancelFlash()
+                    }
+
+                    ExclusiveGroup {
+                        id: firmwareGroup
+                    }
+
+                    ListModel {
+                        id: firmwareTypeList
+
+                        ListElement {
+                            text:           qsTr("Standard Version (stable)")
+                            firmwareType:   FirmwareUpgradeController.StableFirmware
+                        }
+                        ListElement {
+                            text:           qsTr("Beta Testing (beta)")
+                            firmwareType:   FirmwareUpgradeController.BetaFirmware
+                        }
+                        ListElement {
+                            text:           qsTr("Developer Build (master)")
+                            firmwareType:   FirmwareUpgradeController.DeveloperFirmware
+                        }
+                        ListElement {
+                            text:           qsTr("Custom firmware file...")
+                            firmwareType:   FirmwareUpgradeController.CustomFirmware
+                        }
+                    }
+
+                    ListModel {
+                        id: px4FlowTypeList
+
+                        ListElement {
+                            text:           qsTr("Standard Version (stable)")
+                            firmwareType:   FirmwareUpgradeController.StableFirmware
+                        }
+                        ListElement {
+                            text:           qsTr("Custom firmware file...")
+                            firmwareType:   FirmwareUpgradeController.CustomFirmware
+                        }
+                    }
+
+                    ListModel {
+                        id: singleFirmwareModeTypeList
+
+                        ListElement {
+                            text:           qsTr("Standard Version")
+                            firmwareType:   FirmwareUpgradeController.StableFirmware
+                        }
+                        ListElement {
+                            text:           qsTr("Custom firmware file...")
+                            firmwareType:   FirmwareUpgradeController.CustomFirmware
+                        }
+                    }
+
+                    Column {
+                        anchors.fill:   parent
+                        spacing:        defaultTextHeight
+
+                        QGCLabel {
+                            width:      parent.width
+                            wrapMode:   Text.WordWrap
+                            text:       _singleFirmwareMode ? _singleFirmwareLabel : (px4Flow ? _px4FlowLabel : _pixhawkLabel)
+
+                            readonly property string _px4FlowLabel:          qsTr("Detected PX4 Flow board. You can select from the following firmware:")
+                            readonly property string _pixhawkLabel:          qsTr("Detected Pixhawk board. You can select from the following flight stacks:")
+                            readonly property string _singleFirmwareLabel:   qsTr("Press Ok to upgrade your vehicle.")
+                        }
+
+                        function firmwareVersionChanged(model) {
+                            firmwareVersionWarningLabel.visible = false
+                            // All of this bizarre, setting model to null and index to 1 and then to 0 is to work around
+                            // strangeness in the combo box implementation. This sequence of steps correctly changes the combo model
+                            // without generating any warnings and correctly updates the combo text with the new selection.
+                            firmwareVersionCombo.model = null
+                            firmwareVersionCombo.model = model
+                            firmwareVersionCombo.currentIndex = 1
+                            firmwareVersionCombo.currentIndex = 0
+                        }
+
+                        Component.onCompleted: {
+                            if (_defaultFirmwareIsPX4) {
+                                px4FlightStack.checked = true
+                            } else {
+                                apmFlightStack.checked = true
+                            }
+                        }
+
+                        QGCRadioButton {
+                            id:             px4FlightStack
+                            exclusiveGroup: firmwareGroup
+                            text:           qsTr("PX4 Flight Stack ")
+                            visible:        !_singleFirmwareMode && !px4Flow
+
+                            onClicked: {
+                                _defaultFirmwareFact.rawValue = _defaultFimwareTypePX4
+                                parent.firmwareVersionChanged(firmwareTypeList)
+                            }
+                        }
+
+                        QGCRadioButton {
+                            id:             apmFlightStack
+                            exclusiveGroup: firmwareGroup
+                            text:           qsTr("ArduPilot Flight Stack")
+                            visible:        !_singleFirmwareMode && !px4Flow
+
+                            onClicked: {
+                                _defaultFirmwareFact.rawValue = _defaultFimwareTypeAPM
+                                parent.firmwareVersionChanged(firmwareTypeList)
+                            }
+                        }
+
+                        QGCComboBox {
+                            id:             vehicleTypeSelectionCombo
+                            anchors.left:   parent.left
+                            anchors.right:  parent.right
+                            visible:        apmFlightStack.checked
+                            model:          controller.apmAvailableVersions
+                        }
+
+                        Row {
+                            width:      parent.width
+                            spacing:    ScreenTools.defaultFontPixelWidth / 2
+                            visible:    !px4Flow
+
+                            Rectangle {
+                                height: 1
+                                width:      ScreenTools.defaultFontPixelWidth * 5
+                                color:      qgcPal.text
+                                anchors.verticalCenter: _advanced.verticalCenter
+                            }
+
+                            QGCCheckBox {
+                                id:         _advanced
+                                text:       qsTr("Advanced settings")
+                                checked:    px4Flow ? true : false
+
+                                onClicked: {
+                                    firmwareVersionCombo.currentIndex = 0
+                                    firmwareVersionWarningLabel.visible = false
+                                    updatePX4VersionDisplay()
+                                }
+                            }
+
+                            Rectangle {
+                                height:     1
+                                width:      ScreenTools.defaultFontPixelWidth * 5
+                                color:      qgcPal.text
+                                anchors.verticalCenter: _advanced.verticalCenter
+                            }
+                        }
+
+                        QGCLabel {
+                            width:      parent.width
+                            wrapMode:   Text.WordWrap
+                            visible:    showFirmwareTypeSelection
+                            text:       px4Flow ? qsTr("Select which version of the firmware you would like to install:") : qsTr("Select which version of the above flight stack you would like to install:")
+                        }
+
+                        QGCComboBox {
+                            id:             firmwareVersionCombo
+                            anchors.left:   parent.left
+                            anchors.right:  parent.right
+                            visible:        showFirmwareTypeSelection
+                            model:          _singleFirmwareMode ? singleFirmwareModeTypeList: (px4Flow ? px4FlowTypeList : firmwareTypeList)
+                            currentIndex:   controller.selectedFirmwareType
+
+                            onActivated: {
+                                controller.selectedFirmwareType = index
+                                if (model.get(index).firmwareType == FirmwareUpgradeController.BetaFirmware) {
+                                    firmwareVersionWarningLabel.visible = true
+                                    firmwareVersionWarningLabel.text = qsTr("WARNING: BETA FIRMWARE. ") +
+                                            qsTr("This firmware version is ONLY intended for beta testers. ") +
+                                            qsTr("Although it has received FLIGHT TESTING, it represents actively changed code. ") +
+                                            qsTr("Do NOT use for normal operation.")
+                                } else if (model.get(index).firmwareType == FirmwareUpgradeController.DeveloperFirmware) {
+                                    firmwareVersionWarningLabel.visible = true
+                                    firmwareVersionWarningLabel.text = qsTr("WARNING: CONTINUOUS BUILD FIRMWARE. ") +
+                                            qsTr("This firmware has NOT BEEN FLIGHT TESTED. ") +
+                                            qsTr("It is only intended for DEVELOPERS. ") +
+                                            qsTr("Run bench tests without props first. ") +
+                                            qsTr("Do NOT fly this without additional safety precautions. ") +
+                                            qsTr("Follow the mailing list actively when using it.")
+                                } else {
+                                    firmwareVersionWarningLabel.visible = false
+                                }
+                                updatePX4VersionDisplay()
+                            }
+                        }
+
+                        QGCLabel {
+                            id:         firmwareVersionWarningLabel
+                            width:      parent.width
+                            wrapMode:   Text.WordWrap
+                            visible:    false
+                        }
+                    } // Column
+                } // QGCViewDialog
+            } // Component - pixhawkFirmwareSelectDialogComponent
+
+            Component {
+                id: firmwareWarningDialog
+
+                QGCViewMessage {
+                    message: firmwareWarningMessage
+
+                    function accept() {
+                        hideDialog()
+                        controller.doFirmwareUpgrade();
                     }
                 }
+            }
 
-                QGCLabel {
-                    id:         firmwareVersionWarningLabel
-                    width:      parent.width
-                    wrapMode:   Text.WordWrap
-                    visible:    false
+            ProgressBar {
+                id:                 progressBar
+                Layout.preferredWidth:              parent.width
+            }
+
+            TextArea {
+                id:                 statusTextArea
+                Layout.preferredWidth:              parent.width
+                Layout.fillHeight:  true
+                readOnly:           true
+                frameVisible:       false
+                font.pointSize:     ScreenTools.defaultFontPointSize
+                textFormat:         TextEdit.RichText
+                text:               welcomeText
+
+                style: TextAreaStyle {
+                    textColor:          qgcPal.text
+                    backgroundColor:    qgcPal.windowShade
                 }
-            } // Column
-        } // QGCViewDialog
-    } // Component - pixhawkFirmwareSelectDialogComponent
-
-    Component {
-        id: firmwareWarningDialog
-
-        QGCViewMessage {
-            message: firmwareWarningMessage
-
-            function accept() {
-                hideDialog()
-                controller.doFirmwareUpgrade();
             }
-        }
-    }
-
-    QGCViewPanel {
-        id:             panel
-        anchors.fill:   parent
-
-        QGCLabel {
-            id:             titleLabel
-            text:           title
-            font.pointSize: ScreenTools.mediumFontPointSize
-        }
-
-        ProgressBar {
-            id:                 progressBar
-            anchors.topMargin:  ScreenTools.defaultFontPixelHeight
-            anchors.top:        titleLabel.bottom
-            width:              parent.width
-        }
-
-        TextArea {
-            id:                 statusTextArea
-            anchors.topMargin:  ScreenTools.defaultFontPixelHeight
-            anchors.top:        progressBar.bottom
-            anchors.bottom:     parent.bottom
-            width:              parent.width
-            readOnly:           true
-            frameVisible:       false
-            font.pointSize:     ScreenTools.defaultFontPointSize
-            textFormat:         TextEdit.RichText
-            text:               welcomeText
-
-            style: TextAreaStyle {
-                textColor:          qgcPal.text
-                backgroundColor:    qgcPal.windowShade
-            }
-        }
-    } // QGCViewPabel
-} // QGCView
+        } // ColumnLayout
+    } // Component
+} // SetupPage

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -21,7 +21,7 @@ import QGroundControl.Palette       1.0
 import QGroundControl.Controllers   1.0
 import QGroundControl.ScreenTools   1.0
 
-QGCView {
+SetupPage {
     id:         qgcView
     viewPanel:  panel
 
@@ -30,7 +30,8 @@ QGCView {
     // a better way to hightlight them, or use less hightlights.
 
     // User visible strings
-    readonly property string title:             "FIRMWARE"
+    pageName:                                   "Firmware"
+
     readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
     readonly property string highlightSuffix:   "</font>"
     readonly property string welcomeText:       qsTr("%1 can upgrade the firmware on Pixhawk devices, SiK Radios and PX4 Flow Smart Cameras.").arg(QGroundControl.appName)

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -56,23 +56,13 @@ Rectangle {
     function showFirmwarePanel()
     {
         if (!ScreenTools.isMobile) {
-            if (QGroundControl.multiVehicleManager.activeVehicleAvailable && QGroundControl.multiVehicleManager.activeVehicle.armed) {
-                _messagePanelText = _armedVehicleText
-                panelLoader.setSourceComponent(messagePanelComponent)
-            } else {
-                panelLoader.setSource("FirmwareUpgrade.qml")
-            }
+            panelLoader.setSource("FirmwareUpgrade.qml")
         }
     }
 
     function showJoystickPanel()
     {
-        if (QGroundControl.multiVehicleManager.activeVehicleAvailable && QGroundControl.multiVehicleManager.activeVehicle.armed) {
-            _messagePanelText = _armedVehicleText
-            panelLoader.setSourceComponent(messagePanelComponent)
-        } else {
-            panelLoader.setSource("JoystickConfig.qml")
-        }
+        panelLoader.setSource("JoystickConfig.qml")
     }
 
     function showParametersPanel()
@@ -87,24 +77,19 @@ Rectangle {
 
     function showVehicleComponentPanel(vehicleComponent)
     {
-        if (QGroundControl.multiVehicleManager.activeVehicle.armed && !vehicleComponent.allowSetupWhileArmed) {
-            _messagePanelText = _armedVehicleText
+        var autopilotPlugin = QGroundControl.multiVehicleManager.activeVehicle.autopilot
+        var prereq = autopilotPlugin.prerequisiteSetup(vehicleComponent)
+        if (prereq !== "") {
+            //-- TODO: This cannot be translated when built this way.
+            _messagePanelText = prereq + " setup must be completed prior to " + vehicleComponent.name + " setup."
             panelLoader.setSourceComponent(messagePanelComponent)
         } else {
-            var autopilotPlugin = QGroundControl.multiVehicleManager.activeVehicle.autopilot
-            var prereq = autopilotPlugin.prerequisiteSetup(vehicleComponent)
-            if (prereq !== "") {
-                //-- TODO: This cannot be trasnlated when built this way.
-                _messagePanelText = prereq + " setup must be completed prior to " + vehicleComponent.name + " setup."
-                panelLoader.setSourceComponent(messagePanelComponent)
-            } else {
-                panelLoader.setSource(vehicleComponent.setupSource, vehicleComponent)
-                for(var i = 0; i < componentRepeater.count; i++) {
-                    var obj = componentRepeater.itemAt(i);
-                    if (obj.text === vehicleComponent.name) {
-                        obj.checked = true;
-                        break;
-                    }
+            panelLoader.setSource(vehicleComponent.setupSource, vehicleComponent)
+            for(var i = 0; i < componentRepeater.count; i++) {
+                var obj = componentRepeater.itemAt(i);
+                if (obj.text === vehicleComponent.name) {
+                    obj.checked = true;
+                    break;
                 }
             }
         }
@@ -170,6 +155,7 @@ Rectangle {
             }
         }
     }
+
     Component {
         id: missingParametersVehicleSummaryComponent
 


### PR DESCRIPTION
The aim is to make sure the setup pages disable/enable themselves appropriately when they are active and visible during transitions of the armed state.

The current behavior is a bug and safety issue.

This is a rework of https://github.com/mavlink/qgroundcontrol/pull/5525.