### PR TITLE
Don't automatically enable joystick updates to vehicle

### DIFF
--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -364,9 +364,12 @@ SetupPage {
 
                             QGCCheckBox {
                                 id:         enabledCheckBox
-                                enabled:    _activeJoystick ? _activeJoystick.calibrated : false
-                                text:       _activeJoystick ? _activeJoystick.calibrated ? qsTr("Enable joystick input") : qsTr("Enable not allowed (Calibrate First)") : ""
-                                onClicked:  _activeVehicle.joystickEnabled = checked
+                                enabled:    _activeJoystick ? (_activeJoystick.calibrated && !controller.calibrating): false
+                                text:       _activeJoystick ? (_activeJoystick.calibrated && !controller.calibrating) ? qsTr("Enable joystick input") : qsTr("Enable not allowed (Calibrate First)") : ""
+                                onClicked:  {
+                                    _activeVehicle.joystickEnabled = checked
+                                    statusText.text = ""
+                                }
                                 Component.onCompleted: checked = _activeVehicle.joystickEnabled
 
                                 Connections {

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -99,7 +99,7 @@ const JoystickConfigController::stateMachineEntry* JoystickConfigController::_ge
     static const char* msgPitchDown =       "Move the Pitch stick all the way down and hold it there...";
     static const char* msgPitchUp =         "Move the Pitch stick all the way up and hold it there...";
     static const char* msgPitchCenter =     "Allow the Pitch stick to move back to center...";
-    static const char* msgComplete =        "All settings have been captured. Click Next to enable the joystick.";
+    static const char* msgComplete =        "Calibration complete. Click next to save and then check 'enable joystick' to begin sending joystick updates to the vehicle.";
     
     static const stateMachineEntry rgStateMachine[] = {
         //Function
@@ -572,11 +572,6 @@ void JoystickConfigController::_writeCalibration(void)
     
     _stopCalibration();
     _setInternalCalibrationValuesFromSettings();
-
-    Vehicle* vehicle = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
-    if (vehicle) {
-        vehicle->setJoystickEnabled(true);
-    }
 }
 
 /// @brief Starts the calibration process

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -177,12 +177,13 @@ private:
     bool _stickSettleComplete(int axis, int value);
     
     void _validateCalibration(void);
+    void _calibrationComplete(Joystick::AxisFunction_t function, int axis, int value);
     void _writeCalibration(void);
     void _resetInternalCalibrationValues(void);
     void _setInternalCalibrationValuesFromSettings(void);
     
     void _startCalibration(void);
-    void _stopCalibration(void);
+    void _stopCalibration(bool successful = false);
     void _calSave(void);
 
     void _calSaveCurrentValues(void);


### PR DESCRIPTION
fix #7182

- The joystick updates to the vehicle will be disabled during calibration.
- The user will not have to click 'next' after the last step of calibration
- When the calibration is finished, the user will have to click 'enable' themselves to start sending data to the vehicle. This means they can confirm the calibration is correct before enabling the updates.
