### PR TITLE
Offline Maps: Allow custom build override of min/max zoom levels, max tile download

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -601,6 +601,7 @@ HEADERS += \
     src/Settings/BrandImageSettings.h \
     src/Settings/FlightMapSettings.h \
     src/Settings/FlyViewSettings.h \
+    src/Settings/OfflineMapsSettings.h \
     src/Settings/PlanViewSettings.h \
     src/Settings/RTKSettings.h \
     src/Settings/SettingsGroup.h \
@@ -804,6 +805,7 @@ SOURCES += \
     src/Settings/BrandImageSettings.cc \
     src/Settings/FlightMapSettings.cc \
     src/Settings/FlyViewSettings.cc \
+    src/Settings/OfflineMapsSettings.cc \
     src/Settings/PlanViewSettings.cc \
     src/Settings/RTKSettings.cc \
     src/Settings/SettingsGroup.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -226,6 +226,7 @@
         <file alias="FlightMap.SettingsGroup.json">src/Settings/FlightMap.SettingsGroup.json</file>
         <file alias="FWLandingPattern.FactMetaData.json">src/MissionManager/FWLandingPattern.FactMetaData.json</file>
         <file alias="FlyView.SettingsGroup.json">src/Settings/FlyView.SettingsGroup.json</file>
+		<file alias="OfflineMaps.SettingsGroup.json">src/Settings/OfflineMaps.SettingsGroup.json</file>
 		<file alias="PlanView.SettingsGroup.json">src/Settings/PlanView.SettingsGroup.json</file>
         <file alias="MavCmdInfoCommon.json">src/MissionManager/MavCmdInfoCommon.json</file>
         <file alias="MavCmdInfoFixedWing.json">src/MissionManager/MavCmdInfoFixedWing.json</file>

--- a/src/Airmap/AirMapSettings.cc
+++ b/src/Airmap/AirMapSettings.cc
@@ -15,8 +15,7 @@
 
 DECLARE_SETTINGGROUP(AirMap, "AirMap")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
