### PR TITLE
New flight trajectory display algorithm

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Note: This file only contains high level features or important fixes.
 
 ### 3.6.0 - Daily Build
 
+* More performant flight path display algorithm. Mobile builds no longer show limited path length.
 * ArduPilot: Add Motor Test vehicle setup page
 * Compass Instrument: Add indicators for Home, COG and Next Waypoint headings.
 * Log Replay: Support changing speed of playback

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -416,7 +416,7 @@ INCLUDEPATH += \
     src/QtLocationPlugin/QMLControl \
     src/Settings \
     src/Terrain \
-    src/VehicleSetup \
+    src/Vehicle \
     src/ViewWidgets \
     src/Audio \
     src/comm \
@@ -663,7 +663,13 @@ HEADERS += \
     src/SHPFileHelper.h \
     src/Terrain/TerrainQuery.h \
     src/TerrainTile.h \
+    src/Vehicle/ADSBVehicle.h \
+    src/Vehicle/GPSRTKFactGroup.h \
     src/Vehicle/MAVLinkLogManager.h \
+    src/Vehicle/MultiVehicleManager.h \
+    src/Vehicle/TrajectoryPoints.h \
+    src/Vehicle/Vehicle.h \
+    src/Vehicle/VehicleObjectAvoidance.h \
     src/VehicleSetup/JoystickConfigController.h \
     src/comm/LinkConfiguration.h \
     src/comm/LinkInterface.h \
@@ -881,7 +887,13 @@ SOURCES += \
     src/SHPFileHelper.cc \
     src/Terrain/TerrainQuery.cc \
     src/TerrainTile.cc\
+    src/Vehicle/ADSBVehicle.cc \
+    src/Vehicle/GPSRTKFactGroup.cc \
     src/Vehicle/MAVLinkLogManager.cc \
+    src/Vehicle/MultiVehicleManager.cc \
+    src/Vehicle/TrajectoryPoints.cc \
+    src/Vehicle/Vehicle.cc \
+    src/Vehicle/VehicleObjectAvoidance.cc \
     src/VehicleSetup/JoystickConfigController.cc \
     src/comm/LinkConfiguration.cc \
     src/comm/LinkInterface.cc \
@@ -983,7 +995,6 @@ SOURCES += \
 INCLUDEPATH += \
     src/AutoPilotPlugins/Common \
     src/FirmwarePlugin \
-    src/Vehicle \
     src/VehicleSetup \
 
 HEADERS+= \
@@ -998,11 +1009,6 @@ HEADERS+= \
     src/FirmwarePlugin/CameraMetaData.h \
     src/FirmwarePlugin/FirmwarePlugin.h \
     src/FirmwarePlugin/FirmwarePluginManager.h \
