### PR TITLE
CMake: Add missing source on CMake

### DIFF
--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 add_library(Vehicle
 	ADSBVehicle.cc
 	GPSRTKFactGroup.cc
+	VehicleObjectAvoidance.cc
 	MAVLinkLogManager.cc
 	MultiVehicleManager.cc
 	Vehicle.cc


### PR DESCRIPTION
Fixes build
A recent patch added a new file but forgot to add on the CMake project file.