### PR TITLE
Fix cmake building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	add_compile_options(
 		-Wall
 		-Wextra
-		-Werror
 
 		-Wno-address-of-packed-member # ignore for mavlink
 	)
@@ -149,7 +148,6 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	add_compile_options(
 		-Wall
 		-Wextra
-		-Werror
 	)
 	
 elseif (WIN32)

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -26,9 +26,15 @@ target_include_directories(Joystick PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(LINUX)
         find_package(SDL2 REQUIRED)
-	include_directories(${SDL2_INCLUDE_DIRS})
-	string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES) # work around for cmake warning
-	target_link_libraries(Joystick PRIVATE ${SDL2_LIBRARIES})
+        if (IS_DIRECTORY ${SDL2_INCLUDE_DIRS})
+            include_directories(${SDL2_INCLUDE_DIRS})
+            string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
+            target_link_libraries(Joystick PRIVATE ${SDL2_LIBRARIES})
+        else()
+            include_directories(${SDL2_DIR})
+            target_link_libraries(Joystick PRIVATE SDL2::SDL2)
+        endif()
+
 elseif(APPLE)
         include_directories(${CMAKE_SOURCE_DIR}/libs/lib/Frameworks/SDL2.framework/Headers)
         target_link_libraries(Joystick PRIVATE -F${CMAKE_SOURCE_DIR}/libs/lib/Frameworks "-framework SDL2")


### PR DESCRIPTION
---
name: Fix building with Cmake
---

**Steps to fix building**
1. Remove -Werror compiler flag (not in qmake file and cause build to fail)
2. Correctly detect and link SDL2 on Linux
