### PR TITLE
House keeping

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -68,6 +68,8 @@ linux {
         #-- Not forcing anything. Let qmake find the latest, installed SDK.
         #QMAKE_MAC_SDK = macosx10.12
         QMAKE_CXXFLAGS += -fvisibility=hidden
+        #-- Disable annoying warnings comming from mavlink.h
+        QMAKE_CXXFLAGS += -Wno-address-of-packed-member
     } else {
         error("Unsupported Mac toolchain, only 64-bit LLVM+clang is supported")
     }

--- a/libs/airmapd/include/airmap/traffic.h
+++ b/libs/airmapd/include/airmap/traffic.h
@@ -60,6 +60,7 @@ class Traffic : DoNotCopyOrMove {
     /// Subscriber abstracts handling of batches of Update instances.
     class Subscriber {
      public:
+     virtual ~Subscriber() = default;
       /// handle_update is invoked when a new batch of Update instances
       /// is available.
       virtual void handle_update(Update::Type type, const std::vector<Update>& update) = 0;


### PR DESCRIPTION
* Disable the zillion warnings that come out from mavlink.h (macOS)
* Fix warning from error within the Airmap SDK. This is at best temporary until we get a properly functional SDK from Airmap. This was causing the Jenkins build to fail.