### PR TITLE
Link read/write: Better guarding against crashes

### DIFF
--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -75,30 +75,25 @@ QString BluetoothLink::getName() const
 
 void BluetoothLink::_writeBytes(const QByteArray bytes)
 {
-    if(_targetSocket)
-    {
-        if(_targetSocket->isWritable())
-        {
-            if(_targetSocket->write(bytes) > 0) {
-                _logOutputDataRate(bytes.size(), QDateTime::currentMSecsSinceEpoch());
-            }
-            else
-                qWarning() << "Bluetooth write error";
+    if (_targetSocket) {
+        if(_targetSocket->write(bytes) > 0) {
+            _logOutputDataRate(bytes.size(), QDateTime::currentMSecsSinceEpoch());
+        } else {
+            qWarning() << "Bluetooth write error";
         }
-        else
-            qWarning() << "Bluetooth not writable error";
     }
 }
 
 void BluetoothLink::readBytes()
 {
-    while (_targetSocket->bytesAvailable() > 0)
-    {
-        QByteArray datagram;
-        datagram.resize(_targetSocket->bytesAvailable());
-        _targetSocket->read(datagram.data(), datagram.size());
-        emit bytesReceived(this, datagram);
-        _logInputDataRate(datagram.length(), QDateTime::currentMSecsSinceEpoch());
+    if (_targetSocket) {
+        while (_targetSocket->bytesAvailable() > 0) {
+            QByteArray datagram;
+            datagram.resize(_targetSocket->bytesAvailable());
+            _targetSocket->read(datagram.data(), datagram.size());
+            emit bytesReceived(this, datagram);
+            _logInputDataRate(datagram.length(), QDateTime::currentMSecsSinceEpoch());
+        }
     }
 }
 
@@ -114,7 +109,7 @@ void BluetoothLink::_disconnect(void)
 #endif
     if(_targetSocket)
     {
-        delete _targetSocket;
+        _targetSocket->deleteLater();
         _targetSocket = NULL;
         emit disconnected();
     }

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -57,10 +57,6 @@ void SerialLink::requestReset()
 SerialLink::~SerialLink()
 {
     _disconnect();
-    if (_port) {
-        delete _port;
-    }
-    _port = NULL;
 }
 
 bool SerialLink::_isBootloader()
@@ -92,6 +88,7 @@ void SerialLink::_writeBytes(const QByteArray data)
         _port->write(data);
     } else {
         // Error occurred
+        qWarning() << "Serial port not writeable";
         _emitLinkError(tr("Could not send data - link %1 is disconnected!").arg(getName()));
     }
 }
@@ -105,7 +102,7 @@ void SerialLink::_disconnect(void)
 {
     if (_port) {
         _port->close();
-        delete _port;
+        _port->deleteLater();
         _port = NULL;
     }
 
@@ -199,7 +196,7 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
         }
     }
 
-    _port = new QSerialPort(_serialConfig->portName());
+    _port = new QSerialPort(_serialConfig->portName(), this);
 
     QObject::connect(_port, static_cast<void (QSerialPort::*)(QSerialPort::SerialPortError)>(&QSerialPort::error),
                      this, &SerialLink::linkError);
@@ -261,12 +258,18 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
 
 void SerialLink::_readBytes(void)
 {
-    qint64 byteCount = _port->bytesAvailable();
-    if (byteCount) {
-        QByteArray buffer;
-        buffer.resize(byteCount);
-        _port->read(buffer.data(), buffer.size());
-        emit bytesReceived(this, buffer);
+    if (_port && _port->isOpen()) {
+        qint64 byteCount = _port->bytesAvailable();
+        if (byteCount) {
+            QByteArray buffer;
+            buffer.resize(byteCount);
+            _port->read(buffer.data(), buffer.size());
+            emit bytesReceived(this, buffer);
+        }
+    } else {
+        // Error occurred
+        qWarning() << "Serial port not readable";
+        _emitLinkError(tr("Could not read data - link %1 is disconnected!").arg(getName()));
     }
 }
 


### PR DESCRIPTION
In looking through Stable 3.3 android crash reports. There are quite a few in readBytes of various link types. These changes guard against possible null pointer references.