### PR TITLE
More android bitness

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -46,12 +46,18 @@ linux {
         QMAKE_CFLAGS += -Wno-unused-command-line-argument
         QMAKE_LINK += -nostdlib++ # Hack fix?: https://forum.qt.io/topic/103713/error-cannot-find-lc-qt-5-12-android
         target.path = $$DESTDIR
-        equals(ANDROID_TARGET_ARCH, x86)  {
+        equals(ANDROID_TARGET_ARCH, armeabi-v7a)  {
+            DEFINES += __androidArm32__
+            message("Android Arm 32 bit build")
+        } else:equals(ANDROID_TARGET_ARCH, arm64-v8a)  {
+            DEFINES += __androidArm64__
+            message("Android Arm 64 bit build")
+        } else:equals(ANDROID_TARGET_ARCH, x86)  {
             CONFIG += Androidx86Build
             DEFINES += __androidx86__
-            message("Android x86 build")
-        } else {
             message("Android Arm build")
+        } else {
+            error("Unsupported Android architecture: $${ANDROID_TARGET_ARCH}")
         }
     } else {
         error("Unsuported Linux toolchain, only GCC 32- or 64-bit is supported")

--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -136,14 +136,16 @@ MacBuild {
 
 # Include Android OpenSSL libs in order to make Qt OpenSSL support work
 AndroidBuild {
-    contains(QT_ARCH, arm) {
+    equals(ANDROID_TARGET_ARCH, armeabi-v7a)  {
         ANDROID_EXTRA_LIBS += $$BASEDIR/libs/OpenSSL/Android/arch-armeabi-v7a/lib/libcrypto.so
         ANDROID_EXTRA_LIBS += $$BASEDIR/libs/OpenSSL/Android/arch-armeabi-v7a/lib/libssl.so
-    } else:contains(QT_ARCH, arm64) {
+    } else:equals(ANDROID_TARGET_ARCH, arm64-v8a)  {
         # Haven't figured out how to get 64 bit arm OpenSLL yet. This means things like terrain queries will not qork.
-    } else {
+    } else:equals(ANDROID_TARGET_ARCH, x86)  {
         ANDROID_EXTRA_LIBS += $$BASEDIR/libs/OpenSSL/Android/arch-x86/lib/libcrypto.so
         ANDROID_EXTRA_LIBS += $$BASEDIR/libs/OpenSSL/Android/arch-x86/lib/libssl.so
+    } else {
+        error("Unsupported Android architecture: $${ANDROID_TARGET_ARCH}")
     }
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -248,3 +248,14 @@ void QGroundControlQmlGlobal::setFlightMapZoom(double zoom)
         emit flightMapZoomChanged(zoom);
     }
 }
+
+QString QGroundControlQmlGlobal::qgcVersion(void) const
+{
+    QString versionStr = qgcApp()->applicationVersion();
+#ifdef __androidArm32__
+    versionStr += QStringLiteral(" %1").arg(tr("32 bit"));
+#elif __androidArm64__
+    versionStr += QStringLiteral(" %1").arg(tr("64 bit"));
+#endif
+    return versionStr;
+}

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -227,11 +227,11 @@ public:
     void    setFlightMapPosition        (QGeoCoordinate& coordinate);
     void    setFlightMapZoom            (double zoom);
 
-    QString parameterFileExtension(void) const  { return AppSettings::parameterFileExtension; }
-    QString missionFileExtension(void) const    { return AppSettings::missionFileExtension; }
-    QString telemetryFileExtension(void) const  { return AppSettings::telemetryFileExtension; }
+    QString parameterFileExtension  (void) const  { return AppSettings::parameterFileExtension; }
+    QString missionFileExtension    (void) const    { return AppSettings::missionFileExtension; }
+    QString telemetryFileExtension  (void) const  { return AppSettings::telemetryFileExtension; }
 
-    QString qgcVersion(void) const { return qgcApp()->applicationVersion(); }
+    QString qgcVersion              (void) const;
 
 #if defined(QGC_AIRMAP_ENABLED)
     bool    airmapSupported() { return true; }


### PR DESCRIPTION
* There are now ```__androidArm32__``` and ```__androidArm64__``` defines available for source code.
* Version string returned by Qml QGroundControl object.version adds "32/64 bit" to the end so you can see which version you are running. Android only.