### PR TITLE
PR android joystick improvement v2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,18 @@
 
 Note: This file only contains high level features or important fixes.
 
-## 3.5
+## 3.6
 
-### 3.5.0 - Daily Build
+### 3.6.0 - Daily Build
+
+* No changes yet
+
+### 3.5.0 - Stable
+* Plan GeoFence: Fix loading of fence from intermediate 3.4 code
+* Structure Scan: Fix loading of structure scan height
+* ArduPilot: Fix location of planned home position when not connected to vehicle. Issue #6840.
+* Fix loading of parameters from multiple components. Would report download complete too early, thus missing all default component params.
+* Fix file delete in mobile file dialogs
 * Add support for specifying fixed RTK based station location in Settings/General.
 * Added Airmap integration to QGC
 * Added ESTIMATOR_STATUS values to new estimatorStatus Vehicle FactGroup. These are now available to display in instrument panel.
@@ -13,7 +22,6 @@ Note: This file only contains high level features or important fixes.
 * Make Heading to Home available for display from instrument panel.
 * Edit Position dialog available on polygon vertices.
 * Fixed Wing Landing Pattern: Add stop photo/video support. Defaults to on such that doing an RTL will stop camera.
-* Survey Planning: add mode that supports concave polygons
 * Support loading polygons from SHP files
 * Bumped settings version (now 8). This will cause all settings to be reset to defaults.
 * Orbit visuals support changing rotation direction
@@ -22,15 +30,7 @@ Note: This file only contains high level features or important fixes.
 
 ## 3.4
 
-### 3.4.5 - Not yet released
-* Plan GeoFence: Fix loading of fence from intermediate 3.4 code
-* Orbit: Turn off for PX4 since still not supported
-* Structure Scan: Fix loading of structure scan height
-* ArduPilot: Fix location of planned home position when not connected to vehicle. Issue #6840.
-* Fix loading of parameters from multiple components. Would report download complete too early, thus missing all default component params.
-* Fix file delete in mobile file dialogs
-
-### 3.4.4 - Stable
+### 3.4.4
 * Stable desktop versions now inform user at boot if newer version is available.
 * Multi-Vehicle Start Mission and Pause now work correctly. Issue #6864.
 

--- a/Custom-Info.plist
+++ b/Custom-Info.plist
@@ -2,23 +2,25 @@
 <!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
 <plist version="0.9">
 <dict>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
-	<key>CFBundleIconFile</key>
-	<string>macx.icns</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleVersion</key>
-        <string>###</string>
-	<key>CFBundleShortVersionString</key>
-        <string>#.#.#</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleExecutable</key>
-	<string>@EXECUTABLE@</string>
-	<key>CFBundleIdentifier</key>
-	<string>org.qgroundcontrol.qgroundcontrol</string>
-	<key>NOTE</key>
-	<string>Open source ground control app provided by QGroundControl dev team</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>CFBundleIconFile</key>
+    <string>macx.icns</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>###</string>
+    <key>CFBundleShortVersionString</key>
+    <string>#.#.#</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleExecutable</key>
+    <string>@EXECUTABLE@</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.qgroundcontrol.qgroundcontrol</string>
+    <key>NOTE</key>
+    <string>Open source ground control app provided by QGroundControl dev team</string>
+    <key>NSCameraUsageDescription</key>
+    <string>QGC uses UVC camera devices for FPV</string>
 </dict>
 </plist>

