### PR TITLE
Start joystick when JoystickEnabled changes

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2298,6 +2298,7 @@ bool Vehicle::joystickEnabled(void)
 void Vehicle::setJoystickEnabled(bool enabled)
 {
     _joystickEnabled = enabled;
+    _startJoystick(_joystickEnabled);
     _saveSettings();
     emit joystickEnabledChanged(_joystickEnabled);
 }


### PR DESCRIPTION
This partially revert the changes of https://github.com/mavlink/qgroundcontrol/commit/2569fef5546d75d9ba087f32d952c5edc9ad3d60

Currently, if QGC is started with joysticks disabled, the [joystick is set to disabled at start](https://github.com/mavlink/qgroundcontrol/blob/master/src/Vehicle/Vehicle.cc#L2247) and startPolling() is never called.

Fix #7181