### PR TITLE
Add UDP audio support

### DIFF
--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -59,6 +59,9 @@ VideoManager::setToolbox(QGCToolbox *toolbox)
    QString videoSource = _videoSettings->videoSource()->rawValue().toString();
    connect(_videoSettings->videoSource(),   &Fact::rawValueChanged, this, &VideoManager::_videoSourceChanged);
    connect(_videoSettings->udpPort(),       &Fact::rawValueChanged, this, &VideoManager::_udpPortChanged);
+   connect(_videoSettings->audioVolume(),   &Fact::rawValueChanged, this, &VideoManager::_updateAudioVolume);
+   connect(_videoSettings->audioUdpPort(),  &Fact::rawValueChanged, this, &VideoManager::_updateAudioPipeline);
+   connect(_videoSettings->audioEnabled(),  &Fact::rawValueChanged, this, &VideoManager::_updateAudioPipeline);
    connect(_videoSettings->rtspUrl(),       &Fact::rawValueChanged, this, &VideoManager::_rtspUrlChanged);
    connect(_videoSettings->tcpUrl(),        &Fact::rawValueChanged, this, &VideoManager::_tcpUrlChanged);
    connect(_videoSettings->aspectRatio(),   &Fact::rawValueChanged, this, &VideoManager::_aspectRatioChanged);
@@ -246,6 +249,28 @@ VideoManager::_restartVideo()
     _videoReceiver->stop();
     _updateSettings();
     _videoReceiver->start();
