### PR TITLE
Transect alt mode fixes

### DIFF
--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -159,7 +159,7 @@ bool SurveyComplexItem::_loadV4(const QJsonObject& complexObject, int sequenceNu
         { ComplexMissionItem::jsonComplexItemTypeKey,   QJsonValue::String, true },
         { _jsonEntryPointKey,                           QJsonValue::Double, true },
         { _jsonGridAngleKey,                            QJsonValue::Double, true },
-        { _jsonFlyAlternateTransectsKey,                QJsonValue::Double, false },
+        { _jsonFlyAlternateTransectsKey,                QJsonValue::Bool,   false },
     };
     if (!JsonHelper::validateKeys(complexObject, keyInfoList, errorString)) {
         return false;

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -712,8 +712,8 @@ bool TransectStyleComplexItem::exitCoordinateHasRelativeAltitude(void) const
 
 void TransectStyleComplexItem::_followTerrainChanged(bool followTerrain)
 {
+    _cameraCalc.setDistanceToSurfaceRelative(!followTerrain);
     if (followTerrain) {
-        _cameraCalc.setDistanceToSurfaceRelative(false);
         _refly90DegreesFact.setRawValue(false);
         _hoverAndCaptureFact.setRawValue(false);
     }

--- a/src/MissionManager/TransectStyleComplexItemTest.cc
+++ b/src/MissionManager/TransectStyleComplexItemTest.cc
@@ -167,6 +167,30 @@ void TransectStyleComplexItemTest::_adjustSurveAreaPolygon(void)
     _transectStyleItem->surveyAreaPolygon()->adjustVertex(0, vertex);
 }
 
+void TransectStyleComplexItemTest::_testAltMode(void)
+{
+    // Default should be relative
+    QVERIFY(_transectStyleItem->cameraCalc()->distanceToSurfaceRelative());
+
+    // Manual camera allows non-relative altitudes, validate that changing back to known
+    // camera switches back to relative
+    _transectStyleItem->cameraCalc()->cameraName()->setRawValue(_transectStyleItem->cameraCalc()->manualCameraName());
+    _transectStyleItem->cameraCalc()->setDistanceToSurfaceRelative(false);
+    _transectStyleItem->cameraCalc()->cameraName()->setRawValue(_transectStyleItem->cameraCalc()->customCameraName());
+    QVERIFY(_transectStyleItem->cameraCalc()->distanceToSurfaceRelative());
+
+    // When you turn off terrain following mode make sure that the altitude mode changed back to relative altitudes
+    _transectStyleItem->cameraCalc()->setDistanceToSurfaceRelative(false);
+    _transectStyleItem->setFollowTerrain(true);
+
+    QVERIFY(!_transectStyleItem->cameraCalc()->distanceToSurfaceRelative());
+    QVERIFY(_transectStyleItem->followTerrain());
+
+    _transectStyleItem->setFollowTerrain(false);
+    QVERIFY(_transectStyleItem->cameraCalc()->distanceToSurfaceRelative());
+    QVERIFY(!_transectStyleItem->followTerrain());
+}
+
 TransectStyleItem::TransectStyleItem(Vehicle* vehicle, QObject* parent)
     : TransectStyleComplexItem  (vehicle, false /* flyView */, QStringLiteral("UnitTestTransect"), parent)
     , rebuildTransectsCalled    (false)

--- a/src/MissionManager/TransectStyleComplexItemTest.h
+++ b/src/MissionManager/TransectStyleComplexItemTest.h
@@ -32,6 +32,7 @@ private slots:
     void _testDirty                     (void);
     void _testRebuildTransects          (void);
     void _testDistanceSignalling        (void);
+    void _testAltMode                   (void);
 
 private:
     void _setSurveyAreaPolygon  (void);

--- a/src/PlanView/CorridorScanEditor.qml
+++ b/src/PlanView/CorridorScanEditor.qml
@@ -110,6 +110,7 @@ Rectangle {
                 text:               qsTr("Relative altitude")
                 checked:            missionItem.cameraCalc.distanceToSurfaceRelative
                 enabled:            missionItem.cameraCalc.isManualCamera && !missionItem.followTerrain
+                visible:            QGroundControl.corePlugin.options.showMissionAbsoluteAltitude || (!missionItem.cameraCalc.distanceToSurfaceRelative && !missionItem.followTerrain)
                 Layout.columnSpan:  2
                 onClicked:          missionItem.cameraCalc.distanceToSurfaceRelative = checked
 

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -143,6 +143,7 @@ Rectangle {
                 text:               qsTr("Relative altitude")
                 checked:            missionItem.cameraCalc.distanceToSurfaceRelative
                 enabled:            missionItem.cameraCalc.isManualCamera && !missionItem.followTerrain
+                visible:            QGroundControl.corePlugin.options.showMissionAbsoluteAltitude || (!missionItem.cameraCalc.distanceToSurfaceRelative && !missionItem.followTerrain)
                 Layout.columnSpan:  2
                 onClicked:          missionItem.cameraCalc.distanceToSurfaceRelative = checked
 


### PR DESCRIPTION
* When turning off Terrain Follow the item should change to Relative Altitude
* When going from a manual camera to a custom camera should change to Relative Altitude
* Added support for custom build hiding of Relative Altitude checkbox in Survey and Corridor Scan
* Wrote unit tests to verify all the above so it never breaks again