### PR TITLE
Warn user when multiple devices are connected while doing the firmware upgrade

### DIFF
--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -118,6 +118,13 @@ SetupPage {
                         // Board was found right away, so something is already plugged in before we've started upgrade
                         statusTextArea.append(qgcUnplugText1)
                         statusTextArea.append(qgcUnplugText2)
+
+                        var availableDevices = controller.availableBoardsName()
+                        if(availableDevices.length > 1) {
+                            statusTextArea.append(highlightPrefix + qsTr("Multiple devices detected! Remove all detected devices to perform the firmware upgrade."))
+                            statusTextArea.append(qsTr("Detected [%1]: ").arg(availableDevices.length) + availableDevices.join(", "))
+                        }
+
                         QGroundControl.multiVehicleManager.activeVehicle.autoDisconnect = true
                     } else {
                         // We end up here when we detect a board plugged in after we've started upgrade

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -127,6 +127,23 @@ void FirmwareUpgradeController::cancel(void)
     _threadController->cancel();
 }
 
+QStringList FirmwareUpgradeController::availableBoardsName(void)
+{
+    QGCSerialPortInfo::BoardType_t boardType;
+    QString boardName;
+    QStringList names;
+
+    auto ports = QGCSerialPortInfo::availablePorts();
+    for(const auto info : ports) {
+        if(info.canFlash()) {
+            info.getBoardInfo(boardType, boardName);
+            names.append(boardName);
+        }
+    }
+
+    return names;
+}
+
 void FirmwareUpgradeController::_foundBoard(bool firstAttempt, const QSerialPortInfo& info, int boardType, QString boardName)
 {
     _foundBoardInfo = info;

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -152,6 +152,13 @@ public:
     bool pixhawkBoard(void) const { return _foundBoardType == QGCSerialPortInfo::BoardTypePixhawk; }
     bool px4FlowBoard(void) const { return _foundBoardType == QGCSerialPortInfo::BoardTypePX4Flow; }
 
+    /**
+     * @brief Return a human friendly string of available boards
+     *
+     * @return availableBoardNames
+     */
+    Q_INVOKABLE QStringList availableBoardsName(void);
+
 signals:
     void boardFound(void);
     void noBoardFound(void);

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -340,7 +340,7 @@ bool QGCSerialPortInfo::isSystemPort(QSerialPortInfo* port)
     return false;
 }
 
-bool QGCSerialPortInfo::canFlash(void)
+bool QGCSerialPortInfo::canFlash(void) const
 {
     BoardType_t boardType;
     QString     name;

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -43,7 +43,7 @@ public:
     bool getBoardInfo(BoardType_t& boardType, QString& name) const;
 
     /// @return true: we can flash this board type
-    bool canFlash(void);
+    bool canFlash(void) const;
 
     /// @return true: Board is currently in bootloader
     bool isBootloader(void) const;


### PR DESCRIPTION
**Describe the bug**
The user does not have any feedback around how many devices are connected and what kind of device should be removed.
QGC also detects normal FTDIs and Arduinos as SiK radios.

**Expected behavior**
This PR add a human friendly message warning the user that multiple devices are connected and need to be removed before performing the firmware upgrade.

![image](https://user-images.githubusercontent.com/1215497/57469495-2a607400-725d-11e9-8e43-65616ffb0c99.png)

