### PR TITLE
 Replace overly redundant code with macros for settings.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ Note: This file only contains high level features or important fixes.
 * Fixed Wing Landing Pattern: Add stop photo/video support. Defaults to on such that doing an RTL will stop camera.
 * Survey Planning: add mode that supports concave polygons
 * Support loading polygons from SHP files
+* Bumped settings version (now 8). This will cause all settings to be reset to defaults.
 
 ## 3.4
 

--- a/src/Airmap/AirMapSettings.cc
+++ b/src/Airmap/AirMapSettings.cc
@@ -13,18 +13,10 @@
 #include <QQmlEngine>
 #include <QtQml>
 
-DECLARE_SETTINGGROUP(AirMap)
+DECLARE_SETTINGGROUP(AirMap, "AirMap")
 {
-    INIT_SETTINGFACT(usePersonalApiKey);
-    INIT_SETTINGFACT(apiKey);
-    INIT_SETTINGFACT(clientID);
-    INIT_SETTINGFACT(userName);
-    INIT_SETTINGFACT(password);
-    INIT_SETTINGFACT(enableAirMap);
-    INIT_SETTINGFACT(enableAirspace);
-    INIT_SETTINGFACT(enableTelemetry);
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-    qmlRegisterUncreatableType<AirMapSettings>("QGroundControl.SettingsManager", 1, 0, "AirMapSettings", "Reference only");
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
+    qmlRegisterUncreatableType<AirMapSettings>("QGroundControl.SettingsManager", 1, 0, "AirMapSettings", "Reference only"); \
 }
 
 DECLARE_SETTINGSFACT(AirMapSettings, usePersonalApiKey)

--- a/src/Airmap/AirMapSettings.h
+++ b/src/Airmap/AirMapSettings.h
@@ -17,7 +17,7 @@ class AirMapSettings : public SettingsGroup
 public:
     AirMapSettings(QObject* parent = nullptr);
 
-    DEFINE_SETTINGGROUP(AirMap)
+    DEFINE_SETTING_NAME_GROUP()
 
     DEFINE_SETTINGFACT(usePersonalApiKey)
     DEFINE_SETTINGFACT(apiKey)

