### PR TITLE
Mavlink protocol version negotiation fixes

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1230,6 +1230,7 @@ private slots:
     void _trafficUpdate         (bool alert, QString traffic_id, QString vehicle_id, QGeoCoordinate location, float heading);
     void _adsbTimerTimeout      ();
     void _orbitTelemetryTimeout (void);
+    void _protocolVersionTimeOut(void);
 
 private:
     bool _containsLink(LinkInterface* link);
@@ -1297,6 +1298,8 @@ private:
     void _updateArmed(bool armed);
     bool _apmArmingNotRequired(void);
     void _pidTuningAdjustRates(bool setRatesForTuning);
+    void _handleUnsupportedRequestAutopilotCapabilities(void);
+    void _handleUnsupportedRequestProtocolVersion(void);
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
@@ -1354,6 +1357,7 @@ private:
     uint32_t        _telemetryTXBuffer;
     int             _telemetryLNoise;
     int             _telemetryRNoise;
+    bool            _mavlinkProtocolRequestComplete;
     unsigned        _maxProtoVersion;
     bool            _vehicleCapabilitiesKnown;
     uint64_t        _capabilityBits;


### PR DESCRIPTION
Related to #7427

Fixed protocol negotation when the vehicle does not support MAV_CMD_REQUEST_PROTOCOL_VERSION.

Here is how the negotation now works:
* Start with the assumption that the capability bits are known
* Send MAV_CMD_REQUEST_PROTOCOL_VERSION to the vehicle
* Start a timeout on the COMMAND_ACK for MAV_CMD_REQUEST_PROTOCOL_VERSION
  * If GCS receives COMMAND_ACK.result != MAV_RESULT_ACCEPTED or times out waiting for the COMMAND ACK then set the link to Mavlink 2 if the capability bits say it is supported
  * If GCS receives COMMAND_ACK.result == MAV_RESULT_ACCEPTED start a timeout waiting to receive a PROTOCOL_VERSION messsage
    * If PROTOCOL_VERSION is never received then set the link to Mavlink 1
    * If PROTOCOL_VERSION message is received set the link accordingly to 1 or 2