### PR TITLE
Support ROI tool button in WaypointsOnly mode

### DIFF
--- a/src/FirmwarePlugin/PX4/MavCmdInfoCommon.json
+++ b/src/FirmwarePlugin/PX4/MavCmdInfoCommon.json
@@ -13,6 +13,11 @@
             "id":           21,
             "comment":      "MAV_CMD_NAV_LAND",
             "paramRemove":  "1"
+        },
+        {
+            "id":           201,
+            "comment":      "MAV_CMD_DO_SET_ROI",
+            "paramRemove":  "1,2,3"
         }
     ]
 }

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -655,7 +655,7 @@
         {
             "id":                   201,
             "rawName":              "MAV_CMD_DO_SET_ROI",
-            "friendlyName":         "Region of interest (cmd)" ,
+            "friendlyName":         "Region of interest" ,
             "description":          "Sets the region of interest for cameras.",
             "specifiesCoordinate":  true,
             "standaloneCoordinate": true,

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -359,6 +359,30 @@ int MissionController::insertSimpleMissionItem(QGeoCoordinate coordinate, int i)
     return newItem->sequenceNumber();
 }
 
+int MissionController::insertROIMissionItem(QGeoCoordinate coordinate, int i)
+{
+    int sequenceNumber = _nextSequenceNumber();
+    SimpleMissionItem * newItem = new SimpleMissionItem(_controllerVehicle, this);
+    newItem->setSequenceNumber(sequenceNumber);
+    newItem->setCoordinate(coordinate);
+    newItem->setCommand(MavlinkQmlSingleton::MAV_CMD_DO_SET_ROI);
+    _initVisualItem(newItem);
+    newItem->setDefaultsForCommand();
+
+    double      prevAltitude;
+    MAV_FRAME   prevFrame;
+
+    if (_findPreviousAltitude(i, &prevAltitude, &prevFrame)) {
+        newItem->missionItem().setFrame(prevFrame);
+        newItem->missionItem().setParam7(prevAltitude);
+    }
+    _visualItems->insert(i, newItem);
+
+    _recalcAll();
+
+    return newItem->sequenceNumber();
+}
+
 int MissionController::insertComplexMissionItem(QString itemName, QGeoCoordinate mapCenterCoordinate, int i)
 {
     ComplexMissionItem* newItem;

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -95,6 +95,11 @@ public:
     /// @return Sequence number for new item
     Q_INVOKABLE int insertSimpleMissionItem(QGeoCoordinate coordinate, int i);
 
+    /// Add a new ROI mission item to the list
+    ///     @param i: index to insert at
+    /// @return Sequence number for new item
+    Q_INVOKABLE int insertROIMissionItem(QGeoCoordinate coordinate, int i);
+
     /// Add a new complex mission item to the list
     ///     @param itemName: Name of complex item to create (from complexMissionItemNames)
     ///     @param mapCenterCoordinate: coordinate for current center of map

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -349,19 +349,21 @@ QString SimpleMissionItem::commandName(void) const
 QString SimpleMissionItem::abbreviation() const
 {
     if (homePosition())
-        return QStringLiteral("H");
+        return tr("H");
 
     switch(command()) {
+    case MavlinkQmlSingleton::MAV_CMD_NAV_TAKEOFF:
+        return tr("Takeoff");
+    case MavlinkQmlSingleton::MAV_CMD_NAV_LAND:
+        return tr("Land");
+    case MavlinkQmlSingleton::MAV_CMD_NAV_VTOL_TAKEOFF:
+        return tr("VTOL Takeoff");
+    case MavlinkQmlSingleton::MAV_CMD_NAV_VTOL_LAND:
+        return tr("VTOL Land");
+    case MavlinkQmlSingleton::MAV_CMD_DO_SET_ROI:
+        return tr("ROI");
     default:
         return QString();
-    case MavlinkQmlSingleton::MAV_CMD_NAV_TAKEOFF:
-        return QStringLiteral("Takeoff");
-    case MavlinkQmlSingleton::MAV_CMD_NAV_LAND:
-        return QStringLiteral("Land");
-    case MavlinkQmlSingleton::MAV_CMD_NAV_VTOL_TAKEOFF:
-        return QStringLiteral("VTOL Takeoff");
-    case MavlinkQmlSingleton::MAV_CMD_NAV_VTOL_LAND:
-        return QStringLiteral("VTOL Land");
     }
 }
 

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -32,13 +32,14 @@ QGCView {
     viewPanel:  panel
     z:          QGroundControl.zOrderTopMost
 
-    readonly property int       _decimalPlaces:         8
-    readonly property real      _horizontalMargin:      ScreenTools.defaultFontPixelWidth  / 2
-    readonly property real      _margin:                ScreenTools.defaultFontPixelHeight * 0.5
-    readonly property var       _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
-    readonly property real      _rightPanelWidth:       Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 30)
-    readonly property real      _toolButtonTopMargin:   parent.height - ScreenTools.availableHeight + (ScreenTools.defaultFontPixelHeight / 2)
-    readonly property var       _defaultVehicleCoordinate:   QtPositioning.coordinate(37.803784, -122.462276)
+    readonly property int   _decimalPlaces:             8
+    readonly property real  _horizontalMargin:          ScreenTools.defaultFontPixelWidth  / 2
+    readonly property real  _margin:                    ScreenTools.defaultFontPixelHeight * 0.5
+    readonly property var   _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
+    readonly property real  _rightPanelWidth:           Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 30)
+    readonly property real  _toolButtonTopMargin:       parent.height - ScreenTools.availableHeight + (ScreenTools.defaultFontPixelHeight / 2)
+    readonly property var   _defaultVehicleCoordinate:  QtPositioning.coordinate(37.803784, -122.462276)
+    readonly property bool  _waypointsOnlyMode:         QGroundControl.corePlugin.options.missionWaypointsOnly
 
     property var    _planMasterController:      masterController
     property var    _missionController:         _planMasterController.missionController
