### PR TITLE
Add oucoming messages in tlog

### DIFF
--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -78,7 +78,7 @@ void BluetoothLink::_writeBytes(const QByteArray bytes)
 {
     if (_targetSocket) {
         if(_targetSocket->write(bytes) > 0) {
-            emit bytesSent(this, data);
+            emit bytesSent(this, bytes);
             _logOutputDataRate(bytes.size(), QDateTime::currentMSecsSinceEpoch());
         } else {
             qWarning() << "Bluetooth write error";

--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -78,6 +78,7 @@ void BluetoothLink::_writeBytes(const QByteArray bytes)
 {
     if (_targetSocket) {
         if(_targetSocket->write(bytes) > 0) {
+            emit bytesSent(this, data);
             _logOutputDataRate(bytes.size(), QDateTime::currentMSecsSinceEpoch());
         } else {
             qWarning() << "Bluetooth write error";

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -182,6 +182,16 @@ signals:
     void bytesReceived(LinkInterface* link, QByteArray data);
 
     /**
+     * @brief New data has been sent
+     * *
+     * The new data is contained in the QByteArray data.
+     * The data is logged into telemetry logging system
+     *
+     * @param data the new bytes
+     */
+    void bytesSent(LinkInterface* link, QByteArray data);
+
+    /**
      * @brief This signal is emitted instantly when the link is connected
      **/
     void connected();

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -199,6 +199,7 @@ void LinkManager::_addLink(LinkInterface* link)
 
     connect(link, &LinkInterface::communicationError,   _app,               &QGCApplication::criticalMessageBoxOnMainThread);
     connect(link, &LinkInterface::bytesReceived,        _mavlinkProtocol,   &MAVLinkProtocol::receiveBytes);
+    connect(link, &LinkInterface::bytesSent,            _mavlinkProtocol,   &MAVLinkProtocol::logSentBytes);
 
     _mavlinkProtocol->resetMetadataForLink(link);
     _mavlinkProtocol->setVersion(_mavlinkProtocol->getCurrentVersion());

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -170,21 +170,23 @@ void MAVLinkProtocol::logSentBytes(LinkInterface* link, QByteArray b){
     uint8_t bytes_time[sizeof(quint64)];
 
     Q_UNUSED(link);
+    if (!_logSuspendError && !_logSuspendReplay && _tempLogFile.isOpen()) {
 
-    quint64 time = static_cast<quint64>(QDateTime::currentMSecsSinceEpoch() * 1000);
+        quint64 time = static_cast<quint64>(QDateTime::currentMSecsSinceEpoch() * 1000);
 
-    qToBigEndian(time,bytes_time);
+        qToBigEndian(time,bytes_time);
 
-    b.insert(0,QByteArray((const char*)bytes_time,sizeof(bytes_time)));
+        b.insert(0,QByteArray((const char*)bytes_time,sizeof(bytes_time)));
 
-    int len = b.count(); 
+        int len = b.count();
 
-    if(_tempLogFile.write(b) != len)
-    {
-        // If there's an error logging data, raise an alert and stop logging.
-        emit protocolStatusMessage(tr("MAVLink Protocol"), tr("MAVLink Logging failed. Could not write to file %1, logging disabled.").arg(_tempLogFile.fileName()));
-        _stopLogging();
-        _logSuspendError = true;
+        if(_tempLogFile.write(b) != len)
+        {
+            // If there's an error logging data, raise an alert and stop logging.
+            emit protocolStatusMessage(tr("MAVLink Protocol"), tr("MAVLink Logging failed. Could not write to file %1, logging disabled.").arg(_tempLogFile.fileName()));
+            _stopLogging();
+            _logSuspendError = true;
+        }
     }
 
 }

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -81,6 +81,9 @@ public:
 public slots:
     /** @brief Receive bytes from a communication interface */
     void receiveBytes(LinkInterface* link, QByteArray b);
+
+    /** @brief Log bytes sent from a communication interface */
+    void logSentBytes(LinkInterface* link, QByteArray b);
     
     /** @brief Set the system id of this application */
     void setSystemId(int id);

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -84,6 +84,7 @@ bool SerialLink::_isBootloader()
 void SerialLink::_writeBytes(const QByteArray data)
 {
     if(_port && _port->isOpen()) {
+        emit bytesSent(this, data);
         _logOutputDataRate(data.size(), QDateTime::currentMSecsSinceEpoch());
         _port->write(data);
     } else {

--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -81,6 +81,7 @@ void TCPLink::_writeBytes(const QByteArray data)
 
     if (_socket) {
         _socket->write(data);
+        emit bytesSent(this, data);
         _logOutputDataRate(data.size(), QDateTime::currentMSecsSinceEpoch());
     }
 }

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -169,6 +169,7 @@ void UDPLink::_writeBytes(const QByteArray data)
     if (!_socket) {
         return;
     }
+    emit bytesSent(this, data);
     // Send to all manually targeted systems
     for(UDPCLient* target: _udpConfig->targetHosts()) {
         // Skip it if it's part of the session clients below


### PR DESCRIPTION
It appear really useful to have both messages sent and received in the telemetry log from QGC :
- To have the complete story of which order trig which response from the drone
- To analyze all messages sent/received
- To retrieve all orders sent while replaying a mission

Here the changes I propose : 

- Add a signal emitted by writeBytes of each LinkInterface (TCP/UDP for the moment)
- Connect this signal to MAVLinkProtocol::logSentBytes in LinkManager
- MAVLinkProtocol::logSentBytes will log messages sent from
  QGC

