### PR TITLE
Fix textRole usage for QGCComboBox

### DIFF
--- a/src/AutoPilotPlugins/APM/APMCameraComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMCameraComponent.qml
@@ -272,6 +272,7 @@ SetupPage {
                             anchors.left:       gimbalOutLabel.right
                             width:              mountAngMinField.width
                             model:              gimbalOutModel
+                            textRole:           "text"
                             currentIndex:       gimbalOutIndex
 
                             onActivated: setRCFunction(gimbalOutModel.get(index).value, rcFunction)

--- a/src/AutoPilotPlugins/APM/APMCameraSubComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMCameraSubComponent.qml
@@ -316,10 +316,11 @@ SetupPage {
                                             }
 
                                             QGCComboBox {
-                                                id:           outputChan
-                                                width:        servoPWMMinField.width
-                                                model:        gimbalOutModel
-                                                currentIndex: gimbalOutIndex
+                                                id:             outputChan
+                                                width:          servoPWMMinField.width
+                                                model:          gimbalOutModel
+                                                textRole:       "text"
+                                                currentIndex:   gimbalOutIndex
 
                                                 onActivated: setRCFunction(gimbalOutModel.get(index).value, rcFunction)
                                             }

--- a/src/AutoPilotPlugins/APM/APMLightsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMLightsComponent.qml
@@ -191,6 +191,7 @@ SetupPage {
                             anchors.left:       lightsStepLabel.right
                             width:              ScreenTools.defaultFontPixelWidth * 15
                             model:              lightsOutModel
+                            textRole:           "text"
                             currentIndex:       lights1OutIndex
 
                             onActivated: setRCFunction(lightsOutModel.get(index).value, lights1Function)
@@ -211,6 +212,7 @@ SetupPage {
                             anchors.left:       lightsStepLabel.right
                             width:              lights1Combo.width
                             model:              lightsOutModel
+                            textRole:           "text"
                             currentIndex:       lights2OutIndex
 
                             onActivated: setRCFunction(lightsOutModel.get(index).value, lights2Function)

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -398,6 +398,7 @@ SetupPage {
                     id:                     sensorCombo
                     Layout.minimumWidth:    _fieldWidth
                     model:                  sensorModel
+                    textRole:               "text"
 
                     onActivated: {
                         if (index < sensorModel.count - 1) {

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -303,7 +303,8 @@ RowLayout {
             QGCLabel { text: qsTr("Increment/Decrement %") }
 
             QGCComboBox {
-                id:     adjustPercentCombo
+                id:         adjustPercentCombo
+                textRole:   "text"
                 model:  ListModel {
                     id: adjustPercentModel
                     ListElement { text: "5"; value: 0.05 }

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -409,6 +409,7 @@ SetupPage {
                                 anchors.right:  parent.right
                                 visible:        px4Flow
                                 model:          px4FlowFirmwareList
+                                textRole:       "text"
                                 currentIndex:   _defaultFirmwareIsPX4 ? 0 : 1
                             }
 

--- a/src/ui/preferences/MavlinkSettings.qml
+++ b/src/ui/preferences/MavlinkSettings.qml
@@ -513,6 +513,7 @@ Rectangle {
                             id:         windCombo
                             width:      _valueWidth
                             enabled:    !_disableDataPersistence
+                            textRole:   "text"
                             model: ListModel {
                                 id: windItems
                                 ListElement { text: "Please Select"; value: -1 }
@@ -550,6 +551,7 @@ Rectangle {
                             id:         ratingCombo
                             width:      _valueWidth
                             enabled:    !_disableDataPersistence
+                            textRole:   "text"
                             model: ListModel {
                                 id: ratingItems
                                 ListElement { text: "Please Select";            value: "notset"}


### PR DESCRIPTION
Since the switch to Qt Quick Controls2 all the combo boxes which used a ListModel which had multiple named roles in it were broken. In that case textRole must be explicitly set to "text".