### PR TITLE
Handle ArduPilot strangeness with respect to components and mavlink spec for params

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -137,6 +137,7 @@ private:
     // Vehicle specific data should go into APMFirmwarePluginInstanceData
 
     QList<APMCustomMode>    _supportedModes;
+    QMap<int /* vehicle id */, QMap<int /* componentId */, bool /* true: component is part of ArduPilot stack */>> _ardupilotComponentMap;
 
     static const char*      _artooIP;
     static const int        _artooVideoHandshakePort;


### PR DESCRIPTION
Fix for #7431 (I hope)!

* Watch heartbeats which come through the system from components. If they come through with HEARTBEAT.autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA then assume they are running ArduPilot code. If not, assume it is not ArduPilot code and they are coded conform to mavlink spec.
* Since the ESP8266 doesn't send heartbeats it need sto be hardcoded to confirming to mavlink spec. There was already code in for this, but it wasn't quite correct.
* If the component doesn't sent a heartbeat then it is assumes to be ArduPilot code (which it may or may not be). But there is apparently no way to handle this correctly.