### PR TITLE
Automated preflight checklists

### DIFF
--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -171,6 +171,7 @@
         <file alias="APM/BrandImageSub">src/FirmwarePlugin/APM/APMBrandImageSub.png</file>
         <file alias="PX4/BrandImage">src/FirmwarePlugin/PX4/PX4BrandImage.png</file>
         <file alias="subVehicleArrowOpaque.png">src/FlightMap/Images/sub.png</file>
+        <file alias="check.svg">resources/check.svg</file>
     </qresource>
     <qresource prefix="/res">
         <file alias="action.svg">resources/action.svg</file>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -193,6 +193,7 @@
         <file alias="VibrationPageWidget.qml">src/FlightMap/Widgets/VibrationPageWidget.qml</file>
         <file alias="VideoPageWidget.qml">src/FlightMap/Widgets/VideoPageWidget.qml</file>
         <file alias="VirtualJoystick.qml">src/FlightDisplay/VirtualJoystick.qml</file>
+        <file alias="QGroundControl/FlightDisplay/CheckList.qml">src/FlightDisplay/CheckList.qml</file>
     </qresource>
     <qresource prefix="/json">
         <file alias="CameraCalc.FactMetaData.json">src/MissionManager/CameraCalc.FactMetaData.json</file>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -87,6 +87,7 @@
         <file alias="QGroundControl/Controls/ParameterEditorDialog.qml">src/QmlControls/ParameterEditorDialog.qml</file>
         <file alias="QGroundControl/Controls/PlanToolBar.qml">src/PlanView/PlanToolBar.qml</file>
         <file alias="QGroundControl/Controls/QGCButton.qml">src/QmlControls/QGCButton.qml</file>
+        <file alias="QGroundControl/Controls/QGCCheckListItem.qml">src/QmlControls/QGCCheckListItem.qml</file>
         <file alias="QGroundControl/Controls/QGCCheckBox.qml">src/QmlControls/QGCCheckBox.qml</file>
         <file alias="QGroundControl/Controls/QGCColoredImage.qml">src/QmlControls/QGCColoredImage.qml</file>
         <file alias="QGroundControl/Controls/QGCComboBox.qml">src/QmlControls/QGCComboBox.qml</file>

