### PR TITLE
Fix initial load of fence/rally for Plan view

### DIFF
--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -342,8 +342,10 @@ void GeoFenceController::_setReturnPointFromManager(QGeoCoordinate breachReturnP
 void GeoFenceController::_managerLoadComplete(void)
 {
     // Fly view always reloads on _loadComplete
-    // Plan view only reloads on _loadComplete if specifically requested
-    if (_flyView || _itemsRequested) {
+    // Plan view only reloads if:
+    //  - Load was specifically requested
+    //  - There is no current Plan
+    if (_flyView || _itemsRequested || isEmpty()) {
         _setReturnPointFromManager(_geoFenceManager->breachReturnPoint());
         _setFenceFromManager(_geoFenceManager->polygons(), _geoFenceManager->circles());
         setDirty(false);
@@ -518,4 +520,10 @@ void GeoFenceController::_parametersReady(void)
     _px4ParamCircularFenceFact = _managerVehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, _px4ParamCircularFence);
     connect(_px4ParamCircularFenceFact, &Fact::rawValueChanged, this, &GeoFenceController::paramCircularFenceChanged);
     emit paramCircularFenceChanged();
+}
+
+bool GeoFenceController::isEmpty(void) const
+{
+    return _polygons.count() == 0 && _circles.count() == 0 && !_breachReturnPoint.isValid();
+
 }

--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -82,7 +82,8 @@ public:
     QmlObjectListModel* circles                 (void) { return &_circles; }
     QGeoCoordinate      breachReturnPoint       (void) const { return _breachReturnPoint; }
 
-    void setBreachReturnPoint(const QGeoCoordinate& breachReturnPoint);
+    void setBreachReturnPoint   (const QGeoCoordinate& breachReturnPoint);
+    bool isEmpty                (void) const;
 
 signals:
     void breachReturnPointChanged       (QGeoCoordinate breachReturnPoint);

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -148,8 +148,10 @@ void MissionController::_newMissionItemsAvailableFromVehicle(bool removeAllReque
     qCDebug(MissionControllerLog) << "_newMissionItemsAvailableFromVehicle flyView:count" << _flyView << _missionManager->missionItems().count();
 
     // Fly view always reloads on _loadComplete
-    // Plan view only reloads on _loadComplete if specifically requested
-    if (_flyView || removeAllRequested || _itemsRequested || _visualItems->count() <= 1) {
+    // Plan view only reloads if:
+    //  - Load was specifically requested
+    //  - There is no current Plan
+    if (_flyView || removeAllRequested || _itemsRequested || isEmpty()) {
         // Fly Mode (accept if):
         //      - Always accepts new items from the vehicle so Fly view is kept up to date
         // Edit Mode (accept if):
@@ -2173,4 +2175,9 @@ void MissionController::_updateTimeout()
 void MissionController::_complexBoundingBoxChanged()
 {
     _updateTimer.start(UPDATE_TIMEOUT);
+}
+
+bool MissionController::isEmpty(void) const
+{
+    return _visualItems->count() <= 1;
 }

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -196,6 +196,8 @@ public:
     int  batteryChangePoint         (void) const { return _missionFlightStatus.batteryChangePoint; }    ///< -1 for not supported, 0 for not needed
     int  batteriesRequired          (void) const { return _missionFlightStatus.batteriesRequired; }     ///< -1 for not supported
 
+    bool isEmpty                    (void) const;
+
     // These are the names shown in the UI for the pattern items. They are public so custom builds can remove the ones
     // they don't want through the QGCCorePlugin::
     static const QString patternFWLandingName;

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -576,3 +576,10 @@ bool PlanMasterController::syncInProgress(void) const
             _geoFenceController.syncInProgress() ||
             _rallyPointController.syncInProgress();
 }
+
+bool PlanMasterController::isEmpty(void) const
+{
+    return _missionController.isEmpty() &&
+            _geoFenceController.isEmpty() &&
+            _rallyPointController.isEmpty();
+}

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -84,6 +84,7 @@ public:
     QString     currentPlanFile (void) const { return _currentPlanFile; }
     QStringList loadNameFilters (void) const;
     QStringList saveNameFilters (void) const;
+    bool        isEmpty         (void) const;
 
     QJsonDocument saveToJson    ();
 

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -202,8 +202,10 @@ QString RallyPointController::editorQml(void) const
 void RallyPointController::_managerLoadComplete(void)
 {
     // Fly view always reloads on _loadComplete
-    // Plan view only reloads on _loadComplete if specifically requested
-    if (_flyView || _itemsRequested) {
+    // Plan view only reloads if:
+    //  - Load was specifically requested
+    //  - There is no current Plan
+    if (_flyView || _itemsRequested || isEmpty()) {
         _points.clearAndDeleteContents();
         QObjectList pointList;
         for (int i=0; i<_rallyPointManager->points().count(); i++) {
@@ -317,4 +319,9 @@ bool RallyPointController::showPlanFromManagerVehicle (void)
             return false;
         }
     }
+}
+
+bool RallyPointController::isEmpty(void) const
+{
+    return _points.count() == 0;
 }

--- a/src/MissionManager/RallyPointController.h
+++ b/src/MissionManager/RallyPointController.h
@@ -54,7 +54,8 @@ public:
     QString             editorQml               (void) const;
     QObject*            currentRallyPoint       (void) const { return _currentRallyPoint; }
 
-    void setCurrentRallyPoint(QObject* rallyPoint);
+    void setCurrentRallyPoint   (QObject* rallyPoint);
+    bool isEmpty                (void) const;
 
 signals:
     void currentRallyPointChanged(QObject* rallyPoint);


### PR DESCRIPTION
Fix for #7760.

The bug/complexity here relates to this case:
* User creates a Plan while offline
* User connects to vehicle
* We don't want to blow away the Plan the user created while offline with the Plan from the vehicle

The fix I made makes this sequence better in that it fixes #7760. But still not fully correct. There are still problems if the Plan the user created say has no fence, but the vehicle does have a fence in the scenario above.