### PR TITLE
FW Landing Pattern: Z order for landing click is above map items

### DIFF
--- a/src/PlanView/FWLandingPatternMapVisual.qml
+++ b/src/PlanView/FWLandingPatternMapVisual.qml
@@ -159,7 +159,8 @@ Item {
         id:  mouseAreaComponent
 
         MouseArea {
-            anchors.fill: map
+            anchors.fill:   map
+            z:              QGroundControl.zOrderMapItems + 1   // Over item indicators
 
             onClicked: {
                 var coordinate = map.toCoordinate(Qt.point(mouse.x, mouse.y), false /* clipToViewPort */)


### PR DESCRIPTION
Fixes the ability to set landing point to be in the same place as an existing mission item