+#endif
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::_updateAudioPipeline()
+{
+#if defined(QGC_GST_STREAMING)
+    if(!_videoReceiver)
+        return;
+    _videoReceiver->updateAudioPipeline();
+#endif
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::_updateAudioVolume()
+{
+#if defined(QGC_GST_STREAMING)
+    if(!_videoReceiver)
+        return;
+    _videoReceiver->setVolume(_videoSettings->audioVolume()->rawValue().toFloat());
 #endif
 }
 

--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -84,6 +84,8 @@ signals:
 private slots:
     void _videoSourceChanged        ();
     void _udpPortChanged            ();
+    void _updateAudioPipeline       ();
+    void _updateAudioVolume         ();
     void _rtspUrlChanged            ();
     void _tcpUrlChanged             ();
     void _updateUVC                 ();

--- a/src/FlightMap/Widgets/VideoPageWidget.qml
+++ b/src/FlightMap/Widgets/VideoPageWidget.qml
@@ -12,6 +12,7 @@ import QtPositioning            5.2
 import QtQuick.Layouts          1.2
 import QtQuick.Controls         2.4
 import QtQuick.Dialogs          1.2
+import QtQuick.Controls.Styles  1.4
 import QtGraphicalEffects       1.0
 
 import QGroundControl                   1.0
@@ -36,6 +37,7 @@ Item {
     property bool   _recordingVideo:        _videoReceiver && _videoReceiver.recording
     property bool   _videoRunning:          _videoReceiver && _videoReceiver.videoRunning
     property bool   _streamingEnabled:      QGroundControl.settingsManager.videoSettings.streamConfigured
+    property bool   _audioEnabled:          QGroundControl.settingsManager.videoSettings.audioEnabled.rawValue
 
     QGCPalette { id:qgcPal; colorGroupEnabled: true }
 
@@ -70,6 +72,43 @@ Item {
                     QGroundControl.settingsManager.videoSettings.streamEnabled.rawValue = 0
                     _videoReceiver.stop()
                 }
+            }
+        }
+        // Control Audio Volume
+        QGCLabel {
+           text:            qsTr("Volume")
+           font.pointSize:  ScreenTools.smallFontPointSize
+           visible:         _audioEnabled
+        }
+        QGCSlider {
+            id:                             volumeSlider
+            visible:                        _audioEnabled
+            property Fact _volume:          QGroundControl.settingsManager.videoSettings.audioVolume
+            stepSize:                       _volume.increment ? _volume.increment : 0.05
+            property bool _loadComplete:    false
+
+            // Override style to make handles smaller than default
+            style: SliderStyle {
+                handle: Rectangle {
+                    anchors.centerIn:   parent
+                    color:              qgcPal.button
+                    border.color:       qgcPal.buttonText
+                    border.width:       1
+                    implicitWidth:      _radius * 2
+                    implicitHeight:     _radius * 2
+                    radius:             _radius
+
+                    property real _radius: Math.round(ScreenTools.defaultFontPixelHeight * 0.35)
+                }
+            }
+            onValueChanged: {
+                if (_loadComplete) {
+                    _volume.value = value
+                }
+            }
+            Component.onCompleted: {
+                volumeSlider.value = volumeSlider._volume.value
+                volumeSlider._loadComplete = true
             }
         }
         // Grid Lines

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -15,6 +15,30 @@
     "defaultValue":     5600
 },
 {
+    "name":             "audioEnabled",
+    "shortDescription": "Audio Stream Enabled",
+    "longDescription":  "This enables or disables receiving an audio stream.",
+    "type":             "bool",
+    "defaultValue":     true
+},
+{
+    "name":             "audioUdpPort",
+    "shortDescription": "Audio UDP Port",
+    "longDescription":  "UDP port to bind to for audio stream.",
+    "type":             "uint16",
+    "min":              1025,
+    "defaultValue":     5601
+},
+{
+    "name":             "audioVolume",
+    "shortDescription": "Audio Stream Volume",
+    "longDescription":  "Volume level for audio stream.",
+    "type":             "float",
+    "min":              0,
+    "max":              1,
+    "defaultValue":     1
+},
+{
     "name":             "rtspUrl",
     "shortDescription": "Video RTSP Url",
     "longDescription":  "RTSP url address and port to bind to for video stream. Example: rtsp://192.168.42.1:554/live",

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -81,6 +81,7 @@ DECLARE_SETTINGSFACT(VideoSettings, enableStorageLimit)
 DECLARE_SETTINGSFACT(VideoSettings, rtspTimeout)
 DECLARE_SETTINGSFACT(VideoSettings, streamEnabled)
 DECLARE_SETTINGSFACT(VideoSettings, disableWhenDisarmed)
+DECLARE_SETTINGSFACT(VideoSettings, audioEnabled)
 
 DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, videoSource)
 {
@@ -106,6 +107,24 @@ DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, udpPort)
         connect(_udpPortFact, &Fact::valueChanged, this, &VideoSettings::_configChanged);
     }
     return _udpPortFact;
+}
+
+DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, audioVolume)
+{
+    if (!_audioVolumeFact) {
+        _audioVolumeFact = _createSettingsFact(audioVolumeName);
+        connect(_audioVolumeFact, &Fact::valueChanged, this, &VideoSettings::_configChanged);
+    }
+    return _audioVolumeFact;
+}
+
+DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, audioUdpPort)
+{
+    if (!_audioUdpPortFact) {
+        _audioUdpPortFact = _createSettingsFact(audioUdpPortName);
+        connect(_audioUdpPortFact, &Fact::valueChanged, this, &VideoSettings::_configChanged);
+    }
+    return _audioUdpPortFact;
 }
 
 DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, rtspUrl)

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -22,6 +22,9 @@ public:
 
     DEFINE_SETTINGFACT(videoSource)
     DEFINE_SETTINGFACT(udpPort)
