### PR TITLE
Consistent Altitutude Mode labelling in all complex items

### DIFF
--- a/src/FactSystem/FactControls/AltitudeFactTextField.qml
+++ b/src/FactSystem/FactControls/AltitudeFactTextField.qml
@@ -1,20 +1,24 @@
+import QtQuick                      2.3
 import QGroundControl               1.0
 import QGroundControl.FactSystem    1.0
 
 FactTextField {
-    unitsLabel: fact ? fact.units + _altitudeModeExtraUnits : ""
-    showUnits:  true
-    showHelp:   true
+    unitsLabel:         fact ? fact.units : ""
+    extraUnitsLabel:    fact ? _altitudeModeExtraUnits : ""
+    showUnits:          true
+    showHelp:           true
 
     property int altitudeMode: QGroundControl.AltitudeModeNone
 
     readonly property string _altModeNoneExtraUnits:            ""
-    readonly property string _altModeRelativeExtraUnits:        qsTr(" (Rel)")
-    readonly property string _altModeAbsoluteExtraUnits:        qsTr(" (AMSL)")
-    readonly property string _altModeAboveTerrainExtraUnits:    qsTr(" (Abv Terr)")
-    readonly property string _altModeTerrainFrameExtraUnits:    qsTr(" (TerrF)")
+    readonly property string _altModeRelativeExtraUnits:        qsTr("(Rel)")
+    readonly property string _altModeAbsoluteExtraUnits:        qsTr("(AMSL)")
+    readonly property string _altModeAboveTerrainExtraUnits:    qsTr("(Abv Terr)")
+    readonly property string _altModeTerrainFrameExtraUnits:    qsTr("(TerrF)")
 
-    property string _altitudeModeExtraUnits: _altModeRelativeExtraUnits
+    property string _altitudeModeExtraUnits: _altModeNoneExtraUnits
+
+    onAltitudeModeChanged: updateAltitudeModeExtraUnits()
 
     function updateAltitudeModeExtraUnits() {
         if (altitudeMode === QGroundControl.AltitudeModeNone) {
@@ -32,6 +36,4 @@ FactTextField {
             _altitudeModeExtraUnits = ""
         }
     }
-
-    onAltitudeModeChanged: updateAltitudeModeExtraUnits()
 }

--- a/src/PlanView/CameraCalc.qml
+++ b/src/PlanView/CameraCalc.qml
@@ -15,8 +15,9 @@ Column {
     spacing:        _margin
 
     property var    cameraCalc
-    property bool   vehicleFlightIsFrontal: true
+    property bool   vehicleFlightIsFrontal:         true
     property string distanceToSurfaceLabel
+    property int    distanceToSurfaceAltitudeMode:  QGroundControl.AltitudeModeNone
     property string frontalDistanceLabel
     property string sideDistanceLabel
 
@@ -226,8 +227,9 @@ Column {
                     onClicked:              cameraCalc.valueSetIsDistance.value = 1
                 }
 
-                FactTextField {
+                AltitudeFactTextField {
                     fact:                   cameraCalc.distanceToSurface
+                    altitudeMode:           distanceToSurfaceAltitudeMode
                     enabled:                fixedDistanceRadio.checked
                     Layout.fillWidth:       true
                 }
@@ -285,8 +287,9 @@ Column {
             visible:        cameraCalc.isManualCamera
 
             QGCLabel { text: distanceToSurfaceLabel }
-            FactTextField {
+            AltitudeFactTextField {
                 fact:               cameraCalc.distanceToSurface
+                altitudeMode:       distanceToSurfaceAltitudeMode
                 Layout.fillWidth:   true
             }
 

--- a/src/PlanView/CorridorScanEditor.qml
+++ b/src/PlanView/CorridorScanEditor.qml
@@ -67,11 +67,12 @@ Rectangle {
 
 
         CameraCalc {
-            cameraCalc:             missionItem.cameraCalc
-            vehicleFlightIsFrontal: true
-            distanceToSurfaceLabel: qsTr("Altitude")
-            frontalDistanceLabel:   qsTr("Trigger Distance")
-            sideDistanceLabel:      qsTr("Spacing")
+            cameraCalc:                     missionItem.cameraCalc
+            vehicleFlightIsFrontal:         true
+            distanceToSurfaceLabel:         qsTr("Altitude")
+            distanceToSurfaceAltitudeMode:  missionItem.followTerrain ? QGroundControl.AltitudeModeAboveTerrain : QGroundControl.AltitudeModeRelative
+            frontalDistanceLabel:           qsTr("Trigger Dist")
+            sideDistanceLabel:              qsTr("Spacing")
         }
 
         SectionHeader {

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -75,11 +75,12 @@ Rectangle {
         }
 
         CameraCalc {
-            cameraCalc:             missionItem.cameraCalc
-            vehicleFlightIsFrontal: false
-            distanceToSurfaceLabel: qsTr("Scan Distance")
-            frontalDistanceLabel:   qsTr("Layer Height")
-            sideDistanceLabel:      qsTr("Trigger Distance")
+            cameraCalc:                     missionItem.cameraCalc
+            vehicleFlightIsFrontal:         false
+            distanceToSurfaceLabel:         qsTr("Scan Distance")
+            distanceToSurfaceAltitudeMode:  QGroundControl.AltitudeModeNone
+            frontalDistanceLabel:           qsTr("Layer Height")
+            sideDistanceLabel:              qsTr("Trigger Distance")
         }
 
         SectionHeader {
@@ -117,14 +118,16 @@ Rectangle {
                 }
 
                 QGCLabel { text: qsTr("Scan Bottom Alt") }
-                FactTextField {
+                AltitudeFactTextField {
                     fact:               missionItem.scanBottomAlt
+                    altitudeMode:       QGroundControl.AltitudeModeRelative
                     Layout.fillWidth:   true
                 }
 
                 QGCLabel { text: qsTr("Entrance/Exit Alt") }
-                FactTextField {
+                AltitudeFactTextField {
                     fact:               missionItem.entranceAlt
+                    altitudeMode:       QGroundControl.AltitudeModeRelative
                     Layout.fillWidth:   true
                 }
 

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -67,11 +67,12 @@ Rectangle {
         }
 
         CameraCalc {
-            cameraCalc:             missionItem.cameraCalc
-            vehicleFlightIsFrontal: true
-            distanceToSurfaceLabel: qsTr("Altitude")
-            frontalDistanceLabel:   qsTr("Trigger Distance")
-            sideDistanceLabel:      qsTr("Spacing")
+            cameraCalc:                     missionItem.cameraCalc
+            vehicleFlightIsFrontal:         true
+            distanceToSurfaceLabel:         qsTr("Altitude")
+            distanceToSurfaceAltitudeMode:  missionItem.followTerrain ? QGroundControl.AltitudeModeAboveTerrain : QGroundControl.AltitudeModeRelative
+            frontalDistanceLabel:           qsTr("Trigger Dist")
+            sideDistanceLabel:              qsTr("Spacing")
         }
 
         SectionHeader {

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -16,6 +16,8 @@ CheckBox {
     activeFocusOnPress: true
 
     style: CheckBoxStyle {
+        spacing: _noText ? 0 : ScreenTools.defaultFontPixelWidth * 0.25
+
         label: Item {
             implicitWidth:  _noText ? 0 : text.implicitWidth + ScreenTools.defaultFontPixelWidth * 0.25
             implicitHeight: _noText ? 0 : Math.max(text.implicitHeight, ScreenTools.checkBoxIndicatorSize)

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -17,7 +17,7 @@ RadioButton {
     activeFocusOnPress: true
 
     style: RadioButtonStyle {
-        spacing: _noText ? 0 : ScreenTools.defaultFontPixelWidth / 2
+        spacing: _noText ? 0 : ScreenTools.defaultFontPixelWidth * 0.25
 
         label: Item {
             implicitWidth:          _noText ? 0 : text.implicitWidth + ScreenTools.defaultFontPixelWidth * 0.25

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -13,9 +13,10 @@ TextField {
     activeFocusOnPress: true
     antialiasing:       true
 
-    property bool   showUnits:  false
-    property bool   showHelp:   false
-    property string unitsLabel: ""
+    property bool   showUnits:          false
+    property bool   showHelp:           false
+    property string unitsLabel:         ""
+    property string extraUnitsLabel:    ""
 
     signal helpClicked
 
@@ -89,7 +90,17 @@ TextField {
                     font.family:        ScreenTools.normalFontFamily
                     antialiasing:       true
                     color:              control.textColor
-                    visible:            control.showUnits
+                    visible:            control.showUnits && text !== ""
+                }
+
+                Text {
+                    Layout.alignment:   Qt.AlignVCenter
+                    text:               control.extraUnitsLabel
+                    font.pointSize:     ScreenTools.smallFontPointSize
+                    font.family:        ScreenTools.normalFontFamily
+                    antialiasing:       true
+                    color:              control.textColor
+                    visible:            control.showUnits && text !== ""
                 }
 
                 Rectangle {


### PR DESCRIPTION
Also:
* Slight reduction in space between graphic and text for Radio Button and Checkbox
* QGCTextField supports small font extraUnitsLabel
* AltitudeTextField uses new extraUnitsLabel to show altitude mode

![Screen Shot 2019-04-19 at 3 43 02 PM](https://user-images.githubusercontent.com/5876851/56460306-997d3380-6355-11e9-94e1-f68423ca20df.png)
