### PR TITLE
[WIP] git email and org mapping for contributor reports

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,55 @@
+# QGroundControl .mailmap
+# See this guide for help modifying this file https://github.com/sympy/sympy/wiki/Using-.mailmap
+# Please append your entry
+# Example use of this map:
+#   git log --pretty='%aN <%aE>' | sort | uniq -c | sort -rn | HEAD -10
+
+
+Don Gagne <don@thegagnes.com> Don Gagne <DonLakeFlyer@users.noreply.github.com>
+Don Gagne <don@thegagnes.com> DonLakeFlyer <don@thegagnes.com>
+Don Gagne <don@thegagnes.com> Don Gagne <dongagne@outlook.com>
+Don Gagne <don@thegagnes.com> Don Gagne <Don@don-laptop.local>
+Gus Grubba <gus@grubba.com> Gus Grubba <mavlink@grubba.com>
+Gus Grubba <gus@grubba.com> dogmaphobic <mavlink@grubba.com>
+Andreas Bircher <bircher@gmx.ch>
+PX4 Jenkins <bot@pixhawk.org> PX4 Build Bot <bot@pixhawk.org>
+Florian Achermann <florian.achermann@mavt.ethz.ch>
+Patrick José Pereira <patrickelectric@gmail.com> Patrick José Pereira <patrickjp@kde.org>
+Patrick José Pereira <patrickelectric@gmail.com> Patrick J.P <patrickelectric@gmail.com>
+Daniel Agar <daniel@agar.ca>
+Nick Anthony <nickexists@hotmail.com>
+Nick Anthony <nickexists@hotmail.com> Nick Anthony <nanthony@brewerscience.com>
+Philipp Oettershagen <philipp.oettershagen@mavt.ethz.ch>
+Jacob Walser <jwalser90@gmail.com>
+Beat Küng <beat-kueng@gmx.net>
+Sebastian Verling <sverling@student.ethz.ch>
+Lorenz Meier <lorenz@px4.io>
+Anthony Lamping <lamping.ap@gmail.com>
+Thomas Mantel <thomas.mantel@mavt.ethz.ch>
+Barza Nisar <nisarb@student.ethz.ch> barzanisar <nisarb@student.ethz.ch>
+Amy Wagoner <arwagoner@gmail.com>
+Peter Barker <pbarker@barker.dropbear.id.au>
+Julian Oes <julian@oes.ch>
+Hamish Willee <hamishwillee@gmail.com>
+Ahmet Fehmi Ozcan <fehmi.ozcan@maxwell-innovations.com> <Fehmi.Ozcan@maxwell-innovations.com>
+yaoling <165577564@qq.com>
+Nathan Tsoi <nathan@vertile.com>
+Vavooon <vavooon@gmail.com>
+Thomas Gubler <thomas@auterion.com>
+Pierre Kancir <khancyr@gmail.com>
+Oleg Kalachev <okalachev@gmail.com>
+Jin Chengde <jinchengde@gmail.com>
+Jared Szechy <jared.szechy@gmail.com>
+David Sidrane <david_s5@nscdg.com>
+Andre Kjellstrup <andre.kjellstrup@gmail.com>
+Ahmet Fehmi Ozcan <fehmi.ozcan@maxwell-innovations.com> Ahmet Fehmi OZCAN <fehmi.ozcan@maxwell-innovations.com>
+Lorenz Meier <lorenz@px4.io> Lorenz Meier <lm@inf.ethz.ch>
+Lorenz Meier <lorenz@px4.io> LM <lm@student.ethz.ch>
+Lorenz Meier <lorenz@px4.io> lm <mail@qgroundcontrol.org>
+Lorenz Meier <lorenz@px4.io> lm <pixhawk@pixhawk02.(none)>
+Lorenz Meier <lorenz@px4.io> lm <lm@inf.ethz.ch>
+Lorenz Meier <lorenz@px4.io> LM <lm@inf.ethz.ch>
+Lorenz Meier <lorenz@px4.io> lm <pixhawk@student.ethz.ch>
+Lorenz Meier <lorenz@px4.io> lm <pixhawk@switched.com>
+Lorenz Meier <lorenz@px4.io> pixhawk <pixhawk@student.ethz.ch>
+Todd Stellanova <todd@droneflow.com> tstellanova <tstellanova+github@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -5,6 +5,8 @@
 #   git log --pretty='%aN <%aE>' | sort | uniq -c | sort -rn | HEAD -10
 
 
