### PR TITLE
Show how to implement custom video manager

### DIFF
--- a/custom-example/custom.pri
+++ b/custom-example/custom.pri
@@ -58,11 +58,13 @@ QML_IMPORT_PATH += \
 # Our own, custom sources
 SOURCES += \
     $$PWD/src/CustomPlugin.cc \
-    $$PWD/src/CustomQuickInterface.cc
+    $$PWD/src/CustomQuickInterface.cc \
+    $$PWD/src/CustomVideoManager.cc
 
 HEADERS += \
     $$PWD/src/CustomPlugin.h \
-    $$PWD/src/CustomQuickInterface.h
+    $$PWD/src/CustomQuickInterface.h \
+    $$PWD/src/CustomVideoManager.h
 
 INCLUDEPATH += \
     $$PWD/src \

--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -17,6 +17,7 @@
 
 #include "CustomPlugin.h"
 #include "CustomQuickInterface.h"
+#include "CustomVideoManager.h"
 
 #include "MultiVehicleManager.h"
 #include "QGCApplication.h"
@@ -189,6 +190,13 @@ CustomPlugin::overrideSettingsGroupVisibility(QString name)
         return false;
     }
     return true;
+}
+
+//-----------------------------------------------------------------------------
+VideoManager*
+CustomPlugin::createVideoManager(QGCApplication *app, QGCToolbox *toolbox)
+{
+    return new CustomVideoManager(app, toolbox);
 }
 
 //-----------------------------------------------------------------------------

--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -79,6 +79,7 @@ public:
     QString                 brandImageIndoor                () const final;
     QString                 brandImageOutdoor               () const final;
     bool                    overrideSettingsGroupVisibility (QString name) final;
+    VideoManager*           createVideoManager              (QGCApplication* app, QGCToolbox* toolbox) final;
     VideoReceiver*          createVideoReceiver             (QObject* parent) final;
     QQmlApplicationEngine*  createRootWindow                (QObject* parent) final;
     bool                    adjustSettingMetaData           (const QString& settingsGroup, FactMetaData& metaData) final;

--- a/custom-example/src/CustomVideoManager.cc
+++ b/custom-example/src/CustomVideoManager.cc
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "CustomVideoManager.h"
+#include "MultiVehicleManager.h"
+#include "CustomCameraManager.h"
+#include "CustomCameraControl.h"
+
+//-----------------------------------------------------------------------------
+CustomVideoManager::CustomVideoManager(QGCApplication* app, QGCToolbox* toolbox)
+    : VideoManager(app, toolbox)
+{
+}
+
+//-----------------------------------------------------------------------------
+void
+CustomVideoManager::_updateSettings()
+{
+    if(!_videoSettings || !_videoReceiver)
+        return;
+    //-- Check encoding
+    if(_activeVehicle && _activeVehicle->dynamicCameras()) {
+        CustomCameraControl* pCamera = dynamic_cast<CustomCameraControl*>(_activeVehicle->dynamicCameras()->currentCameraInstance());
+        if(pCamera) {
+            Fact *fact = pCamera->videoEncoding();
+            if (fact) {
+                _videoReceiver->setVideoDecoder(static_cast<VideoReceiver::VideoEncoding>(fact->rawValue().toInt()));
+            }
+        }
+    }
+    VideoManager::_updateSettings();
+}
+

--- a/custom-example/src/CustomVideoManager.h
+++ b/custom-example/src/CustomVideoManager.h
@@ -1,0 +1,28 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QTimer>
+#include <QTime>
+#include <QUrl>
+
+#include "VideoManager.h"
+
+class CustomVideoManager : public VideoManager
+{
+    Q_OBJECT
+public:
+    CustomVideoManager      (QGCApplication* app, QGCToolbox* toolbox);
+
+protected:
+    void _updateSettings    ();
+
+};

--- a/custom-example/src/FirmwarePlugin/CustomCameraControl.cc
+++ b/custom-example/src/FirmwarePlugin/CustomCameraControl.cc
@@ -19,6 +19,7 @@ QGC_LOGGING_CATEGORY(CustomCameraVerboseLog, "CustomCameraVerboseLog")
 
 static const char* kCAM_IRPALETTE            = "CAM_IRPALETTE";
 static const char* kCAM_NEXTVISION_IRPALETTE = "IR_SENS_POL";
