### PR TITLE
Safety summary: Rework to better match Safety Page

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
@@ -27,27 +27,27 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText:  qsTr("Frame Type:")
+            labelText:  qsTr("Frame Type")
             valueText:  controller.currentAirframeTypeName() + " " + _oldFrameParam.enumStringValue
             visible:    _useOldFrameParam
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Frame Class:")
+            labelText:  qsTr("Frame Class")
             valueText:  _newFrameParam.enumStringValue
             visible:    !_useOldFrameParam
 
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Frame Type:")
+            labelText:  qsTr("Frame Type")
             valueText:  _frameTypeParam.enumStringValue
             visible:    !_useOldFrameParam
 
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Firmware Version:")
+            labelText: qsTr("Firmware Version")
             valueText: activeVehicle.firmwareMajorVersion == -1 ? qsTr("Unknown") : activeVehicle.firmwareMajorVersion + "." + activeVehicle.firmwareMinorVersion + "." + activeVehicle.firmwarePatchVersion + activeVehicle.firmwareVersionTypeString
         }
     }

--- a/src/AutoPilotPlugins/APM/APMCameraComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMCameraComponentSummary.qml
@@ -27,22 +27,22 @@ FactPanel {
 
         VehicleSummaryRow {
             visible:    _mountTypeExists
-            labelText:  qsTr("Gimbal type:")
+            labelText:  qsTr("Gimbal type")
             valueText:  _mountTypeValue
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Tilt input channel:")
+            labelText:  qsTr("Tilt input channel")
             valueText:  _mountRCInTilt.enumStringValue
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Pan input channel:")
+            labelText:  qsTr("Pan input channel")
             valueText:  _mountRCInPan.enumStringValue
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Roll input channel:")
+            labelText:  qsTr("Roll input channel")
             valueText:  _mountRCInRoll.enumStringValue
         }
     }

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml
@@ -27,32 +27,32 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText: qsTr("Flight Mode 1:")
+            labelText: qsTr("Flight Mode 1")
             valueText: flightMode1.enumStringValue
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Flight Mode 2:")
+            labelText: qsTr("Flight Mode 2")
             valueText: flightMode2.enumStringValue
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Flight Mode 3:")
+            labelText: qsTr("Flight Mode 3")
             valueText: flightMode3.enumStringValue
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Flight Mode 4:")
+            labelText: qsTr("Flight Mode 4")
             valueText: flightMode4.enumStringValue
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Flight Mode 5:")
+            labelText: qsTr("Flight Mode 5")
             valueText: flightMode5.enumStringValue
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Flight Mode 6:")
+            labelText: qsTr("Flight Mode 6")
             valueText: flightMode6.enumStringValue
         }
     }

--- a/src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml
@@ -89,12 +89,12 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText:  qsTr("Lights Output 1:")
+            labelText:  qsTr("Lights Output 1")
             valueText:  lightsOutModel.get(lightsLoader.lights1OutIndex).text
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Lights Output 2:")
+            labelText:  qsTr("Lights Output 2")
             valueText:  lightsOutModel.get(lightsLoader.lights2OutIndex).text
         }
     }

--- a/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
@@ -31,12 +31,12 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText: qsTr("Battery monitor:")
+            labelText: qsTr("Battery monitor")
             valueText: battMonitor.enumStringValue
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Battery capacity:")
+            labelText: qsTr("Battery capacity")
             valueText: battCapacity.valueString + " " + battCapacity.units
         }
     }

