### PR TITLE
Pattern Preset support

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Note: This file only contains high level features or important fixes.
 
 ### 3.6.0 - Daily Build
 
+* Plan/Pattern: Support named presets to simplify commonly used settings setup. Currently only supported by Survey.
 * ArduCopter: Handle 3.7 parameter name change from CH#_OPT to RC#_OPTION.
 * Improved support for flashing/connecting to ChibiOS bootloaders boards.
 * Making the camera API available to all firmwares, not just PX4.

--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -95,7 +95,7 @@ void CameraCalc::_cameraNameChanged(void)
 
     // Validate known camera name
     bool foundKnownCamera = false;
-    CameraMetaData* cameraMetaData = NULL;
+    CameraMetaData* cameraMetaData = nullptr;
     if (!isManualCamera() && !isCustomCamera()) {
         for (int cameraIndex=0; cameraIndex<_knownCameraList.count(); cameraIndex++) {
             cameraMetaData = _knownCameraList[cameraIndex].value<CameraMetaData*>();
@@ -201,11 +201,12 @@ void CameraCalc::save(QJsonObject& json) const
     }
 }
 
-bool CameraCalc::load(const QJsonObject& json, QString& errorString)
+bool CameraCalc::load(const QJsonObject& json, bool forPresets, bool cameraSpecInPreset, QString& errorString)
 {
+    qDebug() << "CameraCalc::load" << forPresets << cameraSpecInPreset;
     QJsonObject v1Json = json;
 
-    if (!v1Json.contains(JsonHelper::jsonVersionKey)) {
+    if (!json.contains(JsonHelper::jsonVersionKey)) {
         // Version 0 file. Differences from Version 1 for conversion:
         //  JsonHelper::jsonVersionKey not stored
         //  _jsonCameraSpecTypeKey stores CameraSpecType
@@ -231,18 +232,13 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
         { adjustedFootprintSideName,        QJsonValue::Double, true },
         { adjustedFootprintFrontalName,     QJsonValue::Double, true },
         { distanceToSurfaceName,            QJsonValue::Double, true },
-        { distanceToSurfaceRelativeName,    QJsonValue::Bool, true },
+        { distanceToSurfaceRelativeName,    QJsonValue::Bool,   true },
     };
     if (!JsonHelper::validateKeys(v1Json, keyInfoList1, errorString)) {
         return false;
     }
 
-    _disableRecalc = true;
-
-    _cameraNameFact.setRawValue                 (v1Json[cameraNameName].toString());
-    _adjustedFootprintSideFact.setRawValue      (v1Json[adjustedFootprintSideName].toDouble());
-    _adjustedFootprintFrontalFact.setRawValue   (v1Json[adjustedFootprintFrontalName].toDouble());
-    _distanceToSurfaceFact.setRawValue          (v1Json[distanceToSurfaceName].toDouble());
+    _disableRecalc = !forPresets;
 
     _distanceToSurfaceRelative = v1Json[distanceToSurfaceRelativeName].toBool();
 
@@ -259,13 +255,40 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
         }
 
         _valueSetIsDistanceFact.setRawValue (v1Json[valueSetIsDistanceName].toBool());
-        _imageDensityFact.setRawValue       (v1Json[imageDensityName].toDouble());
         _frontalOverlapFact.setRawValue     (v1Json[frontalOverlapName].toDouble());
         _sideOverlapFact.setRawValue        (v1Json[sideOverlapName].toDouble());
+    }
 
