### PR TITLE
Use defined, custom application name.

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
         // QApplication is necessary to use QMessageBox
         QApplication errorApp(argc, argv);
         QMessageBox::critical(nullptr, QObject::tr("Error"),
-            QObject::tr("A second instance of QGroundControl is already running. Please close the other instance and try again.")
+            QObject::tr("A second instance of %1 is already running. Please close the other instance and try again.").arg(QGC_APPLICATION_NAME)
         );
         return -1;
     }


### PR DESCRIPTION
When you attempt to run a second instance of QGC, it displays an error message and exits before launching the actual GUI. The error message had the application name hard-coded to QGroundControl.

<img width="597" alt="Screen Shot 2019-09-12 at 9 46 19 AM" src="https://user-images.githubusercontent.com/749243/64785395-a25be500-d542-11e9-944c-2d66c6a3374a.png">