### PR TITLE
Fix for #4564

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1492,7 +1492,16 @@ void Vehicle::_updatePriorityLink(void)
     }
 #endif
 
-    if (!newPriorityLink && !_priorityLink.data() && _links.count()) {
+    bool found_priority_link = false;
+    if (!newPriorityLink && _priorityLink.data()) {
+        for (int i=0; i<_links.count(); i++) {
+            if (_priorityLink->getLinkConfiguration() == _links[i]->getLinkConfiguration()) {
+                found_priority_link = true;
+            }
+        }
+    }
+
+    if (!newPriorityLink && _links.count() && (!_priorityLink.data() || !found_priority_link)) {
         newPriorityLink = _links[0];
     }
 


### PR DESCRIPTION
When two links are connected to one vehicle and the priority link was deleted first, the _priorityLink still contained a shared pointer to the deleted link which caused [#4564](https://github.com/mavlink/qgroundcontrol/issues/4564).

Now if the priority link is deleted and at least one other link is available. The first of the available links is set as the priority link. 