### PR TITLE
Move from Q_ENUMS to Q_ENUM

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponentController.h
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.h
@@ -68,14 +68,14 @@ public:
     
     Q_PROPERTY(int transmitterMode READ transmitterMode WRITE setTransmitterMode NOTIFY transmitterModeChanged)
     Q_PROPERTY(QString imageHelp MEMBER _imageHelp NOTIFY imageHelpChanged)
-    
-    Q_ENUMS(BindModes)
+
     enum BindModes {
         DSM2,
         DSMX7,
         DSMX8
     };
-    
+    Q_ENUM(BindModes)
+
     Q_INVOKABLE void spektrumBindMode(int mode);
     Q_INVOKABLE void cancelButtonClicked(void);
     Q_INVOKABLE void skipButtonClicked(void);

--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -97,10 +97,10 @@ public:
         PHOTO_CAPTURE_TIMELAPSE,
     };
 
-    Q_ENUMS(CameraMode)
-    Q_ENUMS(VideoStatus)
-    Q_ENUMS(PhotoStatus)
-    Q_ENUMS(PhotoMode)
+    Q_ENUM(CameraMode)
+    Q_ENUM(VideoStatus)
+    Q_ENUM(PhotoStatus)
+    Q_ENUM(PhotoMode)
 
     Q_PROPERTY(int          version             READ version            NOTIFY infoChanged)
     Q_PROPERTY(QString      modelName           READ modelName          NOTIFY infoChanged)

--- a/src/MissionManager/CameraSection.h
+++ b/src/MissionManager/CameraSection.h
@@ -33,8 +33,8 @@ public:
         TakeVideo,
         StopTakingVideo,
         TakePhoto
-    };    
-    Q_ENUMS(CameraAction)
+    };
+    Q_ENUM(CameraAction)
 
     Q_PROPERTY(bool     specifyGimbal                   READ specifyGimbal                  WRITE setSpecifyGimbal              NOTIFY specifyGimbalChanged)
     Q_PROPERTY(Fact*    gimbalPitch                     READ gimbalPitch                                                        CONSTANT)

--- a/src/QGCPalette.h
+++ b/src/QGCPalette.h
@@ -54,8 +54,6 @@ class QGCPalette : public QObject
 {
     Q_OBJECT
 
-    Q_ENUMS(Theme)
-
 public:
     enum ColorGroup {
         ColorGroupDisabled = 0,
@@ -68,6 +66,7 @@ public:
         Dark,
         cMaxTheme
     };
+    Q_ENUM(Theme)
 
     typedef QColor PaletteColorInfo_t[cMaxTheme][cMaxColorGroup];
 

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -35,7 +35,7 @@ public:
         ActionExporting,
         ActionDone,
     };
-    Q_ENUMS(ImportAction)
+    Q_ENUM(ImportAction)
 
     Q_PROPERTY(int                  tileX0          READ    tileX0          NOTIFY tileX0Changed)
     Q_PROPERTY(int                  tileX1          READ    tileX1          NOTIFY tileX1Changed)

