### PR TITLE
Disable pairing

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -313,6 +313,9 @@ DebugBuild {
 
 include(src/QtLocationPlugin/QGCLocationPlugin.pri)
 
+# Until pairing can be made to work cleanly on all OS it is turned off
+DEFINES+=QGC_DISABLE_PAIRING
+
 # Pairing
 contains (DEFINES, QGC_DISABLE_PAIRING) {
     message("Skipping support for Pairing")


### PR DESCRIPTION
There is a long list of issues against this with nobody looking at them. I'm tired of fighting with this on my own builds as well. Until this can be made to work on all OS and verified to be working correctly and run correctly on virgin installs of all OS it needs to stay off.

Related to #7743 and all the other Pairing issues