### PR TITLE
CameraManager: bug, cleanups in CameraPageWidget.qml

### DIFF
--- a/src/FlightMap/Widgets/CameraPageWidget.qml
+++ b/src/FlightMap/Widgets/CameraPageWidget.qml
@@ -32,22 +32,22 @@ Column {
 
     property var    _dynamicCameras:        activeVehicle ? activeVehicle.dynamicCameras : null
     property bool   _isCamera:              _dynamicCameras ? _dynamicCameras.cameras.count > 0 : false
+    property int    _curCameraIndex:        _dynamicCameras ? _dynamicCameras.currentCamera : 0
     property var    _camera:                _isCamera ? (_dynamicCameras.cameras.get(_curCameraIndex) && _dynamicCameras.cameras.get(_curCameraIndex).paramComplete ? _dynamicCameras.cameras.get(_curCameraIndex) : null) : null
-    property bool   _cameraModeUndefined:   _camera ? _dynamicCameras.cameras.get(_curCameraIndex).cameraMode === QGCCameraControl.CAMERA_MODE_UNDEFINED : true
-    property bool   _cameraVideoMode:       _camera ? _dynamicCameras.cameras.get(_curCameraIndex).cameraMode === 1 : false
-    property bool   _cameraPhotoMode:       _camera ? _dynamicCameras.cameras.get(_curCameraIndex).cameraMode === 0 : false
-    property bool   _cameraPhotoIdle:       _camera && _camera.photoStatus === QGCCameraControl.PHOTO_CAPTURE_IDLE
+    property bool   _cameraModeUndefined:   _camera ? _camera.cameraMode === QGCCameraControl.CAM_MODE_UNDEFINED : true
+    property bool   _cameraVideoMode:       _camera ? _camera.cameraMode === QGCCameraControl.CAM_MODE_VIDEO : false
+    property bool   _cameraPhotoMode:       _camera ? _camera.cameraMode === QGCCameraControl.CAM_MODE_PHOTO : false
     property bool   _cameraElapsedMode:     _camera && _camera.cameraMode === QGCCameraControl.CAM_MODE_PHOTO && _camera.photoMode === QGCCameraControl.PHOTO_CAPTURE_TIMELAPSE
     property real   _spacers:               ScreenTools.defaultFontPixelHeight * 0.5
     property real   _labelFieldWidth:       ScreenTools.defaultFontPixelWidth * 30
     property real   _editFieldWidth:        ScreenTools.defaultFontPixelWidth * 30
     property bool   _communicationLost:     activeVehicle ? activeVehicle.connectionLost : false
-    property bool   _hasModes:              _camera && _camera && _camera.hasModes
+    property bool   _hasModes:              _camera && _camera.hasModes
     property bool   _videoRecording:        _camera && _camera.videoStatus === QGCCameraControl.VIDEO_CAPTURE_STATUS_RUNNING
+    property bool   _photoIdle:             _camera && _camera.photoStatus === QGCCameraControl.PHOTO_CAPTURE_IDLE
     property bool   _storageReady:          _camera && _camera.storageStatus === QGCCameraControl.STORAGE_READY
     property bool   _storageIgnored:        _camera && _camera.storageStatus === QGCCameraControl.STORAGE_NOT_SUPPORTED
-    property bool   _canShoot:              !_videoRecording && _cameraPhotoIdle && ((_storageReady && _camera.storageFree > 0) || _storageIgnored)
-    property int    _curCameraIndex:        _dynamicCameras ? _dynamicCameras.currentCamera : 0
+    property bool   _canShoot:              !_cameraModeUndefined && !_videoRecording && _photoIdle && ((_storageReady && _camera.storageFree > 0) || _storageIgnored)
 
     function showSettings() {
         mainWindow.showComponentDialog(cameraSettings, _cameraVideoMode ? qsTr("Video Settings") : qsTr("Camera Settings"), 70, StandardButton.Ok)
@@ -154,20 +154,20 @@ Column {
         border.width: 3
         anchors.horizontalCenter: parent.horizontalCenter
         Rectangle {
-            width:      parent.width * (_videoRecording || (_cameraPhotoMode && !_cameraPhotoIdle && _cameraElapsedMode) ? 0.5 : 0.75)
+            width:      parent.width * (_videoRecording || (_cameraPhotoMode && !_photoIdle && _cameraElapsedMode) ? 0.5 : 0.75)
             height:     width
-            radius:     _videoRecording || (_cameraPhotoMode && !_cameraPhotoIdle && _cameraElapsedMode) ? 0 : width * 0.5
-            color:      (_cameraModeUndefined || !_canShoot) ? qgcPal.colorGrey : qgcPal.colorRed
+            radius:     _videoRecording || (_cameraPhotoMode && !_photoIdle && _cameraElapsedMode) ? 0 : width * 0.5
+            color:      _canShoot ? qgcPal.colorRed : qgcPal.colorGrey
             anchors.centerIn:   parent
         }
         MouseArea {
             anchors.fill:   parent
-            enabled:        !_cameraModeUndefined && _canShoot
+            enabled:        _canShoot
             onClicked: {
                 if(_cameraVideoMode) {
                     _camera.toggleVideo()
                 } else {
-                    if(_cameraPhotoMode && !_cameraPhotoIdle && _cameraElapsedMode) {
+                    if(_cameraPhotoMode && !_photoIdle && _cameraElapsedMode) {
                         _camera.stopTakePhoto()
                     } else {
                         _camera.takePhoto()


### PR DESCRIPTION
CameraPageWidget.qml is a bit of a wild coding. This PR attempts to streamline it a bit.

1) bug: QGCCameraControl.CAMERA_MODE_UNDEFINED is not existing, hence changed to QGCCameraControl.CAM_MODE_UNDEFINED.

(I must admit I'm "surprised" that such an error doesn't trigger any compiler warning/error)

2) QGCCameraControl.CAMERA_MODE_VIDEO,  QGCCameraControl.CAMERA_MODE_PHOTO used instead of plain 1 and 0

3) once _camera has been checked there is no need to do _dynamicCameras.cameras.get(_curCameraIndex).cameraMode, replaced by _camera.cameraMode

4) _camera && _camera && _camera.hasModes changed to _camera && _camera.hasModes

5) _cameraPhotoIdle renamed to _photoIdle:  Unlike the other _cameraXXXX variables which relate to the _camera.cameraMode variable, _cameraPhotoIdle relates to a _camera.xxxStatus variable, similar to e.g. _cameraRecording. Hence the naming is streamlined to match the other _camera.xxxStatus.

6) _canShoot appeared only twice and in both instances in combination with !_cameraModeUndefined, which was thus moved up, which makes the logic also cleaner and more transparent

7) variable definitions somewhat reordered to keep logically similar things together

these are all supposed to be NFC. I have tested and things work for me.