--- a/src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml
@@ -23,22 +23,22 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText: qsTr("Roll:")
+            labelText: qsTr("Roll")
             valueText: mapRollFact.value == 0 ? qsTr("Setup required") : qsTr("Channel %1").arg(mapRollFact.valueString)
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Pitch:")
+            labelText: qsTr("Pitch")
             valueText: mapPitchFact.value == 0 ? qsTr("Setup required") : qsTr("Channel %1").arg(mapPitchFact.valueString)
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Yaw:")
+            labelText: qsTr("Yaw")
             valueText: mapYawFact.value == 0 ? qsTr("Setup required") : qsTr("Channel %1").arg(mapYawFact.valueString)
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Throttle:")
+            labelText: qsTr("Throttle")
             valueText: mapThrottleFact.value == 0 ? qsTr("Setup required") : qsTr("Channel %1").arg(mapThrottleFact.valueString)
         }
     }

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml
@@ -34,7 +34,7 @@ FactPanel {
             model: 3
 
             VehicleSummaryRow {
-                labelText:  qsTr("Compass ") + (index + 1) + ":"
+                labelText:  qsTr("Compass ") + (index + 1) + ""
                 valueText:  sensorParams.rgCompassAvailable[index] ?
                                 (sensorParams.rgCompassCalibrated[index] ?
                                      (sensorParams.rgCompassPrimary[index] ? "Primary" : "Secondary") +
@@ -47,7 +47,7 @@ FactPanel {
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Accelerometer(s):")
+            labelText: qsTr("Accelerometer(s)")
             valueText: controller.accelSetupNeeded ? qsTr("Setup required") : qsTr("Ready")
         }
     }

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
@@ -45,17 +45,17 @@ FactPanel {
         anchors.fill:       parent
         VehicleSummaryRow {
             id: nameRow;
-            labelText: qsTr("Frame Type:")
+            labelText: qsTr("Frame Type")
             valueText: frameName()
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Firmware Version:")
+            labelText: qsTr("Firmware Version")
             valueText: activeVehicle.firmwareMajorVersion == -1 ? qsTr("Unknown") : activeVehicle.firmwareMajorVersion + "." + activeVehicle.firmwareMinorVersion + "." + activeVehicle.firmwarePatchVersion + " " + activeVehicle.firmwareVersionTypeString
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Git Revision:")
+            labelText: qsTr("Git Revision")
             valueText: activeVehicle.gitHash == -1 ? qsTr("Unknown") : activeVehicle.gitHash
         }
     }

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
@@ -30,38 +30,38 @@ FactPanel {
     Column {
         anchors.fill:       parent
         VehicleSummaryRow {
-            labelText: qsTr("Firmware Version:")
+            labelText: qsTr("Firmware Version")
             valueText: esp8266.version
         }
         VehicleSummaryRow {
-            labelText: qsTr("WiFi Mode:")
+            labelText: qsTr("WiFi Mode")
             valueText: wifiMode ? (wifiMode.value === 0 ? "AP Mode" : "Station Mode") : "AP Mode"
         }
         VehicleSummaryRow {
-            labelText:  qsTr("WiFi Channel:")
+            labelText:  qsTr("WiFi Channel")
             valueText:  wifiChannel ? wifiChannel.valueString : ""
             visible:    wifiMode ? wifiMode.value === 0 : true
         }
         VehicleSummaryRow {
-            labelText: qsTr("WiFi AP SSID:")
+            labelText: qsTr("WiFi AP SSID")
             valueText: esp8266.wifiSSID
         }
         VehicleSummaryRow {
-            labelText: qsTr("WiFi AP Password:")
+            labelText: qsTr("WiFi AP Password")
             valueText: esp8266.wifiPassword
         }
         /* Too much info makes it all crammed
         VehicleSummaryRow {
-            labelText: qsTr("WiFi STA SSID:")
+            labelText: qsTr("WiFi STA SSID")
             valueText: esp8266.wifiSSIDSta
         }
         VehicleSummaryRow {
-            labelText: qsTr("WiFi STA Password:")
+            labelText: qsTr("WiFi STA Password")
             valueText: esp8266.wifiPasswordSta
         }
         */
         VehicleSummaryRow {
-            labelText: qsTr("UART Baud Rate:")
+            labelText: qsTr("UART Baud Rate")
             valueText: uartBaud ? uartBaud.valueString : ""
         }
     }

--- a/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
@@ -23,20 +23,20 @@ FactPanel {
     Column {
         anchors.fill:       parent
         VehicleSummaryRow {
-            labelText: qsTr("System ID:")
+            labelText: qsTr("System ID")
             valueText: sysIdFact ? sysIdFact.valueString : ""
         }
         VehicleSummaryRow {
-            labelText: qsTr("Airframe type:")
+            labelText: qsTr("Airframe type")
             valueText: autoStartSet ? controller.currentAirframeType : qsTr("Setup required")
         }
         VehicleSummaryRow {
-            labelText: qsTr("Vehicle:")
+            labelText: qsTr("Vehicle")
             valueText: autoStartSet ? controller.currentVehicleName : qsTr("Setup required")
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Firmware Version:")
+            labelText: qsTr("Firmware Version")
             valueText: activeVehicle.firmwareMajorVersion === -1 ? qsTr("Unknown") : activeVehicle.firmwareMajorVersion + "." + activeVehicle.firmwareMinorVersion + "." + activeVehicle.firmwarePatchVersion + activeVehicle.firmwareVersionTypeString
         }
     }

--- a/src/AutoPilotPlugins/PX4/CameraComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/CameraComponentSummary.qml
@@ -25,36 +25,36 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText: qsTr("Trigger interface:")
+            labelText: qsTr("Trigger interface")
             valueText: _camTriggerInterface ? _camTriggerInterface.enumStringValue : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Trigger mode:")
+            labelText: qsTr("Trigger mode")
             valueText: _camTriggerMode ? _camTriggerMode.enumStringValue : ""
         }
 
         VehicleSummaryRow {
             visible:    _timeInterval && _camTriggerMode.value === 2
-            labelText:  qsTr("Time interval:")
+            labelText:  qsTr("Time interval")
             valueText:  _timeInterval ? _timeInterval.value : ""
         }
 
         VehicleSummaryRow {
             visible:    _distanceInterval && _camTriggerMode.value === 3
-            labelText:  qsTr("Distance interval:")
+            labelText:  qsTr("Distance interval")
             valueText:  _distanceInterval ? _distanceInterval.value : ""
         }
 
         VehicleSummaryRow {
             visible:    _auxPins
-            labelText:  qsTr("AUX pins:")
+            labelText:  qsTr("AUX pins")
             valueText:  _auxPins ? _auxPins.value : ""
         }
 
         VehicleSummaryRow {
             visible:    _camTriggerPol
-            labelText:  qsTr("AUX pin polarity:")
+            labelText:  qsTr("AUX pin polarity")
             valueText:  _camTriggerPol ? (_camTriggerPol.value ? "High (3.3V)" : "Low (0V)") : ""
         }
 

--- a/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
@@ -29,13 +29,13 @@ FactPanel {
         id: simple
         Column {
             VehicleSummaryRow {
-                labelText: qsTr("Mode switch:")
+                labelText: qsTr("Mode switch")
                 valueText: _rcMapFltmode.value === 0 ? qsTr("Setup required") : _rcMapFltmode.enumStringValue
             }
             Repeater {
                 model: 6
                 VehicleSummaryRow {
-                    labelText: qsTr("Flight Mode %1 :").arg(index + 1)
+                    labelText: qsTr("Flight Mode %1 ").arg(index + 1)
                     valueText: controller.getParameterFact(-1, "COM_FLTMODE" + (index + 1)).enumStringValue
                 }
             }
@@ -49,19 +49,19 @@ FactPanel {
             property Fact loiterSwFact: controller.getParameterFact(-1, "RC_MAP_LOITER_SW")
             property Fact returnSwFact: controller.getParameterFact(-1, "RC_MAP_RETURN_SW")
             VehicleSummaryRow {
-                labelText: qsTr("Mode switch:")
+                labelText: qsTr("Mode switch")
                 valueText: _rcMapModeSw.value === 0 ? qsTr("Setup required") : _rcMapModeSw.valueString
             }
             VehicleSummaryRow {
-                labelText: qsTr("Position Ctl switch:")
+                labelText: qsTr("Position Ctl switch")
                 valueText: posCtlSwFact.value === 0 ? qsTr("Disabled") : posCtlSwFact.valueString
             }
             VehicleSummaryRow {
-                labelText: qsTr("Loiter switch:")
+                labelText: qsTr("Loiter switch")
                 valueText: loiterSwFact.value === 0 ? qsTr("Disabled") : loiterSwFact.valueString
             }
             VehicleSummaryRow {
-                labelText: qsTr("Return switch:")
+                labelText: qsTr("Return switch")
                 valueText: returnSwFact.value === 0 ? qsTr("Disabled") : returnSwFact.valueString
             }
         }

--- a/src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml
@@ -26,38 +26,38 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText: qsTr("Roll:")
+            labelText: qsTr("Roll")
             valueText: mapRollFact ? (mapRollFact.value === 0 ? qsTr("Setup required") : mapRollFact.valueString) : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Pitch:")
+            labelText: qsTr("Pitch")
             valueText: mapPitchFact ? (mapPitchFact.value === 0 ? qsTr("Setup required") : mapPitchFact.valueString) : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Yaw:")
+            labelText: qsTr("Yaw")
             valueText: mapYawFact ? (mapYawFact.value === 0 ? qsTr("Setup required") : mapYawFact.valueString) : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Throttle:")
+            labelText: qsTr("Throttle")
             valueText: mapThrottleFact ? (mapThrottleFact.value === 0 ? qsTr("Setup required") : mapThrottleFact.valueString) : ""
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Flaps:")
+            labelText:  qsTr("Flaps")
             valueText:  mapFlapsFact ? (mapFlapsFact.value === 0 ? qsTr("Disabled") : mapFlapsFact.valueString) : ""
             visible:    !controller.vehicle.multiRotor
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Aux1:")
+            labelText: qsTr("Aux1")
             valueText: mapAux1Fact ? (mapAux1Fact.value === 0 ? qsTr("Disabled") : mapAux1Fact.valueString) : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Aux2:")
+            labelText: qsTr("Aux2")
             valueText: mapAux2Fact ? (mapAux2Fact.value === 0 ? qsTr("Disabled") : mapAux2Fact.valueString) : ""
         }
     }

--- a/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
@@ -36,17 +36,17 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText: qsTr("Battery Full:")
+            labelText: qsTr("Battery Full")
             valueText: batVChargedFact ? batVChargedFact.valueString + " " + batVChargedFact.units : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Battery Empty:")
+            labelText: qsTr("Battery Empty")
             valueText: batVEmptyFact ? batVEmptyFact.valueString + " " + batVEmptyFact.units : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Number of Cells:")
+            labelText: qsTr("Number of Cells")
             valueText: batCellsFact ? batCellsFact.valueString : ""
         }
     }

--- a/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
@@ -14,46 +14,64 @@ FactPanel {
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
     FactPanelController { id: controller; factPanel: panel }
 
-    property Fact returnAltFact:    controller.getParameterFact(-1, "RTL_RETURN_ALT")
-    property Fact descendAltFact:   controller.getParameterFact(-1, "RTL_DESCEND_ALT")
-    property Fact landDelayFact:    controller.getParameterFact(-1, "RTL_LAND_DELAY")
-    property Fact commRCLossFact:   controller.getParameterFact(-1, "COM_RC_LOSS_T")
-    property Fact lowBattAction:    controller.getParameterFact(-1, "COM_LOW_BAT_ACT")
-    property Fact rcLossAction:     controller.getParameterFact(-1, "NAV_RCL_ACT")
-    property Fact dataLossAction:   controller.getParameterFact(-1, "NAV_DLL_ACT")
+    property Fact   returnAltFact:      controller.getParameterFact(-1, "RTL_RETURN_ALT")
+    property Fact   _descendAltFact:    controller.getParameterFact(-1, "RTL_DESCEND_ALT")
+    property Fact   landDelayFact:      controller.getParameterFact(-1, "RTL_LAND_DELAY")
+    property Fact   commRCLossFact:     controller.getParameterFact(-1, "COM_RC_LOSS_T")
+    property Fact   lowBattAction:      controller.getParameterFact(-1, "COM_LOW_BAT_ACT")
+    property Fact   rcLossAction:       controller.getParameterFact(-1, "NAV_RCL_ACT")
+    property Fact   dataLossAction:     controller.getParameterFact(-1, "NAV_DLL_ACT")
+    property Fact   _rtlLandDelayFact:  controller.getParameterFact(-1, "RTL_LAND_DELAY")
+    property int    _rtlLandDelayValue: _rtlLandDelayFact.value
 
     Column {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText: qsTr("RTL min alt:")
-            valueText: returnAltFact ? returnAltFact.valueString + " " + returnAltFact.units : ""
+            labelText: qsTr("Low Battery Failsafe")
+            valueText: lowBattAction ? lowBattAction.enumStringValue : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("RTL home alt:")
-            valueText: descendAltFact ? descendAltFact.valueString + " " + descendAltFact.units : ""
-        }
-
-        VehicleSummaryRow {
-            labelText: qsTr("RC loss RTL:")
-            valueText: commRCLossFact ? commRCLossFact.valueString + " " + commRCLossFact.units : ""
-        }
-
-        VehicleSummaryRow {
-            labelText: qsTr("RC loss action:")
+            labelText: qsTr("RC Loss Failsafe")
             valueText: rcLossAction ? rcLossAction.enumStringValue : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Link loss action:")
+            labelText: qsTr("RC Loss Timeout")
+            valueText: commRCLossFact ? commRCLossFact.valueString + " " + commRCLossFact.units : ""
+        }
+
+        VehicleSummaryRow {
+            labelText: qsTr("Data Link Loss Failsafe")
             valueText: dataLossAction ? dataLossAction.enumStringValue : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Low battery action:")
-            valueText: lowBattAction ? lowBattAction.enumStringValue : ""
+            labelText: qsTr("RTL Climb To")
+            valueText: returnAltFact ? returnAltFact.valueString + " " + returnAltFact.units : ""
         }
 
+        VehicleSummaryRow {
+            labelText: qsTr("RTL, Then")
+            valueText: _rtlLandDelayValue === 0 ?
+                           qsTr("Land immediately") :
+                           (_rtlLandDelayValue < 0 ?
+                                qsTr("Loiter and do not land") :
+                                qsTr("Loiter and land after specified time"))
+
+        }
+
+        VehicleSummaryRow {
+            labelText: qsTr("Loiter Alt")
+            valueText: _descendAltFact.valueString + " " + _descendAltFact.units
+            visible:    _rtlLandDelayValue !== 0
+        }
+
+        VehicleSummaryRow {
+            labelText: qsTr("Land Delay")
+            valueText: _rtlLandDelayValue + " " + _rtlLandDelayFact.units
+            visible:    _rtlLandDelayValue > 0
+        }
     }
 }

