### PR TITLE
Android: Switch to sdk 25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ matrix:
 
 android:
   components:
-    - android-21
-    - build-tools-21.1.1
+    - android-25
+    - build-tools-25.0.3
     - platform-tools
 
 addons:


### PR DESCRIPTION
Fixes #7032. Hoping this will fix the crash. I can repro crash now using pre-built daily build.