-    qmlRegisterUncreatableType<AirMapSettings>("QGroundControl.SettingsManager", 1, 0, "AirMapSettings", "Reference only"); \
+    qmlRegisterUncreatableType<AirMapSettings>("QGroundControl.SettingsManager", 1, 0, "AirMapSettings", "Reference only");
 }
 
 DECLARE_SETTINGSFACT(AirMapSettings, usePersonalApiKey)

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -33,10 +33,13 @@ QGCView {
 
     property string mapKey:             "lastMapType"
 
-    property Fact   _mapboxFact:        QGroundControl.settingsManager.appSettings.mapboxToken
-    property Fact   _esriFact:          QGroundControl.settingsManager.appSettings.esriToken
+    property var    _settingsManager:   QGroundControl.settingsManager
+    property var    _settings:          _settingsManager.offlineMapsSettings
+    property var    _fmSettings:        _settingsManager.flightMapSettings
+    property Fact   _mapboxFact:        _settingsManager.appSettings.mapboxToken
+    property Fact   _esriFact:          _settingsManager.appSettings.esriToken
 
-    property string mapType:            _settings.mapProvider.enumStringValue + " " + _settings.mapType.enumStringValue
+    property string mapType:            _fmSettings.mapProvider.enumStringValue + " " + _fmSettings.mapType.enumStringValue
     property bool   isMapInteractive:   false
     property var    savedCenter:        undefined
     property real   savedZoom:          3
@@ -52,13 +55,12 @@ QGCView {
 
     property var    _mapAdjustedColor:  _map.isSatelliteMap ? "white" : "black"
     property bool   _tooManyTiles:      QGroundControl.mapEngineManager.tileCount > _maxTilesForDownload
-    property var    _settings:          QGroundControl.settingsManager.flightMapSettings
 
     readonly property real minZoomLevel:    1
     readonly property real maxZoomLevel:    20
     readonly property real sliderTouchArea: ScreenTools.defaultFontPixelWidth * (ScreenTools.isTinyScreen ? 5 : (ScreenTools.isMobile ? 6 : 3))
 
-    readonly property int _maxTilesForDownload: 100000
+    readonly property int _maxTilesForDownload: _settings.maxTilesForDownload.rawValue
 
     QGCPalette { id: qgcPal }
 
@@ -106,7 +108,7 @@ QGCView {
 
     function addNewSet() {
         isMapInteractive = true
-        mapType = _settings.mapProvider.enumStringValue + " " + _settings.mapType.enumStringValue
+        mapType = _fmSettings.mapProvider.enumStringValue + " " + _fmSettings.mapType.enumStringValue
         resetMapToDefaults()
         handleChanges()
         _map.visible = true
@@ -813,11 +815,21 @@ QGCView {
                                 maximumValue:               maxZoomLevel
                                 stepSize:                   1
                                 updateValueWhileDragging:   true
-                                property real _savedZoom
-                                Component.onCompleted:      Math.max(sliderMinZoom.value = _map.zoomLevel - 4, 2)
+
+                                property bool _updateSetting: false
+
+                                Component.onCompleted: {
+                                    sliderMinZoom.value = _settings.minZoomLevelDownload.rawValue
+                                    _updateSetting = true
+                                }
+
                                 onValueChanged: {
                                     if(sliderMinZoom.value > sliderMaxZoom.value) {
                                         sliderMaxZoom.value = sliderMinZoom.value
+                                    }
+                                    if (_updateSetting) {
+                                        // Don't update setting until after Component.onCompleted since bad values come through before that
+                                        _settings.minZoomLevelDownload.rawValue = value
                                     }
                                     handleChanges()
                                 }
@@ -856,11 +868,21 @@ QGCView {
                                 maximumValue:               maxZoomLevel
                                 stepSize:                   1
                                 updateValueWhileDragging:   true
-                                property real _savedZoom
-                                Component.onCompleted:      Math.min(sliderMaxZoom.value = _map.zoomLevel + 2, 20)
+
+                                property bool _updateSetting: false
+
+                                Component.onCompleted: {
+                                    sliderMaxZoom.value = _settings.maxZoomLevelDownload.rawValue
+                                    _updateSetting = true
+                                }
+
                                 onValueChanged: {
                                     if(sliderMaxZoom.value < sliderMinZoom.value) {
                                         sliderMinZoom.value = sliderMaxZoom.value
+                                    }
+                                    if (_updateSetting) {
+                                        // Don't update setting until after Component.onCompleted since bad values come through before that
+                                        _settings.maxZoomLevelDownload.rawValue = value
                                     }
                                     handleChanges()
                                 }

--- a/src/Settings/APMMavlinkStreamRateSettings.cc
+++ b/src/Settings/APMMavlinkStreamRateSettings.cc
@@ -15,7 +15,6 @@
 
 DECLARE_SETTINGGROUP(APMMavlinkStreamRate, "APMMavlinkStreamRate")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<APMMavlinkStreamRateSettings>("QGroundControl.SettingsManager", 1, 0, "APMMavlinkStreamRateSettings", "Reference only");
 
     connect(streamRateRawSensors(),     &Fact::rawValueChanged, this, &APMMavlinkStreamRateSettings::_updateStreamRateRawSensors);

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -36,7 +36,6 @@ const char* AppSettings::crashDirectory =           "CrashLogs";
 
 DECLARE_SETTINGGROUP(App, "")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<AppSettings>("QGroundControl.SettingsManager", 1, 0, "AppSettings", "Reference only");
     QGCPalette::setGlobalTheme(indoorPalette()->rawValue().toBool() ? QGCPalette::Dark : QGCPalette::Light);
 

--- a/src/Settings/AutoConnectSettings.cc
+++ b/src/Settings/AutoConnectSettings.cc
@@ -15,7 +15,6 @@
 
 DECLARE_SETTINGGROUP(AutoConnect, "LinkManager")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
     qmlRegisterUncreatableType<AutoConnectSettings>("QGroundControl.SettingsManager", 1, 0, "AutoConnectSettings", "Reference only"); \
 }
 

--- a/src/Settings/BrandImageSettings.cc
+++ b/src/Settings/BrandImageSettings.cc
@@ -14,7 +14,6 @@
 
 DECLARE_SETTINGGROUP(BrandImage, "Branding")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
     qmlRegisterUncreatableType<BrandImageSettings>("QGroundControl.SettingsManager", 1, 0, "BrandImageSettings", "Reference only"); \
 }
 

--- a/src/Settings/CMakeLists.txt
+++ b/src/Settings/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(Settings
 	BrandImageSettings.cc
 	FlightMapSettings.cc
 	FlyViewSettings.cc
+	OfflineMapsSettings.cc
 	PlanViewSettings.cc
 	RTKSettings.cc
 	SettingsGroup.cc

--- a/src/Settings/FlightMapSettings.cc
+++ b/src/Settings/FlightMapSettings.cc
@@ -18,7 +18,6 @@
 
 DECLARE_SETTINGGROUP(FlightMap, "FlightMap")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<FlightMapSettings>("QGroundControl.SettingsManager", 1, 0, "FlightMapSettings", "Reference only");
 
     // Save the original version since we modify based on map provider

--- a/src/Settings/FlyViewSettings.cc
+++ b/src/Settings/FlyViewSettings.cc
@@ -14,7 +14,6 @@
 
 DECLARE_SETTINGGROUP(FlyView, "FlyView")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
     qmlRegisterUncreatableType<FlyViewSettings>("QGroundControl.SettingsManager", 1, 0, "FlyViewSettings", "Reference only"); \
 }
 

--- a/src/Settings/OfflineMaps.SettingsGroup.json
+++ b/src/Settings/OfflineMaps.SettingsGroup.json
@@ -1,0 +1,24 @@
+[
+{
+    "name":             "minZoomLevelDownload",
+    "shortDescription": "Minimum zoom level for downloads.",
+    "type":             "Uint32",
+    "min":              1,
+    "max":              20,
+    "defaultValue":     13
+},
+{
+    "name":             "maxZoomLevelDownload",
+    "shortDescription": "Maximum zoom level for downloads.",
+    "type":             "Uint32",
+    "min":              1,
+    "max":              20,
+    "defaultValue":     19
+},
+{
+    "name":             "maxTilesForDownload",
+    "shortDescription": "Maximum number of tiles for download.",
+    "type":             "Uint32",
+    "defaultValue":     100000
+}
+]

--- a/src/Settings/OfflineMapsSettings.cc
+++ b/src/Settings/OfflineMapsSettings.cc
@@ -1,0 +1,22 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "OfflineMapsSettings.h"
+
+#include <QQmlEngine>
+#include <QtQml>
+
+DECLARE_SETTINGGROUP(OfflineMaps, "OfflineMaps")
+{
+    qmlRegisterUncreatableType<OfflineMapsSettings>("QGroundControl.SettingsManager", 1, 0, "OfflineMapsSettings", "Reference only");
+}
+
+DECLARE_SETTINGSFACT(OfflineMapsSettings, minZoomLevelDownload)
+DECLARE_SETTINGSFACT(OfflineMapsSettings, maxZoomLevelDownload)
+DECLARE_SETTINGSFACT(OfflineMapsSettings, maxTilesForDownload)

--- a/src/Settings/OfflineMapsSettings.h
+++ b/src/Settings/OfflineMapsSettings.h
@@ -1,0 +1,27 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "SettingsGroup.h"
+
+class OfflineMapsSettings : public SettingsGroup
+{
+    Q_OBJECT
+
+public:
+    OfflineMapsSettings(QObject* parent = nullptr);
+
+    DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(minZoomLevelDownload)
+    DEFINE_SETTINGFACT(maxZoomLevelDownload)
+    DEFINE_SETTINGFACT(maxTilesForDownload)
+
+private:
+};

--- a/src/Settings/PlanViewSettings.cc
+++ b/src/Settings/PlanViewSettings.cc
@@ -14,6 +14,5 @@
 
 DECLARE_SETTINGGROUP(PlanView, "PlanView")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
     qmlRegisterUncreatableType<PlanViewSettings>("QGroundControl.SettingsManager", 1, 0, "PlanViewSettings", "Reference only"); \
 }

--- a/src/Settings/RTKSettings.cc
+++ b/src/Settings/RTKSettings.cc
@@ -14,7 +14,6 @@
 
 DECLARE_SETTINGGROUP(RTK, "RTK")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership); \
     qmlRegisterUncreatableType<RTKSettings>("QGroundControl.SettingsManager", 1, 0, "RTKSettings", "Reference only"); \
 }
 

--- a/src/Settings/SettingsGroup.cc
+++ b/src/Settings/SettingsGroup.cc
@@ -11,6 +11,9 @@
 #include "QGCCorePlugin.h"
 #include "QGCApplication.h"
 
+#include <QQmlEngine>
+#include <QtQml>
+
 static const char* kJsonFile = ":/json/%1.SettingsGroup.json";
 
 SettingsGroup::SettingsGroup(const QString& name, const QString& settingsGroup, QObject* parent)
@@ -19,6 +22,8 @@ SettingsGroup::SettingsGroup(const QString& name, const QString& settingsGroup, 
     , _name         (name)
     , _settingsGroup(settingsGroup)
 {
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
+
     _nameToMetaDataMap = FactMetaData::createMapFromJsonFile(QString(kJsonFile).arg(name), this);
 }
 

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -26,6 +26,7 @@ SettingsManager::SettingsManager(QGCApplication* app, QGCToolbox* toolbox)
     , _flyViewSettings              (nullptr)
     , _planViewSettings             (nullptr)
     , _brandImageSettings           (nullptr)
+    , _offlineMapsSettings          (nullptr)
 #if !defined(NO_ARDUPILOT_DIALECT)
     , _apmMavlinkStreamRateSettings (nullptr)
 #endif
@@ -48,6 +49,7 @@ void SettingsManager::setToolbox(QGCToolbox *toolbox)
     _flyViewSettings =              new FlyViewSettings     (this);
     _planViewSettings =             new PlanViewSettings    (this);
     _brandImageSettings =           new BrandImageSettings  (this);
+    _offlineMapsSettings =          new OfflineMapsSettings (this);
 #if !defined(NO_ARDUPILOT_DIALECT)
     _apmMavlinkStreamRateSettings = new APMMavlinkStreamRateSettings     (this);
 #endif

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -23,6 +23,7 @@
 #include "FlyViewSettings.h"
 #include "PlanViewSettings.h"
 #include "BrandImageSettings.h"
+#include "OfflineMapsSettings.h"
 #include "APMMavlinkStreamRateSettings.h"
 #if defined(QGC_AIRMAP_ENABLED)
 #include "AirMapSettings.h"
@@ -49,6 +50,7 @@ public:
     Q_PROPERTY(QObject* flyViewSettings                 READ flyViewSettings                CONSTANT)
     Q_PROPERTY(QObject* planViewSettings                READ planViewSettings               CONSTANT)
     Q_PROPERTY(QObject* brandImageSettings              READ brandImageSettings             CONSTANT)
+    Q_PROPERTY(QObject* offlineMapsSettings             READ offlineMapsSettings             CONSTANT)
 #if !defined(NO_ARDUPILOT_DIALECT)
     Q_PROPERTY(QObject* apmMavlinkStreamRateSettings    READ apmMavlinkStreamRateSettings   CONSTANT)
 #endif
@@ -67,6 +69,7 @@ public:
     FlyViewSettings*                flyViewSettings             (void) { return _flyViewSettings; }
     PlanViewSettings*               planViewSettings            (void) { return _planViewSettings; }
     BrandImageSettings*             brandImageSettings          (void) { return _brandImageSettings; }
+    OfflineMapsSettings*            offlineMapsSettings         (void) { return _offlineMapsSettings; }
 #if !defined(NO_ARDUPILOT_DIALECT)
     APMMavlinkStreamRateSettings*   apmMavlinkStreamRateSettings(void) { return _apmMavlinkStreamRateSettings; }
 #endif
@@ -83,6 +86,7 @@ private:
     FlyViewSettings*                _flyViewSettings;
     PlanViewSettings*               _planViewSettings;
     BrandImageSettings*             _brandImageSettings;
+    OfflineMapsSettings*            _offlineMapsSettings;
 #if !defined(NO_ARDUPILOT_DIALECT)
     APMMavlinkStreamRateSettings*   _apmMavlinkStreamRateSettings;
 #endif

--- a/src/Settings/UnitsSettings.cc
+++ b/src/Settings/UnitsSettings.cc
@@ -14,7 +14,6 @@
 
 DECLARE_SETTINGGROUP(Units, "Units")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<UnitsSettings>("QGroundControl.SettingsManager", 1, 0, "UnitsSettings", "Reference only");
 }
 

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -28,7 +28,6 @@ const char* VideoSettings::videoSourceMPEGTS    = "MPEG-TS (h.264) Video Stream"
 
 DECLARE_SETTINGGROUP(Video, "Video")
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<VideoSettings>("QGroundControl.SettingsManager", 1, 0, "VideoSettings", "Reference only");
 
     // Setup enum values for videoSource settings into meta data


### PR DESCRIPTION
Converted these values to an OfflineMaps SettingsGroup. The settings themselves are for custom build override only and not exposed to the user.