--- a/src/QtLocationPlugin/qtlocation/src/location/maps/qgeoserviceprovider.h
+++ b/src/QtLocationPlugin/qtlocation/src/location/maps/qgeoserviceprovider.h
@@ -59,7 +59,7 @@ class QGeoServiceProviderPrivate;
 class Q_LOCATION_EXPORT QGeoServiceProvider : public QObject
 {
     Q_OBJECT
-    Q_ENUMS(Error)
+    Q_ENUM(Error)
 public:
     enum Error {
         NoError,

--- a/src/QtLocationPlugin/qtlocation/src/positioning/qgeoareamonitorsource.h
+++ b/src/QtLocationPlugin/qtlocation/src/positioning/qgeoareamonitorsource.h
@@ -55,7 +55,7 @@ public:
         UnknownSourceError = 2,
         NoError = 3
     };
-    Q_ENUMS(Error)
+    Q_ENUM(Error)
 
     enum AreaMonitorFeature {
         PersistentAreaMonitorFeature = 0x00000001,

--- a/src/QtLocationPlugin/qtlocation/src/positioning/qgeopositioninfosource.h
+++ b/src/QtLocationPlugin/qtlocation/src/positioning/qgeopositioninfosource.h
@@ -54,7 +54,7 @@ public:
         UnknownSourceError = 2,
         NoError = 3
     };
-    Q_ENUMS(Error)
+    Q_ENUM(Error)
 
     enum PositioningMethod {
         NoPositioningMethods = 0x00000000,

--- a/src/QtLocationPlugin/qtlocation/src/positioning/qgeosatelliteinfosource.h
+++ b/src/QtLocationPlugin/qtlocation/src/positioning/qgeosatelliteinfosource.h
@@ -54,7 +54,7 @@ public:
         NoError = 2,
         UnknownSourceError = -1
     };
-    Q_ENUMS(Error)
+    Q_ENUM(Error)
 
     explicit QGeoSatelliteInfoSource(QObject *parent);
     virtual ~QGeoSatelliteInfoSource();

--- a/src/QtLocationPlugin/qtlocation/src/positioning/qgeoshape.h
+++ b/src/QtLocationPlugin/qtlocation/src/positioning/qgeoshape.h
@@ -48,7 +48,7 @@ class Q_POSITIONING_EXPORT QGeoShape
     Q_PROPERTY(ShapeType type READ type)
     Q_PROPERTY(bool isValid READ isValid)
     Q_PROPERTY(bool isEmpty READ isEmpty)
-    Q_ENUMS(ShapeType)
+    Q_ENUM(ShapeType)
 
 public:
     QGeoShape();

--- a/src/Settings/UnitsSettings.h
+++ b/src/Settings/UnitsSettings.h
@@ -46,10 +46,10 @@ public:
         TemperatureUnitsFarenheit,
     };
 
-    Q_ENUMS(DistanceUnits)
-    Q_ENUMS(AreaUnits)
-    Q_ENUMS(SpeedUnits)
-    Q_ENUMS(TemperatureUnits)
+    Q_ENUM(DistanceUnits)
+    Q_ENUM(AreaUnits)
+    Q_ENUM(SpeedUnits)
+    Q_ENUM(TemperatureUnits)
 
     Q_PROPERTY(Fact* distanceUnits                      READ distanceUnits                      CONSTANT)
     Q_PROPERTY(Fact* areaUnits                          READ areaUnits                          CONSTANT)

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -67,9 +67,9 @@ public:
             DefaultVehicleFirmware
         } FirmwareVehicleType_t;
 
-        Q_ENUMS(AutoPilotStackType_t)
-        Q_ENUMS(FirmwareType_t)
-        Q_ENUMS(FirmwareVehicleType_t)
+        Q_ENUM(AutoPilotStackType_t)
+        Q_ENUM(FirmwareType_t)
+        Q_ENUM(FirmwareVehicleType_t)
 
     class FirmwareIdentifier
     {

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -146,7 +146,7 @@ public:
         POS_CENTER_LEFT,
         POS_BOTTOM_LEFT
     };
-    Q_ENUMS(Pos)
+    Q_ENUM(Pos)
     CustomInstrumentWidget(QObject* parent = NULL);
     Q_PROPERTY(QUrl     source  READ source CONSTANT)
     Q_PROPERTY(Pos      widgetPosition              READ widgetPosition             NOTIFY widgetPositionChanged)

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -19,7 +19,6 @@ class LinkInterface;
 class LinkConfiguration : public QObject
 {
     Q_OBJECT
-    Q_ENUMS(LinkType)
 
 public:
     LinkConfiguration(const QString& name);
@@ -63,6 +62,7 @@ public:
 #endif
         TypeLast        // Last type value (type >= TypeLast == invalid)
     };
+    Q_ENUM(LinkType)
 
     /*!
      *


### PR DESCRIPTION
Q_ENUMS is deprecated and should not be used.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>
