### PR TITLE
Flight Plan Complete: Better handling of comm last sequence

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -163,6 +163,12 @@ QGCView {
         id: missionCompleteDialogComponent
 
         QGCViewDialog {
+            property var activeVehicleCopy: _activeVehicle
+            onActiveVehicleCopyChanged:
+                if (!activeVehicleCopy) {
+                    hideDialog()
+                }
+
             QGCFlickable {
                 anchors.fill:   parent
                 contentHeight:  column.height
@@ -172,62 +178,80 @@ QGCView {
                     anchors.margins:    _margins
                     anchors.left:       parent.left
                     anchors.right:      parent.right
-                    spacing:            ScreenTools.defaultFontPixelHeight
 
-                    QGCLabel {
-                        Layout.fillWidth:       true
-                        text:                   qsTr("%1 Images Taken").arg(_activeVehicle.cameraTriggerPoints.count)
-                        horizontalAlignment:    Text.AlignHCenter
-                        visible:                _activeVehicle.cameraTriggerPoints.count != 0
-                    }
-
-                    QGCButton {
+                    ColumnLayout {
                         Layout.fillWidth:   true
-                        text:               qsTr("Remove plan from vehicle")
-                        onClicked: {
-                            _planMasterController.removeAllFromVehicle()
-                            hideDialog()
+                        spacing:            ScreenTools.defaultFontPixelHeight
+                        visible:            !_activeVehicle.connectionLost || !_guidedController.showResumeMission
+
+                        QGCLabel {
+                            Layout.fillWidth:       true
+                            text:                   qsTr("%1 Images Taken").arg(_activeVehicle.cameraTriggerPoints.count)
+                            horizontalAlignment:    Text.AlignHCenter
+                            visible:                _activeVehicle.cameraTriggerPoints.count != 0
+                        }
+
+                        QGCButton {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Remove plan from vehicle")
+                            onClicked: {
+                                _planMasterController.removeAllFromVehicle()
+                                hideDialog()
+                            }
+                        }
+
+                        QGCButton {
+                            Layout.fillWidth:   true
+                            Layout.alignment:   Qt.AlignHCenter
+                            text:               qsTr("Leave plan on vehicle")
+                            onClicked:          hideDialog()
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth:   true
+                            color:              qgcPal.text
+                            height:             1
+                        }
+
+                        QGCButton {
+                            Layout.fillWidth:   true
+                            Layout.alignment:   Qt.AlignHCenter
+                            text:               qsTr("Resume Mission From Waypoint %1").arg(_guidedController._resumeMissionIndex)
+                            visible:            _guidedController.showResumeMission
+
+                            onClicked: {
+                                guidedController.executeAction(_guidedController.actionResumeMission, null, null)
+                                hideDialog()
+                            }
+                        }
+
+                        QGCLabel {
+                            Layout.fillWidth:   true
+                            wrapMode:           Text.WordWrap
+                            text:               qsTr("Resume Mission will rebuild the current mission from the last flown waypoint and upload it to the vehicle for the next flight.")
+                            visible:            _guidedController.showResumeMission
+                        }
+
+                        QGCLabel {
+                            Layout.fillWidth:   true
+                            wrapMode:           Text.WordWrap
+                            color:              qgcPal.warningText
+                            text:               qsTr("If you are changing batteries for Resume Mission do not disconnect from the vehicle when communication is lost.")
+                            visible:            _guidedController.showResumeMission
                         }
                     }
 
-                    QGCButton {
+                    ColumnLayout {
                         Layout.fillWidth:   true
-                        Layout.alignment:   Qt.AlignHCenter
-                        text:               qsTr("Leave plan on vehicle")
-                        onClicked:          hideDialog()
-                    }
+                        spacing:            ScreenTools.defaultFontPixelHeight
+                        visible:            _activeVehicle.connectionLost && _guidedController.showResumeMission
 
-                    Rectangle {
-                        Layout.fillWidth:   true
-                        color:              qgcPal.text
-                        height:             1
-                    }
-
-                    QGCButton {
-                        Layout.fillWidth:   true
-                        Layout.alignment:   Qt.AlignHCenter
-                        text:               qsTr("Resume Mission From Waypoint %1").arg(_guidedController._resumeMissionIndex)
-                        visible:            _guidedController.showResumeMission
-
-                        onClicked: {
-                            guidedController.executeAction(_guidedController.actionResumeMission, null, null)
-                            hideDialog()
+                        QGCLabel {
+                            Layout.fillWidth:   true
+                            wrapMode:           Text.WordWrap
+                            color:              qgcPal.warningText
+                            text:               qsTr("If you are changing batteries for Resume Mission do not disconnect from the vehicle.")
                         }
-                    }
-
-                    QGCLabel {
-                        Layout.fillWidth:   true
-                        wrapMode:           Text.WordWrap
-                        text:               qsTr("Resume Mission will rebuild the current mission from the last flown waypoint and upload it to the vehicle for the next flight.")
-                        visible:            _guidedController.showResumeMission
-                    }
-
-                    QGCLabel {
-                        Layout.fillWidth:   true
-                        wrapMode:           Text.WordWrap
-                        color:              qgcPal.warningText
-                        text:               qsTr("If you are changing batteries for Resume Mission do not disconnect from the vehicle when communication is lost.")
-                        visible:            _guidedController.showResumeMission
                     }
                 }
             }

--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -264,6 +264,7 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
         _sideOverlapFact.setRawValue        (v1Json[sideOverlapName].toDouble());
 
         if (!CameraSpec::load(v1Json, errorString)) {
+            _disableRecalc = false;
             return false;
         }
     }


### PR DESCRIPTION
If connection is lost on active vehicle and there is the possibility of a Resume Mission you get this:
![screen shot 2018-11-19 at 11 04 20 am](https://user-images.githubusercontent.com/5876851/48729053-81a95400-ebeb-11e8-9da4-b6faf1a57dbf.png)

Which achieves two things:
* Even more hinting as to how to do a Resume Mission
* Prevents user from clicking on the Flight Plan complete buttons while there is not vehicle really there

If the connect comes back it will go back to normal Flight Plan Complete stuff. If the connection closes the Flight Plan Complete dialog closes as well.