### PR TITLE
Fit map viewport to mission items

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -49,6 +49,7 @@ Map {
     property var    activeVehicleCoordinate:        _activeVehicle ? _activeVehicle.coordinate : QtPositioning.coordinate()
 
     function setVisibleRegion(region) {
+        // TODO: Is this still necessary with Qt 5.11?
         // This works around a bug on Qt where if you set a visibleRegion and then the user moves or zooms the map
         // and then you set the same visibleRegion the map will not move/scale appropriately since it thinks there
         // is nothing to do.

--- a/src/FlightMap/MapItems/MissionLineView.qml
+++ b/src/FlightMap/MapItems/MissionLineView.qml
@@ -26,9 +26,9 @@ MapItemView {
         line.color: "#be781c"                           // Hack, can't get palette to work in here
         z:          QGroundControl.zOrderWaypointLines
 
-        path: [
+        path: object ? [
             object.coordinate1,
             object.coordinate2,
-        ]
+        ] : []
     }
 }

--- a/src/FlightMap/Widgets/MapFitFunctions.qml
+++ b/src/FlightMap/Widgets/MapFitFunctions.qml
@@ -86,7 +86,7 @@ Item {
         west  = west  * 0.9999925
         south = south * 0.9999925
 
-        // Fix the map region to the new bounding rect
+        // Fit the map region to the new bounding rect
         var topLeftCoord      = QtPositioning.coordinate(north - 90.0, west - 180.0)
         var bottomRightCoord  = QtPositioning.coordinate(south - 90.0, east - 180.0)
         map.setVisibleRegion(QtPositioning.rectangle(topLeftCoord, bottomRightCoord))

--- a/src/FlightMap/Widgets/MapFitFunctions.qml
+++ b/src/FlightMap/Widgets/MapFitFunctions.qml
@@ -10,7 +10,8 @@
 import QtQuick          2.3
 import QtPositioning    5.3
 
-import QGroundControl 1.0
+import QGroundControl           1.0
+import QGroundControl.FlightMap 1.0
 
 /// Set of functions for fitting the map viewpoer to a specific constraint
 Item {
@@ -62,38 +63,46 @@ Item {
         var south = north
         var east = normalizeLon(coordList[0].longitude)
         var west = east
-        for (var i=1; i<coordList.length; i++) {
+        for (var i = 1; i < coordList.length; i++) {
             var lat = normalizeLat(coordList[i].latitude)
             var lon = normalizeLon(coordList[i].longitude)
-
             north = Math.max(north, lat)
             south = Math.min(south, lat)
-            east = Math.max(east, lon)
-            west = Math.min(west, lon)
+            east  = Math.max(east,  lon)
+            west  = Math.min(west,  lon)
         }
 
         // Expand the coordinate bounding rect to make room for the tools around the edge of the map
         var latDegreesPerPixel = (north - south) / mapFitViewport.width
-        var lonDegreesPerPixel = (east - west) / mapFitViewport.height
+        var lonDegreesPerPixel = (east  - west)  / mapFitViewport.height
         north = Math.min(north + (mapFitViewport.y * latDegreesPerPixel), 180)
         south = Math.max(south - ((map.height - mapFitViewport.bottom) * latDegreesPerPixel), 0)
-        west = Math.max(west - (mapFitViewport.x * lonDegreesPerPixel), 0)
-        east = Math.min(east + ((map.width - mapFitViewport.right) * lonDegreesPerPixel), 360)
+        west  = Math.max(west  - (mapFitViewport.x * lonDegreesPerPixel), 0)
+        east  = Math.min(east  + ((map.width - mapFitViewport.right) * lonDegreesPerPixel), 360)
+
+        // Back off on zoom level
+        east  = Math.min(east  * 1.0000075, 360)
+        north = Math.min(north * 1.0000075, 180)
+        west  = west  * 0.9999925
+        south = south * 0.9999925
 
         // Fix the map region to the new bounding rect
-        var topLeftCoord = QtPositioning.coordinate(north - 90.0, west - 180.0)
+        var topLeftCoord      = QtPositioning.coordinate(north - 90.0, west - 180.0)
         var bottomRightCoord  = QtPositioning.coordinate(south - 90.0, east - 180.0)
         map.setVisibleRegion(QtPositioning.rectangle(topLeftCoord, bottomRightCoord))
 
-        // Back off on zoom level
-        map.zoomLevel = Math.abs(map.zoomLevel) - 1
     }
 
     function addMissionItemCoordsForFit(coordList) {
-        for (var i=1; i<_missionController.visualItems.count; i++) {
+        for (var i = 1; i < _missionController.visualItems.count; i++) {
             var missionItem = _missionController.visualItems.get(i)
             if (missionItem.specifiesCoordinate && !missionItem.isStandaloneCoordinate) {
-                coordList.push(missionItem.coordinate)
+                if(missionItem.boundingCube.isValid()) {
+                    coordList.push(missionItem.boundingCube.pointNW)
+                    coordList.push(missionItem.boundingCube.pointSE)
+                } else {
+                    coordList.push(missionItem.coordinate)
+                }
             }
         }
     }
@@ -103,6 +112,19 @@ Item {
             // Being called prior to controller.start
             return
         }
+        /*
+        for (var i=1; i<_missionController.visualItems.count; i++) {
+            var missionItem = _missionController.visualItems.get(i)
+            if (missionItem.specifiesCoordinate && !missionItem.isStandaloneCoordinate) {
+                console.log(missionItem.boundingCube.pointNW)
+                console.log(missionItem.boundingCube.pointSE)
+                var loc = QtPositioning.rectangle(missionItem.boundingCube.pointNW, missionItem.boundingCube.pointSE)
+                console.log(loc)
+                map.visibleRegion = loc
+                return
+            }
+        }
+        */
         var coordList = [ ]
         addMissionItemCoordsForFit(coordList)
         fitMapViewportToAllCoordinates(coordList)

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -28,10 +28,6 @@ public:
     /// Signals complexDistanceChanged
     virtual double complexDistance(void) const = 0;
 
-    /// @return The item bounding cube
-    /// Signals boundingCubeChanged
-    virtual QGCGeoBoundingCube boundingCube(void) const { return QGCGeoBoundingCube(); }
-
     /// Load the complex mission item from Json
     ///     @param complexObject Complex mission item json object
     ///     @param sequenceNumber Sequence number for first MISSION_ITEM in survey

--- a/src/MissionManager/QGCMapCircle.h
+++ b/src/MissionManager/QGCMapCircle.h
@@ -23,9 +23,9 @@ class QGCMapCircle : public QObject
     Q_OBJECT
 
 public:
-    QGCMapCircle(QObject* parent = NULL);
-    QGCMapCircle(const QGeoCoordinate& center, double radius, QObject* parent = NULL);
-    QGCMapCircle(const QGCMapCircle& other, QObject* parent = NULL);
+    QGCMapCircle(QObject* parent = nullptr);
+    QGCMapCircle(const QGeoCoordinate& center, double radius, QObject* parent = nullptr);
+    QGCMapCircle(const QGCMapCircle& other, QObject* parent = nullptr);
 
     const QGCMapCircle& operator=(const QGCMapCircle& other);
 

--- a/src/MissionManager/QGCMapPolygon.h
+++ b/src/MissionManager/QGCMapPolygon.h
@@ -24,8 +24,8 @@ class QGCMapPolygon : public QObject
     Q_OBJECT
 
 public:
-    QGCMapPolygon(QObject* parent = NULL);
-    QGCMapPolygon(const QGCMapPolygon& other, QObject* parent = NULL);
+    QGCMapPolygon(QObject* parent = nullptr);
+    QGCMapPolygon(const QGCMapPolygon& other, QObject* parent = nullptr);
 
     const QGCMapPolygon& operator=(const QGCMapPolygon& other);
 

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -41,14 +41,13 @@ const int   TransectStyleComplexItem::_terrainQueryTimeoutMsecs =           1000
 TransectStyleComplexItem::TransectStyleComplexItem(Vehicle* vehicle, bool flyView, QString settingsGroup, QObject* parent)
     : ComplexMissionItem                (vehicle, flyView, parent)
     , _sequenceNumber                   (0)
-    , _dirty                            (false)
-    , _terrainPolyPathQuery             (NULL)
+    , _terrainPolyPathQuery             (nullptr)
     , _ignoreRecalc                     (false)
     , _complexDistance                  (0)
     , _cameraShots                      (0)
     , _cameraCalc                       (vehicle, settingsGroup)
     , _followTerrain                    (false)
-    , _loadedMissionItemsParent         (NULL)
+    , _loadedMissionItemsParent         (nullptr)
     , _metaDataMap                      (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/TransectStyle.SettingsGroup.json"), this))
     , _turnAroundDistanceFact           (settingsGroup, _metaDataMap[_vehicle->multiRotor() ? turnAroundDistanceMultiRotorName : turnAroundDistanceName])
     , _cameraTriggerInTurnAroundFact    (settingsGroup, _metaDataMap[cameraTriggerInTurnAroundName])
@@ -399,14 +398,6 @@ void TransectStyleComplexItem::_rebuildTransects(void)
 
     emit lastSequenceNumberChanged(lastSequenceNumber());
     emit timeBetweenShotsChanged();
-}
-
-void TransectStyleComplexItem::_setBoundingCube(QGCGeoBoundingCube bc)
-{
-    if (bc != _boundingCube) {
-        _boundingCube = bc;
-        emit boundingCubeChanged();
-    }
 }
 
 void TransectStyleComplexItem::_queryTransectsPathHeightInfo(void)

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -77,7 +77,6 @@ public:
     int                 lastSequenceNumber  (void) const final;
     QString             mapVisualQML        (void) const override = 0;
     bool                load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) override = 0;
-    QGCGeoBoundingCube  boundingCube        (void) const override { return _boundingCube; }
 
     double          complexDistance     (void) const final { return _complexDistance; }
     double          greatestDistanceTo  (const QGeoCoordinate &other) const final;
@@ -147,14 +146,11 @@ protected:
     double  _triggerDistance                (void) const;
     bool    _hasTurnaround                  (void) const;
     double  _turnaroundDistance             (void) const;
-    void    _setBoundingCube                (QGCGeoBoundingCube bc);
 
     int                 _sequenceNumber;
-    bool                _dirty;
     QGeoCoordinate      _coordinate;
     QGeoCoordinate      _exitCoordinate;
     QGCMapPolygon       _surveyAreaPolygon;
-    QGCGeoBoundingCube  _boundingCube;
 
     enum CoordType {
         CoordTypeInterior,              ///< Interior waypoint for flight path only

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -45,7 +45,7 @@ VisualMissionItem::VisualMissionItem(Vehicle* vehicle, bool flyView, QObject* pa
 
 VisualMissionItem::VisualMissionItem(const VisualMissionItem& other, bool flyView, QObject* parent)
     : QObject                   (parent)
-    , _vehicle                  (NULL)
+    , _vehicle                  (nullptr)
     , _flyView                  (flyView)
     , _isCurrentItem            (false)
     , _dirty                    (false)
@@ -203,3 +203,12 @@ void VisualMissionItem::_terrainDataReceived(bool success, QList<double> heights
     emit terrainAltitudeChanged(_terrainAltitude);
     sender()->deleteLater();
 }
+
+void VisualMissionItem::_setBoundingCube(QGCGeoBoundingCube bc)
+{
+    if (bc != _boundingCube) {
+        _boundingCube = bc;
+        emit boundingCubeChanged();
+    }
+}
+

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -68,6 +68,8 @@ public:
     Q_PROPERTY(double           missionVehicleYaw                   READ missionVehicleYaw                                              NOTIFY missionVehicleYawChanged)                    ///< Expected vehicle yaw at this point in mission
     Q_PROPERTY(bool             flyView                             READ flyView                                                        CONSTANT)
 
+    Q_PROPERTY(QGCGeoBoundingCube* boundingCube                     READ boundingCube                                                   NOTIFY boundingCubeChanged)
+
     // The following properties are calculated/set by the MissionController recalc methods
 
     Q_PROPERTY(double altDifference     READ altDifference      WRITE setAltDifference      NOTIFY altDifferenceChanged)        ///< Change in altitude from previous waypoint
@@ -120,6 +122,9 @@ public:
     virtual double          specifiedFlightSpeed    (void) = 0;
     virtual double          specifiedGimbalYaw      (void) = 0;
     virtual double          specifiedGimbalPitch    (void) = 0;
+
+    //-- Default implementation returns an invalid bounding cube
+    virtual QGCGeoBoundingCube* boundingCube        (void) { return &_boundingCube; }
 
     /// Update item to mission flight status at point where this item appears in mission.
     /// IMPORTANT: Overrides must call base class implementation
@@ -192,6 +197,7 @@ signals:
     void missionVehicleYawChanged       (double missionVehicleYaw);
     void terrainAltitudeChanged         (double terrainAltitude);
     void additionalTimeDelayChanged     (void);
+    void boundingCubeChanged            (void);
 
     void coordinateHasRelativeAltitudeChanged       (bool coordinateHasRelativeAltitude);
     void exitCoordinateHasRelativeAltitudeChanged   (bool exitCoordinateHasRelativeAltitude);
@@ -214,10 +220,15 @@ protected:
     double      _missionGimbalYaw;
     double      _missionVehicleYaw;
 
+    QGCGeoBoundingCube  _boundingCube;      ///< The bounding "cube" of this element.
+
     MissionController::MissionFlightStatus_t    _missionFlightStatus;
 
     /// This is used to reference any subsequent mission items which do not specify a coordinate.
     QmlObjectListModel  _childItems;
+
+protected:
+    void    _setBoundingCube                (QGCGeoBoundingCube bc);
 
 private slots:
     void _updateTerrainAltitude (void);

--- a/src/PlanView/PlanToolBar.qml
+++ b/src/PlanView/PlanToolBar.qml
@@ -46,12 +46,12 @@ Rectangle {
     property real   _smallValueWidth:           ScreenTools.defaultFontPixelWidth * 3
     property real   _labelToValueSpacing:       ScreenTools.defaultFontPixelWidth
     property real   _rowSpacing:                ScreenTools.isMobile ? 1 : 0
-    property real   _distance:                  _statusValid ? currentMissionItem.distance : NaN
-    property real   _altDifference:             _statusValid ? currentMissionItem.altDifference : NaN
-    property real   _gradient:                  _statusValid && currentMissionItem.distance > 0 ? Math.atan(currentMissionItem.altDifference / currentMissionItem.distance) : NaN
+    property real   _distance:                  _statusValid && currentMissionItem ? currentMissionItem.distance : NaN
+    property real   _altDifference:             _statusValid && currentMissionItem ? currentMissionItem.altDifference : NaN
+    property real   _gradient:                  _statusValid && currentMissionItem && currentMissionItem.distance > 0 ? Math.atan(currentMissionItem.altDifference / currentMissionItem.distance) : NaN
     property real   _gradientPercent:           isNaN(_gradient) ? NaN : _gradient * 100
-    property real   _azimuth:                   _statusValid ? currentMissionItem.azimuth : NaN
-    property real   _heading:                   _statusValid ? currentMissionItem.missionVehicleYaw : NaN
+    property real   _azimuth:                   _statusValid && currentMissionItem ? currentMissionItem.azimuth : NaN
+    property real   _heading:                   _statusValid && currentMissionItem ? currentMissionItem.missionVehicleYaw : NaN
     property real   _missionDistance:           _missionValid ? missionDistance : NaN
     property real   _missionMaxTelemetry:       _missionValid ? missionMaxTelemetry : NaN
     property real   _missionTime:               _missionValid ? missionTime : NaN

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -377,6 +377,7 @@ QGCApplication::~QGCApplication()
 
 void QGCApplication::_initCommon(void)
 {
+    static const char* kRefOnly = "Reference only";
     QSettings settings;
 
     // Register our Qml objects
@@ -384,31 +385,35 @@ void QGCApplication::_initCommon(void)
     qmlRegisterType<QGCPalette>     ("QGroundControl.Palette", 1, 0, "QGCPalette");
     qmlRegisterType<QGCMapPalette>  ("QGroundControl.Palette", 1, 0, "QGCMapPalette");
 
-    qmlRegisterUncreatableType<CoordinateVector>    ("QGroundControl",                      1, 0, "CoordinateVector",       "Reference only");
-    qmlRegisterUncreatableType<QmlObjectListModel>  ("QGroundControl",                      1, 0, "QmlObjectListModel",     "Reference only");
-    qmlRegisterUncreatableType<MissionCommandTree>  ("QGroundControl",                      1, 0, "MissionCommandTree",     "Reference only");
-    qmlRegisterUncreatableType<CameraCalc>          ("QGroundControl",                      1, 0, "CameraCalc",             "Reference only");
+    qmlRegisterUncreatableType<CoordinateVector>    ("QGroundControl",                      1, 0, "CoordinateVector",           kRefOnly);
+    qmlRegisterUncreatableType<QmlObjectListModel>  ("QGroundControl",                      1, 0, "QmlObjectListModel",         kRefOnly);
+    qmlRegisterUncreatableType<MissionCommandTree>  ("QGroundControl",                      1, 0, "MissionCommandTree",         kRefOnly);
+    qmlRegisterUncreatableType<CameraCalc>          ("QGroundControl",                      1, 0, "CameraCalc",                 kRefOnly);
 
-    qmlRegisterUncreatableType<AutoPilotPlugin>     ("QGroundControl.AutoPilotPlugin",      1, 0, "AutoPilotPlugin",        "Reference only");
-    qmlRegisterUncreatableType<VehicleComponent>    ("QGroundControl.AutoPilotPlugin",      1, 0, "VehicleComponent",       "Reference only");
-    qmlRegisterUncreatableType<Vehicle>             ("QGroundControl.Vehicle",              1, 0, "Vehicle",                "Reference only");
-    qmlRegisterUncreatableType<MissionItem>         ("QGroundControl.Vehicle",              1, 0, "MissionItem",            "Reference only");
-    qmlRegisterUncreatableType<MissionManager>      ("QGroundControl.Vehicle",              1, 0, "MissionManager",         "Reference only");
-    qmlRegisterUncreatableType<ParameterManager>    ("QGroundControl.Vehicle",              1, 0, "ParameterManager",       "Reference only");
-    qmlRegisterUncreatableType<QGCCameraManager>    ("QGroundControl.Vehicle",              1, 0, "QGCCameraManager",       "Reference only");
-    qmlRegisterUncreatableType<QGCCameraControl>    ("QGroundControl.Vehicle",              1, 0, "QGCCameraControl",       "Reference only");
-    qmlRegisterUncreatableType<LinkInterface>       ("QGroundControl.Vehicle",              1, 0, "LinkInterface",          "Reference only");
-    qmlRegisterUncreatableType<JoystickManager>     ("QGroundControl.JoystickManager",      1, 0, "JoystickManager",        "Reference only");
-    qmlRegisterUncreatableType<Joystick>            ("QGroundControl.JoystickManager",      1, 0, "Joystick",               "Reference only");
-    qmlRegisterUncreatableType<QGCPositionManager>  ("QGroundControl.QGCPositionManager",   1, 0, "QGCPositionManager",     "Reference only");
-    qmlRegisterUncreatableType<QGCMapPolygon>       ("QGroundControl.FlightMap",            1, 0, "QGCMapPolygon",          "Reference only");
-    qmlRegisterUncreatableType<MissionController>   ("QGroundControl.Controllers",          1, 0, "MissionController",      "Reference only");
-    qmlRegisterUncreatableType<GeoFenceController>  ("QGroundControl.Controllers",          1, 0, "GeoFenceController",     "Reference only");
-    qmlRegisterUncreatableType<RallyPointController>("QGroundControl.Controllers",          1, 0, "RallyPointController",   "Reference only");
-    qmlRegisterUncreatableType<VisualMissionItem>   ("QGroundControl.Controllers",          1, 0, "VisualMissionItem",      "Reference only");
-    qmlRegisterUncreatableType<FactValueSliderListModel>("QGroundControl.FactControls",     1, 0, "FactValueSliderListModel","Reference only");
+    qmlRegisterUncreatableType<AutoPilotPlugin>     ("QGroundControl.AutoPilotPlugin",      1, 0, "AutoPilotPlugin",            kRefOnly);
+    qmlRegisterUncreatableType<VehicleComponent>    ("QGroundControl.AutoPilotPlugin",      1, 0, "VehicleComponent",           kRefOnly);
+    qmlRegisterUncreatableType<Vehicle>             ("QGroundControl.Vehicle",              1, 0, "Vehicle",                    kRefOnly);
+    qmlRegisterUncreatableType<MissionItem>         ("QGroundControl.Vehicle",              1, 0, "MissionItem",                kRefOnly);
+    qmlRegisterUncreatableType<MissionManager>      ("QGroundControl.Vehicle",              1, 0, "MissionManager",             kRefOnly);
+    qmlRegisterUncreatableType<ParameterManager>    ("QGroundControl.Vehicle",              1, 0, "ParameterManager",           kRefOnly);
+    qmlRegisterUncreatableType<QGCCameraManager>    ("QGroundControl.Vehicle",              1, 0, "QGCCameraManager",           kRefOnly);
+    qmlRegisterUncreatableType<QGCCameraControl>    ("QGroundControl.Vehicle",              1, 0, "QGCCameraControl",           kRefOnly);
+    qmlRegisterUncreatableType<LinkInterface>       ("QGroundControl.Vehicle",              1, 0, "LinkInterface",              kRefOnly);
+    qmlRegisterUncreatableType<JoystickManager>     ("QGroundControl.JoystickManager",      1, 0, "JoystickManager",            kRefOnly);
+    qmlRegisterUncreatableType<Joystick>            ("QGroundControl.JoystickManager",      1, 0, "Joystick",                   kRefOnly);
+    qmlRegisterUncreatableType<QGCPositionManager>  ("QGroundControl.QGCPositionManager",   1, 0, "QGCPositionManager",         kRefOnly);
+    qmlRegisterUncreatableType<MissionController>   ("QGroundControl.Controllers",          1, 0, "MissionController",          kRefOnly);
+    qmlRegisterUncreatableType<GeoFenceController>  ("QGroundControl.Controllers",          1, 0, "GeoFenceController",         kRefOnly);
+    qmlRegisterUncreatableType<RallyPointController>("QGroundControl.Controllers",          1, 0, "RallyPointController",       kRefOnly);
+    qmlRegisterUncreatableType<VisualMissionItem>   ("QGroundControl.Controllers",          1, 0, "VisualMissionItem",          kRefOnly);
+    qmlRegisterUncreatableType<FactValueSliderListModel>("QGroundControl.FactControls",     1, 0, "FactValueSliderListModel",   kRefOnly);
 
-    qmlRegisterType<QGCGeoBoundingCube>             ("QGroundControl",                      1, 0, "QGCGeoBoundingCube");
+    qmlRegisterUncreatableType<QGCMapPolygon>       ("QGroundControl.FlightMap",            1, 0, "QGCMapPolygon",              kRefOnly);
+    qmlRegisterUncreatableType<QGCGeoBoundingCube>  ("QGroundControl.FlightMap",            1, 0, "QGCGeoBoundingCube",         kRefOnly);
+
+//    qRegisterMetaType<QGCGeoBoundingCube>("QGCGeoBoundingCube");
+
+    qmlRegisterType<QGCMapCircle>                   ("QGroundControl.FlightMap",   1, 0, "QGCMapCircle");
 
     qmlRegisterType<ParameterEditorController>      ("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
     qmlRegisterType<ESP8266ComponentController>     ("QGroundControl.Controllers", 1, 0, "ESP8266ComponentController");
@@ -421,7 +426,7 @@ void QGCApplication::_initCommon(void)
     qmlRegisterType<LogDownloadController>          ("QGroundControl.Controllers", 1, 0, "LogDownloadController");
     qmlRegisterType<SyslinkComponentController>     ("QGroundControl.Controllers", 1, 0, "SyslinkComponentController");
     qmlRegisterType<EditPositionDialogController>   ("QGroundControl.Controllers", 1, 0, "EditPositionDialogController");
-    qmlRegisterType<QGCMapCircle>                   ("QGroundControl.FlightMap",   1, 0, "QGCMapCircle");
+
 #ifndef __mobile__
     qmlRegisterType<ViewWidgetController>           ("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
     qmlRegisterType<CustomCommandWidgetController>  ("QGroundControl.Controllers", 1, 0, "CustomCommandWidgetController");

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -377,13 +377,28 @@ QGCApplication::~QGCApplication()
 
 void QGCApplication::_initCommon(void)
 {
-    static const char* kRefOnly = "Reference only";
+    static const char* kRefOnly         = "Reference only";
+    static const char* kQGCControllers  = "QGroundControl.Controllers";
+    static const char* kQGCVehicle      = "QGroundControl.Vehicle";
+
     QSettings settings;
 
     // Register our Qml objects
 
     qmlRegisterType<QGCPalette>     ("QGroundControl.Palette", 1, 0, "QGCPalette");
     qmlRegisterType<QGCMapPalette>  ("QGroundControl.Palette", 1, 0, "QGCMapPalette");
+
+    qmlRegisterUncreatableType<Vehicle>             (kQGCVehicle,                           1, 0, "Vehicle",                    kRefOnly);
+    qmlRegisterUncreatableType<MissionItem>         (kQGCVehicle,                           1, 0, "MissionItem",                kRefOnly);
+    qmlRegisterUncreatableType<MissionManager>      (kQGCVehicle,                           1, 0, "MissionManager",             kRefOnly);
+    qmlRegisterUncreatableType<ParameterManager>    (kQGCVehicle,                           1, 0, "ParameterManager",           kRefOnly);
+    qmlRegisterUncreatableType<QGCCameraManager>    (kQGCVehicle,                           1, 0, "QGCCameraManager",           kRefOnly);
+    qmlRegisterUncreatableType<QGCCameraControl>    (kQGCVehicle,                           1, 0, "QGCCameraControl",           kRefOnly);
+    qmlRegisterUncreatableType<LinkInterface>       (kQGCVehicle,                           1, 0, "LinkInterface",              kRefOnly);
+    qmlRegisterUncreatableType<MissionController>   (kQGCControllers,                       1, 0, "MissionController",          kRefOnly);
+    qmlRegisterUncreatableType<GeoFenceController>  (kQGCControllers,                       1, 0, "GeoFenceController",         kRefOnly);
+    qmlRegisterUncreatableType<RallyPointController>(kQGCControllers,                       1, 0, "RallyPointController",       kRefOnly);
+    qmlRegisterUncreatableType<VisualMissionItem>   (kQGCControllers,                       1, 0, "VisualMissionItem",          kRefOnly);
 
     qmlRegisterUncreatableType<CoordinateVector>    ("QGroundControl",                      1, 0, "CoordinateVector",           kRefOnly);
     qmlRegisterUncreatableType<QmlObjectListModel>  ("QGroundControl",                      1, 0, "QmlObjectListModel",         kRefOnly);
@@ -392,47 +407,34 @@ void QGCApplication::_initCommon(void)
 
     qmlRegisterUncreatableType<AutoPilotPlugin>     ("QGroundControl.AutoPilotPlugin",      1, 0, "AutoPilotPlugin",            kRefOnly);
     qmlRegisterUncreatableType<VehicleComponent>    ("QGroundControl.AutoPilotPlugin",      1, 0, "VehicleComponent",           kRefOnly);
-    qmlRegisterUncreatableType<Vehicle>             ("QGroundControl.Vehicle",              1, 0, "Vehicle",                    kRefOnly);
-    qmlRegisterUncreatableType<MissionItem>         ("QGroundControl.Vehicle",              1, 0, "MissionItem",                kRefOnly);
-    qmlRegisterUncreatableType<MissionManager>      ("QGroundControl.Vehicle",              1, 0, "MissionManager",             kRefOnly);
-    qmlRegisterUncreatableType<ParameterManager>    ("QGroundControl.Vehicle",              1, 0, "ParameterManager",           kRefOnly);
-    qmlRegisterUncreatableType<QGCCameraManager>    ("QGroundControl.Vehicle",              1, 0, "QGCCameraManager",           kRefOnly);
-    qmlRegisterUncreatableType<QGCCameraControl>    ("QGroundControl.Vehicle",              1, 0, "QGCCameraControl",           kRefOnly);
-    qmlRegisterUncreatableType<LinkInterface>       ("QGroundControl.Vehicle",              1, 0, "LinkInterface",              kRefOnly);
     qmlRegisterUncreatableType<JoystickManager>     ("QGroundControl.JoystickManager",      1, 0, "JoystickManager",            kRefOnly);
     qmlRegisterUncreatableType<Joystick>            ("QGroundControl.JoystickManager",      1, 0, "Joystick",                   kRefOnly);
     qmlRegisterUncreatableType<QGCPositionManager>  ("QGroundControl.QGCPositionManager",   1, 0, "QGCPositionManager",         kRefOnly);
-    qmlRegisterUncreatableType<MissionController>   ("QGroundControl.Controllers",          1, 0, "MissionController",          kRefOnly);
-    qmlRegisterUncreatableType<GeoFenceController>  ("QGroundControl.Controllers",          1, 0, "GeoFenceController",         kRefOnly);
-    qmlRegisterUncreatableType<RallyPointController>("QGroundControl.Controllers",          1, 0, "RallyPointController",       kRefOnly);
-    qmlRegisterUncreatableType<VisualMissionItem>   ("QGroundControl.Controllers",          1, 0, "VisualMissionItem",          kRefOnly);
     qmlRegisterUncreatableType<FactValueSliderListModel>("QGroundControl.FactControls",     1, 0, "FactValueSliderListModel",   kRefOnly);
 
     qmlRegisterUncreatableType<QGCMapPolygon>       ("QGroundControl.FlightMap",            1, 0, "QGCMapPolygon",              kRefOnly);
     qmlRegisterUncreatableType<QGCGeoBoundingCube>  ("QGroundControl.FlightMap",            1, 0, "QGCGeoBoundingCube",         kRefOnly);
 
-//    qRegisterMetaType<QGCGeoBoundingCube>("QGCGeoBoundingCube");
+    qmlRegisterType<QGCMapCircle>                   ("QGroundControl.FlightMap",            1, 0, "QGCMapCircle");
 
-    qmlRegisterType<QGCMapCircle>                   ("QGroundControl.FlightMap",   1, 0, "QGCMapCircle");
-
-    qmlRegisterType<ParameterEditorController>      ("QGroundControl.Controllers", 1, 0, "ParameterEditorController");
-    qmlRegisterType<ESP8266ComponentController>     ("QGroundControl.Controllers", 1, 0, "ESP8266ComponentController");
-    qmlRegisterType<ScreenToolsController>          ("QGroundControl.Controllers", 1, 0, "ScreenToolsController");
-    qmlRegisterType<PlanMasterController>           ("QGroundControl.Controllers", 1, 0, "PlanMasterController");
-    qmlRegisterType<ValuesWidgetController>         ("QGroundControl.Controllers", 1, 0, "ValuesWidgetController");
-    qmlRegisterType<QGCFileDialogController>        ("QGroundControl.Controllers", 1, 0, "QGCFileDialogController");
-    qmlRegisterType<RCChannelMonitorController>     ("QGroundControl.Controllers", 1, 0, "RCChannelMonitorController");
-    qmlRegisterType<JoystickConfigController>       ("QGroundControl.Controllers", 1, 0, "JoystickConfigController");
-    qmlRegisterType<LogDownloadController>          ("QGroundControl.Controllers", 1, 0, "LogDownloadController");
-    qmlRegisterType<SyslinkComponentController>     ("QGroundControl.Controllers", 1, 0, "SyslinkComponentController");
-    qmlRegisterType<EditPositionDialogController>   ("QGroundControl.Controllers", 1, 0, "EditPositionDialogController");
+    qmlRegisterType<ParameterEditorController>      (kQGCControllers,                       1, 0, "ParameterEditorController");
+    qmlRegisterType<ESP8266ComponentController>     (kQGCControllers,                       1, 0, "ESP8266ComponentController");
+    qmlRegisterType<ScreenToolsController>          (kQGCControllers,                       1, 0, "ScreenToolsController");
+    qmlRegisterType<PlanMasterController>           (kQGCControllers,                       1, 0, "PlanMasterController");
+    qmlRegisterType<ValuesWidgetController>         (kQGCControllers,                       1, 0, "ValuesWidgetController");
+    qmlRegisterType<QGCFileDialogController>        (kQGCControllers,                       1, 0, "QGCFileDialogController");
+    qmlRegisterType<RCChannelMonitorController>     (kQGCControllers,                       1, 0, "RCChannelMonitorController");
+    qmlRegisterType<JoystickConfigController>       (kQGCControllers,                       1, 0, "JoystickConfigController");
+    qmlRegisterType<LogDownloadController>          (kQGCControllers,                       1, 0, "LogDownloadController");
+    qmlRegisterType<SyslinkComponentController>     (kQGCControllers,                       1, 0, "SyslinkComponentController");
+    qmlRegisterType<EditPositionDialogController>   (kQGCControllers,                       1, 0, "EditPositionDialogController");
 
 #ifndef __mobile__
-    qmlRegisterType<ViewWidgetController>           ("QGroundControl.Controllers", 1, 0, "ViewWidgetController");
-    qmlRegisterType<CustomCommandWidgetController>  ("QGroundControl.Controllers", 1, 0, "CustomCommandWidgetController");
-    qmlRegisterType<FirmwareUpgradeController>      ("QGroundControl.Controllers", 1, 0, "FirmwareUpgradeController");
-    qmlRegisterType<GeoTagController>               ("QGroundControl.Controllers", 1, 0, "GeoTagController");
-    qmlRegisterType<MavlinkConsoleController>       ("QGroundControl.Controllers", 1, 0, "MavlinkConsoleController");
+    qmlRegisterType<ViewWidgetController>           (kQGCControllers,                       1, 0, "ViewWidgetController");
+    qmlRegisterType<CustomCommandWidgetController>  (kQGCControllers,                       1, 0, "CustomCommandWidgetController");
+    qmlRegisterType<FirmwareUpgradeController>      (kQGCControllers,                       1, 0, "FirmwareUpgradeController");
+    qmlRegisterType<GeoTagController>               (kQGCControllers,                       1, 0, "GeoTagController");
+    qmlRegisterType<MavlinkConsoleController>       (kQGCControllers,                       1, 0, "MavlinkConsoleController");
 #endif
 
     // Register Qml Singletons

--- a/src/QmlControls/QGCGeoBoundingCube.cc
+++ b/src/QmlControls/QGCGeoBoundingCube.cc
@@ -19,6 +19,13 @@ double QGCGeoBoundingCube::MaxWest   = -180.0;
 double QGCGeoBoundingCube::MaxEast   =  180.0;
 
 //-----------------------------------------------------------------------------
+QGCGeoBoundingCube::QGCGeoBoundingCube(QObject* parent)
+    : QObject(parent)
+{
+    reset();
+}
+
+//-----------------------------------------------------------------------------
 bool
 QGCGeoBoundingCube::isValid() const
 {
@@ -30,8 +37,8 @@ QGCGeoBoundingCube::isValid() const
 void
 QGCGeoBoundingCube::reset()
 {
-    pointSE = QGeoCoordinate();
-    pointNW = QGeoCoordinate();
+    pointNW = QGeoCoordinate(MaxSouth, MaxEast, MaxAlt);
+    pointSE = QGeoCoordinate(MaxNorth, MaxWest, MinAlt);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QmlControls/QGCGeoBoundingCube.h
+++ b/src/QmlControls/QGCGeoBoundingCube.h
@@ -18,17 +18,13 @@
 class QGCGeoBoundingCube : public QObject {
     Q_OBJECT
 public:
+    QGCGeoBoundingCube(QObject* parent = nullptr);
+
     QGCGeoBoundingCube(const QGCGeoBoundingCube& other)
         : QObject()
     {
         pointNW = other.pointNW;
         pointSE = other.pointSE;
-    }
-
-    QGCGeoBoundingCube()
-        : pointNW(QGeoCoordinate(MaxSouth, MaxEast, MaxAlt))
-        , pointSE(QGeoCoordinate(MaxNorth, MaxWest, MinAlt))
-    {
     }
 
     QGCGeoBoundingCube(QGeoCoordinate p1, QGeoCoordinate p2)
@@ -38,7 +34,7 @@ public:
     }
 
     Q_PROPERTY(QGeoCoordinate pointNW MEMBER pointNW CONSTANT)
-    Q_PROPERTY(QGeoCoordinate pointSE MEMBER pointNW CONSTANT)
+    Q_PROPERTY(QGeoCoordinate pointSE MEMBER pointSE CONSTANT)
 
     Q_INVOKABLE void            reset   ();
     Q_INVOKABLE bool            isValid () const;
@@ -64,7 +60,7 @@ public:
     }
 
     //-- 2D
-    QList<QGeoCoordinate> polygon2D(double clipTo = 0.0) const;
+    Q_INVOKABLE QList<QGeoCoordinate> polygon2D(double clipTo = 0.0) const;
 
     Q_INVOKABLE double width    () const;
     Q_INVOKABLE double height   () const;


### PR DESCRIPTION
The code that fits a mission within the screen in plan view was only using the first coordinate of a polygon to center it and compute its "bounding box". That is, it was using a single point to determine the width and height of the bounding box to fit within the screen.

For Airmap support, I had created and exposed `QGCGeoBoundingCube`, which contains the bounding _cube_ (3D as it also has altitude) of a mission. This was to give Airmap the area/volume of the flight plan. This wasn't however, exposed all the way up to the QML side. It was also missing from some complex items such as Structure Scan as it didn't exist when I first added this.

I've exposed `QGCGeoBoundingCube` as a property of the root class (`VisualMissionItem`) and the proper implementation throughout its derived classes where needed. The base class contains an invalid bounding cube, which is then ignored.

The fitting function now uses the bounding "box" (2D) of all the mission items in order to properly fit within the window.

In addition, the function would "back off" the zoom level by decrementing it by 1. This had the side effect of being accumulative. Every time you hit the "zoom to all items" or load a mission off the disk, the zoom level would decrease by one.

This fixes all instances of properly fitting a mission within the screen when loading it from disk or when using the "Center on Mission/All Items".

Also fixed a bunch of warnings while at it.
