### PR TITLE
Firmware Upgrade: Use ArduPilot manifest to get firmware listings

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -599,6 +599,7 @@ HEADERS += \
     src/Settings/AppSettings.h \
     src/Settings/AutoConnectSettings.h \
     src/Settings/BrandImageSettings.h \
+    src/Settings/FirmwareUpgradeSettings.h \
     src/Settings/FlightMapSettings.h \
     src/Settings/FlyViewSettings.h \
     src/Settings/OfflineMapsSettings.h \
@@ -803,6 +804,7 @@ SOURCES += \
     src/Settings/AppSettings.cc \
     src/Settings/AutoConnectSettings.cc \
     src/Settings/BrandImageSettings.cc \
+    src/Settings/FirmwareUpgradeSettings.cc \
     src/Settings/FlightMapSettings.cc \
     src/Settings/FlyViewSettings.cc \
     src/Settings/OfflineMapsSettings.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -224,6 +224,7 @@
         <file alias="AutoConnect.SettingsGroup.json">src/Settings/AutoConnect.SettingsGroup.json</file>
         <file alias="BrandImage.SettingsGroup.json">src/Settings/BrandImage.SettingsGroup.json</file>
         <file alias="CameraSection.FactMetaData.json">src/MissionManager/CameraSection.FactMetaData.json</file>
+		<file alias="FirmwareUpgrade.SettingsGroup.json">src/Settings/FirmwareUpgrade.SettingsGroup.json</file>
         <file alias="FlightMap.SettingsGroup.json">src/Settings/FlightMap.SettingsGroup.json</file>
         <file alias="FWLandingPattern.FactMetaData.json">src/MissionManager/FWLandingPattern.FactMetaData.json</file>
         <file alias="FlyView.SettingsGroup.json">src/Settings/FlyView.SettingsGroup.json</file>

--- a/src/Settings/FirmwareUpgrade.SettingsGroup.json
+++ b/src/Settings/FirmwareUpgrade.SettingsGroup.json
@@ -1,0 +1,22 @@
+[
+{
+    "name":             "defaultFirmwareType",
+    "shortDescription": "Default firmware type for flashing",
+    "type":             "uint32",
+    "defaultValue":     12
+},
+{
+    "name":             "apmChibiOS",
+    "type":             "uint32",
+    "enumStrings":      "ChibiOS,NuttX",
+    "enumValues":       "0,1",
+    "defaultValue":     0
+},
+{
+    "name":             "apmVehicleType",
+    "type":             "uint32",
+    "enumStrings":      "Multi-Rotor,Helicopter,Plane,Rover,Sub",
+    "enumValues":       "0,1,2,3,4",
+    "defaultValue":     0
+}
+]

--- a/src/Settings/FirmwareUpgradeSettings.cc
+++ b/src/Settings/FirmwareUpgradeSettings.cc
@@ -1,0 +1,22 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "FirmwareUpgradeSettings.h"
+
+#include <QQmlEngine>
+#include <QtQml>
+
+DECLARE_SETTINGGROUP(FirmwareUpgrade, "FirmwareUpgrade")
+{
+    qmlRegisterUncreatableType<FirmwareUpgradeSettings>("QGroundControl.SettingsManager", 1, 0, "FirmwareUpgradeSettings", "Reference only");
+}
+
+DECLARE_SETTINGSFACT(FirmwareUpgradeSettings, defaultFirmwareType)
+DECLARE_SETTINGSFACT(FirmwareUpgradeSettings, apmChibiOS)
+DECLARE_SETTINGSFACT(FirmwareUpgradeSettings, apmVehicleType)

