### PR TITLE
Support Log Replay in new Qml only system

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -604,6 +604,7 @@ HEADERS += \
     src/comm/LinkConfiguration.h \
     src/comm/LinkInterface.h \
     src/comm/LinkManager.h \
+    src/comm/LogReplayLink.h \
     src/comm/MAVLinkProtocol.h \
     src/comm/ProtocolInterface.h \
     src/comm/QGCMAVLink.h \
@@ -664,7 +665,6 @@ HEADERS += \
     src/GPS/vehicle_gps_position.h \
     src/Joystick/JoystickSDL.h \
     src/RunGuard.h \
-    src/comm/LogReplayLink.h \
     src/comm/QGCHilLink.h \
     src/comm/QGCJSBSimLink.h \
     src/comm/QGCXPlaneLink.h \
@@ -780,6 +780,7 @@ SOURCES += \
     src/comm/LinkConfiguration.cc \
     src/comm/LinkInterface.cc \
     src/comm/LinkManager.cc \
+    src/comm/LogReplayLink.cc \
     src/comm/MAVLinkProtocol.cc \
     src/comm/QGCMAVLink.cc \
     src/comm/TCPLink.cc \
@@ -822,7 +823,6 @@ SOURCES += \
     src/GPS/RTCM/RTCMMavlink.cc \
     src/Joystick/JoystickSDL.cc \
     src/RunGuard.cc \
-    src/comm/LogReplayLink.cc \
     src/comm/QGCJSBSimLink.cc \
     src/comm/QGCXPlaneLink.cc \
     src/uas/FileManager.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -77,6 +77,7 @@
         <file alias="QGroundControl/Controls/GeoFenceMapVisuals.qml">src/PlanView/GeoFenceMapVisuals.qml</file>
         <file alias="QGroundControl/Controls/IndicatorButton.qml">src/QmlControls/IndicatorButton.qml</file>
         <file alias="QGroundControl/Controls/JoystickThumbPad.qml">src/QmlControls/JoystickThumbPad.qml</file>
