### PR TITLE
Joystick Video/Camera control

### DIFF
--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -97,12 +97,25 @@ public:
     Q_PROPERTY(bool         capturesVideo       READ capturesVideo      NOTIFY infoChanged)
     Q_PROPERTY(bool         capturesPhotos      READ capturesPhotos     NOTIFY infoChanged)
     Q_PROPERTY(bool         hasModes            READ hasModes           NOTIFY infoChanged)
+    Q_PROPERTY(bool         hasZoom             READ hasZoom            NOTIFY infoChanged)
+    Q_PROPERTY(bool         hasFocus            READ hasFocus           NOTIFY infoChanged)
     Q_PROPERTY(bool         photosInVideoMode   READ photosInVideoMode  NOTIFY infoChanged)
     Q_PROPERTY(bool         videoInPhotoMode    READ videoInPhotoMode   NOTIFY infoChanged)
     Q_PROPERTY(bool         isBasic             READ isBasic            NOTIFY infoChanged)
     Q_PROPERTY(quint32      storageFree         READ storageFree        NOTIFY storageFreeChanged)
     Q_PROPERTY(QString      storageFreeStr      READ storageFreeStr     NOTIFY storageFreeChanged)
     Q_PROPERTY(quint32      storageTotal        READ storageTotal       NOTIFY storageTotalChanged)
+    Q_PROPERTY(bool         paramComplete       READ paramComplete      NOTIFY parametersReady)
+
+    Q_PROPERTY(qreal        zoomLevel           READ zoomLevel          WRITE  setZoomLevel         NOTIFY zoomLevelChanged)
+    Q_PROPERTY(qreal        focusLevel          READ focusLevel         WRITE  setFocusLevel        NOTIFY focusLevelChanged)
+
+    Q_PROPERTY(Fact*        exposureMode        READ exposureMode       NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        ev                  READ ev                 NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        iso                 READ iso                NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        shutter             READ shutter            NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        aperture            READ aperture           NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        wb                  READ wb                 NOTIFY parametersReady)
 
     Q_PROPERTY(QStringList  activeSettings      READ activeSettings                                 NOTIFY activeSettingsChanged)
     Q_PROPERTY(VideoStatus  videoStatus         READ videoStatus                                    NOTIFY videoStatusChanged)
@@ -122,6 +135,9 @@ public:
     Q_INVOKABLE virtual bool toggleVideo    ();
     Q_INVOKABLE virtual void resetSettings  ();
     Q_INVOKABLE virtual void formatCard     (int id = 1);
+    Q_INVOKABLE virtual void stepZoom       (int direction);
+    Q_INVOKABLE virtual void startZoom      (int direction);
+    Q_INVOKABLE virtual void stopZoom       ();
 
     virtual int         version             () { return _version; }
     virtual QString     modelName           () { return _modelName; }
@@ -133,6 +149,8 @@ public:
     virtual bool        capturesVideo       () { return _info.flags & CAMERA_CAP_FLAGS_CAPTURE_VIDEO; }
     virtual bool        capturesPhotos      () { return _info.flags & CAMERA_CAP_FLAGS_CAPTURE_IMAGE; }
     virtual bool        hasModes            () { return _info.flags & CAMERA_CAP_FLAGS_HAS_MODES; }
+    virtual bool        hasZoom             () { return _info.flags & CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM; }
+    virtual bool        hasFocus            () { return _info.flags & CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS; }
     virtual bool        photosInVideoMode   () { return _info.flags & CAMERA_CAP_FLAGS_CAN_CAPTURE_IMAGE_IN_VIDEO_MODE; }
     virtual bool        videoInPhotoMode    () { return _info.flags & CAMERA_CAP_FLAGS_CAN_CAPTURE_VIDEO_IN_IMAGE_MODE; }
 
@@ -148,7 +166,19 @@ public:
     virtual quint32     storageFree         () { return _storageFree;  }
     virtual QString     storageFreeStr      ();
     virtual quint32     storageTotal        () { return _storageTotal; }
+    virtual bool        paramComplete       () { return _paramComplete; }
+    virtual qreal       zoomLevel           () { return _zoomLevel; }
+    virtual qreal       focusLevel          () { return _focusLevel; }
 
+    virtual Fact*       exposureMode        ();
+    virtual Fact*       ev                  ();
+    virtual Fact*       iso                 ();
+    virtual Fact*       shutter             ();
+    virtual Fact*       aperture            ();
+    virtual Fact*       wb                  ();
+
+    virtual void        setZoomLevel        (qreal level);
+    virtual void        setFocusLevel       (qreal level);
     virtual void        setCameraMode       (CameraMode mode);
     virtual void        setPhotoMode        (PhotoMode mode);
     virtual void        setPhotoLapse       (qreal interval);