--- a/resources/check.svg
+++ b/resources/check.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 72 72"
+   style="enable-background:new 0 0 72 72;"
+   xml:space="preserve"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="check.svg"><metadata
+     id="metadata3416"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
+     id="defs3414"><linearGradient
+       id="linearGradient4141"
+       osb:paint="solid"><stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4143" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4141"
+       id="linearGradient4145"
+       x1="48.508473"
+       y1="58.423729"
+       x2="79.322032"
+       y2="58.423729"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8414091,0,0,2.2407508,-82.18242,-94.289127)" /></defs><sodipodi:namedview
+     pagecolor="#000000"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1855"
+     inkscape:window-height="1056"
+     id="namedview3412"
+     showgrid="false"
+     inkscape:zoom="3.2777778"
+     inkscape:cx="-54.305085"
+     inkscape:cy="36"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style3406">
+	.st0{fill:#66BD59;stroke:#FFFFFF;stroke-width:5;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style><polyline
+     class="st1"
+     points="55.1,19.8 30.2,52.2 16.9,36.5 "
+     id="polyline3410"
+     transform="matrix(0.85559226,0,0,0.85559226,5.1269823,8.2041673)"
+     style="fill:none;stroke:#ffffff;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10" /><style
+     id="style3419"
+     type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:3;stroke-miterlimit:10;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:8;stroke-miterlimit:10;}
+	.st2{fill:#FFFFFF;}
+</style><circle
+     style="fill:none;stroke:url(#linearGradient4145);stroke-width:3.25963402;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path3339"
+     cx="35.5117"
+     cy="36.62389"
+     r="28.370182" /></svg>

--- a/src/FlightDisplay/CheckList.qml
+++ b/src/FlightDisplay/CheckList.qml
@@ -1,0 +1,206 @@
+import QtQuick                      2.3
+import QtQml.Models                 2.1
+
+import QGroundControl               1.0
+import QGroundControl.FlightDisplay 1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.Vehicle       1.0
+
+// This class stores the data and functions of the check list but NOT the GUI (which is handled somewhere else).
+Item {
+    // Properties
+    property int            unhealthySensors:       _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
+    property bool           gpsLock:                _activeVehicle ? _activeVehicle.gps.lock.rawValue>=3 : 0
+    property var            batPercentRemaining:    _activeVehicle ? _activeVehicle.battery.percentRemaining.value : 0
+    property bool           audioMuted:             QGroundControl.settingsManager.appSettings.audioMuted.rawValue
+    property ObjectModel    checkListItems:         _checkListItems
+    property var            _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
+    property int            _checkState:            _activeVehicle ? (_activeVehicle.armed ? 1 + (buttonActuators._state + buttonMotors._state + buttonMission._state + buttonSoundOutput._state) / 4 / 4 : 0) : 0 ; // Shows progress of checks inside the checklist - unlocks next check steps in groups
+
+    // Connections
+    onBatPercentRemainingChanged:   buttonBattery.updateItem();
+    onGpsLockChanged:               buttonSensors.updateItem();
+    onAudioMutedChanged:            buttonSoundOutput.updateItem();
+    onUnhealthySensorsChanged:      updateVehicleDependentItems();
+
+    Connections {
+        target: QGroundControl.multiVehicleManager
+        onActiveVehicleChanged: onActiveVehicleChanged();
+    }
+    Component.onCompleted: {
+        if(QGroundControl.multiVehicleManager.vehicles.count > 0) {
+            onActiveVehicleChanged();
+        }
+    }
+
+    // Functions
+    function updateVehicleDependentItems() {
+        buttonSensors.updateItem();
+        buttonBattery.updateItem();
+        buttonRC.updateItem();
+        buttonEstimator.updateItem();
+    }
+    function onActiveVehicleChanged() {
+        buttonSoundOutput.updateItem();     // Just updated here for initialization once we connect to a vehicle
+        updateVehicleDependentItems();
+    }
+    function resetNrClicks() {
+        buttonHardware.resetNrClicks();
+        buttonBattery.resetNrClicks();
+        buttonRC.resetNrClicks();
+        buttonActuators.resetNrClicks();
+        buttonMotors.resetNrClicks();
+        buttonMission.resetNrClicks();
+        buttonSoundOutput.resetNrClicks();
+        buttonPayload.resetNrClicks();
+        buttonWeather.resetNrClicks();
+        buttonFlightAreaFree.resetNrClicks();
+    }
+
+    // Check list item data
+    ObjectModel {
+        id: _checkListItems
+
+        // Standard check list items (group 0) - Available from the start
+        QGCCheckListItem {
+            id: buttonHardware
+            name: "Hardware"
+            defaulttext: "Props mounted? Wings secured? Tail secured?"
+        }
+        QGCCheckListItem {
+             id: buttonBattery
+             name: "Battery"
+             pendingtext: "Healthy & charged > 40%. Battery connector firmly plugged?"
+             function updateItem() {
+                 if (!_activeVehicle) {
+                     _state = 0;
+                 } else {
+                     if (!(unhealthySensors & Vehicle.SysStatusSensorBattery) && batPercentRemaining>=40.0) _state = 1+3*(_nrClicked>0);
+                     else {
+                         if(unhealthySensors & Vehicle.SysStatusSensorBattery) failuretext="Not healthy. Check console.";
+                         else if(batPercentRemaining<40.0) failuretext="Low (below 40%). Please recharge.";
+                         _state = 3;
+                     }
+                 }
+             }
+        }
+        QGCCheckListItem {
+             id: buttonSensors
+             name: "Sensors"
+             function updateItem() {
+                 if (!_activeVehicle) {
+                     _state = 0;
+                 } else {
+                     if(!(unhealthySensors & Vehicle.SysStatusSensor3dMag) &&
+                        !(unhealthySensors & Vehicle.SysStatusSensor3dAccel) &&
+                        !(unhealthySensors & Vehicle.SysStatusSensor3dGyro) &&
+                        !(unhealthySensors & Vehicle.SysStatusSensorAbsolutePressure) &&
+                        !(unhealthySensors & Vehicle.SysStatusSensorDifferentialPressure) &&
+                        !(unhealthySensors & Vehicle.SysStatusSensorGPS)) {
+                         if(!gpsLock) {
+                             pendingtext="Pending. Waiting for GPS lock.";
+                             _state=1;
+                         } else {
+                             _state = 4; // All OK
+                         }
+                     } else {
+                         if(unhealthySensors & Vehicle.SysStatusSensor3dMag)                        failuretext="Failure. Magnetometer issues. Check console.";
+                         else if(unhealthySensors & Vehicle.SysStatusSensor3dAccel)                 failuretext="Failure. Accelerometer issues. Check console.";
+                         else if(unhealthySensors & Vehicle.SysStatusSensor3dGyro)                  failuretext="Failure. Gyroscope issues. Check console.";
+                         else if(unhealthySensors & Vehicle.SysStatusSensorAbsolutePressure)        failuretext="Failure. Barometer issues. Check console.";
+                         else if(unhealthySensors & Vehicle.SysStatusSensorDifferentialPressure)    failuretext="Failure. Airspeed sensor issues. Check console.";
+                         else if(unhealthySensors & Vehicle.SysStatusSensorGPS)                     failuretext="Failure. No valid or low quality GPS signal. Check console.";
+                         _state = 3;
+                     }
+                 }
+             }
+        }
+        QGCCheckListItem {
+            id: buttonRC
+            name: "Radio Control"
+            pendingtext: "Receiving signal. Perform range test & confirm."
+            failuretext: "No signal or invalid autopilot-RC config. Check RC and console."
+            function updateItem() {
+                if (!_activeVehicle) {
+                    _state = 0;
+                } else {
+                    if (unhealthySensors & Vehicle.SysStatusSensorRCReceiver) {_state = 3}
+                    else {_state = 1+3*(_nrClicked>0);}
+                }
+            }
+        }
+        QGCCheckListItem {
+            id: buttonEstimator
+            name: "Global position estimate"
+            function updateItem() {
+                if (!_activeVehicle) {
+                    _state = 0;
+                } else {
+                    if (unhealthySensors & Vehicle.SysStatusSensorAHRS) {_state = 3;}
+                    else {_state = 4;}
+                }
+            }
+        }
+
+        // Check list item group 1 - Require arming
+        QGCLabel {text:qsTr("<i>Please arm the vehicle here.</i>") ; opacity: 0.2+0.8*(QGroundControl.multiVehicleManager.vehicles.count > 0) ; anchors.horizontalCenter:buttonHardware.horizontalCenter ; anchors.topMargin:40 ; anchors.bottomMargin:40;}
+        QGCCheckListItem {
+           id: buttonActuators
+           name: "Actuators"
+           group: 1
+           defaulttext: "Move all control surfaces. Did they work properly?"
+        }
+        QGCCheckListItem {
+           id: buttonMotors
+           name: "Motors"
+           group: 1
+           defaulttext: "Propellers free? Then throttle up gently. Working properly?"
+        }
+        QGCCheckListItem {
+           id: buttonMission
+           name: "Mission"
+           group: 1
+           defaulttext: "Please confirm mission is valid (waypoints valid, no terrain collision)."
+        }
+        QGCCheckListItem {
+           id: buttonSoundOutput
+           name: "Sound output"
+           group: 1
+           pendingtext: "QGC audio output enabled. System audio output enabled, too?"
+           failuretext: "Failure, QGC audio output is disabled. Please enable it under application settings->general to hear audio warnings!"
+           function updateItem() {
+               if (!_activeVehicle) {
+                   _state = 0;
+               } else {
+                   if (audioMuted) {_state = 3 ; _nrClicked=0;}
+                   else {_state = 1+3*(_nrClicked>0);}
+               }
+           }
+        }
+
+        // Check list item group 2 - Final checks before launch
+        QGCLabel {text:qsTr("<i>Last preparations before launch</i>") ; opacity : 0.2+0.8*(_checkState >= 2); anchors.horizontalCenter:buttonHardware.horizontalCenter}
+        QGCCheckListItem {
+           id: buttonPayload
+           name: "Payload"
+           group: 2
+           defaulttext: "Configured and started?"
+           pendingtext: "Payload lid closed?"
+        }
+        QGCCheckListItem {
+           id: buttonWeather
+           name: "Wind & weather"
+           group: 2
+           defaulttext: "OK for your platform?"
+           pendingtext: "Launching into the wind?"
+        }
+        QGCCheckListItem {
+           id: buttonFlightAreaFree
+           name: "Flight area"
+           group: 2
+           defaulttext: "Launch area and path free of obstacles/people?"
+        }
+    } // Object Model
+}

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -696,17 +696,19 @@ QGCView {
             id:         checklistRect
             visible:    true
             width:      mainColumn.width + 3*ScreenTools.defaultFontPixelWidth
-            height:     mainColumn.height * 1.04
+            height:     mainColumn.height + ScreenTools.defaultFontPixelHeight
             color:      qgcPal.windowShade
             radius:     3
             enabled:    QGroundControl.multiVehicleManager.vehicles.count > 0;
 
             Column {
-                id:         mainColumn
-                x:          1.5*ScreenTools.defaultFontPixelWidth
-                y:          0.4*ScreenTools.defaultFontPixelWidth
-                width:      40*ScreenTools.defaultFontPixelWidth
-                spacing:    0.8*ScreenTools.defaultFontPixelWidth
+                id:                     mainColumn
+                width:                  40*ScreenTools.defaultFontPixelWidth
+                spacing:                0.8*ScreenTools.defaultFontPixelWidth
+                anchors.left:           parent.left
+                anchors.top:            parent.top
+                anchors.topMargin:      0.6*ScreenTools.defaultFontPixelWidth
+                anchors.leftMargin:     1.5*ScreenTools.defaultFontPixelWidth
 
                 // Header/title of checklist
                 Item {

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -17,6 +17,7 @@ import QtPositioning            5.3
 import QtMultimedia             5.5
 import QtQuick.Layouts          1.2
 import QtQuick.Window           2.2
+import QtQml.Models             2.1
 
 import QGroundControl               1.0
 import QGroundControl.FlightDisplay 1.0
@@ -46,12 +47,12 @@ QGCView {
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property bool   _mainIsMap:             QGroundControl.videoManager.hasVideo ? QGroundControl.loadBoolGlobalSetting(_mainIsMapKey,  true) : true
     property bool   _isPipVisible:          QGroundControl.videoManager.hasVideo ? QGroundControl.loadBoolGlobalSetting(_PIPVisibleKey, true) : false
+    property bool   _useChecklist:          QGroundControl.settingsManager.appSettings.useChecklist.rawValue
     property real   _savedZoomLevel:        0
     property real   _margins:               ScreenTools.defaultFontPixelWidth / 2
     property real   _pipSize:               flightView.width * 0.2
     property alias  _guidedController:      guidedActionsController
     property alias  _altitudeSlider:        altitudeSlider
-
 
     readonly property var       _dynamicCameras:        _activeVehicle ? _activeVehicle.dynamicCameras : null
     readonly property bool      _isCamera:              _dynamicCameras ? _dynamicCameras.cameras.count > 0 : false
@@ -110,6 +111,10 @@ QGCView {
     PlanMasterController {
         id:                     masterController
         Component.onCompleted:  start(true /* flyView */)
+    }
+
+    CheckList {
+        id: checklist
     }
 
     Connections {
@@ -504,8 +509,8 @@ QGCView {
             z:                  _panel.z + 4
             title:              qsTr("Fly")
             maxHeight:          (_flightVideo.visible ? _flightVideo.y : parent.height) - toolStrip.y
-            buttonVisible:      [ QGroundControl.settingsManager.appSettings.useChecklist.rawValue, _guidedController.showTakeoff || !_guidedController.showLand, _guidedController.showLand && !_guidedController.showTakeoff, true, true, true, _guidedController.smartShotsAvailable ]
-            buttonEnabled:      [ QGroundControl.settingsManager.appSettings.useChecklist.rawValue, _guidedController.showTakeoff, _guidedController.showLand, _guidedController.showRTL, _guidedController.showPause, _anyActionAvailable, _anySmartShotAvailable ]
+            buttonVisible:      [ _useChecklist, _guidedController.showTakeoff || !_guidedController.showLand, _guidedController.showLand && !_guidedController.showTakeoff, true, true, true, _guidedController.smartShotsAvailable ]
+            buttonEnabled:      [ _useChecklist, _guidedController.showTakeoff, _guidedController.showLand, _guidedController.showRTL, _guidedController.showPause, _anyActionAvailable, _anySmartShotAvailable ]
 
             property bool _anyActionAvailable: _guidedController.showStartMission || _guidedController.showResumeMission || _guidedController.showChangeAlt || _guidedController.showLandAbort
             property bool _anySmartShotAvailable: _guidedController.showOrbit
@@ -683,291 +688,58 @@ QGCView {
         }
     }
 
+    //-- Checklist GUI
     Component {
         id: checklistDropPanel
 
         Rectangle {
-            id:       checklist
-            width:    mainColumn.width + (ScreenTools.defaultFontPixelWidth * 4)
-            height:   (headerColumn.height+mainColumn.height) * 1.07
-            color:    qgcPal.windowShade
-            radius:   20
-            enabled:  QGroundControl.multiVehicleManager.vehicles.count > 0;
-
-            onBatPercentRemainingChanged: {if(_initialized) buttonBattery.updateItem();}
-            onGpsLockChanged: {buttonSensors.updateItem();}
-
-            // Connections
-            Connections {
-                target: _activeVehicle
-                onUnhealthySensorsChanged: checklist.onUnhealthySensorsChanged();
-            }
-            Connections {
-                target: QGroundControl.multiVehicleManager
-                onActiveVehicleChanged: checklist.onActiveVehicleChanged();
-                onActiveVehicleAvailableChanged: {}
-            }
-            Connections {
-                target: QGroundControl.settingsManager.appSettings.audioMuted
-                onValueChanged: buttonSoundOutput.updateItem(); //TODO(philippoe): We are binding to a signal which is explicitly marked as "only for QT internal use" here.
-            }
-            Component.onCompleted: {
-                if(QGroundControl.multiVehicleManager.vehicles.count > 0) {
-                    onActiveVehicleChanged();
-                    _initialized=true;
-                }
-            }
-
-            function updateVehicleDependentItems() {
-                buttonSensors.updateItem();
-                buttonBattery.updateItem();
-                buttonRC.updateItem();
-                buttonEstimator.updateItem();
-            }
-            function onActiveVehicleChanged() {
-                buttonSoundOutput.updateItem();     // Just updated here for initialization once we connect to a vehicle
-                onUnhealthySensorsChanged();        // The health states could all have changed - need to update them.
-            }
-            function onUnhealthySensorsChanged() {
-                var unhealthySensorsStr = _activeVehicle.unhealthySensors;
-
-                // Set to healthy per default
-                for(var i=0;i<32;i++) _healthFlags[i]=true;
-
-                for(i=0;i<unhealthySensorsStr.length;i++) { // TODO (philippoe): This is terrible, having this data available in the form of a bitfield would be much better than a string list!
-                    switch(unhealthySensorsStr[i]) {
-                    case "Gyro":                    _healthFlags[0]=false; break;
-                    case "Accelerometer":           _healthFlags[1]=false; break;
-                    case "Magnetometer":            _healthFlags[2]=false; break;
-                    case "Absolute pressure":       _healthFlags[3]=false; break;
-                    case "Differential pressure":   _healthFlags[4]=false; break;
-                    case "GPS":                     _healthFlags[5]=false; break;
-                    case "Optical flow":            _healthFlags[6]=false; break;
-                    case "Computer vision position":_healthFlags[7]=false; break;
-                    case "Laser based position":    _healthFlags[8]=false; break;
-                    case "External ground truth":   _healthFlags[9]=false; break;
-                    case "Angular rate control":    _healthFlags[10]=false; break;
-                    case "Attitude stabilization":  _healthFlags[11]=false; break;
-                    case "Yaw position":            _healthFlags[12]=false; break;
-                    case "Z/altitude control":      _healthFlags[13]=false; break;
-                    case "X/Y position control":    _healthFlags[14]=false; break;
-                    case "Motor outputs / control": _healthFlags[15]=false; break;
-                    case "RC receiver":             _healthFlags[16]=false; break;
-                    case "Gyro 2":                  _healthFlags[17]=false; break;
-                    case "Accelerometer 2":         _healthFlags[18]=false; break;
-                    case "Magnetometer 2":          _healthFlags[19]=false; break;
-                    case "GeoFence":                _healthFlags[20]=false; break;
-                    case "AHRS":                    _healthFlags[21]=false; break;
-                    case "Terrain":                 _healthFlags[22]=false; break;
-                    case "Motors reversed":         _healthFlags[23]=false; break;
-                    case "Logging":                 _healthFlags[24]=false; break;
-                    case "Battery":                 _healthFlags[25]=false; break;
-                    default:
-                    }
-                }
-                updateVehicleDependentItems();
-            }
-
-            Column {
-                id:         headerColumn
-                x:          2*ScreenTools.defaultFontPixelWidth
-                y:          2*ScreenTools.defaultFontPixelWidth
-                width:      320
-                spacing:    8
-
-                // Header/title of checklist
-                QGCLabel {anchors.horizontalCenter:   parent.horizontalCenter ; font.pointSize: ScreenTools.mediumFontPointSize ; text: _activeVehicle ? qsTr("Pre-flight checklist")+" (MAV ID:"+_activeVehicle.id+")" : qsTr("Pre-flight checklist (awaiting vehicle...)");}
-                Rectangle {anchors.left:parent.left ; anchors.right:parent.right ; height:1 ; color:qgcPal.text}
-            }
+            id:         checklistRect
+            visible:    true
+            width:      mainColumn.width + 3*ScreenTools.defaultFontPixelWidth
+            height:     mainColumn.height * 1.04
+            color:      qgcPal.windowShade
+            radius:     3
+            enabled:    QGroundControl.multiVehicleManager.vehicles.count > 0;
 
             Column {
                 id:         mainColumn
-                x:          2*ScreenTools.defaultFontPixelWidth
-                anchors.top:headerColumn.bottom
-                anchors.topMargin:ScreenTools.defaultFontPixelWidth
-                width:      320
-                spacing:    6
-                enabled : QGroundControl.multiVehicleManager.vehicles.count > 0;
-                opacity : 0.2+0.8*(QGroundControl.multiVehicleManager.vehicles.count > 0);
+                x:          1.5*ScreenTools.defaultFontPixelWidth
+                y:          0.4*ScreenTools.defaultFontPixelWidth
+                width:      40*ScreenTools.defaultFontPixelWidth
+                spacing:    0.8*ScreenTools.defaultFontPixelWidth
 
-                // Checklist items: Standard
-                QGCCheckListItem {
-                    id: buttonHardware
-                    name: "Hardware"
-                    defaulttext: "Props mounted? Wings secured? Tail secured?"
-                }
+                // Header/title of checklist
+                Item {
+                    width:  parent.width
+                    height: 1.75*ScreenTools.defaultFontPixelHeight
 
-                QGCCheckListItem {
-                     id: buttonBattery
-                     name: "Battery"
-                     pendingtext: "Healthy & charged > 40%. Battery connector firmly plugged?"
-                     function updateItem() {
-                         if (!_activeVehicle) {
-                             _state = 0;
-                         } else {
-                             if (checklist._healthFlags[25] && batPercentRemaining>=40.0) _state = 1+3*(_nrClicked>0);
-                             else {
-                                 if(!checklist._healthFlags[25]) buttonBattery.failuretext="Not healthy. Check console.";
-                                 else if(batPercentRemaining<40.0) buttonBattery.failuretext="Low (below 40%). Please recharge.";
-                                 buttonBattery._state = 3;
-                             }
-                         }
-                     }
-                }
-
-                QGCCheckListItem {
-                     id: buttonSensors
-                     name: "Sensors"
-                     function updateItem() {
-                         if (!_activeVehicle) {
-                             _state = 0;
-                         } else {
-                             if(checklist._healthFlags[0] &&
-                                     checklist._healthFlags[1] &&
-                                     checklist._healthFlags[2] &&
-                                     checklist._healthFlags[3] &&
-                                     checklist._healthFlags[4] &&
-                                     checklist._healthFlags[5]) {
-                                 if(!gpsLock) {
-                                     buttonSensors.pendingtext="Pending. Waiting for GPS lock.";
-                                     buttonSensors._state=1;
-                                 } else {
-                                     _state = 4; // All OK
-                                 }
-                             } else {
-                                 if(!checklist._healthFlags[0]) failuretext="Failure. Gyroscope issues. Check console.";
-                                 else if(!checklist._healthFlags[1]) failuretext="Failure. Accelerometer issues. Check console.";
-                                 else if(!checklist._healthFlags[2]) failuretext="Failure. Magnetometer issues. Check console.";
-                                 else if(!checklist._healthFlags[3]) failuretext="Failure. Barometer issues. Check console.";
-                                 else if(!checklist._healthFlags[4]) failuretext="Failure. Airspeed sensor issues. Check console.";
-                                 else if(!checklist._healthFlags[5]) failuretext="Failure. No valid or low quality GPS signal. Check console.";
-                                 _state = 3;
-                             }
-                         }
-                     }
-                }
-               QGCCheckListItem {
-                    id: buttonRC
-                    name: "Radio Control"
-                    pendingtext: "Receiving signal. Perform range test & confirm."
-                    failuretext: "No signal or invalid autopilot-RC config. Check RC and console."
-                    function updateItem() {
-                        if (!_activeVehicle) {
-                            _state = 0;
-                        } else {
-                            if (_healthFlags[16]) {_state = 1+3*(_nrClicked>0);}
-                            else {_state = 3;}
-                        }
+                    QGCLabel {
+                        text:                   _activeVehicle ? qsTr("Pre-flight checklist")+" (MAV ID:"+_activeVehicle.id+")" : qsTr("Pre-flight checklist (no vehicle)")
+                        anchors.left:           parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        font.pointSize:         ScreenTools.mediumFontPointSize
                     }
-               }
+                    QGCButton {
+                        width:                  1.2*ScreenTools.defaultFontPixelHeight
+                        height:                 1.2*ScreenTools.defaultFontPixelHeight
+                        anchors.right:          parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        opacity :               0.2+0.8*(QGroundControl.multiVehicleManager.vehicles.count > 0)
+                        tooltip:                "Reset the checklist (e.g. after a vehicle reboot)"
 
-               QGCCheckListItem {
-                    id: buttonEstimator
-                    name: "Global position estimate"
-                    function updateItem() {
-                        if (!_activeVehicle) {
-                            _state = 0;
-                        } else {
-                            if (_healthFlags[21]) {_state = 4;}
-                            else {_state = 3;}
-                        }
+                        onClicked:              checklist.resetNrClicks()
+
+                        Image { source:"/qmlimages/MapSyncBlack.svg" ; anchors.fill: parent }
                     }
-               }
+                }
 
-               // Arming header
-               //Rectangle {anchors.left:parent.left ; anchors.right:parent.right ; height:1 ; color:qgcPal.text}
-               QGCLabel {anchors.horizontalCenter:parent.horizontalCenter ; text:qsTr("<i>Please arm the vehicle here.</i>")}
-               //Rectangle {anchors.left:parent.left ; anchors.right:parent.right ; height:1 ; color:qgcPal.text}
+                Rectangle {width:parent.width ; height:1 ; color:qgcPal.text}
 
-              QGCCheckListItem {
-                   id: buttonActuators
-                   name: "Actuators"
-                   group: 1
-                   defaulttext: "Move all control surfaces. Did they work properly?"
-              }
-
-              QGCCheckListItem {
-                   id: buttonMotors
-                   name: "Motors"
-                   group: 1
-                   defaulttext: "Propellers free? Then throttle up gently. Working properly?"
-              }
-
-              QGCCheckListItem {
-                   id: buttonMission
-                   name: "Mission"
-                   group: 1
-                   defaulttext: "Please confirm mission is valid (waypoints valid, no terrain collision)."
-              }
-
-              QGCCheckListItem {
-                   id: buttonSoundOutput
-                   name: "Sound output"
-                   group: 1
-                   pendingtext: "QGC audio output enabled. System audio output enabled, too?"
-                   failuretext: "Failure, QGC audio output is disabled. Please enable it under application settings->general to hear audio warnings!"
-                   function updateItem() {
-                       if (!_activeVehicle) {
-                           _state = 0;
-                       } else {
-                           if (QGroundControl.settingsManager.appSettings.audioMuted.rawValue) {_state = 3;_nrClicked=0;}
-                           else {_state = 1+3*(_nrClicked>0);}
-                       }
-                   }
-              }
-
-              // Directly before launch header
-              //Rectangle {anchors.left:parent.left ; anchors.right:parent.right ; height:1 ; color:qgcPal.text}
-              QGCLabel {anchors.horizontalCenter:parent.horizontalCenter ; text:qsTr("<i>Last preparations before launch</i>") ; opacity : 0.2+0.8*(_checkState >= 2);}
-              //Rectangle {anchors.left:parent.left ; anchors.right:parent.right ; height:1 ; color:qgcPal.text}
-
-              QGCCheckListItem {
-                   id: buttonPayload
-                   name: "Payload"
-                   group: 2
-                   defaulttext: "Configured and started?"
-                   pendingtext: "Payload lid closed?"
-              }
-
-              QGCCheckListItem {
-                   id: buttonWeather
-                   name: "Wind & weather"
-                   group: 2
-                   defaulttext: "OK for your platform?"
-                   pendingtext: "Launching into the wind?"
-              }
-
-              QGCCheckListItem {
-                   id: buttonFlightAreaFree
-                   name: "Flight area"
-                   group: 2
-                   defaulttext: "Launch area and path free of obstacles/people?"
-              }
-
+                // All check list items
+                Repeater {
+                    model: checklist.checkListItems
+                }
             } // Column
-
-            property bool _initialized:false
-            property var _healthFlags: []
-            property int _checkState: _activeVehicle ? (_activeVehicle.armed ? 1 + (buttonActuators._state + buttonMotors._state + buttonMission._state + buttonSoundOutput._state) / 4 / 4 : 0) : 0 ; // Shows progress of checks inside the checklist - unlocks next check steps in groups
-            property bool gpsLock: _activeVehicle ? _activeVehicle.gps.lock.rawValue>=3 : 0
-            property var batPercentRemaining: _activeVehicle ? _activeVehicle.battery.getFact("percentRemaining").value : 0
-
-            // TODO: Having access to MAVLINK enums (or at least QML consts) would be much cleaner than the code below
-            property int subsystem_type_gyro : 1
-            property int subsystem_type_acc : 2
-            property int subsystem_type_mag : 4
-            property int subsystem_type_abspressure : 8
-            property int subsystem_type_diffpressure : 16
-            property int subsystem_type_gps : 32
-            property int subsystem_type_positioncontrol : 16384
-            property int subsystem_type_motorcontrol : 32768
-            property int subsystem_type_rcreceiver : 65536
-            property int subsystem_type_ahrs : 2097152
-            property int subsystem_type_terrain : 4194304
-            property int subsystem_type_reversemotor : 8388608
-            property int subsystem_type_logging : 16777216
-            property int subsystem_type_sensorbattery : 33554432
-            property int subsystem_type_rangefinder : 67108864
         } //Rectangle
     } //Component
 } //QGC View

--- a/src/FlightDisplay/qmldir
+++ b/src/FlightDisplay/qmldir
@@ -9,4 +9,5 @@ GuidedActionsController     1.0 GuidedActionsController.qml
 GuidedActionList            1.0 GuidedActionList.qml
 GuidedAltitudeSlider        1.0 GuidedAltitudeSlider.qml
 MultiVehicleList            1.0 MultiVehicleList.qml
+CheckList                   1.0 CheckList.qml
 

--- a/src/QmlControls/DropPanel.qml
+++ b/src/QmlControls/DropPanel.qml
@@ -64,7 +64,7 @@ Item {
         }
         if (visible) {
             visible = false
-            _dropDownComponent = undefined
+            //_dropDownComponent = undefined //TODO (philippoe) such that drop down component state is not deleted - check with don gagne whether this is necessary
             toolStrip.uncheckAll()
         }
     }

--- a/src/QmlControls/DropPanel.qml
+++ b/src/QmlControls/DropPanel.qml
@@ -64,7 +64,7 @@ Item {
         }
         if (visible) {
             visible = false
-            //_dropDownComponent = undefined //TODO (philippoe) such that drop down component state is not deleted - check with don gagne whether this is necessary
+            _dropDownComponent = undefined
             toolStrip.uncheckAll()
         }
     }

--- a/src/QmlControls/QGCCheckListItem.qml
+++ b/src/QmlControls/QGCCheckListItem.qml
@@ -7,20 +7,19 @@ import QGroundControl.Palette 1.0
 import QGroundControl.ScreenTools 1.0
 
 QGCButton {
-    property string name: ""
-    property int _state: 0
-    property var _color: qgcPal.button;//qgcPal.windowShade;//qgcPal.windowShadeDark;//Qt.rgba(0.5,0.5,0.5,1) //qgcPal.window;//
-    property int _nrClicked: 0
-    property int group: 0
-    property string defaulttext: "Not checked yet"
-    property string pendingtext: ""
-    property string failuretext: "Failure. Check console."
-    property string _text: qsTr(name)+ ": " + qsTr(defaulttext)
+    property string name:           ""
+    property int    group:          0
+    property string defaulttext:    "Not checked yet"
+    property string pendingtext:    ""
+    property string failuretext:    "Failure. Check console."
+    property int    _state:         0
+    property var    _color:         qgcPal.button
+    property int    _nrClicked:     0
+    property string _text:          qsTr(name)+ ": " + qsTr(defaulttext)
 
-    enabled : (_activeVehicle==null || _activeVehicle.connectionLost) ? false : _checkState>=group
-    opacity : (_activeVehicle==null || _activeVehicle.connectionLost) ? 0.4 : 0.2+0.8*(_checkState >= group);
-
-    width: parent.width
+    enabled : (_activeVehicle==null || _activeVehicle.connectionLost) ? false : checklist._checkState>=group
+    opacity : (_activeVehicle==null || _activeVehicle.connectionLost) ? 0.4 : 0.2+0.8*(checklist._checkState >= group);
+    width: 40*ScreenTools.defaultFontPixelWidth
     style: ButtonStyle {
         background: Rectangle {color:_color; border.color: qgcPal.button; radius:3}
         label: Label {
@@ -31,46 +30,45 @@ QGCButton {
         }
     }
 
+    // Connections
+    onPendingtextChanged: { if(_state==1) {getTextFromState(); getColorFromState();} }
+    onFailuretextChanged: { if(_state==3) {getTextFromState(); getColorFromState();} }
+    on_StateChanged: { getTextFromState(); getColorFromState(); }
     onClicked: {
         if(_state<2) _nrClicked=_nrClicked+1; //Only allow click-counter to increase when not failed yet
         updateItem();
     }
-    onPendingtextChanged: { if(_state==1) {getTextFromState(); getColorFromState();} }
-    onFailuretextChanged: { if(_state==3) {getTextFromState(); getColorFromState();} }
-    on_StateChanged: { getTextFromState(); getColorFromState(); }
-//    onEnabledChanged: { //Dont do this for now, because if we only accidentially lose connection, we don't want to delete the checklist state. Instead, we'd need to detect a re-connect, maybe based on the timesincesystemstart (i.e. when it decreases)?
-//        if(enabled==false && group > 0) {
-//            // Reset all check list items of group > 0 if it is disabled again (which e.g. happens after a vehicle reboot or disarm).
-//            _nrClicked = 0;
-//            _state = 0;
-//        }
-//    }
 
+    //Functions
     function updateItem() {
         // This is the default updateFunction. It assumes the item is a MANUAL check list item, i.e. one that
         // only requires user clicks (one click if pendingtext="", two clicks otherwise) for completion.
-        //if(_nrClicked>0) _state = 4;
 
-        if(_nrClicked===1) {
+        if(_nrClicked===0) _state = 0;
+        else if(_nrClicked===1) {
             if(pendingtext.length === 0) _state = 4;
             else _state = 1;
-        } else if(_nrClicked>1) _state = 4;
+        } else _state = 4;
 
         getTextFromState();
         getColorFromState();
     }
     function getTextFromState() {
-        if(_state === 0) {_text= qsTr(name) + ": " + qsTr(defaulttext)}             // Not checked yet
-        else if(_state === 1) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr(pendingtext)}         // Pending
-        else if(_state === 2) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr("Minor problem")}     // Small problem or need further user action to resolve
-        else if(_state === 3) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr(failuretext)}         // Big problem
+        if(_state === 0) {_text= qsTr(name) + ": " + qsTr(defaulttext)}                         // Not checked yet
+        else if(_state === 1) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr(pendingtext)}        // Pending
+        else if(_state === 2) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr("Minor problem")}    // Small problem or need further user action to resolve
+        else if(_state === 3) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr(failuretext)}        // Big problem
         else {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr("OK")}                                // All OK
     }
     function getColorFromState() {
-        if(_state === 0) {_color=qgcPal.button}            // Not checked yet
+        if(_state === 0) {_color=qgcPal.button}                     // Not checked yet
         else if(_state === 1) {_color=Qt.rgba(0.9,0.47,0.2,1)}      // Pending
         else if(_state === 2) {_color=Qt.rgba(1.0,0.6,0.2,1)}       // Small problem or need further user action to resolve
         else if(_state === 3) {_color=Qt.rgba(0.92,0.22,0.22,1)}    // Big problem
         else {_color=Qt.rgba(0.27,0.67,0.42,1)}                     // All OK
+    }
+    function resetNrClicks() {
+        _nrClicked=0;
+        updateItem();
     }
 }

--- a/src/QmlControls/QGCCheckListItem.qml
+++ b/src/QmlControls/QGCCheckListItem.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.3
+import QtQuick.Controls 1.2
+import QtQuick.Controls.Styles 1.4
+
+import QGroundControl 1.0
+import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
+
+QGCButton {
+    property string name: ""
+    property int _state: 0
+    property var _color: qgcPal.button;//qgcPal.windowShade;//qgcPal.windowShadeDark;//Qt.rgba(0.5,0.5,0.5,1) //qgcPal.window;//
+    property int _nrClicked: 0
+    property int group: 0
+    property string defaulttext: "Not checked yet"
+    property string pendingtext: ""
+    property string failuretext: "Failure. Check console."
+    property string _text: qsTr(name)+ ": " + qsTr(defaulttext)
+
+    enabled : (_activeVehicle==null || _activeVehicle.connectionLost) ? false : _checkState>=group
+    opacity : (_activeVehicle==null || _activeVehicle.connectionLost) ? 0.4 : 0.2+0.8*(_checkState >= group);
+
+    width: parent.width
+    style: ButtonStyle {
+        background: Rectangle {color:_color; border.color: qgcPal.button; radius:3}
+        label: Label {
+            text: _text
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            color: _state>0 ? qgcPal.mapWidgetBorderLight : qgcPal.buttonText
+        }
+    }
+
+    onClicked: {
+        if(_state<2) _nrClicked=_nrClicked+1; //Only allow click-counter to increase when not failed yet
+        updateItem();
+    }
+    onPendingtextChanged: { if(_state==1) {getTextFromState(); getColorFromState();} }
+    onFailuretextChanged: { if(_state==3) {getTextFromState(); getColorFromState();} }
+    on_StateChanged: { getTextFromState(); getColorFromState(); }
+//    onEnabledChanged: { //Dont do this for now, because if we only accidentially lose connection, we don't want to delete the checklist state. Instead, we'd need to detect a re-connect, maybe based on the timesincesystemstart (i.e. when it decreases)?
+//        if(enabled==false && group > 0) {
+//            // Reset all check list items of group > 0 if it is disabled again (which e.g. happens after a vehicle reboot or disarm).
+//            _nrClicked = 0;
+//            _state = 0;
+//        }
+//    }
+
+    function updateItem() {
+        // This is the default updateFunction. It assumes the item is a MANUAL check list item, i.e. one that
+        // only requires user clicks (one click if pendingtext="", two clicks otherwise) for completion.
+        //if(_nrClicked>0) _state = 4;
+
+        if(_nrClicked===1) {
+            if(pendingtext.length === 0) _state = 4;
+            else _state = 1;
+        } else if(_nrClicked>1) _state = 4;
+
+        getTextFromState();
+        getColorFromState();
+    }
+    function getTextFromState() {
+        if(_state === 0) {_text= qsTr(name) + ": " + qsTr(defaulttext)}             // Not checked yet
+        else if(_state === 1) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr(pendingtext)}         // Pending
+        else if(_state === 2) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr("Minor problem")}     // Small problem or need further user action to resolve
+        else if(_state === 3) {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr(failuretext)}         // Big problem
+        else {_text= "<b>"+qsTr(name)+"</b>" +": " + qsTr("OK")}                                // All OK
+    }
+    function getColorFromState() {
+        if(_state === 0) {_color=qgcPal.button}            // Not checked yet
+        else if(_state === 1) {_color=Qt.rgba(0.9,0.47,0.2,1)}      // Pending
+        else if(_state === 2) {_color=Qt.rgba(1.0,0.6,0.2,1)}       // Small problem or need further user action to resolve
+        else if(_state === 3) {_color=Qt.rgba(0.92,0.22,0.22,1)}    // Big problem
+        else {_color=Qt.rgba(0.27,0.67,0.42,1)}                     // All OK
+    }
+}

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -34,6 +34,7 @@ ParameterEditor         1.0 ParameterEditor.qml
 ParameterEditorDialog   1.0 ParameterEditorDialog.qml
 PlanToolBar             1.0 PlanToolBar.qml
 QGCButton               1.0 QGCButton.qml
