### PR TITLE
Don't try to start logging if it's been denied.

### DIFF
--- a/src/Vehicle/MAVLinkLogManager.h
+++ b/src/Vehicle/MAVLinkLogManager.h
@@ -140,7 +140,7 @@ public:
     bool        enableAutoStart     () { return _enableAutoStart; }
     bool        uploading                ();
     bool        logRunning          () { return _logRunning; }
-    bool        canStartLog         () { return _vehicle != NULL; }
+    bool        canStartLog         () { return _vehicle != NULL && !_logginDenied; }
     bool        deleteAfterUpload   () { return _deleteAfterUpload; }
     bool        publicLog           () { return _publicLog; }
     int         windSpeed           () { return _windSpeed; }
@@ -226,6 +226,7 @@ private:
     QString                 _rating;
     bool                    _publicLog;
     QString                 _ulogExtension;
+    bool                    _logginDenied;
 
 };
 


### PR DESCRIPTION
In response to #6289 

QGC now keeps a flag telling it logging has been denied. If set, it won't try to start (ulog) streaming again.

Note that I can't test this as I don't have anything (working) that "denies" logs.