### PR TITLE
MAV_CMD_NAV_WAYPOINT message shall express the desired yaw angle in d…

### DIFF
--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -52,7 +52,7 @@
             },
             "param4": {
                 "label":            "Heading",
-                "units":            "radians",
+                "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
                 "decimalPlaces":    2


### PR DESCRIPTION
The desired yaw angle at a waypoint shall be expressed in degree.
Here is the code inside the PX4 firmware that handles the MAV_CMD_NAV_WAYPOINT message:

> switch (mavlink_mission_item->command) {
 case MAV_CMD_NAV_WAYPOINT:
 mission_item->nav_cmd = NAV_CMD_WAYPOINT;
 mission_item->time_inside = mavlink_mission_item->param1;
 mission_item->acceptance_radius = mavlink_mission_item->param2;
 mission_item->yaw = wrap_2pi(math::radians(mavlink_mission_item->param4));
 break;

> 
The yaw field is already converted on the firmware side from degree to radians.

