### PR TITLE
Expose Common (camera) Parameters

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -61,13 +61,13 @@ static const char* kPhotoLapseCount = "PhotoLapseCount";
 
 //-----------------------------------------------------------------------------
 // Known Parameters
-static const char *kCAM_EV          = "CAM_EV";
-static const char *kCAM_EXPMODE     = "CAM_EXPMODE";
-static const char *kCAM_ISO         = "CAM_ISO";
-static const char* kCAM_SHUTTER     = "CAM_SHUTTER";
-static const char* kCAM_APERTURE    = "CAM_APERTURE";
-static const char* kCAM_WBMODE      = "CAM_WBMODE";
-static const char* kCAM_MODE        = "CAM_MODE";
+const char* QGCCameraControl::kCAM_EV          = "CAM_EV";
+const char* QGCCameraControl::kCAM_EXPMODE     = "CAM_EXPMODE";
+const char* QGCCameraControl::kCAM_ISO         = "CAM_ISO";
+const char* QGCCameraControl::kCAM_SHUTTERSPD  = "CAM_SHUTTERSPD";
+const char* QGCCameraControl::kCAM_APERTURE    = "CAM_APERTURE";
+const char* QGCCameraControl::kCAM_WBMODE      = "CAM_WBMODE";
+const char* QGCCameraControl::kCAM_MODE        = "CAM_MODE";
 
 //-----------------------------------------------------------------------------
 QGCCameraOptionExclusion::QGCCameraOptionExclusion(QObject* parent, QString param_, QString value_, QStringList exclusions_)
@@ -1990,9 +1990,9 @@ QGCCameraControl::iso()
 
 //-----------------------------------------------------------------------------
 Fact*
-QGCCameraControl::shutter()
+QGCCameraControl::shutterSpeed()
 {
-    return (_paramComplete && _activeSettings.contains(kCAM_SHUTTER)) ? getFact(kCAM_SHUTTER) : nullptr;
+    return (_paramComplete && _activeSettings.contains(kCAM_SHUTTERSPD)) ? getFact(kCAM_SHUTTERSPD) : nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -144,7 +144,7 @@ public:
     Q_PROPERTY(Fact*        exposureMode        READ exposureMode       NOTIFY parametersReady)
     Q_PROPERTY(Fact*        ev                  READ ev                 NOTIFY parametersReady)
     Q_PROPERTY(Fact*        iso                 READ iso                NOTIFY parametersReady)
-    Q_PROPERTY(Fact*        shutter             READ shutter            NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        shutterSpeed        READ shutterSpeed       NOTIFY parametersReady)
     Q_PROPERTY(Fact*        aperture            READ aperture           NOTIFY parametersReady)
     Q_PROPERTY(Fact*        wb                  READ wb                 NOTIFY parametersReady)
     Q_PROPERTY(Fact*        mode                READ mode               NOTIFY parametersReady)
@@ -222,7 +222,7 @@ public:
     virtual Fact*       exposureMode        ();
     virtual Fact*       ev                  ();
     virtual Fact*       iso                 ();
-    virtual Fact*       shutter             ();
+    virtual Fact*       shutterSpeed        ();
     virtual Fact*       aperture            ();
     virtual Fact*       wb                  ();
     virtual Fact*       mode                ();
@@ -248,6 +248,16 @@ public:
     virtual bool        incomingParameter   (Fact* pFact, QVariant& newValue);
     //-- Allow controller to modify or invalidate parameter change
     virtual bool        validateParameter   (Fact* pFact, QVariant& newValue);
+
+
+    // Known Parameters
+    static const char* kCAM_EV;
+    static const char* kCAM_EXPMODE;
+    static const char* kCAM_ISO;
+    static const char* kCAM_SHUTTERSPD;
+    static const char* kCAM_APERTURE;
+    static const char* kCAM_WBMODE;
+    static const char* kCAM_MODE;
 
 signals:
     void    infoChanged                     ();

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -81,6 +81,7 @@ protected:
         bool    infoReceived = false;
         bool    gaveUp       = false;
         int     tryCount     = 0;
+        uint8_t compID       = 0;
     };
 
     Vehicle*            _vehicle            = nullptr;
@@ -93,5 +94,5 @@ protected:
     QTime               _lastZoomChange;
     QTime               _lastCameraChange;
     QTimer              _cameraTimer;
-    QMap<int, CameraStruct*> _cameraInfoRequest;
+    QMap<QString, CameraStruct*> _cameraInfoRequest;
 };


### PR DESCRIPTION
Expose common parameter names so derived classes can use them.

I've also changed the QMap used for handling camera connections. It went from:
```c++
QMap<int, CameraStruct*> _cameraInfoRequest;
```
To:
```c++
QMap<QString, CameraStruct*> _cameraInfoRequest;
```

The reason was that if you were to:
```c++
int compID = 100;
_cameraInfoRequest[compID] = new CameraStruct();
```
It would create a list with 101 items (and assign the pointer to the 101st element)

Now if you instead use:
```c++
QString compID = "100";
_cameraInfoRequest[compID] = new CameraStruct();
```

It properly creates one single entry in the QMap.