### PR TITLE
Fixed Window landing pattern defaults override support

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -7,12 +7,10 @@
  *
  ****************************************************************************/
 
-
-/// @file
-///     @author Don Gagne <don@thegagnes.com>
-
 #include "Fact.h"
 #include "QGCMAVLink.h"
+#include "QGCApplication.h"
+#include "QGCCorePlugin.h"
 
 #include <QtQml>
 #include <QQmlEngine>
@@ -48,6 +46,21 @@ Fact::Fact(int componentId, QString name, FactMetaData::ValueType_t type, QObjec
     FactMetaData* metaData = new FactMetaData(_type, this);
     setMetaData(metaData);
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
+}
+
+Fact::Fact(FactMetaData* metaData, QObject* parent)
+    : QObject(parent)
+    , _name                     (metaData->name())
+    , _componentId              (0)
+    , _rawValue                 (0)
+    , _type                     (metaData->type())
+    , _metaData                 (NULL)
+    , _sendValueChangedSignals  (true)
+    , _deferredValueChangeSignal(false)
+{
+    // Allow core plugin a chance to override the default value
+    qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(*metaData);
+    setMetaData(metaData, true /* setDefaultFromMetaData */);
 }
 
 Fact::Fact(const Fact& other, QObject* parent)

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -31,6 +31,10 @@ public:
     Fact(int componentId, QString name, FactMetaData::ValueType_t type, QObject* parent = NULL);
     Fact(const Fact& other, QObject* parent = NULL);
 
