### PR TITLE
PreFlight: Reset not working correctly

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -717,9 +717,7 @@ void FirmwarePlugin::_versionFileDownloadFinished(QString& remoteFile, QString& 
     int currType = vehicle->firmwareVersionType();
 
     // Check if lower version than stable or same version but different type
-    if (vehicle->versionCompare(version) < 0
-       || (vehicle->versionCompare(version) == 0 && currType != FIRMWARE_VERSION_TYPE_OFFICIAL))
-    {
+    if (currType == FIRMWARE_VERSION_TYPE_OFFICIAL && vehicle->versionCompare(version) < 0) {
         const static QString currentVersion = QString("%1.%2.%3").arg(vehicle->firmwareMajorVersion())
                                                                  .arg(vehicle->firmwareMinorVersion())
                                                                  .arg(vehicle->firmwarePatchVersion());

--- a/src/QmlControls/PreFlightCheckGroup.qml
+++ b/src/QmlControls/PreFlightCheckGroup.qml
@@ -22,7 +22,7 @@ Column  {
 
     property alias _checked: header.checked
 
-    onPassedChanged: parent.groupPassedChanged(ObjectModel.index)
+    onPassedChanged: parent.groupPassedChanged(ObjectModel.index, passed)
 
     Component.onCompleted: {
         enabled = _checked

--- a/src/QmlControls/PreFlightCheckList.qml
+++ b/src/QmlControls/PreFlightCheckList.qml
@@ -23,7 +23,22 @@ Rectangle {
 
     property alias model: checkListRepeater.model
 
-    property bool _passed: false
+    property bool _passed:  false
+
+    function _handleGroupPassedChanged(index, passed) {
+        if (passed) {
+            // Collapse current group
+            var group = checkListRepeater.itemAt(index)
+            group._checked = false
+            // Expand next group
+            if (index + 1 < checkListRepeater.count) {
+                group = checkListRepeater.itemAt(index + 1)
+                group.enabled = true
+                group._checked = true
+            }
+        }
+        _passed = passed
+    }
 
     // We delay the updates when a group passes so the user can see all items green for a moment prior to hiding
     Timer {
@@ -32,22 +47,7 @@ Rectangle {
 
         property int index
 
-        onTriggered: {
-            var group = checkListRepeater.itemAt(index)
-            group._checked = false
-            if (index + 1 < checkListRepeater.count) {
-                group = checkListRepeater.itemAt(index + 1)
-                group.enabled = true
-                group._checked = true
-            }
-            for (var i=0; i<checkListRepeater.count; i++) {
-                if (!checkListRepeater.itemAt(i).passed) {
-                    _passed = false
-                    return
-                }
-            }
-            _passed = true
-        }
+        onTriggered: _handleGroupPassedChanged(index, true /* passed */)
     }
 
     Column {
@@ -59,9 +59,13 @@ Rectangle {
         anchors.topMargin:      0.6*ScreenTools.defaultFontPixelWidth
         anchors.leftMargin:     1.5*ScreenTools.defaultFontPixelWidth
 
-        function groupPassedChanged(index) {
-            delayedGroupPassed.index = index
-            delayedGroupPassed.restart()
+        function groupPassedChanged(index, passed) {
+            if (passed) {
+                delayedGroupPassed.index = index
+                delayedGroupPassed.restart()
+            } else {
+                _handleGroupPassedChanged(index, passed)
+            }
         }
 
         // Header/title of checklist


### PR DESCRIPTION
It would leave the last group expanded. 

@Williangalvani In this pull I turned off version checks for everythiong other than stable firmware builds. It was popping up all over the place with various SITL testing. Reason being non stable builds tend to have version strangeness.