### PR TITLE
Update to new mavlink ROI commands

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -290,7 +290,7 @@ QList<MAV_CMD> PX4FirmwarePlugin::supportedMissionCommands(void)
          << MAV_CMD_DO_SET_SERVO
          << MAV_CMD_DO_CHANGE_SPEED
          << MAV_CMD_DO_LAND_START
-         << MAV_CMD_DO_SET_ROI
+         << MAV_CMD_DO_SET_ROI_LOCATION << MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET << MAV_CMD_DO_SET_ROI_NONE
          << MAV_CMD_DO_MOUNT_CONFIGURE
          << MAV_CMD_DO_MOUNT_CONTROL
          << MAV_CMD_SET_CAMERA_MODE

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -624,6 +624,52 @@
                 "default":          0
             }
         },
+        {
+            "id":                   195,
+            "rawName":              "MAV_CMD_DO_SET_ROI_LOCATION",
+            "friendlyName":         "Region of interest (ROI)" ,
+            "description":          "Sets the region of interest for cameras.",
+            "specifiesCoordinate":  true,
+            "standaloneCoordinate": true,
+            "friendlyEdit":         true,
+            "category":             "Camera"
+        },
+        {
+            "id":                   196,
+            "rawName":              "MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET",
+            "friendlyName":         "ROI to next waypoint" ,
+            "description":          "Sets the region of interest to point towards the next waypoint with optional offsets.",
+            "specifiesCoordinate":  false,
+            "friendlyEdit":         true,
+            "category":             "Camera",
+            "param5": {
+                "label":            "Pitch offset",
+                "default":          0,
+                "units":            "deg",
+                "decimalPlaces":    0
+            },
+            "param6": {
+                "label":            "Roll offset",
+                "default":          0,
+                "units":            "deg",
+                "decimalPlaces":    0
+            },
+            "param7": {
+                "label":            "Yaw offset",
+                "default":          0,
+                "units":            "deg",
+                "decimalPlaces":    0
+            }
+        },
+        {
+            "id":                   197,
+            "rawName":              "MAV_CMD_DO_SET_ROI_NONE",
+            "friendlyName":         "Cancel ROI" ,
+            "description":          "Cancels the region of interest.",
+            "specifiesCoordinate":  false,
+            "friendlyEdit":         true,
+            "category":             "Camera"
+        },
         { "id": 200, "rawName": "MAV_CMD_DO_CONTROL_VIDEO", "friendlyName": "Control video" },
         {
             "id":                   201,

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -914,12 +914,8 @@ void MockLink::_respondWithAutopilotVersion(void)
                                             (uint8_t *)&customVersion,       // os_custom_version,
                                             0,                               // vendor_id,
                                             0,                               // product_id,
-                                            0                                // uid
-#if defined(NO_ARDUPILOT_DIALECT)
-                                            //-- Once the MAVLink module is updated, this should show up. In the mean time, it's disabled.
-                                            ,0                               // uid2
-#endif
-                                            );
+                                            0,                               // uid
+                                            0);                              // uid2
     respondWithMavlinkMessage(msg);
 }
 


### PR DESCRIPTION
* Switch PX4 to use them
* ArduPilot still uses old ROI command
* These will not work until PX4 firmware side completes implementation
* I did not cut over Structure Scan to use ROI_WPNEXT_OFFSET yet. I will do that once firmware side ROI is fully implemented and tested to work correctly.