### PR TITLE
Add NMEA GPS support for GCS position

### DIFF
--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -22,6 +22,7 @@ QGCPositionManager::QGCPositionManager(QGCApplication* app, QGCToolbox* toolbox)
 QGCPositionManager::~QGCPositionManager()
 {
     delete(_simulatedSource);
+    delete(_nmeaSource);
 }
 
 void QGCPositionManager::setToolbox(QGCToolbox *toolbox)
@@ -41,7 +42,17 @@ void QGCPositionManager::setToolbox(QGCToolbox *toolbox)
    //     _defaultSource = _simulatedSource;
    // }
 
-   setPositionSource(QGCPositionSource::GPS);
+   setPositionSource(QGCPositionSource::InternalGPS);
+}
+
+void QGCPositionManager::setNmeaSourceDevice(QIODevice* device)
+{
+    if (_nmeaSource) {
+        delete _nmeaSource;
+    }
+    _nmeaSource = new QNmeaPositionInfoSource(QNmeaPositionInfoSource::RealTimeMode, this);
+    _nmeaSource->setDevice(device);
+    setPositionSource(QGCPositionManager::NmeaGPS);
 }
 
 void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
@@ -73,7 +84,10 @@ void QGCPositionManager::setPositionSource(QGCPositionManager::QGCPositionSource
     case QGCPositionManager::Simulated:
         _currentSource = _simulatedSource;
         break;
-    case QGCPositionManager::GPS:
+    case QGCPositionManager::NmeaGPS:
+        _currentSource = _nmeaSource;
+        break;
+    case QGCPositionManager::InternalGPS:
     default:        
         _currentSource = _defaultSource;
         break;

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <QGeoPositionInfoSource>
+#include <QNmeaPositionInfoSource>
 
 #include <QVariant>
 
@@ -26,8 +27,9 @@ public:
 
     enum QGCPositionSource {
         Simulated,
-        GPS,
-        Log
+        InternalGPS,
+        Log,
+        NmeaGPS
     };
 
     void setPositionSource(QGCPositionSource source);
@@ -35,6 +37,8 @@ public:
     int updateInterval() const;
 
     void setToolbox(QGCToolbox* toolbox);
+
+    void setNmeaSourceDevice(QIODevice* device);
 
 private slots:
     void _positionUpdated(const QGeoPositionInfo &update);
@@ -48,5 +52,6 @@ private:
     int _updateInterval;
     QGeoPositionInfoSource * _currentSource;
     QGeoPositionInfoSource * _defaultSource;
+    QNmeaPositionInfoSource * _nmeaSource;
     QGeoPositionInfoSource * _simulatedSource;
 };

