### PR TITLE
fix compile with glibc 2.26

### DIFF
--- a/src/QGCGeo.h
+++ b/src/QGCGeo.h
@@ -20,11 +20,6 @@
 
 #include <QGeoCoordinate>
 
-/* Safeguard for systems lacking sincos (e.g. Mac OS X Leopard) */
-#ifndef sincos
-#define sincos(th,x,y) { (*(x))=sin(th); (*(y))=cos(th); }
-#endif
-
 /**
  * @brief Project a geodetic coordinate on to local tangential plane (LTP) as coordinate with East,
  * North, and Down components in meters.


### PR DESCRIPTION
The failure got triggered by 3c55e2b0f7dfc48cfe7eb086bc3a30d6a6166905, but it is seems not to be guilty.

This is fixing "error: expected unqualified-id before ‘{’ token
 #define sincos(th,x,y) { (*(x))=sin(th); (*(y))=cos(th); }"

errors. Not sure if the    #ifndef sincos   might be needed in addition on some platform.