### PR TITLE
Serial connect fixes

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -502,12 +502,6 @@ void LinkManager::_updateAutoConnectLinks(void)
 
         if (portInfo.getBoardInfo(boardType, boardName)) {
 
-            if (portInfo.isSystemPort()) {
-                // Don't connect to system ports
-                qCDebug(LinkManagerLog) << "Not opening known system ports" << portInfo.systemLocation();
-                continue;
-            }
-
             if (portInfo.isBootloader()) {
                 // Don't connect to bootloader
                 qCDebug(LinkManagerLog) << "Waiting for bootloader to finish" << portInfo.systemLocation();

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -501,6 +501,13 @@ void LinkManager::_updateAutoConnectLinks(void)
         QString boardName;
 
         if (portInfo.getBoardInfo(boardType, boardName)) {
+
+            if (portInfo.isSystemPort()) {
+                // Don't connect to system ports
+                qCDebug(LinkManagerLog) << "Not opening known system ports" << portInfo.systemLocation();
+                continue;
+            }
+
             if (portInfo.isBootloader()) {
                 // Don't connect to bootloader
                 qCDebug(LinkManagerLog) << "Waiting for bootloader to finish" << portInfo.systemLocation();

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -252,7 +252,9 @@ QList<QGCSerialPortInfo> QGCSerialPortInfo::availablePorts(void)
     QList<QGCSerialPortInfo>    list;
 
     foreach(QSerialPortInfo portInfo, QSerialPortInfo::availablePorts()) {
-        list << *((QGCSerialPortInfo*)&portInfo);
+        if (!isSystemPort(&portInfo)) {
+            list << *((QGCSerialPortInfo*)&portInfo);
+        }
     }
 
     return list;
@@ -271,21 +273,22 @@ bool QGCSerialPortInfo::isBootloader(void) const
     }
 }
 
-bool QGCSerialPortInfo::isSystemPort(void) const
+bool QGCSerialPortInfo::isSystemPort(QSerialPortInfo* port)
 {
-    // Known operating system peripherals that are NOT a drone
+    // Known operating system peripherals that are NEVER a peripheral
+    // that we should connect to.
 
-    // These are known Mac OS ports that
-    // are never connected to a drone but instead
-    // to other system peripherals.
-    if (systemLocation().contains("tty.MALS")
-        || systemLocation().contains("tty.SOC")
-        || systemLocation().contains("tty.Bluetooth-Incoming-Port")
+    // XXX Add Linux (LTE modems, etc) and Windows as needed
+
+    // MAC OS
+    if (port->systemLocation().contains("tty.MALS")
+        || port->systemLocation().contains("tty.SOC")
+        || port->systemLocation().contains("tty.Bluetooth-Incoming-Port")
         // We open these by their cu.usbserial and cu.usbmodem handles
         // already. We don't want to open them twice and conflict
         // with ourselves.
-        || systemLocation().contains("tty.usbserial")
-        || systemLocation().contains("tty.usbmodem")) {
+        || port->systemLocation().contains("tty.usbserial")
+        || port->systemLocation().contains("tty.usbmodem")) {
 
         return true;
     }

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -271,6 +271,27 @@ bool QGCSerialPortInfo::isBootloader(void) const
     }
 }
 
+bool QGCSerialPortInfo::isSystemPort(void) const
+{
+    // Known operating system peripherals that are NOT a drone
+
+    // These are known Mac OS ports that
+    // are never connected to a drone but instead
+    // to other system peripherals.
+    if (systemLocation().contains("tty.MALS")
+        || systemLocation().contains("tty.SOC")
+        || systemLocation().contains("tty.Bluetooth-Incoming-Port")
+        // We open these by their cu.usbserial and cu.usbmodem handles
+        // already. We don't want to open them twice and conflict
+        // with ourselves.
+        || systemLocation().contains("tty.usbserial")
+        || systemLocation().contains("tty.usbmodem")) {
+
+        return true;
+    }
+    return false;
+}
+
 bool QGCSerialPortInfo::canFlash(void)
 {
     BoardType_t boardType;

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -49,6 +49,9 @@ public:
     /// @return true: Board is currently in bootloader
     bool isBootloader(void) const;
 
+    /// @return true: Port is a system port and not an autopilot
+    bool isSystemPort(void) const;
+
 private:
     typedef struct {
         const char* classString;

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -50,7 +50,7 @@ public:
     bool isBootloader(void) const;
 
     /// @return true: Port is a system port and not an autopilot
-    bool isSystemPort(void) const;
+    static bool isSystemPort(QSerialPortInfo* port);
 
 private:
     typedef struct {


### PR DESCRIPTION
These two commits prevent two bad things on app boot:

  - We stop connecting to ports that are part of the system or are already open under a different alias
  - We continue to run the event loop while connecting

Combined this makes the boot / connect experience of QGC much better and much more responsive. At least on my machine with multiple serial devices connected.