### PR TITLE
Split internet test into separate DNS lookup and connection.

### DIFF
--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -52,6 +52,7 @@ QGCCacheWorker::QGCCacheWorker()
     , _defaultCount(0)
     , _lastUpdate(0)
     , _updateTimeout(SHORT_TIMEOUT)
+    , _hostLookupID(0)
 {
 
 }

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -26,6 +26,7 @@
 #include <QWaitCondition>
 #include <QMutexLocker>
 #include <QtSql/QSqlDatabase>
+#include <QHostInfo>
 
 #include "QGCLoggingCategory.h"
 
@@ -48,6 +49,9 @@ public:
 
 protected:
     void    run             ();
+
+private slots:
+    void        _lookupReady            (QHostInfo info);
 
 private:
     void        _saveTile               (QGCMapTask* mtask);
@@ -93,6 +97,7 @@ private:
     quint32                 _defaultCount;
     time_t                  _lastUpdate;
     int                     _updateTimeout;
+    int                     _hostLookupID;
 };
 
 #endif // QGC_TILE_CACHE_WORKER_H


### PR DESCRIPTION
To test if you have Internet connection, the code used to test a connection to 8.8.8.8:53 (google DNS). It appears that some routers are now blocking TCP connections to port 53. So instead, we started using a TCP connection to "github.com" (80). The problem with using a host name rather than an IP address is that the code must first do a name look up before it can attempt a connection. The lookup itself may take up to a minute on some devices. If you were to attempt to exit QGC while that thread was attempting a connection, it would lock the thread until the call returned. There is no way to cancel a connection attempt.

This PR splits the DNS lookup from the connection. The lookup, unlike the "look up and connect" call, can be canceled.

Why bother with the connection if the lookup succeeded? Because you may have had a connection and no longer have. The OS would have cached the lookup. The connection proves that you are indeed connected to the Internet.

This PR is a branch of Stable_3.2. It can be merged into it directly (as it is setup to do when done) as well as master.