### PR TITLE
[QmlObjectListModel] fix list insert

### DIFF
--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -194,7 +194,7 @@ void QmlObjectListModel::insert(int i, QList<QObject*> objects)
         }
         j++;
 
-        _objectList.insert(i, object);
+        _objectList.insert(j, object);
     }
 
     insertRows(i, objects.count());


### PR DESCRIPTION
Fixes https://github.com/mavlink/qgroundcontrol/issues/6770

I don't think it makes sense to insert the objects at location `i` (`i` stays constant,  `j`  is changed).

Note that  `insert` is called from `append` with `i == _objectList.count()`