### PR TITLE
Support for new AltitudeFactTextField

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -137,6 +137,7 @@
         <file alias="QGroundControl/Controls/VehicleRotationCal.qml">src/QmlControls/VehicleRotationCal.qml</file>
         <file alias="QGroundControl/Controls/VehicleSummaryRow.qml">src/QmlControls/VehicleSummaryRow.qml</file>
         <file alias="QGroundControl/Controls/ViewWidget.qml">src/ViewWidgets/ViewWidget.qml</file>
+        <file alias="QGroundControl/FactControls/AltitudeFactTextField.qml">src/FactSystem/FactControls/AltitudeFactTextField.qml</file>
         <file alias="QGroundControl/FactControls/FactBitmask.qml">src/FactSystem/FactControls/FactBitmask.qml</file>
         <file alias="QGroundControl/FactControls/FactCheckBox.qml">src/FactSystem/FactControls/FactCheckBox.qml</file>
         <file alias="QGroundControl/FactControls/FactComboBox.qml">src/FactSystem/FactControls/FactComboBox.qml</file>

--- a/src/FactSystem/FactControls/AltitudeFactTextField.qml
+++ b/src/FactSystem/FactControls/AltitudeFactTextField.qml
@@ -1,0 +1,37 @@
+import QGroundControl               1.0
+import QGroundControl.FactSystem    1.0
+
+FactTextField {
+    unitsLabel: fact ? fact.units + _altitudeModeExtraUnits : ""
+    showUnits:  true
+    showHelp:   true
+
+    property int altitudeMode: QGroundControl.AltitudeModeNone
+
+    readonly property string _altModeNoneExtraUnits:            ""
+    readonly property string _altModeRelativeExtraUnits:        qsTr(" (Rel)")
+    readonly property string _altModeAbsoluteExtraUnits:        qsTr(" (AMSL)")
+    readonly property string _altModeAboveTerrainExtraUnits:    qsTr(" (Abv Terr)")
+    readonly property string _altModeTerrainFrameExtraUnits:    qsTr(" (TerrF)")
+
+    property string _altitudeModeExtraUnits: _altModeRelativeExtraUnits
+
+    function updateAltitudeModeExtraUnits() {
+        if (altitudeMode === QGroundControl.AltitudeModeNone) {
+            _altitudeModeExtraUnits = _altModeNoneExtraUnits
+        } else if (altitudeMode === QGroundControl.AltitudeModeRelative) {
+            _altitudeModeExtraUnits = _altModeRelativeExtraUnits
+        } else if (altitudeMode === QGroundControl.AltitudeModeAbsolute) {
+            _altitudeModeExtraUnits = _altModeAbsoluteExtraUnits
+        } else if (altitudeMode === QGroundControl.AltitudeModeAboveTerrain) {
+            _altitudeModeExtraUnits = _altModeAboveTerrainExtraUnits
+        } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame) {
+            _altitudeModeExtraUnits = _altModeTerrainFrameExtraUnits
+        } else {
+            console.log("AltitudeFactTextField Internal error: Unknown altitudeMode", altitudeMode)
+            _altitudeModeExtraUnits = ""
+        }
+    }
+
+    onAltitudeModeChanged: updateAltitudeModeExtraUnits()
+}

--- a/src/FactSystem/FactControls/qmldir
+++ b/src/FactSystem/FactControls/qmldir
@@ -1,12 +1,13 @@
 Module QGroundControl.FactControls
 
