### PR TITLE
Android crash fix

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -669,7 +669,9 @@ void QGCApplication::_missingParamsDisplay(void)
 QObject* QGCApplication::_rootQmlObject()
 {
 #ifdef __mobile__
-    return _qmlAppEngine->rootObjects()[0];
+    if(_qmlAppEngine && _qmlAppEngine->rootObjects().size())
+        return _qmlAppEngine->rootObjects()[0];
+    return nullptr;
 #else
     MainWindow * mainWindow = MainWindow::instance();
     if (mainWindow) {
@@ -711,12 +713,16 @@ void QGCApplication::showMessage(const QString& message)
 
 void QGCApplication::showSetupView(void)
 {
-    QMetaObject::invokeMethod(_rootQmlObject(), "showSetupView");
+    if(_rootQmlObject()) {
+        QMetaObject::invokeMethod(_rootQmlObject(), "showSetupView");
+    }
 }
 
 void QGCApplication::qmlAttemptWindowClose(void)
 {
-    QMetaObject::invokeMethod(_rootQmlObject(), "attemptWindowClose");
+    if(_rootQmlObject()) {
+        QMetaObject::invokeMethod(_rootQmlObject(), "attemptWindowClose");
+    }
 }
 
 bool QGCApplication::isInternetAvailable()

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -68,6 +68,8 @@ MAVLinkProtocol::MAVLinkProtocol(QGCApplication* app, QGCToolbox* toolbox)
     memset(totalLossCounter,    0, sizeof(totalLossCounter));
     memset(runningLossPercent,  0, sizeof(runningLossPercent));
     memset(firstMessage,        1, sizeof(firstMessage));
+    memset(&_status,            0, sizeof(_status));
+    memset(&_message,           0, sizeof(_message));
 }
 
 MAVLinkProtocol::~MAVLinkProtocol()

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -108,8 +108,8 @@ protected:
     uint64_t    totalLossCounter[MAVLINK_COMM_NUM_BUFFERS];     ///< Total messages lost during transmission.
     float       runningLossPercent[MAVLINK_COMM_NUM_BUFFERS];   ///< Loss rate
 
-    mavlink_message_t _message = {};
-    mavlink_status_t _status   = {};
+    mavlink_message_t _message;
+    mavlink_status_t _status;
 
     bool        versionMismatchIgnore;
     int         systemId;

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -504,7 +504,7 @@ QGCView {
                             Item { width: rtkGrid.firstColWidth; height: 1 }
                             QGCButton {
                                 text:               qsTr("Save Current Base Position")
-                                enabled:            QGroundControl.gpsRtk.valid.value
+                                enabled:            QGroundControl.gpsRtk && QGroundControl.gpsRtk.valid.value
                                 Layout.columnSpan:  2
 
                                 onClicked: {


### PR DESCRIPTION
This fixes the crash on boot on Android (any mobile actually).

This would only happen the first time you were to run QGC on a device. 

Also getting rid of some build warnings while at it.