### PR TITLE
Switch over to model based storage for the mavlink console

### DIFF
--- a/src/AnalyzeView/MavlinkConsoleController.h
+++ b/src/AnalyzeView/MavlinkConsoleController.h
@@ -14,51 +14,39 @@
 #include "FactMetaData.h"
 #include <QObject>
 #include <QString>
-#include <QThread>
-#include <QFileInfoList>
-#include <QElapsedTimer>
-#include <QDebug>
-#include <QGeoCoordinate>
 #include <QMetaObject>
-
+#include <QStringListModel>
 
 // Fordward decls
 class Vehicle;
 
-
 /// Controller for MavlinkConsole.qml.
-class MavlinkConsoleController : public QObject
+class MavlinkConsoleController : public QStringListModel
 {
     Q_OBJECT
-
-    Q_PROPERTY(int     cursor     READ cursor        NOTIFY cursorChanged)
-    Q_PROPERTY(QString text       READ text          NOTIFY textChanged)
 
 public:
     MavlinkConsoleController();
     ~MavlinkConsoleController();
 
-    int  cursor()    const { return _console_text.size(); }
-    QString text()   const { return _console_text; }
 public slots:
     void sendCommand(QString command);
 
 signals:
     void cursorChanged(int);
-    void textChanged(QString text);
 
 private slots:
     void _setActiveVehicle  (Vehicle* vehicle);
     void _receiveData(uint8_t device, uint8_t flags, uint16_t timeout, uint32_t baudrate, QByteArray data);
 
 private:
-    void _processANSItext();
+    bool _processANSItext(QByteArray &line);
     void _sendSerialData(QByteArray, bool close = false);
+    void writeLine(int line, const QByteArray &text);
 
     int           _cursor_home_pos;
     int           _cursor;
     QByteArray    _incoming_buffer;
-    QString       _console_text;
     Vehicle*      _vehicle;
     QList<QMetaObject::Connection> _uas_connections;
 


### PR DESCRIPTION
This is for #5430. To test for yourself start a mavlink console session and run the help command a few times to generate a bunch of lines, then run top. Before this change rewriting the console lines is a huge drag on QGC and generates way more CPU utilization than is reasonable. 

With this change there is barely a perceptible performance impact. The only disadvantage to this PR is the console text is no longer available for copy/paste.  