### PR TITLE
Add option to disable video auto-delete

### DIFF
--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -75,7 +75,16 @@
     "type":             "uint32",
     "min":              100,
     "units":            "MB",
-    "defaultValue":     2048
+    "defaultValue":     10240,
+    "mobileDefaultValue":   2048
+},
+{
+    "name":             "EnableStorageLimit",
+    "shortDescription": "Enable/Disable Limits on Storage Usage",
+    "longDescription":  "When enabled, old video files will be auto-deleted when the total size of QGC-recorded video exceeds the maximum video storage usage.",
+    "type":             "bool",
+    "defaultValue":     false,
+    "mobileDefaultValue":   true
 },
 {
     "name":             "RtspTimeout",

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -28,6 +28,7 @@ const char* VideoSettings::videoGridLinesName =     "VideoGridLines";
 const char* VideoSettings::showRecControlName =     "ShowRecControl";
 const char* VideoSettings::recordingFormatName =    "RecordingFormat";
 const char* VideoSettings::maxVideoSizeName =       "MaxVideoSize";
+const char* VideoSettings::enableStorageLimitName = "EnableStorageLimit";
 const char* VideoSettings::rtspTimeoutName =        "RtspTimeout";
 
 const char* VideoSettings::videoSourceNoVideo =     "No Video Available";
@@ -47,6 +48,7 @@ VideoSettings::VideoSettings(QObject* parent)
     , _showRecControlFact(NULL)
     , _recordingFormatFact(NULL)
     , _maxVideoSizeFact(NULL)
+    , _enableStorageLimitFact(NULL)
     , _rtspTimeoutFact(NULL)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
@@ -167,6 +169,15 @@ Fact* VideoSettings::maxVideoSize(void)
     }
 
     return _maxVideoSizeFact;
+}
+
+Fact* VideoSettings::enableStorageLimit(void)
+{
+    if (!_enableStorageLimitFact) {
+        _enableStorageLimitFact = _createSettingsFact(enableStorageLimitName);
+    }
+
+    return _enableStorageLimitFact;
 }
 
 Fact* VideoSettings::rtspTimeout(void)

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -28,6 +28,7 @@ public:
     Q_PROPERTY(Fact* showRecControl     READ showRecControl     CONSTANT)
     Q_PROPERTY(Fact* recordingFormat    READ recordingFormat    CONSTANT)
     Q_PROPERTY(Fact* maxVideoSize       READ maxVideoSize       CONSTANT)
+    Q_PROPERTY(Fact* enableStorageLimit READ enableStorageLimit CONSTANT)
     Q_PROPERTY(Fact* rtspTimeout        READ rtspTimeout        CONSTANT)
 
     Fact* videoSource       (void);
@@ -39,6 +40,7 @@ public:
     Fact* showRecControl    (void);
     Fact* recordingFormat   (void);
     Fact* maxVideoSize      (void);
+    Fact* enableStorageLimit(void);
     Fact* rtspTimeout      (void);
 
     static const char* videoSettingsGroupName;
@@ -52,6 +54,7 @@ public:
     static const char* showRecControlName;
     static const char* recordingFormatName;
     static const char* maxVideoSizeName;
+    static const char* enableStorageLimitName;
     static const char* rtspTimeoutName;
 
     static const char* videoSourceNoVideo;
@@ -70,6 +73,7 @@ private:
     SettingsFact* _showRecControlFact;
     SettingsFact* _recordingFormatFact;
     SettingsFact* _maxVideoSizeFact;
+    SettingsFact* _enableStorageLimitFact;
     SettingsFact* _rtspTimeoutFact;
 };
 

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -630,7 +630,21 @@ QGCView {
                         anchors.centerIn: parent
                         Row {
                             spacing:    ScreenTools.defaultFontPixelWidth
-                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 4 && QGroundControl.settingsManager.videoSettings.maxVideoSize.visible
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 4 && QGroundControl.settingsManager.videoSettings.enableStorageLimit.visible
+                            QGCLabel {
+                                text:               qsTr("Auto-Delete Files:")
+                                width:              _labelWidth
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                            FactCheckBox {
+                                text:                   ""
+                                fact:                   QGroundControl.settingsManager.videoSettings.enableStorageLimit
+                                anchors.verticalCenter: parent.verticalCenter
+                            }
+                        }
+                        Row {
+                            spacing:    ScreenTools.defaultFontPixelWidth
+                            visible:    QGroundControl.videoManager.isGStreamer && videoSource.currentIndex && videoSource.currentIndex < 4 && QGroundControl.settingsManager.videoSettings.maxVideoSize.visible && QGroundControl.settingsManager.videoSettings.enableStorageLimit.value
                             QGCLabel {
                                 text:               qsTr("Max Storage Usage:")
                                 width:              _labelWidth


### PR DESCRIPTION
Rework of #5693.

This PR adds the option to enable/disable the video auto-delete feature.  Said feature is enabled by default for mobile builds.  For non-mobile builds, it defaults to disabled.

Max storage limits are also adjusted.  Mobile builds will default to 2 GB (same as current versions), whereas non-mobile builds, when auto-delete is enabled, will default to 10 GB.