### PR TITLE
Keep track of gimbal position locally.

### DIFF
--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -213,6 +213,7 @@ signals:
     void gimbalPitchStep            (int direction);
     void gimbalYawStep              (int direction);
     void centerGimbal               ();
+    void gimbalControlValue         (double pitch, double yaw);
     void setArmed                   (bool arm);
     void setVtolInFwdFlight         (bool set);
     void setFlightMode              (const QString& flightMode);
@@ -229,6 +230,11 @@ protected:
     bool    _validButton            (int button);
     void    _handleAxis             ();
     void    _handleButtons          ();
+
+    void    _pitchStep              (int direction);
+    void    _yawStep                (int direction);
+    double  _localYaw       = 0.0;
+    double  _localPitch     = 0.0;
 
 private:
     virtual bool _open      ()          = 0;
@@ -289,6 +295,7 @@ protected:
     QList<AssignedButtonAction*>    _buttonActionArray;
     QStringList                     _availableActionTitles;
     MultiVehicleManager*            _multiVehicleManager = nullptr;
+
 
 private:
     static const char*  _rgFunctionSettingsKey[maxFunction];


### PR DESCRIPTION
When using a button for controlling the gimbal, you cannot send an absolute position (angle) unless you know the current position. For that I was incrementing/decrementing the current position as received by the MAVLINK_MSG_ID_MOUNT_ORIENTATION message for every button press. Ideally, we need a new _message_ (not command) to stream “steps”. That way we can simply stream these messages while these buttons are down and not incur the overhead of a command nor having to rely on receiving an updated gimbal position so we can increment/decrement it on a subsequent command.

For the moment, what I am doing is keeping a local gimbal “range” (an arbitrary range of -90° to 35° pitch and -180° to 180° yaw). As you move it about, I’m using these values instead of the values returned by the MAVLINK_MSG_ID_MOUNT_ORIENTATION message.