### PR TITLE
Initial support for PX4 Rover

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Note: This file only contains high level features or important fixes.
 
 ### 3.6.0 - Daily Build
 
+* For text to speech engine on Linux to English (all messages are in English)
 * Automated the ingestion of localization from Crowdin
 * Automated the generation of language resources into the application
 * Added all languages that come from Crowdin, even if empty.

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -74,7 +74,7 @@ void ArduRoverFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double 
     qgcApp()->showMessage(QStringLiteral("Change altitude not supported."));
 }
 
-bool ArduRoverFirmwarePlugin::supportsNegativeThrust(void)
+bool ArduRoverFirmwarePlugin::supportsNegativeThrust(Vehicle* /*vehicle*/)
 {
     return true;
 }

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -50,7 +50,7 @@ public:
     void    guidedModeChangeAltitude                (Vehicle* vehicle, double altitudeChange) final;
     int     remapParamNameHigestMinorVersionNumber  (int majorVersionNumber) const final;
     const   FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
-    bool    supportsNegativeThrust                  (void) final;
+    bool    supportsNegativeThrust                  (Vehicle *) final;
     bool    supportsSmartRTL                        (void) const override { return true; }
     QString offlineEditingParamFile                 (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral(":/FirmwarePlugin/APM/Rover.OfflineEditing.params"); }
 

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -50,11 +50,6 @@ FirmwarePluginFactoryRegister* FirmwarePluginFactoryRegister::instance(void)
     return _instance;
 }
 
-FirmwarePlugin::FirmwarePlugin(MAV_TYPE vehicleType)
-{
-    _vehicleType = vehicleType;
-}
-
 AutoPilotPlugin* FirmwarePlugin::autopilotPlugin(Vehicle* vehicle)
 {
     return new GenericAutoPilotPlugin(vehicle, vehicle);
@@ -132,7 +127,7 @@ bool FirmwarePlugin::supportsThrottleModeCenterZero(void)
     return true;
 }
 
-bool FirmwarePlugin::supportsNegativeThrust(void)
+bool FirmwarePlugin::supportsNegativeThrust(Vehicle* /*vehicle*/)
 {
     // By default, this is not supported
     return false;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -50,6 +50,11 @@ FirmwarePluginFactoryRegister* FirmwarePluginFactoryRegister::instance(void)
     return _instance;
 }
 
+FirmwarePlugin::FirmwarePlugin(MAV_TYPE vehicleType)
+{
+    _vehicleType = vehicleType;
+}
+
 AutoPilotPlugin* FirmwarePlugin::autopilotPlugin(Vehicle* vehicle)
 {
     return new GenericAutoPilotPlugin(vehicle, vehicle);

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -49,8 +49,6 @@ public:
         TakeoffVehicleCapability =          1 << 4, ///< Vehicle supports guided takeoff
     } FirmwareCapabilities;
 
-    FirmwarePlugin(MAV_TYPE vehicleType = MAV_TYPE_GENERIC);
-
     /// Maps from on parameter name to another
     ///     key:    parameter name to translate from
     ///     value:  mapped parameter name
@@ -164,7 +162,7 @@ public:
 
     /// Returns true if the vehicle and firmware supports the use of negative thrust
     /// Typically supported rover.
-    virtual bool supportsNegativeThrust(void);
+    virtual bool supportsNegativeThrust(Vehicle *);
 
     /// Returns true if the firmware supports the use of the RC radio and requires the RC radio
     /// setup page. Returns true by default.
@@ -345,9 +343,6 @@ protected:
 
     // Returns regex QString to extract version information from text
     virtual QString _versionRegex() { return QString(); }
-
-protected:
-    MAV_TYPE _vehicleType = MAV_TYPE_GENERIC;
 
 private:
     QVariantList _toolBarIndicatorList;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -49,6 +49,8 @@ public:
         TakeoffVehicleCapability =          1 << 4, ///< Vehicle supports guided takeoff
     } FirmwareCapabilities;
 
