### PR TITLE
Change goto message to set_position for ArduCopter

### DIFF
--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
@@ -59,6 +59,7 @@ public:
 
     // Overrides from FirmwarePlugin
     void    guidedModeLand                      (Vehicle* vehicle) final;
+    void    guidedModeGotoLocation          (Vehicle* vehicle, const QGeoCoordinate& gotoCoord) override;
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     int     remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const final;
     bool    multiRotorCoaxialMotors             (Vehicle* vehicle) final;


### PR DESCRIPTION

**Goto Location does not work anymore on ArduCopter**

The correct message as sent by MissionPlanner is SET_POSITION_GLOBAL

**To Reproduce**
Steps to reproduce the behavior:
1. Drone flying a mission
2. Click on map to send a Goto Location
3. Error + Drone does not fly GotoLocation

**Explanation**
The current message sent in this case is a MissionItem to set a new waypoint, Arducopter now need a SET_POSITION_TARGET_GLOBAL_INT.
This branch implement a ArduCopter specific version of guidedModeGotoLocation to send the correct message.

Tested and works with the last version of Ardupilot simulator.
