### PR TITLE
VFR_HUD: use attitude for user display when available

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1401,6 +1401,7 @@ private:
     uint64_t        _capabilityBits;
     bool            _highLatencyLink;
     bool            _receivingAttitudeQuaternion;
+    bool            _receivingAttitudeHud;
 
     QGCCameraManager* _cameras;
 


### PR DESCRIPTION
( Requires MAVLink PR https://github.com/mavlink/mavlink/pull/1247 )

This PR handles the extension of VFR_HUD with attitude fields meant for user display.

See MAVLink PR for details.