### PR TITLE
Disable full screen video if no vehicle or connection lost

### DIFF
--- a/src/FlightDisplay/VideoManager.h
+++ b/src/FlightDisplay/VideoManager.h
@@ -73,7 +73,7 @@ public:
     virtual bool        uvcEnabled          ();
 #endif
 
-    virtual void        setfullScreen       (bool f) { _fullScreen = f; emit fullScreenChanged(); }
+    virtual void        setfullScreen       (bool f);
     virtual void        setIsTaisync        (bool t) { _isTaisync = t;  emit isTaisyncChanged(); }
 
     // Override from QGCTool
@@ -100,6 +100,7 @@ protected slots:
     void _updateUVC                 ();
     void _setActiveVehicle          (Vehicle* vehicle);
     void _aspectRatioChanged        ();
+    void _connectionLostChanged     (bool connectionLost);
 
 protected:
     void _updateSettings            ();


### PR DESCRIPTION
This fixes an edge case where if you were in full screen video mode, lost a connection to an uncalibrated vehicle and regained connection, QGC would go straight into Vehicle Setup with no main toolbar allowing you to switch away from it.

