### PR TITLE
Fix Resume Mission race condition

### DIFF
--- a/src/MissionManager/MissionManager.h
+++ b/src/MissionManager/MissionManager.h
@@ -122,6 +122,7 @@ private:
     void _handleMissionRequest(const mavlink_message_t& message, bool missionItemInt);
     void _handleMissionAck(const mavlink_message_t& message);
     void _handleMissionCurrent(const mavlink_message_t& message);
+    void _handleHeartbeat(const mavlink_message_t& message);
     void _requestNextMissionItem(void);
     void _clearMissionItems(void);
     void _sendError(ErrorCode_t errorCode, const QString& errorMsg);
@@ -156,6 +157,7 @@ private:
     QList<MissionItem*> _writeMissionItems;     ///< Set of mission items currently being written to vehicle
     int                 _currentMissionIndex;
     int                 _lastCurrentIndex;
+    int                 _cachedLastCurrentIndex;
 };
 
 #endif

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -611,6 +611,8 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         break;
     }
 
+    // This must be emitted after the vehicle processes the message. This way the vehicle state is up to date when anyone else
+    // does processing.
     emit mavlinkMessageReceived(message);
 
     _uas->receiveMessage(message);


### PR DESCRIPTION
Resume mission was relying on a flight mode update happening before a mission index update for RTL handling. This would require HEARTBEAT flight mode change message to come through before the MISSION_CURRENT index update in order to work correctly.

This led to flaky behavior in that it would work sometimes and sometimes now. This change essentially orders the handling to always be in the order HEARTBEAT -> MISSION_CURRENT.