### PR TITLE
Support remainder of HIGH_LATENCY2 fields

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -620,4 +620,9 @@ QGCCameraControl* FirmwarePlugin::createCameraControl(const mavlink_camera_infor
     return NULL;
 }
 
+uint32_t FirmwarePlugin::highLatencyCustomModeTo32Bits(uint16_t hlCustomMode)
+{
+    // Standard implementation assumes no special handling. Upper part of 32 bit value is not used.
+    return hlCustomMode;
+}
 

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -304,6 +304,9 @@ public:
     /// Returns true if the vehicle is a VTOL
     virtual bool isVtol(const Vehicle* vehicle) const;
 
+    /// Convert from HIGH_LATENCY2.custom_mode value to correct 32 bit value.
+    virtual uint32_t highLatencyCustomModeTo32Bits(uint16_t hlCustomMode);
+
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const QString px4FollowMeFlightMode;
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -589,3 +589,12 @@ QGCCameraControl* PX4FirmwarePlugin::createCameraControl(const mavlink_camera_in
 {
     return new QGCCameraControl(info, vehicle, compID, parent);
 }
+
+uint32_t PX4FirmwarePlugin::highLatencyCustomModeTo32Bits(uint16_t hlCustomMode)
+{
+    union px4_custom_mode px4_cm;
+    px4_cm.data = 0;
+    px4_cm.custom_mode_hl = hlCustomMode;
+
+    return px4_cm.data;
+}

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -70,6 +70,7 @@ public:
     QString             autoDisarmParameter             (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral("COM_DISARM_LAND"); }
     QGCCameraManager*   createCameraManager             (Vehicle* vehicle) override;
     QGCCameraControl*   createCameraControl             (const mavlink_camera_information_t* info, Vehicle* vehicle, int compID, QObject* parent = NULL) override;
+    uint32_t            highLatencyCustomModeTo32Bits   (uint16_t hlCustomMode) override;
 
 protected:
     typedef struct {

--- a/src/FirmwarePlugin/PX4/px4_custom_mode.h
+++ b/src/FirmwarePlugin/PX4/px4_custom_mode.h
@@ -71,7 +71,11 @@ union px4_custom_mode {
 		uint8_t main_mode;
 		uint8_t sub_mode;
 	};
-	uint32_t data;
+    struct {
+        uint16_t reserved_hl;
+        uint16_t custom_mode_hl;
+    };
+    uint32_t data;
 	float data_float;
 };
 

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -312,6 +312,10 @@ void MockLink::_sendHighLatency2(void)
 {
     mavlink_message_t   msg;
 
+    union px4_custom_mode   px4_cm;
+    px4_cm.data = _mavCustomMode;
+
+    qDebug() << "Sending" << _mavCustomMode;
     mavlink_msg_high_latency2_pack_chan(_vehicleSystemId,
                                         _vehicleComponentId,
                                         _mavlinkChannel,
@@ -319,7 +323,7 @@ void MockLink::_sendHighLatency2(void)
                                         0,                          // timestamp
                                         _vehicleType,               // MAV_TYPE
                                         _firmwareType,              // MAV_AUTOPILOT
-                                        _flightModeEnumValue(),     // flight_mode
+                                        px4_cm.custom_mode_hl,      // custom_mode
                                         (int32_t)(_vehicleLatitude  * 1E7),
                                         (int32_t)(_vehicleLongitude * 1E7),
                                         (int16_t)_vehicleAltitude,
@@ -340,9 +344,7 @@ void MockLink::_sendHighLatency2(void)
                                         -1,                         // battery, do not use?
                                         0,                          // wp_num
                                         0,                          // failure_flags
-                                        0,                          // failsafe
                                         0, 0, 0);                   // custom0, custom1, custom2
-
     respondWithMavlinkMessage(msg);
 }
 
@@ -1369,9 +1371,4 @@ void MockLink::_sendADSBVehicles(void)
                                        0);                                          // Squawk code
 
     respondWithMavlinkMessage(responseMsg);
-}
-
-uint8_t MockLink::_flightModeEnumValue(void)
-{
-    return FLIGHT_MODE_STABILIZED;
 }

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -202,7 +202,6 @@ private:
     void _logDownloadWorker(void);
     void _sendADSBVehicles(void);
     void _moveADSBVehicle(void);
-    uint8_t _flightModeEnumValue(void);
 
     static MockLink* _startMockLink(MockConfiguration* mockConfig);
 


### PR DESCRIPTION
* Flight mode now works
* Changed to new FLAGS

**Important note for PX4 firmware**
Although PX4 only uses 16 bits for custom_mode flags. They are in the high 16 bits of the 32 bit custom_mode value of HEARTBEAT. This means that you cannot directly copy between HEARTBEAT.custom_mode and HIGH_LATENCY2.custom_mode and expect it to work. In order to do this I'm using the following structure which needs to be matched on the PX4 implementation of HIGH_LATENCY2.custom_mode when sending the message. Or in other words something like HIGH_LATENCY2.custom_mode = cm.custom_mode_hl.

```
union px4_custom_mode {
	struct {
		uint16_t reserved;
		uint8_t main_mode;
		uint8_t sub_mode;
	};
    struct {
        uint16_t reserved_hl;
        uint16_t custom_mode_hl;
    };
    uint32_t data;
	float data_float;
};
```