### PR TITLE
Rover isFlying check fix

### DIFF
--- a/src/AutoPilotPlugins/Common/SetupPage.qml
+++ b/src/AutoPilotPlugins/Common/SetupPage.qml
@@ -40,7 +40,7 @@ QGCView {
     property bool   _vehicleFlying:         _activeVehicle ? _activeVehicle.flying : false
     property bool   _disableDueToArmed:     vehicleComponent ? (!vehicleComponent.allowSetupWhileArmed && _vehicleArmed) : false
     // FIXME: The _vehicleIsRover checkl is a hack to work around https://github.com/PX4/Firmware/issues/10969
-    property bool   _disableDueToFlying:    vehicleComponent ? (_vehicleIsRover || (!vehicleComponent.allowSetupWhileFlying && _vehicleFlying)) : false
+    property bool   _disableDueToFlying:    vehicleComponent ? (!_vehicleIsRover && !vehicleComponent.allowSetupWhileFlying && _vehicleFlying) : false
     property string _disableReason:         _disableDueToArmed ? qsTr("armed") : qsTr("flying")
 
     property real _margins:             ScreenTools.defaultFontPixelHeight * 0.5

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -236,11 +236,13 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     // Parse command line options
 
     bool fClearSettingsOptions = false; // Clear stored settings
+    bool fClearCache = false;           // Clear parameter/airframe caches
     bool logging = false;               // Turn on logging
     QString loggingOptions;
 
     CmdLineOpt_t rgCmdLineOptions[] = {
         { "--clear-settings",   &fClearSettingsOptions, nullptr },
+        { "--clear-cache",      &fClearCache,           nullptr },
         { "--logging",          &logging,               &loggingOptions },
         { "--fake-mobile",      &_fakeMobile,           nullptr },
         { "--log-output",       &_logOutput,            nullptr },
@@ -308,6 +310,15 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
         }
     }
     settings.setValue(_settingsVersionKey, QGC_SETTINGS_VERSION);
+
+    if (fClearCache) {
+        QDir dir(ParameterManager::parameterCacheDir());
+        dir.removeRecursively();
+        QFile airframe(FirmwareImage::cachedAirframeMetaDataFile());
+        airframe.remove();
+        QFile parameter(FirmwareImage::cachedParameterMetaDataFile());
+        parameter.remove();
+    }
 
     // Set up our logging filters
     QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(loggingOptions);

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -89,6 +89,7 @@
 #include "FactValueSliderListModel.h"
 #include "ShapeFileHelper.h"
 #include "QGCFileDownload.h"
+#include "FirmwareImage.h"
 
 #ifndef NO_SERIAL_LINK
 #include "SerialLink.h"

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -315,9 +315,9 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     if (fClearCache) {
         QDir dir(ParameterManager::parameterCacheDir());
         dir.removeRecursively();
-        QFile airframe(FirmwareImage::cachedAirframeMetaDataFile());
+        QFile airframe(cachedAirframeMetaDataFile());
         airframe.remove();
-        QFile parameter(FirmwareImage::cachedParameterMetaDataFile());
+        QFile parameter(cachedParameterMetaDataFile());
         parameter.remove();
     }
 
@@ -851,3 +851,16 @@ void QGCApplication::_gpsNumSatellites(int numSatellites)
     _gpsRtkFactGroup->numSatellites()->setRawValue(numSatellites);
 }
 
+QString QGCApplication::cachedParameterMetaDataFile(void)
+{
+    QSettings settings;
+    QDir parameterDir = QFileInfo(settings.fileName()).dir();
+    return parameterDir.filePath(QStringLiteral("ParameterFactMetaData.xml"));
+}
+
+QString QGCApplication::cachedAirframeMetaDataFile(void)
+{
+    QSettings settings;
+    QDir airframeDir = QFileInfo(settings.fileName()).dir();
+    return airframeDir.filePath(QStringLiteral("PX4AirframeFactMetaData.xml"));
+}

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -98,6 +98,9 @@ public:
 
     FactGroup* gpsRtkFactGroup(void)  { return _gpsRtkFactGroup; }
 
+    static QString cachedParameterMetaDataFile(void);
+    static QString cachedAirframeMetaDataFile(void);
+
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
     void informationMessageBoxOnMainThread(const QString& title, const QString& msg);

--- a/src/VehicleSetup/FirmwareImage.cc
+++ b/src/VehicleSetup/FirmwareImage.cc
@@ -215,21 +215,6 @@ bool FirmwareImage::isCompatible(uint32_t boardId, uint32_t firmwareId) {
     return result;
 }
 