--- a/src/Airmap/AirspaceWeather.qml
+++ b/src/Airmap/AirspaceWeather.qml
@@ -16,7 +16,7 @@ Item {
     height: _valid ? weatherRow.height : 0
     width:  _valid ? weatherRow.width  : 0
     property color  contentColor:       "#ffffff"
-    property var    iconHeight:         ScreenTools.defaultFontPixelHeight * 2
+    property real   iconHeight:         ScreenTools.defaultFontPixelHeight * 2
     property bool   _valid:             QGroundControl.airspaceManager.weatherInfo.valid
     property bool   _celcius:           QGroundControl.settingsManager.unitsSettings.temperatureUnits.rawValue === UnitsSettings.TemperatureUnitsCelsius
     property int    _tempC:             _valid ? QGroundControl.airspaceManager.weatherInfo.temperature : 0

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -23,10 +23,10 @@ Fact::Fact(QObject* parent)
     , _componentId              (-1)
     , _rawValue                 (0)
     , _type                     (FactMetaData::valueTypeInt32)
-    , _metaData                 (NULL)
+    , _metaData                 (nullptr)
     , _sendValueChangedSignals  (true)
     , _deferredValueChangeSignal(false)
-    , _valueSliderModel         (NULL)
+    , _valueSliderModel         (nullptr)
 {    
     FactMetaData* metaData = new FactMetaData(_type, this);
     setMetaData(metaData);
@@ -40,10 +40,10 @@ Fact::Fact(int componentId, QString name, FactMetaData::ValueType_t type, QObjec
     , _componentId              (componentId)
     , _rawValue                 (0)
     , _type                     (type)
-    , _metaData                 (NULL)
+    , _metaData                 (nullptr)
     , _sendValueChangedSignals  (true)
     , _deferredValueChangeSignal(false)
-    , _valueSliderModel         (NULL)
+    , _valueSliderModel         (nullptr)
 {
     FactMetaData* metaData = new FactMetaData(_type, this);
     setMetaData(metaData);
@@ -57,10 +57,10 @@ Fact::Fact(const QString& settingsGroup, FactMetaData* metaData, QObject* parent
     , _componentId              (0)
     , _rawValue                 (0)
     , _type                     (metaData->type())
-    , _metaData                 (NULL)
+    , _metaData                 (nullptr)
     , _sendValueChangedSignals  (true)
     , _deferredValueChangeSignal(false)
-    , _valueSliderModel         (NULL)
+    , _valueSliderModel         (nullptr)
 {
     qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(settingsGroup, *metaData);
     setMetaData(metaData, true /* setDefaultFromMetaData */);
@@ -90,11 +90,11 @@ const Fact& Fact::operator=(const Fact& other)
     _type                       = other._type;
     _sendValueChangedSignals    = other._sendValueChangedSignals;
     _deferredValueChangeSignal  = other._deferredValueChangeSignal;
-    _valueSliderModel       = NULL;
+    _valueSliderModel       = nullptr;
     if (_metaData && other._metaData) {
         *_metaData = *other._metaData;
     } else {
-        _metaData = NULL;
+        _metaData = nullptr;
     }
     
     return *this;

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -48,10 +48,10 @@ public:
 
     typedef QVariant (*Translator)(const QVariant& from);
 
-    FactMetaData(QObject* parent = NULL);
-    FactMetaData(ValueType_t type, QObject* parent = NULL);
-    FactMetaData(ValueType_t type, const QString name, QObject* parent = NULL);
-    FactMetaData(const FactMetaData& other, QObject* parent = NULL);
+    FactMetaData(QObject* parent = nullptr);
+    FactMetaData(ValueType_t type, QObject* parent = nullptr);
+    FactMetaData(ValueType_t type, const QString name, QObject* parent = nullptr);
+    FactMetaData(const FactMetaData& other, QObject* parent = nullptr);
 
     static QMap<QString, FactMetaData*> createMapFromJsonFile(const QString& jsonFilename, QObject* metaDataParent);
     static QMap<QString, FactMetaData*> createMapFromJsonArray(const QJsonArray jsonArray, QObject* metaDataParent);

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -157,7 +157,7 @@ Item {
         id:                     instrumentsColumn
         spacing:                ScreenTools.defaultFontPixelHeight * 0.25
         anchors.top:            parent.top
-        anchors.topMargin:      QGroundControl.corePlugin.options.instrumentWidget.widgetTopMargin + (ScreenTools.defaultFontPixelHeight * 0.5)
+        anchors.topMargin:      QGroundControl.corePlugin.options.instrumentWidget ? (QGroundControl.corePlugin.options.instrumentWidget.widgetTopMargin + (ScreenTools.defaultFontPixelHeight * 0.5)) : 0
         anchors.margins:        ScreenTools.defaultFontPixelHeight * 0.5
         anchors.right:          parent.right
         //-------------------------------------------------------

--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -254,8 +254,8 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
             { sideOverlapName,          QJsonValue::Double, true },
         };
         if (!JsonHelper::validateKeys(v1Json, keyInfoList2, errorString)) {
-            return false;
             _disableRecalc = false;
+            return false;
         }
 
         _valueSetIsDistanceFact.setRawValue (v1Json[valueSetIsDistanceName].toBool());

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -321,20 +321,28 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     }
 #endif
 
-    // gstreamer debug settings
+    // Gstreamer debug settings
+#if defined(__ios__) || defined(__android__)
+    // Initialize Video Streaming
+    initializeVideoStreaming(argc, argv, nullptr, nullptr);
+#else
     QString savePath, gstDebugLevel;
     if (settings.contains(AppSettings::savePathName)) {
-         savePath = settings.value("SavePath").toString() + "/Logs/gst"; // hardcode log path here, appsetting is not available yet
-         if (!QDir(savePath).exists()) {
-             QDir().mkdir(savePath);
-         }
+        savePath = settings.value(AppSettings::savePathName).toString();
     }
-    if (settings.contains(AppSettings::gstDebugName)) {
-        gstDebugLevel = "*:" + settings.value("GstreamerDebugLevel").toString();
+    if(savePath.isEmpty()) {
+        savePath = "/tmp";
     }
-
+    savePath = savePath + "/Logs/gst";
+    if (!QDir(savePath).exists()) {
+        QDir().mkpath(savePath);
+    }
+    if (settings.contains(AppSettings::gstDebugLevelName)) {
+        gstDebugLevel = "*:" + settings.value(AppSettings::gstDebugLevelName).toString();
+    }
     // Initialize Video Streaming
     initializeVideoStreaming(argc, argv, savePath.toUtf8().data(), gstDebugLevel.toUtf8().data());
+#endif
 
     _toolbox = new QGCToolbox(this);
     _toolbox->setChildToolboxes();

--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -10,6 +10,6 @@
 
 // If you need to make an incompatible changes to stored settings, bump this version number
 // up by 1. This will caused store settings to be cleared on next boot.
-#define QGC_SETTINGS_VERSION 7
+#define QGC_SETTINGS_VERSION 8
 
 #endif // QGC_CONFIGURATION_H

--- a/src/QmlControls/AppMessages.qml
+++ b/src/QmlControls/AppMessages.qml
@@ -161,7 +161,7 @@ QGCView {
                 anchors.baseline:    gstCombo.baseline
                 anchors.right:       gstCombo.left
                 anchors.rightMargin: ScreenTools.defaultFontPixelWidth
-                text:                "gstreamer debug level:"
+                text:                qsTr("GStreamer Debug Level:")
             }
 
             FactComboBox {
@@ -171,7 +171,7 @@ QGCView {
                 anchors.bottom:      parent.bottom
                 width:               ScreenTools.defaultFontPixelWidth*20
                 model:               ["disabled", "1", "2", "3", "4", "5", "6", "7", "8"]
-                fact:                QGroundControl.settingsManager.appSettings.gstDebug
+                fact:                QGroundControl.settingsManager.appSettings.gstDebugLevel
             }
 
             BusyIndicator {

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -1,6 +1,6 @@
 [
 {
-    "name":             "OfflineEditingFirmwareType",
+    "name":             "offlineEditingFirmwareType",
     "shortDescription": "Offline editing firmware type",
     "type":             "uint32",
     "enumStrings":      "ArduPilot,PX4 Pro,Mavlink Generic",
@@ -8,7 +8,7 @@
     "defaultValue":     12
 },
 {
-    "name":             "OfflineEditingVehicleType",
+    "name":             "offlineEditingVehicleType",
     "shortDescription": "Offline editing vehicle type",
     "type":             "uint32",
     "enumStrings":      "Fixed Wing,Multi-Rotor,VTOL,Rover,Sub",
@@ -16,7 +16,7 @@
     "defaultValue":     2
 },
 {
-    "name":             "OfflineEditingCruiseSpeed",
+    "name":             "offlineEditingCruiseSpeed",
     "shortDescription": "Offline editing cruise speed",
     "longDescription":  "This value defines the default cruising speed for forward flight vehicles for use in calculating mission statistics. It does not modify the flight speed for a specific flight plan.",
     "type":             "double",
@@ -26,7 +26,7 @@
     "decimalPlaces":    2
 },
 {
-    "name":             "OfflineEditingHoverSpeed",
+    "name":             "offlineEditingHoverSpeed",
     "shortDescription": "Offline editing hover speed",
     "longDescription":  "This value defines the default cruising speed for multi-rotor vehicles for use in calculating mission statistics. It does not modify the flight speed for a specific flight plan.",
     "type":             "double",
@@ -36,7 +36,7 @@
     "decimalPlaces":    2
 },
 {
-    "name":             "OfflineEditingAscentSpeed",
+    "name":             "offlineEditingAscentSpeed",
     "shortDescription": "Offline editing ascent speed",
     "longDescription":  "This value defines the ascent speed for multi-rotor vehicles for use in calculating mission duration.",
     "type":             "double",
@@ -46,7 +46,7 @@
     "decimalPlaces":    2
 },
 {
-    "name":             "OfflineEditingDescentSpeed",
+    "name":             "offlineEditingDescentSpeed",
     "shortDescription": "Offline editing descent speed",
     "longDescription":  "This value defines the cruising speed for multi-rotor vehicles for use in calculating mission duration.",
     "type":             "double",
@@ -66,7 +66,7 @@
     "max":              100
 },
 {
-    "name":             "DefaultMissionItemAltitude",
+    "name":             "defaultMissionItemAltitude",
     "shortDescription": "Default value for altitude",
     "longDescription":  "This value specifies the default altitude for new items added to a mission.",
     "type":             "double",
@@ -76,56 +76,56 @@
     "decimalPlaces":    1
 },
 {
-    "name":             "PromptFLightDataSave",
+    "name":             "telemetrySave",
     "shortDescription": "Save telemetry Log after each flight",
     "longDescription":  "If this option is enabled a telemetry will be saved after each flight completes.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "PromptFLightDataSaveNotArmed",
+    "name":             "telemetrySaveNotArmed",
     "shortDescription": "Save telemetry log even if vehicle was not armed",
     "longDescription":  "If this option is enabled a telemtry log will be saved even if vehicle was never armed.",
     "type":             "bool",
     "defaultValue":     false
 },
 {
-    "name":             "AudioMuted",
+    "name":             "audioMuted",
     "shortDescription": "Mute audio output",
     "longDescription":  "If this option is enabled all audio output will be muted.",
     "type":             "bool",
     "defaultValue":     false
 },
 {
-    "name":             "VirtualTabletJoystick",
+    "name":             "virtualJoystick",
     "shortDescription": "Show virtual joystick",
     "longDescription":  "If this option is enabled the virtual joystick will be shown on the Fly view.",
     "type":             "bool",
     "defaultValue":     false
 },
 {
-    "name":             "GstreamerDebugLevel",
+    "name":             "gstDebugLevel",
     "shortDescription": "Video streaming debug",
     "longDescription":  "Sets the environment variable GST_DEBUG for all pipeline elements on boot.",
     "type":             "uint8",
     "defaultValue":     0
 },
 {
-    "name":             "AutoLoadMissions",
+    "name":             "autoLoadMissions",
     "shortDescription": "AutoLoad mission on vehicle connect",
     "longDescription":  "Automatically load a mission file named AutoLoad#.mission when a vehicle with id # connects.",
     "type":             "bool",
     "defaultValue":     false
 },
 {
-    "name":             "UseChecklist",
+    "name":             "useChecklist",
     "shortDescription": "Use preflight checklist",
     "longDescription":  "If this option is enabled the preflight checklist will be used.",
     "type":             "bool",
     "defaultValue":     false
 },
 {
-    "name":                 "BaseDeviceFontPointSize",
+    "name":                 "appFontPointSize",
     "shortDescription":     "Application font size",
     "longDescription":      "The point size for the default font used.",
     "type":                 "uint32",
@@ -136,7 +136,7 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":             "StyleIsDark",
+    "name":             "indoorPalette",
     "shortDescription": "Application color scheme",
     "longDescription":  "The color scheme for the user interface.",
     "type":             "uint32",
@@ -145,55 +145,55 @@
     "defaultValue":     0
 },
 {
-    "name":             "ShowLargeCompass",
+    "name":             "showLargeCompass",
     "shortDescription": "Show large compass",
     "longDescription":  "Show large compass on instrument panel",
     "type":             "bool",
     "defaultValue":     false
 },
 {
-    "name":             "SavePath",
+    "name":             "savePath",
     "shortDescription": "Application save directory",
     "longDescription":  "Directory to which all data files  are saved/loaded from",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "UserBrandImageIndoor",
+    "name":             "userBrandImageIndoor",
     "shortDescription": "User-selected brand image",
     "longDescription":  "Location in file system of user-selected brand image (indoor)",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "UserBrandImageOutdoor",
+    "name":             "userBrandImageOutdoor",
     "shortDescription": "User-selected brand image",
     "longDescription":  "Location in file system of user-selected brand image (outdoor)",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "MapboxToken",
+    "name":             "mapboxToken",
     "shortDescription": "Access token to Mapbox maps",
     "longDescription":  "Your personal access token for Mapbox maps",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "EsriToken",
+    "name":             "esriToken",
     "shortDescription": "Access token to Esri maps",
     "longDescription":  "Your personal access token for Esri maps",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "DefaultFirmwareType",
+    "name":             "defaultFirmwareType",
     "shortDescription": "Default firmware type for flashing",
     "type":             "uint32",
     "defaultValue":     12
 },
 {
-    "name":             "FollowTarget",
+    "name":             "followTarget",
     "shortDescription": "Stream GCS' coordinates to Autopilot",
     "type":             "uint32",
     "enumStrings":      "Never,Always,When in Follow Me Flight Mode",

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -15,33 +15,6 @@
 #include <QtQml>
 #include <QStandardPaths>
 
-const char* AppSettings::name =                                         "App";
-const char* AppSettings::settingsGroup =                                ""; // settings are in root group
-
-const char* AppSettings::offlineEditingFirmwareTypeSettingsName =       "OfflineEditingFirmwareType";
-const char* AppSettings::offlineEditingVehicleTypeSettingsName =        "OfflineEditingVehicleType";
-const char* AppSettings::offlineEditingCruiseSpeedSettingsName =        "OfflineEditingCruiseSpeed";
-const char* AppSettings::offlineEditingHoverSpeedSettingsName =         "OfflineEditingHoverSpeed";
-const char* AppSettings::offlineEditingAscentSpeedSettingsName =        "OfflineEditingAscentSpeed";
-const char* AppSettings::offlineEditingDescentSpeedSettingsName =       "OfflineEditingDescentSpeed";
-const char* AppSettings::batteryPercentRemainingAnnounceSettingsName =  "batteryPercentRemainingAnnounce";
-const char* AppSettings::defaultMissionItemAltitudeSettingsName =       "DefaultMissionItemAltitude";
-const char* AppSettings::telemetrySaveName =                            "PromptFLightDataSave";
-const char* AppSettings::telemetrySaveNotArmedName =                    "PromptFLightDataSaveNotArmed";
-const char* AppSettings::audioMutedName =                               "AudioMuted";
-const char* AppSettings::virtualJoystickName =                          "VirtualTabletJoystick";
-const char* AppSettings::appFontPointSizeName =                         "BaseDeviceFontPointSize";
-const char* AppSettings::indoorPaletteName =                            "StyleIsDark";
-const char* AppSettings::showLargeCompassName =                         "ShowLargeCompass";
-const char* AppSettings::savePathName =                                 "SavePath";
-const char* AppSettings::autoLoadMissionsName =                         "AutoLoadMissions";
-const char* AppSettings::useChecklistName =                             "UseChecklist";
-const char* AppSettings::mapboxTokenName =                              "MapboxToken";
-const char* AppSettings::esriTokenName =                                "EsriToken";
-const char* AppSettings::defaultFirmwareTypeName =                      "DefaultFirmwareType";
-const char* AppSettings::gstDebugName =                                 "GstreamerDebugLevel";
-const char* AppSettings::followTargetName =                             "FollowTarget";
-
 const char* AppSettings::parameterFileExtension =   "params";
 const char* AppSettings::planFileExtension =        "plan";
 const char* AppSettings::missionFileExtension =     "mission";
@@ -60,31 +33,7 @@ const char* AppSettings::logDirectory =             "Logs";
 const char* AppSettings::videoDirectory =           "Video";
 const char* AppSettings::crashDirectory =           "CrashLogs";
 
-AppSettings::AppSettings(QObject* parent)
-    : SettingsGroup                         (name, settingsGroup, parent)
-    , _offlineEditingFirmwareTypeFact       (nullptr)
-    , _offlineEditingVehicleTypeFact        (nullptr)
-    , _offlineEditingCruiseSpeedFact        (nullptr)
-    , _offlineEditingHoverSpeedFact         (nullptr)
-    , _offlineEditingAscentSpeedFact        (nullptr)
-    , _offlineEditingDescentSpeedFact       (nullptr)
-    , _batteryPercentRemainingAnnounceFact  (nullptr)
-    , _defaultMissionItemAltitudeFact       (nullptr)
-    , _telemetrySaveFact                    (nullptr)
-    , _telemetrySaveNotArmedFact            (nullptr)
-    , _audioMutedFact                       (nullptr)
-    , _virtualJoystickFact                  (nullptr)
-    , _appFontPointSizeFact                 (nullptr)
-    , _indoorPaletteFact                    (nullptr)
-    , _showLargeCompassFact                 (nullptr)
-    , _savePathFact                         (nullptr)
-    , _autoLoadMissionsFact                 (nullptr)
-    , _useChecklistFact                     (nullptr)
-    , _mapboxTokenFact                      (nullptr)
-    , _esriTokenFact                        (nullptr)
-    , _defaultFirmwareTypeFact              (nullptr)
-    , _gstDebugFact                         (nullptr)
-    , _followTargetFact                     (nullptr)
+DECLARE_SETTINGGROUP(App, "")
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<AppSettings>("QGroundControl.SettingsManager", 1, 0, "AppSettings", "Reference only");
@@ -110,8 +59,39 @@ AppSettings::AppSettings(QObject* parent)
 
     connect(savePathFact, &Fact::rawValueChanged, this, &AppSettings::savePathsChanged);
     connect(savePathFact, &Fact::rawValueChanged, this, &AppSettings::_checkSavePathDirectories);
-
     _checkSavePathDirectories();
+}
+
+DECLARE_SETTINGSFACT(AppSettings, offlineEditingFirmwareType)
+DECLARE_SETTINGSFACT(AppSettings, offlineEditingVehicleType)
+DECLARE_SETTINGSFACT(AppSettings, offlineEditingCruiseSpeed)
+DECLARE_SETTINGSFACT(AppSettings, offlineEditingHoverSpeed)
+DECLARE_SETTINGSFACT(AppSettings, offlineEditingAscentSpeed)
+DECLARE_SETTINGSFACT(AppSettings, offlineEditingDescentSpeed)
+DECLARE_SETTINGSFACT(AppSettings, batteryPercentRemainingAnnounce)
+DECLARE_SETTINGSFACT(AppSettings, defaultMissionItemAltitude)
+DECLARE_SETTINGSFACT(AppSettings, telemetrySave)
+DECLARE_SETTINGSFACT(AppSettings, telemetrySaveNotArmed)
+DECLARE_SETTINGSFACT(AppSettings, audioMuted)
+DECLARE_SETTINGSFACT(AppSettings, virtualJoystick)
+DECLARE_SETTINGSFACT(AppSettings, appFontPointSize)
+DECLARE_SETTINGSFACT(AppSettings, showLargeCompass)
+DECLARE_SETTINGSFACT(AppSettings, savePath)
+DECLARE_SETTINGSFACT(AppSettings, autoLoadMissions)
+DECLARE_SETTINGSFACT(AppSettings, useChecklist)
+DECLARE_SETTINGSFACT(AppSettings, mapboxToken)
+DECLARE_SETTINGSFACT(AppSettings, esriToken)
+DECLARE_SETTINGSFACT(AppSettings, defaultFirmwareType)
+DECLARE_SETTINGSFACT(AppSettings, gstDebugLevel)
+DECLARE_SETTINGSFACT(AppSettings, followTarget)
+
+DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
+{
+    if (!_indoorPaletteFact) {
+        _indoorPaletteFact = _createSettingsFact(indoorPaletteName);
+        connect(_indoorPaletteFact, &Fact::rawValueChanged, this, &AppSettings::_indoorPaletteChanged);
+    }
+    return _indoorPaletteFact;
 }
 
 void AppSettings::_checkSavePathDirectories(void)
@@ -130,169 +110,10 @@ void AppSettings::_checkSavePathDirectories(void)
     }
 }
 
-Fact* AppSettings::offlineEditingFirmwareType(void)
-{
-    if (!_offlineEditingFirmwareTypeFact) {
-        _offlineEditingFirmwareTypeFact = _createSettingsFact(offlineEditingFirmwareTypeSettingsName);
-    }
-
-    return _offlineEditingFirmwareTypeFact;
-}
-
-Fact* AppSettings::offlineEditingVehicleType(void)
-{
-    if (!_offlineEditingVehicleTypeFact) {
-        _offlineEditingVehicleTypeFact = _createSettingsFact(offlineEditingVehicleTypeSettingsName);
-    }
-
-    return _offlineEditingVehicleTypeFact;
-}
-
-Fact* AppSettings::offlineEditingCruiseSpeed(void)
-{
-    if (!_offlineEditingCruiseSpeedFact) {
-        _offlineEditingCruiseSpeedFact = _createSettingsFact(offlineEditingCruiseSpeedSettingsName);
-    }
-    return _offlineEditingCruiseSpeedFact;
-}
-
-Fact* AppSettings::offlineEditingHoverSpeed(void)
-{
-    if (!_offlineEditingHoverSpeedFact) {
-        _offlineEditingHoverSpeedFact = _createSettingsFact(offlineEditingHoverSpeedSettingsName);
-    }
-    return _offlineEditingHoverSpeedFact;
-}
-
-Fact* AppSettings::offlineEditingAscentSpeed(void)
-{
-    if (!_offlineEditingAscentSpeedFact) {
-        _offlineEditingAscentSpeedFact = _createSettingsFact(offlineEditingAscentSpeedSettingsName);
-    }
-    return _offlineEditingAscentSpeedFact;
-}
-
-Fact* AppSettings::offlineEditingDescentSpeed(void)
-{
-    if (!_offlineEditingDescentSpeedFact) {
-        _offlineEditingDescentSpeedFact = _createSettingsFact(offlineEditingDescentSpeedSettingsName);
-    }
-    return _offlineEditingDescentSpeedFact;
-}
-
-Fact* AppSettings::batteryPercentRemainingAnnounce(void)
-{
-    if (!_batteryPercentRemainingAnnounceFact) {
-        _batteryPercentRemainingAnnounceFact = _createSettingsFact(batteryPercentRemainingAnnounceSettingsName);
-    }
-
-    return _batteryPercentRemainingAnnounceFact;
-}
-
-Fact* AppSettings::defaultMissionItemAltitude(void)
-{
-    if (!_defaultMissionItemAltitudeFact) {
-        _defaultMissionItemAltitudeFact = _createSettingsFact(defaultMissionItemAltitudeSettingsName);
-    }
-
-    return _defaultMissionItemAltitudeFact;
-}
-
-Fact* AppSettings::telemetrySave(void)
-{
-    if (!_telemetrySaveFact) {
-        _telemetrySaveFact = _createSettingsFact(telemetrySaveName);
-    }
-
-    return _telemetrySaveFact;
-}
-
-Fact* AppSettings::telemetrySaveNotArmed(void)
-{
-    if (!_telemetrySaveNotArmedFact) {
-        _telemetrySaveNotArmedFact = _createSettingsFact(telemetrySaveNotArmedName);
-    }
-
-    return _telemetrySaveNotArmedFact;
-}
-
-Fact* AppSettings::audioMuted(void)
-{
-    if (!_audioMutedFact) {
-        _audioMutedFact = _createSettingsFact(audioMutedName);
-    }
-
-    return _audioMutedFact;
-}
-
-Fact* AppSettings::useChecklist(void)
-{
-    if (!_useChecklistFact) {
-        _useChecklistFact = _createSettingsFact(useChecklistName);
-    }
-
-    return _useChecklistFact;
-}
-
-Fact* AppSettings::appFontPointSize(void)
-{
-    if (!_appFontPointSizeFact) {
-        _appFontPointSizeFact = _createSettingsFact(appFontPointSizeName);
-    }
-
-    return _appFontPointSizeFact;
-}
-
-Fact* AppSettings::virtualJoystick(void)
-{
-    if (!_virtualJoystickFact) {
-        _virtualJoystickFact = _createSettingsFact(virtualJoystickName);
-    }
-
-    return _virtualJoystickFact;
-}
-
-Fact* AppSettings::gstDebug(void)
-{
-    if (!_gstDebugFact) {
-        _gstDebugFact = _createSettingsFact(gstDebugName);
-    }
-
-    return _gstDebugFact;
-}
-
-Fact* AppSettings::indoorPalette(void)
-{
-    if (!_indoorPaletteFact) {
-        _indoorPaletteFact = _createSettingsFact(indoorPaletteName);
-        connect(_indoorPaletteFact, &Fact::rawValueChanged, this, &AppSettings::_indoorPaletteChanged);
-    }
-
-    return _indoorPaletteFact;
-}
-
 void AppSettings::_indoorPaletteChanged(void)
 {
     qgcApp()->_loadCurrentStyleSheet();
     QGCPalette::setGlobalTheme(indoorPalette()->rawValue().toBool() ? QGCPalette::Dark : QGCPalette::Light);
-}
-
-Fact* AppSettings::showLargeCompass(void)
-{
-    if (!_showLargeCompassFact) {
-        _showLargeCompassFact = _createSettingsFact(showLargeCompassName);
-    }
-
-    return _showLargeCompassFact;
-}
-
-Fact* AppSettings::savePath(void)
-{
-    if (!_savePathFact) {
-        _savePathFact = _createSettingsFact(savePathName);
-    }
-
-    return _savePathFact;
 }
 
 QString AppSettings::missionSavePath(void)
@@ -302,7 +123,6 @@ QString AppSettings::missionSavePath(void)
         QDir dir(path);
         return dir.filePath(missionDirectory);
     }
-
     return QString();
 }
 
@@ -313,7 +133,6 @@ QString AppSettings::parameterSavePath(void)
         QDir dir(path);
         return dir.filePath(parameterDirectory);
     }
-
     return QString();
 }
 
@@ -324,7 +143,6 @@ QString AppSettings::telemetrySavePath(void)
         QDir dir(path);
         return dir.filePath(telemetryDirectory);
     }
-
     return QString();
 }
 
@@ -335,7 +153,6 @@ QString AppSettings::logSavePath(void)
         QDir dir(path);
         return dir.filePath(logDirectory);
     }
