### PR TITLE
Better handling of guided map indicator show/hide

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -84,6 +84,7 @@ public:
     QString             flightMode                      (uint8_t base_mode, uint32_t custom_mode) const override;
     bool                setFlightMode                   (const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) override;
     bool                isGuidedMode                    (const Vehicle* vehicle) const override;
+    QString             gotoFlightMode                  (void) const override { return QStringLiteral("Guided"); }
     QString             rtlFlightMode                   (void) const override { return QString("RTL"); }
     QString             missionFlightMode               (void) const override { return QString("Auto"); }
     void                pauseVehicle                    (Vehicle* vehicle) override;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -757,3 +757,8 @@ int FirmwarePlugin::versionCompare(Vehicle* vehicle, QString& compare)
     int patch = versionNumbers[2].toInt();
     return versionCompare(vehicle, major, minor, patch);
 }
+
+QString FirmwarePlugin::gotoFlightMode(void) const
+{
+    return QString();
+}

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -114,6 +114,9 @@ public:
     /// Returns whether the vehicle is in guided mode or not.
     virtual bool isGuidedMode(const Vehicle* vehicle) const;
 
+    /// Returns the flight mode which the vehicle will be in if it is performing a goto location
+    virtual QString gotoFlightMode(void) const;
+
     /// Set guided flight mode
     virtual void setGuidedMode(Vehicle* vehicle, bool guidedMode);
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -42,6 +42,7 @@ public:
     QString             rtlFlightMode                   (void) const override { return _rtlFlightMode; }
     QString             landFlightMode                  (void) const override { return _landingFlightMode; }
     QString             takeControlFlightMode           (void) const override { return _manualFlightMode; }
+    QString             gotoFlightMode                  (void) const override { return _holdFlightMode; }
     void                pauseVehicle                    (Vehicle* vehicle) override;
     void                guidedModeRTL                   (Vehicle* vehicle) override;
     void                guidedModeLand                  (Vehicle* vehicle) override;

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -295,6 +295,7 @@ FlightMap {
         }
     }
 
