### PR TITLE
Terrain: Better error handing

### DIFF
--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -195,9 +195,7 @@ void VisualMissionItem::_reallyUpdateTerrainAltitude(void)
 
 void VisualMissionItem::_terrainDataReceived(bool success, QList<double> heights)
 {
-    if (success) {
-        _terrainAltitude = heights[0];
-        emit terrainAltitudeChanged(_terrainAltitude);
-        sender()->deleteLater();
-    }
+    _terrainAltitude = success ? heights[0] : qQNaN();
+    emit terrainAltitudeChanged(_terrainAltitude);
+    sender()->deleteLater();
 }

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -140,9 +140,9 @@ private:
         QList<QGeoCoordinate>       coordinates;
     } QueuedRequestInfo_t;
 
-    void _tileFailed(void);
-    bool _getAltitudesForCoordinates(const QList<QGeoCoordinate>& coordinates, QList<double>& altitudes);
-    QString _getTileHash(const QGeoCoordinate& coordinate);     /// Method to create a unique string for each tile
+    void    _tileFailed                         (void);
+    bool    _getAltitudesForCoordinates         (const QList<QGeoCoordinate>& coordinates, QList<double>& altitudes, bool& error);
+    QString _getTileHash                        (const QGeoCoordinate& coordinate);
 
     QList<QueuedRequestInfo_t>  _requestQueue;
     State                       _state = State::Idle;

--- a/src/TerrainTile.cc
+++ b/src/TerrainTile.cc
@@ -134,7 +134,7 @@ TerrainTile::TerrainTile(QByteArray byteArray)
 bool TerrainTile::isIn(const QGeoCoordinate& coordinate) const
 {
     if (!_isValid) {
-        qCDebug(TerrainTileLog) << "isIn requested, but tile not valid";
+        qCWarning(TerrainTileLog) << "isIn requested, but tile not valid";
         return false;
     }
     bool ret = coordinate.latitude() >= _southWest.latitude() && coordinate.longitude() >= _southWest.longitude() &&
@@ -157,7 +157,7 @@ double TerrainTile::elevation(const QGeoCoordinate& coordinate) const
         qCDebug(TerrainTileLog) << "indexLat:indexLon" << indexLat << indexLon << "elevation" << _data[indexLat][indexLon];
         return static_cast<double>(_data[indexLat][indexLon]);
     } else {
-        qCDebug(TerrainTileLog) << "Asking for elevation, but no valid data.";
+        qCWarning(TerrainTileLog) << "Asking for elevation, but no valid data.";
         return -1.0;
     }
 }
@@ -284,6 +284,7 @@ int TerrainTile::_latToDataIndex(double latitude) const
     if (isValid() && _southWest.isValid() && _northEast.isValid()) {
         return qRound((latitude - _southWest.latitude()) / (_northEast.latitude() - _southWest.latitude()) * (_gridSizeLat - 1));
     } else {
+        qCWarning(TerrainTileLog) << "TerrainTile::_latToDataIndex internal error" << isValid() << _southWest.isValid() << _northEast.isValid();
         return -1;
     }
 }
@@ -293,6 +294,7 @@ int TerrainTile::_lonToDataIndex(double longitude) const
     if (isValid() && _southWest.isValid() && _northEast.isValid()) {
         return qRound((longitude - _southWest.longitude()) / (_northEast.longitude() - _southWest.longitude()) * (_gridSizeLon - 1));
     } else {
+        qCWarning(TerrainTileLog) << "TerrainTile::_lonToDataIndex internal error" << isValid() << _southWest.isValid() << _northEast.isValid();
         return -1;
     }
 }


### PR DESCRIPTION
Turn internal errors (elevation == -1) into failed query to prevent bogus elevation from reaching upper layers. Related to #6723