### PR TITLE
'manual control lost' when connected joystick with armed UAV

### DIFF
--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -50,8 +50,6 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox
     settings.beginGroup(_flightMapPositionSettingsGroup);
     _coord.setLatitude(settings.value(_flightMapPositionLatitudeSettingsKey, 0).toDouble());
     _coord.setLongitude(settings.value(_flightMapPositionLongitudeSettingsKey, 0).toDouble());
-
-    settings.beginGroup(_flightMapPositionSettingsGroup);
     _zoom = settings.value(_flightMapZoomSettingsKey, 2).toDouble();
     //if config file is clear
     if(_zoom == 0) _zoom = 17.0;
@@ -65,8 +63,6 @@ QGroundControlQmlGlobal::~QGroundControlQmlGlobal()
     settings.beginGroup(_flightMapPositionSettingsGroup);
     settings.setValue(_flightMapPositionLatitudeSettingsKey, _coord.latitude());
     settings.setValue(_flightMapPositionLongitudeSettingsKey, _coord.longitude());
-     
-    settings.beginGroup(_flightMapPositionSettingsGroup);
     settings.setValue(_flightMapZoomSettingsKey, _zoom);
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -24,6 +24,9 @@ const char* QGroundControlQmlGlobal::_flightMapPositionLatitudeSettingsKey =    
 const char* QGroundControlQmlGlobal::_flightMapPositionLongitudeSettingsKey =   "Longitude";
 const char* QGroundControlQmlGlobal::_flightMapZoomSettingsKey =                "FlightMapZoom";
 
+QGeoCoordinate   QGroundControlQmlGlobal::_coord = QGeoCoordinate(0.0,0.0);
+double           QGroundControlQmlGlobal::_zoom = 17;
+
 QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
     , _flightMapInitialZoom(17.0)
@@ -41,11 +44,30 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox
 {
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
     setParent(NULL);
+    // Load last coordinates and zoom from config file
+    QSettings settings;
+    
+    settings.beginGroup(_flightMapPositionSettingsGroup);
+    _coord.setLatitude(settings.value(_flightMapPositionLatitudeSettingsKey, 0).toDouble());
+    _coord.setLongitude(settings.value(_flightMapPositionLongitudeSettingsKey, 0).toDouble());
+
+    settings.beginGroup(_flightMapPositionSettingsGroup);
+    _zoom = settings.value(_flightMapZoomSettingsKey, 2).toDouble();
+    //if config file is clear
+    if(_zoom == 0) _zoom = 17.0;
 }
 
 QGroundControlQmlGlobal::~QGroundControlQmlGlobal()
 {
-
+    // Save last coordinates and zoom to config file
+    QSettings settings;
+    
+    settings.beginGroup(_flightMapPositionSettingsGroup);
+    settings.setValue(_flightMapPositionLatitudeSettingsKey, _coord.latitude());
+    settings.setValue(_flightMapPositionLongitudeSettingsKey, _coord.longitude());
+     
+    settings.beginGroup(_flightMapPositionSettingsGroup);
+    settings.setValue(_flightMapZoomSettingsKey, _zoom);
 }
 
 void QGroundControlQmlGlobal::setToolbox(QGCToolbox* toolbox)
@@ -198,34 +220,12 @@ void QGroundControlQmlGlobal::setSkipSetupPage(bool skip)
     }
 }
 
-QGeoCoordinate QGroundControlQmlGlobal::flightMapPosition(void)
-{
-    QSettings       settings;
-    QGeoCoordinate  coord;
-
-    settings.beginGroup(_flightMapPositionSettingsGroup);
-    coord.setLatitude(settings.value(_flightMapPositionLatitudeSettingsKey, 0).toDouble());
-    coord.setLongitude(settings.value(_flightMapPositionLongitudeSettingsKey, 0).toDouble());
-
-    return coord;
-}
-
-double QGroundControlQmlGlobal::flightMapZoom(void)
-{
-    QSettings settings;
-
-    settings.beginGroup(_flightMapPositionSettingsGroup);
-    return settings.value(_flightMapZoomSettingsKey, 2).toDouble();
-}
-
 void QGroundControlQmlGlobal::setFlightMapPosition(QGeoCoordinate& coordinate)
 {
     if (coordinate != flightMapPosition()) {
-        QSettings settings;
+        _coord.setLatitude(coordinate.latitude());
+        _coord.setLongitude(coordinate.longitude());
 
-        settings.beginGroup(_flightMapPositionSettingsGroup);
-        settings.setValue(_flightMapPositionLatitudeSettingsKey, coordinate.latitude());
-        settings.setValue(_flightMapPositionLongitudeSettingsKey, coordinate.longitude());
         emit flightMapPositionChanged(coordinate);
     }
 }
@@ -233,10 +233,7 @@ void QGroundControlQmlGlobal::setFlightMapPosition(QGeoCoordinate& coordinate)
 void QGroundControlQmlGlobal::setFlightMapZoom(double zoom)
 {
     if (zoom != flightMapZoom()) {
-        QSettings settings;
-
-        settings.beginGroup(_flightMapPositionSettingsGroup);
-        settings.setValue(_flightMapZoomSettingsKey, zoom);
+        _zoom = zoom;
         emit flightMapZoomChanged(zoom);
     }
 }

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -142,8 +142,8 @@ public:
     QGCCorePlugin*          corePlugin          ()  { return _corePlugin; }
     SettingsManager*        settingsManager     ()  { return _settingsManager; }
     FactGroup*              gpsRtkFactGroup     ()  { return &_gpsRtkFactGroup; }
-    static QGeoCoordinate   flightMapPosition   ();
-    static double           flightMapZoom       ();
+    static QGeoCoordinate   flightMapPosition   ()  { return _coord; }
+    static double           flightMapZoom       ()  { return _zoom; }
 
     qreal zOrderTopMost             () { return 1000; }
     qreal zOrderWidgets             () { return 100; }
@@ -209,6 +209,9 @@ private:
     static const char* _flightMapPositionLatitudeSettingsKey;
     static const char* _flightMapPositionLongitudeSettingsKey;
     static const char* _flightMapZoomSettingsKey;
+
+    static QGeoCoordinate   _coord;
+    static double           _zoom;
 };
 
 #endif


### PR DESCRIPTION
Hello @dagar 
The test is done on Windows and Android. Version 3.2.5
When a Mavlink UAV is connected, with the activated USB joystick there is a very strong boost of the program. This causes a constant loss of communication with the UAV and the message: manual control lost.

Each time the user moves the map, the central coordinate and zoom level are stored in the configuration file, and this is read every time to change the position of the map on the screen. When you move the map then this reading / writing is performed many times per second and the system is working incorrectly.

If you redefine these functions in such a way that the map coordinate and zoom level are stored simply in the variable, then the speed grows several times and the map becomes comfortable. And in the configuration file, you can save the coordinate when you exit the program.