### PR TITLE
Revert Camera Names

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -348,7 +348,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         CameraMetaData* metaData;
 
         metaData = new CameraMetaData(
-            tr("Canon S100 @ 5.2mm f/2"),
+            //tr("Canon S100 @ 5.2mm f/2"),
+            tr("Canon S100 PowerShot"),
             7.6,                 // sensorWidth
             5.7,                 // sensorHeight
             4000,                // imageWidth
@@ -361,7 +362,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            tr("Canon EOS-M 22mm f/2"),
+            //tr("Canon EOS-M 22mm f/2"),
+            tr("Canon EOS-M 22mm"),
             22.3,                // sensorWidth
             14.9,                // sensorHeight
             5184,                // imageWidth
@@ -374,7 +376,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            tr("Canon G9X @ 10.2mm f/2"),
+            //tr("Canon G9X @ 10.2mm f/2"),
+            tr("Canon G9 X PowerShot"),
             13.2,                // sensorWidth
             8.8,                 // sensorHeight
             5488,                // imageWidth
@@ -387,7 +390,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            tr("Canon SX260 HS @ 4.5mm f/3.5"),
+            //tr("Canon SX260 HS @ 4.5mm f/3.5"),
+            tr("Canon SX260 HS PowerShot"),
             6.17,                // sensorWidth
             4.55,                // sensorHeight
             4000,                // imageWidth
@@ -413,7 +417,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            tr("Parrot Sequoia RGB"),
+            //tr("Parrot Sequoia RGB"),
+            tr("Parrot Sequioa RGB"),
             6.17,               // sensorWidth
             4.63,               // sendsorHeight
             4608,               // imageWidth
@@ -426,7 +431,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            tr("Parrot Sequoia Monochrome"),
+            //tr("Parrot Sequoia Monochrome"),
+            tr("Parrot Sequioa Monochrome"),
             4.8,                // sensorWidth
             3.6,                // sendsorHeight
             1280,               // imageWidth
@@ -452,7 +458,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            tr("Ricoh GR II 18.3mm f/2.8"),
+            //tr("Ricoh GR II 18.3mm f/2.8"),
+            tr("Ricoh GR II"),
             23.7,               // sensorWidth
             15.7,               // sendsorHeight
             4928,               // imageWidth
@@ -492,7 +499,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
 
         metaData = new CameraMetaData(
             //-- http://www.sony.co.uk/electronics/interchangeable-lens-cameras/ilce-6000-body-kit#product_details_default
-            tr("Sony a6000 Sony 16mm f/2.8"),
+            //tr("Sony a6000 Sony 16mm f/2.8"),
+            tr("Sony a6000 16mm"),
             23.5,               // sensorWidth
             15.6,               // sensorHeight
             6000,               // imageWidth
@@ -572,7 +580,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         metaData = new CameraMetaData(
             //-- http://www.sony.co.uk/electronics/interchangeable-lens-cameras/ilce-qx1-body-kit/specifications
             //-- http://www.sony.com/electronics/camera-lenses/sel16f28/specifications
-            tr("Sony ILCE-QX1 Sony 16mm f/2.8"),
+            //tr("Sony ILCE-QX1 Sony 16mm f/2.8"),
+            tr("Sony ILCE-QX1"),
             23.2,                // sensorWidth
             15.4,                // sensorHeight
             5456,                // imageWidth
@@ -586,7 +595,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
 
         metaData = new CameraMetaData(
             //-- http://www.sony.co.uk/electronics/interchangeable-lens-cameras/ilce-qx1-body-kit/specifications
-            tr("Sony NEX-5R Sony 20mm f/2.8"),
+            //tr("Sony NEX-5R Sony 20mm f/2.8"),
+            tr("Sony NEX-5R 20mm"),
             23.2,                // sensorWidth
             15.4,                // sensorHeight
             4912,                // imageWidth
@@ -599,7 +609,8 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            tr("Sony RX100 II @ 10.4mm f/1.8"),
+            //tr("Sony RX100 II @ 10.4mm f/1.8"),
+            tr("Sony RX100 II 28mm"),
             13.2,                // sensorWidth
             8.8,                 // sensorHeight
             5472,                // imageWidth


### PR DESCRIPTION
Revert the camera names to their original names to avoid messing up old plan files, which use the camera name string to match the camera to the plan.