--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -36,6 +36,7 @@ linux {
         DEFINES += __android__
         DEFINES += __STDC_LIMIT_MACROS
         DEFINES += QGC_ENABLE_BLUETOOTH
+        DEFINES += QGC_GST_TAISYNC_ENABLED
         target.path = $$DESTDIR
         equals(ANDROID_TARGET_ARCH, x86)  {
             CONFIG += Androidx86Build

--- a/android.pri
+++ b/android.pri
@@ -15,7 +15,8 @@ OTHER_FILES += \
     $$PWD/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java \
     $$PWD/android/src/com/hoho/android/usbserial/driver/UsbSerialRuntimeException.java \
     $$PWD/android/src/org/mavlink/qgroundcontrol/QGCActivity.java \
-    $$PWD/android/src/org/mavlink/qgroundcontrol/UsbIoManager.java
+    $$PWD/android/src/org/mavlink/qgroundcontrol/UsbIoManager.java \
+    $$PWD/android/src/org/mavlink/qgroundcontrol/TaiSync.java
 
 DISTFILES += \
     $$PWD/android/gradle/wrapper/gradle-wrapper.jar \

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -7,6 +7,8 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED"/>
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
                 <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"/>
             </intent-filter>
 

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -7,10 +7,12 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED"/>
+                <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"/>
             </intent-filter>
 
             <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
             <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_DEVICE_DETACHED"/>
+            <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"/>
             <!-- Rest of Standard Manifest -->
             <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
             <meta-data android:name="android.app.qt_sources_resource_id" android:resource="@array/qt_sources"/>
@@ -60,13 +62,14 @@
     <!-- Support devices without USB host mode since there are other connection types -->
     <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
 	
-	<!-- Support devices without Bluetooth since there are other connection types -->
-	<uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
+    <!-- Support devices without Bluetooth since there are other connection types -->
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
 	
-	<!-- Support devices that don't have location services -->
+    <!-- Support devices that don't have location services -->
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />
-	<uses-feature android:name="android.hardware.location.network" android:required="false"/>
-	<uses-feature android:name="android.hardware.location" android:required="false"/>
+    <uses-feature android:name="android.hardware.location.network" android:required="false"/>
+    <uses-feature android:name="android.hardware.location" android:required="false"/>
+    <uses-feature android:name="android.hardware.usb.accessory"/>
 	
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE" />

--- a/android/res/xml/device_filter.xml
+++ b/android/res/xml/device_filter.xml
@@ -2,5 +2,6 @@
 <resources>
     <!-- Allow anything connected -->
     <usb-device />
+    <usb-accessory model="android.usbaoa" manufacturer="taisync" version="1.0"/>
 </resources>
 

--- a/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
@@ -29,11 +29,14 @@ package org.mavlink.qgroundcontrol;
 //
 ////////////////////////////////////////////////////////////////////////////////////////////
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.io.IOException;
 
 import android.app.Activity;
@@ -42,12 +45,16 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.hardware.usb.*;
+import android.hardware.usb.UsbAccessory;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbManager;
 import android.widget.Toast;
 import android.util.Log;
 import android.os.PowerManager;
-import android.view.WindowManager;
 import android.os.Bundle;
+import android.app.PendingIntent;
+import android.view.WindowManager;
 
 import com.hoho.android.usbserial.driver.*;
 import org.qtproject.qt5.android.bindings.QtActivity;
@@ -63,8 +70,10 @@ public class QGCActivity extends QtActivity
     private static HashMap<Integer, Integer>            _userDataHashByDeviceId;
     private static final String                         TAG = "QGC_QGCActivity";
     private static PowerManager.WakeLock                _wakeLock;
-    private static final String                         ACTION_USB_PERMISSION = "com.android.example.USB_PERMISSION";
+//    private static final String                         ACTION_USB_PERMISSION = "com.android.example.USB_PERMISSION";
+    private static final String                         ACTION_USB_PERMISSION = "org.mavlink.qgroundcontrol.action.USB_PERMISSION";
     private static PendingIntent                        _usbPermissionIntent = null;
+    private TaiSync                                     taiSync = null;
 
     public static Context m_context;
 
@@ -86,6 +95,26 @@ public class QGCActivity extends QtActivity
                     nativeDeviceNewData(userData, dataA);
                 }
             };
+
+    private final BroadcastReceiver mOpenAccessoryReceiver =
+        new BroadcastReceiver()
+        {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                String action = intent.getAction();
+                if (ACTION_USB_PERMISSION.equals(action)) {
+                    UsbAccessory accessory = intent.getParcelableExtra(UsbManager.EXTRA_ACCESSORY);
+                    if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
+                        openAccessory(accessory);
+                    }
+                } else if( UsbManager.ACTION_USB_ACCESSORY_DETACHED.equals(action)) {
+                    UsbAccessory accessory = intent.getParcelableExtra(UsbManager.EXTRA_ACCESSORY);
+                    if (accessory != null) {
+                        closeAccessory(accessory);
+                    }
+                }
+            }
+        };
 
     private static UsbSerialDriver _findDriverByDeviceId(int deviceId) {
         for (UsbSerialDriver driver: _drivers) {
@@ -169,7 +198,7 @@ public class QGCActivity extends QtActivity
 
         _usbManager = (UsbManager)_instance.getSystemService(Context.USB_SERVICE);
 
-        //  Register for USB Detach and USB Permission intent
+        // Register for USB Detach and USB Permission intent
         IntentFilter filter = new IntentFilter();
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         filter.addAction(ACTION_USB_PERMISSION);
@@ -177,11 +206,24 @@ public class QGCActivity extends QtActivity
 
         // Create intent for usb permission request
         _usbPermissionIntent = PendingIntent.getBroadcast(_instance, 0, new Intent(ACTION_USB_PERMISSION), 0);
+
+        try {
+            taiSync = new TaiSync();
+
+            IntentFilter accessoryFilter = new IntentFilter(ACTION_USB_PERMISSION);
+            filter.addAction(UsbManager.ACTION_USB_ACCESSORY_DETACHED);
+            registerReceiver(mOpenAccessoryReceiver, accessoryFilter);
+
+            probeAccessories();
+        } catch(Exception e) {
+           Log.e(TAG, "Exception: " + e);
+        }
     }
 
     @Override
     protected void onDestroy()
     {
+        unregisterReceiver(mOpenAccessoryReceiver);
         try {
             if(_wakeLock != null) {
                 _wakeLock.release();
@@ -610,6 +652,62 @@ public class QGCActivity extends QtActivity
             return -1;
         else
             return connectL.getFileDescriptor();
+    }
+
+    UsbAccessory openUsbAccessory = null;
+    Object openAccessoryLock = new Object();
+
+    private void openAccessory(UsbAccessory usbAccessory)
+    {
+        Log.i(TAG, "openAccessory: " + usbAccessory.getSerial());
+        try {
+            synchronized(openAccessoryLock) {
+                if ((openUsbAccessory != null && !taiSync.isRunning()) || openUsbAccessory == null) {
+                    openUsbAccessory = usbAccessory;
+                    taiSync.open(_usbManager.openAccessory(usbAccessory));
+                }
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "openAccessory exception: " + e);
+            taiSync.close();
+            closeAccessory(openUsbAccessory);
+        }
+    }
+
+    private void closeAccessory(UsbAccessory usbAccessory)
+    {
+        Log.i(TAG, "closeAccessory");
+
+        synchronized(openAccessoryLock) {
+            if (openUsbAccessory != null && usbAccessory == openUsbAccessory && taiSync.isRunning()) {
+                taiSync.close();
+                openUsbAccessory = null;
+            }
+        }
+    }
+
+    private void probeAccessories()
+    {
+        final PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
+        Timer timer = new Timer();
+        timer.schedule(new TimerTask() {
+           @Override
+           public void run()
+           {
+//               Log.i(TAG, "probeAccessories");
+               UsbAccessory[] accessories = _usbManager.getAccessoryList();
+               if (accessories != null) {
+                   for (UsbAccessory usbAccessory : accessories) {
+                       if (_usbManager.hasPermission(usbAccessory)) {
+                           openAccessory(usbAccessory);
+                       } else {
+                           Log.i(TAG, "requestPermission");
+                           _usbManager.requestPermission(usbAccessory, pendingIntent);
+                       }
+                   }
+               }
+           }
+        }, 0, 3000);
     }
 }
 

--- a/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
@@ -55,6 +55,8 @@ import android.os.PowerManager;
 import android.os.Bundle;
 import android.app.PendingIntent;
 import android.view.WindowManager;
+import android.os.Bundle;
+import android.bluetooth.BluetoothDevice;
 
 import com.hoho.android.usbserial.driver.*;
 import org.qtproject.qt5.android.bindings.QtActivity;
@@ -162,6 +164,12 @@ public class QGCActivity extends QtActivity
                         }
                     }
                 }
