### PR TITLE
Support for Septentrio base station RTK

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -405,7 +405,8 @@ HEADERS += \
     src/api/QGCOptions.h \
     src/api/QGCSettings.h \
     src/api/QmlComponentInfo.h \
-    src/comm/MavlinkMessagesTimer.h
+    src/comm/MavlinkMessagesTimer.h \
+    src/GPS/Drivers/src/base_station.h
 
 SOURCES += \
     src/api/QGCCorePlugin.cc \
@@ -664,6 +665,7 @@ HEADERS += \
     src/GPS/Drivers/src/rtcm.h \
     src/GPS/Drivers/src/ashtech.h \
     src/GPS/Drivers/src/ubx.h \
+    src/GPS/Drivers/src/sbf.h \
     src/GPS/GPSManager.h \
     src/GPS/GPSPositionMessage.h \
     src/GPS/GPSProvider.h \
@@ -851,6 +853,7 @@ SOURCES += \
     src/GPS/Drivers/src/rtcm.cpp \
     src/GPS/Drivers/src/ashtech.cpp \
     src/GPS/Drivers/src/ubx.cpp \
+    src/GPS/Drivers/src/sbf.cpp \
     src/GPS/GPSManager.cc \
     src/GPS/GPSProvider.cc \
     src/GPS/RTCM/RTCMMavlink.cc \

--- a/src/GPS/GPSManager.cc
+++ b/src/GPS/GPSManager.cc
@@ -34,6 +34,9 @@ void GPSManager::connectGPS(const QString& device, const QString& gps_type)
     if (gps_type.contains("trimble",  Qt::CaseInsensitive)) {
         type = GPSProvider::GPSType::trimble;
         qCDebug(RTKGPSLog) << "Connecting Trimble device";
+    } else if (gps_type.contains("septentrio",  Qt::CaseInsensitive)) {
+        type = GPSProvider::GPSType::septentrio;
+        qCDebug(RTKGPSLog) << "Connecting Septentrio device";
     } else {
         type = GPSProvider::GPSType::u_blox;
         qCDebug(RTKGPSLog) << "Connecting U-blox device";

--- a/src/GPS/GPSProvider.cc
+++ b/src/GPS/GPSProvider.cc
@@ -18,6 +18,7 @@
 #include <QDebug>
 
 #include "Drivers/src/ubx.h"
+#include "Drivers/src/sbf.h"
 #include "Drivers/src/ashtech.h"
 #include "Drivers/src/base_station.h"
 #include "definitions.h"
@@ -81,6 +82,9 @@ void GPSProvider::run()
         if (_type == GPSType::trimble) {
             gpsDriver = new GPSDriverAshtech(&callbackEntry, this, &_reportGpsPos, _pReportSatInfo);
             baudrate = 115200;
+        } else if (_type == GPSType::septentrio) {
+            gpsDriver = new GPSDriverSBF(&callbackEntry, this, &_reportGpsPos, _pReportSatInfo, 5);
+            baudrate = 0; // auto-configure
         } else {
             gpsDriver = new GPSDriverUBX(GPSDriverUBX::Interface::UART, &callbackEntry, this, &_reportGpsPos, _pReportSatInfo);
             baudrate = 0; // auto-configure

--- a/src/GPS/GPSProvider.h
+++ b/src/GPS/GPSProvider.h
@@ -32,7 +32,8 @@ public:
 
     enum class GPSType {
         u_blox,
-        trimble
+        trimble,
+        septentrio
     };
 
     GPSProvider(const QString& device,

--- a/src/GPS/definitions.h
+++ b/src/GPS/definitions.h
@@ -63,10 +63,9 @@ public:
     static void usleep(unsigned long usecs) { QThread::usleep(usecs); }
 };
 
-static inline void usleep(unsigned long usecs) {
+static inline void gps_usleep(unsigned long usecs) {
     Sleeper::usleep(usecs);
 }
-
 
 typedef uint64_t gps_abstime;
 

--- a/src/GPS/definitions.h
+++ b/src/GPS/definitions.h
@@ -50,6 +50,8 @@
 #include "vehicle_gps_position.h"
 #include "satellite_info.h"
 
+#define M_DEG_TO_RAD 		M_PI / 180.0
+#define M_RAD_TO_DEG 		180.0 / M_PI
 #define M_DEG_TO_RAD_F 		0.01745329251994f
 #define M_RAD_TO_DEG_F 		57.2957795130823f
 

--- a/src/GPS/definitions.h
+++ b/src/GPS/definitions.h
@@ -50,8 +50,8 @@
 #include "vehicle_gps_position.h"
 #include "satellite_info.h"
 
-#define M_DEG_TO_RAD 		M_PI / 180.0
-#define M_RAD_TO_DEG 		180.0 / M_PI
+#define M_DEG_TO_RAD 		(M_PI / 180.0)
+#define M_RAD_TO_DEG 		(180.0 / M_PI)
 #define M_DEG_TO_RAD_F 		0.01745329251994f
 #define M_RAD_TO_DEG_F 		57.2957795130823f
 

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -29,10 +29,10 @@
         { "vendorID": 1027, "productID": 24577,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "3DR Radio on FTDI" },
         { "vendorID": 4292, "productID": 60000,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "SILabs Radio" },
 
-        { "vendorID": 5446, "productID": 424,        "boardClass": "RTK GPS",    "name": "U-blox RTK GPS",               "comment": "U-blox RTK GPS (M8P)" },
-        { "vendorID": 5446, "productID": 425,        "boardClass": "RTK GPS",    "name": "U-blox RTK GPS",               "comment": "U-blox RTK GPS (F9P)" },
-        { "vendorID": 1317, "productID": 42151,      "boardClass": "RTK GPS",    "name": "Trimble RTK GPS",              "comment": "Trimble RTK GPS" },
-
+        { "vendorID": 5446, "productID": 424,        "boardClass": "RTK GPS",    "name": "U-blox RTK GPS",      "comment": "U-blox RTK GPS (M8P)" },
+        { "vendorID": 5446, "productID": 425,        "boardClass": "RTK GPS",    "name": "U-blox RTK GPS",      "comment": "U-blox RTK GPS (F9P)" },
+        { "vendorID": 1317, "productID": 42151,      "boardClass": "RTK GPS",    "name": "Trimble RTK GPS",     "comment": "Trimble RTK GPS" },
+        { "vendorID": 5418, "productID": 34240,      "boardClass": "RTK GPS",    "name": "Septentrio RTK GPS",  "comment": "Septentrio RTK GPS" },
         { "vendorID": 8352, "productID": 16732,     "boardClass": "OpenPilot",  "name": "OpenPilot OPLink" },
         { "vendorID": 8352, "productID": 16733,     "boardClass": "OpenPilot",  "name": "OpenPilot CC3D" },
         { "vendorID": 8352, "productID": 16734,     "boardClass": "OpenPilot",  "name": "OpenPilot Revolution" },


### PR DESCRIPTION
Septentrio base station is recognized by QGC and configured to send RTCM RTK messages to the flight controller.
Tested on the actual hardware by https://github.com/bkueng

