### PR TITLE
Vehicle handles its own heartbeats (Not to merge yet)

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -304,6 +304,12 @@ public:
     /// Returns true if the vehicle is a VTOL
     virtual bool isVtol(const Vehicle* vehicle) const;
 
+    /// Amount of time (in milliseconds) before a high latency link times out (0 for no timeout)
+    virtual int highLatencyTimeout() { return 0; }
+
+    /// Defines when to send heartbeats on a high latency link (once in every n heartbeat times). 0 for no heartbeats on hight latency.
+    virtual int highLatencyHeartbeatFrequency() { return 0; }
+
     /// Convert from HIGH_LATENCY2.custom_mode value to correct 32 bit value.
     virtual uint32_t highLatencyCustomModeTo32Bits(uint16_t hlCustomMode);
 

--- a/src/Vehicle/MultiVehicleManager.h
+++ b/src/Vehicle/MultiVehicleManager.h
@@ -93,7 +93,6 @@ private slots:
     void _deleteVehiclePhase2(void);
     void _setActiveVehiclePhase2(void);
     void _vehicleParametersReadyChanged(bool parametersReady);
-    void _sendGCSHeartbeat(void);
     void _vehicleHeartbeatInfo(LinkInterface* link, int vehicleId, int componentId, int vehicleFirmwareType, int vehicleType);
     void _requestProtocolVersion(unsigned version);
 
@@ -116,9 +115,7 @@ private:
     JoystickManager*            _joystickManager;
     MAVLinkProtocol*            _mavlinkProtocol;
 
-    QTimer              _gcsHeartbeatTimer;             ///< Timer to emit heartbeats
     bool                _gcsHeartbeatEnabled;           ///< Enabled/disable heartbeat emission
-    static const int    _gcsHeartbeatRateMSecs = 1000;  ///< Heartbeat rate
     static const char*  _gcsHeartbeatEnabledKey;
 };
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -752,6 +752,8 @@ public:
     void _setHomePosition(QGeoCoordinate& homeCoord);
     void _setMaxProtoVersion (unsigned version);
 
+    QList<LinkInterface*>       links() { return _links; }
+
     /// Vehicle is about to be deleted
     void prepareDelete();
 
@@ -886,6 +888,7 @@ private slots:
     void _updateDistanceToHome(void);
     void _updateHobbsMeter(void);
     void _vehicleParamLoaded(bool ready);
+    void _sendGCSHeartbeat(void);
 
 private:
     bool _containsLink(LinkInterface* link);
@@ -1021,6 +1024,10 @@ private:
     QString             _prearmError;
     QTimer              _prearmErrorTimer;
     static const int    _prearmErrorTimeoutMSecs = 35 * 1000;   ///< Take away prearm error after 35 seconds
+
+    QTimer              _gcsHeartbeatTimer;                     ///< Timer to emit heartbeats
+    uint64_t            _gcsHeartbeatCount     = 0;             ///< Number of heartbeats sent
+    static const int    _gcsHeartbeatRateMSecs = 1000;          ///< Heartbeat rate
 
     // Lost connection handling
     bool                _connectionLost;


### PR DESCRIPTION
* Let the vehicle instance control when to send heartbeats (GCS to Vehicle)
* Allow firmware plugin to define heartbeat timeout and frequency for high latency links

Until now, MultiVehicleManager handled all heartbeats from QGC out to the connected links. This moves that logic to the individual vehicles themselves. That's because only they know how to properly handle high latency links.

I'm not merging this until Don is back and have a chance to check and see if this doesn't mess up anything else.