-
     return QString();
 }
 
@@ -346,7 +163,6 @@ QString AppSettings::videoSavePath(void)
         QDir dir(path);
         return dir.filePath(videoDirectory);
     }
-
     return QString();
 }
 
@@ -357,35 +173,7 @@ QString AppSettings::crashSavePath(void)
         QDir dir(path);
         return dir.filePath(crashDirectory);
     }
-
     return QString();
-}
-
-Fact* AppSettings::autoLoadMissions(void)
-{
-    if (!_autoLoadMissionsFact) {
-        _autoLoadMissionsFact = _createSettingsFact(autoLoadMissionsName);
-    }
-
-    return _autoLoadMissionsFact;
-}
-
-Fact* AppSettings::mapboxToken(void)
-{
-    if (!_mapboxTokenFact) {
-        _mapboxTokenFact = _createSettingsFact(mapboxTokenName);
-    }
-
-    return _mapboxTokenFact;
-}
-
-Fact* AppSettings::esriToken(void)
-{
-    if (!_esriTokenFact) {
-        _esriTokenFact = _createSettingsFact(esriTokenName);
-    }
-
-    return _esriTokenFact;
 }
 
 MAV_AUTOPILOT AppSettings::offlineEditingFirmwareTypeFromFirmwareType(MAV_AUTOPILOT firmwareType)
@@ -409,22 +197,4 @@ MAV_TYPE AppSettings::offlineEditingVehicleTypeFromVehicleType(MAV_TYPE vehicleT
     } else {
         return MAV_TYPE_QUADROTOR;
     }
-}
-
-Fact* AppSettings::defaultFirmwareType(void)
-{
-    if (!_defaultFirmwareTypeFact) {
-        _defaultFirmwareTypeFact = _createSettingsFact(defaultFirmwareTypeName);
-    }
-
-    return _defaultFirmwareTypeFact;
-}
-
-Fact* AppSettings::followTarget(void)
-{
-    if (!_followTargetFact) {
-        _followTargetFact = _createSettingsFact(followTargetName);
-    }
-
-    return _followTargetFact;
 }

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -6,9 +6,7 @@
  * COPYING.md in the root of the source code directory.
  *
  ****************************************************************************/
-
-#ifndef AppSettings_H
-#define AppSettings_H
+#pragma once
 
 #include "SettingsGroup.h"
 #include "QGCMAVLink.h"
@@ -20,29 +18,31 @@ class AppSettings : public SettingsGroup
 public:
     AppSettings(QObject* parent = nullptr);
 
-    Q_PROPERTY(Fact* offlineEditingFirmwareType         READ offlineEditingFirmwareType         CONSTANT)
-    Q_PROPERTY(Fact* offlineEditingVehicleType          READ offlineEditingVehicleType          CONSTANT)
-    Q_PROPERTY(Fact* offlineEditingCruiseSpeed          READ offlineEditingCruiseSpeed          CONSTANT)
-    Q_PROPERTY(Fact* offlineEditingHoverSpeed           READ offlineEditingHoverSpeed           CONSTANT)
-    Q_PROPERTY(Fact* offlineEditingAscentSpeed          READ offlineEditingAscentSpeed          CONSTANT)
-    Q_PROPERTY(Fact* offlineEditingDescentSpeed         READ offlineEditingDescentSpeed         CONSTANT)
-    Q_PROPERTY(Fact* batteryPercentRemainingAnnounce    READ batteryPercentRemainingAnnounce    CONSTANT)
-    Q_PROPERTY(Fact* defaultMissionItemAltitude         READ defaultMissionItemAltitude         CONSTANT)
-    Q_PROPERTY(Fact* telemetrySave                      READ telemetrySave                      CONSTANT)
-    Q_PROPERTY(Fact* telemetrySaveNotArmed              READ telemetrySaveNotArmed              CONSTANT)
-    Q_PROPERTY(Fact* audioMuted                         READ audioMuted                         CONSTANT)
-    Q_PROPERTY(Fact* virtualJoystick                    READ virtualJoystick                    CONSTANT)
-    Q_PROPERTY(Fact* appFontPointSize                   READ appFontPointSize                   CONSTANT)
-    Q_PROPERTY(Fact* indoorPalette                      READ indoorPalette                      CONSTANT)
-    Q_PROPERTY(Fact* showLargeCompass                   READ showLargeCompass                   CONSTANT)
-    Q_PROPERTY(Fact* savePath                           READ savePath                           CONSTANT)
-    Q_PROPERTY(Fact* autoLoadMissions                   READ autoLoadMissions                   CONSTANT)
-    Q_PROPERTY(Fact* useChecklist                       READ useChecklist                       CONSTANT)
-    Q_PROPERTY(Fact* mapboxToken                        READ mapboxToken                        CONSTANT)
-    Q_PROPERTY(Fact* esriToken                          READ esriToken                          CONSTANT)
-    Q_PROPERTY(Fact* defaultFirmwareType                READ defaultFirmwareType                CONSTANT)
-    Q_PROPERTY(Fact* gstDebug                           READ gstDebug                           CONSTANT)
-    Q_PROPERTY(Fact* followTarget                       READ followTarget                       CONSTANT)
+    DEFINE_SETTING_NAME_GROUP()
+
+    DEFINE_SETTINGFACT(offlineEditingFirmwareType)
+    DEFINE_SETTINGFACT(offlineEditingVehicleType)
+    DEFINE_SETTINGFACT(offlineEditingCruiseSpeed)
+    DEFINE_SETTINGFACT(offlineEditingHoverSpeed)
+    DEFINE_SETTINGFACT(offlineEditingAscentSpeed)
+    DEFINE_SETTINGFACT(offlineEditingDescentSpeed)
+    DEFINE_SETTINGFACT(batteryPercentRemainingAnnounce)
+    DEFINE_SETTINGFACT(defaultMissionItemAltitude)
+    DEFINE_SETTINGFACT(telemetrySave)
+    DEFINE_SETTINGFACT(telemetrySaveNotArmed)
+    DEFINE_SETTINGFACT(audioMuted)
+    DEFINE_SETTINGFACT(virtualJoystick)
+    DEFINE_SETTINGFACT(appFontPointSize)
+    DEFINE_SETTINGFACT(indoorPalette)
+    DEFINE_SETTINGFACT(showLargeCompass)
+    DEFINE_SETTINGFACT(savePath)
+    DEFINE_SETTINGFACT(autoLoadMissions)
+    DEFINE_SETTINGFACT(useChecklist)
+    DEFINE_SETTINGFACT(mapboxToken)
+    DEFINE_SETTINGFACT(esriToken)
+    DEFINE_SETTINGFACT(defaultFirmwareType)
+    DEFINE_SETTINGFACT(gstDebugLevel)
+    DEFINE_SETTINGFACT(followTarget)
 
     Q_PROPERTY(QString missionSavePath      READ missionSavePath    NOTIFY savePathsChanged)
     Q_PROPERTY(QString parameterSavePath    READ parameterSavePath  NOTIFY savePathsChanged)
@@ -60,66 +60,15 @@ public:
     Q_PROPERTY(QString shpFileExtension         MEMBER shpFileExtension         CONSTANT)
     Q_PROPERTY(QString logFileExtension         MEMBER logFileExtension         CONSTANT)
 
-    Fact* offlineEditingFirmwareType        (void);
-    Fact* offlineEditingVehicleType         (void);
-    Fact* offlineEditingCruiseSpeed         (void);
-    Fact* offlineEditingHoverSpeed          (void);
-    Fact* offlineEditingAscentSpeed         (void);
-    Fact* offlineEditingDescentSpeed        (void);
-    Fact* batteryPercentRemainingAnnounce   (void);
-    Fact* defaultMissionItemAltitude        (void);
-    Fact* telemetrySave                     (void);
-    Fact* telemetrySaveNotArmed             (void);
-    Fact* audioMuted                        (void);
-    Fact* virtualJoystick                   (void);
-    Fact* appFontPointSize                  (void);
-    Fact* indoorPalette                     (void);
-    Fact* showLargeCompass                  (void);
-    Fact* savePath                          (void);
-    Fact* autoLoadMissions                  (void);
-    Fact* useChecklist                      (void);
-    Fact* mapboxToken                       (void);
-    Fact* esriToken                         (void);
-    Fact* defaultFirmwareType               (void);
-    Fact* gstDebug                          (void);
-    Fact* followTarget                      (void);
+    QString missionSavePath     ();
+    QString parameterSavePath   ();
+    QString telemetrySavePath   ();
+    QString logSavePath         ();
+    QString videoSavePath       ();
+    QString crashSavePath       ();
 
-    QString missionSavePath     (void);
-    QString parameterSavePath   (void);
-    QString telemetrySavePath   (void);
-    QString logSavePath         (void);
-    QString videoSavePath       (void);
-    QString crashSavePath       (void);
-
-    static MAV_AUTOPILOT offlineEditingFirmwareTypeFromFirmwareType(MAV_AUTOPILOT firmwareType);
-    static MAV_TYPE offlineEditingVehicleTypeFromVehicleType(MAV_TYPE vehicleType);
-
-    static const char* name;
-    static const char* settingsGroup;
-
-    static const char* offlineEditingFirmwareTypeSettingsName;
-    static const char* offlineEditingVehicleTypeSettingsName;
-    static const char* offlineEditingCruiseSpeedSettingsName;
-    static const char* offlineEditingHoverSpeedSettingsName;
-    static const char* offlineEditingAscentSpeedSettingsName;
-    static const char* offlineEditingDescentSpeedSettingsName;
-    static const char* batteryPercentRemainingAnnounceSettingsName;
-    static const char* defaultMissionItemAltitudeSettingsName;
-    static const char* telemetrySaveName;
-    static const char* telemetrySaveNotArmedName;
-    static const char* audioMutedName;
-    static const char* virtualJoystickName;
-    static const char* appFontPointSizeName;
-    static const char* indoorPaletteName;
-    static const char* showLargeCompassName;
-    static const char* savePathName;
-    static const char* autoLoadMissionsName;
-    static const char* useChecklistName;
-    static const char* mapboxTokenName;
-    static const char* esriTokenName;
-    static const char* defaultFirmwareTypeName;
-    static const char* gstDebugName;
-    static const char* followTargetName;
+    static MAV_AUTOPILOT    offlineEditingFirmwareTypeFromFirmwareType  (MAV_AUTOPILOT firmwareType);
+    static MAV_TYPE         offlineEditingVehicleTypeFromVehicleType    (MAV_TYPE vehicleType);
 
     // Application wide file extensions
     static const char* parameterFileExtension;
@@ -142,36 +91,10 @@ public:
     static const char* crashDirectory;
 
 signals:
-    void savePathsChanged(void);
+    void savePathsChanged();
 
 private slots:
-    void _indoorPaletteChanged(void);
-    void _checkSavePathDirectories(void);
+    void _indoorPaletteChanged();
+    void _checkSavePathDirectories();
 
-private:
-    SettingsFact* _offlineEditingFirmwareTypeFact;
-    SettingsFact* _offlineEditingVehicleTypeFact;
-    SettingsFact* _offlineEditingCruiseSpeedFact;
-    SettingsFact* _offlineEditingHoverSpeedFact;
-    SettingsFact* _offlineEditingAscentSpeedFact;
-    SettingsFact* _offlineEditingDescentSpeedFact;
-    SettingsFact* _batteryPercentRemainingAnnounceFact;
-    SettingsFact* _defaultMissionItemAltitudeFact;
-    SettingsFact* _telemetrySaveFact;
-    SettingsFact* _telemetrySaveNotArmedFact;
-    SettingsFact* _audioMutedFact;
-    SettingsFact* _virtualJoystickFact;
-    SettingsFact* _appFontPointSizeFact;
-    SettingsFact* _indoorPaletteFact;
-    SettingsFact* _showLargeCompassFact;
-    SettingsFact* _savePathFact;
-    SettingsFact* _autoLoadMissionsFact;
-    SettingsFact* _useChecklistFact;
-    SettingsFact* _mapboxTokenFact;
-    SettingsFact* _esriTokenFact;
-    SettingsFact* _defaultFirmwareTypeFact;
-    SettingsFact* _gstDebugFact;
-    SettingsFact* _followTargetFact;
 };
-
-#endif

--- a/src/Settings/AutoConnect.SettingsGroup.json
+++ b/src/Settings/AutoConnect.SettingsGroup.json
@@ -1,76 +1,83 @@
 [
 {
-    "name":             "AutoconnectUDP",
+    "name":             "autoConnectUDP",
     "shortDescription": "Automatically open a connection over UDP",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a vehicle which is detected on a UDP communication link.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "AutoconnectPixhawk",
+    "name":             "autoConnectPixhawk",
     "shortDescription": "Automatically connect to a Pixhawk board",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a Pixhawk board which is connected via USB.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "Autoconnect3DRRadio",
+    "name":             "autoConnectSiKRadio",
     "shortDescription": "Automatically connect to a SiK Radio",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a vehicle which is detected on a SiK Radio communication link.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "AutoconnectPX4Flow",
+    "name":             "autoConnectPX4Flow",
     "shortDescription": "Automatically connect to a P4 Flow",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a PX4 Flow board which is connected via USB.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "AutoconnectRTKGPS",
+    "name":             "autoConnectRTKGPS",
     "shortDescription": "Automatically connect to an RTK GPS",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to an RTK GPS which is connected via USB.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "AutoconnectLibrePilot",
+    "name":             "autoConnectLibrePilot",
     "shortDescription": "Automatically connect to a LibrePilot",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a LibrePilot board which is connected via USB.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "AutoconnectNmeaPort",
+    "name":             "autoConnectNmeaPort",
     "shortDescription": "NMEA GPS device for GCS position",
     "longDescription":  "NMEA GPS device for GCS position",
     "type":             "string",
     "defaultValue":     "disabled"
 },
 {
-    "name":             "AutoconnectNmeaBaud",
+    "name":             "autoConnectNmeaBaud",
     "shortDescription": "NMEA GPS Baudrate",
     "longDescription":  "NMEA GPS Baudrate",
     "type":             "uint32",
     "defaultValue":     4800
 },
 {
-    "name":             "AutoconnectUDPListenPort",
+    "name":             "udpListenPort",
     "shortDescription": "UDP port for autoconnect",
     "type":             "uint32",
     "defaultValue":     14550
 },
 {
-    "name":             "AutoconnectUDPTargetHostIP",
+    "name":             "udpTargetHostIP",
     "shortDescription": "UDP target host IP for autoconnect",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "AutoconnectUDPTargetHostPort",
+    "name":             "udpTargetHostPort",
     "shortDescription": "UDP target host port for autoconnect",
     "type":             "uint32",
     "defaultValue":     14550
+},
+{
+    "name":             "autoConnectTaisyncUSB",
+    "shortDescription": "Automatically connect to a Taisync Ground Module",
+    "longDescription":  "If this option is enabled GroundControl will automatically connect to a Taisync Ground Module which is connected via USB.",
+    "type":             "bool",
+    "defaultValue":     false
 }
 ]