--- a/src/Settings/AutoConnect.SettingsGroup.json
+++ b/src/Settings/AutoConnect.SettingsGroup.json
@@ -42,6 +42,20 @@
     "defaultValue":     true
 },
 {
+    "name":             "AutoconnectNmeaPort",
+    "shortDescription": "NMEA GPS device for GCS position",
+    "longDescription":  "NMEA GPS device for GCS position",
+    "type":             "string",
+    "defaultValue":     "disabled"
+},
+{
+    "name":             "AutoconnectNmeaBaud",
+    "shortDescription": "NMEA GPS Baudrate",
+    "longDescription":  "NMEA GPS Baudrate",
+    "type":             "uint32",
+    "defaultValue":     4800
+},
+{
     "name":             "AutoconnectUDPListenPort",
     "shortDescription": "UDP port for autoconnect",
     "type":             "uint32",

--- a/src/Settings/AutoConnectSettings.cc
+++ b/src/Settings/AutoConnectSettings.cc
@@ -21,6 +21,8 @@ const char* AutoConnectSettings:: autoConnectSiKRadioSettingsName =     "Autocon
 const char* AutoConnectSettings:: autoConnectPX4FlowSettingsName =      "AutoconnectPX4Flow";
 const char* AutoConnectSettings:: autoConnectRTKGPSSettingsName =       "AutoconnectRTKGPS";
 const char* AutoConnectSettings:: autoConnectLibrePilotSettingsName =   "AutoconnectLibrePilot";
+const char* AutoConnectSettings:: autoConnectNmeaPortName =             "AutoconnectNmeaPort";
+const char* AutoConnectSettings:: autoConnectNmeaBaudName =             "AutoconnectNmeaBaud";
 const char* AutoConnectSettings:: udpListenPortName =                   "AutoconnectUDPListenPort";
 const char* AutoConnectSettings:: udpTargetHostIPName =                 "AutoconnectUDPTargetHostIP";
 const char* AutoConnectSettings:: udpTargetHostPortName =               "AutoconnectUDPTargetHostPort";
@@ -35,6 +37,8 @@ AutoConnectSettings::AutoConnectSettings(QObject* parent)
     , _autoConnectPX4FlowFact   (NULL)
     , _autoConnectRTKGPSFact    (NULL)
     , _autoConnectLibrePilotFact(NULL)
+    , _autoConnectNmeaPortFact  (NULL)
+    , _autoConnectNmeaBaudFact  (NULL)
     , _udpListenPortFact        (NULL)
     , _udpTargetHostIPFact      (NULL)
     , _udpTargetHostPortFact    (NULL)
@@ -95,6 +99,24 @@ Fact* AutoConnectSettings::autoConnectLibrePilot(void)
     }
 
     return _autoConnectLibrePilotFact;
+}
+
+Fact* AutoConnectSettings::autoConnectNmeaPort(void)
+{
+    if (!_autoConnectNmeaPortFact) {
+        _autoConnectNmeaPortFact = _createSettingsFact(autoConnectNmeaPortName);
+    }
+
+    return _autoConnectNmeaPortFact;
+}
+
+Fact* AutoConnectSettings::autoConnectNmeaBaud(void)
+{
+    if (!_autoConnectNmeaBaudFact) {
+        _autoConnectNmeaBaudFact = _createSettingsFact(autoConnectNmeaBaudName);
+    }
+
+    return _autoConnectNmeaBaudFact;
 }
 
 Fact* AutoConnectSettings::udpListenPort(void)

--- a/src/Settings/AutoConnectSettings.h
+++ b/src/Settings/AutoConnectSettings.h
@@ -25,6 +25,8 @@ public:
     Q_PROPERTY(Fact* autoConnectPX4Flow     READ autoConnectPX4Flow     CONSTANT)
     Q_PROPERTY(Fact* autoConnectRTKGPS      READ autoConnectRTKGPS      CONSTANT)
     Q_PROPERTY(Fact* autoConnectLibrePilot  READ autoConnectLibrePilot  CONSTANT)
+    Q_PROPERTY(Fact* autoConnectNmeaPort    READ autoConnectNmeaPort    CONSTANT)
+    Q_PROPERTY(Fact* autoConnectNmeaBaud    READ autoConnectNmeaBaud    CONSTANT)
     Q_PROPERTY(Fact* udpListenPort          READ udpListenPort          CONSTANT)   ///< Port to listen on for UDP autoconnect
     Q_PROPERTY(Fact* udpTargetHostIP        READ udpTargetHostIP        CONSTANT)   ///< Target host IP for UDP autoconnect, empty string for none
     Q_PROPERTY(Fact* udpTargetHostPort      READ udpTargetHostPort      CONSTANT)   ///< Target host post for UDP autoconnect
@@ -35,6 +37,8 @@ public:
     Fact* autoConnectPX4Flow    (void);
     Fact* autoConnectRTKGPS     (void);
     Fact* autoConnectLibrePilot (void);
+    Fact* autoConnectNmeaPort   (void);
+    Fact* autoConnectNmeaBaud   (void);
     Fact* udpListenPort         (void);
     Fact* udpTargetHostIP       (void);
     Fact* udpTargetHostPort     (void);