--- a/src/Settings/FirmwareUpgradeSettings.h
+++ b/src/Settings/FirmwareUpgradeSettings.h
@@ -1,0 +1,26 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+#pragma once
+
+#include "SettingsGroup.h"
+#include "QGCMAVLink.h"
+
+class FirmwareUpgradeSettings : public SettingsGroup
+{
+    Q_OBJECT
+
+public:
+    FirmwareUpgradeSettings(QObject* parent = nullptr);
+
+    DEFINE_SETTING_NAME_GROUP()
+
+    DEFINE_SETTINGFACT(defaultFirmwareType)
+    DEFINE_SETTINGFACT(apmChibiOS)
+    DEFINE_SETTINGFACT(apmVehicleType)
+};

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -27,6 +27,7 @@ SettingsManager::SettingsManager(QGCApplication* app, QGCToolbox* toolbox)
     , _planViewSettings             (nullptr)
     , _brandImageSettings           (nullptr)
     , _offlineMapsSettings          (nullptr)
+    , _firmwareUpgradeSettings      (nullptr)
 #if !defined(NO_ARDUPILOT_DIALECT)
     , _apmMavlinkStreamRateSettings (nullptr)
 #endif
@@ -40,20 +41,21 @@ void SettingsManager::setToolbox(QGCToolbox *toolbox)
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     qmlRegisterUncreatableType<SettingsManager>("QGroundControl.SettingsManager", 1, 0, "SettingsManager", "Reference only");
 
-    _unitsSettings =                new UnitsSettings       (this);        // Must be first since AppSettings references it
-    _appSettings =                  new AppSettings         (this);
-    _autoConnectSettings =          new AutoConnectSettings (this);
-    _videoSettings =                new VideoSettings       (this);
-    _flightMapSettings =            new FlightMapSettings   (this);
-    _rtkSettings =                  new RTKSettings         (this);
-    _flyViewSettings =              new FlyViewSettings     (this);
-    _planViewSettings =             new PlanViewSettings    (this);
-    _brandImageSettings =           new BrandImageSettings  (this);
-    _offlineMapsSettings =          new OfflineMapsSettings (this);
+    _unitsSettings =                new UnitsSettings           (this);        // Must be first since AppSettings references it
+    _appSettings =                  new AppSettings             (this);
+    _autoConnectSettings =          new AutoConnectSettings     (this);
+    _videoSettings =                new VideoSettings           (this);
+    _flightMapSettings =            new FlightMapSettings       (this);
+    _rtkSettings =                  new RTKSettings             (this);
+    _flyViewSettings =              new FlyViewSettings         (this);
+    _planViewSettings =             new PlanViewSettings        (this);
+    _brandImageSettings =           new BrandImageSettings      (this);
+    _offlineMapsSettings =          new OfflineMapsSettings     (this);
+    _firmwareUpgradeSettings =      new FirmwareUpgradeSettings (this);
 #if !defined(NO_ARDUPILOT_DIALECT)
-    _apmMavlinkStreamRateSettings = new APMMavlinkStreamRateSettings     (this);
+    _apmMavlinkStreamRateSettings = new APMMavlinkStreamRateSettings(this);
 #endif
 #if defined(QGC_AIRMAP_ENABLED)
-    _airMapSettings =               new AirMapSettings      (this);
+    _airMapSettings =               new AirMapSettings          (this);
 #endif
 }

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -25,6 +25,7 @@
 #include "BrandImageSettings.h"
 #include "OfflineMapsSettings.h"
 #include "APMMavlinkStreamRateSettings.h"
+#include "FirmwareUpgradeSettings.h"
 #if defined(QGC_AIRMAP_ENABLED)
 #include "AirMapSettings.h"
 #endif
@@ -50,7 +51,8 @@ public:
     Q_PROPERTY(QObject* flyViewSettings                 READ flyViewSettings                CONSTANT)
     Q_PROPERTY(QObject* planViewSettings                READ planViewSettings               CONSTANT)
     Q_PROPERTY(QObject* brandImageSettings              READ brandImageSettings             CONSTANT)
-    Q_PROPERTY(QObject* offlineMapsSettings             READ offlineMapsSettings             CONSTANT)
+    Q_PROPERTY(QObject* offlineMapsSettings             READ offlineMapsSettings            CONSTANT)
+    Q_PROPERTY(QObject* firmwareUpgradeSettings         READ firmwareUpgradeSettings        CONSTANT)
 #if !defined(NO_ARDUPILOT_DIALECT)
     Q_PROPERTY(QObject* apmMavlinkStreamRateSettings    READ apmMavlinkStreamRateSettings   CONSTANT)
 #endif
