### PR TITLE
Fixed crash in FactMetadata constructor.

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -32,8 +32,8 @@ const qreal FactMetaData::UnitConsts_s::milesToMeters =         1609.344;
 const qreal FactMetaData::UnitConsts_s::feetToMeters =          0.3048;
 const qreal FactMetaData::UnitConsts_s::inchesToCentimeters =   2.54;
 
-const QString FactMetaData::defaultCategory =   tr("Other");
-const QString FactMetaData::defaultGroup =      tr("Misc");
+static const char* kDefaultCategory = QT_TRANSLATE_NOOP("FactMetaData", "Other");
+static const char* kDefaultGroup    = QT_TRANSLATE_NOOP("FactMetaData", "Misc");
 
 // Built in translations for all Facts
 const FactMetaData::BuiltInTranslation_s FactMetaData::_rgBuiltInTranslations[] = {
@@ -84,8 +84,6 @@ FactMetaData::FactMetaData(QObject* parent)
     , _decimalPlaces        (unknownDecimalPlaces)
     , _rawDefaultValue      (0)
     , _defaultValueAvailable(false)
-    , _category             (defaultCategory)
-    , _group                (defaultGroup)
     , _rawMax               (_maxForType())
     , _maxIsDefaultForType  (true)
     , _rawMin               (_minForType())
@@ -97,7 +95,8 @@ FactMetaData::FactMetaData(QObject* parent)
     , _hasControl           (true)
     , _readOnly             (false)
 {
-
+    _category   = kDefaultCategory;
+    _group      = kDefaultGroup;
 }
 
 FactMetaData::FactMetaData(ValueType_t type, QObject* parent)
@@ -106,8 +105,6 @@ FactMetaData::FactMetaData(ValueType_t type, QObject* parent)
     , _decimalPlaces        (unknownDecimalPlaces)
     , _rawDefaultValue      (0)
     , _defaultValueAvailable(false)
-    , _category             (defaultCategory)
-    , _group                (defaultGroup)
     , _rawMax               (_maxForType())
     , _maxIsDefaultForType  (true)
     , _rawMin               (_minForType())
@@ -119,7 +116,8 @@ FactMetaData::FactMetaData(ValueType_t type, QObject* parent)
     , _hasControl           (true)
     , _readOnly             (false)
 {
-
+    _category   = kDefaultCategory;
+    _group      = kDefaultGroup;
 }
 
 FactMetaData::FactMetaData(const FactMetaData& other, QObject* parent)
@@ -134,8 +132,6 @@ FactMetaData::FactMetaData(ValueType_t type, const QString name, QObject* parent
     , _decimalPlaces        (unknownDecimalPlaces)
     , _rawDefaultValue      (0)
     , _defaultValueAvailable(false)
-    , _category             (defaultCategory)
-    , _group                (defaultGroup)
     , _rawMax               (_maxForType())
     , _maxIsDefaultForType  (true)
     , _rawMin               (_minForType())
@@ -148,7 +144,8 @@ FactMetaData::FactMetaData(ValueType_t type, const QString name, QObject* parent
     , _hasControl           (true)
     , _readOnly             (false)
 {
-
+    _category   = kDefaultCategory;
+    _group      = kDefaultGroup;
 }
 
 const FactMetaData& FactMetaData::operator=(const FactMetaData& other)
@@ -179,6 +176,16 @@ const FactMetaData& FactMetaData::operator=(const FactMetaData& other)
     _hasControl             = other._hasControl;
     _readOnly               = other._readOnly;
     return *this;
+}
+
+const QString FactMetaData::defaultCategory()
+{
+    return QString(kDefaultCategory);
+}
+
+const QString FactMetaData::defaultGroup()
+{
+    return QString(kDefaultGroup);
 }
 
 QVariant FactMetaData::rawDefaultValue(void) const
@@ -253,7 +260,7 @@ QVariant FactMetaData::_minForType(void) const
     case valueTypeCustom:
         return QVariant();
     }
-    
+
     // Make windows compiler happy, even switch is full cased
     return QVariant();
 }
@@ -285,7 +292,7 @@ QVariant FactMetaData::_maxForType(void) const
     case valueTypeCustom:
         return QVariant();
     }
-    
+
     // Make windows compiler happy, even switch is full cased
     return QVariant();
 }
@@ -293,9 +300,9 @@ QVariant FactMetaData::_maxForType(void) const
 bool FactMetaData::convertAndValidateRaw(const QVariant& rawValue, bool convertOnly, QVariant& typedValue, QString& errorString)
 {
     bool convertOk = false;
-    
+
     errorString.clear();
-    
+
     switch (type()) {
     case FactMetaData::valueTypeInt8:
     case FactMetaData::valueTypeInt16:
@@ -347,11 +354,11 @@ bool FactMetaData::convertAndValidateRaw(const QVariant& rawValue, bool convertO
         typedValue = QVariant(rawValue.toByteArray());
         break;
     }
-    
+
     if (!convertOk) {
         errorString += tr("Invalid number");
     }
-    
+
     return convertOk && errorString.isEmpty();
 }
 

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -27,7 +27,7 @@
 class FactMetaData : public QObject
 {
     Q_OBJECT
-    
+
 public:
     typedef enum {
         valueTypeUint8,
@@ -45,7 +45,7 @@ public:
     } ValueType_t;
 
     typedef QVariant (*Translator)(const QVariant& from);
-    
+
     FactMetaData(QObject* parent = NULL);
     FactMetaData(ValueType_t type, QObject* parent = NULL);
     FactMetaData(ValueType_t type, const QString name, QObject* parent = NULL);
@@ -75,6 +75,9 @@ public:
 
     /// Returns the string for distance units which has configued by user
     static QString appSettingsAreaUnitsString(void);
+
+    static const QString defaultCategory    ();
+    static const QString defaultGroup       ();
 
     int             decimalPlaces           (void) const;
     QVariant        rawDefaultValue         (void) const;
@@ -159,9 +162,6 @@ public:
 
     static ValueType_t stringToType(const QString& typeString, bool& unknownType);
     static size_t typeToSize(ValueType_t type);
-
-    static const QString defaultCategory;
-    static const QString defaultGroup;
 
 private:
     QVariant _minForType(void) const;

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.cc
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.cc
@@ -306,7 +306,7 @@ void APMParameterMetaData::correctGroupMemberships(ParameterNametoFactMetaDataMa
     foreach(const QString& groupName, groupMembers.keys()) {
             if (groupMembers[groupName].count() == 1) {
                 foreach(const QString& parameter, groupMembers.value(groupName)) {
-                    parameterToFactMetaDataMap[parameter]->group = FactMetaData::defaultGroup;
+                    parameterToFactMetaDataMap[parameter]->group = FactMetaData::defaultGroup();
                 }
             }
         }


### PR DESCRIPTION
It did not like the use of the tr() macro within a static QString in the constructor.

The fix may be overkill but I didn't have the time to try different things (it takes forever to get a Windows build running for me)

Fixes #5996 