### PR TITLE
Add support for volatile Facts/Parameters

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -662,3 +662,13 @@ bool Fact::readOnly(void) const
         return false;
     }
 }
+
+bool Fact::volatileValue(void) const
+{
+    if (_metaData) {
+        return _metaData->volatileValue();
+    } else {
+        qWarning() << kMissingMetadata << name();
+        return false;
+    }
+}

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -71,6 +71,7 @@ public:
     Q_PROPERTY(bool         typeIsBool              READ typeIsBool                                         CONSTANT)
     Q_PROPERTY(bool         hasControl              READ hasControl                                         CONSTANT)
     Q_PROPERTY(bool         readOnly                READ readOnly                                           CONSTANT)
+    Q_PROPERTY(bool         volatileValue           READ volatileValue                                      CONSTANT)
 
     /// Convert and validate value
     ///     @param convertOnly true: validate type conversion only, false: validate against meta data as well
@@ -118,6 +119,7 @@ public:
     bool            typeIsBool              (void) const { return type() == FactMetaData::valueTypeBool; }
     bool            hasControl              (void) const;
     bool            readOnly                (void) const;
+    bool            volatileValue            (void) const;
 
     /// Returns the values as a string with full 18 digit precision if float/double.
     QString rawValueStringFullPrecision(void) const;

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -96,6 +96,7 @@ FactMetaData::FactMetaData(QObject* parent)
     , _increment            (std::numeric_limits<double>::quiet_NaN())
     , _hasControl           (true)
     , _readOnly             (false)
+    , _volatile             (false)
 {
 
 }
@@ -118,6 +119,7 @@ FactMetaData::FactMetaData(ValueType_t type, QObject* parent)
     , _increment            (std::numeric_limits<double>::quiet_NaN())
     , _hasControl           (true)
     , _readOnly             (false)
+    , _volatile             (false)
 {
 
 }
@@ -147,6 +149,7 @@ FactMetaData::FactMetaData(ValueType_t type, const QString name, QObject* parent
     , _increment            (std::numeric_limits<double>::quiet_NaN())
     , _hasControl           (true)
     , _readOnly             (false)
+    , _volatile             (false)
 {
 
 }
@@ -178,6 +181,7 @@ const FactMetaData& FactMetaData::operator=(const FactMetaData& other)
     _increment              = other._increment;
     _hasControl             = other._hasControl;
     _readOnly               = other._readOnly;
+    _volatile               = other._volatile;
     return *this;
 }
 
@@ -1126,5 +1130,13 @@ QVariant FactMetaData::cookedMin(void) const
         return cookedMax;
     } else {
         return cookedMin;
+    }
+}
+
+void FactMetaData::setVolatileValue(bool bValue)
+{
+    _volatile = bValue;
+    if (_volatile) {
+        _readOnly = true;
     }
 }

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -101,6 +101,7 @@ public:
     bool            rebootRequired          (void) const { return _rebootRequired; }
     bool            hasControl              (void) const { return _hasControl; }
     bool            readOnly                (void) const { return _readOnly; }
+    bool            volatileValue           (void) const { return _volatile; }
 
     /// Amount to increment value when used in controls such as spin button or slider with detents.
     /// NaN for no increment available.
@@ -131,6 +132,7 @@ public:
     void setIncrement       (double increment)                  { _increment = increment; }
     void setHasControl      (bool bValue)                       { _hasControl = bValue; }
     void setReadOnly        (bool bValue)                       { _readOnly = bValue; }
+    void setVolatileValue   (bool bValue);
 
     void setTranslators(Translator rawTranslator, Translator cookedTranslator);
 
@@ -239,6 +241,7 @@ private:
     double          _increment;
     bool            _hasControl;
     bool            _readOnly;
