### PR TITLE
Toolbar: Indicator spacing

### DIFF
--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -96,9 +96,9 @@ Item {
     property bool showEmergenyStop:     _guidedActionsEnabled && !_hideEmergenyStop && _vehicleArmed && _vehicleFlying
     property bool showArm:              _guidedActionsEnabled && !_vehicleArmed
     property bool showDisarm:           _guidedActionsEnabled && _vehicleArmed && !_vehicleFlying
-    property bool showRTL:              _guidedActionsEnabled && _vehicleArmed && activeVehicle.guidedModeSupported && _vehicleFlying && !_vehicleInRTLMode
-    property bool showTakeoff:          _guidedActionsEnabled && activeVehicle.takeoffVehicleSupported && !_vehicleFlying
-    property bool showLand:             _guidedActionsEnabled && activeVehicle.guidedModeSupported && _vehicleArmed && !activeVehicle.fixedWing && !_vehicleInLandMode
+    property bool showRTL:              _guidedActionsEnabled && _vehicleArmed && _activeVehicle.guidedModeSupported && _vehicleFlying && !_vehicleInRTLMode
+    property bool showTakeoff:          _guidedActionsEnabled && _activeVehicle.takeoffVehicleSupported && !_vehicleFlying
+    property bool showLand:             _guidedActionsEnabled && _activeVehicle.guidedModeSupported && _vehicleArmed && !_activeVehicle.fixedWing && !_vehicleInLandMode
     property bool showStartMission:     _guidedActionsEnabled && _missionAvailable && !_missionActive && !_vehicleFlying
     property bool showContinueMission:  _guidedActionsEnabled && _missionAvailable && !_missionActive && _vehicleArmed && _vehicleFlying && (_currentMissionIndex < _missionItemCount - 1)
     property bool showPause:            _guidedActionsEnabled && _vehicleArmed && _activeVehicle.pauseVehicleSupported && _vehicleFlying && !_vehiclePaused && !_fixedWingOnApproach
@@ -108,18 +108,19 @@ Item {
     property bool showGotoLocation:     _guidedActionsEnabled && _vehicleFlying
 
     // Note: The '_missionItemCount - 2' is a hack to not trigger resume mission when a mission ends with an RTL item
-    property bool showResumeMission:    activeVehicle && !_vehicleArmed && _vehicleWasFlying && _missionAvailable && _resumeMissionIndex > 0 && (_resumeMissionIndex < _missionItemCount - 2)
+    property bool showResumeMission:    _activeVehicle && !_vehicleArmed && _vehicleWasFlying && _missionAvailable && _resumeMissionIndex > 0 && (_resumeMissionIndex < _missionItemCount - 2)
 
     property bool guidedUIVisible:      guidedActionConfirm.visible || guidedActionList.visible
 
     property var    _corePlugin:            QGroundControl.corePlugin
-    property bool   _guidedActionsEnabled:  (!ScreenTools.isDebug && QGroundControl.corePlugin.options.guidedActionsRequireRCRSSI && activeVehicle) ? _rcRSSIAvailable : activeVehicle
-    property string _flightMode:            activeVehicle ? activeVehicle.flightMode : ""
+    property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _guidedActionsEnabled:  (!ScreenTools.isDebug && QGroundControl.corePlugin.options.guidedActionsRequireRCRSSI && _activeVehicle) ? _rcRSSIAvailable : _activeVehicle
+    property string _flightMode:            _activeVehicle ? _activeVehicle.flightMode : ""
     property bool   _missionAvailable:      missionController.containsItems
-    property bool   _missionActive:         activeVehicle ? _vehicleArmed && (_vehicleInLandMode || _vehicleInRTLMode || _vehicleInMissionMode) : false
-    property bool   _vehicleArmed:          activeVehicle ? activeVehicle.armed  : false
-    property bool   _vehicleFlying:         activeVehicle ? activeVehicle.flying  : false
-    property bool   _vehicleLanding:        activeVehicle ? activeVehicle.landing  : false
+    property bool   _missionActive:         _activeVehicle ? _vehicleArmed && (_vehicleInLandMode || _vehicleInRTLMode || _vehicleInMissionMode) : false
+    property bool   _vehicleArmed:          _activeVehicle ? _activeVehicle.armed  : false
+    property bool   _vehicleFlying:         _activeVehicle ? _activeVehicle.flying  : false
+    property bool   _vehicleLanding:        _activeVehicle ? _activeVehicle.landing  : false
     property bool   _vehiclePaused:         false
     property bool   _vehicleInMissionMode:  false
     property bool   _vehicleInRTLMode:      false
@@ -134,13 +135,13 @@ Item {
     property bool   _fixedWingOnApproach:   _activeVehicle ? _activeVehicle.fixedWing && _vehicleLanding : false
 
     // You can turn on log output for GuidedActionsController by turning on GuidedActionsControllerLog category
-    property bool __guidedModeSupported:    activeVehicle ? activeVehicle.guidedModeSupported : false
-    property bool __pauseVehicleSupported:  activeVehicle ? activeVehicle.pauseVehicleSupported : false
+    property bool __guidedModeSupported:    _activeVehicle ? _activeVehicle.guidedModeSupported : false
+    property bool __pauseVehicleSupported:  _activeVehicle ? _activeVehicle.pauseVehicleSupported : false
     property bool __flightMode:             _flightMode
 
     function _outputState() {
         if (_corePlugin.guidedActionsControllerLogging()) {
-            console.log(qsTr("activeVehicle(%1) _vehicleArmed(%2) guidedModeSupported(%3) _vehicleFlying(%4) _vehicleWasFlying(%5) _vehicleInRTLMode(%6) pauseVehicleSupported(%7) _vehiclePaused(%8) _flightMode(%9) _missionItemCount(%10)").arg(activeVehicle ? 1 : 0).arg(_vehicleArmed ? 1 : 0).arg(__guidedModeSupported ? 1 : 0).arg(_vehicleFlying ? 1 : 0).arg(_vehicleWasFlying ? 1 : 0).arg(_vehicleInRTLMode ? 1 : 0).arg(__pauseVehicleSupported ? 1 : 0).arg(_vehiclePaused ? 1 : 0).arg(_flightMode).arg(_missionItemCount))
+            console.log(qsTr("_activeVehicle(%1) _vehicleArmed(%2) guidedModeSupported(%3) _vehicleFlying(%4) _vehicleWasFlying(%5) _vehicleInRTLMode(%6) pauseVehicleSupported(%7) _vehiclePaused(%8) _flightMode(%9) _missionItemCount(%10)").arg(_activeVehicle ? 1 : 0).arg(_vehicleArmed ? 1 : 0).arg(__guidedModeSupported ? 1 : 0).arg(_vehicleFlying ? 1 : 0).arg(_vehicleWasFlying ? 1 : 0).arg(_vehicleInRTLMode ? 1 : 0).arg(__pauseVehicleSupported ? 1 : 0).arg(_vehiclePaused ? 1 : 0).arg(_flightMode).arg(_missionItemCount))
         }
     }
 
@@ -208,10 +209,10 @@ Item {
     property var _actionData
 
     on_FlightModeChanged: {
-        _vehiclePaused =        activeVehicle ? _flightMode === activeVehicle.pauseFlightMode : false
-        _vehicleInRTLMode =     activeVehicle ? _flightMode === activeVehicle.rtlFlightMode || _flightMode === activeVehicle.smartRTLFlightMode : false
-        _vehicleInLandMode =    activeVehicle ? _flightMode === activeVehicle.landFlightMode : false
-        _vehicleInMissionMode = activeVehicle ? _flightMode === activeVehicle.missionFlightMode : false // Must be last to get correct signalling for showStartMission popups
+        _vehiclePaused =        _activeVehicle ? _flightMode === _activeVehicle.pauseFlightMode : false
+        _vehicleInRTLMode =     _activeVehicle ? _flightMode === _activeVehicle.rtlFlightMode || _flightMode === _activeVehicle.smartRTLFlightMode : false
+        _vehicleInLandMode =    _activeVehicle ? _flightMode === _activeVehicle.landFlightMode : false
+        _vehicleInMissionMode = _activeVehicle ? _flightMode === _activeVehicle.missionFlightMode : false // Must be last to get correct signalling for showStartMission popups
     }
 
     // Called when an action is about to be executed in order to confirm
@@ -286,7 +287,7 @@ Item {
         case actionRTL:
             confirmDialog.title = rtlTitle
             confirmDialog.message = rtlMessage
-            if (activeVehicle.supportsSmartRTL) {
+            if (_activeVehicle.supportsSmartRTL) {
                 confirmDialog.optionText = qsTr("Smart RTL")
                 confirmDialog.optionChecked = false
             }
@@ -355,13 +356,13 @@ Item {
         var rgVehicle;
         switch (actionCode) {
         case actionRTL:
-            activeVehicle.guidedModeRTL(optionChecked)
+            _activeVehicle.guidedModeRTL(optionChecked)
             break
         case actionLand:
-            activeVehicle.guidedModeLand()
+            _activeVehicle.guidedModeLand()
             break
         case actionTakeoff:
-            activeVehicle.guidedModeTakeoff(actionAltitudeChange)
+            _activeVehicle.guidedModeTakeoff(actionAltitudeChange)
             break
         case actionResumeMission:
         case actionResumeMissionUploadFail:
@@ -369,7 +370,7 @@ Item {
             break
         case actionStartMission:
         case actionContinueMission:
-            activeVehicle.startMission()
+            _activeVehicle.startMission()
             break
         case actionMVStartMission:
             rgVehicle = QGroundControl.multiVehicleManager.vehicles
@@ -378,32 +379,32 @@ Item {
             }
             break
         case actionArm:
-            activeVehicle.armed = true
+            _activeVehicle.armed = true
             break
         case actionDisarm:
-            activeVehicle.armed = false
+            _activeVehicle.armed = false
             break
         case actionEmergencyStop:
-            activeVehicle.emergencyStop()
+            _activeVehicle.emergencyStop()
             break
         case actionChangeAlt:
-            activeVehicle.guidedModeChangeAltitude(actionAltitudeChange)
+            _activeVehicle.guidedModeChangeAltitude(actionAltitudeChange)
             break
         case actionGoto:
-            activeVehicle.guidedModeGotoLocation(actionData)
+            _activeVehicle.guidedModeGotoLocation(actionData)
             break
         case actionSetWaypoint:
-            activeVehicle.setCurrentMissionSequence(actionData)
+            _activeVehicle.setCurrentMissionSequence(actionData)
             break
         case actionOrbit:
-            activeVehicle.guidedModeOrbit(orbitMapCircle.center, orbitMapCircle.radius() * (orbitMapCircle.clockwiseRotation ? 1 : -1), activeVehicle.altitudeAMSL.rawValue + actionAltitudeChange)
+            _activeVehicle.guidedModeOrbit(orbitMapCircle.center, orbitMapCircle.radius() * (orbitMapCircle.clockwiseRotation ? 1 : -1), _activeVehicle.altitudeAMSL.rawValue + actionAltitudeChange)
             break
         case actionLandAbort:
-            activeVehicle.abortLanding(50)     // hardcoded value for climbOutAltitude that is currently ignored
+            _activeVehicle.abortLanding(50)     // hardcoded value for climbOutAltitude that is currently ignored
             break
         case actionPause:
-            activeVehicle.pauseVehicle()
-            activeVehicle.guidedModeChangeAltitude(actionAltitudeChange)
+            _activeVehicle.pauseVehicle()
+            _activeVehicle.guidedModeChangeAltitude(actionAltitudeChange)
             break
         case actionMVPause:
             rgVehicle = QGroundControl.multiVehicleManager.vehicles
@@ -412,10 +413,10 @@ Item {
             }
             break
         case actionVtolTransitionToFwdFlight:
-            activeVehicle.vtolInFwdFlight = true
+            _activeVehicle.vtolInFwdFlight = true
             break
         case actionVtolTransitionToMRFlight:
-            activeVehicle.vtolInFwdFlight = false
+            _activeVehicle.vtolInFwdFlight = false
             break
         default:
             console.warn(qsTr("Internal error: unknown actionCode"), actionCode)

--- a/src/ui/toolbar/ArmedIndicator.qml
+++ b/src/ui/toolbar/ArmedIndicator.qml
@@ -28,6 +28,8 @@ QGCComboBox {
     currentIndex:   -1
     sizeToContents: true
 
+    property bool showIndicator: true
+
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property bool   _armed:         _activeVehicle ? _activeVehicle.armed : false
 

--- a/src/ui/toolbar/BatteryIndicator.qml
+++ b/src/ui/toolbar/BatteryIndicator.qml
@@ -24,6 +24,8 @@ Item {
     anchors.bottom: parent.bottom
     width:          batteryIndicatorRow.width
 
+    property bool showIndicator: true
+
     function getBatteryColor() {
         if(activeVehicle) {
             if(activeVehicle.battery.percentRemaining.value > 75) {

--- a/src/ui/toolbar/GPSIndicator.qml
+++ b/src/ui/toolbar/GPSIndicator.qml
@@ -24,6 +24,8 @@ Item {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
 
+    property bool showIndicator: true
+
     Component {
         id: gpsInfo
 

--- a/src/ui/toolbar/GPSRTKIndicator.qml
+++ b/src/ui/toolbar/GPSRTKIndicator.qml
@@ -19,10 +19,11 @@ import QGroundControl.Palette               1.0
 //-- GPS Indicator
 Item {
     id:             _root
-    width:          visible ? (gpsValuesColumn.x + gpsValuesColumn.width) * 1.1 : 0
+    width:          (gpsValuesColumn.x + gpsValuesColumn.width) * 1.1
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
-    visible:        QGroundControl.gpsRtk.connected.value
+
+    property bool showIndicator: QGroundControl.gpsRtk.connected.value
 
     Component {
         id: gpsInfo

--- a/src/ui/toolbar/LinkIndicator.qml
+++ b/src/ui/toolbar/LinkIndicator.qml
@@ -23,10 +23,9 @@ import QGroundControl.Vehicle               1.0
 Item {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
-    width:          visible ? priorityLinkSelector.width : 0
-    visible:        _visible
+    width:          priorityLinkSelector.width
 
-    property bool _visible: false
+    property bool showIndicator: false
 
     QGCLabel {
         id:                     priorityLinkSelector
@@ -66,7 +65,7 @@ Item {
                     }
                 }
 
-                _visible = links.length > 1 && has_hl
+                showIndicator = links.length > 1 && has_hl
             }
         }
 

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -84,10 +84,12 @@ Item {
         Repeater {
             model:      activeVehicle ? activeVehicle.toolBarIndicators : []
             Loader {
+                id:                 indicatorLoader
                 anchors.top:        parent.top
                 anchors.bottom:     parent.bottom
                 anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.66
-                source:             modelData;
+                source:             modelData
+                visible:            item.showIndicator
             }
         }
     }

--- a/src/ui/toolbar/MessageIndicator.qml
+++ b/src/ui/toolbar/MessageIndicator.qml
@@ -25,7 +25,9 @@ Item {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
 
-    property bool   _isMessageImportant:    activeVehicle ? !activeVehicle.messageTypeNormal && !activeVehicle.messageTypeNone : false
+    property bool showIndicator: true
+
+    property bool _isMessageImportant:    activeVehicle ? !activeVehicle.messageTypeNormal && !activeVehicle.messageTypeNone : false
 
     function getMessageColor() {
         if (activeVehicle) {

--- a/src/ui/toolbar/ModeIndicator.qml
+++ b/src/ui/toolbar/ModeIndicator.qml
@@ -28,6 +28,8 @@ QGCComboBox {
     currentIndex:   -1
     sizeToContents: true
 
+    property bool showIndicator: true
+
     property var _activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
     property var _flightModes:      _activeVehicle ? _activeVehicle.flightModes : [ ]
 

--- a/src/ui/toolbar/MultiVehicleSelector.qml
+++ b/src/ui/toolbar/MultiVehicleSelector.qml
@@ -26,7 +26,8 @@ QGCComboBox {
     currentIndex:   -1
     sizeToContents: true
     model:          _vehicleModel
-    visible:        _multipleVehicles
+
+    property bool showIndicator: _multipleVehicles
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property bool   _multipleVehicles:  _activeVehicle ? QGroundControl.multiVehicleManager.vehicles.count > 1 : false

--- a/src/ui/toolbar/RCRSSIIndicator.qml
+++ b/src/ui/toolbar/RCRSSIIndicator.qml
@@ -23,8 +23,10 @@ Item {
     width:          rssiRow.width * 1.1
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
-    visible:        activeVehicle ? activeVehicle.supportsRadio : true
 
+    property bool showIndicator: _activeVehicle.supportsRadio
+
+    property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property bool   _rcRSSIAvailable:   activeVehicle ? activeVehicle.rcRSSI > 0 && activeVehicle.rcRSSI <= 100 : false
 
     Component {

--- a/src/ui/toolbar/TelemetryRSSIIndicator.qml
+++ b/src/ui/toolbar/TelemetryRSSIIndicator.qml
@@ -22,10 +22,12 @@ Item {
     id:             _root
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
-    width:          _hasTelemetry ? telemIcon.width * 1.1 : 0
-    visible:        _hasTelemetry
+    width:          telemIcon.width * 1.1
 
-    property bool _hasTelemetry:    activeVehicle ? activeVehicle.telemetryLRSSI !== 0 : false
+    property bool showIndicator: _hasTelemetry
+
+    property var  _activeVehicle:   QGroundControl.multiVehicleManager.activeVehicle
+    property bool _hasTelemetry:    _activeVehicle ? _activeVehicle.telemetryLRSSI !== 0 : false
 
     Component {
         id: telemRSSIInfo

--- a/src/ui/toolbar/VTOLModeIndicator.qml
+++ b/src/ui/toolbar/VTOLModeIndicator.qml
@@ -26,10 +26,12 @@ QGCLabel {
     text:               _fwdFlight ? qsTr("VTOL: Fixed Wing") : qsTr("VTOL: Multi-Rotor")
     font.pointSize:     ScreenTools.mediumFontPointSize
     color:              qgcPal.buttonText
-    visible:            activeVehicle ? activeVehicle.vtol && activeVehicle.px4Firmware : false
-    width:              visible ? implicitWidth : 0
+    width:              implicitWidth
 
-    property bool _fwdFlight: activeVehicle ? activeVehicle.vtolInFwdFlight : false
+    property bool showIndicator: _activeVehicle.vtol && _activeVehicle.px4Firmware
+
+    property var  _activeVehicle:   QGroundControl.multiVehicleManager.activeVehicle
+    property bool _fwdFlight:       _activeVehicle.vtolInFwdFlight
 
     QGCMouseArea {
         fillItem: parent


### PR DESCRIPTION
Fix problem with extra empty space on iOs toolbar. Toolbar indicators now require a showIndicator property to determine whether the parent Loader item should be visible or not. Ths indicators themselves no longer set the visible property nor do they set width to 0 with invisible.