+Don Gagne <don@thegagnes.com>
+Don Gagne <don@thegagnes.com> <>
 Don Gagne <don@thegagnes.com> Don Gagne <DonLakeFlyer@users.noreply.github.com>
 Don Gagne <don@thegagnes.com> DonLakeFlyer <don@thegagnes.com>
 Don Gagne <don@thegagnes.com> Don Gagne <dongagne@outlook.com>
@@ -19,6 +21,7 @@ Patrick José Pereira <patrickelectric@gmail.com> Patrick J.P <patrickelectric@g
 Daniel Agar <daniel@agar.ca>
 Nick Anthony <nickexists@hotmail.com>
 Nick Anthony <nickexists@hotmail.com> Nick Anthony <nanthony@brewerscience.com>
+Nick Anthony <nickexists@hotmail.com> nanthony21 <nickexists@hotmail.com>
 Philipp Oettershagen <philipp.oettershagen@mavt.ethz.ch>
 Jacob Walser <jwalser90@gmail.com>
 Beat Küng <beat-kueng@gmx.net>
@@ -53,3 +56,22 @@ Lorenz Meier <lorenz@px4.io> lm <pixhawk@student.ethz.ch>
 Lorenz Meier <lorenz@px4.io> lm <pixhawk@switched.com>
 Lorenz Meier <lorenz@px4.io> pixhawk <pixhawk@student.ethz.ch>
 Todd Stellanova <todd@droneflow.com> tstellanova <tstellanova+github@gmail.com>
+Ramón Roche <mrpollo@gmail.com>
+Julien Lecoeur <julien.lecoeur@gmail.com>
+Julien Lecoeur <julien.lecoeur@gmail.com> Julien Lecoeur <jlecoeur@users.noreply.github.com>
+Julien Lecoeur <julien.lecoeur@gmail.com> Julien Lecoeur <julien.lecoeur@epfl.ch>
+Daniele Pettenuzzo <daniele@px4.io> Daniele Pettenuzzo <dani.pettenuzzo@gmail.com>
+Daniele Pettenuzzo <daniele@px4.io> DanielePettenuzzo <35664507+DanielePettenuzzo@users.noreply.github.com>
+Daniele Pettenuzzo <daniele@px4.io> Daniele Pettenuzzo <35664507+DanielePettenuzzo@users.noreply.github.com>
+Daniele Pettenuzzo <daniele@px4.io> Daniele Pettenuzzo <DanielePettenuzzo@users.noreply.github.com>
+Daniele Pettenuzzo <daniele@px4.io> DanielePettenuzzo <daniele@px4.io>
+PX4 Jenkins Bot <bot@px4.io>
+PX4 Jenkins Bot <bot@px4.io> PX4 Build Bot <bot@px4.io>
+PX4 Jenkins Bot <bot@px4.io> PX4 Build Bot <bot@pixhawk.org>
+PX4 Jenkins Bot <bot@px4.io> PX4 Jenkins <bot@pixhawk.org>
+PX4 Jenkins Bot <bot@px4.io> PX4BuildBot <bot@pixhawk.org>
+PX4 Jenkins Bot <bot@px4.io> PX4BuildBot <bot@px4.io>
+PX4 Jenkins Bot <bot@px4.io> PX4BuildBot <bot@px4.io>
+Sander Smeets <sander@droneslab.com>
+SungTae Moon <munhoney@gmail.com> stmoon <munhoney@gmail.com>
+