+QGCCheckListItem        1.0 QGCCheckListItem.qml
 QGCCheckBox             1.0 QGCCheckBox.qml
 QGCColoredImage         1.0 QGCColoredImage.qml
 QGCComboBox             1.0 QGCComboBox.qml

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -118,6 +118,13 @@
     "defaultValue":     false
 },
 {
+    "name":             "UseChecklist",
+    "shortDescription": "Use preflight checklist",
+    "longDescription":  "If this option is enabled the preflight checklist will be used.",
+    "type":             "bool",
+    "defaultValue":     false
+},
+{
     "name":             "BaseDeviceFontPointSize",
     "shortDescription": "Application font size",
     "longDescription":  "The point size for the default font used.",

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -33,6 +33,7 @@ const char* AppSettings::indoorPaletteName =                            "StyleIs
 const char* AppSettings::showLargeCompassName =                         "ShowLargeCompass";
 const char* AppSettings::savePathName =                                 "SavePath";
 const char* AppSettings::autoLoadMissionsName =                         "AutoLoadMissions";
+const char* AppSettings::useChecklistName =                             "UseChecklist";
 const char* AppSettings::mapboxTokenName =                              "MapboxToken";
 const char* AppSettings::esriTokenName =                                "EsriToken";
 const char* AppSettings::defaultFirmwareTypeName =                      "DefaultFirmwareType";
@@ -75,6 +76,7 @@ AppSettings::AppSettings(QObject* parent)
     , _showLargeCompassFact                 (NULL)
     , _savePathFact                         (NULL)
     , _autoLoadMissionsFact                 (NULL)
+    , _useChecklistFact                     (NULL)
     , _mapboxTokenFact                      (NULL)
     , _esriTokenFact                        (NULL)
     , _defaultFirmwareTypeFact              (NULL)
@@ -218,6 +220,15 @@ Fact* AppSettings::audioMuted(void)
     }
 
     return _audioMutedFact;
