### PR TITLE
main: Returning critical messsage and an error code when QGC is alredy running

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -19,6 +19,7 @@
 #include <QApplication>
 #include <QIcon>
 #include <QSslSocket>
+#include <QMessageBox>
 #include <QProcessEnvironment>
 #include <QHostAddress>
 #include <QUdpSocket>
@@ -222,7 +223,12 @@ int main(int argc, char *argv[])
 #ifndef __mobile__
     RunGuard guard("QGroundControlRunGuardKey");
     if (!guard.tryToRun()) {
-        return 0;
+        // QApplication is necessary to use QMessageBox
+        QApplication errorApp(argc, argv);
+        QMessageBox::critical(nullptr, QObject::tr("Error"),
+            QObject::tr("A second instance of QGroundControl is already running. Please close the other instance and try again.")
+        );
+        return -1;
     }
 #endif
 


### PR DESCRIPTION

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

---
name: QGC fails silently when it fails to initialize 
about: There is no user feedback when it fails to start

---

**Describe the bug**
This patch provides two feedback if QGC fail to initialize, one as a system error number with the return and a critical message with a human string for the user.
