### PR TITLE
Set parameter file extension if needed

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -33,6 +33,7 @@ QGCView {
     property var    _searchResults              ///< List of parameter names from search results
     property bool   _showRCToParam:     !ScreenTools.isMobile && QGroundControl.multiVehicleManager.activeVehicle.px4Firmware
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
+    property var    _appSettings:       QGroundControl.settingsManager.appSettings
 
     ParameterEditorController {
         id:         controller;
@@ -112,28 +113,18 @@ QGCView {
                 MenuItem {
                     text:           qsTr("Load from file...")
                     onTriggered: {
-                        var appSettings = QGroundControl.settingsManager.appSettings
-
                         fileDialog.qgcView =        qgcView
-                        fileDialog.title =          qsTr("Select Parameter File")
+                        fileDialog.title =          qsTr("Load Parameters")
                         fileDialog.selectExisting = true
-                        fileDialog.folder =         appSettings.parameterSavePath
-                        fileDialog.fileExtension =  appSettings.parameterFileExtension
-                        fileDialog.nameFilters =    [ qsTr("Parameter Files (*.%1)").arg(appSettings.parameterFileExtension) , qsTr("All Files (*.*)") ]
                         fileDialog.openForLoad()
                     }
                 }
                 MenuItem {
                     text:           qsTr("Save to file...")
                     onTriggered: {
-                        var appSettings = QGroundControl.settingsManager.appSettings
-
                         fileDialog.qgcView =        qgcView
                         fileDialog.title =          qsTr("Save Parameters")
                         fileDialog.selectExisting = false
-                        fileDialog.folder =         appSettings.parameterSavePath
-                        fileDialog.fileExtension =  appSettings.parameterFileExtension
-                        fileDialog.nameFilters =    [ qsTr("Parameter Files (*.%1)").arg(appSettings.parameterFileExtension) , qsTr("All Files (*.*)") ]
                         fileDialog.openForSave()
                     }
                 }
@@ -292,7 +283,10 @@ QGCView {
     } // QGCViewPanel
 
     QGCFileDialog {
-        id: fileDialog
+        id:             fileDialog
+        folder:         _appSettings.parameterSavePath
+        fileExtension:  _appSettings.parameterFileExtension
+        nameFilters:    [ qsTr("Parameter Files (*.%1)").arg(_appSettings.parameterFileExtension) , qsTr("All Files (*.*)") ]
 
         onAcceptedForSave: {
             controller.saveToFile(file)

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -98,10 +98,15 @@ void ParameterEditorController::clearRCToParam(void)
 void ParameterEditorController::saveToFile(const QString& filename)
 {
     if (!filename.isEmpty()) {
-        QFile file(filename);
+        QString parameterFilename = filename;
+        if (!QFileInfo(filename).fileName().contains(".")) {
+            parameterFilename += QString(".%1").arg(AppSettings::parameterFileExtension);
+        }
+
+        QFile file(parameterFilename);
         
         if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-            qgcApp()->showMessage(tr("Unable to create file: %1").arg(filename));
+            qgcApp()->showMessage(tr("Unable to create file: %1").arg(parameterFilename));
             return;
         }
         


### PR DESCRIPTION
If user doesn't specify a file extension .params is added as file extensions. This matches other file save code.