### PR TITLE
Flight Modes

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -86,6 +86,12 @@ public:
         return QStringList();
     }
 
+    /// Returns the list of all flight modes.
+    virtual QStringList allFlightModes(Vehicle* vehicle) {
+        Q_UNUSED(vehicle);
+        return QStringList();
+    }
+
     /// Returns the name for this flight mode. Flight mode names must be human readable as well as audio speakable.
     ///     @param base_mode Base mode from mavlink HEARTBEAT message
     ///     @param custom_mode Custom mode from mavlink HEARTBEAT message

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -168,6 +168,21 @@ QStringList PX4FirmwarePlugin::flightModes(Vehicle* vehicle)
     return flightModes;
 }
 
+QStringList PX4FirmwarePlugin::allFlightModes(Vehicle* vehicle)
+{
+    QStringList flightModes;
+    foreach (const FlightModeInfo_t& info, _flightModeInfoList) {
+        bool fw = (vehicle->fixedWing() && info.fixedWing);
+        bool mc = (vehicle->multiRotor() && info.multiRotor);
+        // show all modes for generic, vtol, etc
+        bool other = !vehicle->fixedWing() && !vehicle->multiRotor();
+        if (fw || mc || other) {
+            flightModes += *info.name;
+        }
+    }
+    return flightModes;
+}
+
 QString PX4FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) const
 {
     QString flightMode = "Unknown";

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -34,6 +34,7 @@ public:
     AutoPilotPlugin*    autopilotPlugin                 (Vehicle* vehicle) override;
     bool                isCapable                       (const Vehicle *vehicle, FirmwareCapabilities capabilities) override;
     QStringList         flightModes                     (Vehicle* vehicle) override;
+    QStringList         allFlightModes                  (Vehicle* vehicle) override;
     QString             flightMode                      (uint8_t base_mode, uint32_t custom_mode) const override;
     bool                setFlightMode                   (const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) override;
     void                setGuidedMode                   (Vehicle* vehicle, bool guidedMode) override;

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -978,7 +978,7 @@ void Joystick::_executeButtonAction(const QString& action, bool buttonDown)
         if (buttonDown) emit setVtolInFwdFlight(true);
     } else if (action == _buttonActionVTOLMultiRotor) {
         if (buttonDown) emit setVtolInFwdFlight(false);
-    } else if (_activeVehicle->flightModes().contains(action)) {
+    } else if (_activeVehicle->allFlightModes().contains(action)) {
         if (buttonDown) emit setFlightMode(action);
     } else if(action == _buttonActionContinuousZoomIn || action == _buttonActionContinuousZoomOut) {
         if (buttonDown) {
@@ -1096,7 +1096,7 @@ void Joystick::_buildActionList(Vehicle* activeVehicle)
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionDisarm));
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionToggleArm));
     if (activeVehicle) {
-        QStringList list = activeVehicle->flightModes();
+        QStringList list = activeVehicle->allFlightModes();
         foreach(auto mode, list) {
             _assignableButtonActions.append(new AssignableButtonAction(this, mode));
         }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2369,6 +2369,11 @@ QStringList Vehicle::flightModes(void)
     return _firmwarePlugin->flightModes(this);
 }
 
+QStringList Vehicle::allFlightModes(void)
+{
+    return _firmwarePlugin->allFlightModes(this);
+}
+
 QString Vehicle::flightMode(void) const
 {
     return _firmwarePlugin->flightMode(_base_mode, _custom_mode);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -546,6 +546,7 @@ public:
     Q_PROPERTY(bool                 autoDisarm              READ autoDisarm                                             NOTIFY autoDisarmChanged)
     Q_PROPERTY(bool                 flightModeSetAvailable  READ flightModeSetAvailable                                 CONSTANT)
     Q_PROPERTY(QStringList          flightModes             READ flightModes                                            NOTIFY flightModesChanged)
+    Q_PROPERTY(QStringList          allFlightModes          READ allFlightModes                                         NOTIFY flightModesChanged)
     Q_PROPERTY(QString              flightMode              READ flightMode             WRITE setFlightMode             NOTIFY flightModeChanged)
     Q_PROPERTY(bool                 hilMode                 READ hilMode                WRITE setHilMode                NOTIFY hilModeChanged)
     Q_PROPERTY(QmlObjectListModel*  trajectoryPoints        READ trajectoryPoints                                       CONSTANT)
@@ -848,6 +849,7 @@ public:
 
     bool flightModeSetAvailable(void);
     QStringList flightModes(void);
+    QStringList allFlightModes(void);
     QString flightMode(void) const;
     void setFlightMode(const QString& flightMode);
 


### PR DESCRIPTION
* Add access to all (unfiltered) flight modes.
* Have joystick use the unfiltered list of flight modes for button assignment.

<img width="1026" alt="Screen Shot 2019-09-03 at 11 28 21 AM" src="https://user-images.githubusercontent.com/749243/64187375-823f6e00-ce3e-11e9-95b8-476512039c5f.png">

