### PR TITLE
Check box colors

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -181,6 +181,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 #if defined (__macos__)
     locale = QLocale(locale.name());
 #endif
+    qDebug() << "System reported locale:" << locale << locale.name();
     //-- Our localization
     if(_QGCTranslator.load(locale, "qgc_", "", ":/localization"))
         _app->installTranslator(&_QGCTranslator);

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -36,14 +36,14 @@ CheckBox {
             implicitHeight: implicitWidth
             Rectangle {
                 anchors.fill:   parent
-                color:          _qgcPal.window
-                border.color:   _qgcPal.text
+                color:          "white"
+                border.color:   qgcPal.text
                 border.width:   1
                 opacity:        control.checkedState === Qt.PartiallyChecked ? 0.5 : 1
                 QGCColoredImage {
                     source: "/qmlimages/checkbox-check.svg"
-                    color:      _qgcPal.text
-                    opacity:    control.checkedState === Qt.Checked ? control.enabled ? 1 : 0.5 : 0
+                    color:      "black"
+                    opacity:    control.checkedState === Qt.Checked ? (control.enabled ? 1 : 0.5) : 0
                     mipmap:     true
                     fillMode:   Image.PreserveAspectFit
                     width:      parent.width * 0.75


### PR DESCRIPTION
Make checkbox colors consistent with radio buttons (and other UI elements)

<img width="874" alt="screen shot 2019-02-20 at 1 38 33 pm" src="https://user-images.githubusercontent.com/749243/53116074-c1971480-3515-11e9-9667-a3bdf6260832.png">

While at it, I've also added code to output the current locale out to console (to see why some people are getting Turkish localization)

`System reported locale: QLocale(English, Latin, United States) "en_US"`