### PR TITLE
Turn "Sync" menu into a proper "File" menu

### DIFF
--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -40,6 +40,7 @@ public:
     Q_PROPERTY(bool         dirty               READ dirty              WRITE setDirty  NOTIFY dirtyChanged)            ///< true: Unsaved/sent changes are present, false: no changes since last save/send
     Q_PROPERTY(QString      fileExtension       READ fileExtension                      CONSTANT)                       ///< File extension for missions
     Q_PROPERTY(QString      kmlFileExtension    READ kmlFileExtension                   CONSTANT)
+    Q_PROPERTY(QString      currentPlanFile     READ currentPlanFile                    NOTIFY currentPlanFileChanged)
     ///< kml file extension for missions
     Q_PROPERTY(QStringList  loadNameFilters     READ loadNameFilters                    CONSTANT)                       ///< File filter list loading plan files
     Q_PROPERTY(QStringList  saveNameFilters     READ saveNameFilters                    CONSTANT)                       ///< File filter list saving plan files
@@ -63,6 +64,7 @@ public:
     Q_INVOKABLE void loadFromVehicle(void);
     Q_INVOKABLE void sendToVehicle(void);
     Q_INVOKABLE void loadFromFile(const QString& filename);
+    Q_INVOKABLE void saveToCurrent();
     Q_INVOKABLE void saveToFile(const QString& filename);
     Q_INVOKABLE void saveToKml(const QString& filename);
     Q_INVOKABLE void removeAll(void);                       ///< Removes all from controller only, synce required to remove from vehicle
@@ -79,6 +81,7 @@ public:
     void        setDirty        (bool dirty);
     QString     fileExtension   (void) const;
     QString     kmlFileExtension(void) const;
+    QString     currentPlanFile (void) const { return _currentPlanFile; }
     QStringList loadNameFilters (void) const;
     QStringList saveNameFilters (void) const;
     QStringList fileKmlFilters  (void) const;
@@ -93,6 +96,7 @@ signals:
     void syncInProgressChanged  (void);
     void dirtyChanged           (bool dirty);
     void offlineChanged  		(bool offlineEditing);
+    void currentPlanFileChanged ();
 
 private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);
@@ -118,6 +122,7 @@ private:
     bool                    _loadRallyPoints;
     bool                    _sendGeoFence;
     bool                    _sendRallyPoints;
+    QString                 _currentPlanFile;
 
     static const int    _planFileVersion;
     static const char*  _planFileType;

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -815,6 +815,17 @@ QGCView {
         }
     }
 
