### PR TITLE
Polygon: Create circular polygon

### DIFF
--- a/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
@@ -17,10 +17,10 @@ import QGroundControl.Controls      1.0
 /// Use to drag a MissionItemIndicator
 Rectangle {
     id:             itemDragger
-    x:              itemIndicator.x - _touchMarginHorizontal
-    y:              itemIndicator.y - _touchMarginVertical
-    width:          itemIndicator.width + (_touchMarginHorizontal * 2)
-    height:         itemIndicator.height + (_touchMarginVertical * 2)
+    x:              _itemIndicatorX - _touchMarginHorizontal
+    y:              _itemIndicatorY - _touchMarginVertical
+    width:          _itemIndicatorWidth + (_touchMarginHorizontal * 2)
+    height:         _itemIndicatorHeight + (_touchMarginVertical * 2)
     color:          "transparent"
     z:              QGroundControl.zOrderMapItems + 1    // Above item icons
 
@@ -34,11 +34,15 @@ Rectangle {
 
     property bool   _preventCoordinateBindingLoop:  false
 
+    property real _itemIndicatorX:          itemIndicator ? itemIndicator.x : 0
+    property real _itemIndicatorY:          itemIndicator ? itemIndicator.y : 0
+    property real _itemIndicatorWidth:      itemIndicator ? itemIndicator.width : 0
+    property real _itemIndicatorHeight:     itemIndicator ? itemIndicator.height : 0
     property bool _mobile:                  ScreenTools.isMobile
-    property real _touchWidth:              Math.max(itemIndicator.width, ScreenTools.minTouchPixels)
-    property real _touchHeight:             Math.max(itemIndicator.height, ScreenTools.minTouchPixels)
-    property real _touchMarginHorizontal:   _mobile ? (_touchWidth - itemIndicator.width) / 2 : 0
-    property real _touchMarginVertical:     _mobile ? (_touchHeight - itemIndicator.height) / 2 : 0
+    property real _touchWidth:              Math.max(_itemIndicatorWidth, ScreenTools.minTouchPixels)
+    property real _touchHeight:             Math.max(_itemIndicatorHeight, ScreenTools.minTouchPixels)
+    property real _touchMarginHorizontal:   _mobile ? (_touchWidth - _itemIndicatorWidth) / 2 : 0
+    property real _touchMarginVertical:     _mobile ? (_touchHeight - _itemIndicatorHeight) / 2 : 0
     property bool _dragStartSignalled:      false
 
     onXChanged: liveDrag()


### PR DESCRIPTION
Polygon tool now supports creation of circular polygon. This will work anywhere polygons are allowed: Structure Scan, Survey, ...

You can now click on the center drag tool of a polygon to bring up a menu. Click Circle to get a circle, click Polygon to get back a polygon.
<img width="1059" alt="screen shot 2017-11-04 at 1 14 13 pm" src="https://user-images.githubusercontent.com/5876851/32407649-7191e2c6-c162-11e7-9c03-e8dd3c168928.png">

When you have a Circle you can set the Radius:
<img width="1058" alt="screen shot 2017-11-04 at 1 14 32 pm" src="https://user-images.githubusercontent.com/5876851/32407650-719e0844-c162-11e7-9e05-2e9eba57dee3.png">

Note: Load KML coming soon...