### PR TITLE
ParameterManager/FactSystem: Fix force save usage pattern

### DIFF
--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -125,8 +125,8 @@ void AirframeComponentController::_rebootAfterStackUnwind(void)
         QGC::SLEEP::usleep(500);
         qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
     }
-    qgcApp()->toolbox()->linkManager()->disconnectAll();
     qgcApp()->restoreOverrideCursor();
+    qgcApp()->toolbox()->linkManager()->disconnectAll();
 }
 
 AirframeType::AirframeType(const QString& name, const QString& imageResource, QObject* parent) :

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -161,9 +161,11 @@ void Fact::_containerSetRawValue(const QVariant& value)
     if(_rawValue != value) {
         _rawValue = value;
         _sendValueChangedSignal(cookedValue());
-        emit vehicleUpdated(_rawValue);
         emit rawValueChanged(_rawValue);
     }
+
+    // This always need to be signalled in order to support forceSetRawValue usage and waiting for vehicleUpdated signal
+    emit vehicleUpdated(_rawValue);
 }
 
 QString Fact::name(void) const


### PR DESCRIPTION
* Fact::forceSetRawValue was broken by change in Fact system signalling.
* Airframe Config wait cursor would get stuck due the vehicle disconnecting before the code to restore wait cursor was called.

Fix for #5986