### PR TITLE
Zoom buttons move to MapScale control

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -470,6 +470,7 @@ FlightMap {
         anchors.topMargin:      ScreenTools.defaultFontPixelHeight * (0.33) + state === "bottomMode" ? 0 : ScreenTools.toolbarHeight
         anchors.bottomMargin:   ScreenTools.defaultFontPixelHeight * (0.33)
         mapControl:             flightMap
+        zoomButtonsOnLeft:      false
         visible:                !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.enableMapScale
         state:                  "bottomMode"
         states: [

--- a/src/FlightMap/MapScale.qml
+++ b/src/FlightMap/MapScale.qml
@@ -18,13 +18,17 @@ import QGroundControl.SettingsManager   1.0
 /// Map scale control
 Item {
     id:     scale
-    width:  rightEnd.x + rightEnd.width
+    width:  zoomButtonsOnLeft || !_zoomButtonsVisible ? rightEnd.x + rightEnd.width : zoomDownButton.x + zoomDownButton.width
     height: rightEnd.y + rightEnd.height
 
-    property var    mapControl                                                          ///< Map control for which this scale control is being used
+    property var    mapControl                  ///< Map control for which this scale control is being used
+    property bool   zoomButtonsVisible: true
+    property bool   zoomButtonsOnLeft:  true    ///< Zoom buttons to left/right of scale bar
 
     property variant _scaleLengthsMeters: [5, 10, 25, 50, 100, 150, 250, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000, 2000000]
     property variant _scaleLengthsFeet: [10, 25, 50, 100, 250, 500, 1000, 2000, 3000, 4000, 5280, 5280*2, 5280*5, 5280*10, 5280*25, 5280*50, 5280*100, 5280*250, 5280*500, 5280*1000]
+
+    property bool _zoomButtonsVisible:  zoomButtonsVisible && !ScreenTools.isMobile // Zoom buttons don't show on mobile since finger pinch works fine
 
     property var _color: mapControl.isSatelliteMap ? "white" : "black"
 
@@ -143,7 +147,7 @@ Item {
         map:                mapControl
         font.family:        ScreenTools.demiboldFontFamily
         anchors.left:       parent.left
-        anchors.right:      parent.right
+        anchors.right:      rightEnd.right
         horizontalAlignment:Text.AlignRight
         text:               "0 m"
     }
@@ -151,7 +155,8 @@ Item {
     Rectangle {
         id:                 leftEnd
         anchors.top:        scaleText.bottom
-        anchors.left:       parent.left
+        anchors.leftMargin: zoomButtonsOnLeft && _zoomButtonsVisible ? ScreenTools.defaultFontPixelWidth / 2 : 0
+        anchors.left:       zoomButtonsOnLeft && _zoomButtonsVisible ? zoomDownButton.right : parent.left
         width:              2
         height:             ScreenTools.defaultFontPixelHeight
         color:              _color
@@ -173,6 +178,31 @@ Item {
         width:              2
         height:             ScreenTools.defaultFontPixelHeight
         color:              _color
+    }
+
+    QGCButton {
+        id:                 zoomUpButton
+        anchors.top:        scaleText.top
+        anchors.bottom:     rightEnd.bottom
+        anchors.leftMargin: zoomButtonsOnLeft ? 0 : ScreenTools.defaultFontPixelWidth / 2
+        anchors.left:       zoomButtonsOnLeft ? parent.left : rightEnd.right
+        text:               qsTr("+")
+        width:              height
+        opacity:            0.75
+        visible:            _zoomButtonsVisible
+        onClicked:          mapControl.zoomLevel += 0.5
+    }
+
+    QGCButton {
+        id:                 zoomDownButton
+        anchors.leftMargin: ScreenTools.defaultFontPixelWidth / 2
+        anchors.left:       zoomUpButton.right
+        text:               qsTr("-")
+        height:             zoomUpButton.height
+        width:              zoomUpButton.width
+        opacity:            0.75
+        visible:            _zoomButtonsVisible
+        onClicked:          mapControl.zoomLevel -= 0.5
     }
 
     Component.onCompleted: {

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -535,7 +535,6 @@ Item {
             maxHeight:          mapScale.y - toolStrip.y
 
             property bool _isRally:     _editingLayer == _layerRallyPoints
-            property bool _showZoom:    !ScreenTools.isMobile
 
             model: [
                 {
@@ -581,18 +580,6 @@ Item {
                     buttonEnabled:      true,
                     buttonVisible:      true,
                     dropPanelComponent: centerMapDropPanel
-                },
-                {
-                    name:               qsTr("In"),
-                    buttonEnabled:      true,
-                    buttonVisible:      _showZoom,
-                    iconSource:         "/qmlimages/ZoomPlus.svg"
-                },
-                {
-                    name:               qsTr("Out"),
-                    buttonEnabled:      true,
-                    buttonVisible:      _showZoom,
-                    iconSource:         "/qmlimages/ZoomMinus.svg"
                 }
             ]
 
@@ -620,12 +607,6 @@ Item {
                     if (_singleComplexItem) {
                         addComplexItem(_missionController.complexMissionItemNames[0])
                     }
-                    break
-                case 6:
-                    editorMap.zoomLevel += 0.5
-                    break
-                case 7:
-                    editorMap.zoomLevel -= 0.5
                     break
                 }
             }
@@ -832,6 +813,7 @@ Item {
             anchors.bottom:     waypointValuesDisplay.visible ? waypointValuesDisplay.top : parent.bottom
             anchors.left:       parent.left
             mapControl:         editorMap
+            zoomButtonsOnLeft:  true
             visible:            _toolStripBottom < y
         }
 

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -400,6 +400,7 @@ Item {
                 anchors.left:           parent.left
                 anchors.bottom:         parent.bottom
                 mapControl:             _map
+                zoomButtonsOnLeft:      true
             }
 
             //-----------------------------------------------------------------
@@ -602,6 +603,7 @@ Item {
                             anchors.left:           parent.left
                             anchors.bottom:         parent.bottom
                             mapControl:             parent
+                            zoomButtonsVisible:     false
                         }
 
                         Rectangle {
@@ -641,6 +643,7 @@ Item {
                             anchors.left:           parent.left
                             anchors.bottom:         parent.bottom
                             mapControl:             parent
+                            zoomButtonsVisible:     false
                         }
 
                         Rectangle {


### PR DESCRIPTION
* Zoom buttons are now part of the MapScale control (instead of toolstrip)
* Added zoom buttons to Fly view
* Zoom buttons are still not shown on mobile

![Screen Shot 2019-08-30 at 2 58 04 PM](https://user-images.githubusercontent.com/5876851/64053456-5159f300-cb37-11e9-9597-7cba4507f0df.png)
