### PR TITLE
Camera info requests

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -107,8 +107,8 @@ QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
 {
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
-    //-- If this heartbeat is from a different component within the vehicle
-    if(_vehicleReadyState && _vehicle->id() == message.sysid && _vehicle->defaultComponentId() != message.compid) {
+    //-- Only pay attention to "camera" component IDs
+    if(_vehicleReadyState && _vehicle->id() == message.sysid && message.compid >= MAV_COMP_ID_CAMERA && message.compid <= MAV_COMP_ID_CAMERA6) {
         //-- First time hearing from this one?
         QString sCompID = QString::number(message.compid);
         if(!_cameraInfoRequest.contains(sCompID)) {
@@ -135,8 +135,7 @@ QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
                             }
                         } else {
                             pInfo->tryCount++;
-                            //-- Request camera info. Again. It could be something other than a camera, in which
-                            //   case, we won't ever receive it.
+                            //-- Request camera info again.
                             _requestCameraInfo(message.compid);
                         }
                     }


### PR DESCRIPTION
In response to #7433 

Check for camera info when receiving heartbeats from camera component IDs only. 

The original code would send a camera info request to any component ID other than the autopilot itself. This was done as at the time, there was one single `MAV_COMP_ID_CAMERA` and vehicles with multiple cameras had to resort to arbitrary component IDs. Now that we have a set of 6 predefined component IDs, I'm limiting the search to those only.

In practicality it makes little difference. Components that don't support the message would simply ignore and QGC would stop asking for it. On the other hand, limiting to the predefined set of component IDs makes it less confusing.

Closes #7433 
