### PR TITLE
Display the Tools button also while param filtering is active

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -97,7 +97,6 @@ Item {
         anchors.bottom: header.bottom
         anchors.right:  parent.right
         text:           qsTr("Tools")
-        visible:        !_searchFilter
         onClicked:      toolsMenu.popup()
     }
 


### PR DESCRIPTION
A few parameter changes require a vehicle reboot. After changing such a parameter the search filter is in most cases still active. So you have to clear your search before you can access the Tools button to restart the vehicle. I do not see a reason why we should not be able to access the Tools button while having an active search filter.

This is not tested.