### PR TITLE
Plan: Sync indicator fixes

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -54,20 +54,21 @@ const char* MissionController::_jsonMavAutopilotKey =           "MAV_AUTOPILOT";
 const int   MissionController::_missionFileVersion =            2;
 
 MissionController::MissionController(PlanMasterController* masterController, QObject *parent)
-    : PlanElementController(masterController, parent)
-    , _missionManager(_managerVehicle->missionManager())
-    , _visualItems(NULL)
-    , _settingsItem(NULL)
-    , _firstItemsFromVehicle(false)
-    , _itemsRequested(false)
-    , _surveyMissionItemName(tr("Survey"))
-    , _fwLandingMissionItemName(tr("Fixed Wing Landing"))
-    , _structureScanMissionItemName(tr("Structure Scan"))
-    , _corridorScanMissionItemName(tr("Corridor Scan"))
-    , _appSettings(qgcApp()->toolbox()->settingsManager()->appSettings())
-    , _progressPct(0)
-    , _currentPlanViewIndex(-1)
-    , _currentPlanViewItem(NULL)
+    : PlanElementController         (masterController, parent)
+    , _missionManager               (_managerVehicle->missionManager())
+    , _visualItems                  (NULL)
+    , _settingsItem                 (NULL)
+    , _firstItemsFromVehicle        (false)
+    , _itemsRequested               (false)
+    , _inRecalcSequence             (false)
+    , _surveyMissionItemName        (tr("Survey"))
+    , _fwLandingMissionItemName     (tr("Fixed Wing Landing"))
+    , _structureScanMissionItemName (tr("Structure Scan"))
+    , _corridorScanMissionItemName  (tr("Corridor Scan"))
+    , _appSettings                  (qgcApp()->toolbox()->settingsManager()->appSettings())
+    , _progressPct                  (0)
+    , _currentPlanViewIndex         (-1)
+    , _currentPlanViewItem          (NULL)
 {
     _resetMissionFlightStatus();
     managerVehicleChanged(_managerVehicle);
@@ -142,17 +143,17 @@ void MissionController::_init(void)
 // Called when new mission items have completed downloading from Vehicle
 void MissionController::_newMissionItemsAvailableFromVehicle(bool removeAllRequested)
 {
-    qCDebug(MissionControllerLog) << "_newMissionItemsAvailableFromVehicle";
+    qCDebug(MissionControllerLog) << "_newMissionItemsAvailableFromVehicle flyView:count" << _flyView << _missionManager->missionItems().count();
 
     // Fly view always reloads on _loadComplete
     // Plan view only reloads on _loadComplete if specifically requested
-    if (_flyView || removeAllRequested || _itemsRequested) {
+    if (_flyView || removeAllRequested || _itemsRequested || _visualItems->count() <= 1) {
         // Fly Mode (accept if):
         //      - Always accepts new items from the vehicle so Fly view is kept up to date
         // Edit Mode (accept if):
-        //      - Either a load from vehicle was manually requested or
+        //      - Remove all was requested from Fly view (clear mission on flight end)
+        //      - A load from vehicle was manually requested
         //      - The initial automatic load from a vehicle completed and the current editor is empty
-        //      - Remove all way requested from Fly view (clear mission on flight end)
 
         QmlObjectListModel* newControllerMissionItems = new QmlObjectListModel(this);
         const QList<MissionItem*>& newMissionItems = _missionManager->missionItems();
@@ -1481,15 +1482,21 @@ void MissionController::_recalcMissionFlightStatus()
 // This will update the sequence numbers to be sequential starting from 0
 void MissionController::_recalcSequence(void)
 {
+    if (_inRecalcSequence) {
+        // Don't let this call recurse due to signalling
+        return;
+    }
+
     // Setup ascending sequence numbers for all visual items
 
+    _inRecalcSequence = true;
     int sequenceNumber = 0;
     for (int i=0; i<_visualItems->count(); i++) {
         VisualMissionItem* item = qobject_cast<VisualMissionItem*>(_visualItems->get(i));
-
         item->setSequenceNumber(sequenceNumber);
         sequenceNumber = item->lastSequenceNumber() + 1;
-    }
+    }    
+    _inRecalcSequence = false;
 }
 
 // This will update the child item hierarchy

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -267,6 +267,7 @@ private:
     CoordVectHashTable      _linesTable;
     bool                    _firstItemsFromVehicle;
     bool                    _itemsRequested;
+    bool                    _inRecalcSequence;
     MissionFlightStatus_t   _missionFlightStatus;
     QString                 _surveyMissionItemName;
     QString                 _fwLandingMissionItemName;

--- a/src/MissionManager/PlanElementController.h
+++ b/src/MissionManager/PlanElementController.h
@@ -63,7 +63,6 @@ signals:
     void containsItemsChanged   (bool containsItems);
     void syncInProgressChanged  (bool syncInProgress);
     void dirtyChanged           (bool dirty);
-    void vehicleChanged         (Vehicle* vehicle);
     void sendComplete           (void);
     void removeAllComplete      (void);
 

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -153,6 +153,9 @@ protected:
     QList<MissionItem*> _writeMissionItems;     ///< Set of mission items currently being written to vehicle
     int                 _currentMissionIndex;
     int                 _lastCurrentIndex;
+
+private:
+    void _setTransactionInProgress(TransactionType_t type);
 };
 
 #endif

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -34,7 +34,7 @@ public:
     Q_PROPERTY(RallyPointController*    rallyPointController    READ rallyPointController   CONSTANT)
 
     Q_PROPERTY(Vehicle*     controllerVehicle   MEMBER _controllerVehicle               CONSTANT)
-    Q_PROPERTY(bool         offline             READ offline                            NOTIFY offlineEditingChanged)   ///< true: controller is not connected to an active vehicle
+    Q_PROPERTY(bool         offline             READ offline                            NOTIFY offlineChanged)          ///< true: controller is not connected to an active vehicle
     Q_PROPERTY(bool         containsItems       READ containsItems                      NOTIFY containsItemsChanged)    ///< true: Elemement is non-empty
     Q_PROPERTY(bool         syncInProgress      READ syncInProgress                     NOTIFY syncInProgressChanged)   ///< true: Information is currently being saved/sent, false: no active save/send in progress
     Q_PROPERTY(bool         dirty               READ dirty              WRITE setDirty  NOTIFY dirtyChanged)            ///< true: Unsaved/sent changes are present, false: no changes since last save/send
@@ -74,7 +74,7 @@ public:
 
     bool        offline         (void) const { return _offline; }
     bool        containsItems   (void) const;
-    bool        syncInProgress  (void) const { return _syncInProgress; }
+    bool        syncInProgress  (void) const;
     bool        dirty           (void) const;
     void        setDirty        (bool dirty);
     QString     fileExtension   (void) const;
@@ -90,10 +90,9 @@ public:
 
 signals:
     void containsItemsChanged   (bool containsItems);
-    void syncInProgressChanged  (bool syncInProgress);
+    void syncInProgressChanged  (void);
     void dirtyChanged           (bool dirty);
-    void vehicleChanged         (Vehicle* vehicle);
-    void offlineEditingChanged  (bool offlineEditing);
+    void offlineChanged  		(bool offlineEditing);
 
 private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);
@@ -119,7 +118,6 @@ private:
     bool                    _loadRallyPoints;
     bool                    _sendGeoFence;
     bool                    _sendRallyPoints;
-    bool                    _syncInProgress;
 
     static const int    _planFileVersion;
     static const char*  _planFileType;

--- a/src/PlanView/PlanToolBar.qml
+++ b/src/PlanView/PlanToolBar.qml
@@ -310,6 +310,12 @@ Rectangle {
         width:          _controllerProgressPct * parent.width
         color:          qgcPal.colorGreen
         visible:        false
+
+        onVisibleChanged: {
+            if (visible) {
+                largeProgressBar._userHide = false
+            }
+        }
     }
 
     /*


### PR DESCRIPTION
* Sync indicator correctly handled when waiting for initial vehicle load. Fix for #6582.
* Fix hiding giant progress indicator so it can be used more than once.
* Fix a  couple other cases where sync state was wrong.