### PR TITLE
Dual battery display

### DIFF
--- a/custom-example/res/Custom/Widgets/CustomVehicleButton.qml
+++ b/custom-example/res/Custom/Widgets/CustomVehicleButton.qml
@@ -25,13 +25,13 @@ Button {
 
     function getBatteryColor() {
         if(vehicle) {
-            if(vehicle.batteryStatus.percentRemaining.value > 75) {
+            if(vehicle.batterySummary.percentRemaining.value > 75) {
                 return qgcPal.colorGreen
             }
-            if(vehicle.batteryStatus.percentRemaining.value > 50) {
+            if(vehicle.batterySummary.percentRemaining.value > 50) {
                 return qgcPal.colorOrange
             }
-            if(vehicle.batteryStatus.percentRemaining.value > 0.1) {
+            if(vehicle.batterySummary.percentRemaining.value > 0.1) {
                 return qgcPal.colorRed
             }
         }
@@ -40,7 +40,7 @@ Button {
 
     function getBatteryPercentage() {
         if(vehicle) {
-            return vehicle.batteryStatus.percentRemaining.value / 100.0
+            return vehicle.batterySummary.percentRemaining.value / 100.0
         }
         return 1
     }

--- a/custom-example/res/Custom/Widgets/CustomVehicleButton.qml
+++ b/custom-example/res/Custom/Widgets/CustomVehicleButton.qml
@@ -25,13 +25,13 @@ Button {
 
     function getBatteryColor() {
         if(vehicle) {
-            if(vehicle.battery.percentRemaining.value > 75) {
+            if(vehicle.batteryStatus.percentRemaining.value > 75) {
                 return qgcPal.colorGreen
             }
-            if(vehicle.battery.percentRemaining.value > 50) {
+            if(vehicle.batteryStatus.percentRemaining.value > 50) {
                 return qgcPal.colorOrange
             }
-            if(vehicle.battery.percentRemaining.value > 0.1) {
+            if(vehicle.batteryStatus.percentRemaining.value > 0.1) {
                 return qgcPal.colorRed
             }
         }
@@ -40,7 +40,7 @@ Button {
 
     function getBatteryPercentage() {
         if(vehicle) {
-            return vehicle.battery.percentRemaining.value / 100.0
+            return vehicle.batteryStatus.percentRemaining.value / 100.0
         }
         return 1
     }

--- a/custom-example/res/MainToolbar/CustomBatteryIndicator.qml
+++ b/custom-example/res/MainToolbar/CustomBatteryIndicator.qml
@@ -175,7 +175,7 @@ Item {
         id:             batteryIndicatorRow
         anchors.top:    parent.top
         anchors.bottom: parent.bottom
-        opacity:        (activeVehicle && activeVehicle.battery.voltage.value >= 0) ? 1 : 0.5
+        opacity:        (activeVehicle && activeVehicle.batterySummary.voltage.value >= 0) ? 1 : 0.5
         spacing:        ScreenTools.defaultFontPixelWidth
         QGCColoredImage {
             anchors.top:        parent.top
@@ -190,7 +190,7 @@ Item {
                 anchors.left:       parent.left
                 anchors.leftMargin: ScreenTools.defaultFontPixelWidth * 0.25
                 height:             parent.height * 0.35
-                width:              activeVehicle ? (activeVehicle.battery.percentRemaining.value / 100) * parent.width * 0.75 : 0
+                width:              activeVehicle ? (activeVehicle.batterySummary.percentRemaining.value / 100) * parent.width * 0.75 : 0
                 anchors.verticalCenter: parent.verticalCenter
             }
         }

--- a/custom-example/res/MainToolbar/CustomBatteryIndicator.qml
+++ b/custom-example/res/MainToolbar/CustomBatteryIndicator.qml
@@ -27,13 +27,16 @@ Item {
     anchors.top:            parent.top
     anchors.bottom:         parent.bottom
 
-    property var    battery1:           activeVehicle ? activeVehicle.battery  : null
-    property var    battery2:           activeVehicle ? activeVehicle.battery2 : null
+    property var    batterySummary:     activeVehicle ? activeVehicle.batterySummary : null
+    property var    battery1:           activeVehicle ? activeVehicle.battery        : null
+    property var    battery2:           activeVehicle ? activeVehicle.battery2       : null
     property bool   hasSecondBattery:   battery2 && battery2.voltage.value !== -1
 
     function lowestBattery() {
         if(activeVehicle) {
-            if(hasSecondBattery) {
+            if(batterySummary && (batterySummary.voltage.value !== -1 || batterySummary.percentRemaining.value > 0.1)) {
+                return batterySummary;
+            } else if(hasSecondBattery) {
                 if(activeVehicle.battery2.percentRemaining.value < activeVehicle.battery.percentRemaining.value) {
                     return activeVehicle.battery2
                 }

--- a/custom-example/res/MainToolbar/CustomBatteryIndicator.qml
+++ b/custom-example/res/MainToolbar/CustomBatteryIndicator.qml
@@ -28,7 +28,7 @@ Item {
     anchors.bottom:         parent.bottom
 
     property var    batterySummary:     activeVehicle ? activeVehicle.batterySummary : null
-    property var    battery1:           activeVehicle ? activeVehicle.battery        : null
+    property var    battery1:           activeVehicle ? activeVehicle.battery1       : null
     property var    battery2:           activeVehicle ? activeVehicle.battery2       : null
     property bool   hasSecondBattery:   battery2 && battery2.voltage.value !== -1
 
@@ -37,11 +37,11 @@ Item {
             if(batterySummary && (batterySummary.voltage.value !== -1 || batterySummary.percentRemaining.value > 0.1)) {
                 return batterySummary;
             } else if(hasSecondBattery) {
-                if(activeVehicle.battery2.percentRemaining.value < activeVehicle.battery.percentRemaining.value) {
-                    return activeVehicle.battery2
+                if(battery2.percentRemaining.value < battery1.percentRemaining.value) {
+                    return battery2
                 }
             }
-            return activeVehicle.battery
+            return battery1
         }
         return null
     }
@@ -119,11 +119,11 @@ Item {
                         color:          qgcPal.text
                         fillMode:       Image.PreserveAspectFit
                         Rectangle {
-                            color:              getBatteryColor(activeVehicle ? activeVehicle.battery : null)
+                            color:              getBatteryColor(activeVehicle ? activeVehicle.battery1 : null)
                             anchors.left:       parent.left
                             anchors.leftMargin: ScreenTools.defaultFontPixelWidth * 0.125
                             height:             parent.height * 0.35
-                            width:              activeVehicle ? (activeVehicle.battery.percentRemaining.value / 100) * parent.width * 0.875 : 0
+                            width:              activeVehicle ? (activeVehicle.battery1.percentRemaining.value / 100) * parent.width * 0.875 : 0
                             anchors.verticalCenter: parent.verticalCenter
                         }
                     }

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -130,8 +130,8 @@ SetupPage {
                         property Fact battMonitor:      controller.getParameterFact(-1, "BATT_MONITOR", false /* reportMissing */)
                         property Fact battVoltMult:     controller.getParameterFact(-1, "BATT_VOLT_MULT", false /* reportMissing */)
                         property Fact battVoltPin:      controller.getParameterFact(-1, "BATT_VOLT_PIN", false /* reportMissing */)
-                        property Fact vehicleVoltage:   controller.vehicle.battery.voltage
-                        property Fact vehicleCurrent:   controller.vehicle.battery.current
+                        property Fact vehicleVoltage:   controller.vehicle.battery1.voltage
+                        property Fact vehicleCurrent:   controller.vehicle.battery1.current
                     }
                 }
             }

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -130,7 +130,7 @@ SetupPage {
                                     QGCTextField { id: measuredVoltage }
 
                                     QGCLabel { text: qsTr("Vehicle voltage:") }
-                                    QGCLabel { text: controller.vehicle.battery.voltage.valueString }
+                                    QGCLabel { text: controller.vehicle.batterySummary.voltage.valueString }
 
                                     QGCLabel { text: qsTr("Voltage divider:") }
                                     FactLabel { fact: battVoltageDivider }
@@ -144,7 +144,7 @@ SetupPage {
                                         if (measuredVoltageValue === 0 || isNaN(measuredVoltageValue)) {
                                             return
                                         }
-                                        var newVoltageDivider = (measuredVoltageValue * battVoltageDivider.value) / controller.vehicle.battery.voltage.value
+                                        var newVoltageDivider = (measuredVoltageValue * battVoltageDivider.value) / controller.vehicle.batterySummary.voltage.value
                                         if (newVoltageDivider > 0) {
                                             battVoltageDivider.value = newVoltageDivider
                                         }
@@ -188,7 +188,7 @@ SetupPage {
                                     QGCTextField { id: measuredCurrent }
 
                                     QGCLabel { text: qsTr("Vehicle current:") }
-                                    QGCLabel { text: controller.vehicle.battery.current.valueString }
+                                    QGCLabel { text: controller.vehicle.batterySummary.current.valueString }
 
                                     QGCLabel { text: qsTr("Amps per volt:") }
                                     FactLabel { fact: battAmpsPerVolt }
@@ -202,7 +202,7 @@ SetupPage {
                                         if (measuredCurrentValue === 0) {
                                             return
                                         }
-                                        var newAmpsPerVolt = (measuredCurrentValue * battAmpsPerVolt.value) / controller.vehicle.battery.current.value
+                                        var newAmpsPerVolt = (measuredCurrentValue * battAmpsPerVolt.value) / controller.vehicle.batterySummary.current.value
                                         if (newAmpsPerVolt != 0) {
                                             battAmpsPerVolt.value = newAmpsPerVolt
                                         }

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -130,7 +130,7 @@ SetupPage {
                                     QGCTextField { id: measuredVoltage }
 
                                     QGCLabel { text: qsTr("Vehicle voltage:") }
-                                    QGCLabel { text: controller.vehicle.batterySummary.voltage.valueString }
+                                    QGCLabel { text: controller.vehicle.battery1.voltage.valueString }
 
                                     QGCLabel { text: qsTr("Voltage divider:") }
                                     FactLabel { fact: battVoltageDivider }
@@ -144,7 +144,7 @@ SetupPage {
                                         if (measuredVoltageValue === 0 || isNaN(measuredVoltageValue)) {
                                             return
                                         }
-                                        var newVoltageDivider = (measuredVoltageValue * battVoltageDivider.value) / controller.vehicle.batterySummary.voltage.value
+                                        var newVoltageDivider = (measuredVoltageValue * battVoltageDivider.value) / controller.vehicle.battery1.voltage.value
                                         if (newVoltageDivider > 0) {
                                             battVoltageDivider.value = newVoltageDivider
                                         }
@@ -188,7 +188,7 @@ SetupPage {
                                     QGCTextField { id: measuredCurrent }
 
                                     QGCLabel { text: qsTr("Vehicle current:") }
-                                    QGCLabel { text: controller.vehicle.batterySummary.current.valueString }
+                                    QGCLabel { text: controller.vehicle.battery1.current.valueString }
 
                                     QGCLabel { text: qsTr("Amps per volt:") }
                                     FactLabel { fact: battAmpsPerVolt }
@@ -202,7 +202,7 @@ SetupPage {
                                         if (measuredCurrentValue === 0) {
                                             return
                                         }
-                                        var newAmpsPerVolt = (measuredCurrentValue * battAmpsPerVolt.value) / controller.vehicle.batterySummary.current.value
+                                        var newAmpsPerVolt = (measuredCurrentValue * battAmpsPerVolt.value) / controller.vehicle.battery1.current.value
                                         if (newAmpsPerVolt != 0) {
                                             battAmpsPerVolt.value = newAmpsPerVolt
                                         }

--- a/src/FlightDisplay/PreFlightBatteryCheck.qml
+++ b/src/FlightDisplay/PreFlightBatteryCheck.qml
@@ -25,6 +25,6 @@ PreFlightCheckButton {
 
     property int    failurePercent:                 40
     property bool   allowFailurePercentOverride:    false
-    property var    _batPercentRemaining:           activeVehicle ? activeVehicle.battery.percentRemaining.value : 0
+    property var    _batPercentRemaining:           activeVehicle ? activeVehicle.batterySummary.percentRemaining.value : 0
     property bool   _batLow:                        _batPercentRemaining < failurePercent
 }

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -6,9 +6,12 @@ import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
 
 CheckBox {
+    id: _root
+
     property color  textColor:          _qgcPal.text
     property bool   textBold:           false
     property real   textFontPointSize:  ScreenTools.defaultFontPointSize
+    property real   radius:             0
 
     property var    _qgcPal: QGCPalette { colorGroupEnabled: enabled }
     property bool   _noText: text === ""
@@ -43,6 +46,7 @@ CheckBox {
                 border.color:   qgcPal.text
                 border.width:   1
                 opacity:        control.checkedState === Qt.PartiallyChecked ? 0.5 : 1
+                radius:         _root.radius
                 QGCColoredImage {
                     source:     "/qmlimages/checkbox-check.svg"
                     color:      "black"

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -271,4 +271,12 @@
     "type":             "bool",
     "defaultValue":     false
 }
+,
+{
+    "name":             "showDetailedBatteryInfo",
+    "shortDescription": "Additional battery info",
+    "longDescription":  "Show or hide additional battery info in battery dropdown",
+    "type":             "bool",
+    "defaultValue":     false
+}
 ]

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -98,6 +98,7 @@ DECLARE_SETTINGSFACT(AppSettings, language)
 DECLARE_SETTINGSFACT(AppSettings, disableAllPersistence)
 DECLARE_SETTINGSFACT(AppSettings, usePairing)
 DECLARE_SETTINGSFACT(AppSettings, saveCsvTelemetry)
+DECLARE_SETTINGSFACT(AppSettings, showDetailedBatteryInfo)
 
 DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
 {

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -53,6 +53,7 @@ public:
     DEFINE_SETTINGFACT(disableAllPersistence)
     DEFINE_SETTINGFACT(usePairing)
     DEFINE_SETTINGFACT(saveCsvTelemetry)
+    DEFINE_SETTINGFACT(showDetailedBatteryInfo)
 
     // Although this is a global setting it only affects ArduPilot vehicle since PX4 automatically starts the stream from the vehicle side
     DEFINE_SETTINGFACT(apmStartMavlinkStreams)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -84,7 +84,7 @@ const char* Vehicle::_throttlePctFactName =         "throttlePct";
 
 const char* Vehicle::_gpsFactGroupName =                "gps";
 const char* Vehicle::_batterySummaryFactGroupName =     "batterySummary";
-const char* Vehicle::_battery1FactGroupName =           "battery";
+const char* Vehicle::_battery1FactGroupName =           "battery1";
 const char* Vehicle::_battery2FactGroupName =           "battery2";
 const char* Vehicle::_windFactGroupName =               "wind";
 const char* Vehicle::_vibrationFactGroupName =          "vibration";

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -83,6 +83,7 @@ const char* Vehicle::_hobbsFactName =               "hobbs";
 const char* Vehicle::_throttlePctFactName =         "throttlePct";
 
 const char* Vehicle::_gpsFactGroupName =                "gps";
+const char* Vehicle::_batterySummaryFactGroupName =     "batterySummary";
 const char* Vehicle::_battery1FactGroupName =           "battery";
 const char* Vehicle::_battery2FactGroupName =           "battery2";
 const char* Vehicle::_windFactGroupName =               "wind";
@@ -214,6 +215,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _hobbsFact            (0, _hobbsFactName,             FactMetaData::valueTypeString)
     , _throttlePctFact      (0, _throttlePctFactName,       FactMetaData::valueTypeUint16)
     , _gpsFactGroup(this)
+    , _batterySummaryFactGroup(this)
     , _battery1FactGroup(this)
     , _battery2FactGroup(this)
     , _windFactGroup(this)
@@ -413,6 +415,7 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _hobbsFact            (0, _hobbsFactName,             FactMetaData::valueTypeString)
     , _throttlePctFact      (0, _throttlePctFactName,       FactMetaData::valueTypeUint16)
     , _gpsFactGroup(this)
+    , _batterySummaryFactGroup(this)
     , _battery1FactGroup(this)
     , _battery2FactGroup(this)
     , _windFactGroup(this)
@@ -496,6 +499,7 @@ void Vehicle::_commonInit(void)
     _addFact(&_hobbsFact,               _hobbsFactName);
 
     _addFactGroup(&_gpsFactGroup,               _gpsFactGroupName);
+    _addFactGroup(&_batterySummaryFactGroup,    _batterySummaryFactGroupName);
     _addFactGroup(&_battery1FactGroup,          _battery1FactGroupName);
     _addFactGroup(&_battery2FactGroup,          _battery2FactGroupName);
     _addFactGroup(&_windFactGroup,              _windFactGroupName);
@@ -1238,7 +1242,7 @@ void Vehicle::_handleHighLatency2(mavlink_message_t& message)
     _windFactGroup.direction()->setRawValue((double)highLatency2.wind_heading * 2.0);
     _windFactGroup.speed()->setRawValue((double)highLatency2.windspeed / 5.0);
 
-    _battery1FactGroup.percentRemaining()->setRawValue(highLatency2.battery);
+    _batterySummaryFactGroup.percentRemaining()->setRawValue(highLatency2.battery);
 
     _temperatureFactGroup.temperature1()->setRawValue(highLatency2.temperature_air);
 
@@ -1546,19 +1550,21 @@ void Vehicle::_handleSysStatus(mavlink_message_t& message)
     mavlink_msg_sys_status_decode(&message, &sysStatus);
 
     if (sysStatus.current_battery == -1) {
-        _battery1FactGroup.current()->setRawValue(VehicleBatteryFactGroup::_currentUnavailable);
+        _batterySummaryFactGroup.current()->setRawValue(VehicleBatteryFactGroup::_currentUnavailable);
     } else {
         // Current is in Amps, current_battery is 10 * milliamperes (1 = 10 milliampere)
-        _battery1FactGroup.current()->setRawValue((float)sysStatus.current_battery / 100.0f);
+        _batterySummaryFactGroup.current()->setRawValue((float)sysStatus.current_battery / 100.0f);
     }
     if (sysStatus.voltage_battery == UINT16_MAX) {
-        _battery1FactGroup.voltage()->setRawValue(VehicleBatteryFactGroup::_voltageUnavailable);
+        _batterySummaryFactGroup.voltage()->setRawValue(VehicleBatteryFactGroup::_voltageUnavailable);
     } else {
-        _battery1FactGroup.voltage()->setRawValue((double)sysStatus.voltage_battery / 1000.0);
-        // current_battery is 10 mA and voltage_battery is 1mV. (10/1e3 times 1/1e3 = 1/1e5)
-        _battery1FactGroup.instantPower()->setRawValue((float)(sysStatus.current_battery*sysStatus.voltage_battery)/(100000.0));
+        _batterySummaryFactGroup.voltage()->setRawValue((double)sysStatus.voltage_battery / 1000.0);
+        if (sysStatus.current_battery != -1) {
+            // current_battery is 10 mA and voltage_battery is 1mV. (10/1e3 times 1/1e3 = 1/1e5)
+            _batterySummaryFactGroup.instantPower()->setRawValue((float)(sysStatus.current_battery*sysStatus.voltage_battery)/(100000.0));
+        }
     }
-    _battery1FactGroup.percentRemaining()->setRawValue(sysStatus.battery_remaining);
+    _batterySummaryFactGroup.percentRemaining()->setRawValue(sysStatus.battery_remaining);
 
     if (sysStatus.battery_remaining > 0) {
         if (sysStatus.battery_remaining < _settingsManager->appSettings()->batteryPercentRemainingAnnounce()->rawValue().toInt() &&
@@ -1613,27 +1619,48 @@ void Vehicle::_handleBatteryStatus(mavlink_message_t& message)
     } else {
         batteryFactGroup.mahConsumed()->setRawValue(bat_status.current_consumed);
     }
+    if (bat_status.current_battery == -1) {
+        batteryFactGroup.current()->setRawValue(VehicleBatteryFactGroup::_currentUnavailable);
+    } else {
+        // Current is in Amps, current_battery is 10 * milliamperes (1 = 10 milliampere)
+        batteryFactGroup.current()->setRawValue((float)bat_status.current_battery / 100.0f);
+    }
 
+
+    int16_t voltage = 0;
     int cellCount = 0;
     for (int i=0; i<10; i++) {
         if (bat_status.voltages[i] != UINT16_MAX) {
             cellCount++;
+            voltage += bat_status.voltages[i];
         }
     }
     if (cellCount == 0) {
         cellCount = -1;
+    }
+    if (voltage > 0) {
+        batteryFactGroup.voltage()->setRawValue((double)voltage / 1000.0);
+        if(bat_status.current_battery != -1) {
+            // current_battery is 10 mA and voltage_battery is 1mV. (10/1e3 times 1/1e3 = 1/1e5)
+            batteryFactGroup.instantPower()->setRawValue((double)(bat_status.current_battery*voltage)/(100000.0));
+        }
+    } else {
+        batteryFactGroup.voltage()->setRawValue(VehicleBatteryFactGroup::_voltageUnavailable);
     }
 
     batteryFactGroup.cellCount()->setRawValue(cellCount);
 
     //-- Time remaining in seconds (0 means not supported)
     batteryFactGroup.timeRemaining()->setRawValue(bat_status.time_remaining);
+    //-- Percent remaining in % (0 - 100)
+    batteryFactGroup.percentRemaining()->setRawValue(bat_status.battery_remaining);
     //-- Battery charge state (0 means not supported)
     if(bat_status.charge_state <= MAV_BATTERY_CHARGE_STATE_UNHEALTHY) {
         batteryFactGroup.chargeState()->setRawValue(bat_status.charge_state);
     } else {
         batteryFactGroup.chargeState()->setRawValue(0);
     }
+
     //-- TODO: Somewhere, actions would be taken based on this chargeState:
     //   MAV_BATTERY_CHARGE_STATE_CRITICAL:     Battery state is critical, return / abort immediately
     //   MAV_BATTERY_CHARGE_STATE_EMERGENCY:    Battery state is too low for ordinary abortion, fastest possible emergency stop preventing damage

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -682,6 +682,7 @@ public:
     Q_PROPERTY(Fact* throttlePct        READ throttlePct        CONSTANT)
 
     Q_PROPERTY(FactGroup* gps               READ gpsFactGroup               CONSTANT)
+    Q_PROPERTY(FactGroup* batterySummary    READ batterySummaryFactGroup    CONSTANT)
     Q_PROPERTY(FactGroup* battery           READ battery1FactGroup          CONSTANT)
     Q_PROPERTY(FactGroup* battery2          READ battery2FactGroup          CONSTANT)
     Q_PROPERTY(FactGroup* wind              READ windFactGroup              CONSTANT)

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -985,6 +985,7 @@ public:
     Fact* throttlePct       (void) { return &_throttlePctFact; }
 
     FactGroup* gpsFactGroup             (void) { return &_gpsFactGroup; }
+    FactGroup* batterySummaryFactGroup  (void) { return &_batterySummaryFactGroup; }
     FactGroup* battery1FactGroup        (void) { return &_battery1FactGroup; }
     FactGroup* battery2FactGroup        (void) { return &_battery2FactGroup; }
     FactGroup* windFactGroup            (void) { return &_windFactGroup; }
@@ -1549,6 +1550,7 @@ private:
     Fact _throttlePctFact;
 
     VehicleGPSFactGroup             _gpsFactGroup;
+    VehicleBatteryFactGroup         _batterySummaryFactGroup;
     VehicleBatteryFactGroup         _battery1FactGroup;
     VehicleBatteryFactGroup         _battery2FactGroup;
     VehicleWindFactGroup            _windFactGroup;
@@ -1580,6 +1582,7 @@ private:
     static const char* _throttlePctFactName;
 
     static const char* _gpsFactGroupName;
+    static const char* _batterySummaryFactGroupName;
     static const char* _battery1FactGroupName;
     static const char* _battery2FactGroupName;
     static const char* _windFactGroupName;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -683,7 +683,7 @@ public:
 
     Q_PROPERTY(FactGroup* gps               READ gpsFactGroup               CONSTANT)
     Q_PROPERTY(FactGroup* batterySummary    READ batterySummaryFactGroup    CONSTANT)
-    Q_PROPERTY(FactGroup* battery           READ battery1FactGroup          CONSTANT)
+    Q_PROPERTY(FactGroup* battery1          READ battery1FactGroup          CONSTANT)
     Q_PROPERTY(FactGroup* battery2          READ battery2FactGroup          CONSTANT)
     Q_PROPERTY(FactGroup* wind              READ windFactGroup              CONSTANT)
     Q_PROPERTY(FactGroup* vibration         READ vibrationFactGroup         CONSTANT)

--- a/src/ui/toolbar/BatteryIndicator.qml
+++ b/src/ui/toolbar/BatteryIndicator.qml
@@ -33,7 +33,7 @@ Item {
     property var    battery2:           activeVehicle ? activeVehicle.battery2       : null
     property bool   hasSecondBattery:   battery2 && battery2.voltage.value !== -1
 
-    readonly property real _textFontSize: ScreenTools.defaultFontPointSize * (ScreenTools.isMobile ? 1.5 : 1.25)
+    readonly property real _textFontSize: ScreenTools.defaultFontPointSize * (ScreenTools.isMobile ? 1.25 : 1.05)
 
     function getBatteryColor(battery) {
         if(battery) {
@@ -107,7 +107,7 @@ Item {
 
             Column {
                 id:                 battCol
-                spacing:            ScreenTools.defaultFontPixelHeight * 0.5
+                spacing:            ScreenTools.defaultFontPixelHeight * 1
                 width:              batteryInfoComponent.width
                 anchors.margins:    ScreenTools.defaultFontPixelHeight
                 anchors.centerIn:   parent
@@ -129,11 +129,6 @@ Item {
                     property bool moreDetails: moreDetails.checked
                 }
 
-                Item {
-                    height: battLabel.height/2
-                    width: battLabel.width/2
-                }
-
                 Loader {
                     sourceComponent: batteryInfoComponent
 
@@ -143,11 +138,6 @@ Item {
                     property var batteryObj: _root.battery2
                     property var textFontSize: _root._textFontSize
                     property bool moreDetails: moreDetails.checked
-                }
-
-                Item {
-                    height: battLabel.height/2
-                    width: battLabel.width/2
                 }
 
                 QGCCheckBox {


### PR DESCRIPTION
Support for the new changes in `PX4` firmware: https://github.com/PX4/Firmware/pull/12034

**Changes:**
- Provide the battery info from `SYS_STATUS` and `HIGH_LATENCY2` message as `Vehicle.batterySummary` and keep the old us `Vehicle.battery` and `Vehicle.battery2` for first and second battery (optional).
- Take individual battery voltage from battery cell voltages
- Optional more battery details in the detail box
- Bigger fonts for better visibility on small tablets

Note:
 - Keeps backward compatibility

![pr-battery](https://user-images.githubusercontent.com/47554641/61039814-c4fd4080-a3cf-11e9-8029-03d490185f53.png)
![pr-battery_details](https://user-images.githubusercontent.com/47554641/61039816-c4fd4080-a3cf-11e9-8e62-552711c0a36e.png)