@@ -47,6 +48,7 @@ QGCView {
     property var    _visualItems:               _missionController.visualItems
     property bool   _lightWidgetBorders:        editorMap.isSatelliteMap
     property bool   _addWaypointOnClick:        false
+    property bool   _addROIOnClick:             false
     property bool   _singleComplexItem:         _missionController.complexMissionItemNames.length === 1
     property real   _toolbarHeight:             _qgcView.height - ScreenTools.availableHeight
     property int    _editingLayer:              _layerMission
@@ -219,6 +221,16 @@ QGCView {
         _missionController.setCurrentPlanViewIndex(sequenceNumber, true)
     }
 
+    /// Inserts a new ROI mission item
+    ///     @param coordinate Location to insert item
+    ///     @param index Insert item at this index
+    function insertROIMissionItem(coordinate, index) {
+        var sequenceNumber = _missionController.insertROIMissionItem(coordinate, index)
+        _missionController.setCurrentPlanViewIndex(sequenceNumber, true)
+        _addROIOnClick = false
+        toolStrip.uncheckAll()
+    }
+
     property int _moveDialogMissionItemIndex
 
     QGCFileDialog {
@@ -329,6 +341,9 @@ QGCView {
                     case _layerMission:
                         if (_addWaypointOnClick) {
                             insertSimpleMissionItem(coordinate, _missionController.visualItems.count)
+                        } else if (_addROIOnClick) {
+                            _addROIOnClick = false
+                            insertROIMissionItem(coordinate, _missionController.visualItems.count)
                         }
                         break
                     case _layerRallyPoints:
@@ -394,11 +409,11 @@ QGCView {
                 color:              qgcPal.window
                 title:              qsTr("Plan")
                 z:                  QGroundControl.zOrderWidgets
-                showAlternateIcon:  [ false, false, masterController.dirty, false, false, false ]
-                rotateImage:        [ false, false, masterController.syncInProgress, false, false, false ]
-                animateImage:       [ false, false, masterController.dirty, false, false, false ]
-                buttonEnabled:      [ true, true, !masterController.syncInProgress, true, true, true ]
-                buttonVisible:      [ true, true, true, true, _showZoom, _showZoom ]
+                showAlternateIcon:  [ false, false, false, masterController.dirty, false, false, false ]
+                rotateImage:        [ false, false, false, masterController.syncInProgress, false, false, false ]
+                animateImage:       [ false, false, false, masterController.dirty, false, false, false ]
+                buttonEnabled:      [ true, true, true, !masterController.syncInProgress, true, true, true ]
+                buttonVisible:      [ true, _waypointsOnlyMode, true, true, true, _showZoom, _showZoom ]
                 maxHeight:          mapScale.y - toolStrip.y
 
                 property bool _showZoom: !ScreenTools.isMobile
@@ -406,6 +421,11 @@ QGCView {
                 model: [
                     {
                         name:       "Waypoint",
+                        iconSource: "/qmlimages/MapAddMission.svg",
+                        toggle:     true
+                    },
+                    {
+                        name:       "ROI",
                         iconSource: "/qmlimages/MapAddMission.svg",
                         toggle:     true
                     },
@@ -439,16 +459,21 @@ QGCView {
                     switch (index) {
                     case 0:
                         _addWaypointOnClick = checked
+                        _addROIOnClick = false
                         break
                     case 1:
+                        _addROIOnClick = checked
+                        _addWaypointOnClick = false
+                        break
+                    case 2:
                         if (_singleComplexItem) {
                             addComplexItem(_missionController.complexMissionItemNames[0])
                         }
                         break
-                    case 4:
+                    case 5:
                         editorMap.zoomLevel += 0.5
                         break
-                    case 5:
+                    case 6:
                         editorMap.zoomLevel -= 0.5
                         break
                     }

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -84,7 +84,6 @@ void QGCPositionManager::setPositionSource(QGCPositionManager::QGCPositionSource
         _currentSource->setPreferredPositioningMethods(QGeoPositionInfoSource::SatellitePositioningMethods);
         _currentSource->setUpdateInterval(_updateInterval);
         connect(_currentSource, &QGeoPositionInfoSource::positionUpdated,       this, &QGCPositionManager::_positionUpdated);
-        connect(_currentSource, &QGeoPositionInfoSource::updateTimeout,         this, &QGCPositionManager::_updateTimeout);
         connect(_currentSource, SIGNAL(error(QGeoPositionInfoSource::Error)),   this, SLOT(_error(QGeoPositionInfoSource::Error)));
         _currentSource->startUpdates();
     }
@@ -93,9 +92,4 @@ void QGCPositionManager::setPositionSource(QGCPositionManager::QGCPositionSource
 void QGCPositionManager::_error(QGeoPositionInfoSource::Error positioningError)
 {
     qWarning() << "QGCPositionManager error" << positioningError;
-}
-
-void QGCPositionManager::_updateTimeout(void)
-{
-    qWarning() << "QGCPositionManager updateTimeout";
 }

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -39,7 +39,6 @@ public:
 private slots:
     void _positionUpdated(const QGeoPositionInfo &update);
     void _error(QGeoPositionInfoSource::Error positioningError);
-    void _updateTimeout(void);
 
 signals:
     void lastPositionUpdated(bool valid, QVariant lastPosition);


### PR DESCRIPTION
* Allows you to click in map to set ROI. Turns off are single ROI add.
* Note: Waypoints only mode only supported for custom builds

![screen shot 2017-11-15 at 12 59 57 pm](https://user-images.githubusercontent.com/5876851/32860042-3c1046dc-ca05-11e7-8a6a-aceb028f0b15.png)
