### PR TITLE
Bugfix: QGC crashes when Taisync is attached for the first time

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
@@ -72,7 +72,6 @@ public class QGCActivity extends QtActivity
     private static HashMap<Integer, Integer>            _userDataHashByDeviceId;
     private static final String                         TAG = "QGC_QGCActivity";
     private static PowerManager.WakeLock                _wakeLock;
-//    private static final String                         ACTION_USB_PERMISSION = "com.android.example.USB_PERMISSION";
     private static final String                         ACTION_USB_PERMISSION = "org.mavlink.qgroundcontrol.action.USB_PERMISSION";
     private static PendingIntent                        _usbPermissionIntent = null;
     private TaiSync                                     taiSync = null;
@@ -110,7 +109,7 @@ public class QGCActivity extends QtActivity
                     if (accessory != null && intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
                         openAccessory(accessory);
                     }
-                } else if( UsbManager.ACTION_USB_ACCESSORY_DETACHED.equals(action)) {
+                } else if (UsbManager.ACTION_USB_ACCESSORY_DETACHED.equals(action)) {
                     UsbAccessory accessory = intent.getParcelableExtra(UsbManager.EXTRA_ACCESSORY);
                     if (accessory != null) {
                         closeAccessory(accessory);
@@ -726,7 +725,7 @@ public class QGCActivity extends QtActivity
         new Thread(new Runnable() {
             public void run() {
                 synchronized(openAccessoryLock) {
-                    Log.i(TAG, "probeAccessories");
+//                    Log.i(TAG, "probeAccessories");
                     UsbAccessory[] accessories = _usbManager.getAccessoryList();
                     if (accessories != null) {
                        for (UsbAccessory usbAccessory : accessories) {
@@ -735,9 +734,6 @@ public class QGCActivity extends QtActivity
                            }
                            if (_usbManager.hasPermission(usbAccessory)) {
                                openAccessory(usbAccessory);
-                           } else {
-                               Log.i(TAG, "requestPermission");
-                               _usbManager.requestPermission(usbAccessory, pendingIntent);
                            }
                        }
                     }

--- a/android/src/org/mavlink/qgroundcontrol/TaiSync.java
+++ b/android/src/org/mavlink/qgroundcontrol/TaiSync.java
@@ -115,13 +115,13 @@ public class TaiSync
                             if (mBytes[3] == PROTOCOL_VERSION)
                             {
                                 vMaj = mBytes[19];
-                                Log.i("QGC_TaiSync", "Got protocol version message vMaj = " + mBytes[19]);
+                                // Log.i("QGC_TaiSync", "Got protocol version message vMaj = " + mBytes[19]);
                                 sendTaiSyncMessage(PROTOCOL_VERSION, 0, null, 0);
                             }
                             else if (mBytes[3] == PROTOCOL_CHANNEL) {
                                 int dPort = ((mBytes[4] & 0xff)<< 24) | ((mBytes[5]&0xff) << 16) | ((mBytes[6]&0xff) << 8) | (mBytes[7] &0xff);
                                 int dLength = ((mBytes[8] & 0xff)<< 24) | ((mBytes[9]&0xff) << 16) | ((mBytes[10]&0xff) << 8) | (mBytes[11] &0xff);
-                                Log.i("QGC_TaiSync", "Read 2 port = " + dPort + " length = " + dLength);
+                                // Log.i("QGC_TaiSync", "Read 2 port = " + dPort + " length = " + dLength);
                                 sendTaiSyncMessage(PROTOCOL_CHANNEL, dPort, null, 0);
                             }
                             else if (mBytes[3] == PROTOCOL_DATA) {
@@ -220,7 +220,7 @@ public class TaiSync
 
         byte[] lA = new byte[4];
         int len = HEADER_SIZE + dataLen;
-        Log.i("QGC_TaiSync", "Sending to " + dataPort + " length = " + len);
+        // Log.i("QGC_TaiSync", "Sending to " + dataPort + " length = " + len);
         byte[] buffer = new byte[len];
 
         for (int i = 3; i >= 0; i--) {


### PR DESCRIPTION
How to reproduce:
Make a clean install on Android and attach Taisync
A window asking for association of QGC with Taisync pops up.
When user accepts it QGC crashes and restarts.

Fix:
Do not request permission on accessory in a probe accessories timer.