### PR TITLE
Add BlueROV2 heavy default parameter configuration

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
@@ -198,8 +198,17 @@ SetupPage {
                     property var file:   _oldFW ? "Sub/bluerov2-3_5.params" : "Sub/bluerov2-3_5_2.params"
 
                     onClicked : {
-                        console.log(_oldFW)
-                        console.log(_activeVehicle.firmwarePatchVersion)
+                        controller.loadParameters(file)
+                        hideDialog()
+                    }
+                }
+
+                QGCButton {
+                    width:  parent.width
+                    text:   "Blue Robotics BlueROV2 Heavy"
+                    property var file:  "Sub/bluerov2-heavy-3_5_2.params"
+
+                    onClicked : {
                         controller.loadParameters(file)
                         hideDialog()
                     }


### PR DESCRIPTION
This adds a new button to load the default parameters for the BlueROV2 Heavy
![screenshot from 2018-10-08 11-40-50](https://user-images.githubusercontent.com/4013804/46616975-0d5e9980-caf2-11e8-8506-18ff1391862d.png)