+    bool            _volatile;
 
     // Exact conversion constants
     static const struct UnitConsts_s {

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -142,6 +142,8 @@ private:
     void _writeParameterRaw(int componentId, const QString& paramName, const QVariant& value);
     void _writeLocalParamCache(int vehicleId, int componentId);
     void _tryCacheHashLoad(int vehicleId, int componentId, QVariant hash_value);
+    void _loadMetaData(void);
+    void _clearMetaData(void);
     void _addMetaDataToDefaultComponent(void);
     QString _remapParamNameToVersion(const QString& paramName);
     void _loadOfflineEditingParams(void);
@@ -158,8 +160,6 @@ private:
     /// Second mapping is parameter name, to Fact* in QVariant
     QMap<int, QVariantMap>            _mapParameterName2Variant;
 
-    QMap<int, QMap<int, QString> >    _mapParameterId2Name;
-
     // Category map of default component parameters
     QMap<QString /* category */, QMap<QString /* group */, QStringList /* parameter names */> > _categoryMap;
     
@@ -169,6 +169,7 @@ private:
     bool        _initialLoadComplete;           ///< true: Initial load of all parameters complete, whether successful or not
     bool        _waitingForDefaultComponent;    ///< true: last chance wait for default component params
     bool        _saveRequired;                  ///< true: _saveToEEPROM should be called
+    bool        _metaDataAddedToFacts;          ///< true: FactMetaData has been adde to the default component facts
     bool        _logReplay;                     ///< true: running with log replay link
     QString     _versionParam;                  ///< Parameter which contains parameter set version
     int         _parameterSetMajorVersion;      ///< Version for parameter set, -1 if not known

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -218,6 +218,11 @@ public:
     ///         call deleteParameterMetaData when no longer needed.
     virtual QObject* loadParameterMetaData(const QString& metaDataFile) { Q_UNUSED(metaDataFile); return NULL; }
 
+    /// Returns the FactMetaData associated with the parameter name
+    ///     @param opaqueParameterMetaData Opaque pointer returned from loadParameterMetaData
+    ///     @param name Parameter name
+    virtual FactMetaData* getMetaDataForFact(QObject* parameterMetaData, const QString& name, MAV_TYPE vehicleType) { Q_UNUSED(parameterMetaData); Q_UNUSED(name); Q_UNUSED(vehicleType); return NULL; }
+
     /// Adds the parameter meta data to the Fact
     ///     @param opaqueParameterMetaData Opaque pointer returned from loadParameterMetaData
     virtual void addMetaDataToFact(QObject* parameterMetaData, Fact* fact, MAV_TYPE vehicleType) { Q_UNUSED(parameterMetaData); Q_UNUSED(fact); Q_UNUSED(vehicleType); return; }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -247,6 +247,19 @@ bool PX4FirmwarePlugin::sendHomePositionToVehicle(void)
     return false;
 }
 
+FactMetaData* PX4FirmwarePlugin::getMetaDataForFact(QObject* parameterMetaData, const QString& name, MAV_TYPE vehicleType)
+{
+    PX4ParameterMetaData* px4MetaData = qobject_cast<PX4ParameterMetaData*>(parameterMetaData);
+
+    if (px4MetaData) {
+        return px4MetaData->getMetaDataForFact(name, vehicleType);
+    } else {
+        qWarning() << "Internal error: pointer passed to PX4FirmwarePlugin::getMetaDataForFact not PX4ParameterMetaData";
+    }
+
+    return NULL;
+}
+
 void PX4FirmwarePlugin::addMetaDataToFact(QObject* parameterMetaData, Fact* fact, MAV_TYPE vehicleType)
 {
     PX4ParameterMetaData* px4MetaData = qobject_cast<PX4ParameterMetaData*>(parameterMetaData);
@@ -256,6 +269,11 @@ void PX4FirmwarePlugin::addMetaDataToFact(QObject* parameterMetaData, Fact* fact
     } else {
         qWarning() << "Internal error: pointer passed to PX4FirmwarePlugin::addMetaDataToFact not PX4ParameterMetaData";
     }
+}
+
+void PX4FirmwarePlugin::getParameterMetaDataVersionInfo(const QString& metaDataFile, int& majorVersion, int& minorVersion)
+{
+    return PX4ParameterMetaData::getParameterMetaDataVersionInfo(metaDataFile, majorVersion, minorVersion);
 }
 
 QList<MAV_CMD> PX4FirmwarePlugin::supportedMissionCommands(void)
