### PR TITLE
Dealing with pixel density on Windows and iOS

### DIFF
--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -53,20 +53,24 @@ Item {
     readonly property real mediumFontPointRatio:     1.25
     readonly property real largeFontPointRatio:      1.5
 
-    property real realPixelDensity:  QGroundControl.corePlugin.options.devicePixelDensity != 0 ? QGroundControl.corePlugin.options.devicePixelDensity : Screen.pixelDensity
-
-    property real realPixelRatio: {
+    property real realPixelDensity: {
         //-- If a plugin defines it, just use what it tells us
-        if (QGroundControl.corePlugin.options.devicePixelRatio != 0)
-            return QGroundControl.corePlugin.options.devicePixelRatio
-        //-- Mobile is rather unreliable. They all return 1 for Screen.devicePixelRatio.
-        if(isMobile) {
-            //   Lets assume it's unlikely you have a tablet over 300mm wide
-            if((Screen.width / Screen.pixelDensity * Screen.devicePixelRatio) > 300)
-                return 2
+        if(QGroundControl.corePlugin.options.devicePixelDensity != 0) {
+            return QGroundControl.corePlugin.options.devicePixelDensity
         }
-        //-- Use whatever the system tells us
-        return Screen.devicePixelRatio
+        //-- Apple returns proper values
+        if(isiOS || isMac) {
+            return Screen.pixelDensity
+        }
+        //-- Mobile is rather unreliable
+        if(isMobile) {
+            // Lets assume it's unlikely you have a tablet over 300mm wide
+            if((Screen.width / Screen.pixelDensity) > 300) {
+                return Screen.pixelDensity * 2
+            }
+        }
+        //-- Still needs logical pixel density on Windows
+        return Screen.pixelDensity
     }
 
     property bool isAndroid:        ScreenToolsController.isAndroid
@@ -74,9 +78,10 @@ Item {
     property bool isMobile:         ScreenToolsController.isMobile
     property bool isWindows:        ScreenToolsController.isWindows
     property bool isDebug:          ScreenToolsController.isDebug
+    property bool isMac:            ScreenToolsController.isMacOS
     property bool isTinyScreen:     (Screen.width / realPixelDensity) < 120 // 120mm
     property bool isShortScreen:    ScreenToolsController.isMobile && ((Screen.height / Screen.width) < 0.6) // Nexus 7 for example
-    property bool isHugeScreen:     Screen.width >= 1920*2
+    property bool isHugeScreen:     (Screen.width / realPixelDensity) >= (23.5 * 25.4) // 27" monitor
 
     readonly property real minTouchMillimeters: 10      ///< Minimum touch size in millimeters
     property real minTouchPixels:               0       ///< Minimum touch size in pixels
@@ -111,10 +116,6 @@ Item {
         _setBasePointSize(defaultFontPointSize)
     }
 
-    onRealPixelRatioChanged: {
-        _setBasePointSize(defaultFontPointSize)
-    }
-
     function printScreenStats() {
         console.log('ScreenTools: Screen.width: ' + Screen.width + ' Screen.height: ' + Screen.height + ' Screen.pixelDensity: ' + Screen.pixelDensity)
     }
@@ -138,7 +139,7 @@ Item {
         smallFontPointSize      = defaultFontPointSize  * _screenTools.smallFontPointRatio
         mediumFontPointSize     = defaultFontPointSize  * _screenTools.mediumFontPointRatio
         largeFontPointSize      = defaultFontPointSize  * _screenTools.largeFontPointRatio
-        minTouchPixels          = Math.round(minTouchMillimeters * realPixelDensity * realPixelRatio)
+        minTouchPixels          = Math.round(minTouchMillimeters * realPixelDensity)
         if (minTouchPixels / Screen.height > 0.15) {
             // If using physical sizing takes up too much of the vertical real estate fall back to font based sizing
             minTouchPixels      = defaultFontPixelHeight * 3


### PR DESCRIPTION
The fixes in #6782 is not enough for Windows when using a "high DPI" display (aka 4k/5k monitors). The pixel ratio value returned by the system is only available on macOS and iOS. Pixel density however, seems to be a bit more reliable and I am using that instead.

This makes two assumptions:

* A "tablet" can't be larger than 300mm wide (The DJI CrystalSky for instance reports a huge resolution with a pixel ratio of 1. Its pixel density however is accurate enough.)

* A "huge monitor" is one greater than 27" instead of a fixed number of pixels.