### PR TITLE
Restart video stream after change

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -70,6 +70,9 @@ const char* QGCCameraControl::kCAM_SHUTTERSPD  = "CAM_SHUTTERSPD";
 const char* QGCCameraControl::kCAM_APERTURE    = "CAM_APERTURE";
 const char* QGCCameraControl::kCAM_WBMODE      = "CAM_WBMODE";
 const char* QGCCameraControl::kCAM_MODE        = "CAM_MODE";
+const char* QGCCameraControl::kCAM_BITRATE     = "CAM_BITRATE";
+const char* QGCCameraControl::kCAM_FPS         = "CAM_FPS";
+const char* QGCCameraControl::kCAM_ENC         = "CAM_ENC";
 
 //-----------------------------------------------------------------------------
 QGCCameraOptionExclusion::QGCCameraOptionExclusion(QObject* parent, QString param_, QString value_, QStringList exclusions_)
@@ -2103,6 +2106,27 @@ Fact*
 QGCCameraControl::mode()
 {
     return _paramComplete ? getFact(kCAM_MODE) : nullptr;
+}
+
+//-----------------------------------------------------------------------------
+Fact*
+QGCCameraControl::bitRate()
+{
+    return _paramComplete ? getFact(kCAM_BITRATE) : nullptr;
+}
+
+//-----------------------------------------------------------------------------
+Fact*
+QGCCameraControl::frameRate()
+{
+    return _paramComplete ? getFact(kCAM_FPS) : nullptr;
+}
+
+//-----------------------------------------------------------------------------
+Fact*
+QGCCameraControl::videoEncoding()
+{
+    return _paramComplete ? getFact(kCAM_ENC) : nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -167,6 +167,9 @@ public:
     Q_PROPERTY(Fact*        aperture            READ aperture           NOTIFY parametersReady)
     Q_PROPERTY(Fact*        wb                  READ wb                 NOTIFY parametersReady)
     Q_PROPERTY(Fact*        mode                READ mode               NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        bitRate             READ bitRate            NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        frameRate           READ frameRate          NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        videoEncoding       READ videoEncoding      NOTIFY parametersReady)
 
     Q_PROPERTY(QStringList  activeSettings      READ activeSettings                                 NOTIFY activeSettingsChanged)
     Q_PROPERTY(VideoStatus  videoStatus         READ videoStatus                                    NOTIFY videoStatusChanged)
@@ -252,6 +255,9 @@ public:
     virtual Fact*       aperture            ();
     virtual Fact*       wb                  ();
     virtual Fact*       mode                ();
+    virtual Fact*       bitRate             ();
+    virtual Fact*       frameRate           ();
+    virtual Fact*       videoEncoding       ();
 
     //-- Stream names to show the user (for selection)
     virtual QStringList streamLabels        () { return _streamLabels; }
@@ -292,6 +298,9 @@ public:
     static const char* kCAM_APERTURE;
     static const char* kCAM_WBMODE;
     static const char* kCAM_MODE;
+    static const char* kCAM_BITRATE;
+    static const char* kCAM_FPS;
+    static const char* kCAM_ENC;
 
 signals:
     void    infoChanged                     ();

--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *   (c) 2009-2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
@@ -62,6 +62,7 @@ public:
     double      thermalHfov         ();
     bool        autoStreamConfigured();
     bool        hasThermal          ();
+    void        restartVideo        ();
 
     VideoReceiver*  videoReceiver           () { return _videoReceiver; }
     VideoReceiver*  thermalVideoReceiver    () { return _thermalVideoReceiver; }
@@ -99,7 +100,6 @@ private slots:
     void _updateUVC                 ();
     void _setActiveVehicle          (Vehicle* vehicle);
     void _aspectRatioChanged        ();
-    void _restartVideo              ();
 
 private:
     void _updateSettings            ();

--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -138,7 +138,6 @@ newPadCB(GstElement* element, GstPad* pad, gpointer data)
         qCritical() << "newPadCB : failed to link elements\n";
     g_free(name);
 }
-#endif
 
 //-----------------------------------------------------------------------------
 void
@@ -146,6 +145,7 @@ VideoReceiver::_restart_timeout()
 {
     qgcApp()->toolbox()->videoManager()->restartVideo();
 }
+#endif
 
 //-----------------------------------------------------------------------------
 // When we finish our pipeline will look like this:


### PR DESCRIPTION
- Add camera parameters for video stream bitrate, frames per second and encoding.
- When these parameters where changed from QGC, the video stream was not restarted properly and sometimes it was started twice
- If H265 encoding is used change pipeline so that H265 decode is used.