### PR TITLE
Guided: Resume mission

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -584,12 +584,6 @@ QGCView {
                     visible:    _guidedController.showContinueMission
                 },
                 {
-                    title:      _guidedController.resumeMissionTitle,
-                    text:       _guidedController.resumeMissionMessage,
-                    action:     _guidedController.actionResumeMission,
-                    visible:    _guidedController.showResumeMission
-                },
-                {
                     title:      _guidedController.changeAltTitle,
                     text:       _guidedController.changeAltMessage,
                     action:     _guidedController.actionChangeAlt,


### PR DESCRIPTION
Remove leftover deprecated Resume Mission Guided action code. This could cause an empty action item to be added when clicking "Action".