### PR TITLE
Log replay changes

### DIFF
--- a/src/comm/LogReplayLink.cc
+++ b/src/comm/LogReplayLink.cc
@@ -14,6 +14,7 @@
 
 #include <QFileInfo>
 #include <QtEndian>
+#include <QSignalSpy>
 
 const char*  LogReplayLinkConfiguration::_logFilenameKey = "logFilename";
 
@@ -368,7 +369,7 @@ void LogReplayLink::_readNextLogEntry(void)
             timeToNextExecutionMSecs = desiredPacedTimeMSecs - currentTimeMSecs;
         }
 
-        emit currentLogTimeSecs((_logCurrentTimeUSecs - _logStartTimeUSecs) / 1000000);
+        _signalCurrentLogTimeSecs();
 
         // And schedule the next execution of this function.
         _readTickTimer.start(timeToNextExecutionMSecs);
@@ -450,8 +451,12 @@ void LogReplayLink::_resetPlaybackToBeginning(void)
 void LogReplayLink::movePlayhead(int percentComplete)
 {
     if (isPlaying()) {
-        qWarning() << "Should not move playhead while playing, pause first";
-        return;
+        _pauseOnThread();
+        QSignalSpy waitForPause(this, SIGNAL(playbackPaused));
+        waitForPause.wait();
+        if (_readTickTimer.isActive()) {
+            return;
+        }
     }
 
     if (percentComplete < 0 || percentComplete > 100) {
@@ -495,7 +500,8 @@ void LogReplayLink::movePlayhead(int percentComplete)
         // And scan until we reach the start of a MAVLink message. We make sure to record this timestamp for
         // smooth jumping around the file.
         _logCurrentTimeUSecs = _seekToNextMavlinkMessage(&dummy);
-        
+        _signalCurrentLogTimeSecs();
+
         // Now update the UI with our actual final position.
         newRelativeTimeUSecs = (float)(_logCurrentTimeUSecs - _logStartTimeUSecs);
         percentComplete = (newRelativeTimeUSecs / _logDurationUSecs) * 100;
@@ -560,4 +566,9 @@ void LogReplayLink::_playbackError(void)
     _pause();
     _logFile.close();
     emit playbackError();
+}
+
+void LogReplayLink::_signalCurrentLogTimeSecs(void)
+{
+    emit currentLogTimeSecs((_logCurrentTimeUSecs - _logStartTimeUSecs) / 1000000);
 }

--- a/src/comm/LogReplayLink.h
+++ b/src/comm/LogReplayLink.h
@@ -120,6 +120,7 @@ private:
     void _finishPlayback(void);
     void _playbackError(void);
     void _resetPlaybackToBeginning(void);
+    void _signalCurrentLogTimeSecs(void);
 
     // Virtuals from LinkInterface
     virtual bool _connect(void);

--- a/src/ui/MainWindow.cc
+++ b/src/ui/MainWindow.cc
@@ -271,7 +271,7 @@ void MainWindow::_buildCommonWidgets(void)
     // Log player
     // TODO: Make this optional with a preferences setting or under a "View" menu
     logPlayer = new QGCMAVLinkLogPlayer(statusBar());
-    statusBar()->addPermanentWidget(logPlayer);
+    statusBar()->addPermanentWidget(logPlayer, 1);
 
     // Populate widget menu
     for (int i = 0, end = ARRAY_SIZE(rgDockWidgetNames); i < end; i++) {

--- a/src/ui/QGCMAVLinkLogPlayer.cc
+++ b/src/ui/QGCMAVLinkLogPlayer.cc
@@ -142,7 +142,6 @@ void QGCMAVLinkLogPlayer::_playbackStarted(void)
     _enablePlaybackControls(true);
     _ui->playButton->setChecked(true);
     _ui->playButton->setIcon(QIcon(":/res/Pause"));
-    _ui->positionSlider->setEnabled(false);
 }
 
 /// Signalled from LogReplayLink when replay is paused
@@ -150,7 +149,6 @@ void QGCMAVLinkLogPlayer::_playbackPaused(void)
 {
     _ui->playButton->setIcon(QIcon(":/res/Play"));
     _ui->playButton->setChecked(false);
-    _ui->positionSlider->setEnabled(true);
 }
 
 void QGCMAVLinkLogPlayer::_playbackPercentCompleteChanged(int percentComplete)

--- a/src/ui/QGCMAVLinkLogPlayer.ui
+++ b/src/ui/QGCMAVLinkLogPlayer.ui
@@ -75,7 +75,7 @@
       <number>100</number>
      </property>
      <property name="tracking">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
A few changes to make Log Replay a little less crappy:
* The status bar takes up the full width of the window. Making the time slider larger.
* You can drag the time slider while playing back. It will pause and adjust time.
* While dragging time slider the actual time in the log updates.

Related to #7412