### PR TITLE
fixed group image for Plane V-Tail group and talon class

### DIFF
--- a/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
+++ b/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
@@ -579,12 +579,9 @@
       <output name="AUX3">feed-through of RC AUX3 channel</output>
     </airframe>
   </airframe_group>
-  <airframe_group image="AirframeUnknown" name="Plane V-Tail">
+  <airframe_group image="PlaneVTail" name="Plane V-Tail">
     <airframe id="2200" maintainer="Friedrich Beckmann &lt;friedrich.beckmann@hs-augsburg.de&gt;" name="X-UAV Mini Talon">
-      <class>Plane
-The Mini Talon does not have a wheel and
-no flaps. I leave them here because the mixer
-computes also wheel and flap controls.</class>
+      <class>Plane</class>
       <maintainer>Friedrich Beckmann &lt;friedrich.beckmann@hs-augsburg.de&gt;</maintainer>
       <type>Plane V-Tail</type>
       <output name="MAIN1">aileron right</output>


### PR DESCRIPTION
The generated patch from the PX4BuildBot in commit dc8549ace8e04e53 from PR #6923 did not include the image for the Plane V-Tail group. The class was also malformed. This patch fixes the problems from the autogenerated code. 

The code was already o.k. from PR #6852 but that code was later removed
from the PX4BuildBot because the mini talon frame was not in the codebase at
that point of time.

So hopefully the buildbot will leave the image in there...

I opened a PR PX4/Firmware#10699 to avoid the malformed class info.