### PR TITLE
Mobile Log Download

### DIFF
--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -21,6 +21,7 @@
 #include "QGCMapEngine.h"
 #include "ParameterManager.h"
 #include "Vehicle.h"
+#include "SettingsManager.h"
 
 #include <QDebug>
 #include <QSettings>
@@ -511,7 +512,7 @@ LogDownloadController::download(QString path)
     QString dir = path;
 #if defined(__mobile__)
     if(dir.isEmpty()) {
-        dir = QDir::homePath();
+        dir = qgcApp()->toolbox()->settingsManager()->appSettings()->logSavePath();
     }
 #else
     if(dir.isEmpty()) {


### PR DESCRIPTION
For mobile, save log downloads next to where everything else is saved instead of straight into the home directory (which is anybody's guess when it comes to mobile platforms).