### PR TITLE
Offline map: Use FlightMap as base

### DIFF
--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -331,12 +331,14 @@ QGCView {
         id:                 panel
         anchors.fill:       parent
 
-        Map {
-            id:                 _map
-            anchors.fill:       parent
-            center:             QGroundControl.flightMapPosition
-            visible:            false
+        FlightMap {
+            id:                         _map
+            anchors.fill:               parent
+            visible:                    false
+            allowGCSLocationCenter:     true
+            allowVehicleLocationCenter: false
             gesture.flickDeceleration:  3000
+            mapName:                    "OfflineMap"
 
             property bool isSatelliteMap: activeMapType.name.indexOf("Satellite") > -1 || activeMapType.name.indexOf("Hybrid") > -1
 


### PR DESCRIPTION
This way:
* GCS location is shown
* It uses centering semantics of FlightMap: centere same as flight map , center to gcs locaiton if available
* Center on Location works
* Note: Vehicle is not shown

Fix for #5554