### PR TITLE
Load Korean fonts when needed

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -391,12 +391,6 @@ void QGCApplication::setLanguage()
             break;
         case 12:
             locale = QLocale(QLocale::Korean);
-            if(QFontDatabase::addApplicationFont(":/fonts/NanumGothic-Regular") < 0) {
-                qWarning() << "Could not load /fonts/NanumGothic-Regular font";
-            }
-            if(QFontDatabase::addApplicationFont(":/fonts/NanumGothic-Bold") < 0) {
-                qWarning() << "Could not load /fonts/NanumGothic-Bold font";
-            }
             break;
         case 13:
             locale = QLocale(QLocale::Norwegian);
@@ -419,6 +413,16 @@ void QGCApplication::setLanguage()
         case 19:
             locale = QLocale(QLocale::Turkish);
             break;
+        }
+    }
+    //-- We have specific fonts for Korean
+    if(locale == QLocale::Korean) {
+        qDebug() << "Loading Korean fonts" << locale.name();
+        if(QFontDatabase::addApplicationFont(":/fonts/NanumGothic-Regular") < 0) {
+            qWarning() << "Could not load /fonts/NanumGothic-Regular font";
+        }
+        if(QFontDatabase::addApplicationFont(":/fonts/NanumGothic-Bold") < 0) {
+            qWarning() << "Could not load /fonts/NanumGothic-Bold font";
         }
     }
     qDebug() << "Loading localization for" << locale.name();


### PR DESCRIPTION
We have specific fonts for Korean, which were being loaded when the user selected "Korean" from the list of languages. However, when QGC was set to "System" locale, no test was done to see if System == Korean.