### PR TITLE
CMake updates: Enable VideoStreaming while using CMake as buildsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,40 +127,8 @@ if(NOT QT_MKSPEC MATCHES "winrt")
 	)
 endif()
 
-if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-	include(CTest)
-	enable_testing()
-	add_definitions(-DUNITTEST_BUILD)
-endif()
-
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	# clang and AppleClang
-	add_compile_options(
-		-Wall
-		-Wextra
-
-		-Wno-address-of-packed-member # ignore for mavlink
-	)
-
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	# GCC
-	if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
-		add_compile_options(-fdiagnostics-color=always)
-	endif()
-
-	add_compile_options(
-		-Wall
-		-Wextra
-	)
-	
-elseif (WIN32)
-
-	add_definitions(-D_USE_MATH_DEFINES)
-	add_compile_options(
-		/wd4244 # warning C4244: '=': conversion from 'double' to 'float', possible loss of data
-		)
-
-endif()
+# Sets the default flags for compilation and linking.
+include(CompileOptions)
 
 # TODO: get qtquick compiler working
 #qtquick_compiler_add_resources(QGC_RESOURCES ${QGC_RESOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,34 +18,6 @@ if (NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
 endif()
 
-if(DEFINED ENV{QT_VERSION})
-	set(QT_VERSION $ENV{QT_VERSION})
-endif()
-
-if(NOT QT_VERSION)
-	# try Qt 5.12.0 if none specified, last LTS.
-	set(QT_VERSION "5.12.0")
-endif()
-
-if(DEFINED ENV{QT_MKSPEC})
-	set(QT_MKSPEC $ENV{QT_MKSPEC})
-endif()
-
-if(UNIX AND NOT APPLE)
-	set(LINUX TRUE)
-endif()
-
-if(NOT QT_MKSPEC)
-	if(APPLE)
-		set(QT_MKSPEC clang_64)
-	elseif(LINUX)
-		set(QT_MKSPEC gcc_64)
-	elseif(WIN32)
-		set(QT_MKSPEC msvc2017_64)
-		#set(QT_MKSPEC winrt_x64_msvc2017)
-	endif()
-endif()
-
 # Add folder where are supportive functions
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
@@ -89,12 +61,7 @@ endif()
 #=============================================================================
 # Qt5
 #
-set(QT_LIBRARY_HINTS
-		$ENV{HOME}/Qt/${QT_VERSION}/${QT_MKSPEC}
-		$ENV{QT_PATH}/${QT_VERSION}/${QT_MKSPEC}
-		C:/Qt
-)
-
+include(Qt5QGCConfiguration)
 find_package(Qt5 ${QT_VERSION}
 	COMPONENTS
 		Bluetooth

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-
 # CMake build type
 # Debug Release RelWithDebInfo MinSizeRel Coverage
 if (NOT CMAKE_BUILD_TYPE)
@@ -67,7 +66,14 @@ pkg_check_modules(GST
     gstreamer-1.0>=1.14
     gstreamer-video-1.0>=1.14
 )
-
+if (GST_FOUND)
+    include_directories(
+        ${GST_INCLUDE_DIRS}
+    )
+    add_definitions(
+        -DQGC_GST_STREAMING
+    )
+endif()
 #=============================================================================
 # Qt5
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,56 +152,5 @@ if(NOT QT_MKSPEC MATCHES "winrt")
 		)
 endif()
 
