### PR TITLE
Joystick flight modes

### DIFF
--- a/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.cc
+++ b/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.cc
@@ -66,3 +66,19 @@ CustomFirmwarePlugin::toolBarIndicators(const Vehicle* vehicle)
     return _toolBarIndicatorList;
 }
 
+//-----------------------------------------------------------------------------
+QStringList
+CustomFirmwarePlugin::joystickFlightModes(Vehicle* vehicle)
+{
+    QStringList flightModes;
+    foreach (const FlightModeInfo_t& info, _flightModeInfoList) {
+        bool fw = (vehicle->fixedWing() && info.fixedWing);
+        bool mc = (vehicle->multiRotor() && info.multiRotor);
+        // show all modes for generic, vtol, etc
+        bool other = !vehicle->fixedWing() && !vehicle->multiRotor();
+        if (fw || mc || other) {
+            flightModes += *info.name;
+        }
+    }
+    return flightModes;
+}

--- a/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.h
+++ b/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.h
@@ -28,6 +28,7 @@ public:
     QGCCameraManager*   createCameraManager                 (Vehicle *vehicle) override;
     QGCCameraControl*   createCameraControl                 (const mavlink_camera_information_t* info, Vehicle* vehicle, int compID, QObject* parent = nullptr) override;
     const QVariantList& toolBarIndicators                   (const Vehicle* vehicle) override;
+    QStringList         joystickFlightModes                 (Vehicle* vehicle) override;
 private:
     QVariantList _toolBarIndicatorList;
 };

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -86,8 +86,8 @@ public:
         return QStringList();
     }
 
-    /// Returns the list of all flight modes.
-    virtual QStringList allFlightModes(Vehicle* vehicle) {
+    /// Returns the list of available flight modes for joystick button assignment.
+    virtual QStringList joystickFlightModes(Vehicle* vehicle) {
         Q_UNUSED(vehicle);
         return QStringList();
     }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -71,7 +71,7 @@ PX4FirmwarePlugin::PX4FirmwarePlugin()
     };
 
     static const struct Modes2Name rgModes2Name[] = {
-        //main_mode                         sub_mode                                canBeSet  FW      MC
+        //main_mode                         sub_mode                                canBeSet  FW      MR
         { PX4_CUSTOM_MAIN_MODE_MANUAL,      0,                                      true,   true,   true },
         { PX4_CUSTOM_MAIN_MODE_STABILIZED,  0,                                      true,   true,   true },
         { PX4_CUSTOM_MAIN_MODE_ACRO,        0,                                      true,   true,   true },
@@ -80,7 +80,7 @@ PX4FirmwarePlugin::PX4FirmwarePlugin()
         { PX4_CUSTOM_MAIN_MODE_OFFBOARD,    0,                                      true,   false,  true },
         { PX4_CUSTOM_MAIN_MODE_SIMPLE,      0,                                      false,  false,  true },
         { PX4_CUSTOM_MAIN_MODE_POSCTL,      PX4_CUSTOM_SUB_MODE_POSCTL_POSCTL,      true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_POSCTL,      PX4_CUSTOM_SUB_MODE_POSCTL_ORBIT,       false,  false,   false },
+        { PX4_CUSTOM_MAIN_MODE_POSCTL,      PX4_CUSTOM_SUB_MODE_POSCTL_ORBIT,       false,  false,  false },
         { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_LOITER,        true,   true,   true },
         { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_MISSION,       true,   true,   true },
         { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_RTL,           true,   true,   true },
@@ -150,37 +150,24 @@ QList<VehicleComponent*> PX4FirmwarePlugin::componentsForVehicle(AutoPilotPlugin
 QStringList PX4FirmwarePlugin::flightModes(Vehicle* vehicle)
 {
     QStringList flightModes;
-
     foreach (const FlightModeInfo_t& info, _flightModeInfoList) {
         if (info.canBeSet) {
             bool fw = (vehicle->fixedWing() && info.fixedWing);
             bool mc = (vehicle->multiRotor() && info.multiRotor);
-
-            // show all modes for generic, vtol, etc
+            // Show all modes for generic, vtol, etc
             bool other = !vehicle->fixedWing() && !vehicle->multiRotor();
-
             if (fw || mc || other) {
                 flightModes += *info.name;
             }
         }
     }
-
     return flightModes;
 }
 
-QStringList PX4FirmwarePlugin::allFlightModes(Vehicle* vehicle)
+QStringList PX4FirmwarePlugin::joystickFlightModes(Vehicle* vehicle)
 {
-    QStringList flightModes;
-    foreach (const FlightModeInfo_t& info, _flightModeInfoList) {
-        bool fw = (vehicle->fixedWing() && info.fixedWing);
-        bool mc = (vehicle->multiRotor() && info.multiRotor);
-        // show all modes for generic, vtol, etc
-        bool other = !vehicle->fixedWing() && !vehicle->multiRotor();
-        if (fw || mc || other) {
-            flightModes += *info.name;
-        }
-    }
-    return flightModes;
+    //-- By default, this is the same as flightModes()
+    return flightModes(vehicle);
 }
 
 QString PX4FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) const

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -34,7 +34,7 @@ public:
     AutoPilotPlugin*    autopilotPlugin                 (Vehicle* vehicle) override;
     bool                isCapable                       (const Vehicle *vehicle, FirmwareCapabilities capabilities) override;
     QStringList         flightModes                     (Vehicle* vehicle) override;
-    QStringList         allFlightModes                  (Vehicle* vehicle) override;
+    QStringList         joystickFlightModes             (Vehicle* vehicle) override;
     QString             flightMode                      (uint8_t base_mode, uint32_t custom_mode) const override;
     bool                setFlightMode                   (const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) override;
     void                setGuidedMode                   (Vehicle* vehicle, bool guidedMode) override;

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -978,7 +978,7 @@ void Joystick::_executeButtonAction(const QString& action, bool buttonDown)
         if (buttonDown) emit setVtolInFwdFlight(true);
     } else if (action == _buttonActionVTOLMultiRotor) {
         if (buttonDown) emit setVtolInFwdFlight(false);
-    } else if (_activeVehicle->allFlightModes().contains(action)) {
+    } else if (_activeVehicle->joystickFlightModes().contains(action)) {
         if (buttonDown) emit setFlightMode(action);
     } else if(action == _buttonActionContinuousZoomIn || action == _buttonActionContinuousZoomOut) {
         if (buttonDown) {
@@ -1096,7 +1096,7 @@ void Joystick::_buildActionList(Vehicle* activeVehicle)
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionDisarm));
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionToggleArm));
     if (activeVehicle) {
-        QStringList list = activeVehicle->allFlightModes();
+        QStringList list = activeVehicle->joystickFlightModes();
         foreach(auto mode, list) {
             _assignableButtonActions.append(new AssignableButtonAction(this, mode));
         }

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -1127,9 +1127,14 @@ void Joystick::_buildActionList(Vehicle* activeVehicle)
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionThermalOff));
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionThermalNextPalette));
 
