### PR TITLE
Adding code to actually load localization strings.

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -114,7 +114,7 @@
 
 #include "QGCMapEngine.h"
 
-QGCApplication* QGCApplication::_app = NULL;
+QGCApplication* QGCApplication::_app = nullptr;
 
 const char* QGCApplication::_deleteAllSettingsKey           = "DeleteAllSettingsNextBoot";
 const char* QGCApplication::_settingsVersionKey             = "SettingsVersion";
@@ -150,7 +150,7 @@ static QObject* kmlFileHelperSingletonFactory(QQmlEngine*, QJSEngine*)
 QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 #ifdef __mobile__
     : QGuiApplication       (argc, argv)
-    , _qmlAppEngine         (NULL)
+    , _qmlAppEngine         (nullptr)
 #else
     : QApplication          (argc, argv)
 #endif
@@ -161,10 +161,23 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 #ifdef QT_DEBUG
     , _testHighDPI          (false)
 #endif
-    , _toolbox              (NULL)
+    , _toolbox              (nullptr)
     , _bluetoothAvailable   (false)
 {
     _app = this;
+
+
+    QLocale locale = QLocale::system();
+    //-- Some forced locales for testing
+    //QLocale locale = QLocale(QLocale::German);
+    //QLocale locale = QLocale(QLocale::French);
+    //QLocale locale = QLocale(QLocale::Chinese);
+#if defined (__macos__)
+    locale = QLocale(locale.name());
+#endif
+    //-- Our localization
+    if(_QGCTranslator.load(locale, "qgc_", "", ":/localization"))
+        _app->installTranslator(&_QGCTranslator);
 
     // This prevents usage of QQuickWidget to fail since it doesn't support native widget siblings
 #ifndef __android__
@@ -222,12 +235,12 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     QString loggingOptions;
 
     CmdLineOpt_t rgCmdLineOptions[] = {
-        { "--clear-settings",   &fClearSettingsOptions, NULL },
+        { "--clear-settings",   &fClearSettingsOptions, nullptr },
         { "--logging",          &logging,               &loggingOptions },
-        { "--fake-mobile",      &_fakeMobile,           NULL },
-        { "--log-output",       &_logOutput,            NULL },
+        { "--fake-mobile",      &_fakeMobile,           nullptr },
+        { "--log-output",       &_logOutput,            nullptr },
     #ifdef QT_DEBUG
-        { "--test-high-dpi",    &_testHighDPI,          NULL },
+        { "--test-high-dpi",    &_testHighDPI,          nullptr },
     #endif
         // Add additional command line option flags here
     };
@@ -344,7 +357,7 @@ void QGCApplication::_shutdown(void)
 QGCApplication::~QGCApplication()
 {
     // Place shutdown code in _shutdown
-    _app = NULL;
+    _app = nullptr;
 }
 
 void QGCApplication::_initCommon(void)
@@ -648,10 +661,10 @@ QObject* QGCApplication::_rootQmlObject()
         return mainWindow->rootQmlObject();
     } else if (runningUnitTests()){
         // Unit test can run without a main window
-        return NULL;
+        return nullptr;
     } else {
         qWarning() << "Why is MainWindow missing?";
-        return NULL;
+        return nullptr;
     }
 #endif
 }

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -177,6 +177,8 @@ private:
 
     QGCToolbox* _toolbox;
 
+    QTranslator _QGCTranslator;
+
     bool _bluetoothAvailable;
 
     static const char* _settingsVersionKey;             ///< Settings key which hold settings version


### PR DESCRIPTION
This will look for localization strings defined as resources. None exist yet. Once languages are added, they should be submitted into the `localization/` directory and added as a resource. For example:

```
    <qresource prefix="/localization">
        <file alias="qgc_de_DE.qm">localization/qgc_de_DE.qm</file>
        <file alias="qgc_fr_FR.qm">localization/qgc_fr_FR.qm</file>
        <file alias="qgc_zh_CN.qm">localization/qgc_zh_CN.qm</file>
    </qresource>
```

This is in response to 
https://github.com/mavlink/qgroundcontrol/issues/3961#issuecomment-419467723. That work seems to have been done outside crowdin and must be added directly as a PR. It can be added to this branch directly or wait until it's merged.