+		<file alias="QGroundControl/Controls/LogReplayStatusBar.qml">src/QmlControls/LogReplayStatusBar.qml</file>
         <file alias="QGroundControl/Controls/MAVLinkMessageButton.qml">src/QmlControls/MAVLinkMessageButton.qml</file>
         <file alias="QGroundControl/Controls/MissionCommandDialog.qml">src/QmlControls/MissionCommandDialog.qml</file>
         <file alias="QGroundControl/Controls/MissionItemEditor.qml">src/PlanView/MissionItemEditor.qml</file>

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -312,7 +312,10 @@ Item {
 
     Item {
         id:             _mapAndVideo
-        anchors.fill:   parent
+        anchors.left:   parent.left
+        anchors.right:  parent.right
+        anchors.top:    parent.top
+        anchors.bottom: logReplayStatusBar.top
 
         //-- Map View
         Item {
@@ -735,6 +738,14 @@ Item {
             color:              qgcPal.window
             visible:            false
         }
+    }
+
+    LogReplayStatusBar {
+        id:                 logReplayStatusBar
+        anchors.left:       parent.left
+        anchors.right:      parent.right
+        anchors.bottom:     parent.bottom
+        visible:            QGroundControl.settingsManager.flyViewSettings.showLogReplayStatusBar.rawValue &&_flightMapContainer.state === "fullMode"
     }
 
     //-- Airspace Indicator

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -26,7 +26,6 @@ import QGroundControl.Vehicle       1.0
 
 FlightMap {
     id:                         flightMap
-    anchors.fill:               parent
     mapName:                    _mapName
     allowGCSLocationCenter:     !userPanned
     allowVehicleLocationCenter: !_keepVehicleCentered

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -100,6 +100,7 @@
 #include "MavlinkConsoleController.h"
 #include "MAVLinkInspectorController.h"
 #include "GeoTagController.h"
+#include "LogReplayLink.h"
 
 #ifndef __mobile__
 #include "FirmwareUpgradeController.h"
@@ -485,6 +486,9 @@ void QGCApplication::_initCommon()
     qmlRegisterUncreatableType<QmlObjectListModel>  ("QGroundControl",                      1, 0, "QmlObjectListModel",         kRefOnly);
     qmlRegisterUncreatableType<MissionCommandTree>  ("QGroundControl",                      1, 0, "MissionCommandTree",         kRefOnly);
     qmlRegisterUncreatableType<CameraCalc>          ("QGroundControl",                      1, 0, "CameraCalc",                 kRefOnly);
+    qmlRegisterUncreatableType<LogReplayLink>       ("QGroundControl",                      1, 0, "LogReplayLink",              kRefOnly);
+
+    qmlRegisterType<LogReplayLinkController>        ("QGroundControl",                      1, 0, "LogReplayLinkController");
 
     qmlRegisterUncreatableType<AutoPilotPlugin>     ("QGroundControl.AutoPilotPlugin",      1, 0, "AutoPilotPlugin",            kRefOnly);
     qmlRegisterUncreatableType<VehicleComponent>    ("QGroundControl.AutoPilotPlugin",      1, 0, "VehicleComponent",           kRefOnly);

--- a/src/QmlControls/LogReplayStatusBar.qml
+++ b/src/QmlControls/LogReplayStatusBar.qml
@@ -1,0 +1,91 @@
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.11
+import QtQuick.Dialogs  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+
+Rectangle {
+    height:             visible ? (rowLayout.height + (_margins * 2)) : 0
+    color:              qgcPal.window
+
+    property real _margins:         ScreenTools.defaultFontPixelHeight / 4
+    property var  _logReplayLink:   null
+
+    function pickLogFile() {
+        if (mainWindow.activeVehicle) {
+            mainWindow.showMessageDialog(qsTr("Log Replay"), qsTr("You must close all connections prior to replaying a log."), StandardButton.Ok)
+            return
+        }
+
+        filePicker.openForLoad()
+    }
+
+    QGCPalette { id: qgcPal }
+
+    QGCFileDialog {
+        id:                 filePicker
+        title:              qsTr("Select Telemetery Log")
+        nameFilters:        [qsTr("Telemetry Logs (*.%1)").arg(QGroundControl.settingsManager.appSettings.telemetryFileExtension), qsTr("All Files (*)")]
+        selectExisting:     true
+        folder:             QGroundControl.settingsManager.appSettings.telemetrySavePath
+        onAcceptedForLoad: {
+            controller.link = QGroundControl.linkManager.startLogReplay(file)
+            close()
+        }
+    }
+
+    LogReplayLinkController {
+        id: controller
+
+        onPercentCompleteChanged: slider.updatePercentComplete(percentComplete)
+    }
+
+    RowLayout {
+        id:                 rowLayout
+        anchors.margins:    _margins
+        anchors.top:        parent.top
+        anchors.left:       parent.left
+        anchors.right:      parent.right
+
+        QGCButton {
+            text:       controller.isPlaying ? qsTr("Pause") : qsTr("Play")
+            enabled:    controller.link
+            onClicked:  controller.isPlaying = !controller.isPlaying
+        }
+
+        QGCLabel { text: controller.playheadTime }
+
+        Slider {
+            id:                 slider
+            Layout.fillWidth:   true
+            minimumValue:       0
+            maximumValue:       100
+            enabled:            controller.link
+
+            property bool manualUpdate: false
+
+            function updatePercentComplete(percentComplete) {
+                manualUpdate = true
+                value = percentComplete
+                manualUpdate = false
+            }
+
+            onValueChanged: {
+                if (!manualUpdate) {
+                    controller.percentComplete = value
+                }
+            }
+        }
+
+        QGCLabel { text: controller.totalTime }
+
+        QGCButton {
+            text:       qsTr("Load Telemetry Log")
+            onClicked:  pickLogFile()
+            visible:    !controller.link
+        }
+    }
+}

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -20,6 +20,7 @@ GeoFenceMapVisuals      1.0 GeoFenceMapVisuals.qml
 HackFileDialog          1.0 HackFileDialog.qml
 IndicatorButton         1.0 IndicatorButton.qml
 JoystickThumbPad        1.0 JoystickThumbPad.qml
+LogReplayStatusBar      1.0 LogReplayStatusBar.qml
 MAVLinkMessageButton    1.0 MAVLinkMessageButton.qml
 MissionCommandDialog    1.0 MissionCommandDialog.qml
 MissionItemEditor       1.0 MissionItemEditor.qml

--- a/src/Settings/FlyView.SettingsGroup.json
+++ b/src/Settings/FlyView.SettingsGroup.json
@@ -12,5 +12,11 @@
     "type":             "double",
     "units":            "m",
     "defaultValue":     121.92
+},
+{
+    "name":             "showLogReplayStatusBar",
+    "shortDescription": "Show/Hide Log Replay status bar",
+    "type":             "bool",
+    "defaultValue":     false
 }
 ]

--- a/src/Settings/FlyViewSettings.cc
+++ b/src/Settings/FlyViewSettings.cc
@@ -19,3 +19,4 @@ DECLARE_SETTINGGROUP(FlyView, "FlyView")
 
 DECLARE_SETTINGSFACT(FlyViewSettings, guidedMinimumAltitude)
 DECLARE_SETTINGSFACT(FlyViewSettings, guidedMaximumAltitude)
+DECLARE_SETTINGSFACT(FlyViewSettings, showLogReplayStatusBar)

--- a/src/Settings/FlyViewSettings.h
+++ b/src/Settings/FlyViewSettings.h
@@ -16,7 +16,10 @@ class FlyViewSettings : public SettingsGroup
     Q_OBJECT
 public:
     FlyViewSettings(QObject* parent = nullptr);
+
     DEFINE_SETTING_NAME_GROUP()
+
     DEFINE_SETTINGFACT(guidedMinimumAltitude)
     DEFINE_SETTINGFACT(guidedMaximumAltitude)
+    DEFINE_SETTINGFACT(showLogReplayStatusBar)
 };

