### PR TITLE
ArduPilot: Deal with seemingly incorrect protocol support of MAV_MISSION_INVALID_SEQUENCE

### DIFF
--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -589,6 +589,14 @@ void PlanManager::_handleMissionAck(const mavlink_message_t& message)
         return;
     }
 
+    if (_vehicle->apmFirmware() && missionAck.type == MAV_MISSION_INVALID_SEQUENCE) {
+        // ArduPilot sends these Acks which can happen just due to noisy links causing duplicated requests being responded to.
+        // As far as I'm concerned this is incorrect protocol implementation but we need to deal with it anyway. So we just
+        // ignore it and if things really go haywire the timeouts will fire to fail the overall transaction.
+        qCDebug(PlanManagerLog) << QStringLiteral("_handleMissionAck ArduPilot sending possibly bogus MAV_MISSION_INVALID_SEQUENCE").arg(_planTypeString()) << _planType;
+        return;
+    }
+
     // Save the retry ack before calling _checkForExpectedAck since we'll need it to determine what
     // type of a protocol sequence we are in.
     AckType_t savedExpectedAck = _expectedAck;

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -71,7 +71,7 @@ public:
 
     // These values are public so the unit test can set appropriate signal wait times
     // When passively waiting for a mission process, use a longer timeout.
-    static const int _ackTimeoutMilliseconds = 1000;
+    static const int _ackTimeoutMilliseconds = 1500;
     // When actively retrying to request mission items, use a shorter timeout instead.
     static const int _retryTimeoutMilliseconds = 250;
     static const int _maxRetryCount = 5;


### PR DESCRIPTION
QGC assumes that when it gets a mission ack with an error during an upload/download sequence that the entire transaction has errored out. That isn't the case with how ArduPilot sends MAV_MISSION_INVALID_SEQUENCE errors. It will sends this in the middle of the sequence and then continue the transaction. Since these can happen easily when dealing with noisy comm links that caused a problem of failed missions uploads. Specifically with vehicles like ht SkyViper which has an incredibly awful wifi connection with tons of packet loss. So for now I'm hacking in an ArduPilot specific change to deal with this.

Also in this pull is a bump in upload timeouts since the SkyViper is also dog slow when uploading missions and would hit the overall message timout quite often. I still does, but not as often. But I don't think it makes sense to go any higher in timeout than this. So if folks may have to upload a couple times to get things through if it fails.