-QString FirmwareImage::cachedParameterMetaDataFile(void)
-{
-    QSettings settings;
-    QDir parameterDir = QFileInfo(settings.fileName()).dir();
-    return parameterDir.filePath(QStringLiteral("ParameterFactMetaData.xml"));
-}
-
-QString FirmwareImage::cachedAirframeMetaDataFile(void)
-{
-    QSettings settings;
-    QDir airframeDir = QFileInfo(settings.fileName()).dir();
-    return airframeDir.filePath(QStringLiteral("PX4AirframeFactMetaData.xml"));
-}
-
-
 bool FirmwareImage::_px4Load(const QString& imageFilename)
 {
     _imageSize = 0;
@@ -290,8 +275,8 @@ bool FirmwareImage::_px4Load(const QString& imageFilename)
                                         _jsonParamXmlKey,      // key which holds compressed bytes
                                         decompressedBytes);    // Returned decompressed bytes
     if (success) {
-        QString parameterFilename = cachedParameterMetaDataFile();
-        QFile parameterFile(cachedParameterMetaDataFile());
+        QString parameterFilename = QGCApplication::cachedParameterMetaDataFile();
+        QFile parameterFile(QGCApplication::cachedParameterMetaDataFile());
 
         if (parameterFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
             qint64 bytesWritten = parameterFile.write(decompressedBytes);
@@ -317,9 +302,9 @@ bool FirmwareImage::_px4Load(const QString& imageFilename)
                                         _jsonAirframeXmlKey,        // key which holds compressed bytes
                                         decompressedBytes);         // Returned decompressed bytes
     if (success) {
-        QString airframeFilename = cachedAirframeMetaDataFile();
+        QString airframeFilename = QGCApplication::cachedAirframeMetaDataFile();
         //qDebug() << airframeFilename;
-        QFile airframeFile(cachedAirframeMetaDataFile());
+        QFile airframeFile(QGCApplication::cachedAirframeMetaDataFile());
 
         if (airframeFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
             qint64 bytesWritten = airframeFile.write(decompressedBytes);

--- a/src/VehicleSetup/FirmwareImage.cc
+++ b/src/VehicleSetup/FirmwareImage.cc
@@ -215,6 +215,21 @@ bool FirmwareImage::isCompatible(uint32_t boardId, uint32_t firmwareId) {
     return result;
 }
 
+QString FirmwareImage::cachedParameterMetaDataFile(void)
+{
+    QSettings settings;
+    QDir parameterDir = QFileInfo(settings.fileName()).dir();
+    return parameterDir.filePath(QStringLiteral("ParameterFactMetaData.xml"));
+}
+
+QString FirmwareImage::cachedAirframeMetaDataFile(void)
+{
+    QSettings settings;
+    QDir airframeDir = QFileInfo(settings.fileName()).dir();
+    return airframeDir.filePath(QStringLiteral("PX4AirframeFactMetaData.xml"));
+}
+
+
 bool FirmwareImage::_px4Load(const QString& imageFilename)
 {
     _imageSize = 0;
@@ -275,12 +290,8 @@ bool FirmwareImage::_px4Load(const QString& imageFilename)
                                         _jsonParamXmlKey,      // key which holds compressed bytes
                                         decompressedBytes);    // Returned decompressed bytes
     if (success) {
-        // Use settings location as our work directory, this way is something goes wrong the file is still there
-        // sitting next to the cache files.
-        QSettings settings;
-        QDir parameterDir = QFileInfo(settings.fileName()).dir();
-        QString parameterFilename = parameterDir.filePath("ParameterFactMetaData.xml");
-        QFile parameterFile(parameterFilename);
+        QString parameterFilename = cachedParameterMetaDataFile();
+        QFile parameterFile(cachedParameterMetaDataFile());
 
         if (parameterFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
             qint64 bytesWritten = parameterFile.write(decompressedBytes);
@@ -306,12 +317,9 @@ bool FirmwareImage::_px4Load(const QString& imageFilename)
                                         _jsonAirframeXmlKey,        // key which holds compressed bytes
                                         decompressedBytes);         // Returned decompressed bytes
     if (success) {
-        // We cache the airframe xml in the same location as settings and parameters
-        QSettings settings;
-        QDir airframeDir = QFileInfo(settings.fileName()).dir();
-        QString airframeFilename = airframeDir.filePath("PX4AirframeFactMetaData.xml");
+        QString airframeFilename = cachedAirframeMetaDataFile();
         //qDebug() << airframeFilename;
-        QFile airframeFile(airframeFilename);
+        QFile airframeFile(cachedAirframeMetaDataFile());
 
         if (airframeFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
             qint64 bytesWritten = airframeFile.write(decompressedBytes);

--- a/src/VehicleSetup/FirmwareImage.h
+++ b/src/VehicleSetup/FirmwareImage.h
@@ -59,9 +59,6 @@ public:
     /// @return true: actual boardId is compatible with firmware boardId
     bool isCompatible(uint32_t boardId, uint32_t firmwareId);
 
-    static QString cachedParameterMetaDataFile(void);
-    static QString cachedAirframeMetaDataFile(void);
-
 signals:
     void errorMessage(const QString& errorString);
     void statusMessage(const QString& warningtring);

--- a/src/VehicleSetup/FirmwareImage.h
+++ b/src/VehicleSetup/FirmwareImage.h
@@ -59,6 +59,9 @@ public:
     /// @return true: actual boardId is compatible with firmware boardId
     bool isCompatible(uint32_t boardId, uint32_t firmwareId);
 
+    static QString cachedParameterMetaDataFile(void);
+    static QString cachedAirframeMetaDataFile(void);
+
 signals:
     void errorMessage(const QString& errorString);
     void statusMessage(const QString& warningtring);


### PR DESCRIPTION
* Fix the fixf or #7094
* Add --clear-cache command line options. This will erase the parameter value cache for all vehicles as well as the parameter and airframe meta data cached files.