### PR TITLE
Use a menu to delete a vertex

### DIFF
--- a/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
@@ -29,7 +29,6 @@ Rectangle {
     property var itemCoordinate ///< Coordinate we are updating during drag
 
     signal clicked
-    signal doubleClicked
     signal dragStart
     signal dragStop
 
@@ -75,11 +74,6 @@ Rectangle {
         onClicked: {
             focus = true
             itemDragger.clicked()
-        }
-
-        onDoubleClicked: {
-            focus = true
-            itemDragger.doubleClicked()
         }
 
         property bool dragActive: drag.active

--- a/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
@@ -29,6 +29,7 @@ Rectangle {
     property var itemCoordinate ///< Coordinate we are updating during drag
 
     signal clicked
+    signal doubleClicked
     signal dragStart
     signal dragStop
 
@@ -74,6 +75,11 @@ Rectangle {
         onClicked: {
             focus = true
             itemDragger.clicked()
+        }
+
+        onDoubleClicked: {
+            focus = true
+            itemDragger.doubleClicked()
         }
 
         property bool dragActive: drag.active

--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -186,6 +186,59 @@ Item {
         }
     }
 
+    Menu {
+        id: menu
+
+        property int _removeVertexIndex
+
+        function popUpWithIndex(curIndex) {
+            _removeVertexIndex = curIndex
+            removeVertexItem.visible = (mapPolygon.count > 3 && _removeVertexIndex >= 0)
+            menu.popup()
+        }
+
+        MenuItem {
+            id:             removeVertexItem
+            text:           qsTr("Remove vertex")
+            onTriggered: {
+                if(menu._removeVertexIndex >= 0) {
+                    mapPolygon.removeVertex(menu._removeVertexIndex)
+                }
+            }
+        }
+
+        MenuSeparator {
+            visible:        removeVertexItem.visible
+        }
+
+        MenuItem {
+            text:           qsTr("Circle" )
+            onTriggered:    resetCircle()
+        }
+
+        MenuItem {
+            text:           qsTr("Polygon")
+            onTriggered:    resetPolygon()
+        }
+
+        MenuItem {
+            text:           qsTr("Set radius..." )
+            visible:        _circle
+            onTriggered:    radiusDialog.visible = true
+        }
+
+        MenuItem {
+            text:           qsTr("Edit position..." )
+            enabled:        _circle
+            onTriggered:    qgcView.showDialog(editPositionDialog, qsTr("Edit Position"), qgcView.showDialogDefaultWidth, StandardButton.Cancel)
+        }
+
+        MenuItem {
+            text:           qsTr("Load KML...")
+            onTriggered:    kmlLoadDialog.openForLoad()
+        }
+    }
+
     Component {
         id: polygonComponent
 
@@ -291,32 +344,36 @@ Item {
                 }
             }
 
-            onDoubleClicked: mapPolygon.removeVertex(polygonVertex)
+            onClicked: {
+                menu.popUpWithIndex(polygonVertex)
+            }
         }
     }
 
     Component {
         id: centerDragHandle
-
         MapQuickItem {
             id:             mapQuickItem
-            anchorPoint.x:  dragHandle.width / 2
-            anchorPoint.y:  dragHandle.height / 2
+            anchorPoint.x:  dragHandle.width  * 0.5
+            anchorPoint.y:  dragHandle.height * 0.5
             z:              _zorderDragHandle
-
             sourceItem: Rectangle {
-                id:         dragHandle
-                width:      ScreenTools.defaultFontPixelHeight * 1.5
-                height:     width
-                radius:     width / 2
-                color:      "white"
-                opacity:    .90
-
-                QGCLabel {
-                    anchors.horizontalCenter:   parent.horizontalCenter
-                    anchors.verticalCenter:     parent.verticalCenter
-                    text:                       "..."
-                    color:                      "black"
+                id:             dragHandle
+                width:          ScreenTools.defaultFontPixelHeight * 1.5
+                height:         width
+                radius:         width * 0.5
+                color:          Qt.rgba(1,1,1,0.8)
+                border.color:   Qt.rgba(0,0,0,0.25)
+                border.width:   1
+                QGCColoredImage {
+                    width:      parent.width
+                    height:     width
+                    color:      Qt.rgba(0,0,0,1)
+                    mipmap:     true
+                    fillMode:   Image.PreserveAspectFit
+                    source:     "/qmlimages/MapCenter.svg"
+                    sourceSize.height:  height
+                    anchors.centerIn:   parent
                 }
             }
         }
@@ -327,7 +384,7 @@ Item {
 
         MapQuickItem {
             id:             mapQuickItem
-            anchorPoint.x:  dragHandle.width / 2
+            anchorPoint.x:  dragHandle.width  / 2
             anchorPoint.y:  dragHandle.height / 2
             z:              _zorderDragHandle
             visible:        !_circle
@@ -335,12 +392,13 @@ Item {
             property int polygonVertex
 
             sourceItem: Rectangle {
-                id:         dragHandle
-                width:      ScreenTools.defaultFontPixelHeight * 1.5
-                height:     width
-                radius:     width / 2
-                color:      "white"
-                opacity:    .90
+                id:             dragHandle
+                width:          ScreenTools.defaultFontPixelHeight * 1.5
+                height:         width
+                radius:         width * 0.5
+                color:          Qt.rgba(1,1,1,0.8)
+                border.color:   Qt.rgba(0,0,0,0.25)
+                border.width:   1
             }
         }
     }
@@ -393,42 +451,14 @@ Item {
             onItemCoordinateChanged:    mapPolygon.center = itemCoordinate
             onDragStart:                mapPolygon.centerDrag = true
             onDragStop:                 mapPolygon.centerDrag = false
-            onClicked:                  menu.popup()
+
+            onClicked: {
+                menu.popUpWithIndex(-1)      //-- Don't offer a choice to delete vertex (cur index == -1)
+            }
 
             function setRadiusFromDialog() {
                 setCircleRadius(mapPolygon.center, radiusField.text)
                 radiusDialog.visible = false
-            }
-
-            Menu {
-                id: menu
-
-                MenuItem {
-                    text:           qsTr("Circle" )
-                    onTriggered:    resetCircle()
-                }
-
-                MenuItem {
-                    text:           qsTr("Polygon")
-                    onTriggered:    resetPolygon()
-                }
-
-                MenuItem {
-                    text:           qsTr("Set radius..." )
-                    visible:        _circle
-                    onTriggered:    radiusDialog.visible = true
-                }
-
-                MenuItem {
-                    text:           qsTr("Edit position..." )
-                    enabled:        _circle
-                    onTriggered:    qgcView.showDialog(editPositionDialog, qsTr("Edit Position"), qgcView.showDialogDefaultWidth, StandardButton.Cancel)
-                }
-
-                MenuItem {
-                    text:           qsTr("Load KML...")
-                    onTriggered:    kmlLoadDialog.openForLoad()
-                }
             }
 
             Rectangle {

--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -291,7 +291,7 @@ Item {
                 }
             }
 
-            onClicked: mapPolygon.removeVertex(polygonVertex)
+            onDoubleClicked: mapPolygon.removeVertex(polygonVertex)
         }
     }
 

--- a/src/MissionManager/QGCMapPolylineVisuals.qml
+++ b/src/MissionManager/QGCMapPolylineVisuals.qml
@@ -128,21 +128,27 @@ Item {
 
     Menu {
         id: menu
-        property int removeVertex
+        property int _removeVertexIndex
+
+        function popUpWithIndex(curIndex) {
+            _removeVertexIndex = curIndex
+            removeVertexItem.visible = mapPolyline.count > 2
+            menu.popup()
+        }
 
         MenuItem {
             id:             removeVertexItem
             text:           qsTr("Remove vertex" )
-            onTriggered:    mapPolyline.removeVertex(parent.removeVertex)
+            onTriggered:    mapPolyline.removeVertex(menu._removeVertexIndex)
+        }
+
+        MenuSeparator {
+            visible:        removeVertexItem.visible
         }
 
         MenuItem {
             text:           qsTr("Load KML...")
             onTriggered:    kmlLoadDialog.openForLoad()
-        }
-
-        function resetMenu() {
-            removeVertexItem.visible = mapPolyline.count > 2
         }
     }
 
@@ -247,15 +253,7 @@ Item {
             }
 
             onClicked: {
-                menu.resetMenu()
-                menu.removeVertex = polylineVertex
-                menu.popup()
-            }
-
-            onDoubleClicked: {
-                if (polylineVertex != 0) {
-                    mapPolyline.removeVertex(polylineVertex)
-                }
+                menu.popUpWithIndex(polylineVertex)
             }
 
         }
@@ -273,12 +271,13 @@ Item {
             property int polylineVertex
 
             sourceItem: Rectangle {
-                id:         dragHandle
-                width:      ScreenTools.defaultFontPixelHeight * 1.5
-                height:     width
-                radius:     width / 2
-                color:      "white"
-                opacity:    0.9
+                id:             dragHandle
+                width:          ScreenTools.defaultFontPixelHeight * 1.5
+                height:         width
+                radius:         width * 0.5
+                color:          Qt.rgba(1,1,1,0.8)
+                border.color:   Qt.rgba(0,0,0,0.25)
+                border.width:   1
             }
         }
     }

--- a/src/MissionManager/QGCMapPolylineVisuals.qml
+++ b/src/MissionManager/QGCMapPolylineVisuals.qml
@@ -128,10 +128,10 @@ Item {
 
     Menu {
         id: menu
-
         property int removeVertex
 
         MenuItem {
+            id:             removeVertexItem
             text:           qsTr("Remove vertex" )
             onTriggered:    mapPolyline.removeVertex(parent.removeVertex)
         }
@@ -139,6 +139,10 @@ Item {
         MenuItem {
             text:           qsTr("Load KML...")
             onTriggered:    kmlLoadDialog.openForLoad()
+        }
+
+        function resetMenu() {
+            removeVertexItem.visible = mapPolyline.count > 2
         }
     }
 
@@ -167,7 +171,7 @@ Item {
                 width:          ScreenTools.defaultFontPixelHeight * 1.5
                 height:         width
                 radius:         width / 2
-                border.color:      "white"
+                border.color:   "white"
                 color:          "transparent"
                 opacity:        .50
                 z:              _zorderSplitHandle
@@ -243,10 +247,13 @@ Item {
             }
 
             onClicked: {
-                if (polylineVertex == 0) {
-                    menu.removeVertex = polylineVertex
-                    menu.popup()
-                } else {
+                menu.resetMenu()
+                menu.removeVertex = polylineVertex
+                menu.popup()
+            }
+
+            onDoubleClicked: {
+                if (polylineVertex != 0) {
                     mapPolyline.removeVertex(polylineVertex)
                 }
             }
@@ -271,15 +278,7 @@ Item {
                 height:     width
                 radius:     width / 2
                 color:      "white"
-                opacity:    .90
-
-                QGCLabel {
-                    anchors.horizontalCenter:   parent.horizontalCenter
-                    anchors.verticalCenter:     parent.verticalCenter
-                    text:                       "..."
-                    color:                      "black"
-                    visible:                    polylineVertex == 0
-                }
+                opacity:    0.9
             }
         }
     }

--- a/src/PlanView/CorridorScanEditor.qml
+++ b/src/PlanView/CorridorScanEditor.qml
@@ -106,11 +106,11 @@ Rectangle {
 
             QGCCheckBox {
                 id:                 relAlt
-                anchors.left:       parent.left
                 text:               qsTr("Relative altitude")
                 checked:            missionItem.cameraCalc.distanceToSurfaceRelative
                 enabled:            missionItem.cameraCalc.isManualCamera && !missionItem.followTerrain
                 visible:            QGroundControl.corePlugin.options.showMissionAbsoluteAltitude || (!missionItem.cameraCalc.distanceToSurfaceRelative && !missionItem.followTerrain)
+                Layout.alignment:   Qt.AlignLeft
                 Layout.columnSpan:  2
                 onClicked:          missionItem.cameraCalc.distanceToSurfaceRelative = checked
 
@@ -146,12 +146,11 @@ Rectangle {
             }
 
             GridLayout {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                columnSpacing:  _margin
-                rowSpacing:     _margin
-                columns:        2
-                visible:        followsTerrainCheckBox.checked
+                Layout.fillWidth:   true
+                columnSpacing:      _margin
+                rowSpacing:         _margin
+                columns:            2
+                visible:            followsTerrainCheckBox.checked
 
                 QGCLabel { text: qsTr("Tolerance") }
                 FactTextField {


### PR DESCRIPTION
When editing a survey polygon, clicking on a vertex would delete that vertex. It was too easy to click/touch it by mistake. This changes it to a double click for deleting a vertex.

In addition:

For corridor scans, the same double click applies when you want to delete a vertex. When you single click however, you get the menu asking if you want to delete that particular vertex or load a KML file. Also, the "Delete Vertex" menu item only shows if there are more than 2 vertices.

Also fixed a layout/anchor issue within corridor scan.