### PR TITLE
New Resume Mission sequence

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -119,7 +119,6 @@ QGCView {
 
     Connections {
         target:                     _missionController
-        onResumeMissionReady:       guidedActionsController.confirmAction(guidedActionsController.actionResumeMissionReady)
         onResumeMissionUploadFail:  guidedActionsController.confirmAction(guidedActionsController.actionResumeMissionUploadFail)
     }
 
@@ -196,6 +195,39 @@ QGCView {
                         Layout.alignment:   Qt.AlignHCenter
                         text:               qsTr("Leave plan on vehicle")
                         onClicked:          hideDialog()
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth:   true
+                        color:              qgcPal.text
+                        height:             1
+                    }
+
+                    QGCButton {
+                        Layout.fillWidth:   true
+                        Layout.alignment:   Qt.AlignHCenter
+                        text:               qsTr("Resume Mission From Waypoint %1").arg(_guidedController._resumeMissionIndex)
+                        visible:            _guidedController.showResumeMission
+
+                        onClicked: {
+                            guidedController.executeAction(_guidedController.actionResumeMission, null, null)
+                            hideDialog()
+                        }
+                    }
+
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        wrapMode:           Text.WordWrap
+                        text:               qsTr("Resume Mission will rebuild the current mission from the last flown waypoint and upload it to the vehicle for the next flight.")
+                        visible:            _guidedController.showResumeMission
+                    }
+
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        wrapMode:           Text.WordWrap
+                        color:              qgcPal.warningText
+                        text:               qsTr("If you are changing batteries for Resume Mission do not disconnect from the vehicle when communication is lost.")
+                        visible:            _guidedController.showResumeMission
                     }
                 }
             }
@@ -601,7 +633,7 @@ QGCView {
             z:                  _flightVideoPipControl.z + 1
 
             onShowStartMissionChanged: {
-                if (showStartMission && !showResumeMission) {
+                if (showStartMission) {
                     confirmAction(actionStartMission)
                 }
             }
@@ -609,12 +641,6 @@ QGCView {
             onShowContinueMissionChanged: {
                 if (showContinueMission) {
                     confirmAction(actionContinueMission)
-                }
-            }
-
-            onShowResumeMissionChanged: {
-                if (showResumeMission) {
-                    confirmAction(actionResumeMission)
                 }
             }
 

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -42,7 +42,6 @@ Item {
     readonly property string startMissionTitle:             qsTr("Start Mission")
     readonly property string mvStartMissionTitle:           qsTr("Start Mission (MV)")
     readonly property string continueMissionTitle:          qsTr("Continue Mission")
-    readonly property string resumeMissionTitle:            qsTr("Resume Mission")
     readonly property string resumeMissionUploadFailTitle:  qsTr("Resume FAILED")
     readonly property string pauseTitle:                    qsTr("Pause")
     readonly property string mvPauseTitle:                  qsTr("Pause (MV)")
@@ -59,9 +58,7 @@ Item {
     readonly property string takeoffMessage:                    qsTr("Takeoff from ground and hold position.")
     readonly property string startMissionMessage:               qsTr("Takeoff from ground and start the current mission.")
     readonly property string continueMissionMessage:            qsTr("Continue the mission from the current waypoint.")
-             property string resumeMissionMessage:              qsTr("Resume the current mission. This will re-generate the mission from waypoint %1, takeoff and continue the mission.").arg(_resumeMissionIndex)
-             property string resumeMissionUploadFailMessage:    qsTr("Upload of resume mission failed. Confirm to retry upload")
-    readonly property string resumeMissionReadyMessage:         qsTr("Review the modified mission. Confirm if you want to takeoff and begin mission.")
+    readonly property string resumeMissionUploadFailMessage:    qsTr("Upload of resume mission failed. Confirm to retry upload")
     readonly property string landMessage:                       qsTr("Land the vehicle at the current position.")
     readonly property string rtlMessage:                        qsTr("Return to the home position of the vehicle.")
     readonly property string changeAltMessage:                  qsTr("Change the altitude of the vehicle up or down.")
@@ -88,7 +85,7 @@ Item {
     readonly property int actionStartMission:               12
     readonly property int actionContinueMission:            13
     readonly property int actionResumeMission:              14
-    readonly property int actionResumeMissionReady:         15
+    readonly property int _actionUnused:                    15
     readonly property int actionResumeMissionUploadFail:    16
     readonly property int actionPause:                      17
     readonly property int actionMVPause:                    18
@@ -185,6 +182,12 @@ Item {
         }
         _outputState()
     }
+    onShowRTLChanged: {
+        if (_corePlugin.guidedActionsControllerLogging()) {
+            console.log("showRTL", showRTL)
+        }
+        _outputState()
+    }
     // End of hack
 
     on_VehicleFlyingChanged: {
@@ -260,20 +263,12 @@ Item {
             confirmDialog.hideTrigger = Qt.binding(function() { return !showContinueMission })
             break;
         case actionResumeMission:
-            showImmediate = false
-            confirmDialog.title = resumeMissionTitle
-            confirmDialog.message = resumeMissionMessage
-            confirmDialog.hideTrigger = Qt.binding(function() { return !showResumeMission })
-            break;
+            // Resume Mission is handled in mission end dialog
+            return
         case actionResumeMissionUploadFail:
             confirmDialog.title = resumeMissionUploadFailTitle
             confirmDialog.message = resumeMissionUploadFailMessage
             confirmDialog.hideTrigger = Qt.binding(function() { return !showResumeMission })
-            break;
-        case actionResumeMissionReady:
-            confirmDialog.title = resumeMissionTitle
-            confirmDialog.message = resumeMissionReadyMessage
-            confirmDialog.hideTrigger = false
             break;
         case actionLand:
             confirmDialog.title = landTitle
@@ -359,10 +354,6 @@ Item {
         case actionResumeMission:
         case actionResumeMissionUploadFail:
             missionController.resumeMission(missionController.resumeMissionIndex)
-            break
-        case actionResumeMissionReady:
-            _vehicleWasFlying = false
-            _activeVehicle.startMission()
             break
         case actionStartMission:
         case actionContinueMission:


### PR DESCRIPTION
The current Resume Mission / Battery Change sequence is confusing a lot of people for various reasons. The new sequence place Resume Mission in the Flight Plan complete dialog instead of using confirm sliders:

![screen shot 2018-11-17 at 12 46 32 pm](https://user-images.githubusercontent.com/5876851/48665728-8a255180-ea68-11e8-8a0f-770f9dc440ae.png)

And then if you do rebuild the mission, afterwards you just get the regular Start Mission slider.