### PR TITLE
Add Trimble MB-Two GPS support

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -642,6 +642,8 @@ HEADERS += \
     src/AnalyzeView/GeoTagController.h \
     src/AnalyzeView/MavlinkConsoleController.h \
     src/GPS/Drivers/src/gps_helper.h \
+    src/GPS/Drivers/src/rtcm.h \
+    src/GPS/Drivers/src/ashtech.h \
     src/GPS/Drivers/src/ubx.h \
     src/GPS/GPSManager.h \
     src/GPS/GPSPositionMessage.h \
@@ -823,6 +825,8 @@ SOURCES += \
     src/AnalyzeView/GeoTagController.cc \
     src/AnalyzeView/MavlinkConsoleController.cc \
     src/GPS/Drivers/src/gps_helper.cpp \
+    src/GPS/Drivers/src/rtcm.cpp \
+    src/GPS/Drivers/src/ashtech.cpp \
     src/GPS/Drivers/src/ubx.cpp \
     src/GPS/GPSManager.cc \
     src/GPS/GPSProvider.cc \

--- a/src/GPS/GPSManager.cc
+++ b/src/GPS/GPSManager.cc
@@ -26,13 +26,22 @@ GPSManager::~GPSManager()
     disconnectGPS();
 }
 
-void GPSManager::connectGPS(const QString& device)
+void GPSManager::connectGPS(const QString& device, const QString& gps_type)
 {
     RTKSettings* rtkSettings = qgcApp()->toolbox()->settingsManager()->rtkSettings();
 
+    GPSProvider::GPSType type;
+    if (gps_type.contains("trimble",  Qt::CaseInsensitive)) {
+        type = GPSProvider::GPSType::trimble;
+        qCDebug(RTKGPSLog) << "Connecting Trimble device";
+    } else {
+        type = GPSProvider::GPSType::u_blox;
+        qCDebug(RTKGPSLog) << "Connecting U-blox device";
+    }
+
     disconnectGPS();
     _requestGpsStop = false;
-    _gpsProvider = new GPSProvider(device, true, rtkSettings->surveyInAccuracyLimit()->rawValue().toDouble(), rtkSettings->surveyInMinObservationDuration()->rawValue().toInt(), _requestGpsStop);
+    _gpsProvider = new GPSProvider(device, type, true, rtkSettings->surveyInAccuracyLimit()->rawValue().toDouble(), rtkSettings->surveyInMinObservationDuration()->rawValue().toInt(), _requestGpsStop);
     _gpsProvider->start();
 
     //create RTCM device

--- a/src/GPS/GPSManager.h
+++ b/src/GPS/GPSManager.h
@@ -28,7 +28,7 @@ public:
     GPSManager(QGCApplication* app, QGCToolbox* toolbox);
     ~GPSManager();
 
-    void connectGPS     (const QString& device);
+    void connectGPS     (const QString& device, const QString& gps_type);
     void disconnectGPS  (void);
     bool connected      (void) const { return _gpsProvider && _gpsProvider->isRunning(); }
 

--- a/src/GPS/GPSProvider.cc
+++ b/src/GPS/GPSProvider.cc
@@ -63,6 +63,7 @@ void GPSProvider::run()
         }
 
         gpsDriver = new GPSDriverUBX(GPSDriverUBX::Interface::UART, &callbackEntry, this, &_reportGpsPos, _pReportSatInfo);
