### PR TITLE
alow Polyline position edit

### DIFF
--- a/src/MissionManager/QGCMapPolylineVisuals.qml
+++ b/src/MissionManager/QGCMapPolylineVisuals.qml
@@ -147,8 +147,22 @@ Item {
         }
 
         MenuItem {
+            text:           qsTr("Edit position..." )
+            onTriggered:    qgcView.showDialog(editPositionDialog, qsTr("Edit Position"), qgcView.showDialogDefaultWidth, StandardButton.Cancel)
+        }
+
+        MenuItem {
             text:           qsTr("Load KML...")
             onTriggered:    kmlLoadDialog.openForLoad()
+        }
+    }
+
+    Component {
+        id: editPositionDialog
+
+        EditPositionDialog {
+            Component.onCompleted: coordinate = mapPolyline.path[menu._removeVertexIndex]
+            onCoordinateChanged:  mapPolyline.adjustVertex(menu._removeVertexIndex,coordinate)
         }
     }
 


### PR DESCRIPTION
alow position edit in polyline。
![image](https://user-images.githubusercontent.com/631283/43558796-d1202a1c-963d-11e8-8d4b-9884c4d33fc1.png)

in EditPositionDialog  
if use  coordinate = mapPolyline.path[menu._removeVertexIndex]
there will be bind loop  property  