### PR TITLE
Camera mission commands

### DIFF
--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -1024,7 +1024,8 @@
             "rawName": "MAV_CMD_IMAGE_STOP_CAPTURE",
             "friendlyName": "Stop image capture",
             "description":  "Stop taking photos.",
-            "category":     "Camera"
+            "category":     "Camera",
+            "friendlyEdit": true
         },
         { "id": 2003, "rawName": "MAV_CMD_DO_TRIGGER_CONTROL", "friendlyName": "Trigger control" },
         {
@@ -1045,7 +1046,8 @@
             "rawName":      "MAV_CMD_VIDEO_STOP_CAPTURE",
             "friendlyName": "Stop video capture",
             "description":  "Stop video capture.",
-            "category":     "Camera"
+            "category":     "Camera",
+            "friendlyEdit": true
         },
         { "id": 2800, "rawName": "MAV_CMD_PANORAMA_CREATE", "friendlyName": "Create panorama" },
         {

--- a/src/MissionManager/MissionCommandList.cc
+++ b/src/MissionManager/MissionCommandList.cc
@@ -104,7 +104,7 @@ void MissionCommandList::_loadMavCmdInfoJson(const QString& jsonFilename, bool b
 MissionCommandUIInfo* MissionCommandList::getUIInfo(MAV_CMD command) const
 {
     if (!_infoMap.contains(command)) {
-        return NULL;
+        return nullptr;
     }
 
     return _infoMap[command];

--- a/src/MissionManager/MissionCommandTree.cc
+++ b/src/MissionManager/MissionCommandTree.cc
@@ -24,7 +24,7 @@
 MissionCommandTree::MissionCommandTree(QGCApplication* app, QGCToolbox* toolbox, bool unitTest)
     : QGCTool(app, toolbox)
     , _allCommandsCategory(tr("All commands"))
-    , _settingsManager(NULL)
+    , _settingsManager(nullptr)
     , _unitTest(unitTest)
 {
 }

--- a/src/MissionManager/MissionCommandUIInfo.cc
+++ b/src/MissionManager/MissionCommandUIInfo.cc
@@ -409,13 +409,13 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
 
 const MissionCmdParamInfo* MissionCommandUIInfo::getParamInfo(int index, bool& showUI) const
 {
-    const MissionCmdParamInfo* paramInfo = NULL;
+    const MissionCmdParamInfo* paramInfo = nullptr;
 
     if (_paramInfoMap.contains(index)) {
         paramInfo = _paramInfoMap[index];
     }
 
-    showUI = (paramInfo != NULL) && !_paramRemoveList.contains(index);
+    showUI = (paramInfo != nullptr) && !_paramRemoveList.contains(index);
 
     return paramInfo;
 }

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -20,12 +20,12 @@
 #include "QGroundControlQmlGlobal.h"
 #include "SettingsManager.h"
 
-FactMetaData* SimpleMissionItem::_altitudeMetaData =        NULL;
-FactMetaData* SimpleMissionItem::_commandMetaData =         NULL;
-FactMetaData* SimpleMissionItem::_defaultParamMetaData =    NULL;
-FactMetaData* SimpleMissionItem::_frameMetaData =           NULL;
-FactMetaData* SimpleMissionItem::_latitudeMetaData =        NULL;
-FactMetaData* SimpleMissionItem::_longitudeMetaData =       NULL;
+FactMetaData* SimpleMissionItem::_altitudeMetaData =        nullptr;
+FactMetaData* SimpleMissionItem::_commandMetaData =         nullptr;
+FactMetaData* SimpleMissionItem::_defaultParamMetaData =    nullptr;
+FactMetaData* SimpleMissionItem::_frameMetaData =           nullptr;
+FactMetaData* SimpleMissionItem::_latitudeMetaData =        nullptr;
+FactMetaData* SimpleMissionItem::_longitudeMetaData =       nullptr;
 
 const char* SimpleMissionItem::_jsonAltitudeModeKey =           "AltitudeMode";
 const char* SimpleMissionItem::_jsonAltitudeKey =               "Altitude";
@@ -152,8 +152,8 @@ SimpleMissionItem::SimpleMissionItem(const SimpleMissionItem& other, bool flyVie
     , _rawEdit                  (false)
     , _dirty                    (false)
     , _ignoreDirtyChangeSignals (false)
-    , _speedSection             (NULL)
-    , _cameraSection            (NULL)
+    , _speedSection             (nullptr)
+    , _cameraSection            (nullptr)
     , _commandTree              (qgcApp()->toolbox()->missionCommandTree())
     , _supportedCommandFact     (0,         "Command:",             FactMetaData::valueTypeUint32)
     , _altitudeMode             (other._altitudeMode)
@@ -595,7 +595,7 @@ void SimpleMissionItem::_rebuildFacts(void)
 
 bool SimpleMissionItem::friendlyEditAllowed(void) const
 {
-    const MissionCommandUIInfo* uiInfo = _commandTree->getUIInfo(_vehicle, (MAV_CMD)command());
+    const MissionCommandUIInfo* uiInfo = _commandTree->getUIInfo(_vehicle, static_cast<MAV_CMD>(command()));
     if (uiInfo && uiInfo->friendlyEdit()) {
         if (!_missionItem.autoContinue()) {
             return false;
@@ -607,7 +607,6 @@ bool SimpleMissionItem::friendlyEditAllowed(void) const
             case MAV_FRAME_GLOBAL:
             case MAV_FRAME_GLOBAL_RELATIVE_ALT:
                 return true;
-                break;
 
             case MAV_FRAME_GLOBAL_TERRAIN_ALT:
                 return supportsTerrainFrame();
@@ -759,7 +758,7 @@ void SimpleMissionItem::_setDefaultsForCommand(void)
         _missionItem._param7Fact.setRawValue(0);
     }
 
-    MAV_CMD command = (MAV_CMD)this->command();
+    MAV_CMD command = static_cast<MAV_CMD>(this->command());
     const MissionCommandUIInfo* uiInfo = _commandTree->getUIInfo(_vehicle, command);
     if (uiInfo) {
         for (int i=1; i<=7; i++) {
@@ -806,13 +805,13 @@ void SimpleMissionItem::_sendFriendlyEditAllowedChanged(void)
 
 QString SimpleMissionItem::category(void) const
 {
-    return _commandTree->getUIInfo(_vehicle, (MAV_CMD)command())->category();
+    return _commandTree->getUIInfo(_vehicle, static_cast<MAV_CMD>(command()))->category();
 }
 
 void SimpleMissionItem::setCommand(int command)
 {
-    if ((MAV_CMD)command != _missionItem.command()) {
-        _missionItem.setCommand((MAV_CMD)command);
+    if (static_cast<MAV_CMD>(command) != _missionItem.command()) {
+        _missionItem.setCommand(static_cast<MAV_CMD>(command));
         _updateOptionalSections();
     }
 }
@@ -876,18 +875,18 @@ void SimpleMissionItem::_updateOptionalSections(void)
     // Remove previous sections
     if (_cameraSection) {
         _cameraSection->deleteLater();
-        _cameraSection = NULL;
+        _cameraSection = nullptr;
     }
     if (_speedSection) {
         _speedSection->deleteLater();
-        _speedSection = NULL;
+        _speedSection = nullptr;
     }
 
     // Add new sections
 
     _cameraSection = new CameraSection(_vehicle, this);
     _speedSection = new SpeedSection(_vehicle, this);
-    if ((MAV_CMD)command() == MAV_CMD_NAV_WAYPOINT) {
+    if (static_cast<MAV_CMD>(command()) == MAV_CMD_NAV_WAYPOINT) {
         _cameraSection->setAvailable(true);
         _speedSection->setAvailable(true);
     }
@@ -938,11 +937,11 @@ void SimpleMissionItem::appendMissionItems(QList<MissionItem*>& items, QObject* 
 
 void SimpleMissionItem::applyNewAltitude(double newAltitude)
 {
-    MAV_CMD command = (MAV_CMD)this->command();
+    MAV_CMD command = static_cast<MAV_CMD>(this->command());
     const MissionCommandUIInfo* uiInfo = _commandTree->getUIInfo(_vehicle, command);
 
     if (uiInfo->specifiesCoordinate() || uiInfo->specifiesAltitudeOnly()) {
-        switch ((MAV_CMD)this->command()) {
+        switch (static_cast<MAV_CMD>(this->command())) {
         case MAV_CMD_NAV_LAND:
         case MAV_CMD_NAV_VTOL_LAND:
             // Leave alone

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -92,6 +92,7 @@ Rectangle {
                     indexModel:         false
                     model:              object.enumStrings
                     fact:               object
+                    pointSize:          ScreenTools.smallFontPointSize
                     Layout.column:      1
                     Layout.row:         index
                     Layout.fillWidth:   true


### PR DESCRIPTION
A couple of camera mission commands have no editable parameters. As a result, QGC was presenting a raw list of all 7 parameters to edit:
<img width="1026" alt="Screen Shot 2019-07-29 at 9 35 56 AM" src="https://user-images.githubusercontent.com/749243/62053104-f30ebd00-b1e4-11e9-94e1-a650fa85efc6.png">

By flagging the parameters as `friendlyEdit`, this is skipped and nothing is shown (as it should be):
<img width="1026" alt="Screen Shot 2019-07-29 at 9 38 18 AM" src="https://user-images.githubusercontent.com/749243/62053181-176a9980-b1e5-11e9-982d-db404f518c0a.png">
