### PR TITLE
Firmware-specific fact metadata

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -223,6 +223,7 @@
         <file alias="Vehicle/TemperatureFact.json">src/Vehicle/TemperatureFact.json</file>
         <file alias="Vehicle/SubmarineFact.json">src/Vehicle/SubmarineFact.json</file>
         <file alias="BrandImage.SettingsGroup.json">src/Settings/BrandImage.SettingsGroup.json</file>
+        <file alias="Vehicle/ArduSubVehicleFact.json">src/Vehicle/ArduSubVehicleFact.json</file>
     </qresource>
     <qresource prefix="/MockLink">
         <file alias="APMArduCopterMockLink.params">src/comm/APMArduCopterMockLink.params</file>

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -84,10 +84,15 @@ void FactGroup::_addFact(Fact* fact, const QString& name)
         return;
     }
 
-    fact->setSendValueChangedSignals(_updateRateMSecs == 0);
-    if (_nameToFactMetaDataMap.contains(name)) {
-        fact->setMetaData(_nameToFactMetaDataMap[name]);
+    if (!_nameToFactMetaDataMap.contains(name)) {
+        qWarning() << "No metadata for fact:" << name;
+        return;
     }
+
+    fact->setMetaData(_nameToFactMetaDataMap[name]);
+
+    fact->setSendValueChangedSignals(_updateRateMSecs == 0);
+
     _nameToFactMap[name] = fact;
 }
 

--- a/src/Vehicle/ArduSubVehicleFact.json
+++ b/src/Vehicle/ArduSubVehicleFact.json
@@ -1,0 +1,64 @@
+[
+{
+    "name":             "roll",
+    "shortDescription": "Roll",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg"
+},
+{
+    "name":             "pitch",
+    "shortDescription": "Pitch",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg"
+},
+{
+    "name":             "heading",
+    "shortDescription": "Heading",
+    "type":             "double",
+    "decimalPlaces":    0,
+    "units":            "deg"
+},
+{
+    "name":             "groundSpeed",
+    "shortDescription": "Speed",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m/s"
+},
+{
+    "name":             "climbRate",
+    "shortDescription": "Dive Rate",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m/s"
+},
+{
+    "name":             "altitudeRelative",
+    "shortDescription": "Depth",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m"
+},
+{
+    "name":             "flightDistance",
+    "shortDescription": "Dive Distance",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m"
+},
+{
+    "name":             "distanceToHome",
+    "shortDescription": "Distance to Home",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m"
+},
+{
+    "name":             "flightTime",
+    "shortDescription": "Dive Time",
+    "type":             "elapsedSeconds",
+    "decimalPlaces":    1
+}
+]

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2826,6 +2826,9 @@ void Vehicle::sendPlan(QString planFile)
 QString Vehicle::_getVehicleFactFileName(MAV_TYPE vehicleType)
 {
     switch (vehicleType) {
+        case MAV_TYPE_SUBMARINE:
+            return QString(":/json/Vehicle/ArduSubVehicleFact.json");
+
         default:
             return QString(":/json/Vehicle/VehicleFact.json");
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -70,7 +70,7 @@ Vehicle::Vehicle(LinkInterface*             link,
                  MAV_TYPE                   vehicleType,
                  FirmwarePluginManager*     firmwarePluginManager,
                  JoystickManager*           joystickManager)
-    : FactGroup(_vehicleUIUpdateRateMSecs, ":/json/Vehicle/VehicleFact.json")
+    : FactGroup(_vehicleUIUpdateRateMSecs, _getVehicleFactFileName(vehicleType))
     , _id(vehicleId)
     , _defaultComponentId(defaultComponentId)
     , _active(false)
@@ -244,7 +244,7 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
                  MAV_TYPE                   vehicleType,
                  FirmwarePluginManager*     firmwarePluginManager,
                  QObject*                   parent)
-    : FactGroup(_vehicleUIUpdateRateMSecs, ":/json/Vehicle/VehicleFact.json", parent)
+    : FactGroup(_vehicleUIUpdateRateMSecs, _getVehicleFactFileName(vehicleType), parent)
     , _id(0)
     , _defaultComponentId(MAV_COMP_ID_ALL)
     , _active(false)
@@ -2822,6 +2822,14 @@ void Vehicle::sendPlan(QString planFile)
     PlanMasterController::sendPlanToVehicle(this, planFile);
 }
 
+// Return appropriate Vehicle Fact json file for a given vehicle type
+QString Vehicle::_getVehicleFactFileName(MAV_TYPE vehicleType)
+{
+    switch (vehicleType) {
+        default:
+            return QString(":/json/Vehicle/VehicleFact.json");
+    }
+}
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -874,6 +874,7 @@ private:
     void _startPlanRequest(void);
     void _setupAutoDisarmSignalling(void);
     void _setCapabilities(uint64_t capabilityBits);
+    QString _getVehicleFactFileName(MAV_TYPE vehicleType);
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;


### PR DESCRIPTION
Point being to change labels like 'airspeed' and 'altitude' to speed and depth, or whatever's appropriate.