### PR TITLE
Convex survey support

### DIFF
--- a/src/MissionManager/QGCMapPolygon.cc
+++ b/src/MissionManager/QGCMapPolygon.cc
@@ -258,6 +258,19 @@ void QGCMapPolygon::appendVertex(const QGeoCoordinate& coordinate)
     emit pathChanged();
 }
 
+void QGCMapPolygon::appendVertices(const QList<QGeoCoordinate>& coordinates)
+{
+    QList<QObject*> objects;
+
+    foreach (const QGeoCoordinate& coordinate, coordinates) {
+        objects.append(new QGCQGeoCoordinate(coordinate, this));
+        _polygonPath.append(QVariant::fromValue(coordinate));
+    }
+    _polygonModel.append(objects);
+    emit pathChanged();
+}
+
+
 void QGCMapPolygon::_polygonModelDirtyChanged(bool dirty)
 {
     if (dirty) {
@@ -509,9 +522,7 @@ bool QGCMapPolygon::loadKMLFile(const QString& kmlFile)
     }
 
     clear();
-    for (int i=0; i<rgCoords.count(); i++) {
-        appendVertex(rgCoords[i]);
-    }
+    appendVertices(rgCoords);
 
     return true;
 }

--- a/src/MissionManager/QGCMapPolygon.h
+++ b/src/MissionManager/QGCMapPolygon.h
@@ -40,6 +40,7 @@ public:
     Q_INVOKABLE void clear(void);
     Q_INVOKABLE void appendVertex(const QGeoCoordinate& coordinate);
     Q_INVOKABLE void removeVertex(int vertexIndex);
+    Q_INVOKABLE void appendVertices(const QList<QGeoCoordinate>& coordinates);
 
     /// Adjust the value for the specified coordinate
     ///     @param vertexIndex Polygon point index to modify (0-based)

--- a/src/MissionManager/SurveyMissionItem.h
+++ b/src/MissionManager/SurveyMissionItem.h
@@ -217,7 +217,6 @@ private:
     qreal _ccw(QPointF pt1, QPointF pt2, QPointF pt3);
     qreal _dp(QPointF pt1, QPointF pt2);
     void _swapPoints(QList<QPointF>& points, int index1, int index2);
-    QList<QPointF> _convexPolygon(const QList<QPointF>& polygon);
     void _reverseTransectOrder(QList<QList<QGeoCoordinate>>& transects);
     void _reverseInternalTransectPoints(QList<QList<QGeoCoordinate>>& transects);
     void _adjustTransectsToEntryPointLocation(QList<QList<QGeoCoordinate>>& transects);

--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -172,9 +172,40 @@ void QmlObjectListModel::insert(int i, QObject* object)
     setDirty(true);
 }
 
+void QmlObjectListModel::insert(int i, QList<QObject*> objects)
+{
+    if (i < 0 || i > _objectList.count()) {
+        qWarning() << "Invalid index index:count" << i << _objectList.count();
+    }
+
+    int j = i;
+    foreach (QObject* object, objects) {
+        QQmlEngine::setObjectOwnership(object, QQmlEngine::CppOwnership);
+
+        // Look for a dirtyChanged signal on the object
+        if (object->metaObject()->indexOfSignal(QMetaObject::normalizedSignature("dirtyChanged(bool)")) != -1) {
+            if (!_skipDirtyFirstItem || j != 0) {
+                QObject::connect(object, SIGNAL(dirtyChanged(bool)), this, SLOT(_childDirtyChanged(bool)));
+            }
+        }
+        j++;
+
+        _objectList.insert(i, object);
+    }
+
+    insertRows(i, objects.count());
+
+    setDirty(true);
+}
+
 void QmlObjectListModel::append(QObject* object)
 {
     insert(_objectList.count(), object);
+}
+
+void QmlObjectListModel::append(QList<QObject*> objects)
+{
+    insert(_objectList.count(), objects);
 }
 
 QObjectList QmlObjectListModel::swapObjectList(const QObjectList& newlist)

--- a/src/QmlControls/QmlObjectListModel.h
+++ b/src/QmlControls/QmlObjectListModel.h
@@ -37,11 +37,13 @@ public:
     void setDirty(bool dirty);
     
     void append(QObject* object);
+    void append(QList<QObject*> objects);
     QObjectList swapObjectList(const QObjectList& newlist);
     void clear(void);
     QObject* removeAt(int i);
     QObject* removeOne(QObject* object) { return removeAt(indexOf(object)); }
     void insert(int i, QObject* object);
+    void insert(int i, QList<QObject*> objects);
     QObject* operator[](int i);
     const QObject* operator[](int i) const;
     bool contains(QObject* object) { return _objectList.indexOf(object) != -1; }
@@ -63,12 +65,12 @@ private slots:
     
 private:
     // Overrides from QAbstractListModel
-    virtual int	rowCount(const QModelIndex & parent = QModelIndex()) const;
-    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
-    virtual QHash<int, QByteArray> roleNames(void) const;
-    virtual bool insertRows(int position, int rows, const QModelIndex &index = QModelIndex());
-    virtual bool removeRows(int position, int rows, const QModelIndex &index = QModelIndex());
-    virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
+    int	rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames(void) const override;
+    bool insertRows(int position, int rows, const QModelIndex &index = QModelIndex()) override;
+    bool removeRows(int position, int rows, const QModelIndex &index = QModelIndex()) override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 	
 private:
     QList<QObject*> _objectList;


### PR DESCRIPTION
* Fixed dog slow loading of complex KML
* Complicated concave KML loads for generating survey grids was causing bad transect generation
* Change survey grid generation such that the polygon is no longer converted to convex
* New transect intersection algorithm which works with convex polygons

Examples:
![screen shot 2018-03-13 at 3 39 14 pm](https://user-images.githubusercontent.com/5876851/37373884-daf31892-26d5-11e8-9a99-e08fabc6d23e.png)

This .mov shows how it all work while dynamically changing the grid angle of a survey generated from a complex concave KML load:
https://s3-us-west-2.amazonaws.com/qgroundcontrol/DonLakeFlyer/ConvexGrid.mov