### PR TITLE
Add support for custom installer steps

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1288,4 +1288,8 @@ contains (CONFIG, QGC_DISABLE_BUILD_SETUP) {
 # Installer targets
 #
 
-include(QGCInstaller.pri)
+contains (CONFIG, QGC_DISABLE_INSTALLER_SETUP) {
+    message("Disable standard installer setup")
+} else {
+    include(QGCInstaller.pri)
+}


### PR DESCRIPTION
Adding a custom/customQGCInstaller.pri file will override installer steps in QGCInstaller.pri.
However, the QGCInstaller.pri can be imported in the custom one. In this way
a custom build can add pre and post installer steps.