### PR TITLE
Fix inverted close policy logic.

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -153,6 +153,9 @@ ApplicationWindow {
         mainWindowDialog.dialogButtons = buttons
         mainWindowDialog.open()
         if(buttons & StandardButton.Cancel || buttons & StandardButton.Close || buttons & StandardButton.Discard || buttons & StandardButton.Abort || buttons & StandardButton.Ignore) {
+            mainWindowDialog.closePolicy = Popup.NoAutoClose;
+            mainWindowDialog.interactive = false;
+        } else {
             mainWindowDialog.closePolicy = Popup.CloseOnEscape | Popup.CloseOnPressOutside;
             mainWindowDialog.interactive = true;
         }


### PR DESCRIPTION
Those dialogs are supposed to be `Popup.NoAutoClose` if the dialog has a Close/Cancel/Ignore/etc. button. I found it by clicking outside it during a firmware update and having the dialog dismissed on me.