### PR TITLE
More work on mission item indicators

### DIFF
--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -32,7 +32,7 @@ MapQuickItem {
             id:             _label
             checked:        _isCurrentItem
             label:          missionItem ? missionItem.abbreviation : ""
-            index:          missionItem ? missionItem.sequenceNumber : 0
+            //index:          missionItem ? missionItem.sequenceNumber : 0
             gimbalYaw:      missionItem.missionGimbalYaw
             vehicleYaw:     missionItem.missionVehicleYaw
             showGimbalYaw:  !isNaN(missionItem.missionGimbalYaw)

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2112,6 +2112,7 @@ VisualMissionItem* MissionController::currentPlanViewItem(void) const
 
 void MissionController::setCurrentPlanViewIndex(int sequenceNumber, bool force)
 {
+    qDebug() << "setCurrentPlanViewIndex" << sequenceNumber << force << _currentPlanViewIndex;
     if(_visualItems && (force || sequenceNumber != _currentPlanViewIndex)) {
         _splitSegment = nullptr;
         _currentPlanViewItem  = nullptr;

--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -105,7 +105,7 @@ Item {
 
         MissionItemIndicator {
             coordinate:     _missionItem.coordinate
-            visible:        _missionItem.specifiesCoordinate && (_missionItem.abbreviation != "" || map.planView || _missionItem.isCurrentItem || (vehicle.flightMode === vehicle.pauseFlightMode && vehicle.armed))
+            visible:        _missionItem.specifiesCoordinate
             z:              QGroundControl.zOrderMapItems
             missionItem:    _missionItem
             sequenceNumber: _missionItem.sequenceNumber

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -15,7 +15,7 @@ Canvas {
     property string label                           ///< Label to show to the side of the index indicator
     property int    index:                  0       ///< Index to show in the indicator, 0 will show single char label instead, -1 first char of label in indicator full label to the side
     property bool   checked:                false
-    property bool   small:                  false
+    property bool   small:                  !checked
     property bool   child:                  false
     property bool   highlightSelected:      false
     property var    color:                  checked ? "green" : (child ? qgcPal.mapIndicatorChild : qgcPal.mapIndicator)
@@ -30,12 +30,14 @@ Canvas {
     property real   _height:            showGimbalYaw ? _gimbalYawWidth : (labelControl.visible ? labelControl.height : indicator.height)
     property real   _gimbalYawRadius:   ScreenTools.defaultFontPixelHeight
     property real   _gimbalYawWidth:    _gimbalYawRadius * 2
-    property real   _indicatorRadius:   small ? (ScreenTools.defaultFontPixelHeight * ScreenTools.smallFontPointRatio * 1.25 / 2) : (ScreenTools.defaultFontPixelHeight * 0.66)
+    property real   _smallRadius:       (ScreenTools.defaultFontPixelHeight * ScreenTools.smallFontPointRatio) / 2
+    property real   _normalRadius:      ScreenTools.defaultFontPixelHeight * 0.66
+    property real   _indicatorRadius:   small ? _smallRadius : _normalRadius
     property real   _gimbalRadians:     degreesToRadians(vehicleYaw + gimbalYaw - 90)
     property real   _labelMargin:       2
     property real   _labelRadius:       _indicatorRadius + _labelMargin
     property string _label:             label.length > 1 ? label : ""
-    property string _index:             index === 0 || index === -1 ? label.charAt(0) : ""/*index*/
+    property string _index:             index === 0 || index === -1 ? label.charAt(0) : "" /*index*/
 
     onColorChanged:         requestPaint()
     onShowGimbalYawChanged: requestPaint()
@@ -67,6 +69,8 @@ Canvas {
         context.clearRect(0, 0, width, height)
         paintGimbalYaw(context)
     }
+
+    Behavior on _indicatorRadius { PropertyAnimation {} }
 
     Rectangle {
         id:                     labelControl
@@ -115,6 +119,7 @@ Canvas {
         }
     }
 
+    // Extra circle to indicate selection
     Rectangle {
         width:          indicator.width * 2
         height:         width
@@ -126,8 +131,15 @@ Canvas {
         anchors.centerIn: indicator
     }
 
+    // The mouse click area is always the size of a normal indicator
+    Item {
+        id:                 mouseAreaFill
+        anchors.margins:    small ? -(_normalRadius - _smallRadius) : 0
+        anchors.fill:       indicator
+    }
+
     QGCMouseArea {
-        fillItem:   parent
+        fillItem:   mouseAreaFill
         onClicked: {
             focus = true
             parent.clicked()


### PR DESCRIPTION
Getting closer to being happy with this. But still lots of futzing to go before I consider it done.

* Waypoints show small indicators if not selected. As opposed to nothing.
* Labels for things like Takeoff and so forth show up more than before. These were missing at some key points.
* Transtion from unselected to selected item has an animation on size change. Have to have fun somewhere!

![Screen Shot 2019-09-23 at 1 35 15 PM](https://user-images.githubusercontent.com/5876851/65460547-01551000-de07-11e9-9b89-bbd562616064.png)