@@ -180,6 +210,8 @@ signals:
     void    storageTotalChanged             ();
     void    dataReady                       (QByteArray data);
     void    parametersReady                 ();
+    void    zoomLevelChanged                ();
+    void    focusLevelChanged               ();
 
 protected:
     virtual void    _setVideoStatus         (VideoStatus status);
@@ -197,6 +229,7 @@ protected slots:
     virtual void    _mavCommandResult       (int vehicleId, int component, int command, int result, bool noReponseFromVehicle);
     virtual void    _dataReady              (QByteArray data);
     virtual void    _paramDone              ();
+
 
 private:
     bool    _handleLocalization             (QByteArray& bytes);
@@ -224,6 +257,9 @@ protected:
     mavlink_camera_information_t        _info;
     int                                 _version;
     bool                                _cached;
+    bool                                _paramComplete;
+    qreal                               _zoomLevel;
+    qreal                               _focusLevel;
     uint32_t                            _storageFree;
     uint32_t                            _storageTotal;
     QNetworkAccessManager*              _netManager;

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -17,6 +17,8 @@
 
 Q_DECLARE_LOGGING_CATEGORY(CameraManagerLog)
 
+class Joystick;
+
 //-----------------------------------------------------------------------------
 class QGCCameraManager : public QObject
 {
@@ -46,6 +48,9 @@ signals:
 protected slots:
     virtual void    _vehicleReady           (bool ready);
     virtual void    _mavlinkMessageReceived (const mavlink_message_t& message);
+    virtual void    _activeJoystickChanged  (Joystick* joystick);
+    virtual void    _stepZoom               (int direction);
+    virtual void    _stepCamera             (int direction);
 
 protected:
     virtual QGCCameraControl* _findCamera   (int id);
@@ -59,11 +64,14 @@ protected:
     virtual void    _handleCaptureStatus    (const mavlink_message_t& message);
 
 protected:
-    Vehicle*            _vehicle;
-    bool                _vehicleReadyState;
-    int                 _currentTask;
+    Vehicle*            _vehicle            = nullptr;
+    Joystick*           _activeJoystick     = nullptr;
+    bool                _vehicleReadyState  = false;
+    int                 _currentTask        = 0;
     QmlObjectListModel  _cameras;
     QStringList         _cameraLabels;
     QMap<int, bool>     _cameraInfoRequested;
-    int                 _currentCamera;
+    int                 _currentCamera      = 0;
+    QTime               _lastZoomChange;
+    QTime               _lastCameraChange;
 };

--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -28,6 +28,7 @@
 #include "MultiVehicleManager.h"
 #include "Settings/SettingsManager.h"
 #include "Vehicle.h"
+#include "JoystickManager.h"
 
 QGC_LOGGING_CATEGORY(VideoManagerLog, "VideoManagerLog")
 
@@ -36,6 +37,8 @@ VideoManager::VideoManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
 {
     _streamInfo = {};
+    _lastZoomChange.start();
+    _lastStreamChange.start();
 }
 
 //-----------------------------------------------------------------------------
@@ -61,9 +64,11 @@ VideoManager::setToolbox(QGCToolbox *toolbox)
    connect(_videoSettings->udpPort(),       &Fact::rawValueChanged, this, &VideoManager::_udpPortChanged);
    connect(_videoSettings->rtspUrl(),       &Fact::rawValueChanged, this, &VideoManager::_rtspUrlChanged);
    connect(_videoSettings->tcpUrl(),        &Fact::rawValueChanged, this, &VideoManager::_tcpUrlChanged);
-   connect(_videoSettings->aspectRatio(),   &Fact::rawValueChanged, this, &VideoManager::_aspectRatioChanged);
-   MultiVehicleManager *manager = qgcApp()->toolbox()->multiVehicleManager();
-   connect(manager, &MultiVehicleManager::activeVehicleChanged, this, &VideoManager::_setActiveVehicle);
+   connect(_videoSettings->aspectRatio(),   &Fact::rawValueChanged, this, &VideoManager::_streamInfoChanged);
+   MultiVehicleManager *pVehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+   connect(pVehicleMgr, &MultiVehicleManager::activeVehicleChanged, this, &VideoManager::_setActiveVehicle);
+   JoystickManager *pJoyMgr = qgcApp()->toolbox()->joystickManager();
+   connect(pJoyMgr, &JoystickManager::activeJoystickChanged, this, &VideoManager::_activeJoystickChanged);
 
 #if defined(QGC_GST_STREAMING)
 #ifndef QGC_DISABLE_UVC
