### PR TITLE
Fix enabling Advanced Tuning crash

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -158,7 +158,11 @@ static QObject* shapeFileHelperSingletonFactory(QQmlEngine*, QJSEngine*)
 }
 
 QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
+  #if defined(__mobile__)
     : QGuiApplication           (argc, argv)
+  #else
+    : QApplication              (argc, argv)
+  #endif
     , _runningUnitTests         (unitTesting)
 {
     _app = this;

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -51,8 +51,15 @@ class QGCFileDownload;
  * This class is started by the main method and provides
  * the central management unit of the groundstation application.
  *
- **/
-class QGCApplication : public QGuiApplication
+ * Needs QApplication base to support QtCharts drawing module and
+ * avoid application crashing on 5.12. Enforce no widget on mobile
+**/
+class QGCApplication :
+      #if defined(__mobile__)
+        public QGuiApplication
+      #else
+        public QApplication
+      #endif
 {
     Q_OBJECT
 


### PR DESCRIPTION
Fix for https://github.com/mavlink/qgroundcontrol/issues/7962

It seems that QtCharts require `QApplication` instance instead of current used `QGuiApplication` even that we use only QML controls without initializing QWidgets. See `Note: ` for the hint: https://doc.qt.io/qt-5.12/qtcharts-index.html

Then crash stack in QT looks unrelated to the issue