### PR TITLE
Various fixes

### DIFF
--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -18,13 +18,12 @@ import QGroundControl.Palette       1.0
 /// Guided actions confirmation dialog
 Rectangle {
     id:             _root
-    border.color:   qgcPal.alertBorder
-    border.width:   1
     width:          confirmColumn.width  + (_margins * 4)
     height:         confirmColumn.height + (_margins * 4)
     radius:         ScreenTools.defaultFontPixelHeight / 2
-    color:          qgcPal.alertBackground
-    opacity:        0.9
+    color:          qgcPal.window
+    border.color:   _emergencyAction ? "red" : qgcPal.windowShade
+    border.width:   _emergencyAction ? 4 : 1
     z:              guidedController.z
     visible:        false
 
@@ -36,7 +35,8 @@ Rectangle {
     property var    actionData
     property bool   hideTrigger:        false
 
-    property real _margins: ScreenTools.defaultFontPixelWidth
+    property real _margins:         ScreenTools.defaultFontPixelWidth
+    property bool _emergencyAction: action === guidedController.actionEmergencyStop
 
     onHideTriggerChanged: {
         if (hideTrigger) {
@@ -78,7 +78,6 @@ Rectangle {
 
         QGCLabel {
             id:                     titleText
-            color:                  qgcPal.alertText
             anchors.left:           slider.left
             anchors.right:          slider.right
             horizontalAlignment:    Text.AlignHCenter
@@ -87,7 +86,6 @@ Rectangle {
 
         QGCLabel {
             id:                     messageText
-            color:                  qgcPal.alertText
             anchors.left:           slider.left
             anchors.right:          slider.right
             horizontalAlignment:    Text.AlignHCenter
@@ -127,7 +125,7 @@ Rectangle {
         sourceSize.height:  width
         source:             "/res/XDelete.svg"
         fillMode:           Image.PreserveAspectFit
-        color:              qgcPal.alertText
+        color:              qgcPal.text
         QGCMouseArea {
             fillItem:   parent
             onClicked: {

--- a/src/FlightDisplay/GuidedActionList.qml
+++ b/src/FlightDisplay/GuidedActionList.qml
@@ -85,9 +85,9 @@ Rectangle {
                         }
 
                         QGCButton {
-                            id:                         actionButton
-                            anchors.horizontalCenter:   parent.horizontalCenter
-                            text:                       modelData.title
+                            id:                 actionButton
+                            text:               modelData.title
+                            Layout.alignment:   Qt.AlignCenter
 
                             onClicked: {
                                 _root.visible = false

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -32,7 +32,7 @@ Item {
     property var actionList
     property var altitudeSlider
 
-    readonly property string emergencyStopTitle:            qsTr("Emergency Stop")
+    readonly property string emergencyStopTitle:            qsTr("EMERGENCY STOP")
     readonly property string armTitle:                      qsTr("Arm")
     readonly property string disarmTitle:                   qsTr("Disarm")
     readonly property string rtlTitle:                      qsTr("RTL")
@@ -52,7 +52,7 @@ Item {
 
     readonly property string armMessage:                        qsTr("Arm the vehicle.")
     readonly property string disarmMessage:                     qsTr("Disarm the vehicle")
-    readonly property string emergencyStopMessage:              qsTr("WARNING: This will stop all motors. If vehicle is currently in air it will crash.")
+    readonly property string emergencyStopMessage:              qsTr("WARNING: THIS WILL STOP ALL MOTORS. IF VEHICLE IS CURRENTLY IN THE AIR IT WILL CRASH.")
     readonly property string takeoffMessage:                    qsTr("Takeoff from ground and hold position.")
     readonly property string startMissionMessage:               qsTr("Takeoff from ground and start the current mission.")
     readonly property string continueMissionMessage:            qsTr("Continue the mission from the current waypoint.")

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -132,7 +132,7 @@ Rectangle {
                         text:           qsTr("TerrF")
                         exclusiveGroup: altRadios
                         checked:        missionItem.altitudeMode === altModeValue
-                        visible:        missionItem.supportsTerrainFrame || missionItem.altitudeMode === altModeValue
+                        visible:        missionItem.altitudeMode === altModeValue
 
                         readonly property int       altModeValue:   _altModeTerrainFrame
                         readonly property string    helpText:       qsTr("Using terrain reference frame")

--- a/src/QmlControls/SliderSwitch.qml
+++ b/src/QmlControls/SliderSwitch.qml
@@ -11,7 +11,7 @@ Rectangle {
     implicitWidth:  label.contentWidth + (_diameter * 2.5) + (_border * 4)
     implicitHeight: label.height * 2.5
     radius:         height /2
-    color:          qgcPal.text
+    color:          qgcPal.windowShade
 
     signal accept   ///< Action confirmed
     signal reject   ///< Action rejected
@@ -29,7 +29,7 @@ Rectangle {
         anchors.horizontalCenter:   parent.horizontalCenter
         anchors.verticalCenter:     parent.verticalCenter
         text:                       confirmText
-        color:                      qgcPal.window
+        color:                      qgcPal.buttonText
     }
 
     Rectangle {
@@ -39,8 +39,7 @@ Rectangle {
         height:     _diameter
         width:      _diameter
         radius:     _diameter / 2
-        color:      qgcPal.windowShade
-        opacity:    0.8
+        color:      qgcPal.primaryButton
 
         QGCColoredImage {
             anchors.centerIn:       parent
@@ -50,7 +49,7 @@ Rectangle {
             fillMode:               Image.PreserveAspectFit
             smooth:                 false
             mipmap:                 false
-            color:                  qgcPal.text
+            color:                  qgcPal.buttonText
             cache:                  false
             source:                 "/res/ArrowRight.svg"
         }

--- a/src/ui/MainWindowInner.qml
+++ b/src/ui/MainWindowInner.qml
@@ -175,7 +175,7 @@ Item {
     MessageDialog {
         id:                 activeConnectionsCloseDialog
         title:              qsTr("%1 close").arg(QGroundControl.appName)
-        text:               qsTr("There are still active connections to vehicles. Do you want to disconnect these before closing?")
+        text:               qsTr("There are still active connections to vehicles. Are you sure you want to exit?")
         standardButtons:    StandardButton.Yes | StandardButton.Cancel
         modality:           Qt.ApplicationModal
         visible:            false


### PR DESCRIPTION
* Better pallete usage for Guided Actions confirm to make it usable outdoors.
* Emergency Stop now has different visuals from other actions in order to prevent accidental confirm. Fix for #6545.
* Remove visibility of terrain frame option unless mission already contains it. Since QGC does not yet support ArduPilot terrain tile send, this was too confusing to expose. Fix for #6553
* Changed application exit message when vehicles connected to "There are still active connections to vehicles. Are you sure you want to exit?". Fix for #6548.

![screen shot 2018-06-05 at 1 48 50 pm](https://user-images.githubusercontent.com/5876851/41002250-12c3abd6-68c8-11e8-8abe-a5005f1359f0.png)
![screen shot 2018-06-05 at 1 49 00 pm](https://user-images.githubusercontent.com/5876851/41002253-12f19690-68c8-11e8-9de0-52d3e0476434.png)