-        if (!CameraSpec::load(v1Json, errorString)) {
-            _disableRecalc = false;
-            return false;
+    if (forPresets) {
+        if (isManualCamera()) {
+            _distanceToSurfaceFact.setRawValue(v1Json[distanceToSurfaceName].toDouble());
+        } else {
+            if (_valueSetIsDistanceFact.rawValue().toBool()) {
+                _distanceToSurfaceFact.setRawValue(v1Json[distanceToSurfaceName].toDouble());
+            } else {
+                _imageDensityFact.setRawValue(v1Json[imageDensityName].toDouble());
+            }
+
+            if (cameraSpecInPreset) {
+                _cameraNameFact.setRawValue(v1Json[cameraNameName].toString());
+                if (!CameraSpec::load(v1Json, errorString)) {
+                    _disableRecalc = false;
+                    return false;
+                }
+            }
+        }
+    } else {
+        _cameraNameFact.setRawValue                 (v1Json[cameraNameName].toString());
+        _adjustedFootprintSideFact.setRawValue      (v1Json[adjustedFootprintSideName].toDouble());
+        _adjustedFootprintFrontalFact.setRawValue   (v1Json[adjustedFootprintFrontalName].toDouble());
+        _distanceToSurfaceFact.setRawValue          (v1Json[distanceToSurfaceName].toDouble());
+        if (isManualCamera()) {
+            _imageDensityFact.setRawValue(v1Json[imageDensityName].toDouble());
+
+            if (!CameraSpec::load(v1Json, errorString)) {
+                _disableRecalc = false;
+                return false;
+            }
         }
     }
 

--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -282,7 +282,7 @@ bool CameraCalc::load(const QJsonObject& json, bool forPresets, bool cameraSpecI
         _adjustedFootprintSideFact.setRawValue      (v1Json[adjustedFootprintSideName].toDouble());
         _adjustedFootprintFrontalFact.setRawValue   (v1Json[adjustedFootprintFrontalName].toDouble());
         _distanceToSurfaceFact.setRawValue          (v1Json[distanceToSurfaceName].toDouble());
-        if (isManualCamera()) {
+        if (!isManualCamera()) {
             _imageDensityFact.setRawValue(v1Json[imageDensityName].toDouble());
 
             if (!CameraSpec::load(v1Json, errorString)) {

--- a/src/MissionManager/CameraCalc.h
+++ b/src/MissionManager/CameraCalc.h
@@ -70,7 +70,7 @@ public:
     void setDistanceToSurfaceRelative   (bool distanceToSurfaceRelative);
 
     void save(QJsonObject& json) const;
-    bool load(const QJsonObject& json, QString& errorString);
+    bool load(const QJsonObject& json, bool forPresets, bool cameraSpecInPreset, QString& errorString);
 
     static const char* cameraNameName;
     static const char* valueSetIsDistanceName;

--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -8,11 +8,20 @@
  ****************************************************************************/
 
 #include "ComplexMissionItem.h"
+#include "QGCApplication.h"
+
+#include <QSettings>
 
 const char* ComplexMissionItem::jsonComplexItemTypeKey = "complexItemType";
 
+const char* ComplexMissionItem::_presetSettingsKey =        "_presets";
+const char* ComplexMissionItem::_presetNameKey =            "complexItemPresetName";
+const char* ComplexMissionItem::_saveCameraInPresetKey =    "complexItemCameraSavedInPreset";
+const char* ComplexMissionItem::_builtInPresetKey =         "complexItemBuiltInPreset";
+
 ComplexMissionItem::ComplexMissionItem(Vehicle* vehicle, bool flyView, QObject* parent)
-    : VisualMissionItem(vehicle, flyView, parent)
+    : VisualMissionItem         (vehicle, flyView, parent)
+    , _cameraInPreset           (true)
 {
 
 }
@@ -21,5 +30,112 @@ const ComplexMissionItem& ComplexMissionItem::operator=(const ComplexMissionItem
 {
     VisualMissionItem::operator=(other);
 
+    _cameraInPreset = other._cameraInPreset;
+
     return *this;
+}
+
+QStringList ComplexMissionItem::presetNames(void)
+{
+    QStringList names;
+
+    QSettings settings;
+
+    settings.beginGroup(presetsSettingsGroup());
+    settings.beginGroup(_presetSettingsKey);
+    return settings.childKeys();
+}
+
+void ComplexMissionItem::loadPreset(const QString& name)
+{
+    Q_UNUSED(name);
+    qgcApp()->showMessage(tr("This Pattern does not support Presets."));
+}
+
+void ComplexMissionItem::savePreset(const QString& name)
+{
+    Q_UNUSED(name);
+    qgcApp()->showMessage(tr("This Pattern does not support Presets."));
+}
+
+void ComplexMissionItem::clearCurrentPreset(void)
+{
+    _currentPreset.clear();
+    emit currentPresetChanged(_currentPreset);
+}
+
+void ComplexMissionItem::deleteCurrentPreset(void)
+{
+    qDebug() << "deleteCurrentPreset" << _currentPreset;
+    if (!_currentPreset.isEmpty()) {
+        QSettings settings;
+
+        settings.beginGroup(presetsSettingsGroup());
+        settings.beginGroup(_presetSettingsKey);
+        settings.remove(_currentPreset);
+        emit presetNamesChanged();
+
+        clearCurrentPreset();
+    }
+}
+
+void ComplexMissionItem::_savePresetJson(const QString& name, QJsonObject& presetObject)
+{
+    presetObject[_presetNameKey] = name;
+
+    QSettings settings;
+    settings.beginGroup(presetsSettingsGroup());
+    settings.beginGroup(_presetSettingsKey);
+    settings.setValue(name, QJsonDocument(presetObject).toBinaryData());
+    emit presetNamesChanged();
+
+    _currentPreset = name;
+    emit currentPresetChanged(name);
+}
+
+QJsonObject ComplexMissionItem::_loadPresetJson(const QString& name)
+{
+    QSettings settings;
+    settings.beginGroup(presetsSettingsGroup());
+    settings.beginGroup(_presetSettingsKey);
+    return QJsonDocument::fromBinaryData(settings.value(name).toByteArray()).object();
+}
+
+void ComplexMissionItem::_saveItem(QJsonObject& saveObject)
+{
+    qDebug() << "_saveItem" << _cameraInPreset;
+    saveObject[_presetNameKey] =            _currentPreset;
+    saveObject[_saveCameraInPresetKey] =    _cameraInPreset;
+    saveObject[_builtInPresetKey] =         _builtInPreset;
+}
+
+void ComplexMissionItem::_loadItem(const QJsonObject& saveObject)
+{
+    _currentPreset =    saveObject[_presetNameKey].toString();
+    _cameraInPreset =   saveObject[_saveCameraInPresetKey].toBool(false);
+    _builtInPreset =    saveObject[_builtInPresetKey].toBool(false);
+
+    if (!presetNames().contains(_currentPreset)) {
+        _currentPreset.clear();
+    }
+
+    emit cameraInPresetChanged  (_cameraInPreset);
+    emit currentPresetChanged   (_currentPreset);
+    emit builtInPresetChanged   (_builtInPreset);
+}
+
+void ComplexMissionItem::setCameraInPreset(bool cameraInPreset)
+{
+    if (cameraInPreset != _cameraInPreset) {
+        _cameraInPreset = cameraInPreset;
+        emit cameraInPresetChanged(_cameraInPreset);
+    }
+}
+
+void ComplexMissionItem::setBuiltInPreset(bool builtInPreset)
+{
+    if (builtInPreset != _builtInPreset) {
+        _builtInPreset = builtInPreset;
+        emit builtInPresetChanged(_builtInPreset);
+    }
 }

--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -20,8 +20,9 @@ const char* ComplexMissionItem::_saveCameraInPresetKey =    "complexItemCameraSa
 const char* ComplexMissionItem::_builtInPresetKey =         "complexItemBuiltInPreset";
 
 ComplexMissionItem::ComplexMissionItem(Vehicle* vehicle, bool flyView, QObject* parent)
-    : VisualMissionItem         (vehicle, flyView, parent)
-    , _cameraInPreset           (true)
+    : VisualMissionItem (vehicle, flyView, parent)
+    , _cameraInPreset   (true)
+    , _builtInPreset    (false)
 {
 
 }
@@ -30,7 +31,9 @@ const ComplexMissionItem& ComplexMissionItem::operator=(const ComplexMissionItem
 {
     VisualMissionItem::operator=(other);
 
-    _cameraInPreset = other._cameraInPreset;
+    _currentPreset =    other._currentPreset;
+    _cameraInPreset =   other._cameraInPreset;
+    _builtInPreset =    other._builtInPreset;
 
     return *this;
 }

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -13,6 +13,8 @@
 #include "VisualMissionItem.h"
 #include "QGCGeo.h"
 
+#include <QSettings>
+
 class ComplexMissionItem : public VisualMissionItem
 {
     Q_OBJECT
@@ -22,7 +24,12 @@ public:
 
     const ComplexMissionItem& operator=(const ComplexMissionItem& other);
 
-    Q_PROPERTY(double   complexDistance     READ complexDistance    NOTIFY complexDistanceChanged)
+    Q_PROPERTY(double       complexDistance     READ complexDistance                            NOTIFY complexDistanceChanged)
+    Q_PROPERTY(bool         presetsSupported    READ presetsSupported                           CONSTANT)
+    Q_PROPERTY(QStringList  presetNames         READ presetNames                                NOTIFY presetNamesChanged)
+    Q_PROPERTY(QString      currentPreset       READ currentPreset                              NOTIFY currentPresetChanged)
+    Q_PROPERTY(bool         cameraInPreset      READ cameraInPreset     WRITE setCameraInPreset NOTIFY cameraInPresetChanged)
+    Q_PROPERTY(bool         builtInPreset       READ builtInPreset      WRITE setBuiltInPreset  NOTIFY builtInPresetChanged)
 
     /// @return The distance covered the complex mission item in meters.
     /// Signals complexDistanceChanged
@@ -35,11 +42,37 @@ public:
     /// @return true: load success, false: load failed, errorString set
     virtual bool load(const QJsonObject& complexObject, int sequenceNumber, QString& errorString) = 0;
 
+    /// Loads the specified preset into the complex item.
+    ///     @param name Preset name.
+    Q_INVOKABLE virtual void loadPreset(const QString& name);
+
+    /// Saves the current state of the complex item as the named preset.
+    ///     @param name User visible name for preset. Will replace existing preset if already exists.
+    Q_INVOKABLE virtual void savePreset(const QString& name);
+
+    Q_INVOKABLE void clearCurrentPreset(void);
+    Q_INVOKABLE void deleteCurrentPreset(void);
+
     /// Get the point of complex mission item furthest away from a coordinate
     ///     @param other QGeoCoordinate to which distance is calculated
     /// @return the greatest distance from any point of the complex item to some coordinate
     /// Signals greatestDistanceToChanged
     virtual double greatestDistanceTo(const QGeoCoordinate &other) const = 0;
+
+    /// Returns the list of currently saved presets for this complex item type.
+    ///     @param name User visible name for preset. Will replace existing preset if already exists.
+    virtual QStringList presetNames(void);
+
+    /// Returns the name of the settings group for presets.
+    ///     Empty string signals no support for presets.
+    virtual QString presetsSettingsGroup(void) { return QString(); }
+
+    bool    presetsSupported    (void) { return !presetsSettingsGroup().isEmpty(); }
+    QString currentPreset       (void) const { return _currentPreset; }
+    bool    cameraInPreset      (void) const { return _cameraInPreset; }
+    bool    builtInPreset       (void) const { return _builtInPreset; }
+    void    setCameraInPreset   (bool cameraInPreset);
+    void    setBuiltInPreset    (bool builtInPreset);
 
     /// This mission item attribute specifies the type of the complex item.
     static const char* jsonComplexItemTypeKey;
@@ -48,6 +81,29 @@ signals:
     void complexDistanceChanged     (void);
     void boundingCubeChanged        (void);
     void greatestDistanceToChanged  (void);
+    void presetNamesChanged         (void);
+    void currentPresetChanged       (QString currentPreset);
+    void cameraInPresetChanged      (bool cameraInPreset);
+    void builtInPresetChanged       (bool builtInPreset);
+
+protected:
+    void        _saveItem       (QJsonObject& saveObject);
+    void        _loadItem       (const QJsonObject& saveObject);
+    void        _savePresetJson (const QString& name, QJsonObject& presetObject);
+    QJsonObject _loadPresetJson (const QString& name);
+
+
+    QMap<QString, FactMetaData*> _metaDataMap;
+
+    QString         _currentPreset;
+    SettingsFact    _saveCameraInPresetFact;
+    bool            _cameraInPreset;
+    bool            _builtInPreset;
+
+    static const char* _presetSettingsKey;
+    static const char* _presetNameKey;
+    static const char* _saveCameraInPresetKey;
+    static const char* _builtInPresetKey;
 };
 
 #endif

--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -62,7 +62,7 @@ void CorridorScanComplexItem::save(QJsonArray&  planItems)
 {
     QJsonObject saveObject;
 
-    _save(saveObject);
+    TransectStyleComplexItem::_save(saveObject);
 
     saveObject[JsonHelper::jsonVersionKey] =                    2;
     saveObject[VisualMissionItem::jsonTypeKey] =                VisualMissionItem::jsonTypeComplexItemValue;
@@ -115,7 +115,7 @@ bool CorridorScanComplexItem::load(const QJsonObject& complexObject, int sequenc
 
     setSequenceNumber(sequenceNumber);
 
-    if (!_load(complexObject, errorString)) {
+    if (!_load(complexObject, false /* forPresets */, errorString)) {
         _ignoreRecalc = false;
         return false;
     }

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -218,7 +218,7 @@ bool StructureScanComplexItem::load(const QJsonObject& complexObject, int sequen
     setSequenceNumber(sequenceNumber);
 
     // Load CameraCalc first since it will trigger camera name change which will trounce gimbal angles
-    if (!_cameraCalc.load(complexObject[_jsonCameraCalcKey].toObject(), errorString)) {
+    if (!_cameraCalc.load(complexObject[_jsonCameraCalcKey].toObject(), false /* forPresets */, false /* cameraSpecInPreset */, errorString)) {
         return false;
     }
 

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -39,6 +39,9 @@ public:
     // Overrides from ComplexMissionItem
     bool    load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
     QString mapVisualQML        (void) const final { return QStringLiteral("SurveyMapVisual.qml"); }
+    QString presetsSettingsGroup(void) { return settingsGroup; }
+    void    savePreset          (const QString& name);
+    void    loadPreset          (const QString& name);
 
     // Overrides from TransectStyleComplexItem
     void    save                (QJsonArray&  planItems) final;
@@ -114,7 +117,8 @@ private:
     double _turnaroundDistance(void) const;
     bool _hoverAndCaptureEnabled(void) const;
     bool _loadV3(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
-    bool _loadV4V5(const QJsonObject& complexObject, int sequenceNumber, QString& errorString, int version);
+    bool _loadV4V5(const QJsonObject& complexObject, int sequenceNumber, QString& errorString, int version, bool forPresets);
+    void _saveWorker(QJsonObject& complexObject);
     void _rebuildTransectsPhase1Worker(bool refly);
     void _rebuildTransectsPhase1WorkerSinglePolygon(bool refly);
     void _rebuildTransectsPhase1WorkerSplitPolygons(bool refly);

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -141,7 +141,7 @@ protected:
     virtual void _recalcCameraShots         (void) = 0;
 
     void    _save                           (QJsonObject& saveObject);
-    bool    _load                           (const QJsonObject& complexObject, QString& errorString);
+    bool    _load                           (const QJsonObject& complexObject, bool forPresets, QString& errorString);
     void    _setExitCoordinate              (const QGeoCoordinate& coordinate);
     void    _setCameraShots                 (int cameraShots);
     double  _triggerDistance                (void) const;

--- a/src/PlanView/CameraCalc.qml
+++ b/src/PlanView/CameraCalc.qml
@@ -14,37 +14,53 @@ Column {
     anchors.right:  parent.right
     spacing:        _margin
 
+    visible: !usingPreset || !cameraSpecifiedInPreset
+
     property var    cameraCalc
     property bool   vehicleFlightIsFrontal:         true
     property string distanceToSurfaceLabel
     property int    distanceToSurfaceAltitudeMode:  QGroundControl.AltitudeModeNone
     property string frontalDistanceLabel
     property string sideDistanceLabel
+    property bool   usingPreset:                    false
+    property bool   cameraSpecifiedInPreset:        false
 
     property real   _margin:            ScreenTools.defaultFontPixelWidth / 2
-    property int    _cameraIndex:       1
+    property string _cameraName:        cameraCalc.cameraName.value
     property real   _fieldWidth:        ScreenTools.defaultFontPixelWidth * 10.5
     property var    _cameraList:        [ ]
     property var    _vehicle:           QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
     property var    _vehicleCameraList: _vehicle ? _vehicle.staticCameraList : []
+    property bool   _cameraComboFilled: false
 
     readonly property int _gridTypeManual:          0
     readonly property int _gridTypeCustomCamera:    1
     readonly property int _gridTypeCamera:          2
 
-    Component.onCompleted: {
+    Component.onCompleted: _fillCameraCombo()
+
+    on_CameraNameChanged: _updateSelectedCamera()
+
+    function _fillCameraCombo() {
+        _cameraComboFilled = true
         _cameraList.push(cameraCalc.manualCameraName)
         _cameraList.push(cameraCalc.customCameraName)
         for (var i=0; i<_vehicle.staticCameraList.length; i++) {
             _cameraList.push(_vehicle.staticCameraList[i].name)
         }
         gridTypeCombo.model = _cameraList
-        var knownCameraIndex = gridTypeCombo.find(cameraCalc.cameraName.value)
-        if (knownCameraIndex !== -1) {
-            gridTypeCombo.currentIndex = knownCameraIndex
-        } else {
-            console.log("Internal error: Known camera not found", cameraCalc.cameraName.value)
-            gridTypeCombo.currentIndex = _gridTypeCustomCamera
+        _updateSelectedCamera()
+    }
+
+    function _updateSelectedCamera() {
+        if (_cameraComboFilled) {
+            var knownCameraIndex = gridTypeCombo.find(_cameraName)
+            if (knownCameraIndex !== -1) {
+                gridTypeCombo.currentIndex = knownCameraIndex
+            } else {
+                console.log("Internal error: Known camera not found", _cameraName)
+                gridTypeCombo.currentIndex = _gridTypeCustomCamera
+            }
         }
     }
 
@@ -179,6 +195,7 @@ Column {
                 anchors.left:   parent.left
                 anchors.right:  parent.right
                 spacing:        _margin
+                visible:        !usingPreset
                 Item { Layout.fillWidth: true }
                 QGCLabel {
                     Layout.preferredWidth:  _root._fieldWidth
@@ -194,6 +211,7 @@ Column {
                 anchors.left:   parent.left
                 anchors.right:  parent.right
                 spacing:        _margin
+                visible:        !usingPreset
                 QGCLabel { text: qsTr("Overlap"); Layout.fillWidth: true }
                 FactTextField {
                     Layout.preferredWidth:  _root._fieldWidth
@@ -210,6 +228,7 @@ Column {
                 text:                   qsTr("Select one:")
                 Layout.preferredWidth:  parent.width
                 Layout.columnSpan:      2
+                visible:                !usingPreset
             }
 
             GridLayout {
@@ -218,6 +237,7 @@ Column {
                 columnSpacing:  _margin
                 rowSpacing:     _margin
                 columns:        2
+                visible:        !usingPreset
 
                 QGCRadioButton {
                     id:                     fixedDistanceRadio
@@ -248,33 +268,6 @@ Column {
                     Layout.fillWidth:       true
                 }
             }
-
-            // Calculated values
-/*
-            Taking these out for now since they take up so much space. May come back at a later time.
-            GridLayout {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                columnSpacing:  _margin
-                rowSpacing:     _margin
-                columns:        2
-
-                QGCLabel { text: frontalDistanceLabel }
-                FactTextField {
-                    Layout.fillWidth:   true
-                    fact:               cameraCalc.adjustedFootprintFrontal
-                    enabled:            false
-                }
-
-                QGCLabel { text: sideDistanceLabel }
-                FactTextField {
-                    Layout.fillWidth:   true
-                    fact:               cameraCalc.adjustedFootprintSide
-                    enabled:            false
-                }
-            } // GridLayout
-*/
-
         } // Column - Camera spec based ui
 
         // No camera spec ui


### PR DESCRIPTION
This allows you to save settings for a Pattern item as a named reusable preset. So for example if you fly a lot of say NDVI surveys at the same altitude and overlap settings you can save that as a preset. Then you create a new survey for a new area, you just select that Preset and you are done setting up the Survey.

Althought the internal archiecture for this is set up to work with all pattern types it is only supported by Survey now. Once we work through the usability of this on Survey then I'll implement in other Patterns.

![Screen Shot 2019-04-26 at 10 31 18 AM](https://user-images.githubusercontent.com/5876851/56827135-d1cbb880-6812-11e9-90c1-6f4e81e12d50.png)
