### PR TITLE
Add a language selector to the General Settings

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -172,20 +172,6 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 {
     _app = this;
 
-
-    QLocale locale = QLocale::system();
-    //-- Some forced locales for testing
-    //QLocale locale = QLocale(QLocale::German);
-    //QLocale locale = QLocale(QLocale::French);
-    //QLocale locale = QLocale(QLocale::Chinese);
-#if defined (__macos__)
-    locale = QLocale(locale.name());
-#endif
-    qDebug() << "System reported locale:" << locale << locale.name();
-    //-- Our localization
-    if(_QGCTranslator.load(locale, "qgc_", "", ":/localization"))
-        _app->installTranslator(&_QGCTranslator);
-
     // This prevents usage of QQuickWidget to fail since it doesn't support native widget siblings
 #ifndef __android__
     setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
@@ -371,7 +357,47 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
    }
 #endif /* __mobile__ */
 
+   setLanguage();
     _checkForNewVersion();
+}
+
+void QGCApplication::setLanguage()
+{
+    QLocale locale = QLocale::system();
+    //-- See App.SettinsGroup.json for index
+    int langID = toolbox()->settingsManager()->appSettings()->language()->rawValue().toInt();
+    if(langID) {
+        switch(langID) {
+        case 1:
+            locale = QLocale(QLocale::Bulgarian);
+            break;
+        case 2:
+            locale = QLocale(QLocale::German);
+            break;
+        case 3:
+            locale = QLocale(QLocale::French);
+            break;
+        case 4:
+            locale = QLocale(QLocale::Italian);
+            break;
+        case 5:
+            locale = QLocale(QLocale::Korean);
+            break;
+        case 6:
+            locale = QLocale(QLocale::Russian);
+            break;
+        case 7:
+            locale = QLocale(QLocale::Turkish);
+            break;
+        case 8:
+            locale = QLocale(QLocale::Chinese);
+            break;
+        }
+    }
+    qDebug() << "System reported locale:" << locale << locale.name();
+    //-- Our localization
+    if(_QGCTranslator.load(locale, "qgc_", "", ":/localization"))
+        _app->installTranslator(&_QGCTranslator);
 }
 
 void QGCApplication::_shutdown(void)

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -365,32 +365,35 @@ void QGCApplication::setLanguage()
 {
     QLocale locale = QLocale::system();
     qDebug() << "System reported locale:" << locale << locale.name();
-    //-- See App.SettinsGroup.json for index
     int langID = toolbox()->settingsManager()->appSettings()->language()->rawValue().toInt();
+    //-- See App.SettinsGroup.json for index
     if(langID) {
         switch(langID) {
         case 1:
-            locale = QLocale(QLocale::Bulgarian);
+            locale = QLocale(QLocale::English);
             break;
         case 2:
-            locale = QLocale(QLocale::German);
+            locale = QLocale(QLocale::Bulgarian);
             break;
         case 3:
-            locale = QLocale(QLocale::French);
+            locale = QLocale(QLocale::German);
             break;
         case 4:
-            locale = QLocale(QLocale::Italian);
+            locale = QLocale(QLocale::French);
             break;
         case 5:
-            locale = QLocale(QLocale::Korean);
+            locale = QLocale(QLocale::Italian);
             break;
         case 6:
-            locale = QLocale(QLocale::Russian);
+            locale = QLocale(QLocale::Korean);
             break;
         case 7:
-            locale = QLocale(QLocale::Turkish);
+            locale = QLocale(QLocale::Russian);
             break;
         case 8:
+            locale = QLocale(QLocale::Turkish);
+            break;
+        case 9:
             locale = QLocale(QLocale::Chinese);
             break;
         }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -364,6 +364,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 void QGCApplication::setLanguage()
 {
     QLocale locale = QLocale::system();
+    qDebug() << "System reported locale:" << locale << locale.name();
     //-- See App.SettinsGroup.json for index
     int langID = toolbox()->settingsManager()->appSettings()->language()->rawValue().toInt();
     if(langID) {
@@ -394,7 +395,6 @@ void QGCApplication::setLanguage()
             break;
         }
     }
-    qDebug() << "System reported locale:" << locale << locale.name();
     //-- Our localization
     if(_QGCTranslator.load(locale, "qgc_", "", ":/localization"))
         _app->installTranslator(&_QGCTranslator);

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -101,6 +101,8 @@ public:
     static QString cachedParameterMetaDataFile(void);
     static QString cachedAirframeMetaDataFile(void);
 
+    void setLanguage();
+
 public slots:
     /// You can connect to this slot to show an information message box from a different thread.
     void informationMessageBoxOnMainThread(const QString& title, const QString& msg);

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -232,8 +232,8 @@
     "name":             "language",
     "shortDescription": "Language",
     "type":             "uint32",
-    "enumStrings":      "System,български (Bulgarian),Deutsche (German),Français (French),Italiano (Italian),한국어 (Korean),Pусский (Russian),Türk (Turkish),中文 (Chinese)",
-    "enumValues":       "0,1,2,3,4,5,6,7,8",
+    "enumStrings":      "System,English,български (Bulgarian),Deutsche (German),Français (French),Italiano (Italian),한국어 (Korean),Pусский (Russian),Türk (Turkish),中文 (Chinese)",
+    "enumValues":       "0,1,2,3,4,5,6,7,8,9",
     "defaultValue":     0
 }
 ]

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -220,12 +220,20 @@
     "longDescription":  "Enable Taisync Video Support",
     "type":             "bool",
     "defaultValue":     true
