### PR TITLE
AndroidManifest.xml update to enable ChromeOS support

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -59,6 +59,7 @@
 
     <!-- Support devices without USB host mode since there are other connection types -->
     <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
+    <uses-feature android:name="android.hardware.location.GPS" android:required="false" />
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->
     <!-- %%INSERT_FEATURES -->


### PR DESCRIPTION
I'm not sure if this is the right way to do this, but apparently the only reason QGC isn't already available to Chromebook's (with the Play store) is the location.GPS requirement.

![image](https://user-images.githubusercontent.com/84712/34588043-ecf997b0-f178-11e7-8623-4ae0723ba306.png)

https://github.com/mavlink/qgroundcontrol/issues/5967