### PR TITLE
Microhard improvements

### DIFF
--- a/src/Microhard/MicrohardHandler.cc
+++ b/src/Microhard/MicrohardHandler.cc
@@ -13,7 +13,6 @@
 #include "VideoManager.h"
 
 QGC_LOGGING_CATEGORY(MicrohardLog,     "MicrohardLog")
-QGC_LOGGING_CATEGORY(MicrohardVerbose, "MicrohardVerbose")
 
 //-----------------------------------------------------------------------------
 MicrohardHandler::MicrohardHandler(QObject* parent)
@@ -53,10 +52,10 @@ MicrohardHandler::_start(uint16_t port, QHostAddress addr)
     qCDebug(MicrohardLog) << "Connecting to" << addr;
     _tcpSocket->connectToHost(addr, port);
     if (!_tcpSocket->waitForConnected(1000)) {
+        emit connected(0);
         close();
         return false;
     }
-    emit connected();
 
     return true;
 }

--- a/src/Microhard/MicrohardHandler.h
+++ b/src/Microhard/MicrohardHandler.h
@@ -17,7 +17,6 @@
 #define MICROHARD_SETTINGS_PORT   23
 
 Q_DECLARE_LOGGING_CATEGORY(MicrohardLog)
-Q_DECLARE_LOGGING_CATEGORY(MicrohardVerbose)
 
 class MicrohardHandler : public QObject
 {
@@ -36,7 +35,7 @@ protected slots:
     virtual void    _readBytes          () = 0;
 
 signals:
-    void connected                      ();
+    void connected                      (int status);
     void rssiUpdated                    (int rssi);
 
 protected:

--- a/src/Microhard/MicrohardManager.h
+++ b/src/Microhard/MicrohardManager.h
@@ -26,30 +26,32 @@ class MicrohardManager : public QGCTool
     Q_OBJECT
 public:
 
-    Q_PROPERTY(bool         connected           READ connected                                  NOTIFY connectedChanged)
-    Q_PROPERTY(bool         linkConnected       READ linkConnected                              NOTIFY linkConnectedChanged)
+    Q_PROPERTY(int          connected           READ connected                                  NOTIFY connectedChanged)
+    Q_PROPERTY(int          linkConnected       READ linkConnected                              NOTIFY linkConnectedChanged)
     Q_PROPERTY(int          uplinkRSSI          READ uplinkRSSI                                 NOTIFY linkChanged)
     Q_PROPERTY(int          downlinkRSSI        READ downlinkRSSI                               NOTIFY linkChanged)
     Q_PROPERTY(QString      localIPAddr         READ localIPAddr                                NOTIFY localIPAddrChanged)
     Q_PROPERTY(QString      remoteIPAddr        READ remoteIPAddr                               NOTIFY remoteIPAddrChanged)
     Q_PROPERTY(QString      netMask             READ netMask                                    NOTIFY netMaskChanged)
+    Q_PROPERTY(QString      configUserName      READ configUserName                             NOTIFY configUserNameChanged)
     Q_PROPERTY(QString      configPassword      READ configPassword                             NOTIFY configPasswordChanged)
     Q_PROPERTY(QString      encryptionKey       READ encryptionKey                              NOTIFY encryptionKeyChanged)
 
-    Q_INVOKABLE bool setIPSettings              (QString localIP, QString remoteIP, QString netMask, QString cfgPassword, QString encyrptionKey);
+    Q_INVOKABLE bool setIPSettings              (QString localIP, QString remoteIP, QString netMask, QString cfgUserName, QString cfgPassword, QString encyrptionKey);
 
     explicit MicrohardManager                   (QGCApplication* app, QGCToolbox* toolbox);
     ~MicrohardManager                           () override;
 
     void        setToolbox                      (QGCToolbox* toolbox) override;
 
-    bool        connected                       () { return _isConnected && _mhSettingsLoc && _mhSettingsLoc->loggedIn(); }
-    bool        linkConnected                   () { return _linkConnected && _mhSettingsRem && _mhSettingsRem->loggedIn(); }
+    int         connected                       () { return _connectedStatus; }
+    int         linkConnected                   () { return _linkConnectedStatus; }
     int         uplinkRSSI                      () { return _downlinkRSSI; }
     int         downlinkRSSI                    () { return _uplinkRSSI; }
     QString     localIPAddr                     () { return _localIPAddr; }
     QString     remoteIPAddr                    () { return _remoteIPAddr; }
     QString     netMask                         () { return _netMask; }
+    QString     configUserName                  () { return _configUserName; }
     QString     configPassword                  () { return _configPassword; }
     QString     encryptionKey                   () { return _encryptionKey; }
 
@@ -60,13 +62,14 @@ signals:
     void    localIPAddrChanged              ();
     void    remoteIPAddrChanged             ();
     void    netMaskChanged                  ();
+    void    configUserNameChanged           ();
     void    configPasswordChanged           ();
     void    encryptionKeyChanged            ();
 
 private slots:
-    void    _connectedLoc                   ();
+    void    _connectedLoc                   (int status);
     void    _rssiUpdatedLoc                 (int rssi);
-    void    _connectedRem                   ();
+    void    _connectedRem                   (int status);
     void    _rssiUpdatedRem                 (int rssi);
     void    _checkMicrohard                 ();
     void    _setEnabled                     ();
@@ -79,21 +82,22 @@ private:
     FactMetaData *_createMetadata           (const char *name, QStringList enums);
 
 private:
-    bool                    _isConnected    = false;
-    AppSettings*            _appSettings    = nullptr;
-    MicrohardSettings*      _mhSettingsLoc  = nullptr;
-    MicrohardSettings*      _mhSettingsRem  = nullptr;
-    bool            _enabled                = true;
-    bool            _linkConnected          = false;
-    QTimer          _workTimer;
-    QTimer          _locTimer;
-    QTimer          _remTimer;
-    int             _downlinkRSSI           = 0;
-    int             _uplinkRSSI             = 0;
-    QString         _localIPAddr;
-    QString         _remoteIPAddr;
-    QString         _netMask;
-    QString         _configPassword;
-    QString         _encryptionKey;
-    QTime           _timeoutTimer;
+    int                _connectedStatus = 0;
+    AppSettings*       _appSettings = nullptr;
+    MicrohardSettings* _mhSettingsLoc = nullptr;
+    MicrohardSettings* _mhSettingsRem = nullptr;
+    bool               _enabled  = true;
+    int                _linkConnectedStatus = 0;
+    QTimer             _workTimer;
+    QTimer             _locTimer;
+    QTimer             _remTimer;
+    int                _downlinkRSSI = 0;
+    int                _uplinkRSSI = 0;
+    QString            _localIPAddr;
+    QString            _remoteIPAddr;
+    QString            _netMask;
+    QString            _configUserName;
+    QString            _configPassword;
+    QString            _encryptionKey;
+    QTime              _timeoutTimer;
 };