+
+                try {
+                    nativeUpdateAvailableJoysticks();
+                } catch(Exception e) {
+                    Log.e(TAG, "Exception nativeUpdateAvailableJoysticks()");
+                }
             }
         };
 
@@ -169,6 +177,7 @@ public class QGCActivity extends QtActivity
     private static native void nativeDeviceHasDisconnected(int userData);
     private static native void nativeDeviceException(int userData, String messageA);
     private static native void nativeDeviceNewData(int userData, byte[] dataA);
+    private static native void nativeUpdateAvailableJoysticks();
 
     // Native C++ functions called to log output
     public static native void qgcLogDebug(String message);
@@ -200,8 +209,11 @@ public class QGCActivity extends QtActivity
 
         // Register for USB Detach and USB Permission intent
         IntentFilter filter = new IntentFilter();
+        filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         filter.addAction(ACTION_USB_PERMISSION);
+        filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+        filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
         _instance.registerReceiver(_instance._usbReceiver, filter);
 
         // Create intent for usb permission request

--- a/android/src/org/mavlink/qgroundcontrol/TaiSync.java
+++ b/android/src/org/mavlink/qgroundcontrol/TaiSync.java
@@ -1,0 +1,286 @@
+package org.mavlink.qgroundcontrol;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.FileDescriptor;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.Socket;
+import java.net.InetAddress;
+
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
+public class TaiSync
+{
+    private static final int HEADER_SIZE = 0x1C;
+
+    private static final byte PROTOCOL_REQUEST_CONNECTION = 0x00;
+    private static final byte PROTOCOL_VERSION = 0x01;
+    private static final byte PROTOCOL_CHANNEL = 0x02;
+    private static final byte PROTOCOL_DATA = 0x03;
+
+    private static final int VIDEO_PORT = 5600;
+    private static final int TAISYNC_VIDEO_PORT = 8000;
+    private static final int TAISYNC_SETTINGS_PORT = 8200;
+    private static final int TAISYNC_TELEMETRY_PORT = 8400;
+
+    private Object runLock;
+    private boolean running = false;
+    private DatagramSocket udpSocket = null;
+    private Socket tcpSettingsSocket = null;
+    private InputStream settingsInStream = null;
+    private OutputStream settingsOutStream = null;
+    private Socket tcpTelemetrySocket = null;
+    private InputStream telemetryInStream = null;
+    private OutputStream telemetryOutStream = null;
+    private ParcelFileDescriptor mParcelFileDescriptor;
+    private FileInputStream mFileInputStream;
+    private FileOutputStream mFileOutputStream;
+    private ExecutorService mThreadPool;
+    private byte[] mBytes = new byte[32 * 1024];
+    private byte vMaj = 0;
+
+    public TaiSync()
+    {
+        runLock = new Object();
+        mThreadPool = Executors.newFixedThreadPool(3);
+    }
+
+    public boolean isRunning()
+    {
+        synchronized (runLock) {
+            return running;
+        }
+    }
+
+    public void open(ParcelFileDescriptor parcelFileDescriptor) throws IOException
+    {
+//        Log.i("QGC_TaiSync", "Open");
+
+        synchronized (runLock) {
+            if (running) {
+                return;
+            }
+            running = true;
+        }
+
+        mParcelFileDescriptor = parcelFileDescriptor;
+        if (mParcelFileDescriptor == null) {
+            throw new IOException("parcelFileDescriptor is null");
+        }
+
+        FileDescriptor fileDescriptor = mParcelFileDescriptor.getFileDescriptor();
+        mFileInputStream = new FileInputStream(fileDescriptor);
+        mFileOutputStream = new FileOutputStream(fileDescriptor);
+
+        udpSocket = new DatagramSocket();
+        final InetAddress address = InetAddress.getByName("localhost");
+        tcpTelemetrySocket = new Socket(address, TAISYNC_TELEMETRY_PORT);
+        telemetryInStream = tcpTelemetrySocket.getInputStream();
+        telemetryOutStream = tcpTelemetrySocket.getOutputStream();
+        tcpSettingsSocket = new Socket(address, TAISYNC_SETTINGS_PORT);
+        settingsInStream = tcpSettingsSocket.getInputStream();
+        settingsOutStream = tcpSettingsSocket.getOutputStream();
+
+        // Request connection packet
+        sendTaiSyncMessage(PROTOCOL_REQUEST_CONNECTION, 0, null, 0);
+
+        // Read multiplexed data stream coming from TaiSync accessory
+        mThreadPool.execute(new Runnable() {
+            @Override
+            public void run()
+            {
+                int bytesRead = 0;
+
+                try {
+                    while (bytesRead >= 0) {
+                        synchronized (runLock) {
+                            if (!running) {
+                                break;
+                            }
+                        }
+
+                        bytesRead = mFileInputStream.read(mBytes);
+
+                        if (bytesRead > 0)
+                        {
+                            if (mBytes[3] == PROTOCOL_VERSION)
+                            {
+                                vMaj = mBytes[19];
+                                Log.i("QGC_TaiSync", "Got protocol version message vMaj = " + mBytes[19]);
+                                sendTaiSyncMessage(PROTOCOL_VERSION, 0, null, 0);
+                            }
+                            else if (mBytes[3] == PROTOCOL_CHANNEL) {
+                                int dPort = ((mBytes[4] & 0xff)<< 24) | ((mBytes[5]&0xff) << 16) | ((mBytes[6]&0xff) << 8) | (mBytes[7] &0xff);
+                                int dLength = ((mBytes[8] & 0xff)<< 24) | ((mBytes[9]&0xff) << 16) | ((mBytes[10]&0xff) << 8) | (mBytes[11] &0xff);
+                                Log.i("QGC_TaiSync", "Read 2 port = " + dPort + " length = " + dLength);
+                                sendTaiSyncMessage(PROTOCOL_CHANNEL, dPort, null, 0);
+                            }
+                            else if (mBytes[3] == PROTOCOL_DATA) {
+                                int dPort = ((mBytes[4] & 0xff)<< 24) | ((mBytes[5]&0xff) << 16) | ((mBytes[6]&0xff) << 8) | (mBytes[7] &0xff);
+                                int dLength = ((mBytes[8] & 0xff)<< 24) | ((mBytes[9]&0xff) << 16) | ((mBytes[10]&0xff) << 8) | (mBytes[11] &0xff);
+
+                                int payloadOffset = HEADER_SIZE;
+                                int payloadLength = bytesRead - payloadOffset;
+
+                                byte[] sBytes = new byte[payloadLength];
+                                System.arraycopy(mBytes, payloadOffset, sBytes, 0, payloadLength);
+
+                                if (dPort == TAISYNC_VIDEO_PORT) {
+                                    DatagramPacket packet = new DatagramPacket(sBytes, sBytes.length, address, VIDEO_PORT);
+                                    udpSocket.send(packet);
+                                } else if (dPort == TAISYNC_SETTINGS_PORT) {
+                                    settingsOutStream.write(sBytes);
+                                } else if (dPort == TAISYNC_TELEMETRY_PORT) {
+                                    telemetryOutStream.write(sBytes);
+                                }
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    Log.e("QGC_TaiSync", "Exception: " + e);
+                    e.printStackTrace();
+                } finally {
+                    close();
+                }
+            }
+        });
+
+        // Read command & control packets to be sent to telemetry port
+        mThreadPool.execute(new Runnable() {
+            @Override
+            public void run()
+            {
+                byte[] inbuf = new byte[256];
+
+                try {
+                    while (true) {
+                        synchronized (runLock) {
+                            if (!running) {
+                                break;
+                            }
+                        }
+
+                        int bytesRead = telemetryInStream.read(inbuf, 0, inbuf.length);
+                        if (bytesRead > 0) {
+                            sendTaiSyncMessage(PROTOCOL_DATA, TAISYNC_TELEMETRY_PORT, inbuf, bytesRead);
+                        }
+                    }
+                } catch (IOException e) {
+                    Log.e("QGC_TaiSync", "Exception: " + e);
+                    e.printStackTrace();
+                } finally {
+                    close();
+                }
+            }
+        });
+
+        // Read incoming requests for settings socket
+        mThreadPool.execute(new Runnable() {
+            @Override
+            public void run()
+            {
+                byte[] inbuf = new byte[1024];
+
+                try {
+                    while (true) {
+                        synchronized (runLock) {
+                            if (!running) {
+                                break;
+                            }
+                        }
+
+                        int bytesRead = settingsInStream.read(inbuf, 0, inbuf.length);
+                        if (bytesRead > 0) {
+                            sendTaiSyncMessage(PROTOCOL_DATA, TAISYNC_SETTINGS_PORT, inbuf, bytesRead);
+                        }
+                    }
+                } catch (IOException e) {
+                    Log.e("QGC_TaiSync", "Exception: " + e);
+                    e.printStackTrace();
+                } finally {
+                    close();
+                }
+            }
+        });
+   }
+
+    private void sendTaiSyncMessage(byte protocol, int dataPort, byte[] data, int dataLen) throws IOException
+    {
+        byte portMSB = (byte)((dataPort >> 8) & 0xFF);
+        byte portLSB = (byte)(dataPort & 0xFF);
+
+        byte[] lA = new byte[4];
+        int len = HEADER_SIZE + dataLen;
+        Log.i("QGC_TaiSync", "Sending to " + dataPort + " length = " + len);
+        byte[] buffer = new byte[len];
+
+        for (int i = 3; i >= 0; i--) {
+            lA[i] = (byte)(len & 0xFF);
+            len >>= 8;
+        }
+
+        byte[] header = { 0x00, 0x00, 0x00, protocol,   // uint32 - protocol
+                          0x00, 0x00, portMSB, portLSB, // uint32 - dport
+                          lA[0], lA[1], lA[2], lA[3],   // uint32 - length
+                          0x00, 0x00, 0x00, 0x00,       // uint32 - magic
+                          0x00, 0x00, 0x00, vMaj,       // uint32 - version major
+                          0x00, 0x00, 0x00, 0x00,       // uint32 - version minor
+                          0x00, 0x00, 0x00, 0x00 };     // uint32 - padding
+
+        System.arraycopy(header, 0, buffer, 0, header.length);
+        if (data != null && dataLen > 0) {
+            System.arraycopy(data, 0, buffer, header.length, dataLen);
+        }
+
+        synchronized (runLock) {
+            mFileOutputStream.write(buffer);
+        }
+    }
+
+    public void close()
+    {
+//        Log.i("QGC_TaiSync", "Close");
+        synchronized (runLock) {
+            running = false;
+        }
+        try {
+            if (udpSocket != null) {
+                udpSocket.close();
+            }
+        } catch (Exception e) {
+        }
+        try {
+            if (tcpTelemetrySocket != null) {
+                tcpTelemetrySocket.close();
+            }
+        } catch (Exception e) {
+        }
+        try {
+            if (tcpSettingsSocket != null) {
+                tcpSettingsSocket.close();
+            }
+        } catch (Exception e) {
+        }
+        try {
+            if (mParcelFileDescriptor != null) {
+                mParcelFileDescriptor.close();
+            }
+        } catch (Exception e) {
+        }
+        udpSocket = null;
+        tcpSettingsSocket = null;
+        tcpTelemetrySocket = null;
+        settingsInStream = null;
+        settingsOutStream = null;
+        mParcelFileDescriptor = null;
+    }
+}

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -76,7 +76,7 @@ protected:
 
     class CameraStruct : public QObject {
     public:
-        CameraStruct(QObject* parent);
+        CameraStruct(QObject* parent, uint8_t compID_);
         QTime   lastHeartbeat;
         bool    infoReceived = false;
         bool    gaveUp       = false;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -124,6 +124,12 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void):
     }
 
     _nameToFactGroupMap.insert("APMSubInfo", &_infoFactGroup);
+
+    _factRenameMap[QStringLiteral("altitudeRelative")] = QStringLiteral("Depth");
+    _factRenameMap[QStringLiteral("flightTime")] = QStringLiteral("Dive Time");
+    _factRenameMap[QStringLiteral("altitudeAMSL")] = QStringLiteral("");
+    _factRenameMap[QStringLiteral("hobbs")] = QStringLiteral("");
+    _factRenameMap[QStringLiteral("airSpeed")] = QStringLiteral("");
 }
 
 QList<MAV_CMD> ArduSubFirmwarePlugin::supportedMissionCommands(void)
@@ -309,4 +315,15 @@ QString ArduSubFirmwarePlugin::vehicleImageOpaque(const Vehicle* vehicle) const
 QString ArduSubFirmwarePlugin::vehicleImageOutline(const Vehicle* vehicle) const
 {
     return vehicleImageOpaque(vehicle);
+}
+
+void ArduSubFirmwarePlugin::adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData)
+{
+    Q_UNUSED(vehicleType);
+    if (!metaData) {
+        return;
+    }
+    if (_factRenameMap.contains(metaData->name())) {
+        metaData->setShortDescription(QString(_factRenameMap[metaData->name()]));
+    }
 }

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -137,11 +137,13 @@ public:
     const QVariantList& toolBarIndicators(const Vehicle* vehicle) final;
     bool  adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message) final;
     virtual QMap<QString, FactGroup*>* factGroups(void) final;
