### PR TITLE
Made Microhard password fields hidden

### DIFF
--- a/src/Microhard/MicrohardSettings.qml
+++ b/src/Microhard/MicrohardSettings.qml
@@ -222,7 +222,7 @@ QGCView {
                                 id:             configPassword
                                 text:           QGroundControl.microhardManager.configPassword
                                 enabled:        true
-                                inputMethodHints:    Qt.ImhHiddenText
+                                echoMode:       TextInput.Password
                                 Layout.minimumWidth: _valueWidth
                             }
                             QGCLabel {
@@ -232,7 +232,7 @@ QGCView {
                                 id:             encryptionKey
                                 text:           QGroundControl.microhardManager.encryptionKey
                                 enabled:        true
-                                inputMethodHints:    Qt.ImhHiddenText
+                                echoMode:       TextInput.Password
                                 Layout.minimumWidth: _valueWidth
                             }
                         }


### PR DESCRIPTION
Microhard configuration panel contained password fields that showed passwords in full text.
This PR makes those fields hidden.

When echoMode is set to TextInput.Password also inputMethodHints is set automatically to Qt.ImhHiddenText.