### PR TITLE
CameraManager, improve displayed available memory

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -263,7 +263,7 @@ QGCCameraControl::photoStatus()
 QString
 QGCCameraControl::storageFreeStr()
 {
-    return QGCMapEngine::bigSizeToString(static_cast<quint64>(_storageFree) * 1024 * 1024);
+    return QGCMapEngine::storageFreeSizeToString(static_cast<quint64>(_storageFree));
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -473,6 +473,18 @@ QGCMapEngine::bigSizeToString(quint64 size)
 
 //-----------------------------------------------------------------------------
 QString
+QGCMapEngine::storageFreeSizeToString(quint64 size_MB)
+{
+    if(size_MB < 1024)
+        return kLocale.toString(static_cast<double>(size_MB) , 'f', 0) + " MB";
+    else if(size_MB < 1024.0 * 1024.0)
+        return kLocale.toString(static_cast<double>(size_MB) / (1024.0), 'f', 2) + " GB";
+    else
+        return kLocale.toString(static_cast<double>(size_MB) / (1024.0 * 1024), 'f', 2) + " TB";
+}
+
+//-----------------------------------------------------------------------------
+QString
 QGCMapEngine::numberToString(quint64 number)
 {
     return kLocale.toString(number);

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -99,6 +99,7 @@ public:
     static QString              getTileHash         (UrlFactory::MapType type, int x, int y, int z);
     static UrlFactory::MapType  getTypeFromName     (const QString &name);
     static QString              bigSizeToString     (quint64 size);
+    static QString              storageFreeSizeToString(quint64 size_MB);
     static QString              numberToString      (quint64 number);
     static int                  concurrentDownloads (UrlFactory::MapType type);
 


### PR DESCRIPTION
QGCCameraControl::storageFreeStr(): use QGCMapEngine::storageFreeSizeToString()

new string conversion routine for improved displaying of available memory in CameraManager GUI
* the _storagefree variable has a resolution of MB, it thus makes no sense to display no unit or KB, and for the unit MB it makes no sense to have a fraction
* for GB and TB it shows two fraction digits
* adds a blank between value and unit for better visibility
* didn't modify the existing bigSize conversion function, since it's used in several other places, and the unit thing is specific to _storagefree 
