### PR TITLE
Fix joystick activation

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -445,7 +445,7 @@ void Joystick::run(void)
             }
         }
 
-        if (_outputEnabled && _calibrated) {
+        if (_activeVehicle->joystickEnabled() && _calibrated) {
             int     axis = _rgFunctionAxis[rollFunction];
             float   roll = _adjustRange(_rgAxisValues[axis], _rgCalibration[axis], _deadband);
 
@@ -798,18 +798,8 @@ void Joystick::setCalibrationMode(bool calibrating)
     else if (_pollingStartedForCalibration) {
         stopPolling();
     }
-    if (calibrating){
-        setOutputEnabled(false); //Disable the joystick output before calibrating
-    }
-    else if (!calibrating && _calibrated){
-        setOutputEnabled(true); //Enable joystick output after calibration
-    }
 }
 
-void Joystick::setOutputEnabled(bool enabled){
-    _outputEnabled = enabled;
-    emit outputEnabledChanged(_outputEnabled);
-}
 
 void Joystick::_buttonAction(const QString& action)
 {

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -445,7 +445,7 @@ void Joystick::run(void)
             }
         }
 
-        if (_activeVehicle->joystickEnabled() && _calibrated) {
+        if (_activeVehicle->joystickEnabled() && !_calibrationMode && _calibrated) {
             int     axis = _rgFunctionAxis[rollFunction];
             float   roll = _adjustRange(_rgAxisValues[axis], _rgCalibration[axis], _deadband);
 

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -61,7 +61,6 @@ public:
     Q_PROPERTY(QString name READ name CONSTANT)
 
     Q_PROPERTY(bool calibrated MEMBER _calibrated NOTIFY calibratedChanged)
-    Q_PROPERTY(bool outputEnabled MEMBER _outputEnabled WRITE setOutputEnabled NOTIFY outputEnabledChanged)
 
     Q_PROPERTY(int totalButtonCount  READ totalButtonCount    CONSTANT)
     Q_PROPERTY(int axisCount    READ axisCount      CONSTANT)
@@ -129,11 +128,9 @@ public:
 
     /// Set the current calibration mode
     void setCalibrationMode(bool calibrating);
-    void setOutputEnabled(bool enabled);
 
 signals:
     void calibratedChanged(bool calibrated);
-    void outputEnabledChanged(bool enabled);
 
     // The raw signals are only meant for use by calibration
     void rawAxisValueChanged(int index, int value);
@@ -202,7 +199,6 @@ protected:
 
     static int          _transmitterMode;
     bool                _calibrationMode;
-    bool                _outputEnabled;
 
     int*                _rgAxisValues;
     Calibration_t*      _rgCalibration;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1787,6 +1787,7 @@ void Vehicle::_loadSettings(void)
     // Joystick enabled is a global setting so first make sure there are any joysticks connected
     if (_toolbox->joystickManager()->joysticks().count()) {
         setJoystickEnabled(settings.value(_joystickEnabledSettingsKey, false).toBool());
+        _startJoystick(true);
     }
 }
 
@@ -1839,7 +1840,6 @@ bool Vehicle::joystickEnabled(void)
 void Vehicle::setJoystickEnabled(bool enabled)
 {
     _joystickEnabled = enabled;
-    _startJoystick(_joystickEnabled);
     _saveSettings();
     emit joystickEnabledChanged(_joystickEnabled);
 }
@@ -1849,9 +1849,7 @@ void Vehicle::_startJoystick(bool start)
     Joystick* joystick = _joystickManager->activeJoystick();
     if (joystick) {
         if (start) {
-            if (_joystickEnabled) {
-                joystick->startPolling(this);
-            }
+            joystick->startPolling(this);
         } else {
             joystick->stopPolling();
         }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1865,6 +1865,7 @@ void Vehicle::setActive(bool active)
 {
     if (_active != active) {
         _active = active;
+        _startJoystick(false);
         emit activeChanged(_active);
     }
 }

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -366,15 +366,8 @@ SetupPage {
                                 id:         enabledCheckBox
                                 enabled:    _activeJoystick ? _activeJoystick.calibrated : false
                                 text:       _activeJoystick ? _activeJoystick.calibrated ? qsTr("Enable joystick input") : qsTr("Enable not allowed (Calibrate First)") : ""
-
-                                onClicked:  _activeJoystick.outputEnabled = checked
-
-                                Connections {
-                                    target: _activeJoystick
-                                    onOutputEnabledChanged: {
-                                        enabledCheckBox.checked=enabled
-                                    }
-                                }
+                                checked:    _activeVehicle.joystickEnabled
+                                onClicked:  _activeVehicle.joystickEnabled = checked
 
                                 Connections {
                                     target: joystickManager

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -366,8 +366,16 @@ SetupPage {
                                 id:         enabledCheckBox
                                 enabled:    _activeJoystick ? _activeJoystick.calibrated : false
                                 text:       _activeJoystick ? _activeJoystick.calibrated ? qsTr("Enable joystick input") : qsTr("Enable not allowed (Calibrate First)") : ""
-                                checked:    _activeVehicle.joystickEnabled
                                 onClicked:  _activeVehicle.joystickEnabled = checked
+                                Component.onCompleted: checked = _activeVehicle.joystickEnabled
+
+                                Connections {
+                                    target: _activeVehicle
+
+                                    onJoystickEnabledChanged: {
+                                        enabledCheckBox.checked = _activeVehicle.joystickEnabled
+                                    }
+                                }
 
                                 Connections {
                                     target: joystickManager


### PR DESCRIPTION
This fixes issue #6264 which was caused in PR #6117.

This pull request removes the `outputEnabled` member of the `joystick` class as it serves a reduntant function to the `joystickEnabled` member of the `vehicle` class.

It also changes the `vehicle` class to separate the enabling/disabling of the joystick from the starting/stopping of the thread that polls the joystick. This way we can still monitor the joystick even when it is disabled.