### PR TITLE
Add gstreamer debug log option, and dot file output

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -311,8 +311,20 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     }
 #endif
 
+    // gstreamer debug settings
+    QString savePath, gstDebugLevel;
+    if (settings.contains(AppSettings::savePathName)) {
+         savePath = settings.value("SavePath").toString() + "/Logs/gst"; // hardcode log path here, appsetting is not available yet
+         if (!QDir(savePath).exists()) {
+             QDir().mkdir(savePath);
+         }
+    }
+    if (settings.contains(AppSettings::gstDebugName)) {
+        gstDebugLevel = "*:" + settings.value("GstreamerDebugLevel").toString();
+    }
+
     // Initialize Video Streaming
-    initializeVideoStreaming(argc, argv);
+    initializeVideoStreaming(argc, argv, savePath.toUtf8().data(), gstDebugLevel.toUtf8().data());
 
     _toolbox = new QGCToolbox(this);
     _toolbox->setChildToolboxes();

--- a/src/QmlControls/AppMessages.qml
+++ b/src/QmlControls/AppMessages.qml
@@ -15,6 +15,8 @@ import QtQuick.Dialogs          1.2
 import QGroundControl               1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
 import QGroundControl.Controllers   1.0
 import QGroundControl.ScreenTools   1.0
 
@@ -138,6 +140,24 @@ QGCView {
                 anchors.left:    parent.left
                 onClicked:       writeDialog.openForSave()
                 text:            qsTr("Save App Log")
+            }
+
+            QGCLabel {
+                id:                  gstLabel
+                anchors.baseline:    gstCombo.baseline
+                anchors.right:       gstCombo.left
+                anchors.rightMargin: ScreenTools.defaultFontPixelWidth
+                text:                "gstreamer debug level:"
+            }
+
+            FactComboBox {
+                id:                  gstCombo
+                anchors.right:       followTail.left
+                anchors.rightMargin: ScreenTools.defaultFontPixelWidth*20
+                anchors.bottom:      parent.bottom
+                width:               ScreenTools.defaultFontPixelWidth*20
+                model:               ["disabled", "1", "2", "3", "4", "5", "6", "7", "8"]
+                fact:                QGroundControl.settingsManager.appSettings.gstDebug
             }
 
             BusyIndicator {

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -104,6 +104,13 @@
     "defaultValue":     false
 },
 {
+    "name":             "GstreamerDebugLevel",
+    "shortDescription": "Video streaming debug",
+    "longDescription":  "Sets the environment variable GST_DEBUG for all pipeline elements on boot.",
+    "type":             "uint8",
+    "defaultValue":     0
+},
+{
     "name":             "AutoLoadMissions",
     "shortDescription": "AutoLoad mission on vehicle connect",
     "longDescription":  "Automatically load a mission file named AutoLoad#.mission when a vehicle with id # connects.",

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -36,6 +36,7 @@ const char* AppSettings::autoLoadMissionsName =                         "AutoLoa
 const char* AppSettings::mapboxTokenName =                              "MapboxToken";
 const char* AppSettings::esriTokenName =                                "EsriToken";
 const char* AppSettings::defaultFirmwareTypeName =                      "DefaultFirmwareType";
+const char* AppSettings::gstDebugName =                                 "GstreamerDebugLevel";
 
 const char* AppSettings::parameterFileExtension =   "params";
 const char* AppSettings::planFileExtension =        "plan";
@@ -75,6 +76,7 @@ AppSettings::AppSettings(QObject* parent)
     , _mapboxTokenFact(NULL)
     , _esriTokenFact(NULL)
     , _defaultFirmwareTypeFact(NULL)
+    , _gstDebugFact(NULL)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<AppSettings>("QGroundControl.SettingsManager", 1, 0, "AppSettings", "Reference only");
@@ -230,6 +232,15 @@ Fact* AppSettings::virtualJoystick(void)
     }
 
     return _virtualJoystickFact;
+}
+
+Fact* AppSettings::gstDebug(void)
+{
+    if (!_gstDebugFact) {
+        _gstDebugFact = _createSettingsFact(gstDebugName);
+    }
+
+    return _gstDebugFact;
 }
 
 Fact* AppSettings::indoorPalette(void)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -40,6 +40,7 @@ public:
     Q_PROPERTY(Fact* mapboxToken                        READ mapboxToken                        CONSTANT)
     Q_PROPERTY(Fact* esriToken                          READ esriToken                          CONSTANT)
     Q_PROPERTY(Fact* defaultFirmwareType                READ defaultFirmwareType                CONSTANT)
