### PR TITLE
FlightDisplay : Remove sentence about disabling arming check

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -135,7 +135,7 @@ Item {
             z:                          QGroundControl.zOrderTopMost
             color:                      mapPal.text
             font.pointSize:             ScreenTools.largeFontPointSize
-            text:                       "The vehicle has failed a pre-arm check. In order to arm the vehicle, resolve the failure or disable the arming check via the Safety tab on the Vehicle Setup page."
+            text:                       "The vehicle has failed a pre-arm check. In order to arm the vehicle, resolve the failure."
         }
     }
 


### PR DESCRIPTION
We don't want average users to disable the arming check. If the problem is trigger, it is generally because there is a problem so the check shouldn't be advice to be disable.