### PR TITLE
FirmwareUpgrade: Fix firmware type layout with long strings

### DIFF
--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -322,9 +322,9 @@ SetupPage {
 
                         QGCLabel { text: qsTr("Flight Stack") }
 
-                        RowLayout {
+                        ColumnLayout {
                             spacing:            _margins
-                            layoutDirection:    px4FlightStackRadio.checked ? Qt.LeftToRight : Qt.RightToLeft
+                            layoutDirection:    px4FlightStackRadio.checked ? Qt.TopToBottom : Qt.BottomToTop
 
                             // The following craziness of three radio buttons to represent two radio buttons is so that the
                             // order can be changed such that the default firmware button is always on the top


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>

**Describe the bug**
Actual layout breaks if string of both types are bigger than the actual parent width.

Old:
![2019-05-17_10-45](https://user-images.githubusercontent.com/1215497/57932766-040c8b00-7892-11e9-8cf2-06abb0e833b7.png)
New:
![2019-05-17_10-51](https://user-images.githubusercontent.com/1215497/57932775-0969d580-7892-11e9-836c-9146f3335521.png)