--- a/src/Microhard/MicrohardSettings.qml
+++ b/src/Microhard/MicrohardSettings.qml
@@ -121,16 +121,32 @@ Rectangle {
                                 Layout.minimumWidth: _labelWidth
                             }
                             QGCLabel {
-                                text:           QGroundControl.microhardManager.connected ? qsTr("Connected") : qsTr("Not Connected")
-                                color:          QGroundControl.microhardManager.connected ? qgcPal.colorGreen : qgcPal.colorRed
+                                function getStatus(status) {
+                                    if (status === 1)
+                                        return qsTr("Connected");
+                                    else if (status === -1)
+                                        return qsTr("Login Error")
+                                    else
+                                        return qsTr("Not Connected")
+                                }
+                                text:           getStatus(QGroundControl.microhardManager.connected)
+                                color:          QGroundControl.microhardManager.connected === 1 ? qgcPal.colorGreen : qgcPal.colorRed
                                 Layout.minimumWidth: _valueWidth
                             }
                             QGCLabel {
                                 text:           qsTr("Air Unit:")
                             }
                             QGCLabel {
-                                text:           QGroundControl.microhardManager.linkConnected ? qsTr("Connected") : qsTr("Not Connected")
-                                color:          QGroundControl.microhardManager.linkConnected ? qgcPal.colorGreen : qgcPal.colorRed
+                                function getStatus(status) {
+                                    if (status === 1)
+                                        return qsTr("Connected");
+                                    else if (status === -1)
+                                        return qsTr("Login Error")
+                                    else
+                                        return qsTr("Not Connected")
+                                }
+                                text:           getStatus(QGroundControl.microhardManager.linkConnected)
+                                color:          QGroundControl.microhardManager.linkConnected === 1 ? qgcPal.colorGreen : qgcPal.colorRed
                             }
                             QGCLabel {
                                 text:           qsTr("Uplink RSSI:")
@@ -210,7 +226,16 @@ Rectangle {
                                 Layout.minimumWidth: _valueWidth
                             }
                             QGCLabel {
-                                text:           qsTr("Configuration password:")
+                                text:           qsTr("Configuration User Name:")
+                            }
+                            QGCTextField {
+                                id:             configUserName
+                                text:           QGroundControl.microhardManager.configUserName
+                                enabled:        true
+                                Layout.minimumWidth: _valueWidth
+                            }
+                            QGCLabel {
+                                text:           qsTr("Configuration Password:")
                             }
                             QGCTextField {
                                 id:             configPassword
@@ -244,6 +269,7 @@ Rectangle {
                                 if(localIP.text          === QGroundControl.microhardManager.localIPAddr &&
                                     remoteIP.text        === QGroundControl.microhardManager.remoteIPAddr &&
                                     netMask.text         === QGroundControl.microhardManager.netMask &&
+                                    configUserName.text  === QGroundControl.microhardManager.configUserName &&
                                     configPassword.text  === QGroundControl.microhardManager.configPassword &&
                                     encryptionKey.text   === QGroundControl.microhardManager.encryptionKey)
                                     return false
@@ -256,7 +282,7 @@ Rectangle {
                             text:               qsTr("Apply")
                             anchors.horizontalCenter:   parent.horizontalCenter
                             onClicked: {
-                                QGroundControl.microhardManager.setIPSettings(localIP.text, remoteIP.text, netMask.text, configPassword.text, encryptionKey.text)
+                                QGroundControl.microhardManager.setIPSettings(localIP.text, remoteIP.text, netMask.text, configUserName.text, configPassword.text, encryptionKey.text)
                             }
 
                         }


### PR DESCRIPTION
Addresses point 1 from  #7580 Microhard issues

Added possibilty to set Configuration user name.

![QGCLoginOK](https://user-images.githubusercontent.com/7646986/61548286-ac36ff80-aa4d-11e9-8d49-f8f36206c287.png)

Display "Login error" status message in case of wrong configuration username/password.

![QGCLoginError](https://user-images.githubusercontent.com/7646986/61548306-b658fe00-aa4d-11e9-93b3-fb049d6853f4.png)