-if(LINUX)
-
-elseif(APPLE)
-
-	get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
-	get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
-	find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
-
-	add_custom_command(TARGET QGroundControl
-		POST_BUILD
-		COMMAND
-			${MACDEPLOYQT_EXECUTABLE} $<TARGET_FILE_DIR:QGroundControl>/../.. -appstore-compliant -qmldir=${CMAKE_SOURCE_DIR}/src
-		COMMAND
-			rsync -a ${CMAKE_SOURCE_DIR}/libs/lib/Frameworks $<TARGET_FILE_DIR:QGroundControl>/../../Contents/
-		COMMAND
-			${CMAKE_INSTALL_NAME_TOOL} -change "@rpath/SDL2.framework/Versions/A/SDL2" "@executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2" $<TARGET_FILE:QGroundControl>
-	)
-
-	set_target_properties(QGroundControl PROPERTIES MACOSX_BUNDLE YES)
-
-elseif(WIN32)
-
-	if(MSVC) # Check if we are using the Visual Studio compiler
-		set_target_properties(${PROJECT_NAME} PROPERTIES
-			WIN32_EXECUTABLE YES
-			LINK_FLAGS "/ENTRY:mainCRTStartup"
-		)
-	endif()
-
-	# deploy
-	include(Windeployqt)
-	windeployqt(QGroundControl "QGroundControl-installer.exe")
-
-elseif(ANDROID)
-	include(AddQtAndroidApk)
-	add_qt_android_apk(QGroundControl.apk QGroundControl
-		PACKAGE_NAME "io.mavlink.qgroundcontrol"
-		#KEYSTORE ${CMAKE_CURRENT_LIST_DIR}/mykey.keystore myalias
-		#KEYSTORE_PASSWORD xxxxx
-	)
-
-elseif(LINUX)
-	# TODO: investigate https://github.com/probonopd/linuxdeployqt
-
-	add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/release/package/QGroundControl.AppImage
-		COMMAND ${CMAKE_SOURCE_DIR}/deploy/create_linux_appimage.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/release/package;
-		DEPENDS QGroundControl
-		USES_TERMINAL
-	)
-	add_custom_target(appimage DEPENDS ${CMAKE_BINARY_DIR}/release/package/QGroundControl.AppImage)
-
-endif()
+include(QGCDeploy)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,12 @@ endif()
 #=============================================================================
 # Qt5
 #
+set(QT_LIBRARY_HINTS
+		$ENV{HOME}/Qt/${QT_VERSION}/${QT_MKSPEC}
+		$ENV{QT_PATH}/${QT_VERSION}/${QT_MKSPEC}
+		C:/Qt
+)
+
 find_package(Qt5 ${QT_VERSION}
 	COMPONENTS
 		Bluetooth
@@ -108,9 +114,7 @@ find_package(Qt5 ${QT_VERSION}
 		Xml
 	REQUIRED
 	HINTS
-		$ENV{HOME}/Qt/${QT_VERSION}/${QT_MKSPEC}
-		$ENV{QT_PATH}/${QT_VERSION}/${QT_MKSPEC}
-		C:/Qt
+        ${QT_LIBRARY_HINTS}
 )
 
 if(NOT QT_MKSPEC MATCHES "winrt")
@@ -119,9 +123,7 @@ if(NOT QT_MKSPEC MATCHES "winrt")
 			SerialPort
 		REQUIRED
 		HINTS
-			$ENV{HOME}/Qt/${QT_VERSION}/${QT_MKSPEC}
-			$ENV{QT_PATH}/${QT_VERSION}/${QT_MKSPEC}
-			C:/Qt
+            ${QT_LIBRARY_HINTS}
 	)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ find_package(Qt5 ${QT_VERSION}
 		Xml
 	REQUIRED
 	HINTS
-        ${QT_LIBRARY_HINTS}
+		${QT_LIBRARY_HINTS}
 )
 
 if(NOT QT_MKSPEC MATCHES "winrt")
@@ -112,7 +112,7 @@ if(NOT QT_MKSPEC MATCHES "winrt")
 			SerialPort
 		REQUIRED
 		HINTS
-            ${QT_LIBRARY_HINTS}
+			${QT_LIBRARY_HINTS}
 	)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,12 +66,17 @@ pkg_check_modules(GST
     gstreamer-1.0>=1.14
     gstreamer-video-1.0>=1.14
 )
+
 if (GST_FOUND)
     include_directories(
         ${GST_INCLUDE_DIRS}
+        src/Taisync
+        src/Microhard
     )
     add_definitions(
         -DQGC_GST_STREAMING
+        -DQGC_GST_TAISYNC_ENABLED
+        -DQGC_GST_MICROHARD_ENABLED
     )
 endif()
 #=============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.2)
 
-project(QGroundControl LANGUAGES CXX)
+project(QGroundControl LANGUAGES C CXX)
 
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo;MinSizeRel;Coverage")
 
@@ -58,6 +58,16 @@ if (CCACHE AND CCACHE_PROGRAM AND NOT DEFINED ENV{CCACHE_DISABLE})
 	set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 
+
+#=============================================================================
+# GStreamer
+#
+find_package(PkgConfig)
+pkg_check_modules(GST
+    gstreamer-1.0>=1.14
+    gstreamer-video-1.0>=1.14
+)
+
 #=============================================================================
 # Qt5
 #