--- a/src/Settings/AutoConnectSettings.cc
+++ b/src/Settings/AutoConnectSettings.cc
@@ -13,110 +13,74 @@
 #include <QQmlEngine>
 #include <QtQml>
 
-const char* AutoConnectSettings::name =                                 "AutoConnect";
-const char* AutoConnectSettings::settingsGroup =                        "LinkManager";
-
-const char* AutoConnectSettings:: autoConnectUDPSettingsName =          "AutoconnectUDP";
-const char* AutoConnectSettings:: autoConnectPixhawkSettingsName =      "AutoconnectPixhawk";
-const char* AutoConnectSettings:: autoConnectSiKRadioSettingsName =     "Autoconnect3DRRadio";
-const char* AutoConnectSettings:: autoConnectPX4FlowSettingsName =      "AutoconnectPX4Flow";
-const char* AutoConnectSettings:: autoConnectRTKGPSSettingsName =       "AutoconnectRTKGPS";
-const char* AutoConnectSettings:: autoConnectLibrePilotSettingsName =   "AutoconnectLibrePilot";
-const char* AutoConnectSettings:: autoConnectNmeaPortName =             "AutoconnectNmeaPort";
-const char* AutoConnectSettings:: autoConnectNmeaBaudName =             "AutoconnectNmeaBaud";
-const char* AutoConnectSettings:: udpListenPortName =                   "AutoconnectUDPListenPort";
-const char* AutoConnectSettings:: udpTargetHostIPName =                 "AutoconnectUDPTargetHostIP";
-const char* AutoConnectSettings:: udpTargetHostPortName =               "AutoconnectUDPTargetHostPort";
-
-
-AutoConnectSettings::AutoConnectSettings(QObject* parent)
-    : SettingsGroup             (name, settingsGroup, parent)
-    , _autoConnectUDPFact       (NULL)
-    , _autoConnectPixhawkFact   (NULL)
-    , _autoConnectSiKRadioFact  (NULL)
-    , _autoConnectPX4FlowFact   (NULL)
-    , _autoConnectRTKGPSFact    (NULL)
-    , _autoConnectLibrePilotFact(NULL)
-    , _autoConnectNmeaPortFact  (NULL)
-    , _autoConnectNmeaBaudFact  (NULL)
-    , _udpListenPortFact        (NULL)
-    , _udpTargetHostIPFact      (NULL)
-    , _udpTargetHostPortFact    (NULL)
+DECLARE_SETTINGGROUP(AutoConnect, "LinkManager")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-    qmlRegisterUncreatableType<AutoConnectSettings>("QGroundControl.SettingsManager", 1, 0, "AutoConnectSettings", "Reference only");
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
+    qmlRegisterUncreatableType<AutoConnectSettings>("QGroundControl.SettingsManager", 1, 0, "AutoConnectSettings", "Reference only"); \
 }
 
-Fact* AutoConnectSettings::autoConnectUDP(void)
-{
-    if (!_autoConnectUDPFact) {
-        _autoConnectUDPFact = _createSettingsFact(autoConnectUDPSettingsName);
-    }
+DECLARE_SETTINGSFACT(AutoConnectSettings, autoConnectUDP)
+DECLARE_SETTINGSFACT(AutoConnectSettings, udpListenPort)
+DECLARE_SETTINGSFACT(AutoConnectSettings, udpTargetHostIP)
+DECLARE_SETTINGSFACT(AutoConnectSettings, udpTargetHostPort)
+DECLARE_SETTINGSFACT(AutoConnectSettings, autoconnectTaisyncUSB)
 
-    return _autoConnectUDPFact;
-}
-
-Fact* AutoConnectSettings::autoConnectPixhawk(void)
+DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectPixhawk)
 {
     if (!_autoConnectPixhawkFact) {
-        _autoConnectPixhawkFact = _createSettingsFact(autoConnectPixhawkSettingsName);
+        _autoConnectPixhawkFact = _createSettingsFact(autoConnectPixhawkName);
 #ifdef __ios__
         _autoConnectPixhawkFact->setVisible(false);
 #endif
     }
-
     return _autoConnectPixhawkFact;
 }
 
-Fact* AutoConnectSettings::autoConnectSiKRadio(void)
+DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectSiKRadio)
 {
     if (!_autoConnectSiKRadioFact) {
-        _autoConnectSiKRadioFact = _createSettingsFact(autoConnectSiKRadioSettingsName);
+        _autoConnectSiKRadioFact = _createSettingsFact(autoConnectSiKRadioName);
 #ifdef __ios__
         _autoConnectSiKRadioFact->setVisible(false);
 #endif
     }
-
     return _autoConnectSiKRadioFact;
 }
 
-Fact* AutoConnectSettings::autoConnectPX4Flow(void)
+DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectPX4Flow)
 {
     if (!_autoConnectPX4FlowFact) {
-        _autoConnectPX4FlowFact = _createSettingsFact(autoConnectPX4FlowSettingsName);
+        _autoConnectPX4FlowFact = _createSettingsFact(autoConnectPX4FlowName);
 #ifdef __ios__
         _autoConnectPX4FlowFact->setVisible(false);
 #endif
     }
-
     return _autoConnectPX4FlowFact;
 }
 
-Fact* AutoConnectSettings::autoConnectRTKGPS(void)
+DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectRTKGPS)
 {
     if (!_autoConnectRTKGPSFact) {
-        _autoConnectRTKGPSFact = _createSettingsFact(autoConnectRTKGPSSettingsName);
+        _autoConnectRTKGPSFact = _createSettingsFact(autoConnectRTKGPSName);
 #ifdef __ios__
         _autoConnectRTKGPSFact->setVisible(false);
 #endif
     }
-
     return _autoConnectRTKGPSFact;
 }
 
-Fact* AutoConnectSettings::autoConnectLibrePilot(void)
+DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectLibrePilot)
 {
     if (!_autoConnectLibrePilotFact) {
-        _autoConnectLibrePilotFact = _createSettingsFact(autoConnectLibrePilotSettingsName);
+        _autoConnectLibrePilotFact = _createSettingsFact(autoConnectLibrePilotName);
 #ifdef __ios__
         _autoConnectLibrePilotFact->setVisible(false);
 #endif
     }
-
     return _autoConnectLibrePilotFact;
 }
 
-Fact* AutoConnectSettings::autoConnectNmeaPort(void)
+DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectNmeaPort)
 {
     if (!_autoConnectNmeaPortFact) {
         _autoConnectNmeaPortFact = _createSettingsFact(autoConnectNmeaPortName);
@@ -124,11 +88,10 @@ Fact* AutoConnectSettings::autoConnectNmeaPort(void)
         _autoConnectNmeaPortFact->setVisible(false);
 #endif
     }
-
     return _autoConnectNmeaPortFact;
 }
 
-Fact* AutoConnectSettings::autoConnectNmeaBaud(void)
+DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectNmeaBaud)
 {
     if (!_autoConnectNmeaBaudFact) {
         _autoConnectNmeaBaudFact = _createSettingsFact(autoConnectNmeaBaudName);
@@ -136,33 +99,5 @@ Fact* AutoConnectSettings::autoConnectNmeaBaud(void)
         _autoConnectNmeaBaudFact->setVisible(false);
 #endif
     }
-
     return _autoConnectNmeaBaudFact;
-}
-
-Fact* AutoConnectSettings::udpListenPort(void)
-{
-    if (!_udpListenPortFact) {
-        _udpListenPortFact = _createSettingsFact(udpListenPortName);
-    }
-
-    return _udpListenPortFact;
-}
-
-Fact* AutoConnectSettings::udpTargetHostIP(void)
-{
-    if (!_udpTargetHostIPFact) {
-        _udpTargetHostIPFact = _createSettingsFact(udpTargetHostIPName);
-    }
-
-    return _udpTargetHostIPFact;
-}
-
-Fact* AutoConnectSettings::udpTargetHostPort(void)
-{
-    if (!_udpTargetHostPortFact) {
-        _udpTargetHostPortFact = _createSettingsFact(udpTargetHostPortName);
-    }
-
-    return _udpTargetHostPortFact;
 }

--- a/src/Settings/AutoConnectSettings.h
+++ b/src/Settings/AutoConnectSettings.h
@@ -7,8 +7,7 @@
  *
  ****************************************************************************/
 
-#ifndef AutoConnectSettings_H
-#define AutoConnectSettings_H
+#pragma once
 
 #include "SettingsGroup.h"
 
@@ -17,59 +16,21 @@ class AutoConnectSettings : public SettingsGroup
     Q_OBJECT
     
 public:
-    AutoConnectSettings(QObject* parent = NULL);
+    AutoConnectSettings(QObject* parent = nullptr);
 
-    Q_PROPERTY(Fact* autoConnectUDP         READ autoConnectUDP         CONSTANT)
-    Q_PROPERTY(Fact* autoConnectPixhawk     READ autoConnectPixhawk     CONSTANT)
-    Q_PROPERTY(Fact* autoConnectSiKRadio    READ autoConnectSiKRadio    CONSTANT)
-    Q_PROPERTY(Fact* autoConnectPX4Flow     READ autoConnectPX4Flow     CONSTANT)
-    Q_PROPERTY(Fact* autoConnectRTKGPS      READ autoConnectRTKGPS      CONSTANT)
-    Q_PROPERTY(Fact* autoConnectLibrePilot  READ autoConnectLibrePilot  CONSTANT)
-    Q_PROPERTY(Fact* autoConnectNmeaPort    READ autoConnectNmeaPort    CONSTANT)
-    Q_PROPERTY(Fact* autoConnectNmeaBaud    READ autoConnectNmeaBaud    CONSTANT)
-    Q_PROPERTY(Fact* udpListenPort          READ udpListenPort          CONSTANT)   ///< Port to listen on for UDP autoconnect
-    Q_PROPERTY(Fact* udpTargetHostIP        READ udpTargetHostIP        CONSTANT)   ///< Target host IP for UDP autoconnect, empty string for none
-    Q_PROPERTY(Fact* udpTargetHostPort      READ udpTargetHostPort      CONSTANT)   ///< Target host post for UDP autoconnect
+    DEFINE_SETTING_NAME_GROUP()
 
-    Fact* autoConnectUDP        (void);
-    Fact* autoConnectPixhawk    (void);
-    Fact* autoConnectSiKRadio   (void);
-    Fact* autoConnectPX4Flow    (void);
-    Fact* autoConnectRTKGPS     (void);
-    Fact* autoConnectLibrePilot (void);
-    Fact* autoConnectNmeaPort   (void);
-    Fact* autoConnectNmeaBaud   (void);
-    Fact* udpListenPort         (void);
-    Fact* udpTargetHostIP       (void);
-    Fact* udpTargetHostPort     (void);
+    DEFINE_SETTINGFACT(autoConnectUDP)
+    DEFINE_SETTINGFACT(autoConnectPixhawk)
+    DEFINE_SETTINGFACT(autoConnectSiKRadio)
+    DEFINE_SETTINGFACT(autoConnectPX4Flow)
+    DEFINE_SETTINGFACT(autoConnectRTKGPS)
+    DEFINE_SETTINGFACT(autoConnectLibrePilot)
+    DEFINE_SETTINGFACT(autoConnectNmeaPort)
+    DEFINE_SETTINGFACT(autoConnectNmeaBaud)
+    DEFINE_SETTINGFACT(udpListenPort)
+    DEFINE_SETTINGFACT(udpTargetHostIP)
+    DEFINE_SETTINGFACT(udpTargetHostPort)
+    DEFINE_SETTINGFACT(autoconnectTaisyncUSB)
 
-    static const char* name;
-    static const char* settingsGroup;
-
-    static const char* autoConnectUDPSettingsName;
-    static const char* autoConnectPixhawkSettingsName;
-    static const char* autoConnectSiKRadioSettingsName;
-    static const char* autoConnectPX4FlowSettingsName;
-    static const char* autoConnectRTKGPSSettingsName;
-    static const char* autoConnectLibrePilotSettingsName;
-    static const char* autoConnectNmeaPortName;
-    static const char* autoConnectNmeaBaudName;
-    static const char* udpListenPortName;
-    static const char* udpTargetHostIPName;
-    static const char* udpTargetHostPortName;
-
-private:
-    SettingsFact* _autoConnectUDPFact;
-    SettingsFact* _autoConnectPixhawkFact;
-    SettingsFact* _autoConnectSiKRadioFact;
-    SettingsFact* _autoConnectPX4FlowFact;
-    SettingsFact* _autoConnectRTKGPSFact;
-    SettingsFact* _autoConnectLibrePilotFact;
-    SettingsFact* _autoConnectNmeaPortFact;
-    SettingsFact* _autoConnectNmeaBaudFact;
-    SettingsFact* _udpListenPortFact;
-    SettingsFact* _udpTargetHostIPFact;
-    SettingsFact* _udpTargetHostPortFact;
 };
-
-#endif

