### PR TITLE
CustomCommandWidget.qml:Fix URL

### DIFF
--- a/src/ViewWidgets/CustomCommandWidget.qml
+++ b/src/ViewWidgets/CustomCommandWidget.qml
@@ -34,7 +34,7 @@ QGCView {
         "So make sure to test your changes thoroughly before using them in flight.</p>" +
         "<p>Click 'Load Custom Qml file' to provide your custom qml file.</p>" +
         "<p>Click 'Reset' to reset to none.</p>" +
-        "<p>Example usage: <a href='https://dev.qgroundcontrol.com/en/tools/custom_command_widget.html'>https://dev.qgroundcontrol.com/en/tools/custom_command_widget.html</a></p>"
+        "<p>Example usage: <a href='https://docs.qgroundcontrol.com/en/app_menu/custom_command_widget.html'>https://docs.qgroundcontrol.com/en/app_menu/custom_command_widget.html</a></p>"
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 


### PR DESCRIPTION
The Url in custom command widget has been moved to
https://docs.qgroundcontrol.com/en/app_menu/custom_command_widget.html

---
name: Fix Bug
about: The url in CustomCommandWidget.qml is invalid

---
**Describe the bug**
Previously it is pointed to
https://dev.qgroundcontrol.com/en/tools/custom_command_widget.html
![image](https://user-images.githubusercontent.com/1826884/49694861-9b273580-fbc4-11e8-8d17-379f7d0a0450.png)



**To Reproduce**
Steps to reproduce the behavior:
1. Click Menu Widget
2. Click Custom Commands
3. Click select qml file
4. Click Reset.
And there you go. Invalid link, pointed to :
https://dev.qgroundcontrol.com/en/tools/custom_command_widget.html
![image](https://user-images.githubusercontent.com/1826884/49694887-cad63d80-fbc4-11e8-9c78-dbc81e3a6333.png)


**Expected behavior**
Show this link https://docs.qgroundcontrol.com/en/app_menu/custom_command_widget.html instead.


Phew, it's just a small fix. I hope it described enough 😄 .