### PR TITLE
Filter mavlink messages by component ID

### DIFF
--- a/src/AnalyzeView/MAVLinkInspectorController.cc
+++ b/src/AnalyzeView/MAVLinkInspectorController.cc
@@ -324,8 +324,24 @@ QGCMAVLinkVehicle::append(QGCMAVLinkMessage* message)
                 emit m->indexChanged();
             }
         }
+        _checkCompID(message);
     }
     emit messagesChanged();
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCMAVLinkVehicle::_checkCompID(QGCMAVLinkMessage* message)
+{
+    if(_compIDsStr.isEmpty()) {
+        _compIDsStr << tr("All");
+    }
+    if(!_compIDs.contains(static_cast<int>(message->cid()))) {
+        int cid = static_cast<int>(message->cid());
+        _compIDs.append(cid);
+        _compIDsStr << QString::number(cid);
+        emit compIDsChanged();
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -430,9 +446,8 @@ MAVLinkInspectorController::_vehicleRemoved(Vehicle* vehicle)
 
 //-----------------------------------------------------------------------------
 void
-MAVLinkInspectorController::_receiveMessage(LinkInterface* link, mavlink_message_t message)
+MAVLinkInspectorController::_receiveMessage(LinkInterface*, mavlink_message_t message)
 {
-    Q_UNUSED(link);
     QGCMAVLinkMessage* m = nullptr;
     QGCMAVLinkVehicle* v = _findVehicle(message.sysid);
     if(!v) {
@@ -453,7 +468,6 @@ MAVLinkInspectorController::_receiveMessage(LinkInterface* link, mavlink_message
     } else {
         m->update(&message);
     }
-
 }
 
 //-----------------------------------------------------------------------------

--- a/src/AnalyzeView/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspectorController.h
@@ -87,22 +87,32 @@ class QGCMAVLinkVehicle : public QObject {
     Q_OBJECT
     Q_PROPERTY(quint8               id              READ id             CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  messages        READ messages       NOTIFY messagesChanged)
+    Q_PROPERTY(QList<int>           compIDs         READ compIDs        NOTIFY compIDsChanged)
+    Q_PROPERTY(QStringList          compIDsStr      READ compIDsStr     NOTIFY compIDsChanged)
 
 public:
     QGCMAVLinkVehicle(QObject* parent, quint8 id);
 
     quint8              id              () { return _id; }
     QmlObjectListModel* messages        () { return &_messages; }
+    QList<int>          compIDs         () { return _compIDs; }
+    QStringList         compIDsStr      () { return _compIDsStr; }
 
     QGCMAVLinkMessage*  findMessage     (uint32_t id, uint8_t cid);
     void                append          (QGCMAVLinkMessage* message);
 
 signals:
     void messagesChanged                ();
+    void compIDsChanged                 ();
+
+private:
+    void _checkCompID                   (QGCMAVLinkMessage *message);
 
 private:
     quint8              _id;
-    QmlObjectListModel  _messages;  //-- List of QGCMAVLinkMessage
+    QList<int>          _compIDs;
+    QStringList         _compIDsStr;
+    QmlObjectListModel  _messages;      //-- List of QGCMAVLinkMessage
 };
 
 //-----------------------------------------------------------------------------

--- a/src/AnalyzeView/MAVLinkInspectorPage.qml
+++ b/src/AnalyzeView/MAVLinkInspectorPage.qml
@@ -22,9 +22,11 @@ Item {
     anchors.fill:           parent
     anchors.margins:        ScreenTools.defaultFontPixelWidth
 
-    property var curVehicle:        controller ? controller.activeVehicle : null
-    property int curMessageIndex:   0
-    property var curMessage:        curVehicle && curVehicle.messages.count ? curVehicle.messages.get(curMessageIndex) : null
+    property var    curVehicle:     controller ? controller.activeVehicle : null
+    property int    curMessageIndex:0
+    property var    curMessage:     curVehicle && curVehicle.messages.count ? curVehicle.messages.get(curMessageIndex) : null
+    property int    curCompID:      0
+    property bool   selectionValid: false
 
     MAVLinkInspectorController {
         id: controller
@@ -35,11 +37,36 @@ Item {
     }
 
     //-- Header
-    QGCLabel {
+    RowLayout {
         id:                 header
-        text:               qsTr("Inspect real time MAVLink messages.")
         anchors.top:        parent.top
         anchors.left:       parent.left
+        anchors.right:      parent.right
+        QGCLabel {
+            text:           qsTr("Inspect real time MAVLink messages.")
+        }
+        RowLayout {
+            Layout.alignment:   Qt.AlignRight
+            visible:            curVehicle ? curVehicle.compIDsStr.length > 2 : false
+            QGCLabel {
+                text:           qsTr("Component ID:")
+            }
+            QGCComboBox {
+                id:             cidCombo
+                model:          curVehicle ? curVehicle.compIDsStr : []
+                Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 10
+                currentIndex:   0
+                onActivated: {
+                    if(curVehicle && curVehicle.compIDsStr.length > 1) {
+                        selectionValid = false
+                        if(index < 1)
+                            curCompID = 0
+                        else
+                            curCompID = curVehicle.compIDs[index - 1]
+                    }
+                }
+            }
+        }
     }
 
     //-- Messages (Buttons)
@@ -59,10 +86,15 @@ Item {
                 model:      curVehicle ? curVehicle.messages : []
                 delegate:   MAVLinkMessageButton {
                     text:       object.name
+                    compID:     object.cid
                     checked:    curMessageIndex === index
                     messageHz:  object.messageHz
-                    onClicked:  curMessageIndex = index
-                    Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 36
+                    visible:    curCompID === 0 || curCompID === compID
+                    onClicked: {
+                        selectionValid  = true
+                        curMessageIndex = index
+                    }
+                    Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 40
                 }
             }
         }
@@ -70,7 +102,7 @@ Item {
     //-- Message Data
     QGCFlickable {
         id:                 messageGrid
-        visible:            curMessage !== null
+        visible:            curMessage !== null && selectionValid
         anchors.top:        buttonGrid.top
         anchors.bottom:     parent.bottom
         anchors.left:       buttonGrid.right

--- a/src/QmlControls/MAVLinkMessageButton.qml
+++ b/src/QmlControls/MAVLinkMessageButton.qml
@@ -25,12 +25,18 @@ Button {
     }
 
     property double messageHz:  0
+    property int    compID:     0
 
     contentItem: RowLayout {
         QGCLabel {
+            text:   control.compID
+            color:  checked ? qgcPal.buttonHighlightText : qgcPal.buttonText
+            Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 3
+        }
+        QGCLabel {
             text:   control.text
             color:  checked ? qgcPal.buttonHighlightText : qgcPal.buttonText
-            Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 26
+            Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 28
         }
         QGCLabel {
             color:  checked ? qgcPal.buttonHighlightText : qgcPal.buttonText


### PR DESCRIPTION
You can now filter the messages in the MAVLink inspector by Component ID:

<img width="1143" alt="Screen Shot 2019-11-07 at 3 15 18 PM" src="https://user-images.githubusercontent.com/749243/68425886-f7982980-0174-11ea-8438-a616dd7f2c47.png">

The component ID is now shown in the list in order to identify a message when multiple component ID are being displayed at once:

<img width="1143" alt="Screen Shot 2019-11-07 at 3 15 29 PM" src="https://user-images.githubusercontent.com/749243/68425968-20b8ba00-0175-11ea-852d-e2a86ebd16b1.png">

Note that the filter is only available if more than one Component ID is actually found:

<img width="1201" alt="Screen Shot 2019-11-07 at 3 18 17 PM" src="https://user-images.githubusercontent.com/749243/68426082-62496500-0175-11ea-9f91-0695dd311642.png">
