### PR TITLE
More terrain query fixes/logging

### DIFF
--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -225,7 +225,9 @@ bool FixedWingLandingComplexItem::load(const QJsonObject& complexObject, int seq
     _landingCoordSet = true;
 
     _ignoreRecalcSignals = false;
+
     _recalcFromCoordinateChange();
+    emit coordinateChanged(this->coordinate());    // This will kick off terrain query
 
     return true;
 }

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -173,6 +173,10 @@ void VisualMissionItem::setMissionVehicleYaw(double vehicleYaw)
 
 void VisualMissionItem::_updateTerrainAltitude(void)
 {
+    if (coordinate().latitude() == 0 && coordinate().longitude() == 0) {
+        // This is an intermediate state we don't react to
+        return;
+    }
     if (!_flyView && coordinate().isValid()) {
         // We use a timer so that any additional requests before the timer fires result in only a single request
         _updateTerrainTimer.start();


### PR DESCRIPTION
* Don't allow intermediate coordinate(0,0) state to flow down to terrain query
* Better terrain logging
* FW Landing Pattern - Fix terrain query on land point after file load