### PR TITLE
Joystick axes can now be monitored even when joystick control is disabled

### DIFF
--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -61,6 +61,7 @@ public:
     Q_PROPERTY(QString name READ name CONSTANT)
 
     Q_PROPERTY(bool calibrated MEMBER _calibrated NOTIFY calibratedChanged)
+    Q_PROPERTY(bool outputEnabled MEMBER _outputEnabled WRITE setOutputEnabled NOTIFY outputEnabledChanged)
 
     Q_PROPERTY(int totalButtonCount  READ totalButtonCount    CONSTANT)
     Q_PROPERTY(int axisCount    READ axisCount      CONSTANT)
@@ -122,20 +123,13 @@ public:
     void setTXMode(int mode);
     int getTXMode(void) { return _transmitterMode; }
 
-    typedef enum {
-        CalibrationModeOff,         // Not calibrating
-        CalibrationModeMonitor,     // Monitors are active, continue to send to vehicle if already polling
-        CalibrationModeCalibrating, // Calibrating, stop sending joystick to vehicle
-    } CalibrationMode_t;
-
     /// Set the current calibration mode
-    void startCalibrationMode(CalibrationMode_t mode);
-
-    /// Clear the current calibration mode
-    void stopCalibrationMode(CalibrationMode_t mode);
+    void setCalibrationMode(bool calibrating);
+    void setOutputEnabled(bool enabled);
 
 signals:
     void calibratedChanged(bool calibrated);
+    void outputEnabledChanged(bool enabled);
 
     // The raw signals are only meant for use by calibration
     void rawAxisValueChanged(int index, int value);
@@ -201,7 +195,8 @@ protected:
     int     _totalButtonCount;
 
     static int          _transmitterMode;
-    CalibrationMode_t   _calibrationMode;
+    bool                _calibrationMode;
+    bool                _outputEnabled;
 
     int*                _rgAxisValues;
     Calibration_t*      _rgCalibration;

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -366,9 +366,9 @@ SetupPage {
                                 id:         enabledCheckBox
                                 enabled:    _activeJoystick ? _activeJoystick.calibrated : false
                                 text:       _activeJoystick ? _activeJoystick.calibrated ? qsTr("Enable joystick input") : qsTr("Enable not allowed (Calibrate First)") : ""
-                                checked:    _activeVehicle.joystickEnabled
+                                checked:    _activeJoystick.outputEnabled
 
-                                onClicked:  _activeVehicle.joystickEnabled = checked
+                                onClicked:  _activeJoystick.outputEnabled = checked
 
                                 Connections {
                                     target: joystickManager

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -366,9 +366,15 @@ SetupPage {
                                 id:         enabledCheckBox
                                 enabled:    _activeJoystick ? _activeJoystick.calibrated : false
                                 text:       _activeJoystick ? _activeJoystick.calibrated ? qsTr("Enable joystick input") : qsTr("Enable not allowed (Calibrate First)") : ""
-                                checked:    _activeJoystick.outputEnabled
 
                                 onClicked:  _activeJoystick.outputEnabled = checked
+
+                                Connections {
+                                    target: _activeJoystick
+                                    onOutputEnabledChanged: {
+                                        enabledCheckBox.checked=enabled
+                                    }
+                                }
 
                                 Connections {
                                     target: joystickManager

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -82,7 +82,7 @@ void JoystickConfigController::setDeadbandValue(int axis, int value)
 JoystickConfigController::~JoystickConfigController()
 {
     if(_activeJoystick) {
-        _activeJoystick->stopCalibrationMode(Joystick::CalibrationModeMonitor);
+        _activeJoystick->setCalibrationMode(false);
     }
 }
 
@@ -582,7 +582,7 @@ void JoystickConfigController::_writeCalibration(void)
 /// @brief Starts the calibration process
 void JoystickConfigController::_startCalibration(void)
 {
-    _activeJoystick->startCalibrationMode(Joystick::CalibrationModeCalibrating);
+    _activeJoystick->setCalibrationMode(true);
     _resetInternalCalibrationValues();
     
     _nextButton->setProperty("text", "Next");
@@ -598,7 +598,7 @@ void JoystickConfigController::_stopCalibration(void)
 {
     _currentStep = -1;
     
-    _activeJoystick->stopCalibrationMode(Joystick::CalibrationModeCalibrating);
+    _activeJoystick->setCalibrationMode(false);
     _setInternalCalibrationValuesFromSettings();
     
     _statusText->setProperty("text", "");
@@ -763,7 +763,6 @@ void JoystickConfigController::_signalAllAttitudeValueChanges(void)
 void JoystickConfigController::_activeJoystickChanged(Joystick* joystick)
 {
     bool joystickTransition = false;
-    
     if (_activeJoystick) {
         joystickTransition = true;
         disconnect(_activeJoystick, &Joystick::rawAxisValueChanged, this, &JoystickConfigController::_axisValueChanged);
@@ -781,7 +780,7 @@ void JoystickConfigController::_activeJoystickChanged(Joystick* joystick)
         if (joystickTransition) {
             _stopCalibration();
         }
-        _activeJoystick->startCalibrationMode(Joystick::CalibrationModeMonitor);
+        _activeJoystick->setCalibrationMode(false);
         _axisCount = _activeJoystick->axisCount();
         _rgAxisInfo = new struct AxisInfo[_axisCount];
         _axisValueSave = new int[_axisCount];


### PR DESCRIPTION
The current Joystick implementation uses a tristate enumerator to indicate the calibration state of the joystick. However it seems that the state is never set to CalibrationModeOff except sometimes when the Joystick is first plugged in. This makes the use of this tristate enumerator confusing and results in a situation where disabling the joystick not only stops sending out ManualControl packets but also stops processing input from the joystick all together.

This pull request replaces the tri-state enumerator with two boolean values. One to indicate whether the joystick is currently being calibrated and another to indicate whether the joystick should be transmitting ManualControl packets. This allows the user to monitor the value of each joystick axis in QGroundControl even when joystick control is disabled.