### PR TITLE
Make advanced mode persistent

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -86,7 +86,8 @@ CustomPlugin::CustomPlugin(QGCApplication *app, QGCToolbox* toolbox)
     : QGCCorePlugin(app, toolbox)
 {
     _pOptions = new CustomOptions(this, this);
-    _showAdvancedUI = false;
+    if(!_settings.contains(_kShowAdvancedUI))
+        _showAdvancedUI = false;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -23,6 +23,9 @@
 #include <QtQml>
 #include <QQmlEngine>
 
+const char* QGCCorePlugin::_kSettingsGroupName = "CorePlugin";
+const char* QGCCorePlugin::_kShowAdvancedUI = "ShowAdvacedUI";
+
 /// @file
 ///     @brief Core Plugin Interface for QGroundControl - Default Implementation
 ///     @author Gus Grubba <mavlink@grubba.com>
@@ -114,8 +117,9 @@ QGCCorePlugin::~QGCCorePlugin()
 QGCCorePlugin::QGCCorePlugin(QGCApplication *app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
     , _showTouchAreas(false)
-    , _showAdvancedUI(true)
 {
+    _settings.beginGroup(_kSettingsGroupName);
+    _showAdvancedUI = _settings.value(_kShowAdvancedUI, true).toBool();
     _p = new QGCCorePlugin_p;
 }
 
@@ -361,6 +365,7 @@ void QGCCorePlugin::setShowAdvancedUI(bool show)
 {
     if (show != _showAdvancedUI) {
         _showAdvancedUI = show;
+        _settings.setValue(_kShowAdvancedUI, QVariant(_showAdvancedUI));
         emit showAdvancedUIChanged(show);
     }
 }

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -16,6 +16,7 @@
 
 #include <QObject>
 #include <QVariantList>
+#include <QSettings>
 
 /// @file
 ///     @brief Core Plugin Interface for QGroundControl
@@ -177,6 +178,10 @@ protected:
     Vehicle*            _activeVehicle  = nullptr;
     QGCCameraManager*   _dynamicCameras = nullptr;
     QGCCameraControl*   _currentCamera  = nullptr;
+
+    QSettings           _settings;
+    static const char*  _kSettingsGroupName;
+    static const char*  _kShowAdvancedUI;
 
 private:
     QGCCorePlugin_p*    _p;


### PR DESCRIPTION
Keep the state of advanced mode. Default is enabled for QGC and disabled for custom-example