### PR TITLE
Mission controller recalc

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1229,8 +1229,6 @@ void MissionController::_recalcWaypointLines(void)
         _waypointPath.append(QVariant::fromValue(QGeoCoordinate(0, 0)));
     }
 
-    emit waypointLinesChanged();
-    emit directionArrowsChanged();
     emit waypointPathChanged();
 }
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1110,9 +1110,14 @@ void MissionController::_recalcWaypointLines(void)
     qCDebug(MissionControllerLog) << "_recalcWaypointLines homePositionValid" << homePositionValid;
 
     CoordVectHashTable old_table = _linesTable;
+
     _linesTable.clear();
-    _waypointLines.clear();
     _waypointPath.clear();
+
+    _waypointLines.beginReset();
+    _directionArrows.beginReset();
+
+    _waypointLines.clear();
     _directionArrows.clear();
 
     bool linkEndToHome;
@@ -1150,7 +1155,10 @@ void MissionController::_recalcWaypointLines(void)
 
                 lastSegmentVisualItemPair =  VisualItemPair(lastCoordinateItem, item);
                 if (!_flyView || addDirectionArrow) {
-                    _directionArrows.append(_addWaypointLineSegment(old_table, lastSegmentVisualItemPair));
+                    CoordinateVector* coordVector = _addWaypointLineSegment(old_table, lastSegmentVisualItemPair);
+                    if (addDirectionArrow) {
+                        _directionArrows.append(coordVector);
+                    }
                 }
             }
             firstCoordinateItem = false;
@@ -1205,6 +1213,9 @@ void MissionController::_recalcWaypointLines(void)
         _waypointLines.swapObjectList(objs);
     }
 
+    _waypointLines.endReset();
+    _directionArrows.endReset();
+
     // Anything left in the old table is an obsolete line object that can go
     qDeleteAll(old_table);
 
@@ -1219,6 +1230,7 @@ void MissionController::_recalcWaypointLines(void)
     }
 
     emit waypointLinesChanged();
+    emit directionArrowsChanged();
     emit waypointPathChanged();
 }
 

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -70,7 +70,7 @@ public:
     Q_PROPERTY(QmlObjectListModel*  visualItems             READ visualItems                NOTIFY visualItemsChanged)
     Q_PROPERTY(QmlObjectListModel*  waypointLines           READ waypointLines              NOTIFY waypointLinesChanged)        ///< Used by Plan view only for interactive editing
     Q_PROPERTY(QVariantList         waypointPath            READ waypointPath               NOTIFY waypointPathChanged)         ///< Used by Fly view only for static display
-    Q_PROPERTY(QmlObjectListModel*  directionArrows         READ directionArrows            CONSTANT)
+    Q_PROPERTY(QmlObjectListModel*  directionArrows         READ directionArrows            NOTIFY directionArrowsChanged)
     Q_PROPERTY(QStringList          complexMissionItemNames READ complexMissionItemNames    NOTIFY complexMissionItemNamesChanged)
     Q_PROPERTY(QGeoCoordinate       plannedHomePosition     READ plannedHomePosition        NOTIFY plannedHomePositionChanged)
 
@@ -207,6 +207,7 @@ public:
 signals:
     void visualItemsChanged             (void);
     void waypointLinesChanged           (void);
+    void directionArrowsChanged         (void);
     void waypointPathChanged            (void);
     void newItemsFromVehicle            (void);
     void missionDistanceChanged         (double missionDistance);

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -68,9 +68,9 @@ public:
     } MissionFlightStatus_t;
 
     Q_PROPERTY(QmlObjectListModel*  visualItems             READ visualItems                NOTIFY visualItemsChanged)
-    Q_PROPERTY(QmlObjectListModel*  waypointLines           READ waypointLines              NOTIFY waypointLinesChanged)        ///< Used by Plan view only for interactive editing
+    Q_PROPERTY(QmlObjectListModel*  waypointLines           READ waypointLines              CONSTANT)                           ///< Used by Plan view only for interactive editing
     Q_PROPERTY(QVariantList         waypointPath            READ waypointPath               NOTIFY waypointPathChanged)         ///< Used by Fly view only for static display
