### PR TITLE
Add motor test page for sub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ list(APPEND QGC_SRC
 	src/AutoPilotPlugins/APM/APMFlightModesComponent.cc
 	src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
 	src/AutoPilotPlugins/APM/APMLightsComponent.cc
+	src/AutoPilotPlugins/APM/APMMotorComponent.cc
 	src/AutoPilotPlugins/APM/APMPowerComponent.cc
 	src/AutoPilotPlugins/APM/APMRadioComponent.cc
 	src/AutoPilotPlugins/APM/APMSafetyComponent.cc

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -970,6 +970,7 @@ APMFirmwarePlugin {
         src/AutoPilotPlugins/APM/APMHeliComponent.h \
         src/AutoPilotPlugins/APM/APMLightsComponent.h \
         src/AutoPilotPlugins/APM/APMSubFrameComponent.h \
+        src/AutoPilotPlugins/APM/APMMotorComponent.h \
         src/AutoPilotPlugins/APM/APMPowerComponent.h \
         src/AutoPilotPlugins/APM/APMRadioComponent.h \
         src/AutoPilotPlugins/APM/APMSafetyComponent.h \
@@ -996,6 +997,7 @@ APMFirmwarePlugin {
         src/AutoPilotPlugins/APM/APMHeliComponent.cc \
         src/AutoPilotPlugins/APM/APMLightsComponent.cc \
         src/AutoPilotPlugins/APM/APMSubFrameComponent.cc \
+        src/AutoPilotPlugins/APM/APMMotorComponent.cc \
         src/AutoPilotPlugins/APM/APMPowerComponent.cc \
         src/AutoPilotPlugins/APM/APMRadioComponent.cc \
         src/AutoPilotPlugins/APM/APMSafetyComponent.cc \

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -86,7 +86,8 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
             _powerComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_powerComponent));
 
-            if (_vehicle->multiRotor() || _vehicle->vtol()) {
+            int versionInt = _vehicle->firmwareMajorVersion() * 100 + _vehicle->firmwareMinorVersion() * 10 + _vehicle->firmwarePatchVersion();
+            if (_vehicle->sub() && versionInt >= 353) {
                 _motorComponent = new MotorComponent(_vehicle, this);
                 _motorComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_motorComponent));

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -40,10 +40,7 @@ APMAutoPilotPlugin::APMAutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     , _subFrameComponent        (NULL)
     , _flightModesComponent     (NULL)
     , _powerComponent           (NULL)
-#if 0
-        // Temporarily removed, waiting for new command implementation
     , _motorComponent           (NULL)
-#endif
     , _radioComponent           (NULL)
     , _safetyComponent          (NULL)
     , _sensorsComponent         (NULL)
@@ -89,15 +86,11 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
             _powerComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_powerComponent));
 
-#if 0
-    // Temporarily removed, waiting for new command implementation
-
             if (_vehicle->multiRotor() || _vehicle->vtol()) {
                 _motorComponent = new MotorComponent(_vehicle, this);
                 _motorComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_motorComponent));
             }
-#endif
 
             _safetyComponent = new APMSafetyComponent(_vehicle, this);
             _safetyComponent->setupTriggerSignals();

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -23,7 +23,7 @@
 #include "APMTuningComponent.h"
 #include "APMSensorsComponent.h"
 #include "APMPowerComponent.h"
-#include "MotorComponent.h"
+#include "APMMotorComponent.h"
 #include "APMCameraComponent.h"
 #include "APMLightsComponent.h"
 #include "APMSubFrameComponent.h"
@@ -88,7 +88,7 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
 
             int versionInt = _vehicle->firmwareMajorVersion() * 100 + _vehicle->firmwareMinorVersion() * 10 + _vehicle->firmwarePatchVersion();
             if (_vehicle->sub() && versionInt >= 353) {
-                _motorComponent = new MotorComponent(_vehicle, this);
+                _motorComponent = new APMMotorComponent(_vehicle, this);
                 _motorComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_motorComponent));
             }

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
@@ -50,10 +50,7 @@ protected:
     APMSubFrameComponent*       _subFrameComponent;
     APMFlightModesComponent*    _flightModesComponent;
     APMPowerComponent*          _powerComponent;
-#if 0
-    // Temporarily removed, waiting for new command implementation
     MotorComponent*             _motorComponent;
