### PR TITLE
Taisync Tweaks

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1928,13 +1928,16 @@ void
 QGCCameraControl::_checkForVideoStreams()
 {
     if(_info.flags & CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM) {
-        connect(&_streamInfoTimer, &QTimer::timeout, this, &QGCCameraControl::_streamTimeout);
-        _streamInfoTimer.setSingleShot(false);
-        connect(&_streamStatusTimer, &QTimer::timeout, this, &QGCCameraControl::_streamStatusTimeout);
-        _streamStatusTimer.setSingleShot(true);
-        //-- Request all streams
-        _requestStreamInfo(0);
-        _streamInfoTimer.start(2000);
+        //-- Skip it if using Taisync as it has its own video settings
+        if(!qgcApp()->toolbox()->videoManager()->isTaisync()) {
+            connect(&_streamInfoTimer, &QTimer::timeout, this, &QGCCameraControl::_streamTimeout);
+            _streamInfoTimer.setSingleShot(false);
+            connect(&_streamStatusTimer, &QTimer::timeout, this, &QGCCameraControl::_streamStatusTimeout);
+            _streamStatusTimer.setSingleShot(true);
+            //-- Request all streams
+            _requestStreamInfo(0);
+            _streamInfoTimer.start(2000);
+        }
     }
 }
 

--- a/src/Taisync/TaisyncSettings.qml
+++ b/src/Taisync/TaisyncSettings.qml
@@ -438,7 +438,7 @@ QGCView {
                     height:                     ipSettingsLabel.height
                     anchors.margins:            ScreenTools.defaultFontPixelWidth
                     anchors.horizontalCenter:   parent.horizontalCenter
-                    visible:                    _taisyncEnabled
+                    visible:                    _taisyncEnabled && (!ScreenTools.isiOS && !ScreenTools.isAndroid)
                     QGCLabel {
                         id:                     ipSettingsLabel
                         text:                   qsTr("Network Settings")
@@ -449,7 +449,7 @@ QGCView {
                     height:                     ipSettingsCol.height + (ScreenTools.defaultFontPixelHeight * 2)
                     width:                      _panelWidth
                     color:                      qgcPal.windowShade
-                    visible:                    _taisyncEnabled
+                    visible:                    _taisyncEnabled && (!ScreenTools.isiOS && !ScreenTools.isAndroid)
                     anchors.margins:            ScreenTools.defaultFontPixelWidth
                     anchors.horizontalCenter:   parent.horizontalCenter
                     Column {


### PR DESCRIPTION
* Disable network settings on Android and iOS as they use a different link type (USB).
* Skip video stream auto configure if using Taisync Video (it's inherently "auto configured")