### PR TITLE
Corridor Scan initial terrain support

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -380,9 +380,11 @@ void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
                 // Extend the transect ends for turnaround
                 double azimuth = transect[0].azimuthTo(transect[1]);
                 extensionCoord = transect[0].atDistanceAndAzimuth(-_turnAroundDistanceFact.rawValue().toDouble(), azimuth);
+                extensionCoord.setAltitude(qQNaN());
                 transect.prepend(extensionCoord);
                 azimuth = transect.last().azimuthTo(transect[transect.count() - 2]);
                 extensionCoord = transect.last().atDistanceAndAzimuth(-_turnAroundDistanceFact.rawValue().toDouble(), azimuth);
+                extensionCoord.setAltitude(qQNaN());
                 transect.append(extensionCoord);
             }
 

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -36,17 +36,18 @@ public:
     Q_INVOKABLE void rotateEntryPoint(void);
 
     // Overrides from ComplexMissionItem
-
-    int         lastSequenceNumber  (void) const final;
-    bool        load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
-    QString     mapVisualQML        (void) const final { return QStringLiteral("CorridorScanMapVisual.qml"); }
+    int     lastSequenceNumber  (void) const final;
+    bool    load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
+    QString mapVisualQML        (void) const final { return QStringLiteral("CorridorScanMapVisual.qml"); }
 
     // Overrides from TransectStyleComplexItem
+    void    save                (QJsonArray&  planItems) final;
+    bool    specifiesCoordinate (void) const final;
+    void    appendMissionItems  (QList<MissionItem*>& items, QObject* missionItemParent) final;
+    void    applyNewAltitude    (double newAltitude) final;
 
-    void        save                (QJsonArray&  planItems) final;
-    bool        specifiesCoordinate (void) const final;
-    void        appendMissionItems  (QList<MissionItem*>& items, QObject* missionItemParent) final;
-    void        applyNewAltitude    (double newAltitude) final;
+    // Overrides from VisualMissionionItem
+    bool    readyForSave        (void) const;
 
     static const char* jsonComplexItemTypeValue;
 

--- a/src/MissionManager/CorridorScanComplexItemTest.cc
+++ b/src/MissionManager/CorridorScanComplexItemTest.cc
@@ -134,13 +134,26 @@ void CorridorScanComplexItemTest::_testItemCount(void)
 {
     QList<MissionItem*> items;
 
-    _corridorItem->turnAroundDistance()->setRawValue(20);
 
+    _corridorItem->turnAroundDistance()->setRawValue(0);
     _corridorItem->cameraTriggerInTurnAround()->setRawValue(false);
     _corridorItem->appendMissionItems(items, this);
     QCOMPARE(items.count() - 1, _corridorItem->lastSequenceNumber());
     items.clear();
 
+    _corridorItem->turnAroundDistance()->setRawValue(0);
+    _corridorItem->cameraTriggerInTurnAround()->setRawValue(true);
+    _corridorItem->appendMissionItems(items, this);
+    QCOMPARE(items.count() - 1, _corridorItem->lastSequenceNumber());
+    items.clear();
+
+    _corridorItem->turnAroundDistance()->setRawValue(20);
+    _corridorItem->cameraTriggerInTurnAround()->setRawValue(false);
+    _corridorItem->appendMissionItems(items, this);
+    QCOMPARE(items.count() - 1, _corridorItem->lastSequenceNumber());
+    items.clear();
+
+    _corridorItem->turnAroundDistance()->setRawValue(20);
     _corridorItem->cameraTriggerInTurnAround()->setRawValue(true);
     _corridorItem->appendMissionItems(items, this);
     QCOMPARE(items.count() - 1, _corridorItem->lastSequenceNumber());

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -277,7 +277,7 @@ void MissionController::convertToKMLDocument(QDomDocument& document)
         return;
     }
 
-    float altitude = missionJson[_jsonPlannedHomePositionKey].toArray()[2].toDouble();
+    float homeAltitude = missionJson[_jsonPlannedHomePositionKey].toArray()[2].toDouble();
 
     QString coord;
     QStringList coords;