--- a/src/Settings/BrandImage.SettingsGroup.json
+++ b/src/Settings/BrandImage.SettingsGroup.json
@@ -1,13 +1,13 @@
 [
 {
-    "name":             "UserBrandImageIndoor",
+    "name":             "userBrandImageIndoor",
     "shortDescription": "User-selected brand image",
     "longDescription":  "Location in file system of user-selected brand image (indoor)",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "UserBrandImageOutdoor",
+    "name":             "userBrandImageOutdoor",
     "shortDescription": "User-selected brand image",
     "longDescription":  "Location in file system of user-selected brand image (outdoor)",
     "type":             "string",

--- a/src/Settings/BrandImageSettings.cc
+++ b/src/Settings/BrandImageSettings.cc
@@ -12,35 +12,11 @@
 #include <QQmlEngine>
 #include <QtQml>
 
-const char* BrandImageSettings::name =                      "BrandImage";
-const char* BrandImageSettings::settingsGroup =             ""; // settings are in root group
-
-const char* BrandImageSettings::userBrandImageIndoorName =  "UserBrandImageIndoor";
-const char* BrandImageSettings::userBrandImageOutdoorName = "UserBrandImageOutdoor";
-
-BrandImageSettings::BrandImageSettings(QObject* parent)
-    : SettingsGroup(name, settingsGroup, parent)
-    , _userBrandImageIndoorFact(NULL)
-    , _userBrandImageOutdoorFact(NULL)
+DECLARE_SETTINGGROUP(BrandImage, "Branding")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-    qmlRegisterUncreatableType<BrandImageSettings>("QGroundControl.SettingsManager", 1, 0, "BrandImageSettings", "Reference only");
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
+    qmlRegisterUncreatableType<BrandImageSettings>("QGroundControl.SettingsManager", 1, 0, "BrandImageSettings", "Reference only"); \
 }
 
-Fact* BrandImageSettings::userBrandImageIndoor(void)
-{
-    if (!_userBrandImageIndoorFact) {
-        _userBrandImageIndoorFact = _createSettingsFact(userBrandImageIndoorName);
-    }
-
-    return _userBrandImageIndoorFact;
-}
-
-Fact* BrandImageSettings::userBrandImageOutdoor(void)
-{
-    if (!_userBrandImageOutdoorFact) {
-        _userBrandImageOutdoorFact = _createSettingsFact(userBrandImageOutdoorName);
-    }
-
-    return _userBrandImageOutdoorFact;
-}
+DECLARE_SETTINGSFACT(BrandImageSettings, userBrandImageIndoor)
+DECLARE_SETTINGSFACT(BrandImageSettings, userBrandImageOutdoor)

--- a/src/Settings/BrandImageSettings.h
+++ b/src/Settings/BrandImageSettings.h
@@ -7,33 +7,16 @@
  *
  ****************************************************************************/
 
-#ifndef BrandImageSettings_H
-#define BrandImageSettings_H
+#pragma once
 
 #include "SettingsGroup.h"
 
 class BrandImageSettings : public SettingsGroup
 {
     Q_OBJECT
-
 public:
-    BrandImageSettings(QObject* parent = NULL);
-
-    Q_PROPERTY(Fact* userBrandImageIndoor       READ userBrandImageIndoor       CONSTANT)
-    Q_PROPERTY(Fact* userBrandImageOutdoor      READ userBrandImageOutdoor      CONSTANT)
-
-    Fact* userBrandImageIndoor      (void);
-    Fact* userBrandImageOutdoor     (void);
-
-    static const char* name;
-    static const char* settingsGroup;
-
-    static const char* userBrandImageIndoorName;
-    static const char* userBrandImageOutdoorName;
-
-private:
-    SettingsFact* _userBrandImageIndoorFact;
-    SettingsFact* _userBrandImageOutdoorFact;
+    BrandImageSettings(QObject* parent = nullptr);
+    DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(userBrandImageIndoor)
+    DEFINE_SETTINGFACT(userBrandImageOutdoor)
 };
-
-#endif

--- a/src/Settings/FlightMap.SettingsGroup.json
+++ b/src/Settings/FlightMap.SettingsGroup.json
@@ -1,6 +1,6 @@
 [
 {
-    "name":             "MapProvider",
+    "name":             "mapProvider",
     "shortDescription": "Currently selected map provider for flight maps",
     "type":             "uint32",
     "enumStrings":      "Bing,Google,Statkart,Mapbox,Esri,Eniro,VWorld",
@@ -8,7 +8,7 @@
     "defaultValue":     0
 },
 {
-    "name":             "MapType",
+    "name":             "mapType",
     "shortDescription": "Currently selected map type for flight maps",
     "type":             "uint32",
     "enumStrings":      "Street Map,Satellite Map,Hybrid Map,Terrain Map",

--- a/src/Settings/FlightMapSettings.cc
+++ b/src/Settings/FlightMapSettings.cc
@@ -16,23 +16,14 @@
 #include <QQmlEngine>
 #include <QtQml>
 
-const char* FlightMapSettings::name =                       "FlightMap";
-const char* FlightMapSettings::settingsGroup =              "FlightMap";
-
-const char* FlightMapSettings::mapProviderSettingsName =    "MapProvider";
-const char* FlightMapSettings::mapTypeSettingsName =        "MapType";
-
-FlightMapSettings::FlightMapSettings(QObject* parent)
-    : SettingsGroup(name, settingsGroup, parent)
-    , _mapProviderFact(NULL)
-    , _mapTypeFact(NULL)
+DECLARE_SETTINGGROUP(FlightMap, "FlightMap")
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<FlightMapSettings>("QGroundControl.SettingsManager", 1, 0, "FlightMapSettings", "Reference only");
 
     // Save the original version since we modify based on map provider
-    _savedMapTypeStrings = _nameToMetaDataMap[mapTypeSettingsName]->enumStrings();
-    _savedMapTypeValues  = _nameToMetaDataMap[mapTypeSettingsName]->enumValues();
+    _savedMapTypeStrings = _nameToMetaDataMap[mapTypeName]->enumStrings();
+    _savedMapTypeValues  = _nameToMetaDataMap[mapTypeName]->enumValues();
 
 #ifdef QGC_NO_GOOGLE_MAPS
     //-- Remove Google
@@ -47,28 +38,20 @@ FlightMapSettings::FlightMapSettings(QObject* parent)
     _newMapProvider(mapProvider()->rawValue());
 }
 
-Fact* FlightMapSettings::mapProvider(void)
+DECLARE_SETTINGSFACT(FlightMapSettings, mapType)
+
+DECLARE_SETTINGSFACT_NO_FUNC(FlightMapSettings, mapProvider)
 {
     if (!_mapProviderFact) {
-        _mapProviderFact = _createSettingsFact(mapProviderSettingsName);
+        _mapProviderFact = _createSettingsFact(mapProviderName);
         connect(_mapProviderFact, &Fact::rawValueChanged, this, &FlightMapSettings::_newMapProvider);
     }
-
     return _mapProviderFact;
-}
-
-Fact* FlightMapSettings::mapType(void)
-{
-    if (!_mapTypeFact) {
-        _mapTypeFact = _createSettingsFact(mapTypeSettingsName);
-    }
-
-    return _mapTypeFact;
 }
 
 void FlightMapSettings::_excludeProvider(MapProvider_t provider)
 {
-    FactMetaData* metaData = _nameToMetaDataMap[mapProviderSettingsName];
+    FactMetaData* metaData = _nameToMetaDataMap[mapProviderName];
     QVariantList enumValues = metaData->enumValues();
     QStringList enumStrings = metaData->enumStrings();
     _removeEnumValue(provider, enumStrings, enumValues);
@@ -94,7 +77,7 @@ void FlightMapSettings::_removeEnumValue(int value, QStringList& enumStrings, QV
 
 void FlightMapSettings::_newMapProvider(QVariant value)
 {
-    FactMetaData* metaData = _nameToMetaDataMap[mapTypeSettingsName];
+    FactMetaData* metaData = _nameToMetaDataMap[mapTypeName];
 
     QStringList enumStrings = _savedMapTypeStrings;
     QVariantList enumValues = _savedMapTypeValues;

--- a/src/Settings/FlightMapSettings.h
+++ b/src/Settings/FlightMapSettings.h
@@ -7,8 +7,7 @@
  *
  ****************************************************************************/
 
-#ifndef FlightMapSettings_H
-#define FlightMapSettings_H
+#pragma once
 
 #include "SettingsGroup.h"
 
@@ -17,7 +16,7 @@ class FlightMapSettings : public SettingsGroup
     Q_OBJECT
 
 public:
-    FlightMapSettings(QObject* parent = NULL);
+    FlightMapSettings(QObject* parent = nullptr);
 
     // This enum must match the json meta data
     typedef enum {
@@ -38,17 +37,9 @@ public:
         mapTypeTerrain
     } MapType_t;
 
-    Q_PROPERTY(Fact* mapProvider     READ mapProvider   CONSTANT)               ///< Currently selected map provider
-    Q_PROPERTY(Fact* mapType         READ mapType       NOTIFY mapTypeChanged)  ///< Current selected map type
-
-    Fact* mapProvider   (void);
-    Fact* mapType       (void);
-
-    static const char* name;
-    static const char* settingsGroup;
-
-    static const char* mapProviderSettingsName;
-    static const char* mapTypeSettingsName;
+    DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(mapProvider)
+    DEFINE_SETTINGFACT(mapType)
 
 signals:
     void mapTypeChanged(void);
@@ -60,10 +51,6 @@ private:
     void _removeEnumValue(int value, QStringList& enumStrings, QVariantList& enumValues);
     void _excludeProvider(MapProvider_t provider);
 
-    SettingsFact*   _mapProviderFact;
-    SettingsFact*   _mapTypeFact;
     QStringList     _savedMapTypeStrings;
     QVariantList    _savedMapTypeValues;
 };
-
-#endif

--- a/src/Settings/FlyView.SettingsGroup.json
+++ b/src/Settings/FlyView.SettingsGroup.json
@@ -1,13 +1,13 @@
 [
 {
-    "name":             "GuidedMinimumAltitude",
+    "name":             "guidedMinimumAltitude",
     "shortDescription": "Minimum altitude for guided actions altitude slider.",
     "type":             "double",
     "units":            "m",
     "defaultValue":     2
 },
 {
-    "name":             "GuidedMaximumAltitude",
+    "name":             "guidedMaximumAltitude",
     "shortDescription": "Maximum altitude for guided actions altitude slider.",
     "type":             "double",
     "units":            "m",

--- a/src/Settings/FlyViewSettings.cc
+++ b/src/Settings/FlyViewSettings.cc
@@ -8,40 +8,15 @@
  ****************************************************************************/
 
 #include "FlyViewSettings.h"
-#include "QGCPalette.h"
-#include "QGCApplication.h"
 
 #include <QQmlEngine>
 #include <QtQml>
-#include <QStandardPaths>
 
-const char* FlyViewSettings::name =                          "FlyView";
-const char* FlyViewSettings::settingsGroup =                 "FlyView";
-
-const char* FlyViewSettings::guidedMinimumAltitudeName =  "GuidedMinimumAltitude";
-const char* FlyViewSettings::guidedMaximumAltitudeName =  "GuidedMaximumAltitude";
-
-FlyViewSettings::FlyViewSettings(QObject* parent)
-    : SettingsGroup             (name, settingsGroup, parent)
-    , _guidedMinimumAltitudeFact(NULL)
-    , _guidedMaximumAltitudeFact(NULL)
+DECLARE_SETTINGGROUP(FlyView, "FlyView")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-    qmlRegisterUncreatableType<FlyViewSettings>("QGroundControl.SettingsManager", 1, 0, "FlyViewSettings", "Reference only");
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
+    qmlRegisterUncreatableType<FlyViewSettings>("QGroundControl.SettingsManager", 1, 0, "FlyViewSettings", "Reference only"); \
 }
 
-Fact* FlyViewSettings::guidedMinimumAltitude(void)
-{
-    if (!_guidedMinimumAltitudeFact) {
-        _guidedMinimumAltitudeFact = _createSettingsFact(guidedMinimumAltitudeName);
-    }
-    return _guidedMinimumAltitudeFact;
-}
-
-Fact* FlyViewSettings::guidedMaximumAltitude(void)
-{
-    if (!_guidedMaximumAltitudeFact) {
-        _guidedMaximumAltitudeFact = _createSettingsFact(guidedMaximumAltitudeName);
-    }
-    return _guidedMaximumAltitudeFact;
-}
+DECLARE_SETTINGSFACT(FlyViewSettings, guidedMinimumAltitude)
+DECLARE_SETTINGSFACT(FlyViewSettings, guidedMaximumAltitude)

--- a/src/Settings/FlyViewSettings.h
+++ b/src/Settings/FlyViewSettings.h
@@ -14,23 +14,9 @@
 class FlyViewSettings : public SettingsGroup
 {
     Q_OBJECT
-    
 public:
-    FlyViewSettings(QObject* parent = NULL);
-
-    Q_PROPERTY(Fact* guidedMinimumAltitude  READ guidedMinimumAltitude  CONSTANT)
-    Q_PROPERTY(Fact* guidedMaximumAltitude  READ guidedMaximumAltitude  CONSTANT)
-
-    Fact* guidedMinimumAltitude(void);
-    Fact* guidedMaximumAltitude(void);
-
-    static const char* name;
-    static const char* settingsGroup;
-
-    static const char* guidedMinimumAltitudeName;
-    static const char* guidedMaximumAltitudeName;
-
-private:
-    SettingsFact* _guidedMinimumAltitudeFact;
-    SettingsFact* _guidedMaximumAltitudeFact;
+    FlyViewSettings(QObject* parent = nullptr);
+    DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(guidedMinimumAltitude)
+    DEFINE_SETTINGFACT(guidedMaximumAltitude)
 };

--- a/src/Settings/PlanViewSettings.cc
+++ b/src/Settings/PlanViewSettings.cc
@@ -12,12 +12,8 @@
 #include <QQmlEngine>
 #include <QtQml>
 
-const char* PlanViewSettings::name =            "PlanView";
-const char* PlanViewSettings::settingsGroup =   "PlanView";
-
-PlanViewSettings::PlanViewSettings(QObject* parent)
-    : SettingsGroup(name, settingsGroup, parent)
+DECLARE_SETTINGGROUP(PlanView, "PlanView")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-    qmlRegisterUncreatableType<PlanViewSettings>("QGroundControl.SettingsManager", 1, 0, "PlanViewSettings", "Reference only");
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
+    qmlRegisterUncreatableType<PlanViewSettings>("QGroundControl.SettingsManager", 1, 0, "PlanViewSettings", "Reference only"); \
 }

--- a/src/Settings/PlanViewSettings.h
+++ b/src/Settings/PlanViewSettings.h
@@ -14,13 +14,9 @@
 class PlanViewSettings : public SettingsGroup
 {
     Q_OBJECT
-    
 public:
-    PlanViewSettings(QObject* parent = NULL);
-
+    PlanViewSettings(QObject* parent = nullptr);
+    DEFINE_SETTING_NAME_GROUP()
     // This is currently only used to set custom build visibility of the Plan view settings ui.
     // The settings themselves related to PlanView are in still in AppSettings due to historical reasons.
-
-    static const char* name;
-    static const char* settingsGroup;
 };

--- a/src/Settings/RTK.SettingsGroup.json
+++ b/src/Settings/RTK.SettingsGroup.json
@@ -1,6 +1,6 @@
 [
 {
-    "name":                 "SurveyInAccuracyLimit",
+    "name":                 "surveyInAccuracyLimit",
     "shortDescription":     "Survey in accuracy (U-blox only)",
     "longDescription":      "The maximum accuracy allowed prior to completing survey in.",
     "type":                 "double",
@@ -11,7 +11,7 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":                 "SurveyInMinObservationDuration",
+    "name":                 "surveyInMinObservationDuration",
     "shortDescription":     "Minimum observation time",
     "longDescription":      "Defines the minimum amount of observation time for the position calculation.",
     "type":                 "Uint32",
@@ -22,7 +22,7 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":                 "UseFixedBasePosition",
+    "name":                 "useFixedBasePosition",
     "shortDescription":     "Use specified base position",
     "longDescription":      "Specify the values for the RTK base position without having to do a survey in.",
     "type":                 "bool",
@@ -30,7 +30,7 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":                 "FixedBasePositionLatitude",
+    "name":                 "fixedBasePositionLatitude",
     "shortDescription":     "Base Position Latitude",
     "longDescription":      "Defines the latitude of the fixed RTK base position.",
     "type":                 "double",
@@ -41,7 +41,7 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":                 "FixedBasePositionLongitude",
+    "name":                 "fixedBasePositionLongitude",
     "shortDescription":     "Base Position Longitude",
     "longDescription":      "Defines the longitude of the fixed RTK base position.",
     "type":                 "double",
@@ -52,7 +52,7 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":                 "FixedBasePositionAltitude",
+    "name":                 "fixedBasePositionAltitude",
     "shortDescription":     "Base Position Alt (WGS84)",
     "longDescription":      "Defines the altitude of the fixed RTK base position.",
     "type":                 "float",
@@ -62,7 +62,7 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":                 "FixedBasePositionAccuracy",
+    "name":                 "fixedBasePositionAccuracy",
     "shortDescription":     "Base Position Accuracy",
     "longDescription":      "Defines the accuracy of the fixed RTK base position.",
     "type":                 "float",

--- a/src/Settings/RTKSettings.cc
+++ b/src/Settings/RTKSettings.cc
@@ -12,90 +12,16 @@
 #include <QQmlEngine>
 #include <QtQml>
 
-const char* RTKSettings::name =                                 "RTK";
-const char* RTKSettings::settingsGroup =                        "RTK";
-
-const char* RTKSettings::surveyInAccuracyLimitName =            "SurveyInAccuracyLimit";
-const char* RTKSettings::surveyInMinObservationDurationName =   "SurveyInMinObservationDuration";
-const char* RTKSettings::useFixedBasePositionName =             "UseFixedBasePosition";
-const char* RTKSettings::fixedBasePositionLatitudeName =        "FixedBasePositionLatitude";
-const char* RTKSettings::fixedBasePositionLongitudeName =       "FixedBasePositionLongitude";
-const char* RTKSettings::fixedBasePositionAltitudeName =        "FixedBasePositionAltitude";
-const char* RTKSettings::fixedBasePositionAccuracyName =        "FixedBasePositionAccuracy";
-
-RTKSettings::RTKSettings(QObject* parent)
-    : SettingsGroup                         (name, settingsGroup, parent)
-    , _surveyInAccuracyLimitFact            (nullptr)
-    , _surveyInMinObservationDurationFact   (nullptr)
-    , _useFixedBasePositionFact             (nullptr)
-    , _fixedBasePositionLatitudeFact        (nullptr)
-    , _fixedBasePositionLongitudeFact       (nullptr)
-    , _fixedBasePositionAltitudeFact        (nullptr)
-    , _fixedBasePositionAccuracyFact        (nullptr)
+DECLARE_SETTINGGROUP(RTK, "RTK")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-    qmlRegisterUncreatableType<RTKSettings>("QGroundControl.SettingsManager", 1, 0, "RTKSettings", "Reference only");
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
+    qmlRegisterUncreatableType<RTKSettings>("QGroundControl.SettingsManager", 1, 0, "RTKSettings", "Reference only"); \
 }
 
-Fact* RTKSettings::surveyInAccuracyLimit(void)
-{
-    if (!_surveyInAccuracyLimitFact) {
-        _surveyInAccuracyLimitFact = _createSettingsFact(surveyInAccuracyLimitName);
-    }
-
-    return _surveyInAccuracyLimitFact;
-}
-
-Fact* RTKSettings::surveyInMinObservationDuration(void)
-{
-    if (!_surveyInMinObservationDurationFact) {
-        _surveyInMinObservationDurationFact = _createSettingsFact(surveyInMinObservationDurationName);
-    }
-
-    return _surveyInMinObservationDurationFact;
-}
-
-Fact* RTKSettings::useFixedBasePosition(void)
-{
-    if (!_useFixedBasePositionFact) {
-        _useFixedBasePositionFact = _createSettingsFact(useFixedBasePositionName);
-    }
-
-    return _useFixedBasePositionFact;
-}
-
-Fact* RTKSettings::fixedBasePositionLatitude(void)
-{
-    if (!_fixedBasePositionLatitudeFact) {
-        _fixedBasePositionLatitudeFact = _createSettingsFact(fixedBasePositionLatitudeName);
-    }
-
-    return _fixedBasePositionLatitudeFact;
-}
-
-Fact* RTKSettings::fixedBasePositionLongitude(void)
-{
-    if (!_fixedBasePositionLongitudeFact) {
-        _fixedBasePositionLongitudeFact = _createSettingsFact(fixedBasePositionLongitudeName);
-    }
-
-    return _fixedBasePositionLongitudeFact;
-}
-
-Fact* RTKSettings::fixedBasePositionAltitude(void)
-{
-    if (!_fixedBasePositionAltitudeFact) {
-        _fixedBasePositionAltitudeFact = _createSettingsFact(fixedBasePositionAltitudeName);
-    }
-
-    return _fixedBasePositionAltitudeFact;
-}
-
-Fact* RTKSettings::fixedBasePositionAccuracy(void)
-{
-    if (!_fixedBasePositionAccuracyFact) {
-        _fixedBasePositionAccuracyFact = _createSettingsFact(fixedBasePositionAccuracyName);
-    }
-
-    return _fixedBasePositionAccuracyFact;
-}
+DECLARE_SETTINGSFACT(RTKSettings, surveyInAccuracyLimit)
+DECLARE_SETTINGSFACT(RTKSettings, surveyInMinObservationDuration)
+DECLARE_SETTINGSFACT(RTKSettings, useFixedBasePosition)
+DECLARE_SETTINGSFACT(RTKSettings, fixedBasePositionLatitude)
+DECLARE_SETTINGSFACT(RTKSettings, fixedBasePositionLongitude)
+DECLARE_SETTINGSFACT(RTKSettings, fixedBasePositionAltitude)
+DECLARE_SETTINGSFACT(RTKSettings, fixedBasePositionAccuracy)

--- a/src/Settings/RTKSettings.h
+++ b/src/Settings/RTKSettings.h
@@ -14,43 +14,14 @@
 class RTKSettings : public SettingsGroup
 {
     Q_OBJECT
-    
 public:
-    RTKSettings(QObject* parent = NULL);
-
-    Q_PROPERTY(Fact* surveyInAccuracyLimit          READ surveyInAccuracyLimit          CONSTANT)
-    Q_PROPERTY(Fact* surveyInMinObservationDuration READ surveyInMinObservationDuration CONSTANT)
-    Q_PROPERTY(Fact* useFixedBasePosition           READ useFixedBasePosition           CONSTANT)
-    Q_PROPERTY(Fact* fixedBasePositionLatitude      READ fixedBasePositionLatitude      CONSTANT)
-    Q_PROPERTY(Fact* fixedBasePositionLongitude     READ fixedBasePositionLongitude     CONSTANT)
-    Q_PROPERTY(Fact* fixedBasePositionAltitude      READ fixedBasePositionAltitude      CONSTANT)
-    Q_PROPERTY(Fact* fixedBasePositionAccuracy      READ fixedBasePositionAccuracy      CONSTANT)
-
-    Fact* surveyInAccuracyLimit         (void);
-    Fact* surveyInMinObservationDuration(void);
-    Fact* useFixedBasePosition          (void);
-    Fact* fixedBasePositionLatitude     (void);
-    Fact* fixedBasePositionLongitude    (void);
-    Fact* fixedBasePositionAltitude     (void);
-    Fact* fixedBasePositionAccuracy     (void);
-
-    static const char* name;
-    static const char* settingsGroup;
-
-    static const char* surveyInAccuracyLimitName;
-    static const char* surveyInMinObservationDurationName;
-    static const char* useFixedBasePositionName;
-    static const char* fixedBasePositionLatitudeName;
-    static const char* fixedBasePositionLongitudeName;
-    static const char* fixedBasePositionAltitudeName;
-    static const char* fixedBasePositionAccuracyName;
-
-private:
-    SettingsFact* _surveyInAccuracyLimitFact;
-    SettingsFact* _surveyInMinObservationDurationFact;
-    SettingsFact* _useFixedBasePositionFact;
-    SettingsFact* _fixedBasePositionLatitudeFact;
-    SettingsFact* _fixedBasePositionLongitudeFact;
-    SettingsFact* _fixedBasePositionAltitudeFact;
-    SettingsFact* _fixedBasePositionAccuracyFact;
+    RTKSettings(QObject* parent = nullptr);
+    DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(surveyInAccuracyLimit)
+    DEFINE_SETTINGFACT(surveyInMinObservationDuration)
+    DEFINE_SETTINGFACT(useFixedBasePosition)
+    DEFINE_SETTINGFACT(fixedBasePositionLatitude)
+    DEFINE_SETTINGFACT(fixedBasePositionLongitude)
+    DEFINE_SETTINGFACT(fixedBasePositionAltitude)
+    DEFINE_SETTINGFACT(fixedBasePositionAccuracy)
 };

--- a/src/Settings/SettingsGroup.cc
+++ b/src/Settings/SettingsGroup.cc
@@ -11,19 +11,24 @@
 #include "QGCCorePlugin.h"
 #include "QGCApplication.h"
 
+static const char* kJsonFile = ":/json/%1.SettingsGroup.json";
+
 SettingsGroup::SettingsGroup(const QString& name, const QString& settingsGroup, QObject* parent)
     : QObject       (parent)
+    , _visible      (qgcApp()->toolbox()->corePlugin()->overrideSettingsGroupVisibility(name))
     , _name         (name)
     , _settingsGroup(settingsGroup)
-    , _visible      (qgcApp()->toolbox()->corePlugin()->overrideSettingsGroupVisibility(_name))
 {
-    QString jsonNameFormat(":/json/%1.SettingsGroup.json");
-
-    _nameToMetaDataMap = FactMetaData::createMapFromJsonFile(jsonNameFormat.arg(_name), this);
+    _nameToMetaDataMap = FactMetaData::createMapFromJsonFile(QString(kJsonFile).arg(name), this);
 }
 
 SettingsFact* SettingsGroup::_createSettingsFact(const QString& factName)
 {
-    return new SettingsFact(_settingsGroup, _nameToMetaDataMap[factName], this);
+    FactMetaData* m = _nameToMetaDataMap[factName];
+    if(!m) {
+        qCritical() << "Fact name " << factName << "not found in" << QString(kJsonFile).arg(_name);
+        exit(-1);
+    }
+    return new SettingsFact(_settingsGroup, m, this);
 }
 

--- a/src/Settings/SettingsGroup.h
+++ b/src/Settings/SettingsGroup.h
@@ -17,17 +17,19 @@
 
 #include <QVariantList>
 
-#define DEFINE_SETTINGGROUP(CLASS) \
-    static const char* CLASS ## Settings ## GroupName;
+#define DEFINE_SETTING_NAME_GROUP() \
+    static const char* name; \
+    static const char* settingsGroup;
 
-#define DECLARE_SETTINGGROUP(CLASS) \
-    const char* CLASS ## Settings::CLASS ## Settings ## GroupName = #CLASS; \
-    CLASS ## Settings::CLASS ## Settings(QObject* parent) \
-        : SettingsGroup(CLASS ## Settings ## GroupName, QString() /* root settings group */, parent)
+#define DECLARE_SETTINGGROUP(NAME, GROUP) \
+    const char* NAME ## Settings::name = #NAME; \
+    const char* NAME ## Settings::settingsGroup = GROUP; \
+    NAME ## Settings::NAME ## Settings(QObject* parent) \
+        : SettingsGroup(name, settingsGroup, parent)
 
 #define DECLARE_SETTINGSFACT(CLASS, NAME) \
     const char* CLASS::NAME ## Name = #NAME; \
-    Fact* CLASS::NAME(void) \
+    Fact* CLASS::NAME() \
     { \
         if (!_ ## NAME ## Fact) { \
             _ ## NAME ## Fact = _createSettingsFact(NAME ## Name); \
@@ -35,15 +37,17 @@
         return _ ## NAME ## Fact; \
     }
 
+#define DECLARE_SETTINGSFACT_NO_FUNC(CLASS, NAME) \
+    const char* CLASS::NAME ## Name = #NAME; \
+    Fact* CLASS::NAME()
+
 #define DEFINE_SETTINGFACT(NAME) \
+    private: \
+    SettingsFact* _ ## NAME ## Fact = nullptr; \
     public: \
     Q_PROPERTY(Fact* NAME READ NAME CONSTANT) \
     Fact* NAME(); \
-    static const char* NAME ## Name; \
-    private: \
-    SettingsFact* _ ## NAME ## Fact;
-
-#define INIT_SETTINGFACT(NAME) _ ## NAME ## Fact = NULL
+    static const char* NAME ## Name;
 
 /// Provides access to group of settings. The group is named and has a visible property associated with which can control whether the group
 /// is shows in the ui.
@@ -54,16 +58,15 @@ class SettingsGroup : public QObject
 public:
     /// @param name Name for this Settings group
     /// @param settingsGroup Group to place settings in for QSettings::setGroup
-    SettingsGroup(const QString& name, const QString& settingsGroup, QObject* parent = NULL);
+    SettingsGroup(const QString &name, const QString &settingsGroup, QObject* parent = nullptr);
 
     Q_PROPERTY(bool visible MEMBER _visible CONSTANT)
 
 protected:
-    SettingsFact* _createSettingsFact(const QString& factName);
-
-    QString _name;              ///< Name for group. Used to generate name for loaded json meta data file.
-    QString _settingsGroup;     ///< QSettings group which contains these settings. empty for settings in root
-    bool    _visible;
+    SettingsFact*   _createSettingsFact(const QString& factName);
+    bool            _visible;
+    QString         _name;
+    QString         _settingsGroup;
 
     QMap<QString, FactMetaData*> _nameToMetaDataMap;
 };

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -15,17 +15,17 @@
 SettingsManager::SettingsManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
 #if defined(QGC_AIRMAP_ENABLED)
-    , _airMapSettings       (NULL)
+    , _airMapSettings       (nullptr)
 #endif
-    , _appSettings          (NULL)
-    , _unitsSettings        (NULL)
-    , _autoConnectSettings  (NULL)
-    , _videoSettings        (NULL)
-    , _flightMapSettings    (NULL)
-    , _rtkSettings          (NULL)
-    , _flyViewSettings      (NULL)
-    , _planViewSettings     (NULL)
-    , _brandImageSettings   (NULL)
+    , _appSettings          (nullptr)
+    , _unitsSettings        (nullptr)
+    , _autoConnectSettings  (nullptr)
+    , _videoSettings        (nullptr)
+    , _flightMapSettings    (nullptr)
+    , _rtkSettings          (nullptr)
+    , _flyViewSettings      (nullptr)
+    , _planViewSettings     (nullptr)
+    , _brandImageSettings   (nullptr)
 {
 
 }

--- a/src/Settings/UnitsSettings.cc
+++ b/src/Settings/UnitsSettings.cc
@@ -12,116 +12,95 @@
 #include <QQmlEngine>
 #include <QtQml>
 
-const char* UnitsSettings::name =                           "Units";
-const char* UnitsSettings::settingsGroup =                  ""; // settings are in root group
-
-const char* UnitsSettings::distanceUnitsSettingsName =      "DistanceUnits";
-const char* UnitsSettings::areaUnitsSettingsName =          "AreaUnits";
-const char* UnitsSettings::speedUnitsSettingsName =         "SpeedUnits";
-const char* UnitsSettings::temperatureUnitsSettingsName =   "TemperatureUnits";
-
-UnitsSettings::UnitsSettings(QObject* parent)
-    : SettingsGroup(name, settingsGroup, parent)
-    , _distanceUnitsFact(NULL)
-    , _areaUnitsFact(NULL)
-    , _speedUnitsFact(NULL)
-    , _temperatureUnitsFact(NULL)
+DECLARE_SETTINGGROUP(Units, "Units")
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<UnitsSettings>("QGroundControl.SettingsManager", 1, 0, "UnitsSettings", "Reference only");
 }
 
-Fact* UnitsSettings::distanceUnits(void)
+DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, distanceUnits)
 {
     if (!_distanceUnitsFact) {
         // Distance/Area/Speed units settings can't be loaded from json since it creates an infinite loop of meta data loading.
         QStringList     enumStrings;
         QVariantList    enumValues;
-
         enumStrings << "Feet" << "Meters";
-        enumValues << QVariant::fromValue((uint32_t)DistanceUnitsFeet) << QVariant::fromValue((uint32_t)DistanceUnitsMeters);
-        
+        enumValues << QVariant::fromValue(static_cast<uint32_t>(DistanceUnitsFeet)) << QVariant::fromValue(static_cast<uint32_t>(DistanceUnitsMeters));
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
-        metaData->setName(distanceUnitsSettingsName);
+        metaData->setName(distanceUnitsName);
         metaData->setShortDescription(tr("Distance units"));
         metaData->setEnumInfo(enumStrings, enumValues);
         metaData->setRawDefaultValue(DistanceUnitsMeters);
         metaData->setQGCRebootRequired(true);
-
         _distanceUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
-
     }
-
     return _distanceUnitsFact;
-
 }
 
-Fact* UnitsSettings::areaUnits(void)
+DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, areaUnits)
 {
     if (!_areaUnitsFact) {
         // Distance/Area/Speed units settings can't be loaded from json since it creates an infinite loop of meta data loading.
         QStringList     enumStrings;
         QVariantList    enumValues;
-
         enumStrings << "SquareFeet" << "SquareMeters" << "SquareKilometers" << "Hectares" << "Acres" << "SquareMiles";
-        enumValues << QVariant::fromValue((uint32_t)AreaUnitsSquareFeet) << QVariant::fromValue((uint32_t)AreaUnitsSquareMeters) << QVariant::fromValue((uint32_t)AreaUnitsSquareKilometers) << QVariant::fromValue((uint32_t)AreaUnitsHectares) << QVariant::fromValue((uint32_t)AreaUnitsAcres) << QVariant::fromValue((uint32_t)AreaUnitsSquareMiles);
-
+        enumValues <<
+            QVariant::fromValue(static_cast<uint32_t>(AreaUnitsSquareFeet)) <<
+            QVariant::fromValue(static_cast<uint32_t>(AreaUnitsSquareMeters)) <<
+            QVariant::fromValue(static_cast<uint32_t>(AreaUnitsSquareKilometers)) <<
+            QVariant::fromValue(static_cast<uint32_t>(AreaUnitsHectares)) <<
+            QVariant::fromValue(static_cast<uint32_t>(AreaUnitsAcres)) <<
+            QVariant::fromValue(static_cast<uint32_t>(AreaUnitsSquareMiles));
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
-        metaData->setName(areaUnitsSettingsName);
+        metaData->setName(areaUnitsName);
         metaData->setShortDescription(tr("Area units"));
         metaData->setEnumInfo(enumStrings, enumValues);
         metaData->setRawDefaultValue(AreaUnitsSquareMeters);
         metaData->setQGCRebootRequired(true);
-
         _areaUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
-
     return _areaUnitsFact;
-
 }
 
-Fact* UnitsSettings::speedUnits(void)
+DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, speedUnits)
 {
     if (!_speedUnitsFact) {
         // Distance/Area/Speed units settings can't be loaded from json since it creates an infinite loop of meta data loading.
         QStringList     enumStrings;
         QVariantList    enumValues;
-
         enumStrings << "Feet/second" << "Meters/second" << "Miles/hour" << "Kilometers/hour" << "Knots";
-        enumValues << QVariant::fromValue((uint32_t)SpeedUnitsFeetPerSecond) << QVariant::fromValue((uint32_t)SpeedUnitsMetersPerSecond) << QVariant::fromValue((uint32_t)SpeedUnitsMilesPerHour) << QVariant::fromValue((uint32_t)SpeedUnitsKilometersPerHour) << QVariant::fromValue((uint32_t)SpeedUnitsKnots);
-
+        enumValues <<
+            QVariant::fromValue(static_cast<uint32_t>(SpeedUnitsFeetPerSecond)) <<
+            QVariant::fromValue(static_cast<uint32_t>(SpeedUnitsMetersPerSecond)) <<
+            QVariant::fromValue(static_cast<uint32_t>(SpeedUnitsMilesPerHour)) <<
+            QVariant::fromValue(static_cast<uint32_t>(SpeedUnitsKilometersPerHour)) <<
+            QVariant::fromValue(static_cast<uint32_t>(SpeedUnitsKnots));
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
-        metaData->setName(speedUnitsSettingsName);
+        metaData->setName(speedUnitsName);
         metaData->setShortDescription(tr("Speed units"));
         metaData->setEnumInfo(enumStrings, enumValues);
         metaData->setRawDefaultValue(SpeedUnitsMetersPerSecond);
         metaData->setQGCRebootRequired(true);
-
         _speedUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
-
     return _speedUnitsFact;
 }
 
-Fact* UnitsSettings::temperatureUnits(void)
+DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, temperatureUnits)
 {
     if (!_temperatureUnitsFact) {
         // Units settings can't be loaded from json since it creates an infinite loop of meta data loading.
         QStringList     enumStrings;
         QVariantList    enumValues;
-
         enumStrings << "Celsius" << "Farenheit";
-        enumValues << QVariant::fromValue((uint32_t)TemperatureUnitsCelsius) << QVariant::fromValue((uint32_t)TemperatureUnitsFarenheit);
-
+        enumValues << QVariant::fromValue(static_cast<uint32_t>(TemperatureUnitsCelsius)) << QVariant::fromValue(static_cast<uint32_t>(TemperatureUnitsFarenheit));
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
-        metaData->setName(temperatureUnitsSettingsName);
+        metaData->setName(temperatureUnitsName);
         metaData->setShortDescription(tr("Temperature units"));
         metaData->setEnumInfo(enumStrings, enumValues);
         metaData->setRawDefaultValue(TemperatureUnitsCelsius);
         metaData->setQGCRebootRequired(true);
-
         _temperatureUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
-
     return _temperatureUnitsFact;
 }

--- a/src/Settings/UnitsSettings.h
+++ b/src/Settings/UnitsSettings.h
@@ -17,7 +17,7 @@ class UnitsSettings : public SettingsGroup
     Q_OBJECT
     
 public:
-    UnitsSettings(QObject* parent = NULL);
+    UnitsSettings(QObject* parent = nullptr);
 
     enum DistanceUnits {
         DistanceUnitsFeet = 0,
@@ -51,29 +51,12 @@ public:
     Q_ENUM(SpeedUnits)
     Q_ENUM(TemperatureUnits)
 
-    Q_PROPERTY(Fact* distanceUnits                      READ distanceUnits                      CONSTANT)
-    Q_PROPERTY(Fact* areaUnits                          READ areaUnits                          CONSTANT)
-    Q_PROPERTY(Fact* speedUnits                         READ speedUnits                         CONSTANT)
-    Q_PROPERTY(Fact* temperatureUnits                   READ temperatureUnits                   CONSTANT)
+    DEFINE_SETTING_NAME_GROUP()
 
-    Fact* distanceUnits                     (void);
-    Fact* areaUnits                         (void);
-    Fact* speedUnits                        (void);
-    Fact* temperatureUnits                  (void);
-
-    static const char* name;
-    static const char* settingsGroup;
-
-    static const char* distanceUnitsSettingsName;
-    static const char* areaUnitsSettingsName;
-    static const char* speedUnitsSettingsName;
-    static const char* temperatureUnitsSettingsName;
-
-private:
-    SettingsFact* _distanceUnitsFact;
-    SettingsFact* _areaUnitsFact;
-    SettingsFact* _speedUnitsFact;
-    SettingsFact* _temperatureUnitsFact;
+    DEFINE_SETTINGFACT(distanceUnits)
+    DEFINE_SETTINGFACT(areaUnits)
+    DEFINE_SETTINGFACT(speedUnits)
+    DEFINE_SETTINGFACT(temperatureUnits)
 };
 
 #endif

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -1,13 +1,13 @@
 [
 {
-    "name":             "VideoSource",
+    "name":             "videoSource",
     "shortDescription": "Video source",
     "longDescription":  "Source for video. UDP, TCP, RTSP and UVC Cameras may be supported depending on Vehicle and ground station version.",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "VideoUDPPort",
+    "name":             "udpPort",
     "shortDescription": "Video UDP Port",
     "longDescription":  "UDP port to bind to for video stream.",
     "type":             "uint16",
@@ -15,28 +15,28 @@
     "defaultValue":     5600
 },
 {
-    "name":             "VideoRTSPUrl",
+    "name":             "rtspUrl",
     "shortDescription": "Video RTSP Url",
     "longDescription":  "RTSP url address and port to bind to for video stream. Example: rtsp://192.168.42.1:554/live",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "VideoTCPUrl",
+    "name":             "tcpUrl",
     "shortDescription": "Video TCP Url",
     "longDescription":  "TCP url address and port to bind to for video stream. Example: 192.168.143.200:3001",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "VideoSavePath",
+    "name":             "videoSavePath",
     "shortDescription": "Video save directory",
     "longDescription":  "Directory to save videos to.",
     "type":             "string",
     "defaultValue":     ""
 },
 {
-    "name":             "VideoAspectRatio",
+    "name":             "aspectRatio",
     "shortDescription": "Video Aspect Ratio",
     "longDescription":  "Video Aspect Ratio (width / height). Use 0.0 to ignore it.",
     "type":             "float",
@@ -44,7 +44,7 @@
     "defaultValue":     1.777777
 },
 {
-    "name":             "VideoGridLines",
+    "name":             "gridLines",
     "shortDescription": "Video Grid Lines",
     "longDescription":  "Displays a grid overlaid over the video view.",
     "type":             "uint32",
@@ -53,14 +53,23 @@
     "defaultValue":     0
 },
 {
-    "name":             "ShowRecControl",
+    "name":             "videoFit",
+    "shortDescription": "Video Display Fit",
+    "longDescription":  "Handle Video Aspect Ratio.",
+    "type":             "uint32",
+    "enumStrings":      "Fit Width,Fit Height,Stretch",
+    "enumValues":       "0,1,2",
+    "defaultValue":     1
+},
+{
+    "name":             "showRecControl",
     "shortDescription": "Show Video Record Control",
     "longDescription":  "Show recording control in the UI.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "RecordingFormat",
+    "name":             "recordingFormat",
     "shortDescription": "Video Recording Format",
     "longDescription":  "Video recording file format.",
     "type":             "uint32",
@@ -69,7 +78,7 @@
     "defaultValue":     0
 },
 {
-    "name":             "MaxVideoSize",
+    "name":             "maxVideoSize",
     "shortDescription": "Max Video Storage Usage",
     "longDescription":  "Maximum amount of disk space used by video recording.",
     "type":             "uint32",
@@ -79,7 +88,7 @@
     "mobileDefaultValue":   2048
 },
 {
-    "name":             "EnableStorageLimit",
+    "name":             "enableStorageLimit",
     "shortDescription": "Enable/Disable Limits on Storage Usage",
     "longDescription":  "When enabled, old video files will be auto-deleted when the total size of QGC-recorded video exceeds the maximum video storage usage.",
     "type":             "bool",
@@ -87,7 +96,7 @@
     "mobileDefaultValue":   true
 },
 {
-    "name":             "RtspTimeout",
+    "name":             "rtspTimeout",
     "shortDescription": "RTSP Video Timeout",
     "longDescription":  "How long to wait before assuming RTSP link is gone.",
     "type":             "uint32",
@@ -96,14 +105,14 @@
     "defaultValue":     2
 },
 {
-    "name":             "StreamEnabled",
+    "name":             "streamEnabled",
     "shortDescription": "Video Stream Enabled",
     "longDescription":  "Start/Stop Video Stream.",
     "type":             "bool",
     "defaultValue":     true
 },
 {
-    "name":             "DisableWhenDisarmed",
+    "name":             "disableWhenDisarmed",
     "shortDescription": "Video Stream Disnabled When Armed",
     "longDescription":  "Disable Video Stream when disarmed.",
     "type":             "bool",

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -17,44 +17,16 @@
 #include <QCameraInfo>
 #endif
 
-const char* VideoSettings::name =                   "Video";
-const char* VideoSettings::settingsGroup =          ""; // settings are in root group
-
-const char* VideoSettings::videoSourceName =        "VideoSource";
-const char* VideoSettings::udpPortName =            "VideoUDPPort";
-const char* VideoSettings::rtspUrlName =            "VideoRTSPUrl";
-const char* VideoSettings::tcpUrlName =             "VideoTCPUrl";
-const char* VideoSettings::videoAspectRatioName =   "VideoAspectRatio";
-const char* VideoSettings::videoGridLinesName =     "VideoGridLines";
-const char* VideoSettings::showRecControlName =     "ShowRecControl";
-const char* VideoSettings::recordingFormatName =    "RecordingFormat";
-const char* VideoSettings::maxVideoSizeName =       "MaxVideoSize";
-const char* VideoSettings::enableStorageLimitName = "EnableStorageLimit";
-const char* VideoSettings::rtspTimeoutName =        "RtspTimeout";
-const char* VideoSettings::streamEnabledName =      "StreamEnabled";
-const char* VideoSettings::disableWhenDisarmedName ="DisableWhenDisarmed";
-
 const char* VideoSettings::videoSourceNoVideo =     "No Video Available";
 const char* VideoSettings::videoDisabled =          "Video Stream Disabled";
 const char* VideoSettings::videoSourceUDP =         "UDP Video Stream";
 const char* VideoSettings::videoSourceRTSP =        "RTSP Video Stream";
 const char* VideoSettings::videoSourceTCP =         "TCP-MPEG2 Video Stream";
+#ifdef QGC_GST_TAISYNC_USB
+const char* VideoSettings::videoSourceTaiSyncUSB =  "Taisync USB";
+#endif
 
-VideoSettings::VideoSettings(QObject* parent)
-    : SettingsGroup(name, settingsGroup, parent)
-    , _videoSourceFact(NULL)
-    , _udpPortFact(NULL)
-    , _tcpUrlFact(NULL)
-    , _rtspUrlFact(NULL)
-    , _videoAspectRatioFact(NULL)
-    , _gridLinesFact(NULL)
-    , _showRecControlFact(NULL)
-    , _recordingFormatFact(NULL)
-    , _maxVideoSizeFact(NULL)
-    , _enableStorageLimitFact(NULL)
-    , _rtspTimeoutFact(NULL)
-    , _streamEnabledFact(NULL)
-    , _disableWhenDisarmedFact(NULL)
+DECLARE_SETTINGGROUP(Video, "Video")
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<VideoSettings>("QGroundControl.SettingsManager", 1, 0, "VideoSettings", "Reference only");
@@ -68,6 +40,9 @@ VideoSettings::VideoSettings(QObject* parent)
 #endif
     videoSourceList.append(videoSourceRTSP);
     videoSourceList.append(videoSourceTCP);
+#ifdef QGC_GST_TAISYNC_USB
+    videoSourceList.append(videoSourceTaiSyncUSB);
+#endif
 #endif
 #ifndef QGC_DISABLE_UVC
     QList<QCameraInfo> cameras = QCameraInfo::availableCameras();
@@ -95,7 +70,18 @@ VideoSettings::VideoSettings(QObject* parent)
     }
 }
 
-Fact* VideoSettings::videoSource(void)
+DECLARE_SETTINGSFACT(VideoSettings, aspectRatio)
+DECLARE_SETTINGSFACT(VideoSettings, videoFit)
+DECLARE_SETTINGSFACT(VideoSettings, gridLines)
+DECLARE_SETTINGSFACT(VideoSettings, showRecControl)
+DECLARE_SETTINGSFACT(VideoSettings, recordingFormat)
+DECLARE_SETTINGSFACT(VideoSettings, maxVideoSize)
+DECLARE_SETTINGSFACT(VideoSettings, enableStorageLimit)
+DECLARE_SETTINGSFACT(VideoSettings, rtspTimeout)
+DECLARE_SETTINGSFACT(VideoSettings, streamEnabled)
+DECLARE_SETTINGSFACT(VideoSettings, disableWhenDisarmed)
+
+DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, videoSource)
 {
     if (!_videoSourceFact) {
         _videoSourceFact = _createSettingsFact(videoSourceName);
@@ -104,7 +90,7 @@ Fact* VideoSettings::videoSource(void)
     return _videoSourceFact;
 }
 
-Fact* VideoSettings::udpPort(void)
+DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, udpPort)
 {
     if (!_udpPortFact) {
         _udpPortFact = _createSettingsFact(udpPortName);
@@ -113,7 +99,7 @@ Fact* VideoSettings::udpPort(void)
     return _udpPortFact;
 }
 
-Fact* VideoSettings::rtspUrl(void)
+DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, rtspUrl)
 {
     if (!_rtspUrlFact) {
         _rtspUrlFact = _createSettingsFact(rtspUrlName);
@@ -122,85 +108,13 @@ Fact* VideoSettings::rtspUrl(void)
     return _rtspUrlFact;
 }
 
-Fact* VideoSettings::tcpUrl(void)
+DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, tcpUrl)
 {
     if (!_tcpUrlFact) {
         _tcpUrlFact = _createSettingsFact(tcpUrlName);
         connect(_tcpUrlFact, &Fact::valueChanged, this, &VideoSettings::_configChanged);
     }
     return _tcpUrlFact;
-}
-
-Fact* VideoSettings::aspectRatio(void)
-{
-    if (!_videoAspectRatioFact) {
-        _videoAspectRatioFact = _createSettingsFact(videoAspectRatioName);
-    }
-    return _videoAspectRatioFact;
-}
-
-Fact* VideoSettings::gridLines(void)
-{
-    if (!_gridLinesFact) {
-        _gridLinesFact = _createSettingsFact(videoGridLinesName);
-    }
-    return _gridLinesFact;
-}
-
-Fact* VideoSettings::showRecControl(void)
-{
-    if (!_showRecControlFact) {
-        _showRecControlFact = _createSettingsFact(showRecControlName);
-    }
-    return _showRecControlFact;
-}
-
-Fact* VideoSettings::recordingFormat(void)
-{
-    if (!_recordingFormatFact) {
-        _recordingFormatFact = _createSettingsFact(recordingFormatName);
-    }
-    return _recordingFormatFact;
-}
-
-Fact* VideoSettings::maxVideoSize(void)
-{
-    if (!_maxVideoSizeFact) {
-        _maxVideoSizeFact = _createSettingsFact(maxVideoSizeName);
-    }
-    return _maxVideoSizeFact;
-}
-
-Fact* VideoSettings::enableStorageLimit(void)
-{
-    if (!_enableStorageLimitFact) {
-        _enableStorageLimitFact = _createSettingsFact(enableStorageLimitName);
-    }
-    return _enableStorageLimitFact;
-}
-
-Fact* VideoSettings::rtspTimeout(void)
-{
-    if (!_rtspTimeoutFact) {
-        _rtspTimeoutFact = _createSettingsFact(rtspTimeoutName);
-    }
-    return _rtspTimeoutFact;
-}
-
-Fact* VideoSettings::streamEnabled(void)
-{
-    if (!_streamEnabledFact) {
-        _streamEnabledFact = _createSettingsFact(streamEnabledName);
-    }
-    return _streamEnabledFact;
-}
-
-Fact* VideoSettings::disableWhenDisarmed(void)
-{
-    if (!_disableWhenDisarmedFact) {
-        _disableWhenDisarmedFact = _createSettingsFact(disableWhenDisarmedName);
-    }
-    return _disableWhenDisarmedFact;
 }
 
 bool VideoSettings::streamConfigured(void)
@@ -212,6 +126,11 @@ bool VideoSettings::streamConfigured(void)
     if(vSource == videoSourceNoVideo || vSource == videoDisabled) {
         return false;
     }
+#ifdef QGC_GST_TAISYNC_USB
+    if(vSource == videoSourceTaiSyncUSB) {
+        return true;
+    }
+#endif
     //-- If UDP, check if port is set
     if(vSource == videoSourceUDP) {
         return udpPort()->rawValue().toInt() != 0;

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -17,60 +17,36 @@ class VideoSettings : public SettingsGroup
     Q_OBJECT
 
 public:
-    VideoSettings(QObject* parent = NULL);
+    VideoSettings(QObject* parent = nullptr);
+    DEFINE_SETTING_NAME_GROUP()
 
-    Q_PROPERTY(Fact* videoSource            READ videoSource            CONSTANT)
-    Q_PROPERTY(Fact* udpPort                READ udpPort                CONSTANT)
-    Q_PROPERTY(Fact* tcpUrl                 READ tcpUrl                 CONSTANT)
-    Q_PROPERTY(Fact* rtspUrl                READ rtspUrl                CONSTANT)
-    Q_PROPERTY(Fact* aspectRatio            READ aspectRatio            CONSTANT)
-    Q_PROPERTY(Fact* gridLines              READ gridLines              CONSTANT)
-    Q_PROPERTY(Fact* showRecControl         READ showRecControl         CONSTANT)
-    Q_PROPERTY(Fact* recordingFormat        READ recordingFormat        CONSTANT)
-    Q_PROPERTY(Fact* maxVideoSize           READ maxVideoSize           CONSTANT)
-    Q_PROPERTY(Fact* enableStorageLimit     READ enableStorageLimit     CONSTANT)
-    Q_PROPERTY(Fact* rtspTimeout            READ rtspTimeout            CONSTANT)
-    Q_PROPERTY(Fact* streamEnabled          READ streamEnabled          CONSTANT)
-    Q_PROPERTY(Fact* disableWhenDisarmed    READ disableWhenDisarmed    CONSTANT)
+    DEFINE_SETTINGFACT(videoSource)
+    DEFINE_SETTINGFACT(udpPort)
+    DEFINE_SETTINGFACT(tcpUrl)
+    DEFINE_SETTINGFACT(rtspUrl)
+    DEFINE_SETTINGFACT(aspectRatio)
+    DEFINE_SETTINGFACT(videoFit)
+    DEFINE_SETTINGFACT(gridLines)
+    DEFINE_SETTINGFACT(showRecControl)
+    DEFINE_SETTINGFACT(recordingFormat)
+    DEFINE_SETTINGFACT(maxVideoSize)
+    DEFINE_SETTINGFACT(enableStorageLimit)
+    DEFINE_SETTINGFACT(rtspTimeout)
+    DEFINE_SETTINGFACT(streamEnabled)
+    DEFINE_SETTINGFACT(disableWhenDisarmed)
+
     Q_PROPERTY(bool  streamConfigured       READ streamConfigured       NOTIFY streamConfiguredChanged)
 
-    Fact* videoSource           (void);
-    Fact* udpPort               (void);
-    Fact* rtspUrl               (void);
-    Fact* tcpUrl                (void);
-    Fact* aspectRatio           (void);
-    Fact* gridLines             (void);
-    Fact* showRecControl        (void);
-    Fact* recordingFormat       (void);
-    Fact* maxVideoSize          (void);
-    Fact* enableStorageLimit    (void);
-    Fact* rtspTimeout           (void);
-    Fact* streamEnabled         (void);
-    Fact* disableWhenDisarmed   (void);
-    bool  streamConfigured      (void);
-
-    static const char* name;
-    static const char* settingsGroup;
-
-    static const char* videoSourceName;
-    static const char* udpPortName;
-    static const char* rtspUrlName;
-    static const char* tcpUrlName;
-    static const char* videoAspectRatioName;
-    static const char* videoGridLinesName;
-    static const char* showRecControlName;
-    static const char* recordingFormatName;
-    static const char* maxVideoSizeName;
-    static const char* enableStorageLimitName;
-    static const char* rtspTimeoutName;
-    static const char* streamEnabledName;
-    static const char* disableWhenDisarmedName;
+    bool  streamConfigured          ();
 
     static const char* videoSourceNoVideo;
     static const char* videoDisabled;
     static const char* videoSourceUDP;
     static const char* videoSourceRTSP;
     static const char* videoSourceTCP;
+#ifdef QGC_GST_TAISYNC_USB
+    static const char* videoSourceTaiSyncUSB;
+#endif
 
 signals:
     void streamConfiguredChanged    ();
@@ -79,19 +55,6 @@ private slots:
     void _configChanged             (QVariant value);
 
 private:
-    SettingsFact* _videoSourceFact;
-    SettingsFact* _udpPortFact;
-    SettingsFact* _tcpUrlFact;
-    SettingsFact* _rtspUrlFact;
-    SettingsFact* _videoAspectRatioFact;
-    SettingsFact* _gridLinesFact;
-    SettingsFact* _showRecControlFact;
-    SettingsFact* _recordingFormatFact;
-    SettingsFact* _maxVideoSizeFact;
-    SettingsFact* _enableStorageLimitFact;
-    SettingsFact* _rtspTimeoutFact;
-    SettingsFact* _streamEnabledFact;
-    SettingsFact* _disableWhenDisarmedFact;
 };
 
 #endif


### PR DESCRIPTION
Fact settings had a great deal of code redundancy. I've added some macros to deal with it. Macros are used to define and declare settings. 

It went from this:

```c
class BrandImageSettings : public SettingsGroup
{
Q_OBJECT

public:
BrandImageSettings(QObject* parent = NULL);

Q_PROPERTY(Fact* userBrandImageIndoor READ userBrandImageIndoor CONSTANT)
Q_PROPERTY(Fact* userBrandImageOutdoor READ userBrandImageOutdoor CONSTANT)

Fact* userBrandImageIndoor (void);
Fact* userBrandImageOutdoor (void);

static const char* name;
static const char* settingsGroup;

static const char* userBrandImageIndoorName;
static const char* userBrandImageOutdoorName;

private:
SettingsFact* _userBrandImageIndoorFact;
SettingsFact* _userBrandImageOutdoorFact;
};
```

To this:

```c
class BrandImageSettings : public SettingsGroup
{
Q_OBJECT
public:
BrandImageSettings(QObject* parent = nullptr);
DEFINE_SETTING_NAME_GROUP()
DEFINE_SETTINGFACT(userBrandImageIndoor)
DEFINE_SETTINGFACT(userBrandImageOutdoor)
};
```

And the declaration went from this:

```c
const char* BrandImageSettings::name = "BrandImage";
const char* BrandImageSettings::settingsGroup = "Branding";

const char* BrandImageSettings::userBrandImageIndoorName = "UserBrandImageIndoor";
const char* BrandImageSettings::userBrandImageOutdoorName = "UserBrandImageOutdoor";

BrandImageSettings::BrandImageSettings(QObject* parent)
: SettingsGroup(name, settingsGroup, parent)
, _userBrandImageIndoorFact(NULL)
, _userBrandImageOutdoorFact(NULL)
{
QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
qmlRegisterUncreatableType<BrandImageSettings>("QGroundControl.SettingsManager",
1, 0, "BrandImageSettings", "Reference only");
}

Fact* BrandImageSettings::userBrandImageIndoor(void)
{
if (!_userBrandImageIndoorFact) {
_userBrandImageIndoorFact = _createSettingsFact(userBrandImageIndoorName);
}

return _userBrandImageIndoorFact;
}

Fact* BrandImageSettings::userBrandImageOutdoor(void)
{
if (!_userBrandImageOutdoorFact) {
_userBrandImageOutdoorFact = _createSettingsFact(userBrandImageOutdoorName);
}

return _userBrandImageOutdoorFact;
}
```

To this:

```c
DECLARE_SETTINGGROUP(BrandImage, "Branding")
{
QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
qmlRegisterUncreatableType<BrandImageSettings>("QGroundControl.SettingsManager",
1, 0, "BrandImageSettings", "Reference only"); \
}

DECLARE_SETTINGSFACT(BrandImageSettings, userBrandImageIndoor)
DECLARE_SETTINGSFACT(BrandImageSettings, userBrandImageOutdoor)
```

Also cleaning up some warnings and fixing an issue where the GStreamer log was (attempting) to write to the root directory if it didn't find the proper Log directory.

