### PR TITLE
Fix logs Download on Android

### DIFF
--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -604,6 +604,7 @@ LogDownloadController::_prepareLogDownload()
     } else {
         _downloadData->filename += ".bin";
     }
+
     _downloadData->file.setFileName(_downloadPath + _downloadData->filename);
     //-- Append a number to the end if the filename already exists
     if (_downloadData->file.exists()){
@@ -611,12 +612,22 @@ LogDownloadController::_prepareLogDownload()
         QStringList filename_spl = _downloadData->filename.split('.');
         do {
             num_dups +=1;
-            _downloadData->file.setFileName(filename_spl[0] + '_' + QString::number(num_dups) + '.' + filename_spl[1]);
+            _downloadData->file.setFileName(_downloadPath + (filename_spl[0] + '_' + QString::number(num_dups) + '.' + filename_spl[1]));
         } while( _downloadData->file.exists());
+    }
+
+    // On Android the directory inside Logs folder where to save the selected files is entered manually. Therefore it migh be missing.
+    if(_downloadPath.endsWith(QDir::separator())) {
+        QDir dir(_downloadPath);
+        if(!dir.exists()) {
+            if(!dir.mkpath(".")) {
+                qWarning() << "Failed to create directory:" << dir.path();
+            }
+        }
     }
     //-- Create file
     if (!_downloadData->file.open(QIODevice::WriteOnly)) {
-        qWarning() << "Failed to create log file:" <<  _downloadData->filename;
+        qWarning() << "Failed to create log file:" <<  _downloadData->file.fileName();
     } else {
         //-- Preallocate file
         if(!_downloadData->file.resize(entry->size())) {

--- a/src/AnalyzeView/LogDownloadPage.qml
+++ b/src/AnalyzeView/LogDownloadPage.qml
@@ -60,11 +60,17 @@ AnalyzePage {
                     title: qsTr("Id")
                     width: ScreenTools.defaultFontPixelWidth * 6
                     horizontalAlignment: Text.AlignHCenter
-                    delegate : Text  {
-                        horizontalAlignment: Text.AlignHCenter
-                        text: {
-                            var o = logController.model.get(styleData.row)
-                            return o ? o.id : ""
+                    delegate : Rectangle {
+                        color: styleData.selected ? palette.buttonHighlight : ((styleData.row % 2) ? palette.window : palette.windowShade)
+                        Text  {
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            horizontalAlignment: Text.AlignHCenter
+                            color: palette.text
+                            text: {
+                                var o = logController.model.get(styleData.row)
+                                return o ? o.id : ""
+                            }
                         }
                     }
                 }
@@ -73,20 +79,26 @@ AnalyzePage {
                     title: qsTr("Date")
                     width: ScreenTools.defaultFontPixelWidth * 34
                     horizontalAlignment: Text.AlignHCenter
-                    delegate: Text  {
-                        text: {
-                            var o = logController.model.get(styleData.row)
-                            if (o) {
-                                //-- Have we received this entry already?
-                                if(logController.model.get(styleData.row).received) {
-                                    var d = logController.model.get(styleData.row).time
-                                    if(d.getUTCFullYear() < 2010)
-                                        return qsTr("Date Unknown")
-                                    else
-                                        return d.toLocaleString()
+                    delegate: Rectangle {
+                        color: styleData.selected ? palette.buttonHighlight : ((styleData.row % 2) ? palette.window : palette.windowShade)
+                        Text  {
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            color: palette.text
+                            text: {
+                                var o = logController.model.get(styleData.row)
+                                if (o) {
+                                    //-- Have we received this entry already?
+                                    if(logController.model.get(styleData.row).received) {
+                                        var d = logController.model.get(styleData.row).time
+                                        if(d.getUTCFullYear() < 2010)
+                                            return qsTr("Date Unknown")
+                                        else
+                                            return d.toLocaleString()
+                                    }
                                 }
+                                return ""
                             }
-                            return ""
                         }
                     }
                 }
@@ -95,11 +107,17 @@ AnalyzePage {
                     title: qsTr("Size")
                     width: ScreenTools.defaultFontPixelWidth * 18
                     horizontalAlignment: Text.AlignHCenter
-                    delegate : Text  {
-                        horizontalAlignment: Text.AlignRight
-                        text: {
-                            var o = logController.model.get(styleData.row)
-                            return o ? o.sizeStr : ""
+                    delegate : Rectangle {
+                        color: styleData.selected ? palette.buttonHighlight : ((styleData.row % 2) ? palette.window : palette.windowShade)
+                        Text  {
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            horizontalAlignment: Text.AlignRight
+                            color: palette.text
+                            text: {
+                                var o = logController.model.get(styleData.row)
+                                return o ? o.sizeStr : ""
+                            }
                         }
                     }
                 }
@@ -108,11 +126,17 @@ AnalyzePage {
                     title: qsTr("Status")
                     width: ScreenTools.defaultFontPixelWidth * 22
                     horizontalAlignment: Text.AlignHCenter
-                    delegate : Text  {
-                        horizontalAlignment: Text.AlignHCenter
-                        text: {
-                            var o = logController.model.get(styleData.row)
-                            return o ? o.status : ""
+                    delegate : Rectangle {
+                        color: styleData.selected ? palette.buttonHighlight : ((styleData.row % 2) ? palette.window : palette.windowShade)
+                        Text  {
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            horizontalAlignment: Text.AlignHCenter
+                            color: palette.text
+                            text: {
+                                var o = logController.model.get(styleData.row)
+                                return o ? o.status : ""
+                            }
                         }
                     }
                 }
@@ -151,11 +175,11 @@ AnalyzePage {
                         fileDialog.selectExisting = true
                         fileDialog.folder =         QGroundControl.settingsManager.appSettings.logSavePath
                         fileDialog.selectFolder =   true
-                        fileDialog.openForLoad()
+                        fileDialog.openForSave()
                     }
                     QGCFileDialog {
                         id: fileDialog
-                        onAcceptedForLoad: {
+                        onAcceptedForSave: {
                             logController.download(file)
                             close()
                         }

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -158,16 +158,22 @@ Item {
 
         QGCViewDialog {
             function accept() {
-                if (filenameTextField.text == "") {
-                    return
+                if(_root.selectFolder) {
+                    _root.acceptedForSave(_root.folder + (_root.folder.endsWith("/") ? "" : "/") + filenameTextField.text)
                 }
-                if (!replaceMessage.visible) {
-                    if (controller.fileExists(controller.fullyQualifiedFilename(folder, filenameTextField.text, fileExtension))) {
-                        replaceMessage.visible = true
+                else {
+                    if (filenameTextField.text == "") {
                         return
                     }
+                    if (!replaceMessage.visible) {
+                        if (controller.fileExists(controller.fullyQualifiedFilename(folder, filenameTextField.text, fileExtension))) {
+                            replaceMessage.visible = true
+                            return
+                        }
+                    }
+                    _root.acceptedForSave(controller.fullyQualifiedFilename(folder, filenameTextField.text, fileExtension))
                 }
-                _root.acceptedForSave(controller.fullyQualifiedFilename(folder, filenameTextField.text, fileExtension))
+
                 hideDialog()
             }
 
@@ -186,7 +192,7 @@ Item {
                         anchors.right:  parent.right
                         spacing:        ScreenTools.defaultFontPixelWidth
 
-                        QGCLabel { text: qsTr("New file name:") }
+                        QGCLabel { text: _root.selectFolder ? qsTr("Folder name:") : qsTr("File name:") }
 
                         QGCTextField {
                             id:                 filenameTextField
@@ -199,6 +205,7 @@ Item {
                         anchors.left:   parent.left
                         anchors.right:  parent.right
                         wrapMode:       Text.WordWrap
+                        visible:        !_root.selectFolder
                         text:           qsTr("File names must end with .%1 file extension. If missing it will be added.").arg(fileExtension)
                     }
 
@@ -215,6 +222,7 @@ Item {
                     SectionHeader {
                         anchors.left:   parent.left
                         anchors.right:  parent.right
+                        visible:        !_root.selectFolder
                         text:           qsTr("Save to existing file:")
                     }
 


### PR DESCRIPTION
Downloading the firmware logs doesn't work on Android. This is a quick fix.
`QGCFileDialog.qml`: dumps the downloaded files in the  `Logs` sub-folder of application's default data path. Optionally the current selection can go in a custom subfolder in the same `Logs` folder for organizational purposes (like labeling).
`LogDownloadController.cc`: create the new subfolder if folder path if missing
`LogDownloadPage.qml`: fix theme colors making text visible in certain theme configurations