### PR TITLE
PX4 SensorsSetup Airspeed check FW_ARSP_MODE no longer bool

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -410,7 +410,7 @@ Item {
                 width:          _buttonWidth
                 text:           qsTr("Airspeed")
                 visible:        (controller.vehicle.fixedWing || controller.vehicle.vtol) &&
-                                controller.getParameterFact(-1, "FW_ARSP_MODE").value === false &&
+                                controller.getParameterFact(-1, "FW_ARSP_MODE").value === 0 &&
                                 controller.getParameterFact(-1, "CBRK_AIRSPD_CHK").value !== 162128 &&
                                 QGroundControl.corePlugin.options.showSensorCalibrationAirspeed &&
                                 showSensorCalibrationAirspeed


### PR DESCRIPTION
We changed the metadata of FW_ARSP_MODE so it's no longer a boolean.

https://github.com/PX4/Firmware/issues/9120