### PR TITLE
FlightDisplayViewWidgets: increase the maximum widget size from 200 to 400

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -42,8 +42,7 @@ Item {
         if(ScreenTools.isMobile) {
             return ScreenTools.isTinyScreen ? mainWindow.width * 0.2 : mainWindow.width * 0.15
         }
-        var w = mainWindow.width * 0.15
-        return Math.min(w, 200)
+        return ScreenTools.defaultFontPixelWidth * 30
     }
 
     function _setInstrumentWidget() {


### PR DESCRIPTION
On large/high DPI screens, the whole UI scales nicely when increasing the
font size, except for the attitude widget, that was limited to 200 pixels.

Before:
![qgc_small_indicator](https://user-images.githubusercontent.com/281593/30556239-6cc66f50-9caa-11e7-95e5-1575ea5e833c.png)
Now:
![qgc_small_indicater_larger](https://user-images.githubusercontent.com/281593/30556369-e946e80c-9caa-11e7-9fd0-307e369cd933.png)
It's better, but IMO it could still be a bit larger.