### PR TITLE
UVC Video Work

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewUVC.qml
+++ b/src/FlightDisplay/FlightDisplayViewUVC.qml
@@ -16,8 +16,9 @@ Rectangle {
     id:                 _root
     width:              parent.width
     height:             parent.height
-    anchors.centerIn:   parent
     color:              Qt.rgba(0,0,0,0.75)
+    clip:               true
+    anchors.centerIn:   parent
 
     function adjustAspectRatio()
     {

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -90,7 +90,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, videoSource)
     if (!_videoSourceFact) {
         _videoSourceFact = _createSettingsFact(videoSourceName);
         //-- Check for sources no longer available
-        if(!_nameToMetaDataMap.contains(_videoSourceFact->rawValue().toString())) {
+        if(!_videoSourceFact->enumStrings().contains(_videoSourceFact->rawValue().toString())) {
             if (_noVideo) {
                 _videoSourceFact->setRawValue(videoSourceNoVideo);
             } else {


### PR DESCRIPTION
* Check the proper place to see if a saved video source is no longer available.

I was looking in the wrong place and the video source was being reset on each boot. 

* Clip video rectangle so when aspect ratio is adjusted, the image is not larger than the containing (window) rectagle.

This for when the video is within the PIP window (main view is map). 