### PR TITLE
PX4ParameterMetaData: Remove default version

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
@@ -473,12 +473,4 @@ void PX4ParameterMetaData::getParameterMetaDataVersionInfo(const QString& metaDa
         }
         xml.readNext();
     }
-
-    // Assume defaults if not found
-    if (majorVersion == -1) {
-        majorVersion = 1;
-    }
-    if (minorVersion == -1) {
-        minorVersion = 1;
-    }
 }


### PR DESCRIPTION
Current implementation has an issue: any XML file is interpreted as a valid metadata (even if it's not). Modern px4 firmware has a correct version in the metadata. Why the default version has been added in the first place?