### PR TITLE
Add highLatency property to LinkConfiguration

### DIFF
--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -37,6 +37,7 @@ LinkConfiguration::LinkConfiguration(const QString& name)
     , _name(name)
     , _dynamic(false)
     , _autoConnect(false)
+    , _highLatency(false)
 {
     _name = name;
     if (_name.isEmpty()) {
@@ -50,6 +51,7 @@ LinkConfiguration::LinkConfiguration(LinkConfiguration* copy)
     _name       = copy->name();
     _dynamic    = copy->isDynamic();
     _autoConnect= copy->isAutoConnect();
+    _highLatency= copy->isHighLatency();
     Q_ASSERT(!_name.isEmpty());
 }
 
@@ -60,6 +62,7 @@ void LinkConfiguration::copyFrom(LinkConfiguration* source)
     _name       = source->name();
     _dynamic    = source->isDynamic();
     _autoConnect= source->isAutoConnect();
+    _highLatency= source->isHighLatency();
 }
 
 /*!

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -33,6 +33,8 @@ public:
     Q_PROPERTY(bool             autoConnect         READ isAutoConnect  WRITE setAutoConnect    NOTIFY autoConnectChanged)
     Q_PROPERTY(bool             autoConnectAllowed  READ isAutoConnectAllowed                   CONSTANT)
     Q_PROPERTY(QString          settingsURL         READ settingsURL                            CONSTANT)
+    Q_PROPERTY(bool             highLatency         READ isHighLatency  WRITE setHighLatency    NOTIFY highLatencyChanged)
+    Q_PROPERTY(bool             highLatencyAllowed  READ isHighLatencyAllowed                   CONSTANT)
 
     // Property accessors
 
@@ -77,6 +79,13 @@ public:
     bool isAutoConnect() { return _autoConnect; }
 
     /*!
+     *
+     * Is this a High Latency configuration?
+     * @return True if this is an High Latency configuration (link with large delays).
+     */
+    bool isHighLatency() { return _highLatency; }
+
+    /*!
      * Set if this is this a dynamic configuration. (decided at runtime)
     */
     void setDynamic(bool dynamic = true) { _dynamic = dynamic; emit dynamicChanged(); }
@@ -86,6 +95,11 @@ public:
     */
     void setAutoConnect(bool autoc = true) { _autoConnect = autoc; emit autoConnectChanged(); }
 
+    /*!
+     * Set if this is this an High Latency configuration.
+    */
+    void setHighLatency(bool hl = false) { _highLatency = hl; emit highLatencyChanged(); }
+
     /// Virtual Methods
 
     /*!
@@ -94,6 +108,13 @@ public:
      * @return True if this type can be set as an Auto Connect configuration
      */
     virtual bool isAutoConnectAllowed() { return false; }