+    void adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData) override final;
 
 
 private:
     QVariantList _toolBarIndicators;
     static bool _remapParamNameIntialized;
+    QMap<QString, QString> _factRenameMap;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;
     void _handleNamedValueFloat(mavlink_message_t* message);
     void _handleMavlinkMessage(mavlink_message_t* message);

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -309,6 +309,11 @@ public:
     int versionCompare(Vehicle* vehicle, QString& compare);
     int versionCompare(Vehicle* vehicle, int major, int minor, int patch);
 
+    /// Allows the Firmware plugin to override the facts meta data.
+    ///     @param vehicleType - Type of current vehicle
+    ///     @param metaData - MetaData for fact
+    virtual void adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData) {Q_UNUSED(vehicleType); Q_UNUSED(metaData);};
+
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const QString px4FollowMeFlightMode;
 

--- a/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+++ b/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
@@ -4686,8 +4686,8 @@ Temporary Parameter to enable interface testing</short_desc>
     </parameter>
     <parameter default="0.4" name="MPC_TKO_RAMP_T" type="FLOAT">
       <short_desc>Position control smooth takeoff ramp time constant</short_desc>
-      <long_desc>Increasing this value will make automatic and manual takeoff slower. If it's too slow the drone might scratch the ground and tip over.</long_desc>
-      <min>0.1</min>
+      <long_desc>Increasing this value will make automatic and manual takeoff slower. If it's too slow the drone might scratch the ground and tip over. A time constant of 0 disables the ramp</long_desc>
+      <min>0</min>
       <max>1</max>
     </parameter>
     <parameter default="1.5" name="MPC_TKO_SPEED" type="FLOAT">

