### PR TITLE
PARAM_VALUE parsing changes, Rover hack fix

### DIFF
--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -35,10 +35,12 @@ QGCView {
     property alias  advanced:           advancedCheckBox.checked
 
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _vehicleIsRover:        _activeVehicle ? _activeVehicle.rover : false
     property bool   _vehicleArmed:          _activeVehicle ? _activeVehicle.armed : false
     property bool   _vehicleFlying:         _activeVehicle ? _activeVehicle.flying : false
     property bool   _disableDueToArmed:     vehicleComponent ? (!vehicleComponent.allowSetupWhileArmed && _vehicleArmed) : false
-    property bool   _disableDueToFlying:    vehicleComponent ? (!vehicleComponent.allowSetupWhileFlying && _vehicleFlying) : false
+    // FIXME: The _vehicleIsRover checkl is a hack to work around https://github.com/PX4/Firmware/issues/10969
+    property bool   _disableDueToFlying:    vehicleComponent ? (_vehicleIsRover || (!vehicleComponent.allowSetupWhileFlying && _vehicleFlying)) : false
     property string _disableReason:         _disableDueToArmed ? qsTr("armed") : qsTr("flying")
 
     property real _margins:             ScreenTools.defaultFontPixelHeight * 0.5

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -462,8 +462,8 @@ void APMFirmwarePlugin::_handleIncomingHeartbeat(Vehicle* vehicle, mavlink_messa
 
 bool APMFirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message)
 {
-    //-- Don't process messages to/from UDP Bridge. It doesn't suffer from these issues
-    if (message->compid == MAV_COMP_ID_UDP_BRIDGE) {
+    // Only translate messages which come from the autopilot. All other components are expected to follow current mavlink spec.
+    if (message->compid != MAV_COMP_ID_AUTOPILOT1) {
         return true;
     }
 


### PR DESCRIPTION
* ArduPilot: Assume non-autopilot components follow current PARAM_VALUE spec. Related to #7049
* PX4: Hack to allow Rover setup pages to display. Related to https://github.com/PX4/Firmware/issues/10969