### PR TITLE
PlanToolBar: Enable focus of upload button when clicked

### DIFF
--- a/src/PlanView/PlanToolBar.qml
+++ b/src/PlanView/PlanToolBar.qml
@@ -301,7 +301,10 @@ Rectangle {
         enabled:                !_controllerSyncInProgress
         visible:                !_controllerOffline && !_controllerSyncInProgress && !uploadCompleteText.visible
         primary:                _controllerDirty
-        onClicked:              planMasterController.upload()
+        onClicked: {
+            focus = true
+            planMasterController.upload()
+        }
 
         PropertyAnimation on opacity {
             easing.type:    Easing.OutQuart


### PR DESCRIPTION
This causes the signal editingFinished() to be emitted and the current value of
the textField to be updated and validated before uploading.

fix #6150

Signed-off-by: Willian Galvani <williangalvani@gmail.com>