### PR TITLE
LogDownloadController: only skip entry if size==0 && APM firmware

### DIFF
--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -173,7 +173,7 @@ LogDownloadController::_logEntry(UASInterface* uas, uint32_t time_utc, uint32_t 
     //-- Update this log record
     if(num_logs > 0) {
         //-- Skip if empty (APM first packet)
-        if(size) {
+        if(size || _vehicle->firmwareType() != MAV_AUTOPILOT_ARDUPILOTMEGA) {
             id -= _apmOneBased;
             if(id < _logEntriesModel.count()) {
                 QGCLogEntry* entry = _logEntriesModel[id];


### PR DESCRIPTION
On PX4, under certain circumstances and in rare cases, there can be log
files with 0 size. In that case QGC ignored the entry and tried to
re-request the entry indefinitely.

@MaEtUgR you can approve here :)