### PR TITLE
Expose BATT_AMP_OFFSET and add Blue Robotics power sense module

### DIFF
--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -337,6 +337,15 @@ SetupPage {
                 }
 
                 ListElement {
+                    text:       qsTr("Blue Robotics Power Sense Module R2")
+                    voltPin:    2
+                    currPin:    3
+                    voltMult:   11.000
+                    ampPerVolt: 37.8788
+                    ampOffset:  0.330
+                }
+
+                ListElement {
                     text:       qsTr("Other")
                 }
             }

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -124,6 +124,7 @@ SetupPage {
 
                         property Fact armVoltMin:       controller.getParameterFact(-1, "r.BATT_ARM_VOLT", false /* reportMissing */)
                         property Fact battAmpPerVolt:   controller.getParameterFact(-1, "r.BATT_AMP_PERVLT", false /* reportMissing */)
+                        property Fact battAmpOffset:    controller.getParameterFact(-1, "BATT_AMP_OFFSET", false /* reportMissing */)
                         property Fact battCapacity:     controller.getParameterFact(-1, "BATT_CAPACITY", false /* reportMissing */)
                         property Fact battCurrPin:      controller.getParameterFact(-1, "BATT_CURR_PIN", false /* reportMissing */)
                         property Fact battMonitor:      controller.getParameterFact(-1, "BATT_MONITOR", false /* reportMissing */)
@@ -208,6 +209,7 @@ SetupPage {
 
                         property Fact armVoltMin:       controller.getParameterFact(-1, "r.BATT2_ARM_VOLT", false /* reportMissing */)
                         property Fact battAmpPerVolt:   controller.getParameterFact(-1, "r.BATT2_AMP_PERVLT", false /* reportMissing */)
+                        property Fact battAmpOffset:    controller.getParameterFact(-1, "BATT2_AMP_OFFSET", false /* reportMissing */)
                         property Fact battCapacity:     controller.getParameterFact(-1, "BATT2_CAPACITY", false /* reportMissing */)
                         property Fact battCurrPin:      controller.getParameterFact(-1, "BATT2_CURR_PIN", false /* reportMissing */)
                         property Fact battMonitor:      controller.getParameterFact(-1, "BATT2_MONITOR", false /* reportMissing */)
@@ -293,7 +295,8 @@ SetupPage {
                     if (sensorModel.get(i).voltPin == battVoltPin.value &&
                             sensorModel.get(i).currPin == battCurrPin.value &&
                             Math.abs(sensorModel.get(i).voltMult - battVoltMult.value) < 0.001 &&
-                            Math.abs(sensorModel.get(i).ampPerVolt - battAmpPerVolt.value) < 0.0001) {
+                            Math.abs(sensorModel.get(i).ampPerVolt - battAmpPerVolt.value) < 0.0001 &&
+                            Math.abs(sensorModel.get(i).ampOffset - battAmpOffset.value) < 0.0001) {
                         sensorCombo.currentIndex = i
                         return
                     }
@@ -312,6 +315,7 @@ SetupPage {
                     currPin:    3
                     voltMult:   10.1
                     ampPerVolt: 17.0
+                    ampOffset:  0
                 }
 
                 ListElement {
@@ -320,6 +324,7 @@ SetupPage {
                     currPin:    3
                     voltMult:   12.02
                     ampPerVolt: 39.877
+                    ampOffset:  0
                 }
 
                 ListElement {
@@ -328,6 +333,7 @@ SetupPage {
                     currPin:    3
                     voltMult:   12.02
                     ampPerVolt: 17.0
+                    ampOffset:  0
                 }
 
                 ListElement {
@@ -390,6 +396,7 @@ SetupPage {
                             battCurrPin.value = sensorModel.get(index).currPin
                             battVoltMult.value = sensorModel.get(index).voltMult
                             battAmpPerVolt.value = sensorModel.get(index).ampPerVolt
+                            battAmpOffset.value = sensorModel.get(index).ampOffset
                         } else {
 
                         }
@@ -488,6 +495,27 @@ SetupPage {
                     text:               qsTr("If the current draw reported by the vehicle is largely different than the current read externally using a current meter you can adjust the amps per volt value to correct this. Click the Calculate button for help with calculating a new value.")
                     visible:            _showAdvanced
                 }
+
+                QGCLabel {
+                    text:       qsTr("Amps Offset:")
+                    visible:    _showAdvanced
+                }
+
+                FactTextField {
+                    width:      _fieldWidth
+                    fact:       battAmpOffset
+                    visible:    _showAdvanced
+                }
+
+                QGCLabel {
+                    Layout.columnSpan:  3
+                    Layout.fillWidth:   true
+                    font.pointSize:     ScreenTools.smallFontPointSize
+                    wrapMode:           Text.WordWrap
+                    text:               qsTr("If the vehicle reports a high current read when there is little or no current going through it, adjust the Amps Offset. It should be equal to the voltage reported by the sensor when the current is zero.")
+                    visible:            _showAdvanced
+                }
+
             } // GridLayout
         } // Column
     } // Component - powerSetupComponent


### PR DESCRIPTION
This exposes the BATT_AMP_OFFSET parameter for ArduPilot vehicles and adds an entry for the [Blue Robotics Power Sense Module R2](https://www.bluerobotics.com/store/comm-control-power/elec-packages/psm-asm-r2-rp/)

![Screenshot from 2019-06-20 16-30-02](https://user-images.githubusercontent.com/4013804/59876741-c4e2c580-937a-11e9-9538-271591edd475.png)

![Screenshot from 2019-06-20 17-32-42](https://user-images.githubusercontent.com/4013804/59879740-c8c61600-9381-11e9-9ea7-fbf8ae249256.png)
