### PR TITLE
Allow plugins to control mainQmlWidgetHolder creation.

### DIFF
--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -18,6 +18,10 @@
 #include "VideoReceiver.h"
 #include "QGCLoggingCategory.h"
 
+#if !defined(__mobile__)
+#include "QGCQmlWidgetHolder.h"
+#endif
+
 #include <QtQml>
 #include <QQmlEngine>
 
@@ -324,3 +328,17 @@ QString QGCCorePlugin::stableVersionCheckFileUrl(void) const
     return QString("https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGC.version.txt");
 #endif
 }
+
+#if !defined(__mobile__)
+QGCQmlWidgetHolder* QGCCorePlugin::createMainQmlWidgetHolder(QLayout *mainLayout, QWidget* parent)
+{
+    QGCQmlWidgetHolder* pMainQmlWidgetHolder = new QGCQmlWidgetHolder(QString(), nullptr, parent);
+    mainLayout->addWidget(pMainQmlWidgetHolder);
+    pMainQmlWidgetHolder->setVisible(true);
+    QQmlEngine::setObjectOwnership(parent, QQmlEngine::CppOwnership);
+    pMainQmlWidgetHolder->setContextPropertyObject("controller", parent);
+    pMainQmlWidgetHolder->setContextPropertyObject("debugMessageModel", AppMessages::getModel());
+    pMainQmlWidgetHolder->setSource(QUrl::fromUserInput("qrc:qml/MainWindowHybrid.qml"));
+    return pMainQmlWidgetHolder;
+}
+#endif

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -34,6 +34,12 @@ class QmlObjectListModel;
 class VideoReceiver;
 class PlanMasterController;
 
