### PR TITLE
Fly: Hide waypoint indicators unless they are really needed

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -233,7 +233,7 @@ FlightMap {
             map:                flightMap
             largeMapView:       mainIsMap
             masterController:   masterController
-            isActiveVehicle:    _vehicle.active
+            vehicle:            _vehicle
 
             property var _vehicle: object
 

--- a/src/FlightMap/MapItems/PlanMapItems.qml
+++ b/src/FlightMap/MapItems/PlanMapItems.qml
@@ -23,26 +23,26 @@ Item {
     property var    map                 ///< Map control to show items on
     property bool   largeMapView        ///< true: map takes up entire view, false: map is in small window
     property var    masterController    ///< Reference to PlanMasterController for vehicle
-    property bool   isActiveVehicle     ///< true: vehicle associated with plan is active, false: in-active
+    property var    vehicle             ///< Vehicle associated with these items
 
     property var    _map:                       map
+    property var    _vehicle:                   vehicle
     property var    _missionController:         masterController.missionController
     property var    _geoFenceController:        masterController.geoFenceController
     property var    _rallyPointController:      masterController.rallyPointController
     property var    _missionLineViewComponent
+    property bool   _isActiveVehicle:           vehicle.active
+
+    property string fmode: vehicle.flightMode
 
     // Add the mission item visuals to the map
     Repeater {
-        model: largeMapView ? _missionController.visualItems : 0
+        model: _isActiveVehicle && largeMapView ? _missionController.visualItems : 0
 
         delegate: MissionItemMapVisual {
             map:        _map
-            onClicked: {
-                if (isActiveVehicle) {
-                    // Only active vehicle supports click to change current mission item
-                    guidedActionsController.confirmAction(guidedActionsController.actionSetWaypoint, Math.max(object.sequenceNumber, 1))
-                }
-            }
+            vehicle:    _vehicle
+            onClicked:  guidedActionsController.confirmAction(guidedActionsController.actionSetWaypoint, Math.max(object.sequenceNumber, 1))
         }
     }
 

--- a/src/PlanView/MissionItemMapVisual.qml
+++ b/src/PlanView/MissionItemMapVisual.qml
@@ -22,6 +22,7 @@ Item {
     id: _root
 
     property var map        ///< Map control to place item in
+    property var vehicle    ///< Vehicle associated with this item
 
     signal clicked(int sequenceNumber)
 
@@ -33,7 +34,7 @@ Item {
             if (component.status === Component.Error) {
                 console.log("Error loading Qml: ", object.mapVisualQML, component.errorString())
             }
-            _visualItem = component.createObject(map, { "map": _root.map })
+            _visualItem = component.createObject(map, { "map": _root.map, vehicle: _root.vehicle })
             _visualItem.clicked.connect(_root.clicked)
         }
     }

--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -23,6 +23,7 @@ Item {
     id: _root
 
     property var map        ///< Map control to place item in
+    property var vehicle    ///< Vehicle associated with this item
 
     property var    _missionItem:       object
     property var    _itemVisual
@@ -104,7 +105,7 @@ Item {
 
         MissionItemIndicator {
             coordinate:     _missionItem.coordinate
-            visible:        _missionItem.specifiesCoordinate
+            visible:        _missionItem.specifiesCoordinate && (_missionItem.homePosition || map.planView || _missionItem.isCurrentItem || (vehicle.flightMode === vehicle.pauseFlightMode && vehicle.armed))
             z:              QGroundControl.zOrderMapItems
             missionItem:    _missionItem
             sequenceNumber: _missionItem.sequenceNumber

--- a/src/QmlControls/QGCDynamicObjectManager.qml
+++ b/src/QmlControls/QGCDynamicObjectManager.qml
@@ -13,6 +13,9 @@ Item {
 
     function createObject(sourceComponent, parentObject, parentObjectIsMap) {
         var obj = sourceComponent.createObject(parentObject)
+        if (obj.status === Component.Error) {
+            console.log(obj.errorString())
+        }
         rgDynamicObjects.push(obj)
         if (arguments.length < 3) {
             parentObjectIsMap = false


### PR DESCRIPTION
Here is what we have now:
![Screen Shot 2019-09-05 at 4 16 40 PM](https://user-images.githubusercontent.com/5876851/64389786-ec9c0e00-cff8-11e9-8d96-8f14b1710406.png)

That's a massive amount of crap in front of the users faces most of which has no value.

So instead we hide the waypoint indicators except for the one the vehicle is travelling towards:
![Screen Shot 2019-09-05 at 4 14 09 PM](https://user-images.githubusercontent.com/5876851/64389808-0e959080-cff9-11e9-9c97-4587185edda5.png)
![Screen Shot 2019-09-05 at 4 14 24 PM](https://user-images.githubusercontent.com/5876851/64389809-0e959080-cff9-11e9-9626-8ad557423624.png)

The waypoints indicators show up if you Pause the vehicle. This allows you to then do a GoTo Waypoint by clicking on one:
![Screen Shot 2019-09-05 at 4 14 40 PM](https://user-images.githubusercontent.com/5876851/64389840-279e4180-cff9-11e9-8998-45789a213544.png)

Next step: Direction Arrows like I have working in Plan view.