### PR TITLE
HIL (X-Plane): Allow to control aircraft flaps in XPlane

### DIFF
--- a/src/comm/QGCXPlaneLink.cc
+++ b/src/comm/QGCXPlaneLink.cc
@@ -532,6 +532,10 @@ void QGCXPlaneLink::updateActuatorControls(quint64 time, quint64 flags, float ct
             p.f[6] = ctl_3;
             p.f[7] = ctl_3;
             writeBytesSafe((const char*)&p, sizeof(p));
+
+            /* Send flap signals, assuming that they are mapped to channel 5 (ctl_4) */
+            sendDataRef("sim/flightmodel/controls/flaprqst", ctl_4);
+            sendDataRef("sim/flightmodel/controls/flap2rqst", ctl_4);
             break;
         }
 


### PR DESCRIPTION
Quite a nice feature for realistic testing in my opinion. Tested with X-Plane 10.64 and current pixhawk master. Obviously, in X-Plane's plane maker you need to configure your aircraft model to support flaps.