### PR TITLE
Mode/Arm indicators, new QGCComboBox features

### DIFF
--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -1,59 +1,93 @@
 /****************************************************************************
  *
- * (c) 2009-2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
  *
- * @file
- *   @author Gus Grubba <gus@auterion.com>
- */
+ ****************************************************************************/
 
-import QtQuick                      2.11
-import QtQuick.Controls             2.4
-import QtQuick.Layouts              1.11
+import QtQuick                  2.11
+import QtQuick.Window           2.11
+import QtQuick.Controls         2.11
+import QtQuick.Controls.impl    2.11
+import QtQuick.Templates        2.11 as T
 
-import QGroundControl.Controls      1.0
-import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
+import QGroundControl.Palette       1.0
 
-ComboBox {
-    id:         control
-    padding:    ScreenTools.comboBoxPadding
+T.ComboBox {
+    id:             control
+    padding:        ScreenTools.comboBoxPadding
+    spacing:        ScreenTools.defaultFontPixelWidth
+    implicitWidth:  Math.max(implicitBackgroundWidth + leftInset + rightInset,
+                             implicitContentWidth + leftPadding + rightPadding,
+                             sizeToContents ? _popupWidth : 0)
+    implicitHeight: Math.max(implicitBackgroundHeight + topInset + bottomInset,
+                             implicitContentHeight + topPadding + bottomPadding,
+                             implicitIndicatorHeight + topPadding + bottomPadding)
+    leftPadding:    padding + (!control.mirrored || !indicator || !indicator.visible ? 0 : indicator.width + spacing)
+    rightPadding:   padding + (control.mirrored || !indicator || !indicator.visible ? 0 : indicator.width)
 
-    property bool centeredLabel:  false
+    property bool   centeredLabel:  false
+    property bool   sizeToContents: false
+    property string alternateText:  ""
 
-    property var _qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    property var    _qgcPal:           QGCPalette { colorGroupEnabled: enabled }
+    property real   _largestTextWidth: 0
+    property real   _popupWidth:       sizeToContents ? _largestTextWidth + leftPadding + rightPadding : control.width
 
-    Component.onCompleted: indicator.color = Qt.binding(function() { return _qgcPal.text })
-
-    background: Rectangle {
-        implicitWidth:                  ScreenTools.implicitComboBoxWidth
-        implicitHeight:                 ScreenTools.implicitComboBoxHeight
-        color:                          _qgcPal.window
-        border.width:                   enabled ? 1 : 0
-        border.color:                   "#999"
+    TextMetrics {
+        id: textMetrics
     }
 
-    /*! Adding the Combobox list item to the theme.  */
+    onModelChanged: {
+        if (sizeToContents) {
+            _largestTextWidth = 0
+            textMetrics.font = control.font
+            for (var i = 0; i < model.length; i++){
+                textMetrics.text = model[i]
+                _largestTextWidth = Math.max(textMetrics.width, _largestTextWidth)
+            }
+        }
+    }
 
+    // The items in the popup
     delegate: ItemDelegate {
-            width:                      control.width
+        width: _popupWidth
 
-            contentItem: Text {
-                text:                   control.textRole ? (Array.isArray(control.model) ? modelData[control.textRole] : model[control.textRole]) : modelData
-                color:                  control.currentIndex === index ? _qgcPal.buttonHighlightText : _qgcPal.buttonText
-                verticalAlignment:      Text.AlignVCenter
-            }
+        property string _text: control.textRole ? (Array.isArray(control.model) ? modelData[control.textRole] : model[control.textRole]) : modelData
 
-            background: Rectangle {
-                color:                  control.currentIndex === index ? _qgcPal.buttonHighlight : _qgcPal.button
-            }
-
-            highlighted:                control.highlightedIndex === index
+        TextMetrics {
+            id:    popupItemMetrics
+            text:  _text
         }
 
-    /*! This defines the label of the button.  */
+        contentItem: Text {
+            text:                   _text
+            font:                   control.font
+            color:                  control.currentIndex === index ? _qgcPal.buttonHighlightText : _qgcPal.buttonText
+            verticalAlignment:      Text.AlignVCenter
+        }
+
+        background: Rectangle {
+            color:                  control.currentIndex === index ? _qgcPal.buttonHighlight : _qgcPal.button
+        }
+
+        highlighted:                control.highlightedIndex === index
+    }
+
+    // Dropdown indicator
+    indicator: ColorImage {
+        x:              control.mirrored ? control.padding : control.width - width
+        y:              control.topPadding + (control.availableHeight - height) / 2
+        color:          _qgcPal.text
+        defaultColor:   "#353637"
+        source:         "qrc:/qt-project.org/imports/QtQuick/Controls.2/images/double-arrow.png"
+        opacity:        enabled ? 1 : 0.3
+    }
+
+    // The label of the button
     contentItem: Item {
         implicitWidth:                  text.implicitWidth
         implicitHeight:                 text.implicitHeight
@@ -62,8 +96,47 @@ ComboBox {
             id:                         text
             anchors.verticalCenter:     parent.verticalCenter
             anchors.horizontalCenter:   centeredLabel ? parent.horizontalCenter : undefined
-            text:                       control.currentText
+            text:                       control.alternateText === "" ? control.currentText : control.alternateText
+            font:                       control.font
             color:                      _qgcPal.text
+        }
+    }
+
+    background: Rectangle {
+        implicitWidth:  ScreenTools.implicitComboBoxWidth
+        implicitHeight: ScreenTools.implicitComboBoxHeight
+        color:          _qgcPal.window
+        border.width:   enabled ? 1 : 0
+        border.color:   "#999"
+    }
+
+    popup: T.Popup {
+        y:              control.height
+        width:          _popupWidth
+        height:         Math.min(contentItem.implicitHeight, control.Window.height - topMargin - bottomMargin)
+        topMargin:      6
+        bottomMargin:   6
+
+        contentItem: ListView {
+            clip:                   true
+            implicitHeight:         contentHeight
+            model:                  control.delegateModel
+            currentIndex:           control.highlightedIndex
+            highlightMoveDuration:  0
+
+            Rectangle {
+                z:              10
+                width:          parent.width
+                height:         parent.height
+                color:          "transparent"
+                border.color:   _qgcPal.text
+            }
+
+            T.ScrollIndicator.vertical: ScrollIndicator { }
+        }
+
+        background: Rectangle {
+            color: control.palette.window
         }
     }
 }

--- a/src/ui/toolbar/ArmedIndicator.qml
+++ b/src/ui/toolbar/ArmedIndicator.qml
@@ -19,20 +19,24 @@ import QGroundControl.Palette               1.0
 
 //-------------------------------------------------------------------------
 //-- Armed Indicator
-QGCLabel {
-    anchors.top:        parent.top
-    anchors.bottom:     parent.bottom
-    verticalAlignment:  Text.AlignVCenter
-    text:               _armed ? qsTr("Armed") : qsTr("Disarmed")
-    font.pointSize:     ScreenTools.mediumFontPointSize
-    color:              qgcPal.buttonText
+QGCComboBox {
+    anchors.top:    parent.top
+    anchors.bottom: parent.bottom
+    alternateText:  _armed ? qsTr("Armed") : qsTr("Disarmed")
+    model:          [ qsTr("Arm"), qsTr("Disarm") ]
+    font.pointSize: ScreenTools.mediumFontPointSize
+    currentIndex:   -1
+    sizeToContents: true
 
-    property bool   _armed:         activeVehicle ? activeVehicle.armed : false
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _armed:         _activeVehicle ? _activeVehicle.armed : false
 
-    QGCPalette { id: qgcPal }
-
-    QGCMouseArea {
-        fillItem: parent
-        onClicked: _armed ? mainWindow.disarmVehicle() : mainWindow.armVehicle()
+    onActivated: {
+        if (index == 0) {
+            mainWindow.armVehicle()
+        } else {
+            mainWindow.disarmVehicle()
+        }
+        currentIndex = -1
     }
 }

--- a/src/ui/toolbar/ModeIndicator.qml
+++ b/src/ui/toolbar/ModeIndicator.qml
@@ -19,52 +19,20 @@ import QGroundControl.Palette               1.0
 
 //-------------------------------------------------------------------------
 //-- Mode Indicator
-Item {
+QGCComboBox {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
-    width:          flightModeSelector.width
+    alternateText:  _activeVehicle ? _activeVehicle.flightMode : ""
+    model:          _flightModes
+    font.pointSize: ScreenTools.mediumFontPointSize
+    currentIndex:   -1
+    sizeToContents: true
 
-    property var _flightModes:      activeVehicle ? activeVehicle.flightModes : [ ]
+    property var _activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
+    property var _flightModes:      _activeVehicle ? _activeVehicle.flightModes : [ ]
 
-    on_FlightModesChanged: flightModeSelector.updateFlightModesMenu()
-
-    QGCLabel {
-        id:                     flightModeSelector
-        text:                   activeVehicle ? activeVehicle.flightMode : qsTr("N/A", "No data to display")
-        font.pointSize:         ScreenTools.mediumFontPointSize
-        color:                  qgcPal.buttonText
-        anchors.verticalCenter: parent.verticalCenter
-        QGCMenu {
-            id: flightModesMenu
-        }
-        Component {
-            id: flightModeMenuItemComponent
-            QGCMenuItem {
-                onTriggered: activeVehicle.flightMode = text
-            }
-        }
-        property var flightModesMenuItems: []
-        function updateFlightModesMenu() {
-            if (activeVehicle && activeVehicle.flightModeSetAvailable) {
-                // Remove old menu items
-                var i
-                for (i = 0; i < flightModesMenuItems.length; i++) {
-                    flightModesMenu.removeItem(flightModesMenuItems[i])
-                }
-                flightModesMenuItems.length = 0
-                // Add new items
-                for (i = 0; i < _flightModes.length; i++) {
-                    var menuItem = flightModeMenuItemComponent.createObject(null, { "text": _flightModes[i] })
-                    flightModesMenuItems.push(menuItem)
-                    flightModesMenu.insertItem(i, menuItem)
-                }
-            }
-        }
-        Component.onCompleted: flightModeSelector.updateFlightModesMenu()
-        MouseArea {
-            visible:        activeVehicle && activeVehicle.flightModeSetAvailable
-            anchors.fill:   parent
-            onClicked:      flightModesMenu.popup()
-        }
+    onActivated: {
+        _activeVehicle.flightMode = _flightModes[index]
+        currentIndex = -1
     }
 }


### PR DESCRIPTION
Users didn't realize they could click on the flight mode and arm text in the toolbar since it didn't really look like something clickable. Caused a safety problem with respect to Disarming with an Emergency Stop from these controls. Changed theb to be a ComboBox variant instead:

![Screen Shot 2019-10-04 at 10 11 30 AM](https://user-images.githubusercontent.com/5876851/66226454-b1403e00-e68f-11e9-8ed3-2818973740f9.png)

* Modified QGCComboBox for new features:
  * Font is settable
  * QGCComboBox.alternateText - show this text instead of the combo selection
  * QGCComboBox.sizeToContents - set to true, don't set width: combo will automatically size the fit the width of the largest item in the dropdown
* Changed Flight Mode and Armed toolbar indicators to use the new QGCComboBox + features