--- a/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+++ b/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
@@ -8780,7 +8780,7 @@ is less than 50% of this value</short_desc>
     </parameter>
     <parameter default="0" name="SYS_COMPANION" type="INT32">
       <short_desc>TELEM2 as companion computer link (deprecated)</short_desc>
-      <long_desc>This parameter is deprecated. Do not change it, use the more generic serial configuration parameters instead.</long_desc>
+      <long_desc>This parameter is deprecated and will be removed after 1.9.0. Use the generic serial configuration parameters instead (e.g. MAV_0_CONFIG, MAV_0_MODE, etc.).</long_desc>
       <min>0</min>
       <max>6460800</max>
       <reboot_required>true</reboot_required>

--- a/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+++ b/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
@@ -336,15 +336,39 @@ Set to 2 to use heading from motion capture</short_desc>
       <decimal>8</decimal>
     </parameter>
   </group>
+  <group name="Camera Capture">
+    <parameter default="0.0" name="CAM_CAP_DELAY" type="FLOAT">
+      <short_desc>Camera strobe delay</short_desc>
+      <long_desc>This parameter sets the delay between image integration start and strobe firing</long_desc>
+      <min>0.0</min>
+      <max>100.0</max>
+      <unit>ms</unit>
+      <decimal>1</decimal>
+    </parameter>
+  </group>
   <group name="Camera Control">
