### PR TITLE
Structure Scan: Structure height support

### DIFF
--- a/src/MissionManager/CameraCalc.h
+++ b/src/MissionManager/CameraCalc.h
@@ -21,8 +21,9 @@ public:
     CameraCalc(Vehicle* vehicle, QObject* parent = NULL);
 
     Q_PROPERTY(QString          cameraName                  READ cameraName         WRITE setCameraName NOTIFY cameraNameChanged)
-    Q_PROPERTY(QString          customCameraName            READ customCameraName                       CONSTANT)                   // Camera name for custom camera setting
-    Q_PROPERTY(QString          manualCameraName            READ manualCameraName                       CONSTANT)                   // Camera name for manual camera setting
+    Q_PROPERTY(QString          customCameraName            READ customCameraName                       CONSTANT)                   ///< Camera name for custom camera setting
+    Q_PROPERTY(QString          manualCameraName            READ manualCameraName                       CONSTANT)                   ///< Camera name for manual camera setting
+    Q_PROPERTY(bool             isManualCamera              READ isManualCamera                         NOTIFY cameraNameChanged)   ///< true: using manual camera
     Q_PROPERTY(Fact*            valueSetIsDistance          READ valueSetIsDistance                     CONSTANT)                   ///< true: distance specified, resolution calculated
     Q_PROPERTY(Fact*            distanceToSurface           READ distanceToSurface                      CONSTANT)                   ///< Distance to surface for image foot print calculation
     Q_PROPERTY(Fact*            imageDensity                READ imageDensity                           CONSTANT)                   ///< Image density on surface (cm/px)
@@ -48,8 +49,9 @@ public:
     Fact* adjustedFootprintSide     (void) { return &_adjustedFootprintSideFact; }
     Fact* adjustedFootprintFrontal  (void) { return &_adjustedFootprintFrontalFact; }
 
-    double imageFootprintSide             (void) const { return _imageFootprintSide; }
-    double imageFootprintFrontal          (void) const { return _imageFootprintFrontal; }
+    bool    isManualCamera          (void) { return cameraName() == manualCameraName(); }
+    double  imageFootprintSide      (void) const { return _imageFootprintSide; }
+    double  imageFootprintFrontal   (void) const { return _imageFootprintFrontal; }
 
     bool dirty      (void) const { return _dirty; }
     void setDirty   (bool dirty);

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -302,6 +302,6 @@ void MissionSettingsItem::_setHomeAltFromTerrain(double terrainAltitude)
         _plannedHomePositionAltitudeFact.setSendValueChangedSignals(false);
         _plannedHomePositionAltitudeFact.setRawValue(terrainAltitude);
         _plannedHomePositionAltitudeFact.clearDeferredValueChangeSignal();
-        _plannedHomePositionAltitudeFact.setSendValueChangedSignals(false);
+        _plannedHomePositionAltitudeFact.setSendValueChangedSignals(true);
     }
 }

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -31,6 +31,7 @@ public:
     Q_PROPERTY(Fact*            gimbalPitch                 READ gimbalPitch                                                CONSTANT)
     Q_PROPERTY(Fact*            gimbalYaw                   READ gimbalYaw                                                  CONSTANT)
     Q_PROPERTY(Fact*            altitude                    READ altitude                                                   CONSTANT)
+    Q_PROPERTY(Fact*            structureHeight             READ structureHeight                                            CONSTANT)
     Q_PROPERTY(Fact*            layers                      READ layers                                                     CONSTANT)
     Q_PROPERTY(bool             altitudeRelative            READ altitudeRelative           WRITE setAltitudeRelative       NOTIFY altitudeRelativeChanged)
     Q_PROPERTY(int              cameraShots                 READ cameraShots                                                NOTIFY cameraShotsChanged)
@@ -41,6 +42,7 @@ public:
 
     CameraCalc* cameraCalc  (void) { return &_cameraCalc; }
     Fact* altitude          (void) { return &_altitudeFact; }
