### PR TITLE
Mobile visual cleanup

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -488,13 +488,13 @@ QGCView {
                 exclusiveGroup: multiVehicleSelectorGroup
                 text:           qsTr("Single")
                 checked:        true
-                color:          mapPal.text
+                textColor:      mapPal.text
             }
 
             QGCRadioButton {
                 exclusiveGroup: multiVehicleSelectorGroup
                 text:           qsTr("Multi-Vehicle")
-                color:          mapPal.text
+                textColor:      mapPal.text
             }
         }
 

--- a/src/MissionManager/QGCMapCircle.Facts.json
+++ b/src/MissionManager/QGCMapCircle.Facts.json
@@ -3,7 +3,7 @@
     "name":             "Radius",
     "shortDescription": "Radius for geofence circle.",
     "type":             "double",
-    "decimalPlaces":    2,
+    "decimalPlaces":    1,
     "min":              0.1,
     "units":            "m"
 }

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -15,7 +15,7 @@ import QGroundControl.Palette       1.0
 /// Mission item edit control
 Rectangle {
     id:     _root
-    height: editorLoader.y + (editorLoader.visible ? editorLoader.height : 0) + (_margin * 2)
+    height: editorLoader.visible ? (editorLoader.y + editorLoader.height + (_margin * 2)) : (commandPicker.y + commandPicker.height + _margin / 2)
     color:  _currentItem ? qgcPal.missionItemEditor : qgcPal.windowShade
     radius: _radius
 
@@ -90,8 +90,7 @@ Rectangle {
         sourceSize.height:      _hamburgerSize
         source:                 "qrc:/qmlimages/Hamburger.svg"
         visible:                missionItem.isCurrentItem && missionItem.sequenceNumber !== 0
-        color:                  qgcPal.windowShade
-
+        color:                  qgcPal.text
     }
 
     QGCMouseArea {

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -760,14 +760,6 @@ QGCView {
                                 anchors.left:           parent.left
                                 anchors.leftMargin:     ScreenTools.defaultFontPixelWidth
                                 readonly property real _buttonRadius: ScreenTools.defaultFontPixelHeight * 0.75
-                                QGCColoredImage {
-                                    width:                  height
-                                    height:                 ScreenTools.defaultFontPixelWidth * 2.5
-                                    sourceSize.height:      height
-                                    source:                 "qrc:/res/waypoint.svg"
-                                    color:                  qgcPal.text
-                                    anchors.verticalCenter: parent.verticalCenter
-                                }
                                 QGCLabel {
                                     text:           qsTr("Plan")
                                     color:          qgcPal.text
@@ -831,7 +823,7 @@ QGCView {
                 QGCListView {
                     id:             missionItemEditorListView
                     anchors.fill:   parent
-                    spacing:        ScreenTools.defaultFontPixelHeight * 0.5
+                    spacing:        ScreenTools.defaultFontPixelHeight / 4
                     orientation:    ListView.Vertical
                     model:          _missionController.visualItems
                     cacheBuffer:    Math.max(height * 2, 0)
@@ -865,9 +857,9 @@ QGCView {
             GeoFenceEditor {
                 anchors.top:            rightControls.bottom
                 anchors.topMargin:      ScreenTools.defaultFontPixelHeight * 0.5
+                anchors.bottom:         parent.bottom
                 anchors.left:           parent.left
                 anchors.right:          parent.right
-                availableHeight:        ScreenTools.availableHeight
                 myGeoFenceController:   _geoFenceController
                 flightMap:              editorMap
                 visible:                _editingLayer == _layerGeoFence

--- a/src/PlanView/RallyPointItemEditor.qml
+++ b/src/PlanView/RallyPointItemEditor.qml
@@ -50,7 +50,7 @@ Rectangle {
             color:                  _outerTextColor
         }
 
-        Image {
+        QGCColoredImage {
             id:                     hamburger
             anchors.rightMargin:    _margin
             anchors.right:          parent.right
@@ -59,6 +59,7 @@ Rectangle {
             height:                 width
             sourceSize.height:      height
             source:                 "qrc:/qmlimages/Hamburger.svg"
+            color:                  qgcPal.text
 
             MouseArea {
                 anchors.fill:   parent

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -36,7 +36,6 @@ void QGCPositionManager::setToolbox(QGCToolbox *toolbox)
    if(!_defaultSource) {
        //-- Otherwise, create a default one
        _defaultSource = QGeoPositionInfoSource::createDefaultSource(this);
-       qDebug() << _defaultSource;
    }
    _simulatedSource = new SimulatedPosition();
 

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -6,96 +6,50 @@ import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
 
 CheckBox {
-    activeFocusOnPress: true
+    property color  textColor:          _qgcPal.text
+    property bool   textBold:           false
+    property real   textFontPointSize:  ScreenTools.defaultFontPointSize
 
-    property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    property var    _qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    property bool   _noText: text === ""
+    property real   _radius: ScreenTools.defaultFontPixelHeight * 0.16
+
+    activeFocusOnPress: true
 
     style: CheckBoxStyle {
         label: Item {
-            implicitWidth:  text.implicitWidth + 2
-            implicitHeight: ScreenTools.implicitCheckBoxHeight
+            implicitWidth:  _noText ? 0 : text.implicitWidth + ScreenTools.defaultFontPixelWidth * 0.25
+            implicitHeight: _noText ? 0 : Math.max(text.implicitHeight, ScreenTools.checkBoxIndicatorSize)
             baselineOffset: text.baselineOffset
 
-            Rectangle {
-                anchors.margins:    -1
-                anchors.leftMargin: -3
-                anchors.rightMargin: -3
-                anchors.fill:       text
-                visible:            control.activeFocus
-                height:             6
-                radius:             3
-                color:              "#224f9fef"
-                border.color:       "#47b"
-                opacity:            0.6
-            }
-
             Text {
-                id:             text
-                text:           control.text
-                antialiasing:   true
-                font.pointSize: ScreenTools.defaultFontPointSize
-                font.family:    ScreenTools.normalFontFamily
-                color:          control.__qgcPal.text
-                anchors.verticalCenter: parent.verticalCenter
+                id:                 text
+                text:               control.text
+                font.pointSize:     textFontPointSize
+                font.bold:          control.textBold
+                color:              control.textColor
+                anchors.centerIn:   parent
             }
-        } // label
+        }
 
         indicator:  Item {
             implicitWidth:  ScreenTools.checkBoxIndicatorSize
             implicitHeight: implicitWidth
 
             Rectangle {
-                anchors.fill: parent
-                anchors.bottomMargin: -1
-                color: "#44ffffff"
-                radius: baserect.radius
-            }
+                anchors.fill:   parent
+                radius:         _radius
+                border.color:   "black"
+                opacity:        control.checkedState === Qt.PartiallyChecked ? 0.5 : 1
 
-            Rectangle {
-                id: baserect
-                property var enabledGradient: Gradient {
-                    GradientStop {color: "#eee" ; position: 0}
-                    GradientStop {color: control.pressed ? "#eee" : "#fff" ; position: 0.1}
-                    GradientStop {color: "#fff" ; position: 1}
+                Rectangle {
+                    anchors.margins:    parent.height / 4
+                    anchors.fill:       parent
+                    radius:             _radius
+                    color:              "black"
+                    visible:            control.checkedState === Qt.Checked
                 }
-                property var disabledGradient: Gradient {
-                    GradientStop {color: "#999" ; position: 0}
-                    GradientStop {color: __qgcPal.textField ; position: 0.1}
-                    GradientStop {color: __qgcPal.textField ; position: 0.9}
-                    GradientStop {color: "#999" ; position: 1}
-                }
-                gradient: control.enabled ? enabledGradient : disabledGradient
-
-
-                radius: ScreenTools.defaultFontPixelHeight * 0.16
-                anchors.fill: parent
-                border.color: control.activeFocus ? "#47b" : "#999"
-                opacity: control.enabled ? 1 : 0.5
             }
-
-            Image {
-                source: "/qmlimages/check.png"
-                opacity: control.checkedState === Qt.Checked ? control.enabled ? 1 : 0.5 : 0
-                anchors.centerIn: parent
-                anchors.verticalCenterOffset: 1
-                Behavior on opacity {NumberAnimation {duration: 80}}
-            }
-
-            Rectangle {
-                anchors.fill: parent
-                anchors.margins: Math.round(baserect.radius)
-                antialiasing: true
-                gradient: Gradient {
-                    GradientStop {color: control.pressed ? "#555" : "#999" ; position: 0}
-                    GradientStop {color: "#555" ; position: 1}
-                }
-                radius: baserect.radius - 1
-                anchors.centerIn: parent
-                anchors.alignWhenCentered: true
-                border.color: "#222"
-                Behavior on opacity {NumberAnimation {duration: 80}}
-                opacity: control.checkedState === Qt.PartiallyChecked ? control.enabled ? 1 : 0.5 : 0
-            }
-        } // indicator
-    } // style
+        }
+    }
 }

--- a/src/QmlControls/QGCMouseArea.qml
+++ b/src/QmlControls/QGCMouseArea.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.3
+import QtQuick 2.11
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -6,41 +6,30 @@ import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
 
 RadioButton {
-    property var    color:          qgcPal.text    ///< Text color
-    property int    textStyle:      Text.Normal
-    property color  textStyleColor: qgcPal.text
-    property bool   textBold:       false
-    property var    qgcPal:         QGCPalette { colorGroupEnabled: enabled }
+    property color  textColor:          _qgcPal.text
+    property bool   textBold:           false
+    property real   textFontPointSize:  ScreenTools.defaultFontPointSize
+
+    property var    _qgcPal:             QGCPalette { colorGroupEnabled: enabled }
+
+    property bool _noText: text === ""
+
+    activeFocusOnPress: true
 
     style: RadioButtonStyle {
-        label: Item {
-            implicitWidth:          text.implicitWidth + ScreenTools.defaultFontPixelWidth * 0.25
-            implicitHeight:         ScreenTools.implicitRadioButtonHeight
-            baselineOffset:         text.y + text.baselineOffset
+        spacing: _noText ? 0 : ScreenTools.defaultFontPixelWidth / 2
 
-            Rectangle {
-                anchors.fill:       text
-                anchors.margins:    -1
-                anchors.leftMargin: -3
-                anchors.rightMargin:-3
-                visible:            control.activeFocus
-                height:             ScreenTools.defaultFontPixelWidth * 0.25
-                radius:             height * 0.5
-                color:              "#224f9fef"
-                border.color:       "#47b"
-                opacity:            0.6
-            }
+        label: Item {
+            implicitWidth:          _noText ? 0 : text.implicitWidth + ScreenTools.defaultFontPixelWidth * 0.25
+            implicitHeight:         _noText ? 0 : Math.max(text.implicitHeight, ScreenTools.radioButtonIndicatorSize)
+            baselineOffset:         text.y + text.baselineOffset
 
             Text {
                 id:                 text
                 text:               control.text
-                font.pointSize:     ScreenTools.defaultFontPointSize
-                font.family:        ScreenTools.normalFontFamily
+                font.pointSize:     textFontPointSize
                 font.bold:          control.textBold
-                antialiasing:       true
-                color:              control.color
-                style:              control.textStyle
-                styleColor:         control.textStyleColor
+                color:              control.textColor
                 anchors.centerIn:   parent
             }
         }
@@ -49,9 +38,9 @@ RadioButton {
             width:          ScreenTools.radioButtonIndicatorSize
             height:         width
             color:          "white"
-            border.color:   control.qgcPal.text
-            antialiasing:   true
+            border.color:   "black"
             radius:         height / 2
+            opacity:        control.enabled ? 1 : 0.5
 
             Rectangle {
                 anchors.centerIn:   parent
@@ -60,7 +49,7 @@ RadioButton {
                 antialiasing:       true
                 radius:             height / 2
                 color:              "black"
-                opacity:            control.checked ? (control.enabled ? 1 : 0.5) : 0
+                visible:            control.checked
             }
         }
     }

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.3
-import QtQuick.Controls 1.2
+import QtQuick          2.11
+import QtQuick.Controls 1.4
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Palette       1.0
@@ -17,7 +17,7 @@ Rectangle {
     id:         _root
     color:      qgcPal.window
     width:      ScreenTools.isMobile ? ScreenTools.minTouchPixels : ScreenTools.defaultFontPixelWidth * 7
-    height:     buttonStripColumn.height + (buttonStripColumn.anchors.margins * 2)
+    height:     toolStripColumn.height + (toolStripColumn.anchors.margins * 2)
     radius:     _radius
     border.width:   1
     border.color:   qgcPal.globalTheme === QGCPalette.Light ? Qt.rgba(0,0,0,0.35) : Qt.rgba(1,1,1,0.35)
@@ -35,9 +35,7 @@ Rectangle {
 
     readonly property real  _radius:                ScreenTools.defaultFontPixelWidth / 2
     readonly property real  _margin:                ScreenTools.defaultFontPixelWidth / 2
-    readonly property real  _buttonSpacing:         ScreenTools.defaultFontPixelWidth
-
-    property bool _showOptionalElements: !ScreenTools.isTinyScreen
+    readonly property real  _buttonSpacing:         ScreenTools.defaultFontPixelHeight / 4
 
     QGCPalette { id: qgcPal }
     ExclusiveGroup { id: dropButtonsExclusiveGroup }
@@ -57,129 +55,141 @@ Rectangle {
     }
 
     Column {
-        id:                 buttonStripColumn
+        id:                 toolStripColumn
         anchors.margins:    ScreenTools.defaultFontPixelWidth  / 2
         anchors.top:        parent.top
         anchors.left:       parent.left
         anchors.right:      parent.right
+        spacing:            _buttonSpacing
 
         QGCLabel {
             anchors.horizontalCenter:   parent.horizontalCenter
             text:                       title
-            visible:                    _showOptionalElements
+            font.pointSize:             ScreenTools.smallFontPointSize
         }
-
-        Item { width: 1; height: _buttonSpacing; visible: _showOptionalElements }
 
         Rectangle {
             anchors.left:       parent.left
             anchors.right:      parent.right
             height:             1
             color:              qgcPal.text
-            visible:            _showOptionalElements
         }
 
-        Repeater {
-            id: repeater
+        Column {
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            spacing:        _buttonSpacing
 
-            delegate: Column {
-                id:         buttonColumn
-                width:      buttonStripColumn.width
-                visible:    _root.buttonVisible ? _root.buttonVisible[index] : true
+            Repeater {
+                id: repeater
 
-                property bool checked: false
-                property ExclusiveGroup exclusiveGroup: dropButtonsExclusiveGroup
+                delegate: FocusScope {
+                    id:         scope
+                    width:      toolStripColumn.width
+                    height:     buttonRect.height
+                    visible:    _root.buttonVisible ? _root.buttonVisible[index] : true
 
-                QGCPalette { id: _repeaterPal; colorGroupEnabled: _buttonEnabled }
+                    property bool checked: false
+                    property ExclusiveGroup exclusiveGroup: dropButtonsExclusiveGroup
 
-                property bool   _buttonEnabled:         _root.buttonEnabled ? _root.buttonEnabled[index] : true
-                property var    _iconSource:            modelData.iconSource
-                property var    _alternateIconSource:   modelData.alternateIconSource
-                property var    _source:                (_root.showAlternateIcon && _root.showAlternateIcon[index]) ? _alternateIconSource : _iconSource
-                property bool   rotateImage:            _root.rotateImage ? _root.rotateImage[index] : false
-                property bool   animateImage:           _root.animateImage ? _root.animateImage[index] : false
+                    property bool   _buttonEnabled:         _root.buttonEnabled ? _root.buttonEnabled[index] : true
+                    property var    _iconSource:            modelData.iconSource
+                    property var    _alternateIconSource:   modelData.alternateIconSource
+                    property var    _source:                (_root.showAlternateIcon && _root.showAlternateIcon[index]) ? _alternateIconSource : _iconSource
+                    property bool   rotateImage:            _root.rotateImage ? _root.rotateImage[index] : false
+                    property bool   animateImage:           _root.animateImage ? _root.animateImage[index] : false
+                    property bool   _hovered:               false
+                    property bool   _showHighlight:         checked || (_buttonEnabled && _hovered)
 
-                onExclusiveGroupChanged: {
-                    if (exclusiveGroup) {
-                        exclusiveGroup.bindCheckable(buttonColumn)
+                    QGCPalette { id: _repeaterPal; colorGroupEnabled: _buttonEnabled }
+
+                    onExclusiveGroupChanged: {
+                        if (exclusiveGroup) {
+                            exclusiveGroup.bindCheckable(scope)
+                        }
                     }
-                }
 
-                onRotateImageChanged: {
-                    if (rotateImage) {
-                        imageRotation.running = true
-                    } else {
-                        imageRotation.running = false
-                        button.rotation = 0
+                    onRotateImageChanged: {
+                        if (rotateImage) {
+                            imageRotation.running = true
+                        } else {
+                            imageRotation.running = false
+                            buttonImage.rotation = 0
+                        }
                     }
-                }
 
-                onAnimateImageChanged: {
-                    if (animateImage) {
-                        opacityAnimation.running = true
-                    } else {
-                        opacityAnimation.running = false
-                        button.opacity = 1
+                    onAnimateImageChanged: {
+                        if (animateImage) {
+                            opacityAnimation.running = true
+                        } else {
+                            opacityAnimation.running = false
+                            buttonImage.opacity = 1
+                        }
                     }
-                }
-
-                Item {
-                    width:      1
-                    height:     _buttonSpacing
-                    visible:    index == 0 ? _showOptionalElements : true
-                }
-
-                FocusScope {
-                    id:             scope
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    height:         width * 0.8
 
                     Rectangle {
-                        anchors.fill:   parent
-                        color:          checked ? _repeaterPal.buttonHighlight : _repeaterPal.button
+                        id:             buttonRect
+                        anchors.left:   parent.left
+                        anchors.right:  parent.right
+                        height:         buttonColumn.height
+                        color:          _showHighlight ? _repeaterPal.buttonHighlight : _repeaterPal.window
 
-                        QGCColoredImage {
-                            id:                 button
-                            height:             parent.height
-                            width:              height
-                            anchors.centerIn:   parent
-                            source:             _source
-                            sourceSize.height:  height
-                            fillMode:           Image.PreserveAspectFit
-                            mipmap:             true
-                            smooth:             true
-                            color:              checked ? _repeaterPal.buttonHighlightText : _repeaterPal.buttonText
+                        Column {
+                            id:             buttonColumn
+                            anchors.left:   parent.left
+                            anchors.right:  parent.right
+                            spacing:        -buttonImage.height / 8
 
-                            RotationAnimation on rotation {
-                                id:             imageRotation
-                                loops:          Animation.Infinite
-                                from:           0
-                                to:             360
-                                duration:       500
-                                running:        false
+                            QGCColoredImage {
+                                id:             buttonImage
+                                anchors.left:   parent.left
+                                anchors.right:  parent.right
+                                height:         width * 0.8
+                                //anchors.centerIn:   parent
+                                source:             _source
+                                sourceSize.height:  height
+                                fillMode:           Image.PreserveAspectFit
+                                mipmap:             true
+                                smooth:             true
+                                color:              _showHighlight ? _repeaterPal.buttonHighlightText : _repeaterPal.text
+
+                                RotationAnimation on rotation {
+                                    id:             imageRotation
+                                    loops:          Animation.Infinite
+                                    from:           0
+                                    to:             360
+                                    duration:       500
+                                    running:        false
+                                }
+
+                                NumberAnimation on opacity {
+                                    id:         opacityAnimation
+                                    running:    false
+                                    from:       0
+                                    to:         1.0
+                                    loops:      Animation.Infinite
+                                    duration:   2000
+                                }
                             }
 
-                            NumberAnimation on opacity {
-                                id:         opacityAnimation
-                                running:    false
-                                from:       0
-                                to:         1.0
-                                loops:      Animation.Infinite
-                                duration:   2000
+                            QGCLabel {
+                                id:                         buttonLabel
+                                anchors.horizontalCenter:   parent.horizontalCenter
+                                font.pointSize:             ScreenTools.smallFontPointSize
+                                text:                       modelData.name
+                                color:                      _showHighlight ? _repeaterPal.buttonHighlightText : _repeaterPal.text
+                                enabled:                    _buttonEnabled
                             }
-                        }
+                        }  // Column
 
                         QGCMouseArea {
-                            // Size of mouse area is expanded to make touch easier
-                            anchors.leftMargin:     -buttonStripColumn.anchors.margins
-                            anchors.rightMargin:    -buttonStripColumn.anchors.margins
-                            anchors.left:           parent.left
-                            anchors.right:          parent.right
-                            anchors.top:            parent.top
-                            height:                 parent.height + (_showOptionalElements? buttonLabel.height + buttonColumn.spacing : 0)
-                            visible:                _buttonEnabled
-                            preventStealing:        true
+                            anchors.fill:       parent
+                            visible:            _buttonEnabled
+                            hoverEnabled:       true
+                            preventStealing:    true
+
+                            onContainsMouseChanged: _hovered = containsMouse
+                            onContainsPressChanged: _hovered = containsPress
 
                             onClicked: {
                                 scope.focus = true
@@ -205,23 +215,8 @@ Rectangle {
                                 }
                             }
                         }
-                    }
-                }
-
-                Item {
-                    width:      1
-                    height:     ScreenTools.defaultFontPixelHeight * 0.25
-                    visible:    _showOptionalElements
-                }
-
-                QGCLabel {
-                    id:                         buttonLabel
-                    anchors.horizontalCenter:   parent.horizontalCenter
-                    font.pointSize:             ScreenTools.smallFontPointSize
-                    text:                       modelData.name
-                    visible:                    _showOptionalElements
-                    enabled:                    _buttonEnabled
-                }
+                    } // Rectangle
+                } // FocusScope
             }
         }
     }


### PR DESCRIPTION
Big pile of changes for better visuals/layout on Mobile. 

Largest obvious visual change is a major simplification of the radio button and checkbox code. On mobile the checkboxes are larger for better touch targets. This also increased the sise of the checkmark image inside to indicate checked. Which in turn looked like crap when blown up in size. Instead of fighting with it I simplified the check box visuals in a way which works well at any size:
![screen shot 2019-01-05 at 10 39 58 am](https://user-images.githubusercontent.com/5876851/50727999-5cf43780-10d8-11e9-8493-eac936c82cd9.png)

The set of changes make mobile look much better and also lets QGC run much better on smaller screens.
