### PR TITLE
MavLinkProtocol: Fix constructor warnings

### DIFF
--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -53,6 +53,8 @@ const char* MAVLinkProtocol::_logFileExtension = "mavlink";             ///< Ext
 MAVLinkProtocol::MAVLinkProtocol(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
     , m_enable_version_check(true)
+    , _message({})
+    , _status({})
     , versionMismatchIgnore(false)
     , systemId(255)
     , _current_version(100)

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -108,8 +108,8 @@ protected:
     uint64_t    totalLossCounter[MAVLINK_COMM_NUM_BUFFERS];     ///< Total messages lost during transmission.
     float       runningLossPercent[MAVLINK_COMM_NUM_BUFFERS];   ///< Loss rate
 
-    mavlink_message_t _message = {};
-    mavlink_status_t _status   = {};
+    mavlink_message_t _message;
+    mavlink_status_t _status;
 
     bool        versionMismatchIgnore;
     int         systemId;


### PR DESCRIPTION
This fix more than 8k warnings messages.
https://api.travis-ci.org/v3/job/446387610/log.txt
![screenshot from 2018-10-25 19-06-51](https://user-images.githubusercontent.com/1215497/47533261-79c6f000-d889-11e8-82fb-bc65755df132.png)