+    Q_PROPERTY(Fact* gstDebug                           READ gstDebug                           CONSTANT)
 
     Q_PROPERTY(QString missionSavePath      READ missionSavePath    NOTIFY savePathsChanged)
     Q_PROPERTY(QString parameterSavePath    READ parameterSavePath  NOTIFY savePathsChanged)
@@ -75,6 +76,7 @@ public:
     Fact* mapboxToken                       (void);
     Fact* esriToken                         (void);
     Fact* defaultFirmwareType               (void);
+    Fact* gstDebug                          (void);
 
     QString missionSavePath     (void);
     QString parameterSavePath   (void);
@@ -107,6 +109,7 @@ public:
     static const char* mapboxTokenName;
     static const char* esriTokenName;
     static const char* defaultFirmwareTypeName;
+    static const char* gstDebugName;
 
     // Application wide file extensions
     static const char* parameterFileExtension;
@@ -154,6 +157,7 @@ private:
     SettingsFact* _mapboxTokenFact;
     SettingsFact* _esriTokenFact;
     SettingsFact* _defaultFirmwareTypeFact;
+    SettingsFact* _gstDebugFact;
 };
 
 #endif

--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -366,6 +366,7 @@ VideoReceiver::start()
             bus = NULL;
         }
 
+        GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-paused");
         running = gst_element_set_state(_pipeline, GST_STATE_PLAYING) != GST_STATE_CHANGE_FAILURE;
 
     } while(0);
@@ -419,6 +420,7 @@ VideoReceiver::start()
 
         _running = false;
     } else {
+        GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-playing");
         _running = true;
         qCDebug(VideoReceiverLog) << "Running";
     }
@@ -675,6 +677,8 @@ VideoReceiver::startRecording(const QString &videoFile)
     GstPad* sinkpad = gst_element_get_static_pad(_sink->queue, "sink");
     gst_pad_link(_sink->teepad, sinkpad);
     gst_object_unref(sinkpad);
+
+    GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-recording");
 
     _recording = true;
     emit recordingChanged();

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -101,7 +101,7 @@ int start_logger(const char *app_name)
 }
 #endif
 
-void initializeVideoStreaming(int &argc, char* argv[])
+void initializeVideoStreaming(int &argc, char* argv[], char* logpath, char* debuglevel)
 {
 #if defined(QGC_GST_STREAMING)
     #ifdef __macos__
@@ -119,12 +119,19 @@ void initializeVideoStreaming(int &argc, char* argv[])
         QString currentDir = QCoreApplication::applicationDirPath();
         qgcputenv("GST_PLUGIN_PATH", currentDir, "/gstreamer-plugins");
     #endif
+
+
         // Initialize GStreamer
-        #ifdef ANDDROID_GST_DEBUG
-        start_logger("gst_log");
-        qputenv("GST_DEBUG", "*:4");
-        qputenv("GST_DEBUG_NO_COLOR", "1");
-        #endif
+        if (logpath) {
+            if (debuglevel) {
+                qputenv("GST_DEBUG", debuglevel);
+            }
+            qputenv("GST_DEBUG_NO_COLOR", "1");
+            qputenv("GST_DEBUG_FILE", QString("%1/%2").arg(logpath).arg("gstreamer-log.txt").toUtf8());
+            qputenv("GST_DEBUG_DUMP_DOT_DIR", logpath);
+        }
+
+
         GError* error = NULL;
         if (!gst_init_check(&argc, &argv, &error)) {
             qCritical() << "gst_init_check() failed: " << error->message;

--- a/src/VideoStreaming/VideoStreaming.h
+++ b/src/VideoStreaming/VideoStreaming.h
@@ -17,7 +17,7 @@
 #ifndef VIDEO_STREAMING_H
 #define VIDEO_STREAMING_H
 
-extern void initializeVideoStreaming    (int &argc, char *argv[]);
+extern void initializeVideoStreaming    (int &argc, char *argv[], char* filename, char* debuglevel);
 extern void shutdownVideoStreaming      ();
 
 #endif // VIDEO_STREAMING_H


### PR DESCRIPTION
This adds a combobox to the 'Console' page next to the 'Set Logging' button, where the [gstreamer debug log leve](https://gstreamer.freedesktop.org/documentation/tutorials/basic/debugging-tools.html)l can be selected. When video is streaming, dot file will be output to show the pipeline graph structure regardless of debug level setting.

The files will go in to savePath setting/Logs/gst.