### PR TITLE
GeoTag Fixes

### DIFF
--- a/src/AnalyzeView/GeoTagController.cc
+++ b/src/AnalyzeView/GeoTagController.cc
@@ -259,6 +259,11 @@ void GeoTagWorker::run(void)
     int maxIndex = std::min(_imageIndices.count(), _triggerIndices.count());
     maxIndex = std::min(maxIndex, _imageList.count());
     for(int i = 0; i < maxIndex; i++) {
+        int imageIndex = _imageIndices[i];
+        if (imageIndex >= _imageList.count()) {
+            emit error(tr("Geotagging failed. Image requested not present."));
+            return;
+        }
         QFile fileRead(_imageList.at(_imageIndices[i]).absoluteFilePath());
         if (!fileRead.open(QIODevice::ReadOnly)) {
             emit error(tr("Geotagging failed. Couldn't open an image."));

--- a/src/AnalyzeView/ULogParser.cc
+++ b/src/AnalyzeView/ULogParser.cc
@@ -139,15 +139,10 @@ bool ULogParser::getTagsFromLog(QByteArray& log, QList<GeoTagWorker::cameraFeedb
 
             case (int)ULogMessageType::DATA:
             {
-                if (!geotagFound) {
-                    qWarning() << "Could not detect geotag packets in ULog";
-                    return false;
-                }
-
                 uint16_t msgID = -1;
                 memcpy(&msgID, log.data() + index + ULOG_MSG_HEADER_LEN, 2);
 
-                if(msgID == _cameraCaptureMsgID) {
+                if (geotagFound && msgID == _cameraCaptureMsgID) {
 
                     // Completely dynamic parsing, so that changing/reordering the message format will not break the parser
                     GeoTagWorker::cameraFeedbackPacket feedback;
@@ -177,6 +172,11 @@ bool ULogParser::getTagsFromLog(QByteArray& log, QList<GeoTagWorker::cameraFeedb
 
         index += (3 + header.msgSize);
 
+    }
+
+    if (cameraFeedback.count() == 0) {
+        qWarning() << "Could not detect camera_capture packets in ULog";
+        return false;
     }
 
     return true;


### PR DESCRIPTION
* Fix ulog file format parsing (fix for #6234)
* Fix crash when image count is less than trigger image indices

@dogmaphobic @birchera Can you guys look at this? I don't really know much about the log file format. But the logic for an A tag defining the camera_trigger id follow by the actual data seemed wrong. And this change makes it work as far as I can tell.