### PR TITLE
Allow pseudo mobile builds (Native QML on Desktop)

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -233,10 +233,12 @@ QT += \
         multimedia
 }
 
-!MobileBuild {
-QT += \
-    printsupport \
-    serialport \
+AndroidBuild || iOSBuild {
+    # Android and iOS don't unclude these
+} else {
+    QT += \
+        printsupport \
+        serialport \
 }
 
 contains(DEFINES, QGC_ENABLE_BLUETOOTH) {

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -613,11 +613,13 @@ void LinkManager::_updateAutoConnectLinks(void)
     }
 
     // Check for RTK GPS connection gone
+#if !defined(__mobile__)
     if (!_autoConnectRTKPort.isEmpty() && !currentPorts.contains(_autoConnectRTKPort)) {
         qCDebug(LinkManagerLog) << "RTK GPS disconnected" << _autoConnectRTKPort;
         _toolbox->gpsManager()->disconnectGPS();
         _autoConnectRTKPort.clear();
     }
+#endif
 
 #endif
 #endif // NO_SERIAL_LINK


### PR DESCRIPTION
For now, QGC will build "Native" QML on mobile and "Hybrid" otherwise. This PR is to allow to build a native QML on desktop (for testing) until there is a proper switch over to native QML.

The first change is to simply add `serialport` and the second is to skip RTK as it is not available on mobile (and it would be too much work to fix that for the purpose of this test).