### PR TITLE
Allow type coercion for FW_ARSP_MODE param

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentSummaryFixedWing.qml
@@ -25,7 +25,7 @@ FactPanel {
     property Fact airspeedDisabledFact: controller.getParameterFact(-1, "FW_ARSP_MODE")
     property Fact airspeedBreakerFact:  controller.getParameterFact(-1, "CBRK_AIRSPD_CHK")
 
-    property bool _airspeedVisible:     airspeedDisabledFact.value === false && airspeedBreakerFact.value !== 162128
+    property bool _airspeedVisible:     airspeedDisabledFact.value == 0 && airspeedBreakerFact.value !== 162128
     property bool _airspeedCalRequired: _airspeedVisible && dpressOffFact.value === 0
 
     Column {

--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -410,7 +410,7 @@ Item {
                 width:          _buttonWidth
                 text:           qsTr("Airspeed")
                 visible:        (controller.vehicle.fixedWing || controller.vehicle.vtol) &&
-                                controller.getParameterFact(-1, "FW_ARSP_MODE").value === false &&
+                                controller.getParameterFact(-1, "FW_ARSP_MODE").value == 0 &&
                                 controller.getParameterFact(-1, "CBRK_AIRSPD_CHK").value !== 162128 &&
                                 QGroundControl.corePlugin.options.showSensorCalibrationAirspeed &&
                                 showSensorCalibrationAirspeed


### PR DESCRIPTION
Previous code was broken due to no type coercion from int to bool. Without it, possible breaks due to meta data changes.