+    Component {
+        id: clearVehicleMissionDialog
+        QGCViewMessage {
+            message: qsTr("Are you sure you want to remove all mission items and clear the mission from the vehicle?")
+            function accept() {
+                masterController.removeAllFromVehicle()
+                hideDialog()
+            }
+        }
+    }
+
     //- ToolStrip DropPanel Components
 
     Component {
@@ -995,7 +1006,7 @@ QGCView {
                     visible:            !QGroundControl.corePlugin.options.disableVehicleConnection
                     onClicked: {
                         dropPanel.hide()
-                        masterController.removeAllFromVehicle()
+                        _qgcView.showDialog(clearVehicleMissionDialog, text, _qgcView.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
                     }
                 }
 

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -878,32 +878,6 @@ QGCView {
                 columnSpacing:      ScreenTools.defaultFontPixelWidth
 
                 QGCButton {
-                    text:               qsTr("Upload")
-                    Layout.fillWidth:   true
-                    enabled:            !masterController.offline && !masterController.syncInProgress
-                    visible:            _activeVehicle
-                    onClicked: {
-                        dropPanel.hide()
-                        masterController.upload()
-                    }
-                }
-
-                QGCButton {
-                    text:               qsTr("Download")
-                    Layout.fillWidth:   true
-                    enabled:            !masterController.offline && !masterController.syncInProgress
-                    visible:            _activeVehicle
-                    onClicked: {
-                        dropPanel.hide()
-                        if (masterController.dirty) {
-                            _qgcView.showDialog(syncLoadFromVehicleOverwrite, columnHolder._overwriteText, _qgcView.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
-                        } else {
-                            masterController.loadFromVehicle()
-                        }
-                    }
-                }
-
-                QGCButton {
                     text:               qsTr("New...")
                     Layout.fillWidth:   true
                     enabled:            _visualItems.count > 1
@@ -974,6 +948,54 @@ QGCView {
                         }
                         dropPanel.hide()
                         masterController.saveKmlToSelectedFile()
+                    }
+                }
+
+                Rectangle {
+                    width:              parent.width * 0.8
+                    height:             1
+                    color:              qgcPal.text
+                    opacity:            0.5
+                    visible:            !QGroundControl.corePlugin.options.disableVehicleConnection
+                    Layout.fillWidth:   true
+                    Layout.columnSpan:  2
+                }
+
+                QGCButton {
+                    text:               qsTr("Upload")
+                    Layout.fillWidth:   true
+                    enabled:            !masterController.offline && !masterController.syncInProgress && _visualItems.count > 1
+                    visible:            !QGroundControl.corePlugin.options.disableVehicleConnection
+                    onClicked: {
+                        dropPanel.hide()
+                        masterController.upload()
+                    }
+                }
+
+                QGCButton {
+                    text:               qsTr("Download")
+                    Layout.fillWidth:   true
+                    enabled:            !masterController.offline && !masterController.syncInProgress
+                    visible:            !QGroundControl.corePlugin.options.disableVehicleConnection
+                    onClicked: {
+                        dropPanel.hide()
+                        if (masterController.dirty) {
+                            _qgcView.showDialog(syncLoadFromVehicleOverwrite, columnHolder._overwriteText, _qgcView.showDialogDefaultWidth, StandardButton.Yes | StandardButton.Cancel)
+                        } else {
+                            masterController.loadFromVehicle()
+                        }
+                    }
+                }
+
+                QGCButton {
+                    text:               qsTr("Clear Vehicle Mission")
+                    Layout.fillWidth:   true
+                    Layout.columnSpan:  2
+                    enabled:            !masterController.offline && !masterController.syncInProgress
+                    visible:            !QGroundControl.corePlugin.options.disableVehicleConnection
+                    onClicked: {
+                        dropPanel.hide()
+                        masterController.removeAllFromVehicle()
                     }
                 }
 

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -930,7 +930,7 @@ QGCView {
                 QGCButton {
                     text:               qsTr("Save")
                     Layout.fillWidth:   true
-                    enabled:            !masterController.syncInProgress
+                    enabled:            !masterController.syncInProgress && masterController.currentPlanFile !== ""
                     onClicked: {
                         dropPanel.hide()
                         if(masterController.currentPlanFile !== "") {
@@ -944,7 +944,7 @@ QGCView {
                 QGCButton {
                     text:               qsTr("Save As...")
                     Layout.fillWidth:   true
-                    enabled:            !masterController.syncInProgress
+                    enabled:            !masterController.syncInProgress && _visualItems.count > 1
                     onClicked: {
                         dropPanel.hide()
                         masterController.saveToSelectedFile()
@@ -965,7 +965,7 @@ QGCView {
                 QGCButton {
                     text:               qsTr("Save KML...")
                     Layout.fillWidth:   true
-                    enabled:            !masterController.syncInProgress
+                    enabled:            !masterController.syncInProgress && _visualItems.count > 1
                     onClicked: {
                         // First point does not count
                         if (_visualItems.count < 2) {

--- a/src/QmlControls/DropPanel.qml
+++ b/src/QmlControls/DropPanel.qml
@@ -71,11 +71,11 @@ Item {
     }
 
     function _calcPositions() {
-        var panelComponentWidth = panelLoader.item.width
+        var panelComponentWidth  = panelLoader.item.width
         var panelComponentHeight = panelLoader.item.height
 
-        dropDownItem.width = panelComponentWidth + _dropMarginX2 + _arrowPointWidth
-        dropDownItem.height = panelComponentHeight + _dropMarginX2
+        dropDownItem.width  = panelComponentWidth  + (_dropMarginX2 * 2) + _arrowPointWidth
+        dropDownItem.height = panelComponentHeight + (_dropMarginX2 * 2)
 
         dropDownItem.x = _dropEdgeTopPoint.x + _dropMargin
         dropDownItem.y = _dropEdgeTopPoint.y -(dropDownItem.height / 2) + radius

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -16,7 +16,7 @@ import QGroundControl.Palette       1.0
 Rectangle {
     id:         _root
     color:      qgcPal.window
-    width:      ScreenTools.isMobile ? ScreenTools.minTouchPixels : ScreenTools.defaultFontPixelWidth * 6
+    width:      ScreenTools.isMobile ? ScreenTools.minTouchPixels : ScreenTools.defaultFontPixelWidth * 7
     height:     buttonStripColumn.height + (buttonStripColumn.anchors.margins * 2)
     radius:     _radius
     border.width:   1
@@ -133,7 +133,7 @@ Rectangle {
                     id:             scope
                     anchors.left:   parent.left
                     anchors.right:  parent.right
-                    height:         width
+                    height:         width * 0.8
 
                     Rectangle {
                         anchors.fill:   parent
@@ -141,9 +141,11 @@ Rectangle {
 
                         QGCColoredImage {
                             id:                 button
-                            anchors.fill:       parent
+                            height:             parent.height
+                            width:              height
+                            anchors.centerIn:   parent
                             source:             _source
-                            sourceSize.height:  parent.height
+                            sourceSize.height:  height
                             fillMode:           Image.PreserveAspectFit
                             mipmap:             true
                             smooth:             true

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -49,6 +49,7 @@ public:
     Q_PROPERTY(bool                     guidedActionsRequireRCRSSI      READ guidedActionsRequireRCRSSI     CONSTANT)
     Q_PROPERTY(bool                     showMissionAbsoluteAltitude     READ showMissionAbsoluteAltitude    NOTIFY showMissionAbsoluteAltitudeChanged)
     Q_PROPERTY(bool                     showSimpleMissionStart          READ showSimpleMissionStart         NOTIFY showSimpleMissionStartChanged)
+    Q_PROPERTY(bool                     disableVehicleConnection        READ disableVehicleConnection       CONSTANT)
 
     /// Should QGC hide its settings menu and colapse it into one single menu (Settings and Vehicle Setup)?
     /// @return true if QGC should consolidate both menus into one.
@@ -90,6 +91,7 @@ public:
     virtual bool    showOfflineMapImport            () const { return true; }
     virtual bool    showMissionAbsoluteAltitude     () const { return true; }
     virtual bool    showSimpleMissionStart          () const { return false; }
+    virtual bool    disableVehicleConnection        () const { return false; }  ///< true: vehicle connection is disabled
 
 #if defined(__mobile__)
     virtual bool    useMobileFileDialog             () const { return true;}


### PR DESCRIPTION
First stab at reworking the _Sync_ menu:

The _Sync_ menu within the Plan View tool strip is basically a regular _File_ menu. As such, let's call it what it is.

* Renamed _Sync_ to _File_
* Moved it to the top of the list as this is the standard for _File_ menus
* Renamed _Remove All_ to _New_ (and moved it to the top of the list as this is the standard)
* Renamed _Load_ to _Open_
* Added a _Save_ (current) and renamed the existing one to _Save As_ (to new file)
* Hide both _Download_ and _Upload_ buttons if you are not connected (offline)
* Disable the _New_ button if the plan is empty
* Disable save options if there is nothing to save

In addition, I've adjusted the width of the tool strip so long words such as _Waypoint_ or _Checklist_ would fit within it.

Blank mission and not connected to anything:
<img width="1092" alt="screen shot 2018-06-19 at 11 46 44 am" src="https://user-images.githubusercontent.com/749243/41608429-811ab9c8-73b6-11e8-9317-965dbd29426e.png">

Selecting _New_ with a plan loaded/created:
<img width="1120" alt="screen shot 2018-06-19 at 10 02 23 am" src="https://user-images.githubusercontent.com/749243/41603842-cdebd698-73ab-11e8-83a9-21ab90247255.png">

Connected to a vehicle:
<img width="1120" alt="screen shot 2018-06-19 at 10 04 10 am" src="https://user-images.githubusercontent.com/749243/41603945-0027aa88-73ac-11e8-8726-07ddf980efc4.png">

Android for reference:
![screen](https://user-images.githubusercontent.com/749243/41603992-21fd65d0-73ac-11e8-9a55-e8f2a4f4b94d.png)



