### PR TITLE
Plan-Waypoint: Show camera mode if plan contains it

### DIFF
--- a/src/MissionManager/CameraSection.cc
+++ b/src/MissionManager/CameraSection.cc
@@ -578,7 +578,7 @@ void CameraSection::_cameraActionChanged(void)
 
 bool CameraSection::cameraModeSupported(void) const
 {
-    return _vehicle->firmwarePlugin()->supportedMissionCommands().contains(MAV_CMD_SET_CAMERA_MODE);
+    return _specifyCameraMode || _vehicle->firmwarePlugin()->supportedMissionCommands().contains(MAV_CMD_SET_CAMERA_MODE);
 }
 
 void CameraSection::_dirtyIfSpecified(void)


### PR DESCRIPTION
Normally the Camera Mode setting is not shown for ArduPilot since it is not supported. But if a plan file has a MAV_CMD_SET_CAMERA_MODE even if it is ArduPilot that setting should be shown so the user can see it and change it.