+    FirmwarePlugin(MAV_TYPE vehicleType = MAV_TYPE_GENERIC);
+
     /// Maps from on parameter name to another
     ///     key:    parameter name to translate from
     ///     value:  mapped parameter name
@@ -343,6 +345,9 @@ protected:
 
     // Returns regex QString to extract version information from text
     virtual QString _versionRegex() { return QString(); }
+
+protected:
+    MAV_TYPE _vehicleType = MAV_TYPE_GENERIC;
 
 private:
     QVariantList _toolBarIndicatorList;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -35,8 +35,9 @@ PX4FirmwarePluginInstanceData::PX4FirmwarePluginInstanceData(QObject* parent)
 
 }
 
-PX4FirmwarePlugin::PX4FirmwarePlugin(void)
-    : _manualFlightMode     (tr("Manual"))
+PX4FirmwarePlugin::PX4FirmwarePlugin(MAV_TYPE vehicleType)
+    : FirmwarePlugin(vehicleType)
+    , _manualFlightMode     (tr("Manual"))
     , _acroFlightMode       (tr("Acro"))
     , _stabilizedFlightMode (tr("Stabilized"))
     , _rattitudeFlightMode  (tr("Rattitude"))
@@ -257,7 +258,7 @@ FactMetaData* PX4FirmwarePlugin::getMetaDataForFact(QObject* parameterMetaData, 
         qWarning() << "Internal error: pointer passed to PX4FirmwarePlugin::getMetaDataForFact not PX4ParameterMetaData";
     }
 
-    return NULL;
+    return nullptr;
 }
 
 void PX4FirmwarePlugin::addMetaDataToFact(QObject* parameterMetaData, Fact* fact, MAV_TYPE vehicleType)
@@ -306,22 +307,16 @@ QString PX4FirmwarePlugin::missionCommandOverrides(MAV_TYPE vehicleType) const
     switch (vehicleType) {
     case MAV_TYPE_GENERIC:
         return QStringLiteral(":/json/PX4/MavCmdInfoCommon.json");
-        break;
     case MAV_TYPE_FIXED_WING:
         return QStringLiteral(":/json/PX4/MavCmdInfoFixedWing.json");
-        break;
     case MAV_TYPE_QUADROTOR:
         return QStringLiteral(":/json/PX4/MavCmdInfoMultiRotor.json");
-        break;
     case MAV_TYPE_VTOL_QUADROTOR:
         return QStringLiteral(":/json/PX4/MavCmdInfoVTOL.json");
-        break;
     case MAV_TYPE_SUBMARINE:
         return QStringLiteral(":/json/PX4/MavCmdInfoSub.json");
-        break;
     case MAV_TYPE_GROUND_ROVER:
         return QStringLiteral(":/json/PX4/MavCmdInfoRover.json");
-        break;
     default:
         qWarning() << "PX4FirmwarePlugin::missionCommandOverrides called with bad MAV_TYPE:" << vehicleType;
         return QString();
@@ -410,13 +405,14 @@ void PX4FirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double takeoffAltRel
     qDebug() << takeoffAltRel << takeoffAltRelFromVehicle << takeoffAltAMSL << vehicleAltitudeAMSL;
 
     connect(vehicle, &Vehicle::mavCommandResult, this, &PX4FirmwarePlugin::_mavCommandResult);
-    vehicle->sendMavCommand(vehicle->defaultComponentId(),
-                            MAV_CMD_NAV_TAKEOFF,
-                            true,                           // show error is fails
-                            -1,                             // No pitch requested
-                            0, 0,                           // param 2-4 unused
-                            NAN, NAN, NAN,                  // No yaw, lat, lon
-                            takeoffAltAMSL);                // AMSL altitude
+    vehicle->sendMavCommand(
+        vehicle->defaultComponentId(),
+        MAV_CMD_NAV_TAKEOFF,
+        true,                                   // show error is fails
+        -1,                                     // No pitch requested
+        0, 0,                                   // param 2-4 unused
+        NAN, NAN, NAN,                          // No yaw, lat, lon
+        static_cast<float>(takeoffAltAMSL));    // AMSL altitude
 }
 
 void PX4FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordinate& gotoCoord)
