### PR TITLE
Vehicle: Do not clear priority link if it is the last link

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1899,10 +1899,6 @@ void Vehicle::_linkInactiveOrDeleted(LinkInterface* link)
 
     _links.removeOne(link);
 
-    if (_priorityLink.data() == link) {
-        _priorityLink.clear();
-    }
-
     _updatePriorityLink(true /* updateActive */, true /* sendCommand */);
 
     if (_links.count() == 0 && !_allLinksInactiveSent) {


### PR DESCRIPTION
This could cause crashes if you were unlucky on say a Mission download timeout retry in between Vehicle delete phase1 and phase2. 