### PR TITLE
Add ArduSub capabilities

### DIFF
--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -174,6 +174,12 @@ void ArduSubFirmwarePlugin::initializeStreamRates(Vehicle* vehicle) {
     vehicle->requestDataStream(MAV_DATA_STREAM_EXTRA3,          3);
 }
 
+bool ArduSubFirmwarePlugin::isCapable(const Vehicle* vehicle, FirmwareCapabilities capabilities)
+{
+    Q_UNUSED(vehicle);
+    uint32_t available = SetFlightModeCapability | PauseVehicleCapability;
+    return (capabilities & available) == capabilities;
+}
 
 bool ArduSubFirmwarePlugin::supportsThrottleModeCenterZero(void)
 {

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -117,6 +117,8 @@ public:
 
     void initializeStreamRates(Vehicle* vehicle) override final;
 
+    bool isCapable(const Vehicle *vehicle, FirmwareCapabilities capabilities) final;
+
     bool supportsThrottleModeCenterZero(void) final;
 
     bool supportsRadio(void) final;


### PR DESCRIPTION
This disables the guided functions in QGC for sub, such as the "fly" toolbar.