+    DEFINE_SETTINGFACT(audioEnabled)
+    DEFINE_SETTINGFACT(audioUdpPort)
+    DEFINE_SETTINGFACT(audioVolume)
     DEFINE_SETTINGFACT(tcpUrl)
     DEFINE_SETTINGFACT(rtspUrl)
     DEFINE_SETTINGFACT(aspectRatio)

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -779,6 +779,28 @@ QGCView {
                             }
 
                             QGCLabel {
+                                text:                   qsTr("Enable Audio")
+                                visible:                _videoSettings.audioEnabled.visible
+                            }
+                            FactCheckBox {
+                                text:                   ""
+                                fact:                   _videoSettings.audioEnabled
+                                visible:                _videoSettings.audioEnabled.visible
+                            }
+
+                            QGCLabel {
+                                text:                   qsTr("Audio UDP Port")
+                                visible:                _videoSettings.audioEnabled.rawValue
+                                                        && _videoSettings.audioUdpPort.visible
+                            }
+                            FactTextField {
+                                Layout.preferredWidth:  _comboFieldWidth
+                                fact:                   _videoSettings.audioUdpPort
+                                visible:                _videoSettings.audioEnabled.rawValue
+                                                        && _videoSettings.audioUdpPort.visible
+                            }
+
+                            QGCLabel {
                                 text:                   qsTr("Disable When Disarmed")
                                 visible:                _isGst && QGroundControl.settingsManager.videoSettings.disableWhenDisarmed.visible
                             }

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -31,6 +31,7 @@ QGCView {
     anchors.fill:       parent
     anchors.margins:    ScreenTools.defaultFontPixelWidth
 
+    property var  _videoSettings:               QGroundControl.settingsManager.videoSettings
     property Fact _percentRemainingAnnounce:    QGroundControl.settingsManager.appSettings.batteryPercentRemainingAnnounce
     property Fact _savePath:                    QGroundControl.settingsManager.appSettings.savePath
     property Fact _appFontPointSize:            QGroundControl.settingsManager.appSettings.appFontPointSize
@@ -45,12 +46,12 @@ QGCView {
     property real _panelWidth:                  _qgcView.width * _internalWidthRatio
     property real _margins:                     ScreenTools.defaultFontPixelWidth
 
-    property string _videoSource:               QGroundControl.settingsManager.videoSettings.videoSource.value
+    property string _videoSource:               _videoSettings.videoSource.value
     property bool   _isGst:                     QGroundControl.videoManager.isGStreamer
-    property bool   _isUDP:                     _isGst && _videoSource === QGroundControl.settingsManager.videoSettings.udpVideoSource
-    property bool   _isRTSP:                    _isGst && _videoSource === QGroundControl.settingsManager.videoSettings.rtspVideoSource
-    property bool   _isTCP:                     _isGst && _videoSource === QGroundControl.settingsManager.videoSettings.tcpVideoSource
-    property bool   _isMPEGTS:                  _isGst && _videoSource === QGroundControl.settingsManager.videoSettings.mpegtsVideoSource
+    property bool   _isUDP:                     _isGst && _videoSource === _videoSettings.udpVideoSource
+    property bool   _isRTSP:                    _isGst && _videoSource === _videoSettings.rtspVideoSource
+    property bool   _isTCP:                     _isGst && _videoSource === _videoSettings.tcpVideoSource
+    property bool   _isMPEGTS:                  _isGst && _videoSource === _videoSettings.mpegtsVideoSource
 
     property string gpsDisabled: "Disabled"
     property string gpsUdpPort:  "UDP Port"
@@ -710,7 +711,7 @@ QGCView {
                     QGCLabel {
                         id:         videoSectionLabel
                         text:       qsTr("Video")
-                        visible:    QGroundControl.settingsManager.videoSettings.visible && !QGroundControl.videoManager.autoStreamConfigured
+                        visible:    _videoSettings.visible && !QGroundControl.videoManager.autoStreamConfigured
                     }
                     Rectangle {
                         Layout.preferredWidth:  videoGrid.width + (_margins * 2)
@@ -729,53 +730,53 @@ QGCView {
                             columns:                    2
                             QGCLabel {
                                 text:                   qsTr("Video Source")
-                                visible:                QGroundControl.settingsManager.videoSettings.videoSource.visible
+                                visible:                _videoSettings.videoSource.visible
                             }
                             FactComboBox {
                                 id:                     videoSource
                                 Layout.preferredWidth:  _comboFieldWidth
                                 indexModel:             false
-                                fact:                   QGroundControl.settingsManager.videoSettings.videoSource
-                                visible:                QGroundControl.settingsManager.videoSettings.videoSource.visible
+                                fact:                   _videoSettings.videoSource
+                                visible:                _videoSettings.videoSource.visible
                             }
 
                             QGCLabel {
                                 text:                   qsTr("UDP Port")
-                                visible:                (_isUDP || _isMPEGTS)  && QGroundControl.settingsManager.videoSettings.udpPort.visible
+                                visible:                (_isUDP || _isMPEGTS)  && _videoSettings.udpPort.visible
                             }
                             FactTextField {
                                 Layout.preferredWidth:  _comboFieldWidth
-                                fact:                   QGroundControl.settingsManager.videoSettings.udpPort
-                                visible:                (_isUDP || _isMPEGTS) && QGroundControl.settingsManager.videoSettings.udpPort.visible
+                                fact:                   _videoSettings.udpPort
+                                visible:                (_isUDP || _isMPEGTS) && _videoSettings.udpPort.visible
                             }
 
                             QGCLabel {
                                 text:                   qsTr("RTSP URL")
-                                visible:                _isRTSP && QGroundControl.settingsManager.videoSettings.rtspUrl.visible
+                                visible:                _isRTSP && _videoSettings.rtspUrl.visible
                             }
                             FactTextField {
                                 Layout.preferredWidth:  _comboFieldWidth
-                                fact:                   QGroundControl.settingsManager.videoSettings.rtspUrl
-                                visible:                _isRTSP && QGroundControl.settingsManager.videoSettings.rtspUrl.visible
+                                fact:                   _videoSettings.rtspUrl
+                                visible:                _isRTSP && _videoSettings.rtspUrl.visible
                             }
 
                             QGCLabel {
                                 text:                   qsTr("TCP URL")
-                                visible:                _isTCP && QGroundControl.settingsManager.videoSettings.tcpUrl.visible
+                                visible:                _isTCP && _videoSettings.tcpUrl.visible
                             }
                             FactTextField {
                                 Layout.preferredWidth:  _comboFieldWidth
-                                fact:                   QGroundControl.settingsManager.videoSettings.tcpUrl
-                                visible:                _isTCP && QGroundControl.settingsManager.videoSettings.tcpUrl.visible
+                                fact:                   _videoSettings.tcpUrl
+                                visible:                _isTCP && _videoSettings.tcpUrl.visible
                             }
                             QGCLabel {
                                 text:                   qsTr("Aspect Ratio")
-                                visible:                _isGst && QGroundControl.settingsManager.videoSettings.aspectRatio.visible
+                                visible:                _isGst && _videoSettings.aspectRatio.visible
                             }
                             FactTextField {
                                 Layout.preferredWidth:  _comboFieldWidth
-                                fact:                   QGroundControl.settingsManager.videoSettings.aspectRatio
-                                visible:                _isGst && QGroundControl.settingsManager.videoSettings.aspectRatio.visible
+                                fact:                   _videoSettings.aspectRatio
+                                visible:                _isGst && _videoSettings.aspectRatio.visible
                             }
 
                             QGCLabel {
@@ -802,12 +803,12 @@ QGCView {
 
                             QGCLabel {
                                 text:                   qsTr("Disable When Disarmed")
-                                visible:                _isGst && QGroundControl.settingsManager.videoSettings.disableWhenDisarmed.visible
+                                visible:                _isGst && _videoSettings.disableWhenDisarmed.visible
                             }
                             FactCheckBox {
                                 text:                   ""
-                                fact:                   QGroundControl.settingsManager.videoSettings.disableWhenDisarmed
-                                visible:                _isGst && QGroundControl.settingsManager.videoSettings.disableWhenDisarmed.visible
+                                fact:                   _videoSettings.disableWhenDisarmed
+                                visible:                _isGst && _videoSettings.disableWhenDisarmed.visible
                             }
                         }
                     }
@@ -817,7 +818,7 @@ QGCView {
                     QGCLabel {
                         id:                             videoRecSectionLabel
                         text:                           qsTr("Video Recording")
-                        visible:                        (QGroundControl.settingsManager.videoSettings.visible && _isGst) || QGroundControl.videoManager.autoStreamConfigured
+                        visible:                        (_videoSettings.visible && _isGst) || QGroundControl.videoManager.autoStreamConfigured
                     }
                     Rectangle {
                         Layout.preferredWidth:          videoRecCol.width  + (_margins * 2)
@@ -836,32 +837,32 @@ QGCView {
 
                             QGCLabel {
                                 text:                   qsTr("Auto-Delete Files")
-                                visible:                QGroundControl.settingsManager.videoSettings.enableStorageLimit.visible
+                                visible:                _videoSettings.enableStorageLimit.visible
                             }
                             FactCheckBox {
                                 text:                   ""
-                                fact:                   QGroundControl.settingsManager.videoSettings.enableStorageLimit
-                                visible:                QGroundControl.settingsManager.videoSettings.enableStorageLimit.visible
+                                fact:                   _videoSettings.enableStorageLimit
+                                visible:                _videoSettings.enableStorageLimit.visible
                             }
 
                             QGCLabel {
                                 text:                   qsTr("Max Storage Usage")
-                                visible:                QGroundControl.settingsManager.videoSettings.maxVideoSize.visible && QGroundControl.settingsManager.videoSettings.enableStorageLimit.value
+                                visible:                _videoSettings.maxVideoSize.visible && _videoSettings.enableStorageLimit.value
                             }
                             FactTextField {
                                 Layout.preferredWidth:  _comboFieldWidth
-                                fact:                   QGroundControl.settingsManager.videoSettings.maxVideoSize
-                                visible:                QGroundControl.settingsManager.videoSettings.maxVideoSize.visible && QGroundControl.settingsManager.videoSettings.enableStorageLimit.value
+                                fact:                   _videoSettings.maxVideoSize
+                                visible:                _videoSettings.maxVideoSize.visible && _videoSettings.enableStorageLimit.value
                             }
 
                             QGCLabel {
                                 text:                   qsTr("Video File Format")
-                                visible:                QGroundControl.settingsManager.videoSettings.recordingFormat.visible
+                                visible:                _videoSettings.recordingFormat.visible
                             }
                             FactComboBox {
                                 Layout.preferredWidth:  _comboFieldWidth
-                                fact:                   QGroundControl.settingsManager.videoSettings.recordingFormat
-                                visible:                QGroundControl.settingsManager.videoSettings.recordingFormat.visible
+                                fact:                   _videoSettings.recordingFormat
+                                visible:                _videoSettings.recordingFormat.visible
                             }
                         }
                     }


### PR DESCRIPTION
This enables QGC to receive and playback audio via an UDP port. Having an audio stream improves the video experience and is an extra feedback channel for the pilot to better understand what is going on with the vehicle and surroundings.

It adds an audio pipeline with adjustable volume, settings for it, and qml interface to adjust volume.

![audio1](https://user-images.githubusercontent.com/4013804/51703498-9a742280-1ffd-11e9-96b7-85ca53091242.gif)

![audio2](https://user-images.githubusercontent.com/4013804/51703502-9cd67c80-1ffd-11e9-82ee-e863943414a4.gif)

It can be tested with this gstreamer pipeline:
`gst-launch-1.0 -v -e audiotestsrc ! audioconvert ! rtpL16pay ! udpsink host=192.168.15.2 port=5601`

