### PR TITLE
Initialization of Fact prior to Qt init causes crash.

### DIFF
--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -26,8 +26,6 @@ QGC_LOGGING_CATEGORY(ParameterManagerVerbose1Log,           "ParameterManagerVer
 QGC_LOGGING_CATEGORY(ParameterManagerVerbose2Log,           "ParameterManagerVerbose2Log")
 QGC_LOGGING_CATEGORY(ParameterManagerDebugCacheFailureLog,  "ParameterManagerDebugCacheFailureLog") // Turn on to debug parameter cache crc misses
 
-Fact ParameterManager::_defaultFact;
-
 const char* ParameterManager::_cachedMetaDataFilePrefix =   "ParameterFactMetaData";
 const char* ParameterManager::_jsonParametersKey =          "parameters";
 const char* ParameterManager::_jsonCompIdKey =              "compId";

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -201,7 +201,7 @@ private:
     
     QMutex _dataMutex;
     
-    static Fact _defaultFact;   ///< Used to return default fact, when parameter not found
+    Fact _defaultFact;   ///< Used to return default fact, when parameter not found
 
     static const char* _cachedMetaDataFilePrefix;
     static const char* _jsonParametersKey;


### PR DESCRIPTION
I believe this is the fix for #7046 and #7032. The timeframe of that code change looks right from a standpoint of when Android crashes started popping up.