### PR TITLE
Make Apple happy

### DIFF
--- a/Custom-Info.plist
+++ b/Custom-Info.plist
@@ -2,23 +2,25 @@
 <!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
 <plist version="0.9">
 <dict>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
-	<key>CFBundleIconFile</key>
-	<string>macx.icns</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleVersion</key>
-        <string>###</string>
-	<key>CFBundleShortVersionString</key>
-        <string>#.#.#</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleExecutable</key>
-	<string>@EXECUTABLE@</string>
-	<key>CFBundleIdentifier</key>
-	<string>org.qgroundcontrol.qgroundcontrol</string>
-	<key>NOTE</key>
-	<string>Open source ground control app provided by QGroundControl dev team</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>CFBundleIconFile</key>
+    <string>macx.icns</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>###</string>
+    <key>CFBundleShortVersionString</key>
+    <string>#.#.#</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleExecutable</key>
+    <string>@EXECUTABLE@</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.qgroundcontrol.qgroundcontrol</string>
+    <key>NOTE</key>
+    <string>Open source ground control app provided by QGroundControl dev team</string>
+    <key>NSCameraUsageDescription</key>
+    <string>QGC uses UVC camera devices for FPV</string>
 </dict>
 </plist>


### PR DESCRIPTION
I got an error when running a master build today due to the lack of this:

```
    <key>NSCameraUsageDescription</key>
    <string>QGC uses UVC camera devices for FPV</string>
```

It's there now...