### PR TITLE
Moved the preflight checklist to a proper, modal dialog.

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -627,7 +627,6 @@ Item {
                 {
                     name:               "Checklist",
                     iconSource:         "/qmlimages/check.svg",
-                    dropPanelComponent: checklistDropPanel
                 },
                 {
                     name:       _guidedController.takeoffTitle,
@@ -660,6 +659,8 @@ Item {
                 guidedActionsController.closeAll()
                 if(index === 0) {
                     mainWindow.showPlanView()
+                } else if(index === 1) {
+                    checklistDropPanel.open()
                 } else {
                     var action = model[index].action
                     if (action === -1) {
@@ -795,10 +796,24 @@ Item {
     }
 
     //-- Checklist GUI
-    Component {
-        id: checklistDropPanel
+    Popup {
+        id:             checklistDropPanel
+        x:              Math.round((mainWindow.width  - width)  * 0.5)
+        y:              Math.round((mainWindow.height - height) * 0.5)
+        height:         checkList.height
+        width:          checkList.width
+        modal:          true
+        focus:          true
+        closePolicy:    Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        background: Rectangle {
+            anchors.fill:   parent
+            color:          Qt.rgba(0,0,0,0)
+            clip:           true
+        }
         PreFlightCheckList {
-            model: preFlightCheckModel
+            id:     checkList
+            model:  preFlightCheckModel
         }
     }
+
 }

--- a/src/QmlControls/PreFlightCheckButton.qml
+++ b/src/QmlControls/PreFlightCheckButton.qml
@@ -43,9 +43,9 @@ QGCButton {
     readonly property int _stateFailed:     1   ///< Telemetry check is failing, user cannot click to make it pass
     readonly property int _statePassed:     2   ///< Check has passed
 
-    readonly property color _passedColor:   Qt.rgba(0.27,0.67,0.42,1)
-    readonly property color _pendingColor:  Qt.rgba(0.9,0.47,0.2,1)
-    readonly property color _failedColor:   Qt.rgba(0.92,0.22,0.22,1)
+    readonly property color _passedColor:   "#86cc6a"
+    readonly property color _pendingColor:  "#f7a81f"
+    readonly property color _failedColor:   "#c31818"
 
     property string _text: "<b>" + name +"</b>: " +
                            ((_telemetryState !== _statePassed) ?
@@ -136,5 +136,4 @@ QGCButton {
         }
     }
 
-    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
 }

--- a/src/QmlControls/PreFlightCheckList.qml
+++ b/src/QmlControls/PreFlightCheckList.qml
@@ -16,10 +16,10 @@ import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0
 
 Rectangle {
-    width:  mainColumn.width + 3*ScreenTools.defaultFontPixelWidth
-    height: mainColumn.height + ScreenTools.defaultFontPixelHeight
-    color:  qgcPal.windowShade
-    radius: 3
+    width:      mainColumn.width  + ScreenTools.defaultFontPixelWidth * 3
+    height:     mainColumn.height + ScreenTools.defaultFontPixelHeight
+    color:      qgcPal.windowShade
+    radius:     3
 
     property alias model: checkListRepeater.model
 
@@ -52,12 +52,12 @@ Rectangle {
 
     Column {
         id:                     mainColumn
-        width:                  40*ScreenTools.defaultFontPixelWidth
-        spacing:                0.8*ScreenTools.defaultFontPixelWidth
+        width:                  40  * ScreenTools.defaultFontPixelWidth
+        spacing:                0.8 * ScreenTools.defaultFontPixelWidth
         anchors.left:           parent.left
         anchors.top:            parent.top
-        anchors.topMargin:      0.6*ScreenTools.defaultFontPixelWidth
-        anchors.leftMargin:     1.5*ScreenTools.defaultFontPixelWidth
+        anchors.topMargin:      0.6 * ScreenTools.defaultFontPixelWidth
+        anchors.leftMargin:     1.5 * ScreenTools.defaultFontPixelWidth
 
         function groupPassedChanged(index, passed) {
             if (passed) {
@@ -70,8 +70,8 @@ Rectangle {
 
         // Header/title of checklist
         Item {
-            width:  parent.width
-            height: 1.75*ScreenTools.defaultFontPixelHeight
+            width:      parent.width
+            height:     1.75 * ScreenTools.defaultFontPixelHeight
 
             QGCLabel {
                 text:                   qsTr("Pre-Flight Checklist %1").arg(_passed ? qsTr("(passed)") : "")
@@ -80,16 +80,19 @@ Rectangle {
                 font.pointSize:         ScreenTools.mediumFontPointSize
             }
             QGCButton {
-                width:                  1.2*ScreenTools.defaultFontPixelHeight
-                height:                 1.2*ScreenTools.defaultFontPixelHeight
+                width:                  1.2 * ScreenTools.defaultFontPixelHeight
+                height:                 1.2 * ScreenTools.defaultFontPixelHeight
                 anchors.right:          parent.right
                 anchors.verticalCenter: parent.verticalCenter
-                opacity :               0.2+0.8*(QGroundControl.multiVehicleManager.vehicles.count > 0)
                 tooltip:                qsTr("Reset the checklist (e.g. after a vehicle reboot)")
 
-                onClicked: model.reset()
+                onClicked:              model.reset()
 
-                Image { source:"/qmlimages/MapSyncBlack.svg" ; anchors.fill: parent }
+                QGCColoredImage {
+                    source:         "/qmlimages/MapSyncBlack.svg"
+                    color:          qgcPal.buttonText
+                    anchors.fill:   parent
+                }
             }
         }
 
@@ -97,5 +100,5 @@ Rectangle {
         Repeater {
             id: checkListRepeater
         }
-    } // Column
-} //Rectangle
+    }
+}


### PR DESCRIPTION
I don't quite grok the over-complexity/hardcoded dependencies of that Preflight Checklist. I will deal with that when I find the time. In the mean time, I've made it into a proper, modal dialog using current QtQuick controls.

<img width="1026" alt="Screen Shot 2019-06-14 at 3 24 18 PM" src="https://user-images.githubusercontent.com/749243/59533109-82bc0e80-8eb8-11e9-8f58-d345ebf86f5d.png">
