### PR TITLE
Fix problems with ArduRover firmware parameter differences

### DIFF
--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml
@@ -11,14 +11,15 @@ Item {
 
     FactPanelController { id: controller; }
 
-    property var _vehicle: controller.vehicle
+    property var    _vehicle:       controller.vehicle
+    property bool   _roverFirmware: controller.parameterExists(-1, "MODE1") // This catches all usage of ArduRover firmware vehicle types: Rover, Boat...
 
-    property Fact flightMode1: controller.getParameterFact(-1, _vehicle.rover ? "MODE1" : "FLTMODE1")
-    property Fact flightMode2: controller.getParameterFact(-1, _vehicle.rover ? "MODE2" : "FLTMODE2")
-    property Fact flightMode3: controller.getParameterFact(-1, _vehicle.rover ? "MODE3" : "FLTMODE3")
-    property Fact flightMode4: controller.getParameterFact(-1, _vehicle.rover ? "MODE4" : "FLTMODE4")
-    property Fact flightMode5: controller.getParameterFact(-1, _vehicle.rover ? "MODE5" : "FLTMODE5")
-    property Fact flightMode6: controller.getParameterFact(-1, _vehicle.rover ? "MODE6" : "FLTMODE6")
+    property Fact flightMode1: controller.getParameterFact(-1, _roverFirmware ? "MODE1" : "FLTMODE1")
+    property Fact flightMode2: controller.getParameterFact(-1, _roverFirmware ? "MODE2" : "FLTMODE2")
+    property Fact flightMode3: controller.getParameterFact(-1, _roverFirmware ? "MODE3" : "FLTMODE3")
+    property Fact flightMode4: controller.getParameterFact(-1, _roverFirmware ? "MODE4" : "FLTMODE4")
+    property Fact flightMode5: controller.getParameterFact(-1, _roverFirmware ? "MODE5" : "FLTMODE5")
+    property Fact flightMode6: controller.getParameterFact(-1, _roverFirmware ? "MODE6" : "FLTMODE6")
 
     Column {
         anchors.fill:       parent

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -57,8 +57,10 @@ SetupPage {
 
             property Fact _armingCheck: controller.getParameterFact(-1, "ARMING_CHECK")
 
-            property real _margins:     ScreenTools.defaultFontPixelHeight
-            property bool _showIcon:    !ScreenTools.isTinyScreen
+            property real _margins:         ScreenTools.defaultFontPixelHeight
+            property bool _showIcon:        !ScreenTools.isTinyScreen
+            property bool _roverFirmware:   controller.parameterExists(-1, "MODE1") // This catches all usage of ArduRover firmware vehicle types: Rover, Boat...
+
 
             property string _restartRequired: qsTr("Requires vehicle reboot")
 
@@ -322,7 +324,7 @@ SetupPage {
             }
 
             Loader {
-                sourceComponent: controller.vehicle.rover ? roverGeneralFS : undefined
+                sourceComponent: _roverFirmware ? roverGeneralFS : undefined
             }
 
             Component {

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
@@ -27,6 +27,9 @@ Item {
     property Fact _batt2FSCritAct:          controller.getParameterFact(-1, "BATT2_FS_CRT_ACT", false /* reportMissing */)
     property bool _batt1FSCritActAvailable: controller.parameterExists(-1, "BATT_FS_CRT_ACT")
 
+    property bool _roverFirmware:           controller.parameterExists(-1, "MODE1") // This catches all usage of ArduRover firmware vehicle types: Rover, Boat...
+
+
     Column {
         anchors.fill:       parent
 
@@ -56,7 +59,7 @@ Item {
         VehicleSummaryRow {
             labelText:  qsTr("Throttle failsafe:")
             valueText:  fact ? fact.enumStringValue : ""
-            visible:    controller.vehicle.rover
+            visible:    _roverFirmware
 
             property Fact fact: controller.getParameterFact(-1, "FS_THR_ENABLE", false /* reportMissing */)
         }
@@ -64,7 +67,7 @@ Item {
         VehicleSummaryRow {
             labelText:  qsTr("Failsafe Action:")
             valueText:  fact ? fact.enumStringValue : ""
-            visible:    controller.vehicle.rover
+            visible:    _roverFirmware
 
             property Fact fact: controller.getParameterFact(-1, "FS_ACTION", false /* reportMissing */)
         }
@@ -72,7 +75,7 @@ Item {
         VehicleSummaryRow {
             labelText:  qsTr("Failsafe Crash Check:")
             valueText:  fact ? fact.enumStringValue : ""
-            visible:    controller.vehicle.rover
+            visible:    _roverFirmware
 
             property Fact fact: controller.getParameterFact(-1, "FS_CRASH_CHECK", false /* reportMissing */)
         }


### PR DESCRIPTION
You can't use rover as a vehicle type to check for parameter differences since a boat uses ArduRover firmware variant as well. 