+    Fact* structureHeight   (void) { return &_structureHeightFact; }
     Fact* layers            (void) { return &_layersFact; }
 
     bool            altitudeRelative        (void) const { return _altitudeRelative; }
@@ -110,6 +112,7 @@ private slots:
     void _rebuildFlightPolygon      (void);
     void _recalcCameraShots         (void);
     void _resetGimbal               (void);
+    void _recalcLayerInfo           (void);
 
 private:
     void _setExitCoordinate(const QGeoCoordinate& coordinate);
@@ -135,11 +138,13 @@ private:
     static QMap<QString, FactMetaData*> _metaDataMap;
 
     Fact    _altitudeFact;
+    Fact    _structureHeightFact;
     Fact    _layersFact;
     Fact    _gimbalPitchFact;
     Fact    _gimbalYawFact;
 
     static const char* _altitudeFactName;
+    static const char* _structureHeightFactName;
     static const char* _layersFactName;
     static const char* _gimbalPitchFactName;
     static const char* _gimbalYawFactName;

--- a/src/PlanView/CameraCalc.qml
+++ b/src/PlanView/CameraCalc.qml
@@ -248,6 +248,8 @@ Column {
             }
 
             // Calculated values
+/*
+            Taking these out for now since they take up so much space. May come back at a later time.
             GridLayout {
                 anchors.left:   parent.left
                 anchors.right:  parent.right
@@ -269,6 +271,7 @@ Column {
                     enabled:            false
                 }
             } // GridLayout
+*/
 
         } // Column - Camera spec based ui
 

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -87,7 +87,7 @@ Rectangle {
             columnSpacing:  ScreenTools.defaultFontPixelWidth / 2
             rowSpacing:     0
             columns:        3
-            enabled:        missionItem.cameraCalc.cameraName === missionItem.cameraCalc.manualCameraName
+            visible:        missionItem.cameraCalc.isManualCamera
 
             Item { width: 1; height: 1 }
             QGCLabel { text: qsTr("Pitch") }
@@ -126,13 +126,27 @@ Rectangle {
                 rowSpacing:     _margin
                 columns:        2
 
-                QGCLabel { text: qsTr("Layers") }
+                QGCLabel {
+                    text:       qsTr("Structure height")
+                    visible:    !missionItem.cameraCalc.isManualCamera
+                }
+                FactTextField {
+                    fact:               missionItem.structureHeight
+                    Layout.fillWidth:   true
+                    visible:            !missionItem.cameraCalc.isManualCamera
+                }
+
+                QGCLabel {
+                    text:       qsTr("# Layers")
+                    visible:    missionItem.cameraCalc.isManualCamera
+                }
                 FactTextField {
                     fact:               missionItem.layers
                     Layout.fillWidth:   true
+                    visible:            missionItem.cameraCalc.isManualCamera
                 }
 
-                QGCLabel { text: qsTr("Altitude") }
+                QGCLabel { text: qsTr("Bottom layer alt") }
                 FactTextField {
                     fact:               missionItem.altitude
                     Layout.fillWidth:   true


### PR DESCRIPTION
While discussing Structure Scan with users the issue came up that a structure scan needs to be specify structure height when using a camera spec as opposed to a layer count. Without that the user needs to manually calculate the layer count based on camera image footprints which is a real PITA.

Fixing this required some fundamental changes to how structure scan works with respect to layers and camera placement. This also requiredbumping the persistence version number such that old saved structure scans will need to be recreated.

![screen shot 2018-01-19 at 11 52 06 am](https://user-images.githubusercontent.com/5876851/35168817-3813e466-fd0f-11e7-9895-fb9093e66e2e.png)

* You specify the altitude of lower bound of the bottom-most layer. The actual height of the flight path for the first layer will be above this to center the camera within the first layer.
* You specify the height of the structure
* From these two values the number of layers required to fully cover the structure with image at the desired resolution and overlap is calculated automatically.