-FactBitmask         1.0 FactBitmask.qml
-FactCheckBox        1.0 FactCheckBox.qml
-FactComboBox        1.0 FactComboBox.qml
-FactLabel           1.0 FactLabel.qml
-FactPanel           1.0 FactPanel.qml
-FactTextField       1.0 FactTextField.qml
-FactTextFieldGrid   1.0 FactTextFieldGrid.qml
-FactTextFieldRow    1.0 FactTextFieldRow.qml
-FactValueSlider     1.0 FactValueSlider.qml
-FactTextFieldSlider 1.0 FactTextFieldSlider.qml
+AltitudeFactTextField   1.0 AltitudeFactTextField.qml
+FactBitmask             1.0 FactBitmask.qml
+FactCheckBox            1.0 FactCheckBox.qml
+FactComboBox            1.0 FactComboBox.qml
+FactLabel               1.0 FactLabel.qml
+FactPanel               1.0 FactPanel.qml
+FactTextField           1.0 FactTextField.qml
+FactTextFieldGrid       1.0 FactTextFieldGrid.qml
+FactTextFieldRow        1.0 FactTextFieldRow.qml
+FactValueSlider         1.0 FactValueSlider.qml
+FactTextFieldSlider     1.0 FactTextFieldSlider.qml

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -226,7 +226,7 @@ void MissionController::_warnIfTerrainFrameUsed(void)
 {
     for (int i=1; i<_visualItems->count(); i++) {
         SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(_visualItems->get(i));
-        if (simpleItem && simpleItem->altitudeMode() == SimpleMissionItem::AltitudeTerrainFrame) {
+        if (simpleItem && simpleItem->altitudeMode() == QGroundControlQmlGlobal::AltitudeModeTerrainFrame) {
             qgcApp()->showMessage(tr("Warning: You are using MAV_FRAME_GLOBAL_TERRAIN_ALT in a mission. %1 does not support sending terrain tiles to vehicle.").arg(qgcApp()->applicationName()));
             break;
         }
@@ -371,7 +371,7 @@ int MissionController::insertSimpleMissionItem(QGeoCoordinate coordinate, int i)
 
         if (_findPreviousAltitude(i, &prevAltitude, &prevAltitudeMode)) {
             newItem->altitude()->setRawValue(prevAltitude);
-            newItem->setAltitudeMode(static_cast<SimpleMissionItem::AltitudeMode>(prevAltitudeMode));
+            newItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltitudeMode>(prevAltitudeMode));
         }
     }
     newItem->setMissionFlightStatus(_missionFlightStatus);
@@ -399,7 +399,7 @@ int MissionController::insertROIMissionItem(QGeoCoordinate coordinate, int i)
 
     if (_findPreviousAltitude(i, &prevAltitude, &prevAltitudeMode)) {
         newItem->altitude()->setRawValue(prevAltitude);
-        newItem->setAltitudeMode(static_cast<SimpleMissionItem::AltitudeMode>(prevAltitudeMode));
+        newItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltitudeMode>(prevAltitudeMode));
     }
     _visualItems->insert(i, newItem);
 

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -56,11 +56,11 @@ SimpleMissionItem::SimpleMissionItem(Vehicle* vehicle, bool flyView, QObject* pa
     , _rawEdit                          (false)
     , _dirty                            (false)
     , _ignoreDirtyChangeSignals         (false)
-    , _speedSection                     (NULL)
-    , _cameraSection                    (NULL)
+    , _speedSection                     (nullptr)
+    , _cameraSection                    (nullptr)
     , _commandTree                      (qgcApp()->toolbox()->missionCommandTree())
     , _supportedCommandFact             (0, "Command:",             FactMetaData::valueTypeUint32)
-    , _altitudeMode                     (AltitudeRelative)
+    , _altitudeMode                     (QGroundControlQmlGlobal::AltitudeModeRelative)
     , _altitudeFact                     (0, "Altitude",             FactMetaData::valueTypeDouble)
     , _amslAltAboveTerrainFact          (0, "Alt above terrain",    FactMetaData::valueTypeDouble)
     , _param1MetaData                   (FactMetaData::valueTypeDouble)
@@ -90,8 +90,8 @@ SimpleMissionItem::SimpleMissionItem(Vehicle* vehicle, bool flyView, const Missi
     , _rawEdit                  (false)
     , _dirty                    (false)
     , _ignoreDirtyChangeSignals (false)
-    , _speedSection             (NULL)
-    , _cameraSection            (NULL)
+    , _speedSection             (nullptr)
+    , _cameraSection            (nullptr)
     , _commandTree              (qgcApp()->toolbox()->missionCommandTree())
     , _supportedCommandFact     (0,         "Command:",             FactMetaData::valueTypeUint32)
     , _altitudeFact             (0,         "Altitude",             FactMetaData::valueTypeDouble)
@@ -108,16 +108,16 @@ SimpleMissionItem::SimpleMissionItem(Vehicle* vehicle, bool flyView, const Missi
     _editorQml = QStringLiteral("qrc:/qml/SimpleItemEditor.qml");
 
     struct MavFrame2AltMode_s {
-        MAV_FRAME       mavFrame;
-        AltitudeMode    altMode;
+        MAV_FRAME                               mavFrame;
+        QGroundControlQmlGlobal::AltitudeMode   altMode;
     };
 
     const struct MavFrame2AltMode_s rgMavFrame2AltMode[] = {
-        { MAV_FRAME_GLOBAL_TERRAIN_ALT,     AltitudeTerrainFrame },
-        { MAV_FRAME_GLOBAL,                 AltitudeAbsolute },
-        { MAV_FRAME_GLOBAL_RELATIVE_ALT,    AltitudeRelative },
+        { MAV_FRAME_GLOBAL_TERRAIN_ALT,     QGroundControlQmlGlobal::AltitudeModeTerrainFrame },
+        { MAV_FRAME_GLOBAL,                 QGroundControlQmlGlobal::AltitudeModeAbsolute },
+        { MAV_FRAME_GLOBAL_RELATIVE_ALT,    QGroundControlQmlGlobal::AltitudeModeRelative },
     };
-    _altitudeMode = AltitudeRelative;
+    _altitudeMode = QGroundControlQmlGlobal::AltitudeModeRelative;
     for (size_t i=0; i<sizeof(rgMavFrame2AltMode)/sizeof(rgMavFrame2AltMode[0]); i++) {
         const MavFrame2AltMode_s& pMavFrame2AltMode = rgMavFrame2AltMode[i];
         if (pMavFrame2AltMode.mavFrame == missionItem.frame()) {
@@ -319,7 +319,7 @@ bool SimpleMissionItem::load(QTextStream &loadStream)
     bool success;
     if ((success = _missionItem.load(loadStream))) {
         if (specifiesCoordinate()) {
-            _altitudeMode = _missionItem.relativeAltitude() ? AltitudeRelative : AltitudeAbsolute;
+            _altitudeMode = _missionItem.relativeAltitude() ? QGroundControlQmlGlobal::AltitudeModeRelative : QGroundControlQmlGlobal::AltitudeModeAbsolute;
             _altitudeFact.setRawValue(_missionItem._param7Fact.rawValue());
             _amslAltAboveTerrainFact.setRawValue(qQNaN());
         }
@@ -345,11 +345,11 @@ bool SimpleMissionItem::load(const QJsonObject& json, int sequenceNumber, QStrin
                 return false;
             }
 
-            _altitudeMode = (AltitudeMode)(int)json[_jsonAltitudeModeKey].toDouble();
+            _altitudeMode = (QGroundControlQmlGlobal::AltitudeMode)(int)json[_jsonAltitudeModeKey].toDouble();
             _altitudeFact.setRawValue(JsonHelper::possibleNaNJsonValue(json[_jsonAltitudeKey]));
             _amslAltAboveTerrainFact.setRawValue(JsonHelper::possibleNaNJsonValue(json[_jsonAltitudeKey]));
         } else {
-            _altitudeMode = _missionItem.relativeAltitude() ? AltitudeRelative : AltitudeAbsolute;
+            _altitudeMode = _missionItem.relativeAltitude() ? QGroundControlQmlGlobal::AltitudeModeRelative : QGroundControlQmlGlobal::AltitudeModeAbsolute;
             _altitudeFact.setRawValue(_missionItem._param7Fact.rawValue());
             _amslAltAboveTerrainFact.setRawValue(qQNaN());
         }
@@ -662,20 +662,20 @@ void SimpleMissionItem::_sendCoordinateChanged(void)
 void SimpleMissionItem::_altitudeModeChanged(void)
 {
     switch (_altitudeMode) {
-    case AltitudeTerrainFrame:
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
         _missionItem.setFrame(MAV_FRAME_GLOBAL_TERRAIN_ALT);
         break;
-    case AltitudeAboveTerrain:
+    case QGroundControlQmlGlobal::AltitudeModeAboveTerrain:
         // Terrain altitudes are Absolute
         _missionItem.setFrame(MAV_FRAME_GLOBAL);
         // Clear any old calculated values
         _missionItem._param7Fact.setRawValue(qQNaN());
         _amslAltAboveTerrainFact.setRawValue(qQNaN());
         break;
-    case AltitudeAbsolute:
+    case QGroundControlQmlGlobal::AltitudeModeAbsolute:
         _missionItem.setFrame(MAV_FRAME_GLOBAL);
         break;
-    case AltitudeRelative:
+    case QGroundControlQmlGlobal::AltitudeModeRelative:
         _missionItem.setFrame(MAV_FRAME_GLOBAL_RELATIVE_ALT);
         break;
     }
@@ -683,7 +683,7 @@ void SimpleMissionItem::_altitudeModeChanged(void)
     // We always call _altitudeChanged to make sure that param7 is always setup correctly on mode change
     _altitudeChanged();
 
-    emit coordinateHasRelativeAltitudeChanged(_altitudeMode == AltitudeRelative);
+    emit coordinateHasRelativeAltitudeChanged(_altitudeMode == QGroundControlQmlGlobal::AltitudeModeRelative);
 }
 
 void SimpleMissionItem::_altitudeChanged(void)
@@ -692,7 +692,7 @@ void SimpleMissionItem::_altitudeChanged(void)
         return;
     }
 
-    if (_altitudeMode == AltitudeAboveTerrain) {
+    if (_altitudeMode == QGroundControlQmlGlobal::AltitudeModeAboveTerrain) {
         _amslAltAboveTerrainFact.setRawValue(qQNaN());
         _terrainAltChanged();
     } else {
@@ -702,7 +702,7 @@ void SimpleMissionItem::_altitudeChanged(void)
 
 void SimpleMissionItem::_terrainAltChanged(void)
 {
-    if (!specifiesAltitude() || _altitudeMode != AltitudeAboveTerrain) {
+    if (!specifiesAltitude() || _altitudeMode != QGroundControlQmlGlobal::AltitudeModeAboveTerrain) {
         // We don't need terrain data
         return;
     }
@@ -744,7 +744,7 @@ void SimpleMissionItem::_setDefaultsForCommand(void)
     }
 
     // Set global defaults first, then if there are param defaults they will get reset
-    _altitudeMode = AltitudeRelative;
+    _altitudeMode = QGroundControlQmlGlobal::AltitudeModeRelative;
     emit altitudeModeChanged();
     _amslAltAboveTerrainFact.setRawValue(qQNaN());
     if (specifiesCoordinate() || isStandaloneCoordinate() || specifiesAltitudeOnly()) {
@@ -967,7 +967,7 @@ void SimpleMissionItem::setMissionFlightStatus(MissionController::MissionFlightS
     }
 }
 
-void SimpleMissionItem::setAltitudeMode(AltitudeMode altitudeMode)
+void SimpleMissionItem::setAltitudeMode(QGroundControlQmlGlobal::AltitudeMode altitudeMode)
 {
     if (altitudeMode != _altitudeMode) {
         _altitudeMode = altitudeMode;

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -678,6 +678,9 @@ void SimpleMissionItem::_altitudeModeChanged(void)
     case QGroundControlQmlGlobal::AltitudeModeRelative:
         _missionItem.setFrame(MAV_FRAME_GLOBAL_RELATIVE_ALT);
         break;
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qWarning() << "Internal Error SimpleMissionItem::_altitudeModeChanged: Invalid altitudeMode == AltitudeModeNone";
+        break;
     }
 
     // We always call _altitudeChanged to make sure that param7 is always setup correctly on mode change

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -16,6 +16,7 @@
 #include "MissionCommandTree.h"
 #include "CameraSection.h"
 #include "SpeedSection.h"
+#include "QGroundControlQmlGlobal.h"
 
 /// A SimpleMissionItem is used to represent a single MissionItem to the ui.
 class SimpleMissionItem : public VisualMissionItem
@@ -29,21 +30,12 @@ public:
 
     ~SimpleMissionItem();
 
-    enum AltitudeMode {
-        AltitudeRelative,       // MAV_FRAME_GLOBAL_RELATIVE_ALT
-        AltitudeAbsolute,       // MAV_FRAME_GLOBAL
-        AltitudeAboveTerrain,   // Absolute altitude above terrain calculated from terrain data
-        AltitudeTerrainFrame    // MAV_FRAME_GLOBAL_TERRAIN_ALT
-    };
-
-    Q_ENUM(AltitudeMode)
-    
     Q_PROPERTY(QString          category                READ category                                           NOTIFY commandChanged)
     Q_PROPERTY(bool             friendlyEditAllowed     READ friendlyEditAllowed                                NOTIFY friendlyEditAllowedChanged)
     Q_PROPERTY(bool             rawEdit                 READ rawEdit                WRITE setRawEdit            NOTIFY rawEditChanged)              ///< true: raw item editing with all params
     Q_PROPERTY(bool             specifiesAltitude       READ specifiesAltitude                                  NOTIFY commandChanged)
     Q_PROPERTY(Fact*            altitude                READ altitude                                           CONSTANT)                           ///< Altitude as specified by altitudeMode. Not necessarily true mission item altitude
-    Q_PROPERTY(AltitudeMode     altitudeMode            READ altitudeMode           WRITE setAltitudeMode       NOTIFY altitudeModeChanged)
+    Q_PROPERTY(QGroundControlQmlGlobal::AltitudeMode altitudeMode READ altitudeMode WRITE setAltitudeMode       NOTIFY altitudeModeChanged)
     Q_PROPERTY(Fact*            amslAltAboveTerrain     READ amslAltAboveTerrain                                CONSTANT)                           ///< Actual AMSL altitude for item if altitudeMode == AltitudeAboveTerrain
     Q_PROPERTY(int              command                 READ command                WRITE setCommand            NOTIFY commandChanged)
     Q_PROPERTY(bool             supportsTerrainFrame    READ supportsTerrainFrame                               NOTIFY supportsTerrainFrameChanged)
@@ -71,7 +63,7 @@ public:
     bool            friendlyEditAllowed (void) const;
     bool            rawEdit             (void) const;
     bool            specifiesAltitude   (void) const;
-    AltitudeMode    altitudeMode        (void) const { return _altitudeMode; }
+    QGroundControlQmlGlobal::AltitudeMode altitudeMode(void) const { return _altitudeMode; }
     Fact*           altitude            (void) { return &_altitudeFact; }
     Fact*           amslAltAboveTerrain (void) { return &_amslAltAboveTerrainFact; }
     bool            supportsTerrainFrame(void) const { return _vehicle->supportsTerrainFrame(); }
@@ -84,7 +76,7 @@ public:
     QmlObjectListModel* comboboxFacts   (void) { return &_comboboxFacts; }
 
     void setRawEdit(bool rawEdit);
-    void setAltitudeMode(AltitudeMode altitudeMode);
+    void setAltitudeMode(QGroundControlQmlGlobal::AltitudeMode altitudeMode);
     
     void setCommandByIndex(int index);
 
@@ -178,9 +170,9 @@ private:
 
     Fact                _supportedCommandFact;
 
-    AltitudeMode    _altitudeMode;
-    Fact            _altitudeFact;
-    Fact            _amslAltAboveTerrainFact;
+    QGroundControlQmlGlobal::AltitudeMode   _altitudeMode;
+    Fact                                    _altitudeFact;
+    Fact                                    _amslAltAboveTerrainFact;
 
     QmlObjectListModel  _textFieldFacts;
     QmlObjectListModel  _nanFacts;

--- a/src/MissionManager/SimpleMissionItemTest.cc
+++ b/src/MissionManager/SimpleMissionItemTest.cc
@@ -52,17 +52,17 @@ const SimpleMissionItemTest::FactValue_t SimpleMissionItemTest::_rgFactValuesDoJ
 
 const SimpleMissionItemTest::ItemExpected_t SimpleMissionItemTest::_rgItemExpected[] = {
     // Text field facts count                                                                                                   Fact Values                                         Altitude    Altitude Mode
-    { sizeof(SimpleMissionItemTest::_rgFactValuesWaypoint)/sizeof(SimpleMissionItemTest::_rgFactValuesWaypoint[0]),             SimpleMissionItemTest::_rgFactValuesWaypoint,       70.1234567, SimpleMissionItem::AltitudeRelative },
-    { sizeof(SimpleMissionItemTest::_rgFactValuesLoiterUnlim)/sizeof(SimpleMissionItemTest::_rgFactValuesLoiterUnlim[0]),       SimpleMissionItemTest::_rgFactValuesLoiterUnlim,    70.1234567, SimpleMissionItem::AltitudeAbsolute },
-    { sizeof(SimpleMissionItemTest::_rgFactValuesLoiterTurns)/sizeof(SimpleMissionItemTest::_rgFactValuesLoiterTurns[0]),       SimpleMissionItemTest::_rgFactValuesLoiterTurns,    70.1234567, SimpleMissionItem::AltitudeRelative },
-    { sizeof(SimpleMissionItemTest::_rgFactValuesLoiterTime)/sizeof(SimpleMissionItemTest::_rgFactValuesLoiterTime[0]),         SimpleMissionItemTest::_rgFactValuesLoiterTime,     70.1234567, SimpleMissionItem::AltitudeAbsolute },
-    { 0,                                                                                                                        NULL,                                               70.1234567, SimpleMissionItem::AltitudeRelative },
-    { sizeof(SimpleMissionItemTest::_rgFactValuesTakeoff)/sizeof(SimpleMissionItemTest::_rgFactValuesTakeoff[0]),               SimpleMissionItemTest::_rgFactValuesTakeoff,        70.1234567, SimpleMissionItem::AltitudeAbsolute },
-    { sizeof(SimpleMissionItemTest::_rgFactValuesDoJump)/sizeof(SimpleMissionItemTest::_rgFactValuesDoJump[0]),                 SimpleMissionItemTest::_rgFactValuesDoJump,         qQNaN(),    SimpleMissionItem::AltitudeRelative },
+    { sizeof(SimpleMissionItemTest::_rgFactValuesWaypoint)/sizeof(SimpleMissionItemTest::_rgFactValuesWaypoint[0]),             SimpleMissionItemTest::_rgFactValuesWaypoint,       70.1234567, QGroundControlQmlGlobal::AltitudeModeRelative },
+    { sizeof(SimpleMissionItemTest::_rgFactValuesLoiterUnlim)/sizeof(SimpleMissionItemTest::_rgFactValuesLoiterUnlim[0]),       SimpleMissionItemTest::_rgFactValuesLoiterUnlim,    70.1234567, QGroundControlQmlGlobal::AltitudeModeAbsolute },
+    { sizeof(SimpleMissionItemTest::_rgFactValuesLoiterTurns)/sizeof(SimpleMissionItemTest::_rgFactValuesLoiterTurns[0]),       SimpleMissionItemTest::_rgFactValuesLoiterTurns,    70.1234567, QGroundControlQmlGlobal::AltitudeModeRelative },
+    { sizeof(SimpleMissionItemTest::_rgFactValuesLoiterTime)/sizeof(SimpleMissionItemTest::_rgFactValuesLoiterTime[0]),         SimpleMissionItemTest::_rgFactValuesLoiterTime,     70.1234567, QGroundControlQmlGlobal::AltitudeModeAbsolute },
+    { 0,                                                                                                                        nullptr,                                               70.1234567, QGroundControlQmlGlobal::AltitudeModeRelative },
+    { sizeof(SimpleMissionItemTest::_rgFactValuesTakeoff)/sizeof(SimpleMissionItemTest::_rgFactValuesTakeoff[0]),               SimpleMissionItemTest::_rgFactValuesTakeoff,        70.1234567, QGroundControlQmlGlobal::AltitudeModeAbsolute },
+    { sizeof(SimpleMissionItemTest::_rgFactValuesDoJump)/sizeof(SimpleMissionItemTest::_rgFactValuesDoJump[0]),                 SimpleMissionItemTest::_rgFactValuesDoJump,         qQNaN(),    QGroundControlQmlGlobal::AltitudeModeRelative },
 };
 
 SimpleMissionItemTest::SimpleMissionItemTest(void)
-    : _simpleItem(NULL)
+    : _simpleItem(nullptr)
 {
     
 }
@@ -131,7 +131,7 @@ void SimpleMissionItemTest::_testEditorFacts(void)
                                 70.1234567,
                                 true,           // autoContinue
                                 false);         // isCurrentItem
-        SimpleMissionItem simpleMissionItem(vehicle, false /* flyView */, missionItem, NULL);
+        SimpleMissionItem simpleMissionItem(vehicle, false /* flyView */, missionItem, nullptr);
 
         // Validate that the fact values are correctly returned
 
@@ -167,7 +167,7 @@ void SimpleMissionItemTest::_testEditorFacts(void)
 
 void SimpleMissionItemTest::_testDefaultValues(void)
 {
-    SimpleMissionItem item(_offlineVehicle, false /* flyView */, NULL);
+    SimpleMissionItem item(_offlineVehicle, false /* flyView */, nullptr);
 
     item.missionItem().setCommand(MAV_CMD_NAV_WAYPOINT);
     item.missionItem().setFrame(MAV_FRAME_GLOBAL_RELATIVE_ALT);
@@ -225,7 +225,7 @@ void SimpleMissionItemTest::_testSignals(void)
     QVERIFY(_spyVisualItem->checkOnlySignalByMask(dirtyChangedMask));
     _spyVisualItem->clearAllSignals();
 
-    _simpleItem->setAltitudeMode(_simpleItem->altitudeMode() == SimpleMissionItem::AltitudeRelative ? SimpleMissionItem::AltitudeAbsolute : SimpleMissionItem::AltitudeRelative);
+    _simpleItem->setAltitudeMode(_simpleItem->altitudeMode() == QGroundControlQmlGlobal::AltitudeModeRelative ? QGroundControlQmlGlobal::AltitudeModeAbsolute : QGroundControlQmlGlobal::AltitudeModeRelative);
     QVERIFY(_spySimpleItem->checkOnlySignalByMask(dirtyChangedMask | friendlyEditAllowedChangedMask | altitudeModeChangedMask | coordinateHasRelativeAltitudeChangedMask));
     _spySimpleItem->clearAllSignals();
     _spyVisualItem->clearAllSignals();
@@ -312,12 +312,12 @@ void SimpleMissionItemTest::_testAltitudePropogation(void)
 {
     // Make sure that changes to altitude propogate to param 7 of the mission item
 
-    _simpleItem->setAltitudeMode(SimpleMissionItem::AltitudeRelative);
+    _simpleItem->setAltitudeMode(QGroundControlQmlGlobal::AltitudeModeRelative);
     _simpleItem->altitude()->setRawValue(_simpleItem->altitude()->rawValue().toDouble() + 1);
     QCOMPARE(_simpleItem->altitude()->rawValue().toDouble(), _simpleItem->missionItem().param7());
     QCOMPARE(_simpleItem->missionItem().frame(), MAV_FRAME_GLOBAL_RELATIVE_ALT);
 
-    _simpleItem->setAltitudeMode(SimpleMissionItem::AltitudeAbsolute);
+    _simpleItem->setAltitudeMode(QGroundControlQmlGlobal::AltitudeModeAbsolute);
     _simpleItem->altitude()->setRawValue(_simpleItem->altitude()->rawValue().toDouble() + 1);
     QCOMPARE(_simpleItem->altitude()->rawValue().toDouble(), _simpleItem->missionItem().param7());
     QCOMPARE(_simpleItem->missionItem().frame(), MAV_FRAME_GLOBAL);

--- a/src/MissionManager/SimpleMissionItemTest.h
+++ b/src/MissionManager/SimpleMissionItemTest.h
@@ -74,7 +74,7 @@ private:
         size_t                          cFactValues;
         const FactValue_t*              rgFactValues;
         double                          altValue;
-        SimpleMissionItem::AltitudeMode altMode;
+        QGroundControlQmlGlobal::AltitudeMode altMode;
     } ItemExpected_t;
 
     SimpleMissionItem*  _simpleItem;

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -18,11 +18,6 @@ Rectangle {
     color:  qgcPal.windowShadeDark
     radius: _radius
 
-    readonly property int _altModeRelative:     0
-    readonly property int _altModeAbsolute:     1
-    readonly property int _altModeAboveTerrain: 2
-    readonly property int _altModeTerrainFrame: 3
-
     property bool _specifiesAltitude:       missionItem.specifiesAltitude
     property real _margin:                  ScreenTools.defaultFontPixelHeight / 2
     property bool _supportsTerrainFrame:    missionItem
@@ -32,32 +27,22 @@ Rectangle {
     property string _altModeAboveTerrainHelpText:   qsTr("Altitude above terrain\nActual AMSL altitude: %1 %2").arg(missionItem.amslAltAboveTerrain.valueString).arg(missionItem.amslAltAboveTerrain.units)
     property string _altModeTerrainFrameHelpText:   qsTr("Using terrain reference frame")
 
-    readonly property string _altModeRelativeExtraUnits:        qsTr(" (Rel)")
-    readonly property string _altModeAbsoluteExtraUnits:        qsTr(" (AMSL)")
-    readonly property string _altModeAboveTerrainExtraUnits:    qsTr(" (Abv Terr)")
-    readonly property string _altModeTerrainFrameExtraUnits:    qsTr(" (TerrF)")
-
     function updateAltitudeModeText() {
-        if (missionItem.altitudeMode === _altModeRelative) {
+        if (missionItem.altitudeMode === QGroundControl.AltitudeModeRelative) {
             altModeLabel.text = qsTr("Altitude")
             altModeHelp.text = _altModeRelativeHelpText
-            altField.extraUnits = _altModeRelativeExtraUnits
-        } else if (missionItem.altitudeMode === _altModeAbsolute) {
+        } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeAbsolute) {
             altModeLabel.text = qsTr("Above Mean Sea Level")
             altModeHelp.text = _altModeAbsoluteHelpText
-            altField.extraUnits = _altModeAbsoluteExtraUnits
-        } else if (missionItem.altitudeMode === _altModeAboveTerrain) {
+        } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeAboveTerrain) {
             altModeLabel.text = qsTr("Above Terrain")
             altModeHelp.text = Qt.binding(function() { return _altModeAboveTerrainHelpText })
-            altField.extraUnits = _altModeAboveTerrainExtraUnits
-        } else if (missionItem.altitudeMode === _altModeTerrainFrame) {
+        } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame) {
             altModeLabel.text = qsTr("Terrain Frame")
             altModeHelp.text = _altModeTerrainFrameHelpText
-            altField.extraUnits = _altModeTerrainFrameExtraUnits
         } else {
             altModeLabel.text = qsTr("Internal Error")
             altModeHelp.text = ""
-            altField.extraUnits = ""
         }
     }
 
@@ -159,44 +144,42 @@ Rectangle {
                         MenuItem {
                             text:           qsTr("Altitude Relative To Home")
                             checkable:      true
-                            checked:        missionItem.altitudeMode === _altModeRelative
-                            onTriggered:    missionItem.altitudeMode = _altModeRelative
+                            checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeRelative
+                            onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeRelative
                         }
 
                         MenuItem {
                             text:           qsTr("Altitude Above Mean Sea Level")
                             checkable:      true
-                            checked:        missionItem.altitudeMode === _altModeAbsolute
+                            checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeAbsolute
                             visible:        QGroundControl.corePlugin.options.showMissionAbsoluteAltitude
-                            onTriggered:    missionItem.altitudeMode = _altModeAbsolute
+                            onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeAbsolute
                         }
 
                         MenuItem {
                             text:           qsTr("Altitude Above Terrain")
                             checkable:      true
-                            checked:        missionItem.altitudeMode === _altModeAboveTerrain
-                            onTriggered:    missionItem.altitudeMode = _altModeAboveTerrain
+                            checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeAboveTerrain
+                            onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeAboveTerrain
                             visible:        missionItem.specifiesCoordinate
                         }
 
                         MenuItem {
                             text:           qsTr("Terrain Frame")
                             checkable:      true
-                            checked:        missionItem.altitudeMode === _altModeTerrainFrame
-                            visible:        missionItem.altitudeMode === _altModeTerrainFrame
-                            onTriggered:    missionItem.altitudeMode = _altModeTerrainFrame
+                            checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame
+                            visible:        missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame
+                            onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeTerrainFrame
                         }
                     }
                 }
 
-                FactTextField {
+                AltitudeFactTextField {
                     id:                 altField
                     fact:               missionItem.altitude
-                    unitsLabel:         fact.units + extraUnits
+                    altitudeMode:       missionItem.altitudeMode
                     anchors.left:       parent.left
                     anchors.right:      parent.right
-
-                    property string extraUnits
                 }
 
                 QGCLabel {

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -43,6 +43,15 @@ public:
     QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox* toolbox);
     ~QGroundControlQmlGlobal();
 
+    enum AltitudeMode {
+        AltitudeModeNone,           // Being used as distance value unrelated to ground (for example distance to structure)
+        AltitudeModeRelative,       // MAV_FRAME_GLOBAL_RELATIVE_ALT
+        AltitudeModeAbsolute,       // MAV_FRAME_GLOBAL
+        AltitudeModeAboveTerrain,   // Absolute altitude above terrain calculated from terrain data
+        AltitudeModeTerrainFrame    // MAV_FRAME_GLOBAL_TERRAIN_ALT
+    };
+    Q_ENUM(AltitudeMode)
+
     Q_PROPERTY(QString              appName             READ appName                CONSTANT)
 
     Q_PROPERTY(LinkManager*         linkManager         READ linkManager            CONSTANT)


### PR DESCRIPTION
This control supports the additional Rel, AMSL, Abv Terr, ... labels for altitude mode. This will then be used in the other places where altitudes are entered: Survey, Corridor Scan and so forth. Those changes will come later though. So for now this results in an internal change only. No user visible change.