--- a/.organizationmap
+++ b/.organizationmap
@@ -27,12 +27,17 @@ Auterion <contact@auterion.com> Beat Küng <beat-kueng@gmx.net>
 Auterion <contact@auterion.com> Lorenz Meier <lorenz@px4.io>
 Auterion <contact@auterion.com> Barza Nisar <nisarb@student.ethz.ch>
 Auterion <contact@auterion.com> Thomas Gubler <thomas@auterion.com>
+Auterion <contact@auterion.com> Jonas Vautherin <jonas.vautherin@gmail.com>
+Auterion <contact@auterion.com> Daniele Pettenuzzo <daniele@px4.io>
 Copter Express <contact@copterexpress.com> Oleg Kalachev <okalachev@gmail.com>
 Copter Express <contact@copterexpress.com> Elia Tarasov <elias.tarasov@gmail.com>
 DIU <contact@diu.(none)> Hamish Willee <hamishwillee@gmail.com>
+Dronecode <contact@dronecode.com> Ramón Roche <mrpollo@gmail.com>
 ETH Zurich <contact@student.ethz.ch> Florian Achermann <florian.achermann@mavt.ethz.ch>
 ETH Zurich <contact@student.ethz.ch> Philipp Oettershagen <philipp.oettershagen@mavt.ethz.ch>
 ETH Zurich <contact@student.ethz.ch> Thomas Mantel <thomas.mantel@mavt.ethz.ch>
+EPFL <contact@epfl.ch> Julien Lecoeur <julien.lecoeur@gmail.com>
+PX4 Bots <contact@px4.io> PX4 Jenkins <bot@pixhawk.org>
 Unaffiliated <no@organization.net> Don Gagne <don@thegagnes.com>
 Unaffiliated <no@organization.net> Nick Anthony <nickexists@hotmail.com>
 Unaffiliated <no@organization.net> Daniel Agar <daniel@agar.ca>
@@ -51,8 +56,10 @@ Unaffiliated <no@organization.net> Jared Szechy <jared.szechy@gmail.com>
 Unaffiliated <no@organization.net> David Sidrane <david_s5@nscdg.com>
 Unaffiliated <no@organization.net> Andre Kjellstrup <andre.kjellstrup@gmail.com>
 Unaffiliated <no@organization.net> Patrick José Pereira <patrickelectric@gmail.com>
+Unaffiliated <no@organization.net> SungTae Moon <munhoney@gmail.com>
 PX4 Bots <contact@px4.io> PX4 Jenkins <bot@pixhawk.org>
 Wingtra <contact@wingtra.com> Andreas Bircher <bircher@gmx.ch>
 Wingtra <contact@wingtra.com> Sebastian Verling <sverling@student.ethz.ch>
 Yuneec Research <contact@yuneecresearch.com> Julian Oes <julian@oes.ch>
+Vertical Technologies <contact@verticaltechnologies.com> Sander Smeets <sander@droneslab.com>
 

