### PR TITLE
PageView: white wheel, smaller

### DIFF
--- a/src/QmlControls/PageView.qml
+++ b/src/QmlControls/PageView.qml
@@ -33,10 +33,10 @@ Rectangle {
             anchors.leftMargin:     _margins
             anchors.left:           parent.left
             anchors.verticalCenter: parent.verticalCenter
-            source:                 "/res/gear-black.svg"
+            source:                 "/res/gear-white.svg"
             mipmap:                 true
             width:                  parent.height -(_margins * 2)
-            sourceSize.width:       width
+            sourceSize.width:       width * 0.75
             fillMode:               Image.PreserveAspectFit
             visible:                pageWidgetLoader.item ? (pageWidgetLoader.item.showSettingsIcon ? pageWidgetLoader.item.showSettingsIcon : false) : false
 


### PR DESCRIPTION
The PageView currently shows a black gear symbol in the header combo box, which is very had to see given the dark gray background of the combo box.

This PR changes it to a white gear symbol, and also reduces the size of it for better style.