### PR TITLE
Plan/Edit Position: Change position to vehicle position

### DIFF
--- a/src/QmlControls/EditPositionDialog.qml
+++ b/src/QmlControls/EditPositionDialog.qml
@@ -112,6 +112,17 @@ QGCViewDialog {
                     reject()
                 }
             }
+
+            QGCButton {
+                anchors.right:  parent.right
+                text:           qsTr("Set From Vehicle Position")
+                visible:        QGroundControl.multiVehicleManager.activeVehicle && QGroundControl.multiVehicleManager.activeVehicle.coordinate.isValid
+
+                onClicked: {
+                    controller.setFromVehicle()
+                    reject()
+                }
+            }
         } // Column
     } // QGCFlickable
 } // QGCViewDialog

--- a/src/QmlControls/EditPositionDialogController.cc
+++ b/src/QmlControls/EditPositionDialogController.cc
@@ -9,6 +9,7 @@
 
 #include "EditPositionDialogController.h"
 #include "QGCGeo.h"
+#include "QGCApplication.h"
 
 const char*  EditPositionDialogController::_latitudeFactName =      "Latitude";
 const char*  EditPositionDialogController::_longitudeFactName =     "Longitude";
@@ -74,3 +75,10 @@ void EditPositionDialogController::setFromUTM(void)
     qDebug() << _eastingFact.rawValue().toDouble() << _northingFact.rawValue().toDouble() << _zoneFact.rawValue().toInt() << (_hemisphereFact.rawValue().toInt() == 1) << _coordinate;
     emit coordinateChanged(_coordinate);
 }
+
+void EditPositionDialogController::setFromVehicle(void)
+{
+    _coordinate = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->coordinate();
+    emit coordinateChanged(_coordinate);
+}
+

--- a/src/QmlControls/EditPositionDialogController.h
+++ b/src/QmlControls/EditPositionDialogController.h
@@ -42,6 +42,7 @@ public:
     Q_INVOKABLE void initValues(void);
     Q_INVOKABLE void setFromGeo(void);
     Q_INVOKABLE void setFromUTM(void);
+    Q_INVOKABLE void setFromVehicle(void);
 
 signals:
     void coordinateChanged(QGeoCoordinate coordinate);


### PR DESCRIPTION
Allows you to change the position of a mission item to the current vehicle position