### PR TITLE
Coding Style: Unused arguments

### DIFF
--- a/CodingStyle.cc
+++ b/CodingStyle.cc
@@ -85,8 +85,11 @@ void CodingStyle::_methodWithManyArguments(QWidget*         parent,
                                            const QString&   caption,
                                            const QString&   dir,
                                            Options          options1,
-                                           Options          options2,
+                                           Options          /* options2 */,
                                            Options          options3)
 {
+    // options2 is an unused method argument.
+    // Do not use Q_UNUSUED and do not just remove the argument name and leave the type.
+
     // Implementataion here...
 }


### PR DESCRIPTION
Decided that Q_UNUSED is crap. Problem is that you can start to use the th argument and leave Q_UNUSED in there. Instead comment out the argument name as show in the style. This leaves as much information possible still in file for readability and future use. Don't remove the argument name entirely.

Correct:
```void _foo(Foo /* foo */)```

Incorrect:
```void _foo(Foo)```
