### PR TITLE
Multiple vehicle types

### DIFF
--- a/src/FirmwarePlugin/FirmwarePluginManager.cc
+++ b/src/FirmwarePlugin/FirmwarePluginManager.cc
@@ -16,7 +16,7 @@
 
 FirmwarePluginManager::FirmwarePluginManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
-    , _genericFirmwarePlugin(NULL)
+    , _genericFirmwarePlugin(nullptr)
 {
 
 }
@@ -58,7 +58,7 @@ QList<MAV_TYPE> FirmwarePluginManager::supportedVehicleTypes(MAV_AUTOPILOT firmw
 FirmwarePlugin* FirmwarePluginManager::firmwarePluginForAutopilot(MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType)
 {
     FirmwarePluginFactory*  factory = _findPluginFactory(firmwareType);
-    FirmwarePlugin*         plugin = NULL;
+    FirmwarePlugin*         plugin = nullptr;
 
     if (factory) {
         plugin = factory->firmwarePluginForAutopilot(firmwareType, vehicleType);

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
@@ -16,7 +16,7 @@
 PX4FirmwarePluginFactory PX4FirmwarePluginFactory;
 
 PX4FirmwarePluginFactory::PX4FirmwarePluginFactory(void)
-    : _pluginInstance(NULL)
+    : _pluginInstance(nullptr)
 {
 
 }
@@ -40,5 +40,5 @@ FirmwarePlugin* PX4FirmwarePluginFactory::firmwarePluginForAutopilot(MAV_AUTOPIL
         return _pluginInstance;
     }
 
-    return NULL;
+    return nullptr;
 }

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -30,6 +30,7 @@ Rectangle {
     property bool   _showCruiseSpeed:               !_missionVehicle.multiRotor
     property bool   _showHoverSpeed:                _missionVehicle.multiRotor || _missionVehicle.vtol
     property bool   _multipleFirmware:              QGroundControl.supportedFirmwareCount > 2
+    property bool   _multipleVehicleTypes:          QGroundControl.supportedVehicleCount > 1
     property real   _fieldWidth:                    ScreenTools.defaultFontPixelWidth * 16
     property bool   _mobile:                        ScreenTools.isMobile
     property var    _savePath:                      QGroundControl.settingsManager.appSettings.missionSavePath
@@ -158,13 +159,13 @@ Rectangle {
                 QGCLabel {
                     text:               _vehicleLabel
                     Layout.fillWidth:   true
-                    visible:            _showOfflineVehicleCombos
+                    visible:            _multipleVehicleTypes
                 }
                 FactComboBox {
                     fact:                   QGroundControl.settingsManager.appSettings.offlineEditingVehicleType
                     indexModel:             false
                     Layout.preferredWidth:  _fieldWidth
-                    visible:                _showOfflineVehicleCombos
+                    visible:                _multipleVehicleTypes
                     enabled:                _enableOfflineVehicleCombos
                 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -194,11 +194,9 @@ int QGroundControlQmlGlobal::supportedVehicleCount()
 {
     int count = 0;
     QList<MAV_AUTOPILOT> list = _firmwarePluginManager->supportedFirmwareTypes();
-    qDebug() << "Supported Firmwares" << list.count();
     foreach(auto firmware, list) {
         if(firmware != MAV_AUTOPILOT_GENERIC) {
             count += _firmwarePluginManager->supportedVehicleTypes(firmware).count();
-            qDebug() << "Firmware" << firmware << "Vehicles" << _firmwarePluginManager->supportedVehicleTypes(firmware).count();
         }
     }
     return count;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -190,6 +190,20 @@ int QGroundControlQmlGlobal::supportedFirmwareCount()
     return _firmwarePluginManager->supportedFirmwareTypes().count();
 }
 
+int QGroundControlQmlGlobal::supportedVehicleCount()
+{
+    int count = 0;
+    QList<MAV_AUTOPILOT> list = _firmwarePluginManager->supportedFirmwareTypes();
+    qDebug() << "Supported Firmwares" << list.count();
+    foreach(auto firmware, list) {
+        if(firmware != MAV_AUTOPILOT_GENERIC) {
+            count += _firmwarePluginManager->supportedVehicleTypes(firmware).count();
+            qDebug() << "Firmware" << firmware << "Vehicles" << _firmwarePluginManager->supportedVehicleTypes(firmware).count();
+        }
+    }
+    return count;
+}
+
 bool QGroundControlQmlGlobal::px4ProFirmwareSupported()
 {
     return _firmwarePluginManager->supportedFirmwareTypes().contains(MAV_AUTOPILOT_PX4);

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -77,8 +77,9 @@ public:
     Q_PROPERTY(bool                 microhardSupported  READ microhardSupported     CONSTANT)
 
     Q_PROPERTY(int      supportedFirmwareCount          READ supportedFirmwareCount CONSTANT)
+    Q_PROPERTY(int      supportedVehicleCount           READ supportedVehicleCount  CONSTANT)
     Q_PROPERTY(bool     px4ProFirmwareSupported         READ px4ProFirmwareSupported CONSTANT)
-    Q_PROPERTY(int      apmFirmwareSupported            READ apmFirmwareSupported CONSTANT)
+    Q_PROPERTY(int      apmFirmwareSupported            READ apmFirmwareSupported   CONSTANT)
 
     Q_PROPERTY(qreal zOrderTopMost              READ zOrderTopMost              CONSTANT) ///< z order for top most items, toolbar, main window sub view
     Q_PROPERTY(qreal zOrderWidgets              READ zOrderWidgets              CONSTANT) ///< z order value to widgets, for example: zoom controls, hud widgetss
@@ -203,6 +204,7 @@ public:
 #endif
 
     int     supportedFirmwareCount  ();
+    int     supportedVehicleCount   ();
     bool    px4ProFirmwareSupported ();
     bool    apmFirmwareSupported    ();
     bool    skipSetupPage           () { return _skipSetupPage; }


### PR DESCRIPTION
Show vehicle options when offline editing missions.

The original code would only show the list of options if multiple firmware types was supported instead of looking at the number of vehicle types a given firmware supports.

<img width="282" alt="Screen Shot 2019-06-06 at 7 45 10 AM" src="https://user-images.githubusercontent.com/749243/59033804-87891e80-8837-11e9-8d7c-cc3ad086555e.png">
