### PR TITLE
CameraCalc: Remove use of CameraSpecType

### DIFF
--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -21,14 +21,13 @@ const char* CameraCalc::_frontalOverlapName =           "FrontalOverlap";
 const char* CameraCalc::_sideOverlapName =              "SideOverlap";
 const char* CameraCalc::_adjustedFootprintFrontalName = "AdjustedFootprintFrontal";
 const char* CameraCalc::_adjustedFootprintSideName =    "AdjustedFootprintSide";
-const char* CameraCalc::_jsonCameraSpecTypeKey =        "CameraSpecType";
-const char* CameraCalc::_jsonKnownCameraNameKey =       "CameraName";
+const char* CameraCalc::_jsonCameraNameKey =            "CameraName";
 
 CameraCalc::CameraCalc(Vehicle* vehicle, QObject* parent)
     : CameraSpec                    (parent)
     , _vehicle                      (vehicle)
     , _dirty                        (false)
-    , _cameraSpecType               (CameraSpecNone)
+    , _cameraName                   (manualCameraName())
     , _disableRecalc                (false)
     , _metaDataMap                  (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/CameraCalc.FactMetaData.json"), this))
     , _valueSetIsDistanceFact       (0, _valueSetIsDistanceName,        FactMetaData::valueTypeBool)
@@ -52,9 +51,7 @@ CameraCalc::CameraCalc(Vehicle* vehicle, QObject* parent)
     _adjustedFootprintSideFact.setMetaData      (_metaDataMap[_adjustedFootprintSideName],      true);
     _adjustedFootprintFrontalFact.setMetaData   (_metaDataMap[_adjustedFootprintFrontalName],   true);
 
-    connect(this, &CameraCalc::knownCameraNameChanged, this, &CameraCalc::_knownCameraNameChanged);
-
-    connect(this, &CameraCalc::cameraSpecTypeChanged, this, &CameraCalc::_recalcTriggerDistance);
+    connect(this, &CameraCalc::cameraNameChanged, this, &CameraCalc::_recalcTriggerDistance);
 
     connect(&_distanceToSurfaceFact,    &Fact::rawValueChanged, this, &CameraCalc::_recalcTriggerDistance);
     connect(&_imageDensityFact,         &Fact::rawValueChanged, this, &CameraCalc::_recalcTriggerDistance);
@@ -73,59 +70,57 @@ void CameraCalc::setDirty(bool dirty)
     }
 }
 
