### PR TITLE
Remove QtMultimedia import when not needed

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -14,7 +14,6 @@ import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
 import QtLocation               5.3
 import QtPositioning            5.3
-import QtMultimedia             5.5
 import QtQuick.Layouts          1.2
 import QtQuick.Window           2.2
 import QtQml.Models             2.1

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -12,7 +12,6 @@ import QtQuick                  2.3
 import QtQuick.Controls         1.2
 import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs          1.2
-import QtMultimedia             5.5
 import QtQuick.Layouts          1.2
 
 import QGroundControl                       1.0


### PR DESCRIPTION
@dogmaphobic I found these other two references to QtMultimedia which don't seem to be needed.