### PR TITLE
Quick workaround to fix qwdiget leftovers

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -170,39 +170,34 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 #ifdef Q_OS_LINUX
 #ifndef __mobile__
     if (!_runningUnitTests) {
+        // TODO: Proper fix by having a separate failed state UI
         if (getuid() == 0) {
-            QMessageBox msgBox;
-            msgBox.setInformativeText(tr("You are running %1 as root. "
-                                         "You should not do this since it will cause other issues with %1. "
-                                         "%1 will now exit. "
-                                         "If you are having serial port issues on Ubuntu, execute the following commands to fix most issues:\n"
-                                         "sudo usermod -a -G dialout $USER\n"
-                                         "sudo apt-get remove modemmanager").arg(qgcApp()->applicationName()));
-            msgBox.setStandardButtons(QMessageBox::Ok);
-            msgBox.setDefaultButton(QMessageBox::Ok);
-            msgBox.exec();
-            _exit(0);
+            _preInitMessage.first = true;
+            _preInitMessage.second = tr("You are running %1 as root. "
+                                        "You should not do this since it will cause other issues with %1. "
+                                        "%1 will now exit. "
+                                        "If you are having serial port issues on Ubuntu, execute the following commands to fix most issues:\n"
+                                        "sudo usermod -a -G dialout $USER\n"
+                                        "sudo apt-get remove modemmanager").arg(qgcApp()->applicationName());
         }
-
-        // Determine if we have the correct permissions to access USB serial devices
-        QFile permFile("/etc/group");
-        if(permFile.open(QIODevice::ReadOnly)) {
-            while(!permFile.atEnd()) {
-                QString line = permFile.readLine();
-                if (line.contains("dialout") && !line.contains(getenv("USER"))) {
-                    QMessageBox msgBox;
-                    msgBox.setInformativeText("The current user does not have the correct permissions to access serial devices. "
-                                              "You should also remove modemmanager since it also interferes. "
-                                              "If you are using Ubuntu, execute the following commands to fix these issues:\n"
-                                              "sudo usermod -a -G dialout $USER\n"
-                                              "sudo apt-get remove modemmanager");
-                    msgBox.setStandardButtons(QMessageBox::Ok);
-                    msgBox.setDefaultButton(QMessageBox::Ok);
-                    msgBox.exec();
-                    break;
+        else {
+            // Determine if we have the correct permissions to access USB serial devices
+            QFile permFile("/etc/group");
+            if(permFile.open(QIODevice::ReadOnly)) {
+                while(!permFile.atEnd()) {
+                    QString line = permFile.readLine();
+                    if (line.contains("dialout") && !line.contains(getenv("USER"))) {
+                        _preInitMessage.first = false;
+                        _preInitMessage.second = tr("The current user does not have the correct permissions to access serial devices. "
+                                                    "You should also remove modemmanager since it also interferes. "
+                                                    "If you are using Ubuntu, execute the following commands to fix these issues:\n"
+                                                    "sudo usermod -a -G dialout $USER\n"
+                                                    "sudo apt-get remove modemmanager");
+                        break;
+                    }
                 }
+                permFile.close();
             }
-            permFile.close();
         }
     }
 #endif
@@ -552,6 +547,10 @@ bool QGCApplication::_initForNormalAppBoot()
 
     // Probe for joysticks
     toolbox()->joystickManager()->init();
+
+    if(_preInitMessage.second.length() > 0 ) {
+        showMessage(QString(_preInitMessage.first ? tr("Critical: ") : tr("")) + _preInitMessage.second);
+    }
 
     if (_settingsUpgraded) {
         showMessage(QString(tr("The format for %1 saved settings has been modified. "

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -170,6 +170,8 @@ private:
     QTimer              _missingParamsDelayedDisplayTimer;                  ///< Timer use to delay missing fact display
     QStringList         _missingParams;                                     ///< List of missing facts to be displayed
 
+    QPair<bool, QString>    _preInitMessage;                                ///< First param: `true` if the initialization failed and second value holds the message
+
     QQmlApplicationEngine* _qmlAppEngine        = nullptr;
     bool                _logOutput              = false;                    ///< true: Log Qt debug output to file
     bool				_fakeMobile             = false;                    ///< true: Fake ui into displaying mobile interface

--- a/src/comm/QGCFlightGearLink.cc
+++ b/src/comm/QGCFlightGearLink.cc
@@ -728,16 +728,7 @@ bool QGCFlightGearLink::connectSimulation()
     //-- TODO:
     /*
     while (!QFileInfo(fgAppFullyQualified).exists()) {
-        QMessageBox msgBox(QMessageBox::Critical,
-                           tr("FlightGear application not found"),
-                           tr("FlightGear application not found at: %1").arg(fgAppFullyQualified),
-                           QMessageBox::Cancel,
-                           MainWindow::instance());
-        msgBox.setWindowModality(Qt::ApplicationModal);
-        msgBox.addButton(tr("I'll specify directory"), QMessageBox::ActionRole);
-        if (msgBox.exec() == QMessageBox::Cancel) {
-            return false;
-        }
+        QGCApplication::criticalMessageBoxOnMainThread(tr("FlightGear application not found at: %1").arg(fgAppFullyQualified));
 
         // Let the user pick the right directory
         QString dirPath = QString(); //-- TODO: QGCQFileDialog::getExistingDirectory(MainWindow::instance(), tr("Please select directory of FlightGear application : ") + fgAppName);
@@ -885,16 +876,8 @@ bool QGCFlightGearLink::connectSimulation()
     }
 
     if (!QFileInfo(_fgProtocolFileFullyQualified).exists()) {
-        QMessageBox msgBox(QMessageBox::Critical,
-                           tr("FlightGear Failed to Start"),
-                           tr("FlightGear Failed to Start. %1 protocol (%2) not installed to FlightGear Protocol directory (%3)").arg(qgcApp()->applicationName()).arg(fgProtocolXmlFile).arg(fgProtocolDir.path()),
-                           QMessageBox::Cancel,
-                           MainWindow::instance());
-        msgBox.setWindowModality(Qt::ApplicationModal);
-        msgBox.addButton(tr("Fix it for me"), QMessageBox::ActionRole);
-        if (msgBox.exec() == QMessageBox::Cancel) {
-            return false;
-        }
+        // TODO: Add modal message box and the option to return false to cancel autofix
+        QGCApplication::criticalMessageBoxOnMainThread(tr("FlightGear Failed to Start. %1 protocol (%2) not installed to FlightGear Protocol directory (%3)").arg(qgcApp()->applicationName()).arg(fgProtocolXmlFile).arg(fgProtocolDir.path()));
 
         // Now that we made it this far, we should be able to try to copy the protocol file to FlightGear.
         bool succeeded = QFile::copy(qgcProtocolFileFullyQualified, _fgProtocolFileFullyQualified);
@@ -906,20 +889,13 @@ bool QGCFlightGearLink::connectSimulation()
             QString copyCmd = QString("sudo cp %1 %2").arg(qgcProtocolFileFullyQualified).arg(_fgProtocolFileFullyQualified);
 #endif
 
-            QMessageBox msgBox(QMessageBox::Critical,
-                               tr("Copy failed"),
-#ifdef Q_OS_WIN32
+            QGCApplication::criticalMessageBoxOnMainThread(
                                tr("Copy from (%1) to (%2) failed, possibly due to permissions issue. You will need to perform manually. Try pasting the following command into a Command Prompt which was started with Run as Administrator:\n\n").arg(qgcProtocolFileFullyQualified).arg(_fgProtocolFileFullyQualified) + copyCmd,
 #else
                                tr("Copy from (%1) to (%2) failed, possibly due to permissions issue. You will need to perform manually. Try pasting the following command into a shell:\n\n").arg(qgcProtocolFileFullyQualified).arg(_fgProtocolFileFullyQualified) + copyCmd,
 #endif
-                               QMessageBox::Cancel,
-                               MainWindow::instance());
-            msgBox.setWindowModality(Qt::ApplicationModal);
-            msgBox.addButton(tr("Copy to Clipboard"), QMessageBox::ActionRole);
-            if (msgBox.exec() != QMessageBox::Cancel) {
-                QApplication::clipboard()->setText(copyCmd);
-            }
+                               );
+            QApplication::clipboard()->setText(copyCmd);
             return false;
         }
     }


### PR DESCRIPTION
After switching to QML only UI, the `QMessageBox` instances trigger the following error: "QWidget: Cannot create a QWidget without QApplication."
This PR converts QMessageBox popups into regular warnings.