### PR TITLE
Fix MSVC 2015 "fatal error C1060: compiler is out of heap space"

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -50,6 +50,7 @@ LinuxBuild {
 
 WindowsBuild {
     RC_ICONS = resources/icons/qgroundcontrol.ico
+    CONFIG += resources_big
 }
 
 #


### PR DESCRIPTION
I followed the Getting Started page, I've got Qt 5.11.3 with MSVC 2015 32 bit on Windows 8.1 Pro, and I got this error.  The solution was simple.