### PR TITLE
Do not call QString(char*) to build empty string. 

### DIFF
--- a/src/QGCQFileDialog.cc
+++ b/src/QGCQFileDialog.cc
@@ -159,7 +159,7 @@ QString QGCQFileDialog::getSaveFileName(
             }
             break;
         }
-        return QString("");
+        return {};
     }
 }
 
@@ -190,7 +190,7 @@ QString QGCQFileDialog::_getFirstExtensionInFilter(const QString& filter) {
             return match.captured(0).mid(2);
         }
     }
-    return QString("");
+    return {};
 }
 
 /// @brief Validates and updates the parameters for the file dialog calls

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -435,7 +435,7 @@ UrlFactory::_getURL(MapType type, int x, int y, int zoom, QNetworkAccessManager*
         int y_max = 26 * pow(2, gap) + (2*gap - 1);
 
         if ( zoom > 19 ) {
-            return QString("");
+            return {};
         }
         else if ( zoom > 5 && x >= x_min && x <= x_max && y >= y_min && y <= y_max ) {
             return QString("http://xdworld.vworld.kr:8080/2d/Base/service/%1/%2/%3.png").arg(zoom).arg(x).arg(y);
@@ -458,7 +458,7 @@ UrlFactory::_getURL(MapType type, int x, int y, int zoom, QNetworkAccessManager*
         int y_max = 26 * pow(2, gap) + (2*gap - 1);
 
         if ( zoom > 19 ) {
-            return QString("");
+            return {};
         }
         else if ( zoom > 5 && x >= x_min && x <= x_max && y >= y_min && y <= y_max ) {
             return QString("http://xdworld.vworld.kr:8080/2d/Satellite/service/%1/%2/%3.jpeg").arg(zoom).arg(x).arg(y);

--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -390,7 +390,7 @@ void BluetoothConfiguration::setDevName(const QString &name)
 QString BluetoothConfiguration::address()
 {
 #ifdef __ios__
-    return QString("");
+    return {};
 #else
     return _device.address;
 #endif

--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -263,7 +263,7 @@ static QString get_ip_address(const QString& address)
             }
         }
     }
-    return QString("");
+    return {};
 }
 
 TCPConfiguration::TCPConfiguration(const QString& name) : LinkConfiguration(name)

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -65,7 +65,7 @@ static QString get_ip_address(const QString& address)
             }
         }
     }
-    return QString("");
+    return {};
 }
 
 static bool contains_target(const QList<UDPCLient*> list, const QHostAddress& address, quint16 port)


### PR DESCRIPTION
This removes unnecessary build of empty strings before copy. 