### PR TITLE
Add settingsGroup qualifer to settings override

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -62,8 +62,6 @@ Fact::Fact(FactMetaData* metaData, QObject* parent)
     , _deferredValueChangeSignal(false)
     , _valueSliderModel         (NULL)
 {
-    // Allow core plugin a chance to override the default value
-    qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(*metaData);
     setMetaData(metaData, true /* setDefaultFromMetaData */);
 }
 

--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -20,19 +20,19 @@ SettingsFact::SettingsFact(QObject* parent)
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 }
 
-SettingsFact::SettingsFact(QString settingGroup, FactMetaData* metaData, QObject* parent)
-    : Fact(0, metaData->name(), metaData->type(), parent)
-    , _settingGroup(settingGroup)
-    , _visible(true)
+SettingsFact::SettingsFact(QString settingsGroup, FactMetaData* metaData, QObject* parent)
+    : Fact          (0, metaData->name(), metaData->type(), parent)
+    , _settingsGroup(settingsGroup)
+    , _visible      (true)
 {
     QSettings settings;
 
-    if (!_settingGroup.isEmpty()) {
-        settings.beginGroup(_settingGroup);
+    if (!_settingsGroup.isEmpty()) {
+        settings.beginGroup(_settingsGroup);
     }
 
     // Allow core plugin a chance to override the default value
-    _visible = qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(*metaData);
+    _visible = qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(settingsGroup, *metaData);
     setMetaData(metaData);
 
     QVariant rawDefaultValue = metaData->rawDefaultValue();
@@ -60,7 +60,7 @@ const SettingsFact& SettingsFact::operator=(const SettingsFact& other)
 {
     Fact::operator=(other);
     
-    _settingGroup = other._settingGroup;
+    _settingsGroup = other._settingsGroup;
 
     return *this;
 }
@@ -69,8 +69,8 @@ void SettingsFact::_rawValueChanged(QVariant value)
 {
     QSettings settings;
 
-    if (!_settingGroup.isEmpty()) {
-        settings.beginGroup(_settingGroup);
+    if (!_settingsGroup.isEmpty()) {
+        settings.beginGroup(_settingsGroup);
     }
 
     settings.setValue(_name, value);

--- a/src/FactSystem/SettingsFact.h
+++ b/src/FactSystem/SettingsFact.h
@@ -7,12 +7,7 @@
  *
  ****************************************************************************/
 
-
-/// @file
-///     @author Don Gagne <don@thegagnes.com>
-
-#ifndef SettingsFact_H
-#define SettingsFact_H
+#pragma once
 
 #include "Fact.h"
 
@@ -23,7 +18,7 @@ class SettingsFact : public Fact
     
 public:
     SettingsFact(QObject* parent = NULL);
-    SettingsFact(QString settingGroup, FactMetaData* metaData, QObject* parent = NULL);
+    SettingsFact(QString settingsGroup, FactMetaData* metaData, QObject* parent = NULL);
     SettingsFact(const SettingsFact& other, QObject* parent = NULL);
 
     const SettingsFact& operator=(const SettingsFact& other);
@@ -37,8 +32,6 @@ private slots:
     void _rawValueChanged(QVariant value);
 
 private:
-    QString _settingGroup;
+    QString _settingsGroup;
     bool    _visible;
 };
-
-#endif

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -15,7 +15,7 @@
 #include <QtQml>
 #include <QStandardPaths>
 
-const char* AppSettings::appSettingsGroupName =                         "App";
+const char* AppSettings::settingsGroup =                                "App";
 const char* AppSettings::offlineEditingFirmwareTypeSettingsName =       "OfflineEditingFirmwareType";
 const char* AppSettings::offlineEditingVehicleTypeSettingsName =        "OfflineEditingVehicleType";
 const char* AppSettings::offlineEditingCruiseSpeedSettingsName =        "OfflineEditingCruiseSpeed";
@@ -58,7 +58,7 @@ const char* AppSettings::videoDirectory =           "Video";
 const char* AppSettings::crashDirectory =           "CrashLogs";
 
 AppSettings::AppSettings(QObject* parent)
-    : SettingsGroup                         (appSettingsGroupName, QString() /* root settings group */, parent)
+    : SettingsGroup                         (settingsGroup, QString() /* root settings group */, parent)
     , _offlineEditingFirmwareTypeFact       (NULL)
     , _offlineEditingVehicleTypeFact        (NULL)
     , _offlineEditingCruiseSpeedFact        (NULL)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -93,7 +93,7 @@ public:
     static MAV_AUTOPILOT offlineEditingFirmwareTypeFromFirmwareType(MAV_AUTOPILOT firmwareType);
     static MAV_TYPE offlineEditingVehicleTypeFromVehicleType(MAV_TYPE vehicleType);
 
-    static const char* appSettingsGroupName;
+    static const char* settingsGroup;
 
     static const char* offlineEditingFirmwareTypeSettingsName;
     static const char* offlineEditingVehicleTypeSettingsName;

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -190,8 +190,13 @@ bool QGCCorePlugin::overrideSettingsGroupVisibility(QString name)
     return true;
 }
 
-bool QGCCorePlugin::adjustSettingMetaData(FactMetaData& metaData)
+bool QGCCorePlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData)
 {
+    if (settingsGroup != AppSettings::settingsGroup) {
+        // All changes refer to AppSettings
+        return true;
+    }
+
     //-- Default Palette
     if (metaData.name() == AppSettings::indoorPaletteName) {
         QVariant outdoorPalette;

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -72,9 +72,10 @@ public:
     virtual bool overrideSettingsGroupVisibility(QString name);
 
     /// Allows the core plugin to override the setting meta data before the setting fact is created.
+    ///     @param settingsGroup - Settings group which contains this value
     ///     @param metaData - MetaData for setting fact
     /// @return true: Setting should be visible in ui, false: Setting should not be shown in ui
-    virtual bool adjustSettingMetaData(FactMetaData& metaData);
+    virtual bool adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData);
 
     /// Return the resource file which contains the brand image for for Indoor theme.
     virtual QString brandImageIndoor(void) const { return QString(); }


### PR DESCRIPTION
The api for QGCCorePlugin::adjustSettingsMetaData which incorrect in that it only take the meta data as a parameter. In order to fully qualify which settings this is about you also need the settings group name. Without it there can be namespace collisions on the name which currently exist between Survey and Corridor Scan settings.

Note that this is a breaking change to an API for custom builds. Easy to deal with but all the less breaking.