### PR TITLE
Download improvements 

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -204,7 +204,7 @@ void APMAirframeComponentController::loadParameters(const QString& paramFile)
 {
     qgcApp()->setOverrideCursor(Qt::WaitCursor);
 
-    QString paramFileUrl = QStringLiteral("https://api.github.com/repos/ArduPilot/ardupilot/contents/Tools/Frame_params/%1?ref=master");
+    QString paramFileUrl = QStringLiteral("http://api.github.com/repos/ArduPilot/ardupilot/contents/Tools/Frame_params/%1?ref=master");
 
     QGCFileDownload* downloader = new QGCFileDownload(this);
     connect(downloader, &QGCFileDownload::downloadFinished, this, &APMAirframeComponentController::_githubJsonDownloadFinished);

--- a/src/QGCFileDownload.cc
+++ b/src/QGCFileDownload.cc
@@ -76,6 +76,7 @@ bool QGCFileDownload::download(const QString& remoteFile, bool redirect)
     networkRequest.setAttribute(QNetworkRequest::User, localFile);
 
     QNetworkReply* networkReply = get(networkRequest);
+    networkReply->ignoreSslErrors();
     if (!networkReply) {
         qWarning() << "QNetworkAccessManager::get failed";
         return false;

--- a/src/QGCFileDownload.cc
+++ b/src/QGCFileDownload.cc
@@ -87,6 +87,17 @@ bool QGCFileDownload::download(const QString& remoteFile, bool redirect)
     connect(networkReply, static_cast<void (QNetworkReply::*)(QNetworkReply::NetworkError)>(&QNetworkReply::error),
             this, &QGCFileDownload::_downloadError);
 
+    connect(networkReply, &QNetworkReply::sslErrors, this, [](const QList<QSslError> &sslErrors) {
+        for (const auto &error : sslErrors) {
+            qWarning() << "SSL error: " << error.errorString();
+
+            const auto &certificate = error.certificate();
+            if(!certificate.isNull()) {
+                qWarning() << "SSL Certificate problem: " << certificate.toText();
+            }
+        }
+    });
+
     return true;
 }
 

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -813,7 +813,7 @@ void FirmwareUpgradeController::_determinePX4StableVersion(void)
     QGCFileDownload* downloader = new QGCFileDownload(this);
     connect(downloader, &QGCFileDownload::downloadFinished, this, &FirmwareUpgradeController::_px4ReleasesGithubDownloadFinished);
     connect(downloader, &QGCFileDownload::error, this, &FirmwareUpgradeController::_px4ReleasesGithubDownloadError);
-    downloader->download(QStringLiteral("https://api.github.com/repos/PX4/Firmware/releases"));
+    downloader->download(QStringLiteral("http://api.github.com/repos/PX4/Firmware/releases"));
 }
 
 void FirmwareUpgradeController::_px4ReleasesGithubDownloadFinished(QString remoteFile, QString localFile)


### PR DESCRIPTION
This PR tries to minimize issues related to SSL.
- Move urls from https to http.
- Ignore SSL errors while downloading data with QGCFileDownload.
- Print human-readable description of SSL errors.