### PR TITLE
Removing overzealous exclusions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ libs/lib/Frameworks/GStreamer.framework
 CMakeFiles
 tags
 build*/
-Info.plist
 obj
 .DS_Store
 *.log
@@ -28,7 +27,6 @@ doc/html
 doc/doxy.log
 deploy/mac
 deploy/linux
-deploy/qgroundcontrol*
 controller_log*
 user_config.pri
 *.app
@@ -68,8 +66,6 @@ ios/iOSForAppStore-Info.plist
 moc_*
 ui_*
 *.o
-*.a
-*.so*
 *.moc
 *.prl
 


### PR DESCRIPTION
These exclusions aren't needed as the build system enforces shadow builds. The rules were excluding necessary files.

Fixes #7334 