### PR TITLE
Bug in ParameterEditor: 2nd click on group button shrinks mouse area

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -203,8 +203,8 @@ Item {
                             readonly property string groupName: modelData
 
                             onClicked: {
+                                if (!checked) _rowWidth = 10
                                 checked = true
-                                _rowWidth                   = 10
                                 controller.currentCategory  = category
                                 controller.currentGroup     = groupName
                             }


### PR DESCRIPTION
In the ParameterEditor, if one is clicking a 2nd time on an already selected group button, the rectangle in the parameter listview is reduced back to a width of 10, and therewith also the mouse area. The user then can't edit the parameter anymore (except she clicks in this small area of width 10). See picture below (note the very short underline below each parameter).

This happens here:
https://github.com/mavlink/qgroundcontrol/blob/master/src/QmlControls/ParameterEditor.qml#L205-L210
_rowWidth is reset to 10, without the dynamic adjustment in 
https://github.com/mavlink/qgroundcontrol/blob/master/src/QmlControls/ParameterEditor.qml#L262-L265

The PR solves this by resetting the width only if the group button wasn't clicked before.

cheers, Olli

![qgc-param-width10](https://user-images.githubusercontent.com/6089567/68270601-07711a00-005e-11ea-8998-1d0bb797385f.jpg)

