### PR TITLE
Check if qgcApp() actually exists before using it.

### DIFF
--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -472,7 +472,7 @@ VideoReceiver::start()
 void
 VideoReceiver::stop()
 {
-    if(qgcApp()->runningUnitTests()) {
+    if(qgcApp() && qgcApp()->runningUnitTests()) {
         return;
     }
 #if defined(QGC_GST_STREAMING)


### PR DESCRIPTION
This was causing a crash on exit on Android. The app is nullified before video streaming is shutdown.