### PR TITLE
Feature: Concave Polygon Support by Splitting into Sub-Polygons

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ Note: This file only contains high level features or important fixes.
 * Make Heading to Home available for display from instrument panel.
 * Edit Position dialog available on polygon vertices.
 * Fixed Wing Landing Pattern: Add stop photo/video support. Defaults to on such that doing an RTL will stop camera.
+* Survey Planning: add mode that supports concave polygons
 
 ## 3.4
 

--- a/src/MissionManager/Survey.SettingsGroup.json
+++ b/src/MissionManager/Survey.SettingsGroup.json
@@ -14,5 +14,11 @@
     "shortDescription": "Fly every other transect in each pass.",
     "type":             "bool",
     "defaultValue":     false
+},
+{
+    "name":             "SplitConcavePolygons",
+    "shortDescription": "Split mission concave polygons into separate regular, convex polygons.",
+    "type":             "bool",
+    "defaultValue":     true
 }
 ]

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1117,12 +1117,17 @@ void SurveyComplexItem::_rebuildTransectsPhase1Worker(bool refly)
 
     // Create list of separate polygons
     QList<QPolygonF> polygons;
-    polygons << polygon;
+    _PolygonDecomposeConvex(polygon, polygons);
 
     // iterate over polygons
     for (const auto& p : polygons) {
         _rebuildTranscetsFromPolygon(refly, p, tangentOrigin);
     }
+}
+
+void SurveyComplexItem::_PolygonDecomposeConvex(const QPolygonF& polygon, QList<QPolygonF>& polygons)
+{
+    polygons << polygon;
 }
 
 void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin)

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1068,6 +1068,11 @@ void SurveyComplexItem::_rebuildTransectsPhase1(void)
 
 void SurveyComplexItem::_rebuildTransectsPhase1Worker(bool refly)
 {
+    _rebuildTranscetsFromPolygon(refly);
+}
+
+void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly)
+{
     if (_ignoreRecalc) {
         return;
     }

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1068,11 +1068,6 @@ void SurveyComplexItem::_rebuildTransectsPhase1(void)
 
 void SurveyComplexItem::_rebuildTransectsPhase1Worker(bool refly)
 {
-    _rebuildTranscetsFromPolygon(refly);
-}
-
-void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly)
-{
     if (_ignoreRecalc) {
         return;
     }
@@ -1112,6 +1107,19 @@ void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly)
         qCDebug(SurveyComplexItemLog) << "_rebuildTransectsPhase1 vertex:x:y" << vertex << polygonPoints.last().x() << polygonPoints.last().y();
     }
 
+    // convert into QPolygonF
+    QPolygonF polygon;
+    for (int i=0; i<polygonPoints.count(); i++) {
+        qCDebug(SurveyComplexItemLog) << "Vertex" << polygonPoints[i];
+        polygon << polygonPoints[i];
+    }
+    polygon << polygonPoints[0];
+
+    _rebuildTranscetsFromPolygon(refly, polygon, tangentOrigin);
+}
+
+void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin)
+{
     // Generate transects
 
     double gridAngle = _gridAngleFact.rawValue().toDouble();
@@ -1126,12 +1134,6 @@ void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly)
     // Convert polygon to bounding rect
 
     qCDebug(SurveyComplexItemLog) << "_rebuildTransectsPhase1 Polygon";
-    QPolygonF polygon;
-    for (int i=0; i<polygonPoints.count(); i++) {
-        qCDebug(SurveyComplexItemLog) << "Vertex" << polygonPoints[i];
-        polygon << polygonPoints[i];
-    }
-    polygon << polygonPoints[0];
     QRectF boundingRect = polygon.boundingRect();
     QPointF boundingCenter = boundingRect.center();
     qCDebug(SurveyComplexItemLog) << "Bounding rect" << boundingRect.topLeft().x() << boundingRect.topLeft().y() << boundingRect.bottomRight().x() << boundingRect.bottomRight().y();

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1113,14 +1113,17 @@ void SurveyComplexItem::_rebuildTransectsPhase1Worker(bool refly)
         qCDebug(SurveyComplexItemLog) << "Vertex" << polygonPoints[i];
         polygon << polygonPoints[i];
     }
-    polygon << polygonPoints[0];
 
     // Create list of separate polygons
     QList<QPolygonF> polygons;
     _PolygonDecomposeConvex(polygon, polygons);
 
     // iterate over polygons
-    for (const auto& p : polygons) {
+    for (auto& p : polygons) {
+        // close polygon
+        p << p.front();
+        // build transects for this polygon
+        // TODO figure out tangent origin
         _rebuildTranscetsFromPolygon(refly, p, tangentOrigin);
     }
 }

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1115,7 +1115,14 @@ void SurveyComplexItem::_rebuildTransectsPhase1Worker(bool refly)
     }
     polygon << polygonPoints[0];
 
