### PR TITLE
Set video capture status for missions

### DIFF
--- a/src/FirmwarePlugin/PX4/MavCmdInfoCommon.json
+++ b/src/FirmwarePlugin/PX4/MavCmdInfoCommon.json
@@ -18,6 +18,11 @@
             "id":           201,
             "comment":      "MAV_CMD_DO_SET_ROI",
             "paramRemove":  "1,2,3"
+        },
+        {
+            "id":           2500,
+            "comment":      "MAV_CMD_VIDEO_START_CAPTURE",
+            "paramRemove":  "2"
         }
     ]
 }

--- a/src/MissionManager/CameraSection.cc
+++ b/src/MissionManager/CameraSection.cc
@@ -180,11 +180,11 @@ void CameraSection::appendSectionItems(QList<MissionItem*>& items, QObject* miss
             item = new MissionItem(nextSequenceNumber++,
                                    MAV_CMD_VIDEO_START_CAPTURE,
                                    MAV_FRAME_MISSION,
-                                   0,                           // Reserved (Set to 0)
-                                   0,                           // No CAMERA_CAPTURE_STATUS streaming
-                                   NAN, NAN, NAN, NAN, NAN,     // param 3-7 reserved
-                                   true,                        // autoContinue
-                                   false,                       // isCurrentItem
+                                   0,                               // Reserved (Set to 0)
+                                   VIDEO_CAPTURE_STATUS_INTERVAL,   // CAMERA_CAPTURE_STATUS (default to every 5 seconds)
+                                   NAN, NAN, NAN, NAN, NAN,         // param 3-7 reserved
+                                   true,                            // autoContinue
+                                   false,                           // isCurrentItem
                                    missionItemParent);
             break;
 
@@ -360,7 +360,7 @@ bool CameraSection::_scanTakeVideo(QmlObjectListModel* visualItems, int scanInde
     if (item) {
         MissionItem& missionItem = item->missionItem();
         if ((MAV_CMD)item->command() == MAV_CMD_VIDEO_START_CAPTURE) {
-            if (missionItem.param1() == 0 && missionItem.param2() == 0) {
+            if (missionItem.param1() == 0 && missionItem.param2() == VIDEO_CAPTURE_STATUS_INTERVAL) {
                 cameraAction()->setRawValue(TakeVideo);
                 visualItems->removeAt(scanIndex)->deleteLater();
                 return true;

--- a/src/MissionManager/CameraSection.h
+++ b/src/MissionManager/CameraSection.h
@@ -14,6 +14,8 @@
 #include "MissionItem.h"
 #include "Fact.h"
 
+#define VIDEO_CAPTURE_STATUS_INTERVAL 0.2   //-- Send capture status every 5 seconds
+
 class CameraSection : public Section
 {
     Q_OBJECT

--- a/src/MissionManager/CameraSectionTest.cc
+++ b/src/MissionManager/CameraSectionTest.cc
@@ -70,7 +70,7 @@ void CameraSectionTest::init(void)
                                                              MAV_CMD_VIDEO_START_CAPTURE,
                                                              MAV_FRAME_MISSION,
                                                              0,                             // Reserved (Set to 0)
-                                                             0,                             // No CAMERA_CAPTURE_STATUS streaming
+                                                             VIDEO_CAPTURE_STATUS_INTERVAL, // CAMERA_CAPTURE_STATUS (default to every 5 seconds)
                                                              NAN, NAN, NAN, NAN, NAN,       // param 3-7 reserved
                                                              true,                          // autocontinue
                                                              false),                        // isCurrentItem
@@ -896,13 +896,6 @@ void CameraSectionTest::_testScanForStartVideoSection(void)
     QCOMPARE(_cameraSection->settingsSpecified(), false);
     visualItems.clear();
 
-    invalidSimpleItem.missionItem() = _validStartVideoItem->missionItem();
-    invalidSimpleItem.missionItem().setParam2(10);    // must be 0
-    visualItems.append(&invalidSimpleItem);
-    QCOMPARE(_cameraSection->scanForSection(&visualItems, scanIndex), false);
-    QCOMPARE(visualItems.count(), 1);
-    QCOMPARE(_cameraSection->settingsSpecified(), false);
-    visualItems.clear();
 }
 
 void CameraSectionTest::_testScanForStopVideoSection(void)

--- a/src/MissionManager/CameraSectionTest.cc
+++ b/src/MissionManager/CameraSectionTest.cc
@@ -931,6 +931,14 @@ void CameraSectionTest::_testScanForStopVideoSection(void)
     QCOMPARE(visualItems.count(), 1);
     QCOMPARE(_cameraSection->settingsSpecified(), false);
     visualItems.clear();
+
+    invalidSimpleItem.missionItem() = _validStartVideoItem->missionItem();
+    invalidSimpleItem.missionItem().setParam2(VIDEO_CAPTURE_STATUS_INTERVAL + 1);    // must be VIDEO_CAPTURE_STATUS_INTERVAL
+    visualItems.append(&invalidSimpleItem);
+    QCOMPARE(_cameraSection->scanForSection(&visualItems, scanIndex), false);
+    QCOMPARE(visualItems.count(), 1);
+    QCOMPARE(_cameraSection->settingsSpecified(), false);
+    visualItems.clear();
 }
 
 void CameraSectionTest::_testScanForStopImageSection(void)

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -1032,7 +1032,7 @@
             "description":  "Start video capture.",
             "category":     "Camera",
             "param2": {
-                "label":            "Status Interval",
+                "label":            "Status Frequency",
                 "default":          0.2,
                 "units":            "Hz",
                 "decimalPlaces":    2

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -1034,6 +1034,7 @@
             "param2": {
                 "label":            "Status Interval",
                 "default":          0.2,
+                "units":            "Hz",
                 "decimalPlaces":    2
             }
         },

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -1005,11 +1005,6 @@
             "friendlyName": "Start image capture" ,
             "description":  "Start taking one or more photos.",
             "category":     "Camera",
-            "param1": {
-                "label":            "Reserved",
-                "default":          0,
-                "decimalPlaces":    0
-            },
             "param2": {
                 "label":            "Interval",
                 "default":          0,
@@ -1027,12 +1022,7 @@
             "rawName": "MAV_CMD_IMAGE_STOP_CAPTURE",
             "friendlyName": "Stop image capture",
             "description":  "Stop taking photos.",
-            "category":     "Camera",
-            "param1": {
-                "label":            "Reserved",
-                "default":          0,
-                "decimalPlaces":    0
-            }
+            "category":     "Camera"
         },
         { "id": 2003, "rawName": "MAV_CMD_DO_TRIGGER_CONTROL", "friendlyName": "Trigger control" },
         {
@@ -1041,10 +1031,10 @@
             "friendlyName": "Start video capture",
             "description":  "Start video capture.",
             "category":     "Camera",
-            "param1": {
-                "label":            "Reserved",
-                "default":          0,
-                "decimalPlaces":    0
+            "param2": {
+                "label":            "Status Interval",
+                "default":          0.2,
+                "decimalPlaces":    2
             }
         },
         {
@@ -1052,12 +1042,7 @@
             "rawName":      "MAV_CMD_VIDEO_STOP_CAPTURE",
             "friendlyName": "Stop video capture",
             "description":  "Stop video capture.",
-            "category":     "Camera",
-            "param1": {
-                "label":            "Reserved",
-                "default":          0,
-                "decimalPlaces":    0
-            }
+            "category":     "Camera"
         },
         { "id": 2800, "rawName": "MAV_CMD_PANORAMA_CREATE", "friendlyName": "Create panorama" },
         {


### PR DESCRIPTION
When setting up a mission using video capture (as opposed to image capture), tell the autopilot to send capture updates (every 5 seconds). This will tell the UI to update the current status as the video "recording" started by an autopilot command instead of an user command.