### PR TITLE
rename collision prevention parameters to match Firmware

### DIFF
--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -52,7 +52,7 @@ SetupPage {
             property Fact _rcLossAction:        controller.getParameterFact(-1, "NAV_RCL_ACT")
             property Fact _dlLossAction:        controller.getParameterFact(-1, "NAV_DLL_ACT")
             property Fact _disarmLandDelay:     controller.getParameterFact(-1, "COM_DISARM_LAND")
-            property Fact _collisionPrevention: controller.getParameterFact(-1, "MPC_COL_PREV_D")
+            property Fact _collisionPrevention: controller.getParameterFact(-1, "CP_DIST")
             property Fact _objectAvoidance:     controller.getParameterFact(-1, "COM_OBS_AVOID")
             property Fact _landSpeedMC:         controller.getParameterFact(-1, "MPC_LAND_SPEED", false)
             property bool _hitlAvailable:       controller.parameterExists(-1, hitlParam)

--- a/src/Vehicle/VehicleObjectAvoidance.cc
+++ b/src/Vehicle/VehicleObjectAvoidance.cc
@@ -12,7 +12,7 @@
 #include "ParameterManager.h"
 #include <cmath>
 
-static const char* kColPrevParam = "MPC_COL_PREV_D";
+static const char* kColPrevParam = "CP_DIST";
 
 //-----------------------------------------------------------------------------
 VehicleObjectAvoidance::VehicleObjectAvoidance(Vehicle *vehicle, QObject* parent)


### PR DESCRIPTION
Sync collision prevention parameters with Firmware https://github.com/PX4/Firmware/pull/13135
FYI @baumanta