### PR TITLE
Separate terrain from tile maps within cached tile request system.

### DIFF
--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -123,23 +123,23 @@ QGeoTiledMapReplyQGC::networkReplyFinished()
     }
     QByteArray a = _reply->readAll();
     QString format = getQGCMapEngine()->urlFactory()->getImageFormat((UrlFactory::MapType)tileSpec().mapId(), a);
-
-    // convert "a" to binary in case we have elevation data
+    //-- Test for a specialized, elevation data (not map tile)
     if ((UrlFactory::MapType)tileSpec().mapId() == UrlFactory::MapType::AirmapElevation) {
-
         a = TerrainTile::serialize(a);
-        if (a.isEmpty()) {
-            emit aborted();
-            return;
+        //-- Cache it if valid
+        if(!a.isEmpty()) {
+            getQGCMapEngine()->cacheTile(UrlFactory::MapType::AirmapElevation, tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
         }
-
+        emit terrainDone(a, QNetworkReply::NoError);
+    } else {
+        //-- This is a map tile. Process and ache it if valid.
+        setMapImageData(a);
+        if(!format.isEmpty()) {
+            setMapImageFormat(format);
+            getQGCMapEngine()->cacheTile((UrlFactory::MapType)tileSpec().mapId(), tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
+        }
+        setFinished(true);
     }
-    setMapImageData(a);
-    if(!format.isEmpty()) {
-        setMapImageFormat(format);
-        getQGCMapEngine()->cacheTile((UrlFactory::MapType)tileSpec().mapId(), tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
-    }
-    setFinished(true);
     _clearReply();
 }
 
@@ -151,11 +151,17 @@ QGeoTiledMapReplyQGC::networkReplyError(QNetworkReply::NetworkError error)
     if (!_reply) {
         return;
     }
-    if (error != QNetworkReply::OperationCanceledError) {
-        qWarning() << "Fetch tile error:" << _reply->errorString();
-        setError(QGeoTiledMapReply::CommunicationError, _reply->errorString());
+    //-- Test for a specialized, elevation data (not map tile)
+    if ((UrlFactory::MapType)tileSpec().mapId() == UrlFactory::MapType::AirmapElevation) {
+        emit terrainDone(QByteArray(), error);
+    } else {
+        //-- Regular map tile
+        if (error != QNetworkReply::OperationCanceledError) {
+            qWarning() << "Fetch tile error:" << _reply->errorString();
+            setError(QGeoTiledMapReply::CommunicationError, _reply->errorString());
+        }
+        setFinished(true);
     }
-    setFinished(true);
     _clearReply();
 }
 
@@ -164,8 +170,12 @@ void
 QGeoTiledMapReplyQGC::cacheError(QGCMapTask::TaskType type, QString /*errorString*/)
 {
     if(!getQGCMapEngine()->isInternetActive()) {
-        setError(QGeoTiledMapReply::CommunicationError, "Network not available");
-        setFinished(true);
+        if ((UrlFactory::MapType)tileSpec().mapId() == UrlFactory::MapType::AirmapElevation) {
+            emit terrainDone(QByteArray(), QNetworkReply::NetworkSessionFailedError);
+        } else {
+            setError(QGeoTiledMapReply::CommunicationError, "Network not available");
+            setFinished(true);
+        }
     } else {
         if(type != QGCMapTask::taskFetchTile) {
             qWarning() << "QGeoTiledMapReplyQGC::cacheError() for wrong task";
@@ -196,10 +206,16 @@ QGeoTiledMapReplyQGC::cacheError(QGCMapTask::TaskType type, QString /*errorStrin
 void
 QGeoTiledMapReplyQGC::cacheReply(QGCCacheTile* tile)
 {
-    setMapImageData(tile->img());
-    setMapImageFormat(tile->format());
-    setFinished(true);
-    setCached(true);
+    //-- Test for a specialized, elevation data (not map tile)
+    if ((UrlFactory::MapType)tileSpec().mapId() == UrlFactory::MapType::AirmapElevation) {
+        emit terrainDone(tile->img(), QNetworkReply::NoError);
+    } else {
+        //-- Regular map tile
+        setMapImageData(tile->img());
+        setMapImageFormat(tile->format());
+        setFinished(true);
+        setCached(true);
+    }
     tile->deleteLater();
 }
 
@@ -209,6 +225,9 @@ QGeoTiledMapReplyQGC::timeout()
 {
     if(_reply) {
         _reply->abort();
+    }
+    if ((UrlFactory::MapType)tileSpec().mapId() == UrlFactory::MapType::AirmapElevation) {
+        emit terrainDone(QByteArray(), QNetworkReply::TimeoutError);
     }
     emit aborted();
 }

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.h
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.h
@@ -61,6 +61,9 @@ public:
     ~QGeoTiledMapReplyQGC();
     void abort();
 
+signals:
+    void terrainDone            (QByteArray responseBytes, QNetworkReply::NetworkError error);
+
 private slots:
     void networkReplyFinished   ();
     void networkReplyError      (QNetworkReply::NetworkError error);

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -374,8 +374,7 @@ bool TerrainTileManager::_getAltitudesForCoordinates(const QList<QGeoCoordinate>
                 spec.setZoom(1);
                 spec.setMapId(UrlFactory::AirmapElevation);
                 QGeoTiledMapReplyQGC* reply = new QGeoTiledMapReplyQGC(&_networkManager, request, spec);
-                connect(reply, &QGeoTiledMapReplyQGC::finished, this, &TerrainTileManager::_fetchedTile);
-                connect(reply, &QGeoTiledMapReplyQGC::aborted, this, &TerrainTileManager::_fetchedTile);
+                connect(reply, &QGeoTiledMapReplyQGC::terrainDone, this, &TerrainTileManager::_terrainDone);
                 _state = State::Downloading;
             }
             _tilesMutex.unlock();
@@ -406,7 +405,7 @@ void TerrainTileManager::_tileFailed(void)
     _requestQueue.clear();
 }
 
-void TerrainTileManager::_fetchedTile()
+void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::NetworkError error)
 {
     QGeoTiledMapReplyQGC* reply = qobject_cast<QGeoTiledMapReplyQGC*>(QObject::sender());
     _state = State::Idle;
@@ -421,25 +420,18 @@ void TerrainTileManager::_fetchedTile()
     QString hash = QGCMapEngine::getTileHash(UrlFactory::AirmapElevation, spec.x(), spec.y(), spec.zoom());
 
     // handle potential errors
-    if (reply->error() != QGeoTiledMapReply::NoError) {
-        if (reply->error() == QGeoTiledMapReply::CommunicationError) {
-            qCDebug(TerrainQueryLog) << "Elevation tile fetching returned communication error. " << reply->errorString();
-        } else {
-            qCDebug(TerrainQueryLog) << "Elevation tile fetching returned error. " << reply->errorString();
-        }
+    if (error != QNetworkReply::NoError) {
+        qCDebug(TerrainQueryLog) << "Elevation tile fetching returned error (" << error << ")";
         _tileFailed();
         reply->deleteLater();
         return;
     }
-    if (!reply->isFinished()) {
-        qCDebug(TerrainQueryLog) << "Error in fetching elevation tile. Not finished. " << reply->errorString();
+    if (responseBytes.isEmpty()) {
+        qCDebug(TerrainQueryLog) << "Error in fetching elevation tile. Empty response.";
         _tileFailed();
         reply->deleteLater();
         return;
     }
-
-    // parse received data and insert into hash table
-    QByteArray responseBytes = reply->mapImageData();
 
     qWarning() << "Received some bytes of terrain data: " << responseBytes.size();
 

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -62,20 +62,20 @@ public:
     TerrainAirMapQuery(QObject* parent = NULL);
 
     // Overrides from TerrainQueryInterface
-    void requestCoordinateHeights(const QList<QGeoCoordinate>& coordinates) final;
-    void requestPathHeights(const QGeoCoordinate& fromCoord, const QGeoCoordinate& toCoord) final;
-    void requestCarpetHeights(const QGeoCoordinate& swCoord, const QGeoCoordinate& neCoord, bool statsOnly) final;
+    void requestCoordinateHeights   (const QList<QGeoCoordinate>& coordinates) final;
+    void requestPathHeights         (const QGeoCoordinate& fromCoord, const QGeoCoordinate& toCoord) final;
+    void requestCarpetHeights       (const QGeoCoordinate& swCoord, const QGeoCoordinate& neCoord, bool statsOnly) final;
 
 private slots:
-    void _requestError(QNetworkReply::NetworkError code);
-    void _requestFinished(void);
+    void _requestError              (QNetworkReply::NetworkError code);
+    void _requestFinished           ();
 
 private:
-    void _sendQuery             (const QString& path, const QUrlQuery& urlQuery);
-    void _requestFailed         (void);
-    void _parseCoordinateData   (const QJsonValue& coordinateJson);
-    void _parsePathData         (const QJsonValue& pathJson);
-    void _parseCarpetData       (const QJsonValue& carpetJson);
+    void _sendQuery                 (const QString& path, const QUrlQuery& urlQuery);
+    void _requestFailed             (void);
+    void _parseCoordinateData       (const QJsonValue& coordinateJson);
+    void _parsePathData             (const QJsonValue& pathJson);
+    void _parseCarpetData           (const QJsonValue& carpetJson);
 
     enum QueryMode {
         QueryModeCoordinates,
@@ -117,7 +117,7 @@ public:
     void addPathQuery       (TerrainOfflineAirMapQuery* terrainQueryInterface, const QGeoCoordinate& startPoint, const QGeoCoordinate& endPoint);
 
 private slots:
-    void _fetchedTile       (void);                             /// slot to handle fetched elevation tiles
+    void _terrainDone       (QByteArray responseBytes, QNetworkReply::NetworkError error);
 
 private:
     enum class State {


### PR DESCRIPTION
In response to #6352 

I know nothing about SSL on Windows or the parsing of Elevation data. In looking through the existing code, what I saw were some uses of the system that weren't quite right.

The terrain query code, makes use of `QGeoTiledMapReplyQGC` for obvious reasons. It handles all the caching and Internet requests. On the other hand, `QGeoTiledMapReplyQGC` was meant to be used by the QtLocation plugin and not from an outside "client".

The proper fix, which I started and eventually gave up due to the time it would take to do it properly, would be to create a base, virtual class handling the basics. You request a "tile" and you received it (or an error if that's the case). Internally it looks for the "tile" in the cache and if not found, gets it off the Internet. This is what `QGeoTiledMapReplyQGC` does. But the base, virtual class would limit its function to tile retrieval.

A derived class would provide its services to the QtLocation plugin (along with all the other functions that pertain to map tiles) and the terrain code would instantiate its own, separate implementation.

In absence of that, what I've done was to separate all the code related to terrain data from regular map tiles within `QGeoTiledMapReplyQGC`. There is a new signal, which only the terrain code uses to received the "tile" back (or an error if that's the case). When the request is for terrain data, none of the code within `QGeoTiledMapReplyQGC` call the base class functions (`setFinished()`, `setCached()`, etc.) as these only apply to map tiles.

From the perspective of the terrain code, not much changed. To request a "tile" it still creates an instance of `QGeoTiledMapReplyQGC` as always. The difference is that it connects to just one signal, dedicated to terrain data: 

```
    void terrainDone            (QByteArray responseBytes, QNetworkReply::NetworkError error);
```

This signal is called no matter what and it will either contain the requested data or an error.

With that said, this needs quite a bit of testing, especially under error conditions. 
