### PR TITLE
Enable video running time and shutter count

### DIFF
--- a/custom-example/res/CustomCameraControl.qml
+++ b/custom-example/res/CustomCameraControl.qml
@@ -379,22 +379,20 @@ Item {
                             anchors.horizontalCenter: parent.horizontalCenter
                         }
                     }
-                    /*
                     //-----------------------------------------------------------------
                     //-- Recording Time / Images Captured
-                    CustomLabel {
+                    QGCLabel {
                         text:               (_cameraVideoMode && _camera.videoStatus === QGCCameraControl.VIDEO_CAPTURE_STATUS_RUNNING) ? _camera.recordTimeStr : "00:00:00"
                         visible:            _cameraVideoMode
-                        pointSize:          ScreenTools.smallFontPointSize
+                        font.pointSize:     ScreenTools.smallFontPointSize
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
-                    CustomLabel {
+                    QGCLabel {
                         text:               activeVehicle && _cameraPhotoMode ? ('00000' + activeVehicle.cameraTriggerPoints.count).slice(-5) : "00000"
                         visible:            _cameraPhotoMode
-                        pointSize:          ScreenTools.smallFontPointSize
+                        font.pointSize:     ScreenTools.smallFontPointSize
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
-                    */
                     Item {
                         height:     1
                         width:      1


### PR DESCRIPTION
Video running time (when recording video)
<img width="1026" alt="Screen Shot 2019-08-20 at 10 20 29 PM" src="https://user-images.githubusercontent.com/749243/63397630-34842980-c399-11e9-8855-7c42c341d277.png">

Shutter count (when capturing photos)
<img width="1026" alt="Screen Shot 2019-08-20 at 10 21 16 PM" src="https://user-images.githubusercontent.com/749243/63397656-4bc31700-c399-11e9-8759-61342ceb1676.png">
