### PR TITLE
Large parameter progress on outdoor theme

### DIFF
--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -206,12 +206,60 @@ Rectangle {
         }
     }
 
-    // Progress bar
+    // Small parameter download progress bar
     Rectangle {
-        id:             progressBar
         anchors.bottom: parent.bottom
         height:         toolBar.height * 0.05
         width:          _activeVehicle ? _activeVehicle.parameterManager.loadProgress * parent.width : 0
         color:          qgcPal.colorGreen
+        visible:        !largeProgressBar.visible
+    }
+
+    // Large parameter download progress bar
+    Rectangle {
+        id:             largeProgressBar
+        anchors.bottom: parent.bottom
+        anchors.left:   parent.left
+        anchors.right:  parent.right
+        height:         parent.height
+        color:          qgcPal.window
+        visible:        _showLargeProgress
+
+        property bool _showFullHeight:          false
+        property bool _initialDownloadComplete: _activeVehicle ? _activeVehicle.parameterManager.parametersReady : true
+        property bool _userHide:                false
+        property bool _showLargeProgress:       !_initialDownloadComplete && !_userHide && qgcPal.globalTheme === QGCPalette.Light
+
+        Connections {
+            target:                 QGroundControl.multiVehicleManager
+            onActiveVehicleChanged: largeProgressBar._userHide = false
+        }
+
+        Rectangle {
+            anchors.top:    parent.top
+            anchors.bottom: parent.bottom
+            width:          _activeVehicle ? _activeVehicle.parameterManager.loadProgress * parent.width : 0
+            color:          qgcPal.colorGreen
+        }
+
+        QGCLabel {
+            anchors.centerIn:   parent
+            text:               qsTr("Downloading Parameters")
+            font.pointSize:     ScreenTools.largeFontPointSize
+        }
+
+        QGCLabel {
+            anchors.margins:    _margin
+            anchors.right:      parent.right
+            anchors.bottom:     parent.bottom
+            text:               qsTr("Click anywhere to hide")
+
+            property real _margin: ScreenTools.defaultFontPixelWidth / 2
+        }
+
+        MouseArea {
+            anchors.fill:   parent
+            onClicked:      largeProgressBar._userHide = true
+        }
     }
 }


### PR DESCRIPTION
Fix for #5769. This was making me crazy as well so I finally did something about it:
* Only visible if using Outdoor theme
* Only visible while parameters are downloading
* You can click it to hide it if you want to move on to do something else.

![screen shot 2018-05-02 at 3 37 27 pm](https://user-images.githubusercontent.com/5876851/39552611-d83878a2-4e1e-11e8-8a3f-30c4b37e0ebb.png)
