### PR TITLE
Handle text to speech locale

### DIFF
--- a/src/Audio/AudioOutput.cc
+++ b/src/Audio/AudioOutput.cc
@@ -20,7 +20,14 @@ AudioOutput::AudioOutput(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
     , _tts(new QTextToSpeech(this))
 {
+    _tts->setLocale(QLocale::system());
     connect(_tts, &QTextToSpeech::stateChanged, this, &AudioOutput::_stateChanged);
+    connect(qgcApp(), &QGCApplication::languageChanged, this, &AudioOutput::_languageChanged);
+}
+
+void AudioOutput::_languageChanged(const QLocale locale)
+{
+    _tts->setLocale(locale);
 }
 
 bool AudioOutput::say(const QString& inText)

--- a/src/Audio/AudioOutput.cc
+++ b/src/Audio/AudioOutput.cc
@@ -20,14 +20,12 @@ AudioOutput::AudioOutput(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
     , _tts(new QTextToSpeech(this))
 {
-    _tts->setLocale(QLocale::system());
+    //-- Force TTS engine to English as all incoming messages from the autopilot
+    //   are in English and not localized.
+#ifdef Q_OS_LINUX
+    _tts->setLocale(QLocale("en_US"));
+#endif
     connect(_tts, &QTextToSpeech::stateChanged, this, &AudioOutput::_stateChanged);
-    connect(qgcApp(), &QGCApplication::languageChanged, this, &AudioOutput::_languageChanged);
-}
-
-void AudioOutput::_languageChanged(const QLocale locale)
-{
-    _tts->setLocale(locale);
 }
 
 bool AudioOutput::say(const QString& inText)

--- a/src/Audio/AudioOutput.h
+++ b/src/Audio/AudioOutput.h
@@ -33,7 +33,6 @@ public slots:
 
 private slots:
     void            _stateChanged           (QTextToSpeech::State state);
-    void            _languageChanged        (const QLocale locale);
 
 protected:
     QTextToSpeech*  _tts;

--- a/src/Audio/AudioOutput.h
+++ b/src/Audio/AudioOutput.h
@@ -33,6 +33,7 @@ public slots:
 
 private slots:
     void            _stateChanged           (QTextToSpeech::State state);
+    void            _languageChanged        (const QLocale locale);
 
 protected:
     QTextToSpeech*  _tts;

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -351,74 +351,74 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 
 void QGCApplication::setLanguage()
 {
-    QLocale locale = QLocale::system();
-    qDebug() << "System reported locale:" << locale << locale.name();
+    _locale = QLocale::system();
+    qDebug() << "System reported locale:" << _locale << _locale.name();
     int langID = toolbox()->settingsManager()->appSettings()->language()->rawValue().toInt();
     //-- See App.SettinsGroup.json for index
     if(langID) {
         switch(langID) {
         case 1:
-            locale = QLocale(QLocale::Bulgarian);
+            _locale = QLocale(QLocale::Bulgarian);
             break;
         case 2:
-            locale = QLocale(QLocale::Chinese);
+            _locale = QLocale(QLocale::Chinese);
             break;
         case 3:
-            locale = QLocale(QLocale::Dutch);
+            _locale = QLocale(QLocale::Dutch);
             break;
         case 4:
-            locale = QLocale(QLocale::English);
+            _locale = QLocale(QLocale::English);
             break;
         case 5:
-            locale = QLocale(QLocale::Finnish);
+            _locale = QLocale(QLocale::Finnish);
             break;
         case 6:
-            locale = QLocale(QLocale::French);
+            _locale = QLocale(QLocale::French);
             break;
         case 7:
-            locale = QLocale(QLocale::German);
+            _locale = QLocale(QLocale::German);
             break;
         case 8:
-            locale = QLocale(QLocale::Greek);
+            _locale = QLocale(QLocale::Greek);
             break;
         case 9:
-            locale = QLocale(QLocale::Hebrew);
+            _locale = QLocale(QLocale::Hebrew);
             break;
         case 10:
-            locale = QLocale(QLocale::Italian);
+            _locale = QLocale(QLocale::Italian);
             break;
         case 11:
-            locale = QLocale(QLocale::Japanese);
+            _locale = QLocale(QLocale::Japanese);
             break;
         case 12:
-            locale = QLocale(QLocale::Korean);
+            _locale = QLocale(QLocale::Korean);
             break;
         case 13:
-            locale = QLocale(QLocale::Norwegian);
+            _locale = QLocale(QLocale::Norwegian);
             break;
         case 14:
-            locale = QLocale(QLocale::Polish);
+            _locale = QLocale(QLocale::Polish);
             break;
         case 15:
-            locale = QLocale(QLocale::Portuguese);
+            _locale = QLocale(QLocale::Portuguese);
             break;
         case 16:
-            locale = QLocale(QLocale::Russian);
+            _locale = QLocale(QLocale::Russian);
             break;
         case 17:
-            locale = QLocale(QLocale::Spanish);
+            _locale = QLocale(QLocale::Spanish);
             break;
         case 18:
-            locale = QLocale(QLocale::Swedish);
+            _locale = QLocale(QLocale::Swedish);
             break;
         case 19:
-            locale = QLocale(QLocale::Turkish);
+            _locale = QLocale(QLocale::Turkish);
             break;
         }
     }
     //-- We have specific fonts for Korean
-    if(locale == QLocale::Korean) {
-        qDebug() << "Loading Korean fonts" << locale.name();
+    if(_locale == QLocale::Korean) {
+        qDebug() << "Loading Korean fonts" << _locale.name();
         if(QFontDatabase::addApplicationFont(":/fonts/NanumGothic-Regular") < 0) {
             qWarning() << "Could not load /fonts/NanumGothic-Regular font";
         }
@@ -426,22 +426,23 @@ void QGCApplication::setLanguage()
             qWarning() << "Could not load /fonts/NanumGothic-Bold font";
         }
     }
-    qDebug() << "Loading localization for" << locale.name();
+    qDebug() << "Loading localization for" << _locale.name();
     _app->removeTranslator(&_QGCTranslator);
     _app->removeTranslator(&_QGCTranslatorQt);
-    if(_QGCTranslatorQt.load("qt_" + locale.name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
+    if(_QGCTranslatorQt.load("qt_" + _locale.name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
         _app->installTranslator(&_QGCTranslatorQt);
     } else {
-        qDebug() << "Error loading Qt localization for" << locale.name();
+        qDebug() << "Error loading Qt localization for" << _locale.name();
     }
-    if(_QGCTranslator.load(locale, QLatin1String("qgc_"), "", ":/i18n")) {
-        QLocale::setDefault(locale);
+    if(_QGCTranslator.load(_locale, QLatin1String("qgc_"), "", ":/i18n")) {
+        QLocale::setDefault(_locale);
         _app->installTranslator(&_QGCTranslator);
     } else {
-        qDebug() << "Error loading application localization for" << locale.name();
+        qDebug() << "Error loading application localization for" << _locale.name();
     }
     if(_qmlAppEngine)
         _qmlAppEngine->retranslate();
+    emit languageChanged(_locale);
 }
 
 void QGCApplication::_shutdown()

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -42,7 +42,6 @@
 
 #include "QGC.h"
 #include "QGCApplication.h"
-#include "AudioOutput.h"
 #include "CmdLineOptParser.h"
 #include "UDPLink.h"
 #include "LinkManager.h"

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -118,10 +118,15 @@ public slots:
     /// Check that the telemetry save path is set correctly
     void checkTelemetrySavePathOnMainThread();
 
+    /// Get current language
+    const QLocale getCurrentLanguage() { return _locale; }
+
 signals:
     /// This is connected to MAVLinkProtocol::checkForLostLogFiles. We signal this to ourselves to call the slot
     /// on the MAVLinkProtocol thread;
-    void checkForLostLogFiles();
+    void checkForLostLogFiles   ();
+
+    void languageChanged        (const QLocale locale);
 
 public:
     // Although public, these methods are internal and should only be called by UnitTest code
@@ -184,6 +189,7 @@ private:
     bool                _bluetoothAvailable     = false;
     QTranslator         _QGCTranslator;
     QTranslator         _QGCTranslatorQt;
+    QLocale             _locale;
 
     static const char* _settingsVersionKey;             ///< Settings key which hold settings version
     static const char* _deleteAllSettingsKey;           ///< If this settings key is set on boot, all settings will be deleted

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -28,7 +28,6 @@
 #include "ParameterManager.h"
 #include "QGCApplication.h"
 #include "QGCImageProvider.h"
-#include "AudioOutput.h"
 #include "FollowMe.h"
 #include "MissionCommandTree.h"
 #include "QGroundControlQmlGlobal.h"

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -26,7 +26,6 @@
 #include "UAS.h"
 #include "LinkInterface.h"
 #include "QGC.h"
-#include "AudioOutput.h"
 #include "MAVLinkProtocol.h"
 #include "QGCMAVLink.h"
 #include "LinkManager.h"


### PR DESCRIPTION
In response to #7517 

This sets the Text to Speech engine to the current locale. I'm not sure how this will work as 99% of the spoken sentences are in English and are not localized. @ArkadiuszNiemiec could please test this and see how it behaves? This "fix" might be the opposite of what is required. I'm thinking it makes more sense to set the TTS engine to always use English regardless of the current locale as that's the only source of text it will ever see. If that's the case, let me know and I will switch to "always use English" instead.

I can't really test as my system is set to its default (en_US). If I switch the language in QGC, the spoken text is obviously still English but with a weird accent.