@@ -571,5 +589,3 @@ QGCCameraControl* PX4FirmwarePlugin::createCameraControl(const mavlink_camera_in
 {
     return new QGCCameraControl(info, vehicle, compID, parent);
 }
-
-

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -56,10 +56,11 @@ public:
     void                initializeVehicle               (Vehicle* vehicle) override;
     bool                sendHomePositionToVehicle       (void) override;
     void                addMetaDataToFact               (QObject* parameterMetaData, Fact* fact, MAV_TYPE vehicleType) override;
+    FactMetaData*       getMetaDataForFact              (QObject* parameterMetaData, const QString& name, MAV_TYPE vehicleType) override;
     QString             missionCommandOverrides         (MAV_TYPE vehicleType) const override;
     QString             getVersionParam                 (void) override { return QString("SYS_PARAM_VER"); }
     QString             internalParameterMetaDataFile   (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QString(":/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml"); }
-    void                getParameterMetaDataVersionInfo (const QString& metaDataFile, int& majorVersion, int& minorVersion) override { PX4ParameterMetaData::getParameterMetaDataVersionInfo(metaDataFile, majorVersion, minorVersion); }
+    void                getParameterMetaDataVersionInfo (const QString& metaDataFile, int& majorVersion, int& minorVersion) override;
     QObject*            loadParameterMetaData           (const QString& metaDataFile) final;
     bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) override;
     QString             offlineEditingParamFile(Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral(":/FirmwarePlugin/PX4/PX4.OfflineEditing.params"); }

--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
@@ -186,6 +186,20 @@ void PX4ParameterMetaData::loadParameterFactMetaDataFile(const QString& metaData
                     category = QStringLiteral("Standard");
                 }
 
+                bool volatileValue = false;
+                bool readOnly = false;
+                QString volatileStr = xml.attributes().value("volatile").toString();
+                if (volatileStr.compare(QStringLiteral("true")) == 0) {
+                    volatileValue = true;
+                    readOnly = true;
+                }
+                if (!volatileValue) {
+                    QString readOnlyStr = xml.attributes().value("readonly").toString();
+                    if (readOnlyStr.compare(QStringLiteral("true")) == 0) {
+                        readOnly = true;
+                    }
+                }
+
                 qCDebug(PX4ParameterMetaDataLog) << "Found parameter name:" << name << " type:" << type << " default:" << strDefault;
 
                 // Convert type from string to FactMetaData::ValueType_t
@@ -211,6 +225,8 @@ void PX4ParameterMetaData::loadParameterFactMetaDataFile(const QString& metaData
                     metaData->setName(name);
                     metaData->setCategory(category);
                     metaData->setGroup(factGroup);
+                    metaData->setReadOnly(readOnly);
+                    metaData->setVolatileValue(volatileValue);
                     
                     if (xml.attributes().hasAttribute("default") && !strDefault.isEmpty()) {
                         QVariant varDefault;
@@ -384,6 +400,17 @@ void PX4ParameterMetaData::loadParameterFactMetaDataFile(const QString& metaData
             }
         }
         xml.readNext();
+    }
+}
+
+FactMetaData* PX4ParameterMetaData::getMetaDataForFact(const QString& name, MAV_TYPE vehicleType)
+{
+    Q_UNUSED(vehicleType)
+
+    if (_mapParameterName2FactMetaData.contains(name)) {
+        return _mapParameterName2FactMetaData[name];
+    } else {
+        return NULL;
     }
 }
 

--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.h
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.h
@@ -33,8 +33,9 @@ class PX4ParameterMetaData : public QObject
 public:
     PX4ParameterMetaData(void);
 
-    void loadParameterFactMetaDataFile  (const QString& metaDataFile);
-    void addMetaDataToFact              (Fact* fact, MAV_TYPE vehicleType);
+    void            loadParameterFactMetaDataFile   (const QString& metaDataFile);
+    FactMetaData*   getMetaDataForFact              (const QString& name, MAV_TYPE vehicleType);
+    void            addMetaDataToFact               (Fact* fact, MAV_TYPE vehicleType);
 
     static void getParameterMetaDataVersionInfo(const QString& metaDataFile, int& majorVersion, int& minorVersion);
 


### PR DESCRIPTION
This allows for Parameters to be volatile which are not part of the calculated parameter set crc for cache hits.