### PR TITLE
Move plan view index control to MissionController

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -64,6 +64,8 @@ MissionController::MissionController(PlanMasterController* masterController, QOb
     , _structureScanMissionItemName(tr("Structure Scan"))
     , _appSettings(qgcApp()->toolbox()->settingsManager()->appSettings())
     , _progressPct(0)
+    , _currentPlanViewIndex(-1)
+    , _currentPlanViewItem(NULL)
 {
     _resetMissionFlightStatus();
     managerVehicleChanged(_managerVehicle);
@@ -1859,5 +1861,35 @@ void MissionController::_managerRemoveAllComplete(bool error)
     if (!error) {
         // Remove all from vehicle so we always update
         showPlanFromManagerVehicle();
+    }
+}
+
+int MissionController::currentPlanViewIndex(void) const
+{
+    return _currentPlanViewIndex;
+}
+
+VisualMissionItem* MissionController::currentPlanViewItem(void) const
+{
+    return _currentPlanViewItem;
+}
+
+void MissionController::setCurrentPlanViewIndex(int sequenceNumber, bool force)
+{
+    if(_visualItems && (force || sequenceNumber != _currentPlanViewIndex)) {
+        _currentPlanViewItem  = NULL;
+        _currentPlanViewIndex = -1;
+        for (int i = 0; i < _visualItems->count(); i++) {
+            VisualMissionItem* pVI = qobject_cast<VisualMissionItem*>(_visualItems->get(i));
+            if (pVI && pVI->sequenceNumber() == sequenceNumber) {
+                pVI->setIsCurrentItem(true);
+                _currentPlanViewItem  = pVI;
+                _currentPlanViewIndex = sequenceNumber;
+            } else {
+                pVI->setIsCurrentItem(false);
+            }
+        }
+        emit currentPlanViewIndexChanged();
+        emit currentPlanViewItemChanged();
     }
 }

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -74,6 +74,9 @@ public:
     Q_PROPERTY(int                  currentMissionIndex     READ currentMissionIndex        NOTIFY currentMissionIndexChanged)
     Q_PROPERTY(int                  resumeMissionIndex      READ resumeMissionIndex         NOTIFY resumeMissionIndexChanged)   ///< Returns the item index two which a mission should be resumed. -1 indicates resume mission not available.
 
+    Q_PROPERTY(int                  currentPlanViewIndex    READ currentPlanViewIndex       NOTIFY currentPlanViewIndexChanged)
+    Q_PROPERTY(VisualMissionItem*   currentPlanViewItem     READ currentPlanViewItem        NOTIFY currentPlanViewItemChanged)
+
     Q_PROPERTY(double               missionDistance         READ missionDistance            NOTIFY missionDistanceChanged)
     Q_PROPERTY(double               missionTime             READ missionTime                NOTIFY missionTimeChanged)
     Q_PROPERTY(double               missionHoverDistance    READ missionHoverDistance       NOTIFY missionHoverDistanceChanged)
@@ -103,6 +106,10 @@ public:
 
     /// Updates the altitudes of the items in the current mission to the new default altitude
     Q_INVOKABLE void applyDefaultMissionAltitude(void);
+
+    /// Sets a new current mission item (PlanView).
+    ///     @param sequenceNumber - index for new item, -1 to clear current item
+    Q_INVOKABLE void setCurrentPlanViewIndex(int sequenceNumber, bool force);
 
     /// Sends the mission items to the specified vehicle
     static void sendItemsToVehicle(Vehicle* vehicle, QmlObjectListModel* visualMissionItems);
@@ -135,10 +142,12 @@ public:
     QmlObjectListModel* waypointLines           (void) { return &_waypointLines; }
     QStringList         complexMissionItemNames (void) const;
     QGeoCoordinate      plannedHomePosition     (void) const;
+    VisualMissionItem*  currentPlanViewItem     (void) const;
     double              progressPct             (void) const { return _progressPct; }
 
-    int currentMissionIndex(void) const;
-    int resumeMissionIndex(void) const;
+    int currentMissionIndex         (void) const;
+    int resumeMissionIndex          (void) const;
+    int currentPlanViewIndex        (void) const;
 
     double  missionDistance         (void) const { return _missionFlightStatus.totalDistance; }
     double  missionTime             (void) const { return _missionFlightStatus.totalTime; }
@@ -171,6 +180,8 @@ signals:
     void plannedHomePositionChanged(QGeoCoordinate plannedHomePosition);
     void progressPctChanged(double progressPct);
     void currentMissionIndexChanged(int currentMissionIndex);
+    void currentPlanViewIndexChanged();
+    void currentPlanViewItemChanged();
 
 private slots:
     void _newMissionItemsAvailableFromVehicle(bool removeAllRequested);
@@ -234,6 +245,8 @@ private:
     QString                 _structureScanMissionItemName;
     AppSettings*            _appSettings;
     double                  _progressPct;
+    int                     _currentPlanViewIndex;
+    VisualMissionItem*      _currentPlanViewItem;
 
     static const char*  _settingsGroup;
 

--- a/src/PlanView/MissionItemStatus.qml
+++ b/src/PlanView/MissionItemStatus.qml
@@ -61,7 +61,7 @@ Rectangle {
         orientation:            ListView.Horizontal
         spacing:                0
         clip:                   true
-        currentIndex:           _currentMissionIndex
+        currentIndex:           _missionController.currentPlanViewIndex
 
         onCountChanged: {
             var calcLength = (statusListView.count + 1)*statusListView.contentItem.children[0].width

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -45,8 +45,6 @@ QGCView {
     property var    _geoFenceController:        _planMasterController.geoFenceController
     property var    _rallyPointController:      _planMasterController.rallyPointController
     property var    _visualItems:               _missionController.visualItems
-    property var    _currentMissionItem
-    property int    _currentMissionIndex:       0
     property bool   _lightWidgetBorders:        editorMap.isSatelliteMap
     property bool   _addWaypointOnClick:        false
     property bool   _singleComplexItem:         _missionController.complexMissionItemNames.length === 1
@@ -60,7 +58,7 @@ QGCView {
 
     Component.onCompleted: {
         toolbar.planMasterController =  Qt.binding(function () { return _planMasterController })
-        toolbar.currentMissionItem =    Qt.binding(function () { return _currentMissionItem })
+        toolbar.currentMissionItem =    Qt.binding(function () { return _missionController.currentPlanViewItem })
     }
 
     function addComplexItem(complexItemName) {
@@ -73,7 +71,7 @@ QGCView {
 
     function insertComplexMissionItem(complexItemName, coordinate, index) {
         var sequenceNumber = _missionController.insertComplexMissionItem(complexItemName, coordinate, index)
-        setCurrentItem(sequenceNumber, true)
+        _missionController.setCurrentPlanViewIndex(sequenceNumber, true)
     }
 
     property bool _firstMissionLoadComplete:    false
@@ -149,7 +147,7 @@ QGCView {
 
         Component.onCompleted: {
             start(true /* editMode */)
-            setCurrentItem(0, true)
+            _missionController.setCurrentPlanViewIndex(0, true)
         }
 
         function upload() {
@@ -195,7 +193,7 @@ QGCView {
             if (_visualItems && _visualItems.count != 1) {
                 mapFitFunctions.fitMapViewportToMissionItems()
             }
-            setCurrentItem(0, true)
+            _missionController.setCurrentPlanViewIndex(0, true)
         }
     }
 
@@ -205,31 +203,12 @@ QGCView {
         id: _mapTypeButtonsExclusiveGroup
     }
 
-    /// Sets a new current mission item
-    ///     @param sequenceNumber - index for new item, -1 to clear current item
-    function setCurrentItem(sequenceNumber, force) {
-        if (force || sequenceNumber !== _currentMissionIndex) {
-            _currentMissionItem = undefined
-            _currentMissionIndex = -1
-            for (var i=0; i<_visualItems.count; i++) {
-                var visualItem = _visualItems.get(i)
-                if (visualItem.sequenceNumber == sequenceNumber) {
-                    _currentMissionItem = visualItem
-                    _currentMissionItem.isCurrentItem = true
-                    _currentMissionIndex = sequenceNumber
-                } else {
-                    visualItem.isCurrentItem = false
-                }
-            }
-        }
-    }
-
     /// Inserts a new simple mission item
     ///     @param coordinate Location to insert item
     ///     @param index Insert item at this index
     function insertSimpleMissionItem(coordinate, index) {
         var sequenceNumber = _missionController.insertSimpleMissionItem(coordinate, index)
-        setCurrentItem(sequenceNumber, true)
+        _missionController.setCurrentPlanViewIndex(sequenceNumber, true)
     }
 
     property int _moveDialogMissionItemIndex
@@ -250,7 +229,7 @@ QGCView {
         onAcceptedForLoad: {
             masterController.loadFromFile(file)
             masterController.fitViewportToItems()
-            setCurrentItem(0, true)
+            _missionController.setCurrentPlanViewIndex(0, true)
             close()
         }
     }
@@ -359,7 +338,7 @@ QGCView {
 
                 delegate: MissionItemMapVisual {
                     map:        editorMap
-                    onClicked:  setCurrentItem(sequenceNumber, false)
+                    onClicked:  _missionController.setCurrentPlanViewIndex(sequenceNumber, false)
                     visible:    _editingLayer == _layerMission
                 }
             }
@@ -562,7 +541,7 @@ QGCView {
                     model:          _missionController.visualItems
                     cacheBuffer:    Math.max(height * 2, 0)
                     clip:           true
-                    currentIndex:   _currentMissionIndex
+                    currentIndex:   _missionController.currentPlanViewIndex
                     highlightMoveDuration: 250
 
                     delegate: MissionItemEditor {
@@ -573,7 +552,7 @@ QGCView {
                         readOnly:           false
                         rootQgcView:        _qgcView
 
-                        onClicked:  setCurrentItem(object.sequenceNumber, false)
+                        onClicked:  _missionController.setCurrentPlanViewIndex(object.sequenceNumber, false)
 
                         onRemove: {
                             var removeIndex = index
@@ -581,8 +560,7 @@ QGCView {
                             if (removeIndex >= _missionController.visualItems.count) {
                                 removeIndex--
                             }
-                            _currentMissionIndex = -1
-                            rootQgcView.setCurrentItem(removeIndex, true)
+                            _missionController.setCurrentPlanViewIndex(removeIndex, true)
                         }
 
                         onInsertWaypoint:       insertSimpleMissionItem(editorMap.center, index)

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -82,6 +82,7 @@
 #include "QGCCorePlugin.h"
 #include "QGCCameraManager.h"
 #include "CameraCalc.h"
+#include "VisualMissionItem.h"
 
 #ifndef NO_SERIAL_LINK
 #include "SerialLink.h"
@@ -366,6 +367,7 @@ void QGCApplication::_initCommon(void)
     qmlRegisterUncreatableType<MissionController>   ("QGroundControl.Controllers",          1, 0, "MissionController",      "Reference only");
     qmlRegisterUncreatableType<GeoFenceController>  ("QGroundControl.Controllers",          1, 0, "GeoFenceController",     "Reference only");
     qmlRegisterUncreatableType<RallyPointController>("QGroundControl.Controllers",          1, 0, "RallyPointController",   "Reference only");
+    qmlRegisterUncreatableType<VisualMissionItem>   ("QGroundControl.Controllers",          1, 0, "VisualMissionItem",      "Reference only");
 
     qmlRegisterType<ParameterEditorController>      ("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
     qmlRegisterType<ESP8266ComponentController>     ("QGroundControl.Controllers", 1, 0, "ESP8266ComponentController");


### PR DESCRIPTION
This moves the current selected mission item (Plan View) away from QML and to c++. It can now be accessed from anywhere.