### PR TITLE
Flight Widget

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -93,6 +93,20 @@ QGCView {
         QGroundControl.saveBoolGlobalSetting(_PIPVisibleKey, state)
     }
 
+    function isInstrumentRight() {
+        if(QGroundControl.corePlugin.options.instrumentWidget) {
+            if(QGroundControl.corePlugin.options.instrumentWidget.source.toString().length) {
+                switch(QGroundControl.corePlugin.options.instrumentWidget.widgetPosition) {
+                case CustomInstrumentWidget.POS_TOP_LEFT:
+                case CustomInstrumentWidget.POS_BOTTOM_LEFT:
+                case CustomInstrumentWidget.POS_CENTER_LEFT:
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     PlanMasterController {
         id:                     masterController
         Component.onCompleted:  start(false /* editMode */)
@@ -446,8 +460,10 @@ QGCView {
         ToolStrip {
             visible:            (_activeVehicle ? _activeVehicle.guidedModeSupported : true) && !QGroundControl.videoManager.fullScreen
             id:                 toolStrip
-            anchors.leftMargin: ScreenTools.defaultFontPixelWidth
-            anchors.left:       _panel.left
+            anchors.leftMargin: isInstrumentRight() ? ScreenTools.defaultFontPixelWidth : undefined
+            anchors.left:       isInstrumentRight() ? _panel.left : undefined
+            anchors.rightMargin:isInstrumentRight() ? undefined : ScreenTools.defaultFontPixelWidth
+            anchors.right:      isInstrumentRight() ? undefined : _panel.right
             anchors.topMargin:  ScreenTools.toolbarHeight + (_margins * 2)
             anchors.top:        _panel.top
             z:                  _panel.z + 4

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -52,15 +52,24 @@ Item {
             if(QGroundControl.corePlugin.options.instrumentWidget.source.toString().length) {
                 instrumentsLoader.source = QGroundControl.corePlugin.options.instrumentWidget.source
                 switch(QGroundControl.corePlugin.options.instrumentWidget.widgetPosition) {
+                case CustomInstrumentWidget.POS_TOP_LEFT:
+                    instrumentsLoader.state  = "topLeftMode"
+                    break;
+                case CustomInstrumentWidget.POS_BOTTOM_LEFT:
+                    instrumentsLoader.state  = "bottomLeftMode"
+                    break;
+                case CustomInstrumentWidget.POS_CENTER_LEFT:
+                    instrumentsLoader.state  = "centerLeftMode"
+                    break;
                 case CustomInstrumentWidget.POS_TOP_RIGHT:
-                    instrumentsLoader.state  = "topMode"
+                    instrumentsLoader.state  = "topRightMode"
                     break;
                 case CustomInstrumentWidget.POS_BOTTOM_RIGHT:
-                    instrumentsLoader.state  = "bottomMode"
+                    instrumentsLoader.state  = "bottomRightMode"
                     break;
                 case CustomInstrumentWidget.POS_CENTER_RIGHT:
                 default:
-                    instrumentsLoader.state  = "centerMode"
+                    instrumentsLoader.state  = "centerRightMode"
                     break;
                 }
             } else {
@@ -69,10 +78,9 @@ Item {
                 var useAlternateInstruments = true//QGroundControl.settingsManager.appSettings.virtualJoystick.value || ScreenTools.isTinyScreen
                 if(useAlternateInstruments) {
                     instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidgetAlternate.qml"
-                    instrumentsLoader.state  = "topMode"
                 } else {
                     instrumentsLoader.source = "qrc:/qml/QGCInstrumentWidget.qml"
-                    instrumentsLoader.state  = QGroundControl.settingsManager.appSettings.showLargeCompass.value === 1 ? "centerMode" : "topMode"
+                    instrumentsLoader.state  = QGroundControl.settingsManager.appSettings.showLargeCompass.value === 1 ? "centerRightMode" : "topRightMode"
                 }
             }
         } else {
@@ -141,30 +149,69 @@ Item {
         property real maxHeight:parent.height - (anchors.margins * 2)
         states: [
             State {
-                name:   "topMode"
+                name:   "topRightMode"
                 AnchorChanges {
                     target:                 instrumentsLoader
                     anchors.verticalCenter: undefined
                     anchors.bottom:         undefined
                     anchors.top:            _root ? _root.top : undefined
+                    anchors.right:          _root ? _root.right : undefined
+                    anchors.left:           undefined
                 }
             },
             State {
-                name:   "centerMode"
+                name:   "centerRightMode"
                 AnchorChanges {
                     target:                 instrumentsLoader
                     anchors.top:            undefined
                     anchors.bottom:         undefined
                     anchors.verticalCenter: _root ? _root.verticalCenter : undefined
+                    anchors.right:          _root ? _root.right : undefined
+                    anchors.left:           undefined
                 }
             },
             State {
-                name:   "bottomMode"
+                name:   "bottomRightMode"
                 AnchorChanges {
                     target:                 instrumentsLoader
                     anchors.top:            undefined
                     anchors.verticalCenter: undefined
                     anchors.bottom:         _root ? _root.bottom : undefined
+                    anchors.right:          _root ? _root.right : undefined
+                    anchors.left:           undefined
+                }
+            },
+            State {
+                name:   "topLeftMode"
+                AnchorChanges {
+                    target:                 instrumentsLoader
+                    anchors.verticalCenter: undefined
+                    anchors.bottom:         undefined
+                    anchors.top:            _root ? _root.top : undefined
+                    anchors.right:          undefined
+                    anchors.left:           _root ? _root.left : undefined
+                }
+            },
+            State {
+                name:   "centerLeftMode"
+                AnchorChanges {
+                    target:                 instrumentsLoader
+                    anchors.top:            undefined
+                    anchors.bottom:         undefined
+                    anchors.verticalCenter: _root ? _root.verticalCenter : undefined
+                    anchors.right:          undefined
+                    anchors.left:           _root ? _root.left : undefined
+                }
+            },
+            State {
+                name:   "bottomLeftMode"
+                AnchorChanges {
+                    target:                 instrumentsLoader
+                    anchors.top:            undefined
+                    anchors.verticalCenter: undefined
+                    anchors.bottom:         _root ? _root.bottom : undefined
+                    anchors.right:          undefined
+                    anchors.left:           _root ? _root.left : undefined
                 }
             }
         ]

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -123,16 +123,19 @@ class CustomInstrumentWidget : public QObject
 public:
     //-- Widget Position
     enum Pos {
-        POS_TOP_RIGHT           = 0,
-        POS_CENTER_RIGHT        = 1,
-        POS_BOTTOM_RIGHT        = 2,
+        POS_TOP_RIGHT,
+        POS_CENTER_RIGHT,
+        POS_BOTTOM_RIGHT,
+        POS_TOP_LEFT,
+        POS_CENTER_LEFT,
+        POS_BOTTOM_LEFT
     };
     Q_ENUMS(Pos)
     CustomInstrumentWidget(QObject* parent = NULL);
     Q_PROPERTY(QUrl     source  READ source CONSTANT)
     Q_PROPERTY(Pos      widgetPosition              READ widgetPosition             NOTIFY widgetPositionChanged)
     virtual QUrl        source                      () { return QUrl(); }
-    virtual Pos         widgetPosition              () { return POS_CENTER_RIGHT; }
+    virtual Pos         widgetPosition              () { return POS_TOP_RIGHT; }
 signals:
     void widgetPositionChanged  ();
 };


### PR DESCRIPTION
Allow a plugin to define a left placement for its custom flight widget.
When placed on the left, the action tool strip is placed on the right side.