@@ -272,16 +277,91 @@ VideoManager::_vehicleMessageReceived(const mavlink_message_t& message)
 {
     //-- For now we only handle one stream. There is no UI to pick different streams.
     if(message.msgid == MAVLINK_MSG_ID_VIDEO_STREAM_INFORMATION) {
+        _videoStreamCompID = message.compid;
         mavlink_msg_video_stream_information_decode(&message, &_streamInfo);
+        _hasAutoStream = true;
         qCDebug(VideoManagerLog) << "Received video stream info:" << _streamInfo.uri;
         _restartVideo();
-        emit aspectRatioChanged();
+        emit streamInfoChanged();
     }
 }
 
 //----------------------------------------------------------------------------------------
 void
-VideoManager::_aspectRatioChanged()
+VideoManager::_activeJoystickChanged(Joystick* joystick)
 {
-    emit aspectRatioChanged();
+    if(_activeJoystick) {
+        disconnect(_activeJoystick, &Joystick::stepZoom,   this, &VideoManager::stepZoom);
+        disconnect(_activeJoystick, &Joystick::stepStream, this, &VideoManager::stepStream);
+    }
+    _activeJoystick = joystick;
+    if(_activeJoystick) {
+        connect(_activeJoystick, &Joystick::stepZoom,   this, &VideoManager::stepZoom);
+        connect(_activeJoystick, &Joystick::stepStream, this, &VideoManager::stepStream);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::stepZoom(int direction)
+{
+    if(_lastZoomChange.elapsed() > 250) {
+        _lastZoomChange.start();
+        qCDebug(VideoManagerLog) << "Step Stream Zoom" << direction;
+        if(_activeVehicle && hasZoom()) {
+            _activeVehicle->sendMavCommand(
+                _videoStreamCompID,                     // Target component
+                MAV_CMD_SET_CAMERA_ZOOM,                // Command id
+                false,                                  // ShowError
+                ZOOM_TYPE_STEP,                         // Zoom type
+                direction);                             // Direction (-1 wide, 1 tele)
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::stepStream(int direction)
+{
+    if(_lastStreamChange.elapsed() > 250) {
+        _lastStreamChange.start();
+        int s = _currentStream + direction;
+        if(s < 1) s = _streamInfo.count;
+        if(s > _streamInfo.count) s = 1;
+        setCurrentStream(s);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::setCurrentStream(int stream)
+{
+    qCDebug(VideoManagerLog) << "Set Stream" << stream;
+    //-- TODO: Handle multiple streams
+    if(_hasAutoStream && stream <= _streamInfo.count && stream > 0 && _activeVehicle) {
+        if(_currentStream != stream) {
+            //-- Stop current stream
+            _activeVehicle->sendMavCommand(
+                _videoStreamCompID,                     // Target component
+                MAV_CMD_VIDEO_STOP_STREAMING,           // Command id
+                false,                                  // ShowError
+                _currentStream);                        // Stream ID
+            //-- Start new stream
+            _currentStream = stream;
+            _activeVehicle->sendMavCommand(
+                _videoStreamCompID,                     // Target component
+                MAV_CMD_VIDEO_START_STREAMING,          // Command id
+                false,                                  // ShowError
+                _currentStream);                        // Stream ID
+            _currentStream = stream;
+            emit currentStreamChanged();
+        }
+    }
+}
+
+//----------------------------------------------------------------------------------------
+void
+VideoManager::_streamInfoChanged()
+{
+    emit streamInfoChanged();
 }

--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -13,6 +13,7 @@
 
 #include <QObject>
 #include <QTimer>
+#include <QTime>
 #include <QUrl>
 
 #include "QGCMAVLink.h"
@@ -24,6 +25,7 @@ Q_DECLARE_LOGGING_CATEGORY(VideoManagerLog)
 
 class VideoSettings;
 class Vehicle;
+class Joystick;
 
 class VideoManager : public QGCTool
 {
@@ -41,7 +43,10 @@ public:
     Q_PROPERTY(bool             uvcEnabled          READ    uvcEnabled                                  CONSTANT)
     Q_PROPERTY(bool             fullScreen          READ    fullScreen      WRITE   setfullScreen       NOTIFY fullScreenChanged)
     Q_PROPERTY(VideoReceiver*   videoReceiver       READ    videoReceiver                               CONSTANT)
-    Q_PROPERTY(double           aspectRatio         READ    aspectRatio                                 NOTIFY aspectRatioChanged)
+    Q_PROPERTY(double           aspectRatio         READ    aspectRatio                                 NOTIFY streamInfoChanged)
+    Q_PROPERTY(bool             hasZoom             READ    hasZoom                                     NOTIFY streamInfoChanged)
+    Q_PROPERTY(int              streamCount         READ    streamCount                                 NOTIFY streamCountChanged)
+    Q_PROPERTY(int              currentStream       READ    currentStream   WRITE setCurrentStream      NOTIFY currentStreamChanged)
 
     bool        hasVideo            ();
     bool        isGStreamer         ();
@@ -51,6 +56,9 @@ public:
     QString     videoSourceID       () { return _videoSourceID; }
     QString     autoURL             () { return QString(_streamInfo.uri); }
     double      aspectRatio         ();
+    bool        hasZoom             () { return _streamInfo.flags & VIDEO_STREAM_HAS_BASIC_ZOOM; }
+    int         currentStream       () { return _currentStream; }
+    int         streamCount         () { return _streamInfo.count; }
 
     VideoReceiver*  videoReceiver   () { return _videoReceiver; }
 
@@ -62,12 +70,15 @@ public:
 
     void        setfullScreen       (bool f) { _fullScreen = f; emit fullScreenChanged(); }
     void        setIsTaisync        (bool t) { _isTaisync = t;  emit isTaisyncChanged(); }
+    void        setCurrentStream    (int stream);
 
     // Override from QGCTool
     void        setToolbox          (QGCToolbox *toolbox);
 
-    Q_INVOKABLE void startVideo()   {_videoReceiver->start();}
-    Q_INVOKABLE void stopVideo()    {_videoReceiver->stop(); }
+    Q_INVOKABLE void startVideo     () { _videoReceiver->start(); }
+    Q_INVOKABLE void stopVideo      () { _videoReceiver->stop();  }
+    Q_INVOKABLE void stepZoom       (int direction);
+    Q_INVOKABLE void stepStream     (int direction);
 
 signals:
     void hasVideoChanged            ();
@@ -75,8 +86,10 @@ signals:
     void videoSourceIDChanged       ();
     void fullScreenChanged          ();
     void isAutoStreamChanged        ();
-    void aspectRatioChanged         ();
+    void streamInfoChanged          ();
     void isTaisyncChanged           ();
+    void currentStreamChanged       ();
+    void streamCountChanged         ();
 
 private slots:
     void _videoSourceChanged        ();
@@ -84,8 +97,9 @@ private slots:
     void _rtspUrlChanged            ();
     void _tcpUrlChanged             ();
     void _updateUVC                 ();
-    void _aspectRatioChanged        ();
+    void _streamInfoChanged         ();
     void _setActiveVehicle          (Vehicle* vehicle);
+    void _activeJoystickChanged     (Joystick* joystick);
     void _vehicleMessageReceived    (const mavlink_message_t& message);
 
 private:
@@ -99,7 +113,13 @@ private:
     QString         _videoSourceID;
     bool            _fullScreen         = false;
     Vehicle*        _activeVehicle      = nullptr;
+    Joystick*       _activeJoystick     = nullptr;
     mavlink_video_stream_information_t _streamInfo;
+    bool            _hasAutoStream      = false;
+    uint8_t         _videoStreamCompID  = 0;
+    int             _currentStream      = 1;
+    QTime           _lastZoomChange;
+    QTime           _lastStreamChange;
 };
 
 #endif

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -164,7 +164,10 @@ signals:
 
     void buttonActionTriggered(int action);
 
-    void frequencyChanged();
+    void frequencyChanged   ();
+    void stepZoom           (int direction);
+    void stepCamera         (int direction);
+    void stepStream         (int direction);
 
 protected:
     void    _setDefaultCalibration(void);
@@ -252,6 +255,12 @@ private:
     static const char* _buttonActionDisarm;
     static const char* _buttonActionVTOLFixedWing;
     static const char* _buttonActionVTOLMultiRotor;
+    static const char* _buttonActionZoomIn;
+    static const char* _buttonActionZoomOut;
+    static const char* _buttonActionNextStream;
+    static const char* _buttonActionPreviousStream;
+    static const char* _buttonActionNextCamera;
+    static const char* _buttonActionPreviousCamera;
 
 private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);


### PR DESCRIPTION
Work in progress.

Allowing the user to assign camera/stream functions to joystick buttons.

Keep in mind that QGC for now only supports one single video stream. Work is still in progress for implementing the support of multiple streams. It does however, support multiple cameras.

You can now assign joystick buttons to:

- Zoom In
- Zoom Out
- Next Camera
- Previous Camera
- Next Stream
- Previous Stream

If the camera and/or video stream supports zoom, the zoom command will affect the current stream/camera.

<img width="1070" alt="screen shot 2019-01-06 at 1 49 21 pm" src="https://user-images.githubusercontent.com/749243/50740308-9c935000-11ba-11e9-8e7c-b7afd84ccba2.png">

This dialog is in desperate need for some TLC. Note that the dialog seems to limit assignment to only the first 16 buttons (out of 43 in the case above). It also lacks the ability to assign analog channels to actions (such as zoom and focus control). I will look into these at some point.

Also, it would be nice to have a similar dialog for assigning keyboard keys to actions in the same way it is done for joysticks.

