### PR TITLE
QGCMapPolygon: Preserve clockwise winding when adjusting vertices

### DIFF
--- a/src/KMLFileHelper.cc
+++ b/src/KMLFileHelper.cc
@@ -100,7 +100,7 @@ bool KMLFileHelper::loadPolygonFromFile(const QString& kmlFile, QList<QGeoCoordi
         rgCoords.append(coord);
     }
 
-    // Determine winding, reverse if needed
+    // Determine winding, reverse if needed. QGC wants clockwise winding
     double sum = 0;
     for (int i=0; i<rgCoords.count(); i++) {
         QGeoCoordinate coord1 = rgCoords[i];

--- a/src/MissionManager/QGCMapPolygon.cc
+++ b/src/MissionManager/QGCMapPolygon.cc
@@ -94,7 +94,7 @@ void QGCMapPolygon::adjustVertex(int vertexIndex, const QGeoCoordinate coordinat
     _polygonPath[vertexIndex] = QVariant::fromValue(coordinate);
     _polygonModel.value<QGCQGeoCoordinate*>(vertexIndex)->setCoordinate(coordinate);
     if (!_centerDrag) {
-        // When dragging center we don't signal path changed until add vertices are updated
+        // When dragging center we don't signal path changed until all vertices are updated
         emit pathChanged();
     }
     setDirty(true);
@@ -340,7 +340,7 @@ void QGCMapPolygon::setCenter(QGeoCoordinate newCenter)
         }
 
         if (_centerDrag) {
-            // When center dragging signals are delayed until all vertices are updated
+            // When center dragging, signals from adjustVertext are not sent. So we need to signal here when all adjusting is complete.
             emit pathChanged();
         }
 
@@ -485,4 +485,31 @@ double QGCMapPolygon::area(void) const
         }
     }
     return 0.5 * fabs(coveredArea);
+}
+
+void QGCMapPolygon::verifyClockwiseWinding(void)
+{
+    if (_polygonPath.count() <= 2) {
+        return;
+    }
+
+    double sum = 0;
+    for (int i=0; i<_polygonPath.count(); i++) {
+        QGeoCoordinate coord1 = _polygonPath[i].value<QGeoCoordinate>();
+        QGeoCoordinate coord2 = (i == _polygonPath.count() - 1) ? _polygonPath[0].value<QGeoCoordinate>() : _polygonPath[i+1].value<QGeoCoordinate>();
+
+        sum += (coord2.longitude() - coord1.longitude()) * (coord2.latitude() + coord1.latitude());
+    }
+
+    if (sum < 0.0) {
+        // Winding is counter-clockwise and needs reversal
+
+        QList<QGeoCoordinate> rgReversed;
+        for (const QVariant& varCoord: _polygonPath) {
+            rgReversed.prepend(varCoord.value<QGeoCoordinate>());
+        }
+
+        clear();
+        appendVertices(rgReversed);
+    }
 }

--- a/src/MissionManager/QGCMapPolygon.h
+++ b/src/MissionManager/QGCMapPolygon.h
@@ -66,6 +66,9 @@ public:
     /// Returns the QGeoCoordinate for the vertex specified
     Q_INVOKABLE QGeoCoordinate vertexCoordinate(int vertex) const;
 
+    /// Adjust polygon winding order to be clockwise (if needed)
+    Q_INVOKABLE void verifyClockwiseWinding(void);
+
     /// Saves the polygon to the json object.
     ///     @param json Json object to save to
     void saveToJson(QJsonObject& json);

--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -344,6 +344,7 @@ Item {
             mapControl: _root.mapControl
             z:          _zorderDragHandle
             visible:    !_circle
+            onDragStop: mapPolygon.verifyClockwiseWinding()
 
             property int polygonVertex
 
@@ -466,7 +467,10 @@ Item {
 
         EditPositionDialog {
             coordinate:             mapPolygon.vertexCoordinate(menu._editingVertexIndex)
-            onCoordinateChanged:    mapPolygon.adjustVertex(menu._editingVertexIndex, coordinate)
+            onCoordinateChanged: {
+                mapPolygon.adjustVertex(menu._editingVertexIndex, coordinate)
+                mapPolygon.verifyClockwiseWinding()
+            }
         }
     }
 


### PR DESCRIPTION
QGC expects all polygons to have clockwise winding.