### PR TITLE
Structure Scan: Add support for Start From Top/Bottom, plus more helpful stats

### DIFF
--- a/src/MissionManager/StructureScan.SettingsGroup.json
+++ b/src/MissionManager/StructureScan.SettingsGroup.json
@@ -32,5 +32,11 @@
     "units":            "m",
     "min":              1,
     "defaultValue":     100
+},
+{
+    "name":             "StartFromTop",
+    "shortDescription": "Start scan from top of structure.",
+    "type":             "bool",
+    "defaultValue":     true
 }
 ]

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -35,6 +35,7 @@ public:
     Q_PROPERTY(Fact*            structureHeight             READ structureHeight                                            CONSTANT)
     Q_PROPERTY(Fact*            layers                      READ layers                                                     CONSTANT)
     Q_PROPERTY(Fact*            gimbalPitch                 READ gimbalPitch                                                CONSTANT)
+    Q_PROPERTY(Fact*            startFromTop                READ startFromTop                                               CONSTANT)
     Q_PROPERTY(bool             altitudeRelative            READ altitudeRelative           WRITE setAltitudeRelative       NOTIFY altitudeRelativeChanged)
     Q_PROPERTY(int              cameraShots                 READ cameraShots                                                NOTIFY cameraShotsChanged)
     Q_PROPERTY(double           timeBetweenShots            READ timeBetweenShots                                           NOTIFY timeBetweenShotsChanged)
@@ -46,6 +47,7 @@ public:
     Fact* structureHeight   (void) { return &_structureHeightFact; }
     Fact* layers            (void) { return &_layersFact; }
     Fact* gimbalPitch       (void) { return &_gimbalPitchFact; }
+    Fact* startFromTop      (void) { return &_startFromTopFact; }
 
     bool            altitudeRelative        (void) const { return _altitudeRelative; }
     int             cameraShots             (void) const;
@@ -102,6 +104,7 @@ public:
     static const char* structureHeightName;
     static const char* layersName;
     static const char* gimbalPitchName;
+    static const char* startFromTopName;
 
 signals:
     void cameraShotsChanged             (int cameraShots);
@@ -147,6 +150,7 @@ private:
     SettingsFact    _structureHeightFact;
     SettingsFact    _layersFact;
     SettingsFact    _gimbalPitchFact;
+    SettingsFact    _startFromTopFact;
 
     static const char* _jsonCameraCalcKey;
     static const char* _jsonAltitudeRelativeKey;

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -100,6 +100,14 @@ Rectangle {
                 rowSpacing:     _margin
                 columns:        2
 
+                FactComboBox {
+                    fact:               missionItem.startFromTop
+                    indexModel:         true
+                    model:              [ qsTr("Start Scan From Bottom"), qsTr("Start Scan From Top") ]
+                    Layout.columnSpan:  2
+                    Layout.fillWidth:   true
+                }
+
                 QGCLabel {
                     text:       qsTr("Structure height")
                     visible:    !missionItem.cameraCalc.isManualCamera
@@ -165,13 +173,19 @@ Rectangle {
             columnSpacing:  ScreenTools.defaultFontPixelWidth
             visible:        statsHeader.checked
 
+            QGCLabel { text: qsTr("Layers") }
+            QGCLabel { text: missionItem.layers.valueString }
+
+            QGCLabel { text: qsTr("Layer height") }
+            QGCLabel { text: missionItem.cameraCalc.adjustedFootprintFrontal.valueString + " " + QGroundControl.appSettingsDistanceUnitsString }
+
             QGCLabel { text: qsTr("Photo count") }
             QGCLabel { text: missionItem.cameraShots }
 
             QGCLabel { text: qsTr("Photo interval") }
             QGCLabel { text: missionItem.timeBetweenShots.toFixed(1) + " " + qsTr("secs") }
 
-            QGCLabel { text: qsTr("Trigger Distance") }
+            QGCLabel { text: qsTr("Trigger distance") }
             QGCLabel { text: missionItem.cameraCalc.adjustedFootprintSide.valueString + " " + QGroundControl.appSettingsDistanceUnitsString }
         }
     } // Column


### PR DESCRIPTION
How structure scan works was causing confusion. Specifically the concept of layes when using known cameras as well as the altitude that the vehicle enters the structure scan at. In order to try to make that better:
* Include Layer count and Layer height in Stats
* Add option for "Start Scan From Top/Bottom" which is useful as an option by itself. But also I hope indicates a little better that the vehicle will enter the scan from either the top or bottom of the defined structure.

![screen shot 2019-02-15 at 11 53 36 am](https://user-images.githubusercontent.com/5876851/52881231-e9066f80-3118-11e9-8254-691933edeea8.png)
