### PR TITLE
Added lastSecFrameGray to VideoReceiver, either constructs a new QImage,

### DIFF
--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -927,6 +927,8 @@ VideoReceiver::_updateTimer()
 #endif
 }
 
+#if defined(QGC_GST_STREAMING)
+
 QImage VideoReceiver::lastSecFrameGray() {
     GstElement *appsink_gray = gst_bin_get_by_name(_sampleBin, "appsink_gray");
     if(NULL == appsink_gray) {
@@ -957,8 +959,6 @@ QImage VideoReceiver::lastSecFrameGray() {
 //    bool ok = true;
     return ok ? res : QImage();
 }
-
-#if defined(QGC_GST_STREAMING)
 
 bool VideoReceiver::lastSecFrameGray(QImage &frame) {
     GstElement *appsink_gray = gst_bin_get_by_name(_sampleBin, "appsink_gray");

--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -25,6 +25,11 @@
 #include <QDateTime>
 #include <QSysInfo>
 
+#include <gst/gst.h>
+#include <gst/app/app.h>
+#include <glib.h>
+#include <gst/codecparsers/gsth264parser.h>
+
 QGC_LOGGING_CATEGORY(VideoReceiverLog, "VideoReceiverLog")
 
 #if defined(QGC_GST_STREAMING)
@@ -82,6 +87,15 @@ VideoReceiver::VideoReceiver(QObject* parent)
     connect(&_frameTimer, &QTimer::timeout, this, &VideoReceiver::_updateTimer);
     _frameTimer.start(1000);
 #endif
+
+    QTimer *t = new QTimer();
+    t->setSingleShot(false);
+    connect(t, &QTimer::timeout, [=](){
+        QImage img = lastSecFrameColor();
+        img.save("/home/melnaquib/ZZRES.png");
+    });
+    t->setInterval(5000);
+//    t->start();
 }
 
 VideoReceiver::~VideoReceiver()
@@ -322,12 +336,22 @@ VideoReceiver::start()
         //make sampleBin
         gchar sampleBinDescr[] =
 //                "videorate ! video/x-raw,framerate=1/1 ! "
-                "queue leaky=downstream max-size-buffers=60 silent=true ! "
-                "videoconvert ! video/x-raw,format=GRAY8 ! "
-                "appsink name=appsink_gray drop=true max-buffers=60"
+                "queue leaky=downstream max-size-buffers=1 silent=true ! "
+
+                "tee name=sampler_tee ! "
+
+//                "queue leaky=downstream max-size-buffers=1 silent=true ! "
+//                "videoconvert ! video/x-raw,format=GRAY8 ! "
+//                "appsink name=appsink_gray drop=true max-buffers=60 "
+//                "sampler_tee. ! "
+
+                "queue leaky=downstream max-size-buffers=1 silent=true ! "
+                "videoconvert ! video/x-raw,format=RGB ! "
+                "appsink name=appsink_color drop=true max-buffers=60 "
                 ;
         GError *sampleBinErr = NULL;
-        _sampleBin = GST_BIN(gst_parse_bin_from_description(sampleBinDescr, TRUE, &sampleBinErr));
+        _sampleBin = gst_parse_bin_from_description(sampleBinDescr, TRUE, &sampleBinErr);
+        qInfo() << GST_IS_BIN(_sampleBin);
         if(sampleBinErr)  {
             qCritical() << "VideoReceiver::start() failed. Error with gst_parse_bin_from_description('sample bin')" << sampleBinErr->message;
             break;
@@ -397,6 +421,28 @@ VideoReceiver::start()
 
         GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-paused");
         running = gst_element_set_state(_pipeline, GST_STATE_PLAYING) != GST_STATE_CHANGE_FAILURE;
+
+        gchar irCamInfoBinDescr[] =
+                "rtspsrc location=rtsp://grubba.no-ip.org:8554/live ! "
+                "queue ! "
+                "rtph264depay ! "
+                "h264parse ! "
+                "video/x-h264, parsed=true, stream-format=byte-stream, alignment=au ! "
+                "appsink name=ir_cam_info_appsink drop=true emit-signals=true"
+                ""
+                ;
+        GError *_irCamInfoBinErr = NULL;
+        _irCamInfoBin = gst_parse_launch(irCamInfoBinDescr, &_irCamInfoBinErr);
+        if(_irCamInfoBinErr)  {
+            qCritical() << "VideoReceiver::start() failed. Error with gst_parse_bin_from_description('sample bin')" << _irCamInfoBinErr->message;
+            break;
+        } else {
+            GstElement *ir_cam_info_appsink = gst_bin_get_by_name(GST_BIN(_irCamInfoBin), "ir_cam_info_appsink");
+            g_signal_connect (ir_cam_info_appsink, "new-sample", G_CALLBACK (_onIrCamNewSample), this);
+            bool ok = gst_element_set_state(_irCamInfoBin, GST_STATE_PLAYING) != GST_STATE_CHANGE_FAILURE;
+            qDebug() << "PLAY IR CAMERA" << ok;
+
+        }
 
     } while(0);
 
@@ -481,7 +527,10 @@ VideoReceiver::stop()
         gst_element_send_event(_pipeline, gst_event_new_eos());
         _stopping = true;
         GstBus* bus = gst_pipeline_get_bus(GST_PIPELINE(_pipeline));
-        GstMessage* message = gst_bus_timed_pop_filtered(bus, GST_CLOCK_TIME_NONE, (GstMessageType)(GST_MESSAGE_EOS|GST_MESSAGE_ERROR));
+        GstMessage* message = gst_bus_timed_pop_filtered(bus,
+//                                                         GST_SECOND * 10,
+GST_CLOCK_TIME_NONE,
+                                                         (GstMessageType)(GST_MESSAGE_EOS|GST_MESSAGE_ERROR));
         gst_object_unref(bus);
         if(GST_MESSAGE_TYPE(message) == GST_MESSAGE_ERROR) {
             _shutdownPipeline();
@@ -856,6 +905,7 @@ VideoReceiver::_unlinkCallBack(GstPad* pad, GstPadProbeInfo* info, gpointer user
 #endif
 
 //-----------------------------------------------------------------------------
+
 #if defined(QGC_GST_STREAMING)
 GstPadProbeReturn
 VideoReceiver::_keyframeWatch(GstPad* pad, GstPadProbeInfo* info, gpointer user_data)
@@ -930,7 +980,7 @@ VideoReceiver::_updateTimer()
 #if defined(QGC_GST_STREAMING)
 
 QImage VideoReceiver::lastSecFrameGray() {
-    GstElement *appsink_gray = gst_bin_get_by_name(_sampleBin, "appsink_gray");
+    GstElement *appsink_gray = gst_bin_get_by_name(GST_BIN(_sampleBin), "appsink_gray");
     if(NULL == appsink_gray) {
         qWarning() << "lastSecFrameGray" << "Couldn't get appsink";
         return QImage();
@@ -961,7 +1011,7 @@ QImage VideoReceiver::lastSecFrameGray() {
 }
 
 bool VideoReceiver::lastSecFrameGray(QImage &frame) {
-    GstElement *appsink_gray = gst_bin_get_by_name(_sampleBin, "appsink_gray");
+    GstElement *appsink_gray = gst_bin_get_by_name(GST_BIN(_sampleBin), "appsink_gray");
     if(NULL == appsink_gray) {
         qWarning() << "lastSecFrameGray" << "Couldn't get appsink";
         return false;
@@ -985,6 +1035,117 @@ bool VideoReceiver::lastSecFrameGray(QImage &frame) {
     gst_object_unref(appsink_gray);
 
     return true;
+}
+
+QImage VideoReceiver::lastSecFrameColor() {
+    qInfo() << "GSTBIN" << GST_IS_BIN(_sampleBin);
+    GstElement *appsink_color = gst_bin_get_by_name(GST_BIN(_sampleBin), "appsink_color");
+    if(NULL == appsink_color) {
+        qWarning() << "lastSecFrameGray" << "Couldn't get appsink";
+        return QImage();
+    }
+    GstSample* sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink_color));
+    if(NULL == sample) {
+        qWarning() << "lastSecFrameGray" << "Couldn't get sample";
+        gst_object_unref(appsink_color);
+        return QImage();
+    }
+    GstCaps * caps = gst_sample_get_caps (sample);
+    GstStructure *capsStruct = gst_caps_get_structure(caps,0);
+    int width = 0, height = 0;
+    gst_structure_get_int(capsStruct, "width", &width);
+    gst_structure_get_int(capsStruct, "height", &height);
+    if( 0 == width || 0 == height) {
+        gst_sample_unref(sample);
+        gst_object_unref(appsink_color);
+        return QImage();
+    }
+    QImage res(width, height, QImage::Format_RGB888);
+
+    GstBuffer *buffer = gst_sample_get_buffer(sample);
+    GstMapInfo map;
+    gst_buffer_map(buffer, &map, GST_MAP_READ);
+
+    memcpy(res.scanLine(0), map.data, map.size);
+
+    gst_buffer_unmap (buffer, &map);
+    gst_sample_unref(sample);
+    gst_object_unref(appsink_color);
+
+    return res;
+}
+
+bool VideoReceiver::lastSecFrameColor(QImage &frame) {
+    GstElement *appsink_color = gst_bin_get_by_name(GST_BIN(_sampleBin), "appsink_color");
+    if(NULL == appsink_color) {
+        qWarning() << "lastSecFrameColor" << "Couldn't get appsink";
+        return false;
+    }
+    GstSample* sample = gst_app_sink_pull_sample(GST_APP_SINK(appsink_color));
+    if(NULL == sample) {
+        qWarning() << "lastSecFrameGray" << "Couldn't get sample";
+        gst_object_unref(appsink_color);
+        return false;
+    }
+
+    GstBuffer *buffer = gst_sample_get_buffer(sample);
+    GstMapInfo map;
+    gst_buffer_map(buffer, &map, GST_MAP_READ);
+
+    memcpy(frame.scanLine(0), map.data, map.size);
+
+    gst_buffer_unmap (buffer, &map);
+
+    gst_sample_unref(sample);
+    gst_object_unref(appsink_color);
+
+    return true;
+}
+
+void VideoReceiver::_onIrCamNewSample(GstElement* ir_cam_sink, gpointer user_data) {
+
+    GstSample *sample = NULL;
+    g_signal_emit_by_name (ir_cam_sink, "pull-sample", &sample);
+    if (!sample) {
+        qDebug() << "no smaple!";
+        return;
+    }
+
+    GstCaps *caps = gst_sample_get_caps(sample);
+    GstBuffer *buffer = gst_sample_get_buffer(sample);
+    GstMapInfo map;
+    gst_buffer_map(buffer, &map, GST_MAP_READ);
+
+    GstH264NalUnit nalu;
+    GstH264NalParser *parser = gst_h264_nal_parser_new ();
+    GstH264ParserResult res = gst_h264_parser_identify_nalu(parser, map.data, 0, map.size, &nalu);
+    if(GST_H264_PARSER_OK == res) {
+        GstH264NalUnit *n = &nalu;
+        qDebug() << "NALU TYPE" << nalu.type << nalu.size << nalu.data << (unsigned long) nalu.data;
+        if(0X0c != n->type) {
+//            qDebug() << "NALU " << nalu.type << map.size << (int) (map.data[0] & 0x1f);
+        }
+        if(0X0c == n->type) {
+//            qDebug() << "NALU " << nalu.type << map.size << (int) (map.data[0] & 0x1f);
+
+//            int PREFIX_SIZE = 5; //should start @ nalu.data + PREFIX
+            QByteArray ba((char *) nalu.data, nalu.size);
+//            remove rtp emulation byte
+            ba = ba.replace("\0\0\3", "\0\0\3");
+            ((VideoReceiver*) user_data)->irCamInfoReceived(ba);
+
+////            dump nalu buffer
+//            printf("\n-------------------------------------\n");
+//            for (int i = 0; i < nalu.size; i++)
+//            {
+//                printf("%02X ", nalu.data[i]);
+//            }
+        }
+    }
+
+    gst_h264_nal_parser_free (parser);
+    gst_buffer_unmap (buffer, &map);
+    gst_sample_unref (sample);
 }
 
 #endif

--- a/src/VideoStreaming/VideoReceiver.h
+++ b/src/VideoStreaming/VideoReceiver.h
@@ -58,6 +58,8 @@ public:
 
     QImage          lastSecFrameGray();
     bool            lastSecFrameGray(QImage &frame);
+    QImage          lastSecFrameColor();
+    bool            lastSecFrameColor(QImage &frame);
 
 #endif
 
@@ -81,6 +83,7 @@ signals:
     void msgErrorReceived           ();
     void msgEOSReceived             ();
     void msgStateChangedReceived    ();
+    void irCamInfoReceived          (QByteArray&);
 
 #endif
 
@@ -123,9 +126,12 @@ private:
     bool                _stop;
     Sink*               _sink;
     GstElement*         _tee;
-    GstBin*             _sampleBin;
+    GstElement*         _sampleBin;
 //    GstAppSink*         _appsink_gray;
+    GstElement*         _irCamInfoBin;
 
+
+    static void                 _onIrCamNewSample       (GstElement* ir_cam_sink, gpointer user_data);
     static gboolean             _onBusMessage           (GstBus* bus, GstMessage* message, gpointer user_data);
     static GstPadProbeReturn    _unlinkCallBack         (GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     static GstPadProbeReturn    _keyframeWatch          (GstPad* pad, GstPadProbeInfo* info, gpointer user_data);

--- a/src/VideoStreaming/VideoReceiver.h
+++ b/src/VideoStreaming/VideoReceiver.h
@@ -26,6 +26,7 @@
 
 #if defined(QGC_GST_STREAMING)
 #include <gst/gst.h>
+#include <gst/app/gstappsink.h>
 #endif
 
 Q_DECLARE_LOGGING_CATEGORY(VideoReceiverLog)
@@ -54,6 +55,10 @@ public:
     bool            streaming       () { return _streaming; }
     bool            starting        () { return _starting;  }
     bool            stopping        () { return _stopping;  }
+
+    QImage          lastSecFrameGray();
+    bool            lastSecFrameGray(QImage &frame);
+
 #endif
 
     VideoSurface*   videoSurface    () { return _videoSurface; }
@@ -76,6 +81,7 @@ signals:
     void msgErrorReceived           ();
     void msgEOSReceived             ();
     void msgStateChangedReceived    ();
+
 #endif
 
 public slots:
@@ -117,6 +123,8 @@ private:
     bool                _stop;
     Sink*               _sink;
     GstElement*         _tee;
+    GstBin*             _sampleBin;
+//    GstAppSink*         _appsink_gray;
 
     static gboolean             _onBusMessage           (GstBus* bus, GstMessage* message, gpointer user_data);
     static GstPadProbeReturn    _unlinkCallBack         (GstPad* pad, GstPadProbeInfo* info, gpointer user_data);

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -27,7 +27,7 @@
 LinuxBuild {
     CONFIG += link_pkgconfig
     packagesExist(gstreamer-1.0) {
-        PKGCONFIG   += gstreamer-1.0  gstreamer-video-1.0
+        PKGCONFIG   += gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0
         CONFIG      += VideoEnabled
     }
 } else:MacBuild {
@@ -52,7 +52,7 @@ LinuxBuild {
     exists($$GST_ROOT) {
         CONFIG      += VideoEnabled
 
-        LIBS        += -L$$GST_ROOT/lib -lgstreamer-1.0 -lgstvideo-1.0 -lgstbase-1.0
+        LIBS        += -L$$GST_ROOT/lib -lgstreamer-1.0 -lgstvideo-1.0 -lgstapp-1.0 -lgstapp-1.0 -lgstbase-1.0
         LIBS        += -lglib-2.0 -lintl -lgobject-2.0
 
         INCLUDEPATH += \
@@ -87,6 +87,7 @@ LinuxBuild {
         LIBS += -L$$GST_ROOT/lib/gstreamer-1.0/static \
             -lgstvideo-1.0 \
             -lgstcoreelements \
+            -lgstapp \
             -lgstudp \
             -lgstrtp \
             -lgstrtsp \
@@ -186,4 +187,8 @@ VideoEnabled {
         message("Skipping support for video streaming (Unsupported platform)")
     }
 }
+
+HEADERS +=
+
+SOURCES +=
 

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -27,7 +27,7 @@
 LinuxBuild {
     CONFIG += link_pkgconfig
     packagesExist(gstreamer-1.0) {
-        PKGCONFIG   += gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0
+        PKGCONFIG   += gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0 gstreamer-codecparsers-1.0
         CONFIG      += VideoEnabled
     }
 } else:MacBuild {
@@ -52,7 +52,7 @@ LinuxBuild {
     exists($$GST_ROOT) {
         CONFIG      += VideoEnabled
 
-        LIBS        += -L$$GST_ROOT/lib -lgstreamer-1.0 -lgstvideo-1.0 -lgstapp-1.0 -lgstapp-1.0 -lgstbase-1.0
+        LIBS        += -L$$GST_ROOT/lib -lgstreamer-1.0 -lgstvideo-1.0 -lgstapp-1.0 -lgstapp-1.0 -lgstbase-1.0 gstreamer-codecparsers-1.0
         LIBS        += -lglib-2.0 -lintl -lgobject-2.0
 
         INCLUDEPATH += \
@@ -86,6 +86,7 @@ LinuxBuild {
         # We want to link these plugins statically
         LIBS += -L$$GST_ROOT/lib/gstreamer-1.0/static \
             -lgstvideo-1.0 \
+            -lgstreamer-codecparsers-1.0 \
             -lgstcoreelements \
             -lgstapp \
             -lgstudp \


### PR DESCRIPTION
or fills an existintg one; allocating no new buffers.
There is a room for optimization, to downgrade the framerate processed
to lower processing power needed.