### PR TITLE
ParameterEditorController: MAVLink COMP ID names for components

### DIFF
--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -73,6 +73,7 @@ private:
     ParameterManager*   _parameterMgr;
     QString             _componentCategoryPrefix;
     bool                _showModifiedOnly;
+    QHash<QString, int> _componentCategoryHash;
 };
 
 #endif


### PR DESCRIPTION
This shows the MAVLink name for a component instead of "Component XXX" in the parameter editor window. See the screenshot below.

I'm not sure this is the sort of thing you guys like, but I like it (obviously)(LOL). 

The mavlink hash could probably go to a more central location. Pl advise.

cheers, Olli

![qgc-compidname](https://user-images.githubusercontent.com/6089567/68176202-29966980-ff84-11e9-9a47-f7007da38d45.jpg)
