### PR TITLE
Formatting fixes

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -41,6 +41,8 @@ Item {
     function getPreferredInstrumentWidth() {
         if(ScreenTools.isMobile) {
             return mainWindow.width * 0.25
+        } else if(ScreenTools.isHugeScreen) {
+            return mainWindow.width * 0.11
         }
         return ScreenTools.defaultFontPixelWidth * 30
     }

--- a/src/FlightMap/Widgets/ValuePageWidget.qml
+++ b/src/FlightMap/Widgets/ValuePageWidget.qml
@@ -82,7 +82,7 @@ Column {
             QGCLabel {
                 width:                  parent.width
                 horizontalAlignment:    Text.AlignHCenter
-                fontSizeMode:           Text.HorizontalFit
+                wrapMode:               Text.WordWrap
                 text:                   fact.shortDescription + (fact.units ? " (" + fact.units + ")" : "")
             }
             QGCLabel {
@@ -105,9 +105,9 @@ Column {
 
             QGCLabel {
                 width:                  parent.width
+                wrapMode:               Text.WordWrap
                 horizontalAlignment:    Text.AlignHCenter
                 font.pointSize:         ScreenTools.isTinyScreen ? ScreenTools.smallFontPointSize * 0.75 : ScreenTools.smallFontPointSize
-                fontSizeMode:           Text.HorizontalFit
                 text:                   fact.shortDescription
             }
             QGCLabel {

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -60,6 +60,7 @@ Item {
     property bool isDebug:          ScreenToolsController.isDebug
     property bool isTinyScreen:     (Screen.width / Screen.pixelDensity) < 120 // 120mm
     property bool isShortScreen:    ScreenToolsController.isMobile && ((Screen.height / Screen.width) < 0.6) // Nexus 7 for example
+    property bool isHugeScreen:     Screen.width >= 1920*2
 
     readonly property real minTouchMillimeters: 10      ///< Minimum touch size in millimeters
     property real minTouchPixels:               0       ///< Minimum touch size in pixels
@@ -88,6 +89,10 @@ Item {
             if(ScreenToolsController.isDebug)
                 _setBasePointSize(QGroundControl.settingsManager.appSettings.appFontPointSize.value)
         }
+    }
+
+    function printScreenStats() {
+        console.log('ScreenTools: Screen.width: ' + Screen.width + ' Screen.height: ' + Screen.height + ' Screen.pixelDensity: ' + Screen.pixelDensity)
     }
 
     /// Returns the current x position of the mouse in global screen coordinates.


### PR DESCRIPTION
Currently indicator widgets look funny on laptops with 4k screens.

## Before:

![qgc-old-formatting](https://user-images.githubusercontent.com/8315108/34229547-bbf696d6-e5a2-11e7-812a-75f388091a7f.png)

## After:

![qgc-formatting-fixes-11-10pt](https://user-images.githubusercontent.com/8315108/34229549-bd24e562-e5a2-11e7-86b5-b2102e6ecef6.png)
