### PR TITLE
PlanToolBar: Change upload button visibility

### DIFF
--- a/src/PlanView/PlanToolBar.qml
+++ b/src/PlanView/PlanToolBar.qml
@@ -300,7 +300,7 @@ Rectangle {
         anchors.verticalCenter: parent.verticalCenter
         text:                   _controllerDirty ? qsTr("Upload Required") : qsTr("Upload")
         enabled:                !_controllerSyncInProgress
-        visible:                !_controllerOffline && !_controllerSyncInProgress && !uploadCompleteText.visible
+        visible:                !_controllerOffline && !_controllerSyncInProgress && !uploadCompleteText.visible && missionItems.count > 1
         primary:                _controllerDirty
         onClicked:              planMasterController.upload()
 


### PR DESCRIPTION
The upload button is necessary only when the mission have more than the home point

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>