+
+    /*!
+     *
+     * Is High Latency allowed for this type?
+     * @return True if this type can be set as an High Latency configuration
+     */
+    virtual bool isHighLatencyAllowed() { return false; }
 
     /*!
      * @brief Connection type
@@ -174,6 +195,7 @@ signals:
     void dynamicChanged     ();
     void autoConnectChanged ();
     void linkChanged        (LinkInterface* link);
+    void highLatencyChanged ();
 
 protected:
     LinkInterface* _link; ///< Link currently using this configuration (if any)
@@ -181,6 +203,7 @@ private:
     QString _name;
     bool    _dynamic;       ///< A connection added automatically and not persistent (unless it's edited).
     bool    _autoConnect;   ///< This connection is started automatically at boot
+    bool    _highLatency;
 };
 
 typedef QSharedPointer<LinkConfiguration> SharedLinkConfigurationPointer;

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -23,7 +23,7 @@ uint8_t LinkInterface::mavlinkChannel(void) const
 LinkInterface::LinkInterface(SharedLinkConfigurationPointer& config)
     : QThread                   (0)
     , _config                   (config)
-    , _highLatency              (false)
+    , _highLatency              (config->isHighLatency())
     , _mavlinkChannelSet        (false)
     , _active                   (false)
     , _enableRateCollection     (false)

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -86,6 +86,7 @@ public:
     /// From LinkConfiguration
     LinkType    type            () { return LinkConfiguration::TypeSerial; }
     void        copyFrom        (LinkConfiguration* source);
+    bool        isHighLatencyAllowed () { return true; }
     void        loadSettings    (QSettings& settings, const QString& root);
     void        saveSettings    (QSettings& settings, const QString& root);
     void        updateSettings  ();

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -97,6 +97,7 @@ public:
     /// From LinkConfiguration
     LinkType    type            () { return LinkConfiguration::TypeTcp; }
     void        copyFrom        (LinkConfiguration* source);
+    bool        isHighLatencyAllowed () { return true; }
     void        loadSettings    (QSettings& settings, const QString& root);
     void        saveSettings    (QSettings& settings, const QString& root);
     void        updateSettings  ();

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -134,6 +134,7 @@ public:
     void        saveSettings         (QSettings& settings, const QString& root);
     void        updateSettings       ();
     bool        isAutoConnectAllowed () { return true; }
+    bool        isHighLatencyAllowed () { return true; }
     QString     settingsURL          () { return "UdpSettings.qml"; }
 
 signals:

--- a/src/ui/preferences/SerialSettings.qml
+++ b/src/ui/preferences/SerialSettings.qml
@@ -43,24 +43,6 @@ Item {
             height: ScreenTools.defaultFontPixelHeight / 2
             width:  parent.width
         }
-        QGCCheckBox {
-            text:       "High Latency"
-            checked:    false
-            visible:    editConfig ? editConfig.highLatencyAllowed : false
-            onCheckedChanged: {
-                if(editConfig) {
-                    editConfig.highLatency = checked
-                }
-            }
-            Component.onCompleted: {
-                if(editConfig)
-                    checked = editConfig.highLatency
-            }
-        }
-        Item {
-            height: ScreenTools.defaultFontPixelHeight / 2
-            width:  parent.width
-        }
         Row {
             spacing:    ScreenTools.defaultFontPixelWidth
             QGCLabel {
@@ -251,6 +233,20 @@ Item {
                     }
                     stopCombo.currentIndex = index
                 }
+            }
+        }
+        QGCCheckBox {
+            text:       "High Latency"
+            checked:    false
+            visible:    editConfig ? editConfig.highLatencyAllowed : false
+            onCheckedChanged: {
+                if(editConfig) {
+                    editConfig.highLatency = checked
+                }
+            }
+            Component.onCompleted: {
+                if(editConfig)
+                    checked = editConfig.highLatency
             }
         }
     }

--- a/src/ui/preferences/SerialSettings.qml
+++ b/src/ui/preferences/SerialSettings.qml
@@ -43,6 +43,24 @@ Item {
             height: ScreenTools.defaultFontPixelHeight / 2
             width:  parent.width
         }
+        QGCCheckBox {
+            text:       "High Latency"
+            checked:    false
+            visible:    editConfig ? editConfig.highLatencyAllowed : false
+            onCheckedChanged: {
+                if(editConfig) {
+                    editConfig.highLatency = checked
+                }
+            }
+            Component.onCompleted: {
+                if(editConfig)
+                    checked = editConfig.highLatency
+            }
+        }
+        Item {
+            height: ScreenTools.defaultFontPixelHeight / 2
+            width:  parent.width
+        }
         Row {
             spacing:    ScreenTools.defaultFontPixelWidth
             QGCLabel {

--- a/src/ui/preferences/TcpSettings.qml
+++ b/src/ui/preferences/TcpSettings.qml
@@ -46,24 +46,6 @@ Item {
             height: ScreenTools.defaultFontPixelHeight / 2
             width:  parent.width
         }
-        QGCCheckBox {
-            text:       "High Latency"
-            checked:    false
-            visible:    editConfig ? editConfig.highLatencyAllowed : false
-            onCheckedChanged: {
-                if(editConfig) {
-                    editConfig.highLatency = checked
-                }
-            }
-            Component.onCompleted: {
-                if(editConfig)
-                    checked = editConfig.highLatency
-            }
-        }
-        Item {
-            height: ScreenTools.defaultFontPixelHeight / 2
-            width:  parent.width
-        }
         Row {
             spacing:    ScreenTools.defaultFontPixelWidth
             QGCLabel {
@@ -91,6 +73,20 @@ Item {
                 width:  _firstColumn
                 inputMethodHints:       Qt.ImhFormattedNumbersOnly
                 anchors.verticalCenter: parent.verticalCenter
+            }
+        }
+        QGCCheckBox {
+            text:       "High Latency"
+            checked:    false
+            visible:    editConfig ? editConfig.highLatencyAllowed : false
+            onCheckedChanged: {
+                if(editConfig) {
+                    editConfig.highLatency = checked
+                }
+            }
+            Component.onCompleted: {
+                if(editConfig)
+                    checked = editConfig.highLatency
             }
         }
     }

--- a/src/ui/preferences/TcpSettings.qml
+++ b/src/ui/preferences/TcpSettings.qml
@@ -46,6 +46,24 @@ Item {
             height: ScreenTools.defaultFontPixelHeight / 2
             width:  parent.width
         }
+        QGCCheckBox {
+            text:       "High Latency"
+            checked:    false
+            visible:    editConfig ? editConfig.highLatencyAllowed : false
+            onCheckedChanged: {
+                if(editConfig) {
+                    editConfig.highLatency = checked
+                }
+            }
+            Component.onCompleted: {
+                if(editConfig)
+                    checked = editConfig.highLatency
+            }
+        }
+        Item {
+            height: ScreenTools.defaultFontPixelHeight / 2
+            width:  parent.width
+        }
         Row {
             spacing:    ScreenTools.defaultFontPixelWidth
             QGCLabel {

--- a/src/ui/preferences/UdpSettings.qml
+++ b/src/ui/preferences/UdpSettings.qml
@@ -52,24 +52,6 @@ Item {
             height: ScreenTools.defaultFontPixelHeight / 2
             width:  parent.width
         }
-        QGCCheckBox {
-            text:       "High Latency"
-            checked:    false
-            visible:    editConfig ? editConfig.highLatencyAllowed : false
-            onCheckedChanged: {
-                if(editConfig) {
-                    editConfig.highLatency = checked
-                }
-            }
-            Component.onCompleted: {
-                if(editConfig)
-                    checked = editConfig.highLatency
-            }
-        }
-        Item {
-            height: ScreenTools.defaultFontPixelHeight / 2
-            width:  parent.width
-        }
         Row {
             spacing:    ScreenTools.defaultFontPixelWidth
             QGCLabel {
@@ -191,6 +173,20 @@ Item {
                         }
                     }
                 }
+            }
+        }
+        QGCCheckBox {
+            text:       "High Latency"
+            checked:    false
+            visible:    editConfig ? editConfig.highLatencyAllowed : false
+            onCheckedChanged: {
+                if(editConfig) {
+                    editConfig.highLatency = checked
+                }
+            }
+            Component.onCompleted: {
+                if(editConfig)
+                    checked = editConfig.highLatency
             }
         }
     }

--- a/src/ui/preferences/UdpSettings.qml
+++ b/src/ui/preferences/UdpSettings.qml
@@ -52,6 +52,24 @@ Item {
             height: ScreenTools.defaultFontPixelHeight / 2
             width:  parent.width
         }
+        QGCCheckBox {
+            text:       "High Latency"
+            checked:    false
+            visible:    editConfig ? editConfig.highLatencyAllowed : false
+            onCheckedChanged: {
+                if(editConfig) {
+                    editConfig.highLatency = checked
+                }
+            }
+            Component.onCompleted: {
+                if(editConfig)
+                    checked = editConfig.highLatency
+            }
+        }
+        Item {
+            height: ScreenTools.defaultFontPixelHeight / 2
+            width:  parent.width
+        }
         Row {
             spacing:    ScreenTools.defaultFontPixelWidth
             QGCLabel {


### PR DESCRIPTION
- Add a highLatency variable to the LinkConfiguration and set the variable in the LinkInterface accordingly.
- Wenn manually connecting a link there is now a checkbox for UDP, TCP, and serial links to specify if the new link is a high latency link.