@@ -446,8 +442,8 @@ void PX4FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoord
                                 MAV_DO_REPOSITION_FLAGS_CHANGE_MODE,
                                 0.0f,
                                 NAN,
-                                gotoCoord.latitude(),
-                                gotoCoord.longitude(),
+                                static_cast<float>(gotoCoord.latitude()),
+                                static_cast<float>(gotoCoord.longitude()),
                                 vehicle->altitudeAMSL()->rawValue().toFloat());
     }
 }
@@ -475,7 +471,7 @@ void PX4FirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
                             NAN,
                             NAN,
                             NAN,
-                            vehicle->homePosition().altitude() + newAltRel);
+                            static_cast<float>(vehicle->homePosition().altitude() + newAltRel));
 }
 
 void PX4FirmwarePlugin::startMission(Vehicle* vehicle)
@@ -593,4 +589,9 @@ QString PX4FirmwarePlugin::_getLatestVersionFileUrl(Vehicle* vehicle){
 
 QString PX4FirmwarePlugin::_versionRegex() {
     return QStringLiteral("v([0-9,\\.]*) Stable");
+}
+
+bool PX4FirmwarePlugin::supportsNegativeThrust(void)
+{
+    return _vehicleType == MAV_TYPE_GROUND_ROVER;
 }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -35,9 +35,8 @@ PX4FirmwarePluginInstanceData::PX4FirmwarePluginInstanceData(QObject* parent)
 
 }
 
-PX4FirmwarePlugin::PX4FirmwarePlugin(MAV_TYPE vehicleType)
-    : FirmwarePlugin(vehicleType)
-    , _manualFlightMode     (tr("Manual"))
+PX4FirmwarePlugin::PX4FirmwarePlugin()
+    : _manualFlightMode     (tr("Manual"))
     , _acroFlightMode       (tr("Acro"))
     , _stabilizedFlightMode (tr("Stabilized"))
     , _rattitudeFlightMode  (tr("Rattitude"))
@@ -591,7 +590,7 @@ QString PX4FirmwarePlugin::_versionRegex() {
     return QStringLiteral("v([0-9,\\.]*) Stable");
 }
 
-bool PX4FirmwarePlugin::supportsNegativeThrust(void)
+bool PX4FirmwarePlugin::supportsNegativeThrust(Vehicle* vehicle)
 {
-    return _vehicleType == MAV_TYPE_GROUND_ROVER;
+    return vehicle->vehicleType() == MAV_TYPE_GROUND_ROVER;
 }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -23,7 +23,7 @@ class PX4FirmwarePlugin : public FirmwarePlugin
     Q_OBJECT
 
 public:
-    PX4FirmwarePlugin   (MAV_TYPE vehicleType);
+    PX4FirmwarePlugin   ();
     ~PX4FirmwarePlugin  () override;
 
     // Overrides from FirmwarePlugin
@@ -69,7 +69,7 @@ public:
     QString             autoDisarmParameter             (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral("COM_DISARM_LAND"); }
     uint32_t            highLatencyCustomModeTo32Bits   (uint16_t hlCustomMode) override;
     bool                supportsTerrainFrame            (void) const override { return false; }