--- a/src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml
@@ -29,29 +29,29 @@ FactPanel {
         anchors.fill:       parent
 
         VehicleSummaryRow {
-            labelText: qsTr("Compass 0:")
+            labelText: qsTr("Compass 0")
             valueText: mag0IdFact ? (mag0IdFact.value === 0 ? qsTr("Setup required") : qsTr("Ready")) : ""
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Compass 1:")
+            labelText:  qsTr("Compass 1")
             visible:    mag1IdFact.value !== 0
             valueText:  qsTr("Ready")
         }
 
         VehicleSummaryRow {
-            labelText:  qsTr("Compass 2:")
+            labelText:  qsTr("Compass 2")
             visible:    mag2IdFact.value !== 0
             valueText:  qsTr("Ready")
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Gyro:")
+            labelText: qsTr("Gyro")
             valueText: gyro0IdFact ? (gyro0IdFact.value === 0 ? qsTr("Setup required") : qsTr("Ready")) : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("Accelerometer:")
+            labelText: qsTr("Accelerometer")
             valueText: accel0IdFact ? (accel0IdFact.value === 0 ? qsTr("Setup required") : qsTr("Ready")) : ""
         }
     }


### PR DESCRIPTION
Example with all value shown:
![screen shot 2018-04-30 at 5 10 09 pm](https://user-images.githubusercontent.com/5876851/39456222-d669b77e-4c99-11e8-998a-6f7de9bce56c.png)

I also removed all of the ":"s from the summary labels. To better match the rest of the UI which doesn't use that model.

Fix for #6062 