### PR TITLE
Revert "PX4 PowerComponent add missing override"

### DIFF
--- a/src/AutoPilotPlugins/PX4/PowerComponent.h
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.h
@@ -25,7 +25,7 @@ public:
     PowerComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
     
     // Overrides from VehicleComponent
-    virtual QStringList setupCompleteChangedTriggerList(void) const override;
+    virtual QStringList setupCompleteChangedTriggerList(void) const;
     
     // Overrides from VehicleComponent
     QString name                    (void) const override;


### PR DESCRIPTION
Reverts mavlink/qgroundcontrol#6280

This was already fixed in pulls that were sitting in the queue. Easier to revert this than fix the merge conflicts in multiple pulls. Ends up doing the same thing.