@@ -70,6 +72,7 @@ public:
     PlanViewSettings*               planViewSettings            (void) { return _planViewSettings; }
     BrandImageSettings*             brandImageSettings          (void) { return _brandImageSettings; }
     OfflineMapsSettings*            offlineMapsSettings         (void) { return _offlineMapsSettings; }
+    FirmwareUpgradeSettings*        firmwareUpgradeSettings     (void) { return _firmwareUpgradeSettings; }
 #if !defined(NO_ARDUPILOT_DIALECT)
     APMMavlinkStreamRateSettings*   apmMavlinkStreamRateSettings(void) { return _apmMavlinkStreamRateSettings; }
 #endif
@@ -87,6 +90,7 @@ private:
     PlanViewSettings*               _planViewSettings;
     BrandImageSettings*             _brandImageSettings;
     OfflineMapsSettings*            _offlineMapsSettings;
+    FirmwareUpgradeSettings*        _firmwareUpgradeSettings;
 #if !defined(NO_ARDUPILOT_DIALECT)
     APMMavlinkStreamRateSettings*   _apmMavlinkStreamRateSettings;
 #endif

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3325,6 +3325,10 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
         //_startPlanRequest();
     }
 
+    if (ack.command == MAV_CMD_FLASH_BOOTLOADER && ack.result == MAV_RESULT_ACCEPTED) {
+        qgcApp()->showMessage(tr("Bootloader flash succeeded"));
+    }
+
     if (_mavCommandQueue.count() && ack.command == _mavCommandQueue[0].command) {
         _mavCommandAckTimer.stop();
         showError = _mavCommandQueue[0].showError;

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -189,7 +189,6 @@ SetupPage {
                     }
 
                     function accept() {
-                        hideDialog()
                         if (_singleFirmwareMode) {
                             controller.flashSingleFirmwareMode(controller.selectedFirmwareBuildType)
                         } else {
@@ -210,13 +209,18 @@ SetupPage {
                                             // Not ready yet, or no firmware available
                                             return
                                         }
+                                        var firmwareUrl = controller.apmFirmwareUrls[ardupilotFirmwareSelectionCombo.currentIndex]
+                                        if (firmwareUrl == "") {
+                                            return
+                                        }
                                         controller.flashFirmwareUrl(controller.apmFirmwareUrls[ardupilotFirmwareSelectionCombo.currentIndex])
+                                        hideDialog()
                                         return
                                     }
                                 }
                             }
-
                             controller.flash(stack, firmwareBuildType, vehicleType)
+                            hideDialog()
                         }
                     }
 

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -290,6 +290,7 @@ private:
         QList<int>              rgPID;
         QString                 friendlyName;
         bool                    chibios;
+        bool                    fmuv2;
     } ManifestFirmwareInfo_t;
 
 


### PR DESCRIPTION
The manifest of available firmwares is downloaded from the ArduPilot web site. This then gives you the list of available firmwares which can be flashed to the board.

The UI is reworked such that you can pick ChibiOS/NuttX and then vehicle type followed by the actual firmware.

If the board leads to a single firmware (like when the ArduPilot bootloader indicates specific board type) you get that specific firmware to flash:
![Screen Shot 2019-05-11 at 1 45 17 PM](https://user-images.githubusercontent.com/5876851/57574735-6299bb00-73f3-11e9-80bb-156cbcddbc52.png)

If it is a generic board like an old Pixhawk then you have to pick the firmware you want:
![Screen Shot 2019-05-11 at 1 45 42 PM](https://user-images.githubusercontent.com/5876851/57574754-9b399480-73f3-11e9-82c7-5a0699279f20.png)

I would consider this a bit of a WIP since I'm not still too happy with all the choices the user has to make in some cases (for example the old Pixhawk 2 case aboce). But I need to put some more though into that first to figure out what to do about it.
