### PR TITLE
Change default autopilot to MAV_AUTOPILOT_GENERIC when requesting parameters meta

### DIFF
--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -1179,7 +1179,7 @@ void ParameterManager::_initialRequestTimeout(void)
 QString ParameterManager::parameterMetaDataFile(Vehicle* vehicle, MAV_AUTOPILOT firmwareType, int wantedMajorVersion, int& majorVersion, int& minorVersion)
 {
     bool            cacheHit = false;
-    FirmwarePlugin* plugin = qgcApp()->toolbox()->firmwarePluginManager()->firmwarePluginForAutopilot(firmwareType, MAV_TYPE_QUADROTOR);
+    FirmwarePlugin* plugin = qgcApp()->toolbox()->firmwarePluginManager()->firmwarePluginForAutopilot(firmwareType, MAV_TYPE_GENERIC);
 
     // Cached files are stored in settings location
     QSettings settings;

--- a/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
@@ -36,6 +36,7 @@ FirmwarePlugin* APMFirmwarePluginFactory::firmwarePluginForAutopilot(MAV_AUTOPIL
 {
     if (autopilotType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
         switch (vehicleType) {
+        case MAV_TYPE_GENERIC:
         case MAV_TYPE_QUADROTOR:
         case MAV_TYPE_HEXAROTOR:
         case MAV_TYPE_OCTOROTOR:


### PR DESCRIPTION
ParameterManager uses MAV_TYPE_QUADROTOR as a system type to request parameters meta. Custom FirmwarePlugins may not support quadrotors so it's better to use MAV_TYPE_GENERIC for this purpose.