@@ -292,11 +292,12 @@ void MissionController::convertToKMLDocument(QDomDocument& document)
                 qgcApp()->toolbox()->missionCommandTree()->getUIInfo(_controllerVehicle, item->command());
 
         if (uiInfo && uiInfo->specifiesCoordinate() && !uiInfo->isStandaloneCoordinate()) {
+            double amslAltitude = item->param7() + (item->frame() == MAV_FRAME_GLOBAL ? 0 : homeAltitude);
             coord = QString::number(item->param6(),'f',7) \
                     + "," \
                     + QString::number(item->param5(),'f',7) \
                     + "," \
-                    + QString::number(item->param7() + altitude,'f',2);
+                    + QString::number(amslAltitude,'f',2);
             coords.append(coord);
         }
     }

--- a/src/MissionManager/TransectStyle.SettingsGroup.json
+++ b/src/MissionManager/TransectStyle.SettingsGroup.json
@@ -34,5 +34,32 @@
     "shortDescription": "Refly the pattern at a 90 degree angle",
     "type":             "bool",
     "defaultValue":     false
+},
+{
+    "name":             "TerrainAdjustTolerance",
+    "shortDescription": "TerrainAdjustTolerance",
+    "type":             "double",
+    "decimalPlaces":    2,
+    "min":              0,
+    "units":            "m",
+    "defaultValue":     10
+},
+{
+    "name":             "TerrainAdjustMaxClimbRate",
+    "shortDescription": "TerrainAdjustMaxClimbRate",
+    "type":             "double",
+    "decimalPlaces":    2,
+    "min":              0,
+    "units":            "m/s",
+    "defaultValue":     0
+},
+{
+    "name":             "TerrainAdjustMaxDescentRate",
+    "shortDescription": "TerrainAdjustMaxDescentRate",
+    "type":             "double",
+    "decimalPlaces":    2,
+    "min":              0,
+    "units":            "m/s",
+    "defaultValue":     0
 }
 ]

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -26,29 +26,44 @@ const char* TransectStyleComplexItem::turnAroundDistanceMultiRotorName =    "Tur
 const char* TransectStyleComplexItem::cameraTriggerInTurnAroundName =       "CameraTriggerInTurnAround";
 const char* TransectStyleComplexItem::hoverAndCaptureName =                 "HoverAndCapture";
 const char* TransectStyleComplexItem::refly90DegreesName =                  "Refly90Degrees";
+const char* TransectStyleComplexItem::terrainAdjustToleranceName =          "TerrainAdjustTolerance";
+const char* TransectStyleComplexItem::terrainAdjustMaxClimbRateName =       "TerrainAdjustMaxClimbRate";
+const char* TransectStyleComplexItem::terrainAdjustMaxDescentRateName =     "TerrainAdjustMaxDescentRate";
 
 const char* TransectStyleComplexItem::_jsonTransectStyleComplexItemKey =    "TransectStyleComplexItem";
 const char* TransectStyleComplexItem::_jsonCameraCalcKey =                  "CameraCalc";
 const char* TransectStyleComplexItem::_jsonTransectPointsKey =              "TransectPoints";
 const char* TransectStyleComplexItem::_jsonItemsKey =                       "Items";
 
+const int       TransectStyleComplexItem::_terrainQueryTimeoutMsecs =   500;
+const double    TransectStyleComplexItem::_surveyEdgeIndicator =        -10;
+
 TransectStyleComplexItem::TransectStyleComplexItem(Vehicle* vehicle, QString settingsGroup, QObject* parent)
