### PR TITLE
Some smaller UX improvements

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -32,7 +32,7 @@ QGCView {
     property Fact   _editorDialogFact: Fact { }
     property int    _rowHeight:         ScreenTools.defaultFontPixelHeight * 2
     property int    _rowWidth:          10      // Dynamic adjusted at runtime
-    property bool   _searchFilter:      searchText.text != ""   ///< true: showing results of search
+    property bool   _searchFilter:      searchText.text.trim() != ""   ///< true: showing results of search
     property var    _searchResults              ///< List of parameter names from search results
     property bool   _showRCToParam:     !ScreenTools.isMobile && QGroundControl.multiVehicleManager.activeVehicle.px4Firmware
 

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -158,8 +158,9 @@ void ParameterEditorController::setRCToParam(const QString& paramName)
 void ParameterEditorController::_updateParameters(void)
 {
     QObjectList newParameterList;
+    QStringList searchItems = _searchText.split(' ', QString::SkipEmptyParts);
 
-    if (_searchText.isEmpty()) {
+    if (searchItems.isEmpty()) {
         const QMap<int, QMap<QString, QStringList> >& groupMap = _vehicle->parameterManager()->getGroupMap();
         foreach (const QString& parameter, groupMap[_currentComponentId][_currentGroup]) {
             newParameterList.append(_vehicle->parameterManager()->getParameter(_currentComponentId, parameter));
@@ -167,9 +168,17 @@ void ParameterEditorController::_updateParameters(void)
     } else {
         foreach(const QString &parameter, _vehicle->parameterManager()->parameterNames(_vehicle->defaultComponentId())) {
             Fact* fact = _vehicle->parameterManager()->getParameter(_vehicle->defaultComponentId(), parameter);
-            if (fact->name().contains(_searchText, Qt::CaseInsensitive) ||
-                    fact->shortDescription().contains(_searchText, Qt::CaseInsensitive) ||
-                    fact->longDescription().contains(_searchText, Qt::CaseInsensitive)) {
+            bool matched = true;
+
+            // all of the search items must match in order for the parameter to be added to the list
+            for (const auto& searchItem : searchItems) {
+                if (!fact->name().contains(searchItem, Qt::CaseInsensitive) &&
+                        !fact->shortDescription().contains(searchItem, Qt::CaseInsensitive) &&
+                        !fact->longDescription().contains(searchItem, Qt::CaseInsensitive)) {
+                    matched = false;
+                }
+            }
+            if (matched) {
                 newParameterList.append(fact);
             }
         }

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -88,7 +88,7 @@ QGCViewDialog {
 	// set focus to the text field when becoming visible (in case of an Enum,
 	// the valueField is not visible, but it's not an issue because the combo
 	// box cannot have a focus)
-	onVisibleChanged: if (visible) valueField.forceActiveFocus()
+	onVisibleChanged: if (visible && !ScreenTools.isMobile) valueField.forceActiveFocus()
 
     QGCFlickable {
         anchors.fill:       parent

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -85,6 +85,11 @@ QGCViewDialog {
         }
     }
 
+	// set focus to the text field when becoming visible (in case of an Enum,
+	// the valueField is not visible, but it's not an issue because the combo
+	// box cannot have a focus)
+	onVisibleChanged: if (visible) valueField.forceActiveFocus()
+
     QGCFlickable {
         anchors.fill:       parent
         contentHeight:      _column.y + _column.height

--- a/src/QmlControls/QGCViewDialog.qml
+++ b/src/QmlControls/QGCViewDialog.qml
@@ -31,7 +31,7 @@ FactPanel {
         if (event.key == Qt.Key_Escape) {
             reject()
             event.accepted = true
-        } else if (event.key == Qt.Key_Return) {
+        } else if (event.key == Qt.Key_Return || event.key == Qt.Key_Enter) {
             accept()
             event.accepted = true
         }


### PR DESCRIPTION
UX improvements that have bothered me (and others too) for quite some time now:
- activate the keyboard focus to the parameter value when start to edit a parameter
- accept numpad enter key to change a param
- allow to search for multiple independent words in parameter names & descriptions.

There's one more thing I wanted to do: set the focus to the mavlink console text input when opening the console view. But I could not get that to work. @DonLakeFlyer would be great if you could do that.