### PR TITLE
Skip custom instrument widget test if none exists.

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -101,7 +101,7 @@ FlightMap {
         var vehiclePoint = flightMap.fromCoordinate(_activeVehicleCoordinate, false /* clipToViewport */)
         var toolStripRightEdge = mapFromItem(toolStrip, toolStrip.x, 0).x + toolStrip.width
         var instrumentsWidth = 0
-        if (QGroundControl.corePlugin.options.instrumentWidget.widgetPosition === CustomInstrumentWidget.POS_TOP_RIGHT) {
+        if (QGroundControl.corePlugin.options.instrumentWidget && QGroundControl.corePlugin.options.instrumentWidget.widgetPosition === CustomInstrumentWidget.POS_TOP_RIGHT) {
             // Assume standard instruments
             instrumentsWidth = flightDisplayViewWidgets.getPreferredInstrumentWidth()
         }


### PR DESCRIPTION
The code was not testing to see if there was a valid `instrumentWidget` before trying to access one of its properties. If it happens to be NULL, you would end up with a never ending stream of these:

```
qrc:///qml/QGroundControl/FlightDisplay/FlightDisplayViewMap.qml:104: TypeError: Cannot read property 'widgetPosition' of null
```