### PR TITLE
Fix for java open accessory crash

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
@@ -107,7 +107,7 @@ public class QGCActivity extends QtActivity
                 String action = intent.getAction();
                 if (ACTION_USB_PERMISSION.equals(action)) {
                     UsbAccessory accessory = intent.getParcelableExtra(UsbManager.EXTRA_ACCESSORY);
-                    if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
+                    if (accessory != null && intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
                         openAccessory(accessory);
                     }
                 } else if( UsbManager.ACTION_USB_ACCESSORY_DETACHED.equals(action)) {
@@ -730,6 +730,9 @@ public class QGCActivity extends QtActivity
                     UsbAccessory[] accessories = _usbManager.getAccessoryList();
                     if (accessories != null) {
                        for (UsbAccessory usbAccessory : accessories) {
+                           if (usbAccessory == null) {
+                               continue;
+                           }
                            if (_usbManager.hasPermission(usbAccessory)) {
                                openAccessory(usbAccessory);
                            } else {


### PR DESCRIPTION
Bug reported in #7444

Caused by: java.lang.NullPointerException:
at org.mavlink.qgroundcontrol.QGCActivity.openAccessory (QGCActivity.java:674)

I could not reproduce it in my environment but few commits agot line 674 was 
Log.i(TAG, "openAccessory: " + usbAccessory.getSerial());
which means that usbAccessory was null when openAccessory was called.

This PR makes sure that usbAccessory is checked for null before being used.

