### PR TITLE
Fixes

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -349,7 +349,7 @@ int MissionController::insertSimpleMissionItem(QGeoCoordinate coordinate, int i)
     newItem->setCoordinate(coordinate);
     newItem->setCommand(MAV_CMD_NAV_WAYPOINT);
     _initVisualItem(newItem);
-    if (_visualItems->count() == 1) {
+    if (_visualItems->count() == 1 && (_controllerVehicle->fixedWing() || _controllerVehicle->vtol() || _controllerVehicle->multiRotor())) {
         MAV_CMD takeoffCmd = _controllerVehicle->vtol() ? MAV_CMD_NAV_VTOL_TAKEOFF : MAV_CMD_NAV_TAKEOFF;
         if (_controllerVehicle->firmwarePlugin()->supportedMissionCommands().contains((MAV_CMD)takeoffCmd)) {
             newItem->setCommand(takeoffCmd);

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -36,8 +36,9 @@ Rectangle {
     property var    _fileExtension:                 QGroundControl.settingsManager.appSettings.missionFileExtension
     property var    _appSettings:                   QGroundControl.settingsManager.appSettings
     property bool   _waypointsOnlyMode:             QGroundControl.corePlugin.options.missionWaypointsOnly
-    property bool   _showCameraSection:             !_waypointsOnlyMode || QGroundControl.corePlugin.showAdvancedUI
+    property bool   _showCameraSection:             (!_waypointsOnlyMode || QGroundControl.corePlugin.showAdvancedUI) && !_missionVehicle.apmFirmware
     property bool   _simpleMissionStart:            QGroundControl.corePlugin.options.showSimpleMissionStart
+    property bool   _showFlightSpeed:               !_missionVehicle.vtol && !_simpleMissionStart && !_missionVehicle.apmFirmware
 
     readonly property string _firmwareLabel:    qsTr("Firmware")
     readonly property string _vehicleLabel:     qsTr("Vehicle")
@@ -72,14 +73,14 @@ Rectangle {
             QGCCheckBox {
                 id:         flightSpeedCheckBox
                 text:       qsTr("Flight speed")
-                visible:    !_missionVehicle.vtol && !_simpleMissionStart
+                visible:    _showFlightSpeed
                 checked:    missionItem.speedSection.specifyFlightSpeed
                 onClicked:   missionItem.speedSection.specifyFlightSpeed = checked
             }
             FactTextField {
                 Layout.fillWidth:   true
                 fact:               missionItem.speedSection.flightSpeed
-                visible:            flightSpeedCheckBox.visible
+                visible:            _showFlightSpeed
                 enabled:            flightSpeedCheckBox.checked
             }
         }


### PR DESCRIPTION
* Plan: Don't add takeoff as first item for vehicles which don't need it: Rover, Sub, ...
* Mission Start (ArduPIlot only): Hide flight speed and camera section since these items cannot be before the Takeoff command.

Fixes #6776, #6777