@@ -73,6 +83,7 @@ find_package(Qt5 ${QT_VERSION}
 		Positioning
 		Quick
 		QuickWidgets
+		OpenGL
 		Sql
 		Svg
 		Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@ project(QGroundControl LANGUAGES CXX)
 
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebInfo;MinSizeRel;Coverage")
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+
 # CMake build type
 # Debug Release RelWithDebInfo MinSizeRel Coverage
 if (NOT CMAKE_BUILD_TYPE)
@@ -69,12 +76,6 @@ add_definitions(
 	)
 
 message(STATUS "QGroundControl version: ${git_tag}")
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 #=============================================================================
 # ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,8 @@ if(DEFINED ENV{QT_VERSION})
 endif()
 
 if(NOT QT_VERSION)
-	# try Qt 5.11.2 if none specified
-	set(QT_VERSION "5.11.2")
+	# try Qt 5.12.0 if none specified, last LTS.
+	set(QT_VERSION "5.12.0")
 endif()
 
 if(DEFINED ENV{QT_MKSPEC})

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -1,0 +1,30 @@
+
+if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+	include(CTest)
+	enable_testing()
+	add_definitions(-DUNITTEST_BUILD)
+endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	# clang and AppleClang
+	add_compile_options(
+		-Wall
+		-Wextra
+		-Wno-address-of-packed-member # ignore for mavlink
+	)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	# GCC
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
+		add_compile_options(-fdiagnostics-color=always)
+	endif()
+
+	add_compile_options(
+		-Wall
+		-Wextra
+	)
+elseif (WIN32)
+	add_definitions(-D_USE_MATH_DEFINES)
+	add_compile_options(
+		/wd4244 # warning C4244: '=': conversion from 'double' to 'float', possible loss of data
+    )
+endif()

--- a/cmake/QGCDeploy.cmake
+++ b/cmake/QGCDeploy.cmake
@@ -1,0 +1,49 @@
+
+if(LINUX)
+	# TODO: investigate https://github.com/probonopd/linuxdeployqt
+
+	add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/release/package/QGroundControl.AppImage
+		COMMAND ${CMAKE_SOURCE_DIR}/deploy/create_linux_appimage.sh ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/release/package;
+		DEPENDS QGroundControl
+		USES_TERMINAL
+	)
+	add_custom_target(appimage DEPENDS ${CMAKE_BINARY_DIR}/release/package/QGroundControl.AppImage)
+
+elseif(APPLE)
+
+	get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+	get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
+	find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
+
+	add_custom_command(TARGET QGroundControl
+		POST_BUILD
+		COMMAND
+			${MACDEPLOYQT_EXECUTABLE} $<TARGET_FILE_DIR:QGroundControl>/../.. -appstore-compliant -qmldir=${CMAKE_SOURCE_DIR}/src
+		COMMAND
+			rsync -a ${CMAKE_SOURCE_DIR}/libs/lib/Frameworks $<TARGET_FILE_DIR:QGroundControl>/../../Contents/
+		COMMAND
+			${CMAKE_INSTALL_NAME_TOOL} -change "@rpath/SDL2.framework/Versions/A/SDL2" "@executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2" $<TARGET_FILE:QGroundControl>
+	)
+
+	set_target_properties(QGroundControl PROPERTIES MACOSX_BUNDLE YES)
+
+elseif(WIN32)
+	if(MSVC) # Check if we are using the Visual Studio compiler
+		set_target_properties(${PROJECT_NAME} PROPERTIES
+			WIN32_EXECUTABLE YES
+			LINK_FLAGS "/ENTRY:mainCRTStartup"
+		)
+	endif()
+
+	# deploy
+	include(Windeployqt)
+	windeployqt(QGroundControl "QGroundControl-installer.exe")
+
+elseif(ANDROID)
+	include(AddQtAndroidApk)
+	add_qt_android_apk(QGroundControl.apk QGroundControl
+		PACKAGE_NAME "io.mavlink.qgroundcontrol"
+		#KEYSTORE ${CMAKE_CURRENT_LIST_DIR}/mykey.keystore myalias
+		#KEYSTORE_PASSWORD xxxxx
+	)
+endif()

