### PR TITLE
PX4ParameterMetaData: Fix getParameterMetaDataVersionInfo results

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
@@ -427,6 +427,9 @@ void PX4ParameterMetaData::addMetaDataToFact(Fact* fact, MAV_TYPE vehicleType)
 
 void PX4ParameterMetaData::getParameterMetaDataVersionInfo(const QString& metaDataFile, int& majorVersion, int& minorVersion)
 {
+    majorVersion = -1;
+    minorVersion = -1;
+
     QFile xmlFile(metaDataFile);
 
     if (!xmlFile.exists()) {
@@ -445,9 +448,6 @@ void PX4ParameterMetaData::getParameterMetaDataVersionInfo(const QString& metaDa
         qWarning() << "Badly formed XML" << xml.errorString();
         return;
     }
-
-    majorVersion = -1;
-    minorVersion = -1;
 
     while (!xml.atEnd() && (majorVersion == -1 || minorVersion == -1)) {
         if (xml.isStartElement()) {


### PR DESCRIPTION
According to the documentation this function returns -1 in the version numbers if the meta data is not found. 

https://github.com/mavlink/qgroundcontrol/blob/5240e67a32255330bc0f1fd549daca7ecef35165/src/FirmwarePlugin/FirmwarePlugin.h#L209

However, it doesn't write -1 in cases where the metadata file doesn't exists, application can't open the file or xml file has errors.