### PR TITLE
Don't clear results for airspeed/level calibration

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -7,10 +7,6 @@
  *
  ****************************************************************************/
 
-
-/// @file
-///     @author Don Gagne <don@thegagnes.com>
-
 #include "SensorsComponentController.h"
 #include "QGCMAVLink.h"
 #include "UAS.h"
@@ -22,46 +18,48 @@
 
 QGC_LOGGING_CATEGORY(SensorsComponentControllerLog, "SensorsComponentControllerLog")
 
-SensorsComponentController::SensorsComponentController(void) :
-    _statusLog(NULL),
-    _progressBar(NULL),
-    _compassButton(NULL),
-    _gyroButton(NULL),
-    _accelButton(NULL),
-    _airspeedButton(NULL),
-    _levelButton(NULL),
-    _cancelButton(NULL),
-    _setOrientationsButton(NULL),
-    _showOrientationCalArea(false),
-    _gyroCalInProgress(false),
-    _magCalInProgress(false),
-    _accelCalInProgress(false),
-    _orientationCalDownSideDone(false),
-    _orientationCalUpsideDownSideDone(false),
-    _orientationCalLeftSideDone(false),
-    _orientationCalRightSideDone(false),
-    _orientationCalNoseDownSideDone(false),
-    _orientationCalTailDownSideDone(false),
-    _orientationCalDownSideVisible(false),
-    _orientationCalUpsideDownSideVisible(false),
-    _orientationCalLeftSideVisible(false),
-    _orientationCalRightSideVisible(false),
-    _orientationCalNoseDownSideVisible(false),
-    _orientationCalTailDownSideVisible(false),
-    _orientationCalDownSideInProgress(false),
-    _orientationCalUpsideDownSideInProgress(false),
-    _orientationCalLeftSideInProgress(false),
-    _orientationCalRightSideInProgress(false),
-    _orientationCalNoseDownSideInProgress(false),
-    _orientationCalTailDownSideInProgress(false),
-    _orientationCalDownSideRotate(false),
-    _orientationCalUpsideDownSideRotate(false),
-    _orientationCalLeftSideRotate(false),
-    _orientationCalRightSideRotate(false),
-    _orientationCalNoseDownSideRotate(false),
-    _orientationCalTailDownSideRotate(false),
-    _unknownFirmwareVersion(false),
-    _waitingForCancel(false)
+SensorsComponentController::SensorsComponentController(void)
+    : _statusLog                                (NULL)
+    , _progressBar                              (NULL)
+    , _compassButton                            (NULL)
+    , _gyroButton                               (NULL)
+    , _accelButton                              (NULL)
+    , _airspeedButton                           (NULL)
+    , _levelButton                              (NULL)
+    , _cancelButton                             (NULL)
+    , _setOrientationsButton                    (NULL)
+    , _showOrientationCalArea                   (false)
+    , _gyroCalInProgress                        (false)
+    , _magCalInProgress                         (false)
+    , _accelCalInProgress                       (false)
+    , _airspeedCalInProgress                    (false)
+    , _levelCalInProgress                       (false)
+    , _orientationCalDownSideDone               (false)
+    , _orientationCalUpsideDownSideDone         (false)
+    , _orientationCalLeftSideDone               (false)
+    , _orientationCalRightSideDone              (false)
+    , _orientationCalNoseDownSideDone           (false)
+    , _orientationCalTailDownSideDone           (false)
+    , _orientationCalDownSideVisible            (false)
+    , _orientationCalUpsideDownSideVisible      (false)
+    , _orientationCalLeftSideVisible            (false)
+    , _orientationCalRightSideVisible           (false)
+    , _orientationCalNoseDownSideVisible        (false)
+    , _orientationCalTailDownSideVisible        (false)
+    , _orientationCalDownSideInProgress         (false)
+    , _orientationCalUpsideDownSideInProgress   (false)
+    , _orientationCalLeftSideInProgress         (false)
+    , _orientationCalRightSideInProgress        (false)
+    , _orientationCalNoseDownSideInProgress     (false)
+    , _orientationCalTailDownSideInProgress     (false)
+    , _orientationCalDownSideRotate             (false)
+    , _orientationCalUpsideDownSideRotate       (false)
+    , _orientationCalLeftSideRotate             (false)
+    , _orientationCalRightSideRotate            (false)
+    , _orientationCalNoseDownSideRotate         (false)
+    , _orientationCalTailDownSideRotate         (false)
+    , _unknownFirmwareVersion                   (false)
+    , _waitingForCancel                         (false)
 {
 }
 
@@ -165,7 +163,9 @@ void SensorsComponentController::_stopCalibration(SensorsComponentController::St
     switch (code) {
         case StopCalibrationSuccess:
             _orientationCalAreaHelpText->setProperty("text", tr("Calibration complete"));
-            emit resetStatusTextArea();
+            if (!_airspeedCalInProgress && !_levelCalInProgress) {
+                emit resetStatusTextArea();
+            }
             if (_magCalInProgress) {
                 emit setCompassRotations();
             }
@@ -186,6 +186,7 @@ void SensorsComponentController::_stopCalibration(SensorsComponentController::St
     _magCalInProgress = false;
     _accelCalInProgress = false;
     _gyroCalInProgress = false;
+    _airspeedCalInProgress = false;
 }
 
 void SensorsComponentController::calibrateGyro(void)
@@ -336,6 +337,10 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
             emit orientationCalSidesVisibleChanged();
             emit orientationCalSidesInProgressChanged();
             _updateAndEmitShowOrientationCalArea(true);
+        } else if (text == "airspeed") {
+            _airspeedCalInProgress = true;
+        } else if (text == "level") {
+            _levelCalInProgress = true;
         }
         return;
     }

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -131,7 +131,9 @@ private:
     bool _gyroCalInProgress;
     bool _magCalInProgress;
     bool _accelCalInProgress;
-    
+    bool _airspeedCalInProgress;
+    bool _levelCalInProgress;
+
     bool _orientationCalDownSideDone;
     bool _orientationCalUpsideDownSideDone;
     bool _orientationCalLeftSideDone;

--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -140,9 +140,7 @@ Item {
 
         onWaitingForCancelChanged: {
             if (controller.waitingForCancel) {
-                showMessage(qsTr("Calibration Cancel"), qsTr("Waiting for Vehicle to response to Cancel. This may take a few seconds."), 0)
-            } else {
-                hideDialog()
+                showDialog(waitForCancelDialogComponent, qsTr("Calibration Cancel"), qgcView.showDialogDefaultWidth, 0)
             }
         }
     }
@@ -151,6 +149,24 @@ Item {
         var usingUDP = controller.usingUDPLink()
         if (usingUDP && !_wifiReliableForCalibration) {
             showMessage(qsTr("Sensor Calibration"), qsTr("Performing sensor calibration over a WiFi connection is known to be unreliable. You should disconnect and perform calibration using a direct USB connection instead."), StandardButton.Ok)
+        }
+    }
+
+    Component {
+        id: waitForCancelDialogComponent
+
+        QGCViewMessage {
+            message: qsTr("Waiting for Vehicle to response to Cancel. This may take a few seconds.")
+
+            Connections {
+                target: controller
+
+                onWaitingForCancelChanged: {
+                    if (!controller.waitingForCancel) {
+                        hideDialog()
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This makes is easier to understand what happened on success.

Fix for #6333