### PR TITLE
Use enumString for large indicators on instrument widget

### DIFF
--- a/src/FlightMap/Widgets/ValuePageWidget.qml
+++ b/src/FlightMap/Widgets/ValuePageWidget.qml
@@ -91,7 +91,7 @@ Column {
                 font.pointSize:         ScreenTools.mediumFontPointSize * (largeValue ? 1.3 : 1.0)
                 font.family:            largeValue ? ScreenTools.demiboldFontFamily : ScreenTools.normalFontFamily
                 fontSizeMode:           Text.HorizontalFit
-                text:                   fact.valueString
+                text:                   fact.enumOrValueString
             }
         }
     }


### PR DESCRIPTION
Instrument widget:

Indicators on the values page use enumerated strings when available for small indicators but always display the raw string value for large indicators.  This fix uses the enumerated strings for both large and small indicators.  See "GPS Lock" below:

|![screen shot 2017-08-31 at 9 35 57 am](https://user-images.githubusercontent.com/10507633/29934469-29426f82-8e30-11e7-905e-9397c5015241.png)|![screen shot 2017-08-31 at 9 35 18 am](https://user-images.githubusercontent.com/10507633/29934471-2bc5b25a-8e30-11e7-92a6-487d9eda7ea3.png)|
| --- | --- |
| Current (integer) | This PR (enumString) |

