### PR TITLE
Remove unused (and non-existing) library

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -110,7 +110,6 @@ LinuxBuild {
         libQt5Gui.so.5 \
         libQt5Location.so.5 \
         libQt5Multimedia.so.5 \
-        libQt5MultimediaQuick_p.so.5 \
         libQt5Network.so.5 \
         libQt5OpenGL.so.5 \
         libQt5Positioning.so.5 \


### PR DESCRIPTION
Linux seems to be working fine with Qt 5.11. This library was in the "copy list" but it doesn't exist in Qt 5.11. I'm not sure who added it in the first place and what was the reason behind it. It may require some investigation.

![screenshot from 2018-05-31 00-47-49](https://user-images.githubusercontent.com/749243/40762043-b237b92e-646c-11e8-9c2e-cf5695d1fe76.png)


