### PR TITLE
No more foreachs !

### DIFF
--- a/src/AnalyzeView/GeoTagController.cc
+++ b/src/AnalyzeView/GeoTagController.cc
@@ -114,7 +114,7 @@ void GeoTagController::startTagging(void)
                 _setErrorMessage(tr("Save folder not empty"));
                 return;
             }
-            foreach(QString dirFile, imageList)
+            for(QString dirFile: imageList)
             {
                 if(!saveDirectory.remove(dirFile)) {
                     _setErrorMessage(tr("Couldn't replace the existing images"));

--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -33,7 +33,7 @@ void AutoPilotPlugin::_recalcSetupComplete(void)
 {
     bool newSetupComplete = true;
 
-    foreach(const QVariant componentVariant, vehicleComponents()) {
+    for(const QVariant componentVariant: vehicleComponents()) {
         VehicleComponent* component = qobject_cast<VehicleComponent*>(qvariant_cast<QObject *>(componentVariant));
         if (component) {
             if (!component->setupComplete()) {
@@ -61,7 +61,7 @@ void AutoPilotPlugin::parametersReadyPreChecks(void)
     _recalcSetupComplete();
 
     // Connect signals in order to keep setupComplete up to date
-    foreach(const QVariant componentVariant, vehicleComponents()) {
+    for(const QVariant componentVariant: vehicleComponents()) {
         VehicleComponent* component = qobject_cast<VehicleComponent*>(qvariant_cast<QObject *>(componentVariant));
         if (component) {
             connect(component, &VehicleComponent::setupCompleteChanged, this, &AutoPilotPlugin::_recalcSetupComplete);

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -917,7 +917,7 @@ void
 QGCCameraControl::_requestAllParameters()
 {
     //-- Reset receive list
-    foreach(QString paramName, _paramIO.keys()) {
+    for(QString paramName: _paramIO.keys()) {
         if(_paramIO[paramName]) {
             _paramIO[paramName]->setParamRequest();
         } else {
@@ -984,7 +984,7 @@ QGCCameraControl::_updateActiveList()
 {
     //-- Clear out excluded parameters based on exclusion rules
     QStringList exclusionList;
-    foreach(QGCCameraOptionExclusion* param, _valueExclusions) {
+    for(QGCCameraOptionExclusion* param: _valueExclusions) {
         Fact* pFact = getFact(param->param);
         if(pFact) {
             QString option = pFact->rawValueString();
@@ -994,7 +994,7 @@ QGCCameraControl::_updateActiveList()
         }
     }
     QStringList active;
-    foreach(QString key, _settings) {
+    for(QString key: _settings) {
         if(!exclusionList.contains(key)) {
             active.append(key);
         }
@@ -1094,7 +1094,7 @@ QGCCameraControl::_updateRanges(Fact* pFact)
     QStringList resetList;
     QStringList updates;
     //-- Iterate range sets looking for limited ranges
-    foreach(QGCCameraOptionRange* pRange, _optionRanges) {
+    for(QGCCameraOptionRange* pRange: _optionRanges) {
         //-- If this fact or one of its conditions is part of this range set
         if(!changedList.contains(pRange->targetParam) && (pRange->param == pFact->name() || pRange->condition.contains(pFact->name()))) {
             Fact* pRFact = getFact(pRange->param);          //-- This parameter
@@ -1115,7 +1115,7 @@ QGCCameraControl::_updateRanges(Fact* pFact)
         }
     }
     //-- Iterate range sets again looking for resets
-    foreach(QGCCameraOptionRange* pRange, _optionRanges) {
+    for(QGCCameraOptionRange* pRange: _optionRanges) {
         if(!changedList.contains(pRange->targetParam) && (pRange->param == pFact->name() || pRange->condition.contains(pFact->name()))) {
             Fact* pTFact = getFact(pRange->targetParam);    //-- The target parameter (the one its range is to change)
             if(!resetList.contains(pRange->targetParam)) {
@@ -1128,7 +1128,7 @@ QGCCameraControl::_updateRanges(Fact* pFact)
         }
     }
     //-- Update limited range set
-    foreach (Fact* f, rangesSet.keys()) {
+    for (Fact* f: rangesSet.keys()) {
         f->setEnumInfo(rangesSet[f]->optNames, rangesSet[f]->optVariants);
         if(!updates.contains(f->name())) {
             _paramIO[f->name()]->optNames = rangesSet[f]->optNames;
@@ -1139,7 +1139,7 @@ QGCCameraControl::_updateRanges(Fact* pFact)
         }
     }
     //-- Restore full range set
-    foreach (Fact* f, rangesReset.keys()) {
+    for (Fact* f: rangesReset.keys()) {
         f->setEnumInfo(_originalOptNames[rangesReset[f]], _originalOptValues[rangesReset[f]]);
         if(!updates.contains(f->name())) {
             _paramIO[f->name()]->optNames = _originalOptNames[rangesReset[f]];
@@ -1151,7 +1151,7 @@ QGCCameraControl::_updateRanges(Fact* pFact)
     }
     //-- Parameter update requests
     if(_requestUpdates.contains(pFact->name())) {
-        foreach(QString param, _requestUpdates[pFact->name()]) {
+        for(QString param: _requestUpdates[pFact->name()]) {
             if(!_updatesToRequest.contains(param)) {
                 _updatesToRequest << param;
             }
@@ -1166,7 +1166,7 @@ QGCCameraControl::_updateRanges(Fact* pFact)
 void
 QGCCameraControl::_requestParamUpdates()
 {
-    foreach(QString param, _updatesToRequest) {
+    for(QString param: _updatesToRequest) {
         _paramIO[param]->paramRequest();
     }
     _updatesToRequest.clear();
@@ -1358,7 +1358,7 @@ void
 QGCCameraControl::_processRanges()
 {
     //-- After all parameter are loaded, process parameter ranges
-    foreach(QGCCameraOptionRange* pRange, _optionRanges) {
+    for(QGCCameraOptionRange* pRange: _optionRanges) {
         Fact* pRFact = getFact(pRange->targetParam);
         if(pRFact) {
             for(int i = 0; i < pRange->optNames.size(); i++) {
@@ -1488,7 +1488,7 @@ QGCCameraControl::_dataReady(QByteArray data)
 void
 QGCCameraControl::_paramDone()
 {
-    foreach(QString param, _paramIO.keys()) {
+    for(QString param: _paramIO.keys()) {
         if(!_paramIO[param]->paramDone()) {
             return;
         }

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -221,7 +221,7 @@ int Fact::enumIndex(void)
         //-- Only enums have an index
         if(_metaData->enumValues().count()) {
             int index = 0;
-            foreach (QVariant enumValue, _metaData->enumValues()) {
+            for (QVariant enumValue: _metaData->enumValues()) {
                 if (enumValue == rawValue()) {
                     return index;
                 }

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -120,7 +120,7 @@ void FactGroup::_addFactGroup(FactGroup* factGroup, const QString& name)
 
 void FactGroup::_updateAllValues(void)
 {
-    foreach(Fact* fact, _nameToFactMap) {
+    for(Fact* fact: _nameToFactMap) {
         fact->sendDeferredValueChangedSignal();
     }
 }

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -228,21 +228,21 @@ void ParameterManager::_parameterUpdate(int vehicleId, int componentId, QString 
     int waitingReadParamNameCount = 0;
     int waitingWriteParamNameCount = 0;
 
-    foreach(int waitingComponentId, _waitingReadParamIndexMap.keys()) {
+    for(int waitingComponentId: _waitingReadParamIndexMap.keys()) {
         waitingReadParamIndexCount += _waitingReadParamIndexMap[waitingComponentId].count();
     }
     if (waitingReadParamIndexCount) {
         qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "waitingReadParamIndexCount:" << waitingReadParamIndexCount;
     }
 
-    foreach(int waitingComponentId, _waitingReadParamNameMap.keys()) {
+    for(int waitingComponentId: _waitingReadParamNameMap.keys()) {
         waitingReadParamNameCount += _waitingReadParamNameMap[waitingComponentId].count();
     }
     if (waitingReadParamNameCount) {
         qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "waitingReadParamNameCount:" << waitingReadParamNameCount;
     }
 
-    foreach(int waitingComponentId, _waitingWriteParamNameMap.keys()) {
+    for(int waitingComponentId: _waitingWriteParamNameMap.keys()) {
         waitingWriteParamNameCount += _waitingWriteParamNameMap[waitingComponentId].count();
     }
     if (waitingWriteParamNameCount) {
@@ -418,7 +418,7 @@ void ParameterManager::refreshAllParameters(uint8_t componentId)
     }
 
     // Reset index wait lists
-    foreach (int cid, _paramCountMap.keys()) {
+    for (int cid: _paramCountMap.keys()) {
         // Add/Update all indices to the wait list, parameter index is 0-based
         if(componentId != MAV_COMP_ID_ALL && componentId != cid)
             continue;
@@ -486,7 +486,7 @@ void ParameterManager::refreshParametersPrefix(int componentId, const QString& n
     componentId = _actualComponentId(componentId);
     qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "refreshParametersPrefix - name:" << namePrefix << ")";
 
-    foreach(const QString &name, _mapParameterName2Variant[componentId].keys()) {
+    for(const QString &name: _mapParameterName2Variant[componentId].keys()) {
         if (name.startsWith(namePrefix)) {
             refreshParameter(componentId, name);
         }
@@ -522,7 +522,7 @@ QStringList ParameterManager::parameterNames(int componentId)
 {
     QStringList names;
 
-    foreach(const QString &paramName, _mapParameterName2Variant[_actualComponentId(componentId)].keys()) {
+    for(const QString &paramName: _mapParameterName2Variant[_actualComponentId(componentId)].keys()) {
         names << paramName;
     }
 
@@ -534,7 +534,7 @@ void ParameterManager::_setupCategoryMap(void)
     // Must be able to handle being called multiple times
     _categoryMap.clear();
 
-    foreach (const QString &name, _mapParameterName2Variant[_vehicle->defaultComponentId()].keys()) {
+    for (const QString &name: _mapParameterName2Variant[_vehicle->defaultComponentId()].keys()) {
         Fact* fact = _mapParameterName2Variant[_vehicle->defaultComponentId()][name].value<Fact*>();
         _categoryMap[fact->category()][fact->group()] += name;
     }
@@ -564,13 +564,13 @@ bool ParameterManager::_fillIndexBatchQueue(bool waitingParamTimeout)
         qCDebug(ParameterManagerLog) << "Refilling index based batch queue due to received parameter";
     }
 
-    foreach(int componentId, _waitingReadParamIndexMap.keys()) {
+    for(int componentId: _waitingReadParamIndexMap.keys()) {
         if (_waitingReadParamIndexMap[componentId].count()) {
             qCDebug(ParameterManagerLog) << _logVehiclePrefix() << "_waitingReadParamIndexMap count" << _waitingReadParamIndexMap[componentId].count();
             qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix() << "_waitingReadParamIndexMap" << _waitingReadParamIndexMap[componentId];
         }
 
-        foreach(int paramIndex, _waitingReadParamIndexMap[componentId].keys()) {
+        for(int paramIndex: _waitingReadParamIndexMap[componentId].keys()) {
             if (_indexBatchQueue.contains(paramIndex)) {
                 // Don't add more than once
                 continue;
@@ -629,8 +629,8 @@ void ParameterManager::_waitingParamTimeout(void)
     _checkInitialLoadComplete();
 
     if (!paramsRequested) {
-        foreach(int componentId, _waitingWriteParamNameMap.keys()) {
-            foreach(const QString &paramName, _waitingWriteParamNameMap[componentId].keys()) {
+        for(int componentId: _waitingWriteParamNameMap.keys()) {
+            for(const QString &paramName: _waitingWriteParamNameMap[componentId].keys()) {
                 paramsRequested = true;
                 _waitingWriteParamNameMap[componentId][paramName]++;   // Bump retry count
                 if (_waitingWriteParamNameMap[componentId][paramName] <= _maxReadWriteRetry) {
@@ -651,8 +651,8 @@ void ParameterManager::_waitingParamTimeout(void)
     }
 
     if (!paramsRequested) {
-        foreach(int componentId, _waitingReadParamNameMap.keys()) {
-            foreach(const QString &paramName, _waitingReadParamNameMap[componentId].keys()) {
+        for(int componentId: _waitingReadParamNameMap.keys()) {
+            for(const QString &paramName: _waitingReadParamNameMap[componentId].keys()) {
                 paramsRequested = true;
                 _waitingReadParamNameMap[componentId][paramName]++;   // Bump retry count
                 if (_waitingReadParamNameMap[componentId][paramName] <= _maxReadWriteRetry) {
@@ -759,7 +759,7 @@ void ParameterManager::_writeLocalParamCache(int vehicleId, int componentId)
 {
     CacheMapName2ParamTypeVal cacheMap;
 
-    foreach(const QString& name, _mapParameterName2Variant[componentId].keys()) {
+    for(const QString& name: _mapParameterName2Variant[componentId].keys()) {
         const Fact *fact = _mapParameterName2Variant[componentId][name].value<Fact*>();
         cacheMap[name] = ParamTypeVal(fact->type(), fact->rawValue());
     }
@@ -810,7 +810,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, QVarian
     /* compute the crc of the local cache to check against the remote */
 
     FirmwarePlugin* firmwarePlugin = _vehicle->firmwarePlugin();
-    foreach (const QString& name, cacheMap.keys()) {
+    for (const QString& name: cacheMap.keys()) {
         bool volatileValue = false;
 
         FactMetaData* metaData = firmwarePlugin->getMetaDataForFact(_parameterMetaData, name, _vehicle->vehicleType());
@@ -836,7 +836,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, QVarian
 
         int count = cacheMap.count();
         int index = 0;
-        foreach (const QString& name, cacheMap.keys()) {
+        for (const QString& name: cacheMap.keys()) {
             const ParamTypeVal& paramTypeVal = cacheMap[name];
             const FactMetaData::ValueType_t fact_type = static_cast<FactMetaData::ValueType_t>(paramTypeVal.first);
             const int mavType = _factTypeToMavType(fact_type);
@@ -888,7 +888,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, QVarian
         if (ParameterManagerDebugCacheFailureLog().isDebugEnabled()) {
             _debugCacheCRC[componentId] = true;
             _debugCacheMap[componentId] = cacheMap;
-            foreach (const QString& name, cacheMap.keys()) {
+            for (const QString& name: cacheMap.keys()) {
                 _debugCacheParamSeen[componentId][name] = false;
             }
             qgcApp()->showMessage(tr("Parameter cache CRC match failed"));
@@ -958,8 +958,8 @@ void ParameterManager::writeParametersToStream(QTextStream &stream)
     stream << "#\n";
     stream << "# Vehicle-Id Component-Id Name Value Type\n";
 
-    foreach (int componentId, _mapParameterName2Variant.keys()) {
-        foreach (const QString &paramName, _mapParameterName2Variant[componentId].keys()) {
+    for (int componentId: _mapParameterName2Variant.keys()) {
+        for (const QString &paramName: _mapParameterName2Variant[componentId].keys()) {
             Fact* fact = _mapParameterName2Variant[componentId][paramName].value<Fact*>();
             if (fact) {
                 stream << _vehicle->id() << "\t" << componentId << "\t" << paramName << "\t" << fact->rawValueStringFullPrecision() << "\t" << QString("%1").arg(_factTypeToMavType(fact->type())) << "\n";
@@ -1084,7 +1084,7 @@ void ParameterManager::_addMetaDataToDefaultComponent(void)
 
     // Loop over all parameters in default component adding meta data
     QVariantMap& factMap = _mapParameterName2Variant[_vehicle->defaultComponentId()];
-    foreach (const QString& key, factMap.keys()) {
+    for (const QString& key: factMap.keys()) {
         _vehicle->firmwarePlugin()->addMetaDataToFact(_parameterMetaData, factMap[key].value<Fact*>(), _vehicle->vehicleType());
     }
 }
@@ -1096,7 +1096,7 @@ void ParameterManager::_checkInitialLoadComplete(void)
         return;
     }
 
-    foreach (int componentId, _waitingReadParamIndexMap.keys()) {
+    for (int componentId: _waitingReadParamIndexMap.keys()) {
         if (_waitingReadParamIndexMap[componentId].count()) {
             // We are still waiting on some parameters, not done yet
             return;
@@ -1112,9 +1112,9 @@ void ParameterManager::_checkInitialLoadComplete(void)
     _initialLoadComplete = true;
 
 	// Parameter cache crc failure debugging
-	foreach (int componentId, _debugCacheParamSeen.keys()) {
+	for (int componentId: _debugCacheParamSeen.keys()) {
         if (!_logReplay && _debugCacheCRC.contains(componentId) && _debugCacheCRC[componentId]) {
-            foreach (const QString& paramName, _debugCacheParamSeen[componentId].keys()) {
+            for (const QString& paramName: _debugCacheParamSeen[componentId].keys()) {
                 if (!_debugCacheParamSeen[componentId][paramName]) {
                     qDebug() << "Parameter in cache but not on vehicle componentId:Name" << componentId << paramName;
                 }
@@ -1128,8 +1128,8 @@ void ParameterManager::_checkInitialLoadComplete(void)
     // Check for index based load failures
     QString indexList;
     bool initialLoadFailures = false;
-    foreach (int componentId, _failedReadParamIndexMap.keys()) {
-        foreach (int paramIndex, _failedReadParamIndexMap[componentId]) {
+    for (int componentId: _failedReadParamIndexMap.keys()) {
+        for (int paramIndex: _failedReadParamIndexMap[componentId]) {
             if (initialLoadFailures) {
                 indexList += ", ";
             }

--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -66,7 +66,7 @@ VideoManager::setToolbox(QGCToolbox *toolbox)
 #ifndef QGC_DISABLE_UVC
    // If we are using a UVC camera setup the device name
     QList<QCameraInfo> cameras = QCameraInfo::availableCameras();
-    foreach (const QCameraInfo &cameraInfo, cameras) {
+    for (const QCameraInfo &cameraInfo: cameras) {
         if(cameraInfo.description() == videoSource) {
             _videoSourceID = cameraInfo.deviceName();
             emit videoSourceIDChanged();

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -153,7 +153,7 @@ QVariantList JoystickManager::joysticks(void)
 {
     QVariantList list;
     
-    foreach (const QString &name, _name2JoystickMap.keys()) {
+    for (const QString &name: _name2JoystickMap.keys()) {
         list += QVariant::fromValue(_name2JoystickMap[name]);
     }
     

--- a/src/MissionManager/CameraCalcTest.cc
+++ b/src/MissionManager/CameraCalcTest.cc
@@ -68,7 +68,7 @@ void CameraCalcTest::_testDirty(void)
             << _cameraCalc->sideOverlap ()
             << _cameraCalc->adjustedFootprintSide()
             << _cameraCalc->adjustedFootprintFrontal();
-    foreach(Fact* fact, rgFacts) {
+    for(Fact* fact: rgFacts) {
         qDebug() << fact->name();
         QVERIFY(!_cameraCalc->dirty());
         if (fact->typeIsBool()) {

--- a/src/MissionManager/CameraSectionTest.cc
+++ b/src/MissionManager/CameraSectionTest.cc
@@ -421,7 +421,7 @@ void CameraSectionTest::_testItemCount(void)
 
     QList<int> rgCameraActions;
     rgCameraActions << CameraSection::TakePhotosIntervalTime << CameraSection::TakePhotoIntervalDistance << CameraSection::StopTakingPhotos << CameraSection::TakeVideo << CameraSection::StopTakingVideo << CameraSection::TakePhoto;
-    foreach(int cameraAction, rgCameraActions) {
+    for(int cameraAction: rgCameraActions) {
         qDebug() << "camera action" << cameraAction;
 
         // Reset
@@ -1063,8 +1063,8 @@ void CameraSectionTest::_testScanForMultipleItems(void)
     rgActionItems << _validDistanceItem << _validTimeItem <<  _validStartVideoItem <<  _validStopVideoItem << _validTakePhotoItem;
 
     // Camera action followed by gimbal/mode
-    foreach (SimpleMissionItem* actionItem, rgActionItems) {
-        foreach (SimpleMissionItem* cameraItem, rgCameraItems) {
+    for (SimpleMissionItem* actionItem: rgActionItems) {
+        for (SimpleMissionItem* cameraItem: rgCameraItems) {
             SimpleMissionItem* item1 = new SimpleMissionItem(_offlineVehicle, false /* flyView */, this);
             item1->missionItem() = actionItem->missionItem();
             SimpleMissionItem* item2 = new SimpleMissionItem(_offlineVehicle, false /* flyView */, this);
@@ -1084,8 +1084,8 @@ void CameraSectionTest::_testScanForMultipleItems(void)
     }
 
     // Gimbal/Mode followed by camera action
-    foreach (SimpleMissionItem* actionItem, rgCameraItems) {
-        foreach (SimpleMissionItem* cameraItem, rgActionItems) {
+    for (SimpleMissionItem* actionItem: rgCameraItems) {
+        for (SimpleMissionItem* cameraItem: rgActionItems) {
             SimpleMissionItem* item1 = new SimpleMissionItem(_offlineVehicle, false /* flyView */, this);
             item1->missionItem() = actionItem->missionItem();
             SimpleMissionItem* item2 = new SimpleMissionItem(_offlineVehicle, false /* flyView */, this);

--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -149,7 +149,7 @@ void CorridorScanComplexItem::_appendLoadedMissionItems(QList<MissionItem*>& ite
 
     int seqNum = _sequenceNumber;
 
-    foreach (const MissionItem* loadedMissionItem, _loadedMissionItems) {
+    for (const MissionItem* loadedMissionItem: _loadedMissionItems) {
         MissionItem* item = new MissionItem(*loadedMissionItem, missionItemParent);
         item->setSequenceNumber(seqNum++);
         items.append(item);
@@ -171,11 +171,11 @@ void CorridorScanComplexItem::_buildAndAppendMissionItems(QList<MissionItem*>& i
     MAV_FRAME mavFrame = followTerrain() || !_cameraCalc.distanceToSurfaceRelative() ? MAV_FRAME_GLOBAL : MAV_FRAME_GLOBAL_RELATIVE_ALT;
 
     //qDebug() << "_buildAndAppendMissionItems";
-    foreach (const QList<TransectStyleComplexItem::CoordInfo_t>& transect, _transects) {
+    for (const QList<TransectStyleComplexItem::CoordInfo_t>& transect: _transects) {
         bool entryPoint = true;
 
         //qDebug() << "start transect";
-        foreach (const CoordInfo_t& transectCoordInfo, transect) {
+        for (const CoordInfo_t& transectCoordInfo: transect) {
             //qDebug() << transectCoordInfo.coordType;
 
             item = new MissionItem(seqNum++,
@@ -309,7 +309,7 @@ void CorridorScanComplexItem::_rebuildCorridorPolygon(void)
     _surveyAreaPolygon.clear();
 
     QList<QGeoCoordinate> rgCoord;
-    foreach (const QGeoCoordinate& vertex, firstSideVertices) {
+    for (const QGeoCoordinate& vertex: firstSideVertices) {
         rgCoord.append(vertex);
     }
     for (int i=secondSideVertices.count() - 1; i >= 0; i--) {
@@ -386,7 +386,7 @@ void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
 
 #if 0
             qDebug() << "transect debug";
-            foreach (const TransectStyleComplexItem::CoordInfo_t& coordInfo, transect) {
+            for (const TransectStyleComplexItem::CoordInfo_t& coordInfo: transect) {
                 qDebug() << coordInfo.coordType;
             }
 #endif
@@ -423,7 +423,7 @@ void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
         }
         if (reverseTransects) {
             QList<QList<TransectStyleComplexItem::CoordInfo_t>> reversedTransects;
-            foreach (const QList<TransectStyleComplexItem::CoordInfo_t>& transect, _transects) {
+            for (const QList<TransectStyleComplexItem::CoordInfo_t>& transect: _transects) {
                 reversedTransects.prepend(transect);
             }
             _transects = reversedTransects;
@@ -431,7 +431,7 @@ void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
         if (reverseVertices) {
             for (int i=0; i<_transects.count(); i++) {
                 QList<TransectStyleComplexItem::CoordInfo_t> reversedVertices;
-                foreach (const TransectStyleComplexItem::CoordInfo_t& vertex, _transects[i]) {
+                for (const TransectStyleComplexItem::CoordInfo_t& vertex: _transects[i]) {
                     reversedVertices.prepend(vertex);
                 }
                 _transects[i] = reversedVertices;

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -143,7 +143,7 @@ bool GeoFenceController::load(const QJsonObject& json, QString& errorString)
     }
 
     QJsonArray jsonPolygonArray = json[_jsonPolygonsKey].toArray();
-    foreach (const QJsonValue& jsonPolygonValue, jsonPolygonArray) {
+    for (const QJsonValue& jsonPolygonValue: jsonPolygonArray) {
         if (jsonPolygonValue.type() != QJsonValue::Object) {
             errorString = tr("GeoFence polygon not stored as object");
             return false;
@@ -157,7 +157,7 @@ bool GeoFenceController::load(const QJsonObject& json, QString& errorString)
     }
 
     QJsonArray jsonCircleArray = json[_jsonCirclesKey].toArray();
-    foreach (const QJsonValue& jsonCircleValue, jsonCircleArray) {
+    for (const QJsonValue& jsonCircleValue: jsonCircleArray) {
         if (jsonCircleValue.type() != QJsonValue::Object) {
             errorString = tr("GeoFence circle not stored as object");
             return false;

--- a/src/MissionManager/MissionCommandList.cc
+++ b/src/MissionManager/MissionCommandList.cc
@@ -71,7 +71,7 @@ void MissionCommandList::_loadMavCmdInfoJson(const QString& jsonFilename, bool b
 
     // Iterate over MissionCommandUIInfo objects
     QJsonArray jsonArray = jsonValue.toArray();
-    foreach(QJsonValue info, jsonArray) {
+    for(QJsonValue info: jsonArray) {
         if (!info.isObject()) {
             qWarning() << jsonFilename << "mavCmdArray should contain objects";
             return;
@@ -96,7 +96,7 @@ void MissionCommandList::_loadMavCmdInfoJson(const QString& jsonFilename, bool b
     }
 
     // Build id list
-    foreach (MAV_CMD id, _infoMap.keys()) {
+    for (MAV_CMD id: _infoMap.keys()) {
         _ids << id;
     }
 }

--- a/src/MissionManager/MissionCommandTree.cc
+++ b/src/MissionManager/MissionCommandTree.cc
@@ -47,13 +47,13 @@ void MissionCommandTree::setToolbox(QGCToolbox* toolbox)
     } else {
 #endif
         // Load all levels of hierarchy
-        foreach (MAV_AUTOPILOT firmwareType, _toolbox->firmwarePluginManager()->supportedFirmwareTypes()) {
+        for (MAV_AUTOPILOT firmwareType: _toolbox->firmwarePluginManager()->supportedFirmwareTypes()) {
             FirmwarePlugin* plugin = _toolbox->firmwarePluginManager()->firmwarePluginForAutopilot(firmwareType, MAV_TYPE_QUADROTOR);
 
             QList<MAV_TYPE> vehicleTypes;
             vehicleTypes << MAV_TYPE_GENERIC << MAV_TYPE_FIXED_WING << MAV_TYPE_QUADROTOR << MAV_TYPE_VTOL_QUADROTOR << MAV_TYPE_GROUND_ROVER << MAV_TYPE_SUBMARINE;
 
-            foreach(MAV_TYPE vehicleType, vehicleTypes) {
+            for(MAV_TYPE vehicleType: vehicleTypes) {
                 QString overrideFile = plugin->missionCommandOverrides(vehicleType);
                 if (!overrideFile.isEmpty()) {
                     _staticCommandTree[firmwareType][vehicleType] = new MissionCommandList(overrideFile, firmwareType == MAV_AUTOPILOT_GENERIC && vehicleType == MAV_TYPE_GENERIC /* baseCommandList */, this);
@@ -105,7 +105,7 @@ void MissionCommandTree::_collapseHierarchy(Vehicle*                            
 
     _baseVehicleInfo(vehicle, baseFirmwareType, baseVehicleType);
 
-    foreach (MAV_CMD command, cmdList->commandIds()) {
+    for (MAV_CMD command: cmdList->commandIds()) {
         // Only add supported command to tree (MAV_CMD_NAV_LAST is used for planned home position)
         if (!qgcApp()->runningUnitTests()
                 && !vehicle->firmwarePlugin()->supportedMissionCommands().isEmpty()
@@ -238,7 +238,7 @@ QVariantList MissionCommandTree::getCommandsForCategory(Vehicle* vehicle, const 
 
     QVariantList list;
     QMap<MAV_CMD, MissionCommandUIInfo*> commandMap = _availableCommands[baseFirmwareType][baseVehicleType];
-    foreach (MAV_CMD command, commandMap.keys()) {
+    for (MAV_CMD command: commandMap.keys()) {
         if (command == MAV_CMD_NAV_LAST) {
             // MAV_CMD_NAV_LAST is used for Mission Settings item. Although we want to be able to get command info for it.
             // The user should not be able to use it as a command.

--- a/src/MissionManager/MissionCommandTreeTest.cc
+++ b/src/MissionManager/MissionCommandTreeTest.cc
@@ -206,8 +206,8 @@ void MissionCommandTreeTest::testAllTrees(void)
     vehicleList << MAV_TYPE_GENERIC << MAV_TYPE_QUADROTOR << MAV_TYPE_FIXED_WING << MAV_TYPE_GROUND_ROVER << MAV_TYPE_SUBMARINE << MAV_TYPE_VTOL_QUADROTOR;
 
     // This will cause all of the variants of collapsed trees to be built
-    foreach(MAV_AUTOPILOT firmwareType, firmwareList) {
-        foreach (MAV_TYPE vehicleType, vehicleList) {
+    for(MAV_AUTOPILOT firmwareType: firmwareList) {
+        for (MAV_TYPE vehicleType: vehicleList) {
             if (firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA && vehicleType == MAV_TYPE_VTOL_QUADROTOR) {
                 // VTOL in ArduPilot shows up as plane so we can test this pair
                 continue;

--- a/src/MissionManager/MissionCommandUIInfo.cc
+++ b/src/MissionManager/MissionCommandUIInfo.cc
@@ -85,7 +85,7 @@ const MissionCommandUIInfo& MissionCommandUIInfo::operator=(const MissionCommand
     _infoMap =          other._infoMap;
     _paramRemoveList =  other._paramRemoveList;
 
-    foreach (int index, other._paramInfoMap.keys()) {
+    for (int index: other._paramInfoMap.keys()) {
         _paramInfoMap[index] = new MissionCmdParamInfo(*other._paramInfoMap[index], this);
     }
 
@@ -167,19 +167,19 @@ bool MissionCommandUIInfo::specifiesAltitudeOnly(void) const
 void MissionCommandUIInfo::_overrideInfo(MissionCommandUIInfo* uiInfo)
 {
     // Override info values
-    foreach (const QString& valueKey, uiInfo->_infoMap.keys()) {
+    for (const QString& valueKey: uiInfo->_infoMap.keys()) {
         _setInfoValue(valueKey, uiInfo->_infoMap[valueKey]);
     }
 
     // Add to the remove params list
-    foreach (int removeIndex, uiInfo->_paramRemoveList) {
+    for (int removeIndex: uiInfo->_paramRemoveList) {
         if (!_paramRemoveList.contains(removeIndex)) {
             _paramRemoveList.append(removeIndex);
         }
     }
 
     // Override param info
-    foreach (const int paramIndex, uiInfo->_paramInfoMap.keys()) {
+    for (const int paramIndex: uiInfo->_paramInfoMap.keys()) {
         _paramRemoveList.removeOne(paramIndex);
         // MissionCmdParamInfo objects are owned by MissionCommandTree are are in existence for the entire run so
         // we can just use the same pointer reference.
@@ -202,7 +202,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
             << _paramRemoveJsonKey << _categoryJsonKey << _specifiesAltitudeOnlyJsonKey;
 
     // Look for unknown keys in top level object
-    foreach (const QString& key, jsonObject.keys()) {
+    for (const QString& key: jsonObject.keys()) {
         if (!allKeys.contains(key) && key != _commentJsonKey) {
             errorString = _loadErrorString(QString("Unknown key: %1").arg(key));
             return false;
@@ -267,7 +267,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
     }
     if (jsonObject.contains(_paramRemoveJsonKey)) {
         QStringList indexList = jsonObject.value(_paramRemoveJsonKey).toString().split(QStringLiteral(","));
-        foreach (const QString& indexString, indexList) {
+        for (const QString& indexString: indexList) {
             _paramRemoveList.append(indexString.toInt());
         }
     }
@@ -308,7 +308,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
     }
 
     QString debugOutput;
-    foreach (const QString& infoKey, _infoMap.keys()) {
+    for (const QString& infoKey: _infoMap.keys()) {
         debugOutput.append(QString("MavCmdInfo %1: %2 ").arg(infoKey).arg(_infoMap[infoKey].toString()));
     }
     qCDebug(MissionCommandsLog) << debugOutput;
@@ -325,7 +325,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
             allParamKeys << _defaultJsonKey << _decimalPlacesJsonKey << _enumStringsJsonKey << _enumValuesJsonKey << _labelJsonKey << _unitsJsonKey << _nanUnchangedJsonKey;
 
             // Look for unknown keys in param object
-            foreach (const QString& key, paramObject.keys()) {
+            for (const QString& key: paramObject.keys()) {
                 if (!allParamKeys.contains(key) && key != _commentJsonKey) {
                     errorString = _loadErrorString(QString("Unknown param key: %1").arg(key));
                     return false;
@@ -372,7 +372,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
             }
 
             QStringList enumValues = paramObject.value(_enumValuesJsonKey).toString().split(",", QString::SkipEmptyParts);
-            foreach (const QString &enumValue, enumValues) {
+            for (const QString &enumValue: enumValues) {
                 bool    convertOk;
                 double  value = enumValue.toDouble(&convertOk);
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1156,7 +1156,7 @@ void MissionController::_recalcWaypointLines(void)
         // Create a temporary QObjectList and replace the model data
         QObjectList objs;
         objs.reserve(_linesTable.count());
-        foreach(CoordinateVector *vect, _linesTable.values()) {
+        for(CoordinateVector *vect: _linesTable.values()) {
             objs.append(vect);
         }
 

--- a/src/MissionManager/MissionItemTest.cc
+++ b/src/MissionManager/MissionItemTest.cc
@@ -301,7 +301,7 @@ void MissionItemTest::_testLoadFromJsonV1(void)
 
     QStringList removeKeys;
     removeKeys << MissionItem::_jsonParam1Key << MissionItem::_jsonParam2Key << MissionItem::_jsonParam3Key << MissionItem::_jsonParam4Key;
-    foreach (const QString& removeKey, removeKeys) {
+    for (const QString& removeKey: removeKeys) {
         QJsonObject badObject = jsonObject;
         badObject.remove(removeKey);
         QCOMPARE(missionItem.load(badObject, _seq, errorString), false);
@@ -329,7 +329,7 @@ void MissionItemTest::_testLoadFromJsonV2(void)
 
     QStringList removeKeys;
     removeKeys << MissionItem::_jsonCoordinateKey;
-    foreach(const QString& removeKey, removeKeys) {
+    for(const QString& removeKey: removeKeys) {
         QJsonObject badObject = jsonObject;
         badObject.remove(removeKey);
         QCOMPARE(missionItem.load(badObject, _seq, errorString), false);
@@ -399,7 +399,7 @@ void MissionItemTest::_testLoadFromJsonV3(void)
                   MissionItem::_jsonFrameKey <<
                   MissionItem::_jsonParamsKey <<
                   VisualMissionItem::jsonTypeKey;
-    foreach(const QString& removeKey, removeKeys) {
+    for(const QString& removeKey: removeKeys) {
         QJsonObject badObject = jsonObject;
         badObject.remove(removeKey);
         QCOMPARE(missionItem.load(badObject, _seq, errorString), false);

--- a/src/MissionManager/QGCMapPolygon.cc
+++ b/src/MissionManager/QGCMapPolygon.cc
@@ -58,7 +58,7 @@ const QGCMapPolygon& QGCMapPolygon::operator=(const QGCMapPolygon& other)
 
     QVariantList vertices = other.path();
     QList<QGeoCoordinate> rgCoord;
-    foreach (const QVariant& vertexVar, vertices) {
+    for (const QVariant& vertexVar: vertices) {
         rgCoord.append(vertexVar.value<QGeoCoordinate>());
     }
     appendVertices(rgCoord);
@@ -162,7 +162,7 @@ void QGCMapPolygon::setPath(const QList<QGeoCoordinate>& path)
 {
     _polygonPath.clear();
     _polygonModel.clearAndDeleteContents();
-    foreach(const QGeoCoordinate& coord, path) {
+    for(const QGeoCoordinate& coord: path) {
         _polygonPath.append(QVariant::fromValue(coord));
         _polygonModel.append(new QGCQGeoCoordinate(coord, this));
     }
@@ -265,7 +265,7 @@ void QGCMapPolygon::appendVertices(const QList<QGeoCoordinate>& coordinates)
 {
     QList<QObject*> objects;
 
-    foreach (const QGeoCoordinate& coordinate, coordinates) {
+    for (const QGeoCoordinate& coordinate: coordinates) {
         objects.append(new QGCQGeoCoordinate(coordinate, this));
         _polygonPath.append(QVariant::fromValue(coordinate));
     }

--- a/src/MissionManager/QGCMapPolyline.cc
+++ b/src/MissionManager/QGCMapPolyline.cc
@@ -120,7 +120,7 @@ void QGCMapPolyline::setPath(const QList<QGeoCoordinate>& path)
 {
     _polylinePath.clear();
     _polylineModel.clearAndDeleteContents();
-    foreach (const QGeoCoordinate& coord, path) {
+    for (const QGeoCoordinate& coord: path) {
         _polylinePath.append(QVariant::fromValue(coord));
         _polylineModel.append(new QGCQGeoCoordinate(coord, this));
     }
@@ -382,7 +382,7 @@ void QGCMapPolyline::appendVertices(const QList<QGeoCoordinate>& coordinates)
 {
     QList<QObject*> objects;
 
-    foreach (const QGeoCoordinate& coordinate, coordinates) {
+    for (const QGeoCoordinate& coordinate: coordinates) {
         objects.append(new QGCQGeoCoordinate(coordinate, this));
         _polylinePath.append(QVariant::fromValue(coordinate));
     }

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -250,7 +250,7 @@ void SimpleMissionItem::_setupMetaData(void)
         enumStrings.clear();
         enumValues.clear();
         MissionCommandTree* commandTree = qgcApp()->toolbox()->missionCommandTree();
-        foreach (const MAV_CMD command, commandTree->allCommandIds()) {
+        for (const MAV_CMD command: commandTree->allCommandIds()) {
             enumStrings.append(commandTree->rawName(command));
             enumValues.append(QVariant((int)command));
         }

--- a/src/MissionManager/StructureScanComplexItemTest.cc
+++ b/src/MissionManager/StructureScanComplexItemTest.cc
@@ -60,7 +60,7 @@ void StructureScanComplexItemTest::_testDirty(void)
     // These facts should set dirty when changed
     QList<Fact*> rgFacts;
     rgFacts << _structureScanItem->altitude() << _structureScanItem->layers();
-    foreach(Fact* fact, rgFacts) {
+    for(Fact* fact: rgFacts) {
         qDebug() << fact->name();
         QVERIFY(!_structureScanItem->dirty());
         if (fact->typeIsBool()) {

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -819,10 +819,10 @@ void SurveyComplexItem::_buildAndAppendMissionItems(QList<MissionItem*>& items, 
 
     MAV_FRAME mavFrame = followTerrain() || !_cameraCalc.distanceToSurfaceRelative() ? MAV_FRAME_GLOBAL : MAV_FRAME_GLOBAL_RELATIVE_ALT;
 
-    foreach (const QList<TransectStyleComplexItem::CoordInfo_t>& transect, _transects) {
+    for (const QList<TransectStyleComplexItem::CoordInfo_t>& transect: _transects) {
         bool entryPoint = true;
 
-        foreach (const CoordInfo_t& transectCoordInfo, transect) {
+        for (const CoordInfo_t& transectCoordInfo: transect) {
             item = new MissionItem(seqNum++,
                                    MAV_CMD_NAV_WAYPOINT,
                                    mavFrame,
@@ -940,7 +940,7 @@ bool SurveyComplexItem::_buildAndAppendMissionItems(QList<MissionItem*>& items, 
         firstWaypointTrigger = true;
     }
 
-    foreach (const QList<TransectStyleComplexItem::CoordInfo_t>& transect, _transects) {
+    for (const QList<TransectStyleComplexItem::CoordInfo_t>& transect: _transects) {
         int pointIndex = 0;
         QGeoCoordinate coord;
         CameraTriggerCode cameraTrigger;
@@ -1182,7 +1182,7 @@ void SurveyComplexItem::_rebuildTransectsPhase1Worker(bool refly)
 
     // Convert from NED to Geo
     QList<QList<QGeoCoordinate>> transects;
-    foreach (const QLineF& line, resultLines) {
+    for (const QLineF& line: resultLines) {
         QGeoCoordinate          coord;
         QList<QGeoCoordinate>   transect;
 
@@ -1234,7 +1234,7 @@ void SurveyComplexItem::_rebuildTransectsPhase1Worker(bool refly)
     }
 
     // Convert to CoordInfo transects and append to _transects
-    foreach (const QList<QGeoCoordinate>& transect, transects) {
+    for (const QList<QGeoCoordinate>& transect: transects) {
         QGeoCoordinate                                  coord;
         QList<TransectStyleComplexItem::CoordInfo_t>    coordInfoTransect;
         TransectStyleComplexItem::CoordInfo_t           coordInfo;
@@ -1293,7 +1293,7 @@ void SurveyComplexItem::_rebuildTransectsPhase2(void)
         _cameraShots = qCeil(_complexDistance / triggerDistance());
     } else {
         _cameraShots = 0;
-        foreach (const QList<TransectStyleComplexItem::CoordInfo_t>& transect, _transects) {
+        for (const QList<TransectStyleComplexItem::CoordInfo_t>& transect: _transects) {
             QGeoCoordinate firstCameraCoord, lastCameraCoord;
             if (_hasTurnaround()) {
                 firstCameraCoord = transect[1].coord;
@@ -1345,7 +1345,7 @@ void SurveyComplexItem::_appendLoadedMissionItems(QList<MissionItem*>& items, QO
 
     int seqNum = _sequenceNumber;
 
-    foreach (const MissionItem* loadedMissionItem, _loadedMissionItems) {
+    for (const MissionItem* loadedMissionItem: _loadedMissionItems) {
         MissionItem* item = new MissionItem(*loadedMissionItem, missionItemParent);
         item->setSequenceNumber(seqNum++);
         items.append(item);

--- a/src/MissionManager/SurveyComplexItemTest.cc
+++ b/src/MissionManager/SurveyComplexItemTest.cc
@@ -71,7 +71,7 @@ void SurveyComplexItemTest::_testDirty(void)
     // These facts should set dirty when changed
     QList<Fact*> rgFacts;
     rgFacts << _surveyItem->gridAngle() << _surveyItem->flyAlternateTransects();
-    foreach(Fact* fact, rgFacts) {
+    for(Fact* fact: rgFacts) {
         qDebug() << fact->name();
         QVERIFY(!_surveyItem->dirty());
         if (fact->typeIsBool()) {

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -162,7 +162,7 @@ void TransectStyleComplexItem::_save(QJsonObject& complexObject)
     QObject* missionItemParent = new QObject();
     QList<MissionItem*> missionItems;
     appendMissionItems(missionItems, missionItemParent);
-    foreach (const MissionItem* missionItem, missionItems) {
+    for (const MissionItem* missionItem: missionItems) {
         QJsonObject missionItemJsonObject;
         missionItem->save(missionItemJsonObject);
         missionItemsJsonArray.append(missionItemJsonObject);
@@ -228,7 +228,7 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, QString& 
     // Load generated mission items
     _loadedMissionItemsParent = new QObject(this);
     QJsonArray missionItemsJsonArray = innerObject[_jsonItemsKey].toArray();
-    foreach (const QJsonValue& missionItemJson, missionItemsJsonArray) {
+    for (const QJsonValue& missionItemJson: missionItemsJsonArray) {
         MissionItem* missionItem = new MissionItem(_loadedMissionItemsParent);
         if (!missionItem->load(missionItemJson.toObject(), 0 /* sequenceNumber */, errorString)) {
             _loadedMissionItemsParent->deleteLater();
@@ -371,8 +371,8 @@ void TransectStyleComplexItem::_rebuildTransects(void)
     double top = 0.;
     // Generate the visuals transect representation
     _visualTransectPoints.clear();
-    foreach (const QList<CoordInfo_t>& transect, _transects) {
-        foreach (const CoordInfo_t& coordInfo, transect) {
+    for (const QList<CoordInfo_t>& transect: _transects) {
+        for (const CoordInfo_t& coordInfo: transect) {
             _visualTransectPoints.append(QVariant::fromValue(coordInfo.coord));
             double lat = coordInfo.coord.latitude()  + 90.0;
             double lon = coordInfo.coord.longitude() + 180.0;
@@ -440,8 +440,8 @@ void TransectStyleComplexItem::_reallyQueryTransectsPathHeightInfo(void)
 
     QList<QGeoCoordinate> transectPoints;
 
-    foreach (const QList<CoordInfo_t>& transect, _transects) {
-        foreach (const CoordInfo_t& coordInfo, transect) {
+    for (const QList<CoordInfo_t>& transect: _transects) {
+        for (const CoordInfo_t& coordInfo: transect) {
             transectPoints.append(coordInfo.coord);
         }
     }
@@ -645,7 +645,7 @@ void TransectStyleComplexItem::_adjustForTolerance(QList<CoordInfo_t>& transect)
 
 #if 0
     qDebug() << "_adjustForTolerance";
-    foreach (const TransectStyleComplexItem::CoordInfo_t& coordInfo, adjustedPoints) {
+    for (const TransectStyleComplexItem::CoordInfo_t& coordInfo: adjustedPoints) {
         qDebug() << coordInfo.coordType;
     }
 #endif
@@ -698,7 +698,7 @@ void TransectStyleComplexItem::_addInterstitialTerrainPoints(QList<CoordInfo_t>&
 
 #if 0
     qDebug() << "_addInterstitialTerrainPoints";
-    foreach (const TransectStyleComplexItem::CoordInfo_t& coordInfo, adjustedTransect) {
+    for (const TransectStyleComplexItem::CoordInfo_t& coordInfo: adjustedTransect) {
         qDebug() << coordInfo.coordType;
     }
 #endif
@@ -723,7 +723,7 @@ int TransectStyleComplexItem::lastSequenceNumber(void) const
         // We have to determine from transects
         int itemCount = 0;
 
-        foreach (const QList<CoordInfo_t>& rgCoordInfo, _transects) {
+        for (const QList<CoordInfo_t>& rgCoordInfo: _transects) {
             itemCount += rgCoordInfo.count() * (hoverAndCaptureEnabled() ? 2 : 1);
         }
 

--- a/src/MissionManager/TransectStyleComplexItemTest.cc
+++ b/src/MissionManager/TransectStyleComplexItemTest.cc
@@ -77,7 +77,7 @@ void TransectStyleComplexItemTest::_testDirty(void)
             << _transectStyleItem->cameraTriggerInTurnAround()
             << _transectStyleItem->hoverAndCapture()
             << _transectStyleItem->refly90Degrees();
-    foreach(Fact* fact, rgFacts) {
+    for(Fact* fact: rgFacts) {
         qDebug() << fact->name();
         QVERIFY(!_transectStyleItem->dirty());
         changeFactValue(fact);
@@ -102,7 +102,7 @@ void TransectStyleComplexItemTest::_testDirty(void)
 
 void TransectStyleComplexItemTest::_setSurveyAreaPolygon(void)
 {
-    foreach (const QGeoCoordinate vertex, _polygonVertices) {
+    for (const QGeoCoordinate vertex: _polygonVertices) {
         _transectStyleItem->surveyAreaPolygon()->appendVertex(vertex);
     }
 }
@@ -132,7 +132,7 @@ void TransectStyleComplexItemTest::_testRebuildTransects(void)
             << _transectStyleItem->refly90Degrees()
             << _transectStyleItem->cameraCalc()->frontalOverlap()
             << _transectStyleItem->cameraCalc()->sideOverlap();
-    foreach(Fact* fact, rgFacts) {
+    for(Fact* fact: rgFacts) {
         qDebug() << fact->name();
         changeFactValue(fact);
         QVERIFY(_transectStyleItem->rebuildTransectsPhase1Called);
@@ -175,7 +175,7 @@ void TransectStyleComplexItemTest::_testDistanceSignalling(void)
     rgFacts << _transectStyleItem->turnAroundDistance()
             << _transectStyleItem->hoverAndCapture()
             << _transectStyleItem->refly90Degrees();
-    foreach(Fact* fact, rgFacts) {
+    for(Fact* fact: rgFacts) {
         qDebug() << fact->name();
         changeFactValue(fact);
         QVERIFY(_multiSpy->checkSignalsByMask(complexDistanceChangedMask | greatestDistanceToChangedMask));

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -70,7 +70,7 @@ QStringList ParameterEditorController::searchParameters(const QString& searchTex
 {
     QStringList list;
     
-    foreach(const QString &paramName, _vehicle->parameterManager()->parameterNames(_vehicle->defaultComponentId())) {
+    for(const QString &paramName: _vehicle->parameterManager()->parameterNames(_vehicle->defaultComponentId())) {
         if (searchText.isEmpty()) {
             list += paramName;
         } else {
@@ -168,11 +168,11 @@ void ParameterEditorController::_updateParameters(void)
 
     if (searchItems.isEmpty()) {
         const QMap<QString, QMap<QString, QStringList> >& categoryMap = _vehicle->parameterManager()->getCategoryMap();
-        foreach (const QString& parameter, categoryMap[_currentCategory][_currentGroup]) {
+        for (const QString& parameter: categoryMap[_currentCategory][_currentGroup]) {
             newParameterList.append(_vehicle->parameterManager()->getParameter(_vehicle->defaultComponentId(), parameter));
         }
     } else {
-        foreach(const QString &parameter, _vehicle->parameterManager()->parameterNames(_vehicle->defaultComponentId())) {
+        for(const QString &parameter: _vehicle->parameterManager()->parameterNames(_vehicle->defaultComponentId())) {
             Fact* fact = _vehicle->parameterManager()->getParameter(_vehicle->defaultComponentId(), parameter);
             bool matched = true;
 

--- a/src/QmlControls/QGCFileDialogController.cc
+++ b/src/QmlControls/QGCFileDialogController.cc
@@ -24,13 +24,13 @@ QStringList QGCFileDialogController::getFiles(const QString& directoryPath, cons
     QDir fileDir(directoryPath);
 
     QStringList infoListExtensions;
-    foreach (const QString& extension, fileExtensions) {
+    for (const QString& extension: fileExtensions) {
         infoListExtensions.append(QStringLiteral("*.%1").arg(extension));
     }
 
     QFileInfoList fileInfoList = fileDir.entryInfoList(infoListExtensions,  QDir::Files, QDir::Name);
 
-    foreach (const QFileInfo& fileInfo, fileInfoList) {
+    for (const QFileInfo& fileInfo: fileInfoList) {
         qCDebug(QGCFileDialogControllerLog) << "getFiles found" << fileInfo.fileName();
         files << fileInfo.fileName();
     }

--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -183,7 +183,7 @@ void QmlObjectListModel::insert(int i, QList<QObject*> objects)
     }
 
     int j = i;
-    foreach (QObject* object, objects) {
+    for (QObject* object: objects) {
         QQmlEngine::setObjectOwnership(object, QQmlEngine::CppOwnership);
 
         // Look for a dirtyChanged signal on the object
@@ -233,7 +233,7 @@ void QmlObjectListModel::setDirty(bool dirty)
         _dirty = dirty;
         if (!dirty) {
             // Need to clear dirty from all children
-            foreach(QObject* object, _objectList) {
+            for(QObject* object: _objectList) {
                 if (object->property("dirty").isValid()) {
                     object->setProperty("dirty", false);
                 }

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -71,7 +71,7 @@ VideoSettings::VideoSettings(QObject* parent)
 #endif
 #ifndef QGC_DISABLE_UVC
     QList<QCameraInfo> cameras = QCameraInfo::availableCameras();
-    foreach (const QCameraInfo &cameraInfo, cameras) {
+    for (const QCameraInfo &cameraInfo: cameras) {
         videoSourceList.append(cameraInfo.description());
     }
 #endif
@@ -82,7 +82,7 @@ VideoSettings::VideoSettings(QObject* parent)
         videoSourceList.insert(0, videoDisabled);
     }
     QVariantList videoSourceVarList;
-    foreach (const QString& videoSource, videoSourceList) {
+    for (const QString& videoSource: videoSourceList) {
         videoSourceVarList.append(QVariant::fromValue(videoSource));
     }
     _nameToMetaDataMap[videoSourceName]->setEnumInfo(videoSourceList, videoSourceVarList);

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -46,7 +46,7 @@ void TerrainAirMapQuery::requestCoordinateHeights(const QList<QGeoCoordinate>& c
     }
 
     QString points;
-    foreach (const QGeoCoordinate& coord, coordinates) {
+    for (const QGeoCoordinate& coord: coordinates) {
             points += QString::number(coord.latitude(), 'f', 10) + ","
                     + QString::number(coord.longitude(), 'f', 10) + ",";
     }
@@ -236,7 +236,7 @@ void TerrainAirMapQuery::_parsePathData(const QJsonValue& pathJson)
     double lonStep = stepArray[1].toDouble();
 
     QList<double> heights;
-    foreach (const QJsonValue& profileValue, profileArray) {
+    for (const QJsonValue& profileValue: profileArray) {
         heights.append(profileValue.toDouble());
     }
 
@@ -404,7 +404,7 @@ bool TerrainTileManager::_getAltitudesForCoordinates(const QList<QGeoCoordinate>
 {
     error = false;
 
-    foreach (const QGeoCoordinate& coordinate, coordinates) {
+    for (const QGeoCoordinate& coordinate: coordinates) {
         QString tileHash = _getTileHash(coordinate);
         qCDebug(TerrainQueryLog) << "TerrainTileManager::_getAltitudesForCoordinates hash:coordinate" << tileHash << coordinate;
 
@@ -451,7 +451,7 @@ void TerrainTileManager::_tileFailed(void)
 {
     QList<double>    noAltitudes;
 
-    foreach (const QueuedRequestInfo_t& requestInfo, _requestQueue) {
+    for (const QueuedRequestInfo_t& requestInfo: _requestQueue) {
         if (requestInfo.queryMode == QueryMode::QueryModeCoordinates) {
             requestInfo.terrainQueryInterface->_signalCoordinateHeights(false, noAltitudes);
         } else if (requestInfo.queryMode == QueryMode::QueryModePath) {
@@ -584,7 +584,7 @@ void TerrainAtCoordinateBatchManager::_sendNextBatch(void)
     // Convert coordinates to point strings for json query
     QList<QGeoCoordinate> coords;
     int requestQueueAdded = 0;
-    foreach (const QueuedRequestInfo_t& requestInfo, _requestQueue) {
+    for (const QueuedRequestInfo_t& requestInfo: _requestQueue) {
         SentRequestInfo_t sentRequestInfo = { requestInfo.terrainAtCoordinateQuery, false, requestInfo.coordinates.count() };
         _sentRequests.append(sentRequestInfo);
         coords += requestInfo.coordinates;
@@ -604,7 +604,7 @@ void TerrainAtCoordinateBatchManager::_batchFailed(void)
 {
     QList<double> noHeights;
 
-    foreach (const SentRequestInfo_t& sentRequestInfo, _sentRequests) {
+    for (const SentRequestInfo_t& sentRequestInfo: _sentRequests) {
         if (!sentRequestInfo.queryObjectDestroyed) {
             disconnect(sentRequestInfo.terrainAtCoordinateQuery, &TerrainAtCoordinateQuery::destroyed, this, &TerrainAtCoordinateBatchManager::_queryObjectDestroyed);
             sentRequestInfo.terrainAtCoordinateQuery->_signalTerrainData(false, noHeights);
@@ -663,7 +663,7 @@ void TerrainAtCoordinateBatchManager::_coordinateHeights(bool success, QList<dou
     }
 
     int currentIndex = 0;
-    foreach (const SentRequestInfo_t& sentRequestInfo, _sentRequests) {
+    for (const SentRequestInfo_t& sentRequestInfo: _sentRequests) {
         if (!sentRequestInfo.queryObjectDestroyed) {
             qCDebug(TerrainQueryVerboseLog) << "TerrainAtCoordinateBatchManager::_coordinateHeights returned TerrainCoordinateQuery:count" <<  sentRequestInfo.terrainAtCoordinateQuery << sentRequestInfo.cCoord;
             disconnect(sentRequestInfo.terrainAtCoordinateQuery, &TerrainAtCoordinateQuery::destroyed, this, &TerrainAtCoordinateBatchManager::_queryObjectDestroyed);
@@ -730,7 +730,7 @@ void TerrainPolyPathQuery::requestData(const QVariantList& polyPath)
 {
     QList<QGeoCoordinate> path;
 
-    foreach (const QVariant& geoVar, polyPath) {
+    for (const QVariant& geoVar: polyPath) {
         path.append(geoVar.value<QGeoCoordinate>());
     }
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2004,7 +2004,7 @@ bool Vehicle::xConfigMotors(void)
 QString Vehicle::formatedMessages()
 {
     QString messages;
-    foreach(UASMessage* message, _toolbox->uasMessageHandler()->messages()) {
+    for(UASMessage* message: _toolbox->uasMessageHandler()->messages()) {
         messages += message->getFormatedText();
     }
     return messages;
@@ -2281,7 +2281,7 @@ QString Vehicle::priorityLinkName(void) const
 QVariantList Vehicle::links(void) const {
     QVariantList ret;
 
-    foreach( const auto &item, _links )
+    for( const auto &item: _links )
         ret << QVariant::fromValue(item);
 
     return ret;

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -354,7 +354,7 @@ void FirmwareUpgradeController::_initFirmwareHash()
 #endif
 
     // PX4 Firmwares
-    foreach (const FirmwareType_t& firmwareType, px4MapFirmwareTypeToDir.keys()) {
+    for (const FirmwareType_t& firmwareType: px4MapFirmwareTypeToDir.keys()) {
         QString dir = px4MapFirmwareTypeToDir[firmwareType];
         _rgPX4FMUV5Firmware.insert      (FirmwareIdentifier(AutoPilotStackPX4, firmwareType, DefaultVehicleFirmware), px4Url.arg(dir).arg("v5"));
         _rgPX4FMUV4PROFirmware.insert   (FirmwareIdentifier(AutoPilotStackPX4, firmwareType, DefaultVehicleFirmware), px4Url.arg(dir).arg("v4pro"));
@@ -365,9 +365,9 @@ void FirmwareUpgradeController::_initFirmwareHash()
 
 #if !defined(NO_ARDUPILOT_DIALECT)
     // ArduPilot Firmwares
-    foreach (const FirmwareType_t& firmwareType, apmMapFirmwareTypeToDir.keys()) {
+    for (const FirmwareType_t& firmwareType: apmMapFirmwareTypeToDir.keys()) {
         QString firmwareTypeDir = apmMapFirmwareTypeToDir[firmwareType];
-        foreach (const FirmwareVehicleType_t& vehicleType, apmMapVehicleTypeToDir.keys()) {
+        for (const FirmwareVehicleType_t& vehicleType: apmMapVehicleTypeToDir.keys()) {
             QString vehicleTypeDir = apmMapVehicleTypeToDir[vehicleType];
             QString px4Dir = apmMapVehicleTypeToPX4Dir[vehicleType];
             QString filename = apmMapVehicleTypeToFilename[vehicleType];
@@ -382,9 +382,9 @@ void FirmwareUpgradeController::_initFirmwareHash()
 
 #if !defined(NO_ARDUPILOT_DIALECT)
     // ArduPilot ChibiOS Firmwares
-    foreach (const FirmwareType_t& firmwareType, apmMapFirmwareTypeToDir.keys()) {
+    for (const FirmwareType_t& firmwareType: apmMapFirmwareTypeToDir.keys()) {
         QString firmwareTypeDir = apmMapFirmwareTypeToDir[firmwareType];
-        foreach (const FirmwareVehicleType_t& vehicleType, apmChibiOSMapVehicleTypeToDir.keys()) {
+        for (const FirmwareVehicleType_t& vehicleType: apmChibiOSMapVehicleTypeToDir.keys()) {
             QString vehicleTypeDir = apmChibiOSMapVehicleTypeToDir[vehicleType];
             QString fmuDir = apmChibiOSMapVehicleTypeToFmuDir[vehicleType];
             QString filename = apmChibiOSMapVehicleTypeToFilename[vehicleType];
@@ -692,7 +692,7 @@ void FirmwareUpgradeController::_loadAPMVersions(uint32_t bootloaderBoardID)
 
     QHash<FirmwareIdentifier, QString>* prgFirmware = _firmwareHashForBoardId(static_cast<int>(bootloaderBoardID));
 
-    foreach (FirmwareIdentifier firmwareId, prgFirmware->keys()) {
+    for (FirmwareIdentifier firmwareId: prgFirmware->keys()) {
         if (firmwareId.autopilotStackType == AutoPilotStackAPM) {
             QString versionFile = QFileInfo(prgFirmware->value(firmwareId)).path() + "/git-version.txt";
 
@@ -733,7 +733,7 @@ void FirmwareUpgradeController::_apmVersionDownloadFinished(QString remoteFile, 
     QHash<FirmwareIdentifier, QString>* prgFirmware = _firmwareHashForBoardId(static_cast<int>(_bootloaderBoardID));
 
     QString remotePath = QFileInfo(remoteFile).path();
-    foreach (FirmwareIdentifier firmwareId, prgFirmware->keys()) {
+    for (FirmwareIdentifier firmwareId: prgFirmware->keys()) {
         if (remotePath == QFileInfo((*prgFirmware)[firmwareId]).path()) {
             qCDebug(FirmwareUpgradeLog) << "Adding version to map, version:firwmareType:vehicleType" << version << firmwareId.firmwareType << firmwareId.firmwareVehicleType;
             _apmVersionMap[firmwareId.firmwareType][firmwareId.firmwareVehicleType] = version;
@@ -761,7 +761,7 @@ QStringList FirmwareUpgradeController::apmAvailableVersions(void)
 
     _apmVehicleTypeFromCurrentVersionList.clear();
 
-    foreach (FirmwareVehicleType_t vehicleType, vehicleTypes) {
+    for (FirmwareVehicleType_t vehicleType: vehicleTypes) {
         if (_apmVersionMap[_selectedFirmwareType].contains(vehicleType)) {
             QString version;
 

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
@@ -119,7 +119,7 @@ void PX4FirmwareUpgradeThreadWorker::_findBoardOnce(void)
 
 bool PX4FirmwareUpgradeThreadWorker::_findBoardFromPorts(QGCSerialPortInfo& portInfo, QGCSerialPortInfo::BoardType_t& boardType, QString& boardName)
 {
-    foreach (QGCSerialPortInfo info, QGCSerialPortInfo::availablePorts()) {
+    for (QGCSerialPortInfo info: QGCSerialPortInfo::availablePorts()) {
         info.getBoardInfo(boardType, boardName);
 
         qCDebug(FirmwareUpgradeVerboseLog) << "Serial Port --------------";

--- a/src/VehicleSetup/VehicleComponent.cc
+++ b/src/VehicleSetup/VehicleComponent.cc
@@ -54,7 +54,7 @@ void VehicleComponent::addSummaryQmlComponent(QQmlContext* context, QQuickItem* 
 void VehicleComponent::setupTriggerSignals(void)
 {
     // Watch for changed on trigger list params
-    foreach (const QString &paramName, setupCompleteChangedTriggerList()) {
+    for (const QString &paramName: setupCompleteChangedTriggerList()) {
         if (_vehicle->parameterManager()->parameterExists(FactSystem::defaultComponentId, paramName)) {
             Fact* fact = _vehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, paramName);
             connect(fact, &Fact::valueChanged, this, &VehicleComponent::_triggerUpdated);

--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -340,7 +340,7 @@ void BluetoothConfiguration::deviceDiscovered(QBluetoothDeviceInfo info)
         qDebug() << "Address:        " << info.address().toString();
         qDebug() << "Service Classes:" << info.serviceClasses();
         QList<QBluetoothUuid> uuids = info.serviceUuids();
-        foreach (QBluetoothUuid uuid, uuids) {
+        for (QBluetoothUuid uuid: uuids) {
             qDebug() << "Service UUID:   " << uuid.toString();
         }
 #endif
@@ -373,7 +373,7 @@ void BluetoothConfiguration::doneScanning()
 
 void BluetoothConfiguration::setDevName(const QString &name)
 {
-    foreach(const BluetoothData& data, _deviceList)
+    for(const BluetoothData& data: _deviceList)
     {
         if(data.name == name)
         {

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -497,7 +497,7 @@ void LinkManager::_updateAutoConnectLinks(void)
 #endif
 
     // Iterate Comm Ports
-    foreach (QGCSerialPortInfo portInfo, portList) {
+    for (QGCSerialPortInfo portInfo: portList) {
         qCDebug(LinkManagerVerboseLog) << "-----------------------------------------------------";
         qCDebug(LinkManagerVerboseLog) << "portName:          " << portInfo.portName();
         qCDebug(LinkManagerVerboseLog) << "systemLocation:    " << portInfo.systemLocation();
@@ -638,7 +638,7 @@ void LinkManager::_updateAutoConnectLinks(void)
     }
 
     // Now remove all configs that are gone
-    foreach (LinkConfiguration* pDeleteConfig, _confToDelete) {
+    for (LinkConfiguration* pDeleteConfig: _confToDelete) {
         qCDebug(LinkManagerLog) << "Removing unused autoconnect config" << pDeleteConfig->name();
         if (pDeleteConfig->link()) {
             disconnectLink(pDeleteConfig->link());
@@ -703,7 +703,7 @@ void LinkManager::_updateSerialPorts()
     _commPortDisplayList.clear();
 #ifndef NO_SERIAL_LINK
     QList<QSerialPortInfo> portList = QSerialPortInfo::availablePorts();
-    foreach (const QSerialPortInfo &info, portList)
+    for (const QSerialPortInfo &info: portList)
     {
         QString port = info.systemLocation().trimmed();
         _commPortList += port;

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -453,7 +453,7 @@ void MAVLinkProtocol::checkForLostLogFiles(void)
     QFileInfoList fileInfoList = tempDir.entryInfoList(QStringList(filter), QDir::Files);
     //qDebug() << "Orphaned log file count" << fileInfoList.count();
 
-    foreach(const QFileInfo fileInfo, fileInfoList) {
+    for(const QFileInfo fileInfo: fileInfoList) {
         //qDebug() << "Orphaned log file" << fileInfo.filePath();
         if (fileInfo.size() == 0) {
             // Delete all zero length files
@@ -476,7 +476,7 @@ void MAVLinkProtocol::deleteTempLogFiles(void)
     QString filter(QString("*.%1").arg(_logFileExtension));
     QFileInfoList fileInfoList = tempDir.entryInfoList(QStringList(filter), QDir::Files);
 
-    foreach(const QFileInfo fileInfo, fileInfoList) {
+    for(const QFileInfo fileInfo: fileInfoList) {
         QFile::remove(fileInfo.filePath());
     }
 }

--- a/src/comm/QGCFlightGearLink.cc
+++ b/src/comm/QGCFlightGearLink.cc
@@ -956,7 +956,7 @@ void QGCFlightGearLink::_printFgfsOutput(void)
    QByteArray byteArray = _fgProcess->readAllStandardOutput();
    QStringList strLines = QString(byteArray).split("\n");
 
-   foreach (const QString &line, strLines){
+   for (const QString &line: strLines){
     qDebug() << line;
    }
 }
@@ -968,7 +968,7 @@ void QGCFlightGearLink::_printFgfsError(void)
    QByteArray byteArray = _fgProcess->readAllStandardError();
    QStringList strLines = QString(byteArray).split("\n");
 
-   foreach (const QString &line, strLines){
+   for (const QString &line: strLines){
     qDebug() << line;
    }
 }

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -252,7 +252,7 @@ QList<QGCSerialPortInfo> QGCSerialPortInfo::availablePorts(void)
 {
     QList<QGCSerialPortInfo>    list;
 
-    foreach(QSerialPortInfo portInfo, QSerialPortInfo::availablePorts()) {
+    for(QSerialPortInfo portInfo: QSerialPortInfo::availablePorts()) {
         if (!isSystemPort(&portInfo)) {
             list << *((QGCSerialPortInfo*)&portInfo);
         }

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -65,7 +65,7 @@ bool SerialLink::_isBootloader()
     if( portList.count() == 0){
         return false;
     }
-    foreach (const QSerialPortInfo &info, portList)
+    for (const QSerialPortInfo &info: portList)
     {
         qCDebug(SerialLinkLog) << "PortName    : " << info.portName() << "Description : " << info.description();
         qCDebug(SerialLinkLog) << "Manufacturer: " << info.manufacturer();

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -70,7 +70,7 @@ static QString get_ip_address(const QString& address)
 
 static bool contains_target(const QList<UDPCLient*> list, const QHostAddress& address, quint16 port)
 {
-    foreach(UDPCLient* target, list) {
+    for(UDPCLient* target: list) {
         if(target->address == address && target->port == port) {
             return true;
         }
@@ -91,7 +91,7 @@ UDPLink::UDPLink(SharedLinkConfigurationPointer& config)
     if (!_udpConfig) {
         qWarning() << "Internal error";
     }
-    foreach (const QHostAddress &address, QNetworkInterface::allAddresses()) {
+    for (const QHostAddress &address: QNetworkInterface::allAddresses()) {
         _localAddress.append(QHostAddress(address));
     }
     moveToThread(this);
@@ -156,7 +156,7 @@ bool UDPLink::_isIpLocal(const QHostAddress& add)
     // On Windows, this is a very expensive call only Redmond would know
     // why. As such, we make it once and keep the list locally. If a new
     // interface shows up after we start, it won't be on this list.
-    foreach (const QHostAddress &address, _localAddress) {
+    for (const QHostAddress &address: _localAddress) {
         if (address == add) {
             // This is a local address of the same host
             return true;
@@ -171,14 +171,14 @@ void UDPLink::_writeBytes(const QByteArray data)
         return;
     }
     // Send to all manually targeted systems
-    foreach(UDPCLient* target, _udpConfig->targetHosts()) {
+    for(UDPCLient* target: _udpConfig->targetHosts()) {
         // Skip it if it's part of the session clients below
         if(!contains_target(_sessionTargets, target->address, target->port)) {
             _writeDataGram(data, target);
         }
     }
     // Send to all connected systems
-    foreach(UDPCLient* target, _sessionTargets) {
+    for(UDPCLient* target: _sessionTargets) {
         _writeDataGram(data, target);
     }
 }
@@ -401,7 +401,7 @@ void UDPConfiguration::_copyFrom(LinkConfiguration *source)
     if (usource) {
         _localPort = usource->localPort();
         _clearTargetHosts();
-        foreach(UDPCLient* target, usource->targetHosts()) {
+        for(UDPCLient* target: usource->targetHosts()) {
             if(!contains_target(_targetHosts, target->address, target->port)) {
                 UDPCLient* newTarget = new UDPCLient(target);
                 _targetHosts.append(newTarget);

--- a/src/qgcunittest/MavlinkLogTest.cc
+++ b/src/qgcunittest/MavlinkLogTest.cc
@@ -38,7 +38,7 @@ void MavlinkLogTest::init(void)
     // Make sure temp directory is clear of mavlink logs
     QDir tmpDir(QStandardPaths::writableLocation(QStandardPaths::TempLocation));
     QStringList logFiles(tmpDir.entryList(QStringList(QString("*.%1").arg(_logFileExtension)), QDir::Files));
-    foreach(const QString &logFile, logFiles) {
+    for(const QString &logFile: logFiles) {
         bool success = tmpDir.remove(logFile);
         Q_UNUSED(success);
         Q_ASSERT(success);

--- a/src/qgcunittest/RadioConfigTest.cc
+++ b/src/qgcunittest/RadioConfigTest.cc
@@ -207,7 +207,7 @@ void RadioConfigTest::_init(MAV_AUTOPILOT firmwareType)
 
     // Find the radio component
     QObject* vehicleComponent = NULL;
-    foreach (const QVariant& varVehicleComponent, _autopilot->vehicleComponents()) {
+    for (const QVariant& varVehicleComponent: _autopilot->vehicleComponents()) {
         if (firmwareType == MAV_AUTOPILOT_PX4) {
             PX4RadioComponent* radioComponent = qobject_cast<PX4RadioComponent*>(varVehicleComponent.value<VehicleComponent*>());
             if (radioComponent) {
@@ -370,7 +370,7 @@ void RadioConfigTest::_fullCalibrationWorker(MAV_AUTOPILOT firmwareType)
                     QStringList switchList;
                     switchList << "RC_MAP_MODE_SW" << "RC_MAP_LOITER_SW" << "RC_MAP_RETURN_SW" << "RC_MAP_POSCTL_SW" << "RC_MAP_ACRO_SW";
 
-                    foreach (const QString &switchParam, switchList) {
+                    for (const QString &switchParam: switchList) {
                         Q_ASSERT(_vehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, switchParam)->rawValue().toInt() != channel + 1);
                     }
                 }

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -81,7 +81,7 @@ int UnitTest::run(QString& singleTest)
 {
     int ret = 0;
     
-    foreach (QObject* test, _testList()) {
+    for (QObject* test: _testList()) {
         if (singleTest.isEmpty() || singleTest == test->objectName()) {
             QStringList args;
             args << "*" << "-maxwarnings" << "0";

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -347,7 +347,7 @@ bool MainWindow::_createInnerDockWidget(const QString& widgetName)
 
 void MainWindow::_hideAllDockWidgets(void)
 {
-    foreach(QGCDockWidget* dockWidget, _mapName2DockWidget) {
+    for(QGCDockWidget* dockWidget: _mapName2DockWidget) {
         dockWidget->setVisible(false);
     }
 }
@@ -448,7 +448,7 @@ void MainWindow::_vehicleAdded(Vehicle* vehicle)
 void MainWindow::_storeCurrentViewState(void)
 {
 #ifndef __mobile__
-    foreach(QGCDockWidget* dockWidget, _mapName2DockWidget) {
+    for(QGCDockWidget* dockWidget: _mapName2DockWidget) {
         dockWidget->saveSettings();
     }
 #endif
@@ -482,7 +482,7 @@ void MainWindow::_loadVisibleWidgetsSettings(void)
     if (!widgets.isEmpty()) {
         QStringList nameList = widgets.split(",");
 
-        foreach (const QString &name, nameList) {
+        for (const QString &name: nameList) {
             _showDockWidget(name, true);
         }
     }
@@ -493,7 +493,7 @@ void MainWindow::_storeVisibleWidgetsSettings(void)
     QString widgetNames;
     bool firstWidget = true;
 
-    foreach (const QString &name, _mapName2DockWidget.keys()) {
+    for (const QString &name: _mapName2DockWidget.keys()) {
         if (_mapName2DockWidget[name]->isVisible()) {
             if (!firstWidget) {
                 widgetNames += ",";

--- a/src/ui/QGCMAVLinkInspector.cc
+++ b/src/ui/QGCMAVLinkInspector.cc
@@ -83,7 +83,7 @@ void QGCMAVLinkInspector::rebuildComponentList()
     {
         UASInterface* uas = vehicle->uas();
         QMap<int, QString> components = uas->getComponents();
-        foreach (int id, components.keys())
+        for (int id: components.keys())
         {
             QString name = components.value(id);
             ui->componentComboBox->addItem(name, id);


### PR DESCRIPTION
c++11 fix temporary containers to be created needlessly, also c++11 for or normal range loops is prefered over `foreach` since the compiler generates less and more optimized code for this ones.
Reference:
https://www.kdab.com/goodbye-q_foreach/