### PR TITLE
Structure scan: Support for scan distance from structure polygon

### DIFF
--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -911,7 +911,7 @@ void PlanManager::removeAll(void)
         return;
     }
 
-    qCDebug(PlanManagerLog) << QStringLiteral("removeAll").arg(_planTypeString());
+    qCDebug(PlanManagerLog) << QStringLiteral("removeAll %1").arg(_planTypeString());
 
     _clearAndDeleteMissionItems();
 

--- a/src/MissionManager/QGCMapPolygon.h
+++ b/src/MissionManager/QGCMapPolygon.h
@@ -52,6 +52,9 @@ public:
     /// Returns true if the specified coordinate is within the polygon
     Q_INVOKABLE bool containsCoordinate(const QGeoCoordinate& coordinate) const;
 
+    /// Offsets the current polygon edges by the specified distance in meters
+    Q_INVOKABLE void offset(double distance);
+
     /// Returns the path in a list of QGeoCoordinate's format
     QList<QGeoCoordinate> coordinateList(void) const;
 
@@ -68,6 +71,9 @@ public:
     ///     @param errorString Error string if return is false
     /// @return true: success, false: failure (errorString set)
     bool loadFromJson(const QJsonObject& json, bool required, QString& errorString);
+
+    /// Convert polygon to NED and return (D is ignored)
+    QList<QPointF> nedPolygon(void);
 
     // Property methods
 

