### PR TITLE
CameraManager: disallow mode change during shooting

### DIFF
--- a/src/FlightMap/Widgets/CameraPageWidget.qml
+++ b/src/FlightMap/Widgets/CameraPageWidget.qml
@@ -48,6 +48,7 @@ Column {
     property bool   _storageIgnored:        _camera && _camera.storageStatus === QGCCameraControl.STORAGE_NOT_SUPPORTED
     property bool   _canShoot:              !_videoRecording && _cameraPhotoIdle && ((_storageReady && _camera.storageFree > 0) || _storageIgnored)
     property int    _curCameraIndex:        _dynamicCameras ? _dynamicCameras.currentCamera : 0
+    property bool   _isShooting:            (_cameraVideoMode && _videoRecording) || (_cameraPhotoMode && !_photoIdle)
 
     function showSettings() {
         mainWindow.showComponentDialog(cameraSettings, _cameraVideoMode ? qsTr("Video Settings") : qsTr("Camera Settings"), 70, StandardButton.Ok)
@@ -106,7 +107,7 @@ Column {
                 color:              _cameraVideoMode ? qgcPal.colorGreen : qgcPal.text
                 MouseArea {
                     anchors.fill:   parent
-                    enabled:        _cameraPhotoMode
+                    enabled:        _cameraPhotoMode && !_isShooting
                     onClicked: {
                         _camera.setVideoMode()
                     }
@@ -133,7 +134,7 @@ Column {
                 color:              _cameraPhotoMode ? qgcPal.colorGreen : qgcPal.text
                 MouseArea {
                     anchors.fill:   parent
-                    enabled:        _cameraVideoMode
+                    enabled:        _cameraVideoMode && !_isShooting
                     onClicked: {
                         _camera.setPhotoMode()
                     }
@@ -154,9 +155,9 @@ Column {
         border.width: 3
         anchors.horizontalCenter: parent.horizontalCenter
         Rectangle {
-            width:      parent.width * (_videoRecording || (_cameraPhotoMode && !_cameraPhotoIdle && _cameraElapsedMode) ? 0.5 : 0.75)
+            width:      parent.width * (_isShooting ? 0.5 : 0.75)
             height:     width
-            radius:     _videoRecording || (_cameraPhotoMode && !_cameraPhotoIdle && _cameraElapsedMode) ? 0 : width * 0.5
+            radius:     _isShooting ? 0 : width * 0.5
             color:      (_cameraModeUndefined || !_canShoot) ? qgcPal.colorGrey : qgcPal.colorRed
             anchors.centerIn:   parent
         }
@@ -176,6 +177,7 @@ Column {
             }
         }
     }
+    //-- Timer/Counter
     Item { width: 1; height: ScreenTools.defaultFontPixelHeight * 0.75; visible: _camera; }
     QGCLabel {
         text: (_cameraVideoMode && _camera.videoStatus === QGCCameraControl.VIDEO_CAPTURE_STATUS_RUNNING) ? _camera.recordTimeStr : "00:00:00"
@@ -189,6 +191,7 @@ Column {
         visible: _cameraPhotoMode
         anchors.horizontalCenter: parent.horizontalCenter
     }
+    //-- Settings
     Item { width: 1; height: ScreenTools.defaultFontPixelHeight; visible: _camera; }
     Component {
         id: cameraSettings


### PR DESCRIPTION
Currently it was possible to change the camera mode while the video is recording or a photo timelpase is running.

This PR prevents this by disabling the respective MouseArea when a video or photo is running.

Resolves point (3) in issue #7471.
In combination with PR #7689 it also resolves point (4) in issue #7471.