### PR TITLE
Simplify Survey visuals

### DIFF
--- a/src/PlanView/SurveyMapVisual.qml
+++ b/src/PlanView/SurveyMapVisual.qml
@@ -24,25 +24,37 @@ Item {
 
     property var map        ///< Map control to place item in
 
-    property var _missionItem:      object
-    property var _mapPolygon:       object.surveyAreaPolygon
-    property var _visualTransectsComponent
-    property var _entryCoordinate
-    property var _exitCoordinate
+    property var    _missionItem:               object
+    property var    _mapPolygon:                object.surveyAreaPolygon
+    property bool   _currentItem:               object.isCurrentItem
+    property var    _transectPoints:            _missionItem.visualTransectPoints
+    property bool   _showPartialEntryExit:      !_currentItem && _missionItem.turnAroundDistance.rawValue != 0 &&_transectPoints.length > 1
+    property var    _fullTransectsComponent:    null
+    property var    _entryTransectsComponent:   null
+    property var    _exitTransectsComponent:    null
+    property var    _entryCoordinate
+    property var    _exitCoordinate
 
     signal clicked(int sequenceNumber)
 
     function _addVisualElements() {
-        _visualTransectsComponent = visualTransectsComponent.createObject(map)
-        _entryCoordinate = entryPointComponent.createObject(map)
-        _exitCoordinate = exitPointComponent.createObject(map)
-        map.addMapItem(_visualTransectsComponent)
+        _fullTransectsComponent =   fullTransectsComponent.createObject(map)
+        _entryTransectsComponent =  entryTransectComponent.createObject(map)
+        _exitTransectsComponent =   exitTransectComponent.createObject(map)
+        _entryCoordinate =          entryPointComponent.createObject(map)
+        _exitCoordinate =           exitPointComponent.createObject(map)
+
+        map.addMapItem(_fullTransectsComponent)
+        map.addMapItem(_entryTransectsComponent)
+        map.addMapItem(_exitTransectsComponent)
         map.addMapItem(_entryCoordinate)
         map.addMapItem(_exitCoordinate)
     }
 
     function _destroyVisualElements() {
-        _visualTransectsComponent.destroy()
+        _fullTransectsComponent.destroy()
+        _entryTransectsComponent.destroy()
+        _exitTransectsComponent.destroy()
         _entryCoordinate.destroy()
         _exitCoordinate.destroy()
     }
@@ -98,14 +110,39 @@ Item {
         interiorOpacity:    0.5
     }
 
-    // Transect lines
+    // Full set of transects lines. Shown when item is selected.
     Component {
-        id: visualTransectsComponent
+        id: fullTransectsComponent
 
         MapPolyline {
             line.color: "white"
             line.width: 2
-            path:       _missionItem.visualTransectPoints
+            path:       _transectPoints
+            visible:    _currentItem
+        }
+    }
+
+    // Entry and exit transect lines only. Used when item is not selected.
+    Component {
+        id: entryTransectComponent
+
+        MapPolyline {
+            line.color: "white"
+            line.width: 2
+            path:       _showPartialEntryExit ? [ _transectPoints[0], _transectPoints[1] ] : []
+            visible:    _showPartialEntryExit
+        }
+    }
+    Component {
+        id: exitTransectComponent
+
+        MapPolyline {
+            line.color: "white"
+            line.width: 2
+            path:       _showPartialEntryExit ? [ _transectPoints[lastPointIndex - 1], _transectPoints[lastPointIndex] ] : []
+            visible:    _showPartialEntryExit
+
+            property int lastPointIndex: _transectPoints.length - 1
         }
     }
 


### PR DESCRIPTION
Working to simplify Plan/Fly views and make things easier to use. This is just the start of a long set of changes...

Full Survey visuals are not only show when the item is selected.
![Screen Shot 2019-09-01 at 12 20 53 PM](https://user-images.githubusercontent.com/5876851/64081358-948da080-ccb4-11e9-8c80-ca0311bf0d01.png)

When the Survey item is not selected you get partials visuals. This makes thing like working on other Plan items which are within the survey way easier.
![Screen Shot 2019-09-01 at 12 20 37 PM](https://user-images.githubusercontent.com/5876851/64081360-99525480-ccb4-11e9-83a9-c3195a1b6299.png)
