### PR TITLE
Camera Calc: Incorrectly setting valueSetIsDistance to false

### DIFF
--- a/src/MissionManager/CameraCalc.FactMetaData.json
+++ b/src/MissionManager/CameraCalc.FactMetaData.json
@@ -18,7 +18,7 @@
     "min":              0.1,
     "units":            "m",
     "decimalPlaces":    2,
-    "defaultValue":     10.0
+    "defaultValue":     50.0
 },
 {
     "name":             "ImageDensity",
@@ -27,7 +27,7 @@
     "min":              0,
     "units":            "cm/px",
     "decimalPlaces":    1,
-    "defaultValue":     25
+    "defaultValue":     1.2
 },
 {
     "name":             "FrontalOverlap",

--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -127,8 +127,8 @@ void CameraCalc::_cameraNameChanged(void)
             // These values are unknown for these types
             fixedOrientation()->setRawValue(false);
             minTriggerInterval()->setRawValue(0);
-            if (isManualCamera()) {
-                valueSetIsDistance()->setRawValue(false);
+            if (isManualCamera() && !valueSetIsDistance()->rawValue().toBool()) {
+                valueSetIsDistance()->setRawValue(true);
             }
         } else {
             qWarning() << "Internal Error: Not known camera, but now manual or custom either";


### PR DESCRIPTION
When you changed to manual camera it would set valueSetIsDistance to false instead of true. This would in turn cause a default Survey item when changed to a specific camera to have a really high GSD causing the survey to be flown way up in the air.

New/correct behavior keeps survey item specific as altitude even when you switch to camera. Which then sets a resonable GSD as well.