### PR TITLE
Plan: Presets - tweak settings from tab

### DIFF
--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -61,7 +61,7 @@ Rectangle {
             anchors.left:   parent.left
             anchors.right:  parent.right
 
-            Component.onCompleted: currentIndex = 0
+            Component.onCompleted: currentIndex = QGroundControl.settingsManager.planViewSettings.displayPresetsTabFirst.rawValue ? 2 : 0
 
             QGCTabButton { text: qsTr("Grid") }
             QGCTabButton { text: qsTr("Camera") }
@@ -255,7 +255,11 @@ Rectangle {
                 text:   qsTr("Statistics")
             }
 
-            TransectStyleComplexItemStats { }
+            TransectStyleComplexItemStats {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                visible:        statsHeader.checked
+            }
         } // Grid Column
 
         Column {
@@ -320,6 +324,63 @@ Rectangle {
                 Layout.fillWidth:   true
                 text:               qsTr("Save Settings As New Preset")
                 onClicked:          mainWindow.showComponentDialog(savePresetDialog, qsTr("Save Preset"), mainWindow.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel)
+            }
+
+            SectionHeader {
+                id:                 presectsTransectsHeader
+                anchors.left:       undefined
+                anchors.right:      undefined
+                Layout.fillWidth:   true
+                text:               qsTr("Transects")
+            }
+
+            GridLayout {
+                Layout.fillWidth:   true
+                columnSpacing:      _margin
+                rowSpacing:         _margin
+                columns:            2
+                visible:            presectsTransectsHeader.checked
+
+                QGCLabel { text: qsTr("Angle") }
+                FactTextField {
+                    fact:                   missionItem.gridAngle
+                    Layout.fillWidth:       true
+                    onUpdated:              presetsAngleSlider.value = missionItem.gridAngle.value
+                }
+
+                QGCSlider {
+                    id:                     presetsAngleSlider
+                    minimumValue:           0
+                    maximumValue:           359
+                    stepSize:               1
+                    tickmarksEnabled:       false
+                    Layout.fillWidth:       true
+                    Layout.columnSpan:      2
+                    Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.5
+                    onValueChanged:         missionItem.gridAngle.value = value
+                    Component.onCompleted:  value = missionItem.gridAngle.value
+                    updateValueWhileDragging: true
+                }
+
+                QGCButton {
+                    Layout.columnSpan:  2
+                    Layout.fillWidth:   true
+                    text:               qsTr("Rotate Entry Point")
+                    onClicked:          missionItem.rotateEntryPoint();
+                }
+            }
+
+            SectionHeader {
+                id:     presetsStatsHeader
+                anchors.left:       undefined
+                anchors.right:      undefined
+                Layout.fillWidth:   true
+                text:   qsTr("Statistics")
+            }
+
+            TransectStyleComplexItemStats {
+                Layout.fillWidth:   true
+                visible:            presetsStatsHeader.checked
             }
         } // Camera Column
 

--- a/src/PlanView/TransectStyleComplexItemStats.qml
+++ b/src/PlanView/TransectStyleComplexItemStats.qml
@@ -10,11 +10,8 @@ Grid {
     // The following properties must be available up the hierarchy chain
     //property var    missionItem       ///< Mission Item for editor
 
-    anchors.left:   parent.left
-    anchors.right:  parent.right
     columns:        2
     columnSpacing:  ScreenTools.defaultFontPixelWidth
-    visible:        statsHeader.checked
 
     QGCLabel { text: qsTr("Survey Area") }
     QGCLabel { text: QGroundControl.squareMetersToAppSettingsAreaUnits(missionItem.coveredArea).toFixed(2) + " " + QGroundControl.appSettingsAreaUnitsString }

--- a/src/Settings/PlanView.SettingsGroup.json
+++ b/src/Settings/PlanView.SettingsGroup.json
@@ -1,2 +1,8 @@
 [
+{
+    "name":             "displayPresetsTabFirst",
+    "shortDescription": "Display the presets tab at start",
+    "type":             "bool",
+    "defaultValue":     false
+}
 ]

--- a/src/Settings/PlanViewSettings.cc
+++ b/src/Settings/PlanViewSettings.cc
@@ -16,3 +16,5 @@ DECLARE_SETTINGGROUP(PlanView, "PlanView")
 {
     qmlRegisterUncreatableType<PlanViewSettings>("QGroundControl.SettingsManager", 1, 0, "PlanViewSettings", "Reference only"); \
 }
+
+DECLARE_SETTINGSFACT(PlanViewSettings, displayPresetsTabFirst)

--- a/src/Settings/PlanViewSettings.h
+++ b/src/Settings/PlanViewSettings.h
@@ -17,6 +17,8 @@ class PlanViewSettings : public SettingsGroup
 public:
     PlanViewSettings(QObject* parent = nullptr);
     DEFINE_SETTING_NAME_GROUP()
-    // This is currently only used to set custom build visibility of the Plan view settings ui.
-    // The settings themselves related to PlanView are in still in AppSettings due to historical reasons.
+
+    // Most individual settings related to PlanView are still in AppSettings due to historical reasons.
+
+    DEFINE_SETTINGFACT(displayPresetsTabFirst)
 };


### PR DESCRIPTION
* This allows you to complete a Survey setup all from the Presets tab
* Added a setting which specifies whether the Presets or Grid tab is shown as initial selection. Default is show Grid. Custom builds can override to show Presets for situations where most customers will use presets.

<img width="244" alt="Screen Shot 2019-09-28 at 6 31 34 PM" src="https://user-images.githubusercontent.com/5876851/65824559-0a3b4c80-e220-11e9-938b-583dbc0e878c.png">