--- a/cmake/Qt5QGCConfiguration.cmake
+++ b/cmake/Qt5QGCConfiguration.cmake
@@ -1,0 +1,33 @@
+if(DEFINED ENV{QT_VERSION})
+	set(QT_VERSION $ENV{QT_VERSION})
+endif()
+
+if(NOT QT_VERSION)
+	# try Qt 5.12.0 if none specified, last LTS.
+	set(QT_VERSION "5.12.0")
+endif()
+
+if(DEFINED ENV{QT_MKSPEC})
+	set(QT_MKSPEC $ENV{QT_MKSPEC})
+endif()
+
+if(UNIX AND NOT APPLE)
+	set(LINUX TRUE)
+endif()
+
+if(NOT QT_MKSPEC)
+	if(APPLE)
+		set(QT_MKSPEC clang_64)
+	elseif(LINUX)
+		set(QT_MKSPEC gcc_64)
+	elseif(WIN32)
+		set(QT_MKSPEC msvc2017_64)
+		#set(QT_MKSPEC winrt_x64_msvc2017)
+	endif()
+endif()
+
+set(QT_LIBRARY_HINTS
+		$ENV{HOME}/Qt/${QT_VERSION}/${QT_MKSPEC}
+		$ENV{QT_PATH}/${QT_VERSION}/${QT_MKSPEC}
+		C:/Qt
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(
 	.
 	${CMAKE_CURRENT_BINARY_DIR}
 	${Qt5Location_PRIVATE_INCLUDE_DIRS}
+	VideoStreaming
 )
 
 set(EXTRA_SRC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,6 @@
 include_directories(
 	.
 	${CMAKE_CURRENT_BINARY_DIR}
-
 	${Qt5Location_PRIVATE_INCLUDE_DIRS}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,23 @@ if(MOBILE)
 		MobileScreenMgr.cc
 	)
 endif()
+if(GST_FOUND)
+	# TODO: Transform those in targets.
+	list(APPEND EXTRA_SRC
+		Taisync/TaisyncManager.cc
+		Taisync/TaisyncHandler.cc
+		Taisync/TaisyncSettings.cc
+		Microhard/MicrohardManager.cc
+		Microhard/MicrohardHandler.cc
+		Microhard/MicrohardSettings.cc
+	)
+	if(ANDROID) # Should also be expanded to iOS
+		list(APPEND EXTRA_SRC
+			src/Taisync/TaisyncTelemetry.cc
+			src/Taisync/TaisyncVideoReceiver.cc
+		)
+	endif()
+endif()
 
 if(BUILD_TESTING)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,15 +139,15 @@ add_subdirectory(VideoStreaming)
 add_subdirectory(ViewWidgets)
 
 target_link_libraries(qgc
-        PRIVATE
+	PRIVATE
 		shp
 
 	PUBLIC
-                Qt5::QuickWidgets
-                Qt5::Widgets
+		Qt5::QuickWidgets
+		Qt5::Widgets
 
 		Airmap
-                AnalyzeView
+		AnalyzeView
 		api
 		Audio
 		AutoPilotPlugins
@@ -158,7 +158,7 @@ target_link_libraries(qgc
 		FlightDisplay
 		FlightMap
 		FollowMe
-                gps
+		gps
 		Joystick
 		MissionManager
 		PositionManager
@@ -179,11 +179,11 @@ if(BUILD_TESTING)
 endif()
 
 target_include_directories(qgc
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}/ui/ui_autogen/include # HACK: AUTOUIC paths not inheriting?
-        ${CMAKE_CURRENT_BINARY_DIR}/ui/ui_autogen/include_Debug
-        ${CMAKE_CURRENT_BINARY_DIR}/qgc_autogen/include # HACK: AUTOUIC paths not inheriting?
-        ${CMAKE_CURRENT_BINARY_DIR}/qgc_autogen/include_Debug
-        )
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}
+		${CMAKE_CURRENT_BINARY_DIR}/ui/ui_autogen/include # HACK: AUTOUIC paths not inheriting?
+		${CMAKE_CURRENT_BINARY_DIR}/ui/ui_autogen/include_Debug
+		${CMAKE_CURRENT_BINARY_DIR}/qgc_autogen/include # HACK: AUTOUIC paths not inheriting?
+		${CMAKE_CURRENT_BINARY_DIR}/qgc_autogen/include_Debug
+)
 

--- a/src/Settings/CMakeLists.txt
+++ b/src/Settings/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(Settings
 target_link_libraries(Settings
 	PUBLIC
 		qgc
+		Qt5::Multimedia
 )
 
 target_include_directories(Settings PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -16,8 +16,8 @@ add_library(Vehicle
 )
 
 target_link_libraries(Vehicle
-        PRIVATE
-            ui
+	PRIVATE
+		ui
 	PUBLIC
 		qgc
 )

--- a/src/VideoStreaming/CMakeLists.txt
+++ b/src/VideoStreaming/CMakeLists.txt
@@ -1,6 +1,5 @@
 if (GST_FOUND)
     include_directories(
-        ${GST_INCLUDE_DIRS}
         gstqtvideosink/utils/
         )
 

--- a/src/VideoStreaming/CMakeLists.txt
+++ b/src/VideoStreaming/CMakeLists.txt
@@ -1,45 +1,48 @@
+set(EXTRA_LIBRARIES)
+
 if (GST_FOUND)
-    include_directories(
-        gstqtvideosink/utils/
-        )
+	include_directories(
+		gstqtvideosink/utils/
+	)
 
-    set(EXTRA_SRC
-        gstqtvideosink/delegates/basedelegate.cpp
-        gstqtvideosink/delegates/qtquick2videosinkdelegate.cpp
-        gstqtvideosink/delegates/qtvideosinkdelegate.cpp
-        gstqtvideosink/delegates/qwidgetvideosinkdelegate.cpp
-        gstqtvideosink/gstqtglvideosink.cpp
-        gstqtvideosink/gstqtglvideosinkbase.cpp
-        gstqtvideosink/gstqtquick2videosink.cpp
-        gstqtvideosink/gstqtvideosink.cpp
-        gstqtvideosink/gstqtvideosinkbase.cpp
-        gstqtvideosink/gstqtvideosinkplugin.cpp
-        gstqtvideosink/gstqwidgetvideosink.cpp
-        gstqtvideosink/gstqtvideosinkmarshal.c
-        gstqtvideosink/painters/genericsurfacepainter.cpp
-        gstqtvideosink/painters/openglsurfacepainter.cpp
-        gstqtvideosink/painters/videomaterial.cpp
-        gstqtvideosink/painters/videonode.cpp
-        gstqtvideosink/utils/bufferformat.cpp
-        gstqtvideosink/utils/utils.cpp
-    )
-
-    add_library(VideoStreaming
-        VideoItem.cc
-        VideoReceiver.cc
-        VideoStreaming.cc
-        VideoSurface.cc
-        SubtitleWriter.cc
-        ${EXTRA_SRC}
-    )
-
-    target_link_libraries(VideoStreaming
-        PUBLIC
-            qgc
-            Qt5::Multimedia
-            Qt5::OpenGL
-            ${GST_LIBRARIES}
-    )
-
-    target_include_directories(VideoStreaming INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+	set(EXTRA_SRC
+		gstqtvideosink/delegates/basedelegate.cpp
+		gstqtvideosink/delegates/qtquick2videosinkdelegate.cpp
+		gstqtvideosink/delegates/qtvideosinkdelegate.cpp
+		gstqtvideosink/delegates/qwidgetvideosinkdelegate.cpp
+		gstqtvideosink/gstqtglvideosink.cpp
+		gstqtvideosink/gstqtglvideosinkbase.cpp
+		gstqtvideosink/gstqtquick2videosink.cpp
+		gstqtvideosink/gstqtvideosink.cpp
+		gstqtvideosink/gstqtvideosinkbase.cpp
+		gstqtvideosink/gstqtvideosinkplugin.cpp
+		gstqtvideosink/gstqwidgetvideosink.cpp
+		gstqtvideosink/gstqtvideosinkmarshal.c
+		gstqtvideosink/painters/genericsurfacepainter.cpp
+		gstqtvideosink/painters/openglsurfacepainter.cpp
+		gstqtvideosink/painters/videomaterial.cpp
+		gstqtvideosink/painters/videonode.cpp
+		gstqtvideosink/utils/bufferformat.cpp
+		gstqtvideosink/utils/utils.cpp
+	)
+	set(EXTRA_LIBRARIES ${GST_LIBRARIES})
 endif()
+
+add_library(VideoStreaming
+	VideoItem.cc
+	VideoReceiver.cc
+	VideoStreaming.cc
+	VideoSurface.cc
+	SubtitleWriter.cc
+	${EXTRA_SRC}
+)
+
+target_link_libraries(VideoStreaming
+	PUBLIC
+		qgc
+		Qt5::Multimedia
+		Qt5::OpenGL
+		${EXTRA_LIBRARIES}
+)
+
+target_include_directories(VideoStreaming INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/VideoStreaming/CMakeLists.txt
+++ b/src/VideoStreaming/CMakeLists.txt
@@ -1,41 +1,46 @@
+if (GST_FOUND)
+    include_directories(
+        ${GST_INCLUDE_DIRS}
+        gstqtvideosink/utils/
+        )
 
-set(EXTRA_SRC)
-if(VIDEO)
-	list(APPEND EXTRA_SRC
-		gstqtvideosink/delegates/basedelegate.cpp
-		gstqtvideosink/delegates/qtquick2videosinkdelegate.cpp
-		gstqtvideosink/delegates/qtvideosinkdelegate.cpp
-		gstqtvideosink/delegates/qwidgetvideosinkdelegate.cpp
-		gstqtvideosink/gstqtglvideosink.cpp
-		gstqtvideosink/gstqtglvideosinkbase.cpp
-		gstqtvideosink/gstqtquick2videosink.cpp
-		gstqtvideosink/gstqtvideosink.cpp
-		gstqtvideosink/gstqtvideosinkbase.cpp
-		gstqtvideosink/gstqtvideosinkplugin.cpp
-		gstqtvideosink/gstqwidgetvideosink.cpp
-		gstqtvideosink/painters/genericsurfacepainter.cpp
-		gstqtvideosink/painters/openglsurfacepainter.cpp
-		gstqtvideosink/painters/videomaterial.cpp
-		gstqtvideosink/painters/videonode.cpp
-		gstqtvideosink/utils/bufferformat.cpp
-		gstqtvideosink/utils/utils.cpp
-	)
+    set(EXTRA_SRC
+        gstqtvideosink/delegates/basedelegate.cpp
+        gstqtvideosink/delegates/qtquick2videosinkdelegate.cpp
+        gstqtvideosink/delegates/qtvideosinkdelegate.cpp
+        gstqtvideosink/delegates/qwidgetvideosinkdelegate.cpp
+        gstqtvideosink/gstqtglvideosink.cpp
+        gstqtvideosink/gstqtglvideosinkbase.cpp
+        gstqtvideosink/gstqtquick2videosink.cpp
+        gstqtvideosink/gstqtvideosink.cpp
+        gstqtvideosink/gstqtvideosinkbase.cpp
+        gstqtvideosink/gstqtvideosinkplugin.cpp
+        gstqtvideosink/gstqwidgetvideosink.cpp
+        gstqtvideosink/gstqtvideosinkmarshal.c
+        gstqtvideosink/painters/genericsurfacepainter.cpp
+        gstqtvideosink/painters/openglsurfacepainter.cpp
+        gstqtvideosink/painters/videomaterial.cpp
+        gstqtvideosink/painters/videonode.cpp
+        gstqtvideosink/utils/bufferformat.cpp
+        gstqtvideosink/utils/utils.cpp
+    )
+
+    add_library(VideoStreaming
+        VideoItem.cc
+        VideoReceiver.cc
+        VideoStreaming.cc
+        VideoSurface.cc
+        SubtitleWriter.cc
+        ${EXTRA_SRC}
+    )
+
+    target_link_libraries(VideoStreaming
+        PUBLIC
+            qgc
+            Qt5::Multimedia
+            Qt5::OpenGL
+            ${GST_LIBRARIES}
+    )
+
+    target_include_directories(VideoStreaming INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
-
-add_library(VideoStreaming
-	VideoItem.cc
-	VideoReceiver.cc
-	VideoStreaming.cc
-	VideoSurface.cc
-	SubtitleWriter.cc
-	${EXTRA_SRC}
-)
-
-target_link_libraries(VideoStreaming
-	PUBLIC
-		qgc
-
-		Qt5::Multimedia
-)
-
-target_include_directories(VideoStreaming INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
VideoStreaming is not enabled while building using CMake, we missed the gstreamer libraries and a few other things. I also took the time to make cmake a bit more easy to handle.