### PR TITLE
Fixed checked state logic 

### DIFF
--- a/src/FactSystem/FactControls/FactCheckBox.qml
+++ b/src/FactSystem/FactControls/FactCheckBox.qml
@@ -8,7 +8,8 @@ import QGroundControl.Controls 1.0
 
 QGCCheckBox {
     property Fact fact: Fact { }
-
+    property variant checkedValue:   1
+    property variant uncheckedValue: 0
     checkedState: fact ?
                       (fact.typeIsBool ?
                            (fact.value === false ? Qt.Unchecked : Qt.Checked) :
@@ -17,5 +18,5 @@ QGCCheckBox {
 
     text: qsTr("Label")
 
-    onClicked: fact.value = checked ? 1 : 0
+    onClicked: fact.value == checked ? checkedValue : uncheckedValue
 }


### PR DESCRIPTION
Also restore `checkedValue` and `uncheckedValue` properties, which are used by `APMCameraComponent.qml`