-    _rebuildTranscetsFromPolygon(refly, polygon, tangentOrigin);
+    // Create list of separate polygons
+    QList<QPolygonF> polygons;
+    polygons << polygon;
+
+    // iterate over polygons
+    for (const auto& p : polygons) {
+        _rebuildTranscetsFromPolygon(refly, p, tangentOrigin);
+    }
 }
 
 void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin)

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -89,6 +89,8 @@ SurveyComplexItem::SurveyComplexItem(Vehicle* vehicle, bool flyView, const QStri
     connect(&_flyAlternateTransectsFact,&Fact::valueChanged,                        this, &SurveyComplexItem::_rebuildTransects);
     connect(this,                       &SurveyComplexItem::refly90DegreesChanged,  this, &SurveyComplexItem::_rebuildTransects);
 
+    connect(qgcApp()->toolbox()->settingsManager()->appSettings()->splitConcavePolygons(), &Fact::valueChanged, this, &SurveyComplexItem::_rebuildTransects);
+
     // FIXME: Shouldn't these be in TransectStyleComplexItem? They are also in CorridorScanComplexItem constructur
     connect(&_cameraCalc, &CameraCalc::distanceToSurfaceRelativeChanged, this, &SurveyComplexItem::coordinateHasRelativeAltitudeChanged);
     connect(&_cameraCalc, &CameraCalc::distanceToSurfaceRelativeChanged, this, &SurveyComplexItem::exitCoordinateHasRelativeAltitudeChanged);

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -20,6 +20,7 @@
 #include <QPolygonF>
 
 QGC_LOGGING_CATEGORY(SurveyComplexItemLog, "SurveyComplexItemLog")
+QGC_LOGGING_CATEGORY(PolygonDecomposeLog, "PolygonDecomposeLog")
 
 const char* SurveyComplexItem::jsonComplexItemTypeValue =   "survey";
 const char* SurveyComplexItem::jsonV3ComplexItemTypeValue = "survey";
@@ -1116,78 +1117,132 @@ void SurveyComplexItem::_rebuildTransectsPhase1Worker(bool refly)
 
     // Create list of separate polygons
     QList<QPolygonF> polygons{};
+    qCDebug(PolygonDecomposeLog) << "*********_PolygonDecomposeConvex begin of recursion**************";
     _PolygonDecomposeConvex(polygon, polygons);
+    qCDebug(PolygonDecomposeLog) << "polygons.size() " << polygons.size() ;
 
     // iterate over polygons
-    for (auto& p : polygons) {
+    for (auto p = polygons.begin(); p != polygons.end(); ++p) {
+        QPointF* vMatch = nullptr;
+        // find matching vertex in previous polygon
+        if (p != polygons.begin()) {
+            auto pLast = p - 1;
+            for (auto& i : *p) {
+                for (auto& j : *pLast) {
+                   if (i == j) {
+                       vMatch = &i;
+                       break;
+                   }
+                   if (vMatch) break;
+                }
+            }
+            if (nullptr == vMatch) qCDebug(PolygonDecomposeLog) << "no match found";
+
+        }
+
+
         // close polygon
-        p << p.front();
+        *p << p->front();
         // build transects for this polygon
         // TODO figure out tangent origin
-        qCDebug(SurveyComplexItemLog) << "Transects from polynom p " << p;
-        _rebuildTranscetsFromPolygon(refly, p, tangentOrigin);
+        // TODO improve selection of entry points
+//        qCDebug(SurveyComplexItemLog) << "Transects from polynom p " << p;
+        _rebuildTranscetsFromPolygon(refly, *p, tangentOrigin, vMatch);
     }
 }
 
 void SurveyComplexItem::_PolygonDecomposeConvex(const QPolygonF& polygon, QList<QPolygonF>& decomposedPolygons)
 {
-    qCDebug(SurveyComplexItemLog) << "_PolygonDecomposeConvex polygon.size() " << polygon.size();
-    if (polygon.size() < 3) return;
-
+//    qCDebug(SurveyComplexItemLog) << "_PolygonDecomposeConvex polygon.size() " << polygon.size();
     int decompSize = std::numeric_limits<int>::max();
+    if (polygon.size() < 3) return;
+    if (polygon.size() == 3) {
+        decomposedPolygons << polygon;
+//        qCDebug(PolygonDecomposeLog) << polygon << " polygon of 3";
+        return;
+    }
+
     QList<QPolygonF> decomposedPolygonsMin{};
 
     for (auto vertex = polygon.begin(); vertex != polygon.end(); ++vertex)
     {
         // is vertex reflex?
-        auto vertexBefore = vertex == polygon.begin() ? polygon.end() - 1 : vertex - 1;
-        auto vertexAfter = vertex == polygon.end() -1 ? polygon.begin() : vertex + 1;
-        auto area = (((vertex->x() - vertexBefore->x())*(vertexAfter->y() - vertexBefore->y()))-((vertexAfter->x() - vertexBefore->x())*(vertex->y() - vertexBefore->y())));
-        bool vertexIsReflex = area > 0;
-        qCDebug(SurveyComplexItemLog) << "area " << area << " vertexIsReflex " << vertexIsReflex;
+        bool vertexIsReflex = _VertexIsReflex(polygon, vertex);
+//        qCDebug(SurveyComplexItemLog) << "area " << area << " vertexIsReflex " << vertexIsReflex;
 
         if (!vertexIsReflex) continue;
 
         for (auto vertexOther = polygon.begin(); vertexOther != polygon.end(); ++vertexOther)
         {
+            auto vertexBefore = vertex == polygon.begin() ? polygon.end() - 1 : vertex - 1;
+            auto vertexAfter = vertex == polygon.end() - 1 ? polygon.begin() : vertex + 1;
             if (vertexOther == vertex) continue;
+            if (vertexAfter == vertexOther) continue;
+            if (vertexBefore == vertexOther) continue;
             bool canSee = _VertexCanSeeOther(polygon, vertex, vertexOther);
+//            qCDebug(SurveyComplexItemLog) << "canSee " << canSee;
             if (!canSee) continue;
 
             QPolygonF polyLeft;
             auto v = vertex;
+            auto polyLeftContainsReflex = false;
             while ( v != vertexOther) {
+                if (v != vertex && _VertexIsReflex(polygon, v)) {
+                    polyLeftContainsReflex = true;
+                }
                 polyLeft << *v;
                 ++v;
                 if (v == polygon.end()) v = polygon.begin();
             }
             polyLeft << *vertexOther;
-            qCDebug(SurveyComplexItemLog) << "polyLeft.size() " << polyLeft.size();
+            auto polyLeftValid = !(polyLeftContainsReflex && polyLeft.size() == 3);
 
             QPolygonF polyRight;
             v = vertexOther;
+            auto polyRightContainsReflex = false;
             while ( v != vertex) {
+                if (v != vertex && _VertexIsReflex(polygon, v)) {
+                    polyRightContainsReflex = true;
+                }
                 polyRight << *v;
                 ++v;
                 if (v == polygon.end()) v = polygon.begin();
             }
             polyRight << *vertex;
-            qCDebug(SurveyComplexItemLog) << "polyRight.size() " << polyRight.size();
+            auto polyRightValid = !(polyRightContainsReflex && polyRight.size() == 3);
+
+            if (!polyLeftValid || ! polyRightValid) {
+//                decompSize = std::numeric_limits<int>::max();
+                continue;
+            }
 
             // recursion
             QList<QPolygonF> polyLeftDecomposed{};
+//            qCDebug(PolygonDecomposeLog) << " polyLeft "<< polyLeft;
             _PolygonDecomposeConvex(polyLeft, polyLeftDecomposed);
+
             QList<QPolygonF> polyRightDecomposed{};
+//            qCDebug(PolygonDecomposeLog) << " polyRight "<< polyRight;
             _PolygonDecomposeConvex(polyRight, polyRightDecomposed);
 
             // compositon
-            if (polyLeftDecomposed.size() + polyRightDecomposed.size() < decompSize) {
-                decompSize = polyLeftDecomposed.size() + polyRightDecomposed.size();
+            auto subSize = polyLeftDecomposed.size() + polyRightDecomposed.size();
+            if ((polyLeftContainsReflex && polyLeftDecomposed.size() == 1)
+                    || (polyRightContainsReflex && polyRightDecomposed.size() == 1))
+            {
+                // don't accept polygons that contian reflex vertices and were not split
+                subSize = std::numeric_limits<int>::max();
+            }
+            if (subSize < decompSize) {
+                decompSize = subSize;
                 decomposedPolygonsMin = polyLeftDecomposed + polyRightDecomposed;
-                qCDebug(SurveyComplexItemLog) << "changing decomposedPolygonsMin";
+//            qCDebug(PolygonDecomposeLog) << "_PolygonDecomposeConvex polygon " << polygon;
+//            qCDebug(PolygonDecomposeLog) << "polyLeft.size() " << polyLeft.size() << " polyRight.size() " << polyRight.size() << " out of " << polygon.size();
+//            qCDebug(PolygonDecomposeLog) << "vertex " << *vertex << " vertexOther " << *vertexOther << " vertexAfter " << *vertexAfter << " vertexBefore " << *vertexBefore;
+//            qCDebug(SurveyComplexItemLog) << "changing decomposedPolygonsMin";
             }
             else {
-                qCDebug(SurveyComplexItemLog) << "NOT changing decomposedPolygonsMin";
+//                qCDebug(SurveyComplexItemLog) << "NOT changing decomposedPolygonsMin";
             }
         }
 
@@ -1195,23 +1250,71 @@ void SurveyComplexItem::_PolygonDecomposeConvex(const QPolygonF& polygon, QList<
 
     // assemble output
     if (decomposedPolygonsMin.size() > 0) {
-        qCDebug(SurveyComplexItemLog) << "use decomposed polygon, decomposedPolygonsMin.size() " << decomposedPolygonsMin.size();
+//        qCDebug(SurveyComplexItemLog) << "use decomposed polygon, decomposedPolygonsMin.size() " << decomposedPolygonsMin.size();
         decomposedPolygons << decomposedPolygonsMin;
+//        qCDebug(PolygonDecomposeLog) << decomposedPolygonsMin;
     } else {
-        qCDebug(SurveyComplexItemLog) << "use default polygon";
+//        qCDebug(SurveyComplexItemLog) << "use default polygon";
         decomposedPolygons << polygon;
+//        qCDebug(PolygonDecomposeLog) << polygon << " empty polygon";
     }
+
+    return;
 }
 
-bool SurveyComplexItem::_VertexCanSeeOther(const QPolygonF& polygon, const QPointF* VertexA, const QPointF* VertexB) {
-    if (VertexA == VertexB) return false;
-    if (VertexA + 1 == VertexB) return false;
-    if (VertexA - 1 == VertexB) return false;
+bool SurveyComplexItem::_VertexCanSeeOther(const QPolygonF& polygon, const QPointF* vertexA, const QPointF* vertexB) {
+    if (vertexA == vertexB) return false;
+    auto vertexAAfter = vertexA + 1 == polygon.end() ? polygon.begin() : vertexA + 1;
+    auto vertexABefore = vertexA == polygon.begin() ? polygon.end() - 1 : vertexA - 1;
+    if (vertexAAfter == vertexB) return false;
+    if (vertexABefore == vertexB) return false;
+//    qCDebug(SurveyComplexItemLog) << "_VertexCanSeeOther false after first checks ";
 
-    return true;
+    bool visible = true;
+//    auto diff = *vertexA - *vertexB;
+    QLineF lineAB{*vertexA, *vertexB};
+    auto distanceAB = lineAB.length();//sqrtf(diff.x() * diff.x() + diff.y()*diff.y());
+
+//    qCDebug(SurveyComplexItemLog) << "_VertexCanSeeOther distanceAB " << distanceAB;
+    for (auto vertexC = polygon.begin(); vertexC != polygon.end(); ++vertexC)
+    {
+        if (vertexC == vertexA) continue;
+        if (vertexC == vertexB) continue;
+        auto vertexD = vertexC + 1 == polygon.end() ? polygon.begin() : vertexC + 1;
+        if (vertexD == vertexA) continue;
+        if (vertexD == vertexB) continue;
+        QLineF lineCD(*vertexC, *vertexD);
+        QPointF intersection{};
+        auto intersects = lineAB.intersect(lineCD, &intersection);
+        if (intersects == QLineF::IntersectType::BoundedIntersection) {
+//            auto diffIntersection = *vertexA - intersection;
+//            auto distanceIntersection = sqrtf(diffIntersection.x() * diffIntersection.x() + diffIntersection.y()*diffIntersection.y());
+//            qCDebug(SurveyComplexItemLog) << "*vertexA " << *vertexA << "*vertexB " << *vertexB  << " intersection " << intersection;
+
+            QLineF lineIntersection{*vertexA, intersection};
+            auto distanceIntersection = lineIntersection.length();//sqrtf(diff.x() * diff.x() + diff.y()*diff.y());
+            qCDebug(SurveyComplexItemLog) << "_VertexCanSeeOther distanceIntersection " << distanceIntersection;
+            if (distanceIntersection < distanceAB) {
+                visible = false;
+                break;
+            }
+        }
+
+    }
+
+    return visible;
 }
 
-void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin)
+bool SurveyComplexItem::_VertexIsReflex(const QPolygonF& polygon, const QPointF* vertex) {
+    auto vertexBefore = vertex == polygon.begin() ? polygon.end() - 1 : vertex - 1;
+    auto vertexAfter = vertex == polygon.end() - 1 ? polygon.begin() : vertex + 1;
+    auto area = (((vertex->x() - vertexBefore->x())*(vertexAfter->y() - vertexBefore->y()))-((vertexAfter->x() - vertexBefore->x())*(vertex->y() - vertexBefore->y())));
+    return area > 0;
+
+}
+
+
+void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin, const QPointF* const transitionPoint)
 {
     // Generate transects
 
@@ -1282,9 +1385,19 @@ void SurveyComplexItem::_rebuildTranscetsFromPolygon(bool refly, const QPolygonF
 
     // Convert from NED to Geo
     QList<QList<QGeoCoordinate>> transects;
-    for (const QLineF& line: resultLines) {
-        QGeoCoordinate          coord;
+
+    if (transitionPoint != nullptr) {
         QList<QGeoCoordinate>   transect;
+        QGeoCoordinate          coord;
+        convertNedToGeo(transitionPoint->y(), transitionPoint->x(), 0, tangentOrigin, &coord);
+        transect.append(coord);
+        transect.append(coord); //TODO
+        transects.append(transect);
+    }
+
+    for (const QLineF& line: resultLines) {
+        QList<QGeoCoordinate>   transect;
+        QGeoCoordinate          coord;
 
         convertNedToGeo(line.p1().y(), line.p1().x(), 0, tangentOrigin, &coord);
         transect.append(coord);

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1194,7 +1194,7 @@ void SurveyComplexItem::_rebuildTransectsPhase1WorkerSinglePolygon(bool refly)
 
     // Convert from NED to Geo
     QList<QList<QGeoCoordinate>> transects;
-    foreach (const QLineF& line, resultLines) {
+    for (const QLineF& line : resultLines) {
         QGeoCoordinate          coord;
         QList<QGeoCoordinate>   transect;
 
@@ -1246,7 +1246,7 @@ void SurveyComplexItem::_rebuildTransectsPhase1WorkerSinglePolygon(bool refly)
     }
 
     // Convert to CoordInfo transects and append to _transects
-    foreach (const QList<QGeoCoordinate>& transect, transects) {
+    for (const QList<QGeoCoordinate>& transect : transects) {
         QGeoCoordinate                                  coord;
         QList<TransectStyleComplexItem::CoordInfo_t>    coordInfoTransect;
         TransectStyleComplexItem::CoordInfo_t           coordInfo;

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -111,7 +111,8 @@ private:
     bool _loadV3(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     bool _loadV4(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     void _rebuildTransectsPhase1Worker(bool refly);
-    void _rebuildTranscetsFromPolygon(bool refly); ///< Adds to the _transects array from one polygon
+    /// Adds to the _transects array from one polygon
+    void _rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin);
 
     QMap<QString, FactMetaData*> _metaDataMap;
 

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -112,11 +112,12 @@ private:
     bool _loadV4(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     void _rebuildTransectsPhase1Worker(bool refly);
     /// Adds to the _transects array from one polygon
-    void _rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin);
+    void _rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin, const QPointF* const transitionPoint);
     // Decompose polygon into list of convex sub polygons
     void _PolygonDecomposeConvex(const QPolygonF& polygon, QList<QPolygonF>& decomposedPolygons);
     // return true if vertex a can see vertex b
-    bool _VertexCanSeeOther(const QPolygonF& polygon, const QPointF* VertexA, const QPointF* VertexB);
+    bool _VertexCanSeeOther(const QPolygonF& polygon, const QPointF* vertexA, const QPointF* vertexB);
+    bool _VertexIsReflex(const QPolygonF& polygon, const QPointF* vertex);
 
     QMap<QString, FactMetaData*> _metaDataMap;
 

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -113,6 +113,7 @@ private:
     void _rebuildTransectsPhase1Worker(bool refly);
     /// Adds to the _transects array from one polygon
     void _rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin);
+    void _PolygonDecomposeConvex(const QPolygonF& polygon, QList<QPolygonF>& polygons);
 
     QMap<QString, FactMetaData*> _metaDataMap;
 

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -111,6 +111,7 @@ private:
     bool _loadV3(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     bool _loadV4(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     void _rebuildTransectsPhase1Worker(bool refly);
+    void _rebuildTranscetsFromPolygon(bool refly); ///< Adds to the _transects array from one polygon
 
     QMap<QString, FactMetaData*> _metaDataMap;
 

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -113,7 +113,10 @@ private:
     void _rebuildTransectsPhase1Worker(bool refly);
     /// Adds to the _transects array from one polygon
     void _rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin);
-    void _PolygonDecomposeConvex(const QPolygonF& polygon, QList<QPolygonF>& polygons);
+    // Decompose polygon into list of convex sub polygons
+    void _PolygonDecomposeConvex(const QPolygonF& polygon, QList<QPolygonF>& decomposedPolygons);
+    // return true if vertex a can see vertex b
+    bool _VertexCanSeeOther(const QPolygonF& polygon, const QPointF* VertexA, const QPointF* VertexB);
 
     QMap<QString, FactMetaData*> _metaDataMap;
 

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -111,6 +111,8 @@ private:
     bool _loadV3(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     bool _loadV4(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     void _rebuildTransectsPhase1Worker(bool refly);
+    void _rebuildTransectsPhase1WorkerSinglePolygon(bool refly);
+    void _rebuildTransectsPhase1WorkerSplitPolygons(bool refly);
     /// Adds to the _transects array from one polygon
     void _rebuildTranscetsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin, const QPointF* const transitionPoint);
     // Decompose polygon into list of convex sub polygons

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -112,7 +112,7 @@ private:
     double _turnaroundDistance(void) const;
     bool _hoverAndCaptureEnabled(void) const;
     bool _loadV3(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
-    bool _loadV4(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
+    bool _loadV4V5(const QJsonObject& complexObject, int sequenceNumber, QString& errorString, int version);
     void _rebuildTransectsPhase1Worker(bool refly);
     void _rebuildTransectsPhase1WorkerSinglePolygon(bool refly);
     void _rebuildTransectsPhase1WorkerSplitPolygons(bool refly);

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -28,9 +28,11 @@ public:
 
     Q_PROPERTY(Fact* gridAngle              READ gridAngle              CONSTANT)
     Q_PROPERTY(Fact* flyAlternateTransects  READ flyAlternateTransects  CONSTANT)
+    Q_PROPERTY(Fact* splitConcavePolygons   READ splitConcavePolygons   CONSTANT)
 
     Fact* gridAngle             (void) { return &_gridAngleFact; }
     Fact* flyAlternateTransects (void) { return &_flyAlternateTransectsFact; }
+    Fact* splitConcavePolygons  (void) { return &_splitConcavePolygonsFact; }
 
     Q_INVOKABLE void rotateEntryPoint(void);
 
@@ -66,6 +68,7 @@ public:
     static const char* gridAngleName;
     static const char* gridEntryLocationName;
     static const char* flyAlternateTransectsName;
+    static const char* splitConcavePolygonsName;
 
     static const char* jsonV3ComplexItemTypeValue;
 
@@ -125,11 +128,13 @@ private:
 
     SettingsFact    _gridAngleFact;
     SettingsFact    _flyAlternateTransectsFact;
+    SettingsFact    _splitConcavePolygonsFact;
     int             _entryPoint;
 
     static const char* _jsonGridAngleKey;
     static const char* _jsonEntryPointKey;
     static const char* _jsonFlyAlternateTransectsKey;
+    static const char* _jsonSplitConcavePolygonsKey;
 
     static const char* _jsonV3GridObjectKey;
     static const char* _jsonV3GridAltitudeKey;

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -9,6 +9,7 @@ import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.FlightMap     1.0
@@ -117,6 +118,13 @@ Rectangle {
                 Layout.columnSpan:  2
                 text:               qsTr("Rotate Entry Point")
                 onClicked:          missionItem.rotateEntryPoint();
+            }
+
+            FactCheckBox {
+                text:       qsTr("Split concave polygons")
+                fact:       _splitConcave
+                visible:    _splitConcave.visible
+                property Fact _splitConcave: QGroundControl.settingsManager.appSettings.splitConcavePolygons
             }
 
             FactCheckBox {

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -124,7 +124,7 @@ Rectangle {
                 text:       qsTr("Split concave polygons")
                 fact:       _splitConcave
                 visible:    _splitConcave.visible
-                property Fact _splitConcave: QGroundControl.settingsManager.appSettings.splitConcavePolygons
+                property Fact _splitConcave: missionItem.splitConcavePolygons
             }
 
             FactCheckBox {

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -199,12 +199,5 @@
     "enumStrings":      "Never,Always,When in Follow Me Flight Mode",
     "enumValues":       "0,1,2",
     "defaultValue":     0
-},
-{
-    "name":             "SplitConcavePolygons",
-    "shortDescription": "Split mission concave polygons",
-    "longDescription":  "Split mission concave polygons into separate regular, convex polygons",
-    "type":             "bool",
-    "defaultValue":     false
 }
 ]

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -199,5 +199,12 @@
     "enumStrings":      "Never,Always,When in Follow Me Flight Mode",
     "enumValues":       "0,1,2",
     "defaultValue":     0
+},
+{
+    "name":             "SplitConcavePolygons",
+    "shortDescription": "Split mission concave polygons",
+    "longDescription":  "Split mission concave polygons into separate regular, convex polygons",
+    "type":             "bool",
+    "defaultValue":     false
 }
 ]

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -41,6 +41,7 @@ const char* AppSettings::esriTokenName =                                "EsriTok
 const char* AppSettings::defaultFirmwareTypeName =                      "DefaultFirmwareType";
 const char* AppSettings::gstDebugName =                                 "GstreamerDebugLevel";
 const char* AppSettings::followTargetName =                             "FollowTarget";
+const char* AppSettings::splitConcavePolygonsName =                     "SplitConcavePolygons";
 
 const char* AppSettings::parameterFileExtension =   "params";
 const char* AppSettings::planFileExtension =        "plan";
@@ -84,6 +85,7 @@ AppSettings::AppSettings(QObject* parent)
     , _defaultFirmwareTypeFact              (NULL)
     , _gstDebugFact                         (NULL)
     , _followTargetFact                     (NULL)
+    , _splitConcavePolygonsFact             (NULL)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<AppSettings>("QGroundControl.SettingsManager", 1, 0, "AppSettings", "Reference only");
@@ -426,5 +428,14 @@ Fact* AppSettings::followTarget(void)
     }
 
     return _followTargetFact;
+}
+
+Fact* AppSettings::splitConcavePolygons(void)
+{
+    if (!_splitConcavePolygonsFact) {
+        _splitConcavePolygonsFact = _createSettingsFact(splitConcavePolygonsName);
+    }
+
+    return _splitConcavePolygonsFact;
 }
 

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -41,7 +41,6 @@ const char* AppSettings::esriTokenName =                                "EsriTok
 const char* AppSettings::defaultFirmwareTypeName =                      "DefaultFirmwareType";
 const char* AppSettings::gstDebugName =                                 "GstreamerDebugLevel";
 const char* AppSettings::followTargetName =                             "FollowTarget";
-const char* AppSettings::splitConcavePolygonsName =                     "SplitConcavePolygons";
 
 const char* AppSettings::parameterFileExtension =   "params";
 const char* AppSettings::planFileExtension =        "plan";
@@ -62,30 +61,29 @@ const char* AppSettings::crashDirectory =           "CrashLogs";
 
 AppSettings::AppSettings(QObject* parent)
     : SettingsGroup                         (name, settingsGroup, parent)
-    , _offlineEditingFirmwareTypeFact       (NULL)
-    , _offlineEditingVehicleTypeFact        (NULL)
-    , _offlineEditingCruiseSpeedFact        (NULL)
-    , _offlineEditingHoverSpeedFact         (NULL)
-    , _offlineEditingAscentSpeedFact        (NULL)
-    , _offlineEditingDescentSpeedFact       (NULL)
-    , _batteryPercentRemainingAnnounceFact  (NULL)
-    , _defaultMissionItemAltitudeFact       (NULL)
-    , _telemetrySaveFact                    (NULL)
-    , _telemetrySaveNotArmedFact            (NULL)
-    , _audioMutedFact                       (NULL)
-    , _virtualJoystickFact                  (NULL)
-    , _appFontPointSizeFact                 (NULL)
-    , _indoorPaletteFact                    (NULL)
-    , _showLargeCompassFact                 (NULL)
-    , _savePathFact                         (NULL)
-    , _autoLoadMissionsFact                 (NULL)
-    , _useChecklistFact                     (NULL)
-    , _mapboxTokenFact                      (NULL)
-    , _esriTokenFact                        (NULL)
-    , _defaultFirmwareTypeFact              (NULL)
-    , _gstDebugFact                         (NULL)
-    , _followTargetFact                     (NULL)
-    , _splitConcavePolygonsFact             (NULL)
+    , _offlineEditingFirmwareTypeFact       (nullptr)
+    , _offlineEditingVehicleTypeFact        (nullptr)
+    , _offlineEditingCruiseSpeedFact        (nullptr)
+    , _offlineEditingHoverSpeedFact         (nullptr)
+    , _offlineEditingAscentSpeedFact        (nullptr)
+    , _offlineEditingDescentSpeedFact       (nullptr)
+    , _batteryPercentRemainingAnnounceFact  (nullptr)
+    , _defaultMissionItemAltitudeFact       (nullptr)
+    , _telemetrySaveFact                    (nullptr)
+    , _telemetrySaveNotArmedFact            (nullptr)
+    , _audioMutedFact                       (nullptr)
+    , _virtualJoystickFact                  (nullptr)
+    , _appFontPointSizeFact                 (nullptr)
+    , _indoorPaletteFact                    (nullptr)
+    , _showLargeCompassFact                 (nullptr)
+    , _savePathFact                         (nullptr)
+    , _autoLoadMissionsFact                 (nullptr)
+    , _useChecklistFact                     (nullptr)
+    , _mapboxTokenFact                      (nullptr)
+    , _esriTokenFact                        (nullptr)
+    , _defaultFirmwareTypeFact              (nullptr)
+    , _gstDebugFact                         (nullptr)
+    , _followTargetFact                     (nullptr)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<AppSettings>("QGroundControl.SettingsManager", 1, 0, "AppSettings", "Reference only");
@@ -429,13 +427,3 @@ Fact* AppSettings::followTarget(void)
 
     return _followTargetFact;
 }
-
-Fact* AppSettings::splitConcavePolygons(void)
-{
-    if (!_splitConcavePolygonsFact) {
-        _splitConcavePolygonsFact = _createSettingsFact(splitConcavePolygonsName);
-    }
-
-    return _splitConcavePolygonsFact;
-}
-

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -18,7 +18,7 @@ class AppSettings : public SettingsGroup
     Q_OBJECT
     
 public:
-    AppSettings(QObject* parent = NULL);
+    AppSettings(QObject* parent = nullptr);
 
     Q_PROPERTY(Fact* offlineEditingFirmwareType         READ offlineEditingFirmwareType         CONSTANT)
     Q_PROPERTY(Fact* offlineEditingVehicleType          READ offlineEditingVehicleType          CONSTANT)
@@ -43,7 +43,6 @@ public:
     Q_PROPERTY(Fact* defaultFirmwareType                READ defaultFirmwareType                CONSTANT)
     Q_PROPERTY(Fact* gstDebug                           READ gstDebug                           CONSTANT)
     Q_PROPERTY(Fact* followTarget                       READ followTarget                       CONSTANT)
-    Q_PROPERTY(Fact* splitConcavePolygons               READ splitConcavePolygons               CONSTANT)
 
     Q_PROPERTY(QString missionSavePath      READ missionSavePath    NOTIFY savePathsChanged)
     Q_PROPERTY(QString parameterSavePath    READ parameterSavePath  NOTIFY savePathsChanged)
@@ -83,7 +82,6 @@ public:
     Fact* defaultFirmwareType               (void);
     Fact* gstDebug                          (void);
     Fact* followTarget                      (void);
-    Fact* splitConcavePolygons              (void);
 
     QString missionSavePath     (void);
     QString parameterSavePath   (void);
@@ -121,7 +119,6 @@ public:
     static const char* defaultFirmwareTypeName;
     static const char* gstDebugName;
     static const char* followTargetName;
-    static const char* splitConcavePolygonsName;
 
     // Application wide file extensions
     static const char* parameterFileExtension;
@@ -173,7 +170,6 @@ private:
     SettingsFact* _defaultFirmwareTypeFact;
     SettingsFact* _gstDebugFact;
     SettingsFact* _followTargetFact;
-    SettingsFact* _splitConcavePolygonsFact;
 };
 
 #endif

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -43,6 +43,7 @@ public:
     Q_PROPERTY(Fact* defaultFirmwareType                READ defaultFirmwareType                CONSTANT)
     Q_PROPERTY(Fact* gstDebug                           READ gstDebug                           CONSTANT)
     Q_PROPERTY(Fact* followTarget                       READ followTarget                       CONSTANT)
+    Q_PROPERTY(Fact* splitConcavePolygons               READ splitConcavePolygons               CONSTANT)
 
     Q_PROPERTY(QString missionSavePath      READ missionSavePath    NOTIFY savePathsChanged)
     Q_PROPERTY(QString parameterSavePath    READ parameterSavePath  NOTIFY savePathsChanged)
@@ -82,13 +83,14 @@ public:
     Fact* defaultFirmwareType               (void);
     Fact* gstDebug                          (void);
     Fact* followTarget                      (void);
+    Fact* splitConcavePolygons              (void);
 
     QString missionSavePath     (void);
     QString parameterSavePath   (void);
     QString telemetrySavePath   (void);
     QString logSavePath         (void);
-    QString videoSavePath         (void);
-    QString crashSavePath         (void);
+    QString videoSavePath       (void);
+    QString crashSavePath       (void);
 
     static MAV_AUTOPILOT offlineEditingFirmwareTypeFromFirmwareType(MAV_AUTOPILOT firmwareType);
     static MAV_TYPE offlineEditingVehicleTypeFromVehicleType(MAV_TYPE vehicleType);
@@ -119,6 +121,7 @@ public:
     static const char* defaultFirmwareTypeName;
     static const char* gstDebugName;
     static const char* followTargetName;
+    static const char* splitConcavePolygonsName;
 
     // Application wide file extensions
     static const char* parameterFileExtension;
@@ -170,6 +173,7 @@ private:
     SettingsFact* _defaultFirmwareTypeFact;
     SettingsFact* _gstDebugFact;
     SettingsFact* _followTargetFact;
+    SettingsFact* _splitConcavePolygonsFact;
 };
 
 #endif


### PR DESCRIPTION
This PR adds a new mode for planning a survey which makes the planned flight path stay within concave polygons.
This is achieved by splitting the polygon into concave sub polygons and treating each as an independent area to be surveyed. Because this introduces additional turns, the flight time might be increased. Hence, the original (current) mode that does not support concave polygons is preserved to give user the option to chose the mode they like.

Original mode (stays default after this PR):
![screenshot from 2018-10-29 08-30-29](https://user-images.githubusercontent.com/1419479/47635463-62238c00-db55-11e8-8a8c-870e35400997.png)

New mode that splits polygons:
![screenshot from 2018-10-29 08-31-01](https://user-images.githubusercontent.com/1419479/47635466-6485e600-db55-11e8-85f9-cdb7ff17782f.png)

The UI work for toggling between the modes was done by @dogmaphobic 

@dogmaphobic this is a cherrypick of the original branch on top of master

Fixes #5830 #5215