### PR TITLE
Clickable deadzone

### DIFF
--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -537,6 +537,21 @@ SetupPage {
                                     onClicked:  controller.deadbandToggle = checked
                                 }
                             }
+                            Row{
+                                width: parent.width
+                                spacing: ScreenTools.defaultFontPixelWidth
+                                visible: advancedSettings.checked
+                                QGCLabel{
+                                    width:       parent.width * 0.85
+                                    font.pointSize:     ScreenTools.smallFontPointSize
+                                    wrapMode:           Text.WordWrap
+                                    text:   qsTr("Deadband can be set during the first ") +
+                                            qsTr("step of calibration by gently wiggling each axis. ") +
+                                            qsTr("Deadband can also be adjusted by clicking and ") +
+                                            qsTr("dragging vertically on the corresponding axis monitor.")
+                                    visible: controller.deadbandToggle
+                                }
+                            }
                         }
                     } // Column - left column
 

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -86,6 +86,7 @@ SetupPage {
                     property int axisValue: 0
                     property int deadbandValue: 0
                     property bool narrowIndicator: false
+                    property color deadbandColor: "#8c161a"
 
                     property color          __barColor:             qgcPal.windowShade
 
@@ -105,7 +106,7 @@ SetupPage {
                         x:                      _deadbandPosition
                         width:                  _deadbandWidth
                         height:                 parent.height / 2
-                        color:                  "#8c161a"
+                        color:                  deadbandColor
                         visible:                controller.deadbandToggle
 
                         property real _percentDeadband:    ((2 * deadbandValue) / (32768.0 * 2))
@@ -801,11 +802,13 @@ SetupPage {
                                 MouseArea {
                                     id:             deadbandMouseArea
                                     anchors.fill:   parent.item
+                                    enabled:        controller.deadbandToggle
 
                                     property real startY
 
                                     onPressed: {
                                         startY = mouseY
+                                        parent.item.deadbandColor = "#3C6315"
                                     }
                                     onPositionChanged: {
                                         var newValue = parent.item.deadbandValue + (startY - mouseY)*15
@@ -814,6 +817,7 @@ SetupPage {
                                     }
                                     onReleased: {
                                         controller.setDeadbandValue(modelData,parent.item.deadbandValue)
+                                        parent.item.deadbandColor = "#8c161a"
                                     }
                                 }
                             }

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -796,7 +796,28 @@ SetupPage {
                                 property real defaultTextWidth:     ScreenTools.defaultFontPixelWidth
                                 property bool mapped:               true
                                 readonly property bool reversed:    false
+
+
+                                MouseArea {
+                                    id:             deadbandMouseArea
+                                    anchors.fill:   parent.item
+
+                                    property real startY
+
+                                    onPressed: {
+                                        startY = mouseY
+                                    }
+                                    onPositionChanged: {
+                                        var newValue = parent.item.deadbandValue + (startY - mouseY)*15
+                                        if ((newValue > 0) && (newValue <32768)){parent.item.deadbandValue=newValue;}
+                                        startY = mouseY
+                                    }
+                                    onReleased: {
+                                        controller.setDeadbandValue(modelData,parent.item.deadbandValue)
+                                    }
+                                }
                             }
+
                         }
                     }
                 } // Column - Axis Monitor

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -85,6 +85,7 @@ SetupPage {
                 Item {
                     property int axisValue: 0
                     property int deadbandValue: 0
+                    property bool narrowIndicator: false
 
                     property color          __barColor:             qgcPal.windowShade
 
@@ -123,8 +124,8 @@ SetupPage {
                     // Indicator
                     Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
-                        width:                  parent.height * 0.75
-                        height:                 width
+                        width:                  parent.narrowIndicator ?  height/6 : height
+                        height:                 parent.height * 0.75
                         x:                      (reversed ? (parent.width - _indicatorPosition) : _indicatorPosition) - (width / 2)
                         radius:                 width / 2
                         color:                  qgcPal.text
@@ -790,6 +791,7 @@ SetupPage {
                                 height:                 ScreenTools.defaultFontPixelHeight
                                 width:                  200
                                 sourceComponent:        axisMonitorDisplayComponent
+                                Component.onCompleted:  item.narrowIndicator = true
 
                                 property real defaultTextWidth:     ScreenTools.defaultFontPixelWidth
                                 property bool mapped:               true

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -16,7 +16,6 @@
 
 QGC_LOGGING_CATEGORY(JoystickConfigControllerLog, "JoystickConfigControllerLog")
 
-const int JoystickConfigController::_updateInterval =       150;        ///< Interval for timer which updates radio channel widgets
 const int JoystickConfigController::_calCenterPoint =       0;
 const int JoystickConfigController::_calValidMinValue =     -32768;     ///< Largest valid minimum axis value
 const int JoystickConfigController::_calValidMaxValue =     32767;      ///< Smallest valid maximum axis value

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -416,8 +416,8 @@ void JoystickConfigController::_inputCenterWait(Joystick::AxisFunction_t functio
     
     if (_stickDetectAxis == _axisNoAxis) {
         // Sticks have not yet moved close enough to center
-        
-        if (abs(_calCenterPoint - value) < _calRoughCenterDelta) {
+        int roughCenter = getDeadbandToggle() ? _rgAxisInfo[axis].deadband : _calRoughCenterDelta;
+        if (abs(_calCenterPoint - value) < roughCenter) {
             // Stick has moved close enough to center that we can start waiting for it to settle
             _stickDetectAxis = axis;
             _stickDetectInitialValue = value;

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -415,7 +415,7 @@ void JoystickConfigController::_inputCenterWait(Joystick::AxisFunction_t functio
     
     if (_stickDetectAxis == _axisNoAxis) {
         // Sticks have not yet moved close enough to center
-        int roughCenter = getDeadbandToggle() ? _rgAxisInfo[axis].deadband : _calRoughCenterDelta;
+        int roughCenter = getDeadbandToggle() ? std::max(_rgAxisInfo[axis].deadband,_calRoughCenterDelta) : _calRoughCenterDelta;
         if (abs(_calCenterPoint - value) < roughCenter) {
             // Stick has moved close enough to center that we can start waiting for it to settle
             _stickDetectAxis = axis;

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -71,6 +71,15 @@ void JoystickConfigController::start(void)
     _stopCalibration();
 }
 
+void JoystickConfigController::setDeadbandValue(int axis, int value)
+{
+    _axisDeadbandChanged(axis,value);
+    Joystick* joystick = _joystickManager->activeJoystick();
+    Joystick::Calibration_t calibration = joystick->getCalibration(axis);
+    calibration.deadband = value;
+    joystick->setCalibration(axis,calibration);
+}
+
 JoystickConfigController::~JoystickConfigController()
 {
     if(_activeJoystick) {

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -208,8 +208,6 @@ private:
     static const char* _imagePitchUp;
     static const char* _imagePitchDown;
     
-    static const int _updateInterval;   ///< Interval for ui update timer
-    
     int _rgFunctionAxisMapping[Joystick::maxFunction]; ///< Maps from joystick function to axis index. _axisMax indicates axis not set for this function.
 
     static const int _attitudeControls = 5;

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -67,6 +67,7 @@ public:
     Q_INVOKABLE void skipButtonClicked(void);
     Q_INVOKABLE void nextButtonClicked(void);
     Q_INVOKABLE void start(void);
+    Q_INVOKABLE void setDeadbandValue(int axis, int value);
 
     bool rollAxisMapped(void);
     bool pitchAxisMapped(void);


### PR DESCRIPTION
This makes it so that joystick deadband for each axis can be adjusted by clicking on the corresponding axis on the right side of the screen and dragging vertically. I have also added a short explanation of the deadband setting process which will appear below the deadband checkbox when it is enabled.

While the current method of setting works pretty well I've found that it often times doesn't end up quite right. This will make it easy to adjust the settings without going through the whole calibration process again.