--- a/src/VideoStreaming/SubtitleWriter.cc
+++ b/src/VideoStreaming/SubtitleWriter.cc
@@ -40,11 +40,14 @@ void SubtitleWriter::setVideoReceiver(VideoReceiver* videoReceiver)
         return;
     }
     _videoReceiver = videoReceiver;
+
+#if defined(QGC_GST_STREAMING)
     // Only start writing subtitles once the recording pipeline actually starts
     connect(_videoReceiver, &VideoReceiver::gotFirstRecordingKeyFrame,  this,  &SubtitleWriter::_startCapturingTelemetry);
 
     // Captures recordingChanged() signals to stop writing subtitles
     connect(_videoReceiver, &VideoReceiver::recordingChanged,           this,  &SubtitleWriter::_onVideoRecordingChanged);
+#endif
 
     // Timer for telemetry capture and writing to file
     connect(&_timer,        &QTimer::timeout,                           this,  &SubtitleWriter::_captureTelemetry);
@@ -52,12 +55,14 @@ void SubtitleWriter::setVideoReceiver(VideoReceiver* videoReceiver)
 
 void SubtitleWriter::_onVideoRecordingChanged()
 {
+#if defined(QGC_GST_STREAMING)
     // Stop capturing data if recording stopped
     if(!_videoReceiver->recording()) {
         qCDebug(SubtitleWriterLog) << "Stopping writing";
         _timer.stop();
         _file.close();
     }
+#endif
 }
 
 void SubtitleWriter::_startCapturingTelemetry()

--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -20,9 +20,7 @@
 #endif
 #include "UDPLink.h"
 #include "TCPLink.h"
-#if !defined(__mobile__)
 #include "LogReplayLink.h"
-#endif
 #ifdef QGC_ENABLE_BLUETOOTH
 #include "BluetoothLink.h"
 #endif
