### PR TITLE
MissionManager: correct frame on Rally mission items

### DIFF
--- a/src/MissionManager/RallyPointManager.cc
+++ b/src/MissionManager/RallyPointManager.cc
@@ -55,7 +55,7 @@ void RallyPointManager::sendToVehicle(const QList<QGeoCoordinate>& rgPoints)
 
         MissionItem* item = new MissionItem(0,
                                             MAV_CMD_NAV_RALLY_POINT,
-                                            MAV_FRAME_GLOBAL,
+                                            MAV_FRAME_GLOBAL_RELATIVE_ALT,
                                             0, 0, 0, 0,                 // param 1-4 unused
                                             rgPoints[i].latitude(),
                                             rgPoints[i].longitude(),


### PR DESCRIPTION
Frame is incorrect; altitudes used are relative.