-    for(int i = 0; i < _assignableButtonActions.count(); i++) {
+    //-- Leave "No Action" out
+    for(int i = 1; i < _assignableButtonActions.count(); i++) {
         AssignableButtonAction* p = qobject_cast<AssignableButtonAction*>(_assignableButtonActions[i]);
         _availableActionTitles << p->action();
     }
+    //-- Sort list
+    _availableActionTitles.sort(Qt::CaseInsensitive);
+    //-- Append "No Action" to top of list
+    _availableActionTitles.insert(0,_buttonActionNone);
     emit assignableActionsChanged();
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2369,9 +2369,9 @@ QStringList Vehicle::flightModes(void)
     return _firmwarePlugin->flightModes(this);
 }
 
-QStringList Vehicle::allFlightModes(void)
+QStringList Vehicle::joystickFlightModes(void)
 {
-    return _firmwarePlugin->allFlightModes(this);
+    return _firmwarePlugin->joystickFlightModes(this);
 }
 
 QString Vehicle::flightMode(void) const

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -546,7 +546,7 @@ public:
     Q_PROPERTY(bool                 autoDisarm              READ autoDisarm                                             NOTIFY autoDisarmChanged)
     Q_PROPERTY(bool                 flightModeSetAvailable  READ flightModeSetAvailable                                 CONSTANT)
     Q_PROPERTY(QStringList          flightModes             READ flightModes                                            NOTIFY flightModesChanged)
-    Q_PROPERTY(QStringList          allFlightModes          READ allFlightModes                                         NOTIFY flightModesChanged)
+    Q_PROPERTY(QStringList          joystickFlightModes     READ joystickFlightModes                                    NOTIFY flightModesChanged)
     Q_PROPERTY(QString              flightMode              READ flightMode             WRITE setFlightMode             NOTIFY flightModeChanged)
     Q_PROPERTY(bool                 hilMode                 READ hilMode                WRITE setHilMode                NOTIFY hilModeChanged)
     Q_PROPERTY(QmlObjectListModel*  trajectoryPoints        READ trajectoryPoints                                       CONSTANT)
@@ -849,7 +849,7 @@ public:
 
     bool flightModeSetAvailable(void);
     QStringList flightModes(void);
-    QStringList allFlightModes(void);
+    QStringList joystickFlightModes(void);
     QString flightMode(void) const;
     void setFlightMode(const QString& flightMode);
 


### PR DESCRIPTION
Follow up on https://github.com/mavlink/qgroundcontrol/pull/7753

* Allow plugins to define what modes are available for joystick button assignment.
* Sort button action list

The API now has two methods for returning the flight modes. The original one, which is used for controlling what is displayed in the flight mode selector/indicator, and a new `FirmwarePlugin:: joystickFlightModes()`, which controls what modes are available for joystick button assignment.

The default implementation returns the same list. Custom plugins can have a different set of modes for each as shown below (it includes modes that are not usually available for selection from the flight mode menu).

<img width="1026" alt="Screen Shot 2019-09-03 at 5 55 08 PM" src="https://user-images.githubusercontent.com/749243/64211388-052eeb80-ce74-11e9-9775-25824b4743f1.png">