+    // GoTo Location visuals
     MapQuickItem {
         id:             gotoLocationItem
         visible:        false
@@ -308,6 +309,15 @@ FlightMap {
             label:      qsTr("Goto here", "Goto here waypoint")
         }
 
+        property bool inGotoFlightMode: _activeVehicle ? _activeVehicle.flightMode === _activeVehicle.gotoFlightMode : false
+
+        onInGotoFlightModeChanged: {
+            if (!inGotoFlightMode && visible) {
+                // Hide goto indicator when vehicle falls out of guided mode
+                visible = false
+            }
+        }
+
         function show(coord) {
             gotoLocationItem.coordinate = coord
             gotoLocationItem.visible = true
@@ -316,10 +326,17 @@ FlightMap {
         function hide() {
             gotoLocationItem.visible = false
         }
+
+        function actionConfirmed() {
+            // We leave the indicator visible. The handling for onInGuidedModeChanged will hide it.
+        }
+
+        function actionCancelled() {
+            hide()
+        }
     }
 
-    // Orbit visuals
-
+    // Orbit editing visuals
     QGCMapCircleVisuals {
         id:             orbitMapCircle
         mapControl:     parent
@@ -341,6 +358,15 @@ FlightMap {
             orbitMapCircle.visible = false
         }
 
+        function actionConfirmed() {
+            // Live orbit status is handled by telemetry so we hide here and telemetry will show again.
+            hide()
+        }
+
+        function actionCancelled() {
+            hide()
+        }
+
         function radius() {
             return _mapCircle.radius.rawValue
         }
@@ -357,7 +383,6 @@ FlightMap {
     }
 
     // Orbit telemetry visuals
-
     QGCMapCircleVisuals {
         id:             orbitTelemetryCircle
         mapControl:     parent
@@ -395,7 +420,7 @@ FlightMap {
                 onTriggered: {
                     gotoLocationItem.show(clickMenu.coord)
                     orbitMapCircle.hide()
-                    guidedActionsController.confirmAction(guidedActionsController.actionGoto, clickMenu.coord)
+                    guidedActionsController.confirmAction(guidedActionsController.actionGoto, clickMenu.coord, gotoLocationItem)
                 }
             }
 
@@ -406,7 +431,7 @@ FlightMap {
                 onTriggered: {
                     orbitMapCircle.show(clickMenu.coord)
                     gotoLocationItem.hide()
-                    guidedActionsController.confirmAction(guidedActionsController.actionOrbit, clickMenu.coord)
+                    guidedActionsController.confirmAction(guidedActionsController.actionOrbit, clickMenu.coord, orbitMapCircle)
                 }
             }
         }

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -310,10 +310,17 @@ FlightMap {
         }
 
         property bool inGotoFlightMode: _activeVehicle ? _activeVehicle.flightMode === _activeVehicle.gotoFlightMode : false
+        property var activeVehicle: _activeVehicle
 
         onInGotoFlightModeChanged: {
             if (!inGotoFlightMode && visible) {
                 // Hide goto indicator when vehicle falls out of guided mode
+                visible = false
+            }
+        }
+
+        onActiveVehicleChanged: {
+            if (!_activeVehicle) {
                 visible = false
             }
         }
@@ -345,8 +352,15 @@ FlightMap {
 
         property alias center:              _mapCircle.center
         property alias clockwiseRotation:   _mapCircle.clockwiseRotation
+        property var   activeVehicle:       _activeVehicle
 
         readonly property real defaultRadius: 30
+
+        onActiveVehicleChanged: {
+            if (!_activeVehicle) {
+                visible = false
+            }
+        }
 
         function show(coord) {
             _mapCircle.radius.rawValue = defaultRadius

--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -34,16 +34,14 @@ Rectangle {
     property int    action
     property var    actionData
     property bool   hideTrigger:        false
+    property var    mapIndicator
 
     property real _margins:         ScreenTools.defaultFontPixelWidth
     property bool _emergencyAction: action === guidedController.actionEmergencyStop
 
     onHideTriggerChanged: {
         if (hideTrigger) {
-            hideTrigger = false
-            altitudeSlider.visible = false
-            visibleTimer.stop()
-            visible = false
+            confirmCancelled()
         }
     }
 
@@ -54,6 +52,17 @@ Rectangle {
             // We delay showing the confirmation for a small amount in order to any other state
             // changes to propogate through the system. This way only the final state shows up.
             visibleTimer.restart()
+        }
+    }
+
+    function confirmCancelled() {
+        altitudeSlider.visible = false
+        visible = false
+        hideTrigger = false
+        visibleTimer.stop()
+        if (mapIndicator) {
+            mapIndicator.actionCancelled()
+            mapIndicator = undefined
         }
     }
 
@@ -107,12 +116,10 @@ Rectangle {
                 }
                 hideTrigger = false
                 guidedController.executeAction(_root.action, _root.actionData, altitudeChange)
-            }
-
-            onReject: {
-                altitudeSlider.visible = false
-                _root.visible = false
-                hideTrigger = false
+                if (mapIndicator) {
+                    mapIndicator.actionConfirmed()
+                    mapIndicator = undefined
+                }
             }
         }
     }
@@ -127,12 +134,10 @@ Rectangle {
         source:             "/res/XDelete.svg"
         fillMode:           Image.PreserveAspectFit
         color:              qgcPal.text
+
         QGCMouseArea {
             fillItem:   parent
-            onClicked: {
-                altitudeSlider.visible = false
-                _root.visible = false
-            }
+            onClicked:  confirmCancelled()
         }
     }
 }

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -209,12 +209,13 @@ Item {
     }
 
     // Called when an action is about to be executed in order to confirm
-    function confirmAction(actionCode, actionData) {
+    function confirmAction(actionCode, actionData, mapIndicator) {
         var showImmediate = true
         closeAll()
         confirmDialog.action = actionCode
         confirmDialog.actionData = actionData
         confirmDialog.hideTrigger = true
+        confirmDialog.mapIndicator = mapIndicator
         _actionData = actionData
         switch (actionCode) {
         case actionArm:
@@ -385,7 +386,6 @@ Item {
             break
         case actionOrbit:
             _activeVehicle.guidedModeOrbit(orbitMapCircle.center, orbitMapCircle.radius() * (orbitMapCircle.clockwiseRotation ? 1 : -1), _activeVehicle.altitudeAMSL.rawValue + actionAltitudeChange)
-            orbitMapCircle.hide()
             break
         case actionLandAbort:
             _activeVehicle.abortLanding(50)     // hardcoded value for climbOutAltitude that is currently ignored

--- a/src/QmlControls/SliderSwitch.qml
+++ b/src/QmlControls/SliderSwitch.qml
@@ -14,7 +14,6 @@ Rectangle {
     color:          qgcPal.windowShade
 
     signal accept   ///< Action confirmed
-    signal reject   ///< Action rejected
 
     property string confirmText                         ///< Text for slider
     property alias  fontPointSize: label.font.pointSize ///< Point size for text
@@ -69,12 +68,6 @@ Rectangle {
         property real _maxXDrag:    _root.width - (_diameter + _border)
         property bool dragActive:   drag.active
         property real _dragOffset:  1
-
-        //Component.onCompleted: console.log(height, ScreenTools.minTouchPixels)
-
-        onPressed: {
-            mouse.x
-        }
 
         onDragActiveChanged: {
             if (!sliderDragArea.drag.active) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2962,6 +2962,11 @@ bool Vehicle::takeoffVehicleSupported() const
     return _firmwarePlugin->isCapable(this, FirmwarePlugin::TakeoffVehicleCapability);
 }
 
+QString Vehicle::gotoFlightMode() const
+{
+    return _firmwarePlugin->gotoFlightMode();
+}
+
 void Vehicle::guidedModeRTL(void)
 {
     if (!guidedModeSupported()) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -636,13 +636,14 @@ public:
     Q_PROPERTY(QGCMapCircle*    orbitMapCircle  READ orbitMapCircle     CONSTANT)
 
     // Vehicle state used for guided control
-    Q_PROPERTY(bool flying                  READ flying NOTIFY flyingChanged)                               ///< Vehicle is flying
-    Q_PROPERTY(bool landing                 READ landing NOTIFY landingChanged)                             ///< Vehicle is in landing pattern (DO_LAND_START)
-    Q_PROPERTY(bool guidedMode              READ guidedMode WRITE setGuidedMode NOTIFY guidedModeChanged)   ///< Vehicle is in Guided mode and can respond to guided commands
-    Q_PROPERTY(bool guidedModeSupported     READ guidedModeSupported CONSTANT)                              ///< Guided mode commands are supported by this vehicle
-    Q_PROPERTY(bool pauseVehicleSupported   READ pauseVehicleSupported CONSTANT)                            ///< Pause vehicle command is supported
-    Q_PROPERTY(bool orbitModeSupported      READ orbitModeSupported CONSTANT)                               ///< Orbit mode is supported by this vehicle
-    Q_PROPERTY(bool takeoffVehicleSupported READ takeoffVehicleSupported CONSTANT)                          ///< Guided takeoff supported
+    Q_PROPERTY(bool     flying                  READ flying                                         NOTIFY flyingChanged)       ///< Vehicle is flying
+    Q_PROPERTY(bool     landing                 READ landing                                        NOTIFY landingChanged)      ///< Vehicle is in landing pattern (DO_LAND_START)
+    Q_PROPERTY(bool     guidedMode              READ guidedMode                 WRITE setGuidedMode NOTIFY guidedModeChanged)   ///< Vehicle is in Guided mode and can respond to guided commands
+    Q_PROPERTY(bool     guidedModeSupported     READ guidedModeSupported                            CONSTANT)                   ///< Guided mode commands are supported by this vehicle
+    Q_PROPERTY(bool     pauseVehicleSupported   READ pauseVehicleSupported                          CONSTANT)                   ///< Pause vehicle command is supported
+    Q_PROPERTY(bool     orbitModeSupported      READ orbitModeSupported                             CONSTANT)                   ///< Orbit mode is supported by this vehicle
+    Q_PROPERTY(bool     takeoffVehicleSupported READ takeoffVehicleSupported                        CONSTANT)                   ///< Guided takeoff supported
+    Q_PROPERTY(QString  gotoFlightMode          READ gotoFlightMode                                 CONSTANT)                   ///< Flight mode vehicle is in while performing goto
 
     Q_PROPERTY(ParameterManager* parameterManager READ parameterManager CONSTANT)
 
@@ -761,10 +762,11 @@ public:
     ///     @param percent 0-no power, 100-full power
     Q_INVOKABLE void motorTest(int motor, int percent);
 
-    bool guidedModeSupported    (void) const;
-    bool pauseVehicleSupported  (void) const;
-    bool orbitModeSupported     (void) const;
-    bool takeoffVehicleSupported(void) const;
+    bool    guidedModeSupported     (void) const;
+    bool    pauseVehicleSupported   (void) const;
+    bool    orbitModeSupported      (void) const;
+    bool    takeoffVehicleSupported (void) const;
+    QString gotoFlightMode          (void) const;
 
     // Property accessors
 


### PR DESCRIPTION
* If you cancel the guided confirmation dialog the Orbit/Goto indicator will go away
* If you perform a GoTo and then after the vehicles changes away from the flight mode which performs the goto the GoTo Indicator will go away

About as good as it's going to get given the vehicle telemetry I have available to base things on.

Fixes for #6720