### PR TITLE
Guided Altitude Slider

### DIFF
--- a/src/FlightDisplay/GuidedAltitudeSlider.qml
+++ b/src/FlightDisplay/GuidedAltitudeSlider.qml
@@ -26,6 +26,7 @@ Rectangle {
     property bool _fixedWing:           activeVehicle ? activeVehicle.fixedWing : false
     property real _sliderMaxAlt:        _flyViewSettings ? _flyViewSettings.guidedMaximumAltitude.rawValue : 0
     property real _sliderMinAlt:        _flyViewSettings ? _flyViewSettings.guidedMinimumAltitude.rawValue : 0
+    property bool _flying:              activeVehicle ? activeVehicle.flying : false
 
     function reset() {
         altSlider.value = 0
@@ -89,14 +90,14 @@ Rectangle {
         anchors.left:       parent.left
         anchors.right:      parent.right
         orientation:        Qt.Vertical
-        minimumValue:       -1
+        minimumValue:       _flying ? -1 : 0
         maximumValue:       1
         zeroCentered:       true
         rotation:           180
 
         // We want slide up to be positive values
         transform: Rotation {
-            origin.x:   altSlider.width / 2
+            origin.x:   altSlider.width  / 2
             origin.y:   altSlider.height / 2
             angle:      180
         }

--- a/src/QmlControls/QGCSlider.qml
+++ b/src/QmlControls/QGCSlider.qml
@@ -23,8 +23,6 @@ Slider {
     property bool zeroCentered: false
     property bool displayValue: false
 
-    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
-
     style: SliderStyle {
         groove: Item {
             anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
Make guided altitude slider zero-based when vehicle is on the ground (positive values only). Once you are airborne, it goes back to -1 to 1 as you may go up or down.

<img width="1197" alt="Screen Shot 2019-06-30 at 3 07 24 PM" src="https://user-images.githubusercontent.com/749243/60400359-1cd2b680-9b49-11e9-866c-fff9bdacdd45.png">
