### PR TITLE
Set Android Joystick native methods from JNI_OnLoad

### DIFF
--- a/src/Joystick/JoystickAndroid.cc
+++ b/src/Joystick/JoystickAndroid.cc
@@ -211,9 +211,7 @@ static JoystickManager *_manager = nullptr;
 
 //helper method
 bool JoystickAndroid::init(JoystickManager *manager) {
-    if (_manager == nullptr) {
-        setNativeMethods(manager);
-    }
+    _manager = manager;
 
     //this gets list of all possible buttons - this is needed to check how many buttons our gamepad supports
     //instead of the whole logic below we could have just a simple array of hardcoded int values as these 'should' not change
@@ -267,11 +265,9 @@ static void jniUpdateAvailableJoysticks(JNIEnv *envA, jobject thizA)
     }
 }
 
-void JoystickAndroid::setNativeMethods(JoystickManager *manager)
+void JoystickAndroid::setNativeMethods()
 {
     qCDebug(JoystickLog) << "Registering Native Functions";
-
-    _manager = manager;
 
     //  REGISTER THE C++ FUNCTION WITH JNI
     JNINativeMethod javaMethods[] {

--- a/src/Joystick/JoystickAndroid.h
+++ b/src/Joystick/JoystickAndroid.h
@@ -21,13 +21,13 @@ public:
 
     static bool init(JoystickManager *manager);
 
+    static void setNativeMethods();
+
     static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager);
 
 private:
     bool handleKeyEvent(jobject event);
     bool handleGenericMotionEvent(jobject event);
-
-    static void setNativeMethods(JoystickManager *manager);
 
     virtual bool _open();
     virtual void _close();

--- a/src/main.cc
+++ b/src/main.cc
@@ -78,9 +78,12 @@ int WindowsCrtReportHook(int reportType, char* message, int* returnValue)
 
 #endif
 
-#if defined(__android__) && !defined(NO_SERIAL_LINK)
+#if defined(__android__)
 #include <jni.h>
+#include "JoystickAndroid.h"
+#if !defined(NO_SERIAL_LINK)
 #include "qserialport.h"
+#endif
 
 jint JNI_OnLoad(JavaVM* vm, void* reserved)
 {
@@ -90,8 +93,10 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
         return -1;
     }
-
+ #if !defined(NO_SERIAL_LINK)
     QSerialPort::setNativeMethods();
+ #endif
+    JoystickAndroid::setNativeMethods();
 
     return JNI_VERSION_1_6;
 }


### PR DESCRIPTION
Bug report: #7445

The problem could not be reproduced on my devices but I found that the joystick native methods were not registered at the same point of time as the serial port native methods so it is very likely that they were not registered yet when this crash happens.
Solution registers joystick native methods from JNI_OnLoad - in the same way as serial port JNI methods.