### PR TITLE
Write only metadata

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,7 +15,7 @@ environment:
 install:
   - git submodule update --init --recursive
   - call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
-  - set PATH=C:\Qt\Tools\QtCreator\bin;C:\Qt\5.9.2\msvc2015\bin;%PATH%
+  - set PATH=C:\Qt\Tools\QtCreator\bin;C:\Qt\5.9.3\msvc2015\bin;%PATH%
   - mkdir %LOCALAPPDATA%\QtProject && copy test\qtlogging.ini %LOCALAPPDATA%\QtProject\
   - ps: |
       Write-Host "Installing GStreamer..." -ForegroundColor Cyan
@@ -35,7 +35,7 @@ install:
       Write-Host "Installed" -ForegroundColor Green
 
 build_script:
-  - mkdir %SHADOW_BUILD_DIR% && cd %SHADOW_BUILD_DIR% && C:\Qt\5.9.2\msvc2015\bin\qmake -r CONFIG-=debug_and_release CONFIG+=%CONFIG% CONFIG+=WarningsAsErrorsOn %APPVEYOR_BUILD_FOLDER%\qgroundcontrol.pro
+  - mkdir %SHADOW_BUILD_DIR% && cd %SHADOW_BUILD_DIR% && C:\Qt\5.9.3\msvc2015\bin\qmake -r CONFIG-=debug_and_release CONFIG+=%CONFIG% CONFIG+=WarningsAsErrorsOn %APPVEYOR_BUILD_FOLDER%\qgroundcontrol.pro
   - cd %SHADOW_BUILD_DIR% && jom
   - if "%CONFIG%" EQU "installer" ( copy %SHADOW_BUILD_DIR%\release\QGroundControl-installer.exe %APPVEYOR_BUILD_FOLDER%\QGroundControl-installer.exe )
 # Generate the source server information to embed in the PDB

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -806,7 +806,7 @@ QGCCameraControl::_loadSettings(const QDomNodeList nodeList)
                     metaData->setRawUnits(attr);
                 }
             }
-            qCDebug(CameraControlLog) << "New parameter:" << factName;
+            qCDebug(CameraControlLog) << "New parameter:" << factName << (readOnly ? "ReadOnly" : "Writable") << (writeOnly ? "WriteOnly" : "Readable");
             _nameToFactMetaDataMap[factName] = metaData;
             Fact* pFact = new Fact(_compID, factName, factType, this);
             QQmlEngine::setObjectOwnership(pFact, QQmlEngine::CppOwnership);

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -40,6 +40,7 @@ static const char* kParameterrange  = "parameterrange";
 static const char* kParameterranges = "parameterranges";
 static const char* kParameters      = "parameters";
 static const char* kReadOnly        = "readonly";
+static const char* kWriteOnly       = "writeonly";
 static const char* kRoption         = "roption";
 static const char* kStep            = "step";
 static const char* kStrings         = "strings";
@@ -659,6 +660,13 @@ QGCCameraControl::_loadSettings(const QDomNodeList nodeList)
         //-- Is it read only?
         bool readOnly = false;
         read_attribute(parameterNode, kReadOnly, readOnly);
+        //-- Is it write only?
+        bool writeOnly = false;
+        read_attribute(parameterNode, kWriteOnly, writeOnly);
+        //-- It can't be both
+        if(readOnly && writeOnly) {
+            qCritical() << QString("Parameter %1 cannot be both read only and write only").arg(factName);
+        }
         //-- Param type
         bool unknownType;
         FactMetaData::ValueType_t factType = FactMetaData::stringToType(type, unknownType);
@@ -689,6 +697,7 @@ QGCCameraControl::_loadSettings(const QDomNodeList nodeList)
         metaData->setLongDescription(description);
         metaData->setHasControl(control);
         metaData->setReadOnly(readOnly);
