### PR TITLE
Simplify PreFlightCheckButton implementation

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -510,7 +510,7 @@ QGCView {
             title:              qsTr("Fly")
             maxHeight:          (_flightVideo.visible ? _flightVideo.y : parent.height) - toolStrip.y
             buttonVisible:      [ _useChecklist, _guidedController.showTakeoff || !_guidedController.showLand, _guidedController.showLand && !_guidedController.showTakeoff, true, true, true, _guidedController.smartShotsAvailable ]
-            buttonEnabled:      [ _useChecklist, _guidedController.showTakeoff, _guidedController.showLand, _guidedController.showRTL, _guidedController.showPause, _anyActionAvailable, _anySmartShotAvailable ]
+            buttonEnabled:      [ _useChecklist && _activeVehicle, _guidedController.showTakeoff, _guidedController.showLand, _guidedController.showRTL, _guidedController.showPause, _anyActionAvailable, _anySmartShotAvailable ]
 
             property bool _anyActionAvailable: _guidedController.showStartMission || _guidedController.showResumeMission || _guidedController.showChangeAlt || _guidedController.showLandAbort
             property bool _anySmartShotAvailable: _guidedController.showOrbit
@@ -729,7 +729,7 @@ QGCView {
                         opacity :               0.2+0.8*(QGroundControl.multiVehicleManager.vehicles.count > 0)
                         tooltip:                qsTr("Reset the checklist (e.g. after a vehicle reboot)")
 
-                        onClicked:              preFlightCheckList.resetNrClicks()
+                        onClicked:              preFlightCheckList.reset()
 
                         Image { source:"/qmlimages/MapSyncBlack.svg" ; anchors.fill: parent }
                     }

--- a/src/FlightDisplay/PreFlightAHRSCheck.qml
+++ b/src/FlightDisplay/PreFlightAHRSCheck.qml
@@ -14,25 +14,10 @@ import QGroundControl.Controls  1.0
 import QGroundControl.Vehicle   1.0
 
 PreFlightCheckButton {
-    name: qsTr("Global position estimate")
+    name:                   qsTr("Global position estimate")
+    telemetryTextFailure:   qsTr("AHRS Unhealthy. Check console.")
+    telemetryFailure:       _unhealthySensors & Vehicle.SysStatusSensorAHRS
 
-    property int _unhealthySensors:  _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
     property var _activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
-
-    on_UnhealthySensorsChanged: updateItem()
-    on_ActiveVehicleChanged:    updateItem()
-
-    Component.onCompleted: updateItem()
-
-    function updateItem() {
-        if (!_activeVehicle) {
-            state = stateNotChecked
-        } else {
-            if (_unhealthySensors & Vehicle.SysStatusSensorAHRS) {
-                state = stateMajorIssue
-            } else {
-                state = statePassed
-            }
-        }
-    }
+    property int _unhealthySensors: _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
 }

--- a/src/FlightDisplay/PreFlightBatteryCheck.qml
+++ b/src/FlightDisplay/PreFlightBatteryCheck.qml
@@ -15,34 +15,17 @@ import QGroundControl.Vehicle   1.0
 
 // This class stores the data and functions of the check list but NOT the GUI (which is handled somewhere else).
 PreFlightCheckButton {
-    name:           qsTr("Battery")
-    pendingText:    qsTr("Healthy & charged > %1. Battery connector firmly plugged?").arg(failureVoltage)
+    name:                   qsTr("Battery")
+    manualText:             qsTr("Healthy & charged > %1. Battery connector firmly plugged?").arg(failureVoltage)
+    telemetryTextFailure:   _batUnHealthy ?
+                                qsTr("Not healthy. Check console.") :
+                                ("Low (below %1). Please recharge.").arg(failureVoltage)
 
     property int failureVoltage: 40
 
+    property var _activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
     property int _unhealthySensors:     _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
     property var _batPercentRemaining:  _activeVehicle ? _activeVehicle.battery.percentRemaining.value : 0
-    property var _activeVehicle:        QGroundControl.multiVehicleManager.activeVehicle
-
-    on_BatPercentRemainingChanged:  updateItem()
-    on_UnhealthySensorsChanged:     updateItem()
-    on_ActiveVehicleChanged:        updateItem()
-
-    Component.onCompleted: updateItem()
-
-    function updateItem() {
-        if (!_activeVehicle) {
-            state = stateNotChecked
-        } else {
-            if (_unhealthySensors & Vehicle.SysStatusSensorBattery) {
-                failureText = qsTr("Not healthy. Check console.")
-                state = stateMajorIssue
-            } else if (_batPercentRemaining < failureVoltage) {
-                failureText = qsTr("Low (below %1). Please recharge.").arg(failureVoltage)
-                state = stateMajorIssue
-            } else {
-                state = _nrClicked > 0 ? statePassed : statePending
-            }
-        }
-    }
+    property bool _batUnHealthy:        _unhealthySensors & Vehicle.SysStatusSensorBattery
+    property bool _batLow:              _batPercentRemaining < failureVoltage
 }

--- a/src/FlightDisplay/PreFlightCheckList.qml
+++ b/src/FlightDisplay/PreFlightCheckList.qml
@@ -24,17 +24,17 @@ Item {
     property var            _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property int            _checkState:            _activeVehicle ? (_activeVehicle.armed ? 1 + (buttonActuators.state + buttonMotors.state + buttonMission.state + buttonSoundOutput.state) / 4 / 4 : 0) : 0 ; // Shows progress of checks inside the checklist - unlocks next check steps in groups
 
-    function resetNrClicks() {
-        buttonHardware.resetNrClicks();
-        buttonBattery.resetNrClicks();
-        buttonRC.resetNrClicks();
-        buttonActuators.resetNrClicks();
-        buttonMotors.resetNrClicks();
-        buttonMission.resetNrClicks();
-        buttonSoundOutput.resetNrClicks();
-        buttonPayload.resetNrClicks();
-        buttonWeather.resetNrClicks();
-        buttonFlightAreaFree.resetNrClicks();
+    function reset() {
+        buttonHardware.reset();
+        buttonBattery.reset();
+        buttonRC.reset();
+        buttonActuators.reset();
+        buttonMotors.reset();
+        buttonMission.reset();
+        buttonSoundOutput.reset();
+        buttonPayload.reset();
+        buttonWeather.reset();
+        buttonFlightAreaFree.reset();
     }
 
     // Check list item data
@@ -43,9 +43,9 @@ Item {
 
         // Standard check list items (group 0) - Available from the start
         PreFlightCheckButton {
-            id: buttonHardware
-            name: "Hardware"
-            defaultText: "Props mounted? Wings secured? Tail secured?"
+            id:             buttonHardware
+            name:           qsTr("Hardware")
+            manualText:     qsTr("Props mounted? Wings secured? Tail secured?")
         }
         PreFlightBatteryCheck {
              id:                buttonBattery
@@ -64,22 +64,22 @@ Item {
         // Check list item group 1 - Require arming
         QGCLabel {text:qsTr("<i>Please arm the vehicle here.</i>") ; opacity: 0.2+0.8*(QGroundControl.multiVehicleManager.vehicles.count > 0) ; anchors.horizontalCenter:buttonHardware.horizontalCenter ; anchors.topMargin:40 ; anchors.bottomMargin:40;}
         PreFlightCheckButton {
-           id: buttonActuators
-           name: "Actuators"
-           group: 1
-           defaultText: "Move all control surfaces. Did they work properly?"
+           id:              buttonActuators
+           name:            qsTr("Actuators")
+           group:           1
+           manualText:      qsTr("Move all control surfaces. Did they work properly?")
         }
         PreFlightCheckButton {
-           id: buttonMotors
-           name: "Motors"
-           group: 1
-           defaultText: "Propellers free? Then throttle up gently. Working properly?"
+           id:              buttonMotors
+           name:            qsTr("Motors")
+           group:           1
+           manualText:      qsTr("Propellers free? Then throttle up gently. Working properly?")
         }
         PreFlightCheckButton {
-           id: buttonMission
-           name: "Mission"
-           group: 1
-           defaultText: "Please confirm mission is valid (waypoints valid, no terrain collision)."
+           id:          buttonMission
+           name:        qsTr("Mission")
+           group:       1
+           manualText:  qsTr("Please confirm mission is valid (waypoints valid, no terrain collision).")
         }
         PreFlightSoundCheck {
            id:      buttonSoundOutput
@@ -89,24 +89,22 @@ Item {
         // Check list item group 2 - Final checks before launch
         QGCLabel {text:qsTr("<i>Last preparations before launch</i>") ; opacity : 0.2+0.8*(_checkState >= 2); anchors.horizontalCenter:buttonHardware.horizontalCenter}
         PreFlightCheckButton {
-           id: buttonPayload
-           name: "Payload"
-           group: 2
-           defaultText: "Configured and started?"
-           pendingText: "Payload lid closed?"
+           id:          buttonPayload
+           name:        qsTr("Payload")
+           group:       2
+           manualText:  qsTr("Configured and started? Payload lid closed?")
         }
         PreFlightCheckButton {
-           id: buttonWeather
-           name: "Wind & weather"
-           group: 2
-           defaultText: "OK for your platform?"
-           pendingText: "Launching into the wind?"
+           id:          buttonWeather
+           name:        "Wind & weather"
+           group:       2
+           manualText:  qsTr("OK for your platform? Lauching into the wind?")
         }
         PreFlightCheckButton {
-           id: buttonFlightAreaFree
-           name: "Flight area"
-           group: 2
-           defaultText: "Launch area and path free of obstacles/people?"
+           id:          buttonFlightAreaFree
+           name:        qsTr("Flight area")
+           group:       2
+           manualText:  qsTr("Launch area and path free of obstacles/people?")
         }
     } // Object Model
 }

--- a/src/FlightDisplay/PreFlightRCCheck.qml
+++ b/src/FlightDisplay/PreFlightRCCheck.qml
@@ -14,27 +14,11 @@ import QGroundControl.Controls  1.0
 import QGroundControl.Vehicle   1.0
 
 PreFlightCheckButton {
-    name:           qsTr("Radio Control")
-    pendingText:    qsTr("Receiving signal. Perform range test & confirm.")
-    failureText:    qsTr("No signal or invalid autopilot-RC config. Check RC and console.")
+    name:                   qsTr("Radio Control")
+    manualText:             qsTr("Receiving signal. Perform range test & confirm.")
+    telemetryTextFailure:   qsTr("No signal or invalid autopilot-RC config. Check RC and console.")
+    telemetryFailure:       _unhealthySensors & Vehicle.SysStatusSensorRCReceiver
 
-    property int _unhealthySensors: _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
     property var _activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
-
-    on_UnhealthySensorsChanged: updateItem()
-    on_ActiveVehicleChanged:    updateItem()
-
-    Component.onCompleted: updateItem()
-
-    function updateItem() {
-        if (!_activeVehicle) {
-            state = stateNotChecked
-        } else {
-            if (_unhealthySensors & Vehicle.SysStatusSensorRCReceiver) {
-                state = stateMajorIssue
-            } else {
-                state = _nrClicked > 0 ? statePassed : statePending
-            }
-        }
-    }
+    property int _unhealthySensors: _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
 }

--- a/src/FlightDisplay/PreFlightSensorsCheck.qml
+++ b/src/FlightDisplay/PreFlightSensorsCheck.qml
@@ -14,14 +14,16 @@ import QGroundControl.Controls  1.0
 import QGroundControl.Vehicle   1.0
 
 PreFlightCheckButton {
-    name: qsTr("Sensors")
+    name:               qsTr("Sensors")
+    telemetryFailure:   (_unhealthySensors & _allCheckedSensors) || !_gpsLock || _satCountFailure
 
     property int failureSatCount: -1    ///< -1 indicates no sat count check
 
+    property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property int    _unhealthySensors:  _activeVehicle ? _activeVehicle.sensorsUnhealthyBits : 0
     property bool   _gpsLock:           _activeVehicle ? _activeVehicle.gps.lock.rawValue >= 3 : 0
-    property bool   _satCount:          _activeVehicle ? _activeVehicle.gps.count : 0
-    property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
+    property int    _satCount:          _activeVehicle ? _activeVehicle.gps.count.rawValue : 0
+    property bool   _satCountFailure:   failureSatCount !== -1 && _satCount <= failureSatCount
     property int    _allCheckedSensors: Vehicle.SysStatusSensor3dMag |
                                         Vehicle.SysStatusSensor3dAccel |
                                         Vehicle.SysStatusSensor3dGyro |
@@ -29,37 +31,24 @@ PreFlightCheckButton {
                                         Vehicle.SysStatusSensorDifferentialPressure |
                                         Vehicle.SysStatusSensorGPS
 
+    on_GpsLockChanged:          updateTelemetryTextFailure()
+    on_SatCountFailureChanged:  updateTelemetryTextFailure()
+    on_UnhealthySensorsChanged: updateTelemetryTextFailure()
 
-    on_GpsLockChanged:          updateItem()
-    on_SatCountChanged:         updateItem()
-    on_UnhealthySensorsChanged: updateItem()
-    on_ActiveVehicleChanged:    updateItem()
+    Component.onCompleted: updateTelemetryTextFailure()
 
-    Component.onCompleted: updateItem()
-
-    function updateItem() {
-        if (!_activeVehicle) {
-            state = stateNotChecked
-        } else {
-            if(!(_unhealthySensors & _allCheckedSensors)) {
-                if (!_gpsLock) {
-                    pendingText = qsTr("Pending. Waiting for GPS lock.")
-                    state = statePending
-                } else if (failureSatCount !== -1 && _satCount <= failureSatCount) {
-                    pendingText = qsTr("Pending. Waiting for Sat Count > %1.").arg(failureSatCount)
-                    state = statePending
-                } else {
-                    state = statePassed
-                }
-            } else {
-                if (_unhealthySensors & Vehicle.SysStatusSensor3dMag)                       failureText=qsTr("Failure. Magnetometer issues. Check console.")
-                else if(_unhealthySensors & Vehicle.SysStatusSensor3dAccel)                 failureText=qsTr("Failure. Accelerometer issues. Check console.")
-                else if(_unhealthySensors & Vehicle.SysStatusSensor3dGyro)                  failureText=qsTr("Failure. Gyroscope issues. Check console.")
-                else if(_unhealthySensors & Vehicle.SysStatusSensorAbsolutePressure)        failureText=qsTr("Failure. Barometer issues. Check console.")
-                else if(_unhealthySensors & Vehicle.SysStatusSensorDifferentialPressure)    failureText=qsTr("Failure. Airspeed sensor issues. Check console.")
-                else if(_unhealthySensors & Vehicle.SysStatusSensorGPS)                     failureText=qsTr("Failure. No valid or low quality GPS signal. Check console.")
-                state = stateMajorIssue
-            }
+    function updateTelemetryTextFailure() {
+        if(_unhealthySensors & _allCheckedSensors) {
+            if (_unhealthySensors & Vehicle.SysStatusSensor3dMag)                       telemetryTextFailure = qsTr("Failure. Magnetometer issues. Check console.")
+            else if(_unhealthySensors & Vehicle.SysStatusSensor3dAccel)                 telemetryTextFailure = qsTr("Failure. Accelerometer issues. Check console.")
+            else if(_unhealthySensors & Vehicle.SysStatusSensor3dGyro)                  telemetryTextFailure = qsTr("Failure. Gyroscope issues. Check console.")
+            else if(_unhealthySensors & Vehicle.SysStatusSensorAbsolutePressure)        telemetryTextFailure = qsTr("Failure. Barometer issues. Check console.")
+            else if(_unhealthySensors & Vehicle.SysStatusSensorDifferentialPressure)    telemetryTextFailure = qsTr("Failure. Airspeed sensor issues. Check console.")
+            else if(_unhealthySensors & Vehicle.SysStatusSensorGPS)                     telemetryTextFailure = qsTr("Failure. No valid or low quality GPS signal. Check console.")
+        } else if (!_gpsLock) {
+            telemetryTextFailure = qsTr("Pending. Waiting for GPS lock.")
+        } else if (_satCountFailure) {
+            telemetryTextFailure = qsTr("Pending. Waiting for Sat Count > %1.").arg(failureSatCount)
         }
     }
 }

--- a/src/FlightDisplay/PreFlightSoundCheck.qml
+++ b/src/FlightDisplay/PreFlightSoundCheck.qml
@@ -11,36 +11,10 @@ import QtQuick 2.3
 
 import QGroundControl           1.0
 import QGroundControl.Controls  1.0
-import QGroundControl.Vehicle   1.0
 
 PreFlightCheckButton {
-    name:           qsTr("Sound output")
-    pendingText:    qsTr("QGC audio output enabled. System audio output enabled, too?")
-    failureText:    qsTr("Failure, QGC audio output is disabled. Please enable it under application settings->general to hear audio warnings!")
-
-    property bool   _audioMuted:     QGroundControl.settingsManager.appSettings.audioMuted.rawValue
-    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
-
-    on_AudioMutedChanged:       updateItem()
-    on_ActiveVehicleChanged:    updateItem()
-
-    Component.onCompleted: updateItem()
-
-    function onActiveVehicleChanged() {
-        buttonSoundOutput.updateItem();     // Just updated here for initialization once we connect to a vehicle
-        updateVehicleDependentItems();
-    }
-
-    function updateItem() {
-        if (!_activeVehicle) {
-            state = stateNotChecked
-        } else {
-            if (_audioMuted) {
-                state = stateMajorIssue
-                _nrClicked = 0
-            } else {
-                state = _nrClicked > 0 ? statePassed : statePending
-            }
-        }
-    }
+    name:                   qsTr("Sound output")
+    manualText:             qsTr("QGC audio output enabled. System audio output enabled, too?")
+    telemetryTextFailure:   qsTr("QGC audio output is disabled. Please enable it under application settings->general to hear audio warnings!")
+    telemetryFailure:       QGroundControl.settingsManager.appSettings.audioMuted.rawValue
 }

--- a/src/QmlControls/PreFlightCheckButton.qml
+++ b/src/QmlControls/PreFlightCheckButton.qml
@@ -15,103 +15,120 @@ import QGroundControl               1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
 
+/// The PreFlightCheckButtons supports creating a button which the user then has to verify/click to confirm a check.
+/// It also supports failing the check based on values from within the system: telemetry or QGC app values.
+///
+/// Two types of checks may be included on the button:
+///     Manual - This is simply a check which the user must verify and confirm. It is not based on any system state.
+///     Telemetry - This type of check can fail due to some state within the system. A telemetry check failure can be
+///                 a hard stop in that there is no way to pass the checklist until the system state resolves itself.
+///                 Or it can also optionall be override by the user.
+/// If a button uses both manual and telemetry checks, the telemetry check takes precendence and must be passed first.
 QGCButton {
-    property string name:           ""
-    property int    group:          0
-    property string defaultText:    qsTr("Not checked yet")
-    property string pendingText:    ""
-    property string failureText:    qsTr("Failure. Check console.")
-    property int    state:         stateNotChecked
+    property string name:                  ""
+    property int    group:                  0
+    property string manualText:             ""      ///< text to show for a manual check, "" signals no manual check
+    property string telemetryTextOverride:  ""      ///< text to show if telemetry check failed and override is allowed
+    property string telemetryTextFailure            ///< text to show if telemetry check failed (override not allowed)
+    property bool   telemetryFailure:       false   ///< true: telemetry check failing, false: telemetry check passing
+    property bool   passed:                 _manualState === _statePassed && _telemetryState === _statePassed
 
-    readonly property int stateNotChecked:  0
-    readonly property int statePending:     1
-    readonly property int stateMinorIssue:  2
-    readonly property int stateMajorIssue:  3
-    readonly property int statePassed:      4
+    property int _manualState:          manualText === "" ? _statePassed : _statePending
+    property int _telemetryState:       _statePassed
+    property int _horizontalPadding:    ScreenTools.defaultFontPixelWidth
+    property int _verticalPadding:      Math.round(ScreenTools.defaultFontPixelHeight / 2)
+    property real _stateFlagWidth:      ScreenTools.defaultFontPixelWidth * 4
 
-    property var    _color:         qgcPal.button
-    property int    _nrClicked:     0
-    property string _text:          name + ": " + defaultText
+    readonly property int _statePending:    0   ///< Telemetry check has failed or manual check not yet verified, user can click to make it pass
+    readonly property int _stateFailed:     1   ///< Telemetry check has failed, user cannot click to make it pass
+    readonly property int _statePassed:     2   ///< Check has passed
+
+    readonly property color _passedColor:   Qt.rgba(0.27,0.67,0.42,1)
+    readonly property color _pendingColor:  Qt.rgba(0.9,0.47,0.2,1)
+    readonly property color _failedColor:   Qt.rgba(0.92,0.22,0.22,1)
+
+    property string _text: "<b>" + name +"</b>: " +
+                           ((_telemetryState !== _statePassed) ?
+                               (_telemetryState === _statePending ? telemetryTextOverride : telemetryTextFailure) :
+                               (_manualState !== _statePassed ? manualText : qsTr("OK")))
+    property color  _color: _telemetryState === _statePassed && _manualState === _statePassed ?
+                                _passedColor :
+                                (_telemetryState == _stateFailed ?
+                                     _failedColor :
+                                     (_telemetryState === _statePending || _manualState === _statePending ?
+                                          _pendingColor :
+                                          _failedColor))
+
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _allowTelemetryFailureOverride:  telemetryTextOverride !== ""
 
-    enabled:    (!_activeVehicle || _activeVehicle.connectionLost) ? false : preFlightCheckList._checkState >= group
-    opacity:    (!_activeVehicle || _activeVehicle.connectionLost) ? 0.4 : 0.2 + (0.8 * (preFlightCheckList._checkState >= group))
+    enabled:    preFlightCheckList._checkState >= group
+    opacity:    0.2 + (0.8 * (preFlightCheckList._checkState >= group))
     width:      40 * ScreenTools.defaultFontPixelWidth
 
     style: ButtonStyle {
-        background: Rectangle {color:_color; border.color: qgcPal.button; radius:3}
+        padding {
+            top:    _verticalPadding
+            bottom: _verticalPadding
+            left:   (_horizontalPadding * 2) + _stateFlagWidth
+            right:  _horizontalPadding
+        }
+
+        background: Rectangle {
+            color:          qgcPal.button
+            border.color:   qgcPal.button;
+            radius:         3
+
+            Rectangle {
+                color:          _color
+                anchors.left:   parent.left
+                anchors.top:    parent.top
+                anchors.bottom: parent.bottom
+                width:          _stateFlagWidth
+            }
+        }
+
         label: Label {
             text:                   _text
             wrapMode:               Text.WordWrap
             horizontalAlignment:    Text.AlignHCenter
-            color:                  state > 0 ? qgcPal.mapWidgetBorderLight : qgcPal.buttonText
+            color:                  qgcPal.buttonText
         }
     }
 
-    onPendingTextChanged: { if (state === statePending) { getTextFromState(); getColorFromState(); } }
-    onFailureTextChanged: { if (state === stateMajorIssue) { getTextFromState(); getColorFromState(); } }
-    onStateChanged: { getTextFromState(); getColorFromState(); }
+    onTelemetryFailureChanged: {
+        if (telemetryFailure) {
+            // We have a new telemetry failure, reset user pass
+            _telemetryState = _allowTelemetryFailureOverride ? _statePending : _stateFailed
+        } else {
+            _telemetryState = _statePassed
+        }
+    }
+
     onClicked: {
-        if (state <= statePending) {
-            _nrClicked = _nrClicked + 1 //Only allow click-counter to increase when not failed yet
+        if (telemetryFailure && !_allowTelemetryFailureOverride) {
+            // No way to proceed past this failure
+            return
         }
-        updateItem()
+        if (telemetryFailure && _allowTelemetryFailureOverride && _telemetryState !== _statePassed) {
+            // User is allowed to proceed past this failure
+            _telemetryState = _statePassed
+            return
+        }
+        if (manualText !== "" && _manualState !== _statePassed) {
+            // User is confirming a manual check
+            _manualState = _statePassed
+        }
     }
 
-    function updateItem() {
-        // This is the default updateFunction. It assumes the item is a MANUAL check list item, i.e. one that
-        // only requires user clicks (one click if pendingText="", two clicks otherwise) for completion.
-
-        if (_nrClicked === 0) {
-            state = stateNotChecked
-        } else if (_nrClicked === 1) {
-            if (pendingText.length === 0) {
-                state = statePassed
-            } else {
-                state = statePending
-            }
+    function reset() {
+        _manualState = manualText === "" ? statePass : _statePending
+        if (telemetryFailure) {
+            _telemetryState = _allowTelemetryFailureOverride ? _statePending : _stateFailed
         } else {
-            state = statePassed
-        }
-
-        getTextFromState();
-        getColorFromState();
-    }
-
-    function getTextFromState() {
-        if (state === stateNotChecked) {
-            _text = qsTr(name) + ": " + qsTr(defaultText)
-        } else if (state === statePending) {
-            _text = "<b>"+qsTr(name)+"</b>" +": " + pendingText
-        } else if (state === stateMinorIssue) {
-            _text = "<b>"+qsTr(name)+"</b>" +": " + qsTr("Minor problem")
-        } else if (state === stateMajorIssue) {
-            _text = "<b>"+qsTr(name)+"</b>" +": " + failureText
-        } else if (state === statePassed) {
-            _text = "<b>"+qsTr(name)+"</b>" +": " + qsTr("OK")
-        } else {
-            console.warn("Internal Error: invalid state", state)
+            _telemetryState = _statePassed
         }
     }
 
-    function getColorFromState() {
-        if (state === stateNotChecked) {
-            _color = qgcPal.button
-        } else if (state === statePending) {
-            _color = Qt.rgba(0.9,0.47,0.2,1)
-        } else if (state === stateMinorIssue) {
-            _color = Qt.rgba(1.0,0.6,0.2,1)
-        } else if (state === stateMajorIssue) {
-            _color = Qt.rgba(0.92,0.22,0.22,1)
-        } else if (state === statePassed ) {
-            _color = Qt.rgba(0.27,0.67,0.42,1)
-        } else {
-            console.warn("Internal Error: invalid state", state)
-        }
-    }
-
-    function resetNrClicks() {
-        _nrClicked=0;
-        updateItem();
-    }
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 }


### PR DESCRIPTION
* New implementation makes it easier to implement check buttons
* Changed visuals such that they are readable outdoors on a tablet
* Checklist is only available when you have a vehicle connected
* Should be a mostly no-op functionality wise except for manual checks only support single step now.

![screen shot 2018-05-25 at 10 07 19 am](https://user-images.githubusercontent.com/5876851/40557022-9aa75ea8-6003-11e8-9fc7-8b928eba6f56.png)

Known work left:
* I've tested but I'm sure I still broke something. I'll be continuing on this right away. So I'll find anything as I go along.
* Move the color usage into QGCPalette
* Support double manual steps