### PR TITLE
Create Helper functions to simplify version checking

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -72,7 +72,7 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
             }
 
             // No flight modes component for Sub versions 3.5 and up
-            if (!_vehicle->sub() || (_vehicle->firmwareMajorVersion() == 3 && _vehicle->firmwareMinorVersion() <= 4)) {
+            if (!_vehicle->sub() || (_vehicle->versionCompare(3, 5, 0) < 0)) {
                 _flightModesComponent = new APMFlightModesComponent(_vehicle, this);
                 _flightModesComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_flightModesComponent));
@@ -86,8 +86,7 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
             _powerComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_powerComponent));
 
-            int versionInt = _vehicle->firmwareMajorVersion() * 100 + _vehicle->firmwareMinorVersion() * 10 + _vehicle->firmwarePatchVersion();
-            if (_vehicle->sub() && versionInt >= 353) {
+            if (_vehicle->sub() && _vehicle->versionCompare(3, 5, 3) >= 0) {
                 _motorComponent = new APMMotorComponent(_vehicle, this);
                 _motorComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_motorComponent));
@@ -116,7 +115,7 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
                 _lightsComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_lightsComponent));
 
-                if(_vehicle->firmwareMajorVersion() > 3 || (_vehicle->firmwareMajorVersion() == 3 && _vehicle->firmwareMinorVersion() >= 5)) {
+                if(_vehicle->versionCompare(3, 5, 0) >= 0) {
                     _subFrameComponent = new APMSubFrameComponent(_vehicle, this);
                     _subFrameComponent->setupTriggerSignals();
                     _components.append(QVariant::fromValue((VehicleComponent*)_subFrameComponent));

--- a/src/AutoPilotPlugins/APM/APMLightsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMLightsComponent.qml
@@ -34,7 +34,7 @@ SetupPage {
             QGCPalette { id: palette; colorGroupEnabled: true }
 
             property var  _activeVehicle:       QGroundControl.multiVehicleManager.activeVehicle
-            property bool _oldFW:               !(_activeVehicle.firmwareMajorVersion > 3 || _activeVehicle.firmwareMinorVersion > 5 || _activeVehicle.firmwarePatchVersion >= 2)
+            property bool _oldFW:               _activeVehicle.versionCompare(3, 5, 2) < 0
             property Fact _rc5Function:         controller.getParameterFact(-1, "r.SERVO5_FUNCTION")
             property Fact _rc6Function:         controller.getParameterFact(-1, "r.SERVO6_FUNCTION")
             property Fact _rc7Function:         controller.getParameterFact(-1, "r.SERVO7_FUNCTION")

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
@@ -36,7 +36,7 @@ SetupPage {
             QGCPalette { id: ggcPal; colorGroupEnabled: true }
 
             property var _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
-            property bool _firmware34: _activeVehicle.firmwareMajorVersion == 3 && _activeVehicle.firmwareMinorVersion == 4
+            property bool _firmware34:       _activeVehicle.versionCompare(3, 5, 0) < 0
 
             // Enable/Action parameters
             property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT")

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
@@ -13,7 +13,7 @@ FactPanel {
     color:          qgcPal.windowShadeDark
 
     property var _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
-    property bool _firmware34: _activeVehicle.firmwareMajorVersion == 3 && _activeVehicle.firmwareMinorVersion == 4
+    property bool _firmware34:       _activeVehicle.versionCompare(3, 5, 0) < 0
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
     FactPanelController { id: controller; factPanel: panel }

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
@@ -25,7 +25,7 @@ SetupPage {
     pageComponent:      subFramePageComponent
 
     property var  _activeVehicle:       QGroundControl.multiVehicleManager.activeVehicle
-    property bool _oldFW:   !(_activeVehicle.firmwareMajorVersion > 3 || _activeVehicle.firmwareMinorVersion > 5 || _activeVehicle.firmwarePatchVersion >= 2)
+    property bool _oldFW:   _activeVehicle.versionCompare(3 ,5 ,2) < 0
 
     APMAirframeComponentController { id: controller; factPanel: subFramePage.viewPanel }
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -761,9 +761,6 @@ void APMFirmwarePlugin::_artooSocketError(QAbstractSocket::SocketError socketErr
 
 QString APMFirmwarePlugin::internalParameterMetaDataFile(Vehicle* vehicle)
 {
-    int majorVersion = vehicle->firmwareMajorVersion();
-    int minorVersion = vehicle->firmwareMinorVersion();
-
     switch (vehicle->vehicleType()) {
     case MAV_TYPE_QUADROTOR:
     case MAV_TYPE_HEXAROTOR:
@@ -771,25 +768,17 @@ QString APMFirmwarePlugin::internalParameterMetaDataFile(Vehicle* vehicle)
     case MAV_TYPE_TRICOPTER:
     case MAV_TYPE_COAXIAL:
     case MAV_TYPE_HELICOPTER:
-        if (majorVersion < 3) {
+        if (vehicle->versionCompare(3,4,0) < 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.3.xml");
-        } else if (majorVersion == 3) {
-            switch (minorVersion) {
-            case 0:
-            case 1:
-            case 2:
-            case 3:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.3.xml");
-            case 4:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.4.xml");
-            case 5:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.5.xml");
-            case 6:
-            default:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.6.xml");
-            }
         }
-        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.5.xml");
+        if (vehicle->versionCompare(3,5,0) < 0) {
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.4.xml");
+        }
+        if (vehicle->versionCompare(3,6,0) < 0) {
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.5.xml");
+        }
+        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.6.xml");
+
     case MAV_TYPE_VTOL_DUOROTOR:
     case MAV_TYPE_VTOL_QUADROTOR:
     case MAV_TYPE_VTOL_TILTROTOR:
@@ -798,45 +787,27 @@ QString APMFirmwarePlugin::internalParameterMetaDataFile(Vehicle* vehicle)
     case MAV_TYPE_VTOL_RESERVED4:
     case MAV_TYPE_VTOL_RESERVED5:
     case MAV_TYPE_FIXED_WING:
-        if (majorVersion < 3) {
+        if (vehicle->versionCompare(3,5,0) < 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.3.xml");
-        } else if (majorVersion == 3) {
-            switch (minorVersion) {
-            case 0:
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.3.xml");
-            case 5:
-            case 6:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.5.xml");
-            case 7:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.7.xml");
-            case 8:
-            default:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.8.xml");
-            }
+        }
+        if (vehicle->versionCompare(3,7,0) < 0) {
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.5.xml");
+        }
+        if (vehicle->versionCompare(3,8,0) < 0) {
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.7.xml");
         }
         return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.8.xml");
+
     case MAV_TYPE_GROUND_ROVER:
     case MAV_TYPE_SURFACE_BOAT:
-        if (majorVersion < 3) {
+        if (vehicle->versionCompare(3,2,0) < 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.0.xml");
-        } else if (majorVersion == 3) {
-            switch (minorVersion) {
-            case 0:
-            case 1:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.0.xml");
-            case 2:
-            case 3:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.2.xml");
-            case 4:
-            default:
-                return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.4.xml");
-            }
         }
-        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.2.xml");
+        if (vehicle->versionCompare(3,4,0) < 0) {
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.2.xml");
+        }
+        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.4.xml");
+
     case MAV_TYPE_SUBMARINE:
         if (vehicle->firmwareMajorVersion() < 3 || (vehicle->firmwareMajorVersion() == 3 && vehicle->firmwareMinorVersion() <= 4)) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.4.xml");

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -768,16 +768,17 @@ QString APMFirmwarePlugin::internalParameterMetaDataFile(Vehicle* vehicle)
     case MAV_TYPE_TRICOPTER:
     case MAV_TYPE_COAXIAL:
     case MAV_TYPE_HELICOPTER:
-        if (vehicle->versionCompare(3,4,0) < 0) {
-            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.3.xml");
+        if (vehicle->versionCompare(3, 6, 0) >= 0) {  // 3.6.0 and higher
+             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.6.xml");
         }
-        if (vehicle->versionCompare(3,5,0) < 0) {
-            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.4.xml");
-        }
-        if (vehicle->versionCompare(3,6,0) < 0) {
+        if (vehicle->versionCompare(3, 5, 0) >= 0) {  // 3.5.x
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.5.xml");
         }
-        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.6.xml");
+        if (vehicle->versionCompare(3, 4, 0) >= 0) {  // 3.4.x
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.4.xml");
+        }
+        // Up to 3.3.x
+        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.3.xml");
 
     case MAV_TYPE_VTOL_DUOROTOR:
     case MAV_TYPE_VTOL_QUADROTOR:
@@ -787,35 +788,39 @@ QString APMFirmwarePlugin::internalParameterMetaDataFile(Vehicle* vehicle)
     case MAV_TYPE_VTOL_RESERVED4:
     case MAV_TYPE_VTOL_RESERVED5:
     case MAV_TYPE_FIXED_WING:
-        if (vehicle->versionCompare(3,5,0) < 0) {
-            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.3.xml");
+        if (vehicle->versionCompare(3, 8, 0) >= 0) {  // 3.8.0 and higher
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.8.xml");
         }
-        if (vehicle->versionCompare(3,7,0) < 0) {
-            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.5.xml");
-        }
-        if (vehicle->versionCompare(3,8,0) < 0) {
+        if (vehicle->versionCompare(3, 7, 0) >= 0) {  // 3.7.x
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.7.xml");
         }
-        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.8.xml");
+        if (vehicle->versionCompare(3, 5, 0) >= 0) {  // 3.5.x to 3.6.x
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.5.xml");
+        }
+        // up to 3.4.x
+        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.3.xml");
 
     case MAV_TYPE_GROUND_ROVER:
     case MAV_TYPE_SURFACE_BOAT:
-        if (vehicle->versionCompare(3,2,0) < 0) {
-            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.0.xml");
+        if (vehicle->versionCompare(3, 4, 0) >= 0) {  // 3.4.0 and higher
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.4.xml");
         }
-        if (vehicle->versionCompare(3,4,0) < 0) {
+        if (vehicle->versionCompare(3, 2, 0) >= 0) { // 3.2.x to 3.3.x
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.2.xml");
         }
-        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.4.xml");
+        // up to 3.1.x
+        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.0.xml");
 
     case MAV_TYPE_SUBMARINE:
-        if (vehicle->firmwareMajorVersion() < 3 || (vehicle->firmwareMajorVersion() == 3 && vehicle->firmwareMinorVersion() <= 4)) {
-            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.4.xml");
-        } else if (vehicle->firmwareMinorVersion() <= 5) {
-            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.5.xml");
-        } else {
+        if (vehicle->versionCompare(3, 6, 0) >= 0) { // 3.5.x
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.6dev.xml");
         }
+        if (vehicle->versionCompare(3, 5, 0) >= 0) { // 3.5.x
+            return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.5.xml");
+        }
+        // up to 3.4.x
+        return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.4.xml");
+
     default:
         return QString();
     }

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -740,3 +740,35 @@ void FirmwarePlugin::_versionFileDownloadFinished(QString& remoteFile, QString& 
         qgcApp()->showMessage(message.arg(vehicle->firmwareVersionTypeString(), currentVersion, version));
     }
 }
+
+int FirmwarePlugin::versionCompare(Vehicle* vehicle, int major, int minor, int patch)
+{
+    int currMajor = vehicle->firmwareMajorVersion();
+    int currMinor = vehicle->firmwareMinorVersion();
+    int currPatch = vehicle->firmwarePatchVersion();
+
+    if (currMajor == major && currMinor == minor && currPatch == patch) {
+        return 0;
+    }
+
+    if (currMajor > major
+       || (currMajor == major && currMinor > minor)
+       || (currMajor == major && currMinor == minor && currPatch > patch))
+    {
+        return 1;
+    }
+    return -1;
+}
+
+int FirmwarePlugin::versionCompare(Vehicle* vehicle, QString& compare)
+{
+    QStringList versionNumbers = compare.split(".");
+    if(versionNumbers.size() != 3) {
+        qCWarning(FirmwarePluginLog) << "Error parsing version number: wrong format";
+        return -1;
+    }
+    int major = versionNumbers[0].toInt();
+    int minor = versionNumbers[1].toInt();
+    int patch = versionNumbers[2].toInt();
+    return versionCompare(vehicle, major, minor, patch);
+}

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -713,25 +713,12 @@ void FirmwarePlugin::_versionFileDownloadFinished(QString& remoteFile, QString& 
     }
 
     qCDebug(FirmwarePluginLog) << "Latest stable version = "  << version;
-    QStringList versionNumbers = version.split(".");
-    if(versionNumbers.size() != 3) {
-        qCWarning(FirmwarePluginLog) << "Error parsing version number: wrong format";
-        return;
-    }
-    int stableMajor = versionNumbers[0].toInt();
-    int stableMinor = versionNumbers[1].toInt();
-    int stablePatch = versionNumbers[2].toInt();
 
-    int currMajor = vehicle->firmwareMajorVersion();
-    int currMinor = vehicle->firmwareMinorVersion();
-    int currPatch = vehicle->firmwarePatchVersion();
     int currType = vehicle->firmwareVersionType();
 
-    if (currMajor < stableMajor
-        || (currMajor == stableMajor && currMinor < stableMinor)
-        || (currMajor == stableMajor && currMinor == stableMinor && currPatch < stablePatch)
-        || (currMajor == stableMajor && currMinor == stableMinor && currPatch == stablePatch && currType != FIRMWARE_VERSION_TYPE_OFFICIAL)
-        )
+    // Check if lower version than stable or same version but different type
+    if (vehicle->versionCompare(version) < 0
+       || (vehicle->versionCompare(version) == 0 && currType != FIRMWARE_VERSION_TYPE_OFFICIAL))
     {
         const static QString currentVersion = QString("%1.%2.%3").arg(vehicle->firmwareMajorVersion())
                                                                  .arg(vehicle->firmwareMinorVersion())

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -309,6 +309,11 @@ public:
     /// Used to check if running firmware is latest stable version.
     virtual void checkIfIsLatestStable(Vehicle* vehicle);
 
+    /// Used to check if running current version is equal or higher than the one being compared.
+    /// returns 1 if current > compare, 0 if current == compare, -1 if current < compare
+    int versionCompare(Vehicle* vehicle, QString& compare);
+    int versionCompare(Vehicle* vehicle, int major, int minor, int patch);
+
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const QString px4FollowMeFlightMode;
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3770,6 +3770,16 @@ void Vehicle::_mavlinkMessageStatus(int uasId, uint64_t totalSent, uint64_t tota
     }
 }
 
+int  Vehicle::versionCompare(QString& compare)
+{
+    return _firmwarePlugin->versionCompare(this, compare);
+}
+
+int  Vehicle::versionCompare(int major, int minor, int patch)
+{
+    return _firmwarePlugin->versionCompare(this, major, minor, patch);
+}
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -746,6 +746,11 @@ public:
     Q_INVOKABLE void triggerCamera(void);
     Q_INVOKABLE void sendPlan(QString planFile);
 
+    /// Used to check if running current version is equal or higher than the one being compared.
+    //  returns 1 if current > compare, 0 if current == compare, -1 if current < compare
+    Q_INVOKABLE int versionCompare(QString& compare);
+    Q_INVOKABLE int versionCompare(int major, int minor, int patch);
+
     /// Test motor
     ///     @param motor Motor number, 1-based
     ///     @param percent 0-no power, 100-full power


### PR DESCRIPTION
This is to simplify cases where both major, minor, and patch versions had to be checked independently, which resulted in hard to read code