### PR TITLE
Display warning if the user exceeds video storage limit

### DIFF
--- a/src/VideoStreaming/VideoReceiver.h
+++ b/src/VideoStreaming/VideoReceiver.h
@@ -83,6 +83,7 @@ private slots:
     void _updateTimer               ();
 #if defined(QGC_GST_STREAMING)
     void _timeout                   ();
+    void _checkVideoStorage         ();
     void _connected                 ();
     void _socketError               (QAbstractSocket::SocketError socketError);
     void _handleError               ();
@@ -116,7 +117,6 @@ private:
     void                        _detachRecordingBranch  (GstPadProbeInfo* info);
     void                        _shutdownRecordingBranch();
     void                        _shutdownPipeline       ();
-    void                        _cleanupOldVideos       ();
     void                        _setVideoSink           (GstElement* sink);
 
     GstElement*     _pipeline;
@@ -128,6 +128,9 @@ private:
     QTimer          _timer;
     QTcpSocket*     _socket;
     bool            _serverPresent;
+
+    //-- Check disk usage periodically
+    QTimer          _videoStorageTimer;
 
 #endif
 


### PR DESCRIPTION
Some of our customers have complained about loss of video footage due to the video-storage-limiting auto-video-delete feature.  For longer missions the default 2 GB limit on video storage is insufficient and the lack of a notification when the limit is reached exacerbates the problem.  As recorded footage is often very valuable to our customers, we feel the prospect of auto-deletion of footage by default is incredibly risky.

This PR removes the auto-deletion of footage from the video storage limiter and instead displays and announces a warning when either:
- the prescribed limit is reached during recording, or
- a recording is started after the limit has been reached.

The displayed message also displays the current video storage limit and free space on the disk.
![screen shot 2017-09-22 at 11 35 33 am](https://user-images.githubusercontent.com/10507633/30761320-a7f41d8a-9f92-11e7-9ace-025a169f1e38.png)
