### PR TITLE
Use QtQuick.Controls 1.x menus

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -111,6 +111,9 @@
         <file alias="QGroundControl/Controls/QGCMapLabel.qml">src/QmlControls/QGCMapLabel.qml</file>
         <file alias="QGroundControl/Controls/QGCMapPolygonVisuals.qml">src/MissionManager/QGCMapPolygonVisuals.qml</file>
         <file alias="QGroundControl/Controls/QGCMapPolylineVisuals.qml">src/MissionManager/QGCMapPolylineVisuals.qml</file>
+        <file alias="QGroundControl/Controls/QGCMenu.qml">src/QmlControls/QGCMenu.qml</file>
+        <file alias="QGroundControl/Controls/QGCMenuItem.qml">src/QmlControls/QGCMenuItem.qml</file>
+        <file alias="QGroundControl/Controls/QGCMenuSeparator.qml">src/QmlControls/QGCMenuSeparator.qml</file>
         <file alias="QGroundControl/Controls/QGCMouseArea.qml">src/QmlControls/QGCMouseArea.qml</file>
         <file alias="QGroundControl/Controls/QGCMovableItem.qml">src/QmlControls/QGCMovableItem.qml</file>
         <file alias="QGroundControl/Controls/QGCPipable.qml">src/QmlControls/QGCPipable.qml</file>

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -415,12 +415,12 @@ FlightMap {
     MouseArea {
         anchors.fill: parent
 
-        Menu {
+        QGCMenu {
             id: clickMenu
 
             property var coord
 
-            MenuItem {
+            QGCMenuItem {
                 text:           qsTr("Go to location")
                 visible:        guidedActionsController.showGotoLocation
 
@@ -431,7 +431,7 @@ FlightMap {
                 }
             }
 
-            MenuItem {
+            QGCMenuItem {
                 text:           qsTr("Orbit at location")
                 visible:        guidedActionsController.showOrbit
 

--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -186,7 +186,7 @@ Item {
         }
     }
 
-    Menu {
+    QGCMenu {
         id: menu
 
         property int _editingVertexIndex: -1
@@ -201,7 +201,7 @@ Item {
             menu.popup()
         }
 
-        MenuItem {
+        QGCMenuItem {
             id:             removeVertexItem
             visible:        !_circle
             text:           qsTr("Remove vertex")
@@ -212,39 +212,39 @@ Item {
             }
         }
 
-        MenuSeparator {
+        QGCMenuSeparator {
             visible:        removeVertexItem.visible
         }
 
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Circle" )
             onTriggered:    resetCircle()
         }
 
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Polygon")
             onTriggered:    resetPolygon()
         }
 
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Set radius..." )
             visible:        _circle
             onTriggered:    _editCircleRadius = true
         }
 
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Edit position..." )
             visible:        _circle
             onTriggered:    mainWindow.showComponentDialog(editCenterPositionDialog, qsTr("Edit Center Position"), mainWindow.showDialogDefaultWidth, StandardButton.Close)
         }
 
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Edit position..." )
             visible:        !_circle && menu._editingVertexIndex >= 0
             onTriggered:    mainWindow.showComponentDialog(editVertexPositionDialog, qsTr("Edit Vertex Position"), mainWindow.showDialogDefaultWidth, StandardButton.Close)
         }
 
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Load KML/SHP...")
             onTriggered:    kmlOrSHPLoadDialog.openForLoad()
         }

--- a/src/MissionManager/QGCMapPolylineVisuals.qml
+++ b/src/MissionManager/QGCMapPolylineVisuals.qml
@@ -126,7 +126,7 @@ Item {
         }
     }
 
-    Menu {
+    QGCMenu {
         id: menu
         property int _removeVertexIndex
 
@@ -136,22 +136,22 @@ Item {
             menu.popup()
         }
 
-        MenuItem {
+        QGCMenuItem {
             id:             removeVertexItem
             text:           qsTr("Remove vertex" )
             onTriggered:    mapPolyline.removeVertex(menu._removeVertexIndex)
         }
 
-        MenuSeparator {
+        QGCMenuSeparator {
             visible:        removeVertexItem.visible
         }
 
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Edit position..." )
             onTriggered:    mainWindow.showComponentDialog(editPositionDialog, qsTr("Edit Position"), mainWindow.showDialogDefaultWidth, StandardButton.Cancel)
         }
 
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Load KML...")
             onTriggered:    kmlLoadDialog.openForLoad()
         }

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -100,15 +100,15 @@ Rectangle {
             hamburgerMenu.popup()
         }
 
-        Menu {
+        QGCMenu {
             id: hamburgerMenu
 
-            MenuItem {
+            QGCMenuItem {
                 text:           qsTr("Insert waypoint")
                 onTriggered:    insertWaypoint()
             }
 
-            Menu {
+            QGCMenu {
                 id:         patternMenu
                 title:      qsTr("Insert pattern")
                 visible:    !_singleComplexItem
@@ -119,41 +119,41 @@ Rectangle {
                     onObjectAdded:      patternMenu.insertItem(index, object)
                     onObjectRemoved:    patternMenu.removeItem(object)
 
-                    MenuItem {
+                    QGCMenuItem {
                         text:           modelData
                         onTriggered:    insertComplexItem(modelData)
                     }
                 }
             }
 
-            MenuItem {
+            QGCMenuItem {
                 text:           qsTr("Insert ") + _missionController.complexMissionItemNames[0]
                 visible:        _singleComplexItem
                 onTriggered:    insertComplexItem(_missionController.complexMissionItemNames[0])
             }
 
-            MenuItem {
+            QGCMenuItem {
                 text:           qsTr("Delete")
                 onTriggered:    remove()
             }
 
-            MenuItem {
+            QGCMenuItem {
                 text:           qsTr("Change command...")
                 onTriggered:    commandPicker.clicked()
                 visible:        missionItem.isSimpleItem && !_waypointsOnlyMode
             }
 
-            MenuItem {
+            QGCMenuItem {
                 text:           qsTr("Edit position...")
                 visible:        missionItem.specifiesCoordinate
                 onTriggered:    mainWindow.showComponentDialog(editPositionDialog, qsTr("Edit Position"), mainWindow.showDialogDefaultWidth, StandardButton.Close)
             }
 
-            MenuSeparator {
+            QGCMenuSeparator {
                 visible: missionItem.isSimpleItem && !_waypointsOnlyMode
             }
 
-            MenuItem {
+            QGCMenuItem {
                 text:       qsTr("Show all values")
                 checkable:  true
                 checked:    missionItem.isSimpleItem ? missionItem.rawEdit : false

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -180,7 +180,7 @@ Item {
         id: _planMasterController
 
         Component.onCompleted: {
-            start(false /* flyView */)
+            _planMasterController.start(false /* flyView */)
             _missionController.setCurrentPlanViewIndex(0, true)
             mainWindow.planMasterControllerPlan = _planMasterController
         }

--- a/src/PlanView/RallyPointItemEditor.qml
+++ b/src/PlanView/RallyPointItemEditor.qml
@@ -65,10 +65,10 @@ Rectangle {
                 anchors.fill:   parent
                 onClicked:      hamburgerMenu.popup()
 
-                Menu {
+                QGCMenu {
                     id: hamburgerMenu
 
-                    MenuItem {
+                    QGCMenuItem {
                         text:           qsTr("Delete")
                         onTriggered:    controller.removePoint(rallyPoint)
                     }

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -137,17 +137,17 @@ Rectangle {
                         onClicked:      altHamburgerMenu.popup()
                     }
 
-                    Menu {
+                    QGCMenu {
                         id: altHamburgerMenu
 
-                        MenuItem {
+                        QGCMenuItem {
                             text:           qsTr("Altitude Relative To Home")
                             checkable:      true
                             checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeRelative
                             onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeRelative
                         }
 
-                        MenuItem {
+                        QGCMenuItem {
                             text:           qsTr("Altitude Above Mean Sea Level")
                             checkable:      true
                             checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeAbsolute
@@ -155,7 +155,7 @@ Rectangle {
                             onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeAbsolute
                         }
 
-                        MenuItem {
+                        QGCMenuItem {
                             text:           qsTr("Altitude Above Terrain")
                             checkable:      true
                             checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeAboveTerrain
@@ -163,7 +163,7 @@ Rectangle {
                             visible:        missionItem.specifiesCoordinate
                         }
 
-                        MenuItem {
+                        QGCMenuItem {
                             text:           qsTr("Terrain Frame")
                             checkable:      true
                             checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame

--- a/src/QmlControls/FlightModeMenu.qml
+++ b/src/QmlControls/FlightModeMenu.qml
@@ -21,14 +21,14 @@ QGCLabel {
 
     property var currentVehicle: QGroundControl.multiVehicleManager.activeVehicle
 
-    Menu {
+    QGCMenu {
         id: flightModesMenu
     }
 
     Component {
         id: flightModeMenuItemComponent
 
-        MenuItem {
+        QGCMenuItem {
             onTriggered: currentVehicle.flightMode = text
         }
     }

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -101,24 +101,24 @@ Item {
         onClicked:      toolsMenu.popup()
     }
 
-    Menu {
+    QGCMenu {
         id:                 toolsMenu
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Refresh")
             onTriggered:	controller.refresh()
         }
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Reset all to firmware's defaults")
             visible:        !activeVehicle.apmFirmware
             onTriggered:    mainWindow.showComponentDialog(resetToDefaultConfirmComponent, qsTr("Reset All"), mainWindow.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Reset)
         }
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Reset to vehicle's configuration defaults")
             visible:        !activeVehicle.apmFirmware
             onTriggered:    mainWindow.showComponentDialog(resetToVehicleConfigurationConfirmComponent, qsTr("Reset All"), mainWindow.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Reset)
         }
-        MenuSeparator { }
-        MenuItem {
+        QGCMenuSeparator { }
+        QGCMenuItem {
             text:           qsTr("Load from file...")
             onTriggered: {
                 fileDialog.title =          qsTr("Load Parameters")
@@ -126,7 +126,7 @@ Item {
                 fileDialog.openForLoad()
             }
         }
-        MenuItem {
+        QGCMenuItem {
             text:           qsTr("Save to file...")
             onTriggered: {
                 fileDialog.title =          qsTr("Save Parameters")
@@ -134,14 +134,14 @@ Item {
                 fileDialog.openForSave()
             }
         }
-        MenuSeparator { visible: _showRCToParam }
-        MenuItem {
+        QGCMenuSeparator { visible: _showRCToParam }
+        QGCMenuItem {
             text:           qsTr("Clear RC to Param")
             onTriggered:	controller.clearRCToParam()
             visible:        _showRCToParam
         }
-        MenuSeparator { }
-        MenuItem {
+        QGCMenuSeparator { }
+        QGCMenuItem {
             text:           qsTr("Reboot Vehicle")
             onTriggered:    mainWindow.showComponentDialog(rebootVehicleConfirmComponent, qsTr("Reboot Vehicle"), mainWindow.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Ok)
         }

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -104,7 +104,7 @@ Button {
 
     ExclusiveGroup { id: eg }
 
-    Menu {
+    QGCMenu {
         id:             popup
         __minimumWidth: combo.width
         __visualItem:   combo
@@ -233,7 +233,7 @@ Button {
 
             onObjectRemoved: popup.removeItem(object)
 
-            MenuItem {
+            QGCMenuItem {
                 text:           popup.textRole === '' ? modelData : ((popup._modelIsArray ? modelData[popup.textRole] : model[popup.textRole]) || '')
                 checked:        index == currentIndex
                 checkable:      true

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -126,14 +126,14 @@ Item {
                                 hamburgerMenu.popup()
                             }
 
-                            Menu {
+                            QGCMenu {
                                 id: hamburgerMenu
 
                                 property string fileToDelete
 
                                 onAboutToHide: fileButton.highlight = false
 
-                                MenuItem {
+                                QGCMenuItem {
                                     text:           qsTr("Delete")
                                     onTriggered: {
                                         controller.deleteFile(hamburgerMenu.fileToDelete)
@@ -239,14 +239,14 @@ Item {
                                 hamburgerMenu.popup()
                             }
 
-                            Menu {
+                            QGCMenu {
                                 id: hamburgerMenu
 
                                 property string fileToDelete
 
                                 onAboutToHide: fileButton.highlight = false
 
-                                MenuItem {
+                                QGCMenuItem {
                                     text:           qsTr("Delete")
                                     onTriggered: {
                                         controller.deleteFile(hamburgerMenu.fileToDelete)

--- a/src/QmlControls/QGCMenu.qml
+++ b/src/QmlControls/QGCMenu.qml
@@ -1,0 +1,8 @@
+// QtQuick.Control 1.x Menu
+
+import QtQuick          2.6
+import QtQuick.Controls 1.4
+
+Menu {
+
+}

--- a/src/QmlControls/QGCMenuItem.qml
+++ b/src/QmlControls/QGCMenuItem.qml
@@ -1,0 +1,8 @@
+// QtQuick.Control 1.x Menu
+
+import QtQuick          2.6
+import QtQuick.Controls 1.4
+
+MenuItem {
+
+}

--- a/src/QmlControls/QGCMenuSeparator.qml
+++ b/src/QmlControls/QGCMenuSeparator.qml
@@ -1,0 +1,8 @@
+// QtQuick.Control 1.x Menu
+
+import QtQuick          2.6
+import QtQuick.Controls 1.4
+
+MenuSeparator {
+
+}

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -50,6 +50,9 @@ QGCMapCircleVisuals     1.0 QGCMapCircleVisuals.qml
 QGCMapLabel             1.0 QGCMapLabel.qml
 QGCMapPolygonVisuals    1.0 QGCMapPolygonVisuals.qml
 QGCMapPolylineVisuals   1.0 QGCMapPolylineVisuals.qml
+QGCMenu                 1.0 QGCMenu.qml
+QGCMenuItem             1.0 QGCMenuItem.qml
+QGCMenuSeparator        1.0 QGCMenuSeparator.qml
 QGCMouseArea            1.0 QGCMouseArea.qml
 QGCMovableItem          1.0 QGCMovableItem.qml
 QGCPipable              1.0 QGCPipable.qml

--- a/src/QmlControls/QmlTest.qml
+++ b/src/QmlControls/QmlTest.qml
@@ -491,13 +491,13 @@ Rectangle {
                         }
                         Menu {
                             id: buttonMenu
-                            MenuItem {
+                            QGCMenuItem {
                                 text: qsTr("Item 1")
                             }
-                            MenuItem {
+                            QGCMenuItem {
                                 text: qsTr("Item 2")
                             }
-                            MenuItem {
+                            QGCMenuItem {
                                 text: qsTr("Item 3")
                             }
                         }

--- a/src/ui/toolbar/LinkIndicator.qml
+++ b/src/ui/toolbar/LinkIndicator.qml
@@ -34,12 +34,12 @@ Item {
         font.pointSize:         ScreenTools.mediumFontPointSize
         color:                  qgcPal.buttonText
         anchors.verticalCenter: parent.verticalCenter
-        Menu {
+        QGCMenu {
             id: linkSelectionMenu
         }
         Component {
             id: linkSelectionMenuItemComponent
-            MenuItem {
+            QGCMenuItem {
                 onTriggered: activeVehicle.priorityLinkName = text
             }
         }

--- a/src/ui/toolbar/ModeIndicator.qml
+++ b/src/ui/toolbar/ModeIndicator.qml
@@ -34,12 +34,12 @@ Item {
         font.pointSize:         ScreenTools.mediumFontPointSize
         color:                  qgcPal.buttonText
         anchors.verticalCenter: parent.verticalCenter
-        Menu {
+        QGCMenu {
             id: flightModesMenu
         }
         Component {
             id: flightModeMenuItemComponent
-            MenuItem {
+            QGCMenuItem {
                 onTriggered: activeVehicle.flightMode = text
             }
         }

--- a/src/ui/toolbar/MultiVehicleSelector.qml
+++ b/src/ui/toolbar/MultiVehicleSelector.qml
@@ -38,12 +38,12 @@ Item {
         font.pointSize:         ScreenTools.mediumFontPointSize
         color:                  qgcPal.buttonText
         anchors.verticalCenter: parent.verticalCenter
-        Menu {
+        QGCMenu {
             id: multiVehiclesMenu
         }
         Component {
             id: multiVehicleMenuItemComponent
-            MenuItem {
+            QGCMenuItem {
                 onTriggered: QGroundControl.multiVehicleManager.activeVehicle = vehicle
                 property int vehicleId: Number(text.split(" ")[1])
                 property var vehicle:   QGroundControl.multiVehicleManager.getVehicleById(vehicleId)


### PR DESCRIPTION
A roundabout way to make sure all QML Menus are using QtQuick.Controls 1.x. Using QtQuick.Controls 2.x, you end up with weird artifacts when the menus are over a map. 

Closes #7562 