+        metaData->setWriteOnly(writeOnly);
         //-- Options (enums)
         QDomElement optionElem = parameterNode.toElement();
         QDomNodeList optionsRoot = optionElem.elementsByTagName(kOptions);

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -55,6 +55,8 @@ QGCCameraParamIO::QGCCameraParamIO(QGCCameraControl *control, Fact* fact, Vehicl
         case FactMetaData::valueTypeFloat:
             _mavParamType = MAV_PARAM_EXT_TYPE_REAL32;
             break;
+            //-- String and custom are the same for now
+        case FactMetaData::valueTypeString:
         case FactMetaData::valueTypeCustom:
             _mavParamType = MAV_PARAM_EXT_TYPE_CUSTOM;
             break;
@@ -139,6 +141,8 @@ QGCCameraParamIO::_sendParameter()
         case FactMetaData::valueTypeFloat:
             union_value.param_float = _fact->rawValue().toFloat();
             break;
+            //-- String and custom are the same for now
+        case FactMetaData::valueTypeString:
         case FactMetaData::valueTypeCustom:
             {
                 QByteArray custom = _fact->rawValue().toByteArray();

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -28,8 +28,13 @@ QGCCameraParamIO::QGCCameraParamIO(QGCCameraControl *control, Fact* fact, Vehicl
     _paramWriteTimer.setInterval(3000);
     _paramRequestTimer.setSingleShot(true);
     _paramRequestTimer.setInterval(3500);
+    if(_fact->writeOnly()) {
+        //-- Write mode is always "done" as it won't ever read
+        _done = true;
+    } else {
+        connect(&_paramRequestTimer, &QTimer::timeout, this, &QGCCameraParamIO::_paramRequestTimeout);
+    }
     connect(&_paramWriteTimer,   &QTimer::timeout, this, &QGCCameraParamIO::_paramWriteTimeout);
-    connect(&_paramRequestTimer, &QTimer::timeout, this, &QGCCameraParamIO::_paramRequestTimeout);
     connect(_fact, &Fact::rawValueChanged, this, &QGCCameraParamIO::_factChanged);
     connect(_fact, &Fact::_containerRawValueChanged, this, &QGCCameraParamIO::_containerRawValueChanged);
     _pMavlink = qgcApp()->toolbox()->mavlinkProtocol();
@@ -73,9 +78,11 @@ QGCCameraParamIO::QGCCameraParamIO(QGCCameraControl *control, Fact* fact, Vehicl
 void
 QGCCameraParamIO::setParamRequest()
 {
-    _paramRequestReceived = false;
-    _requestRetries = 0;
-    _paramRequestTimer.start();
+    if(!_fact->writeOnly()) {
+        _paramRequestReceived = false;
+        _requestRetries = 0;
+        _paramRequestTimer.start();
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Camera/QGCCameraIO.h
+++ b/src/Camera/QGCCameraIO.h
@@ -67,7 +67,7 @@ private:
     QTimer              _paramRequestTimer;
     bool                _done;
     bool                _updateOnSet;
-    MAV_PARAM_TYPE      _mavParamType;
+    MAV_PARAM_EXT_TYPE  _mavParamType;
     MAVLinkProtocol*    _pMavlink;
     bool                _forceUIUpdate;
 };

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -663,6 +663,16 @@ bool Fact::readOnly(void) const
     }
 }
 
+bool Fact::writeOnly(void) const
+{
+    if (_metaData) {
+        return _metaData->writeOnly();
+    } else {
+        qWarning() << kMissingMetadata << name();
+        return false;
+    }
+}
+
 bool Fact::volatileValue(void) const
 {
     if (_metaData) {

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -71,6 +71,7 @@ public:
     Q_PROPERTY(bool         typeIsBool              READ typeIsBool                                         CONSTANT)
     Q_PROPERTY(bool         hasControl              READ hasControl                                         CONSTANT)
     Q_PROPERTY(bool         readOnly                READ readOnly                                           CONSTANT)
+    Q_PROPERTY(bool         writeOnly               READ writeOnly                                          CONSTANT)
     Q_PROPERTY(bool         volatileValue           READ volatileValue                                      CONSTANT)
 
     /// Convert and validate value
@@ -119,7 +120,8 @@ public:
     bool            typeIsBool              (void) const { return type() == FactMetaData::valueTypeBool; }
     bool            hasControl              (void) const;
     bool            readOnly                (void) const;
-    bool            volatileValue            (void) const;
+    bool            writeOnly               (void) const;
+    bool            volatileValue           (void) const;
 
     /// Returns the values as a string with full 18 digit precision if float/double.
     QString rawValueStringFullPrecision(void) const;

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -94,6 +94,7 @@ FactMetaData::FactMetaData(QObject* parent)
     , _increment            (std::numeric_limits<double>::quiet_NaN())
     , _hasControl           (true)
     , _readOnly             (false)
+    , _writeOnly            (false)
     , _volatile             (false)
 {
     _category   = kDefaultCategory;
@@ -116,6 +117,7 @@ FactMetaData::FactMetaData(ValueType_t type, QObject* parent)
     , _increment            (std::numeric_limits<double>::quiet_NaN())
     , _hasControl           (true)
     , _readOnly             (false)
+    , _writeOnly            (false)
     , _volatile             (false)
 {
     _category   = kDefaultCategory;
@@ -145,6 +147,7 @@ FactMetaData::FactMetaData(ValueType_t type, const QString name, QObject* parent
     , _increment            (std::numeric_limits<double>::quiet_NaN())
     , _hasControl           (true)
     , _readOnly             (false)
+    , _writeOnly            (false)
     , _volatile             (false)
 {
     _category   = kDefaultCategory;
@@ -178,6 +181,7 @@ const FactMetaData& FactMetaData::operator=(const FactMetaData& other)
     _increment              = other._increment;
     _hasControl             = other._hasControl;
     _readOnly               = other._readOnly;
+    _writeOnly              = other._writeOnly;
     _volatile               = other._volatile;
     return *this;
 }

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -104,6 +104,7 @@ public:
     bool            rebootRequired          (void) const { return _rebootRequired; }
     bool            hasControl              (void) const { return _hasControl; }
     bool            readOnly                (void) const { return _readOnly; }
+    bool            writeOnly               (void) const { return _writeOnly; }
     bool            volatileValue           (void) const { return _volatile; }
 
     /// Amount to increment value when used in controls such as spin button or slider with detents.
@@ -135,6 +136,7 @@ public:
     void setIncrement       (double increment)                  { _increment = increment; }
     void setHasControl      (bool bValue)                       { _hasControl = bValue; }
     void setReadOnly        (bool bValue)                       { _readOnly = bValue; }
+    void setWriteOnly       (bool bValue)                       { _writeOnly = bValue; }
     void setVolatileValue   (bool bValue);
 
     void setTranslators(Translator rawTranslator, Translator cookedTranslator);
@@ -241,6 +243,7 @@ private:
     double          _increment;
     bool            _hasControl;
     bool            _readOnly;
+    bool            _writeOnly;
     bool            _volatile;
 
     // Exact conversion constants

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -155,6 +155,8 @@ void initializeVideoStreaming(int &argc, char* argv[], char* logpath, char* debu
 #else
     Q_UNUSED(argc);
     Q_UNUSED(argv);
+    Q_UNUSED(logpath);
+    Q_UNUSED(debuglevel);
 #endif
     qmlRegisterType<VideoItem>              ("QGroundControl.QgcQtGStreamer", 1, 0, "VideoItem");
     qmlRegisterUncreatableType<VideoSurface>("QGroundControl.QgcQtGStreamer", 1, 0, "VideoSurface", QLatin1String("VideoSurface from QML is not supported"));


### PR DESCRIPTION
Set a "Write Only" attribute to define parameter is only writable and not readable (password for example).

Updated camera control to use the updated `MAV_PARAM_EXT_TYPE_xxx` types.

