### PR TITLE
Plan/Fly: Remove child item display

### DIFF
--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -109,22 +109,6 @@ Item {
             missionItem:    _missionItem
             sequenceNumber: _missionItem.sequenceNumber
             onClicked:      _root.clicked(_missionItem.sequenceNumber)
-            // These are the non-coordinate child mission items attached to this item
-            Row {
-                anchors.top:    parent.top
-                anchors.left:   parent.right
-                Repeater {
-                    model: _missionItem.childItems
-                    delegate: MissionItemIndexLabel {
-                        z:                      2
-                        label:                  object.abbreviation.length === 0 ? object.sequenceNumber : object.abbreviation.charAt(0)
-                        checked:                object.isCurrentItem
-                        child:                  true
-                        specifiesCoordinate:    false
-                        onClicked:              _root.clicked(object.sequenceNumber)
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Items which have no lat/lon no longer display in views.