### PR TITLE
Add QtGamepad library support for platforms that currently do not hav…

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -21,6 +21,7 @@ linux {
         message("Linux build")
         CONFIG += LinuxBuild
         DEFINES += __STDC_LIMIT_MACROS
+        DEFINES += QGC_ENABLE_GAMEPAD
         linux-clang {
             message("Linux clang")
             QMAKE_CXXFLAGS += -Qunused-arguments -fcolor-diagnostics
@@ -29,6 +30,7 @@ linux {
         message("Linux R-Pi2 build")
         CONFIG += LinuxBuild
         DEFINES += __STDC_LIMIT_MACROS __rasp_pi2__
+        DEFINES += QGC_ENABLE_GAMEPAD
     } else : android-g++ {
         CONFIG += AndroidBuild MobileBuild
         DEFINES += __android__
@@ -83,6 +85,7 @@ linux {
     DEFINES += QGC_NO_GOOGLE_MAPS
     DEFINES += NO_SERIAL_LINK
     DEFINES += QGC_DISABLE_UVC
+    DEFINES += QGC_ENABLE_GAMEPAD
     QMAKE_IOS_DEPLOYMENT_TARGET = 8.0
     QMAKE_APPLE_TARGETED_DEVICE_FAMILY = 1,2 # Universal
     QMAKE_LFLAGS += -Wl,-no_pie

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -238,7 +238,8 @@ QT += \
     svg \
     widgets \
     xml \
-    texttospeech
+    texttospeech \
+    gamepad
 
 # Multimedia only used if QVC is enabled
 !contains (DEFINES, QGC_DISABLE_UVC) {
@@ -527,6 +528,7 @@ HEADERS += \
     src/FlightMap/Widgets/ValuesWidgetController.h \
     src/FollowMe/FollowMe.h \
     src/Joystick/Joystick.h \
+    src/Joystick/JoystickQGamepad.h \
     src/Joystick/JoystickManager.h \
     src/JsonHelper.h \
     src/KMLFileHelper.h \
@@ -731,6 +733,7 @@ SOURCES += \
     src/FlightMap/Widgets/ValuesWidgetController.cc \
     src/FollowMe/FollowMe.cc \
     src/Joystick/Joystick.cc \
+    src/Joystick/JoystickQGamepad.cc \
     src/Joystick/JoystickManager.cc \
     src/JsonHelper.cc \
     src/KMLFileHelper.cc \

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -78,7 +78,12 @@ void JoystickManager::_setActiveJoystickFromSettings(void)
 
     auto gamepads = QGamepadManager::instance()->connectedGamepads();
     for (const int& id : gamepads) {
+#ifdef __ios__
+        // ios does not have gamepadName because it uses QT < 5.11.0
+        QString name = "gamepad" + QString::number(id);
+#else
         QString name = QGamepadManager::instance()->gamepadName(id);
+#endif
         names.append(name);
         if (!_name2JoystickMap.contains(name)) {
             qCDebug(JoystickManagerLog) << "New joystick added: " << name;

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -58,7 +58,7 @@ void JoystickManager::init() {
 #ifdef QGC_ENABLE_GAMEPAD
     connect(&_joystickCheckTimer, &QTimer::timeout, this, &JoystickManager::_setActiveJoystickFromSettings);
     _joystickCheckTimer.start(1000);
-#elif __sdljoystick__
+#elif defined(__sdljoystick__)
     if (JoystickSDL::init()) {
         _setActiveJoystickFromSettings();
         connect(&_joystickCheckTimer, &QTimer::timeout, this, &JoystickManager::_updateAvailableJoysticks);
@@ -121,7 +121,7 @@ void JoystickManager::_setActiveJoystickFromSettings(void)
 #else
     QMap<QString,Joystick*> newMap;
 
-#if __sdljoystick__
+#ifdef __sdljoystick__
     // Get the latest joystick mapping
     newMap = JoystickSDL::discover(_multiVehicleManager);
 #elif defined(__android__)

--- a/src/Joystick/JoystickQGamepad.cc
+++ b/src/Joystick/JoystickQGamepad.cc
@@ -1,0 +1,119 @@
+#include "JoystickQGamepad.h"
+
+#include "QGCApplication.h"
+
+#include <QQmlEngine>
+
+#define NUM_AXIS 6
+#define NUM_BUTTONS 19
+
+JoystickQGamepad::JoystickQGamepad(int id, QString name, MultiVehicleManager *multiVehicleManager, QObject *_parent)
+    : Joystick(name, NUM_AXIS, NUM_BUTTONS, 0, multiVehicleManager)
+{
+    setParent(_parent);
+    axisValue = new int[NUM_AXIS];
+    btnValue = new bool[NUM_BUTTONS];
+
+    gamepad = new QGamepad(id, this);
+}
+
+JoystickQGamepad::~JoystickQGamepad()
+{
+    if (gamepad != nullptr) {
+        delete gamepad;
+        gamepad = nullptr;
+    }
+}
+
+bool JoystickQGamepad::_open(void)
+{
+    return true;
+}
+
+void JoystickQGamepad::_close(void)
+{
+}
+
+bool JoystickQGamepad::_update(void)
+{
+    return true;
+}
+
+bool JoystickQGamepad::_getButton(int i)
+{
+    switch (i) {
+        case 0:
+            return gamepad->buttonA();
+        case 1:
+            return gamepad->buttonB();
+        case 2:
+            return gamepad->buttonCenter();
+        case 3:
+            return gamepad->buttonDown();
+        case 4:
+            return gamepad->buttonGuide();
+        case 5:
+            return gamepad->buttonL1();
+        case 6:
+            return gamepad->buttonL2() >= 0.1;
+        case 7:
+            return gamepad->buttonL3();
+        case 8:
+            return gamepad->buttonLeft();
+        case 9:
+            return gamepad->buttonR1();
+        case 10:
+            return gamepad->buttonR2() >= 0.1;
+        case 11:
+            return gamepad->buttonR3();
+        case 12:
+            return gamepad->buttonRight();
+        case 13:
+            return gamepad->buttonSelect();
+        case 14:
+            return gamepad->buttonStart();
+        case 15:
+            return gamepad->buttonUp();
+        case 16:
+            return gamepad->buttonDown();
+        case 17:
+            return gamepad->buttonX();
+        case 18:
+            return gamepad->buttonY();
+    }
+
+    return false;
+}
+
+inline int getAxisValue(double v)
+{
+    return static_cast<int>(round(v * 32767));
+}
+
+int JoystickQGamepad::_getAxis(int i)
+{
+    switch (i) {
+        case 0:
+            return getAxisValue(gamepad->axisLeftX());
+        case 1:
+            return getAxisValue(gamepad->axisLeftY());
+        case 2:
+            return getAxisValue(gamepad->axisRightX());
+        case 3:
+            return getAxisValue(gamepad->axisRightY());
+        case 4:
+            return getAxisValue(gamepad->buttonL2());
+        case 5:
+            return getAxisValue(gamepad->buttonR2());
+    }
+
+    return 0;
+}
+
+uint8_t JoystickQGamepad::_getHat(int hat, int i)
+{
+    Q_UNUSED(hat);
+    Q_UNUSED(i);
+
+    return 0;
+}

--- a/src/Joystick/JoystickQGamepad.h
+++ b/src/Joystick/JoystickQGamepad.h
@@ -1,0 +1,31 @@
+#ifndef JOYSTICKQGAMEPAD_H
+#define JOYSTICKQGAMEPAD_H
+
+#include "Joystick.h"
+#include "Vehicle.h"
+#include "MultiVehicleManager.h"
+
+#include <QtGamepad/QGamepad>
+
+class JoystickQGamepad : public Joystick
+{
+public:
+    JoystickQGamepad(int id, QString name, MultiVehicleManager *multiVehicleManager, QObject *_parent = nullptr);
+
+    ~JoystickQGamepad();
+
+private:
+    QGamepad *gamepad;
+    bool *btnValue;
+    int *axisValue;
+
+    virtual bool _open();
+    virtual void _close();
+    virtual bool _update();
+
+    virtual bool _getButton(int i);
+    virtual int _getAxis(int i);
+    virtual uint8_t _getHat(int hat, int i);
+};
+
+#endif // JOYSTICKQGAMEPAD_H


### PR DESCRIPTION
Currently gamepads are not supported on all platforms.
This PR adds generic QT gamepad support.

It was tested on Linux and Android. On Linux it worked correctly with previously undetected gamepad (Ipega 9083). On Android some mappings were overlapping so the previous solution was kept.
