### PR TITLE
Fix startup crash on initial font change signalling qgc reboot required

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -27,6 +27,7 @@ Fact::Fact(QObject* parent)
     , _sendValueChangedSignals  (true)
     , _deferredValueChangeSignal(false)
     , _valueSliderModel         (nullptr)
+    , _ignoreQGCRebootRequired  (false)
 {    
     FactMetaData* metaData = new FactMetaData(_type, this);
     setMetaData(metaData);
@@ -44,6 +45,7 @@ Fact::Fact(int componentId, QString name, FactMetaData::ValueType_t type, QObjec
     , _sendValueChangedSignals  (true)
     , _deferredValueChangeSignal(false)
     , _valueSliderModel         (nullptr)
+    , _ignoreQGCRebootRequired  (false)
 {
     FactMetaData* metaData = new FactMetaData(_type, this);
     setMetaData(metaData);
@@ -61,6 +63,7 @@ Fact::Fact(const QString& settingsGroup, FactMetaData* metaData, QObject* parent
     , _sendValueChangedSignals  (true)
     , _deferredValueChangeSignal(false)
     , _valueSliderModel         (nullptr)
+    , _ignoreQGCRebootRequired  (false)
 {
     qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(settingsGroup, *metaData);
     setMetaData(metaData, true /* setDefaultFromMetaData */);
@@ -90,7 +93,8 @@ const Fact& Fact::operator=(const Fact& other)
     _type                       = other._type;
     _sendValueChangedSignals    = other._sendValueChangedSignals;
     _deferredValueChangeSignal  = other._deferredValueChangeSignal;
-    _valueSliderModel       = nullptr;
+    _valueSliderModel           = nullptr;
+    _ignoreQGCRebootRequired    = other._ignoreQGCRebootRequired;
     if (_metaData && other._metaData) {
         *_metaData = *other._metaData;
     } else {
@@ -615,7 +619,9 @@ bool Fact::vehicleRebootRequired(void) const
 
 bool Fact::qgcRebootRequired(void) const
 {
-    if (_metaData) {
+    if (_ignoreQGCRebootRequired) {
+        return false;
+    } else if (_metaData) {
         return _metaData->qgcRebootRequired();
     } else {
         qWarning() << kMissingMetadata << name();
@@ -742,4 +748,9 @@ void Fact::_checkForRebootMessaging(void)
             }
         }
     }
+}
+
+void Fact::_setIgnoreQGCRebootRequired(bool ignore)
+{
+    _ignoreQGCRebootRequired = ignore;
 }

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -129,6 +129,10 @@ public:
     bool            writeOnly               (void) const;
     bool            volatileValue           (void) const;
 
+    // Internal hack to allow changes to fact which do not signal reboot. Currently used by font point size
+    // code in ScreenTools.qml to set initial sizing at first boot.
+    Q_INVOKABLE void _setIgnoreQGCRebootRequired(bool ignore);
+
     Q_INVOKABLE FactValueSliderListModel* valueSliderModel(void);
 
     /// Returns the values as a string with full 18 digit precision if float/double.
@@ -208,6 +212,7 @@ protected:
     bool                        _sendValueChangedSignals;
     bool                        _deferredValueChangeSignal;
     FactValueSliderListModel*   _valueSliderModel;
+    bool                        _ignoreQGCRebootRequired;
 };
 
 #endif

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -181,7 +181,9 @@ Item {
                 } else {
                     baseSize = _defaultFont.font.pointSize;
                 }
+                _appFontPointSizeFact._setIgnoreQGCRebootRequired(true)
                 _appFontPointSizeFact.value = baseSize
+                _appFontPointSizeFact._setIgnoreQGCRebootRequired(false)
                 //-- Release build doesn't get signal
                 if(!ScreenToolsController.isDebug)
                     _screenTools._setBasePointSize(baseSize);

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -504,7 +504,7 @@ void MainWindow::_storeVisibleWidgetsSettings(void)
 
 QObject* MainWindow::rootQmlObject(void)
 {
-    return _mainQmlWidgetHolder->getRootObject();
+    return _mainQmlWidgetHolder ? _mainQmlWidgetHolder->getRootObject() : nullptr;
 }
 
 void MainWindow::_showAdvancedUIChanged(bool advanced)


### PR DESCRIPTION
Fix for #7144

The initiall setting of the font size was caused a QGC Reboot Required message to pop too early in the boot sequence.