### PR TITLE
Fix double-close bug on OSX

### DIFF
--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -395,7 +395,7 @@ void MainWindow::showStatusBarCallback(bool checked)
     checked ? statusBar()->show() : statusBar()->hide();
 }
 
-void MainWindow::reallyClose(void)
+void MainWindow::_reallyClose(void)
 {
     _forceClose = true;
     close();
@@ -458,6 +458,7 @@ void MainWindow::connectCommonActions()
 {
     // Connect internal actions
     connect(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::vehicleAdded, this, &MainWindow::_vehicleAdded);
+    connect(this, &MainWindow::reallyClose, this, &MainWindow::_reallyClose, Qt::QueuedConnection); // Queued to allow closeEvent to fully unwind before _reallyClose is called
 }
 
 void MainWindow::_openUrl(const QString& url, const QString& errorMessage)

--- a/src/ui/MainWindow.h
+++ b/src/ui/MainWindow.h
@@ -80,7 +80,7 @@ public:
     void saveLastUsedConnection(const QString connection);
 
     // Called from MainWindow.qml when the user accepts the window close dialog
-    Q_INVOKABLE void reallyClose(void);
+    void _reallyClose(void);
 
     /// @return Root qml object of main window QML
     QObject* rootQmlObject(void);
@@ -104,6 +104,7 @@ signals:
     void initStatusChanged(const QString& message, int alignment, const QColor &color);
     /** Emitted when any value changes from any source */
     void valueChanged(const int uasId, const QString& name, const QString& unit, const QVariant& value, const quint64 msec);
+    void reallyClose(void);
 
     // Used for unit tests to know when the main window closes
     void mainWindowClosed(void);


### PR DESCRIPTION
Fix for #5926. Something in Qt 5.9.3 plus maybe Mac OS version changes caused close events to be processed differerntly.