### PR TITLE
Display FW custom version in the summary page

### DIFF
--- a/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
@@ -39,5 +39,10 @@ FactPanel {
             labelText: qsTr("Firmware Version")
             valueText: activeVehicle.firmwareMajorVersion === -1 ? qsTr("Unknown") : activeVehicle.firmwareMajorVersion + "." + activeVehicle.firmwareMinorVersion + "." + activeVehicle.firmwarePatchVersion + activeVehicle.firmwareVersionTypeString
         }
+        VehicleSummaryRow {
+            visible: activeVehicle.firmwareCustomMajorVersion !== -1
+            labelText: qsTr("Custom Fw. Ver.")
+            valueText: activeVehicle.firmwareCustomMajorVersion + "." + activeVehicle.firmwareCustomMinorVersion + "." + activeVehicle.firmwareCustomPatchVersion
+        }
     }
 }


### PR DESCRIPTION
Previously only the px4 version was displayed which will help identifying the custom firmware version while keeping track of the upstream version as well.