### PR TITLE
Plan Patterns: Minimum transect spacing of 0.5 meters

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -144,9 +144,8 @@ bool CorridorScanComplexItem::specifiesCoordinate(void) const
 
 int CorridorScanComplexItem::_transectCount(void) const
 {
-    double transectSpacing = _cameraCalc.adjustedFootprintSide()->rawValue().toDouble();
     double fullWidth = _corridorWidthFact.rawValue().toDouble();
-    return fullWidth > 0.0 ? qCeil(fullWidth / transectSpacing) : 1;
+    return fullWidth > 0.0 ? qCeil(fullWidth / _transectSpacing()) : 1;
 }
 
 void CorridorScanComplexItem::_appendLoadedMissionItems(QList<MissionItem*>& items, QObject* missionItemParent)
@@ -343,7 +342,7 @@ void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
     _transects.clear();
     _transectsPathHeightInfo.clear();
 
-    double transectSpacing = _cameraCalc.adjustedFootprintSide()->rawValue().toDouble();
+    double transectSpacing = _transectSpacing();
     double fullWidth = _corridorWidthFact.rawValue().toDouble();
     double halfWidth = fullWidth / 2.0;
     int transectCount = _transectCount();
@@ -500,4 +499,17 @@ CorridorScanComplexItem::ReadyForSaveState CorridorScanComplexItem::readyForSave
 double CorridorScanComplexItem::timeBetweenShots(void)
 {
     return _cruiseSpeed == 0 ? 0 : _cameraCalc.adjustedFootprintFrontal()->rawValue().toDouble() / _cruiseSpeed;
+}
+
+double CorridorScanComplexItem::_transectSpacing(void) const
+{
+    double transectSpacing = _cameraCalc.adjustedFootprintSide()->rawValue().toDouble();
+    if (transectSpacing < 0.5) {
+        // We can't let spacing get too small otherwise we will end up with too many transects.
+        // So we limit to 0.5 meter spacing as min and set to huge value which will cause a single
+        // transect to be added.
+        transectSpacing = 100000;
+    }
+
+    return transectSpacing;
 }

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -69,9 +69,10 @@ private slots:
     void _recalcCameraShots         (void) final;
 
 private:
-    int _transectCount              (void) const;
-    void _buildAndAppendMissionItems(QList<MissionItem*>& items, QObject* missionItemParent);
-    void _appendLoadedMissionItems  (QList<MissionItem*>& items, QObject* missionItemParent);
+    double  _transectSpacing            (void) const;
+    int     _transectCount              (void) const;
+    void    _buildAndAppendMissionItems (QList<MissionItem*>& items, QObject* missionItemParent);
+    void    _appendLoadedMissionItems   (QList<MissionItem*>& items, QObject* missionItemParent);
 
     QGCMapPolyline                  _corridorPolyline;
     QList<QList<QGeoCoordinate>>    _transectSegments;      ///< Internal transect segments including grid exit, turnaround and internal camera points

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -834,6 +834,12 @@ void SurveyComplexItem::_rebuildTransectsPhase1WorkerSinglePolygon(bool refly)
 
     double gridAngle = _gridAngleFact.rawValue().toDouble();
     double gridSpacing = _cameraCalc.adjustedFootprintSide()->rawValue().toDouble();
+    if (gridSpacing < 0.5) {
+        // We can't let gridSpacing get too small otherwise we will end up with too many transects.
+        // So we limit to 0.5 meter spacing as min and set to huge value which will cause a single
+        // transect to be added.
+        gridSpacing = 100000;
+    }
 
     gridAngle = _clampGridAngle90(gridAngle);
     gridAngle += refly ? 90 : 0;


### PR DESCRIPTION
If you let the transect spacing get too small you end up with way too many transects and QGC will blow up from perf problems. In order to prevent this the minimum transect spacing is set internally to 0.5 meters. Anything lower than that will automatically just generate a single transect.

Fix for #7870