### PR TITLE
Mavlink Console Improvements

### DIFF
--- a/src/AnalyzeView/MavlinkConsoleController.cc
+++ b/src/AnalyzeView/MavlinkConsoleController.cc
@@ -33,10 +33,23 @@ MavlinkConsoleController::~MavlinkConsoleController()
 void
 MavlinkConsoleController::sendCommand(QString command)
 {
+    _history.append(command);
     command.append("\n");
     _sendSerialData(qPrintable(command));
     _cursor_home_pos = -1;
     _cursor = rowCount();
+}
+
+QString
+MavlinkConsoleController::historyUp(const QString& current)
+{
+    return _history.up(current);
+}
+
+QString
+MavlinkConsoleController::historyDown(const QString& current)
+{
+    return _history.down(current);
 }
 
 void
@@ -191,4 +204,44 @@ MavlinkConsoleController::writeLine(int line, const QByteArray &text)
     }
     auto idx = index(line);
     setData(idx, data(idx, Qt::DisplayRole).toString() + text);
+}
+
+void MavlinkConsoleController::CommandHistory::append(const QString& command)
+{
+    if (command.length() > 0) {
+
+        // do not append duplicates
+        if (_history.length() == 0 || _history.last() != command) {
+
+            if (_history.length() >= maxHistoryLength) {
+                _history.removeFirst();
+            }
+            _history.append(command);
+        }
+    }
+    _index = _history.length();
+}
+
+QString MavlinkConsoleController::CommandHistory::up(const QString& current)
+{
+    if (_index <= 0)
+        return current;
+
+    --_index;
+    if (_index < _history.length()) {
+        return _history[_index];
+    }
+    return "";
+}
+
+QString MavlinkConsoleController::CommandHistory::down(const QString& current)
+{
+    if (_index >= _history.length())
+        return current;
+
+    ++_index;
+    if (_index < _history.length()) {
+        return _history[_index];
+    }
+    return "";
 }

--- a/src/AnalyzeView/MavlinkConsoleController.h
+++ b/src/AnalyzeView/MavlinkConsoleController.h
@@ -27,13 +27,12 @@ class MavlinkConsoleController : public QStringListModel
 
 public:
     MavlinkConsoleController();
-    ~MavlinkConsoleController();
+    virtual ~MavlinkConsoleController();
 
-public slots:
-    void sendCommand(QString command);
+    Q_INVOKABLE void sendCommand(QString command);
 
-signals:
-    void cursorChanged(int);
+    Q_INVOKABLE QString historyUp(const QString& current);
+    Q_INVOKABLE QString historyDown(const QString& current);
 
 private slots:
     void _setActiveVehicle  (Vehicle* vehicle);
@@ -44,10 +43,23 @@ private:
     void _sendSerialData(QByteArray, bool close = false);
     void writeLine(int line, const QByteArray &text);
 
+    class CommandHistory
+    {
+    public:
+        void append(const QString& command);
+        QString up(const QString& current);
+        QString down(const QString& current);
+    private:
+        static constexpr int maxHistoryLength = 100;
+        QList<QString> _history;
+        int _index = 0;
+    };
+
     int           _cursor_home_pos;
     int           _cursor;
     QByteArray    _incoming_buffer;
     Vehicle*      _vehicle;
     QList<QMetaObject::Connection> _uas_connections;
+    CommandHistory _history;
 
 };

--- a/src/AnalyzeView/MavlinkConsolePage.qml
+++ b/src/AnalyzeView/MavlinkConsolePage.qml
@@ -96,6 +96,15 @@ AnalyzePage {
                         conController.sendCommand(text)
                         text = ""
                     }
+                    Keys.onPressed: {
+                        if (event.key == Qt.Key_Up) {
+                            text = conController.historyUp(text);
+                            event.accepted = true;
+                        } else if (event.key == Qt.Key_Down) {
+                            text = conController.historyDown(text);
+                            event.accepted = true;
+                        }
+                    }
                 }
 
                 QGCButton {

--- a/src/AnalyzeView/MavlinkConsolePage.qml
+++ b/src/AnalyzeView/MavlinkConsolePage.qml
@@ -53,7 +53,7 @@ AnalyzePage {
                 id: delegateItem
                 Rectangle {
                     color:  qgcPal.windowShade
-                    height: Math.round(ScreenTools.defaultFontPixelHeight * 0.5 + field.height)
+                    height: Math.round(ScreenTools.defaultFontPixelHeight * 0.1 + field.height)
                     width:  listview.width
 
                     QGCLabel {


### PR DESCRIPTION
- add a command history
- reduce line spacing to 1.1

before:
![qgc_console_linespacing_1 5](https://user-images.githubusercontent.com/281593/40576619-e3d4473e-60f9-11e8-87ec-f5cce3fdda59.png)

after:
![qgc_console_linespacing_1 1](https://user-images.githubusercontent.com/281593/40576624-e8e75a2c-60f9-11e8-9be2-6df320a3f7fc.png)

Making the text selectable does not seem to be a simple thing, because each line is displayed in a separate text UI element.

Partially fixes #5945