### PR TITLE
Cleanup layout issues throughout QGC

### DIFF
--- a/src/AnalyzeView/LogDownloadPage.qml
+++ b/src/AnalyzeView/LogDownloadPage.qml
@@ -51,8 +51,7 @@ AnalyzePage {
 
             TableView {
                 id: tableView
-                anchors.top:        parent.top
-                anchors.bottom:     parent.bottom
+                Layout.fillHeight:  true
                 model:              logController.model
                 selectionMode:      SelectionMode.MultiSelection
                 Layout.fillWidth:   true

--- a/src/AnalyzeView/MavlinkConsolePage.qml
+++ b/src/AnalyzeView/MavlinkConsolePage.qml
@@ -26,7 +26,7 @@ AnalyzePage {
     pageName:        qsTr("Mavlink Console")
     pageDescription: qsTr("Mavlink Console provides a connection to the vehicle's system shell.")
 
-    property bool loaded: false
+    property bool isLoaded: false
 
     Component {
         id: pageComponent
@@ -41,7 +41,7 @@ AnalyzePage {
 
                 onDataChanged: {
                     // Keep the view in sync if the button is checked
-                    if (loaded) {
+                    if (isLoaded) {
                         if (followTail.checked) {
                             listview.positionViewAtEnd();
                         }
@@ -69,11 +69,10 @@ AnalyzePage {
 
             QGCListView {
                 Component.onCompleted: {
-                    loaded = true
+                    isLoaded = true
                 }
                 Layout.fillHeight: true
-                anchors.left:      parent.left
-                anchors.right:     parent.right
+                Layout.fillWidth:  true
                 clip:              true
                 id:                listview
                 model:             conController
@@ -86,8 +85,7 @@ AnalyzePage {
             }
 
             RowLayout {
-                anchors.left:  parent.left
-                anchors.right: parent.right
+                Layout.fillWidth:   true
                 QGCTextField {
                     id:               command
                     Layout.fillWidth: true
@@ -105,7 +103,7 @@ AnalyzePage {
                     checked:   true
 
                     onCheckedChanged: {
-                        if (checked && loaded) {
+                        if (checked && isLoaded) {
                             listview.positionViewAtEnd();
                         }
                     }

--- a/src/AutoPilotPlugins/PX4/CameraComponent.qml
+++ b/src/AutoPilotPlugins/PX4/CameraComponent.qml
@@ -121,14 +121,14 @@ SetupPage {
                         }
 
                         QGCLabel {
-                            anchors.baseline:   camTrigCombo.baseline
+                            Layout.alignment:   Qt.AlignVCenter
                             text:               qsTr("Trigger mode")
                         }
                         FactComboBox {
-                            id:                 camTrigCombo
                             fact:               _camTriggerMode
                             indexModel:         false
                             enabled:            !_rebooting
+                            Layout.alignment:   Qt.AlignVCenter
                             Layout.minimumWidth: _editFieldWidth
                             onActivated: {
                                 applyAndRestart.visible = true
@@ -136,14 +136,14 @@ SetupPage {
                         }
 
                         QGCLabel {
-                            anchors.baseline:   camInterfaceCombo.baseline
+                            Layout.alignment:   Qt.AlignVCenter
                             text:               qsTr("Trigger interface")
                         }
                         FactComboBox {
-                            id:                 camInterfaceCombo
                             fact:               _camTriggerInterface
                             indexModel:         false
                             enabled:            !_rebooting && (_camTriggerInterface ? true : false)
+                            Layout.alignment:   Qt.AlignVCenter
                             Layout.minimumWidth: _editFieldWidth
                             onActivated: {
                                 applyAndRestart.visible = true
@@ -152,7 +152,7 @@ SetupPage {
 
                         QGCLabel {
                             text:               qsTr("Time Interval")
-                            anchors.baseline:   timeIntervalField.baseline
+                            Layout.alignment:   Qt.AlignVCenter
                             color:              qgcPal.text
                             visible:            timeIntervalField.visible
                         }
@@ -161,12 +161,13 @@ SetupPage {
                             fact:               controller.getParameterFact(-1, "TRIG_INTERVAL", false)
                             showUnits:          true
                             Layout.minimumWidth: _editFieldWidth
+                            Layout.alignment:   Qt.AlignVCenter
                             visible:            _camTriggerMode.value === 2
                         }
 
                         QGCLabel {
                             text:               qsTr("Distance Interval")
-                            anchors.baseline:   trigDistField.baseline
+                            Layout.alignment:   Qt.AlignVCenter
                             color:              qgcPal.text
                             visible:            trigDistField.visible
                         }
@@ -174,6 +175,7 @@ SetupPage {
                             id:                 trigDistField
                             fact:               controller.getParameterFact(-1, "TRIG_DISTANCE", false)
                             showUnits:          true
+                            Layout.alignment:   Qt.AlignVCenter
                             Layout.minimumWidth: _editFieldWidth
                             visible:            _camTriggerMode.value === 3
                         }
@@ -199,8 +201,8 @@ SetupPage {
                             }
 
                             Row {
-                                spacing:                    _margins
-                                anchors.horizontalCenter:   parent.horizontalCenter
+                                spacing:                _margins
+                                Layout.alignment:       Qt.AlignHCenter
 
                                 GridLayout {
                                     rows: 2

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -348,9 +348,9 @@ SetupPage {
                 } // QGCGroupBox - Battery settings
 
                 QGCGroupBox {
-                    anchors.left:   batteryGroup.left
-                    anchors.right:  batteryGroup.right
-                    title:          qsTr("ESC PWM Minimum and Maximum Calibration")
+                    Layout.maximumWidth:    batteryGroup.width
+                    Layout.fillWidth:       true
+                    title:                  qsTr("ESC PWM Minimum and Maximum Calibration")
 
                     ColumnLayout {
                         anchors.left:   parent.left
@@ -383,10 +383,10 @@ SetupPage {
                 }
 
                 QGCGroupBox {
-                    anchors.left:   batteryGroup.left
-                    anchors.right:  batteryGroup.right
-                    title:          qsTr("UAVCAN Bus Configuration")
-                    visible:        showUAVCAN.checked
+                    Layout.maximumWidth:    batteryGroup.width
+                    Layout.fillWidth:       true
+                    title:                  qsTr("UAVCAN Bus Configuration")
+                    visible:                showUAVCAN.checked
 
                     Row {
                         id:         uavCanConfigRow
@@ -407,10 +407,10 @@ SetupPage {
                 }
 
                 QGCGroupBox {
-                    anchors.left:   batteryGroup.left
-                    anchors.right:  batteryGroup.right
-                    title:          qsTr("UAVCAN Motor Index and Direction Assignment")
-                    visible:        showUAVCAN.checked
+                    Layout.maximumWidth:    batteryGroup.width
+                    Layout.fillWidth:       true
+                    title:                  qsTr("UAVCAN Motor Index and Direction Assignment")
+                    visible:                showUAVCAN.checked
 
                     ColumnLayout {
                         anchors.left:   parent.left
@@ -456,10 +456,10 @@ SetupPage {
                 }
 
                 QGCGroupBox {
-                    anchors.left:   batteryGroup.left
-                    anchors.right:  batteryGroup.right
-                    title:          qsTr("Advanced Power Settings")
-                    visible:        showAdvanced.checked
+                    Layout.maximumWidth:    batteryGroup.width
+                    Layout.fillWidth:       true
+                    title:                  qsTr("Advanced Power Settings")
+                    visible:                showAdvanced.checked
 
                     ColumnLayout {
                         anchors.left:   parent.left
@@ -487,7 +487,7 @@ SetupPage {
                             text:               qsTr("Batteries show less voltage at high throttle. Enter the difference in Volts between idle throttle and full ") +
                                                 qsTr("throttle, divided by the number of battery cells. Leave at the default if unsure. ") +
                                                 highlightPrefix + qsTr("If this value is set too high, the battery might be deep discharged and damaged.") + highlightSuffix
-                            Layout.fillWidth:   true
+                            Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 60
                         }
 
                         Row {

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -193,9 +193,9 @@ QGCView {
 
                     QGCButton {
                         Layout.fillWidth:   true
+                        Layout.alignment:   Qt.AlignHCenter
                         text:               qsTr("Leave plan on vehicle")
-                        anchors.horizontalCenter:   parent.horizontalCenter
-                        onClicked:                  hideDialog()
+                        onClicked:          hideDialog()
                     }
                 }
             }

--- a/src/FlightDisplay/MultiVehicleList.qml
+++ b/src/FlightDisplay/MultiVehicleList.qml
@@ -107,8 +107,7 @@ Item {
                 spacing:            _margin
 
                 RowLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.left
+                    Layout.fillWidth:       true
 
                     QGCLabel {
                         Layout.alignment:   Qt.AlignTop
@@ -121,14 +120,14 @@ Item {
                         spacing:            _margin
 
                         FlightModeMenu {
-                            anchors.horizontalCenter:   parent.horizontalCenter
+                            Layout.alignment:           Qt.AlignHCenter
                             font.pointSize:             ScreenTools.largeFontPointSize
                             color:                      _textColor
                             activeVehicle:              _vehicle
                         }
 
                         QGCLabel {
-                            anchors.horizontalCenter:   parent.horizontalCenter
+                            Layout.alignment:           Qt.AlignHCenter
                             text:                       _vehicle.armed ? qsTr("Armed") : qsTr("Disarmed")
                             color:                      _textColor
                         }

--- a/src/PlanView/PlanToolBar.qml
+++ b/src/PlanView/PlanToolBar.qml
@@ -157,11 +157,10 @@ Rectangle {
         columns:                3
 
         GridLayout {
-            anchors.verticalCenter: parent.verticalCenter
             columns:                8
             rowSpacing:             _rowSpacing
             columnSpacing:          _labelToValueSpacing
-            Layout.alignment:       Qt.AlignHCenter
+            Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
 
             QGCLabel {
                 text:               qsTr("Selected Waypoint")
@@ -212,11 +211,10 @@ Rectangle {
         }
 
         GridLayout {
-            anchors.verticalCenter: parent.verticalCenter
             columns:                5
             rowSpacing:             _rowSpacing
             columnSpacing:          _labelToValueSpacing
-            Layout.alignment:       Qt.AlignHCenter
+            Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
 
             QGCLabel {
                 text:               qsTr("Total Mission")
@@ -249,11 +247,10 @@ Rectangle {
         }
 
         GridLayout {
-            anchors.verticalCenter: parent.verticalCenter
             columns:                3
             rowSpacing:             _rowSpacing
             columnSpacing:          _labelToValueSpacing
-            Layout.alignment:       Qt.AlignHCenter
+            Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
             visible:                _batteryInfoAvailable
 
             QGCLabel {

--- a/src/PlanView/SectionHeader.qml
+++ b/src/PlanView/SectionHeader.qml
@@ -46,16 +46,14 @@ FocusScope {
             }
 
             QGCLabel {
-                id:             label
-                anchors.left:   parent.left
-                anchors.right:  parent.right
+                id:                 label
+                Layout.fillWidth:   true
 
                 QGCColoredImage {
                     id:                     image
                     width:                  label.height / 2
                     height:                 width
-                    anchors.right:          parent.right
-                    anchors.verticalCenter: parent.verticalCenter
+                    Layout.alignment:       Qt.AlignRight | Qt.AlignVCenter
                     source:                 "/qmlimages/arrow-down.png"
                     color:                  qgcPal.text
                     visible:                !_root.checked
@@ -63,10 +61,9 @@ FocusScope {
             }
 
             Rectangle {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                height:         1
-                color:          qgcPal.text
+                Layout.fillWidth:   true
+                height:             1
+                color:              qgcPal.text
             }
         }
     }

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -139,7 +139,7 @@ Rectangle {
 
             QGCCheckBox {
                 id:                 relAlt
-                anchors.left:       parent.left
+                Layout.alignment:   Qt.AlignLeft
                 text:               qsTr("Relative altitude")
                 checked:            missionItem.cameraCalc.distanceToSurfaceRelative
                 enabled:            missionItem.cameraCalc.isManualCamera && !missionItem.followTerrain
@@ -173,12 +173,11 @@ Rectangle {
             }
 
             GridLayout {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                columnSpacing:  _margin
-                rowSpacing:     _margin
-                columns:        2
-                visible:        followsTerrainCheckBox.checked
+                Layout.fillWidth:   true
+                columnSpacing:      _margin
+                rowSpacing:         _margin
+                columns:            2
+                visible:            followsTerrainCheckBox.checked
 
                 QGCLabel { text: qsTr("Tolerance") }
                 FactTextField {

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -77,7 +77,7 @@ TextField {
                 onWidthChanged:         control._helpLayoutWidth = unitsHelpLayout.width
 
                 Text {
-                    anchors.verticalCenter: parent.verticalCenter
+                    Layout.alignment:       Qt.AlignVCenter
                     text:                   control.unitsLabel
                     font.pointSize:         backgroundItem.showHelp ? ScreenTools.smallFontPointSize : ScreenTools.defaultFontPointSize
                     font.family:            ScreenTools.normalFontFamily
@@ -87,10 +87,9 @@ TextField {
                 }
 
                 Rectangle {
-                    anchors.margins:    2
-                    anchors.top:        parent.top
-                    anchors.bottom:     parent.bottom
-                    anchors.right:      parent.right
+                    Layout.margins:     2
+                    Layout.fillHeight:  true
+                    Layout.alignment:   Qt.AlignRight
                     width:              height * 0.75
                     color:              control.textColor
                     radius:             2

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -210,8 +210,7 @@ Rectangle {
             spacing:    _defaultTextHeight / 2
 
             QGCLabel {
-                anchors.left:           parent.left
-                anchors.right:          parent.right
+                Layout.fillWidth:       true
                 text:                   qsTr("Vehicle Setup")
                 wrapMode:               Text.WordWrap
                 horizontalAlignment:    Text.AlignHCenter

--- a/src/ui/AppSettings.qml
+++ b/src/ui/AppSettings.qml
@@ -58,8 +58,7 @@ Rectangle {
             property real _maxButtonWidth: 0
 
             QGCLabel {
-                anchors.left:           parent.left
-                anchors.right:          parent.right
+                Layout.fillWidth:       true
                 text:                   qsTr("Application Settings")
                 wrapMode:               Text.WordWrap
                 horizontalAlignment:    Text.AlignHCenter

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -385,11 +385,11 @@ QGCView {
                             visible:    _savePath.visible && !ScreenTools.isMobile
 
                             QGCLabel {
-                                anchors.baseline:   savePathBrowse.baseline
-                                text:               qsTr("File Save Path:")
+                                Layout.alignment:       Qt.AlignVCenter
+                                text:                   qsTr("File Save Path:")
                             }
                             QGCLabel {
-                                anchors.baseline:       savePathBrowse.baseline
+                                Layout.alignment:       Qt.AlignVCenter
                                 Layout.maximumWidth:    _panelWidth * 0.5
                                 elide:                  Text.ElideMiddle
                                 text:                   _savePath.rawValue === "" ? qsTr("<not set>") : _savePath.value

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -81,10 +81,9 @@ Rectangle {
         //---------------------------------------------
         // Toolbar Row
         Row {
-            id:             viewRow
-            anchors.top:    parent.top
-            anchors.bottom: parent.bottom
-            spacing:        ScreenTools.defaultFontPixelWidth / 2
+            id:                 viewRow
+            Layout.fillHeight:  true
+            spacing:            ScreenTools.defaultFontPixelWidth / 2
 
             ExclusiveGroup { id: mainActionGroup }
 
@@ -153,7 +152,7 @@ Rectangle {
             width:                  ScreenTools.defaultFontPixelHeight * 8
             text:                   "Vehicle " + (_activeVehicle ? _activeVehicle.id : "None")
             visible:                QGroundControl.multiVehicleManager.vehicles.count > 1
-            anchors.verticalCenter: parent.verticalCenter
+            Layout.alignment:       Qt.AlignVCenter
 
             menu: vehicleMenu
 
@@ -175,14 +174,15 @@ Rectangle {
             property var vehicleMenuItems: []
 
             function updateVehicleMenu() {
+                var i;
                 // Remove old menu items
-                for (var i = 0; i < vehicleMenuItems.length; i++) {
+                for (i = 0; i < vehicleMenuItems.length; i++) {
                     vehicleMenu.removeItem(vehicleMenuItems[i])
                 }
                 vehicleMenuItems.length = 0
 
                 // Add new items
-                for (var i=0; i<QGroundControl.multiVehicleManager.vehicles.count; i++) {
+                for (i = 0; i < QGroundControl.multiVehicleManager.vehicles.count; i++) {
                     var vehicle = QGroundControl.multiVehicleManager.vehicles.get(i)
                     var menuItem = vehicleMenuItemComponent.createObject(null, { "text": "Vehicle " + vehicle.id })
                     vehicleMenuItems.push(menuItem)
@@ -199,10 +199,9 @@ Rectangle {
         }
 
         MainToolBarIndicators {
-            anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.66
-            anchors.top:        parent.top
-            anchors.bottom:     parent.bottom
             Layout.fillWidth:   true
+            Layout.fillHeight:  true
+            Layout.margins:     ScreenTools.defaultFontPixelHeight * 0.66
         }
     }
 


### PR DESCRIPTION
There were several layout errors throughout the program that went unnoticed until I built it with Qt 5.11. 

In summary: Don't use `anchor` anything within a layout control.

@DonLakeFlyer I didn't test 5.10 but 5.11 is working fine on macOS, iOS, Android and Windows (I have not yet tested on Linux).