### PR TITLE
Don't go into Hold before takeoff

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2702,7 +2702,6 @@ void Vehicle::guidedModeTakeoff(double altitudeRelative)
         qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
-    setGuidedMode(true);
     _firmwarePlugin->guidedModeTakeoff(this, altitudeRelative);
 }
 


### PR DESCRIPTION
Not sure why it did that. But it cause takeoff to no work when using optical flow for guidance.