### PR TITLE
Prevent Microhard handler from locking main thread

### DIFF
--- a/src/Microhard/MicrohardHandler.cc
+++ b/src/Microhard/MicrohardHandler.cc
@@ -42,21 +42,27 @@ MicrohardHandler::close()
 }
 
 //-----------------------------------------------------------------------------
-bool
+void
 MicrohardHandler::_start(uint16_t port, QHostAddress addr)
 {
     close();
-
     _tcpSocket = new QTcpSocket();
     QObject::connect(_tcpSocket, &QIODevice::readyRead, this, &MicrohardHandler::_readBytes);
     qCDebug(MicrohardLog) << "Connecting to" << addr;
     _tcpSocket->connectToHost(addr, port);
-    //-- TODO: This has to be removed. It's blocking the main thread.
-    if (!_tcpSocket->waitForConnected(1000)) {
+    QTimer::singleShot(1000, this, &MicrohardHandler::_testConnection);
+}
+
+//-----------------------------------------------------------------------------
+void
+MicrohardHandler::_testConnection()
+{
+    if(_tcpSocket) {
+        if(_tcpSocket->state() == QAbstractSocket::ConnectedState) {
+            qCDebug(MicrohardLog) << "Connected";
+            return;
+        }
         emit connected(0);
         close();
-        return false;
     }
-
-    return true;
 }

--- a/src/Microhard/MicrohardHandler.h
+++ b/src/Microhard/MicrohardHandler.h
@@ -29,10 +29,11 @@ public:
     virtual bool close                  ();
 
 protected:
-    virtual bool    _start              (uint16_t port, QHostAddress addr = QHostAddress::AnyIPv4);
+    virtual void _start                 (uint16_t port, QHostAddress addr = QHostAddress::AnyIPv4);
 
 protected slots:
     virtual void    _readBytes          () = 0;
+    virtual void    _testConnection     ();
 
 signals:
     void connected                      (int status);

--- a/src/Microhard/MicrohardManager.cc
+++ b/src/Microhard/MicrohardManager.cc
@@ -205,7 +205,13 @@ MicrohardManager::_setEnabled()
 void
 MicrohardManager::_connectedLoc(int status)
 {
-    qCDebug(MicrohardLog) << "GND Microhard Settings Connected";
+    static const char* msg = "GND Microhard Settings: ";
+    if(status > 0)
+        qCDebug(MicrohardLog) << msg << "Connected";
+    else if(status < 0)
+        qCDebug(MicrohardLog) << msg << "Error";
+    else
+        qCDebug(MicrohardLog) << msg << "Not Connected";
     _connectedStatus = status;
     _locTimer.start(LONG_TIMEOUT);
     emit connectedChanged();
@@ -215,7 +221,13 @@ MicrohardManager::_connectedLoc(int status)
 void
 MicrohardManager::_connectedRem(int status)
 {
-    qCDebug(MicrohardLog) << "AIR Microhard Settings Connected";
+    static const char* msg = "AIR Microhard Settings: ";
+    if(status > 0)
+        qCDebug(MicrohardLog) << msg << "Connected";
+    else if(status < 0)
+        qCDebug(MicrohardLog) << msg << "Error";
+    else
+        qCDebug(MicrohardLog) << msg << "Not Connected";
     _linkConnectedStatus = status;
     _remTimer.start(LONG_TIMEOUT);
     emit linkConnectedChanged();

--- a/src/Microhard/MicrohardSettings.cc
+++ b/src/Microhard/MicrohardSettings.cc
@@ -27,7 +27,8 @@ MicrohardSettings::start()
 {
     qCDebug(MicrohardLog) << "Start Microhard Settings";
     _loggedIn = false;
-    return _start(MICROHARD_SETTINGS_PORT, QHostAddress(_address));
+    _start(MICROHARD_SETTINGS_PORT, QHostAddress(_address));
+    return true;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Don't wait for connection on main thread. Instead, use a `QTimer::singleShot()` to check it later.