-    bool                supportsNegativeThrust          (void) override;
+    bool                supportsNegativeThrust          (Vehicle *vehicle) override;
 
 protected:
     typedef struct {

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -23,8 +23,8 @@ class PX4FirmwarePlugin : public FirmwarePlugin
     Q_OBJECT
 
 public:
-    PX4FirmwarePlugin(void);
-    ~PX4FirmwarePlugin();
+    PX4FirmwarePlugin   (MAV_TYPE vehicleType);
+    ~PX4FirmwarePlugin  () override;
 
     // Overrides from FirmwarePlugin
 
@@ -69,6 +69,7 @@ public:
     QString             autoDisarmParameter             (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral("COM_DISARM_LAND"); }
     uint32_t            highLatencyCustomModeTo32Bits   (uint16_t hlCustomMode) override;
     bool                supportsTerrainFrame            (void) const override { return false; }
+    bool                supportsNegativeThrust          (void) override;
 
 protected:
     typedef struct {
@@ -122,7 +123,7 @@ class PX4FirmwarePluginInstanceData : public QObject
     Q_OBJECT
 
 public:
-    PX4FirmwarePluginInstanceData(QObject* parent = NULL);
+    PX4FirmwarePluginInstanceData(QObject* parent = nullptr);
 
     bool versionNotified;  ///< true: user notified over version issue
 };

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
@@ -13,6 +13,7 @@
 
 #include "PX4FirmwarePluginFactory.h"
 #include "PX4/PX4FirmwarePlugin.h"
+
 PX4FirmwarePluginFactory PX4FirmwarePluginFactory;
 
 PX4FirmwarePluginFactory::PX4FirmwarePluginFactory(void)
@@ -24,21 +25,17 @@ PX4FirmwarePluginFactory::PX4FirmwarePluginFactory(void)
 QList<MAV_AUTOPILOT> PX4FirmwarePluginFactory::supportedFirmwareTypes(void) const
 {
     QList<MAV_AUTOPILOT> list;
-
     list.append(MAV_AUTOPILOT_PX4);
     return list;
 }
 
 FirmwarePlugin* PX4FirmwarePluginFactory::firmwarePluginForAutopilot(MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType)
 {
-    Q_UNUSED(vehicleType);
-
     if (autopilotType == MAV_AUTOPILOT_PX4) {
         if (!_pluginInstance) {
-            _pluginInstance = new PX4FirmwarePlugin;
+            _pluginInstance = new PX4FirmwarePlugin(vehicleType);
         }
         return _pluginInstance;
     }
-
     return nullptr;
 }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
@@ -29,11 +29,11 @@ QList<MAV_AUTOPILOT> PX4FirmwarePluginFactory::supportedFirmwareTypes(void) cons
     return list;
 }
 
-FirmwarePlugin* PX4FirmwarePluginFactory::firmwarePluginForAutopilot(MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType)
+FirmwarePlugin* PX4FirmwarePluginFactory::firmwarePluginForAutopilot(MAV_AUTOPILOT autopilotType, MAV_TYPE /*vehicleType*/)
 {
     if (autopilotType == MAV_AUTOPILOT_PX4) {
         if (!_pluginInstance) {
-            _pluginInstance = new PX4FirmwarePlugin(vehicleType);
+            _pluginInstance = new PX4FirmwarePlugin();
         }
         return _pluginInstance;
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2871,9 +2871,9 @@ bool Vehicle::supportsThrottleModeCenterZero(void) const
     return _firmwarePlugin->supportsThrottleModeCenterZero();
 }
 
-bool Vehicle::supportsNegativeThrust(void) const
+bool Vehicle::supportsNegativeThrust(void)
 {
-    return _firmwarePlugin->supportsNegativeThrust();
+    return _firmwarePlugin->supportsNegativeThrust(this);
 }
 
 bool Vehicle::supportsRadio(void) const

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -854,7 +854,7 @@ public:
     bool sub(void) const;
 
     bool supportsThrottleModeCenterZero (void) const;
-    bool supportsNegativeThrust         (void) const;
+    bool supportsNegativeThrust         (void);
     bool supportsRadio                  (void) const;
     bool supportsJSButton               (void) const;
     bool supportsMotorInterference      (void) const;


### PR DESCRIPTION
This is just the beginning. Currently, a lot of the variables that define a vehicle type are specified on a per firmware plugin type. That works for APM given that it has different firmwares for each vehicle type but not so much for PX4 where one single firmware supports everything.

This change assigns a vehicle type during the creation of an instance of `FirmwarePlugin`. It further implements `supportsNegativeThrust()` based on the vehicle type (for PX4 only).

Now we just need to do the other 99.9% of missing rover support :P

@DonLakeFlyer, @dagar The whole Joystick/Radio setup is hardcoded for full, 3 axis attitude in addition to throttle. We need to sort out how to handle just "steering" and "throttle" (and a button for brake, etc.)
