### PR TITLE
Camera Control

### DIFF
--- a/src/QmlControls/QGCSlider.qml
+++ b/src/QmlControls/QGCSlider.qml
@@ -21,6 +21,7 @@ Slider {
 
     // Value indicator starts display from zero instead of min value
     property bool zeroCentered: false
+    property bool displayValue: false
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 
@@ -67,8 +68,15 @@ Slider {
             implicitWidth:  _radius * 2
             implicitHeight: _radius * 2
             radius:         _radius
-
             property real _radius: Math.round(ScreenTools.defaultFontPixelHeight * 0.75)
+            Label {
+                text:               _root.value.toFixed(0)
+                visible:            _root.displayValue
+                anchors.centerIn:   parent
+                font.family:        ScreenTools.normalFontFamily
+                font.pointSize:     ScreenTools.smallFontPointSize
+                color:              qgcPal.buttonText
+            }
         }
     }
 }


### PR DESCRIPTION
Added a few things to the camera control:

* Time lapse mode (allows to switch between single and time lapse)
* Camera free storage space left
* Shutter counter (Photo Mode) / Running time (Video Mode)

Yes, basic camera support is now in Gazebo :P

![screen shot 2018-02-07 at 2 17 57 pm](https://user-images.githubusercontent.com/749243/35936628-ca54dd2e-0c11-11e8-9011-252fbe9c37b0.png)
![screen shot 2018-02-07 at 2 18 08 pm](https://user-images.githubusercontent.com/749243/35936632-cc92bbe2-0c11-11e8-9dc3-1d9075f1e882.png)



