### PR TITLE
Update QGC menus to match the application's theme

### DIFF
--- a/src/QmlControls/QGCMenu.qml
+++ b/src/QmlControls/QGCMenu.qml
@@ -1,8 +1,20 @@
 // QtQuick.Control 1.x Menu
 
 import QtQuick          2.6
-import QtQuick.Controls 1.4
+import QtQuick.Controls 2.4
+
+import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 Menu {
 
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    background: Rectangle {
+        implicitWidth: 200
+        implicitHeight: 40
+        color: "#ffffff"
+        border.color: "#21be2b"
+        radius: 2
+    }
 }

--- a/src/QmlControls/QGCMenu.qml
+++ b/src/QmlControls/QGCMenu.qml
@@ -1,6 +1,6 @@
 // QtQuick.Control 1.x Menu
 
-import QtQuick          2.6
+import QtQuick          2.11
 import QtQuick.Controls 2.4
 
 import QGroundControl.Palette 1.0
@@ -8,13 +8,26 @@ import QGroundControl.ScreenTools 1.0
 
 Menu {
 
+    id: _root
+
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     background: Rectangle {
-        implicitWidth: 200
+
+        implicitWidth: {
+                var result = 0;
+                var padding = 0;
+                for (var i = 0; i < count; ++i) {
+                    var item = itemAt(i);
+                    result = Math.max(item.contentItem.implicitWidth, result);
+                    padding = Math.max(item.padding, padding);
+                }
+                return result + padding * 2;
+            }
+
         implicitHeight: 40
-        color: "#ffffff"
-        border.color: "#21be2b"
+        color: qgcPal.window
+        border.color: qgcPal.windowShadeDark
         radius: 2
     }
 }

--- a/src/QmlControls/QGCMenuItem.qml
+++ b/src/QmlControls/QGCMenuItem.qml
@@ -1,8 +1,28 @@
 // QtQuick.Control 1.x Menu
 
-import QtQuick          2.6
-import QtQuick.Controls 1.4
+import QtQuick          2.11
+import QtQuick.Controls 2.4
+
+import QGroundControl.Palette 1.0
+import QGroundControl.ScreenTools 1.0
 
 MenuItem {
+    id: _root
 
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    implicitWidth: textLabel.contentWidth * 1.2
+    implicitHeight: textLabel.contentHeight * 1.2
+
+    background: Rectangle {
+        anchors.fill: _root
+        color: _root.highlighted ? qgcPal.buttonHighlight : qgcPal.window
+    }
+
+    contentItem: Text {
+        id: textLabel
+        text: _root.text
+        color: qgcPal.text
+        font.pointSize: ScreenTools.defaultFontPixelHeight
+    }
 }

--- a/src/QmlControls/QGCMenuItem.qml
+++ b/src/QmlControls/QGCMenuItem.qml
@@ -12,7 +12,7 @@ MenuItem {
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     implicitWidth: textLabel.contentWidth * 1.2
-    implicitHeight: textLabel.contentHeight * 1.2
+    implicitHeight: textLabel.contentHeight * 2
 
     background: Rectangle {
         anchors.fill: _root
@@ -24,5 +24,6 @@ MenuItem {
         text: _root.text
         color: qgcPal.text
         font.pointSize: ScreenTools.defaultFontPixelHeight
+        verticalAlignment: Text.AlignVCenter
     }
 }


### PR DESCRIPTION
Drop the native looking menus and customize the menus  based on theme including scaling factor.
Change the base QGCMenu and QGCMenuItem components