### PR TITLE
Allow logging console output to file from command line

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -138,7 +138,7 @@ static QObject* qgroundcontrolQmlGlobalSingletonFactory(QQmlEngine*, QJSEngine*)
     return qmlGlobal;
 }
 
-QGCApplication::QGCApplication(int &argc, char* argv[], bool logOutput, bool unitTesting)
+QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 #ifdef __mobile__
     : QGuiApplication       (argc, argv)
     , _qmlAppEngine         (NULL)
@@ -146,7 +146,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool logOutput, bool uni
     : QApplication          (argc, argv)
 #endif
     , _runningUnitTests     (unitTesting)
-    , _logOutput            (logOutput)
+    , _logOutput            (false)
     , _fakeMobile           (false)
     , _settingsUpgraded     (false)
 #ifdef QT_DEBUG
@@ -216,6 +216,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool logOutput, bool uni
         { "--clear-settings",   &fClearSettingsOptions, NULL },
         { "--logging",          &logging,               &loggingOptions },
         { "--fake-mobile",      &_fakeMobile,           NULL },
+        { "--log-output",       &_logOutput,            NULL },
     #ifdef QT_DEBUG
         { "--test-high-dpi",    &_testHighDPI,          NULL },
     #endif

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -138,31 +138,22 @@ static QObject* qgroundcontrolQmlGlobalSingletonFactory(QQmlEngine*, QJSEngine*)
     return qmlGlobal;
 }
 
-/**
- * @brief Constructor for the main application.
- *
- * This constructor initializes and starts the whole application. It takes standard
- * command-line parameters
- *
- * @param argc The number of command-line parameters
- * @param argv The string array of parameters
- **/
-
-QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
+QGCApplication::QGCApplication(int &argc, char* argv[], bool logOutput, bool unitTesting)
 #ifdef __mobile__
-    : QGuiApplication(argc, argv)
-    , _qmlAppEngine(NULL)
-    #else
-    : QApplication(argc, argv)
-    #endif
-    , _runningUnitTests(unitTesting)
-    , _fakeMobile(false)
-    , _settingsUpgraded(false)
-    #ifdef QT_DEBUG
-    , _testHighDPI(false)
-    #endif
-    , _toolbox(NULL)
-    , _bluetoothAvailable(false)
+    : QGuiApplication       (argc, argv)
+    , _qmlAppEngine         (NULL)
+#else
+    : QApplication          (argc, argv)
+#endif
+    , _runningUnitTests     (unitTesting)
+    , _logOutput            (logOutput)
+    , _fakeMobile           (false)
+    , _settingsUpgraded     (false)
+#ifdef QT_DEBUG
+    , _testHighDPI          (false)
+#endif
+    , _toolbox              (NULL)
+    , _bluetoothAvailable   (false)
 {
     _app = this;
 

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -60,7 +60,7 @@ class QGCApplication : public
     Q_OBJECT
 
 public:
-    QGCApplication(int &argc, char* argv[], bool logOutput, bool unitTesting);
+    QGCApplication(int &argc, char* argv[], bool unitTesting);
     ~QGCApplication();
 
     /// @brief Sets the persistent flag to delete all settings the next time QGroundControl is started.

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -60,7 +60,7 @@ class QGCApplication : public
     Q_OBJECT
 
 public:
-    QGCApplication(int &argc, char* argv[], bool unitTesting);
+    QGCApplication(int &argc, char* argv[], bool logOutput, bool unitTesting);
     ~QGCApplication();
 
     /// @brief Sets the persistent flag to delete all settings the next time QGroundControl is started.
@@ -69,8 +69,11 @@ public:
     /// @brief Clears the persistent flag to delete all settings the next time QGroundControl is started.
     void clearDeleteAllSettingsNextBoot(void);
 
-    /// @brief Returns truee if unit test are being run
+    /// @brief Returns true if unit tests are being run
     bool runningUnitTests(void) { return _runningUnitTests; }
+
+    /// @brief Returns true if Qt debug output should be logged to a file
+    bool logOutput(void) { return _logOutput; }
 
     /// Used to report a missing Parameter. Warning will be displayed to user. Method may be called
     /// multiple times.
@@ -158,6 +161,7 @@ private:
 #endif
 
     bool _runningUnitTests; ///< true: running unit tests, false: normal app
+    bool _logOutput;        ///< true: Log Qt debug output to file
 
     static const char*  _darkStyleFile;
     static const char*  _lightStyleFile;

--- a/src/QmlControls/AppMessages.cc
+++ b/src/QmlControls/AppMessages.cc
@@ -11,8 +11,12 @@
 
 // Allows QGlobalStatic to work on this translation unit
 #define _LOG_CTOR_ACCESS_ public
+
 #include "AppMessages.h"
-#include <QFile>
+#include "QGCApplication.h"
+#include "SettingsManager.h"
+#include "AppSettings.h"
+
 #include <QStringListModel>
 #include <QtConcurrent>
 #include <QTextStream>
@@ -87,4 +91,26 @@ void AppLogModel::threadsafeLog(const QString message)
     const int line = rowCount();
     insertRows(line, 1);
     setData(index(line), message, Qt::DisplayRole);
+
+    if (qgcApp()->logOutput()) {
+        if (_logFile.fileName().isEmpty()) {
+            QGCToolbox* toolbox = qgcApp()->toolbox();
+            // Be careful of toolbox not being open yet
+            if (toolbox) {
+                QString saveDirPath = qgcApp()->toolbox()->settingsManager()->appSettings()->crashSavePath();
+                QDir saveDir(saveDirPath);
+                QString saveFilePath = saveDir.absoluteFilePath(QStringLiteral("QGCConsole.log"));
+
+                _logFile.setFileName(saveFilePath);
+                if (!_logFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+                    qgcApp()->showMessage(tr("Open console log output file failed %1 : %2").arg(_logFile.fileName()).arg(_logFile.errorString()));
+                }
+            }
+        }
+
+        if (_logFile.isOpen()) {
+            QTextStream out(&_logFile);
+            out << message << "\n";
+        }
+    }
 }

