### PR TITLE
Remove dynamic cast

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -47,7 +47,7 @@ customQuickInterfaceSingletonFactory(QQmlEngine*, QJSEngine*)
 {
     qCDebug(CustomLog) << "Creating CustomQuickInterface instance";
     CustomQuickInterface* pIFace = new CustomQuickInterface();
-    CustomPlugin* pPlug = dynamic_cast<CustomPlugin*>(qgcApp()->toolbox()->corePlugin());
+    auto* pPlug = qobject_cast<CustomPlugin*>(qgcApp()->toolbox()->corePlugin());
     if(pPlug) {
         pIFace->init();
     } else {

--- a/custom-example/src/CustomVideoManager.cc
+++ b/custom-example/src/CustomVideoManager.cc
@@ -26,7 +26,7 @@ CustomVideoManager::_updateSettings()
         return;
     //-- Check encoding
     if(_activeVehicle && _activeVehicle->dynamicCameras()) {
-        CustomCameraControl* pCamera = dynamic_cast<CustomCameraControl*>(_activeVehicle->dynamicCameras()->currentCameraInstance());
+        auto* pCamera = qobject_cast<CustomCameraControl*>(_activeVehicle->dynamicCameras()->currentCameraInstance());
         if(pCamera) {
             Fact *fact = pCamera->videoEncoding();
             if (fact) {

--- a/src/Airmap/AirMapAdvisoryManager.cc
+++ b/src/Airmap/AirMapAdvisoryManager.cc
@@ -84,7 +84,7 @@ AirMapAdvisoryManager::_requestAdvisories()
     }
     params.geometry = Geometry(polygon);
     //-- Rulesets
-    AirMapRulesetsManager* pRulesMgr = dynamic_cast<AirMapRulesetsManager*>(qgcApp()->toolbox()->airspaceManager()->ruleSets());
+    auto* pRulesMgr = qobject_cast<AirMapRulesetsManager*>(qgcApp()->toolbox()->airspaceManager()->ruleSets());
     QString ruleIDs;
     if(pRulesMgr) {
         for(int rs = 0; rs < pRulesMgr->ruleSets()->count(); rs++) {

--- a/src/Airmap/AirMapFlightPlanManager.cc
+++ b/src/Airmap/AirMapFlightPlanManager.cc
@@ -428,7 +428,7 @@ AirMapFlightPlanManager::_createFlightPlan()
 void
 AirMapFlightPlanManager::_updateRulesAndFeatures(std::vector<RuleSet::Id>& rulesets, std::unordered_map<std::string, RuleSet::Feature::Value>& features, bool updateFeatures)
 {
-    AirMapRulesetsManager* pRulesMgr = dynamic_cast<AirMapRulesetsManager*>(qgcApp()->toolbox()->airspaceManager()->ruleSets());
+    auto* pRulesMgr = qobject_cast<AirMapRulesetsManager*>(qgcApp()->toolbox()->airspaceManager()->ruleSets());
     if(pRulesMgr) {
         for(int rs = 0; rs < pRulesMgr->ruleSets()->count(); rs++) {
             AirMapRuleSet* ruleSet = qobject_cast<AirMapRuleSet*>(pRulesMgr->ruleSets()->get(rs));

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -360,7 +360,7 @@ void PX4FirmwarePlugin::_mavCommandResult(int vehicleId, int component, int comm
     Q_UNUSED(component);
     Q_UNUSED(noReponseFromVehicle);
 
-    Vehicle* vehicle = dynamic_cast<Vehicle*>(sender());
+    auto* vehicle = qobject_cast<Vehicle*>(sender());
     if (!vehicle) {
         qWarning() << "Dynamic cast failed!";
         return;
@@ -520,7 +520,7 @@ void PX4FirmwarePlugin::_handleAutopilotVersion(Vehicle* vehicle, mavlink_messag
 {
     Q_UNUSED(vehicle);
 
-    PX4FirmwarePluginInstanceData* instanceData = qobject_cast<PX4FirmwarePluginInstanceData*>(vehicle->firmwarePluginInstanceData());
+    auto* instanceData = qobject_cast<PX4FirmwarePluginInstanceData*>(vehicle->firmwarePluginInstanceData());
     if (!instanceData->versionNotified) {
         bool notifyUser = false;
         int supportedMajorVersion = 1;

--- a/src/Taisync/TaisyncManager.cc
+++ b/src/Taisync/TaisyncManager.cc
@@ -318,7 +318,7 @@ TaisyncManager::_setEnabled()
 void
 TaisyncManager::_restoreVideoSettings(Fact* setting)
 {
-    SettingsFact* pFact = dynamic_cast<SettingsFact*>(setting);
+    auto* pFact = qobject_cast<SettingsFact*>(setting);
     if(pFact) {
         pFact->setVisible(qgcApp()->toolbox()->corePlugin()->adjustSettingMetaData(VideoSettings::settingsGroup, *setting->metaData()));
     }

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -304,7 +304,7 @@ void MultiVehicleManager::_setActiveVehiclePhase2(void)
 
 void MultiVehicleManager::_vehicleParametersReadyChanged(bool parametersReady)
 {
-    ParameterManager* paramMgr = dynamic_cast<ParameterManager*>(sender());
+    auto* paramMgr = qobject_cast<ParameterManager*>(sender());
 
     if (!paramMgr) {
         qWarning() << "Dynamic cast failed!";

--- a/src/Vehicle/VehicleObjectAvoidance.cc
+++ b/src/Vehicle/VehicleObjectAvoidance.cc
@@ -46,7 +46,7 @@ VehicleObjectAvoidance::update(mavlink_obstacle_distance_t* message)
     //-- Create a plottable grid with found objects
     _objGrid.clear();
     _objDistance.clear();
-    VehicleSetpointFactGroup* sp = dynamic_cast<VehicleSetpointFactGroup*>(_vehicle->setpointFactGroup());
+    auto* sp = qobject_cast<VehicleSetpointFactGroup*>(_vehicle->setpointFactGroup());
     qreal startAngle = sp->yaw()->rawValue().toDouble() + _angleOffset;
     for(int i = 0; i < MAVLINK_MSG_OBSTACLE_DISTANCE_FIELD_DISTANCES_LEN; i++) {
         if(_distances[i] < _maxDistance && message->distances[i] != UINT16_MAX) {

--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -270,7 +270,7 @@ QString BluetoothConfiguration::settingsTitle()
 void BluetoothConfiguration::copyFrom(LinkConfiguration *source)
 {
     LinkConfiguration::copyFrom(source);
-    BluetoothConfiguration* usource = dynamic_cast<BluetoothConfiguration*>(source);
+    auto* usource = qobject_cast<BluetoothConfiguration*>(source);
     Q_ASSERT(usource != nullptr);
     _device = usource->device();
 }
@@ -303,7 +303,7 @@ void BluetoothConfiguration::loadSettings(QSettings& settings, const QString& ro
 void BluetoothConfiguration::updateSettings()
 {
     if(_link) {
-        BluetoothLink* ulink = dynamic_cast<BluetoothLink*>(_link);
+        auto* ulink = qobject_cast<BluetoothLink*>(_link);
         if(ulink) {
             ulink->_restartConnection();
         }

--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -118,26 +118,26 @@ LinkConfiguration* LinkConfiguration::duplicateSettings(LinkConfiguration* sourc
     switch(source->type()) {
 #ifndef NO_SERIAL_LINK
         case TypeSerial:
-            dupe = new SerialConfiguration(dynamic_cast<SerialConfiguration*>(source));
+            dupe = new SerialConfiguration(qobject_cast<SerialConfiguration*>(source));
             break;
 #endif
         case TypeUdp:
-            dupe = new UDPConfiguration(dynamic_cast<UDPConfiguration*>(source));
+            dupe = new UDPConfiguration(qobject_cast<UDPConfiguration*>(source));
             break;
         case TypeTcp:
-            dupe = new TCPConfiguration(dynamic_cast<TCPConfiguration*>(source));
+            dupe = new TCPConfiguration(qobject_cast<TCPConfiguration*>(source));
             break;
 #ifdef QGC_ENABLE_BLUETOOTH
         case TypeBluetooth:
-            dupe = new BluetoothConfiguration(dynamic_cast<BluetoothConfiguration*>(source));
+            dupe = new BluetoothConfiguration(qobject_cast<BluetoothConfiguration*>(source));
             break;
 #endif
         case TypeLogReplay:
-            dupe = new LogReplayLinkConfiguration(dynamic_cast<LogReplayLinkConfiguration*>(source));
+            dupe = new LogReplayLinkConfiguration(qobject_cast<LogReplayLinkConfiguration*>(source));
             break;
 #ifdef QT_DEBUG
         case TypeMock:
-            dupe = new MockConfiguration(dynamic_cast<MockConfiguration*>(source));
+            dupe = new MockConfiguration(qobject_cast<MockConfiguration*>(source));
             break;
 #endif
         case TypeLast:

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -114,11 +114,11 @@ LinkInterface* LinkManager::createConnectedLink(SharedLinkConfigurationPointer& 
 #ifndef NO_SERIAL_LINK
     case LinkConfiguration::TypeSerial:
     {
-        SerialConfiguration* serialConfig = dynamic_cast<SerialConfiguration*>(config.data());
+        auto* serialConfig = qobject_cast<SerialConfiguration*>(config.data());
         if (serialConfig) {
             pLink = new SerialLink(config, isPX4Flow);
             if (serialConfig->usbDirect()) {
-                _activeLinkCheckList.append(dynamic_cast<SerialLink*>(pLink));
+                _activeLinkCheckList.append(qobject_cast<SerialLink*>(pLink));
                 if (!_activeLinkCheckTimer.isActive()) {
                     _activeLinkCheckTimer.start();
                 }
@@ -378,26 +378,26 @@ void LinkManager::loadLinkConfigurationList()
                             switch(type) {
 #ifndef NO_SERIAL_LINK
                             case LinkConfiguration::TypeSerial:
-                                pLink = dynamic_cast<LinkConfiguration*>(new SerialConfiguration(name));
+                                pLink = new SerialConfiguration(name);
                                 break;
 #endif
                             case LinkConfiguration::TypeUdp:
-                                pLink = dynamic_cast<LinkConfiguration*>(new UDPConfiguration(name));
+                                pLink = new UDPConfiguration(name);
                                 break;
                             case LinkConfiguration::TypeTcp:
-                                pLink = dynamic_cast<LinkConfiguration*>(new TCPConfiguration(name));
+                                pLink = new TCPConfiguration(name);
                                 break;
 #ifdef QGC_ENABLE_BLUETOOTH
                             case LinkConfiguration::TypeBluetooth:
-                                pLink = dynamic_cast<LinkConfiguration*>(new BluetoothConfiguration(name));
+                                pLink = new BluetoothConfiguration(name);
                                 break;
 #endif
                             case LinkConfiguration::TypeLogReplay:
-                                pLink = dynamic_cast<LinkConfiguration*>(new LogReplayLinkConfiguration(name));
+                                pLink = new LogReplayLinkConfiguration(name);
                                 break;
 #ifdef QT_DEBUG
                             case LinkConfiguration::TypeMock:
-                                pLink = dynamic_cast<LinkConfiguration*>(new MockConfiguration(name));
+                                pLink = new MockConfiguration(name);
                                 break;
 #endif
                             case LinkConfiguration::TypeLast:

--- a/src/comm/LogReplayLink.cc
+++ b/src/comm/LogReplayLink.cc
@@ -33,7 +33,7 @@ LogReplayLinkConfiguration::LogReplayLinkConfiguration(LogReplayLinkConfiguratio
 void LogReplayLinkConfiguration::copyFrom(LinkConfiguration *source)
 {
     LinkConfiguration::copyFrom(source);
-    LogReplayLinkConfiguration* ssource = dynamic_cast<LogReplayLinkConfiguration*>(source);
+    auto* ssource = qobject_cast<LogReplayLinkConfiguration*>(source);
     if (ssource) {
         _logFilename = ssource->logFilename();
     } else {

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -1134,7 +1134,7 @@ MockConfiguration::MockConfiguration(MockConfiguration* source)
 void MockConfiguration::copyFrom(LinkConfiguration *source)
 {
     LinkConfiguration::copyFrom(source);
-    MockConfiguration* usource = dynamic_cast<MockConfiguration*>(source);
+    auto* usource = qobject_cast<MockConfiguration*>(source);
 
     if (!usource) {
         qWarning() << "dynamic_cast failed" << source << usource;

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -405,7 +405,7 @@ SerialConfiguration::SerialConfiguration(SerialConfiguration* copy) : LinkConfig
 void SerialConfiguration::copyFrom(LinkConfiguration *source)
 {
     LinkConfiguration::copyFrom(source);
-    SerialConfiguration* ssource = dynamic_cast<SerialConfiguration*>(source);
+    auto* ssource = qobject_cast<SerialConfiguration*>(source);
     if (ssource) {
         _baud               = ssource->baud();
         _flowControl        = ssource->flowControl();
@@ -423,7 +423,7 @@ void SerialConfiguration::copyFrom(LinkConfiguration *source)
 void SerialConfiguration::updateSettings()
 {
     if(_link) {
-        SerialLink* serialLink = dynamic_cast<SerialLink*>(_link);
+        auto* serialLink = qobject_cast<SerialLink*>(_link);
         if(serialLink) {
             serialLink->_resetConfiguration();
         }

--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -280,7 +280,7 @@ TCPConfiguration::TCPConfiguration(TCPConfiguration* source) : LinkConfiguration
 void TCPConfiguration::copyFrom(LinkConfiguration *source)
 {
     LinkConfiguration::copyFrom(source);
-    TCPConfiguration* usource = dynamic_cast<TCPConfiguration*>(source);
+    auto* usource = qobject_cast<TCPConfiguration*>(source);
     Q_ASSERT(usource != NULL);
     _port    = usource->port();
     _address = usource->address();
@@ -326,7 +326,7 @@ void TCPConfiguration::loadSettings(QSettings& settings, const QString& root)
 void TCPConfiguration::updateSettings()
 {
     if(_link) {
-        TCPLink* ulink = dynamic_cast<TCPLink*>(_link);
+        auto* ulink = qobject_cast<TCPLink*>(_link);
         if(ulink) {
             ulink->_restartConnection();
         }

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -396,7 +396,7 @@ void UDPConfiguration::copyFrom(LinkConfiguration *source)
 
 void UDPConfiguration::_copyFrom(LinkConfiguration *source)
 {
-    UDPConfiguration* usource = dynamic_cast<UDPConfiguration*>(source);
+    auto* usource = qobject_cast<UDPConfiguration*>(source);
     if (usource) {
         _localPort = usource->localPort();
         _clearTargetHosts();

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -1094,7 +1094,7 @@ void UAS::pairRX(int rxType, int rxSubType)
 #ifndef __mobile__
 void UAS::enableHilJSBSim(bool enable, QString options)
 {
-    QGCJSBSimLink* link = dynamic_cast<QGCJSBSimLink*>(simulation);
+    auto* link = qobject_cast<QGCJSBSimLink*>(simulation);
     if (!link) {
         // Delete wrong sim
         if (simulation) {
@@ -1104,7 +1104,7 @@ void UAS::enableHilJSBSim(bool enable, QString options)
         simulation = new QGCJSBSimLink(_vehicle, options);
     }
     // Connect Flight Gear Link
-    link = dynamic_cast<QGCJSBSimLink*>(simulation);
+    link = qobject_cast<QGCJSBSimLink*>(simulation);
     link->setStartupArguments(options);
     if (enable)
     {
@@ -1123,7 +1123,7 @@ void UAS::enableHilJSBSim(bool enable, QString options)
 #ifndef __mobile__
 void UAS::enableHilXPlane(bool enable)
 {
-    QGCXPlaneLink* link = dynamic_cast<QGCXPlaneLink*>(simulation);
+    auto* link = qobject_cast<QGCXPlaneLink*>(simulation);
     if (!link) {
         if (simulation) {
             stopHil();


### PR DESCRIPTION
Remove dynaic casts thru the software for objects that inherti from QObject.
qobject_cast does not use RTTI and thus is much faster. Also, use `auto` keyword to not repeat class names when the class name is explicit.