### PR TITLE
Fix test for rally and geofence support.

### DIFF
--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -117,7 +117,9 @@ void GeoFenceController::managerVehicleChanged(Vehicle* managerVehicle)
     connect(_geoFenceManager, &GeoFenceManager::removeAllComplete,              this, &GeoFenceController::_managerRemoveAllComplete);
     connect(_geoFenceManager, &GeoFenceManager::inProgressChanged,              this, &GeoFenceController::syncInProgressChanged);
 
+    //-- GeoFenceController::supported() tests both the capability bit AND the protocol version.
     connect(_managerVehicle,  &Vehicle::capabilityBitsChanged,                  this, &GeoFenceController::supportedChanged);
+    connect(_managerVehicle,  &Vehicle::requestProtocolVersion,                 this, &GeoFenceController::supportedChanged);
 
     connect(_managerVehicle->parameterManager(), &ParameterManager::parametersReadyChanged, this, &GeoFenceController::_parametersReady);
     _parametersReady();

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -71,7 +71,9 @@ void RallyPointController::managerVehicleChanged(Vehicle* managerVehicle)
     connect(_rallyPointManager, &RallyPointManager::removeAllComplete,  this, &RallyPointController::_managerRemoveAllComplete);
     connect(_rallyPointManager, &RallyPointManager::inProgressChanged,  this, &RallyPointController::syncInProgressChanged);
 
+    //-- RallyPointController::supported() tests both the capability bit AND the protocol version.
     connect(_managerVehicle,    &Vehicle::capabilityBitsChanged,        this, &RallyPointController::supportedChanged);
+    connect(_managerVehicle,    &Vehicle::requestProtocolVersion,       this, &RallyPointController::supportedChanged);
 
     emit supportedChanged(supported());
 }


### PR DESCRIPTION
Both Geofence and Rally tests for support check not only the flight controller capability field but also the (MAVLink) protocol version. However, there was nothing keeping track of version changes. If you were to start QGC with no connections, QGC creates a dummy vehicle in order to handle mission planning. If later you were to connect to a real vehicle, the handing over between dummy and real vehicle was not updating the protocol version. You ended up with protocol version "0" and the test for Geofence and Rally would return false.

@DonLakeFlyer Do we really need to check protocol version if the capability flag is set? Also, that signal name (`Vehicle::requestProtocolVersion()`) is not exactly in line with the use in this context. I didn't spend a great deal of time trying to make sense of it though.
