### PR TITLE
PR Remove Microhard configuration for air and ground unit IPs as they're not needed.

### DIFF
--- a/src/Microhard/MicrohardManager.cc
+++ b/src/Microhard/MicrohardManager.cc
@@ -15,13 +15,12 @@
 
 #include <QSettings>
 
-#define LONG_TIMEOUT 5000
+#define SHORT_TIMEOUT 2500
+#define LONG_TIMEOUT  5000
 
 static const char *kMICROHARD_GROUP     = "Microhard";
 static const char *kLOCAL_IP            = "LocalIP";
 static const char *kREMOTE_IP           = "RemoteIP";
-static const char *kGROUND_IP           = "GroundIP";
-static const char *kAIR_IP              = "AirIP";
 static const char *kNET_MASK            = "NetMask";
 static const char *kCFG_PASSWORD        = "ConfigPassword";
 static const char *kENC_KEY             = "EncryptionKey";
@@ -38,8 +37,6 @@ MicrohardManager::MicrohardManager(QGCApplication* app, QGCToolbox* toolbox)
     settings.beginGroup(kMICROHARD_GROUP);
     _localIPAddr    = settings.value(kLOCAL_IP,       QString("192.168.168.1")).toString();
     _remoteIPAddr   = settings.value(kREMOTE_IP,      QString("192.168.168.2")).toString();
-    _groundIPAddr   = settings.value(kGROUND_IP,      QString("192.168.168.101")).toString();
-    _airIPAddr      = settings.value(kAIR_IP,         QString("192.168.168.213")).toString();
     _netMask        = settings.value(kNET_MASK,       QString("255.255.255.0")).toString();
     _configPassword = settings.value(kCFG_PASSWORD,   QString("admin")).toString();
     _encryptionKey  = settings.value(kENC_KEY,        QString("1234567890")).toString();
@@ -117,10 +114,10 @@ MicrohardManager::setToolbox(QGCToolbox* toolbox)
 
 //-----------------------------------------------------------------------------
 bool
-MicrohardManager::setIPSettings(QString localIP_, QString remoteIP_, QString groundIP_, QString airIP_, QString netMask_, QString cfgPassword_, QString encryptionKey_)
+MicrohardManager::setIPSettings(QString localIP_, QString remoteIP_, QString netMask_, QString cfgPassword_, QString encryptionKey_)
 {
     if (_localIPAddr != localIP_ || _remoteIPAddr != remoteIP_ || _netMask != netMask_ ||
-        _configPassword != cfgPassword_ || _encryptionKey != encryptionKey_ || _groundIPAddr != groundIP_ || _airIPAddr != airIP_)
+        _configPassword != cfgPassword_ || _encryptionKey != encryptionKey_)
     {
         if (_mhSettingsLoc && _encryptionKey != encryptionKey_) {
             _mhSettingsLoc->setEncryptionKey(encryptionKey_);
@@ -128,8 +125,6 @@ MicrohardManager::setIPSettings(QString localIP_, QString remoteIP_, QString gro
 
         _localIPAddr    = localIP_;
         _remoteIPAddr   = remoteIP_;
-        _groundIPAddr   = groundIP_;
-        _airIPAddr      = airIP_;
         _netMask        = netMask_;
         _configPassword = cfgPassword_;
         _encryptionKey  = encryptionKey_;
@@ -138,8 +133,6 @@ MicrohardManager::setIPSettings(QString localIP_, QString remoteIP_, QString gro
         settings.beginGroup(kMICROHARD_GROUP);
         settings.setValue(kLOCAL_IP, localIP_);
         settings.setValue(kREMOTE_IP, remoteIP_);
-        settings.setValue(kGROUND_IP, groundIP_);
-        settings.setValue(kAIR_IP, airIP_);
         settings.setValue(kNET_MASK, netMask_);
         settings.setValue(kCFG_PASSWORD, cfgPassword_);
         settings.setValue(kENC_KEY, encryptionKey_);
@@ -169,7 +162,7 @@ MicrohardManager::_setEnabled()
             connect(_mhSettingsRem, &MicrohardSettings::connected,      this, &MicrohardManager::_connectedRem);
             connect(_mhSettingsRem, &MicrohardSettings::rssiUpdated,    this, &MicrohardManager::_rssiUpdatedRem);
         }
-        _workTimer.start(1000);
+        _workTimer.start(SHORT_TIMEOUT);
     } else {
         //-- Stop everything
         _close();
@@ -268,5 +261,5 @@ MicrohardManager::_checkMicrohard()
             _mhSettingsRem->getStatus();
         }
     }
-    _workTimer.start(_isConnected ? 1000 : LONG_TIMEOUT);
+    _workTimer.start(_isConnected ? SHORT_TIMEOUT : LONG_TIMEOUT);
 }

--- a/src/Microhard/MicrohardManager.h
+++ b/src/Microhard/MicrohardManager.h
@@ -32,13 +32,11 @@ public:
     Q_PROPERTY(int          downlinkRSSI        READ downlinkRSSI                               NOTIFY linkChanged)
     Q_PROPERTY(QString      localIPAddr         READ localIPAddr                                NOTIFY localIPAddrChanged)
     Q_PROPERTY(QString      remoteIPAddr        READ remoteIPAddr                               NOTIFY remoteIPAddrChanged)
