### PR TITLE
Turn on popup errors for mobile builds

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -478,6 +478,12 @@ bool QGCApplication::_initForNormalAppBoot(void)
 
 #ifdef __mobile__
     _qmlAppEngine = toolbox()->corePlugin()->createRootWindow(this);
+
+    // Safe to show popup error messages now that main window is created
+    UASMessageHandler* msgHandler = qgcApp()->toolbox()->uasMessageHandler();
+    if (msgHandler) {
+        msgHandler->showErrorsInToolbar();
+    }
 #else
     // Start the user interface
     MainWindow* mainWindow = MainWindow::_create();


### PR DESCRIPTION
Mobile builds were not showing pop up errors.

Caused by sequence of changes sort of doc'ed here: https://github.com/mavlink/qgroundcontrol/issues/2829. 

I believe there was an initial problem with error messages popping up before the main window was created either causing crashes or a strange race condition on main window creation. There was a fix for that which went in which screwed thing up. Then a fix for that screw up went in which only worked on desktop builds.

Mobile builds don't really have the same race condition crash problems. But even so I changed the code to match enabling popup errors to only display after the main qml window was created.