### PR TITLE
Create standalone controls for PreFlight CheckList

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -152,7 +152,12 @@
         <file alias="QGroundControl/FlightDisplay/GuidedActionsController.qml">src/FlightDisplay/GuidedActionsController.qml</file>
         <file alias="QGroundControl/FlightDisplay/GuidedAltitudeSlider.qml">src/FlightDisplay/GuidedAltitudeSlider.qml</file>
         <file alias="QGroundControl/FlightDisplay/MultiVehicleList.qml">src/FlightDisplay/MultiVehicleList.qml</file>
+		<file alias="QGroundControl/FlightDisplay/PreFlightAHRSCheck.qml">src/FlightDisplay/PreFlightAHRSCheck.qml</file>
+		<file alias="QGroundControl/FlightDisplay/PreFlightBatteryCheck.qml">src/FlightDisplay/PreFlightBatteryCheck.qml</file>
 		<file alias="QGroundControl/FlightDisplay/PreFlightCheckList.qml">src/FlightDisplay/PreFlightCheckList.qml</file>
+		<file alias="QGroundControl/FlightDisplay/PreFlightRCCheck.qml">src/FlightDisplay/PreFlightRCCheck.qml</file>
+		<file alias="QGroundControl/FlightDisplay/PreFlightSensorsCheck.qml">src/FlightDisplay/PreFlightSensorsCheck.qml</file>
+		<file alias="QGroundControl/FlightDisplay/PreFlightSoundCheck.qml">src/FlightDisplay/PreFlightSoundCheck.qml</file>
         <file alias="QGroundControl/FlightDisplay/qmldir">src/FlightDisplay/qmldir</file>
         <file alias="QGroundControl/FlightMap/CameraTriggerIndicator.qml">src/FlightMap/MapItems/CameraTriggerIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/CenterMapDropButton.qml">src/FlightMap/Widgets/CenterMapDropButton.qml</file>

--- a/src/FlightDisplay/PreFlightAHRSCheck.qml
+++ b/src/FlightDisplay/PreFlightAHRSCheck.qml
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick 2.3
+
+import QGroundControl           1.0
+import QGroundControl.Controls  1.0
+import QGroundControl.Vehicle   1.0
+
+PreFlightCheckButton {
+    name: qsTr("Global position estimate")
+
+    property int _unhealthySensors:  _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
+    property var _activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
+
+    on_UnhealthySensorsChanged: updateItem()
+    on_ActiveVehicleChanged:    updateItem()
+
+    Component.onCompleted: updateItem()
+
+    function updateItem() {
+        if (!_activeVehicle) {
+            state = stateNotChecked
+        } else {
+            if (_unhealthySensors & Vehicle.SysStatusSensorAHRS) {
+                state = stateMajorIssue
+            } else {
+                state = statePassed
+            }
+        }
+    }
+}

--- a/src/FlightDisplay/PreFlightBatteryCheck.qml
+++ b/src/FlightDisplay/PreFlightBatteryCheck.qml
@@ -1,0 +1,48 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick 2.3
+
+import QGroundControl           1.0
+import QGroundControl.Controls  1.0
+import QGroundControl.Vehicle   1.0
+
+// This class stores the data and functions of the check list but NOT the GUI (which is handled somewhere else).
+PreFlightCheckButton {
+    name:           qsTr("Battery")
+    pendingtext:    qsTr("Healthy & charged > %1. Battery connector firmly plugged?").arg(failureVoltage)
+
+    property int failureVoltage: 40
+
+    property int _unhealthySensors:     _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
+    property var _batPercentRemaining:  _activeVehicle ? _activeVehicle.battery.percentRemaining.value : 0
+    property var _activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
+
+    on_BatPercentRemainingChanged:  updateItem()
+    on_UnhealthySensorsChanged:     updateItem()
+    on_ActiveVehicleChanged:        updateItem()
+
+    Component.onCompleted: updateItem()
+
+    function updateItem() {
+        if (!_activeVehicle) {
+            state = stateNotChecked
+        } else {
+            if (_unhealthySensors & Vehicle.SysStatusSensorBattery) {
+                failuretext = qsTr("Not healthy. Check console.")
+                state = stateMajorIssue
+            } else if (_batPercentRemaining < failureVoltage) {
+                failuretext = qsTr("Low (below %1). Please recharge.").arg(failureVoltage)
+                state = stateMajorIssue
+            } else {
+                state = _nrClicked > 0 ? statePassed : statePending
+            }
+        }
+    }
+}

--- a/src/FlightDisplay/PreFlightRCCheck.qml
+++ b/src/FlightDisplay/PreFlightRCCheck.qml
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick 2.3
+
+import QGroundControl           1.0
+import QGroundControl.Controls  1.0
+import QGroundControl.Vehicle   1.0
+
+PreFlightCheckButton {
+    name:           qsTr("Radio Control")
+    pendingtext:    qsTr("Receiving signal. Perform range test & confirm.")
+    failuretext:    qsTr("No signal or invalid autopilot-RC config. Check RC and console.")
+
+    property int _unhealthySensors: _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
+    property var _activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
+
+    on_UnhealthySensorsChanged: updateItem()
+    on_ActiveVehicleChanged:    updateItem()
+
+    Component.onCompleted: updateItem()
+
+    function updateItem() {
+        if (!_activeVehicle) {
+            state = stateNotChecked
+        } else {
+            if (_unhealthySensors & Vehicle.SysStatusSensorRCReceiver) {
+                state = stateMajorIssue
+            } else {
+                state = _nrClicked > 0 ? statePassed : statePending
+            }
+        }
+    }
+}

