### PR TITLE
Windows build fix

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -107,7 +107,6 @@ SOURCES += \
 MacBuild {
     INCLUDEPATH += \
         $$BASEDIR/libs/lib/Frameworks/SDL2.framework/Headers
-
     LIBS += \
         -F$$BASEDIR/libs/lib/Frameworks \
         -framework SDL2
@@ -115,8 +114,6 @@ MacBuild {
     PKGCONFIG = sdl2
 } else:WindowsBuild {
     INCLUDEPATH += $$BASEDIR/libs/lib/sdl2/msvc/include
-    INCLUDEPATH += $$BASEDIR/libs/zlib/Windows/include
-
     contains(QT_ARCH, i386) {
         INCLUDEPATH += $$BASEDIR/libs/OpenSSL/Windows/x86/include
         LIBS += -L$$BASEDIR/libs/lib/sdl2/msvc/lib/x86
@@ -126,12 +123,9 @@ MacBuild {
         LIBS += -L$$BASEDIR/libs/lib/sdl2/msvc/lib/x64
         LIBS += -L$$BASEDIR/libs/OpenSSL/Windows/x64/lib
     }
-    LIBS += -L$$BASEDIR/libs/zlib/Windows/libs
     LIBS += \
         -lSDL2main \
-        -lSDL2 \
-		-lz \
-		-llibeay32
+        -lSDL2
 }
 
 # Include Android OpenSSL libs in order to make Qt OpenSSL support work
@@ -163,6 +157,10 @@ contains(DEFINES, QGC_ENABLE_PAIRING) {
             DEFINES -= QGC_ENABLE_NFC
             DEFINES -= QGC_ENABLE_PAIRING
         }
+    } else:WindowsBuild {
+        #- Pairing is not supported on Windows
+        DEFINES -= QGC_ENABLE_NFC
+        DEFINES -= QGC_ENABLE_PAIRING
     } else {
         LIBS += -lcrypto -lz
         AndroidBuild {
@@ -193,7 +191,6 @@ contains (DEFINES, DISABLE_ZEROCONF) {
 } else {
     message("Skipping support for Zeroconf (unsupported platform)")
 }
-
 
 #
 # [OPTIONAL] AirMap Support


### PR DESCRIPTION
Pairing not supported under Windows
Remove zlib dependency for Windows.

Fixes https://github.com/mavlink/qgroundcontrol/issues/7954