-    Q_PROPERTY(QmlObjectListModel*  directionArrows         READ directionArrows            NOTIFY directionArrowsChanged)
+    Q_PROPERTY(QmlObjectListModel*  directionArrows         READ directionArrows            CONSTANT)
     Q_PROPERTY(QStringList          complexMissionItemNames READ complexMissionItemNames    NOTIFY complexMissionItemNamesChanged)
     Q_PROPERTY(QGeoCoordinate       plannedHomePosition     READ plannedHomePosition        NOTIFY plannedHomePositionChanged)
 
@@ -206,8 +206,6 @@ public:
 
 signals:
     void visualItemsChanged             (void);
-    void waypointLinesChanged           (void);
-    void directionArrowsChanged         (void);
     void waypointPathChanged            (void);
     void newItemsFromVehicle            (void);
     void missionDistanceChanged         (double missionDistance);

--- a/src/MissionManager/MissionControllerTest.cc
+++ b/src/MissionManager/MissionControllerTest.cc
@@ -48,7 +48,6 @@ void MissionControllerTest::_initForFirmwareType(MAV_AUTOPILOT firmwareType)
 
     // MissionController signals
     _rgMissionControllerSignals[visualItemsChangedSignalIndex] =    SIGNAL(visualItemsChanged());
-    _rgMissionControllerSignals[waypointLinesChangedSignalIndex] =  SIGNAL(waypointLinesChanged());
 
     // Master controller pulls offline vehicle info from settings
     qgcApp()->toolbox()->settingsManager()->appSettings()->offlineEditingFirmwareType()->setRawValue(firmwareType);
@@ -62,7 +61,7 @@ void MissionControllerTest::_initForFirmwareType(MAV_AUTOPILOT firmwareType)
     _masterController->start(false /* flyView */);
 
     // All signals should some through on start
-    QCOMPARE(_multiSpyMissionController->checkOnlySignalsByMask(visualItemsChangedSignalMask | waypointLinesChangedSignalMask), true);
+    QCOMPARE(_multiSpyMissionController->checkOnlySignalsByMask(visualItemsChangedSignalMask), true);
     _multiSpyMissionController->clearAllSignals();
 
     QmlObjectListModel* visualItems = _missionController->visualItems();
@@ -119,8 +118,6 @@ void MissionControllerTest::_testAddWaypointWorker(MAV_AUTOPILOT firmwareType)
     QGeoCoordinate coordinate(37.803784, -122.462276);
 
     _missionController->insertSimpleMissionItem(coordinate, _missionController->visualItems()->count());
-
-    QCOMPARE(_multiSpyMissionController->checkOnlySignalsByMask(waypointLinesChangedSignalMask), true);
 
     QmlObjectListModel* visualItems = _missionController->visualItems();
     QVERIFY(visualItems);

--- a/src/MissionManager/MissionControllerTest.h
+++ b/src/MissionManager/MissionControllerTest.h
@@ -70,13 +70,11 @@ private:
 
     enum {
         visualItemsChangedSignalIndex = 0,
-        waypointLinesChangedSignalIndex,
         missionControllerMaxSignalIndex
     };
 
     enum {
         visualItemsChangedSignalMask =                 1 << visualItemsChangedSignalIndex,
-        waypointLinesChangedSignalMask =                1 << waypointLinesChangedSignalIndex,
     };
 
     MultiSignalSpy*     _multiSpyMissionController;

--- a/src/QmlControls/QmlObjectListModel.h
+++ b/src/QmlControls/QmlObjectListModel.h
@@ -33,6 +33,7 @@ public:
     
     int         count               () const;
     bool        dirty               () const { return _dirty; }
+
     void        setDirty            (bool dirty);
     void        append              (QObject* object);
     void        append              (QList<QObject*> objects);
@@ -56,8 +57,8 @@ public:
     /// Clears the list and calls deleteLater on each entry
     void clearAndDeleteContents     ();
 
-    void beginReset                 () { beginResetModel(); }
-    void endReset                   () { endResetModel();   }
+    void beginReset                 ();
+    void endReset                   ();
 
 signals:
     void countChanged               (int count);
@@ -80,6 +81,7 @@ private:
     
     bool _dirty;
     bool _skipDirtyFirstItem;
+    bool _externalBeginResetModel;
         
     static const int ObjectRole;
     static const int TextRole;


### PR DESCRIPTION
* Fixes #7778
* Use external begin/endReset calls on QmlObjectListModels when making major changes to them. This keeps Qt from blowing it's brains out.
* Also fixed Plan View arrows which I broke with last Fly View arrow pull