### PR TITLE
Handle settings when armed

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
@@ -22,7 +22,6 @@ import QGroundControl.ScreenTools   1.0
 SetupPage {
     id:                 safetyPage
     pageComponent:      safetyPageComponent
-    visibleWhileArmed:   true
 
     Component {
         id: safetyPageComponent

--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -21,8 +21,9 @@ import QGroundControl.Controllers   1.0
 
 /// Base view control for all Setup pages
 QGCView {
-    id:         setupView
-    viewPanel:  setupPanel
+    id:             setupView
+    viewPanel:      setupPanel
+    enabled:        !_shouldDisableWhenArmed
 
     property alias  pageComponent:      pageLoader.sourceComponent
     property string pageName:           vehicleComponent ? vehicleComponent.name : ""
@@ -30,52 +31,12 @@ QGCView {
     property real   availableWidth:     width - pageLoader.x
     property real   availableHeight:    height - pageLoader.y
 
-    property real _margins: ScreenTools.defaultFontPixelHeight / 2
+    property bool _vehicleArmed:         QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle.armed : false
+    property bool _shouldDisableWhenArmed: _vehicleArmed ? (vehicleComponent ? !vehicleComponent.allowSetupWhileArmed : false) : false
 
-    property bool visibleWhileArmed: false
-
-    property bool vehicleArmed: QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle.armed : false
-
-    onVehicleArmedChanged: {
-        if (visibleWhileArmed) {
-            return
-        }
-
-        if (vehicleArmed) {
-            disabledWhileArmed.visible = true
-            setupView.viewPanel.enabled = false
-        } else {
-            disabledWhileArmed.visible = false
-            setupView.viewPanel.enabled = true
-        }
-    }
+    property real _margins:             ScreenTools.defaultFontPixelHeight * 0.5
 
     QGCPalette { id: qgcPal; colorGroupEnabled: setupPanel.enabled }
-
-    // Overlay to display when vehicle is armed and the setup page needs
-    // to be disabled
-    Item {
-        id: disabledWhileArmed
-        visible: false
-        z: 9999
-        anchors.fill: parent
-        Rectangle {
-            anchors.fill: parent
-            color: "black"
-            opacity: 0.5
-        }
-
-        QGCLabel {
-            anchors.margins:        defaultTextWidth * 2
-            anchors.fill:           parent
-            verticalAlignment:      Text.AlignVCenter
-            horizontalAlignment:    Text.AlignHCenter
-            wrapMode:               Text.WordWrap
-            font.pointSize:         ScreenTools.largeFontPointSize
-            color:                  "red"
-            text:                   "Setup disabled while the vehicle is armed"
-        }
-    }
 
     QGCViewPanel {
         id:             setupPanel
@@ -88,13 +49,13 @@ QGCView {
             clip:           true
 
             Column {
-                id:             headingColumn
-                width:          setupPanel.width
-                spacing:        _margins
+                id:                 headingColumn
+                width:              setupPanel.width
+                spacing:            _margins
 
                 QGCLabel {
                     font.pointSize: ScreenTools.largeFontPointSize
-                    text:           pageName + " " + qsTr("Setup")
+                    text:           qsTr("%1 Setup").arg(pageName)
                     visible:        !ScreenTools.isShortScreen
                 }
 
@@ -114,4 +75,27 @@ QGCView {
             }
         }
     }
+
+    // Overlay to display when vehicle is armed and this setup page needs
+    // to be disabled
+    Item {
+        visible:                    _shouldDisableWhenArmed
+        anchors.fill:               parent
+        Rectangle {
+            anchors.fill:           parent
+            color:                  "black"
+            opacity:                0.5
+        }
+        QGCLabel {
+            anchors.margins:        defaultTextWidth * 2
+            anchors.fill:           parent
+            verticalAlignment:      Text.AlignVCenter
+            horizontalAlignment:    Text.AlignHCenter
+            wrapMode:               Text.WordWrap
+            font.pointSize:         ScreenTools.largeFontPointSize
+            color:                  "red"
+            text:                   qsTr("Setup disabled while the vehicle is armed")
+        }
+    }
+
 }

--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -81,6 +81,7 @@ QGCView {
     Item {
         visible:                    _shouldDisableWhenArmed
         anchors.fill:               parent
+        z:                          9999
         Rectangle {
             anchors.fill:           parent
             color:                  "black"

--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -35,6 +35,8 @@ QGCView {
     property bool _shouldDisableWhenArmed: _vehicleArmed ? (vehicleComponent ? !vehicleComponent.allowSetupWhileArmed : false) : false
 
     property real _margins:             ScreenTools.defaultFontPixelHeight * 0.5
+    property string _pageTitle:         qsTr("%1 Setup").arg(pageName)
+
 
     QGCPalette { id: qgcPal; colorGroupEnabled: setupPanel.enabled }
 
@@ -55,7 +57,7 @@ QGCView {
 
                 QGCLabel {
                     font.pointSize: ScreenTools.largeFontPointSize
-                    text:           qsTr("%1 Setup").arg(pageName)
+                    text:           _shouldDisableWhenArmed ? _pageTitle + "<font color=\"red\">" + qsTr(" (Disabled while the vehicle is armed)") + "</font>" : _pageTitle
                     visible:        !ScreenTools.isShortScreen
                 }
 
@@ -73,30 +75,14 @@ QGCView {
                 anchors.topMargin:  _margins
                 anchors.top:        headingColumn.bottom
             }
+            // Overlay to display when vehicle is armed and this setup page needs
+            // to be disabled
+            Rectangle {
+                visible:            _shouldDisableWhenArmed
+                anchors.fill:       pageLoader
+                color:              "black"
+                opacity:            0.5
+            }
         }
     }
-
-    // Overlay to display when vehicle is armed and this setup page needs
-    // to be disabled
-    Item {
-        visible:                    _shouldDisableWhenArmed
-        anchors.fill:               parent
-        z:                          9999
-        Rectangle {
-            anchors.fill:           parent
-            color:                  "black"
-            opacity:                0.5
-        }
-        QGCLabel {
-            anchors.margins:        defaultTextWidth * 2
-            anchors.fill:           parent
-            verticalAlignment:      Text.AlignVCenter
-            horizontalAlignment:    Text.AlignHCenter
-            wrapMode:               Text.WordWrap
-            font.pointSize:         ScreenTools.largeFontPointSize
-            color:                  "red"
-            text:                   qsTr("Setup disabled while the vehicle is armed")
-        }
-    }
-
 }

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -43,23 +43,23 @@ SetupPage {
             readonly property string highlightPrefix:   "<font color=\"" + qgcPal.warningText + "\">"
             readonly property string highlightSuffix:   "</font>"
 
+            function getBatteryImage()
+            {
+                switch(battNumCells.value) {
+                case 1:  return "/qmlimages/PowerComponentBattery_01cell.svg";
+                case 2:  return "/qmlimages/PowerComponentBattery_02cell.svg"
+                case 3:  return "/qmlimages/PowerComponentBattery_03cell.svg"
+                case 4:  return "/qmlimages/PowerComponentBattery_04cell.svg"
+                case 5:  return "/qmlimages/PowerComponentBattery_05cell.svg"
+                case 6:  return "/qmlimages/PowerComponentBattery_06cell.svg"
+                default: return "/qmlimages/PowerComponentBattery_01cell.svg";
+                }
+            }
+
             ColumnLayout {
                 id:                         innerColumn
                 anchors.horizontalCenter:   parent.horizontalCenter
                 spacing:                    ScreenTools.defaultFontPixelHeight
-
-                function getBatteryImage()
-                {
-                    switch(battNumCells.value) {
-                    case 1:  return "/qmlimages/PowerComponentBattery_01cell.svg";
-                    case 2:  return "/qmlimages/PowerComponentBattery_02cell.svg"
-                    case 3:  return "/qmlimages/PowerComponentBattery_03cell.svg"
-                    case 4:  return "/qmlimages/PowerComponentBattery_04cell.svg"
-                    case 5:  return "/qmlimages/PowerComponentBattery_05cell.svg"
-                    case 6:  return "/qmlimages/PowerComponentBattery_06cell.svg"
-                    default: return "/qmlimages/PowerComponentBattery_01cell.svg";
-                    }
-                }
 
                 function drawArrowhead(ctx, x, y, radians)
                 {

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -250,7 +250,6 @@ Rectangle {
                 setupIndicator:     false
                 exclusiveGroup:     setupButtonGroup
                 visible:            !ScreenTools.isMobile && _corePlugin.options.showFirmwareUpgrade
-                enabled:            !_vehicleArmed
                 text:               qsTr("Firmware")
                 Layout.fillWidth:   true
 
@@ -291,7 +290,6 @@ Rectangle {
                     exclusiveGroup:     setupButtonGroup
                     text:               modelData.name
                     visible:            modelData.setupSource.toString() !== ""
-                    enabled:            _vehicleArmed ? modelData.allowSetupWhileArmed : true
                     Layout.fillWidth:   true
 
                     onClicked: showVehicleComponentPanel(modelData)

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -34,6 +34,7 @@ Rectangle {
     readonly property real      _buttonWidth:       _defaultTextWidth * 18
     readonly property string    _armedVehicleText:  qsTr("This operation cannot be performed while the vehicle is armed.")
 
+    property bool   _vehicleArmed:                  QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle.armed : false
     property string _messagePanelText:              qsTr("missing message panel text")
     property bool   _fullParameterVehicleAvailable: QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable && !QGroundControl.multiVehicleManager.activeVehicle.parameterManager.missingParameters
     property var    _corePlugin:                    QGroundControl.corePlugin
@@ -41,7 +42,7 @@ Rectangle {
     function showSummaryPanel()
     {
         if (_fullParameterVehicleAvailable) {
-            if (QGroundControl.multiVehicleManager.activeVehicle.autopilot.vehicleComponents.length == 0) {
+            if (QGroundControl.multiVehicleManager.activeVehicle.autopilot.vehicleComponents.length === 0) {
                 panelLoader.setSourceComponent(noComponentsVehicleSummaryComponent)
             } else {
                 panelLoader.setSource("VehicleSummary.qml")
@@ -80,8 +81,7 @@ Rectangle {
         var autopilotPlugin = QGroundControl.multiVehicleManager.activeVehicle.autopilot
         var prereq = autopilotPlugin.prerequisiteSetup(vehicleComponent)
         if (prereq !== "") {
-            //-- TODO: This cannot be translated when built this way.
-            _messagePanelText = prereq + " setup must be completed prior to " + vehicleComponent.name + " setup."
+            _messagePanelText = qsTr("%1 setup must be completed prior to %2 setup.").arg(prereq).arg(vehicleComponent.name)
             panelLoader.setSourceComponent(messagePanelComponent)
         } else {
             panelLoader.setSource(vehicleComponent.setupSource, vehicleComponent)
@@ -250,6 +250,7 @@ Rectangle {
                 setupIndicator:     false
                 exclusiveGroup:     setupButtonGroup
                 visible:            !ScreenTools.isMobile && _corePlugin.options.showFirmwareUpgrade
+                enabled:            !_vehicleArmed
                 text:               qsTr("Firmware")
                 Layout.fillWidth:   true
 
@@ -272,7 +273,7 @@ Rectangle {
                 setupIndicator:     true
                 setupComplete:      joystickManager.activeJoystick ? joystickManager.activeJoystick.calibrated : false
                 exclusiveGroup:     setupButtonGroup
-                visible:            _fullParameterVehicleAvailable && joystickManager.joysticks.length != 0
+                visible:            _fullParameterVehicleAvailable && joystickManager.joysticks.length !== 0
                 text:               qsTr("Joystick")
                 Layout.fillWidth:   true
 
@@ -289,7 +290,8 @@ Rectangle {
                     setupComplete:      modelData.setupComplete
                     exclusiveGroup:     setupButtonGroup
                     text:               modelData.name
-                    visible:            modelData.setupSource.toString() != ""
+                    visible:            modelData.setupSource.toString() !== ""
+                    enabled:            _vehicleArmed ? modelData.allowSetupWhileArmed : true
                     Layout.fillWidth:   true
 
                     onClicked: showVehicleComponentPanel(modelData)


### PR DESCRIPTION
Instead of blocking all settings if the vehicle is armed, check the provided `VehicleComponent::allowSetupWhileArmed()` method. This change not only disables the settings button, but also shows @jaxxzer's overlay only when appropriate.