### PR TITLE
Work around android Qt bug where wrong virtual keyboard is displayed

### DIFF
--- a/src/FactSystem/FactControls/FactValueSlider.qml
+++ b/src/FactSystem/FactControls/FactValueSlider.qml
@@ -71,7 +71,8 @@ Rectangle {
         id: editDialogComponent
 
         ParameterEditorDialog {
-            fact:           _fact
+            fact:       _fact
+            setFocus:   ScreenTools.isMobile ? false : true // Works around strange android bug where wrong virtual keyboard is displayed
         }
     }
 

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -27,6 +27,7 @@ QGCViewDialog {
     property bool   showRCToParam:  false
     property bool   validate:       false
     property string validateValue
+    property bool   setFocus:       true    ///< true: focus is set to text field on display, false: focus not set (works around strange virtual keyboard bug with FactValueSlider
 
     signal valueChanged
 
@@ -122,7 +123,7 @@ QGCViewDialog {
                     unitsLabel:         fact.units
                     showUnits:          fact.units != ""
                     Layout.fillWidth:   true
-                    focus:              true
+                    focus:              setFocus
                     inputMethodHints:   (fact.typeIsString || ScreenTools.isiOS) ?
                                           Qt.ImhNone :                // iOS numeric keyboard has no done button, we can't use it
                                           Qt.ImhFormattedNumbersOnly  // Forces use of virtual numeric keyboard


### PR DESCRIPTION
For the ParameterEditorDialog which pops up from FactValueSlider the focus will not be set.