### PR TITLE
Compass Cal: Don't show compass orientations for fixed orientation vehicles.

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -132,10 +132,8 @@ Item {
         onResetStatusTextArea: statusLog.text = statusTextAreaDefaultText
 
         onMagCalComplete: {
-            //if (!_sensorsHaveFixedOrientation && (showCompass0Rot || showCompass1Rot || showCompass2Rot)) {
-                setOrientationsDialogShowBoardOrientation = false
-                showDialog(setOrientationsDialogComponent, qsTr("Compass Calibration Complete"), qgcView.showDialogDefaultWidth, StandardButton.Ok)
-            //}
+            setOrientationsDialogShowBoardOrientation = false
+            showDialog(setOrientationsDialogComponent, qsTr("Compass Calibration Complete"), qgcView.showDialogDefaultWidth, StandardButton.Ok)
         }
 
         onWaitingForCancelChanged: {
@@ -255,7 +253,9 @@ Item {
                     QGCLabel {
                         width:      parent.width
                         wrapMode:   Text.WordWrap
-                        text:       qsTr("Set your compass orientations below and the make sure to reboot the vehicle prior to flight.")
+                        text:       _sensorsHaveFixedOrientation ?
+                                        qsTr("Make sure to reboot the vehicle prior to flight.") :
+                                        qsTr("Set your compass orientations below and the make sure to reboot the vehicle prior to flight.")
                     }
 
                     QGCButton {
@@ -270,6 +270,7 @@ Item {
                         width:      parent.width
                         wrapMode:   Text.WordWrap
                         text:       boardRotationText
+                        visible:    !_sensorsHaveFixedOrientation
                     }
 
                     Column {
@@ -287,8 +288,10 @@ Item {
                         }
                     }
 
+                    // Compass 0 rotation
                     Column {
-                        // Compass 0 rotation
+                        visible: !_sensorsHaveFixedOrientation
+
                         Component {
                             id: compass0ComponentLabel2
 
@@ -312,8 +315,10 @@ Item {
                         Loader { sourceComponent: showCompass0Rot ? compass0ComponentCombo2 : null }
                     }
 
+                    // Compass 1 rotation
                     Column {
-                        // Compass 1 rotation
+                        visible: !_sensorsHaveFixedOrientation
+
                         Component {
                             id: compass1ComponentLabel2
 
@@ -337,10 +342,11 @@ Item {
                         Loader { sourceComponent: showCompass1Rot ? compass1ComponentCombo2 : null }
                     }
 
+                    // Compass 2 rotation
                     Column {
+                        visible: !_sensorsHaveFixedOrientation
                         spacing: ScreenTools.defaultFontPixelWidth
 
-                        // Compass 2 rotation
                         Component {
                             id: compass2ComponentLabel2
 


### PR DESCRIPTION
This was broken by #6773