@@ -98,11 +96,9 @@ LinkConfiguration* LinkConfiguration::createSettings(int type, const QString& na
         config = new BluetoothConfiguration(name);
         break;
 #endif
-#ifndef __mobile__
         case LinkConfiguration::TypeLogReplay:
             config = new LogReplayLinkConfiguration(name);
             break;
-#endif
 #ifdef QT_DEBUG
         case LinkConfiguration::TypeMock:
             config = new MockConfiguration(name);
@@ -136,11 +132,9 @@ LinkConfiguration* LinkConfiguration::duplicateSettings(LinkConfiguration* sourc
             dupe = new BluetoothConfiguration(dynamic_cast<BluetoothConfiguration*>(source));
             break;
 #endif
-#ifndef __mobile__
         case TypeLogReplay:
             dupe = new LogReplayLinkConfiguration(dynamic_cast<LogReplayLinkConfiguration*>(source));
             break;
-#endif
 #ifdef QT_DEBUG
         case TypeMock:
             dupe = new MockConfiguration(dynamic_cast<MockConfiguration*>(source));

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -57,9 +57,7 @@ public:
 #ifdef QT_DEBUG
         TypeMock,       ///< Mock Link for Unitesting
 #endif
-#ifndef __mobile__
         TypeLogReplay,
-#endif
         TypeLast        // Last type value (type >= TypeLast == invalid)
     };
     Q_ENUM(LinkType)

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -21,6 +21,7 @@
 #include "UDPLink.h"
 #include "TCPLink.h"
 #include "SettingsManager.h"
+#include "LogReplayLink.h"
 #ifdef QGC_ENABLE_BLUETOOTH
 #include "BluetoothLink.h"
 #endif
@@ -139,11 +140,9 @@ LinkInterface* LinkManager::createConnectedLink(SharedLinkConfigurationPointer& 
         pLink = new BluetoothLink(config);
         break;
 #endif
-#ifndef __mobile__
     case LinkConfiguration::TypeLogReplay:
         pLink = new LogReplayLink(config);
         break;
-#endif
 #ifdef QT_DEBUG
     case LinkConfiguration::TypeMock:
         pLink = new MockLink(config);
@@ -393,11 +392,9 @@ void LinkManager::loadLinkConfigurationList()
                                 pLink = dynamic_cast<LinkConfiguration*>(new BluetoothConfiguration(name));
                                 break;
 #endif
-#ifndef __mobile__
                             case LinkConfiguration::TypeLogReplay:
                                 pLink = dynamic_cast<LinkConfiguration*>(new LogReplayLinkConfiguration(name));
                                 break;
-#endif
 #ifdef QT_DEBUG
                             case LinkConfiguration::TypeMock:
                                 pLink = dynamic_cast<LinkConfiguration*>(new MockConfiguration(name));
@@ -847,7 +844,6 @@ void LinkManager::_fixUnnamed(LinkConfiguration* config)
             }
                 break;
 #endif
-#ifndef __mobile__
             case LinkConfiguration::TypeLogReplay: {
                 LogReplayLinkConfiguration* tconfig = dynamic_cast<LogReplayLinkConfiguration*>(config);
                 if(tconfig) {
@@ -855,7 +851,6 @@ void LinkManager::_fixUnnamed(LinkConfiguration* config)
                 }
             }
                 break;
-#endif
 #ifdef QT_DEBUG
             case LinkConfiguration::TypeMock:
                 config->setName(QString("Mock Link"));
@@ -1014,4 +1009,14 @@ void LinkManager::_freeMavlinkChannel(int channel)
 
 void LinkManager::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t message) {
     link->startMavlinkMessagesTimer(message.sysid);
+}
+
+LogReplayLink* LinkManager::startLogReplay(const QString& logFile)
+{
+    LogReplayLinkConfiguration* linkConfig = new LogReplayLinkConfiguration(tr("Log Replay"));
+    linkConfig->setLogFilename(logFile);
+    linkConfig->setName(linkConfig->logFilenameShort());
+
+    SharedLinkConfigurationPointer sharedConfig = addConfiguration(linkConfig);
+    return qobject_cast<LogReplayLink*>(createConnectedLink(sharedConfig));
 }

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -43,6 +43,7 @@ Q_DECLARE_LOGGING_CATEGORY(LinkManagerVerboseLog)
 class QGCApplication;
 class UDPConfiguration;
 class AutoConnectSettings;
+class LogReplayLink;
 
 /// Manage communication links
 ///
@@ -128,6 +129,8 @@ public:
 
     // Called to signal app shutdown. Disconnects all links while turning off auto-connect.
     Q_INVOKABLE void shutdown(void);
+
+    Q_INVOKABLE LogReplayLink* startLogReplay(const QString& logFile);
 
 #ifdef QT_DEBUG
     // Only used by unit test tp restart after a shutdown

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -247,7 +247,6 @@ Rectangle {
                                     }
                                 }
 
-
                                 FactCheckBox {
                                     text:       qsTr("Mute all audio output")
                                     fact:       _audioMuted
@@ -430,11 +429,19 @@ Rectangle {
                             spacing:                    _margins
 
                             FactCheckBox {
-                                text:       qsTr("Use preflight checklist")
+                                text:       qsTr("Use Preflight Checklist")
                                 fact:       _useChecklist
                                 visible:    _useChecklist.visible
 
                                 property Fact _useChecklist: QGroundControl.settingsManager.appSettings.useChecklist
+                            }
+
+                            FactCheckBox {
+                                text:       qsTr("Show Telemetry Log Replay Status Bar")
+                                fact:       _showLogReplayStatusBar
+                                visible:    _showLogReplayStatusBar.visible
+
+                                property Fact _showLogReplayStatusBar: QGroundControl.settingsManager.flyViewSettings.showLogReplayStatusBar
                             }
 
                             FactCheckBox {


### PR DESCRIPTION
Note the Log Replay Status Bar on/off setting has moved to Fly View Settings. Because of this your previous setting will not be preserved.

Also a benefit of this new code is that Log Reaply is now available on Mobile as well.

![Screen Shot 2019-06-05 at 3 46 57 PM](https://user-images.githubusercontent.com/5876851/58996441-1866e800-87ad-11e9-9c13-25c52afcdc05.png)

![Screen Shot 2019-06-05 at 3 47 39 PM](https://user-images.githubusercontent.com/5876851/58996443-1d2b9c00-87ad-11e9-8bb8-10bb1614bc93.png)