--- a/.organizationmap
+++ b/.organizationmap
@@ -1,0 +1,58 @@
+# QGC Organization map
+# More information at
+#  http://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide
+#
+# See .githubmap for GitHub username contributors
+# See .mailmap for name and mail normalization.
+# See .peoplemap for unique list of people
+#
+# To display the 10 organization who contributed
+# most commits to ceph ( requires git >= 1.8.4 ):
+#
+# git log --pretty='%aN <%aE>' | \
+#   git -c mailmap.file=.organizationmap check-mailmap --stdin | \
+#   sort | uniq -c | sort -rn | nl | head -10
+#     1	13235 Auterion <contact@auterion.com>
+#     2	4106 Unaffiliated <no@organization.net>
+#     3	2076 Yuneec Research <contact@yuneecresearch.com>
+#     4	1408 Nuttx <contact@nuttx.org>
+#     5	 977 Anton Babushkin <anton.babushkin@me.com>
+#     6	 811 px4dev <px4@purgatory.org>
+#     7	 720 Qualcomm <contact@qualcomm.com>
+#     8	 421 UAVenture <contact@uaventure.com>
+#     9	 295 James Goppert <james.goppert@gmail.com>
+#    10	 244 Mark Whitehorn <kd0aij@gmail.com>
+Auterion <contact@auterion.com> Gus Grubba <gus@grubba.com>
+Auterion <contact@auterion.com> Beat Küng <beat-kueng@gmx.net>
+Auterion <contact@auterion.com> Lorenz Meier <lorenz@px4.io>
+Auterion <contact@auterion.com> Barza Nisar <nisarb@student.ethz.ch>
+Auterion <contact@auterion.com> Thomas Gubler <thomas@auterion.com>
+Copter Express <contact@copterexpress.com> Oleg Kalachev <okalachev@gmail.com>
+Copter Express <contact@copterexpress.com> Elia Tarasov <elias.tarasov@gmail.com>
+DIU <contact@diu.(none)> Hamish Willee <hamishwillee@gmail.com>
+ETH Zurich <contact@student.ethz.ch> Florian Achermann <florian.achermann@mavt.ethz.ch>
+ETH Zurich <contact@student.ethz.ch> Philipp Oettershagen <philipp.oettershagen@mavt.ethz.ch>
+ETH Zurich <contact@student.ethz.ch> Thomas Mantel <thomas.mantel@mavt.ethz.ch>
+Unaffiliated <no@organization.net> Don Gagne <don@thegagnes.com>
+Unaffiliated <no@organization.net> Nick Anthony <nickexists@hotmail.com>
+Unaffiliated <no@organization.net> Daniel Agar <daniel@agar.ca>
+Unaffiliated <no@organization.net> mak <maktrefa@gmail.com>
+Unaffiliated <no@organization.net> Jacob Walser <jwalser90@gmail.com>
+Unaffiliated <no@organization.net> Anthony Lamping <lamping.ap@gmail.com>
+Unaffiliated <no@organization.net> Ahmet Fehmi Ozcan <fehmi.ozcan@maxwell-innovations.com>
+Unaffiliated <no@organization.net> Peter Barker <pbarker@barker.dropbear.id.au>
+Unaffiliated <no@organization.net> Amy Wagoner <arwagoner@gmail.com>
+Unaffiliated <no@organization.net> yaoling <165577564@qq.com>
+Unaffiliated <no@organization.net> Vavooon <vavooon@gmail.com>
+Unaffiliated <no@organization.net> Pierre Kancir <khancyr@gmail.com>
+Unaffiliated <no@organization.net> Nathan Tsoi <nathan@vertile.com>
+Unaffiliated <no@organization.net> Jin Chengde <jinchengde@gmail.com>
+Unaffiliated <no@organization.net> Jared Szechy <jared.szechy@gmail.com>
+Unaffiliated <no@organization.net> David Sidrane <david_s5@nscdg.com>
+Unaffiliated <no@organization.net> Andre Kjellstrup <andre.kjellstrup@gmail.com>
+Unaffiliated <no@organization.net> Patrick José Pereira <patrickelectric@gmail.com>
+PX4 Bots <contact@px4.io> PX4 Jenkins <bot@pixhawk.org>
+Wingtra <contact@wingtra.com> Andreas Bircher <bircher@gmx.ch>
+Wingtra <contact@wingtra.com> Sebastian Verling <sverling@student.ethz.ch>
+Yuneec Research <contact@yuneecresearch.com> Julian Oes <julian@oes.ch>
+


### PR DESCRIPTION
The following files can be used to provide an accurate contributors report as well as a report that can show the number of commits per registered company.

- [ ] Validate the mail map data with developers
- [ ] Validate the organizational data with developers
- [ ] provide a way to track developer contributions attributing the right company over time

examples

