### PR TITLE
Disable Pairing code on Android 64 bit builds

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -92,20 +92,6 @@ exists($$MAVLINKPATH/common) {
 INCLUDEPATH += libs/eigen
 DEFINES += NOMINMAX
 
-# Pairing
-MacBuild {
-    #- Pairing is generally not supported on macOS. This is here solely for development.
-    exists(/usr/local/Cellar/openssl/1.0.2s/include) {
-        INCLUDEPATH += /usr/local/Cellar/openssl/1.0.2s/include
-        LIBS += -L/usr/local/Cellar/openssl/1.0.2s/lib
-        LIBS += -lcrypto -lz
-    } else {
-        DEFINES += QGC_DISABLE_PAIRING
-    }
-} else {
-    LIBS += -lcrypto -lz
-}
-
 #
 # [REQUIRED] shapelib library
 INCLUDEPATH += libs/shapelib
@@ -148,19 +134,44 @@ MacBuild {
 		-llibeay32
 }
 
+# Include Android OpenSSL libs in order to make Qt OpenSSL support work
 AndroidBuild {
     contains(QT_ARCH, arm) {
         ANDROID_EXTRA_LIBS += $$BASEDIR/libs/OpenSSL/Android/arch-armeabi-v7a/lib/libcrypto.so
         ANDROID_EXTRA_LIBS += $$BASEDIR/libs/OpenSSL/Android/arch-armeabi-v7a/lib/libssl.so
-        LIBS += $$ANDROID_EXTRA_LIBS
-        INCLUDEPATH += $$BASEDIR/libs/OpenSSL/Android/arch-armeabi-v7a/include
     } else:contains(QT_ARCH, arm64) {
         # Haven't figured out how to get 64 bit arm OpenSLL yet. This means things like terrain queries will not qork.
     } else {
         ANDROID_EXTRA_LIBS += $$BASEDIR/libs/OpenSSL/Android/arch-x86/lib/libcrypto.so
         ANDROID_EXTRA_LIBS += $$BASEDIR/libs/OpenSSL/Android/arch-x86/lib/libssl.so
-        LIBS += $$ANDROID_EXTRA_LIBS
-        INCLUDEPATH += $$BASEDIR/libs/OpenSSL/Android/arch-x86/include
+    }
+}
+
+# Pairing
+contains(DEFINES, QGC_ENABLE_PAIRING) {
+    MacBuild {
+        #- Pairing is generally not supported on macOS. This is here solely for development.
+        exists(/usr/local/Cellar/openssl/1.0.2s/include) {
+            INCLUDEPATH += /usr/local/Cellar/openssl/1.0.2s/include
+            LIBS += -L/usr/local/Cellar/openssl/1.0.2s/lib
+            LIBS += -lcrypto -lz
+        } else {
+            # There is some circular reference settings going on between QGCExternalLibs.pri and gqgroundcontrol.pro.
+            # So this duplicates some of the enable/disable logic which would normally be in qgroundcontrol.pro.
+            DEFINES -= QGC_ENABLE_NFC
+            DEFINES -= QGC_ENABLE_PAIRING
+        }
+    } else {
+        LIBS += -lcrypto -lz
+        AndroidBuild {
+            contains(QT_ARCH, arm) {
+                LIBS += $$ANDROID_EXTRA_LIBS
+                INCLUDEPATH += $$BASEDIR/libs/OpenSSL/Android/arch-armeabi-v7a/include
+            } else {
+                LIBS += $$ANDROID_EXTRA_LIBS
+                INCLUDEPATH += $$BASEDIR/libs/OpenSSL/Android/arch-x86/include
+            }
+        }
     }
 }
 

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -313,12 +313,6 @@ DebugBuild {
 
 include(src/QtLocationPlugin/QGCLocationPlugin.pri)
 
-#
-# External library configuration
-#
-
-include(QGCExternalLibs.pri)
-
 # Pairing
 contains (DEFINES, QGC_DISABLE_PAIRING) {
     message("Skipping support for Pairing")
@@ -326,10 +320,20 @@ contains (DEFINES, QGC_DISABLE_PAIRING) {
 } else:exists(user_config.pri):infile(user_config.pri, DEFINES, QGC_DISABLE_PAIRING) {
     message("Skipping support for Pairing (manual override from user_config.pri)")
     DEFINES -= QGC_ENABLE_NFC
+} else:AndroidBuild:contains(QT_ARCH, arm64) {
+    # Haven't figured out how to get 64 bit arm OpenSLL yet which pairing requires
+    message("Skipping support for Pairing (Missing Android OpenSSL 64 bit support)")
+    DEFINES -= QGC_ENABLE_NFC
 } else {
     message("Enabling support for Pairing")
     DEFINES += QGC_ENABLE_PAIRING
 }
+
+#
+# External library configuration
+#
+
+include(QGCExternalLibs.pri)
 
 #
 # Resources (custom code can replace them)


### PR DESCRIPTION
Haven't found any Android OpenSSL builds yet to make this work.