### PR TITLE
Compute plan view items visibility on the fly.

### DIFF
--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -53,6 +53,7 @@ QGCView {
     property bool   _singleComplexItem:         _missionController.complexMissionItemNames.length === 1
     property real   _toolbarHeight:             _qgcView.height - ScreenTools.availableHeight
     property int    _editingLayer:              _layerMission
+    property int    _toolStripBottom:           toolStrip.height + toolStrip.y
 
     readonly property int       _layerMission:              1
     readonly property int       _layerGeoFence:             2
@@ -646,7 +647,7 @@ QGCView {
             anchors.bottom:     waypointValuesDisplay.visible ? waypointValuesDisplay.top : parent.bottom
             anchors.left:       parent.left
             mapControl:         editorMap
-            visible:            !ScreenTools.isTinyScreen
+            visible:            _toolStripBottom < y
         }
 
         MissionItemStatus {
@@ -657,7 +658,7 @@ QGCView {
             maxWidth:           parent.width - rightPanel.width - x
             anchors.bottom:     parent.bottom
             missionItems:       _missionController.visualItems
-            visible:            _editingLayer === _layerMission && (ScreenTools.isMobile ? height < Screen.height * 0.25 : true)
+            visible:            _editingLayer === _layerMission && (_toolStripBottom + mapScale.height) < y && QGroundControl.corePlugin.options.showMissionStatus
         }
     } // QGCViewPanel
 

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -45,6 +45,7 @@ public:
     Q_PROPERTY(bool                     showOfflineMapExport            READ showOfflineMapExport           NOTIFY showOfflineMapExportChanged)
     Q_PROPERTY(bool                     showOfflineMapImport            READ showOfflineMapImport           NOTIFY showOfflineMapImportChanged)
     Q_PROPERTY(bool                     useMobileFileDialog             READ useMobileFileDialog            CONSTANT)
+    Q_PROPERTY(bool                     showMissionStatus               READ showMissionStatus              CONSTANT)
 
     /// Should QGC hide its settings menu and colapse it into one single menu (Settings and Vehicle Setup)?
     /// @return true if QGC should consolidate both menus into one.
@@ -61,6 +62,10 @@ public:
     /// Provides an alternate instrument widget for the Fly View
     /// @return An alternate widget (see QGCInstrumentWidget.qml, the default widget)
     virtual CustomInstrumentWidget* instrumentWidget();
+
+    /// Should the mission status indicator (Plan View) be shown?
+    /// @return Yes or no
+    virtual bool        showMissionStatus           () { return true; }
 
     /// Allows access to the full fly view window
     virtual QUrl    flyViewOverlay                  () const { return QUrl(); }

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -135,6 +135,7 @@ MainWindow::MainWindow()
     _ui.setupUi(this);
     // Make sure tool bar elements all fit before changing minimum width
     setMinimumWidth(1008);
+    setMinimumHeight(520);
     configureWindowName();
 
     // Setup central widget with a layout to hold the views


### PR DESCRIPTION
Instead of checking for "Mobile" or screen percentage (when mobile), compute the available space on the fly to determine if the Mission Status and Map Scale should be shown in the Plan View. For mobile devices, that means it will be shown or not based on the device's screen size. For desktop, the decision to show them or not is dynamically computed based on the current window height.

Also added an option for plugins to determine if mission status should be shown or not.

Plan View on a "short" mobile device (room for the scale but not for the Mission Status):

![screen](https://user-images.githubusercontent.com/749243/35065167-6cd98c12-fb9a-11e7-8970-f5cfbdff1613.png)

Plan View on a "large enough" desktop window:

![screen shot 2018-01-17 at 2 31 37 pm](https://user-images.githubusercontent.com/749243/35065239-ab4e250c-fb9a-11e7-83eb-91677269af3a.png)

Plan View on a desktop window where it can't fit either the Scale or the Mission Status:

![screen shot 2018-01-17 at 2 31 31 pm](https://user-images.githubusercontent.com/749243/35065302-e48de8de-fb9a-11e7-8d6d-da07f21afb5a.png)
