### PR TITLE
travis-ci and vagrant don't fetch latest PX4 metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,10 +144,6 @@ install:
 before_script:
   - cd ${TRAVIS_BUILD_DIR}
 
-  # grab latest PX4 parameter and airframe metadata
-  - wget --quiet http://px4-travis.s3.amazonaws.com/Firmware/master/parameters.xml -O src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
-  - wget --quiet http://px4-travis.s3.amazonaws.com/Firmware/master/airframes.xml -O src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
-
   # switch android config from installer to release if the android storepass isn't available
   - if [[ "${SPEC}" = "android-g++" && "${CONFIG}" = "installer" && -z ${ANDROID_STOREPASS} ]]; then
         export CONFIG=release;

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,10 +65,6 @@ Vagrant.configure(2) do |config|
      su - vagrant -c 'cd %{project_root_dir}; tar jxf "%{qt_deps_tarball}" -C  %{qt_deps_unpack_parent_dir}'
      su - vagrant -c 'rm -rf %{shadow_build_dir}'
 
-     # grab latest PX4 parameter and airframe metadata
-     su - vagrant -c 'wget http://px4-travis.s3.amazonaws.com/Firmware/master/parameters.xml -O %{project_root_dir}/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml'
-     su - vagrant -c 'wget http://px4-travis.s3.amazonaws.com/Firmware/master/airframes.xml -O %{project_root_dir}/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml'
-
      su - vagrant -c 'mkdir -p %{shadow_build_dir}'
      su - vagrant -c "cd %{shadow_build_dir}; LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir} PATH=%{qt_deps_bin_unpack_dir}:\$PATH qmake -r %{pro} CONFIG+=\${CONFIG} CONFIG+=WarningsAsErrorsOn -spec %{spec}"
      su - vagrant -c "cd %{shadow_build_dir}; LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir} PATH=%{qt_deps_bin_unpack_dir}:\$PATH make -j${JOBS}"


### PR DESCRIPTION
PX4 Firmware metadata (airframes and params) is now auto updated by jenkins. http://ci.px4.io:8080/job/mavlink/job/qgroundcontrol_px4_metadata/