-#endif
     APMRadioComponent*          _radioComponent;
     APMSafetyComponent*         _safetyComponent;
     APMSensorsComponent*        _sensorsComponent;

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
@@ -22,7 +22,7 @@ class APMTuningComponent;
 class APMSafetyComponent;
 class APMSensorsComponent;
 class APMPowerComponent;
-class MotorComponent;
+class APMMotorComponent;
 class APMCameraComponent;
 class APMLightsComponent;
 class APMSubFrameComponent;
@@ -50,7 +50,7 @@ protected:
     APMSubFrameComponent*       _subFrameComponent;
     APMFlightModesComponent*    _flightModesComponent;
     APMPowerComponent*          _powerComponent;
-    MotorComponent*             _motorComponent;
+    APMMotorComponent*          _motorComponent;
     APMRadioComponent*          _radioComponent;
     APMSafetyComponent*         _safetyComponent;
     APMSensorsComponent*        _sensorsComponent;

--- a/src/AutoPilotPlugins/APM/APMMotorComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMMotorComponent.cc
@@ -1,0 +1,27 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "APMMotorComponent.h"
+
+APMMotorComponent::APMMotorComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
+    MotorComponent(vehicle, autopilot, parent),
+    _name(tr("Motors"))
+{
+
+}
+
+QUrl APMMotorComponent::setupSource(void) const
+{
+    switch (_vehicle->vehicleType()) {
+    case MAV_TYPE_SUBMARINE:
+        return QUrl::fromUserInput(QStringLiteral("qrc:/qml/APMSubMotorComponent.qml"));
+    default:
+        return QUrl::fromUserInput(QStringLiteral("qrc:/qml/MotorComponent.qml"));
+    }
+}

