### PR TITLE
Remove the concept of reserved buttons for manual control

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -228,13 +228,6 @@ bool APMFirmwarePlugin::setFlightMode(const QString& flightMode, uint8_t* base_m
     return found;
 }
 
-int APMFirmwarePlugin::manualControlReservedButtonCount(void)
-{
-    // We don't know whether the firmware is going to used any of these buttons.
-    // So reserve them all.
-    return -1;
-}
-
 void APMFirmwarePlugin::_handleIncomingParamValue(Vehicle* vehicle, mavlink_message_t* message)
 {
     Q_UNUSED(vehicle);

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -90,7 +90,6 @@ public:
     void                pauseVehicle                    (Vehicle* vehicle) override;
     void                guidedModeRTL                   (Vehicle* vehicle) override;
     void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeChange) override;
-    int                 manualControlReservedButtonCount(void) override;
     bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) override;
     void                adjustOutgoingMavlinkMessage    (Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message) override;
     virtual void        initializeStreamRates           (Vehicle* vehicle);

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -164,11 +164,6 @@ int ArduSubFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersi
     return majorVersionNumber == 3 ? 6 : Vehicle::versionNotSetValue;
 }
 
-int ArduSubFirmwarePlugin::manualControlReservedButtonCount(void)
-{
-    return 0;
-}
-
 void ArduSubFirmwarePlugin::initializeStreamRates(Vehicle* vehicle) {
     vehicle->requestDataStream(MAV_DATA_STREAM_RAW_SENSORS,     2);
     vehicle->requestDataStream(MAV_DATA_STREAM_EXTENDED_STATUS, 2);

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -110,9 +110,6 @@ public:
 
     QList<MAV_CMD> supportedMissionCommands(void) final;
 
-    // Overrides from FirmwarePlugin
-    int manualControlReservedButtonCount(void) final;
-
     int defaultJoystickTXMode(void) final { return 3; }
 
     void initializeStreamRates(Vehicle* vehicle) override final;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -115,13 +115,6 @@ bool FirmwarePlugin::setFlightMode(const QString& flightMode, uint8_t* base_mode
     return false;
 }
 
-int FirmwarePlugin::manualControlReservedButtonCount(void)
-{
-    // We don't know whether the firmware is going to used any of these buttons.
-    // So reserve them all.
-    return -1;
-}
-
 int FirmwarePlugin::defaultJoystickTXMode(void)
 {
     return 2;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -146,14 +146,6 @@ public:
     ///     @param altitudeChange If > 0, go up by amount specified, if < 0, go down by amount specified
     virtual void guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange);
 
-    /// FIXME: This isn't quite correct being here. All code for Joystick suvehicleTypepport is currently firmware specific
-    /// not just this. I'm going to try to change that. If not, this will need to be removed.
-    /// Returns the number of buttons which are reserved for firmware use in the MANUAL_CONTROL mavlink
-    /// message. For example PX4 Flight Stack reserves the first 8 buttons to simulate rc switches.
-    /// The remainder can be assigned to Vehicle actions.
-    /// @return -1: reserver all buttons, >0 number of buttons to reserve
-    virtual int manualControlReservedButtonCount(void);
-
     /// Default tx mode to apply to joystick axes
     /// TX modes are as outlined here: http://www.rc-airplane-world.com/rc-transmitter-modes.html
     virtual int defaultJoystickTXMode(void);

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -225,11 +225,6 @@ bool PX4FirmwarePlugin::setFlightMode(const QString& flightMode, uint8_t* base_m
     return found;
 }
 
-int PX4FirmwarePlugin::manualControlReservedButtonCount(void)
-{
-    return 0;   // 0 buttons reserved for rc switch simulation
-}
-
 bool PX4FirmwarePlugin::isCapable(const Vehicle *vehicle, FirmwareCapabilities capabilities)
 {
     int available = SetFlightModeCapability | PauseVehicleCapability | GuidedModeCapability;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -52,7 +52,6 @@ public:
     double              minimumTakeoffAltitude          (Vehicle* vehicle) override;
     void                startMission                    (Vehicle* vehicle) override;
     bool                isGuidedMode                    (const Vehicle* vehicle) const override;
-    int                 manualControlReservedButtonCount(void) override;
     void                initializeVehicle               (Vehicle* vehicle) override;
     bool                sendHomePositionToVehicle       (void) override;
     void                addMetaDataToFact               (QObject* parameterMetaData, Fact* fact, MAV_TYPE vehicleType) override;

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -506,12 +506,6 @@ void Joystick::run(void)
 
             // Set up button pressed information
 
-            // We only send the buttons the firmwware has reserved
-            int reservedButtonCount = _activeVehicle->manualControlReservedButtonCount();
-            if (reservedButtonCount == -1) {
-                reservedButtonCount = _totalButtonCount;
-            }
-
             quint16 newButtonBits = 0;      // New set of button which are down
             quint16 buttonPressedBits = 0;  // Buttons pressed for manualControl signal
 
@@ -526,7 +520,7 @@ void Joystick::run(void)
                         // Button was up last time through, but is now down which indicates a button press
                         qCDebug(JoystickLog) << "button triggered" << buttonIndex;
 
-                        if (buttonIndex >= reservedButtonCount) {
+                        if (buttonIndex >= _totalButtonCount) {
                             // Button is above firmware reserved set
                             QString buttonAction =_rgButtonActions[buttonIndex];
                             if (!buttonAction.isEmpty()) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2214,11 +2214,6 @@ void Vehicle::resetMessages()
     }
 }
 
-int Vehicle::manualControlReservedButtonCount(void)
-{
-    return _firmwarePlugin->manualControlReservedButtonCount();
-}
-
 void Vehicle::_loadSettings(void)
 {
     if (!_active) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -691,12 +691,6 @@ public:
     /// Resets link status counters
     Q_INVOKABLE void resetCounters  ();
 
-    /// Returns the number of buttons which are reserved for firmware use in the MANUAL_CONTROL mavlink
-    /// message. For example PX4 Flight Stack reserves the first 8 buttons to simulate rc switches.
-    /// The remainder can be assigned to Vehicle actions.
-    /// @return -1: reserver all buttons, >0 number of buttons to reserve
-    Q_PROPERTY(int manualControlReservedButtonCount READ manualControlReservedButtonCount CONSTANT)
-
     // Called when the message drop-down is invoked to clear current count
     Q_INVOKABLE void        resetMessages();
 
@@ -820,8 +814,6 @@ public:
 
     /// Provides access to the Firmware Plugin for this Vehicle
     FirmwarePlugin* firmwarePlugin(void) { return _firmwarePlugin; }
-
-    int manualControlReservedButtonCount(void);
 
     MissionManager*     missionManager(void)    { return _missionManager; }
     GeoFenceManager*    geoFenceManager(void)   { return _geoFenceManager; }

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -620,20 +620,13 @@ SetupPage {
                             width:      parent.width
                             spacing:    ScreenTools.defaultFontPixelHeight / 3
 
-                            QGCLabel {
-                                visible: _activeVehicle.manualControlReservedButtonCount != 0
-                                text: qsTr("Buttons 0-%1 reserved for firmware use").arg(reservedButtonCount)
-
-                                property int reservedButtonCount: _activeVehicle.manualControlReservedButtonCount == -1 ? _activeJoystick.totalButtonCount : _activeVehicle.manualControlReservedButtonCount
-                            }
-
                             Repeater {
                                 id:     buttonActionRepeater
                                 model:  _activeJoystick ? Math.min(_activeJoystick.totalButtonCount, _maxButtons) : 0
 
                                 Row {
                                     spacing: ScreenTools.defaultFontPixelWidth
-                                    visible: (_activeVehicle.manualControlReservedButtonCount == -1 ? false : modelData >= _activeVehicle.manualControlReservedButtonCount) && !_activeVehicle.supportsJSButton
+                                    visible: !_activeVehicle.supportsJSButton
 
                                     property bool pressed
 


### PR DESCRIPTION
Neither PX4 nor ArduPilot need this. Fix for #7115

@jaxxzer Could you or one of your folks review and test this? I don't want to screw you guys up and you know most about joystick stuff.

Also the joystick code send button bits to the MANUAL_CONTROL message. Seems like it would make sense to never send those button bits since QGC takes all the buttons. Opinions?