### PR TITLE
Track offline editing settings only for offline editing vehicle

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -413,11 +413,13 @@ void Vehicle::_commonInit(void)
     connect(_rallyPointManager, &RallyPointManager::error,          this, &Vehicle::_rallyPointManagerError);
     connect(_rallyPointManager, &RallyPointManager::loadComplete,   this, &Vehicle::_rallyPointLoadComplete);
 
-    // Offline editing vehicle tracks settings changes for offline editing settings
-    connect(_settingsManager->appSettings()->offlineEditingFirmwareType(),  &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
-    connect(_settingsManager->appSettings()->offlineEditingVehicleType(),   &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
-    connect(_settingsManager->appSettings()->offlineEditingCruiseSpeed(),   &Fact::rawValueChanged, this, &Vehicle::_offlineCruiseSpeedSettingChanged);
-    connect(_settingsManager->appSettings()->offlineEditingHoverSpeed(),    &Fact::rawValueChanged, this, &Vehicle::_offlineHoverSpeedSettingChanged);
+    if (_offlineEditingVehicle) {
+        // Offline editing vehicle tracks settings changes for offline editing settings
+        connect(_settingsManager->appSettings()->offlineEditingFirmwareType(),  &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
+        connect(_settingsManager->appSettings()->offlineEditingVehicleType(),   &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
+        connect(_settingsManager->appSettings()->offlineEditingCruiseSpeed(),   &Fact::rawValueChanged, this, &Vehicle::_offlineCruiseSpeedSettingChanged);
+        connect(_settingsManager->appSettings()->offlineEditingHoverSpeed(),    &Fact::rawValueChanged, this, &Vehicle::_offlineHoverSpeedSettingChanged);
+    }
 
     // Flight modes can differ based on advanced mode
     connect(_toolbox->corePlugin(), &QGCCorePlugin::showAdvancedUIChanged, this, &Vehicle::flightModesChanged);


### PR DESCRIPTION
When using QGC in multi-vehicle mode, there is a problem, that vehicles' firmware plugins are changed to base `FirmwarePlugin`. It happens when [this](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/PlanMasterController.cc#L115) code is executed. So, instead of normal modes widget, after switching between vehicles we see something like this:

<img width="595" alt="2018-05-24 23 48 48" src="https://user-images.githubusercontent.com/1683279/40517928-8d77c2d8-5fc0-11e8-80fd-6ea81b39afa1.png">

Haven't figured out, why this bug is not happening in single-vehicle mode, but this change fixes it. Actually, I think, we don't want to subscribe to offline editing settings changes, if we are not in offline editing vehicle.