### PR TITLE
Persist link name when switching types.

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -762,6 +762,7 @@ bool LinkManager::endConfigurationEditing(LinkConfiguration* config, LinkConfigu
         saveLinkConfigurationList();
         // Tell link about changes (if any)
         config->updateSettings();
+        emit config->nameChanged(config->name());
         // Discard temporary duplicate
         delete editedConfig;
     } else {

--- a/src/ui/preferences/LinkSettings.qml
+++ b/src/ui/preferences/LinkSettings.qml
@@ -67,7 +67,6 @@ Rectangle {
                     text:                       object.name
                     exclusiveGroup:             linkGroup
                     visible:                    !object.dynamic
-
                     onClicked: {
                         checked = true
                         _currentSelection = object
@@ -275,7 +274,7 @@ Rectangle {
                                             linkSettingLoader.source = ""
                                             linkSettingLoader.visible = false
                                             // Save current name
-                                            var name = editConfig.name
+                                            var name = nameField.text
                                             // Discard link configuration (old type)
                                             QGroundControl.linkManager.cancelConfigurationEditing(editConfig)
                                             // Create new link configuration


### PR DESCRIPTION
When creating a new link, if you named it and then switched type (e.g. from Serial to UDP), the name would revert to "Unnamed".

Also, when editing a link name, the name change was not being signaled and the UI was not reflecting the new, edited name.

