### PR TITLE
Revert ParameterEditor to QtQuick.Controls 1.x

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -6,7 +6,7 @@
  * COPYING.md in the root of the source code directory.
  *
  *   @brief Custom QGCCorePlugin Implementation
- *   @author Gus Grubba <gus@custom.com>
+ *   @author Gus Grubba <gus@auterion.com>
  */
 
 #include <QtQml>

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -7,10 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick                      2.11
-import QtQuick.Controls             2.4
+import QtQuick                      2.3
+import QtQuick.Controls             1.2
 import QtQuick.Dialogs              1.2
-import QtQuick.Layouts              1.11
+import QtQuick.Layouts              1.2
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0


### PR DESCRIPTION
In response to #7547

I had to revert `ParameterEditor` to QtQuick.Controls 1.x as it makes use of `ExclusiveGroup`, which no longer exists in newer versions of QtQuick.Controls. I will need to take a closer look at these and find a way around it.

Closes #7547 

P.S. These errors, when they occur, are all shown in the console:

```
qrc:/qml/SetupParameterEditor.qml:18:1: Type ParameterEditor unavailable
qrc:/qml/QGroundControl/Controls/ParameterEditor.qml:41:5: ExclusiveGroup is not a type
```

That would immediately tell me what went wrong.
 