### PR TITLE
LogDownloadController: start the timeout timer when requesting the first chunk

### DIFF
--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -407,6 +407,7 @@ LogDownloadController::_receivedAllData()
     if(_prepareLogDownload()) {
         //-- Request Log
         _requestLogData(_downloadData->ID, 0, _downloadData->chunk_table.size()*MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN);
+        _timer.start(kTimeOutMilliseconds);
     } else {
         _resetSelection();
         _setDownloading(false);


### PR DESCRIPTION
The timer was only started in _logData(), which was called after receiving
the first chunk of data (and only if that was successful), which means
if the first request failed or timed out, the UI would never switch to
a timed out state.

Fixes the 2. bug described in https://github.com/mavlink/qgroundcontrol/issues/5610.