-    <parameter default="0" name="CAM_FBACK_MODE" type="INT32">
-      <short_desc>Camera feedback mode</short_desc>
-      <long_desc>Sets the camera feedback mode.</long_desc>
-      <min>0</min>
-      <max>1</max>
+    <parameter default="0" name="CAM_CAP_EDGE" type="INT32">
+      <short_desc>Camera capture edge</short_desc>
+      <reboot_required>true</reboot_required>
       <values>
-        <value code="0">Disabled</value>
-        <value code="1">Feedback on trigger</value>
+        <value code="0">Falling edge</value>
+        <value code="1">Rising edge</value>
+      </values>
+    </parameter>
+    <parameter default="0" name="CAM_CAP_FBACK" type="INT32">
+      <short_desc>Camera capture feedback</short_desc>
+      <long_desc>Enables camera capture feedback</long_desc>
+      <boolean />
+      <reboot_required>true</reboot_required>
+    </parameter>
+    <parameter default="0" name="CAM_CAP_MODE" type="INT32">
+      <short_desc>Camera capture timestamping mode</short_desc>
+      <long_desc>Change time measurement</long_desc>
+      <reboot_required>true</reboot_required>
+      <values>
+        <value code="0">Get absolute timestamp</value>
+        <value code="1">Get timestamp of mid exposure (active high)</value>
+        <value code="2">Get timestamp of mid exposure (active low)</value>
       </values>
     </parameter>
   </group>

