### PR TITLE
Fix bugs in updating priority link

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1500,8 +1500,11 @@ void Vehicle::_updatePriorityLink(void)
     // Check for the existing priority link to still be valid
     for (int i=0; i<_links.count(); i++) {
         if (_priorityLink.data() == _links[i]) {
-            // Still valid
-            return;
+            if (!_priorityLink.data()->highLatency()) {
+                // Link is still valid. Continue to use it unless it is high latency. In that case we still look for a better
+                // link to use as priority link.
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
* Also handles correct prioritization of high latency links

Replacement for #4564.

@acfloria Can you take a look at this. I believe this fixes the leaking shared pointer. I can now disconnect two links on the same vehicle. It also makes the code way more understandable. The previous code was making my head hurt.