### PR TITLE
Handle auto video stream

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -34,7 +34,7 @@ Item {
     property bool   _hasZoom:           _camera && _camera.hasZoom
     property int    _fitMode:           QGroundControl.settingsManager.videoSettings.videoFit.rawValue
 
-    property double _thermalHeightFactor: 0.666 //-- TODO
+    property double _thermalHeightFactor: 0.85 //-- TODO
 
     Rectangle {
         id:             noVideo
@@ -83,7 +83,7 @@ Item {
             anchors.centerIn: parent
             receiver:       _videoReceiver
             display:        _videoReceiver && _videoReceiver.videoSurface
-            visible:        _videoReceiver && _videoReceiver.videoRunning
+            visible:        _videoReceiver && _videoReceiver.videoRunning && !(QGroundControl.videoManager.hasThermal && _camera.thermalMode === QGCCameraControl.THERMAL_FULL)
             Connections {
                 target:         _videoReceiver
                 onImageFileChanged: {
@@ -127,7 +127,7 @@ Item {
         Item {
             id:                 thermalItem
             width:              height * QGroundControl.videoManager.thermalAspectRatio
-            height:             _camera ? (_camera.thermalMode === QGCCameraControl.THERMAL_PIP ? ScreenTools.defaultFontPixelHeight * 12 : parent.height * _thermalHeightFactor) : 0
+            height:             _camera ? (_camera.thermalMode === QGCCameraControl.THERMAL_FULL ? parent.height : (_camera.thermalMode === QGCCameraControl.THERMAL_PIP ? ScreenTools.defaultFontPixelHeight * 12 : parent.height * _thermalHeightFactor)) : 0
             anchors.centerIn:   parent
             visible:            QGroundControl.videoManager.hasThermal && _camera.thermalMode !== QGCCameraControl.THERMAL_OFF
             function pipOrNot() {

--- a/src/FlightMap/Widgets/CameraPageWidget.qml
+++ b/src/FlightMap/Widgets/CameraPageWidget.qml
@@ -390,9 +390,52 @@ Column {
                         }
                     }
                     //-------------------------------------------
+                    // Grid Lines
+                    Row {
+                        visible:                _camera && _camera.autoStream
+                        spacing:                ScreenTools.defaultFontPixelWidth
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        QGCLabel {
+                           text:                qsTr("Grid Lines")
+                           width:               _labelFieldWidth
+                           anchors.verticalCenter: parent.verticalCenter
+                        }
+                        QGCSwitch {
+                            enabled:            _streamingEnabled && activeVehicle
+                            checked:            QGroundControl.settingsManager.videoSettings.gridLines.rawValue
+                            width:              _editFieldWidth
+                            anchors.verticalCenter: parent.verticalCenter
+                            onClicked: {
+                                if(checked) {
+                                    QGroundControl.settingsManager.videoSettings.gridLines.rawValue = 1
+                                } else {
+                                    QGroundControl.settingsManager.videoSettings.gridLines.rawValue = 0
+                                }
+                            }
+                        }
+                    }
+                    //-------------------------------------------
+                    //-- Video Fit
+                    Row {
+                        visible:                _camera && _camera.autoStream
+                        spacing:                ScreenTools.defaultFontPixelWidth
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        QGCLabel {
+                            text:               qsTr("Video Screen Fit")
+                            width:               _labelFieldWidth
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        FactComboBox {
+                            fact:               QGroundControl.settingsManager.videoSettings.videoFit
+                            indexModel:         false
+                            width:              _editFieldWidth
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                    }
+                    //-------------------------------------------
                     //-- Reset Camera
                     Row {
-                        spacing:        ScreenTools.defaultFontPixelWidth
+                        spacing:                ScreenTools.defaultFontPixelWidth
                         anchors.horizontalCenter: parent.horizontalCenter
                         QGCLabel {
                             text:       qsTr("Reset Camera Defaults")

--- a/src/FlightMap/Widgets/VideoPageWidget.qml
+++ b/src/FlightMap/Widgets/VideoPageWidget.qml
@@ -35,6 +35,10 @@ Item {
     property bool   _recordingVideo:        _videoReceiver && _videoReceiver.recording
     property bool   _videoRunning:          _videoReceiver && _videoReceiver.videoRunning
     property bool   _streamingEnabled:      QGroundControl.settingsManager.videoSettings.streamConfigured
+    property var    _dynamicCameras:        activeVehicle ? activeVehicle.dynamicCameras : null
+    property int    _curCameraIndex:        _dynamicCameras ? _dynamicCameras.currentCamera : 0
+    property bool   _isCamera:              _dynamicCameras ? _dynamicCameras.cameras.count > 0 : false
+    property var    _camera:                _isCamera ? (_dynamicCameras.cameras.get(_curCameraIndex) && _dynamicCameras.cameras.get(_curCameraIndex).paramComplete ? _dynamicCameras.cameras.get(_curCameraIndex) : null) : null
 
     QGCPalette { id:qgcPal; colorGroupEnabled: true }
 
@@ -55,9 +59,11 @@ Item {
         QGCLabel {
            text:                qsTr("Enable Stream")
            font.pointSize:      ScreenTools.smallFontPointSize
+           visible:             !_camera || !_camera.autoStream
         }
         QGCSwitch {
             id:                 enableSwitch
+            visible:            !_camera || !_camera.autoStream
             enabled:            _streamingEnabled
             checked:            QGroundControl.settingsManager.videoSettings.streamEnabled.rawValue
             Layout.alignment:   Qt.AlignHCenter
@@ -93,10 +99,12 @@ Item {
         //-- Video Fit
         QGCLabel {
             text:               qsTr("Video Screen Fit")
+            visible:            !_camera || !_camera.autoStream
             font.pointSize:     ScreenTools.smallFontPointSize
         }
         FactComboBox {
             fact:               QGroundControl.settingsManager.videoSettings.videoFit
+            visible:            !_camera || !_camera.autoStream
             indexModel:         false
             Layout.alignment:   Qt.AlignHCenter
         }
@@ -104,7 +112,7 @@ Item {
         QGCLabel {
            text:            _recordingVideo ? qsTr("Stop Recording") : qsTr("Record Stream")
            font.pointSize:  ScreenTools.smallFontPointSize
-           visible:         QGroundControl.settingsManager.videoSettings.showRecControl.rawValue
+           visible:         (!_camera || !_camera.autoStream) && QGroundControl.settingsManager.videoSettings.showRecControl.rawValue
         }
         // Button to start/stop video recording
         Item {
@@ -112,7 +120,7 @@ Item {
             height:             ScreenTools.defaultFontPixelHeight * 2
             width:              height
             Layout.alignment:   Qt.AlignHCenter
-            visible:            QGroundControl.settingsManager.videoSettings.showRecControl.rawValue
+            visible:            (!_camera || !_camera.autoStream) && QGroundControl.settingsManager.videoSettings.showRecControl.rawValue
             Rectangle {
                 id:                 recordBtnBackground
                 anchors.top:        parent.top

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -34,6 +34,7 @@ class QmlObjectListModel;
 class VideoReceiver;
 class PlanMasterController;
 class QGCCameraManager;
+class QGCCameraControl;
 
 class QGCCorePlugin : public QGCTool
 {
@@ -163,6 +164,7 @@ protected slots:
     void _activeVehicleChanged  (Vehicle* activeVehicle);
     void _dynamicCamerasChanged ();
     void _currentCameraChanged  ();
+    void _autoStreamChanged     ();
 
 protected:
     void _resetInstrumentPages  ();
@@ -172,6 +174,7 @@ protected:
     bool                _showAdvancedUI;
     Vehicle*            _activeVehicle  = nullptr;
     QGCCameraManager*   _dynamicCameras = nullptr;
+    QGCCameraControl*   _currentCamera  = nullptr;
 
 private:
     QGCCorePlugin_p*    _p;

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -33,6 +33,7 @@ class LinkInterface;
 class QmlObjectListModel;
 class VideoReceiver;
 class PlanMasterController;
+class QGCCameraManager;
 
 class QGCCorePlugin : public QGCTool
 {
@@ -158,9 +159,19 @@ signals:
     void showTouchAreasChanged  (bool showTouchAreas);
     void showAdvancedUIChanged  (bool showAdvancedUI);
 
+protected slots:
+    void _activeVehicleChanged  (Vehicle* activeVehicle);
+    void _dynamicCamerasChanged ();
+    void _currentCameraChanged  ();
+
+protected:
+    void _resetInstrumentPages  ();
+
 protected:
     bool                _showTouchAreas;
     bool                _showAdvancedUI;
+    Vehicle*            _activeVehicle  = nullptr;
+    QGCCameraManager*   _dynamicCameras = nullptr;
 
 private:
     QGCCorePlugin_p*    _p;


### PR DESCRIPTION
If a camera supports the full camera API, including the video streaming API, both camera and video streaming and handled through one same interface. In this case, the "Video" widget is disabled as it becomes redundant.