### PR TITLE
Show indicator for mission terrain data

### DIFF
--- a/src/PlanView/MissionItemStatus.qml
+++ b/src/PlanView/MissionItemStatus.qml
@@ -72,9 +72,9 @@ Rectangle {
             width:      display ? (indicator.width + spacing)  : 0
             visible:    display
 
-            property real availableHeight:  height - indicator.height
-            property bool showTerrain:      !isNaN(object.terrainPercent)
-            property real _terrainPercent:  showTerrain ? object.terrainPercent : 0
+            property real availableHeight:      height - indicator.height
+            property bool _terrainAvailable:    !isNaN(object.terrainPercent)
+            property real _terrainPercent:      _terrainAvailable ? object.terrainPercent : 1
 
             readonly property bool display: object.specifiesCoordinate && !object.isStandaloneCoordinate
             readonly property real spacing: ScreenTools.defaultFontPixelWidth * ScreenTools.smallFontPointRatio
@@ -83,9 +83,8 @@ Rectangle {
                 anchors.bottom:             parent.bottom
                 anchors.horizontalCenter:   parent.horizontalCenter
                 width:                      indicator.width
-                height:                     Math.max(availableHeight * _terrainPercent, 1)
-                color:                      _terrainPercent > object.altPercent ? "red": qgcPal.text
-                visible:                    !isNaN(object.terrainPercent)
+                height:                     _terrainAvailable ? Math.max(availableHeight * _terrainPercent, 1) : parent.height
+                color:                      _terrainAvailable ? (_terrainPercent > object.altPercent ? "red": qgcPal.text) : "yellow"
             }
 
             MissionItemIndexLabel {


### PR DESCRIPTION
The terrain bars in mission item status display at bottom of Plan will show full yellow while terrain data is downloading or missing. This does two things:
* The indicators switching from yellow to normal terrain value display provides a progress indicator for terrain download.
* If the indicators stay yellow they show missing data.