### PR TITLE
OfflineMaps: Fix tile set counts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Note: This file only contains high level features or important fixes.
 
 ## 3.5
 
+### 3.5.1 - Not yet released
+* Fix tile set count but in OfflineMaps which would cause image and elevation tile set to have incorrect counts and be incorrectly marked as download incomplete.
+
 ### 3.5.0 - Stable
 * Plan GeoFence: Fix loading of fence from intermediate 3.4 code
 * Structure Scan: Fix loading of structure scan height

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -78,19 +78,19 @@ QGCMapEngineManager::updateForCurrentView(double lon0, double lat0, double lon1,
     _bottomRightLon = lon1;
     _minZoom        = minZoom;
     _maxZoom        = maxZoom;
-    _totalSet.clear();
+
+    _imageSet.clear();
+    _elevationSet.clear();
+
     for(int z = minZoom; z <= maxZoom; z++) {
         QGCTileSet set = QGCMapEngine::getTileCount(z, lon0, lat0, lon1, lat1, mapType);
-        _totalSet += set;
+        _imageSet += set;
     }
     if (_fetchElevation) {
         QGCTileSet set = QGCMapEngine::getTileCount(1, lon0, lat0, lon1, lat1, UrlFactory::AirmapElevation);
-        _totalSet += set;
+        _elevationSet += set;
     }
-    emit tileX0Changed();
-    emit tileX1Changed();
-    emit tileY0Changed();
-    emit tileY1Changed();
+
     emit tileCountChanged();
     emit tileSizeChanged();
 
@@ -101,14 +101,14 @@ QGCMapEngineManager::updateForCurrentView(double lon0, double lat0, double lon1,
 QString
 QGCMapEngineManager::tileCountStr()
 {
-    return QGCMapEngine::numberToString(_totalSet.tileCount);
+    return QGCMapEngine::numberToString(_imageSet.tileCount + _elevationSet.tileCount);
 }
 
 //-----------------------------------------------------------------------------
 QString
 QGCMapEngineManager::tileSizeStr()
 {
-    return QGCMapEngine::bigSizeToString(_totalSet.tileSize);
+    return QGCMapEngine::bigSizeToString(_imageSet.tileSize + _elevationSet.tileSize);
 }
 
 //-----------------------------------------------------------------------------
@@ -142,7 +142,7 @@ QGCMapEngineManager::_tileSetFetched(QGCCachedTileSet* tileSet)
 void
 QGCMapEngineManager::startDownload(const QString& name, const QString& mapType)
 {
-    if(_totalSet.tileSize) {
+    if(_imageSet.tileSize) {
         QGCCachedTileSet* set = new QGCCachedTileSet(name);
         set->setMapTypeStr(mapType);
         set->setTopleftLat(_topleftLat);
@@ -151,8 +151,8 @@ QGCMapEngineManager::startDownload(const QString& name, const QString& mapType)
         set->setBottomRightLon(_bottomRightLon);
         set->setMinZoom(_minZoom);
         set->setMaxZoom(_maxZoom);
-        set->setTotalTileSize(_totalSet.tileSize);
-        set->setTotalTileCount(_totalSet.tileCount);
+        set->setTotalTileSize(_imageSet.tileSize);
+        set->setTotalTileCount(_imageSet.tileCount);
         set->setType(QGCMapEngine::getTypeFromName(mapType));
         QGCCreateTileSetTask* task = new QGCCreateTileSetTask(set);
         //-- Create Tile Set (it will also create a list of tiles to download)
@@ -171,8 +171,8 @@ QGCMapEngineManager::startDownload(const QString& name, const QString& mapType)
         set->setBottomRightLon(_bottomRightLon);
         set->setMinZoom(1);
         set->setMaxZoom(1);
-        set->setTotalTileSize(_totalSet.tileSize);
-        set->setTotalTileCount(_totalSet.tileCount);
+        set->setTotalTileSize(_elevationSet.tileSize);
+        set->setTotalTileCount(_elevationSet.tileCount);
         set->setType(QGCMapEngine::getTypeFromName("Airmap Elevation Data"));
         QGCCreateTileSetTask* task = new QGCCreateTileSetTask(set);
         //-- Create Tile Set (it will also create a list of tiles to download)

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -37,10 +37,6 @@ public:
     };
     Q_ENUM(ImportAction)
 
-    Q_PROPERTY(int                  tileX0          READ    tileX0          NOTIFY tileX0Changed)
-    Q_PROPERTY(int                  tileX1          READ    tileX1          NOTIFY tileX1Changed)
-    Q_PROPERTY(int                  tileY0          READ    tileY0          NOTIFY tileY0Changed)
-    Q_PROPERTY(int                  tileY1          READ    tileY1          NOTIFY tileY1Changed)
     Q_PROPERTY(quint64              tileCount       READ    tileCount       NOTIFY tileCountChanged)
     Q_PROPERTY(QString              tileCountStr    READ    tileCountStr    NOTIFY tileCountChanged)
     Q_PROPERTY(quint64              tileSize        READ    tileSize        NOTIFY tileSizeChanged)
@@ -76,13 +72,9 @@ public:
     Q_INVOKABLE bool                importSets              (QString path = QString());
     Q_INVOKABLE void                resetAction             ();
 
-    int                             tileX0                  () { return _totalSet.tileX0; }
-    int                             tileX1                  () { return _totalSet.tileX1; }
-    int                             tileY0                  () { return _totalSet.tileY0; }
-    int                             tileY1                  () { return _totalSet.tileY1; }
-    quint64                         tileCount               () { return _totalSet.tileCount; }
+    quint64                         tileCount               () { return _imageSet.tileCount + _elevationSet.tileCount; }
     QString                         tileCountStr            ();
-    quint64                         tileSize                () { return _totalSet.tileSize; }
+    quint64                         tileSize                () { return _imageSet.tileSize + _elevationSet.tileSize; }
     QString                         tileSizeStr             ();
     QStringList                     mapList                 ();
     QmlObjectListModel*             tileSets                () { return &_tileSets; }
@@ -108,10 +100,6 @@ public:
     void setToolbox(QGCToolbox *toolbox);
 
 signals:
-    void tileX0Changed          ();
-    void tileX1Changed          ();
-    void tileY0Changed          ();
-    void tileY1Changed          ();
     void tileCountChanged       ();
     void tileSizeChanged        ();
     void tileSetsChanged        ();
@@ -141,7 +129,8 @@ private:
     void _updateDiskFreeSpace   ();
 
 private:
-    QGCTileSet  _totalSet;
+    QGCTileSet  _imageSet;
+    QGCTileSet  _elevationSet;
     double      _topleftLat;
     double      _topleftLon;
     double      _bottomRightLat;


### PR DESCRIPTION
If you created a new tile set and included elevation data the tile counts stored in the two separate tile sets would be the total tile count for both image and elevation tiles. This would cause the system to think download was incomplete if you left the offline maps page and went back to it.

The fix is to maintain the tile counts separately for image and elevation tile sets and to store the appropriate value for each in the database.