### PR TITLE
PX4 PID tuning support

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -224,6 +224,7 @@
         <file alias="Vehicle/ClockFact.json">src/Vehicle/ClockFact.json</file>
         <file alias="Vehicle/GPSFact.json">src/Vehicle/GPSFact.json</file>
         <file alias="Vehicle/GPSRTKFact.json">src/Vehicle/GPSRTKFact.json</file>
+		<file alias="Vehicle/SetpointFact.json">src/Vehicle/SetpointFact.json</file>
         <file alias="Vehicle/SubmarineFact.json">src/Vehicle/SubmarineFact.json</file>
         <file alias="Vehicle/TemperatureFact.json">src/Vehicle/TemperatureFact.json</file>
         <file alias="Vehicle/VehicleFact.json">src/Vehicle/VehicleFact.json</file>

--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -10,6 +10,7 @@
 import QtQuick          2.3
 import QtQuick.Controls 1.2
 import QtQuick.Dialogs  1.2
+import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.FactSystem    1.0
@@ -30,6 +31,8 @@ QGCView {
     property string pageDescription:    vehicleComponent ? vehicleComponent.description : ""
     property real   availableWidth:     width - pageLoader.x
     property real   availableHeight:    height - pageLoader.y
+    property bool   showAdvanced:       false
+    property alias  advanced:           advancedCheckBox.checked
 
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property bool   _vehicleArmed:          _activeVehicle ? _activeVehicle.armed : false
@@ -53,31 +56,45 @@ QGCView {
             contentHeight:  pageLoader.y + pageLoader.item.height
             clip:           true
 
-            Column {
-                id:                 headingColumn
-                width:              setupPanel.width
+            RowLayout {
+                id:                 headingRow
+                anchors.left:       parent.left
+                anchors.right:      parent.right
                 spacing:            _margins
+                layoutDirection:    Qt.RightToLeft
 
-                QGCLabel {
-                    font.pointSize: ScreenTools.largeFontPointSize
-                    text:           !setupView.enabled ? _pageTitle + "<font color=\"red\">" + qsTr(" (Disabled while the vehicle is %1)").arg(_disableReason) + "</font>" : _pageTitle
-                    visible:        !ScreenTools.isShortScreen
+                QGCCheckBox {
+                    id:         advancedCheckBox
+                    text:       qsTr("Advanced")
+                    visible:    showAdvanced
                 }
 
-                QGCLabel {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    wrapMode:       Text.WordWrap
-                    text:           pageDescription
-                    visible:        !ScreenTools.isShortScreen
+                Column {
+                    spacing:            _margins
+                    Layout.fillWidth:   true
+
+                    QGCLabel {
+                        font.pointSize: ScreenTools.largeFontPointSize
+                        text:           !setupView.enabled ? _pageTitle + "<font color=\"red\">" + qsTr(" (Disabled while the vehicle is %1)").arg(_disableReason) + "</font>" : _pageTitle
+                        visible:        !ScreenTools.isShortScreen
+                    }
+
+                    QGCLabel {
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        wrapMode:       Text.WordWrap
+                        text:           pageDescription
+                        visible:        !ScreenTools.isShortScreen
+                    }
                 }
             }
 
             Loader {
                 id:                 pageLoader
                 anchors.topMargin:  _margins
-                anchors.top:        headingColumn.bottom
+                anchors.top:        headingRow.bottom
             }
+
             // Overlay to display when vehicle is armed and this setup page needs
             // to be disabled
             Rectangle {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.h
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.h
@@ -32,6 +32,7 @@ public:
     QUrl setupSource(void) const final;
     QUrl summaryQmlSource(void) const final;
     bool allowSetupWhileArmed(void) const final { return true; }
+    bool allowSetupWhileFlying(void) const final { return true; }
 
 private:
     const QString   _name;

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -7,11 +7,16 @@
  *
  ****************************************************************************/
 
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtCharts         2.2
+import QtQuick.Layouts  1.2
 
-import QtQuick              2.3
-import QtQuick.Controls     1.2
-
-import QGroundControl.Controls  1.0
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
 
 SetupPage {
     id:             tuningPage
@@ -20,47 +25,486 @@ SetupPage {
     Component {
         id: pageComponent
 
-        FactSliderPanel {
-            width:          availableWidth
-            qgcViewPanel:   tuningPage.viewPanel
+        Column {
+            width: availableWidth
 
-            sliderModel: ListModel {
-                ListElement {
-                    title:          qsTr("Hover Throttle")
-                    description:    qsTr("Adjust throttle so hover is at mid-throttle. Slide to the left if hover is lower than throttle center. Slide to the right if hover is higher than throttle center.")
-                    param:          "MPC_THR_HOVER"
-                    min:            20
-                    max:            80
-                    step:           1
+            property real   _chartHeight:       ScreenTools.defaultFontPixelHeight * 20
+            property real   _margins:           ScreenTools.defaultFontPixelHeight / 2
+            property string _currentTuneType:   _tuneList[0]
+            property real   _roll:              _activeVehicle.roll.value
+            property real   _rollSetpoint:      _activeVehicle.setpoint.roll.value
+            property real   _rollRate:          _activeVehicle.rollRate.value
+            property real   _rollRateSetpoint:  _activeVehicle.setpoint.rollRate.value
+            property real   _pitch:             _activeVehicle.pitch.value
+            property real   _pitchSetpoint:     _activeVehicle.setpoint.pitch.value
+            property real   _pitchRate:         _activeVehicle.pitchRate.value
+            property real   _pitchRateSetpoint: _activeVehicle.setpoint.pitchRate.value
+            property real   _yaw:               _activeVehicle.heading.value
+            property real   _yawSetpoint:       _activeVehicle.setpoint.yaw.value
+            property real   _yawRate:           _activeVehicle.yawRate.value
+            property real   _yawRateSetpoint:   _activeVehicle.setpoint.yawRate.value
+            property var    _valueXAxis:        valueXAxis
+            property var    _valueRateXAxis:    valueRateXAxis
+            property var    _valueYAxis:        valueYAxis
+            property var    _valueRateYAxis:    valueRateYAxis
+            property int    _msecs:             0
+            property var    _savedTuningParamValues:    [ ]
+
+            // The following are set when getValues is called
+            property real   _value
+            property real   _valueSetpoint
+            property real   _valueRate
+            property real   _valueRateSetpoint
+
+            readonly property int _tickSeparation:      5
+            readonly property int _tuneListRollIndex:   0
+            readonly property int _tuneListPitchIndex:  1
+            readonly property int _tuneListYawIndex:    2
+            readonly property var _tuneList:            [ qsTr("Roll"), qsTr("Pitch"), qsTr("Yaw") ]
+            readonly property var _params:              [
+                [ controller.getParameterFact(-1, "MC_ROLL_P"),
+                 controller.getParameterFact(-1, "MC_ROLLRATE_P"),
+                 controller.getParameterFact(-1, "MC_ROLLRATE_I"),
+                 controller.getParameterFact(-1, "MC_ROLLRATE_D"),
+                 controller.getParameterFact(-1, "MC_ROLLRATE_FF") ],
+                [ controller.getParameterFact(-1, "MC_PITCH_P"),
+                 controller.getParameterFact(-1, "MC_PITCHRATE_P"),
+                 controller.getParameterFact(-1, "MC_PITCHRATE_I"),
+                 controller.getParameterFact(-1, "MC_PITCHRATE_D"),
+                 controller.getParameterFact(-1, "MC_PITCHRATE_FF") ],
+                [ controller.getParameterFact(-1, "MC_YAW_P"),
+                 controller.getParameterFact(-1, "MC_YAWRATE_P"),
+                 controller.getParameterFact(-1, "MC_YAWRATE_I"),
+                 controller.getParameterFact(-1, "MC_YAWRATE_D"),
+                 controller.getParameterFact(-1, "MC_YAW_FF"),
+                 controller.getParameterFact(-1, "MC_YAWRATE_FF") ] ]
+
+            function adjustYAxisMin(yAxis, newValue) {
+                var newMin = Math.min(yAxis.min, newValue)
+                if (newMin % 5 != 0) {
+                    newMin -= 5
+                    newMin = Math.floor(newMin / _tickSeparation) * _tickSeparation
                 }
+                yAxis.min = newMin
+            }
 
-                ListElement {
-                    title:          qsTr("Manual minimum throttle")
-                    description:    qsTr("Slide to the left to start the motors with less idle power. Slide to the right if descending in manual flight becomes unstable.")
-                    param:          "MPC_MANTHR_MIN"
-                    min:            0
-                    max:            15
-                    step:           1
+            function adjustYAxisMax(yAxis, newValue) {
+                var newMax = Math.max(yAxis.max, newValue)
+                if (newMax % 5 != 0) {
+                    newMax += 5
+                    newMax = Math.floor(newMax / _tickSeparation) * _tickSeparation
                 }
+                yAxis.max = newMax
+            }
 
-                ListElement {
-                    title:          qsTr("Roll sensitivity")
-                    description:    qsTr("Slide to the left to make roll control faster and more accurate. Slide to the right if roll oscillates or is too twitchy.")
-                    param:          "MC_ROLL_TC"
-                    min:            0.15
-                    max:            0.25
-                    step:           0.01
-                }
-
-                ListElement {
-                    title:          qsTr("Pitch sensitivity")
-                    description:    qsTr("Slide to the left to make pitch control faster and more accurate. Slide to the right if pitch oscillates or is too twitchy.")
-                    param:          "MC_PITCH_TC"
-                    min:            0.15
-                    max:            0.25
-                    step:           0.01
+            function getValues() {
+                if (_currentTuneType === _tuneList[_tuneListRollIndex]) {
+                    _value = _roll
+                    _valueSetpoint = _rollSetpoint
+                    _valueRate = _rollRate
+                    _valueRateSetpoint = _rollRateSetpoint
+                } else if (_currentTuneType === _tuneList[_tuneListPitchIndex]) {
+                    _value = _pitch
+                    _valueSetpoint = _pitchSetpoint
+                    _valueRate = _pitchRate
+                    _valueRateSetpoint = _pitchRateSetpoint
+                } else if (_currentTuneType === _tuneList[_tuneListYawIndex]) {
+                    _value = _yaw
+                    _valueSetpoint = _yawSetpoint
+                    _valueRate = _yawRate
+                    _valueRateSetpoint = _yawRateSetpoint
                 }
             }
-        }
-    } // Component
+
+            function resetGraphs() {
+                valueSeries.removePoints(0, valueSeries.count)
+                valueSetpointSeries.removePoints(0, valueSetpointSeries.count)
+                valueRateSeries.removePoints(0, valueRateSeries.count)
+                valueRateSetpointSeries.removePoints(0, valueRateSetpointSeries.count)
+                _valueXAxis.min = 0
+                _valueXAxis.max = 0
+                _valueRateXAxis.min = 0
+                _valueRateXAxis.max = 0
+                _valueYAxis.min = 0
+                _valueYAxis.max = 10
+                _valueRateYAxis.min = 0
+                _valueRateYAxis.max = 10
+                _msecs = 0
+            }
+
+            function currentTuneTypeIndex() {
+                if (_currentTuneType === _tuneList[_tuneListRollIndex]) {
+                    return _tuneListRollIndex
+                } else if (_currentTuneType === _tuneList[_tuneListPitchIndex]) {
+                    return _tuneListPitchIndex
+                } else if (_currentTuneType === _tuneList[_tuneListYawIndex]) {
+                    return _tuneListYawIndex
+                }
+            }
+
+            // Save the current set of tuning values so we can reset to them
+            function saveTuningParamValues() {
+                var tuneTypeIndex = currentTuneTypeIndex()
+
+                _savedTuningParamValues = [ ]
+                var currentTuneParams = _params[tuneTypeIndex]
+                for (var i=0; i<currentTuneParams.length; i++) {
+                    _savedTuningParamValues.push(currentTuneParams[i].valueString)
+                }
+                savedRepeater.model = _savedTuningParamValues
+            }
+
+            function resetToSavedTuningParamValues() {
+                var tuneTypeIndex = currentTuneTypeIndex()
+
+                for (var i=0; i<_savedTuningParamValues.length; i++) {
+                    _params[tuneTypeIndex][i].value = _savedTuningParamValues[i]
+                }
+            }
+
+            Component.onCompleted: {
+                showAdvanced = true
+                saveTuningParamValues()
+            }
+
+            on_CurrentTuneTypeChanged: {
+                saveTuningParamValues()
+                resetGraphs()
+            }
+
+            FactPanelController {
+                id:         controller
+                factPanel:  tuningPage.viewPanel
+            }
+
+            ExclusiveGroup {
+                id: tuneTypeRadios
+            }
+
+            ValueAxis {
+                id:             valueXAxis
+                min:            0
+                max:            0
+                labelFormat:    "%d"
+                titleText:      "sec"
+            }
+
+            ValueAxis {
+                id:             valueRateXAxis
+                min:            0
+                max:            0
+                labelFormat:    "%d"
+                titleText:      "sec"
+            }
+
+            ValueAxis {
+                id:         valueYAxis
+                min:        0
+                max:        10
+                titleText:  "deg"
+                tickCount:  ((max - min) / _tickSeparation) + 1
+            }
+
+            ValueAxis {
+                id:         valueRateYAxis
+                min:        0
+                max:        10
+                titleText:  "deg/s"
+                tickCount:  ((max - min) / _tickSeparation) + 1
+            }
+
+            Timer {
+                id:         dataTimer
+                interval:   50
+                running:    false
+                repeat:     true
+
+                onTriggered: {
+                    var seconds = _msecs / 1000
+                    _valueXAxis.max = seconds
+                    _valueRateXAxis.max = seconds
+
+                    getValues()
+
+                    valueSeries.append(seconds, _value)
+                    adjustYAxisMin(_valueYAxis, _value)
+                    adjustYAxisMax(_valueYAxis, _value)
+
+                    valueSetpointSeries.append(seconds, _valueSetpoint)
+                    adjustYAxisMin(_valueYAxis, _valueSetpoint)
+                    adjustYAxisMax(_valueYAxis, _valueSetpoint)
+
+                    valueRateSeries.append(seconds, _valueRate)
+                    adjustYAxisMin(_valueRateYAxis, _valueRate)
+                    adjustYAxisMax(_valueRateYAxis, _valueRate)
+
+                    valueRateSetpointSeries.append(seconds, _valueRateSetpoint)
+                    adjustYAxisMin(_valueRateYAxis, _valueRateSetpoint)
+                    adjustYAxisMax(_valueRateYAxis, _valueRateSetpoint)
+
+                    _msecs += interval
+                    if (valueSeries.count > _maxPointCount) {
+                        valueSeries.remove(0)
+                        valueSetpointSeries.remove(0)
+                        valueRateSeries.remove(0)
+                        valueRateSetpointSeries.remove(0)
+                        valueXAxis.min = valueSeries.at(0).x
+                        valueRateXAxis.min = valueSeries.at(0).x
+                    }
+                }
+
+                property var _activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
+                property int _maxPointCount:    10000 / interval
+            }
+
+            // Standard tuning page
+            FactSliderPanel {
+                width:          availableWidth
+                qgcViewPanel:   tuningPage.viewPanel
+                visible:        !advanced
+
+                sliderModel: ListModel {
+                    ListElement {
+                        title:          qsTr("Hover Throttle")
+                        description:    qsTr("Adjust throttle so hover is at mid-throttle. Slide to the left if hover is lower than throttle center. Slide to the right if hover is higher than throttle center.")
+                        param:          "MPC_THR_HOVER"
+                        min:            20
+                        max:            80
+                        step:           1
+                    }
+
+                    ListElement {
+                        title:          qsTr("Manual minimum throttle")
+                        description:    qsTr("Slide to the left to start the motors with less idle power. Slide to the right if descending in manual flight becomes unstable.")
+                        param:          "MPC_MANTHR_MIN"
+                        min:            0
+                        max:            15
+                        step:           1
+                    }
+/*
+  These seem to have disappeared from PX4 firmware!
+                    ListElement {
+                        title:          qsTr("Roll sensitivity")
+                        description:    qsTr("Slide to the left to make roll control faster and more accurate. Slide to the right if roll oscillates or is too twitchy.")
+                        param:          "MC_ROLL_TC"
+                        min:            0.15
+                        max:            0.25
+                        step:           0.01
+                    }
+
+                    ListElement {
+                        title:          qsTr("Pitch sensitivity")
+                        description:    qsTr("Slide to the left to make pitch control faster and more accurate. Slide to the right if pitch oscillates or is too twitchy.")
+                        param:          "MC_PITCH_TC"
+                        min:            0.15
+                        max:            0.25
+                        step:           0.01
+                    }
+*/
+                }
+            }
+
+            // Advanced page
+            RowLayout {
+                anchors.left:       parent.left
+                anchors.right:      parent.right
+                layoutDirection:    Qt.RightToLeft
+                visible:            advanced
+
+                Column {
+                    spacing:            _margins
+                    Layout.alignment:   Qt.AlignTop
+
+                    QGCLabel { text: qsTr("Tuning Axis:") }
+
+                    RowLayout {
+                        spacing: _margins
+
+                        Repeater {
+                            model: _tuneList
+                            QGCRadioButton {
+                                text:           modelData
+                                checked:        _currentTuneType === modelData
+                                exclusiveGroup: tuneTypeRadios
+
+                                onClicked: _currentTuneType = modelData
+                            }
+                        }
+                    }
+
+                    Item { width: 1; height: 1 }
+
+                    QGCLabel { text: qsTr("Tuning Values:") }
+
+                    GridLayout {
+                        rows:           factList.length
+                        flow:           GridLayout.TopToBottom
+                        rowSpacing:     _margins
+                        columnSpacing:  _margins
+
+                        property var factList: _params[_tuneList.indexOf(_currentTuneType)]
+
+                        Repeater {
+                            model: parent.factList
+
+                            QGCLabel { text: modelData.name }
+                        }
+
+                        Repeater {
+                            model: parent.factList
+
+                            QGCButton {
+                                text: "-"
+                                onClicked: {
+                                    var value = modelData.value
+                                    modelData.value -= value * adjustPercentModel.get(adjustPercentCombo.currentIndex).value
+                                }
+                            }
+                        }
+
+                        Repeater {
+                            model: parent.factList
+
+                            FactTextField {
+                                Layout.fillWidth:   true
+                                fact:               modelData
+                                showUnits:          false
+                            }
+                        }
+
+                        Repeater {
+                            model: parent.factList
+
+                            QGCButton {
+                                text: "+"
+                                onClicked: {
+                                    var value = modelData.value
+                                    modelData.value += value * adjustPercentModel.get(adjustPercentCombo.currentIndex).value
+                                }
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        QGCLabel { text: qsTr("Increment/Decrement %") }
+
+                        QGCComboBox {
+                            id:     adjustPercentCombo
+                            model:  ListModel {
+                                id: adjustPercentModel
+                                ListElement { text: "5"; value: 0.05 }
+                                ListElement { text: "10"; value: 0.10 }
+                                ListElement { text: "15"; value: 0.15 }
+                                ListElement { text: "20"; value: 0.20 }
+                            }
+                        }
+                    }
+                    Item { width: 1; height: 1 }
+
+                    QGCLabel { text: qsTr("Saved Tuning Values:") }
+
+                    GridLayout {
+                        rows:           savedRepeater.model.length
+                        flow:           GridLayout.TopToBottom
+                        rowSpacing:     _margins
+                        columnSpacing:  _margins
+
+                        Repeater {
+                            model: _params[_tuneList.indexOf(_currentTuneType)]
+
+                            QGCLabel { text: modelData.name }
+                        }
+
+                        Repeater {
+                            id: savedRepeater
+
+                            QGCLabel { text: modelData }
+                        }
+                    }
+
+                    RowLayout {
+                        spacing: _margins
+
+                        QGCButton {
+                            text:       qsTr("Save Values")
+                            onClicked:  saveTuningParamValues()
+                        }
+
+                        QGCButton {
+                            text:       qsTr("Reset To Saved Values")
+                            onClicked:  resetToSavedTuningParamValues()
+                        }
+                    }
+
+                    Item { width: 1; height: 1 }
+
+                    QGCLabel { text: qsTr("Chart:") }
+
+                    RowLayout {
+                        spacing: _margins
+
+                        QGCButton {
+                            text:       qsTr("Clear")
+                            onClicked:  resetGraphs()
+                        }
+
+                        QGCButton {
+                            text:       dataTimer.running ? qsTr("Stop") : qsTr("Start")
+                            onClicked:  dataTimer.running = !dataTimer.running
+                        }
+                    }
+                }
+
+                Column {
+                    Layout.fillWidth: true
+
+                    ChartView {
+                        anchors.left:       parent.left
+                        anchors.right:      parent.right
+                        height:             availableHeight / 2
+                        title:              _currentTuneType
+                        antialiasing:       true
+                        legend.alignment:   Qt.AlignRight
+
+                        LineSeries {
+                            id:         valueSeries
+                            name:       "Response"
+                            axisY:      valueYAxis
+                            axisX:      valueXAxis
+                        }
+
+                        LineSeries {
+                            id:         valueSetpointSeries
+                            name:       "Command"
+                            axisY:      valueYAxis
+                            axisX:      valueXAxis
+                        }
+                    }
+
+                    ChartView {
+                        anchors.left:       parent.left
+                        anchors.right:      parent.right
+                        height:             availableHeight / 2
+                        title:              _currentTuneType + qsTr(" Rate")
+                        antialiasing:       true
+                        legend.alignment:   Qt.AlignRight
+
+                        LineSeries {
+                            id:         valueRateSeries
+                            name:       "Response"
+                            axisY:      valueRateYAxis
+                            axisX:      valueRateXAxis
+                        }
+
+                        LineSeries {
+                            id:         valueRateSetpointSeries
+                            name:       "Command"
+                            axisY:      valueRateYAxis
+                            axisX:      valueRateXAxis
+                        }
+                    }
+                }
+            } // RowLayout - Advanced Page
+        } // Column
+    } // Component - pageComponent
 } // SetupPage

--- a/src/Vehicle/SetpointFact.json
+++ b/src/Vehicle/SetpointFact.json
@@ -1,0 +1,44 @@
+[
+{
+    "name":             "roll",
+    "shortDescription": "Roll Setpoint",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg"
+},
+{
+    "name":             "pitch",
+    "shortDescription": "Pitch Setpoint",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg"
+},
+{
+    "name":             "yaw",
+    "shortDescription": "Yaw Setpoint",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg"
+},
+{
+    "name":             "rollRate",
+    "shortDescription": "Roll Rate Setpoint",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg/s"
+},
+{
+    "name":             "pitchRate",
+    "shortDescription": "Pitch Rate Setpoint",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg/s"
+},
+{
+    "name":             "yawRate",
+    "shortDescription": "Yaw Rate Setpoint",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg/s"
+}
+]

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -40,6 +40,43 @@ Q_DECLARE_LOGGING_CATEGORY(VehicleLog)
 
 class Vehicle;
 
+class VehicleSetpointFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+public:
+    VehicleSetpointFactGroup(QObject* parent = NULL);
+
+    Q_PROPERTY(Fact* roll       READ roll       CONSTANT)
+    Q_PROPERTY(Fact* pitch      READ pitch      CONSTANT)
+    Q_PROPERTY(Fact* yaw        READ yaw        CONSTANT)
+    Q_PROPERTY(Fact* rollRate   READ rollRate   CONSTANT)
+    Q_PROPERTY(Fact* pitchRate  READ pitchRate  CONSTANT)
+    Q_PROPERTY(Fact* yawRate    READ yawRate    CONSTANT)
+
+    Fact* roll      (void) { return &_rollFact; }
+    Fact* pitch     (void) { return &_pitchFact; }
+    Fact* yaw       (void) { return &_yawFact; }
+    Fact* rollRate  (void) { return &_rollRateFact; }
+    Fact* pitchRate (void) { return &_pitchRateFact; }
+    Fact* yawRate   (void) { return &_yawRateFact; }
+
+    static const char* _rollFactName;
+    static const char* _pitchFactName;
+    static const char* _yawFactName;
+    static const char* _rollRateFactName;
+    static const char* _pitchRateFactName;
+    static const char* _yawRateFactName;
+
+private:
+    Fact _rollFact;
+    Fact _pitchFact;
+    Fact _yawFact;
+    Fact _rollRateFact;
+    Fact _pitchRateFact;
+    Fact _yawRateFact;
+};
+
 class VehicleVibrationFactGroup : public FactGroup
 {
     Q_OBJECT
@@ -370,6 +407,9 @@ public:
     Q_PROPERTY(Fact* roll               READ roll               CONSTANT)
     Q_PROPERTY(Fact* pitch              READ pitch              CONSTANT)
     Q_PROPERTY(Fact* heading            READ heading            CONSTANT)
+    Q_PROPERTY(Fact* rollRate           READ rollRate           CONSTANT)
+    Q_PROPERTY(Fact* pitchRate          READ pitchRate          CONSTANT)
+    Q_PROPERTY(Fact* yawRate            READ yawRate            CONSTANT)
     Q_PROPERTY(Fact* groundSpeed        READ groundSpeed        CONSTANT)
     Q_PROPERTY(Fact* airSpeed           READ airSpeed           CONSTANT)
     Q_PROPERTY(Fact* climbRate          READ climbRate          CONSTANT)
@@ -385,6 +425,7 @@ public:
     Q_PROPERTY(FactGroup* vibration   READ vibrationFactGroup   CONSTANT)
     Q_PROPERTY(FactGroup* temperature READ temperatureFactGroup CONSTANT)
     Q_PROPERTY(FactGroup* clock       READ clockFactGroup       CONSTANT)
+    Q_PROPERTY(FactGroup* setpoint    READ setpointFactGroup    CONSTANT)
 
     Q_PROPERTY(int      firmwareMajorVersion        READ firmwareMajorVersion       NOTIFY firmwareVersionChanged)
     Q_PROPERTY(int      firmwareMinorVersion        READ firmwareMinorVersion       NOTIFY firmwareVersionChanged)
@@ -645,8 +686,11 @@ public:
     unsigned        maxProtoVersion         () const { return _maxProtoVersion; }
 
     Fact* roll              (void) { return &_rollFact; }
-    Fact* heading           (void) { return &_headingFact; }
     Fact* pitch             (void) { return &_pitchFact; }
+    Fact* heading           (void) { return &_headingFact; }
+    Fact* rollRate          (void) { return &_rollRateFact; }
+    Fact* pitchRate         (void) { return &_pitchRateFact; }
+    Fact* yawRate           (void) { return &_yawRateFact; }
     Fact* airSpeed          (void) { return &_airSpeedFact; }
     Fact* groundSpeed       (void) { return &_groundSpeedFact; }
     Fact* climbRate         (void) { return &_climbRateFact; }
@@ -662,6 +706,7 @@ public:
     FactGroup* vibrationFactGroup   (void) { return &_vibrationFactGroup; }
     FactGroup* temperatureFactGroup (void) { return &_temperatureFactGroup; }
     FactGroup* clockFactGroup       (void) { return &_clockFactGroup; }
+    FactGroup* setpointFactGroup    (void) { return &_setpointFactGroup; }
 
     void setConnectionLostEnabled(bool connectionLostEnabled);
 
@@ -916,6 +961,8 @@ private:
     void _handleScaledPressure2(mavlink_message_t& message);
     void _handleScaledPressure3(mavlink_message_t& message);
     void _handleHighLatency2(mavlink_message_t& message);
+    void _handleAttitude(mavlink_message_t& message);
+    void _handleAttitudeTarget(mavlink_message_t& message);
     // ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)
     void _handleCameraFeedback(const mavlink_message_t& message);
@@ -1106,6 +1153,9 @@ private:
     Fact _rollFact;
     Fact _pitchFact;
     Fact _headingFact;
+    Fact _rollRateFact;
+    Fact _pitchRateFact;
+    Fact _yawRateFact;
     Fact _groundSpeedFact;
     Fact _airSpeedFact;
     Fact _climbRateFact;
@@ -1122,10 +1172,14 @@ private:
     VehicleVibrationFactGroup   _vibrationFactGroup;
     VehicleTemperatureFactGroup _temperatureFactGroup;
     VehicleClockFactGroup       _clockFactGroup;
+    VehicleSetpointFactGroup    _setpointFactGroup;
 
     static const char* _rollFactName;
     static const char* _pitchFactName;
     static const char* _headingFactName;
+    static const char* _rollRateFactName;
+    static const char* _pitchRateFactName;
+    static const char* _yawRateFactName;
     static const char* _groundSpeedFactName;
     static const char* _airSpeedFactName;
     static const char* _climbRateFactName;

--- a/src/Vehicle/VehicleFact.json
+++ b/src/Vehicle/VehicleFact.json
@@ -21,6 +21,27 @@
     "units":            "deg"
 },
 {
+    "name":             "rollRate",
+    "shortDescription": "Roll Rate",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg/s"
+},
+{
+    "name":             "pitchRate",
+    "shortDescription": "Pitch Rate",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg/s"
+},
+{
+    "name":             "yawRate",
+    "shortDescription": "Yaw Rate",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg/s"
+},
+{
     "name":             "groundSpeed",
     "shortDescription": "Ground Speed",
     "type":             "double",


### PR DESCRIPTION
![screen shot 2018-04-01 at 5 35 55 pm](https://user-images.githubusercontent.com/5876851/38179099-de0cb35a-35d3-11e8-8c27-a27049a2db2f.png)

This is a pretty major working in progress from a user model standpoint. Mostly trying thing out at this point. Here are the possibly non-obvious things:
* You get to it from Tuning and then check Advanced
* When the page loads it saves the parameter values for the current tuning set internally. The idea is as you futz with them you have an "oh shit" button to get you back to what are hopefully good values by clicking the Reset button.
* As you adjust and get better values you can save them as new reset values by clicking the Save Values button.
* The +/- buttons increment the values by the amount specified in the Increment/Decrement % combo box. This way you can start by futzing with the 15% changes and then as you fine tune you can drop to 10% or 5% increments.
* You can start/stop and clear the graphs using the Chart buttons.

The above currently is only supported for PX4 Pro firmware and multi-rotors. But that said the whole thing is implemented in a generic fashion such that it just works off of generic lists of parameters. So all I need to do is figure out what all the other param sets are to implemenent other vehicle types and ArduPilot support.

In order to implement all of this I added a bunch of generic support as well:
* SetupPages have a new Advanced checkbox which you can turn on and use
* Added rollRate, pitchRate, yawRow to Vehicle object main FactGroup
* Added new setpoint FactGroup to vehicle with the values: roll, pitch, yaw, rollRate, pitchRate, yawRate
* All new FactGroup values are available for display in the Instrument Panel

Related to #2878