-    Q_PROPERTY(QString      groundIPAddr        READ groundIPAddr                               NOTIFY groundIPAddrChanged)
-    Q_PROPERTY(QString      airIPAddr           READ airIPAddr                                  NOTIFY airIPAddrChanged)
     Q_PROPERTY(QString      netMask             READ netMask                                    NOTIFY netMaskChanged)
     Q_PROPERTY(QString      configPassword      READ configPassword                             NOTIFY configPasswordChanged)
     Q_PROPERTY(QString      encryptionKey       READ encryptionKey                              NOTIFY encryptionKeyChanged)
 
-    Q_INVOKABLE bool setIPSettings              (QString localIP, QString remoteIP, QString groundIP, QString airIP, QString netMask, QString cfgPassword, QString encyrptionKey);
+    Q_INVOKABLE bool setIPSettings              (QString localIP, QString remoteIP, QString netMask, QString cfgPassword, QString encyrptionKey);
 
     explicit MicrohardManager                   (QGCApplication* app, QGCToolbox* toolbox);
     ~MicrohardManager                           () override;
@@ -51,8 +49,6 @@ public:
     int         downlinkRSSI                    () { return _uplinkRSSI; }
     QString     localIPAddr                     () { return _localIPAddr; }
     QString     remoteIPAddr                    () { return _remoteIPAddr; }
-    QString     airIPAddr                       () { return _airIPAddr; }
-    QString     groundIPAddr                    () { return _groundIPAddr; }
     QString     netMask                         () { return _netMask; }
     QString     configPassword                  () { return _configPassword; }
     QString     encryptionKey                   () { return _encryptionKey; }
@@ -63,8 +59,6 @@ signals:
     void    connectedChanged                ();
     void    localIPAddrChanged              ();
     void    remoteIPAddrChanged             ();
-    void    airIPAddrChanged                ();
-    void    groundIPAddrChanged             ();
     void    netMaskChanged                  ();
     void    configPasswordChanged           ();
     void    encryptionKeyChanged            ();
@@ -98,8 +92,6 @@ private:
     int             _uplinkRSSI             = 0;
     QString         _localIPAddr;
     QString         _remoteIPAddr;
-    QString         _groundIPAddr;
-    QString         _airIPAddr;
     QString         _netMask;
     QString         _configPassword;
     QString         _encryptionKey;

--- a/src/Microhard/MicrohardSettings.qml
+++ b/src/Microhard/MicrohardSettings.qml
@@ -206,27 +206,6 @@ QGCView {
                                 Layout.minimumWidth: _valueWidth
                             }
                             QGCLabel {
-                                text:           qsTr("Ground Unit IP Address:")
-                                Layout.minimumWidth: _labelWidth
-                            }
-                            QGCTextField {
-                                id:             groundIP
-                                text:           QGroundControl.microhardManager.groundIPAddr
-                                enabled:        true
-                                inputMethodHints:    Qt.ImhFormattedNumbersOnly
-                                Layout.minimumWidth: _valueWidth
-                            }
-                            QGCLabel {
-                                text:           qsTr("Air Unit IP Address:")
-                            }
-                            QGCTextField {
-                                id:             airIP
-                                text:           QGroundControl.microhardManager.airIPAddr
-                                enabled:        true
-                                inputMethodHints:    Qt.ImhFormattedNumbersOnly
-                                Layout.minimumWidth: _valueWidth
-                            }
-                            QGCLabel {
                                 text:           qsTr("Network Mask:")
                             }
                             QGCTextField {
@@ -270,16 +249,12 @@ QGCView {
                             function testEnabled() {
                                 if(localIP.text          === QGroundControl.microhardManager.localIPAddr &&
                                     remoteIP.text        === QGroundControl.microhardManager.remoteIPAddr &&
-                                    groundIP.text        === QGroundControl.microhardManager.groundIPAddr &&
-                                    airIP.text           === QGroundControl.microhardManager.airIPAddr &&
                                     netMask.text         === QGroundControl.microhardManager.netMask &&
                                     configPassword.text  === QGroundControl.microhardManager.configPassword &&
                                     encryptionKey.text   === QGroundControl.microhardManager.encryptionKey)
                                     return false
                                 if(!validateIPaddress(localIP.text))  return false
                                 if(!validateIPaddress(remoteIP.text)) return false
-                                if(!validateIPaddress(groundIP.text)) return false
-                                if(!validateIPaddress(airIP.text)) return false
                                 if(!validateIPaddress(netMask.text))  return false
                                 return true
                             }
@@ -287,7 +262,7 @@ QGCView {
                             text:               qsTr("Apply")
                             anchors.horizontalCenter:   parent.horizontalCenter
                             onClicked: {
-                                QGroundControl.microhardManager.setIPSettings(localIP.text, remoteIP.text, groundIP.text, airIP.text, netMask.text, configPassword.text, encryptionKey.text)
+                                QGroundControl.microhardManager.setIPSettings(localIP.text, remoteIP.text, netMask.text, configPassword.text, encryptionKey.text)
                             }
 
                         }


### PR DESCRIPTION
Found out that ground and air unit IPs are not needed. Remote can send UDP packets to Microhard address 192.168.168.255:14550 and they're broadcasted and received by QGC listening on standard port.