### PR TITLE
Terrain: Use NaN for bad elevation value

### DIFF
--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -412,7 +412,7 @@ bool TerrainTileManager::_getAltitudesForCoordinates(const QList<QGeoCoordinate>
         if (_tiles.contains(tileHash)) {
             if (_tiles[tileHash].isIn(coordinate)) {
                 double elevation = _tiles[tileHash].elevation(coordinate);
-                if (elevation < 0.0) {
+                if (qIsNaN(elevation)) {
                     error = true;
                     qCWarning(TerrainQueryLog) << "TerrainTileManager::_getAltitudesForCoordinates Internal Error: negative elevation in tile cache";
                 } else {
@@ -421,7 +421,7 @@ bool TerrainTileManager::_getAltitudesForCoordinates(const QList<QGeoCoordinate>
                 altitudes.push_back(elevation);
             } else {
                 qCWarning(TerrainQueryLog) << "TerrainTileManager::_getAltitudesForCoordinates Internal Error: coordinate not in tile region";
-                altitudes.push_back(-1.0);
+                altitudes.push_back(qQNaN());
                 error = true;
             }
         } else {

--- a/src/TerrainTile.cc
+++ b/src/TerrainTile.cc
@@ -121,13 +121,13 @@ double TerrainTile::elevation(const QGeoCoordinate& coordinate) const
         int indexLon = _lonToDataIndex(coordinate.longitude());
         if (indexLat == -1 || indexLon == -1) {
             qCWarning(TerrainTileLog) << "Internal error indexLat:indexLon == -1" << indexLat << indexLon;
-            return -1.0;
+            return qQNaN();
         }
         qCDebug(TerrainTileLog) << "indexLat:indexLon" << indexLat << indexLon << "elevation" << _data[indexLat][indexLon];
         return static_cast<double>(_data[indexLat][indexLon]);
     } else {
         qCWarning(TerrainTileLog) << "Asking for elevation, but no valid data.";
-        return -1.0;
+        return qQNaN();
     }
 }
 


### PR DESCRIPTION
Lower levels of terrain system populates internal error return elevation with NaN. This is then caught in upper layers and replaced with query failure. This is also better since if there is a bug where a NaN is not caught and passed up QGC will treat at is no terrain data instead of creating a bad plan.

Related to #6722