### PR TITLE
Replace usage of QMessageBox with a QML window.

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -28,6 +28,7 @@
         <file alias="DebugWindow.qml">src/ui/preferences/DebugWindow.qml</file>
         <file alias="ESP8266Component.qml">src/AutoPilotPlugins/Common/ESP8266Component.qml</file>
         <file alias="ESP8266ComponentSummary.qml">src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml</file>
+        <file alias="ExitWithErrorWindow.qml">src/ui/ExitWithErrorWindow.qml</file>
         <file alias="FirmwareUpgrade.qml">src/VehicleSetup/FirmwareUpgrade.qml</file>
         <file alias="FlightDisplayViewDummy.qml">src/FlightDisplay/FlightDisplayViewDummy.qml</file>
         <file alias="FlightDisplayViewUVC.qml">src/FlightDisplay/FlightDisplayViewUVC.qml</file>

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -145,6 +145,8 @@ public:
 
     static QGCApplication*  _app;   ///< Our own singleton. Should be reference directly by qgcApp
 
+    bool    isErrorState()  { return _error; }
+
 public:
     // Although public, these methods are internal and should only be called by UnitTest code
 
@@ -166,6 +168,7 @@ private slots:
 private:
     QObject*    _rootQmlObject          ();
     void        _checkForNewVersion     ();
+    void        _exitWithError          (QString errorMessage);
 
 
     bool _runningUnitTests; ///< true: running unit tests, false: normal app
@@ -190,6 +193,7 @@ private:
     QTranslator         _QGCTranslator;
     QTranslator         _QGCTranslatorQt;
     QLocale             _locale;
+    bool                _error                  = false;
 
     static const char* _settingsVersionKey;             ///< Settings key which hold settings version
     static const char* _deleteAllSettingsKey;           ///< If this settings key is set on boot, all settings will be deleted

--- a/src/main.cc
+++ b/src/main.cc
@@ -328,6 +328,10 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     QGCApplication* app = new QGCApplication(argc, argv, runUnitTests);
     Q_CHECK_PTR(app);
+    if(app->isErrorState()) {
+        app->exec();
+        return -1;
+    }
 
 #ifdef Q_OS_LINUX
     QApplication::setWindowIcon(QIcon(":/res/resources/icons/qgroundcontrol.ico"));

--- a/src/ui/ExitWithErrorWindow.qml
+++ b/src/ui/ExitWithErrorWindow.qml
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.11
+import QtQuick.Controls 2.4
+import QtQuick.Dialogs  1.3
+import QtQuick.Layouts  1.11
+import QtQuick.Window   2.11
+
+ApplicationWindow {
+    id:             errorWindow
+    minimumWidth:   messageArea.width  + 60
+    minimumHeight:  messageArea.height + 60
+    width:          messageArea.width  + 60
+    height:         messageArea.height + 60
+    visible:        true
+
+    //-------------------------------------------------------------------------
+    //-- Main, full window background (Fly View)
+    background: Item {
+        id:             rootBackground
+        anchors.fill:   parent
+        Rectangle {
+            anchors.fill:   parent
+            color:          "#000000"
+        }
+    }
+
+    Column {
+        id:                 messageArea
+        spacing:            20
+        anchors.centerIn:   parent
+        Label {
+            width:          600
+            text:           errorMessage
+            color:          "#eecc44"
+            wrapMode:       Text.WordWrap
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+        Button {
+            text:           qsTr("Close")
+            highlighted:    true
+            onClicked:      errorWindow.close()
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+    }
+
+}


### PR DESCRIPTION
There were a couple of places in the code where `QMessageBox` was still being used. As these don't work with a QtQuick application, it was causing a crash when used. Primarily on Linux (the only place where these were being called).

The code now loads a specific error QML "main window" showing the error message, which can be used for other fatal errors to be shown before the main QML window is shown.

This replaces #7479 
