### PR TITLE
Parameter write progress bar

### DIFF
--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -274,6 +274,17 @@ void ParameterManager::_parameterUpdate(int vehicleId, int componentId, QString 
         _setLoadProgress((double)(_totalParamCount - readWaitingParamCount) / (double)_totalParamCount);
     }
 
+    // Update progress bar for waiting writes
+    if (waitingWriteParamNameCount == 0) {
+        // We are no longer waiting for any writes to complete
+        if (_prevWaitingWriteParamNameCount != 0) {
+            // Set progress to 0 if not already there
+            _setLoadProgress(0.0);
+        }
+    } else {
+        _setLoadProgress((double)(_totalParamCount - waitingWriteParamNameCount) / (double)_totalParamCount);
+    }
+
     // Get parameter set version
     if (!_versionParam.isEmpty() && _versionParam == parameterName) {
         _parameterSetMajorVersion = value.toInt();


### PR DESCRIPTION
Added in logic to display the progress bar when writing parameters from QGC to the vehicle via MAVLink.

This is especially useful when writing a large parameter file to the vehicle for the first time or when transferring over an unreliable data link.

Tested successfully on Ubuntu 18.04.

I did notice every time I did a `Load from file...`it would give me this error, however this happened before my changes, so I imagine it is probably related to the build being a debug build, and I am running using *qgroundcontrol-start.sh*

The presence of the error did not effect anything, all parameter writes were successful.

![Selection_035](https://user-images.githubusercontent.com/37091262/67994411-c8306c80-fc0a-11e9-8039-9b07abdbc115.png)
