### PR TITLE
Show Orbit telemetry on map

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -354,6 +354,13 @@ FlightMap {
         }
     }
 
+    // Used to show orbit status telemetry from the vehicle
+    QGCMapCircleVisuals {
+        mapControl:     parent
+        mapCircle:      _activeVehicle.orbitMapCircle
+        visible:        _activeVehicle ? _activeVehicle.orbitActive : false
+    }
+
     // Handle guided mode clicks
     MouseArea {
         anchors.fill: parent

--- a/src/MissionManager/QGCMapCircleVisuals.qml
+++ b/src/MissionManager/QGCMapCircleVisuals.qml
@@ -105,8 +105,7 @@ Item {
         id: rotationIndicatorComponent
 
         MapQuickItem {
-            z:          QGroundControl.zOrderMapItems + 2
-            visible:    mapCircle.showRotation
+            visible: mapCircle.showRotation
 
             property bool topIndicator: true
 


### PR DESCRIPTION
![screen shot 2018-12-05 at 6 39 29 pm](https://user-images.githubusercontent.com/5876851/49557788-a83ede80-f8bd-11e8-93b9-b8b62ac1ae78.png)

Example above shows a vehicle which is partially through it's first orbit. Still would like an indicator in the center to say this is an orbit but that will come later. This is at least enough to test telemetry working.

* Orbit circle is drawn on map from orbit telemetry values
* Orbit circle will go away after 3 seconds of no orbit telemetry

Related to https://github.com/PX4/Firmware/pull/10989