+        baudrate = 0; // auto-configure
         gpsDriver->setSurveyInSpecs(_surveyInAccMeters * 10000, _surveryInDurationSecs);
 
         if (gpsDriver->configure(baudrate, GPSDriverUBX::OutputMode::RTCM) == 0) {

--- a/src/GPS/GPSProvider.cc
+++ b/src/GPS/GPSProvider.cc
@@ -16,6 +16,7 @@
 #include <QDebug>
 
 #include "Drivers/src/ubx.h"
+#include "Drivers/src/ashtech.h"
 #include "Drivers/src/gps_helper.h"
 #include "definitions.h"
 
@@ -53,7 +54,7 @@ void GPSProvider::run()
     _serial->setFlowControl(QSerialPort::NoFlowControl);
 
     unsigned int baudrate;
-    GPSDriverUBX* gpsDriver = nullptr;
+    GPSHelper* gpsDriver = nullptr;
 
     while (!_requestStop) {
 
@@ -62,8 +63,13 @@ void GPSProvider::run()
             gpsDriver = nullptr;
         }
 
-        gpsDriver = new GPSDriverUBX(GPSDriverUBX::Interface::UART, &callbackEntry, this, &_reportGpsPos, _pReportSatInfo);
-        baudrate = 0; // auto-configure
+        if (_type == GPSType::trimble) {
+            gpsDriver = new GPSDriverAshtech(&callbackEntry, this, &_reportGpsPos, _pReportSatInfo);
+            baudrate = 115200;
+        } else {
+            gpsDriver = new GPSDriverUBX(GPSDriverUBX::Interface::UART, &callbackEntry, this, &_reportGpsPos, _pReportSatInfo);
+            baudrate = 0; // auto-configure
+        }
         gpsDriver->setSurveyInSpecs(_surveyInAccMeters * 10000, _surveryInDurationSecs);
 
         if (gpsDriver->configure(baudrate, GPSDriverUBX::OutputMode::RTCM) == 0) {
@@ -102,8 +108,9 @@ void GPSProvider::run()
     qCDebug(RTKGPSLog) << "Exiting GPS thread";
 }
 
-GPSProvider::GPSProvider(const QString& device, bool enableSatInfo, double surveyInAccMeters, int surveryInDurationSecs, const std::atomic_bool& requestStop)
+GPSProvider::GPSProvider(const QString& device, GPSType type, bool enableSatInfo, double surveyInAccMeters, int surveryInDurationSecs, const std::atomic_bool& requestStop)
     : _device(device)
+    , _type(type)
     , _requestStop(requestStop)
     , _surveyInAccMeters(surveyInAccMeters)
     , _surveryInDurationSecs(surveryInDurationSecs)

--- a/src/GPS/GPSProvider.h
+++ b/src/GPS/GPSProvider.h
@@ -29,7 +29,14 @@ class GPSProvider : public QThread
 {
     Q_OBJECT
 public:
-    GPSProvider(const QString& device, bool enableSatInfo, double surveyInAccMeters, int surveryInDurationSecs, const std::atomic_bool& requestStop);
+
+    enum class GPSType {
+        u_blox,
+        trimble
+    };
+
+    GPSProvider(const QString& device, GPSType type, bool enableSatInfo, double surveyInAccMeters, int surveryInDurationSecs,
+            const std::atomic_bool& requestStop);
     ~GPSProvider();
 
     /**
@@ -57,6 +64,7 @@ private:
 	int callback(GPSCallbackType type, void *data1, int data2);
 
     QString _device;
+    GPSType _type;
     const std::atomic_bool& _requestStop;
     double  _surveyInAccMeters;
     int     _surveryInDurationSecs;

--- a/src/GPS/vehicle_gps_position.h
+++ b/src/GPS/vehicle_gps_position.h
@@ -63,6 +63,7 @@ struct vehicle_gps_position_s {
 	float vel_d_m_s;
 	float cog_rad;
 	int32_t timestamp_time_relative;
+	float heading;
 	uint8_t fix_type;
 	bool vel_ned_valid;
 	uint8_t satellites_used;

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -586,7 +586,7 @@ void LinkManager::_updateAutoConnectLinks(void)
                     if (_autoConnectSettings->autoConnectRTKGPS()->rawValue().toBool() && !_toolbox->gpsManager()->connected()) {
                         qCDebug(LinkManagerLog) << "RTK GPS auto-connected" << portInfo.portName().trimmed();
                         _autoConnectRTKPort = portInfo.systemLocation();
-                        _toolbox->gpsManager()->connectGPS(portInfo.systemLocation());
+                        _toolbox->gpsManager()->connectGPS(portInfo.systemLocation(), boardName);
                     }
                     break;
 #endif

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -26,7 +26,8 @@
         { "vendorID": 1027, "productID": 24577,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "3DR Radio on FTDI" },
         { "vendorID": 4292, "productID": 60000,    "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "SILabs Radio" },
 
-        { "vendorID": 5446, "productID": 424,        "boardClass": "RTK GPS",    "name": "RTK GPS",              "comment": "Ublox RTK GPS" },
+        { "vendorID": 5446, "productID": 424,        "boardClass": "RTK GPS",    "name": "U-blox RTK GPS",               "comment": "U-blox RTK GPS" },
+        { "vendorID": 1317, "productID": 42151,      "boardClass": "RTK GPS",    "name": "Trimble RTK GPS",              "comment": "Trimble RTK GPS" },
 
         { "vendorID": 8352, "productID": 16732,     "boardClass": "OpenPilot",  "name": "OpenPilot OPLink" },
         { "vendorID": 8352, "productID": 16733,     "boardClass": "OpenPilot",  "name": "OpenPilot CC3D" },

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -402,7 +402,7 @@ QGCView {
                             anchors.horizontalCenter:   parent.horizontalCenter
                             columns:                    2
 
-                            QGCLabel { text: qsTr("Survey in accuracy") }
+                            QGCLabel { text: qsTr("Survey in accuracy (U-blox only)") }
                             FactTextField {
                                 Layout.preferredWidth:  _valueFieldWidth
                                 fact:                   QGroundControl.settingsManager.rtkSettings.surveyInAccuracyLimit

--- a/src/ui/toolbar/GPSRTKIndicator.qml
+++ b/src/ui/toolbar/GPSRTKIndicator.qml
@@ -69,9 +69,11 @@ Item {
                     QGCLabel {
                         // during survey-in show the current accuracy, after that show the final accuracy
                         text: QGroundControl.gpsRtk.valid.value ? qsTr("Accuracy:") : qsTr("Current Accuracy:")
+                        visible: QGroundControl.gpsRtk.currentAccuracy.value > 0
                         }
                     QGCLabel {
                         text: QGroundControl.gpsRtk.currentAccuracy.valueString + " " + QGroundControl.appSettingsDistanceUnitsString
+                        visible: QGroundControl.gpsRtk.currentAccuracy.value > 0
                         }
                     QGCLabel { text: qsTr("Satellites:") }
                     QGCLabel { text: QGroundControl.gpsRtk.numSatellites.value }


### PR DESCRIPTION
This adds base station support for the Trimble MB-Two RTK GPS.
- The device gets automatically detected & connected
- Survey-in works similar as for u-blox, except that no minimum accuracy can be specified
- After that it starts streaming RTCM correction messages

GPS driver update: https://github.com/PX4/GpsDrivers/pull/28