### PR TITLE
Flash: Add support for board/firmware detection using ArduPilot port naming

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -199,11 +199,11 @@ private:
     QString _portName;
     QString _portDescription;
 
-    // firmware hashes
-    QHash<FirmwareIdentifier, QString> _rgPX4FMUV5Firmware;
-    QHash<FirmwareIdentifier, QString> _rgPX4FMUV4PROFirmware;
-    QHash<FirmwareIdentifier, QString> _rgPX4FMUV4Firmware;
-    QHash<FirmwareIdentifier, QString> _rgPX4FMUV3Firmware;
+    // Firmware hashes
+    QHash<FirmwareIdentifier, QString> _rgFMUV5Firmware;
+    QHash<FirmwareIdentifier, QString> _rgFMUV4PROFirmware;
+    QHash<FirmwareIdentifier, QString> _rgFMUV4Firmware;
+    QHash<FirmwareIdentifier, QString> _rgFMUV3Firmware;
     QHash<FirmwareIdentifier, QString> _rgPX4FMUV2Firmware;
     QHash<FirmwareIdentifier, QString> _rgAeroCoreFirmware;
     QHash<FirmwareIdentifier, QString> _rgAUAVX2_1Firmware;
@@ -214,6 +214,10 @@ private:
     QHash<FirmwareIdentifier, QString> _rgNXPHliteV3Firmware;
     QHash<FirmwareIdentifier, QString> _rgPX4FLowFirmware;
     QHash<FirmwareIdentifier, QString> _rg3DRRadioFirmware;
+
+    // Hash map for ArduPilot ChibiOS lookup by board name
+    QHash<FirmwareIdentifier, QString> _rgAPMChibiosReplaceNamedBoardFirmware;
+    QHash<FirmwareIdentifier, QString> _rgFirmwareDynamic;
 
     QMap<FirmwareType_t, QMap<FirmwareVehicleType_t, QString> > _apmVersionMap;
     QList<FirmwareVehicleType_t>                                _apmVehicleTypeFromCurrentVersionList;
@@ -260,6 +264,8 @@ private:
 
     QString _px4StableVersion;  // Version strange for latest PX4 stable
     QString _px4BetaVersion;    // Version strange for latest PX4 beta
+
+    const QString _apmBoardDescriptionReplaceText;
 };
 
 // global hashing function


### PR DESCRIPTION
If the board shows up using the ArduPilot port naming scheme then that will determine the board type as well as the firmware directly to load from. Otherwise it falls back to the board id detection mechanism.

This pull also changes the order of the ArduPilot firmware list to show ChibiOS build first.