-void CameraCalc::setCameraSpecType(CameraSpecType cameraSpecType)
+void CameraCalc::setCameraName(QString cameraName)
 {
-    if (cameraSpecType != _cameraSpecType) {
-        _cameraSpecType = cameraSpecType;
-        emit cameraSpecTypeChanged(_cameraSpecType);
-    }
-}
+    if (cameraName != _cameraName) {
+        _cameraName = cameraName;
 
-void CameraCalc::setKnownCameraName(QString knownCameraName)
-{
-    if (knownCameraName != _knownCameraName) {
-        _knownCameraName = knownCameraName;
-        emit knownCameraNameChanged(_knownCameraName);
-    }
-}
-
-void CameraCalc::_knownCameraNameChanged(QString knownCameraName)
-{
-    if (_cameraSpecType == CameraSpecKnown) {
-        CameraMetaData* cameraMetaData = NULL;
-
-        // Update camera specs to new camera
-        for (int cameraIndex=0; cameraIndex<_knownCameraList.count(); cameraIndex++) {
-            cameraMetaData = _knownCameraList[cameraIndex].value<CameraMetaData*>();
-            if (knownCameraName == cameraMetaData->name()) {
-                break;
+        if (_cameraName == manualCameraName() || _cameraName == customCameraName()) {
+            // These values are unknown for these types
+            fixedOrientation()->setRawValue(false);
+            minTriggerInterval()->setRawValue(0);
+            if (_cameraName == manualCameraName()) {
+                valueSetIsDistance()->setRawValue(false);
             }
-        }
-
-        _disableRecalc = true;
-        if (cameraMetaData) {
-            sensorWidth()->setRawValue          (cameraMetaData->sensorWidth());
-            sensorHeight()->setRawValue         (cameraMetaData->sensorHeight());
-            imageWidth()->setRawValue           (cameraMetaData->imageWidth());
-            imageHeight()->setRawValue          (cameraMetaData->imageHeight());
-            focalLength()->setRawValue          (cameraMetaData->focalLength());
-            landscape()->setRawValue            (cameraMetaData->landscape());
-            fixedOrientation()->setRawValue     (cameraMetaData->fixedOrientation());
-            minTriggerInterval()->setRawValue   (cameraMetaData->minTriggerInterval());
         } else {
-            // We don't know this camera, switch back to custom
-            _cameraSpecType = CameraSpecCustom;
-            emit cameraSpecTypeChanged(_cameraSpecType);
-        }
-        _disableRecalc = false;
+            // This should be a known camera name. Update camera specs to new camera
 
-        _recalcTriggerDistance();
+            bool foundKnownCamera = false;
+            CameraMetaData* cameraMetaData = NULL;
+            for (int cameraIndex=0; cameraIndex<_knownCameraList.count(); cameraIndex++) {
+                cameraMetaData = _knownCameraList[cameraIndex].value<CameraMetaData*>();
+                if (cameraName == cameraMetaData->name()) {
+                    foundKnownCamera = true;
+                    break;
+                }
+            }
+
+            _disableRecalc = true;
+            if (foundKnownCamera) {
+                sensorWidth()->setRawValue          (cameraMetaData->sensorWidth());
+                sensorHeight()->setRawValue         (cameraMetaData->sensorHeight());
+                imageWidth()->setRawValue           (cameraMetaData->imageWidth());
+                imageHeight()->setRawValue          (cameraMetaData->imageHeight());
+                focalLength()->setRawValue          (cameraMetaData->focalLength());
+                landscape()->setRawValue            (cameraMetaData->landscape());
+                fixedOrientation()->setRawValue     (cameraMetaData->fixedOrientation());
+                minTriggerInterval()->setRawValue   (cameraMetaData->minTriggerInterval());
+            } else {
+                // We don't know this camera, switch back to custom
+                _cameraName = customCameraName();
+                fixedOrientation()->setRawValue(false);
+                minTriggerInterval()->setRawValue(0);
+            }
+            _disableRecalc = false;
+        }
+
+        emit cameraNameChanged(_cameraName);
     }
 }
 
 void CameraCalc::_recalcTriggerDistance(void)
 {
-    if (_disableRecalc || _cameraSpecType == CameraSpecNone) {
+    if (_disableRecalc || _cameraName == manualCameraName()) {
         return;
     }
 
@@ -168,14 +163,13 @@ void CameraCalc::_recalcTriggerDistance(void)
 
 void CameraCalc::save(QJsonObject& json) const
 {
-    json[_jsonCameraSpecTypeKey] =          (int)_cameraSpecType;
     json[_adjustedFootprintSideName] =      _adjustedFootprintSideFact.rawValue().toDouble();
     json[_adjustedFootprintFrontalName] =   _adjustedFootprintFrontalFact.rawValue().toDouble();
     json[_distanceToSurfaceName] =  _distanceToSurfaceFact.rawValue().toDouble();
+    json[_jsonCameraNameKey] = _cameraName;
 
-    if (_cameraSpecType != CameraSpecNone) {
+    if (_cameraName != manualCameraName()) {
         CameraSpec::save(json);
-        json[_jsonKnownCameraNameKey] = _knownCameraName;
         json[_valueSetIsDistanceName] = _valueSetIsDistanceFact.rawValue().toBool();
         json[_imageDensityName] =       _imageDensityFact.rawValue().toDouble();
         json[_frontalOverlapName] =     _frontalOverlapFact.rawValue().toDouble();
@@ -186,7 +180,7 @@ void CameraCalc::save(QJsonObject& json) const
 bool CameraCalc::load(const QJsonObject& json, QString& errorString)
 {    
     QList<JsonHelper::KeyValidateInfo> keyInfoList1 = {
-        { _jsonCameraSpecTypeKey,           QJsonValue::Double, true },
+        { _jsonCameraNameKey,               QJsonValue::String, true },
         { _adjustedFootprintSideName,       QJsonValue::Double, true },
         { _adjustedFootprintFrontalName,    QJsonValue::Double, true },
         { _distanceToSurfaceName,           QJsonValue::Double, true },
@@ -195,27 +189,15 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
         return false;
     }
 
-    int cameraSpecType = json[_jsonCameraSpecTypeKey].toInt();
-    switch (cameraSpecType) {
-    case CameraSpecNone:
-    case CameraSpecCustom:
-    case CameraSpecKnown:
-        break;
-    default:
-        errorString = tr("Unsupported CameraSpecType %d").arg(cameraSpecType);
-        return false;
-    }
-
     _disableRecalc = true;
 
-    setCameraSpecType((CameraSpecType)cameraSpecType);
+    setCameraName(json[_jsonCameraNameKey].toString());
     _adjustedFootprintSideFact.setRawValue      (json[_adjustedFootprintSideName].toDouble());
     _adjustedFootprintFrontalFact.setRawValue   (json[_adjustedFootprintFrontalName].toDouble());
     _distanceToSurfaceFact.setRawValue          (json[_distanceToSurfaceName].toDouble());
 
-    if (_cameraSpecType != CameraSpecNone) {
+    if (_cameraName != manualCameraName()) {
         QList<JsonHelper::KeyValidateInfo> keyInfoList2 = {
-            { _jsonKnownCameraNameKey,          QJsonValue::String, true },
             { _valueSetIsDistanceName,          QJsonValue::Bool,   true },
             { _imageDensityName,                QJsonValue::Double, true },
             { _frontalOverlapName,              QJsonValue::Double, true },
@@ -226,7 +208,6 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
             _disableRecalc = false;
         }
 
-        setKnownCameraName(json[_jsonKnownCameraNameKey].toString());
         _valueSetIsDistanceFact.setRawValue (json[_valueSetIsDistanceName].toBool());
         _imageDensityFact.setRawValue       (json[_imageDensityName].toDouble());
         _frontalOverlapFact.setRawValue     (json[_frontalOverlapName].toDouble());
@@ -240,4 +221,14 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
     _disableRecalc = false;
 
     return true;
+}
+
+QString CameraCalc::customCameraName(void)
+{
+    return tr("Custom Camera");
+}
+
+QString CameraCalc::manualCameraName(void)
+{
+    return tr("Manual (no camera specs)");
 }

--- a/src/MissionManager/CameraCalc.h
+++ b/src/MissionManager/CameraCalc.h
@@ -20,32 +20,25 @@ class CameraCalc : public CameraSpec
 public:
     CameraCalc(Vehicle* vehicle, QObject* parent = NULL);
 
-    Q_ENUMS(CameraSpecType)
-
-    Q_PROPERTY(CameraSpecType   cameraSpecType              READ cameraSpecType     WRITE setCameraSpecType     NOTIFY cameraSpecTypeChanged)
-    Q_PROPERTY(QString          knownCameraName             READ knownCameraName    WRITE setKnownCameraName    NOTIFY knownCameraNameChanged)
-    Q_PROPERTY(Fact*            valueSetIsDistance          READ valueSetIsDistance         CONSTANT)                       ///< true: distance specified, resolution calculated
-    Q_PROPERTY(Fact*            distanceToSurface           READ distanceToSurface          CONSTANT)                       ///< Distance to surface for image foot print calculation
-    Q_PROPERTY(Fact*            imageDensity                READ imageDensity               CONSTANT)                       ///< Image density on surface (cm/px)
-    Q_PROPERTY(Fact*            frontalOverlap              READ frontalOverlap             CONSTANT)
-    Q_PROPERTY(Fact*            sideOverlap                 READ sideOverlap                CONSTANT)
-    Q_PROPERTY(Fact*            adjustedFootprintSide       READ adjustedFootprintSide      CONSTANT)                       ///< Side footprint adjusted down for overlap
-    Q_PROPERTY(Fact*            adjustedFootprintFrontal    READ adjustedFootprintFrontal   CONSTANT)                       ///< Frontal footprint adjusted down for overlap
+    Q_PROPERTY(QString          cameraName                  READ cameraName         WRITE setCameraName NOTIFY cameraNameChanged)
+    Q_PROPERTY(QString          customCameraName            READ customCameraName                       CONSTANT)                   // Camera name for custom camera setting
+    Q_PROPERTY(QString          manualCameraName            READ manualCameraName                       CONSTANT)                   // Camera name for manual camera setting
+    Q_PROPERTY(Fact*            valueSetIsDistance          READ valueSetIsDistance                     CONSTANT)                   ///< true: distance specified, resolution calculated
+    Q_PROPERTY(Fact*            distanceToSurface           READ distanceToSurface                      CONSTANT)                   ///< Distance to surface for image foot print calculation
+    Q_PROPERTY(Fact*            imageDensity                READ imageDensity                           CONSTANT)                   ///< Image density on surface (cm/px)
+    Q_PROPERTY(Fact*            frontalOverlap              READ frontalOverlap                         CONSTANT)
+    Q_PROPERTY(Fact*            sideOverlap                 READ sideOverlap                            CONSTANT)
+    Q_PROPERTY(Fact*            adjustedFootprintSide       READ adjustedFootprintSide                  CONSTANT)                   ///< Side footprint adjusted down for overlap
+    Q_PROPERTY(Fact*            adjustedFootprintFrontal    READ adjustedFootprintFrontal               CONSTANT)                   ///< Frontal footprint adjusted down for overlap
 
     // The following values are calculated from the camera properties
-    Q_PROPERTY(double imageFootprintSide              READ imageFootprintSide               NOTIFY imageFootprintSideChanged)                 ///< Size of image size side in meters
-    Q_PROPERTY(double imageFootprintFrontal           READ imageFootprintFrontal            NOTIFY imageFootprintFrontalChanged)              ///< Size of image size frontal in meters
+    Q_PROPERTY(double imageFootprintSide    READ imageFootprintSide     NOTIFY imageFootprintSideChanged)       ///< Size of image size side in meters
+    Q_PROPERTY(double imageFootprintFrontal READ imageFootprintFrontal  NOTIFY imageFootprintFrontalChanged)    ///< Size of image size frontal in meters
 
-    enum CameraSpecType {
-        CameraSpecNone,
-        CameraSpecCustom,
-        CameraSpecKnown
-    };
-
-    CameraSpecType cameraSpecType(void) const { return _cameraSpecType; }
-    QString knownCameraName(void) const { return _knownCameraName; }
-    void setCameraSpecType(CameraSpecType cameraSpecType);
-    void setKnownCameraName(QString knownCameraName);
+    static QString customCameraName(void);
+    static QString manualCameraName(void);
+    QString cameraName(void) const { return _cameraName; }
+    void setCameraName(QString cameraName);
 
     Fact* valueSetIsDistance        (void) { return &_valueSetIsDistanceFact; }
     Fact* distanceToSurface         (void) { return &_distanceToSurfaceFact; }
@@ -65,21 +58,18 @@ public:
     bool load(const QJsonObject& json, QString& errorString);
 
 signals:
-    void cameraSpecTypeChanged          (CameraSpecType cameraSpecType);
-    void knownCameraNameChanged         (QString knownCameraName);
+    void cameraNameChanged              (QString cameraName);
     void dirtyChanged                   (bool dirty);
     void imageFootprintSideChanged      (double imageFootprintSide);
     void imageFootprintFrontalChanged   (double imageFootprintFrontal);
 
 private slots:
-    void _knownCameraNameChanged(QString knownCameraName);
     void _recalcTriggerDistance(void);
 
 private:
     Vehicle*        _vehicle;
     bool            _dirty;
-    CameraSpecType  _cameraSpecType;
-    QString         _knownCameraName;
+    QString         _cameraName;
     bool            _disableRecalc;
 
     QMap<QString, FactMetaData*> _metaDataMap;
@@ -104,6 +94,5 @@ private:
     static const char* _sideOverlapName;
     static const char* _adjustedFootprintSideName;
     static const char* _adjustedFootprintFrontalName;
-    static const char* _jsonCameraSpecTypeKey;
-    static const char* _jsonKnownCameraNameKey;
+    static const char* _jsonCameraNameKey;
 };

--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -418,7 +418,7 @@ Item {
 
                 MenuItem {
                     text:           qsTr("Set radius..." )
-                    enabled:        _circle
+                    visible:        _circle
                     onTriggered:    radiusDialog.visible = true
                 }
 

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -113,7 +113,7 @@ private slots:
     void _updateCoordinateAltitudes (void);
     void _rebuildFlightPolygon      (void);
     void _recalcCameraShots         (void);
-    void _cameraSpecTypeChanged     (CameraCalc::CameraSpecType cameraSpecType);
+    void _resetGimbal               (void);
 
 private:
     void _setExitCoordinate(const QGeoCoordinate& coordinate);

--- a/src/MissionManager/StructureScanComplexItemTest.cc
+++ b/src/MissionManager/StructureScanComplexItemTest.cc
@@ -99,7 +99,7 @@ void StructureScanComplexItemTest::_initItem(void)
         mapPolygon->appendVertex(vertex);
     }
 
-    _structureScanItem->cameraCalc()->setCameraSpecType(CameraCalc::CameraSpecNone);
+    _structureScanItem->cameraCalc()->setCameraName(CameraCalc::manualCameraName());
     _structureScanItem->gimbalPitch()->setCookedValue(45);
     _structureScanItem->gimbalYaw()->setCookedValue(45);
     _structureScanItem->layers()->setCookedValue(2);
@@ -118,7 +118,7 @@ void StructureScanComplexItemTest::_validateItem(StructureScanComplexItem* item)
         QCOMPARE(expectedVertex, actualVertex);
     }
 
-    QCOMPARE((int)item->cameraCalc()->cameraSpecType(), (int)CameraCalc::CameraSpecNone);
+    QCOMPARE(_structureScanItem->cameraCalc()->cameraName() , CameraCalc::manualCameraName());
     QCOMPARE(item->gimbalPitch()->cookedValue().toDouble(), 45.0);
     QCOMPARE(item->gimbalYaw()->cookedValue().toDouble(), 45.0);
     QCOMPARE(item->layers()->cookedValue().toInt(), 2);
@@ -144,8 +144,8 @@ void StructureScanComplexItemTest::_testGimbalAngleUpdate(void)
     // This sets the item to CameraCalc::CameraSpecNone and non-standard gimbal angles
     _initItem();
 
-    // Switching to a camera specific setup should set gimbal angles to defaults surface scan
-    _structureScanItem->cameraCalc()->setCameraSpecType(CameraCalc::CameraSpecCustom);
+    // Switching to a camera specific setup should set gimbal angles to defaults
+    _structureScanItem->cameraCalc()->setCameraName(CameraCalc::customCameraName());
     QCOMPARE(_structureScanItem->gimbalPitch()->cookedValue().toDouble(), 0.0);
     QCOMPARE(_structureScanItem->gimbalYaw()->cookedValue().toDouble(), 90.0);
 }

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -92,7 +92,7 @@ Rectangle {
             columnSpacing:  ScreenTools.defaultFontPixelWidth / 2
             rowSpacing:     0
             columns:        3
-            enabled:        missionItem.cameraCalc.cameraSpecType === CameraCalc.CameraSpecNone
+            enabled:        missionItem.cameraCalc.cameraName === missionItem.cameraCalc.manualCameraName
 
             Item { width: 1; height: 1 }
             QGCLabel { text: qsTr("Pitch") }


### PR DESCRIPTION
This was leading to flaky loading of unknown camera type. New implementation simplifies this. Fix for #5905.

This unfortunately required a backwards incompatible bump of the structure scan version number for saving. This means old structure scans won't load.