### PR TITLE
jenkins: agent fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,11 @@ pipeline {
             sh 'mkdir build; cd build; ${QT_PATH}/${QMAKE_VER} -r ${WORKSPACE}/qgroundcontrol.pro CONFIG+=${QGC_CONFIG} CONFIG+=WarningsAsErrorsOn'
             sh 'cd build; make -j`nproc --all`'
             sh 'ccache -s'
-            sh 'git clean -ff -x -d .'
+          }
+          post {
+            cleanup {
+              sh 'git clean -ff -x -d .'
+            }
           }
         }
 
@@ -51,7 +55,11 @@ pipeline {
             sh 'mkdir build; cd build; ${QT_PATH}/${QMAKE_VER} -r ${WORKSPACE}/qgroundcontrol.pro CONFIG+=${QGC_CONFIG} CONFIG+=WarningsAsErrorsOn'
             sh 'cd build; make -j`nproc --all`'
             sh 'ccache -s'
-            sh 'git clean -ff -x -d .'
+          }
+          post {
+            cleanup {
+              sh 'git clean -ff -x -d .'
+            }
           }
         }
 
@@ -76,7 +84,11 @@ pipeline {
             sh 'mkdir build; cd build; ${QT_PATH}/${QMAKE_VER} -r ${WORKSPACE}/qgroundcontrol.pro CONFIG+=${QGC_CONFIG} CONFIG+=WarningsAsErrorsOn'
             sh 'cd build; make -j`nproc --all`'
             sh 'ccache -s'
-            sh 'git clean -ff -x -d .'
+          }
+          post {
+            cleanup {
+              sh 'git clean -ff -x -d .'
+            }
           }
         }
 
@@ -100,7 +112,11 @@ pipeline {
             sh 'mkdir build; cd build; ${QT_PATH}/${QMAKE_VER} -r ${WORKSPACE}/qgroundcontrol.pro CONFIG+=${QGC_CONFIG} CONFIG+=WarningsAsErrorsOn'
             sh 'cd build; make -j`sysctl -n hw.ncpu`'
             sh 'ccache -s'
-            sh 'git clean -ff -x -d .'
+          }
+          post {
+            cleanup {
+              sh 'git clean -ff -x -d .'
+            }
           }
         }
 
@@ -124,8 +140,14 @@ pipeline {
             sh 'mkdir build; cd build; ${QT_PATH}/${QMAKE_VER} -r ${WORKSPACE}/qgroundcontrol.pro CONFIG+=${QGC_CONFIG} CONFIG+=WarningsAsErrorsOn'
             sh 'cd build; make -j`sysctl -n hw.ncpu`'
             sh 'ccache -s'
-            archiveArtifacts(artifacts: 'build/**/*.dmg', fingerprint: true, onlyIfSuccessful: true)
-            sh 'git clean -ff -x -d .'
+          }
+          post {
+            success {
+              archiveArtifacts(artifacts: 'build/**/*.dmg', fingerprint: true)
+            }
+            cleanup {
+              sh 'git clean -ff -x -d .'
+            }
           }
         }
       } // parallel

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 pipeline {
   agent none
   stages {
+
     stage('build') {
       parallel {
 
@@ -127,10 +128,9 @@ pipeline {
             sh 'git clean -ff -x -d .'
           }
         }
-
-      }
-    }
-  }
+      } // parallel
+    } // stage('build')
+  } // stages
 
   environment {
     CCACHE_CPP2 = '1'
@@ -142,5 +142,4 @@ pipeline {
     buildDiscarder(logRotator(numToKeepStr: '10', artifactDaysToKeepStr: '30'))
     timeout(time: 60, unit: 'MINUTES')
   }
-
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-  agent any
+  agent none
   stages {
     stage('build') {
       parallel {


### PR DESCRIPTION
Currently an overall pipeline agent is assigned to the whole build, essentially blocking the assigned slave from performing any build steps as the individual stages define the agent to use. The blocking prevents it from doing other jobs in the queue until the whole QGC build is done. This fixes that, and adds small formatting fixes.

The images below shows how slaves are blocked when there are other tasks to do in the build queue.
![screenshot from 2018-05-29 18-55-33](https://user-images.githubusercontent.com/10533707/40753340-9a0a3af0-6441-11e8-91f8-2bd40f42c90b.png)

![screenshot from 2018-05-29 18-59-33](https://user-images.githubusercontent.com/10533707/40753342-9e0d3b20-6441-11e8-8473-de675218cb0f.png)

FYI @dagar 