### PR TITLE
Terrain Tiles: Persist header info as doubles

### DIFF
--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -75,7 +75,7 @@ public:
         EsriWorldSatellite      = 7001,
         EsriTerrain             = 7002,
 
-        AirmapElevation         = 8000
+        AirmapElevation         = 8001
     };
 
     UrlFactory      ();

--- a/src/TerrainTile.h
+++ b/src/TerrainTile.h
@@ -95,6 +95,15 @@ public:
     static constexpr double terrainAltitudeSpacing = 30.0;
 
 private:
+    typedef struct {
+        double  swLat,swLon, neLat, neLon;
+        int16_t minElevation;
+        int16_t maxElevation;
+        double  avgElevation;
+        int16_t gridSizeLat;
+        int16_t gridSizeLon;
+    } TileInfo_t;
+
     inline int _latToDataIndex(double latitude) const;
     inline int _lonToDataIndex(double longitude) const;
 
@@ -103,7 +112,7 @@ private:
 
     int16_t             _minElevation;                                  /// Minimum elevation in tile
     int16_t             _maxElevation;                                  /// Maximum elevation in tile
-    float               _avgElevation;                                  /// Average elevation of the tile
+    double              _avgElevation;                                  /// Average elevation of the tile
 
     int16_t**           _data;                                          /// 2D elevation data array
     int16_t             _gridSizeLat;                                   /// data grid size in latitude direction


### PR DESCRIPTION
This prevents float<->double precision different from causing tile loads to fail. Previously lat/lon which was exactly at the edge of a tile would fail load.

Note: This change bumps to terrain tile format version thus invalidating all previously stored terrain tiles.

Related to #6723