### PR TITLE
Skip serial related code if serial links are disabled.

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -922,13 +922,13 @@ HEADERS+= \
     src/Vehicle/Vehicle.h \
     src/VehicleSetup/VehicleComponent.h \
 
-!MobileBuild {
+!MobileBuild { !NoSerialBuild {
     HEADERS += \
         src/VehicleSetup/Bootloader.h \
         src/VehicleSetup/FirmwareImage.h \
         src/VehicleSetup/FirmwareUpgradeController.h \
         src/VehicleSetup/PX4FirmwareUpgradeThread.h \
-}
+}}
 
 SOURCES += \
     src/AutoPilotPlugins/AutoPilotPlugin.cc \
@@ -948,13 +948,13 @@ SOURCES += \
     src/Vehicle/Vehicle.cc \
     src/VehicleSetup/VehicleComponent.cc \
 
-!MobileBuild {
+!MobileBuild { !NoSerialBuild {
     SOURCES += \
         src/VehicleSetup/Bootloader.cc \
         src/VehicleSetup/FirmwareImage.cc \
         src/VehicleSetup/FirmwareUpgradeController.cc \
         src/VehicleSetup/PX4FirmwareUpgradeThread.cc \
-}
+}}
 
 # ArduPilot FirmwarePlugin
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -440,7 +440,9 @@ void QGCApplication::_initCommon(void)
 #ifndef __mobile__
     qmlRegisterType<ViewWidgetController>           (kQGCControllers,                       1, 0, "ViewWidgetController");
     qmlRegisterType<CustomCommandWidgetController>  (kQGCControllers,                       1, 0, "CustomCommandWidgetController");
+#ifndef NO_SERIAL_LINK
     qmlRegisterType<FirmwareUpgradeController>      (kQGCControllers,                       1, 0, "FirmwareUpgradeController");
+#endif
     qmlRegisterType<GeoTagController>               (kQGCControllers,                       1, 0, "GeoTagController");
     qmlRegisterType<MavlinkConsoleController>       (kQGCControllers,                       1, 0, "MavlinkConsoleController");
 #endif

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -52,7 +52,9 @@ LinkManager::LinkManager(QGCApplication* app, QGCToolbox* toolbox)
     , _autoConnectSettings(NULL)
     , _mavlinkProtocol(NULL)
 #ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     , _nmeaPort(NULL)
+#endif
 #endif
 {
     qmlRegisterUncreatableType<LinkManager>         ("QGroundControl", 1, 0, "LinkManager",         "Reference only");
@@ -69,7 +71,9 @@ LinkManager::LinkManager(QGCApplication* app, QGCToolbox* toolbox)
 LinkManager::~LinkManager()
 {
 #ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     delete _nmeaPort;
+#endif
 #endif
 }
 
@@ -513,6 +517,7 @@ void LinkManager::_updateAutoConnectLinks(void)
         QGCSerialPortInfo::BoardType_t boardType;
         QString boardName;
 
+#ifndef NO_SERIAL_LINK
 #ifndef __mobile__
         if (portInfo.systemLocation().trimmed() == _autoConnectSettings->autoConnectNmeaPort()->cookedValueString()) {
             if (portInfo.systemLocation().trimmed() != _nmeaDeviceName) {
@@ -538,6 +543,7 @@ void LinkManager::_updateAutoConnectLinks(void)
                 qCDebug(LinkManagerLog) << "Configuring nmea baudrate" << _nmeaBaud;
             }
         } else
+#endif
 #endif
         if (portInfo.getBoardInfo(boardType, boardName)) {
             if (portInfo.isBootloader()) {

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -237,9 +237,11 @@ private:
 
     // NMEA GPS device for GCS position
 #ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     QString      _nmeaDeviceName;
     QSerialPort* _nmeaPort;
     uint32_t     _nmeaBaud;
+#endif
 #endif
 };
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -56,7 +56,9 @@
 #endif
 
 #ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     Q_DECLARE_METATYPE(QGCSerialPortInfo)
+#endif
 #endif
 
 #ifdef Q_OS_WIN
@@ -159,7 +161,9 @@ int main(int argc, char *argv[])
 #endif
     qRegisterMetaType<QAbstractSocket::SocketError>();
 #ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     qRegisterMetaType<QGCSerialPortInfo>();
+#endif
 #endif
 
     // We statically link our own QtLocation plugin


### PR DESCRIPTION
As the title suggests, this excludes any and all code that uses a serial port if serial is disabled. A lot of it was already dealt with checks for "mobile" or "iOS" but there are cases where a custom desktop build excludes serial links as well.

