### PR TITLE
QGCExternalLibs: Test Qt version before adding AirMap

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -153,20 +153,22 @@ contains (DEFINES, DISABLE_AIRMAP) {
     message("Skipping support for AirMap (manual override from user_config.pri)")
 } else {
     AIRMAPD_PATH = $$PWD/libs/airmapd
-    MacBuild {
-        exists($${AIRMAPD_PATH}/macOS/Qt.5.11.0) {
-            message("Including support for AirMap for macOS")
-            LIBS += -L$${AIRMAPD_PATH}/macOS/Qt.5.11.0 -lairmap-qt
-            DEFINES += QGC_AIRMAP_ENABLED
+    contains(QT_VERSION, ˆ5\\.11\..*) {
+        MacBuild {
+            exists($${AIRMAPD_PATH}/macOS/Qt.5.11.0) {
+                message("Including support for AirMap for macOS")
+                LIBS += -L$${AIRMAPD_PATH}/macOS/Qt.5.11.0 -lairmap-qt
+                DEFINES += QGC_AIRMAP_ENABLED
+            }
+        } else:LinuxBuild {
+            exists($${AIRMAPD_PATH}/linux/Qt.5.11.0) {
+                message("Including support for AirMap for Linux")
+                LIBS += -L$${AIRMAPD_PATH}/linux/Qt.5.11.0 -lairmap-qt
+                DEFINES += QGC_AIRMAP_ENABLED
+            }
+        } else {
+            message("Skipping support for Airmap (unsupported platform)")
         }
-    } else:LinuxBuild {
-        exists($${AIRMAPD_PATH}/linux/Qt.5.11.0) {
-            message("Including support for AirMap for Linux")
-            LIBS += -L$${AIRMAPD_PATH}/linux/Qt.5.11.0 -lairmap-qt
-            DEFINES += QGC_AIRMAP_ENABLED
-        }
-    } else {
-        message("Skipping support for Airmap (unsupported platform)")
     }
     contains (DEFINES, QGC_AIRMAP_ENABLED) {
         INCLUDEPATH += \


### PR DESCRIPTION
This is necessary to avoid problems with others Qt versions. 