### PR TITLE
CameraManager: identify camera component by MAV_TYPE, not by compID

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -107,8 +107,10 @@ QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
 {
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
-    //-- Only pay attention to camera components, as identified by their MAV_TYPE
-    if(_vehicleReadyState && _vehicle->id() == message.sysid && heartbeat.autopilot == MAV_AUTOPILOT_INVALID && heartbeat.type == MAV_TYPE_CAMERA) {
+    //-- Only pay attention to camera components, as identified by their MAV_TYPE, and as fallback by their compId
+    if(_vehicleReadyState && _vehicle->id() == message.sysid &&
+            ((heartbeat.autopilot == MAV_AUTOPILOT_INVALID && heartbeat.type == MAV_TYPE_CAMERA) ||
+             (message.compid >= MAV_COMP_ID_CAMERA && message.compid <= MAV_COMP_ID_CAMERA6))) {
         //-- First time hearing from this one?
         QString sCompID = QString::number(message.compid);
         if(!_cameraInfoRequest.contains(sCompID)) {

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -107,8 +107,8 @@ QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
 {
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
-    //-- Only pay attention to "camera" component IDs
-    if(_vehicleReadyState && _vehicle->id() == message.sysid && message.compid >= MAV_COMP_ID_CAMERA && message.compid <= MAV_COMP_ID_CAMERA6) {
+    //-- Only pay attention to camera components, as identified by their MAV_TYPE
+    if(_vehicleReadyState && _vehicle->id() == message.sysid && heartbeat.autopilot == MAV_AUTOPILOT_INVALID && heartbeat.type == MAV_TYPE_CAMERA) {
         //-- First time hearing from this one?
         QString sCompID = QString::number(message.compid);
         if(!_cameraInfoRequest.contains(sCompID)) {


### PR DESCRIPTION
currently the CameraManager identifies a camera component by checking if it's component ID is a default camera ID, i.e. in range MAV_COMP_ID_CAMERA to MAV_COMP_ID_CAMERA6.

This is incorrect, it doesn't comply with the MAVLink specification.

The MAVLink specification suggests that a camera component should use one of the IDs MAV_COMP_ID_CAMERA ... MAV_COMP_ID_CAMERA6, but it does not require it! Instead the camera component should identify itself by it's MAV_TYPE, i.e. heartbeat fields autopilot = MAV_AUTOPILTO_UNDEFINED and type = MAV_TYPE_CAMERA.

This PR is doing this. I have checked it and it is working for me.