### PR TITLE
QtQuick.Controls 2.4

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -8,11 +8,11 @@
  ****************************************************************************/
 
 
-import QtQuick          2.4
-import QtQuick.Controls 1.2
-import QtLocation       5.3
-import QtPositioning    5.3
-import QtQuick.Dialogs  1.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
+import QtLocation                   5.3
+import QtPositioning                5.3
+import QtQuick.Dialogs              1.2
 
 import QGroundControl               1.0
 import QGroundControl.Airspace      1.0
@@ -174,10 +174,6 @@ FlightMap {
                 firstVehiclePositionReceived = true
             }
         }
-    }
-
-    ExclusiveGroup {
-        id: _mapTypeButtonsExclusiveGroup
     }
 
     MapFitFunctions {

--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -7,11 +7,11 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.3
-import QtQuick.Controls 1.2
-import QtLocation       5.3
-import QtPositioning    5.3
-import QtQuick.Dialogs  1.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
+import QtLocation                   5.3
+import QtPositioning                5.3
+import QtQuick.Dialogs              1.2
 
 import QGroundControl                   1.0
 import QGroundControl.ScreenTools       1.0

--- a/src/MissionManager/QGCMapPolylineVisuals.qml
+++ b/src/MissionManager/QGCMapPolylineVisuals.qml
@@ -7,11 +7,11 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.3
-import QtQuick.Controls 1.2
-import QtLocation       5.3
-import QtPositioning    5.3
-import QtQuick.Dialogs  1.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
+import QtLocation                   5.3
+import QtPositioning                5.3
+import QtQuick.Dialogs              1.2
 
 import QGroundControl                   1.0
 import QGroundControl.ScreenTools       1.0

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -1,8 +1,8 @@
-import QtQuick                  2.3
-import QtQuick.Controls         1.2
-import QtQuick.Controls.Styles  1.4
-import QtQuick.Dialogs          1.2
-import QtQml                    2.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
+import QtQuick.Controls.Styles      1.4
+import QtQuick.Dialogs              1.2
+import QtQml                        2.2
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -264,12 +264,6 @@ Item {
         }
     }
 
-    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
-
-    ExclusiveGroup {
-        id: _mapTypeButtonsExclusiveGroup
-    }
-
     /// Inserts a new simple mission item
     ///     @param coordinate Location to insert item
     ///     @param index Insert item at this index
@@ -1031,7 +1025,7 @@ Item {
                 }
 
                 QGCButton {
-                    text:               qsTr("Save Mission Waypoints As KML...")                    
+                    text:               qsTr("Save Mission Waypoints As KML...")
                     Layout.columnSpan:  2
                     enabled:            !_planMasterController.syncInProgress && _visualItems.count > 1
                     onClicked: {

--- a/src/PlanView/RallyPointItemEditor.qml
+++ b/src/PlanView/RallyPointItemEditor.qml
@@ -1,6 +1,6 @@
-import QtQuick          2.3
-import QtQuick.Controls 1.2
-import QtQuick.Layouts  1.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
+import QtQuick.Layouts              1.11
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -1,8 +1,7 @@
-import QtQuick                  2.3
-import QtQuick.Controls         1.2
-import QtQuick.Controls.Styles  1.4
-import QtQuick.Dialogs          1.2
-import QtQuick.Layouts          1.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
+import QtQuick.Controls.Styles      1.4
+import QtQuick.Layouts              1.11
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/FlightModeMenu.qml
+++ b/src/QmlControls/FlightModeMenu.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.3
-import QtQuick.Controls 1.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.3
-import QtQuick.Controls 1.2
-import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
+import QtQuick.Dialogs              1.2
+import QtQuick.Layouts              1.11
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -1,7 +1,7 @@
-import QtQuick          2.3
-import QtQuick.Controls 1.2
-import QtQuick.Dialogs  1.2
-import QtQuick.Layouts  1.2
+import QtQuick                      2.11
+import QtQuick.Controls             2.4
+import QtQuick.Dialogs              1.2
+import QtQuick.Layouts              1.11
 
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0

--- a/src/QmlControls/QmlTest.qml
+++ b/src/QmlControls/QmlTest.qml
@@ -1,7 +1,7 @@
 import QtQuick                  2.11
 import QtQuick.Controls         2.4
 import QtQuick.Controls.Styles  1.4
-import QtQuick.Layouts          1.2
+import QtQuick.Layouts          1.11
 
 import QGroundControl.Palette       1.0
 import QGroundControl.Controls      1.0

--- a/src/ui/toolbar/LinkIndicator.qml
+++ b/src/ui/toolbar/LinkIndicator.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.3
-import QtQuick.Controls 1.2
+import QtQuick                              2.11
+import QtQuick.Controls                     2.4
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/ModeIndicator.qml
+++ b/src/ui/toolbar/ModeIndicator.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.3
-import QtQuick.Controls 1.2
+import QtQuick                              2.11
+import QtQuick.Controls                     2.4
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0

--- a/src/ui/toolbar/MultiVehicleSelector.qml
+++ b/src/ui/toolbar/MultiVehicleSelector.qml
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 
-import QtQuick          2.3
-import QtQuick.Controls 1.2
+import QtQuick                              2.11
+import QtQuick.Controls                     2.4
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0


### PR DESCRIPTION
Update all files that use a QML Menu item to QtQuick.Controls 2.4 to solve the issue of a menu showing up in random places on Android.