### PR TITLE
Fix CheckBox centralization 

### DIFF
--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -24,7 +24,8 @@ RadioButton {
         y:                      parent.height / 2 - height / 2
         Rectangle {
             anchors.centerIn:   parent
-            width:              Math.round(parent.width * 0.5)
+            // Width should be an odd number to be centralized by the parent properly
+            width:              2 * Math.floor(parent.width / 4) + 1
             height:             width
             antialiasing:       true
             radius:             height * 0.5

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -91,7 +91,8 @@ Item {
     property real implicitComboBoxHeight:           Math.round(defaultFontPixelHeight * (isMobile ? 2.0 : 1.6))
     property real implicitComboBoxWidth:            Math.round(defaultFontPixelWidth *  (isMobile ? 7.0 : 5.0))
     property real implicitSliderHeight:             isMobile ? Math.max(defaultFontPixelHeight, minTouchPixels) : defaultFontPixelHeight
-    property real checkBoxIndicatorSize:            Math.round(defaultFontPixelHeight * (isMobile ? 1.5 : 1.0))
+    // It's not possible to centralize an even number of pixels, checkBoxIndicatorSize should be an odd number to allow centralization
+    property real checkBoxIndicatorSize:            2 * Math.floor(defaultFontPixelHeight * (isMobile ? 1.5 : 1.0) / 2) + 1
     property real radioButtonIndicatorSize:         checkBoxIndicatorSize
 
     readonly property string normalFontFamily:      ScreenToolsController.normalFontFamily


### PR DESCRIPTION
**Describe the bug**
CheckBox is not centralized correctly if the size of the outside and inside circle are even numbers.

old:
![2019-05-17_11-15](https://user-images.githubusercontent.com/1215497/57934488-3ae4a000-7896-11e9-9fdf-173c845d4add.png)

new:

![2019-05-17_11-18](https://user-images.githubusercontent.com/1215497/57934476-36b88280-7896-11e9-9ba4-af2ac778949b.png)



