### PR TITLE
Add delay to guided commands to catch up with multiple state changes

### DIFF
--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -42,8 +42,26 @@ NoMouseThroughRectangle {
         if (hideTrigger) {
             hideTrigger = false
             altitudeSlider.visible = false
+            visibleTimer.stop()
             visible = false
         }
+    }
+
+    function show(immediate) {
+        if (immediate) {
+            visible = true
+        } else {
+            // We delay showing the confirmation for a small amount in order to any other state
+            // changes to propogate through the system. This way only the final state shows up.
+            visibleTimer.restart()
+        }
+    }
+
+    Timer {
+        id:             visibleTimer
+        interval:       1000
+        repeat:         false
+        onTriggered:    visible = true
     }
 
     QGCPalette { id: qgcPal }

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -185,9 +185,11 @@ Item {
 
     // Called when an action is about to be executed in order to confirm
     function confirmAction(actionCode, actionData) {
+        var showImmediate = true
         closeAll()
         confirmDialog.action = actionCode
         confirmDialog.actionData = actionData
+        confirmDialog.hideTrigger = true
         _actionData = actionData
         switch (actionCode) {
         case actionArm:
@@ -219,6 +221,7 @@ Item {
             altitudeSlider.visible = true
             break;
         case actionStartMission:
+            showImmediate = false
             confirmDialog.title = startMissionTitle
             confirmDialog.message = startMissionMessage
             confirmDialog.hideTrigger = Qt.binding(function() { return !showStartMission })
@@ -229,11 +232,13 @@ Item {
             confirmDialog.hideTrigger = true
             break;
         case actionContinueMission:
+            showImmediate = false
             confirmDialog.title = continueMissionTitle
             confirmDialog.message = continueMissionMessage
             confirmDialog.hideTrigger = Qt.binding(function() { return !showContinueMission })
             break;
         case actionResumeMission:
+            showImmediate = false
             confirmDialog.title = resumeMissionTitle
             confirmDialog.message = resumeMissionMessage
             confirmDialog.hideTrigger = Qt.binding(function() { return !showResumeMission })
@@ -308,7 +313,7 @@ Item {
             console.warn("Unknown actionCode", actionCode)
             return
         }
-        confirmDialog.visible = true
+        confirmDialog.show(showImmediate)
     }
 
     // Executes the specified action


### PR DESCRIPTION
This prevents incorrect confirmation slider to display for very short periods of time.