### PR TITLE
custom-example: Add GPS info to the Vehicle Indicator

### DIFF
--- a/custom-example/res/CustomFlyView.qml
+++ b/custom-example/res/CustomFlyView.qml
@@ -266,68 +266,59 @@ Item {
             rowSpacing:             ScreenTools.defaultFontPixelHeight * 0.5
             columns:                7
             anchors.centerIn:       parent
-        //-- Chronometer
-            QGCColoredImage {
+            //-- Latitude
+            QGCLabel {
                 height:                 _indicatorsHeight
                 width:                  height
-                source:                 "/custom/img/chronometer.svg"
-                fillMode:               Image.PreserveAspectFit
-                sourceSize.height:      height
                 Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
                 color:                  qgcPal.text
-        }
-        QGCLabel {
-            text: {
-                    if(activeVehicle)
-                        return secondsToHHMMSS(activeVehicle.getFact("flightTime").value)
-                return "00:00:00"
-            }
-            color:                  _indicatorsColor
-            font.pointSize:         ScreenTools.smallFontPointSize
-            Layout.fillWidth:       true
-            Layout.minimumWidth:    indicatorValueWidth
-            horizontalAlignment:    Text.AlignRight
-        }
-            //-- Ground Speed
-            QGCColoredImage {
-                height:                 _indicatorsHeight
-                width:                  height
-                source:                 "/custom/img/horizontal_speed.svg"
-                fillMode:               Image.PreserveAspectFit
-                sourceSize.height:      height
-                Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
-                color:                  qgcPal.text
+                text:                   "lat:"
             }
             QGCLabel {
-                text:                   activeVehicle ? activeVehicle.groundSpeed.value.toFixed(1) + ' ' + activeVehicle.groundSpeed.units : "0.0"
+                id:                     firstLabel
+                text:                   activeVehicle ? activeVehicle.gps.lat.value.toFixed(activeVehicle.gps.lat.decimalPlaces) : "-"
                 color:                  _indicatorsColor
                 font.pointSize:         ScreenTools.smallFontPointSize
                 Layout.fillWidth:       true
                 Layout.minimumWidth:    indicatorValueWidth
-                horizontalAlignment:    Text.AlignRight
+                horizontalAlignment:    Text.AlignLeft
             }
-            //-- Vertical Speed
-            QGCColoredImage {
+            //-- Longitude
+            QGCLabel {
                 height:                 _indicatorsHeight
                 width:                  height
-                source:                 "/custom/img/vertical_speed.svg"
-                fillMode:               Image.PreserveAspectFit
-                sourceSize.height:      height
                 Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
                 color:                  qgcPal.text
+                text:                   "lon:"
+            }
+            QGCLabel {
+                text:                   activeVehicle ? activeVehicle.gps.lon.value.toFixed(activeVehicle.gps.lon.decimalPlaces) : "-"
+                color:                  _indicatorsColor
+                font.pointSize:         ScreenTools.smallFontPointSize
+                Layout.fillWidth:       true
+                Layout.minimumWidth:    indicatorValueWidth
+                horizontalAlignment:    firstLabel.horizontalAlignment
+            }
+            //-- HDOP
+            QGCLabel {
+                height:                 _indicatorsHeight
+                width:                  height
+                Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
+                color:                  qgcPal.text
+                text:                   "HDOP:"
+            }
+            QGCLabel {
+                text:                   activeVehicle ? activeVehicle.gps.hdop.value.toFixed(activeVehicle.gps.hdop.decimalPlaces) : "-"
+                color:                  _indicatorsColor
+                font.pointSize:         ScreenTools.smallFontPointSize
+                Layout.fillWidth:       true
+                Layout.minimumWidth:    indicatorValueWidth
+                horizontalAlignment:    firstLabel.horizontalAlignment
+            }
 
-            }
-            QGCLabel {
-                text:                   activeVehicle ? activeVehicle.climbRate.value.toFixed(1) + ' ' + activeVehicle.climbRate.units : "0.0"
-                color:                  _indicatorsColor
-                font.pointSize:         ScreenTools.smallFontPointSize
-                Layout.fillWidth:       true
-                Layout.minimumWidth:    indicatorValueWidth
-                horizontalAlignment:    Text.AlignRight
-            }
             //-- Compass
             Item {
-                Layout.rowSpan:         2
+                Layout.rowSpan:         3
                 Layout.minimumWidth:    mainIsMap ? parent.height * 1.25 : 0
                 Layout.fillHeight:      true
                 Layout.fillWidth:       true
@@ -395,6 +386,66 @@ Item {
                 }
             }
             //-- Second Row
+            //-- Chronometer
+            QGCColoredImage {
+                height:                 _indicatorsHeight
+                width:                  height
+                source:                 "/custom/img/chronometer.svg"
+                fillMode:               Image.PreserveAspectFit
+                sourceSize.height:      height
+                Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
+                color:                  qgcPal.text
+            }
+            QGCLabel {
+                text: {
+                        if(activeVehicle)
+                            return secondsToHHMMSS(activeVehicle.getFact("flightTime").value)
+                    return "00:00:00"
+                }
+                color:                  _indicatorsColor
+                font.pointSize:         ScreenTools.smallFontPointSize
+                Layout.fillWidth:       true
+                Layout.minimumWidth:    indicatorValueWidth
+                horizontalAlignment:    firstLabel.horizontalAlignment
+            }
+            //-- Ground Speed
+            QGCColoredImage {
+                height:                 _indicatorsHeight
+                width:                  height
+                source:                 "/custom/img/horizontal_speed.svg"
+                fillMode:               Image.PreserveAspectFit
+                sourceSize.height:      height
+                Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
+                color:                  qgcPal.text
+            }
+            QGCLabel {
+                text:                   activeVehicle ? activeVehicle.groundSpeed.value.toFixed(1) + ' ' + activeVehicle.groundSpeed.units : "0.0"
+                color:                  _indicatorsColor
+                font.pointSize:         ScreenTools.smallFontPointSize
+                Layout.fillWidth:       true
+                Layout.minimumWidth:    indicatorValueWidth
+                horizontalAlignment:    firstLabel.horizontalAlignment
+            }
+            //-- Vertical Speed
+            QGCColoredImage {
+                height:                 _indicatorsHeight
+                width:                  height
+                source:                 "/custom/img/vertical_speed.svg"
+                fillMode:               Image.PreserveAspectFit
+                sourceSize.height:      height
+                Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
+                color:                  qgcPal.text
+
+            }
+            QGCLabel {
+                text:                   activeVehicle ? activeVehicle.climbRate.value.toFixed(1) + ' ' + activeVehicle.climbRate.units : "0.0"
+                color:                  _indicatorsColor
+                font.pointSize:         ScreenTools.smallFontPointSize
+                Layout.fillWidth:       true
+                Layout.minimumWidth:    indicatorValueWidth
+                horizontalAlignment:    firstLabel.horizontalAlignment
+            }
+            //-- Third Row
             //-- Odometer
             QGCColoredImage {
                 height:                 _indicatorsHeight
@@ -412,9 +463,9 @@ Item {
                 font.pointSize:         ScreenTools.smallFontPointSize
                 Layout.fillWidth:       true
                 Layout.minimumWidth:    indicatorValueWidth
-                horizontalAlignment:    Text.AlignRight
+                horizontalAlignment:    firstLabel.horizontalAlignment
             }
-        //-- Altitude
+            //-- Altitude
             QGCColoredImage {
                 height:                 _indicatorsHeight
                 width:                  height
@@ -424,16 +475,16 @@ Item {
                 Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
                 color:                  qgcPal.text
 
-        }
-        QGCLabel {
-            text:                   _altitude
-            color:                  _indicatorsColor
-            font.pointSize:         ScreenTools.smallFontPointSize
-            Layout.fillWidth:       true
-            Layout.minimumWidth:    indicatorValueWidth
-            horizontalAlignment:    Text.AlignRight
-        }
-        //-- Distance
+            }
+            QGCLabel {
+                text:                   _altitude
+                color:                  _indicatorsColor
+                font.pointSize:         ScreenTools.smallFontPointSize
+                Layout.fillWidth:       true
+                Layout.minimumWidth:    indicatorValueWidth
+                horizontalAlignment:    firstLabel.horizontalAlignment
+            }
+            //-- Distance
             QGCColoredImage {
                 height:                 _indicatorsHeight
                 width:                  height
@@ -443,15 +494,15 @@ Item {
                 Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
                 color:                  qgcPal.text
 
-        }
-        QGCLabel {
-            text:                   _distance ? _distanceStr : noGPS
-            color:                  _distance ? _indicatorsColor : qgcPal.colorOrange
-            font.pointSize:         ScreenTools.smallFontPointSize
-            Layout.fillWidth:       true
-            Layout.minimumWidth:    indicatorValueWidth
-            horizontalAlignment:    Text.AlignRight
-        }
+            }
+            QGCLabel {
+                text:                   _distance ? _distanceStr : noGPS
+                color:                  _distance ? _indicatorsColor : qgcPal.colorOrange
+                font.pointSize:         ScreenTools.smallFontPointSize
+                Layout.fillWidth:       true
+                Layout.minimumWidth:    indicatorValueWidth
+                horizontalAlignment:    firstLabel.horizontalAlignment
+            }
         }
         MouseArea {
             anchors.fill:       parent

--- a/custom-example/res/CustomFlyView.qml
+++ b/custom-example/res/CustomFlyView.qml
@@ -61,7 +61,6 @@ Item {
     property real   _distance:              0.0
     property string _messageTitle:          ""
     property string _messageText:           ""
-    property bool   _showAttitude:          true
 
     function secondsToHHMMSS(timeS) {
         var sec_num = parseInt(timeS, 10);
@@ -260,19 +259,25 @@ Item {
         anchors.bottomMargin:   ScreenTools.defaultFontPixelWidth
         anchors.right:          attitudeIndicator.visible ? attitudeIndicator.left : parent.right
         anchors.rightMargin:    attitudeIndicator.visible ? -ScreenTools.defaultFontPixelWidth : ScreenTools.defaultFontPixelWidth
-    GridLayout {
-        id:                     vehicleStatusGrid
-        columnSpacing:          ScreenTools.defaultFontPixelWidth  * 1.5
+
+        readonly property bool  _showGps: CustomQuickInterface.showAttitudeWidget
+
+
+        GridLayout {
+            id:                     vehicleStatusGrid
+            columnSpacing:          ScreenTools.defaultFontPixelWidth  * 1.5
             rowSpacing:             ScreenTools.defaultFontPixelHeight * 0.5
             columns:                7
             anchors.centerIn:       parent
+
             //-- Latitude
             QGCLabel {
                 height:                 _indicatorsHeight
                 width:                  height
                 Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
                 color:                  qgcPal.text
-                text:                   "lat:"
+                text:                   "Lat:"
+                visible:                vehicleIndicator._showGps
             }
             QGCLabel {
                 id:                     firstLabel
@@ -282,6 +287,7 @@ Item {
                 Layout.fillWidth:       true
                 Layout.minimumWidth:    indicatorValueWidth
                 horizontalAlignment:    Text.AlignLeft
+                visible:                vehicleIndicator._showGps
             }
             //-- Longitude
             QGCLabel {
@@ -289,7 +295,8 @@ Item {
                 width:                  height
                 Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
                 color:                  qgcPal.text
-                text:                   "lon:"
+                text:                   "Lon:"
+                visible:                vehicleIndicator._showGps
             }
             QGCLabel {
                 text:                   activeVehicle ? activeVehicle.gps.lon.value.toFixed(activeVehicle.gps.lon.decimalPlaces) : "-"
@@ -298,6 +305,7 @@ Item {
                 Layout.fillWidth:       true
                 Layout.minimumWidth:    indicatorValueWidth
                 horizontalAlignment:    firstLabel.horizontalAlignment
+                visible:                vehicleIndicator._showGps
             }
             //-- HDOP
             QGCLabel {
@@ -306,6 +314,7 @@ Item {
                 Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
                 color:                  qgcPal.text
                 text:                   "HDOP:"
+                visible:                vehicleIndicator._showGps
             }
             QGCLabel {
                 text:                   activeVehicle ? activeVehicle.gps.hdop.value.toFixed(activeVehicle.gps.hdop.decimalPlaces) : "-"
@@ -314,6 +323,7 @@ Item {
                 Layout.fillWidth:       true
                 Layout.minimumWidth:    indicatorValueWidth
                 horizontalAlignment:    firstLabel.horizontalAlignment
+                visible:                vehicleIndicator._showGps
             }
 
             //-- Compass
@@ -506,7 +516,7 @@ Item {
         }
         MouseArea {
             anchors.fill:       parent
-            onDoubleClicked:    _showAttitude = !_showAttitude
+            onDoubleClicked:    CustomQuickInterface.showAttitudeWidget = !CustomQuickInterface.showAttitudeWidget
         }
     }
     //-------------------------------------------------------------------------
@@ -515,7 +525,7 @@ Item {
         color:                  qgcPal.window
         width:                  attitudeIndicator.width * 0.5
         height:                 vehicleIndicator.height
-        visible:                _showAttitude
+        visible:                CustomQuickInterface.showAttitudeWidget
         anchors.top:            vehicleIndicator.top
         anchors.left:           vehicleIndicator.right
     }
@@ -529,7 +539,7 @@ Item {
         width:                  height
         radius:                 height * 0.5
         color:                  qgcPal.windowShade
-        visible:                _showAttitude
+        visible:                CustomQuickInterface.showAttitudeWidget
             CustomAttitudeWidget {
             size:               parent.height * 0.95
             vehicle:            activeVehicle

--- a/custom-example/res/CustomFlyView.qml
+++ b/custom-example/res/CustomFlyView.qml
@@ -329,6 +329,7 @@ Item {
             //-- Compass
             Item {
                 Layout.rowSpan:         3
+                Layout.column:          6
                 Layout.minimumWidth:    mainIsMap ? parent.height * 1.25 : 0
                 Layout.fillHeight:      true
                 Layout.fillWidth:       true

--- a/custom-example/src/CustomQuickInterface.cc
+++ b/custom-example/src/CustomQuickInterface.cc
@@ -25,6 +25,7 @@
 
 static const char* kGroupName       = "CustomSettings";
 static const char* kShowGimbalCtl   = "ShowGimbalCtl";
+static const char* kShowAttitudeWidget = "ShowAttitudeWidget";
 
 //-----------------------------------------------------------------------------
 CustomQuickInterface::CustomQuickInterface(QObject* parent)
@@ -45,7 +46,8 @@ CustomQuickInterface::init()
 {
     QSettings settings;
     settings.beginGroup(kGroupName);
-    _showGimbalControl = settings.value(kShowGimbalCtl, true).toBool();
+    _showGimbalControl = settings.value(kShowGimbalCtl, false).toBool();
+    _showAttitudeWidget = settings.value(kShowAttitudeWidget, false).toBool();
 }
 
 //-----------------------------------------------------------------------------
@@ -58,5 +60,18 @@ CustomQuickInterface::setShowGimbalControl(bool set)
         settings.beginGroup(kGroupName);
         settings.setValue(kShowGimbalCtl,set);
         emit showGimbalControlChanged();
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+CustomQuickInterface::setShowAttitudeWidget(bool set)
+{
+    if(_showAttitudeWidget != set) {
+        _showAttitudeWidget = set;
+        QSettings settings;
+        settings.beginGroup(kGroupName);
+        settings.setValue(kShowAttitudeWidget,set);
+        emit showAttitudeWidgetChanged();
     }
 }

--- a/custom-example/src/CustomQuickInterface.h
+++ b/custom-example/src/CustomQuickInterface.h
@@ -29,12 +29,20 @@ public:
     CustomQuickInterface(QObject* parent = nullptr);
     ~CustomQuickInterface();
     Q_PROPERTY(bool     showGimbalControl   READ showGimbalControl  WRITE setShowGimbalControl  NOTIFY showGimbalControlChanged)
+    Q_PROPERTY(bool         showAttitudeWidget  READ    showAttitudeWidget WRITE setShowAttitudeWidget NOTIFY showAttitudeWidgetChanged)
 
     bool    showGimbalControl           () { return _showGimbalControl; }
     void    setShowGimbalControl        (bool set);
     void    init                        ();
+
+    bool    showAttitudeWidget      () { return _showAttitudeWidget; }
+    void    setShowAttitudeWidget   (bool set);
+
 signals:
     void    showGimbalControlChanged    ();
+    void    showAttitudeWidgetChanged();
+
 private:
     bool    _showGimbalControl  = true;
+    bool _showAttitudeWidget = false;
 };


### PR DESCRIPTION
Add one row at the top of the Custom Vehicle Indicator control to show: lat, lon and hdop

![Screenshot from 2019-08-13 11-12-10](https://user-images.githubusercontent.com/47554641/62929781-7589a600-bdbb-11e9-9332-25b60d3ac52a.png)