+}
+
+Fact* AppSettings::useChecklist(void)
+{
+    if (!_useChecklistFact) {
+        _useChecklistFact = _createSettingsFact(useChecklistName);
+    }
+
+    return _useChecklistFact;
 }
 
 Fact* AppSettings::appFontPointSize(void)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -37,6 +37,7 @@ public:
     Q_PROPERTY(Fact* showLargeCompass                   READ showLargeCompass                   CONSTANT)
     Q_PROPERTY(Fact* savePath                           READ savePath                           CONSTANT)
     Q_PROPERTY(Fact* autoLoadMissions                   READ autoLoadMissions                   CONSTANT)
+    Q_PROPERTY(Fact* useChecklist                       READ useChecklist                       CONSTANT)
     Q_PROPERTY(Fact* mapboxToken                        READ mapboxToken                        CONSTANT)
     Q_PROPERTY(Fact* esriToken                          READ esriToken                          CONSTANT)
     Q_PROPERTY(Fact* defaultFirmwareType                READ defaultFirmwareType                CONSTANT)
@@ -75,6 +76,7 @@ public:
     Fact* showLargeCompass                  (void);
     Fact* savePath                          (void);
     Fact* autoLoadMissions                  (void);
+    Fact* useChecklist                      (void);
     Fact* mapboxToken                       (void);
     Fact* esriToken                         (void);
     Fact* defaultFirmwareType               (void);