--- a/src/QmlControls/AppMessages.h
+++ b/src/QmlControls/AppMessages.h
@@ -13,6 +13,7 @@
 #include <QObject>
 #include <QStringListModel>
 #include <QUrl>
+#include <QFile>
 
 // Hackish way to force only this translation unit to have public ctor access
 #ifndef _LOG_CTOR_ACCESS_
@@ -33,6 +34,9 @@ signals:
 
 private slots:
     void threadsafeLog(const QString message);
+
+private:
+    QFile _logFile;
 
 _LOG_CTOR_ACCESS_:
     AppLogModel();

--- a/src/main.cc
+++ b/src/main.cc
@@ -176,12 +176,14 @@ int main(int argc, char *argv[])
 
     bool stressUnitTests = false;       // Stress test unit tests
     bool quietWindowsAsserts = false;   // Don't let asserts pop dialog boxes
+    bool logOutput = false;             // true: Log Qt debug output to file
 
     QString unitTestOptions;
     CmdLineOpt_t rgCmdLineOptions[] = {
         { "--unittest",             &runUnitTests,          &unitTestOptions },
         { "--unittest-stress",      &stressUnitTests,       &unitTestOptions },
         { "--no-windows-assert-ui", &quietWindowsAsserts,   NULL },
+        { "--log-output",           &logOutput,             NULL },
         // Add additional command line option flags here
     };
 
@@ -206,7 +208,7 @@ int main(int argc, char *argv[])
 #endif
 #endif // QT_DEBUG
 
-    QGCApplication* app = new QGCApplication(argc, argv, runUnitTests);
+    QGCApplication* app = new QGCApplication(argc, argv, logOutput, runUnitTests);
     Q_CHECK_PTR(app);
 
 #ifdef Q_OS_LINUX

--- a/src/main.cc
+++ b/src/main.cc
@@ -176,14 +176,12 @@ int main(int argc, char *argv[])
 
     bool stressUnitTests = false;       // Stress test unit tests
     bool quietWindowsAsserts = false;   // Don't let asserts pop dialog boxes
-    bool logOutput = false;             // true: Log Qt debug output to file
 
     QString unitTestOptions;
     CmdLineOpt_t rgCmdLineOptions[] = {
         { "--unittest",             &runUnitTests,          &unitTestOptions },
         { "--unittest-stress",      &stressUnitTests,       &unitTestOptions },
         { "--no-windows-assert-ui", &quietWindowsAsserts,   NULL },
-        { "--log-output",           &logOutput,             NULL },
         // Add additional command line option flags here
     };
 
@@ -208,7 +206,7 @@ int main(int argc, char *argv[])
 #endif
 #endif // QT_DEBUG
 
-    QGCApplication* app = new QGCApplication(argc, argv, logOutput, runUnitTests);
+    QGCApplication* app = new QGCApplication(argc, argv, runUnitTests);
     Q_CHECK_PTR(app);
 
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
```--log-output``` on the command line will log console otuput to CrashLogs\QGCConsole.log

More work to help with debugging crashes.