--- a/src/FlightDisplay/PreFlightSensorsCheck.qml
+++ b/src/FlightDisplay/PreFlightSensorsCheck.qml
@@ -1,0 +1,56 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick 2.3
+
+import QGroundControl           1.0
+import QGroundControl.Controls  1.0
+import QGroundControl.Vehicle   1.0
+
+PreFlightCheckButton {
+    name: qsTr("Sensors")
+
+    property int    _unhealthySensors:  _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
+    property bool   _gpsLock:           _activeVehicle ? _activeVehicle.gps.lock.rawValue>=3 : 0
+    property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
+
+    on_GpsLockChanged:          updateItem()
+    on_UnhealthySensorsChanged: updateItem()
+    on_ActiveVehicleChanged:    updateItem()
+
+    Component.onCompleted: updateItem()
+
+    function updateItem() {
+        if (!_activeVehicle) {
+            state = stateNotChecked
+        } else {
+            if(!(_unhealthySensors & Vehicle.SysStatusSensor3dMag) &&
+                    !(_unhealthySensors & Vehicle.SysStatusSensor3dAccel) &&
+                    !(_unhealthySensors & Vehicle.SysStatusSensor3dGyro) &&
+                    !(_unhealthySensors & Vehicle.SysStatusSensorAbsolutePressure) &&
+                    !(_unhealthySensors & Vehicle.SysStatusSensorDifferentialPressure) &&
+                    !(_unhealthySensors & Vehicle.SysStatusSensorGPS)) {
+                if (!_gpsLock) {
+                    pendingtext = qsTr("Pending. Waiting for GPS lock.")
+                    state = statePending
+                } else {
+                    state = statePassed
+                }
+            } else {
+                if (_unhealthySensors & Vehicle.SysStatusSensor3dMag)                       failuretext=qsTr("Failure. Magnetometer issues. Check console.")
+                else if(_unhealthySensors & Vehicle.SysStatusSensor3dAccel)                 failuretext=qsTr("Failure. Accelerometer issues. Check console.")
+                else if(_unhealthySensors & Vehicle.SysStatusSensor3dGyro)                  failuretext=qsTr("Failure. Gyroscope issues. Check console.")
+                else if(_unhealthySensors & Vehicle.SysStatusSensorAbsolutePressure)        failuretext=qsTr("Failure. Barometer issues. Check console.")
+                else if(_unhealthySensors & Vehicle.SysStatusSensorDifferentialPressure)    failuretext=qsTr("Failure. Airspeed sensor issues. Check console.")
+                else if(_unhealthySensors & Vehicle.SysStatusSensorGPS)                     failuretext=qsTr("Failure. No valid or low quality GPS signal. Check console.")
+                state = stateMajorIssue
+            }
+        }
+    }
+}

--- a/src/FlightDisplay/PreFlightSoundCheck.qml
+++ b/src/FlightDisplay/PreFlightSoundCheck.qml
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick 2.3
+
+import QGroundControl           1.0
+import QGroundControl.Controls  1.0
+import QGroundControl.Vehicle   1.0
+
+PreFlightCheckButton {
+    name:           qsTr("Sound output")
+    pendingtext:    qsTr("QGC audio output enabled. System audio output enabled, too?")
+    failuretext:    qsTr("Failure, QGC audio output is disabled. Please enable it under application settings->general to hear audio warnings!")
+
+    property bool   _audioMuted:     QGroundControl.settingsManager.appSettings.audioMuted.rawValue
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+    on_AudioMutedChanged:       updateItem()
+    on_ActiveVehicleChanged:    updateItem()
+
+    Component.onCompleted: updateItem()
+
+    function onActiveVehicleChanged() {
+        buttonSoundOutput.updateItem();     // Just updated here for initialization once we connect to a vehicle
+        updateVehicleDependentItems();
+    }
+
+    function updateItem() {
+        if (!_activeVehicle) {
+            state = stateNotChecked
+        } else {
+            if (_audioMuted) {
+                state = stateMajorIssue
+                _nrClicked = 0
+            } else {
+                state = _nrClicked > 0 ? statePassed : statePending
+            }
+        }
+    }
+}

--- a/src/FlightDisplay/qmldir
+++ b/src/FlightDisplay/qmldir
@@ -9,5 +9,10 @@ GuidedActionsController     1.0 GuidedActionsController.qml
 GuidedActionList            1.0 GuidedActionList.qml
 GuidedAltitudeSlider        1.0 GuidedAltitudeSlider.qml
 MultiVehicleList            1.0 MultiVehicleList.qml
+PreFlightBatteryCheck       1.0 PreFlightBatteryCheck.qml
+PreFlightAHRSCheck          1.0 PreFlightAHRSCheck.qml
 PreFlightCheckList          1.0 PreFlightCheckList.qml
+PreFlightRCCheck            1.0 PreFlightRCCheck.qml
+PreFlightSensorsCheck       1.0 PreFlightSensorsCheck.qml
+PreFlightSoundCheck         1.0 PreFlightSoundCheck.qml
 


### PR DESCRIPTION
This makes them much easier to reuse. Other than the ability to define failureVoltage for the battery check this is just packaging changes. Functionality stays exactly the same.