### PR TITLE
Disable QtQuick compiler for Debug builds

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -201,8 +201,13 @@ LinuxBuild {
 
 CONFIG += qt \
     thread \
-    c++11 \
-    qtquickcompiler \
+    c++11
+
+DebugBuild {
+    CONFIG -= qtquickcompiler
+} else {
+    CONFIG += qtquickcompiler
+}
 
 contains(DEFINES, ENABLE_VERBOSE_OUTPUT) {
     message("Enable verbose compiler output (manual override from command line)")


### PR DESCRIPTION
It increases build time considerably for no real benefit during development.