### PR TITLE
PX4 PowerComponent add missing override

### DIFF
--- a/src/AutoPilotPlugins/PX4/PowerComponent.h
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.h
@@ -25,7 +25,7 @@ public:
     PowerComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Overrides from VehicleComponent
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
+    virtual QStringList setupCompleteChangedTriggerList(void) const override;
     
     // Overrides from VehicleComponent
     QString name                    (void) const override;


### PR DESCRIPTION
This should fix the OSX build failing on Jenkins.