+    /// Creates a Fact using the name and type from metaData. Also calls QGCCorePlugin::adjustSettingsMetaData allowing
+    /// custom builds to override the metadata.
+    Fact(FactMetaData* metaData, QObject* parent = NULL);
+
     const Fact& operator=(const Fact& other);
 
     Q_PROPERTY(int          componentId             READ componentId                                        CONSTANT)

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -986,29 +986,58 @@ FactMetaData* FactMetaData::createFromJsonObject(const QJsonObject& json, QObjec
     if (json.contains(_unitsJsonKey)) {
         metaData->setRawUnits(json[_unitsJsonKey].toString());
     }
+
+    QString defaultValueJsonKey;
 #ifdef __mobile__
     if (json.contains(_mobileDefaultValueJsonKey)) {
-        metaData->setRawDefaultValue(json[_mobileDefaultValueJsonKey].toVariant());
-    } else if (json.contains(_defaultValueJsonKey)) {
-        metaData->setRawDefaultValue(json[_defaultValueJsonKey].toVariant());
-    }
-#else
-    if (json.contains(_defaultValueJsonKey)) {
-        metaData->setRawDefaultValue(json[_defaultValueJsonKey].toVariant());
+        defaultValueJsonKey = _mobileDefaultValueJsonKey
     }
 #endif
+    if (defaultValueJsonKey.isEmpty() && json.contains(_defaultValueJsonKey)) {
+        defaultValueJsonKey = _defaultValueJsonKey;
+    }
+    if (!defaultValueJsonKey.isEmpty()) {
+        QVariant typedValue;
+        QString errorString;
+        QVariant initialValue = json[defaultValueJsonKey].toVariant();
+        if (metaData->convertAndValidateRaw(initialValue, true /* convertOnly */, typedValue, errorString)) {
+            metaData->setRawDefaultValue(typedValue);
+        } else {
+            qWarning() << "Invalid default value, name:" << metaData->name()
+                       << " type:" << metaData->type()
+                       << " value:" << initialValue
+                       << " error:" << errorString;
+        }
+    }
+
     if (json.contains(_minJsonKey)) {
         QVariant typedValue;
         QString errorString;
-        metaData->convertAndValidateRaw(json[_minJsonKey].toVariant(), true /* convertOnly */, typedValue, errorString);
-        metaData->setRawMin(typedValue);
+        QVariant initialValue = json[_minJsonKey].toVariant();
+        if (metaData->convertAndValidateRaw(initialValue, true /* convertOnly */, typedValue, errorString)) {
+            metaData->setRawMin(typedValue);
+        } else {
+            qWarning() << "Invalid min value, name:" << metaData->name()
+                       << " type:" << metaData->type()
+                       << " value:" << initialValue
+                       << " error:" << errorString;
+        }
     }
+
     if (json.contains(_maxJsonKey)) {
         QVariant typedValue;
         QString errorString;
-        metaData->convertAndValidateRaw(json[_maxJsonKey].toVariant(), true /* convertOnly */, typedValue, errorString);
-        metaData->setRawMax(typedValue);
+        QVariant initialValue = json[_maxJsonKey].toVariant();
+        if (metaData->convertAndValidateRaw(initialValue, true /* convertOnly */, typedValue, errorString)) {
+            metaData->setRawMax(typedValue);
+        } else {
+            qWarning() << "Invalid max value, name:" << metaData->name()
+                       << " type:" << metaData->type()
+                       << " value:" << initialValue
+                       << " error:" << errorString;
+        }
     }
+
     if (json.contains(_hasControlJsonKey)) {
         metaData->setHasControl(json[_hasControlJsonKey].toBool());
     } else {

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -990,7 +990,7 @@ FactMetaData* FactMetaData::createFromJsonObject(const QJsonObject& json, QObjec
     QString defaultValueJsonKey;
 #ifdef __mobile__
     if (json.contains(_mobileDefaultValueJsonKey)) {
-        defaultValueJsonKey = _mobileDefaultValueJsonKey
+        defaultValueJsonKey = _mobileDefaultValueJsonKey;
     }
 #endif
     if (defaultValueJsonKey.isEmpty() && json.contains(_defaultValueJsonKey)) {

--- a/src/MissionManager/FWLandingPattern.FactMetaData.json
+++ b/src/MissionManager/FWLandingPattern.FactMetaData.json
@@ -1,6 +1,6 @@
 [
 {
-    "name":             "Landing dist",
+    "name":             "LandingDistance",
     "shortDescription": "Distance between landing and loiter points.",
     "type":             "double",
     "units":            "m",
@@ -9,7 +9,7 @@
     "defaultValue":     300.0
 },
 {
-    "name":             "Landing heading",
+    "name":             "LandingHeading",
     "shortDescription": "Heading from loiter point to land point.",
     "type":             "double",
     "units":            "deg",
@@ -19,7 +19,7 @@
     "defaultValue":     270.0
 },
 {
-    "name":             "Loiter altitude",
+    "name":             "LoiterAltitude",
     "shortDescription": "Aircraft will proceed to the loiter point and loiter until it reaches this altitude. Once altitude is reached the aircraft will proceed to land.",
     "type":             "double",
     "units":            "m",
@@ -27,7 +27,7 @@
     "defaultValue":     40.0
 },
 {
-    "name":             "Loiter radius",
+    "name":             "LoiterRadius",
     "shortDescription": "Loiter radius.",
     "type":             "double",
     "decimalPlaces":    1,
@@ -36,7 +36,7 @@
     "defaultValue":     75.0
 },
 {
-    "name":             "Landing altitude",
+    "name":             "LandingAltitude",
     "shortDescription": "Altitude for landing point.",
     "type":             "double",
     "units":            "m",
@@ -44,7 +44,7 @@
     "defaultValue":     0.0
 },
 {
-    "name":             "Descent rate",
+    "name":             "DescentRate",
     "shortDescription": "Descent rate between landing and loiter altitude.",
     "type":             "double",
     "units":            "%",

--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -20,12 +20,12 @@ QGC_LOGGING_CATEGORY(FixedWingLandingComplexItemLog, "FixedWingLandingComplexIte
 
 const char* FixedWingLandingComplexItem::jsonComplexItemTypeValue = "fwLandingPattern";
 
-const char* FixedWingLandingComplexItem::_loiterToLandDistanceName =    "Landing dist";
-const char* FixedWingLandingComplexItem::_landingHeadingName =          "Landing heading";
-const char* FixedWingLandingComplexItem::_loiterAltitudeName =          "Loiter altitude";
-const char* FixedWingLandingComplexItem::_loiterRadiusName =            "Loiter radius";
-const char* FixedWingLandingComplexItem::_landingAltitudeName =         "Landing altitude";
-const char* FixedWingLandingComplexItem::_fallRateName =                "Descent rate";
+const char* FixedWingLandingComplexItem::loiterToLandDistanceName = "LandingDistance";
+const char* FixedWingLandingComplexItem::landingHeadingName =       "LandingHeading";
+const char* FixedWingLandingComplexItem::loiterAltitudeName =       "LoiterAltitude";
+const char* FixedWingLandingComplexItem::loiterRadiusName =         "LoiterRadius";
+const char* FixedWingLandingComplexItem::landingAltitudeName =      "LandingAltitude";
+const char* FixedWingLandingComplexItem::fallRateName =             "DescentRate";
 
 const char* FixedWingLandingComplexItem::_jsonLoiterCoordinateKey =         "loiterCoordinate";
 const char* FixedWingLandingComplexItem::_jsonLoiterRadiusKey =             "loiterRadius";
@@ -35,43 +35,24 @@ const char* FixedWingLandingComplexItem::_jsonLandingCoordinateKey =        "lan
 const char* FixedWingLandingComplexItem::_jsonLandingAltitudeRelativeKey =  "landAltitudeRelative";
 const char* FixedWingLandingComplexItem::_jsonFallRateKey =                 "fallRate";
 
-QMap<QString, FactMetaData*> FixedWingLandingComplexItem::_metaDataMap;
-
 FixedWingLandingComplexItem::FixedWingLandingComplexItem(Vehicle* vehicle, QObject* parent)
-    : ComplexMissionItem(vehicle, parent)
-    , _sequenceNumber(0)
-    , _dirty(false)
-    , _landingCoordSet(false)
-    , _ignoreRecalcSignals(false)
-    , _landingDistanceFact  (0, _loiterToLandDistanceName,  FactMetaData::valueTypeDouble)
-    , _loiterAltitudeFact   (0, _loiterAltitudeName,        FactMetaData::valueTypeDouble)
-    , _loiterRadiusFact     (0, _loiterRadiusName,          FactMetaData::valueTypeDouble)
-    , _landingHeadingFact   (0, _landingHeadingName,        FactMetaData::valueTypeDouble)
-    , _landingAltitudeFact  (0, _landingAltitudeName,       FactMetaData::valueTypeDouble)
-    , _fallRateFact         (0, _fallRateName,              FactMetaData::valueTypeDouble)
-    , _loiterClockwise(true)
-    , _loiterAltitudeRelative(true)
-    , _landingAltitudeRelative(true)
+    : ComplexMissionItem        (vehicle, parent)
+    , _sequenceNumber           (0)
+    , _dirty                    (false)
+    , _landingCoordSet          (false)
+    , _ignoreRecalcSignals      (false)
+    , _metaDataMap              (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/FWLandingPattern.FactMetaData.json"), this))
+    , _landingDistanceFact      (_metaDataMap[loiterToLandDistanceName])
+    , _loiterAltitudeFact       (_metaDataMap[loiterAltitudeName])
+    , _loiterRadiusFact         (_metaDataMap[loiterRadiusName])
+    , _landingHeadingFact       (_metaDataMap[landingHeadingName])
+    , _landingAltitudeFact      (_metaDataMap[landingAltitudeName])
+    , _fallRateFact             (_metaDataMap[fallRateName])
+    , _loiterClockwise          (true)
+    , _loiterAltitudeRelative   (true)
+    , _landingAltitudeRelative  (true)
 {
     _editorQml = "qrc:/qml/FWLandingPatternEditor.qml";
-
-    if (_metaDataMap.isEmpty()) {
-        _metaDataMap = FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/FWLandingPattern.FactMetaData.json"), NULL /* metaDataParent */);
-    }
-
-    _landingDistanceFact.setMetaData    (_metaDataMap[_loiterToLandDistanceName]);
-    _loiterAltitudeFact.setMetaData     (_metaDataMap[_loiterAltitudeName]);
-    _loiterRadiusFact.setMetaData       (_metaDataMap[_loiterRadiusName]);
-    _landingHeadingFact.setMetaData     (_metaDataMap[_landingHeadingName]);
-    _landingAltitudeFact.setMetaData    (_metaDataMap[_landingAltitudeName]);
-    _fallRateFact.setMetaData           (_metaDataMap[_fallRateName]);
-
-    _landingDistanceFact.setRawValue    (_landingDistanceFact.rawDefaultValue());
-    _loiterAltitudeFact.setRawValue     (_loiterAltitudeFact.rawDefaultValue());
-    _loiterRadiusFact.setRawValue       (_loiterRadiusFact.rawDefaultValue());
-    _landingHeadingFact.setRawValue     (_landingHeadingFact.rawDefaultValue());
-    _landingAltitudeFact.setRawValue    (_landingAltitudeFact.rawDefaultValue());
-    _fallRateFact.setRawValue           (_fallRateFact.rawDefaultValue());
 
     connect(&_loiterAltitudeFact,       &Fact::valueChanged,                                    this, &FixedWingLandingComplexItem::_updateLoiterCoodinateAltitudeFromFact);
     connect(&_landingAltitudeFact,      &Fact::valueChanged,                                    this, &FixedWingLandingComplexItem::_updateLandingCoodinateAltitudeFromFact);

--- a/src/MissionManager/FixedWingLandingComplexItem.h
+++ b/src/MissionManager/FixedWingLandingComplexItem.h
@@ -92,6 +92,13 @@ public:
 
     static const char* jsonComplexItemTypeValue;
 
+    static const char* loiterToLandDistanceName;
+    static const char* loiterAltitudeName;
+    static const char* loiterRadiusName;
+    static const char* landingHeadingName;
+    static const char* landingAltitudeName;
+    static const char* fallRateName;
+
 signals:
     void loiterCoordinateChanged        (QGeoCoordinate coordinate);
     void loiterTangentCoordinateChanged (QGeoCoordinate coordinate);
@@ -122,6 +129,8 @@ private:
     bool            _landingCoordSet;
     bool            _ignoreRecalcSignals;
 
+    QMap<QString, FactMetaData*> _metaDataMap;
+
     Fact            _landingDistanceFact;
     Fact            _loiterAltitudeFact;
     Fact            _loiterRadiusFact;
@@ -132,15 +141,6 @@ private:
     bool            _loiterClockwise;
     bool            _loiterAltitudeRelative;
     bool            _landingAltitudeRelative;
-
-    static QMap<QString, FactMetaData*> _metaDataMap;
-
-    static const char* _loiterToLandDistanceName;
-    static const char* _loiterAltitudeName;
-    static const char* _loiterRadiusName;
-    static const char* _landingHeadingName;
-    static const char* _landingAltitudeName;
-    static const char* _fallRateName;
 
     static const char* _jsonLoiterCoordinateKey;
     static const char* _jsonLoiterRadiusKey;

--- a/src/PlanView/FWLandingPatternEditor.qml
+++ b/src/PlanView/FWLandingPatternEditor.qml
@@ -52,6 +52,7 @@ Rectangle {
             anchors.left:   parent.left
             anchors.right:  parent.right
             factList:       [ missionItem.loiterAltitude, missionItem.loiterRadius ]
+            factLabels:     [ qsTr("Altitude"), qsTr("Radius") ]
         }
 
         Item { width: 1; height: _spacer }
@@ -82,14 +83,14 @@ Rectangle {
             anchors.right:   parent.right
             columns:         2
 
-                QGCLabel { text: missionItem.landingHeading.name }
+                QGCLabel { text: qsTr("Heading") }
 
                 FactTextField {
                     Layout.fillWidth:   true
                     fact:               missionItem.landingHeading
                 }
 
-                QGCLabel { text: missionItem.landingAltitude.name }
+                QGCLabel { text: qsTr("Altitude") }
 
                 FactTextField {
                     Layout.fillWidth:   true
@@ -98,7 +99,7 @@ Rectangle {
 
             QGCRadioButton {
                 id:                     useLandingDistance
-                text:                   missionItem.landingDistance.name
+                text:                   qsTr("Landing dist")
                 checked:                !useFallRate.checked
                 onClicked: {
                     useFallRate.checked = false
@@ -115,7 +116,7 @@ Rectangle {
 
             QGCRadioButton {
                 id:                     useFallRate
-                text:                   missionItem.fallRate.name
+                text:                   qsTr("Descent rate")
                 checked:                !useLandingDistance.checked
                 onClicked: {
                     useLandingDistance.checked = false
@@ -160,18 +161,11 @@ Rectangle {
     Column {
         id:                 editorColumnNeedLandingPoint
         anchors.margins:    _margin
+        anchors.top:        parent.top
         anchors.left:       parent.left
         anchors.right:      parent.right
         visible:            !missionItem.landingCoordSet
         spacing:            ScreenTools.defaultFontPixelHeight
-
-        QGCLabel {
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            wrapMode:       Text.WordWrap
-            font.pointSize: ScreenTools.smallFontPointSize
-            text:           qsTr("WIP (NOT FOR REAL FLIGHT!)")
-        }
 
         QGCLabel {
             anchors.left:   parent.left


### PR DESCRIPTION
Also added new Fact contructor:
```
    /// Creates a Fact using the name and type from metaData. Also calls QGCCorePlugin::adjustSettingsMetaData allowing
    /// custom builds to override the metadata.
    Fact(FactMetaData* metaData, QObject* parent = NULL);
```

Used when you want a metadata driven Fact that can be overriden by QGCCorePlugin but does not store values in settings like SettingsFact.