### PR TITLE
Joystick: Add circle correction option

### DIFF
--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -76,8 +76,9 @@ public:
     Q_PROPERTY(bool negativeThrust READ negativeThrust WRITE setNegativeThrust NOTIFY negativeThrustChanged)
     Q_PROPERTY(float exponential READ exponential WRITE setExponential NOTIFY exponentialChanged)
     Q_PROPERTY(bool accumulator READ accumulator WRITE setAccumulator NOTIFY accumulatorChanged)
-	Q_PROPERTY(bool requiresCalibration READ requiresCalibration CONSTANT)
-    
+    Q_PROPERTY(bool requiresCalibration READ requiresCalibration CONSTANT)
+    Q_PROPERTY(bool circleCorrection READ circleCorrection WRITE setCircleCorrection NOTIFY circleCorrectionChanged)
+
     // Property accessors
 
     int axisCount(void) { return _axisCount; }
@@ -120,6 +121,9 @@ public:
     bool deadband(void);
     void setDeadband(bool accu);
 
+    bool circleCorrection(void);
+    void setCircleCorrection(bool circleCorrection);
+
     void setTXMode(int mode);
     int getTXMode(void) { return _transmitterMode; }
 
@@ -146,6 +150,8 @@ signals:
     void accumulatorChanged(bool accumulator);
 
     void enabledChanged(bool enabled);
+
+    void circleCorrectionChanged(bool circleCorrection);
 
     /// Signal containing new joystick information
     ///     @param roll     Range is -1:1, negative meaning roll left, positive meaning roll right
@@ -213,6 +219,7 @@ protected:
     float                _exponential;
     bool                _accumulator;
     bool                _deadband;
+    bool                _circleCorrection;
 
     Vehicle*            _activeVehicle;
     bool                _pollingStartedForCalibration;
@@ -229,6 +236,7 @@ private:
     static const char* _exponentialSettingsKey;
     static const char* _accumulatorSettingsKey;
     static const char* _deadbandSettingsKey;
+    static const char* _circleCorrectionSettingsKey;
     static const char* _txModeSettingsKey;
     static const char* _fixedWingTXModeSettingsKey;
     static const char* _multiRotorTXModeSettingsKey;

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -534,6 +534,22 @@ SetupPage {
                                 width:      parent.width
                                 spacing:    ScreenTools.defaultFontPixelWidth
                                 visible:    advancedSettings.checked
+                                QGCCheckBox {
+                                    id:         joystickCircleCorrection
+                                    checked:    _activeVehicle.joystickMode != 0
+                                    text:       qsTr("Enable circle correction")
+
+                                    Component.onCompleted: checked = _activeJoystick.circleCorrection
+                                    onClicked: {
+                                        _activeJoystick.circleCorrection = checked
+                                    }
+                                }
+                            }
+
+                            Row {
+                                width:      parent.width
+                                spacing:    ScreenTools.defaultFontPixelWidth
+                                visible:    advancedSettings.checked
 
                                 QGCCheckBox {
                                     id:         deadband


### PR DESCRIPTION
Some digital joysticks have already this correction
Add habilit to add or remove circle correction

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>