--- a/src/AutoPilotPlugins/APM/APMMotorComponent.h
+++ b/src/AutoPilotPlugins/APM/APMMotorComponent.h
@@ -1,0 +1,29 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2018 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+#ifndef APMMotorComponent_H
+#define APMMotorComponent_H
+
+#include "MotorComponent.h"
+
+class APMMotorComponent : public MotorComponent
+{
+    Q_OBJECT
+
+public:
+    APMMotorComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = NULL);
+
+    QUrl setupSource(void) const final;
+
+private:
+    const QString   _name;
+};
+
+#endif

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
@@ -1,0 +1,225 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 2.4
+import QtQuick.Dialogs  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.ScreenTools   1.0
+
+SetupPage {
+    id:             motorPage
+    pageComponent:  pageComponent
+    enabled:        true
+
+    readonly property int _barHeight:       10
+    readonly property int _barWidth:        5
+    readonly property int _sliderHeight:    10
+
+    property int neutralValue: 50;
+    property int _lastIndex: 0;
+
+    FactPanelController {
+        id:             controller
+        factPanel:      motorPage.viewPanel
+    }
+
+    function setMotorDirection(num, reversed) {
+        var fact = controller.getParameterFact(-1, "MOT_" + num + "_DIRECTION")
+        fact.value = reversed ? -1 : 1;
+    }
+
+    Component.onCompleted: controller.vehicle.armed = false
+
+    Component {
+        id: pageComponent
+
+        Column {
+            spacing: 10
+
+            Row {
+                id:         motorSliders
+                enabled:    controller.vehicle.armed
+                spacing:    ScreenTools.defaultFontPixelWidth * 4
+
+                Column {
+                    spacing:    ScreenTools.defaultFontPixelWidth * 2
+
+                    Row {
+                        id: sliderRow
+                        spacing:    ScreenTools.defaultFontPixelWidth * 4
+
+                        Repeater {
+                            id:         sliderRepeater
+                            model:      controller.vehicle.motorCount == -1 ? 8 : controller.vehicle.motorCount
+
+                            Column {
+                                property alias motorSlider: slider
+                                spacing:    ScreenTools.defaultFontPixelWidth
+
+                                QGCLabel {
+                                    anchors.horizontalCenter:   parent.horizontalCenter
+                                    text:                       index + 1
+                                }
+
+                                QGCSlider {
+                                    id:                         slider
+                                    height:                     ScreenTools.defaultFontPixelHeight * _sliderHeight
+                                    orientation:                Qt.Vertical
+                                    maximumValue:               100
+                                    value:                      neutralValue
+
+                                    // Give slider 'center sprung' behavior
+                                    onPressedChanged: {
+                                        if (!slider.pressed) {
+                                            slider.value = neutralValue
+                                        }
+                                        _lastIndex = index
+                                    }
+                                    // Disable mouse scroll
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        onWheel: {
+                                            // do nothing
+                                            wheel.accepted = true;
+                                        }
+                                        onPressed: {
+                                            // propogate/accept
+                                            mouse.accepted = false;
+                                        }
+                                        onReleased: {
+                                            // propogate/accept
+                                            mouse.accepted = false;
+                                        }
+                                    }
+                                }
+                            } // Column
+                        } // Repeater
+                    } // Row
+
+                    QGCLabel {
+                        width: parent.width
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        wrapMode:       Text.WordWrap
+                        text:           qsTr("Reverse Motor Direction")
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignBottom
+                    }
+                    Rectangle {
+                        anchors.margins: ScreenTools.defaultFontPixelWidth * 3
+                        width:              parent.width
+                        height:             1
+                        color:              qgcPal.text
+                    }
+
+                    Row {
+                        anchors.margins: ScreenTools.defaultFontPixelWidth
+
+                        Repeater {
+                            id:         cbRepeater
+                            model:      controller.vehicle.motorCount == -1 ? 8 : controller.vehicle.motorCount
+
+                            Column {
+                                spacing:    ScreenTools.defaultFontPixelWidth
+
+                                QGCCheckBox {
+                                    width: sliderRow.width / (controller.vehicle.motorCount - 0.5)
+                                    checked: controller.getParameterFact(-1, "MOT_" + (index + 1) + "_DIRECTION").value == -1
+                                    onClicked: {
+                                        sliderRepeater.itemAt(index).motorSlider.value = neutralValue
+                                        setMotorDirection(index + 1, checked)
+                                    }
+                                }
+                            } // Column
+                        } // Repeater
+                    } // Row
+                } // Column
+
+                // Display the frame currently in use with motor numbers
+                APMSubMotorDisplay {
+                    anchors.top:    parent.top
+                    anchors.bottom: parent.bottom
+                    width:          height
+                    frameType: controller.getParameterFact(-1, "FRAME_CONFIG").value
+                }
+            } // Row
+
+            QGCLabel {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                wrapMode:       Text.WordWrap
+                text:           qsTr("Moving the sliders will cause the motors to spin. Make sure the motors and propellers are clear from obstructions! The direction of the motor rotation is dependent on how the three phases of the motor are physically connected to the ESCs (if any two wires are swapped, the direction of rotation will flip). Because we cannot guarantee what order the phases are connected, the motor directions must be configured in software. When a slider is moved DOWN, the thruster should push air/water TOWARD the cable entering the housing. Click the checkbox to reverse the direction of the corresponding thruster.\n\n"
+                                     + "Blue Robotics thrusters are lubricated by water and are not designed to be run in air. Testing the thrusters in air is ok at low speeds for short periods of time. Extended operation of Blue Robotics in air may lead to overheating and permanent damage. Without water lubrication, Blue Robotics thrusters may also make some unpleasant noises when operated in air; this is normal.")
+            }
+
+            Row {
+                spacing: ScreenTools.defaultFontPixelWidth
+                Switch {
+                    id: safetySwitch
+                    onToggled: {
+                        if (controller.vehicle.armed) {
+                            timer.stop()
+                        }
+
+                        controller.vehicle.armed = checked
+                        checked = controller.vehicle.armed // Makes the switch stay off if it's not possible to arm
+                    }
+                }
+
+                // Make sure external changes to Armed are reflected on the switch
+                Connections {
+                    target: controller.vehicle
+                    onArmedChanged:
+                    {
+                        safetySwitch.checked = armed
+                            if (!armed) {
+                                timer.stop()
+                            } else {
+                                timer.start()
+                            }
+                            for (var sliderIndex=0; sliderIndex<sliderRepeater.count; sliderIndex++) {
+                                sliderRepeater.itemAt(sliderIndex).motorSlider.value = neutralValue
+                            }
+                        }
+                }
+
+                QGCLabel {
+                    anchors.verticalCenter: safetySwitch.verticalCenter
+                    color:  qgcPal.warningText
+                    text:   qsTr("Slide this switch to arm the vehicle and enable the motor test (CAUTION!)")
+                }
+            } // Row
+
+            // Repeats the command signal and updates the checkbox every 50 ms
+            Timer {
+                id: timer
+                interval:       50
+                repeat:         true
+
+                onTriggered: {
+                    if (controller.vehicle.armed) {
+                            var slider = sliderRepeater.itemAt(_lastIndex)
+
+                            var reversed = controller.getParameterFact(-1, "MOT_" + (_lastIndex + 1) + "_DIRECTION").value == -1
+
+                            if (reversed) {
+                                controller.vehicle.motorTest(_lastIndex, 100 - slider.motorSlider.value)
+                            } else {
+                                controller.vehicle.motorTest(_lastIndex, slider.motorSlider.value)
+                            }
+                    }
+                }
+            }
+        } // Column
+    } // Component
+} // SetupPahe

