### PR TITLE
Bugfix joystick input handling with multi-vehicle scenario

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -182,7 +182,8 @@ Vehicle::Vehicle(LinkInterface*             link,
 {
     _addLink(link);
 
-    connect(_joystickManager, &JoystickManager::activeJoystickChanged, this, &Vehicle::_activeJoystickChanged);
+    connect(_joystickManager, &JoystickManager::activeJoystickChanged, this, &Vehicle::_loadSettings);
+    connect(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::activeVehicleAvailableChanged, this, &Vehicle::_loadSettings);
 
     _mavlink = _toolbox->mavlinkProtocol();
 
@@ -230,7 +231,6 @@ Vehicle::Vehicle(LinkInterface*             link,
     connect(_mav, SIGNAL(attitudeChanged                    (UASInterface*,double,double,double,quint64)),              this, SLOT(_updateAttitude(UASInterface*, double, double, double, quint64)));
     connect(_mav, SIGNAL(attitudeChanged                    (UASInterface*,int,double,double,double,quint64)),          this, SLOT(_updateAttitude(UASInterface*,int,double, double, double, quint64)));
 
-    _loadSettings();
 
     // Ask the vehicle for protocol version info.
     sendMavCommand(MAV_COMP_ID_ALL,                         // Don't know default component id yet.
@@ -1611,6 +1611,10 @@ int Vehicle::manualControlReservedButtonCount(void)
 
 void Vehicle::_loadSettings(void)
 {
+    if (!_active) {
+        return;
+    }
+
     QSettings settings;
 
     settings.beginGroup(QString(_settingsGroup).arg(_id));
@@ -1669,12 +1673,6 @@ QStringList Vehicle::joystickModes(void)
     return list;
 }
 
-void Vehicle::_activeJoystickChanged(void)
-{
-    _loadSettings();
-    _startJoystick(true);
-}
-
 bool Vehicle::joystickEnabled(void)
 {
     return _joystickEnabled;
@@ -1713,8 +1711,6 @@ void Vehicle::setActive(bool active)
         _active = active;
         emit activeChanged(_active);
     }
-
-    _startJoystick(_active);
 }
 
 QGeoCoordinate Vehicle::homePosition(void)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1982,7 +1982,6 @@ void Vehicle::_parametersReady(bool parametersReady)
     if (parametersReady) {
         _setupAutoDisarmSignalling();
         _startPlanRequest();
-        setJoystickEnabled(_joystickEnabled);
     }
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -870,7 +870,6 @@ private slots:
     void _geoFenceLoadComplete(void);
     void _rallyPointLoadComplete(void);
     void _sendMavCommandAgain(void);
-    void _activeJoystickChanged(void);
     void _clearTrajectoryPoints(void);
     void _clearCameraTriggerPoints(void);
     void _updateDistanceToHome(void);


### PR DESCRIPTION
_loadSettings should not be called in the Vehicle constructor, it may enable/disable the joystick for the active vehicle when a new vehicle connects.

_loadSettings should be called when the active vehicle changes.