### PR TITLE
Split constructor of HeartbeatTimer up in two functions

### DIFF
--- a/src/comm/HeartbeatTimer.cc
+++ b/src/comm/HeartbeatTimer.cc
@@ -17,7 +17,11 @@ HeartbeatTimer::HeartbeatTimer(int vehicle_id, bool high_latency) :
     _vehicleID(vehicle_id),
     _high_latency(high_latency)
 {
-    if (!high_latency) {
+}
+
+void HeartbeatTimer::init()
+{
+    if (!_high_latency) {
         _timer->setInterval(_heartbeatReceivedTimeoutMSecs);
         _timer->setSingleShot(true);
         _timer->start();
@@ -26,7 +30,9 @@ HeartbeatTimer::HeartbeatTimer(int vehicle_id, bool high_latency) :
     QObject::connect(_timer, &QTimer::timeout, this, &HeartbeatTimer::timerTimeout);
 }
 
-HeartbeatTimer::~HeartbeatTimer() {
+
+HeartbeatTimer::~HeartbeatTimer()
+{
     if (_timer) {
         QObject::disconnect(_timer, &QTimer::timeout, this, &HeartbeatTimer::timerTimeout);
         _timer->stop();

--- a/src/comm/HeartbeatTimer.h
+++ b/src/comm/HeartbeatTimer.h
@@ -36,6 +36,13 @@ public:
      */
     HeartbeatTimer(int vehicle_id, bool high_latency);
 
+    /**
+     * @brief init
+     *
+     * Starts the timer and emits the signal that the link is active for this vehicle ID
+     */
+    void init();
+
     ~HeartbeatTimer();
 
     /**

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -195,6 +195,7 @@ void LinkInterface::startHeartbeatTimer(int vehicle_id) {
     } else {
         _heartbeatTimers.insert(vehicle_id, new HeartbeatTimer(vehicle_id, _highLatency));
         QObject::connect(_heartbeatTimers.value(vehicle_id), &HeartbeatTimer::activeChanged, this, &LinkInterface::_activeChanged);
+        _heartbeatTimers.value(vehicle_id)->init();
     }
 }
 


### PR DESCRIPTION
Previously the first activeChanged signal got lost because it was not connected yet to the LinkInterface which resulted in a link incorrectly shown as inactive.