### PR TITLE
ArduPilot: Compass auto rot support

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
@@ -43,7 +43,7 @@ FactPanel {
 
         VehicleSummaryRow {
             labelText:  qsTr("Throttle failsafe:")
-            valueText:  Fact.enumStringValue
+            valueText:  fact.enumStringValue
             visible:    controller.vehicle.multiRotor
 
             property Fact fact: controller.getParameterFact(-1, "FS_THR_ENABLE", false /* reportMissing */)

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -79,6 +79,9 @@ SetupPage {
             property int    _orientationDialogCalType
             property var    _activeVehicle:                 QGroundControl.multiVehicleManager.activeVehicle
             property real   _margins:                       ScreenTools.defaultFontPixelHeight / 2
+            property bool   _compassAutoRotAvailable:       controller.parameterExists(-1, "COMPASS_AUTO_ROT")
+            property Fact   _compassAutoRotFact:            controller.getParameterFact(-1, "COMPASS_AUTO_ROT", false /* reportMissing */)
+            property bool   _compassAutoRot:                _compassAutoRotAvailable ? _compassAutoRotFact.rawValue == 2 : false
 
             function showOrientationsDialog(calType) {
                 var dialogTitle
@@ -346,7 +349,7 @@ SetupPage {
                         }
 
                         Column {
-                            visible: sensorParams.rgCompassExternal[index] && sensorParams.rgCompassRotParamAvailable[index]
+                            visible: !_compassAutoRot && sensorParams.rgCompassExternal[index] && sensorParams.rgCompassRotParamAvailable[index]
 
                             QGCLabel { text: qsTr("Orientation:") }
 

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -371,7 +371,6 @@ void FirmwareUpgradeController::_initFirmwareHash()
             QString vehicleTypeDir = apmMapVehicleTypeToDir[vehicleType];
             QString px4Dir = apmMapVehicleTypeToPX4Dir[vehicleType];
             QString filename = apmMapVehicleTypeToFilename[vehicleType];
-            qDebug() << firmwareTypeDir << vehicleTypeDir << px4Dir << filename;
             _rgPX4FMUV5Firmware.insert  (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg(px4Dir).arg(filename).arg("5"));
             _rgPX4FMUV4Firmware.insert  (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg(px4Dir).arg(filename).arg("4"));
             _rgPX4FMUV3Firmware.insert  (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg(px4Dir).arg(filename).arg("3"));
@@ -388,7 +387,6 @@ void FirmwareUpgradeController::_initFirmwareHash()
             QString vehicleTypeDir = apmChibiOSMapVehicleTypeToDir[vehicleType];
             QString fmuDir = apmChibiOSMapVehicleTypeToFmuDir[vehicleType];
             QString filename = apmChibiOSMapVehicleTypeToFilename[vehicleType];
-            qDebug() << firmwareTypeDir << vehicleTypeDir << fmuDir << filename;
             _rgPX4FMUV5Firmware.insert      (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmChibiOSUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg("5").arg(fmuDir).arg(filename));
             _rgPX4FMUV4Firmware.insert      (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmChibiOSUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg("4").arg(fmuDir).arg(filename));
             _rgPX4FMUV3Firmware.insert      (FirmwareIdentifier(AutoPilotStackAPM, firmwareType, vehicleType), apmChibiOSUrl.arg(vehicleTypeDir).arg(firmwareTypeDir).arg("3").arg(fmuDir).arg(filename));


### PR DESCRIPTION
If COMPASS_AUTO_ROT is set to automatically set orientations don't show user orientation setting ui.