### PR TITLE
Android hotplugging

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -225,7 +225,8 @@ QT += \
     svg \
     widgets \
     xml \
-    texttospeech
+    texttospeech\
+    gamepad
 
 # Multimedia only used if QVC is enabled
 !contains (DEFINES, QGC_DISABLE_UVC) {

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -76,11 +76,6 @@ void JoystickManager::_setActiveJoystickFromSettings(void)
     newMap = JoystickAndroid::discover(_multiVehicleManager);
 #endif
 
-    if (_activeJoystick && !newMap.contains(_activeJoystick->name())) {
-        qCDebug(JoystickManagerLog) << "Active joystick removed";
-        setActiveJoystick(NULL);
-    }
-
     // Check to see if our current mapping contains any joysticks that are not in the new mapping
     // If so, those joysticks have been unplugged, and need to be cleaned up
     QMap<QString, Joystick*>::iterator i;
@@ -93,12 +88,19 @@ void JoystickManager::_setActiveJoystickFromSettings(void)
         }
     }
 
+
     _name2JoystickMap = newMap;
     emit availableJoysticksChanged();
+
 
     if (!_name2JoystickMap.count()) {
         setActiveJoystick(NULL);
         return;
+    }
+
+    if (_activeJoystick && !newMap.contains(_activeJoystick->name())) {
+        qCDebug(JoystickManagerLog) << "Active joystick removed";
+        setActiveJoystick(NULL);
     }
 
     QSettings settings;

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -61,7 +61,7 @@ void JoystickManager::init() {
     }
 #elif defined(__android__)
     _setActiveJoystickFromSettings();
-    connect(QGamepadManager::instance(), &QGamepadManager::connectedGamepadsChanged, this, &JoystickManager::_updateAvailableJoysticks);
+    connect(QGamepadManager::instance(), &QGamepadManager::connectedGamepadsChanged, this, &JoystickManager::_setActiveJoystickFromSettings);
 #endif
 }
 
@@ -206,23 +206,5 @@ void JoystickManager::_updateAvailableJoysticks(void)
             break;
         }
     }
-#elif defined(__android__)
-    QList<int> gamepads = QGamepadManager::instance()->connectedGamepads();
-    static QList<int> previousGamepads;
-    if (gamepads != previousGamepads){
-        previousGamepads = gamepads;
-        qCDebug(JoystickManagerLog) << "GPChange!: "<<previousGamepads;
-        _setActiveJoystickFromSettings();
-    }
-    /*
-     * TODO: Investigate Android events for Joystick hot plugging
-     */
 #endif
-}
-void JoystickManager::androidGPConnected(int id){
-    qDebug()<<"conn";
-
-}
-void JoystickManager::androidGPDisconnected(int id){
-    qDebug()<< "disconn";
 }

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -61,7 +61,7 @@ void JoystickManager::init() {
     }
 #elif defined(__android__)
     _setActiveJoystickFromSettings();
-    //TODO: Investigate Android events for Joystick hot plugging & run _joystickCheckTimer if possible
+    connect(QGamepadManager::instance(), &QGamepadManager::connectedGamepadsChanged, this, &JoystickManager::_updateAvailableJoysticks);
 #endif
 }
 
@@ -207,8 +207,22 @@ void JoystickManager::_updateAvailableJoysticks(void)
         }
     }
 #elif defined(__android__)
+    QList<int> gamepads = QGamepadManager::instance()->connectedGamepads();
+    static QList<int> previousGamepads;
+    if (gamepads != previousGamepads){
+        previousGamepads = gamepads;
+        qCDebug(JoystickManagerLog) << "GPChange!: "<<previousGamepads;
+        _setActiveJoystickFromSettings();
+    }
     /*
      * TODO: Investigate Android events for Joystick hot plugging
      */
 #endif
+}
+void JoystickManager::androidGPConnected(int id){
+    qDebug()<<"conn";
+
+}
+void JoystickManager::androidGPDisconnected(int id){
+    qDebug()<< "disconn";
 }

--- a/src/Joystick/JoystickManager.h
+++ b/src/Joystick/JoystickManager.h
@@ -15,6 +15,7 @@
 #include "Joystick.h"
 #include "MultiVehicleManager.h"
 #include "QGCToolbox.h"
+#include <QGamepadManager>
 
 #include <QVariantList>
 

--- a/src/Joystick/JoystickQGP.h
+++ b/src/Joystick/JoystickQGP.h
@@ -1,4 +1,0 @@
-#ifndef JOYSTICKQGP_H
-#define JOYSTICKQGP_H
-
-#endif // JOYSTICKQGP_H

--- a/src/Joystick/JoystickQGP.h
+++ b/src/Joystick/JoystickQGP.h
@@ -1,0 +1,4 @@
+#ifndef JOYSTICKQGP_H
+#define JOYSTICKQGP_H
+
+#endif // JOYSTICKQGP_H


### PR DESCRIPTION
QGroundControl on android can currently only detect a new joystick on startup. If a joystick is added or removed after startup then this will not be detected and the joystick interface will simply freeze up.

This pull request uses QGamepadManager to signal when a gamepad/joystick has been removed or added. The active joystick is then set or cleared appropriately.