### PR TITLE
Allow custom fact json files for different vehicles

### DIFF
--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -124,6 +124,9 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void):
     }
 
     _nameToFactGroupMap.insert("APMSubInfo", &_infoFactGroup);
+
+    _factRenameMap[QStringLiteral("altitudeRelative")] = QStringLiteral("Depth");
+    _factRenameMap[QStringLiteral("flightTime")] = QStringLiteral("Dive Time");
 }
 
 QList<MAV_CMD> ArduSubFirmwarePlugin::supportedMissionCommands(void)
@@ -309,4 +312,15 @@ QString ArduSubFirmwarePlugin::vehicleImageOpaque(const Vehicle* vehicle) const
 QString ArduSubFirmwarePlugin::vehicleImageOutline(const Vehicle* vehicle) const
 {
     return vehicleImageOpaque(vehicle);
+}
+
+void ArduSubFirmwarePlugin::adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData)
+{
+    Q_UNUSED(vehicleType);
+    if (!metaData) {
+        return;
+    }
+    if (_factRenameMap.contains(metaData->name())) {
+        metaData->setShortDescription(QString(_factRenameMap[metaData->name()]));
+    }
 }

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -127,6 +127,9 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void):
 
     _factRenameMap[QStringLiteral("altitudeRelative")] = QStringLiteral("Depth");
     _factRenameMap[QStringLiteral("flightTime")] = QStringLiteral("Dive Time");
+    _factRenameMap[QStringLiteral("altitudeAMSL")] = QStringLiteral("");
+    _factRenameMap[QStringLiteral("hobbs")] = QStringLiteral("");
+    _factRenameMap[QStringLiteral("airSpeed")] = QStringLiteral("");
 }
 
 QList<MAV_CMD> ArduSubFirmwarePlugin::supportedMissionCommands(void)

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -137,11 +137,13 @@ public:
     const QVariantList& toolBarIndicators(const Vehicle* vehicle) final;
     bool  adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message) final;
     virtual QMap<QString, FactGroup*>* factGroups(void) final;
+    void adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData) override final;
 
 
 private:
     QVariantList _toolBarIndicators;
     static bool _remapParamNameIntialized;
+    QMap<QString, QString> _factRenameMap;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;
     void _handleNamedValueFloat(mavlink_message_t* message);
     void _handleMavlinkMessage(mavlink_message_t* message);

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -309,6 +309,11 @@ public:
     int versionCompare(Vehicle* vehicle, QString& compare);
     int versionCompare(Vehicle* vehicle, int major, int minor, int patch);
 
+    /// Allows the Firmware plugin to override the facts meta data.
+    ///     @param vehicleType - Type of current vehicle
+    ///     @param metaData - MetaData for fact
+    virtual void adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData) {Q_UNUSED(vehicleType); Q_UNUSED(metaData);};
+
     // FIXME: Hack workaround for non pluginize FollowMe support
     static const QString px4FollowMeFlightMode;
 

--- a/src/FlightMap/Widgets/ValuePageWidget.qml
+++ b/src/FlightMap/Widgets/ValuePageWidget.qml
@@ -222,6 +222,7 @@ Column {
 
                     RowLayout {
                         spacing: _margins
+                        visible: factGroup.getFact(modelData).shortDescription !== ""
 
                         property string propertyName: factGroupName + "." + modelData
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -278,6 +278,9 @@ Vehicle::Vehicle(LinkInterface*             link,
     }
 
     _firmwarePlugin->initializeVehicle(this);
+    for(auto& factName: factNames()) {
+        _firmwarePlugin->adjustMetaData(vehicleType, getFact(factName)->metaData());
+    }
 
     _sendMultipleTimer.start(_sendMessageMultipleIntraMessageDelay);
     connect(&_sendMultipleTimer, &QTimer::timeout, this, &Vehicle::_sendMessageMultipleNext);


### PR DESCRIPTION
This enables vehicle-specific fact jsons to take care of things like displaying "depth" instead of altitude and "dive time" instead of "flight time".

Also added headingToGCS fact.