### PR TITLE
Motor test fixes for Sub

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
@@ -168,6 +168,8 @@ SetupPage {
                     onToggled: {
                         if (controller.vehicle.armed) {
                             timer.stop()
+                            enabled = false
+                            coolDownTimer.start()
                         }
 
                         controller.vehicle.armed = checked
@@ -183,6 +185,8 @@ SetupPage {
                         safetySwitch.checked = armed
                             if (!armed) {
                                 timer.stop()
+                                safetySwitch.enabled = false
+                                coolDownTimer.start()
                             } else {
                                 timer.start()
                             }
@@ -198,7 +202,14 @@ SetupPage {
                     text:   qsTr("Slide this switch to arm the vehicle and enable the motor test (CAUTION!)")
                 }
             } // Row
-
+            Row {
+                QGCLabel {
+                    id: cooldownLabel
+                    visible: coolDownTimer.running
+                    color:  qgcPal.warningText
+                    text:   qsTr("A 10 second coooldown is required before testing again, please stand by...")
+                }
+            }
             // Repeats the command signal and updates the checkbox every 50 ms
             Timer {
                 id: timer
@@ -217,6 +228,15 @@ SetupPage {
                                 controller.vehicle.motorTest(_lastIndex, slider.motorSlider.value, 0)
                             }
                     }
+                }
+            }
+            Timer {
+                id: coolDownTimer
+                interval:       11000
+                repeat:         false
+
+                onTriggered: {
+                    safetySwitch.enabled = true
                 }
             }
         } // Column


### PR DESCRIPTION
This updates the call of motorTest() to use the signature changed in https://github.com/mavlink/qgroundcontrol/commit/3089da58b4d6ddab9daf74f6a0a095fde36357ef and adds a timer to the motor test switch so we wait for the firmware side motor test cooldown:

![motortest](https://user-images.githubusercontent.com/4013804/64715565-1a6cd100-d497-11e9-885a-db19df7156b7.gif)