--- a/src/FlightMap/Widgets/ValuePageWidget.qml
+++ b/src/FlightMap/Widgets/ValuePageWidget.qml
@@ -222,6 +222,7 @@ Column {
 
                     RowLayout {
                         spacing: _margins
+                        visible: factGroup.getFact(modelData).shortDescription !== ""
 
                         property string propertyName: factGroupName + "." + modelData
 

--- a/src/Joystick/JoystickAndroid.cc
+++ b/src/Joystick/JoystickAndroid.cc
@@ -76,8 +76,6 @@ QMap<QString, Joystick*> JoystickAndroid::discover(MultiVehicleManager* _multiVe
     bool joystickFound = false;
     static QMap<QString, Joystick*> ret;
 
-    _initStatic(); //it's enough to run it once, should be in a static constructor
-
     QMutexLocker lock(&m_mutex);
 
     QAndroidJniEnvironment env;
@@ -194,7 +192,7 @@ uint8_t JoystickAndroid::_getHat(int hat,int i) {
 }
 
 //helper method
-void JoystickAndroid::_initStatic() {
+bool JoystickAndroid::init() {
     //this gets list of all possible buttons - this is needed to check how many buttons our gamepad supports
     //instead of the whole logic below we could have just a simple array of hardcoded int values as these 'should' not change
 
@@ -229,5 +227,7 @@ void JoystickAndroid::_initStatic() {
 
     ACTION_DOWN = QAndroidJniObject::getStaticField<jint>("android/view/KeyEvent", "ACTION_DOWN");
     ACTION_UP = QAndroidJniObject::getStaticField<jint>("android/view/KeyEvent", "ACTION_UP");
+
+    return true;
 }
 

--- a/src/Joystick/JoystickAndroid.h
+++ b/src/Joystick/JoystickAndroid.h
@@ -16,9 +16,12 @@ class JoystickAndroid : public Joystick, public QtAndroidPrivate::GenericMotionE
 {
 public:
     JoystickAndroid(const QString& name, int axisCount, int buttonCount, int id, MultiVehicleManager* multiVehicleManager);
+
     ~JoystickAndroid();
 
-    static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager); 
+    static bool init();
+
+    static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager);
 
 private:
     bool handleKeyEvent(jobject event);
@@ -37,7 +40,6 @@ private:
     bool *btnValue;
     int *axisValue;
 
-    static void _initStatic();
     static int * _androidBtnList; //list of all possible android buttons
     static int _androidBtnListCount;
 

--- a/src/Joystick/JoystickAndroid.h
+++ b/src/Joystick/JoystickAndroid.h
@@ -19,13 +19,15 @@ public:
 
     ~JoystickAndroid();
 
-    static bool init();
+    static bool init(JoystickManager *manager);
 
     static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager);
 
 private:
     bool handleKeyEvent(jobject event);
     bool handleGenericMotionEvent(jobject event);
+
+    static void setNativeMethods(JoystickManager *manager);
 
     virtual bool _open();
     virtual void _close();

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *   (c) 2009-2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
@@ -29,8 +29,8 @@ const char * JoystickManager::_settingsKeyActiveJoystick =  "ActiveJoystick";
 
 JoystickManager::JoystickManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
-    , _activeJoystick(NULL)
-    , _multiVehicleManager(NULL)
+    , _activeJoystick(nullptr)
+    , _multiVehicleManager(nullptr)
 {
 }
 
@@ -54,18 +54,17 @@ void JoystickManager::setToolbox(QGCToolbox *toolbox)
 
 void JoystickManager::init() {
 #ifdef __sdljoystick__
-    if (JoystickSDL::init()) {
-        _setActiveJoystickFromSettings();
-        connect(&_joystickCheckTimer, &QTimer::timeout, this, &JoystickManager::_updateAvailableJoysticks);
-        _joystickCheckTimer.start(250);
+    if (!JoystickSDL::init()) {
+        return;
     }
+    _setActiveJoystickFromSettings();
 #elif defined(__android__)
-    if (JoystickAndroid::init()) {
-        _setActiveJoystickFromSettings();
-        connect(&_joystickCheckTimer, &QTimer::timeout, this, &JoystickManager::_updateAvailableJoysticks);
-        _joystickCheckTimer.start(250);
+    if (!JoystickAndroid::init()) {
+        return;
     }
 #endif
+    connect(&_joystickCheckTimer, &QTimer::timeout, this, &JoystickManager::_updateAvailableJoysticks);
+    _joystickCheckTimer.start(1000);
 }
 
 void JoystickManager::_setActiveJoystickFromSettings(void)
@@ -81,7 +80,7 @@ void JoystickManager::_setActiveJoystickFromSettings(void)
 
     if (_activeJoystick && !newMap.contains(_activeJoystick->name())) {
         qCDebug(JoystickManagerLog) << "Active joystick removed";
-        setActiveJoystick(NULL);
+        setActiveJoystick(nullptr);
     }
 
     // Check to see if our current mapping contains any joysticks that are not in the new mapping
@@ -100,7 +99,7 @@ void JoystickManager::_setActiveJoystickFromSettings(void)
     emit availableJoysticksChanged();
 
     if (!_name2JoystickMap.count()) {
-        setActiveJoystick(NULL);
+        setActiveJoystick(nullptr);
         return;
     }
 
@@ -126,7 +125,7 @@ void JoystickManager::setActiveJoystick(Joystick* joystick)
 {
     QSettings settings;
 
-    if (joystick != NULL && !_name2JoystickMap.contains(joystick->name())) {
+    if (joystick != nullptr && !_name2JoystickMap.contains(joystick->name())) {
         qCWarning(JoystickManagerLog) << "Set active not in map" << joystick->name();
         return;
     }
@@ -141,7 +140,7 @@ void JoystickManager::setActiveJoystick(Joystick* joystick)
     
     _activeJoystick = joystick;
     
-    if (_activeJoystick != NULL) {
+    if (_activeJoystick != nullptr) {
         qCDebug(JoystickManagerLog) << "Set active:" << _activeJoystick->name();
 
         settings.beginGroup(_settingsGroup);
@@ -208,8 +207,6 @@ void JoystickManager::_updateAvailableJoysticks(void)
         }
     }
 #elif defined(__android__)
-    /*
-     * TODO: Investigate Android events for Joystick hot plugging
-     */
+    _setActiveJoystickFromSettings();
 #endif
 }

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -60,8 +60,11 @@ void JoystickManager::init() {
         _joystickCheckTimer.start(250);
     }
 #elif defined(__android__)
-    _setActiveJoystickFromSettings();
-    //TODO: Investigate Android events for Joystick hot plugging & run _joystickCheckTimer if possible
+    if (JoystickAndroid::init()) {
+        _setActiveJoystickFromSettings();
+        connect(&_joystickCheckTimer, &QTimer::timeout, this, &JoystickManager::_updateAvailableJoysticks);
+        _joystickCheckTimer.start(250);
+    }
 #endif
 }
 

--- a/src/Joystick/JoystickManager.h
+++ b/src/Joystick/JoystickManager.h
@@ -45,6 +45,8 @@ public:
     QString activeJoystickName(void);
     void setActiveJoystickName(const QString& name);
 
+    void restartJoystickCheckTimer(void);
+
     // Override from QGCTool
     virtual void setToolbox(QGCToolbox *toolbox);
 
@@ -55,6 +57,7 @@ signals:
     void activeJoystickChanged(Joystick* joystick);
     void activeJoystickNameChanged(const QString& name);
     void availableJoysticksChanged(void);
+    void updateAvailableJoysticksSignal();
 
 private slots:
     void _updateAvailableJoysticks(void);
@@ -70,6 +73,7 @@ private:
     static const char * _settingsGroup;
     static const char * _settingsKeyActiveJoystick;
 
+    int _joystickCheckTimerCounter;
     QTimer _joystickCheckTimer;
 };
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -56,9 +56,9 @@ const char* MissionController::_jsonMavAutopilotKey =           "MAV_AUTOPILOT";
 
 const int   MissionController::_missionFileVersion =            2;
 
-const QString MissionController::patternFWLandingName      (tr("Fixed Wing Landing"));
-const QString MissionController::patternStructureScanName  (tr("Structure Scan"));
-const QString MissionController::patternCorridorScanName   (tr("Corridor Scan"));
+const QString MissionController::patternFWLandingName      (QT_TRANSLATE_NOOP("MissionController", "Fixed Wing Landing"));
+const QString MissionController::patternStructureScanName  (QT_TRANSLATE_NOOP("MissionController", "Structure Scan"));
+const QString MissionController::patternCorridorScanName   (QT_TRANSLATE_NOOP("MissionController", "Corridor Scan"));
 
 MissionController::MissionController(PlanMasterController* masterController, QObject *parent)
     : PlanElementController     (masterController, parent)

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -781,6 +781,7 @@ void SimpleMissionItem::_setDefaultsForCommand(void)
 
     case MAV_CMD_NAV_LAND:
     case MAV_CMD_NAV_VTOL_LAND:
+    case MAV_CMD_DO_SET_ROI_LOCATION:
         _altitudeFact.setRawValue(0);
         _missionItem.setParam7(0);
         break;

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -11,6 +11,7 @@ TextField {
     textColor:          qgcPal.textFieldText
     implicitHeight:     ScreenTools.implicitTextFieldHeight
     activeFocusOnPress: true
+    antialiasing:       true
 
     property bool   showUnits:  false
     property bool   showHelp:   false
@@ -47,7 +48,11 @@ TextField {
     }
 
     style: TextFieldStyle {
+        id:             tfs
         font.pointSize: ScreenTools.defaultFontPointSize
+        font.family:    ScreenTools.normalFontFamily
+        renderType:     ScreenTools.isWindows ? Text.QtRendering : tfs.renderType   // This works around font rendering problems on windows
+
         background: Item {
             id: backgroundItem
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -278,6 +278,9 @@ Vehicle::Vehicle(LinkInterface*             link,
     }
 
     _firmwarePlugin->initializeVehicle(this);
+    for(auto& factName: factNames()) {
+        _firmwarePlugin->adjustMetaData(vehicleType, getFact(factName)->metaData());
+    }
 
     _sendMultipleTimer.start(_sendMessageMultipleIntraMessageDelay);
     connect(&_sendMultipleTimer, &QTimer::timeout, this, &Vehicle::_sendMessageMultipleNext);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2298,6 +2298,7 @@ bool Vehicle::joystickEnabled(void)
 void Vehicle::setJoystickEnabled(bool enabled)
 {
     _joystickEnabled = enabled;
+    _startJoystick(_joystickEnabled);
     _saveSettings();
     emit joystickEnabledChanged(_joystickEnabled);
 }

--- a/src/VideoStreaming/README.md
+++ b/src/VideoStreaming/README.md
@@ -70,16 +70,19 @@ The installer places them under ~/Library/Developer/GStreamer/iPhone.sdk/GStream
 ### Android
 
 Binaries found in http://gstreamer.freedesktop.org/data/pkg/android
-Download the [gstreamer-1.0-android-armv7-1.5.2.tar.bz2](http://gstreamer.freedesktop.org/data/pkg/android/1.5.2/gstreamer-1.0-android-armv7-1.5.2.tar.bz2) archive (assuming you want the ARM V7 platform. For x86, replace `armv7` with `x86` accordingly). 
+Download the [gstreamer-1.0-android-universal-1.14.4.tar.bz2](https://gstreamer.freedesktop.org/data/pkg/android/1.14.4/gstreamer-1.0-android-universal-1.14.4.tar.bz2) archive. 
 
-Create a directory named "gstreamer-1.0-android-armv7-1.5.2" under the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). Extract the gstreamer tar file under this directory. That's where the build system will look for it. Make sure your archive tool doesn't create any additional top level directories. The structure after extracting the archive should look like this:
+Create a directory named "gstreamer-1.0-android-universal-1.14.4" under the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). Extract the downloaded archive under this directory. That's where the build system will look for it. Make sure your archive tool doesn't create any additional top level directories. The structure after extracting the archive should look like this:
 ```
 qgroundcontrol
-├── gstreamer-1.0-android-armv7-1.5.2
-│   ├── etc
-│   ├── include
-│   ├── lib
-│   └── share
+├── gstreamer-1.0-android-universal-1.14.4
+│   │
+│   ├──armv7
+│   │   ├── etc
+│   │   ├── include
+│   │   ├── lib
+│   │   └── share
+│   ├──x86
 ```
 ### Windows
 

--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -539,7 +539,8 @@ VideoReceiver::_shutdownPipeline() {
 void
 VideoReceiver::_handleError() {
     qCDebug(VideoReceiverLog) << "Gstreamer error!";
-    _shutdownPipeline();
+    stop();
+    start();
 }
 #endif
 
@@ -554,7 +555,8 @@ VideoReceiver::_handleEOS() {
         _shutdownRecordingBranch();
     } else {
         qWarning() << "VideoReceiver: Unexpected EOS!";
-        _shutdownPipeline();
+        stop();
+        start();
     }
 }
 #endif


### PR DESCRIPTION
Bugfix: Joystick is not visible if connected after start of QGC

On Android the Joysticks are probed only at the start of QGC. If the Joystick is connected after QGC is started it never appears in the system.

Steps to reproduce the behavior:

    Drone switched on
    QGC is started and connected to the drone
    Bluetooth joystick or gamepad is connected to the system
    Joystick tab does not appear in configuration

Expected behavior:
Joystick should appear when it is available to the system regardles even after QGC is up and running

Fix:
Android joysticks are periodically checked and probed in the same was as SDL joysticks on other platforms.