-    src/Vehicle/ADSBVehicle.h \
-    src/Vehicle/MultiVehicleManager.h \
-    src/Vehicle/GPSRTKFactGroup.h \
-    src/Vehicle/Vehicle.h \
-    src/Vehicle/VehicleObjectAvoidance.h \
     src/VehicleSetup/VehicleComponent.h \
 
 !MobileBuild { !NoSerialBuild {
@@ -1025,11 +1031,6 @@ SOURCES += \
     src/FirmwarePlugin/CameraMetaData.cc \
     src/FirmwarePlugin/FirmwarePlugin.cc \
     src/FirmwarePlugin/FirmwarePluginManager.cc \
-    src/Vehicle/ADSBVehicle.cc \
-    src/Vehicle/MultiVehicleManager.cc \
-    src/Vehicle/GPSRTKFactGroup.cc \
-    src/Vehicle/Vehicle.cc \
-    src/Vehicle/VehicleObjectAvoidance.cc \
     src/VehicleSetup/VehicleComponent.cc \
 
 !MobileBuild { !NoSerialBuild {

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -96,6 +96,7 @@
 #include "GeoTagController.h"
 #include "LogReplayLink.h"
 #include "VehicleObjectAvoidance.h"
+#include "TrajectoryPoints.h"
 
 #if defined(QGC_ENABLE_PAIRING)
 #include "PairingManager.h"
@@ -508,6 +509,7 @@ void QGCApplication::_initCommon()
 
     qmlRegisterUncreatableType<QGCMapPolygon>       ("QGroundControl.FlightMap",            1, 0, "QGCMapPolygon",              kRefOnly);
     qmlRegisterUncreatableType<QGCGeoBoundingCube>  ("QGroundControl.FlightMap",            1, 0, "QGCGeoBoundingCube",         kRefOnly);
+    qmlRegisterUncreatableType<TrajectoryPoints>    ("QGroundControl.FlightMap",            1, 0, "TrajectoryPoints",           kRefOnly);
 
     qmlRegisterType<QGCMapCircle>                   ("QGroundControl.FlightMap",            1, 0, "QGCMapCircle");
 

--- a/src/Vehicle/TrajectoryPoints.cc
+++ b/src/Vehicle/TrajectoryPoints.cc
@@ -1,0 +1,60 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "TrajectoryPoints.h"
+#include "Vehicle.h"
+
+TrajectoryPoints::TrajectoryPoints(Vehicle* vehicle, QObject* parent)
+    : QObject       (parent)
+    , _vehicle      (vehicle)
+    , _lastAzimuth  (qQNaN())
+{
+}
+
+void TrajectoryPoints::_vehicleCoordinateChanged(QGeoCoordinate coordinate)
+{
+    if (_lastPoint.isValid()) {
+        if (_lastPoint.distanceTo(coordinate) > _distanceTolerance) {
+            double newAzimuth = _lastPoint.azimuthTo(coordinate);
+            if (qIsNaN(_lastAzimuth) || qAbs(newAzimuth - _lastAzimuth) > _azimuthTolerance) {
+                _lastAzimuth = _lastPoint.azimuthTo(coordinate);
+                _lastPoint = coordinate;
+                _points.append(QVariant::fromValue(coordinate));
+                emit pointAdded(coordinate);
+            } else {
+                _lastPoint = coordinate;
+                _points[_points.count() - 1] = QVariant::fromValue(coordinate);
+                emit updateLastPoint(coordinate);
+            }
+        }
+    } else {
+        _lastAzimuth = _lastPoint.azimuthTo(coordinate);
+        _lastPoint = coordinate;
+        _points.append(QVariant::fromValue(coordinate));
+        emit pointAdded(coordinate);
+    }
+}
+
+void TrajectoryPoints::start(void)
+{
+    clear();
+    connect(_vehicle, &Vehicle::coordinateChanged, this, &TrajectoryPoints::_vehicleCoordinateChanged);
+}
+
+void TrajectoryPoints::stop(void)
+{
+    qDebug() << "Stop" << _points.count();
+    disconnect(_vehicle, &Vehicle::coordinateChanged, this, &TrajectoryPoints::_vehicleCoordinateChanged);
+}
+
+void TrajectoryPoints::clear(void)
+{
+    _points.clear();
+    emit pointsCleared();
+}

--- a/src/Vehicle/TrajectoryPoints.h
+++ b/src/Vehicle/TrajectoryPoints.h
@@ -44,6 +44,6 @@ private:
     QGeoCoordinate  _lastPoint;
     double          _lastAzimuth;
 
-    static constexpr double _distanceTolerance = 1.0;
+    static constexpr double _distanceTolerance = 2.0;
     static constexpr double _azimuthTolerance = 1.5;
 };

--- a/src/Vehicle/TrajectoryPoints.h
+++ b/src/Vehicle/TrajectoryPoints.h
@@ -1,0 +1,49 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QmlObjectListModel.h"
+
+#include <QGeoCoordinate>
+
+class Vehicle;
+
+class TrajectoryPoints : public QObject
+{
+    Q_OBJECT
+
+public:
+    TrajectoryPoints(Vehicle* vehicle, QObject* parent = nullptr);
+
+    Q_INVOKABLE QVariantList list(void) const { return _points; }
+
+    void start  (void);
+    void stop   (void);
+
+public slots:
+    void clear  (void);
+
+signals:
+    void pointAdded     (QGeoCoordinate coordinate);
+    void updateLastPoint(QGeoCoordinate coordinate);
+    void pointsCleared  (void);
+
+private slots:
+    void _vehicleCoordinateChanged(QGeoCoordinate coordinate);
+
+private:
+    Vehicle*        _vehicle;
+    QVariantList    _points;
+    QGeoCoordinate  _lastPoint;
+    double          _lastAzimuth;
+
+    static constexpr double _distanceTolerance = 1.0;
+    static constexpr double _azimuthTolerance = 1.5;
+};

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -38,6 +38,7 @@ class ADSBVehicle;
 class QGCCameraManager;
 class Joystick;
 class VehicleObjectAvoidance;
+class TrajectoryPoints;
 
 #if defined(QGC_AIRMAP_ENABLED)
 class AirspaceVehicleManager;
@@ -548,7 +549,7 @@ public:
     Q_PROPERTY(QStringList          flightModes             READ flightModes                                            NOTIFY flightModesChanged)
     Q_PROPERTY(QString              flightMode              READ flightMode             WRITE setFlightMode             NOTIFY flightModeChanged)
     Q_PROPERTY(bool                 hilMode                 READ hilMode                WRITE setHilMode                NOTIFY hilModeChanged)
-    Q_PROPERTY(QmlObjectListModel*  trajectoryPoints        READ trajectoryPoints                                       CONSTANT)
+    Q_PROPERTY(TrajectoryPoints*    trajectoryPoints        MEMBER _trajectoryPoints                                    CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  cameraTriggerPoints     READ cameraTriggerPoints                                    CONSTANT)
     Q_PROPERTY(float                latitude                READ latitude                                               NOTIFY coordinateChanged)
     Q_PROPERTY(float                longitude               READ longitude                                              NOTIFY coordinateChanged)
@@ -877,9 +878,8 @@ public:
     QString prearmError(void) const { return _prearmError; }
     void setPrearmError(const QString& prearmError);
 
-    QmlObjectListModel* trajectoryPoints(void) { return &_mapTrajectoryList; }
-    QmlObjectListModel* cameraTriggerPoints(void) { return &_cameraTriggerPoints; }
-    QmlObjectListModel* adsbVehicles(void) { return &_adsbVehicles; }
+    QmlObjectListModel* cameraTriggerPoints (void) { return &_cameraTriggerPoints; }
+    QmlObjectListModel* adsbVehicles        (void) { return &_adsbVehicles; }
 
     int  flowImageIndex() { return _flowImageIndex; }
 
@@ -1226,7 +1226,6 @@ private slots:
     void _linkInactiveOrDeleted(LinkInterface* link);
     void _sendMessageOnLink(LinkInterface* link, mavlink_message_t message);
     void _sendMessageMultipleNext(void);
-    void _addNewMapTrajectoryPoint(void);
     void _parametersReady(bool parametersReady);
     void _remoteControlRSSIChanged(uint8_t rssi);
     void _handleFlightModeChanged(const QString& flightMode);
@@ -1246,7 +1245,6 @@ private slots:
     void _geoFenceLoadComplete(void);
     void _rallyPointLoadComplete(void);
     void _sendMavCommandAgain(void);
-    void _clearTrajectoryPoints(void);
     void _clearCameraTriggerPoints(void);
     void _updateDistanceHeadingToHome(void);
     void _updateHeadingToNextWP(void);
@@ -1313,8 +1311,6 @@ private:
     void _missionManagerError(int errorCode, const QString& errorMsg);
     void _geoFenceManagerError(int errorCode, const QString& errorMsg);
     void _rallyPointManagerError(int errorCode, const QString& errorMsg);
-    void _mapTrajectoryStart(void);
-    void _mapTrajectoryStop(void);
     void _linkActiveChanged(LinkInterface* link, bool active, int vehicleID);
     void _say(const QString& text);
     QString _vehicleIdSpeech(void);
@@ -1334,6 +1330,7 @@ private:
     void _handleUnsupportedRequestProtocolVersion(void);
     void _initializeCsv();
     void _writeCsvLine();
+    void _flightTimerStart(void);
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
@@ -1463,15 +1460,9 @@ private:
     QTimer  _sendMultipleTimer;
     int     _nextSendMessageMultipleIndex;
 
-    QTime               _flightTimer;
-    QTimer              _mapTrajectoryTimer;
-    QmlObjectListModel  _mapTrajectoryList;
-    QGeoCoordinate      _mapTrajectoryLastCoordinate;
-    bool                _mapTrajectoryHaveFirstCoordinate;
-    static const int    _mapTrajectoryMsecsBetweenPoints = 1000;
-
-    QmlObjectListModel  _cameraTriggerPoints;
-
+    QTime                           _flightTimer;
+    TrajectoryPoints*               _trajectoryPoints;
+    QmlObjectListModel              _cameraTriggerPoints;
     QmlObjectListModel              _adsbVehicles;
     QMap<uint32_t, ADSBVehicle*>    _adsbICAOMap;
     QMap<QString, ADSBVehicle*>     _trafficVehicleMap;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1258,6 +1258,7 @@ private slots:
     void _adsbTimerTimeout      ();
     void _orbitTelemetryTimeout (void);
     void _protocolVersionTimeOut(void);
+    void _updateFlightTime      (void);
 
 private:
     bool _containsLink          (LinkInterface* link);
@@ -1331,6 +1332,7 @@ private:
     void _initializeCsv();
     void _writeCsvLine();
     void _flightTimerStart(void);
+    void _flightTimerStop(void);
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
@@ -1461,6 +1463,7 @@ private:
     int     _nextSendMessageMultipleIndex;
 
     QTime                           _flightTimer;
+    QTimer                          _flightTimeUpdater;
     TrajectoryPoints*               _trajectoryPoints;
     QmlObjectListModel              _cameraTriggerPoints;
     QmlObjectListModel              _adsbVehicles;

--- a/src/uas/UASMessageHandler.h
+++ b/src/uas/UASMessageHandler.h
@@ -7,20 +7,12 @@
  *
  ****************************************************************************/
 
-
-/*!
- * @file
- *   @brief Message Handler
- *   @author Gus Grubba <mavlink@grubba.com>
- */
-
 #pragma once
 
 #include <QObject>
 #include <QVector>
 #include <QMutex>
 
-#include "Vehicle.h"
 #include "QGCToolbox.h"
 
 class Vehicle;


### PR DESCRIPTION
Problems with previous algorithm:
* Performance was crap. Too many points were added. Mobile builds had to limit path length due to perf problems.
* Run SITL it higher speed or replay log at higher speed an the flight path was really bad.

New algorithm is distance and azimuth change based with tolerances set to reduce point count yet still show high quality fligh path. This new code reduces point count for lines on the map by 80%+. But if you compare old to new the flight path shown is actually closer to the true flight path.