--- a/src/AutoPilotPlugins/Common/MotorComponent.h
+++ b/src/AutoPilotPlugins/Common/MotorComponent.h
@@ -30,7 +30,7 @@ public:
     QString iconResource(void) const final;
     bool requiresSetup(void) const final;
     bool setupComplete(void) const final;
-    QUrl setupSource(void) const final;
+    virtual QUrl setupSource(void) const;
     QUrl summaryQmlSource(void) const final;
 
 private:

--- a/src/FirmwarePlugin/APM/APMResources.qrc
+++ b/src/FirmwarePlugin/APM/APMResources.qrc
@@ -11,6 +11,8 @@
         <file alias="APMLightsComponentSummary.qml">../../AutoPilotPlugins/APM/APMLightsComponentSummary.qml</file>
         <file alias="APMSubFrameComponent.qml">../../AutoPilotPlugins/APM/APMSubFrameComponent.qml</file>
         <file alias="APMSubFrameComponentSummary.qml">../../AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml</file>
+        <file alias="APMSubMotorComponent.qml">../../AutoPilotPlugins/APM/APMSubMotorComponent.qml</file>
+        <file alias="QGroundControl/Controls/APMSubMotorDisplay.qml">../../QmlControls/APMSubMotorDisplay.qml</file>
         <file alias="APMNotSupported.qml">../../AutoPilotPlugins/APM/APMNotSupported.qml</file>
         <file alias="APMPowerComponent.qml">../../AutoPilotPlugins/APM/APMPowerComponent.qml</file>
         <file alias="APMPowerComponentSummary.qml">../../AutoPilotPlugins/APM/APMPowerComponentSummary.qml</file>

--- a/src/QmlControls/APMSubMotorDisplay.qml
+++ b/src/QmlControls/APMSubMotorDisplay.qml
@@ -1,0 +1,44 @@
+import QtQuick 2.3
+
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl               1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+Item {
+    id: root
+
+    property var frameType: 0
+    // TODO need a better class for getting vehicle parameters into qml?
+    // according to comments in FactPanelController.h, this is not the intended use case
+
+    function getImage() {
+        switch (frameType) {
+        case 0:
+                return "qrc:///qmlimages/Frames/BlueROV1.png"
+        case 1:
+                return "qrc:///qmlimages/Frames/Vectored.png"
+        case 2:
+                return "qrc:///qmlimages/Frames/Vectored6DOF.png"
+        case 4:
+                return "qrc:///qmlimages/Frames/SimpleROV-3.png"
+        case 5:
+                return "qrc:///qmlimages/Frames/SimpleROV-4.png"
+        }
+        return ""
+    }
+
+    Component.onCompleted: {
+        console.log(getImage())
+        subImage.source = getImage()
+    }
+
+    Image {
+        id: subImage
+        anchors.margins:    ScreenTools.defaultFontPixelWidth
+        anchors.fill:       parent
+        fillMode:           Image.PreserveAspectFit
+        smooth:             true
+        mipmap:             true
+    }
+} // Item

--- a/src/QmlControls/QGroundControl.Controls.qmldir
+++ b/src/QmlControls/QGroundControl.Controls.qmldir
@@ -3,6 +3,7 @@ Module QGroundControl.Controls
 AnalyzePage             1.0 AnalyzePage.qml
 AppMessages             1.0 AppMessages.qml
 CameraCalc              1.0 CameraCalc.qml
+APMSubMotorDisplay      1.0 APMSubMotorDisplay.qml
 CameraSection           1.0 CameraSection.qml
 ClickableColor          1.0 ClickableColor.qml
 DeadMouseArea           1.0 DeadMouseArea.qml

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3290,9 +3290,9 @@ void Vehicle::setSoloFirmware(bool soloFirmware)
     }
 }
 