--- a/src/MissionManager/StructureScan.SettingsGroup.json
+++ b/src/MissionManager/StructureScan.SettingsGroup.json
@@ -24,6 +24,15 @@
     "defaultValue":     25
 },
 {
+    "name":             "Scan distance",
+    "shortDescription": "Scan distance away from structure.",
+    "type":             "double",
+    "decimalPlaces":    2,
+    "min":              0,
+    "units":            "m",
+    "defaultValue":     25
+},
+{
     "name":             "Trigger distance",
     "shortDescription": "Distance between each triggering of the camera. 0 specifies not camera trigger.",
     "type":             "double",

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -30,20 +30,24 @@ public:
     Q_PROPERTY(Fact*            layers                      READ layers                         CONSTANT)
     Q_PROPERTY(Fact*            layerDistance               READ layerDistance                  CONSTANT)
     Q_PROPERTY(Fact*            cameraTriggerDistance       READ cameraTriggerDistance          CONSTANT)
+    Q_PROPERTY(Fact*            scanDistance                READ scanDistance                   CONSTANT)
     Q_PROPERTY(bool             altitudeRelative            MEMBER _altitudeRelative            NOTIFY altitudeRelativeChanged)
     Q_PROPERTY(int              cameraShots                 READ cameraShots                    NOTIFY cameraShotsChanged)
     Q_PROPERTY(double           timeBetweenShots            READ timeBetweenShots               NOTIFY timeBetweenShotsChanged)
     Q_PROPERTY(double           cameraMinTriggerInterval    MEMBER _cameraMinTriggerInterval    NOTIFY cameraMinTriggerIntervalChanged)
-    Q_PROPERTY(QGCMapPolygon*   mapPolygon                  READ mapPolygon                     CONSTANT)
+    Q_PROPERTY(QGCMapPolygon*   structurePolygon            READ structurePolygon               CONSTANT)
+    Q_PROPERTY(QGCMapPolygon*   flightPolygon               READ flightPolygon                  CONSTANT)
 
     Fact* altitude              (void) { return &_altitudeFact; }
     Fact* layers                (void) { return &_layersFact; }
     Fact* layerDistance         (void) { return &_layerDistanceFact; }
     Fact* cameraTriggerDistance (void) { return &_cameraTriggerDistanceFact; }
+    Fact* scanDistance          (void) { return &_scanDistanceFact; }
 
     int             cameraShots     (void) const;
     double          timeBetweenShots(void) const;
-    QGCMapPolygon*  mapPolygon      (void) { return &_mapPolygon; }
+    QGCMapPolygon*  structurePolygon(void) { return &_structurePolygon; }
+    QGCMapPolygon*  flightPolygon   (void) { return &_flightPolygon; }
 
     Q_INVOKABLE void rotateEntryPoint(void);
 
@@ -95,9 +99,10 @@ private slots:
     void _setDirty(void);
     void _polygonDirtyChanged(bool dirty);
     void _polygonCountChanged(int count);
-    void _polygonPathChanged(void);
+    void _flightPathChanged(void);
     void _clearInternal(void);
     void _updateCoordinateAltitudes(void);
+    void _rebuildFlightPolygon(void);
 
 private:
     void _setExitCoordinate(const QGeoCoordinate& coordinate);
@@ -107,7 +112,8 @@ private:
 
     int             _sequenceNumber;
     bool            _dirty;
-    QGCMapPolygon   _mapPolygon;
+    QGCMapPolygon   _structurePolygon;
+    QGCMapPolygon   _flightPolygon;
     bool            _altitudeRelative;
     int             _entryVertex;       // Polygon vertext which is used as the mission entry point
 
@@ -124,39 +130,13 @@ private:
     Fact    _layersFact;
     Fact    _layerDistanceFact;
     Fact    _cameraTriggerDistanceFact;
+    Fact    _scanDistanceFact;
 
     static const char* _altitudeFactName;
     static const char* _layersFactName;
     static const char* _layerDistanceFactName;
     static const char* _cameraTriggerDistanceFactName;
-
-    static const char* _jsonGridObjectKey;
-    static const char* _jsonGridAltitudeKey;
-    static const char* _jsonGridAltitudeRelativeKey;
-    static const char* _jsonGridAngleKey;
-    static const char* _jsonGridSpacingKey;
-    static const char* _jsonGridEntryLocationKey;
-    static const char* _jsonTurnaroundDistKey;
-    static const char* _jsonCameraTriggerDistanceKey;
-    static const char* _jsonCameraTriggerInTurnaroundKey;
-    static const char* _jsonHoverAndCaptureKey;
-    static const char* _jsonGroundResolutionKey;
-    static const char* _jsonFrontalOverlapKey;
-    static const char* _jsonSideOverlapKey;
-    static const char* _jsonCameraSensorWidthKey;
-    static const char* _jsonCameraSensorHeightKey;
-    static const char* _jsonCameraResolutionWidthKey;
-    static const char* _jsonCameraResolutionHeightKey;
-    static const char* _jsonCameraFocalLengthKey;
-    static const char* _jsonCameraMinTriggerIntervalKey;
-    static const char* _jsonManualGridKey;
-    static const char* _jsonCameraObjectKey;
-    static const char* _jsonCameraNameKey;
-    static const char* _jsonCameraOrientationLandscapeKey;
-    static const char* _jsonFixedValueIsAltitudeKey;
-    static const char* _jsonRefly90DegreesKey;
-
-    static const int _hoverAndCaptureDelaySeconds = 1;
+    static const char* _scanDistanceFactName;
 };
 
 #endif

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -60,9 +60,17 @@ Rectangle {
         QGCLabel {
             anchors.left:   parent.left
             anchors.right:  parent.right
-            text:           qsTr("WARNING: WORK IN PROGRESS. USE AT YOUR OWN RISK.")
+            text:           qsTr("WARNING: WORK IN PROGRESS. USE AT YOUR OWN RISK. MEANT FOR DISCUSSION ONLY. DO NOT REPORT BUGS.")
             wrapMode:       Text.WordWrap
             color:          qgcPal.warningText
+        }
+
+        QGCLabel {
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            text:           qsTr("Note: Polygon respresents structure surface not vehicle flight path.")
+            wrapMode:       Text.WordWrap
+            font.pointSize: ScreenTools.smallFontPointSize
         }
 
         QGCLabel {
@@ -96,6 +104,12 @@ Rectangle {
             QGCLabel { text: qsTr("Layer distance") }
             FactTextField {
                 fact:               missionItem.layerDistance
+                Layout.fillWidth:   true
+            }
+
+            QGCLabel { text: qsTr("Scan distance") }
+            FactTextField {
+                fact:               missionItem.scanDistance
                 Layout.fillWidth:   true
             }
 

--- a/src/PlanView/StructureScanMapVisual.qml
+++ b/src/PlanView/StructureScanMapVisual.qml
@@ -25,31 +25,28 @@ Item {
     property var map    ///< Map control to place item in
 
     property var _missionItem:      object
-    property var _mapPolygon:       object.mapPolygon
-    property var _gridComponent
+    property var _structurePolygon: object.structurePolygon
+    property var _flightPolygon:    object.flightPolygon
     property var _entryCoordinate
     property var _exitCoordinate
 
     signal clicked(int sequenceNumber)
 
     function _addVisualElements() {
-        _gridComponent = gridComponent.createObject(map)
         _entryCoordinate = entryPointComponent.createObject(map)
         _exitCoordinate = exitPointComponent.createObject(map)
-        map.addMapItem(_gridComponent)
         map.addMapItem(_entryCoordinate)
         map.addMapItem(_exitCoordinate)
     }
 
     function _destroyVisualElements() {
-        _gridComponent.destroy()
         _entryCoordinate.destroy()
         _exitCoordinate.destroy()
     }
 
     /// Add an initial 4 sided polygon if there is none
     function _addInitialPolygon() {
-        if (_mapPolygon.count < 3) {
+        if (_structurePolygon.count < 3) {
             // Initial polygon is inset to take 2/3rds space
             var rect = Qt.rect(map.centerViewport.x, map.centerViewport.y, map.centerViewport.width, map.centerViewport.height)
             rect.x += (rect.width * 0.25) / 2
@@ -71,10 +68,10 @@ Item {
             bottomLeftCoord =   centerCoord.atDistanceAndAzimuth(halfWidthMeters, -90).atDistanceAndAzimuth(halfHeightMeters, 180)
             bottomRightCoord =  centerCoord.atDistanceAndAzimuth(halfWidthMeters, 90).atDistanceAndAzimuth(halfHeightMeters, 180)
 
-            _mapPolygon.appendVertex(topLeftCoord)
-            _mapPolygon.appendVertex(topRightCoord)
-            _mapPolygon.appendVertex(bottomRightCoord)
-            _mapPolygon.appendVertex(bottomLeftCoord)
+            _structurePolygon.appendVertex(topLeftCoord)
+            _structurePolygon.appendVertex(topRightCoord)
+            _structurePolygon.appendVertex(bottomRightCoord)
+            _structurePolygon.appendVertex(bottomLeftCoord)
         }
     }
 
@@ -88,9 +85,8 @@ Item {
     }
 
     QGCMapPolygonVisuals {
-        id:                 mapPolygonVisuals
         mapControl:         map
-        mapPolygon:         _mapPolygon
+        mapPolygon:         _structurePolygon
         interactive:        _missionItem.isCurrentItem
         borderWidth:        1
         borderColor:        "black"
@@ -98,15 +94,12 @@ Item {
         interiorOpacity:    0.5
     }
 
-    // Survey grid lines
-    Component {
-        id: gridComponent
-
-        MapPolyline {
-            line.color: "white"
-            line.width: 2
-            path:       _missionItem.gridPoints
-        }
+    QGCMapPolygonVisuals {
+        mapControl:         map
+        mapPolygon:         _flightPolygon
+        interactive:        false
+        borderWidth:        2
+        borderColor:        "white"
     }
 
     // Entry point

--- a/src/comm/MockLinkMissionItemHandler.cc
+++ b/src/comm/MockLinkMissionItemHandler.cc
@@ -70,11 +70,7 @@ bool MockLinkMissionItemHandler::handleMessage(const mavlink_message_t& msg)
         break;
 
     case MAVLINK_MSG_ID_MISSION_CLEAR_ALL:
-        // Delete all plan items
-        _missionItems.clear();
-        _fenceItems.clear();
-        _rallyItems.clear();
-        _sendAck(MAV_MISSION_ACCEPTED);
+        _handleMissionClearAll(msg);
         break;
 
     default:
@@ -82,6 +78,40 @@ bool MockLinkMissionItemHandler::handleMessage(const mavlink_message_t& msg)
     }
     
     return true;
+}
+
+void MockLinkMissionItemHandler::_handleMissionClearAll(const mavlink_message_t& msg)
+{
+
+    mavlink_mission_clear_all_t clearAll;
+
+    mavlink_msg_mission_clear_all_decode(&msg, &clearAll);
+
+    Q_ASSERT(clearAll.target_system == _mockLink->vehicleId());
+
+    _requestType = (MAV_MISSION_TYPE)clearAll.mission_type;
+    qCDebug(MockLinkMissionItemHandlerLog) << QStringLiteral("_handleMissionClearAll %1").arg(_requestType);
+
+    switch (_requestType) {
+    case MAV_MISSION_TYPE_MISSION:
+        _missionItems.clear();
+        break;
+    case MAV_MISSION_TYPE_FENCE:
+        _fenceItems.clear();
+        break;
+    case MAV_MISSION_TYPE_RALLY:
+        _rallyItems.clear();
+        break;
+    case MAV_MISSION_TYPE_ALL:
+        _missionItems.clear();
+        _fenceItems.clear();
+        _rallyItems.clear();
+        break;
+    default:
+        Q_ASSERT(false);
+    }
+
+    _sendAck(MAV_MISSION_ACCEPTED);
 }
 
 void MockLinkMissionItemHandler::_handleMissionRequestList(const mavlink_message_t& msg)

--- a/src/comm/MockLinkMissionItemHandler.h
+++ b/src/comm/MockLinkMissionItemHandler.h
@@ -88,6 +88,7 @@ private:
     void _handleMissionRequest(const mavlink_message_t& msg);
     void _handleMissionItem(const mavlink_message_t& msg);
     void _handleMissionCount(const mavlink_message_t& msg);
+    void _handleMissionClearAll(const mavlink_message_t& msg);
     void _requestNextMissionItem(int sequenceNumber);
     void _sendAck(MAV_MISSION_RESULT ackType);
     void _startMissionItemResponseTimer(void);


### PR DESCRIPTION
* The polygon you manipulate now represents the actual structure.
* You can specify the Scan distance from the sructure. This will generate the flight path/
* Green filled polygon is structure
* White polygon outline is flight path
![screen shot 2017-10-17 at 3 28 24 pm](https://user-images.githubusercontent.com/5876851/31692874-7f91215e-b350-11e7-80b9-3518cbc880e4.png)

Note: Still not quite ready to fly but almost. This pull gives me the backend functionality to implement things like structure scan based on camera image resolution like Survey.

Related to #5694.