### PR TITLE
APMParameterFact: Solve typo in BATT2_VOLT_MULT description

### DIFF
--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.3.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.3.xml
@@ -5054,7 +5054,7 @@
 <value code=" 101">PX4</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.4.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.4.xml
@@ -5595,7 +5595,7 @@
 <value code=" 101">PX4</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.5.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.5.xml
@@ -3080,7 +3080,7 @@
 <value code=" 101">PX4-v1</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.5.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.5.xml
@@ -4977,7 +4977,7 @@
 <value code=" 101">PX4</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.7.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.7.xml
@@ -5844,7 +5844,7 @@
 <value code=" 101">PX4</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.8.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.8.xml
@@ -2794,7 +2794,7 @@
 <value code=" 101">PX4</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.0.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.0.xml
@@ -5133,7 +5133,7 @@
 <value code=" 101">PX4</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.2.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.2.xml
@@ -2794,7 +2794,7 @@
 <value code=" 101">PX4</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.4.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.4.xml
@@ -5034,7 +5034,7 @@
 <value code=" 101">PX4</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.5.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.5.xml
@@ -707,7 +707,7 @@
 <value code=" 101">PX4-v1</value>
 </values>
 </param>
-<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
+<param humanName="Voltage Multiplier" name="BATT2_VOLT_MULT" documentation="Used to convert the voltage of the voltage sensing pin (BATT2_VOLT_PIN) to the actual battery's voltage (pin_voltage * VOLT_MULT). For the 3DR Power brick on APM2 or Pixhawk, this should be set to 10.1. For the Pixhawk with the 3DR 4in1 ESC this should be 12.02. For the PX4 using the PX4IO power supply this should be set to 1." user="Advanced">
 </param>
 <param humanName="Amps per volt" name="BATT2_AMP_PERVOL" documentation="Number of amps that a 1V reading on the current sensor corresponds to. On the APM2 or Pixhawk using the 3DR Power brick this should be set to 17. For the Pixhawk with the 3DR 4in1 ESC this should be 17." user="Standard">
 <field name="Units">Amps/Volt</field>


### PR DESCRIPTION
Change from BATT_VOLT_PIN to BATT2_VOLT_PIN.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>