### PR TITLE
Joystick settings

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -114,9 +114,6 @@ Joystick::Joystick(const QString& name, int axisCount, int buttonCount, int hatC
         _rgButtonValues[i] = BUTTON_UP;
         _buttonActionArray.append(nullptr);
     }
-    _buildActionList(_multiVehicleManager->activeVehicle());
-    _updateTXModeSettingsKey(_multiVehicleManager->activeVehicle());
-    _loadSettings();
     connect(_multiVehicleManager, &MultiVehicleManager::activeVehicleChanged, this, &Joystick::_activeVehicleChanged);
 }
 
@@ -201,10 +198,9 @@ void Joystick::_activeVehicleChanged(Vehicle* activeVehicle)
 {
     _updateTXModeSettingsKey(activeVehicle);
     if(activeVehicle) {
-        QSettings settings;
-        settings.beginGroup(_settingsGroup);
-        int mode = settings.value(_txModeSettingsKey, activeVehicle->firmwarePlugin()->defaultJoystickTXMode()).toInt();
-        setTXMode(mode);
+        _buildActionList(activeVehicle);
+        _updateTXModeSettingsKey(activeVehicle);
+        _loadSettings();
     }
 }
 
@@ -285,15 +281,20 @@ void Joystick::_loadSettings()
 
     for (int button = 0; button < _totalButtonCount; button++) {
         QString a = settings.value(QString(_buttonActionNameKey).arg(button), QString()).toString();
-        if(!a.isEmpty() && _findAssignableButtonAction(a) >= 0 && a != _buttonActionNone) {
-            if(_buttonActionArray[button]) {
-                _buttonActionArray[button]->deleteLater();
+        qCDebug(JoystickLog) << "Button" << button << QString(_buttonActionNameKey).arg(button) << a;
+        if(!a.isEmpty()) {
+            if(_findAssignableButtonAction(a) >= 0) {
+                if(a != _buttonActionNone) {
+                    if(_buttonActionArray[button]) {
+                        _buttonActionArray[button]->deleteLater();
+                    }
+                    AssignedButtonAction* ap = new AssignedButtonAction(this, a);
+                    ap->repeat = settings.value(QString(_buttonActionRepeatKey).arg(button), false).toBool();
+                    _buttonActionArray[button] = ap;
+                    _buttonActionArray[button]->buttonTime.start();
+                    qCDebug(JoystickLog) << "_loadSettings button:action" << button << _buttonActionArray[button]->action << _buttonActionArray[button]->repeat;
+                }
             }
-            AssignedButtonAction* ap = new AssignedButtonAction(this, a);
-            ap->repeat = settings.value(QString(_buttonActionRepeatKey).arg(button), false).toBool();
-            _buttonActionArray[button] = ap;
-            _buttonActionArray[button]->buttonTime.start();
-            qCDebug(JoystickLog) << "_loadSettings button:action" << button << _buttonActionArray[button]->action << _buttonActionArray[button]->repeat;
         }
     }
 
@@ -397,9 +398,11 @@ void Joystick::_remapAxes(int currentMode, int newMode, int (&newMapping)[maxFun
 
 void Joystick::setTXMode(int mode) {
     if(mode > 0 && mode <= 4) {
-        _remapAxes(_transmitterMode, mode, _rgFunctionAxis);
-        _transmitterMode = mode;
-        _saveSettings();
+        if(_transmitterMode != mode) {
+            _remapAxes(_transmitterMode, mode, _rgFunctionAxis);
+            _transmitterMode = mode;
+            _saveSettings();
+        }
     } else {
         qCWarning(JoystickLog) << "Invalid mode:" << mode;
     }

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -14,7 +14,7 @@
 
 QGC_LOGGING_CATEGORY(JoystickConfigControllerLog, "JoystickConfigControllerLog")
 
-#define ENABLE_GIMBAL 1
+#define ENABLE_GIMBAL 0
 
 const int JoystickConfigController::_calCenterPoint =       0;
 const int JoystickConfigController::_calValidMinValue =     -32768;     ///< Largest valid minimum axis value
@@ -97,7 +97,9 @@ JoystickConfigController::JoystickConfigController(void)
     _setStickPositions();
     _resetInternalCalibrationValues();
     _currentStickPositions  << _sticksCentered.leftX  << _sticksCentered.leftY  << _sticksCentered.rightX  << _sticksCentered.rightY;
+#if ENABLE_GIMBAL
     _currentGimbalPositions << stGimbalCentered.leftX << stGimbalCentered.leftY << stGimbalCentered.rightX << stGimbalCentered.rightY;
+#endif
 }
 
 void JoystickConfigController::start(void)
@@ -214,10 +216,12 @@ void JoystickConfigController::_setupCurrentState()
     _calSaveCurrentValues();
     _currentStickPositions.clear();
     _currentStickPositions << state->stickPositions.leftX << state->stickPositions.leftY << state->stickPositions.rightX << state->stickPositions.rightY;
+#if ENABLE_GIMBAL
     _currentGimbalPositions.clear();
     _currentGimbalPositions << state->gimbalPositions.leftX << state->gimbalPositions.leftY << state->gimbalPositions.rightX << state->gimbalPositions.rightY;
-    emit stickPositionsChanged();
     emit gimbalPositionsChanged();
+#endif
+    emit stickPositionsChanged();
     emit nextEnabledChanged();
     emit skipEnabledChanged();
 }
@@ -619,11 +623,13 @@ void JoystickConfigController::_stopCalibration()
     _setStatusText("");
     emit calibratingChanged();
     _currentStickPositions.clear();
-    _currentGimbalPositions.clear();
     _currentStickPositions  << _sticksCentered.leftX  << _sticksCentered.leftY  << _sticksCentered.rightX  << _sticksCentered.rightY;
-    _currentGimbalPositions << stGimbalCentered.leftX << stGimbalCentered.leftY << stGimbalCentered.rightX << stGimbalCentered.rightY;
     emit stickPositionsChanged();
+#if ENABLE_GIMBAL
+    _currentGimbalPositions.clear();
+    _currentGimbalPositions << stGimbalCentered.leftX << stGimbalCentered.leftY << stGimbalCentered.rightX << stGimbalCentered.rightY;
     emit gimbalPositionsChanged();
+#endif
 }
 
 /// @brief Saves the current axis values, so that we can detect when the use moves an input.


### PR DESCRIPTION
* Load joystick settings whenever there is a vehicle change.
The original code would load the settings on boot and never again. This would cause the button mapping to be loaded before QGC knows what modes are available for a given vehicle. Note that there is no way currently to have a same joystick with different settings for different vehicles. There is no standard way to ID a vehicle and tag a set of joystick settings to that vehicle.

* Disable gimbal control using joystick analog channels.
That code was experimental and incomplete. The joystick calibration is hardwired to only work with the four, vehicle attitude controls. It will need to be properly modified to handle further channels.
