### PR TITLE
ArduCopter 3.6 tuning page fixes

### DIFF
--- a/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
@@ -39,13 +39,16 @@ SetupPage {
             property real _hoverTuneMax:    _throttleMidExists ? 800 : 1
             property real _hoverTuneStep:   _throttleMidExists ? 10 : 0.01
 
-            property Fact _rcFeel:          controller.getParameterFact(-1, "RC_FEEL_RP")
-            property Fact _rateRollP:       controller.getParameterFact(-1, "r.ATC_RAT_RLL_P")
-            property Fact _rateRollI:       controller.getParameterFact(-1, "r.ATC_RAT_RLL_I")
-            property Fact _ratePitchP:      controller.getParameterFact(-1, "r.ATC_RAT_PIT_P")
-            property Fact _ratePitchI:      controller.getParameterFact(-1, "r.ATC_RAT_PIT_I")
-            property Fact _rateClimbP:      controller.getParameterFact(-1, "ACCEL_Z_P")
-            property Fact _rateClimbI:      controller.getParameterFact(-1, "ACCEL_Z_I")
+            property bool _rcFeelAvailable:     controller.parameterExists(-1, "RC_FEEL")
+            property bool _atcInputTCAvailable: controller.parameterExists(-1, "ATC_INPUT_TC")
+            property Fact _rcFeel:              controller.getParameterFact(-1, "RC_FEEL", false)
+            property Fact _atcInputTC:          controller.getParameterFact(-1, "ATC_INPUT_TC", false)
+            property Fact _rateRollP:           controller.getParameterFact(-1, "r.ATC_RAT_RLL_P")
+            property Fact _rateRollI:           controller.getParameterFact(-1, "r.ATC_RAT_RLL_I")
+            property Fact _ratePitchP:          controller.getParameterFact(-1, "r.ATC_RAT_PIT_P")
+            property Fact _ratePitchI:          controller.getParameterFact(-1, "r.ATC_RAT_PIT_I")
+            property Fact _rateClimbP:          controller.getParameterFact(-1, "r.PSC_ACCZ_P")
+            property Fact _rateClimbI:          controller.getParameterFact(-1, "r.PSC_ACCZ_I")
 
             property Fact _ch7Opt:  controller.getParameterFact(-1, "CH7_OPT")
             property Fact _ch8Opt:  controller.getParameterFact(-1, "CH8_OPT")
@@ -78,7 +81,12 @@ SetupPage {
                 throttleHover.value = _hoverTuneParam.value
                 rollPitch.value = _rateRollP.value
                 climb.value = _rateClimbP.value
-                rcFeel.value = _rcFeel.value
+                if (_rcFeelAvailable) {
+                    rcFeel.value = _rcFeel.value
+                }
+                if (_atcInputTCAvailable) {
+                    atcInputTC.value = _atcInputTC.value
+                }
                 _loadComplete = true
 
                 calcAutoTuneChannel()
@@ -240,6 +248,7 @@ SetupPage {
                     Column {
                         anchors.left:   parent.left
                         anchors.right:  parent.right
+                        visible:        _rcFeelAvailable
 
                         QGCLabel {
                             text:       qsTr("RC Roll/Pitch Feel")
@@ -262,6 +271,37 @@ SetupPage {
                             onValueChanged: {
                                 if (_loadComplete) {
                                     _rcFeel.value = value
+                                }
+                            }
+                        }
+                    }
+
+                    Column {
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        visible:        _atcInputTCAvailable
+
+                        QGCLabel {
+                            text:       qsTr("RC Roll/Pitch Feel")
+                            font.family: ScreenTools.demiboldFontFamily
+                        }
+
+                        QGCLabel {
+                            text: qsTr("Slide to the left for soft control, slide to the right for crisp control")
+                        }
+
+                        Slider {
+                            id:                 atcInputTC
+                            anchors.left:       parent.left
+                            anchors.right:      parent.right
+                            minimumValue:       _atcInputTC.min
+                            maximumValue:       _atcInputTC.max
+                            stepSize:           _atcInputTC.increment
+                            tickmarksEnabled:   true
+
+                            onValueChanged: {
+                                if (_loadComplete) {
+                                    _atcInputTC.value = value
                                 }
                             }
                         }

--- a/src/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.6.xml
+++ b/src/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.6.xml
@@ -1684,7 +1684,7 @@
 </param>
 <param humanName="Battery capacity" name="BATT2_CAPACITY" documentation="Capacity of the battery in mAh when full" user="Standard">
 <field name="Increment">50</field>
-<field name="Units">mA.h</field>
+<field name="Units">mAh</field>
 <field name="UnitText">milliampere hour</field>
 </param>
 <param humanName="Maximum allowed power (Watts)" name="BATT2_WATT_MAX" documentation="If battery wattage (voltage * current) exceeds this value then the system will reduce max throttle (THR_MAX, TKOFF_THR_MAX and THR_MIN for reverse thrust) to satisfy this limit. This helps limit high current to low C rated batteries regardless of battery voltage. The max throttle will slowly grow back to THR_MAX (or TKOFF_THR_MAX ) and THR_MIN if demanding the current max and under the watt max. Use 0 to disable." user="Advanced">
@@ -1713,7 +1713,7 @@
 </param>
 <param humanName="Low battery capacity" name="BATT2_LOW_MAH" documentation="Battery capacity at which the low battery failsafe is triggered. Set to 0 to disable battery remaining failsafe. If the battery capacity drops below this level the vehicle will perform the failsafe specified by the BATT2_FS_LOW_ACT parameter." user="Standard">
 <field name="Increment">50</field>
-<field name="Units">mA.h</field>
+<field name="Units">mAh</field>
 <field name="UnitText">milliampere hour</field>
 </param>
 <param humanName="Critical battery voltage" name="BATT2_CRT_VOLT" documentation="Battery voltage that triggers a critical battery failsafe. Set to 0 to disable. If the battery voltage drops below this voltage continuously for more then the period specified by the BATT2_LOW_TIMER parameter then the vehicle will perform the failsafe specified by the BATT2_FS_CRT_ACT parameter." user="Standard">
@@ -1723,12 +1723,12 @@
 </param>
 <param humanName="Battery critical capacity" name="BATT2_CRT_MAH" documentation="Battery capacity at which the critical battery failsafe is triggered. Set to 0 to disable battery remaining failsafe. If the battery capacity drops below this level the vehicle will perform the failsafe specified by the BATT2__FS_CRT_ACT parameter." user="Standard">
 <field name="Increment">50</field>
-<field name="Units">mA.h</field>
+<field name="Units">mAh</field>
 <field name="UnitText">milliampere hour</field>
 </param>
 <param humanName="Low battery failsafe action" name="BATT2_FS_LOW_ACT" documentation="What action the vehicle should perform if it hits a low battery failsafe" user="Standard">
 <values>
-<value code="0">Nothing</value>
+<value code="0">None</value>
 <value code="1">Land</value>
 <value code="2">RTL</value>
 <value code="3">SmartRTL</value>
@@ -1738,7 +1738,7 @@
 </param>
 <param humanName="Critical battery failsafe action" name="BATT2_FS_CRT_ACT" documentation="What action the vehicle should perform if it hits a critical battery failsafe" user="Standard">
 <values>
-<value code="0">Nothing</value>
+<value code="0">None</value>
 <value code="1">Land</value>
 <value code="2">RTL</value>
 <value code="3">SmartRTL</value>
@@ -1791,7 +1791,7 @@
 </param>
 <param humanName="Battery capacity" name="BATT_CAPACITY" documentation="Capacity of the battery in mAh when full" user="Standard">
 <field name="Increment">50</field>
-<field name="Units">mA.h</field>
+<field name="Units">mAh</field>
 <field name="UnitText">milliampere hour</field>
 </param>
 <param humanName="Maximum allowed power (Watts)" name="BATT_WATT_MAX" documentation="If battery wattage (voltage * current) exceeds this value then the system will reduce max throttle (THR_MAX, TKOFF_THR_MAX and THR_MIN for reverse thrust) to satisfy this limit. This helps limit high current to low C rated batteries regardless of battery voltage. The max throttle will slowly grow back to THR_MAX (or TKOFF_THR_MAX ) and THR_MIN if demanding the current max and under the watt max. Use 0 to disable." user="Advanced">
@@ -1820,7 +1820,7 @@
 </param>
 <param humanName="Low battery capacity" name="BATT_LOW_MAH" documentation="Battery capacity at which the low battery failsafe is triggered. Set to 0 to disable battery remaining failsafe. If the battery capacity drops below this level the vehicle will perform the failsafe specified by the BATT_FS_LOW_ACT parameter." user="Standard">
 <field name="Increment">50</field>
-<field name="Units">mA.h</field>
+<field name="Units">mAh</field>
 <field name="UnitText">milliampere hour</field>
 </param>
 <param humanName="Critical battery voltage" name="BATT_CRT_VOLT" documentation="Battery voltage that triggers a critical battery failsafe. Set to 0 to disable. If the battery voltage drops below this voltage continuously for more then the period specified by the BATT_LOW_TIMER parameter then the vehicle will perform the failsafe specified by the BATT_FS_CRT_ACT parameter." user="Standard">
@@ -1830,12 +1830,12 @@
 </param>
 <param humanName="Battery critical capacity" name="BATT_CRT_MAH" documentation="Battery capacity at which the critical battery failsafe is triggered. Set to 0 to disable battery remaining failsafe. If the battery capacity drops below this level the vehicle will perform the failsafe specified by the BATT__FS_CRT_ACT parameter." user="Standard">
 <field name="Increment">50</field>
-<field name="Units">mA.h</field>
+<field name="Units">mAh</field>
 <field name="UnitText">milliampere hour</field>
 </param>
 <param humanName="Low battery failsafe action" name="BATT_FS_LOW_ACT" documentation="What action the vehicle should perform if it hits a low battery failsafe" user="Standard">
 <values>
-<value code="0">Nothing</value>
+<value code="0">None</value>
 <value code="1">Land</value>
 <value code="2">RTL</value>
 <value code="3">SmartRTL</value>
@@ -1845,7 +1845,7 @@
 </param>
 <param humanName="Critical battery failsafe action" name="BATT_FS_CRT_ACT" documentation="What action the vehicle should perform if it hits a critical battery failsafe" user="Standard">
 <values>
-<value code="0">Nothing</value>
+<value code="0">None</value>
 <value code="1">Land</value>
 <value code="2">RTL</value>
 <value code="3">SmartRTL</value>

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -150,11 +150,13 @@ ArduCopterFirmwarePlugin::ArduCopterFirmwarePlugin(void)
 
         FirmwarePlugin::remapParamNameMap_t& remapV3_6 = _remapParamName[3][6];
 
-        remapV3_6["BATT_AMP_PERVLT"] = QStringLiteral("BATT_AMP_PERVOL");
+        remapV3_6["BATT_AMP_PERVLT"] =  QStringLiteral("BATT_AMP_PERVOL");
         remapV3_6["BATT2_AMP_PERVLT"] = QStringLiteral("BATT2_AMP_PERVOL");
-        remapV3_6["BATT_LOW_MAH"] = QStringLiteral("FS_BATT_MAH");
-        remapV3_6["BATT_LOW_VOLT"] = QStringLiteral("FS_BATT_VOLTAGE");
-        remapV3_6["BATT_FS_LOW_ACT"] = QStringLiteral("FS_BATT_ENABLE");
+        remapV3_6["BATT_LOW_MAH"] =     QStringLiteral("FS_BATT_MAH");
+        remapV3_6["BATT_LOW_VOLT"] =    QStringLiteral("FS_BATT_VOLTAGE");
+        remapV3_6["BATT_FS_LOW_ACT"] =  QStringLiteral("FS_BATT_ENABLE");
+        remapV3_6["PSC_ACCZ_P"] =       QStringLiteral("ACCEL_Z_P");
+        remapV3_6["PSC_ACCZ_I"] =       QStringLiteral("ACCEL_Z_I");
 
         _remapParamNameIntialized = true;
     }


### PR DESCRIPTION
Related to #6503.

![screen shot 2018-05-26 at 11 33 22 am](https://user-images.githubusercontent.com/5876851/40579279-a21f6b00-60d8-11e8-9ccc-ac15c8dbf30c.png)

This tracks the renames of these parameters:
```
        remapV3_6["PSC_ACCZ_P"] =       QStringLiteral("ACCEL_Z_P");
        remapV3_6["PSC_ACCZ_I"] =       QStringLiteral("ACCEL_Z_I");
```

It also supports both ```RC_FEEL_P``` on older firmwares and ```ATC_INPUT_TC``` on newer firmwares.

I'm no longer sure whether the way this page implements Roll/Pitch/Climb Sensitivity is valid. It seems odd. To describe:

Roll/Pitch Sensitivity Slider
* The slider position is initially set from ATC_RAT_RLL_P
* When the user changes the slider the ATC_RAT_RLL_P, ATC_RAT_RLL_P, ATC_RAT_PIT_P and ATC_RAT_PIT_I values are all set to the slider value.

Climb Sensitivity Slider
* The slider position is initially set from PSC_ACCZ_P
* When the user changes the slider the PSC_ACCZ_P value is set to the slider value. The PSC_ACCZ_I value is set to two times the slider value.