-    : ComplexMissionItem            (vehicle, parent)
-    , _settingsGroup                (settingsGroup)
-    , _sequenceNumber               (0)
-    , _dirty                        (false)
-    , _ignoreRecalc                 (false)
-    , _complexDistance              (0)
-    , _cameraShots                  (0)
-    , _cameraMinTriggerInterval     (0)
-    , _cameraCalc                   (vehicle)
-    , _loadedMissionItemsParent     (NULL)
-    , _metaDataMap                  (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/TransectStyle.SettingsGroup.json"), this))
-    , _turnAroundDistanceFact       (_settingsGroup, _metaDataMap[_vehicle->multiRotor() ? turnAroundDistanceMultiRotorName : turnAroundDistanceName])
-    , _cameraTriggerInTurnAroundFact(_settingsGroup, _metaDataMap[cameraTriggerInTurnAroundName])
-    , _hoverAndCaptureFact          (_settingsGroup, _metaDataMap[hoverAndCaptureName])
-    , _refly90DegreesFact           (_settingsGroup, _metaDataMap[refly90DegreesName])
+    : ComplexMissionItem                (vehicle, parent)
+    , _settingsGroup                    (settingsGroup)
+    , _sequenceNumber                   (0)
+    , _dirty                            (false)
+    , _terrainPolyPathQuery             (NULL)
+    , _ignoreRecalc                     (false)
+    , _complexDistance                  (0)
+    , _cameraShots                      (0)
+    , _cameraMinTriggerInterval         (0)
+    , _cameraCalc                       (vehicle)
+    , _followTerrain                    (false)
+    , _loadedMissionItemsParent         (NULL)
+    , _metaDataMap                      (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/TransectStyle.SettingsGroup.json"), this))
+    , _turnAroundDistanceFact           (_settingsGroup, _metaDataMap[_vehicle->multiRotor() ? turnAroundDistanceMultiRotorName : turnAroundDistanceName])
+    , _cameraTriggerInTurnAroundFact    (_settingsGroup, _metaDataMap[cameraTriggerInTurnAroundName])
+    , _hoverAndCaptureFact              (_settingsGroup, _metaDataMap[hoverAndCaptureName])
+    , _refly90DegreesFact               (_settingsGroup, _metaDataMap[refly90DegreesName])
+    , _terrainAdjustToleranceFact       (_settingsGroup, _metaDataMap[terrainAdjustToleranceName])
+    , _terrainAdjustMaxClimbRateFact    (_settingsGroup, _metaDataMap[terrainAdjustMaxClimbRateName])
+    , _terrainAdjustMaxDescentRateFact  (_settingsGroup, _metaDataMap[terrainAdjustMaxDescentRateName])
 {
+    _terrainQueryTimer.setInterval(_terrainQueryTimeoutMsecs);
+    _terrainQueryTimer.setSingleShot(true);
+    connect(&_terrainQueryTimer, &QTimer::timeout, this, &TransectStyleComplexItem::_reallyQueryTransectsPathHeightInfo);
+
     connect(&_turnAroundDistanceFact,                   &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
     connect(&_hoverAndCaptureFact,                      &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
     connect(&_refly90DegreesFact,                       &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
@@ -302,4 +317,89 @@ void TransectStyleComplexItem::_rebuildTransects(void)
 {
     _rebuildTransectsPhase1();
     _rebuildTransectsPhase2();
+}
+
+void TransectStyleComplexItem::_queryTransectsPathHeightInfo(void)
+{
+    _transectsPathHeightInfo.clear();
+    if (_terrainPolyPathQuery) {
+        // Toss previous query
+        _terrainPolyPathQuery->deleteLater();
+        _terrainPolyPathQuery = NULL;
+    }
+
+    if (_transectPoints.count() > 1) {
+        // We don't actually send the query until this timer times out. This way we only send
+        // the laset request if we get a bunch in a row.
+        _terrainQueryTimer.start();
+    }
+}
+
+void TransectStyleComplexItem::_reallyQueryTransectsPathHeightInfo(void)
+{
+    if (_transectPoints.count() > 1) {
+        _terrainPolyPathQuery = new TerrainPolyPathQuery(this);
+        connect(_terrainPolyPathQuery, &TerrainPolyPathQuery::terrainData, this, &TransectStyleComplexItem::_polyPathTerrainData);
+        _terrainPolyPathQuery->requestData(_transectPoints);
+    }
+}
+
+void TransectStyleComplexItem::_polyPathTerrainData(bool success, const QList<TerrainPathQuery::PathHeightInfo_t>& rgPathHeightInfo)
+{
+    if (success) {
+        _transectsPathHeightInfo = rgPathHeightInfo;
+    } else {
+        _transectsPathHeightInfo.clear();
+    }
+}
+
+bool TransectStyleComplexItem::readyForSave(void) const
+{
+    // Make sure we have the terrain data we need
+    return _transectPoints.count() > 1 ? _transectsPathHeightInfo.count() : false;
+}
+
+void TransectStyleComplexItem::_adjustTransectPointsForTerrain(void)
+{
+    if (_followTerrain && !readyForSave()) {
+        qCWarning(TransectStyleComplexItemLog) << "_adjustTransectPointsForTerrain called when terrain data not ready";
+        qgcApp()->showMessage(tr("INTERNAL ERROR: TransectStyleComplexItem::_adjustTransectPointsForTerrain called when terrain data not ready. Plan will be incorrect."));
+        return;
+    }
+
+    double altitude = _cameraCalc.distanceToSurface()->rawValue().toDouble();
+
+    for (int i=0; i<_transectPoints.count() - 1; i++) {
+        QGeoCoordinate transectPoint = _transectPoints[i].value<QGeoCoordinate>();
+
+        bool surveyEdgeIndicator = transectPoint.altitude() == _surveyEdgeIndicator;
+        if (_followTerrain) {
+            transectPoint.setAltitude(_transectsPathHeightInfo[i].rgHeight[0] + altitude);
+        } else {
+            transectPoint.setAltitude(altitude);
+        }
+        if (surveyEdgeIndicator) {
+            // Use to indicate survey edge
+            transectPoint.setAltitude(-transectPoint.altitude());
+        }
+
+        _transectPoints[i] = QVariant::fromValue(transectPoint);
+    }
+
+    // Take care of last point
+    QGeoCoordinate transectPoint = _transectPoints.last().value<QGeoCoordinate>();
+    if (_followTerrain){
+        transectPoint.setAltitude(_transectsPathHeightInfo.last().rgHeight.last() + altitude);
+    } else {
+        transectPoint.setAltitude(altitude);
+    }
+    _transectPoints[_transectPoints.count() - 1] = QVariant::fromValue(transectPoint);
+}
+
+void TransectStyleComplexItem::setFollowTerrain(bool followTerrain)
+{
+    if (followTerrain != _followTerrain) {
+        _followTerrain = followTerrain;
+        emit followTerrainChanged(followTerrain);
+    }
 }

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -388,10 +388,15 @@ void TransectStyleComplexItem::_adjustTransectPointsForTerrain(void)
 
     // Take care of last point
     QGeoCoordinate transectPoint = _transectPoints.last().value<QGeoCoordinate>();
+    bool surveyEdgeIndicator = transectPoint.altitude() == _surveyEdgeIndicator;
     if (_followTerrain){
         transectPoint.setAltitude(_transectsPathHeightInfo.last().rgHeight.last() + altitude);
     } else {
         transectPoint.setAltitude(altitude);
+    }
+    if (surveyEdgeIndicator) {
+        // Use to indicate survey edge
+        transectPoint.setAltitude(-transectPoint.altitude());
     }
     _transectPoints[_transectPoints.count() - 1] = QVariant::fromValue(transectPoint);
 }

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -16,6 +16,7 @@
 #include "QGCMapPolyline.h"
 #include "QGCMapPolygon.h"
 #include "CameraCalc.h"
+#include "TerrainQuery.h"
 
 Q_DECLARE_LOGGING_CATEGORY(TransectStyleComplexItemLog)
 
@@ -26,34 +27,45 @@ class TransectStyleComplexItem : public ComplexMissionItem
 public:
     TransectStyleComplexItem(Vehicle* vehicle, QString settignsGroup, QObject* parent = NULL);
 
-    Q_PROPERTY(QGCMapPolygon*   surveyAreaPolygon           READ surveyAreaPolygon         CONSTANT)
-    Q_PROPERTY(CameraCalc*      cameraCalc                  READ cameraCalc                 CONSTANT)
-    Q_PROPERTY(Fact*            turnAroundDistance          READ turnAroundDistance         CONSTANT)
-    Q_PROPERTY(Fact*            cameraTriggerInTurnAround   READ cameraTriggerInTurnAround  CONSTANT)
-    Q_PROPERTY(Fact*            hoverAndCapture             READ hoverAndCapture            CONSTANT)
-    Q_PROPERTY(Fact*            refly90Degrees              READ refly90Degrees             CONSTANT)
+    Q_PROPERTY(QGCMapPolygon*   surveyAreaPolygon           READ surveyAreaPolygon                                  CONSTANT)
+    Q_PROPERTY(CameraCalc*      cameraCalc                  READ cameraCalc                                         CONSTANT)
+    Q_PROPERTY(Fact*            turnAroundDistance          READ turnAroundDistance                                 CONSTANT)
+    Q_PROPERTY(Fact*            cameraTriggerInTurnAround   READ cameraTriggerInTurnAround                          CONSTANT)
+    Q_PROPERTY(Fact*            hoverAndCapture             READ hoverAndCapture                                    CONSTANT)
+    Q_PROPERTY(Fact*            refly90Degrees              READ refly90Degrees                                     CONSTANT)
 
-    Q_PROPERTY(int              cameraShots                 READ cameraShots                NOTIFY cameraShotsChanged)
-    Q_PROPERTY(double           timeBetweenShots            READ timeBetweenShots           NOTIFY timeBetweenShotsChanged)
-    Q_PROPERTY(double           coveredArea                 READ coveredArea                NOTIFY coveredAreaChanged)
-    Q_PROPERTY(double           cameraMinTriggerInterval    READ cameraMinTriggerInterval   NOTIFY cameraMinTriggerIntervalChanged)
-    Q_PROPERTY(bool             hoverAndCaptureAllowed      READ hoverAndCaptureAllowed     CONSTANT)
-    Q_PROPERTY(QVariantList     transectPoints              READ transectPoints             NOTIFY transectPointsChanged)
+    Q_PROPERTY(int              cameraShots                 READ cameraShots                                        NOTIFY cameraShotsChanged)
+    Q_PROPERTY(double           timeBetweenShots            READ timeBetweenShots                                   NOTIFY timeBetweenShotsChanged)
+    Q_PROPERTY(double           coveredArea                 READ coveredArea                                        NOTIFY coveredAreaChanged)
+    Q_PROPERTY(double           cameraMinTriggerInterval    READ cameraMinTriggerInterval                           NOTIFY cameraMinTriggerIntervalChanged)
+    Q_PROPERTY(bool             hoverAndCaptureAllowed      READ hoverAndCaptureAllowed                             CONSTANT)
+    Q_PROPERTY(QVariantList     transectPoints              READ transectPoints                                     NOTIFY transectPointsChanged)
+
+    Q_PROPERTY(bool             followTerrain               READ followTerrain              WRITE setFollowTerrain  NOTIFY followTerrainChanged)
+    Q_PROPERTY(Fact*            terrainAdjustTolerance      READ terrainAdjustTolerance                             CONSTANT)
+    Q_PROPERTY(Fact*            terrainAdjustMaxDescentRate READ terrainAdjustMaxDescentRate                        CONSTANT)
+    Q_PROPERTY(Fact*            terrainAdjustMaxClimbRate   READ terrainAdjustMaxClimbRate                          CONSTANT)
 
     QGCMapPolygon*  surveyAreaPolygon   (void) { return &_surveyAreaPolygon; }
     CameraCalc*     cameraCalc          (void) { return &_cameraCalc; }
     QVariantList    transectPoints      (void) { return _transectPoints; }
 
-    Fact* turnAroundDistance        (void) { return &_turnAroundDistanceFact; }
-    Fact* cameraTriggerInTurnAround (void) { return &_cameraTriggerInTurnAroundFact; }
-    Fact* hoverAndCapture           (void) { return &_hoverAndCaptureFact; }
-    Fact* refly90Degrees            (void) { return &_refly90DegreesFact; }
+    Fact* turnAroundDistance            (void) { return &_turnAroundDistanceFact; }
+    Fact* cameraTriggerInTurnAround     (void) { return &_cameraTriggerInTurnAroundFact; }
+    Fact* hoverAndCapture               (void) { return &_hoverAndCaptureFact; }
+    Fact* refly90Degrees                (void) { return &_refly90DegreesFact; }
+    Fact* terrainAdjustTolerance        (void) { return &_terrainAdjustToleranceFact; }
+    Fact* terrainAdjustMaxDescentRate   (void) { return &_terrainAdjustMaxClimbRateFact; }
+    Fact* terrainAdjustMaxClimbRate     (void) { return &_terrainAdjustMaxDescentRateFact; }
 
     int             cameraShots             (void) const { return _cameraShots; }
     double          timeBetweenShots        (void);
     double          coveredArea             (void) const;
     double          cameraMinTriggerInterval(void) const { return _cameraMinTriggerInterval; }
     bool            hoverAndCaptureAllowed  (void) const;
+    bool            followTerrain           (void) const { return _followTerrain; }
+
+    void setFollowTerrain(bool followTerrain);
 
     // Overrides from ComplexMissionItem
 
@@ -85,6 +97,7 @@ public:
     double          specifiedGimbalYaw      (void) final { return std::numeric_limits<double>::quiet_NaN(); }
     double          specifiedGimbalPitch    (void) final { return std::numeric_limits<double>::quiet_NaN(); }
     void            setMissionFlightStatus  (MissionController::MissionFlightStatus_t& missionFlightStatus) final;
+    bool            readyForSave            (void) const override;
 
     bool coordinateHasRelativeAltitude      (void) const final { return true /*_altitudeRelative*/; }
     bool exitCoordinateHasRelativeAltitude  (void) const final { return true /*_altitudeRelative*/; }
@@ -99,6 +112,9 @@ public:
     static const char* cameraTriggerInTurnAroundName;
     static const char* hoverAndCaptureName;
     static const char* refly90DegreesName;
+    static const char* terrainAdjustToleranceName;
+    static const char* terrainAdjustMaxClimbRateName;
+    static const char* terrainAdjustMaxDescentRateName;
 
 signals:
     void cameraShotsChanged             (void);
@@ -106,6 +122,7 @@ signals:
     void cameraMinTriggerIntervalChanged(double cameraMinTriggerInterval);
     void transectPointsChanged          (void);
     void coveredAreaChanged             (void);
+    void followTerrainChanged           (bool followTerrain);
 
 protected slots:
     virtual void _rebuildTransectsPhase1    (void) = 0;
@@ -115,23 +132,30 @@ protected slots:
     void _setIfDirty                        (bool dirty);
     void _updateCoordinateAltitudes         (void);
     void _signalLastSequenceNumberChanged   (void);
+    void _polyPathTerrainData               (bool success, const QList<TerrainPathQuery::PathHeightInfo_t>& rgPathHeightInfo);
 
 protected:
-    void    _save               (QJsonObject& saveObject);
-    bool    _load               (const QJsonObject& complexObject, QString& errorString);
-    void    _setExitCoordinate  (const QGeoCoordinate& coordinate);
-    void    _setCameraShots     (int cameraShots);
-    double  _triggerDistance    (void) const;
-    bool    _hasTurnaround      (void) const;
-    double  _turnaroundDistance (void) const;
+    void    _save                           (QJsonObject& saveObject);
+    bool    _load                           (const QJsonObject& complexObject, QString& errorString);
+    void    _setExitCoordinate              (const QGeoCoordinate& coordinate);
+    void    _setCameraShots                 (int cameraShots);
+    double  _triggerDistance                (void) const;
+    bool    _hasTurnaround                  (void) const;
+    double  _turnaroundDistance             (void) const;
+    void    _queryTransectsPathHeightInfo   (void);
+    void    _adjustTransectPointsForTerrain (void);
 
     QString         _settingsGroup;
     int             _sequenceNumber;
     bool            _dirty;
     QGeoCoordinate  _coordinate;
     QGeoCoordinate  _exitCoordinate;
-    QVariantList    _transectPoints;
     QGCMapPolygon   _surveyAreaPolygon;
+
+    QVariantList                                _transectPoints;
+    QList<TerrainPathQuery::PathHeightInfo_t>   _transectsPathHeightInfo;
+    TerrainPolyPathQuery*                       _terrainPolyPathQuery;
+    QTimer                                      _terrainQueryTimer;
 
     bool            _ignoreRecalc;
     double          _complexDistance;
@@ -140,6 +164,7 @@ protected:
     double          _cameraMinTriggerInterval;
     double          _cruiseSpeed;
     CameraCalc      _cameraCalc;
+    bool            _followTerrain;
 
     QObject*            _loadedMissionItemsParent;	///< Parent for all items in _loadedMissionItems for simpler delete
     QList<MissionItem*> _loadedMissionItems;		///< Mission items loaded from plan file
@@ -150,12 +175,20 @@ protected:
     SettingsFact _cameraTriggerInTurnAroundFact;
     SettingsFact _hoverAndCaptureFact;
     SettingsFact _refly90DegreesFact;
+    SettingsFact _terrainAdjustToleranceFact;
+    SettingsFact _terrainAdjustMaxClimbRateFact;
+    SettingsFact _terrainAdjustMaxDescentRateFact;
 
     static const char* _jsonCameraCalcKey;
     static const char* _jsonTransectStyleComplexItemKey;
     static const char* _jsonTransectPointsKey;
     static const char* _jsonItemsKey;
 
+    static const int _terrainQueryTimeoutMsecs;
+    static const double _surveyEdgeIndicator;   ///< Altitude value in _transectPoints which indicates survey entry
+
 private slots:
-    void _rebuildTransects(void);
+    void _rebuildTransects                      (void);
+    void _reallyQueryTransectsPathHeightInfo    (void);
+
 };

--- a/src/PlanView/CorridorScanEditor.qml
+++ b/src/PlanView/CorridorScanEditor.qml
@@ -57,6 +57,11 @@ Rectangle {
         spacing:            _margin
 
         QGCLabel {
+            text: "WIP: Careful!"
+            color:  qgcPal.warningText
+        }
+
+        QGCLabel {
             anchors.left:   parent.left
             anchors.right:  parent.right
             text:           qsTr("WARNING: Photo interval is below minimum interval (%1 secs) supported by camera.").arg(missionItem.cameraMinTriggerInterval.toFixed(1))
@@ -124,6 +129,59 @@ Rectangle {
         QGCButton {
             text:       qsTr("Rotate Entry Point")
             onClicked:  missionItem.rotateEntryPoint()
+        }
+
+        SectionHeader {
+            id:         terrainHeader
+            text:       qsTr("Terrain")
+            checked:    false
+        }
+
+        ColumnLayout {
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            spacing:        _margin
+            visible:        terrainHeader.checked
+
+            QGCCheckBox {
+                id:         followsTerrainCheckBox
+                text:       qsTr("Vehicle follows terrain")
+                checked:    missionItem.followTerrain
+                onClicked:  missionItem.followTerrain = checked
+            }
+
+            GridLayout {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                columnSpacing:  _margin
+                rowSpacing:     _margin
+                columns:        2
+                visible:        followsTerrainCheckBox.checked
+
+                QGCLabel {
+                    text: "WIP: Careful!"
+                    color:  qgcPal.warningText
+                    Layout.columnSpan: 2
+                }
+
+                QGCLabel { text: qsTr("Tolerance") }
+                FactTextField {
+                    fact:               missionItem.terrainAdjustTolerance
+                    Layout.fillWidth:   true
+                }
+
+                QGCLabel { text: qsTr("Max Climb Rate") }
+                FactTextField {
+                    fact:               missionItem.terrainAdjustMaxClimbRate
+                    Layout.fillWidth:   true
+                }
+
+                QGCLabel { text: qsTr("Max Descent Rate") }
+                FactTextField {
+                    fact:               missionItem.terrainAdjustMaxDescentRate
+                    Layout.fillWidth:   true
+                }
+            }
         }
 
         SectionHeader {


### PR DESCRIPTION
![screen shot 2018-03-17 at 9 12 17 am](https://user-images.githubusercontent.com/5876851/37557568-b6c63274-29c3-11e8-8b1e-770bdbfe0bb9.png)

* Terrain follow checkbox is live
* The various terrain follow settings Tolerance, ... are NYI
* Current implemenation only adjusts existing waypoints for terrain heights. It does not add additional waypoints in between yet.

The end result looks like this. A little hard to see, but you can see all points adjusted for 10m over terrain. If you look closely you can also see why just this is inadequate where the one transect goes through terrain:
![screen shot 2018-03-17 at 9 12 06 am](https://user-images.githubusercontent.com/5876851/37557571-c0888e06-29c3-11e8-9405-7a262c98828c.png)

Related to #6204