### PR TITLE
Setup View: No click/indicator for hidden pages

### DIFF
--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -127,10 +127,14 @@ Rectangle {
                                 height:                 width
                                 radius:                 width / 2
                                 color:                  modelData.setupComplete ? "#00d932" : "red"
-                                visible:                modelData.requiresSetup
+                                visible:                modelData.requiresSetup && modelData.setupSource != ""
                             }
+
                             onClicked : {
-                                setupView.showVehicleComponentPanel(modelData)
+                                console.log(modelData.setupSource)
+                                if (modelData.setupSource != "") {
+                                    setupView.showVehicleComponentPanel(modelData)
+                                }
                             }
                         }
                         // Summary Qml


### PR DESCRIPTION
For custom builds which hide setup pages but still show the summary page for the component:
* Click on summary box does nothing
* Setup red/green indicator is hidden