### PR TITLE
Robustify mission upload/download

### DIFF
--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -36,8 +36,7 @@ PlanManager::PlanManager(Vehicle* vehicle, MAV_MISSION_TYPE planType)
 {
     _ackTimeoutTimer = new QTimer(this);
     _ackTimeoutTimer->setSingleShot(true);
-    _ackTimeoutTimer->setInterval(_ackTimeoutMilliseconds);
-    
+
     connect(_ackTimeoutTimer, &QTimer::timeout, this, &PlanManager::_ackTimeout);
 }
 
@@ -245,6 +244,24 @@ void PlanManager::_ackTimeout(void)
 
 void PlanManager::_startAckTimeout(AckType_t ack)
 {
+    switch (ack) {
+    case AckMissionItem:
+        // We are actively trying to get the mission item, so we don't want to wait as long.
+        _ackTimeoutTimer->setInterval(_retryTimeoutMilliseconds);
+        break;
+    case AckNone:
+        // FALLTHROUGH
+    case AckMissionCount:
+        // FALLTHROUGH
+    case AckMissionRequest:
+        // FALLTHROUGH
+    case AckMissionClearAll:
+        // FALLTHROUGH
+    case AckGuidedItem:
+        _ackTimeoutTimer->setInterval(_ackTimeoutMilliseconds);
+        break;
+    }
+
     _expectedAck = ack;
     _ackTimeoutTimer->start();
 }

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -30,6 +30,7 @@ PlanManager::PlanManager(Vehicle* vehicle, MAV_MISSION_TYPE planType)
     , _transactionInProgress(TransactionNone)
     , _resumeMission(false)
     , _lastMissionRequest(-1)
+    , _missionItemCountToRead(-1)
     , _currentMissionIndex(-1)
     , _lastCurrentIndex(-1)
 {
@@ -317,6 +318,7 @@ void PlanManager::_handleMissionCount(const mavlink_message_t& message)
         for (int i=0; i<missionCount.count; i++) {
             _itemIndicesToRead << i;
         }
+        _missionItemCountToRead = missionCount.count;
         _requestNextMissionItem();
     }
 }
@@ -460,7 +462,7 @@ void PlanManager::_handleMissionItem(const mavlink_message_t& message, bool miss
         return;
     }
 
-    emit progressPct((double)seq / (double)_missionItems.count());
+    emit progressPct((double)seq / (double)_missionItemCountToRead);
     
     _retryCount = 0;
     if (_itemIndicesToRead.count() == 0) {

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -144,6 +144,7 @@ protected:
     QList<int>          _itemIndicesToWrite;    ///< List of mission items which still need to be written to vehicle
     QList<int>          _itemIndicesToRead;     ///< List of mission items which still need to be requested from vehicle
     int                 _lastMissionRequest;    ///< Index of item last requested by MISSION_REQUEST
+    int                 _missionItemCountToRead;///< Count of all mission items to read
     
     QList<MissionItem*> _missionItems;          ///< Set of mission items on vehicle
     QList<MissionItem*> _writeMissionItems;     ///< Set of mission items currently being written to vehicle

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -28,11 +28,11 @@ Q_DECLARE_LOGGING_CATEGORY(PlanManagerLog)
 class PlanManager : public QObject
 {
     Q_OBJECT
-    
+
 public:
     PlanManager(Vehicle* vehicle, MAV_MISSION_TYPE planType);
     ~PlanManager();
-    
+
     bool inProgress(void) const;
     const QList<MissionItem*>& missionItems(void) { return _missionItems; }
 
@@ -41,11 +41,11 @@ public:
 
     /// Last current mission item reported while in Mission flight mode
     int lastCurrentIndex(void) const { return _lastCurrentIndex; }
-    
+
     /// Load the mission items from the vehicle
     ///     Signals newMissionItemsAvailable when done
     void loadFromVehicle(void);
-    
+
     /// Writes the specified set of mission items to the vehicle
     /// IMPORTANT NOTE: PlanManager will take control of the MissionItem objects with the missionItems list. It will free them when done.
     ///     @param missionItems Items to send to vehicle
@@ -70,9 +70,12 @@ public:
     } ErrorCode_t;
 
     // These values are public so the unit test can set appropriate signal wait times
+    // When passively waiting for a mission process, use a longer timeout.
     static const int _ackTimeoutMilliseconds = 1000;
+    // When actively retrying to request mission items, use a shorter timeout instead.
+    static const int _retryTimeoutMilliseconds = 250;
     static const int _maxRetryCount = 5;
-    
+
 signals:
     void newMissionItemsAvailable   (bool removeAllRequested);
     void inProgressChanged          (bool inProgress);
@@ -88,7 +91,7 @@ signals:
 private slots:
     void _mavlinkMessageReceived(const mavlink_message_t& message);
     void _ackTimeout(void);
-    
+
 protected:
     typedef enum {
         AckNone,            ///< State machine is idle
@@ -134,18 +137,18 @@ protected:
     Vehicle*            _vehicle;
     MAV_MISSION_TYPE    _planType;
     LinkInterface*      _dedicatedLink;
-    
+
     QTimer*             _ackTimeoutTimer;
     AckType_t           _expectedAck;
     int                 _retryCount;
-    
+
     TransactionType_t   _transactionInProgress;
     bool                _resumeMission;
     QList<int>          _itemIndicesToWrite;    ///< List of mission items which still need to be written to vehicle
     QList<int>          _itemIndicesToRead;     ///< List of mission items which still need to be requested from vehicle
     int                 _lastMissionRequest;    ///< Index of item last requested by MISSION_REQUEST
     int                 _missionItemCountToRead;///< Count of all mission items to read
-    
+
     QList<MissionItem*> _missionItems;          ///< Set of mission items on vehicle
     QList<MissionItem*> _writeMissionItems;     ///< Set of mission items currently being written to vehicle
     int                 _currentMissionIndex;


### PR DESCRIPTION
This is the result of 2 days debugging mission upload and download over a lossy link.

The way I debugged this was to filter out some of the mavlink mission messages on the firmware side.

For more information, please check the commit messages.

Tested with current PX4/Firmware master but also with https://github.com/PX4/Firmware/pull/8750.