### PR TITLE
QGCMapPolygon: Fix bug in center polygon item

### DIFF
--- a/src/MissionManager/QGCMapPolygon.cc
+++ b/src/MissionManager/QGCMapPolygon.cc
@@ -44,7 +44,7 @@ void QGCMapPolygon::_init(void)
 {
     connect(&_polygonModel, &QmlObjectListModel::dirtyChanged, this, &QGCMapPolygon::_polygonModelDirtyChanged);
     connect(&_polygonModel, &QmlObjectListModel::countChanged, this, &QGCMapPolygon::_polygonModelCountChanged);
-    connect(&_polygonModel, &QmlObjectListModel::countChanged, this, &QGCMapPolygon::_updateCenter);
+    connect(this, &QGCMapPolygon::pathChanged, this, &QGCMapPolygon::_updateCenter);
 }
 
 const QGCMapPolygon& QGCMapPolygon::operator=(const QGCMapPolygon& other)
@@ -284,8 +284,6 @@ void QGCMapPolygon::removeVertex(int vertexIndex)
 
     _polygonPath.removeAt(vertexIndex);
     emit pathChanged();
-
-    _updateCenter();
 }
 
 void QGCMapPolygon::_polygonModelCountChanged(int count)


### PR DESCRIPTION
When creating new points, center need to be updated.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>