### PR TITLE
Fix default option for UDP NMEA Device

### DIFF
--- a/src/Settings/AutoConnect.SettingsGroup.json
+++ b/src/Settings/AutoConnect.SettingsGroup.json
@@ -46,7 +46,7 @@
     "shortDescription": "NMEA GPS device for GCS position",
     "longDescription":  "NMEA GPS device for GCS position",
     "type":             "string",
-    "defaultValue":     "disabled"
+    "defaultValue":     "Disabled"
 },
 {
     "name":             "autoConnectNmeaBaud",


### PR DESCRIPTION
With clean settings, QGC is defaulting to lower-case "disabled", when it should be "Disabled" (an option in the combo box) instead.

Before:
![screenshot from 2019-01-30 12-37-20](https://user-images.githubusercontent.com/4013804/52079206-36f97000-257c-11e9-9346-0747b4a494e5.png)

After:
![screenshot from 2019-01-31 17-19-07](https://user-images.githubusercontent.com/4013804/52079265-585a5c00-257c-11e9-9a5d-5f450baf8603.png)
