### PR TITLE
Missing file extension for QGCFileDialog when loading KML files.

### DIFF
--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -177,8 +177,7 @@ Item {
         title:          qsTr("Select KML File")
         selectExisting: true
         nameFilters:    [ qsTr("KML files (*.kml)") ]
-
-
+        fileExtension:  "kml"
         onAcceptedForLoad: {
             mapPolygon.loadKMLFile(file)
             close()


### PR DESCRIPTION
Don changed something with the file picker on mobile (to work around some Android issues). In the process, I think he forgot to update the call to the file picker from when loading KML files (on mobile). It was not defining the file extension to look for. Or it wasn't using the method expected by QGCFileDialog.

@DonLakeFlyer, the call was specifying `nameFilters` but the dialog was only evaluating `fileExtension`. You might want to take a closer look and see what else may be calling this with the wrong property.