### PR TITLE
VideoStreaming: Check for gstreamer in pkg-config in mac

### DIFF
--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -37,6 +37,13 @@ LinuxBuild {
         CONFIG      += VideoEnabled
         INCLUDEPATH += $$GST_ROOT/Headers
         LIBS        += -F/Library/Frameworks -framework GStreamer
+    } else {
+        CONFIG      += link_pkgconfig
+        packagesExist(gstreamer-1.0) {
+            #- gstremaer framework in pkg-config
+            CONFIG    += VideoEnabled
+            PKGCONFIG += gstreamer-1.0 gstreamer-video-1.0
+        }
     }
 } else:iOSBuild {
     #- gstreamer framework installed by the gstreamer iOS SDK installer (default to home directory)


### PR DESCRIPTION
Use pkg-config to find for gstreamer installation 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>