Contributor list (clean) 1 year
```
git log --pretty='%aN <%aE>' --since="1 year" | sort | uniq -c | sort -rn

1015 Don Gagne <don@thegagnes.com>
 370 Gus Grubba <gus@grubba.com>
  82 PX4 Jenkins Bot <bot@px4.io>
  41 Beat Küng <beat-kueng@gmx.net>
  40 Patrick José Pereira <patrickelectric@gmail.com>
  33 Andreas Bircher <bircher@gmx.ch>
  21 Jacob Walser <jwalser90@gmail.com>
  20 Florian Achermann <florian.achermann@mavt.ethz.ch>
  20 Daniel Agar <daniel@agar.ca>
  14 Nick Anthony <nickexists@hotmail.com>
   9 Lorenz Meier <lorenz@px4.io>
   7 mak <maktrefa@gmail.com>
   4 dheideman <dheideman@socal.rr.com>
   4 Philipp Oettershagen <philipp.oettershagen@mavt.ethz.ch>
   3 Sebastian Verling <sverling@student.ethz.ch>
   3 Jonas Vautherin <jonas.vautherin@gmail.com>
   3 Anthony Lamping <lamping.ap@gmail.com>
   3 Andre Kjellstrup <andre.kjellstrup@gmail.com>
   3 Ahmet Fehmi Ozcan <fehmi.ozcan@maxwell-innovations.com>
   2 yaoling <165577564@qq.com>
   2 Willian Galvani <williangalvani@gmail.com>
   2 Thomas Mantel <thomas.mantel@mavt.ethz.ch>
   2 Thomas Gubler <thomas@auterion.com>
   2 SungTae Moon <munhoney@gmail.com>
   2 Sander Smeets <sander@droneslab.com>
   2 Ramón Roche <mrpollo@gmail.com>
   2 Peter Barker <pbarker@barker.dropbear.id.au>
   2 Julien Lecoeur <julien.lecoeur@gmail.com>
   2 Julian Oes <julian@oes.ch>
   2 Hamish Willee <hamishwillee@gmail.com>
   2 G_I_V_D <gigorvd@gmail.com>
   2 Barza Nisar <nisarb@student.ethz.ch>
   2 Amy Wagoner <arwagoner@gmail.com>
   1 Vavooon <vavooon@gmail.com>
   1 Sam Duff <sam@samduff.com>
   1 Pritam Ghanghas <pritam.ghanghas@senserobotics.com>
   1 Pierre Kancir <khancyr@gmail.com>
   1 Oleg Kalachev <okalachev@gmail.com>
   1 Nathan Tsoi <nathan@vertile.com>
   1 Luis Vale Gonçalves <luisvale@gmail.com>
   1 Jin Chengde <jinchengde@gmail.com>
   1 Jared Szechy <jared.szechy@gmail.com>
   1 Holger Steinhaus <hsteinhaus@gmx.de>
   1 Friedrich Beckmann <friedrich.beckmann@gmx.de>
   1 David Sidrane <david_s5@nscdg.com>
   1 Daniele Pettenuzzo <daniele@px4.io>
   1 Adrian Schröter <adrian@suse.de>
```

Organization list 1 year
```
git log --pretty='%aN <%aE>' --since="1 year" | git -c mailmap.file=.organizationmap check-mailmap --stdin | sort | uniq -c | sort -rn

1140 Unaffiliated <no@organization.net>
 428 Auterion <contact@auterion.com>
  82 PX4 Jenkins Bot <bot@px4.io>
  36 Wingtra <contact@wingtra.com>
  26 ETH Zurich <contact@student.ethz.ch>
   4 dheideman <dheideman@socal.rr.com>
   2 Yuneec Research <contact@yuneecresearch.com>
   2 Willian Galvani <williangalvani@gmail.com>
   2 Vertical Technologies <contact@verticaltechnologies.com>
   2 G_I_V_D <gigorvd@gmail.com>
   2 EPFL <contact@epfl.ch>
   2 Dronecode <contact@dronecode.com>
   2 DIU <contact@diu.(none)>
   1 Sam Duff <sam@samduff.com>
   1 Pritam Ghanghas <pritam.ghanghas@senserobotics.com>
   1 Luis Vale Gonçalves <luisvale@gmail.com>
   1 Holger Steinhaus <hsteinhaus@gmx.de>
   1 Friedrich Beckmann <friedrich.beckmann@gmx.de>
   1 Copter Express <contact@copterexpress.com>
   1 Adrian Schröter <adrian@suse.de>
```