### PR TITLE
We don't have to restart video when stream config changes

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1564,9 +1564,7 @@ QGCCameraControl::handleVideoStatus(const mavlink_video_stream_status_t* vs)
     qCDebug(CameraControlLog) << "handleVideoStatus:" << vs->stream_id;
     QGCVideoStreamInfo* pInfo = _findStream(vs->stream_id);
     if(pInfo) {
-        if(pInfo->update(vs)) {
-            emit _vehicle->dynamicCameras()->streamChanged();
-        }
+        pInfo->update(vs);
     }
 }
 


### PR DESCRIPTION
When stream configuration changed QGC restarted the video receiver which resulted in double video restart thus taking longer for the new video to reappear.
Specifically this happened when changing between video and photo mode on Sony cameras.
We don't have to restart video streaming receiver when we receive video stream configuration message. When source changes the video is restarted automatically.