### PR TITLE
Fly view: Gimbal angles show on wrong items

### DIFF
--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -227,7 +227,7 @@ private:
     bool _loadJsonMissionFileV2(const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString);
     bool _loadTextMissionFile(QTextStream& stream, QmlObjectListModel* visualItems, QString& errorString);
     int _nextSequenceNumber(void);
-    static void _scanForAdditionalSettings(QmlObjectListModel* visualItems, Vehicle* vehicle);
+    void _scanForAdditionalSettings(QmlObjectListModel* visualItems, Vehicle* vehicle);
     static bool _convertToMissionItems(QmlObjectListModel* visualMissionItems, QList<MissionItem*>& rgMissionItems, QObject* missionItemParent);
     void _setPlannedHomePositionFromFirstCoordinate(void);
     void _resetMissionFlightStatus(void);


### PR DESCRIPTION
Fly view now slurps up additional sections like CameraSection. Without that the gimbal angle changes come after the waypoint item they related to. Which then shows incorrectly on the view.

With this change, gimbal angles show correctly. Consequence is that slurped in mission items not longer show in fly view. Which I think is sort of a good thing.