@@ -110,6 +112,7 @@ public:
     static const char* showLargeCompassName;
     static const char* savePathName;
     static const char* autoLoadMissionsName;
+    static const char* useChecklistName;
     static const char* mapboxTokenName;
     static const char* esriTokenName;
     static const char* defaultFirmwareTypeName;
@@ -160,6 +163,7 @@ private:
     SettingsFact* _showLargeCompassFact;
     SettingsFact* _savePathFact;
     SettingsFact* _autoLoadMissionsFact;
+    SettingsFact* _useChecklistFact;
     SettingsFact* _mapboxTokenFact;
     SettingsFact* _esriTokenFact;
     SettingsFact* _defaultFirmwareTypeFact;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -380,7 +380,7 @@ public:
         SysStatusSensor3dGyro =                 MAV_SYS_STATUS_SENSOR_3D_GYRO,
         SysStatusSensor3dAccel =                MAV_SYS_STATUS_SENSOR_3D_ACCEL,
         SysStatusSensor3dMag =                  MAV_SYS_STATUS_SENSOR_3D_MAG,
-        SysStatusSensorAsolutePressure =        MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE,
+        SysStatusSensorAbsolutePressure =       MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE,
         SysStatusSensorDifferentialPressure =   MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE,
         SysStatusSensorGPS =                    MAV_SYS_STATUS_SENSOR_GPS,
         SysStatusSensorOpticalFlow =            MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW,

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -411,6 +411,16 @@ QGCView {
                                 }
                             }
                         }
