### PR TITLE
Assume all vehicles support MANUAL_CONTROL

### DIFF
--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -111,8 +111,3 @@ bool ArduRoverFirmwarePlugin::supportsNegativeThrust(void)
 {
     return true;
 }
-
-bool ArduRoverFirmwarePlugin::supportsManualControl(void)
-{
-    return true;
-}

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -56,7 +56,6 @@ public:
     int     remapParamNameHigestMinorVersionNumber  (int majorVersionNumber) const final;
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     bool supportsNegativeThrust(void) final;
-    bool supportsManualControl(void) final;
 
 private:
     static bool _remapParamNameIntialized;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -132,11 +132,6 @@ bool ArduSubFirmwarePlugin::supportsThrottleModeCenterZero(void)
     return false;
 }
 
-bool ArduSubFirmwarePlugin::supportsManualControl(void)
-{
-    return true;
-}
-
 bool ArduSubFirmwarePlugin::supportsRadio(void)
 {
     return false;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -107,8 +107,6 @@ public:
 
     bool supportsThrottleModeCenterZero(void) final;
 
-    bool supportsManualControl(void) final;
-
     bool supportsRadio(void) final;
 
     bool supportsJSButton(void) final;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -135,11 +135,6 @@ bool FirmwarePlugin::supportsNegativeThrust(void)
     return false;
 }
 
-bool FirmwarePlugin::supportsManualControl(void)
-{
-    return false;
-}
-
 bool FirmwarePlugin::supportsRadio(void)
 {
     return true;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -163,10 +163,6 @@ public:
     /// Typically supported rover.
     virtual bool supportsNegativeThrust(void);
 
-    /// Returns true if the firmware supports the use of the MAVlink "MANUAL_CONTROL" message.
-    /// By default, this returns false unless overridden in the firmware plugin.
-    virtual bool supportsManualControl(void);
-
     /// Returns true if the firmware supports the use of the RC radio and requires the RC radio
     /// setup page. Returns true by default.
     virtual bool supportsRadio(void);

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -220,11 +220,6 @@ int PX4FirmwarePlugin::manualControlReservedButtonCount(void)
     return 0;   // 0 buttons reserved for rc switch simulation
 }
 
-bool PX4FirmwarePlugin::supportsManualControl(void)
-{
-    return true;
-}
-
 bool PX4FirmwarePlugin::isCapable(const Vehicle *vehicle, FirmwareCapabilities capabilities)
 {
     int available = MavCmdPreflightStorageCapability | SetFlightModeCapability | PauseVehicleCapability | GuidedModeCapability;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -51,7 +51,6 @@ public:
     void                startMission                    (Vehicle* vehicle) override;
     bool                isGuidedMode                    (const Vehicle* vehicle) const override;
     int                 manualControlReservedButtonCount(void) override;
-    bool                supportsManualControl           (void) override;
     void                initializeVehicle               (Vehicle* vehicle) override;
     bool                sendHomePositionToVehicle       (void) override;
     void                addMetaDataToFact               (QObject* parameterMetaData, Fact* fact, MAV_TYPE vehicleType) override;

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -92,12 +92,6 @@ QGCView {
         QGroundControl.saveBoolGlobalSetting(_PIPVisibleKey, state)
     }
 
-    function px4JoystickCheck() {
-        if ( _activeVehicle && !_activeVehicle.supportsManualControl && (QGroundControl.settingsManager.appSettings.virtualJoystick.value || _activeVehicle.joystickEnabled)) {
-            px4JoystickSupport.open()
-        }
-    }
-
     PlanMasterController {
         id:                     masterController
         Component.onCompleted:  start(false /* editMode */)
@@ -109,28 +103,8 @@ QGCView {
         onResumeMissionUploadFail:  guidedActionsController.confirmAction(guidedActionsController.actionResumeMissionUploadFail)
     }
 
-    MessageDialog {
-        id:     px4JoystickSupport
-        text:   qsTr("Joystick support requires MAVLink MANUAL_CONTROL support. ") +
-                qsTr("The firmware you are running does not normally support this. ") +
-                qsTr("It will only work if you have modified the firmware to add MANUAL_CONTROL support.")
-    }
-
-    Connections {
-        target:                 QGroundControl.multiVehicleManager
-        onActiveVehicleChanged: px4JoystickCheck()
-    }
-
-    Connections {
-        target:         QGroundControl.settingsManager.appSettings.virtualJoystick
-        onValueChanged: px4JoystickCheck()
-    }
-
-    onActiveVehicleJoystickEnabledChanged: px4JoystickCheck()
-
     Component.onCompleted: {
         setStates()
-        px4JoystickCheck()
         if(QGroundControl.corePlugin.options.flyViewOverlay.toString().length) {
             flyViewOverlay.source = QGroundControl.corePlugin.options.flyViewOverlay
         }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2097,11 +2097,6 @@ bool Vehicle::vtol(void) const
     return _firmwarePlugin->isVtol(this);
 }
 
-bool Vehicle::supportsManualControl(void) const
-{
-    return _firmwarePlugin->supportsManualControl();
-}
-
 bool Vehicle::supportsThrottleModeCenterZero(void) const
 {
     return _firmwarePlugin->supportsThrottleModeCenterZero();

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -282,7 +282,6 @@ public:
     Q_PROPERTY(bool                 vtol                    READ vtol                                                   NOTIFY vehicleTypeChanged)
     Q_PROPERTY(bool                 rover                   READ rover                                                  NOTIFY vehicleTypeChanged)
     Q_PROPERTY(bool                 sub                     READ sub                                                    NOTIFY vehicleTypeChanged)
-    Q_PROPERTY(bool                 supportsManualControl   READ supportsManualControl                                  CONSTANT)
     Q_PROPERTY(bool        supportsThrottleModeCenterZero   READ supportsThrottleModeCenterZero                         CONSTANT)
     Q_PROPERTY(bool                supportsNegativeThrust   READ supportsNegativeThrust                                 CONSTANT)
     Q_PROPERTY(bool                 supportsJSButton        READ supportsJSButton                                       CONSTANT)
@@ -515,7 +514,6 @@ public:
     bool rover(void) const;
     bool sub(void) const;
 
-    bool supportsManualControl(void) const;
     bool supportsThrottleModeCenterZero(void) const;
     bool supportsNegativeThrust(void) const;
     bool supportsRadio(void) const;


### PR DESCRIPTION
All ArduPilot vehicle support MANUAL_CONTROL now so no need to:
* Pop the joystick warning
* Have a plugin mechanism to signal MANUAL_CONTROL support

Fix for #5644