@@ -47,6 +51,8 @@ public:
     static const char* autoConnectPX4FlowSettingsName;
     static const char* autoConnectRTKGPSSettingsName;
     static const char* autoConnectLibrePilotSettingsName;
+    static const char* autoConnectNmeaPortName;
+    static const char* autoConnectNmeaBaudName;
     static const char* udpListenPortName;
     static const char* udpTargetHostIPName;
     static const char* udpTargetHostPortName;
@@ -58,6 +64,8 @@ private:
     SettingsFact* _autoConnectPX4FlowFact;
     SettingsFact* _autoConnectRTKGPSFact;
     SettingsFact* _autoConnectLibrePilotFact;
+    SettingsFact* _autoConnectNmeaPortFact;
+    SettingsFact* _autoConnectNmeaBaudFact;
     SettingsFact* _udpListenPortFact;
     SettingsFact* _udpTargetHostIPFact;
     SettingsFact* _udpTargetHostPortFact;

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -233,6 +233,11 @@ private:
     static const char*  _defaultUPDLinkName;
     static const int    _autoconnectUpdateTimerMSecs;
     static const int    _autoconnectConnectDelayMSecs;
+
+    // NMEA GPS device for GCS position
+    QString      _nmeaDeviceName;
+    QSerialPort* _nmeaPort;
+    uint32_t     _nmeaBaud;
 };
 
 #endif

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -464,7 +464,7 @@ QGCView {
 
                     Column {
                         id:         autoConnectCol
-                        spacing:    ScreenTools.defaultFontPixelWidth
+                        spacing:    ScreenTools.defaultFontPixelWidth * 2
                         anchors.centerIn: parent
 
                         Row {
@@ -486,6 +486,61 @@ QGCView {
                                     text:       autoConnectRepeater.names[index]
                                     fact:       modelData
                                     visible:    !ScreenTools.isiOS && modelData.visible
+                                }
+                            }
+                        }
+
+                        Row {
+                            width:    parent.width
+                            spacing:  ScreenTools.defaultFontPixelWidth
+                            visible:  !ScreenTools.isiOS
+                                      && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.visible
+                                      && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.visible
+
+                            QGCLabel {
+                                anchors.baseline: nmeaPortCombo.baseline
+                                text: qsTr("NMEA GPS Device:")
+                            }
+
+                            QGCComboBox {
+                                id:     nmeaPortCombo
+                                width:  parent.width/3
+                                model:  ListModel {
+                                            ListElement { text: "disabled" }
+                                        }
+
+                                onActivated: {
+                                    if (index != -1) {
+                                        QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.value = textAt(index);
+                                    }
+                                }
+                                Component.onCompleted: {
+                                    for (var i in QGroundControl.linkManager.serialPorts) {
+                                        nmeaPortCombo.model.append({text:QGroundControl.linkManager.serialPorts[i]})
+                                    }
+                                    var index = nmeaPortCombo.find(QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.valueString);
+                                    nmeaPortCombo.currentIndex = index;
+                                }
+                            }
+
+                            QGCLabel {
+                                anchors.baseline: nmeaBaudCombo.baseline
+                                text: qsTr("NMEA GPS Baudrate:")
+                            }
+
+                            QGCComboBox {
+                                id:     nmeaBaudCombo
+                                width:  parent.width/3
+                                model:  [4800, 9600, 19200, 38400, 57600, 115200]
+
+                                onActivated: {
+                                    if (index != -1) {
+                                        QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.value = textAt(index);
+                                    }
+                                }
+                                Component.onCompleted: {
+                                    var index = nmeaBaudCombo.find(QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.valueString);
+                                    nmeaBaudCombo.currentIndex = index;
                                 }
                             }
                         }


### PR DESCRIPTION
This will allow the use of USB/Serial GPS for computers or mobile devices without built in positioning. The user must specify the serial port and baudrate for reading data.

![screenshot 2018-01-02 18 43 47](https://user-images.githubusercontent.com/8315108/34504689-194bca22-efee-11e7-8a1b-52a4330b7dae.png)


