### PR TITLE
Mavlink Orbit support

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -270,12 +270,6 @@ void FirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double takeoffAltRel)
     qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
 }
 
-void FirmwarePlugin::guidedModeOrbit(Vehicle* /*vehicle*/, const QGeoCoordinate& /*centerCoord*/, double /*radius*/, double /*velocity*/, double /*altitude*/)
-{
-    // Not supported by generic vehicle
-    qgcApp()->showMessage(guided_mode_not_supported_by_vehicle);
-}
-
 void FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordinate& gotoCoord)
 {
     // Not supported by generic vehicle

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -136,10 +136,6 @@ public:
     /// Command the vehicle to start the mission
     virtual void startMission(Vehicle* vehicle);
 
-    /// Command vehicle to orbit given center point
-    ///     @param centerCoord Center Coordinates
-    virtual void guidedModeOrbit(Vehicle* vehicle, const QGeoCoordinate& centerCoord, double radius, double velocity, double altitude);
-
     /// Command vehicle to move to specified location (altitude is included and relative)
     virtual void guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordinate& gotoCoord);
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -232,7 +232,7 @@ bool PX4FirmwarePlugin::isCapable(const Vehicle *vehicle, FirmwareCapabilities c
 {
     int available = SetFlightModeCapability | PauseVehicleCapability | GuidedModeCapability;
     if (vehicle->multiRotor() || vehicle->vtol()) {
-        available |= TakeoffVehicleCapability;
+        available |= TakeoffVehicleCapability | OrbitModeCapability;
     }
 
     return (capabilities & available) == capabilities;
@@ -362,24 +362,6 @@ void PX4FirmwarePlugin::guidedModeRTL(Vehicle* vehicle)
 void PX4FirmwarePlugin::guidedModeLand(Vehicle* vehicle)
 {
     _setFlightModeAndValidate(vehicle, _landingFlightMode);
-}
-
-void PX4FirmwarePlugin::guidedModeOrbit(Vehicle* vehicle, const QGeoCoordinate& centerCoord, double radius, double velocity, double altitude)
-{
-    if (!isGuidedMode(vehicle)) {
-        setGuidedMode(vehicle, true);
-    }
-
-    vehicle->sendMavCommand(vehicle->defaultComponentId(),
-                            MAV_CMD_SET_GUIDED_SUBMODE_CIRCLE,
-                            true,   // show error if fails
-                            radius,
-                            velocity,
-                            altitude,
-                            NAN,
-                            centerCoord.isValid() ? centerCoord.latitude()  : NAN,
-                            centerCoord.isValid() ? centerCoord.longitude() : NAN,
-                            centerCoord.isValid() ? centerCoord.altitude()  : NAN);
 }
 
 void PX4FirmwarePlugin::_mavCommandResult(int vehicleId, int component, int command, int result, bool noReponseFromVehicle)

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -46,7 +46,6 @@ public:
     void                guidedModeRTL                   (Vehicle* vehicle) override;
     void                guidedModeLand                  (Vehicle* vehicle) override;
     void                guidedModeTakeoff               (Vehicle* vehicle, double takeoffAltRel) override;
-    void                guidedModeOrbit                 (Vehicle* vehicle, const QGeoCoordinate& centerCoord = QGeoCoordinate(), double radius = NAN, double velocity = NAN, double altitude = NAN) override;
     void                guidedModeGotoLocation          (Vehicle* vehicle, const QGeoCoordinate& gotoCoord) override;
     void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeRel) override;
     double              minimumTakeoffAltitude          (Vehicle* vehicle) override;

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -508,11 +508,10 @@ QGCView {
             z:                  _panel.z + 4
             title:              qsTr("Fly")
             maxHeight:          (_flightVideo.visible ? _flightVideo.y : parent.height) - toolStrip.y
-            buttonVisible:      [ _useChecklist, _guidedController.showTakeoff || !_guidedController.showLand, _guidedController.showLand && !_guidedController.showTakeoff, true, true, true, _guidedController.smartShotsAvailable ]
-            buttonEnabled:      [ _useChecklist && _activeVehicle, _guidedController.showTakeoff, _guidedController.showLand, _guidedController.showRTL, _guidedController.showPause, _anyActionAvailable, _anySmartShotAvailable ]
+            buttonVisible:      [ _useChecklist, _guidedController.showTakeoff || !_guidedController.showLand, _guidedController.showLand && !_guidedController.showTakeoff, true, true, true ]
+            buttonEnabled:      [ _useChecklist && _activeVehicle, _guidedController.showTakeoff, _guidedController.showLand, _guidedController.showRTL, _guidedController.showPause, _anyActionAvailable ]
 
             property bool _anyActionAvailable: _guidedController.showStartMission || _guidedController.showResumeMission || _guidedController.showChangeAlt || _guidedController.showLandAbort
-            property bool _anySmartShotAvailable: _guidedController.showOrbit
             property var _actionModel: [
                 {
                     title:      _guidedController.startMissionTitle,
@@ -543,14 +542,6 @@ QGCView {
                     text:       _guidedController.landAbortMessage,
                     action:     _guidedController.actionLandAbort,
                     visible:    _guidedController.showLandAbort
-                }
-            ]
-            property var _smartShotModel: [
-                {
-                    title:      _guidedController.orbitTitle,
-                    text:       _guidedController.orbitMessage,
-                    action:     _guidedController.actionOrbit,
-                    visible:    _guidedController.showOrbit
                 }
             ]
 
@@ -584,28 +575,15 @@ QGCView {
                     name:       qsTr("Action"),
                     iconSource: "/res/action.svg",
                     action:     -1
-                },
-                /*
-                  No firmware support any smart shots yet
-                {
-                    name:       qsTr("Smart"),
-                    iconSource: "/qmlimages/MapCenter.svg",
-                    action:     -1
-                },
-                */
+                }
             ]
 
             onClicked: {
                 guidedActionsController.closeAll()
                 var action = model[index].action
                 if (action === -1) {
-                    if (index == 5) {
-                        guidedActionList.model   = _actionModel
-                        guidedActionList.visible = true
-                    } else if (index == 6) {
-                        guidedActionList.model   = _smartShotModel
-                        guidedActionList.visible = true
-                    }
+                    guidedActionList.model   = _actionModel
+                    guidedActionList.visible = true
                 } else {
                     _guidedController.confirmAction(action)
                 }

--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -100,12 +100,13 @@ Rectangle {
 
             onAccept: {
                 _root.visible = false
+                var altitudeChange = 0
                 if (altitudeSlider.visible) {
-                    _root.actionData = altitudeSlider.getValue()
+                    altitudeChange = altitudeSlider.getAltitudeChangeValue()
                     altitudeSlider.visible = false
                 }
                 hideTrigger = false
-                guidedController.executeAction(_root.action, _root.actionData)
+                guidedController.executeAction(_root.action, _root.actionData, altitudeChange)
             }
 
             onReject: {

--- a/src/FlightDisplay/GuidedAltitudeSlider.qml
+++ b/src/FlightDisplay/GuidedAltitudeSlider.qml
@@ -36,7 +36,8 @@ Rectangle {
         altField.setToMinimumTakeoff()
     }
 
-    function getValue() {
+    /// Returns the user specified change in altitude from the current vehicle altitude
+    function getAltitudeChangeValue() {
         return altField.newAltitudeMeters - _vehicleAltitude
     }
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2751,13 +2751,30 @@ void Vehicle::guidedModeChangeAltitude(double altitudeChange)
     _firmwarePlugin->guidedModeChangeAltitude(this, altitudeChange);
 }
 
-void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, double velocity, double altitude)
+void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, double amslAltitude)
 {
     if (!orbitModeSupported()) {
         qgcApp()->showMessage(QStringLiteral("Orbit mode not supported by Vehicle."));
         return;
     }
-    _firmwarePlugin->guidedModeOrbit(this, centerCoord, radius, velocity, altitude);
+
+    double lat, lon, alt;
+    if (centerCoord.isValid()) {
+        lat = lon = alt = qQNaN();
+    } else {
+        lat = centerCoord.latitude();
+        lon = centerCoord.longitude();
+        alt = amslAltitude;
+    }
+
+    sendMavCommand(defaultComponentId(),
+                   MAV_CMD_DO_ORBIT,
+                   true,            // show error if fails
+                   radius,
+                   qQNaN(),         // Use default velocity
+                   0,               // Vehicle points to center
+                   qQNaN(),         // reserved
+                   lat, lon, alt);
 }
 
 void Vehicle::pauseVehicle(void)

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -582,11 +582,10 @@ public:
     Q_INVOKABLE void guidedModeChangeAltitude(double altitudeChange);
 
     /// Command vehicle to orbit given center point
-    ///     @param centerCoord Center Coordinates
+    ///     @param centerCoord Orit around this point
     ///     @param radius Distance from vehicle to centerCoord
-    ///     @param velocity Orbit velocity (positive CW, negative CCW)
-    ///     @param altitude Desired Vehicle Altitude
-    Q_INVOKABLE void guidedModeOrbit(const QGeoCoordinate& centerCoord = QGeoCoordinate(), double radius = NAN, double velocity = NAN, double altitude = NAN);
+    ///     @param amslAltitude Desired vehicle altitude
+    Q_INVOKABLE void guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, double amslAltitude);
 
     /// Command vehicle to pause at current location. If vehicle supports guide mode, vehicle will be left
     /// in guided mode after pause.


### PR DESCRIPTION
Initial implementation of new MAV_CMD_DO_ORBIT command (https://github.com/mavlink/mavlink/pull/924). Still much work to do, but enough to start firmware testing.

Caveats to current implementation (@MaEtUgR FYI):
* Initial implementation uses COMMAND_LONG (COMMAND_INT supports requires a bunch of changes to QGC command retry infrastructure). I implemented assuming altitude for COMMAND_LONG version was absolute amsl. Mavlink spec should specify the frame for this when not using COMMAND_INT.
* Radius is hardwired to 10 meters.

Work left to do:
* Switch to COMMAND_INT
* Radius visuals and editing

Click in map to set position:
![screen shot 2018-06-19 at 11 49 36 am](https://user-images.githubusercontent.com/5876851/41618128-2720f850-73b7-11e8-9f67-91d52f94e48a.png)

Pick Orbit:
![screen shot 2018-06-19 at 11 49 40 am](https://user-images.githubusercontent.com/5876851/41618147-2f30b9f4-73b7-11e8-837c-affd1bca6884.png)