### PR TITLE
Rename NXPhlite to FMUK66

### DIFF
--- a/src/VehicleSetup/Bootloader.h
+++ b/src/VehicleSetup/Bootloader.h
@@ -75,7 +75,7 @@ public:
     static const int boardIDASCV1 = 65;         ///< ASC V1 board, as from USB PID
     static const int boardIDCrazyflie2 = 12;    ///< Crazyflie 2.0 board, as from USB PID
     static const int boardIDOmnibusF4SD = 42;   ///< Omnibus F4 SD, as from USB PID
-    static const int boardIDNXPHliteV3 = 28;    ///< NXPHliteV3 board, as from USB PID
+    static const int boardIDFMUK66V3 = 28;    ///< FMUK66V3 board, as from USB PID
 
     /// Simulated board id for V3 which is a V2 board which supports larger flash space
     /// IMPORTANT: Make sure this id does not conflict with any newly added real board ids

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -526,8 +526,8 @@ QHash<FirmwareUpgradeController::FirmwareIdentifier, QString>* FirmwareUpgradeCo
     case Bootloader::boardIDOmnibusF4SD:
         _rgFirmwareDynamic = _rgOmnibusF4SDFirmware;
         break;
-    case Bootloader::boardIDNXPHliteV3:
-        _rgFirmwareDynamic = _rgNXPHliteV3Firmware;
+    case Bootloader::boardIDFMUK66V3:
+        _rgFirmwareDynamic = _rgFMUK66V3Firmware;
         break;
     case Bootloader::boardID3DRRadio:
         _rgFirmwareDynamic = _rg3DRRadioFirmware;

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -212,7 +212,7 @@ private:
     QHash<FirmwareIdentifier, QString> _rgASCV1Firmware;
     QHash<FirmwareIdentifier, QString> _rgCrazyflie2Firmware;
     QHash<FirmwareIdentifier, QString> _rgOmnibusF4SDFirmware;
-    QHash<FirmwareIdentifier, QString> _rgNXPHliteV3Firmware;
+    QHash<FirmwareIdentifier, QString> _rgFMUK66V3Firmware;
     QHash<FirmwareIdentifier, QString> _rgPX4FLowFirmware;
     QHash<FirmwareIdentifier, QString> _rg3DRRadioFirmware;
 

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -19,7 +19,7 @@
         { "vendorID": 9900, "productID": 65,        "boardClass": "Pixhawk",    "name": "ASC V1" },
         { "vendorID": 9900, "productID": 22,        "boardClass": "Pixhawk",    "name": "Crazyflie 2" },
         { "vendorID": 9900, "productID": 1,         "boardClass": "Pixhawk",    "name": "Omnibus F4 SD" },
-        { "vendorID": 8137, "productID": 28,        "boardClass": "Pixhawk",    "name": "PX4 NXPHlite v3.x" },
+        { "vendorID": 8137, "productID": 28,        "boardClass": "Pixhawk",    "name": "PX4 FMUK66 v3.x" },
 
         { "vendorID": 1155, "productID": 22336,     "boardClass": "Pixhawk",    "name": "ArduPilot ChibiOS" },
         { "vendorID": 4617, "productID": 22336,     "boardClass": "Pixhawk",    "name": "ArduPilot ChibiOS" },


### PR DESCRIPTION
Rename NXPhlite to FMUK66 everywhere, as was already done in PX4 and the PX4 Bootloader.

Related:
mavlink/qgroundcontrol#7360
PX4/Bootloader#133