### PR TITLE
Survey: Fix Survey additionalTimeDelay as it relates to hover and capture

### DIFF
--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -44,10 +44,6 @@ public:
     /// This mission item attribute specifies the type of the complex item.
     static const char* jsonComplexItemTypeKey;
 
-    // Overrides from VisualMissionItem
-    double additionalTimeDelay(void) const final { return 0; }
-
-
 signals:
     void complexDistanceChanged     (void);
     void boundingCubeChanged        (void);

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -52,6 +52,7 @@ public:
     QString commandName         (void) const final { return tr("Corridor Scan"); }
     QString abbreviation        (void) const final { return tr("C"); }
     bool    readyForSave        (void) const;
+    double  additionalTimeDelay (void) const final { return 0; }
 
     static const char* jsonComplexItemTypeValue;
 

--- a/src/MissionManager/FixedWingLandingComplexItem.h
+++ b/src/MissionManager/FixedWingLandingComplexItem.h
@@ -91,6 +91,7 @@ public:
     double          specifiedGimbalPitch    (void) final { return std::numeric_limits<double>::quiet_NaN(); }
     void            appendMissionItems      (QList<MissionItem*>& items, QObject* missionItemParent) final;
     void            applyNewAltitude        (double newAltitude) final;
+    double          additionalTimeDelay     (void) const final { return 0; }
 
     bool coordinateHasRelativeAltitude      (void) const final { return _altitudesAreRelative; }
     bool exitCoordinateHasRelativeAltitude  (void) const final { return _altitudesAreRelative; }

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -77,6 +77,7 @@ public:
     void            appendMissionItems      (QList<MissionItem*>& items, QObject* missionItemParent) final;
     void            applyNewAltitude        (double newAltitude) final { Q_UNUSED(newAltitude); /* no action */ }
     double          specifiedFlightSpeed    (void) final;
+    double          additionalTimeDelay     (void) const final { return 0; }
 
     bool coordinateHasRelativeAltitude      (void) const final { return false; }
     bool exitCoordinateHasRelativeAltitude  (void) const final { return false; }

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -84,6 +84,7 @@ public:
     void            appendMissionItems      (QList<MissionItem*>& items, QObject* missionItemParent) final;
     void            setMissionFlightStatus  (MissionController::MissionFlightStatus_t& missionFlightStatus) final;
     void            applyNewAltitude        (double newAltitude) final;
+    double          additionalTimeDelay     (void) const final { return 0; }
 
     bool coordinateHasRelativeAltitude      (void) const final { return _altitudeRelative; }
     bool exitCoordinateHasRelativeAltitude  (void) const final { return _altitudeRelative; }

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1476,3 +1476,16 @@ double SurveyComplexItem::timeBetweenShots(void)
 {
     return _cruiseSpeed == 0 ? 0 : triggerDistance() / _cruiseSpeed;
 }
+
+double SurveyComplexItem::additionalTimeDelay (void) const
+{
+    double hoverTime = 0;
+
+    if (hoverAndCaptureEnabled()) {
+        for (const QList<TransectStyleComplexItem::CoordInfo_t>& transect: _transects) {
+            hoverTime += _hoverAndCaptureDelaySeconds * transect.count();
+        }
+    }
+
+    return hoverTime;
+}

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -52,6 +52,7 @@ public:
     QString commandName         (void) const final { return tr("Survey"); }
     QString abbreviation        (void) const final { return tr("S"); }
     bool    readyForSave        (void) const final;
+    double  additionalTimeDelay (void) const final;
 
     // Must match json spec for GridEntryLocation
     enum EntryLocation {

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -398,6 +398,7 @@ void TransectStyleComplexItem::_rebuildTransects(void)
 
     emit lastSequenceNumberChanged(lastSequenceNumber());
     emit timeBetweenShotsChanged();
+    emit additionalTimeDelayChanged();
 }
 
 void TransectStyleComplexItem::_queryTransectsPathHeightInfo(void)

--- a/src/MissionManager/TransectStyleComplexItemTest.h
+++ b/src/MissionManager/TransectStyleComplexItemTest.h
@@ -94,6 +94,7 @@ public:
     bool    specifiesCoordinate (void) const final { return true; }
     void    appendMissionItems  (QList<MissionItem*>& items, QObject* missionItemParent) final { Q_UNUSED(items); Q_UNUSED(missionItemParent); }
     void    applyNewAltitude    (double newAltitude) final { Q_UNUSED(newAltitude); }
+    double  additionalTimeDelay (void) const final { return 0; }
 
     bool rebuildTransectsPhase1Called;
     bool rebuildTransectsPhase2Called;


### PR DESCRIPTION
Plan time was incorrect when using Hover and Capture in Survey