### PR TITLE
Add EKF vision velocity fusion to EKF_AID_MASK

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+++ b/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
@@ -1236,9 +1236,9 @@ This parameter controls the time constant of the decay</short_desc>
     </parameter>
     <parameter default="1" name="EKF2_AID_MASK" type="INT32">
       <short_desc>Integer bitmask controlling data fusion and aiding methods</short_desc>
-      <long_desc>Set bits in the following positions to enable: 0 : Set to true to use GPS data if available 1 : Set to true to use optical flow data if available 2 : Set to true to inhibit IMU delta velocity bias estimation 3 : Set to true to enable vision position fusion 4 : Set to true to enable vision yaw fusion. Cannot be used if bit position 7 is true. 5 : Set to true to enable multi-rotor drag specific force fusion 6 : set to true if the EV observations are in a non NED reference frame and need to be rotated before being used 7 : Set to true to enable GPS yaw fusion. Cannot be used if bit position 4 is true.</long_desc>
+      <long_desc>Set bits in the following positions to enable: 0 : Set to true to use GPS data if available 1 : Set to true to use optical flow data if available 2 : Set to true to inhibit IMU delta velocity bias estimation 3 : Set to true to enable vision position fusion 4 : Set to true to enable vision yaw fusion. Cannot be used if bit position 7 is true. 5 : Set to true to enable multi-rotor drag specific force fusion 6 : set to true if the EV observations are in a non NED reference frame and need to be rotated before being used 7 : Set to true to enable GPS yaw fusion. Cannot be used if bit position 4 is true. 8 : Set to true to enable EV velocity fusion.</long_desc>
       <min>0</min>
-      <max>255</max>
+      <max>511</max>
       <reboot_required>true</reboot_required>
       <bitmask>
         <bit index="0">use GPS</bit>
@@ -1249,6 +1249,7 @@ This parameter controls the time constant of the decay</short_desc>
         <bit index="5">multi-rotor drag fusion</bit>
         <bit index="6">rotate external vision</bit>
         <bit index="7">GPS yaw fusion</bit>
+        <bit index="8">vision velocity fusion</bit>
       </bitmask>
     </parameter>
     <parameter default="0.1" name="EKF2_ANGERR_INIT" type="FLOAT">


### PR DESCRIPTION
This adds the possibility to set the fusion of external vision velocity with the EKF_AID_MASK.
The external vision velocity will be introduced with: https://github.com/PX4/ecl/pull/642