### PR TITLE
Restructure for TerrainQueryInterface abstract base class

### DIFF
--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -374,7 +374,7 @@ void TransectStyleComplexItem::_adjustTransectPointsForTerrain(void)
 
         bool surveyEdgeIndicator = transectPoint.altitude() == _surveyEdgeIndicator;
         if (_followTerrain) {
-            transectPoint.setAltitude(_transectsPathHeightInfo[i].rgHeight[0] + altitude);
+            transectPoint.setAltitude(_transectsPathHeightInfo[i].heights[0] + altitude);
         } else {
             transectPoint.setAltitude(altitude);
         }
@@ -390,7 +390,7 @@ void TransectStyleComplexItem::_adjustTransectPointsForTerrain(void)
     QGeoCoordinate transectPoint = _transectPoints.last().value<QGeoCoordinate>();
     bool surveyEdgeIndicator = transectPoint.altitude() == _surveyEdgeIndicator;
     if (_followTerrain){
-        transectPoint.setAltitude(_transectsPathHeightInfo.last().rgHeight.last() + altitude);
+        transectPoint.setAltitude(_transectsPathHeightInfo.last().heights.last() + altitude);
     } else {
         transectPoint.setAltitude(altitude);
     }

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -180,10 +180,10 @@ void VisualMissionItem::_reallyUpdateTerrainAltitude(void)
     }
 }
 
-void VisualMissionItem::_terrainDataReceived(bool success, QList<float> altitudes)
+void VisualMissionItem::_terrainDataReceived(bool success, QList<double> heights)
 {
     if (success) {
-        _terrainAltitude = altitudes[0];
+        _terrainAltitude = heights[0];
         emit terrainAltitudeChanged(_terrainAltitude);
         sender()->deleteLater();
     }

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -211,7 +211,7 @@ protected:
 private slots:
     void _updateTerrainAltitude (void);
     void _reallyUpdateTerrainAltitude (void);
-    void _terrainDataReceived   (bool success, QList<float> altitudes);
+    void _terrainDataReceived   (bool success, QList<double> heights);
 
 private:
     QTimer _updateTerrainTimer;


### PR DESCRIPTION
This restructures the terrain query code such that all queries go through a TerrainQueryInterface abstract base class definition. This way the actual terrain query mechanism can be coded without the upper level client code changes affecting it. I have implemented the AirMap version. Then the offline code just needs to implement another version of this interface and change the code in the three places that instantiates TerrainAirMapQuery to the offline implementation. Should be fairly straightforward.

```
/// Base class for offline/online terrain queries
class TerrainQueryInterface : public QObject
{
    Q_OBJECT

public:
    TerrainQueryInterface(QObject* parent) : QObject(parent) { }

    /// Request terrain heights for specified coodinates.
    /// Signals: coordinateHeights when data is available
    virtual void requestCoordinateHeights(const QList<QGeoCoordinate>& coordinates) = 0;

    /// Requests terrain heights along the path specified by the two coordinates.
    /// Signals: pathHeights
    ///     @param coordinates to query
    virtual void requestPathHeights(const QGeoCoordinate& fromCoord, const QGeoCoordinate& toCoord) = 0;

    /// Request terrain heights for the rectangular area specified.
    /// Signals: carpetHeights when data is available
    ///     @param swCoord South-West bound of rectangular area to query
    ///     @param neCoord North-East bound of rectangular area to query
    ///     @param statsOnly true: Return only stats, no carpet data
    virtual void requestCarpetHeights(const QGeoCoordinate& swCoord, const QGeoCoordinate& neCoord, bool statsOnly) = 0;

signals:
    void coordinateHeights(bool success, QList<double> heights);
    void pathHeights(bool success, double latStep, double lonStep, const QList<double>& heights);
    void carpetHeights(bool success, double minHeight, double maxHeight, const QList<QList<double>>& carpet);
};
```

FYI: @birchera 
Related to #5842