-void Vehicle::motorTest(int motor, int percent, int timeoutSecs)
+void Vehicle::motorTest(int motor, int percent)
 {
-    sendMavCommand(_defaultComponentId, MAV_CMD_DO_MOTOR_TEST, motor, MOTOR_TEST_THROTTLE_PERCENT, percent, timeoutSecs);
+    sendMavCommand(_defaultComponentId, MAV_CMD_DO_MOTOR_TEST, true, motor, MOTOR_TEST_THROTTLE_PERCENT, percent, 0, 0, MOTOR_TEST_ORDER_BOARD);
 }
 
 QString Vehicle::brandImageIndoor(void) const

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3290,13 +3290,10 @@ void Vehicle::setSoloFirmware(bool soloFirmware)
     }
 }
 
-#if 0
-// Temporarily removed, waiting for new command implementation
 void Vehicle::motorTest(int motor, int percent, int timeoutSecs)
 {
-    doCommandLongUnverified(_defaultComponentId, MAV_CMD_DO_MOTOR_TEST, motor, MOTOR_TEST_THROTTLE_PERCENT, percent, timeoutSecs);
+    sendMavCommand(_defaultComponentId, MAV_CMD_DO_MOTOR_TEST, motor, MOTOR_TEST_THROTTLE_PERCENT, percent, timeoutSecs);
 }
-#endif
 
 QString Vehicle::brandImageIndoor(void) const
 {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1986,6 +1986,47 @@ int Vehicle::motorCount(void)
         return 6;
     case MAV_TYPE_OCTOROTOR:
         return 8;
+    case MAV_TYPE_SUBMARINE:
+    {
+        // Supported frame types
+        enum {
+            SUB_FRAME_BLUEROV1,
+            SUB_FRAME_VECTORED,
+            SUB_FRAME_VECTORED_6DOF,
+            SUB_FRAME_VECTORED_6DOF_90DEG,
+            SUB_FRAME_SIMPLEROV_3,
+            SUB_FRAME_SIMPLEROV_4,
+            SUB_FRAME_SIMPLEROV_5,
+            SUB_FRAME_CUSTOM
+        };
+
+        uint8_t frameType = parameterManager()->getParameter(_compID, "FRAME_CONFIG")->rawValue().toInt();
+
+        switch (frameType) {  // ardupilot/libraries/AP_Motors/AP_Motors6DOF.h sub_frame_t
+
+        case SUB_FRAME_BLUEROV1:
+        case SUB_FRAME_VECTORED:
+            return 6;
+
+        case SUB_FRAME_SIMPLEROV_3:
+            return 3;
+
+        case SUB_FRAME_SIMPLEROV_4:
+            return 4;
+
+        case SUB_FRAME_SIMPLEROV_5:
+            return 5;
+
+        case SUB_FRAME_VECTORED_6DOF:
+        case SUB_FRAME_VECTORED_6DOF_90DEG:
+        case SUB_FRAME_CUSTOM:
+            return 8;
+
+        default:
+            return -1;
+        }
+    }
+
     default:
         return -1;
     }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -744,14 +744,11 @@ public:
     Q_INVOKABLE void triggerCamera(void);
     Q_INVOKABLE void sendPlan(QString planFile);
 
-#if 0
-    // Temporarily removed, waiting for new command implementation
     /// Test motor
     ///     @param motor Motor number, 1-based
     ///     @param percent 0-no power, 100-full power
     ///     @param timeoutSecs Number of seconds for motor to run
     Q_INVOKABLE void motorTest(int motor, int percent, int timeoutSecs);
-#endif
 
     bool guidedModeSupported    (void) const;
     bool pauseVehicleSupported  (void) const;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -747,8 +747,7 @@ public:
     /// Test motor
     ///     @param motor Motor number, 1-based
     ///     @param percent 0-no power, 100-full power
-    ///     @param timeoutSecs Number of seconds for motor to run
-    Q_INVOKABLE void motorTest(int motor, int percent, int timeoutSecs);
+    Q_INVOKABLE void motorTest(int motor, int percent);
 
     bool guidedModeSupported    (void) const;
     bool pauseVehicleSupported  (void) const;


### PR DESCRIPTION
This adds a motor test interface for Sub. This interface is important to test individual motors to check if they are connected correctly, diagnose issues and reverse motor direction when necessary.

This is what it looks like:
![deepin-screen-recorder_select area_20181008111918](https://user-images.githubusercontent.com/4013804/46614673-d2a63280-caec-11e8-901a-980563d3fd20.gif)
