### PR TITLE
Set NoProxy for the TCP Socket used for Videostreaming

### DIFF
--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -181,6 +181,7 @@ VideoReceiver::_timeout()
     //   found to be working, only then we actually start the stream.
     QUrl url(_uri);
     _socket = new QTcpSocket;
+    _socket->setProxy(QNetworkProxy::NoProxy);
     connect(_socket, static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error), this, &VideoReceiver::_socketError);
     connect(_socket, &QTcpSocket::connected, this, &VideoReceiver::_connected);
     //qCDebug(VideoReceiverLog) << "Trying to connect to:" << url.host() << url.port();


### PR DESCRIPTION
QGC is not able to receive the RTSP video stream from the drone, when the Ubuntu machine which runs QGC is disconnected from the Internet. This issue can be resolved by setting no-proxy for the TCP socket used for video-streaming. Please refer the issue #5577 for details.