### PR TITLE
ArduPilot: Start possible Solo video

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -125,7 +125,7 @@ private:
     bool _handleIncomingStatusText(Vehicle* vehicle, mavlink_message_t* message);
     void _handleIncomingHeartbeat(Vehicle* vehicle, mavlink_message_t* message);
     void _handleOutgoingParamSet(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message);
-    void _soloVideoHandshake(Vehicle* vehicle);    
+    void _soloVideoHandshake(Vehicle* vehicle, bool originalSoloFirmware);
     bool _guidedModeTakeoff(Vehicle* vehicle, double altitudeRel);
 
     // Any instance data here must be global to all vehicles


### PR DESCRIPTION
Replacement for #6425.

* Fixes a bug in #6425 
* Handles possible errors coming back from connect. When we specifically know what are connected to a Solo show the error if a video start fails. When we are unsure of Solo connection don't show errors from video start, since these will popup when the vehicle is not a Solo.