-}
-,
+},
 {
     "name":             "enableMicrohard",
     "shortDescription": "Enable Microhard Module Support",
     "longDescription":  "Enable Microhard Module Support",
     "type":             "bool",
     "defaultValue":     false
-}]
+},
+{
+    "name":             "language",
+    "shortDescription": "Language",
+    "type":             "uint32",
+    "enumStrings":      "System,български (Bulgarian),Deutsche (German),Français (French),Italiano (Italian),한국어 (Korean),Pусский (Russian),Türk (Turkish),中文 (Chinese)",
+    "enumValues":       "0,1,2,3,4,5,6,7,8",
+    "defaultValue":     0
+}
+]

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -59,7 +59,11 @@ DECLARE_SETTINGGROUP(App, "")
 
     connect(savePathFact, &Fact::rawValueChanged, this, &AppSettings::savePathsChanged);
     connect(savePathFact, &Fact::rawValueChanged, this, &AppSettings::_checkSavePathDirectories);
+
     _checkSavePathDirectories();
+    //-- Same for language
+    SettingsFact* languageFact = qobject_cast<SettingsFact*>(language());
+    connect(languageFact, &Fact::rawValueChanged, this, &AppSettings::_languageChanged);
 }
 
 DECLARE_SETTINGSFACT(AppSettings, offlineEditingFirmwareType)
@@ -88,6 +92,7 @@ DECLARE_SETTINGSFACT(AppSettings, apmStartMavlinkStreams)
 DECLARE_SETTINGSFACT(AppSettings, enableTaisync)
 DECLARE_SETTINGSFACT(AppSettings, enableTaisyncVideo)
 DECLARE_SETTINGSFACT(AppSettings, enableMicrohard)
+DECLARE_SETTINGSFACT(AppSettings, language)
 
 DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
 {
@@ -96,6 +101,11 @@ DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
         connect(_indoorPaletteFact, &Fact::rawValueChanged, this, &AppSettings::_indoorPaletteChanged);
     }
     return _indoorPaletteFact;
+}
+
+void AppSettings::_languageChanged()
+{
+    qgcApp()->setLanguage();
 }
 
 void AppSettings::_checkSavePathDirectories(void)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -7,6 +7,7 @@
  *
  ****************************************************************************/
 #pragma once
+#include <QTranslator>
 
 #include "SettingsGroup.h"
 #include "QGCMAVLink.h"
@@ -46,6 +47,7 @@ public:
     DEFINE_SETTINGFACT(enableTaisync)
     DEFINE_SETTINGFACT(enableTaisyncVideo)
     DEFINE_SETTINGFACT(enableMicrohard)
+    DEFINE_SETTINGFACT(language)
 
     // Although this is a global setting it only affects ArduPilot vehicle since PX4 automatically starts the stream from the vehicle side
     DEFINE_SETTINGFACT(apmStartMavlinkStreams)
@@ -102,5 +104,9 @@ signals:
 private slots:
     void _indoorPaletteChanged();
     void _checkSavePathDirectories();
+    void _languageChanged();
+
+private:
+    QTranslator _QGCTranslator;
 
 };

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -142,6 +142,17 @@ QGCView {
                                 columns:                    2
 
                                 QGCLabel {
+                                    text:           qsTr("Language")
+                                    visible: QGroundControl.settingsManager.appSettings.language.visible
+                                }
+                                FactComboBox {
+                                    Layout.preferredWidth:  _comboFieldWidth
+                                    fact:                   QGroundControl.settingsManager.appSettings.language
+                                    indexModel:             false
+                                    visible:                QGroundControl.settingsManager.appSettings.language.visible
+                                }
+
+                                QGCLabel {
                                     text:           qsTr("Color Scheme")
                                     visible: QGroundControl.settingsManager.appSettings.indoorPalette.visible
                                 }


### PR DESCRIPTION
You can now select the localization of QGC. By default, it will try to use the locale given by the underlying OS.

<img width="957" alt="Screen Shot 2019-03-20 at 10 37 24 PM" src="https://user-images.githubusercontent.com/749243/54731107-beb63080-4b62-11e9-8754-936bfa50acda.png">