+#if !defined(__mobile__)
+class QLayout;
+class QMainWindow;
+class QGCQmlWidgetHolder;
+#endif
+
 class QGCCorePlugin : public QGCTool
 {
     Q_OBJECT
@@ -101,6 +107,11 @@ public:
 
     /// Allows the plugin to override the creation of the root (native) window.
     virtual QQmlApplicationEngine* createRootWindow(QObject* parent);
+
+    /// Allows the plugin to have a chance to initialize the creation of the root (non native) window.
+#if !defined(__mobile__)
+    virtual QGCQmlWidgetHolder* createMainQmlWidgetHolder(QLayout* mainLayout, QWidget *parent);
+#endif
 
     /// Allows the plugin to override the creation of VideoReceiver.
     virtual VideoReceiver* createVideoReceiver(QObject* parent);

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -84,7 +84,7 @@ static const char *rgDockWidgetNames[] = {
 static const char* _visibleWidgetsKey = "VisibleWidgets";
 #endif
 
-static MainWindow* _instance = NULL;   ///< @brief MainWindow singleton
+static MainWindow* _instance = nullptr;   ///< @brief MainWindow singleton
 
 MainWindow* MainWindow::_create()
 {
@@ -106,10 +106,10 @@ void MainWindow::deleteInstance(void)
 ///         by MainWindow::_create method. Hence no other code should have access to
 ///         constructor.
 MainWindow::MainWindow()
-    : _mavlinkDecoder       (NULL)
+    : _mavlinkDecoder       (nullptr)
     , _lowPowerMode         (false)
     , _showStatusBar        (false)
-    , _mainQmlWidgetHolder  (NULL)
+    , _mainQmlWidgetHolder  (nullptr)
     , _forceClose           (false)
 {
     _instance = this;
@@ -138,21 +138,15 @@ MainWindow::MainWindow()
     _centralLayout->setContentsMargins(0, 0, 0, 0);
     centralWidget()->setLayout(_centralLayout);
 
-    _mainQmlWidgetHolder = new QGCQmlWidgetHolder(QString(), NULL, this);
-    _centralLayout->addWidget(_mainQmlWidgetHolder);
-    _mainQmlWidgetHolder->setVisible(true);
-
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
-    _mainQmlWidgetHolder->setContextPropertyObject("controller", this);
-    _mainQmlWidgetHolder->setContextPropertyObject("debugMessageModel", AppMessages::getModel());
-    _mainQmlWidgetHolder->setSource(QUrl::fromUserInput("qrc:qml/MainWindowHybrid.qml"));
+    //-- Allow plugin to initialize main QML Widget
+    _mainQmlWidgetHolder = qgcApp()->toolbox()->corePlugin()->createMainQmlWidgetHolder(_centralLayout, this);
 
     // Image provider
     QQuickImageProvider* pImgProvider = dynamic_cast<QQuickImageProvider*>(qgcApp()->toolbox()->imageProvider());
     _mainQmlWidgetHolder->getEngine()->addImageProvider(QStringLiteral("QGCImages"), pImgProvider);
 
     // Set dock options
-    setDockOptions(0);
+    setDockOptions(nullptr);
     // Setup corners
     setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
 
@@ -162,7 +156,7 @@ MainWindow::MainWindow()
 #endif
 
 #ifdef UNITTEST_BUILD
-    QAction* qmlTestAction = new QAction("Test QML palette and controls", NULL);
+    QAction* qmlTestAction = new QAction("Test QML palette and controls", nullptr);
     connect(qmlTestAction, &QAction::triggered, this, &MainWindow::_showQmlTestWidget);
     _ui.menuWidgets->addAction(qmlTestAction);
 #endif
@@ -246,14 +240,14 @@ MainWindow::~MainWindow()
         _mavlinkDecoder->finish();
         _mavlinkDecoder->wait(1000);
         _mavlinkDecoder->deleteLater();
-        _mavlinkDecoder = NULL;
+        _mavlinkDecoder = nullptr;
     }
 
     // This needs to happen before we get into the QWidget dtor
     // otherwise  the QML engine reads freed data and tries to
     // destroy MainWindow a second time.
     delete _mainQmlWidgetHolder;
-    _instance = NULL;
+    _instance = nullptr;
 }
 
 QString MainWindow::_getWindowGeometryKey()
@@ -315,7 +309,7 @@ void MainWindow::_showDockWidget(const QString& name, bool show)
 /// Creates the specified inner dock widget and adds to the QDockWidget
 bool MainWindow::_createInnerDockWidget(const QString& widgetName)
 {
-    QGCDockWidget* widget = NULL;
+    QGCDockWidget* widget = nullptr;
     QAction *action = _mapName2Action[widgetName];
     if(action) {
         switch(action->data().toInt()) {
@@ -339,7 +333,7 @@ bool MainWindow::_createInnerDockWidget(const QString& widgetName)
             _mapName2DockWidget[widgetName] = widget;
         }
     }
-    return widget != NULL;
+    return widget != nullptr;
 }
 
 void MainWindow::_hideAllDockWidgets(void)


### PR DESCRIPTION
The CorePlugin now exposes an API for the main window creation (Desktop--it already did for mobile). Custom builds now have access to the creation process and can insert their own elements or replace it all altogether.

This is the default implementation:

```c++
QGCQmlWidgetHolder* QGCCorePlugin::createMainQmlWidgetHolder(QLayout *mainLayout, QWidget* parent)
{
    QGCQmlWidgetHolder* pMainQmlWidgetHolder = new QGCQmlWidgetHolder(QString(), nullptr, parent);
    mainLayout->addWidget(pMainQmlWidgetHolder);
    pMainQmlWidgetHolder->setVisible(true);
    QQmlEngine::setObjectOwnership(parent, QQmlEngine::CppOwnership);
    pMainQmlWidgetHolder->setContextPropertyObject("controller", parent);
    pMainQmlWidgetHolder->setContextPropertyObject("debugMessageModel", AppMessages::getModel());
    pMainQmlWidgetHolder->setSource(QUrl::fromUserInput("qrc:qml/MainWindowHybrid.qml"));
    return pMainQmlWidgetHolder;
}
```