### PR TITLE
Update gstreamer Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You **need to install Qt as described below** instead of using pre-built package
     * Windows: Make sure to install VS 2015 32 bit package.
 
 ###### Install additional packages:
-* Ubuntu: sudo apt-get install speech-dispatcher libudev-dev libsdl2-dev libgstreamer1.0-0 gstreamer1.0-plugins-base libgstreamer-plugins-base1.0-dev gstreamer1.0*
+* Ubuntu: sudo apt-get install speech-dispatcher libudev-dev libsdl2-dev
 * Fedora: sudo dnf install speech-dispatcher SDL2-devel SDL2 systemd-devel
 * Arch Linux: pacman -Sy speech-dispatcher
 * Windows: [USB Driver](http://www.pixhawk.org/firmware/downloads) to connect to Pixhawk/PX4Flow/3DR Radio

--- a/src/VideoStreaming/README.md
+++ b/src/VideoStreaming/README.md
@@ -40,6 +40,9 @@ list=$(apt-cache --names-only search ^gstreamer1.0-* | awk '{ print $1 }' | grep
 ```
 sudo apt-get install $list
 ```
+```
+sudo apt-get install libgstreamer-plugins-base1.0-dev
+```
 
 The build system is setup to use pkgconfig and it will find the necessary headers and libraries automatically.
 

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -181,24 +181,7 @@ VideoEnabled {
 } else {
     LinuxBuild|MacBuild|iOSBuild|WindowsBuild|AndroidBuild {
         message("Skipping support for video streaming (GStreamer libraries not installed)")
-        MacBuild {
-            message("  You can download it from http://gstreamer.freedesktop.org/data/pkg/osx/")
-            message("  Select the devel package and install it (gstreamer-1.0-devel-1.x.x-x86_64.pkg)")
-            message("  It will be installed in /Libraries/Frameworks")
-        }
-        LinuxBuild {
-            message("  You can install it using apt-get")
-            message("  sudo apt-get install gstreamer1.0*")
-        }
-        WindowsBuild {
-            message("  You can download it from http://gstreamer.freedesktop.org/data/pkg/windows/")
-            message("  Select the devel AND runtime packages and install them (x86, not the 64-Bit)")
-            message("  It will be installed in C:/gstreamer. You need to update you PATH to point to the bin directory.")
-        }
-        AndroidBuild {
-            message("  You can download it from http://gstreamer.freedesktop.org/data/pkg/android/")
-            message("  Uncompress the archive into the qgc root source directory (same directory where qgroundcontrol.pro is found.")
-        }
+        message("Installation instructions here: https://github.com/mavlink/qgroundcontrol/blob/master/src/VideoStreaming/README.md")
     } else {
         message("Skipping support for video streaming (Unsupported platform)")
     }


### PR DESCRIPTION
Changes in latest Ubuntu 16.04 were causing them to fail.

@barzanisar When you created #6166 was there a reason you didn't update the instructions to match what you found to work in #6165?

@dogmaphobic Can you take a look.