### PR TITLE
Add JSON key for mobile-specific default values

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -68,6 +68,7 @@ const char* FactMetaData::_shortDescriptionJsonKey =    "shortDescription";
 const char* FactMetaData::_longDescriptionJsonKey =     "longDescription";
 const char* FactMetaData::_unitsJsonKey =               "units";
 const char* FactMetaData::_defaultValueJsonKey =        "defaultValue";
+const char* FactMetaData::_mobileDefaultValueJsonKey =  "mobileDefaultValue";
 const char* FactMetaData::_minJsonKey =                 "min";
 const char* FactMetaData::_maxJsonKey =                 "max";
 
@@ -861,9 +862,17 @@ FactMetaData* FactMetaData::createFromJsonObject(const QJsonObject& json, QObjec
     if (json.contains(_unitsJsonKey)) {
         metaData->setRawUnits(json[_unitsJsonKey].toString());
     }
+#ifdef __mobile__
+    if (json.contains(_mobileDefaultValueJsonKey)) {
+        metaData->setRawDefaultValue(json[_mobileDefaultValueJsonKey].toVariant());
+    } else if (json.contains(_defaultValueJsonKey)) {
+        metaData->setRawDefaultValue(json[_defaultValueJsonKey].toVariant());
+    }
+#else
     if (json.contains(_defaultValueJsonKey)) {
         metaData->setRawDefaultValue(json[_defaultValueJsonKey].toVariant());
     }
+#endif
     if (json.contains(_minJsonKey)) {
         QVariant typedValue;
         QString errorString;

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -245,6 +245,7 @@ private:
     static const char*  _longDescriptionJsonKey;
     static const char*  _unitsJsonKey;
     static const char*  _defaultValueJsonKey;
+    static const char*  _mobileDefaultValueJsonKey;
     static const char*  _minJsonKey;
     static const char*  _maxJsonKey;
 };


### PR DESCRIPTION
This PR adds a "mobileDefaultValue" JSON key that mobile builds will use in place of "defaultValue" when available.  If the "mobileDefaultValue" key is not available for a given fact, mobile devices will instead default to the "defaultValue" key's value.

Non-mobile builds will ignore the "mobileDefaultValue" key.

This allows developers to set different default fact values for mobile/desktop users.