### PR TITLE
Fix multiple selected state for offline maps buttons.

### DIFF
--- a/src/QmlControls/OfflineMapButton.qml
+++ b/src/QmlControls/OfflineMapButton.qml
@@ -20,6 +20,8 @@ Rectangle {
     border.width:   _showBorder ? 1: 0
     border.color:   qgcPal.buttonText
 
+    property var    tileSet:    null
+    property var    currentSet: null
     property bool   checked:    false
     property bool   complete:   false
     property alias  text:       nameLabel.text
@@ -36,6 +38,19 @@ Rectangle {
     property bool   _hovered:          false
 
     signal clicked()
+
+    property ExclusiveGroup exclusiveGroup:  null
+    onExclusiveGroupChanged: {
+        if (exclusiveGroup) {
+            checked = false
+            exclusiveGroup.bindCheckable(mapButton)
+        }
+    }
+    onCheckedChanged: {
+        if(checked) {
+            currentSet = tileSet
+        }
+    }
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
@@ -85,26 +100,53 @@ Rectangle {
 
     MouseArea {
         anchors.fill: parent
-        hoverEnabled: true
+        hoverEnabled: !ScreenTools.isMobile
         onMouseXChanged: {
-            _lastGlobalMouseX = ScreenTools.mouseX()
-            _lastGlobalMouseY = ScreenTools.mouseY()
+            if(!ScreenTools.isMobile) {
+                _lastGlobalMouseX = ScreenTools.mouseX()
+                _lastGlobalMouseY = ScreenTools.mouseY()
+            }
         }
         onMouseYChanged: {
-            _lastGlobalMouseX = ScreenTools.mouseX()
-            _lastGlobalMouseY = ScreenTools.mouseY()
+            if(!ScreenTools.isMobile) {
+                _lastGlobalMouseX = ScreenTools.mouseX()
+                _lastGlobalMouseY = ScreenTools.mouseY()
+            }
         }
-        onEntered:  { _hovered = true;  _forceHoverOff = false; hoverTimer.start() }
-        onExited:   { _hovered = false; _forceHoverOff = false; hoverTimer.stop()  }
-        onPressed:  { _pressed = true;  }
-        onReleased: { _pressed = false; }
-        onClicked:  mapButton.clicked()
+        onEntered:  {
+            if(!ScreenTools.isMobile) {
+                _hovered = true
+                _forceHoverOff = false
+                hoverTimer.start()
+            }
+        }
+        onExited:   {
+            if(!ScreenTools.isMobile) {
+                _hovered = false
+                _forceHoverOff = false
+                hoverTimer.stop()
+            }
+        }
+        onPressed:  {
+            if(!ScreenTools.isMobile) {
+                _pressed = true
+            }
+        }
+        onReleased: {
+            if(!ScreenTools.isMobile) {
+                _pressed = false
+            }
+        }
+        onClicked: {
+            checked = true
+            mapButton.clicked()
+        }
     }
 
     Timer {
         id:         hoverTimer
         interval:   250
-        repeat:     true
+        repeat:     !ScreenTools.isMobile
         onTriggered: {
             if (_lastGlobalMouseX !== ScreenTools.mouseX() || _lastGlobalMouseY !== ScreenTools.mouseY()) {
                 _forceHoverOff = true

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -918,11 +918,14 @@ QGCView {
                 width:      Math.min(_tileSetList.width, (ScreenTools.defaultFontPixelWidth  * 50).toFixed(0))
                 spacing:    ScreenTools.defaultFontPixelHeight * 0.5
                 anchors.horizontalCenter: parent.horizontalCenter
+                ExclusiveGroup { id: selectionGroup }
                 OfflineMapButton {
                     id:             firstButton
                     text:           qsTr("Add New Set")
                     width:          _cacheList.width
-                    height:         ScreenTools.defaultFontPixelHeight * 2
+                    height:         ScreenTools.defaultFontPixelHeight * (ScreenTools.isMobile ? 3 : 2)
+                    currentSet:     _currentSelection
+                    exclusiveGroup: selectionGroup
                     onClicked: {
                         offlineMapView._currentSelection = null
                         addNewSet()
@@ -936,7 +939,10 @@ QGCView {
                         tiles:          object.totalTileCount
                         complete:       object.complete
                         width:          firstButton.width
-                        height:         ScreenTools.defaultFontPixelHeight * 2
+                        height:         ScreenTools.defaultFontPixelHeight * (ScreenTools.isMobile ? 3 : 2)
+                        exclusiveGroup: selectionGroup
+                        currentSet:     _currentSelection
+                        tileSet:        object
                         onClicked: {
                             offlineMapView._currentSelection = object
                             showInfo()


### PR DESCRIPTION
On mobile devices, if you have enough map tile sets that you need to scroll, you could end up with multiple buttons in selected state. It was a combination of lack of exclusive group and hover state management, which is not applicable to mobile/touch devices.

I've also made the buttons slightly larger for mobile devices.