### PR TITLE
Clear resume mission index

### DIFF
--- a/src/MissionManager/MissionManager.h
+++ b/src/MissionManager/MissionManager.h
@@ -38,10 +38,6 @@ public:
     /// from mission start to resumeIndex in the generate mission.
     void generateResumeMission(int resumeIndex);
 
-signals:
-    void currentIndexChanged        (int currentIndex);
-    void lastCurrentIndexChanged    (int lastCurrentIndex);
-
 private slots:
     void _mavlinkMessageReceived(const mavlink_message_t& message);
 


### PR DESCRIPTION
Remove all wasn't clearing resume mission index. Causing Resume Mission slider to pop up at wrong times.