### PR TITLE
QGCGeo.h: remove unused sincos define

### DIFF
--- a/src/QGCGeo.h
+++ b/src/QGCGeo.h
@@ -20,11 +20,6 @@
 
 #include <QGeoCoordinate>
 
-/* Safeguard for systems lacking sincos (e.g. Mac OS X Leopard) */
-#ifndef sincos
-#define sincos(th,x,y) { (*(x))=sin(th); (*(y))=cos(th); }
-#endif
-
 /**
  * @brief Project a geodetic coordinate on to local tangential plane (LTP) as coordinate with East,
  * North, and Down components in meters.


### PR DESCRIPTION
It conflicts with the system (On Linux, GCC 7.2.1):
```
In file included from ../src/MissionManager/QGCMapPolygon.cc:11:0:
../src/QGCGeo.h:25:24: error: expected unqualified-id before ‘{’ token
 #define sincos(th,x,y) { (*(x))=sin(th); (*(y))=cos(th); }
                        ^
In file included from /usr/include/features.h:423:0,
                 from /usr/include/c++/7/x86_64-redhat-linux/bits/os_defines.h:39,
                 from /usr/include/c++/7/x86_64-redhat-linux/bits/c++config.h:2494,
                 from /usr/include/c++/7/type_traits:38,
                 from /opt/install/qt5.9.1/5.9.1/gcc_64/include/QtCore/qglobal.h:45,
                 from /opt/install/qt5.9.1/5.9.1/gcc_64/include/QtCore/qnamespace.h:43,
                 from /opt/install/qt5.9.1/5.9.1/gcc_64/include/QtCore/qobjectdefs.h:48,
                 from /opt/install/qt5.9.1/5.9.1/gcc_64/include/QtCore/qobject.h:46,
                 from /opt/install/qt5.9.1/5.9.1/gcc_64/include/QtCore/QObject:1,
                 from ../src/MissionManager/QGCMapPolygon.h:13,
                 from ../src/MissionManager/QGCMapPolygon.cc:10:
/usr/include/bits/mathcalls.h:79:1: error: expected unqualified-id before ‘throw’
 __MATHDECL_VEC (void,sincos,,
```