### PR TITLE
Update hosts list on UDP Configuration creation

### DIFF
--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -405,6 +405,7 @@ void UDPConfiguration::_copyFrom(LinkConfiguration *source)
             if(!contains_target(_targetHosts, target->address, target->port)) {
                 UDPCLient* newTarget = new UDPCLient(target);
                 _targetHosts.append(newTarget);
+                _updateHostList();
             }
         }
     } else {


### PR DESCRIPTION
This patch fixes a bug when UDP target hosts list was empty in connection edit screen. One had to add new host in order to display existing entries.
Here is a screenshot of the screen which I mean https://imgur.com/ajmqbfu