+
+                        //-----------------------------------------------------------------
+                        //-- Checklist Settings
+                        FactCheckBox {
+                            text:       qsTr("Use preflight checklist")
+                            fact:       _useChecklist
+                            visible:    _useChecklist.visible
+
+                            property Fact _useChecklist: QGroundControl.settingsManager.appSettings.useChecklist
+                        }
                     }
                 }
 


### PR DESCRIPTION
This PR adds automated preflight checklists. This was discussed in https://github.com/mavlink/qgroundcontrol/issues/4119 . I'll quickly copy and paste the main points here:

### GUI overview
The GUI below is the current (default) setup for a fixed-wing vehicle. Directly after startup, not many tests run yet:
![screenshot from 2018-04-11 11-22-23](https://user-images.githubusercontent.com/2565608/38611887-3d292de2-3d85-11e8-9491-b1b989bfd573.png)

A bit further into startup for indoor and outdoor scheme with some automatic and some manual checks passed already (automatic battery check fails because i am running on USB):

![screenshot from 2018-04-11 12-34-57](https://user-images.githubusercontent.com/2565608/38612117-faeeed8a-3d85-11e8-96ac-48010be4ce5e.png)
![screenshot from 2018-04-11 12-35-46](https://user-images.githubusercontent.com/2565608/38612120-fc4fe0b2-3d85-11e8-9f0e-dd1e0e8df2e5.png)

### Overview
 - Designed to use as many automatic checks as possible. In cooperation with @dagar, we've been working on getting the [MAV_SYS_SENSOR_STATUS flags ](https://mavlink.io/en/messages/common.html#MAV_SYS_STATUS_SENSOR) in the [SYS_STATUS  message](https://mavlink.io/en/messages/common.html#SYS_STATUS) filled with something meaningful in PX4 (update: This is PR https://github.com/PX4/Firmware/pull/9436). This mainly means that commander & preflight check are automatically checking for connection/calibration/validity of a certain sensor (currently implemented: Accel, Mag, Gyro, Baro, Airspeed, GPS, RC). This means that, as indicated in some comments above, the checks are driven from the vehicle side, and QGC just has to check the validity flags.
 - Some manual or hybrid checks remain. These can be multi-step tests: For example, the RC connection and calibration of the RC are currently checked automatically, and when this is OK, the respective check list item changes to a "Perform range test and confirm".
 - This is also NOT targeted towards the hobbyist "just quickly flying his quadcopter in his garden", but towards slightly more serious applications of UAVs.
 - This is NOT supposed to just indicate system status (QGC has other means for that), but really IS designed to replace your standard paper-based preflight checklist. I know there exist more concise versions of a checklist or check-method (e.g. in DJI vehicles), but we have made the experience that with non-COTS/modified platforms there are always custom or not-automatically-checkable items ("are the screws in part XXY inserted") that one still definitely needs to check. In our case, this semi-automated checklist will for example replace our current 2.5 page paper-based checklist.
 - This should in the end be reconfigurable. As a function of the airframe set in QGC, different .xml files (fixed-wing, multicopter, ground rover...) can be loaded. If a user wants to add specific checklist items ("is my super-truper 4th camera OK?"), then this could also be allowed via a custom.xml file or so.
 - At some point, we could connect the checklist such that the "start mission" button only pops up if the checklist is completed. However, one will also be able to completely disable the checklist via the settings (for pro-users).
 - There have been tons of great ideas around the discussions with members: Automatic checking of actuators (perform pre-defined movement after arming), automatic mission check (which @dagar plans to finalize soon as i understood), etc. This will therefore be extended over time.
 - Initially, this functionality is disabled by default, but people flying fixed-wings can enable it under QGCs "General settings" (check box "use preflight checklist").

### Open questions
There is still some implementation questions remaining. @DonLakeFlyer I would appreciate your input/suggestions here.
- [x] To automatically update the "Sound output enabled" check list item every time, the user changes this setting, [this line](https://github.com/philipoe/qgroundcontrol/blob/checklist_draft/src/FlightDisplay/FlightDisplayView.qml#L677)  binds to a signal which is explicitly marked as "for internal use only". It works flawlessly however. Is this a problem, and is there an alternative to using this signal?
- [x] To find unhealthy sensors, I am simply using those that are already identified by QGC. This is quite neat. However, the QGC vehicle class stores the unhealthy sensors in a QStringList that I then need to parse in [this code](https://github.com/philipoe/qgroundcontrol/blob/checklist_draft/src/FlightDisplay/FlightDisplayView.qml#L702) . @DonLakeFlyer If you agree, i will implement a separate set of flags (i.e. an array of booleans) in the vehicle class that contains the same information but that avoids the string parsing in any code outside of the vehicle class. I will of course leave the QStringList, too.
- [x] I have asked this before, but there is no way to make the MAVLINK enums known inside the qml file, right? Because [here](https://github.com/philipoe/qgroundcontrol/blob/checklist_draft/src/FlightDisplay/FlightDisplayView.qml#L921) I currently need to define the respective enum values as properties, which is very bad. Once we are on Qt5.10, i can at least use enums...
- [x] Most of the checklist functionality is nicely separated from the remaining code, but I had to do one potentially significant change: I changed [this line](https://github.com/philipoe/qgroundcontrol/blob/checklist_draft/src/QmlControls/DropPanel.qml#L67), to make sure that when the user closes the drop panel (which contains the checklist as you can see in the screenshots), its content (i.e. its state of what has been checked yet and what not) does not get deleted. I have not seen any bad influence on other items, but the question that remains is: Does this influence anything else? How could that change be avoided (without explicitly storing the current state somewhere else)?