### PR TITLE
Update camera specs on creation

### DIFF
--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -68,6 +68,8 @@ CameraCalc::CameraCalc(Vehicle* vehicle, QString settingsGroup, QObject* parent)
     connect(landscape(),                &Fact::rawValueChanged, this, &CameraCalc::_recalcTriggerDistance);
 
     _cameraNameChanged();
+
+    setDirty(false);
 }
 
 void CameraCalc::setDirty(bool dirty)

--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -67,7 +67,7 @@ CameraCalc::CameraCalc(Vehicle* vehicle, QString settingsGroup, QObject* parent)
     connect(&_sideOverlapFact,          &Fact::rawValueChanged, this, &CameraCalc::_recalcTriggerDistance);
     connect(landscape(),                &Fact::rawValueChanged, this, &CameraCalc::_recalcTriggerDistance);
 
-    _recalcTriggerDistance();
+    _cameraNameChanged();
 }
 
 void CameraCalc::setDirty(bool dirty)


### PR DESCRIPTION
If a custom build overrode the default camera setting, the camera specs were not updated correctly to the new camera spec.