### PR TITLE
Allow plugin to override pixel ratio and density

### DIFF
--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -131,6 +131,7 @@ Item {
             minTouchPixels      = defaultFontPixelHeight * 3
         }
         toolbarHeight           = isMobile ? minTouchPixels : defaultFontPixelHeight * 3
+        toolbarHeight           = toolbarHeight * QGroundControl.corePlugin.options.toolbarHeightMultiplier
     }
 
     Text {

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -53,12 +53,15 @@ Item {
     readonly property real mediumFontPointRatio:     1.25
     readonly property real largeFontPointRatio:      1.5
 
+    property real realPixelDensity:  QGroundControl.corePlugin.options.devicePixelDensity != 0 ? QGroundControl.corePlugin.options.devicePixelDensity : Screen.pixelDensity
+    property real realPixelRatio:    QGroundControl.corePlugin.options.devicePixelRatio   != 0 ? QGroundControl.corePlugin.options.devicePixelRatio   : Screen.devicePixelRatio
+
     property bool isAndroid:        ScreenToolsController.isAndroid
     property bool isiOS:            ScreenToolsController.isiOS
     property bool isMobile:         ScreenToolsController.isMobile
     property bool isWindows:        ScreenToolsController.isWindows
     property bool isDebug:          ScreenToolsController.isDebug
-    property bool isTinyScreen:     (Screen.width / Screen.pixelDensity) < 120 // 120mm
+    property bool isTinyScreen:     (Screen.width / realPixelDensity) < 120 // 120mm
     property bool isShortScreen:    ScreenToolsController.isMobile && ((Screen.height / Screen.width) < 0.6) // Nexus 7 for example
     property bool isHugeScreen:     Screen.width >= 1920*2
 
@@ -91,6 +94,14 @@ Item {
         }
     }
 
+    onRealPixelDensityChanged: {
+        _setBasePointSize(defaultFontPointSize)
+    }
+
+    onRealPixelRatioChanged: {
+        _setBasePointSize(defaultFontPointSize)
+    }
+
     function printScreenStats() {
         console.log('ScreenTools: Screen.width: ' + Screen.width + ' Screen.height: ' + Screen.height + ' Screen.pixelDensity: ' + Screen.pixelDensity)
     }
@@ -114,13 +125,11 @@ Item {
         smallFontPointSize      = defaultFontPointSize  * _screenTools.smallFontPointRatio
         mediumFontPointSize     = defaultFontPointSize  * _screenTools.mediumFontPointRatio
         largeFontPointSize      = defaultFontPointSize  * _screenTools.largeFontPointRatio
-        minTouchPixels          = Math.round(minTouchMillimeters * Screen.pixelDensity)
+        minTouchPixels          = Math.round(minTouchMillimeters * realPixelDensity * realPixelRatio)
         if (minTouchPixels / Screen.height > 0.15) {
-            // If using physical sizing takes up too much o fthe vertical real estate fall back to font based sizing
+            // If using physical sizing takes up too much of the vertical real estate fall back to font based sizing
             minTouchPixels      = defaultFontPixelHeight * 3
         }
-
-        //console.log(minTouchPixels / Screen.height)
         toolbarHeight           = isMobile ? minTouchPixels : defaultFontPixelHeight * 3
     }
 
@@ -151,7 +160,7 @@ Item {
                         } else {
                             baseSize = 14;
                         }
-                    } else if((Screen.width / Screen.pixelDensity) < 120) {
+                    } else if((Screen.width / realPixelDensity) < 120) {
                         baseSize = 11;
                     // Other Android
                     } else {

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -50,6 +50,8 @@ public:
     Q_PROPERTY(bool                     showMissionAbsoluteAltitude     READ showMissionAbsoluteAltitude    NOTIFY showMissionAbsoluteAltitudeChanged)
     Q_PROPERTY(bool                     showSimpleMissionStart          READ showSimpleMissionStart         NOTIFY showSimpleMissionStartChanged)
     Q_PROPERTY(bool                     disableVehicleConnection        READ disableVehicleConnection       CONSTANT)
+    Q_PROPERTY(float                    devicePixelRatio                READ devicePixelRatio               NOTIFY devicePixelRatioChanged)
+    Q_PROPERTY(float                    devicePixelDensity              READ devicePixelDensity             NOTIFY devicePixelDensityChanged)
 
     /// Should QGC hide its settings menu and colapse it into one single menu (Settings and Vehicle Setup)?
     /// @return true if QGC should consolidate both menus into one.
@@ -104,6 +106,10 @@ public:
     /// the Advanced options.
     virtual QString firmwareUpgradeSingleURL        () const { return QString(); }
 
+    /// Device specific pixel ratio/density (for when Qt doesn't properly read it from the hardware)
+    virtual float   devicePixelRatio                () const { return 0.0f; }
+    virtual float   devicePixelDensity              () const { return 0.0f; }
+
 signals:
     void showSensorCalibrationCompassChanged    (bool show);
     void showSensorCalibrationGyroChanged       (bool show);
@@ -119,6 +125,8 @@ signals:
     void showOfflineMapImportChanged            ();
     void showMissionAbsoluteAltitudeChanged     ();
     void showSimpleMissionStartChanged          ();
+    void devicePixelRatioChanged                ();
+    void devicePixelDensityChanged              ();
 
 private:
     CustomInstrumentWidget* _defaultInstrumentWidget;


### PR DESCRIPTION
I bumped into a custom Android tablet (CrystalSky), which even though it has a high density display, it reports otherwise. At least Qt thinks that's the case. `Screen.devicePixelRatio` returns 1 instead of 2. The pixel density is also slightly off as they probably measured the entire width of the device instead of the screen area.

As there is no way to find this at runtime, and this happens to be a "custom" case, I've added an API where a plugin can override both the pixel ratio and pixel density.

While at it, I found that `minTouchPixels` was being computed without taking in consideration the pixel ratio. For a given size, it was computing the pixel count using density only:

`minTouchPixels = Math.round(minTouchMillimeters * Screen.pixelDensity)`

Where it should also take into account the ratio given how it is used.

`minTouchPixels = Math.round(minTouchMillimeters * realPixelDensity * realPixelRatio)`

This change _should_ only affect high density, mobile devices.