### PR TITLE
ArduPilot: ChibiOS flash support for Pixhawk family boards

### DIFF
--- a/src/VehicleSetup/FirmwareImage.cc
+++ b/src/VehicleSetup/FirmwareImage.cc
@@ -57,6 +57,9 @@ bool FirmwareImage::load(const QString& imageFilename, uint32_t boardId)
     } else if (imageFilename.endsWith(".px4")) {
         _binFormat = true;
         return _px4Load(imageFilename);
+    } else if (imageFilename.endsWith(".apj")) {
+        _binFormat = true;
+        return _px4Load(imageFilename);
     } else if (imageFilename.endsWith(".ihx")) {
         _binFormat = false;
         return _ihxLoad(imageFilename);

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -278,7 +278,7 @@ void FirmwareUpgradeController::_initFirmwareHash()
 #endif
 
     QString px4Url          ("http://px4-travis.s3.amazonaws.com/Firmware/%1/px4fmu-%2_default.px4");
-    QString apmUrl          ("http://firmware.ardupilot.org/%1/%2/%3/%4-%5.px4");
+    QString apmUrl          ("http://firmware.ardupilot.org/%1/%2/%3/%4-v%5.px4");
     QString apmChibiOSUrl   ("http://firmware.ardupilot.org/%1/%2/fmuv%3%4/%5.apj");
 
     QMap<FirmwareType_t, QString> px4MapFirmwareTypeToDir;

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -314,7 +314,7 @@ void FirmwareUpgradeController::_initFirmwareHash()
 
     QMap<FirmwareVehicleType_t, QString> apmMapVehicleTypeToFilename;
     apmMapVehicleTypeToFilename[CopterFirmware] =   QStringLiteral("ArduCopter");
-    apmMapVehicleTypeToFilename[HeliFirmware] =     QStringLiteral("PX4-ArduCopter");
+    apmMapVehicleTypeToFilename[HeliFirmware] =     QStringLiteral("ArduCopter");
     apmMapVehicleTypeToFilename[PlaneFirmware] =    QStringLiteral("ArduPlane");
     apmMapVehicleTypeToFilename[RoverFirmware] =    QStringLiteral("APMrover2");
     apmMapVehicleTypeToFilename[SubFirmware] =      QStringLiteral("ArduSub");
@@ -328,7 +328,7 @@ void FirmwareUpgradeController::_initFirmwareHash()
 
     QMap<FirmwareVehicleType_t, QString> apmChibiOSMapVehicleTypeToFilename;
     apmChibiOSMapVehicleTypeToFilename[CopterChibiOSFirmware] = QStringLiteral("arducopter");
-    apmChibiOSMapVehicleTypeToFilename[HeliChibiOSFirmware] =   QStringLiteral("arducopter");
+    apmChibiOSMapVehicleTypeToFilename[HeliChibiOSFirmware] =   QStringLiteral("arducopter-heli");
     apmChibiOSMapVehicleTypeToFilename[PlaneChibiOSFirmware] =  QStringLiteral("arduplane");
     apmChibiOSMapVehicleTypeToFilename[RoverChibiOSFirmware] =  QStringLiteral("ardurover");
     apmChibiOSMapVehicleTypeToFilename[SubChibiOSFirmware] =    QStringLiteral("ardusub");

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -191,112 +191,19 @@ void FirmwareUpgradeController::_initFirmwareHash()
         return;
     }
 
