### PR TITLE
Plan: If vehicle updates home position don't mark plan dirty

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1499,10 +1499,9 @@ void MissionController::_managerVehicleHomePositionChanged(const QGeoCoordinate&
         } else {
             qWarning() << "First item is not MissionSettingsItem";
         }
-        if (_visualItems->count() == 1) {
-            // Don't let this trip the dirty bit
-            _visualItems->setDirty(false);
-        }
+        // Don't let this trip the dirty bit. Otherwise plan will keep getting marked dirty if vehicle home
+        // changes.
+        _visualItems->setDirty(false);
     }
 }
 


### PR DESCRIPTION
This would cause uneeded "Upload Required" state.