### PR TITLE
Remove all references to Pairing if it's not supported.

### DIFF
--- a/custom-example/res/MainToolbar/CustomMainToolBarIndicators.qml
+++ b/custom-example/res/MainToolbar/CustomMainToolBarIndicators.qml
@@ -34,7 +34,7 @@ Item {
         anchors.left:               parent.left
         QGCColoredImage {
             id:                     menuEdge
-            visible:                !QGroundControl.settingsManager.appSettings.usePairing.rawValue
+            visible:                !QGroundControl.supportsPairing || !QGroundControl.settingsManager.appSettings.usePairing.rawValue
             anchors.verticalCenter: parent.verticalCenter
             height:                 ScreenTools.defaultFontPixelHeight
             width:                  height
@@ -44,14 +44,14 @@ Item {
             color:                  qgcPal.buttonText
         }
         QGCLabel {
-            visible:                !QGroundControl.settingsManager.appSettings.usePairing.rawValue
+            visible:                menuEdge.visible
             anchors.verticalCenter: parent.verticalCenter
             text:                   qsTr("Waiting for a vehicle")
             font.pointSize:         ScreenTools.mediumFontPointSize
             font.family:            ScreenTools.demiboldFontFamily
         }
         Loader {
-            visible:                QGroundControl.settingsManager.appSettings.usePairing.rawValue
+            visible:                !menuEdge.visible
             anchors.top:            parent.top
             anchors.bottom:         parent.bottom
             anchors.margins:        _indicatorMargins

--- a/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.cc
+++ b/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.cc
@@ -55,7 +55,9 @@ CustomFirmwarePlugin::toolBarIndicators(const Vehicle* vehicle)
 {
     Q_UNUSED(vehicle);
     if(_toolBarIndicatorList.size() == 0) {
+#if defined(QGC_ENABLE_PAIRING)
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/PairingIndicator.qml")));
+#endif
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")));
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")));
         _toolBarIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")));

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -78,6 +78,7 @@ public:
     Q_PROPERTY(bool                 taisyncSupported    READ taisyncSupported       CONSTANT)
     Q_PROPERTY(MicrohardManager*    microhardManager    READ microhardManager       CONSTANT)
     Q_PROPERTY(bool                 microhardSupported  READ microhardSupported     CONSTANT)
+    Q_PROPERTY(bool                 supportsPairing     READ supportsPairing        CONSTANT)
 #if defined(QGC_ENABLE_PAIRING)
     Q_PROPERTY(PairingManager*      pairingManager      READ pairingManager         CONSTANT)
 #endif
@@ -176,19 +177,22 @@ public:
     FactGroup*              gpsRtkFactGroup     ()  { return _gpsRtkFactGroup; }
     AirspaceManager*        airspaceManager     ()  { return _airspaceManager; }
 #if defined(QGC_ENABLE_PAIRING)
+    bool                    supportsPairing     ()  { return true; }
     PairingManager*         pairingManager      ()  { return _pairingManager; }
+#else
+    bool                    supportsPairing     ()  { return false; }
 #endif
     static QGeoCoordinate   flightMapPosition   ()  { return _coord; }
     static double           flightMapZoom       ()  { return _zoom; }
 
     TaisyncManager*         taisyncManager      ()  { return _taisyncManager; }
 #if defined(QGC_GST_TAISYNC_ENABLED)
-    bool                    taisyncSupported    () { return true; }
+    bool                    taisyncSupported    ()  { return true; }
 #else
     bool                    taisyncSupported    () { return false; }
 #endif
 
-    MicrohardManager*       microhardManager    ()  { return _microhardManager; }
+    MicrohardManager*       microhardManager    () { return _microhardManager; }
 #if defined(QGC_GST_TAISYNC_ENABLED)
     bool                    microhardSupported  () { return true; }
 #else

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -251,7 +251,7 @@ Rectangle {
                                 FactCheckBox {
                                     text:       qsTr("Use Vehicle Pairing")
                                     fact:       _usePairing
-                                    visible:    _usePairing && _usePairing.visible
+                                    visible:    _usePairing && _usePairing.visible && QGroundControl.supportsPairing
                                     property Fact _usePairing: QGroundControl.settingsManager.appSettings.usePairing
                                 }
 

--- a/src/ui/toolbar/PairingIndicator.qml
+++ b/src/ui/toolbar/PairingIndicator.qml
@@ -124,7 +124,7 @@ Item {
                 }
                 Item { width: 1; height: 1; }
                 Repeater {
-                    model:          QGroundControl.pairingManager.pairingLinkTypeStrings
+                    model:          QGroundControl.pairingManager ? QGroundControl.pairingManager.pairingLinkTypeStrings : []
                     delegate:       QGCButton {
                         text:       modelData
                         width:      _contentWidth
@@ -309,7 +309,7 @@ Item {
                 anchors.centerIn:   parent
                 Item { width: 1; height: 1; }
                 QGCLabel {
-                    text:           QGroundControl.pairingManager.pairingStatusStr
+                    text:           QGroundControl.pairingManager ? QGroundControl.pairingManager.pairingStatusStr : ""
                     font.pointSize: ScreenTools.mediumFontPointSize
                     font.family:    ScreenTools.demiboldFontFamily
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -336,20 +336,20 @@ Item {
                     }
                 }
                 QGCLabel {
-                    text:           qsTr("List Of Available Devices")
-                    visible:        QGroundControl.pairingManager.pairedDeviceNameList.length > 0 && !cancelButton.visible
-                    font.pointSize: ScreenTools.mediumFontPointSize
-                    font.family:    ScreenTools.demiboldFontFamily
+                    text:               qsTr("List Of Available Devices")
+                    visible:            QGroundControl.pairingManager ? (QGroundControl.pairingManager.pairedDeviceNameList.length > 0 && !cancelButton.visible) : false
+                    font.pointSize:     ScreenTools.mediumFontPointSize
+                    font.family:        ScreenTools.demiboldFontFamily
                 }
                 Item { width: 1; height: 1; }
                 GridLayout {
-                    columns:        3
-                    visible:        QGroundControl.pairingManager.pairedDeviceNameList.length > 0 && !cancelButton.visible
-                    columnSpacing:  ScreenTools.defaultFontPixelWidth
-                    rowSpacing:     ScreenTools.defaultFontPixelHeight * 0.25
+                    columns:            3
+                    visible:            QGroundControl.pairingManager ? (QGroundControl.pairingManager.pairedDeviceNameList.length > 0 && !cancelButton.visible) : false
+                    columnSpacing:      ScreenTools.defaultFontPixelWidth
+                    rowSpacing:         ScreenTools.defaultFontPixelHeight * 0.25
                     anchors.horizontalCenter: parent.horizontalCenter
                     Repeater {
-                        model:      QGroundControl.pairingManager.pairedDeviceNameList
+                        model:          QGroundControl.pairingManager ? QGroundControl.pairingManager.pairedDeviceNameList : []
                         QGCLabel {
                             text:   modelData
                             Layout.row:         index
@@ -359,7 +359,7 @@ Item {
                         }
                     }
                     Repeater {
-                        model:      QGroundControl.pairingManager.pairedDeviceNameList
+                        model:          QGroundControl.pairingManager ? QGroundControl.pairingManager.pairedDeviceNameList : []
                         QGCButton {
                             text:               qsTr("Connect")
                             Layout.row:         index
@@ -370,7 +370,7 @@ Item {
                         }
                     }
                     Repeater {
-                        model:      QGroundControl.pairingManager.pairedDeviceNameList
+                        model:          QGroundControl.pairingManager ? QGroundControl.pairingManager.pairedDeviceNameList : []
                         QGCColoredImage {
                             height:             ScreenTools.defaultFontPixelHeight * 1.5
                             width:              height
@@ -391,7 +391,7 @@ Item {
                 Item { width: 1; height: 1; }
                 RowLayout {
                     id:                         connectedButtons
-                    visible:                    QGroundControl.pairingManager.pairingStatus === PairingManager.PairingConnected || QGroundControl.pairingManager.pairingStatus === PairingManager.PairingIdle
+                    visible:                    QGroundControl.pairingManager ? (QGroundControl.pairingManager.pairingStatus === PairingManager.PairingConnected || QGroundControl.pairingManager.pairingStatus === PairingManager.PairingIdle) : false
                     spacing:                    ScreenTools.defaultFontPixelWidth * 4
                     anchors.horizontalCenter:   parent.horizontalCenter
                     QGCButton {
@@ -408,7 +408,7 @@ Item {
                         }
                     }
                     QGCButton {
-                        text:                   QGroundControl.pairingManager.pairingStatus === PairingManager.PairingConnected ? qsTr("Go And Fly") : qsTr("Close")
+                        text:                   QGroundControl.pairingManager ? (QGroundControl.pairingManager.pairingStatus === PairingManager.PairingConnected ? qsTr("Go And Fly") : qsTr("Close")) : ""
                         Layout.minimumWidth:    _contentWidth * 0.333
                         Layout.fillWidth:       true
                         onClicked: {
@@ -418,7 +418,7 @@ Item {
                 }
                 QGCButton {
                     id:                         cancelButton
-                    visible:                    QGroundControl.pairingManager.pairingStatus === PairingManager.PairingActive || QGroundControl.pairingManager.pairingStatus === PairingManager.PairingConnecting
+                    visible:                    QGroundControl.pairingManager ? (QGroundControl.pairingManager.pairingStatus === PairingManager.PairingActive || QGroundControl.pairingManager.pairingStatus === PairingManager.PairingConnecting) : false
                     text:                       qsTr("Cancel")
                     width:                      _contentWidth
                     anchors.horizontalCenter:   parent.horizontalCenter


### PR DESCRIPTION
If pairing is not supported (or disabled manually), make sure all UI elements related to it are not shown.