+static const char* kCAM_ENC                  = "CAM_ENC";
 
 //-----------------------------------------------------------------------------
 CustomCameraControl::CustomCameraControl(const mavlink_camera_information_t *info, Vehicle* vehicle, int compID, QObject* parent)
@@ -114,6 +115,13 @@ CustomCameraControl::irPalette()
         }
     }
     return nullptr;
+}
+
+//-----------------------------------------------------------------------------
+Fact*
+CustomCameraControl::videoEncoding()
+{
+    return _paramComplete ? getFact(kCAM_ENC) : nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/custom-example/src/FirmwarePlugin/CustomCameraControl.h
+++ b/custom-example/src/FirmwarePlugin/CustomCameraControl.h
@@ -29,8 +29,11 @@ public:
     CustomCameraControl(const mavlink_camera_information_t* info, Vehicle* vehicle, int compID, QObject* parent = nullptr);
 
     Q_PROPERTY(Fact*        irPalette       READ    irPalette           NOTIFY parametersReady)
+    Q_PROPERTY(Fact*        videoEncoding   READ    videoEncoding       NOTIFY parametersReady)
 
     Fact*       irPalette           ();
+    Fact*       videoEncoding       ();
+
     bool        takePhoto           () override;
     bool        stopTakePhoto       () override;
     bool        startVideo          () override;

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -70,9 +70,6 @@ const char* QGCCameraControl::kCAM_SHUTTERSPD  = "CAM_SHUTTERSPD";
 const char* QGCCameraControl::kCAM_APERTURE    = "CAM_APERTURE";
 const char* QGCCameraControl::kCAM_WBMODE      = "CAM_WBMODE";
 const char* QGCCameraControl::kCAM_MODE        = "CAM_MODE";
-const char* QGCCameraControl::kCAM_BITRATE     = "CAM_BITRATE";
-const char* QGCCameraControl::kCAM_FPS         = "CAM_FPS";
-const char* QGCCameraControl::kCAM_ENC         = "CAM_ENC";
 
 //-----------------------------------------------------------------------------
 QGCCameraOptionExclusion::QGCCameraOptionExclusion(QObject* parent, QString param_, QString value_, QStringList exclusions_)
@@ -2114,27 +2111,6 @@ Fact*
 QGCCameraControl::mode()
 {
     return _paramComplete ? getFact(kCAM_MODE) : nullptr;
-}
-
-//-----------------------------------------------------------------------------
-Fact*
-QGCCameraControl::bitRate()
-{
-    return _paramComplete ? getFact(kCAM_BITRATE) : nullptr;
-}
-
-//-----------------------------------------------------------------------------
-Fact*
-QGCCameraControl::frameRate()
-{
-    return _paramComplete ? getFact(kCAM_FPS) : nullptr;
-}
-
-//-----------------------------------------------------------------------------
-Fact*
-QGCCameraControl::videoEncoding()
-{
-    return _paramComplete ? getFact(kCAM_ENC) : nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -167,9 +167,6 @@ public:
     Q_PROPERTY(Fact*        aperture            READ aperture           NOTIFY parametersReady)
     Q_PROPERTY(Fact*        wb                  READ wb                 NOTIFY parametersReady)
     Q_PROPERTY(Fact*        mode                READ mode               NOTIFY parametersReady)
-    Q_PROPERTY(Fact*        bitRate             READ bitRate            NOTIFY parametersReady)
-    Q_PROPERTY(Fact*        frameRate           READ frameRate          NOTIFY parametersReady)
-    Q_PROPERTY(Fact*        videoEncoding       READ videoEncoding      NOTIFY parametersReady)
 
     Q_PROPERTY(QStringList  activeSettings      READ activeSettings                                 NOTIFY activeSettingsChanged)
     Q_PROPERTY(VideoStatus  videoStatus         READ videoStatus                                    NOTIFY videoStatusChanged)
@@ -255,9 +252,6 @@ public:
     virtual Fact*       aperture            ();
     virtual Fact*       wb                  ();
     virtual Fact*       mode                ();
-    virtual Fact*       bitRate             ();
-    virtual Fact*       frameRate           ();
-    virtual Fact*       videoEncoding       ();
 
     //-- Stream names to show the user (for selection)
     virtual QStringList streamLabels        () { return _streamLabels; }
@@ -289,7 +283,6 @@ public:
     //-- Allow controller to modify or invalidate parameter change
     virtual bool        validateParameter   (Fact* pFact, QVariant& newValue);
 
-
     // Known Parameters
     static const char* kCAM_EV;
     static const char* kCAM_EXPMODE;
@@ -298,9 +291,6 @@ public:
     static const char* kCAM_APERTURE;
     static const char* kCAM_WBMODE;
     static const char* kCAM_MODE;
-    static const char* kCAM_BITRATE;
-    static const char* kCAM_FPS;
-    static const char* kCAM_ENC;
 
 signals:
     void    infoChanged                     ();

--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -279,13 +279,6 @@ VideoManager::_updateSettings()
         return;
     //-- Auto discovery
     if(_activeVehicle && _activeVehicle->dynamicCameras()) {
-        QGCCameraControl* pCamera = _activeVehicle->dynamicCameras()->currentCameraInstance();
-        if(pCamera) {
-            Fact *fact = pCamera->videoEncoding();
-            if (fact) {
-                _videoReceiver->setVideoDecoder(static_cast<VideoReceiver::VideoEncoding>(fact->rawValue().toInt()));
-            }
-        }
         QGCVideoStreamInfo* pInfo = _activeVehicle->dynamicCameras()->currentStreamInstance();
         if(pInfo) {
             qCDebug(VideoManagerLog) << "Configure primary stream: " << pInfo->uri();

--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -34,7 +34,7 @@ class VideoManager : public QGCTool
 
 public:
     VideoManager    (QGCApplication* app, QGCToolbox* toolbox);
-    ~VideoManager   ();
+    virtual ~VideoManager   ();
 
     Q_PROPERTY(bool             hasVideo                READ    hasVideo                                    NOTIFY hasVideoChanged)
     Q_PROPERTY(bool             isGStreamer             READ    isGStreamer                                 NOTIFY isGStreamerChanged)
@@ -51,34 +51,33 @@ public:
     Q_PROPERTY(bool             autoStreamConfigured    READ    autoStreamConfigured                        NOTIFY autoStreamConfiguredChanged)
     Q_PROPERTY(bool             hasThermal              READ    hasThermal                                  NOTIFY aspectRatioChanged)
 
-    bool        hasVideo            ();
-    bool        isGStreamer         ();
-    bool        isAutoStream        ();
-    bool        isTaisync           () { return _isTaisync; }
-    bool        fullScreen          () { return _fullScreen; }
-    QString     videoSourceID       () { return _videoSourceID; }
-    double      aspectRatio         ();
-    double      thermalAspectRatio  ();
-    double      hfov                ();
-    double      thermalHfov         ();
-    bool        autoStreamConfigured();
-    bool        hasThermal          ();
-    void        restartVideo        ();
+    virtual bool        hasVideo            ();
+    virtual bool        isGStreamer         ();
+    virtual bool        isTaisync           () { return _isTaisync; }
+    virtual bool        fullScreen          () { return _fullScreen; }
+    virtual QString     videoSourceID       () { return _videoSourceID; }
+    virtual double      aspectRatio         ();
+    virtual double      thermalAspectRatio  ();
+    virtual double      hfov                ();
+    virtual double      thermalHfov         ();
+    virtual bool        autoStreamConfigured();
+    virtual bool        hasThermal          ();
+    virtual void        restartVideo        ();
 
-    VideoReceiver*  videoReceiver           () { return _videoReceiver; }
-    VideoReceiver*  thermalVideoReceiver    () { return _thermalVideoReceiver; }
+    virtual VideoReceiver*  videoReceiver           () { return _videoReceiver; }
+    virtual VideoReceiver*  thermalVideoReceiver    () { return _thermalVideoReceiver; }
 
 #if defined(QGC_DISABLE_UVC)
-    bool        uvcEnabled          () { return false; }
+    virtual bool        uvcEnabled          () { return false; }
 #else
-    bool        uvcEnabled          ();
+    virtual bool        uvcEnabled          ();
 #endif
 
-    void        setfullScreen       (bool f) { _fullScreen = f; emit fullScreenChanged(); }
-    void        setIsTaisync        (bool t) { _isTaisync = t;  emit isTaisyncChanged(); }
+    virtual void        setfullScreen       (bool f) { _fullScreen = f; emit fullScreenChanged(); }
+    virtual void        setIsTaisync        (bool t) { _isTaisync = t;  emit isTaisyncChanged(); }
 
     // Override from QGCTool
-    void        setToolbox          (QGCToolbox *toolbox);
+    virtual void        setToolbox          (QGCToolbox *toolbox);
 
     Q_INVOKABLE void startVideo     ();
     Q_INVOKABLE void stopVideo      ();
@@ -93,7 +92,7 @@ signals:
     void aspectRatioChanged         ();
     void autoStreamConfiguredChanged();
 
-private slots:
+protected slots:
     void _videoSourceChanged        ();
     void _udpPortChanged            ();
     void _rtspUrlChanged            ();
@@ -102,10 +101,10 @@ private slots:
     void _setActiveVehicle          (Vehicle* vehicle);
     void _aspectRatioChanged        ();
 
-private:
+protected:
     void _updateSettings            ();
 
-private:
+protected:
     SubtitleWriter  _subtitleWriter;
     bool            _isTaisync              = false;
     VideoReceiver*  _videoReceiver          = nullptr;

--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -611,14 +611,14 @@ VideoReceiver::setVideoDecoder(VideoEncoding encoding)
     */
 
     if (encoding == H265_HW || encoding == H265_SW) {
-        _depayName = "rtph265depay";
+        _depayName  = "rtph265depay";
         _parserName = "h265parse";
 #if defined(__android__)
         _hwDecoderName = "amcviddec-omxgooglehevcdecoder";
 #endif
         _swDecoderName = "avdec_h265";
     } else {
-        _depayName = "rtph264depay";
+        _depayName  = "rtph264depay";
         _parserName = "h264parse";
 #if defined(__android__)
         _hwDecoderName = "amcviddec-omxgoogleh264decoder";
@@ -630,6 +630,7 @@ VideoReceiver::setVideoDecoder(VideoEncoding encoding)
         _hwDecoderName = nullptr;
     }
 }
+
 //-----------------------------------------------------------------------------
 // When we finish our pipeline will look like this:
 //

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -15,6 +15,7 @@
 #include "SettingsManager.h"
 #include "AppMessages.h"
 #include "QmlObjectListModel.h"
+#include "VideoManager.h"
 #include "VideoReceiver.h"
 #include "QGCLoggingCategory.h"
 #include "QGCCameraManager.h"
@@ -406,6 +407,11 @@ bool QGCCorePlugin::mavlinkMessage(Vehicle* vehicle, LinkInterface* link, mavlin
 QmlObjectListModel* QGCCorePlugin::customMapItems()
 {
     return &_p->_emptyCustomMapItems;
+}
+
+VideoManager* QGCCorePlugin::createVideoManager(QGCApplication *app, QGCToolbox *toolbox)
+{
+    return new VideoManager(app, toolbox);
 }
 
 VideoReceiver* QGCCorePlugin::createVideoReceiver(QObject* parent)

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -104,6 +104,8 @@ public:
     /// Allows the plugin to override the creation of the root (native) window.
     virtual QQmlApplicationEngine* createRootWindow(QObject* parent);
 
+    /// Allows the plugin to override the creation of VideoManager.
+    virtual VideoManager* createVideoManager(QGCApplication* app, QGCToolbox* toolbox);
     /// Allows the plugin to override the creation of VideoReceiver.
     virtual VideoReceiver* createVideoReceiver(QObject* parent);
 


### PR DESCRIPTION
This shows how to implement a custom VideoManager. It handles a custom camera parameter (`CAM_ENC`), which defines the video stream encoding, which is then parsed and handled by the video manager.