-    //////////////////////////////////// PX4FMUV5 firmwares //////////////////////////////////////////////////
-    FirmwareToUrlElement_t rgPX4FMV5FirmwareArray[] = {
-        { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/px4fmu-v5_default.px4"},
-        { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/px4fmu-v5_default.px4"},
-        { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v5_default.px4"},
-        { SingleFirmwareMode,StableFirmware,    DefaultVehicleFirmware, _singleFirmwareURL},
-    };
-
-    //////////////////////////////////// PX4FMUV4PRO firmwares //////////////////////////////////////////////////
-    FirmwareToUrlElement_t rgPX4FMV4PROFirmwareArray[] = {
-        { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/px4fmu-v4pro_default.px4"},
-        { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/px4fmu-v4pro_default.px4"},
-        { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v4pro_default.px4"},
-        { SingleFirmwareMode,StableFirmware,    DefaultVehicleFirmware, _singleFirmwareURL},
-    };
-
-    //////////////////////////////////// PX4FMUV4 firmwares //////////////////////////////////////////////////
-    FirmwareToUrlElement_t rgPX4FMV4FirmwareArray[] = {
-        { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/px4fmu-v4_default.px4"},
-        { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/px4fmu-v4_default.px4"},
-        { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v4_default.px4"},
-        { AutoPilotStackAPM, StableFirmware,    CopterFirmware,         "http://firmware.ardupilot.org/Copter/stable/PX4/ArduCopter-v4.px4"},
-        { AutoPilotStackAPM, StableFirmware,    HeliFirmware,           "http://firmware.ardupilot.org/Copter/stable/PX4-heli/ArduCopter-v4.px4"},
-        { AutoPilotStackAPM, StableFirmware,    PlaneFirmware,          "http://firmware.ardupilot.org/Plane/stable/PX4/ArduPlane-v4.px4"},
-        { AutoPilotStackAPM, StableFirmware,    RoverFirmware,          "http://firmware.ardupilot.org/Rover/stable/PX4/APMrover2-v4.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      CopterFirmware,         "http://firmware.ardupilot.org/Copter/beta/PX4/ArduCopter-v4.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      HeliFirmware,           "http://firmware.ardupilot.org/Copter/beta/PX4-heli/ArduCopter-v4.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      PlaneFirmware,          "http://firmware.ardupilot.org/Plane/beta/PX4/ArduPlane-v4.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      RoverFirmware,          "http://firmware.ardupilot.org/Rover/beta/PX4/APMrover2-v4.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, CopterFirmware,         "http://firmware.ardupilot.org/Copter/latest/PX4/ArduCopter-v4.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, HeliFirmware,           "http://firmware.ardupilot.org/Copter/latest/PX4-heli/ArduCopter-v4.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, PlaneFirmware,          "http://firmware.ardupilot.org/Plane/latest/PX4/ArduPlane-v4.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, RoverFirmware,          "http://firmware.ardupilot.org/Rover/latest/PX4/APMrover2-v4.px4"},
-        { SingleFirmwareMode,StableFirmware,    DefaultVehicleFirmware, _singleFirmwareURL},
-    };
-
-    //////////////////////////////////// PX4FMUV3 firmwares //////////////////////////////////////////////////
-    FirmwareToUrlElement_t rgPX4FMV3FirmwareArray[] = {
-        { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/px4fmu-v3_default.px4"},
-        { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/px4fmu-v3_default.px4"},
-        { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v3_default.px4"},
-        { AutoPilotStackAPM, StableFirmware,    CopterFirmware,         "http://firmware.ardupilot.org/Copter/stable/PX4/ArduCopter-v3.px4"},
-        { AutoPilotStackAPM, StableFirmware,    HeliFirmware,           "http://firmware.ardupilot.org/Copter/stable/PX4-heli/ArduCopter-v3.px4"},
-        { AutoPilotStackAPM, StableFirmware,    PlaneFirmware,          "http://firmware.ardupilot.org/Plane/stable/PX4/ArduPlane-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    RoverFirmware,          "http://firmware.ardupilot.org/Rover/stable/PX4/APMrover2-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    SubFirmware,            "http://firmware.ardupilot.org/Sub/stable/PX4/ArduSub-v2.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      CopterFirmware,         "http://firmware.ardupilot.org/Copter/beta/PX4/ArduCopter-v3.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      HeliFirmware,           "http://firmware.ardupilot.org/Copter/beta/PX4-heli/ArduCopter-v3.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      PlaneFirmware,          "http://firmware.ardupilot.org/Plane/beta/PX4/ArduPlane-v3.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      RoverFirmware,          "http://firmware.ardupilot.org/Rover/beta/PX4/APMrover2-v3.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      SubFirmware,            "http://firmware.ardupilot.org/Sub/beta/PX4/ArduSub-v3.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, CopterFirmware,         "http://firmware.ardupilot.org/Copter/latest/PX4/ArduCopter-v3.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, HeliFirmware,           "http://firmware.ardupilot.org/Copter/latest/PX4-heli/ArduCopter-v3.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, PlaneFirmware,          "http://firmware.ardupilot.org/Plane/latest/PX4/ArduPlane-v3.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, RoverFirmware,          "http://firmware.ardupilot.org/Rover/latest/PX4/APMrover2-v3.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, SubFirmware,            "http://firmware.ardupilot.org/Sub/latest/PX4/ArduSub-v3.px4"},
-        { SingleFirmwareMode,StableFirmware,    DefaultVehicleFirmware, _singleFirmwareURL},
-    };
-
-    //////////////////////////////////// PX4FMUV2 firmwares //////////////////////////////////////////////////
-    FirmwareToUrlElement_t rgPX4FMV2FirmwareArray[] = {
-        { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/px4fmu-v2_default.px4"},
-        { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/px4fmu-v2_default.px4"},
-        { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/px4fmu-v2_default.px4"},
-        { AutoPilotStackAPM, StableFirmware,    CopterFirmware,         "http://firmware.ardupilot.org/Copter/stable/PX4/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    HeliFirmware,           "http://firmware.ardupilot.org/Copter/stable/PX4-heli/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    PlaneFirmware,          "http://firmware.ardupilot.org/Plane/stable/PX4/ArduPlane-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    RoverFirmware,          "http://firmware.ardupilot.org/Rover/stable/PX4/APMrover2-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    SubFirmware,            "http://firmware.ardupilot.org/Sub/stable/PX4/ArduSub-v2.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      CopterFirmware,         "http://firmware.ardupilot.org/Copter/beta/PX4/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      HeliFirmware,           "http://firmware.ardupilot.org/Copter/beta/PX4-heli/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      PlaneFirmware,          "http://firmware.ardupilot.org/Plane/beta/PX4/ArduPlane-v2.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      RoverFirmware,          "http://firmware.ardupilot.org/Rover/beta/PX4/APMrover2-v2.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      SubFirmware,            "http://firmware.ardupilot.org/Sub/beta/PX4/ArduSub-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, CopterFirmware,         "http://firmware.ardupilot.org/Copter/latest/PX4/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, HeliFirmware,           "http://firmware.ardupilot.org/Copter/latest/PX4-heli/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, PlaneFirmware,          "http://firmware.ardupilot.org/Plane/latest/PX4/ArduPlane-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, RoverFirmware,          "http://firmware.ardupilot.org/Rover/latest/PX4/APMrover2-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, SubFirmware,            "http://firmware.ardupilot.org/Sub/latest/PX4/ArduSub-v2.px4"},
-        { SingleFirmwareMode,StableFirmware,    DefaultVehicleFirmware, _singleFirmwareURL},
-    };
-
     //////////////////////////////////// PX4FMU aerocore firmwares //////////////////////////////////////////////////
     FirmwareToUrlElement_t  rgAeroCoreFirmwareArray[] = {
         { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://gumstix-aerocore.s3.amazonaws.com/PX4/stable/aerocore_default.px4"},
         { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://gumstix-aerocore.s3.amazonaws.com/PX4/beta/aerocore_default.px4"},
         { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://gumstix-aerocore.s3.amazonaws.com/PX4/master/aerocore_default.px4"},
-        { AutoPilotStackAPM, StableFirmware,    QuadFirmware,           "http://gumstix-aerocore.s3.amazonaws.com/APM/Copter/stable/PX4-quad/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    X8Firmware,             "http://gumstix-aerocore.s3.amazonaws.com/Copter/stable/PX4-octa-quad/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    HexaFirmware,           "http://gumstix-aerocore.s3.amazonaws.com/Copter/stable/PX4-hexa/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    OctoFirmware,           "http://gumstix-aerocore.s3.amazonaws.com/Copter/stable/PX4-octa/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    YFirmware,              "http://gumstix-aerocore.s3.amazonaws.com/Copter/stable/PX4-tri/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, StableFirmware,    Y6Firmware,             "http://gumstix-aerocore.s3.amazonaws.com/Copter/stable/PX4-y6/ArduCopter-v2.px4"},
+        { AutoPilotStackAPM, BetaFirmware,      CopterFirmware,         "http://firmware.ardupilot.org/Copter/beta/PX4/ArduCopter-v2.px4"},
         { AutoPilotStackAPM, StableFirmware,    HeliFirmware,           "http://gumstix-aerocore.s3.amazonaws.com/Copter/stable/PX4-heli/ArduCopter-v2.px4"},
         { AutoPilotStackAPM, StableFirmware,    PlaneFirmware,          "http://gumstix-aerocore.s3.amazonaws.com/Plane/stable/PX4/ArduPlane-v2.px4"},
         { AutoPilotStackAPM, StableFirmware,    RoverFirmware,          "http://gumstix-aerocore.s3.amazonaws.com/Rover/stable/PX4/APMrover2-v2.px4"},
-        { AutoPilotStackAPM, BetaFirmware,      CopterFirmware,         "http://firmware.ardupilot.org/Copter/beta/PX4/ArduCopter-v2.px4"},
         { AutoPilotStackAPM, BetaFirmware,      HeliFirmware,           "http://firmware.ardupilot.org/Copter/beta/PX4-heli/ArduCopter-v2.px4"},
         { AutoPilotStackAPM, BetaFirmware,      PlaneFirmware,          "http://firmware.ardupilot.org/Plane/beta/PX4/ArduPlane-v2.px4"},
         { AutoPilotStackAPM, BetaFirmware,      RoverFirmware,          "http://firmware.ardupilot.org/Rover/beta/PX4/APMrover2-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, QuadFirmware,           "http://gumstix-aerocore.s3.amazonaws.com/Copter/latest/PX4-quad/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, X8Firmware,             "http://gumstix-aerocore.s3.amazonaws.com/Copter/latest/PX4-octa-quad/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, HexaFirmware,           "http://gumstix-aerocore.s3.amazonaws.com/Copter/latest/PX4-hexa/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, OctoFirmware,           "http://gumstix-aerocore.s3.amazonaws.com/Copter/latest/PX4-octa/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, YFirmware,              "http://gumstix-aerocore.s3.amazonaws.com/Copter/latest/PX4-tri/ArduCopter-v2.px4"},
-        { AutoPilotStackAPM, DeveloperFirmware, Y6Firmware,             "http://gumstix-aerocore.s3.amazonaws.com/Copter/latest/PX4-y6/ArduCopter-v2.px4"},
+        { AutoPilotStackAPM, DeveloperFirmware, CopterFirmware,         "http://gumstix-aerocore.s3.amazonaws.com/Copter/latest/PX4/ArduCopter-v2.px4"},
         { AutoPilotStackAPM, DeveloperFirmware, HeliFirmware,           "http://gumstix-aerocore.s3.amazonaws.com/Copter/latest/PX4-heli/ArduCopter-v2.px4"},
         { AutoPilotStackAPM, DeveloperFirmware, PlaneFirmware,          "http://gumstix-aerocore.s3.amazonaws.com/Plane/latest/PX4/ArduPlane-v2.px4"},
         { AutoPilotStackAPM, DeveloperFirmware, RoverFirmware,          "http://gumstix-aerocore.s3.amazonaws.com/Rover/latest/PX4/APMrover2-v2.px4"}
@@ -361,38 +268,112 @@ void FirmwareUpgradeController::_initFirmwareHash()
         { ThreeDRRadio, StableFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/SiK/stable/radio~hm_trp.ihx"}
     };
 
-    // populate hashes now
-    int size = sizeof(rgPX4FMV5FirmwareArray)/sizeof(rgPX4FMV5FirmwareArray[0]);
-    for (int i = 0; i < size; i++) {
-        const FirmwareToUrlElement_t& element = rgPX4FMV5FirmwareArray[i];
-        _rgPX4FMUV5Firmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
+    // We build the maps for PX4 and ArduPilot firmwares dynamically using the data below
+
+#if 0
+    Example URLs for PX4 and ArduPilot
+    { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/px4fmu-v4_default.px4"},
+    { AutoPilotStackAPM, StableFirmware,    CopterFirmware,         "http://firmware.ardupilot.org/Copter/stable/PX4/ArduCopter-v4.px4"},
+    { AutoPilotStackAPM, DeveloperFirmware, CopterChibiosFirmware,  "http://firmware.ardupilot.org/Copter/latest/fmuv4/arducopter.apj"},
+#endif
+
+    QString px4Url          ("http://px4-travis.s3.amazonaws.com/Firmware/%1/px4fmu-%2_default.px4");
+    QString apmUrl          ("http://firmware.ardupilot.org/%1/%2/%3/%4-%5.px4");
+    QString apmChibiOSUrl   ("http://firmware.ardupilot.org/%1/%2/fmuv%3%4/%5.apj");
+
+    QMap<FirmwareType_t, QString> px4MapFirmwareTypeToDir;
+    px4MapFirmwareTypeToDir[StableFirmware] =     QStringLiteral("stable");
+    px4MapFirmwareTypeToDir[BetaFirmware] =       QStringLiteral("beta");
+    px4MapFirmwareTypeToDir[DeveloperFirmware] =  QStringLiteral("master");
+
+    QMap<FirmwareVehicleType_t, QString> apmMapVehicleTypeToDir;
+    apmMapVehicleTypeToDir[CopterFirmware] =  QStringLiteral("Copter");
+    apmMapVehicleTypeToDir[HeliFirmware] =    QStringLiteral("Copter");
+    apmMapVehicleTypeToDir[PlaneFirmware] =   QStringLiteral("Plane");
+    apmMapVehicleTypeToDir[RoverFirmware] =   QStringLiteral("Rover");
+    apmMapVehicleTypeToDir[SubFirmware] =     QStringLiteral("Sub");
+
+    QMap<FirmwareVehicleType_t, QString> apmChibiOSMapVehicleTypeToDir;
+    apmChibiOSMapVehicleTypeToDir[CopterChibiOSFirmware] =  QStringLiteral("Copter");
+    apmChibiOSMapVehicleTypeToDir[HeliChibiOSFirmware] =    QStringLiteral("Copter");
+    apmChibiOSMapVehicleTypeToDir[PlaneChibiOSFirmware] =   QStringLiteral("Plane");
+    apmChibiOSMapVehicleTypeToDir[RoverChibiOSFirmware] =   QStringLiteral("Rover");
+    apmChibiOSMapVehicleTypeToDir[SubChibiOSFirmware] =     QStringLiteral("Sub");
+
+    QMap<FirmwareType_t, QString> apmMapFirmwareTypeToDir;
+    apmMapFirmwareTypeToDir[StableFirmware] =     QStringLiteral("stable");
+    apmMapFirmwareTypeToDir[BetaFirmware] =       QStringLiteral("beta");
+    apmMapFirmwareTypeToDir[DeveloperFirmware] =  QStringLiteral("latest");
+
+    QMap<FirmwareVehicleType_t, QString> apmMapVehicleTypeToPX4Dir;
+    apmMapVehicleTypeToPX4Dir[CopterFirmware] =  QStringLiteral("PX4");
+    apmMapVehicleTypeToPX4Dir[HeliFirmware] =    QStringLiteral("PX4-heli");
+    apmMapVehicleTypeToPX4Dir[PlaneFirmware] =   QStringLiteral("PX4");
+    apmMapVehicleTypeToPX4Dir[RoverFirmware] =   QStringLiteral("PX4");
+    apmMapVehicleTypeToPX4Dir[SubFirmware] =     QStringLiteral("PX4");
+
+    QMap<FirmwareVehicleType_t, QString> apmMapVehicleTypeToFilename;
+    apmMapVehicleTypeToFilename[CopterFirmware] =  QStringLiteral("ArduCopter");
+    apmMapVehicleTypeToFilename[HeliFirmware] =    QStringLiteral("PX4-ArduCopter");
+    apmMapVehicleTypeToFilename[PlaneFirmware] =   QStringLiteral("ArduPlane");
+    apmMapVehicleTypeToFilename[RoverFirmware] =   QStringLiteral("APMrover2");
+    apmMapVehicleTypeToFilename[SubFirmware] =     QStringLiteral("ArduSub");
+
+    QMap<FirmwareVehicleType_t, QString> apmChibiOSMapVehicleTypeToFmuDir;
+    apmChibiOSMapVehicleTypeToFmuDir[CopterChibiOSFirmware] =  QString();
+    apmChibiOSMapVehicleTypeToFmuDir[HeliChibiOSFirmware] =    QStringLiteral("-heli");
+    apmChibiOSMapVehicleTypeToFmuDir[PlaneChibiOSFirmware] =   QString();
+    apmChibiOSMapVehicleTypeToFmuDir[RoverChibiOSFirmware] =   QString();
+    apmChibiOSMapVehicleTypeToFmuDir[SubChibiOSFirmware] =     QString();
+
+    QMap<FirmwareVehicleType_t, QString> apmChibiOSMapVehicleTypeToFilename;
+    apmChibiOSMapVehicleTypeToFilename[CopterChibiOSFirmware] =  QStringLiteral("arducopter");
+    apmChibiOSMapVehicleTypeToFilename[HeliChibiOSFirmware] =    QStringLiteral("arducopter");
+    apmChibiOSMapVehicleTypeToFilename[PlaneChibiOSFirmware] =   QStringLiteral("arduplane");
+    apmChibiOSMapVehicleTypeToFilename[RoverChibiOSFirmware] =   QStringLiteral("ardurover");
+    apmChibiOSMapVehicleTypeToFilename[SubChibiOSFirmware] =     QStringLiteral("ardusub");
+
+    // PX4 Firmwares
+    foreach (const FirmwareType_t& firmwareType, px4MapFirmwareTypeToDir.keys()) {
+        QString dir = px4MapFirmwareTypeToDir[firmwareType];
+        _rgPX4FMUV5Firmware.insert      (FirmwareIdentifier(AutoPilotStackPX4, firmwareType, DefaultVehicleFirmware), px4Url.arg(dir).arg("v5"));
+        _rgPX4FMUV4PROFirmware.insert   (FirmwareIdentifier(AutoPilotStackPX4, firmwareType, DefaultVehicleFirmware), px4Url.arg(dir).arg("v4pro"));
+        _rgPX4FMUV4Firmware.insert      (FirmwareIdentifier(AutoPilotStackPX4, firmwareType, DefaultVehicleFirmware), px4Url.arg(dir).arg("v4"));
+        _rgPX4FMUV3Firmware.insert      (FirmwareIdentifier(AutoPilotStackPX4, firmwareType, DefaultVehicleFirmware), px4Url.arg(dir).arg("v3"));
+        _rgPX4FMUV2Firmware.insert      (FirmwareIdentifier(AutoPilotStackPX4, firmwareType, DefaultVehicleFirmware), px4Url.arg(dir).arg("v2"));
     }
 
-    size = sizeof(rgPX4FMV4PROFirmwareArray)/sizeof(rgPX4FMV4PROFirmwareArray[0]);
-    for (int i = 0; i < size; i++) {
-        const FirmwareToUrlElement_t& element = rgPX4FMV4PROFirmwareArray[i];
-        _rgPX4FMUV4PROFirmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
+    // ArduPilot Firmwares
+    foreach (const FirmwareType_t& firmwareType, apmMapFirmwareTypeToDir.keys()) {
+        QString firmwareTypeDir = apmMapFirmwareTypeToDir[firmwareType];
+        foreach (const FirmwareVehicleType_t& vehicleType, apmMapVehicleTypeToDir.keys()) {
+            QString vehicleTypeDir = apmMapVehicleTypeToDir[vehicleType];
+            QString px4Dir = apmMapVehicleTypeToPX4Dir[vehicleType];
+            QString filename = apmMapVehicleTypeToFilename[vehicleType];
+            qDebug() << firmwareTypeDir << vehicleTypeDir << px4Dir << filename;
+            _rgPX4FMUV5Firmware.insert  (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg(px4Dir).arg(filename).arg("5"));
+            _rgPX4FMUV4Firmware.insert  (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg(px4Dir).arg(filename).arg("4"));
+            _rgPX4FMUV3Firmware.insert  (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg(px4Dir).arg(filename).arg("3"));
+            _rgPX4FMUV2Firmware.insert  (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg(px4Dir).arg(filename).arg("2"));
+        }
     }
 
-    size = sizeof(rgPX4FMV4FirmwareArray)/sizeof(rgPX4FMV4FirmwareArray[0]);
-    for (int i = 0; i < size; i++) {
-        const FirmwareToUrlElement_t& element = rgPX4FMV4FirmwareArray[i];
-        _rgPX4FMUV4Firmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
+    // ArduPilot ChibiOS Firmwares
+    foreach (const FirmwareType_t& firmwareType, apmMapFirmwareTypeToDir.keys()) {
+        QString firmwareTypeDir = apmMapFirmwareTypeToDir[firmwareType];
+        foreach (const FirmwareVehicleType_t& vehicleType, apmChibiOSMapVehicleTypeToDir.keys()) {
+            QString vehicleTypeDir = apmChibiOSMapVehicleTypeToDir[vehicleType];
+            QString fmuDir = apmChibiOSMapVehicleTypeToFmuDir[vehicleType];
+            QString filename = apmChibiOSMapVehicleTypeToFilename[vehicleType];
+            qDebug() << firmwareTypeDir << vehicleTypeDir << fmuDir << filename;
+            _rgPX4FMUV5Firmware.insert      (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmChibiOSUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg("5").arg(fmuDir).arg(filename));
+            _rgPX4FMUV4Firmware.insert      (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmChibiOSUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg("4").arg(fmuDir).arg(filename));
+            _rgPX4FMUV3Firmware.insert      (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmChibiOSUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg("3").arg(fmuDir).arg(filename));
+            _rgPX4FMUV2Firmware.insert      (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmChibiOSUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg("2").arg(fmuDir).arg(filename));
+        }
     }
 
-    size = sizeof(rgPX4FMV3FirmwareArray)/sizeof(rgPX4FMV3FirmwareArray[0]);
-    for (int i = 0; i < size; i++) {
-        const FirmwareToUrlElement_t& element = rgPX4FMV3FirmwareArray[i];
-        _rgPX4FMUV3Firmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
-    }
-
-    size = sizeof(rgPX4FMV2FirmwareArray)/sizeof(rgPX4FMV2FirmwareArray[0]);
-    for (int i = 0; i < size; i++) {
-        const FirmwareToUrlElement_t& element = rgPX4FMV2FirmwareArray[i];
-        _rgPX4FMUV2Firmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
-    }
-
-    size = sizeof(rgAeroCoreFirmwareArray)/sizeof(rgAeroCoreFirmwareArray[0]);
+    int size = sizeof(rgAeroCoreFirmwareArray)/sizeof(rgAeroCoreFirmwareArray[0]);
     for (int i = 0; i < size; i++) {
         const FirmwareToUrlElement_t& element = rgAeroCoreFirmwareArray[i];
         _rgAeroCoreFirmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
@@ -719,6 +700,7 @@ void FirmwareUpgradeController::_apmVersionDownloadFinished(QString remoteFile, 
 
     if (version.isEmpty()) {
         qWarning() << "Unable to parse version info from file" << remoteFile;
+        sender()->deleteLater();
         return;
     }
 
@@ -735,6 +717,7 @@ void FirmwareUpgradeController::_apmVersionDownloadFinished(QString remoteFile, 
     }
 
     emit apmAvailableVersionsChanged();
+    sender()->deleteLater();
 }
 
 void FirmwareUpgradeController::setSelectedFirmwareType(FirmwareType_t firmwareType)
@@ -750,7 +733,7 @@ QStringList FirmwareUpgradeController::apmAvailableVersions(void)
     QList<FirmwareVehicleType_t>    vehicleTypes;
 
     // This allows up to force the order of the combo box display
-    vehicleTypes << CopterFirmware << HeliFirmware << PlaneFirmware << RoverFirmware << SubFirmware;
+    vehicleTypes << CopterFirmware << HeliFirmware << PlaneFirmware << RoverFirmware << SubFirmware << CopterChibiOSFirmware << HeliChibiOSFirmware << PlaneChibiOSFirmware << RoverChibiOSFirmware << SubChibiOSFirmware;
 
     _apmVehicleTypeFromCurrentVersionList.clear();
 
@@ -759,36 +742,24 @@ QStringList FirmwareUpgradeController::apmAvailableVersions(void)
             QString version;
 
             switch (vehicleType) {
-            case QuadFirmware:
-                version = "Quad - ";
-                break;
-            case X8Firmware:
-                version = "X8 - ";
-                break;
-            case HexaFirmware:
-                version = "Hexa - ";
-                break;
-            case OctoFirmware:
-                version = "Octo - ";
-                break;
-            case YFirmware:
-                version = "Y - ";
-                break;
-            case Y6Firmware:
-                version = "Y6 - ";
+            case CopterFirmware:
+                version = tr("MultiRotor - ");
                 break;
             case HeliFirmware:
-                version = "Heli - ";
+                version = tr("Heli - ");
                 break;
-            case CopterFirmware:
-                version = "MultiRotor - ";
+            case CopterChibiOSFirmware:
+                version = tr("ChibiOS:MultiRotor - ");
                 break;
-            case SubFirmware:
-                version = "Sub - ";
+            case HeliChibiOSFirmware:
+                version = tr("ChibiOS:Heli - ");
                 break;
-            case PlaneFirmware:
-            case RoverFirmware:
-            case DefaultVehicleFirmware:
+            case PlaneChibiOSFirmware:
+            case RoverChibiOSFirmware:
+            case SubChibiOSFirmware:
+                version = tr("ChibiOS - ");
+                break;
+            default:
                 break;
             }
 
@@ -806,7 +777,7 @@ FirmwareUpgradeController::FirmwareVehicleType_t FirmwareUpgradeController::vehi
 {
     if (index < 0 || index >= _apmVehicleTypeFromCurrentVersionList.count()) {
         qWarning() << "Invalid index, index:count" << index << _apmVehicleTypeFromCurrentVersionList.count();
-        return QuadFirmware;
+        return CopterFirmware;
     }
 
     return _apmVehicleTypeFromCurrentVersionList[index];

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -282,16 +282,16 @@ void FirmwareUpgradeController::_initFirmwareHash()
     QString apmChibiOSUrl   ("http://firmware.ardupilot.org/%1/%2/fmuv%3%4/%5.apj");
 
     QMap<FirmwareType_t, QString> px4MapFirmwareTypeToDir;
-    px4MapFirmwareTypeToDir[StableFirmware] =     QStringLiteral("stable");
-    px4MapFirmwareTypeToDir[BetaFirmware] =       QStringLiteral("beta");
-    px4MapFirmwareTypeToDir[DeveloperFirmware] =  QStringLiteral("master");
+    px4MapFirmwareTypeToDir[StableFirmware] =       QStringLiteral("stable");
+    px4MapFirmwareTypeToDir[BetaFirmware] =         QStringLiteral("beta");
+    px4MapFirmwareTypeToDir[DeveloperFirmware] =    QStringLiteral("master");
 
     QMap<FirmwareVehicleType_t, QString> apmMapVehicleTypeToDir;
-    apmMapVehicleTypeToDir[CopterFirmware] =  QStringLiteral("Copter");
-    apmMapVehicleTypeToDir[HeliFirmware] =    QStringLiteral("Copter");
-    apmMapVehicleTypeToDir[PlaneFirmware] =   QStringLiteral("Plane");
-    apmMapVehicleTypeToDir[RoverFirmware] =   QStringLiteral("Rover");
-    apmMapVehicleTypeToDir[SubFirmware] =     QStringLiteral("Sub");
+    apmMapVehicleTypeToDir[CopterFirmware] =    QStringLiteral("Copter");
+    apmMapVehicleTypeToDir[HeliFirmware] =      QStringLiteral("Copter");
+    apmMapVehicleTypeToDir[PlaneFirmware] =     QStringLiteral("Plane");
+    apmMapVehicleTypeToDir[RoverFirmware] =     QStringLiteral("Rover");
+    apmMapVehicleTypeToDir[SubFirmware] =       QStringLiteral("Sub");
 
     QMap<FirmwareVehicleType_t, QString> apmChibiOSMapVehicleTypeToDir;
     apmChibiOSMapVehicleTypeToDir[CopterChibiOSFirmware] =  QStringLiteral("Copter");
@@ -301,37 +301,37 @@ void FirmwareUpgradeController::_initFirmwareHash()
     apmChibiOSMapVehicleTypeToDir[SubChibiOSFirmware] =     QStringLiteral("Sub");
 
     QMap<FirmwareType_t, QString> apmMapFirmwareTypeToDir;
-    apmMapFirmwareTypeToDir[StableFirmware] =     QStringLiteral("stable");
-    apmMapFirmwareTypeToDir[BetaFirmware] =       QStringLiteral("beta");
-    apmMapFirmwareTypeToDir[DeveloperFirmware] =  QStringLiteral("latest");
+    apmMapFirmwareTypeToDir[StableFirmware] =       QStringLiteral("stable");
+    apmMapFirmwareTypeToDir[BetaFirmware] =         QStringLiteral("beta");
+    apmMapFirmwareTypeToDir[DeveloperFirmware] =    QStringLiteral("latest");
 
     QMap<FirmwareVehicleType_t, QString> apmMapVehicleTypeToPX4Dir;
-    apmMapVehicleTypeToPX4Dir[CopterFirmware] =  QStringLiteral("PX4");
-    apmMapVehicleTypeToPX4Dir[HeliFirmware] =    QStringLiteral("PX4-heli");
-    apmMapVehicleTypeToPX4Dir[PlaneFirmware] =   QStringLiteral("PX4");
-    apmMapVehicleTypeToPX4Dir[RoverFirmware] =   QStringLiteral("PX4");
-    apmMapVehicleTypeToPX4Dir[SubFirmware] =     QStringLiteral("PX4");
+    apmMapVehicleTypeToPX4Dir[CopterFirmware] = QStringLiteral("PX4");
+    apmMapVehicleTypeToPX4Dir[HeliFirmware] =   QStringLiteral("PX4-heli");
+    apmMapVehicleTypeToPX4Dir[PlaneFirmware] =  QStringLiteral("PX4");
+    apmMapVehicleTypeToPX4Dir[RoverFirmware] =  QStringLiteral("PX4");
+    apmMapVehicleTypeToPX4Dir[SubFirmware] =    QStringLiteral("PX4");
 
     QMap<FirmwareVehicleType_t, QString> apmMapVehicleTypeToFilename;
-    apmMapVehicleTypeToFilename[CopterFirmware] =  QStringLiteral("ArduCopter");
-    apmMapVehicleTypeToFilename[HeliFirmware] =    QStringLiteral("PX4-ArduCopter");
-    apmMapVehicleTypeToFilename[PlaneFirmware] =   QStringLiteral("ArduPlane");
-    apmMapVehicleTypeToFilename[RoverFirmware] =   QStringLiteral("APMrover2");
-    apmMapVehicleTypeToFilename[SubFirmware] =     QStringLiteral("ArduSub");
+    apmMapVehicleTypeToFilename[CopterFirmware] =   QStringLiteral("ArduCopter");
+    apmMapVehicleTypeToFilename[HeliFirmware] =     QStringLiteral("PX4-ArduCopter");
+    apmMapVehicleTypeToFilename[PlaneFirmware] =    QStringLiteral("ArduPlane");
+    apmMapVehicleTypeToFilename[RoverFirmware] =    QStringLiteral("APMrover2");
+    apmMapVehicleTypeToFilename[SubFirmware] =      QStringLiteral("ArduSub");
 
     QMap<FirmwareVehicleType_t, QString> apmChibiOSMapVehicleTypeToFmuDir;
-    apmChibiOSMapVehicleTypeToFmuDir[CopterChibiOSFirmware] =  QString();
-    apmChibiOSMapVehicleTypeToFmuDir[HeliChibiOSFirmware] =    QStringLiteral("-heli");
-    apmChibiOSMapVehicleTypeToFmuDir[PlaneChibiOSFirmware] =   QString();
-    apmChibiOSMapVehicleTypeToFmuDir[RoverChibiOSFirmware] =   QString();
-    apmChibiOSMapVehicleTypeToFmuDir[SubChibiOSFirmware] =     QString();
+    apmChibiOSMapVehicleTypeToFmuDir[CopterChibiOSFirmware] =   QString();
+    apmChibiOSMapVehicleTypeToFmuDir[HeliChibiOSFirmware] =     QStringLiteral("-heli");
+    apmChibiOSMapVehicleTypeToFmuDir[PlaneChibiOSFirmware] =    QString();
+    apmChibiOSMapVehicleTypeToFmuDir[RoverChibiOSFirmware] =    QString();
+    apmChibiOSMapVehicleTypeToFmuDir[SubChibiOSFirmware] =      QString();
 
     QMap<FirmwareVehicleType_t, QString> apmChibiOSMapVehicleTypeToFilename;
-    apmChibiOSMapVehicleTypeToFilename[CopterChibiOSFirmware] =  QStringLiteral("arducopter");
-    apmChibiOSMapVehicleTypeToFilename[HeliChibiOSFirmware] =    QStringLiteral("arducopter");
-    apmChibiOSMapVehicleTypeToFilename[PlaneChibiOSFirmware] =   QStringLiteral("arduplane");
-    apmChibiOSMapVehicleTypeToFilename[RoverChibiOSFirmware] =   QStringLiteral("ardurover");
-    apmChibiOSMapVehicleTypeToFilename[SubChibiOSFirmware] =     QStringLiteral("ardusub");
+    apmChibiOSMapVehicleTypeToFilename[CopterChibiOSFirmware] = QStringLiteral("arducopter");
+    apmChibiOSMapVehicleTypeToFilename[HeliChibiOSFirmware] =   QStringLiteral("arducopter");
+    apmChibiOSMapVehicleTypeToFilename[PlaneChibiOSFirmware] =  QStringLiteral("arduplane");
+    apmChibiOSMapVehicleTypeToFilename[RoverChibiOSFirmware] =  QStringLiteral("ardurover");
+    apmChibiOSMapVehicleTypeToFilename[SubChibiOSFirmware] =    QStringLiteral("ardusub");
 
     // PX4 Firmwares
     foreach (const FirmwareType_t& firmwareType, px4MapFirmwareTypeToDir.keys()) {

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -54,17 +54,16 @@ public:
         } FirmwareType_t;
 
         typedef enum {
-            QuadFirmware,
-            X8Firmware,
-            HexaFirmware,
-            OctoFirmware,
-            YFirmware,
-            Y6Firmware,
-            HeliFirmware,
             CopterFirmware,
+            HeliFirmware,
             PlaneFirmware,
             RoverFirmware,
             SubFirmware,
+            CopterChibiOSFirmware,
+            HeliChibiOSFirmware,
+            PlaneChibiOSFirmware,
+            RoverChibiOSFirmware,
+            SubChibiOSFirmware,
             DefaultVehicleFirmware
         } FirmwareVehicleType_t;
 

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -185,6 +185,8 @@ QGCSerialPortInfo::BoardType_t QGCSerialPortInfo::_boardClassStringToType(const 
 
 bool QGCSerialPortInfo::getBoardInfo(QGCSerialPortInfo::BoardType_t& boardType, QString& name) const
 {
+    boardType = BoardTypeUnknown;
+
     _loadJsonData();
 
     if (isNull()) {
@@ -220,7 +222,6 @@ bool QGCSerialPortInfo::getBoardInfo(QGCSerialPortInfo::BoardType_t& boardType, 
         }
     }
 
-    boardType = BoardTypeUnknown;
     return false;
 }
 

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -57,6 +57,7 @@
         { "regExp": "^PX4 Crazyflie v2.0",  "boardClass": "Pixhawk" },
         { "regExp": "^Crazyflie BL",        "boardClass": "Pixhawk" },
         { "regExp": "^PX4 OmnibusF4SD",     "boardClass": "Pixhawk" },
+        { "regExp": "^fmuv[2345]$",         "boardClass": "Pixhawk" },
         { "regExp": "PX4.*Flow",            "boardClass": "PX4 Flow" },
         { "regExp": "^FT231X USB UART$",    "boardClass": "SiK Radio" },
         { "regExp": "USB UART$",            "boardClass": "SiK Radio",  "androidOnly": true, "comment": "Very broad fallback, too dangerous for non-android" }


### PR DESCRIPTION
Note: Support for non-pixhawk family boards is NYI.

Related to #6760