### PR TITLE
Plane: Fix handling of dirty bit when home position changes from vehicle side

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1714,15 +1714,20 @@ void MissionController::managerVehicleChanged(Vehicle* managerVehicle)
 void MissionController::_managerVehicleHomePositionChanged(const QGeoCoordinate& homePosition)
 {
     if (_visualItems) {
+        bool currentDirtyBit = dirty();
+
         MissionSettingsItem* settingsItem = qobject_cast<MissionSettingsItem*>(_visualItems->get(0));
         if (settingsItem) {
             settingsItem->setHomePositionFromVehicle(homePosition);
         } else {
             qWarning() << "First item is not MissionSettingsItem";
         }
-        // Don't let this trip the dirty bit. Otherwise plan will keep getting marked dirty if vehicle home
-        // changes.
-        _visualItems->setDirty(false);
+
+        if (!currentDirtyBit) {
+            // Don't let this trip the dirty bit. Otherwise plan will keep getting marked dirty if vehicle home
+            // changes.
+            _visualItems->setDirty(false);
+        }
     }
 }
 


### PR DESCRIPTION
Bug:
* Plan a mission while not connected to a vehicle
* Don't save the Plan so dirty bit is set
* Connect to vehicle
* Dirty bit gets cleared incorrectly