### PR TITLE
More work in high latency

### DIFF
--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -359,7 +359,7 @@ void MultiVehicleManager::_sendGCSHeartbeat(void)
     LinkManager* linkMgr = _toolbox->linkManager();
     for (int i=0; i<linkMgr->links().count(); i++) {
         LinkInterface* link = linkMgr->links()[i];
-        if (link->isConnected()) {
+        if (link->isConnected() && !link->highLatency()) {
             mavlink_message_t message;
             mavlink_msg_heartbeat_pack_chan(_mavlinkProtocol->getSystemId(),
                                             _mavlinkProtocol->getComponentId(),

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1016,6 +1016,7 @@ private:
     int                             _mavCommandRetryCount;
     static const int                _mavCommandMaxRetryCount = 3;
     static const int                _mavCommandAckTimeoutMSecs = 3000;
+    static const int                _mavCommandAckTimeoutMSecsHighLatency = 120000;
 
     QString             _prearmError;
     QTimer              _prearmErrorTimer;


### PR DESCRIPTION
* Command ack timeout based on normal/high latency link (2 minute timeout for high latency)
* Correctly update ack timeout and high latency bit at correct times
* Fix altitude values from HIGH_LATENCY2. Absolute altitude will display correctly. Relative altitude is NaN'ed to get good display of no value there.

![screen shot 2018-02-01 at 3 10 46 pm](https://user-images.githubusercontent.com/5876851/35708773-8014499a-0764-11e8-9764-9f872f7b2bd9.png)


Related to #6072