### PR TITLE
Firmware Upgrade Fixes

### DIFF
--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -168,7 +168,7 @@ SetupPage {
                     function accept() {
                         hideDialog()
                         if (_singleFirmwareMode) {
-                            controller.flashSingleFirmwareMode()
+                            controller.flashSingleFirmwareMode(controller.selectedFirmwareType)
                         } else {
                             var stack = apmFlightStack.checked ? FirmwareUpgradeController.AutoPilotStackAPM : FirmwareUpgradeController.AutoPilotStackPX4
                             if (px4Flow) {
@@ -353,7 +353,7 @@ SetupPage {
                             currentIndex:   controller.selectedFirmwareType
 
                             onActivated: {
-                                controller.selectedFirmwareType = index
+                                controller.selectedFirmwareType = model.get(index).firmwareType
                                 if (model.get(index).firmwareType === FirmwareUpgradeController.BetaFirmware) {
                                     firmwareVersionWarningLabel.visible = true
                                     firmwareVersionWarningLabel.text = qsTr("WARNING: BETA FIRMWARE. ") +

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -114,9 +114,9 @@ void FirmwareUpgradeController::flash(const FirmwareIdentifier& firmwareId)
     flash(firmwareId.autopilotStackType, firmwareId.firmwareType, firmwareId.firmwareVehicleType);
 }
 
-void FirmwareUpgradeController::flashSingleFirmwareMode(void)
+void FirmwareUpgradeController::flashSingleFirmwareMode(FirmwareType_t firmwareType)
 {
-    flash(SingleFirmwareMode, StableFirmware, DefaultVehicleFirmware);
+    flash(SingleFirmwareMode, firmwareType, DefaultVehicleFirmware);
 }
 
 void FirmwareUpgradeController::cancel(void)

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -123,7 +123,7 @@ public:
                            FirmwareVehicleType_t vehicleType = DefaultVehicleFirmware );
 
     /// Called to flash when upgrade is running in singleFirmwareMode
-    Q_INVOKABLE void flashSingleFirmwareMode(void);
+    Q_INVOKABLE void flashSingleFirmwareMode(FirmwareType_t firmwareType);
 
     Q_INVOKABLE FirmwareVehicleType_t vehicleTypeFromVersionIndex(int index);
     


### PR DESCRIPTION
* Custom, single firmware upgrades were fixed to "stable", even if the user selected "custom".
* The code, when selecting the firmware type was using the combo box model index instead of the actual type defined by the list model. This would only work for when updating the standard flight stack. If you were trying to flash a custom firmware for "SingleFirmwareMode" (custom builds) or for PX4 Flow, the _index_ would point to _Beta_ instead.

@DonLakeFlyer, unrelated to this fix, while looking, I noticed this error:

`qrc:qml/FirmwareUpgrade.qml:127: ReferenceError: hideDialog is not defined`

It comes from here: https://github.com/mavlink/qgroundcontrol/blob/firmwareUpgrade/src/VehicleSetup/FirmwareUpgrade.qml#L127

I don't quite understand how these dialogs work and what this is trying to "hide".