### PR TITLE
Bug, CameraManager: Proper filtering of component IDs

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -73,11 +73,9 @@ QGCCameraManager::_mavlinkMessageReceived(const mavlink_message_t& message)
             _handleHeartbeat(message);
             return;
         }
-
         if (!_cameraInfoRequest.contains(QString::number(message.compid))) {
             return;
         }
-
         switch (message.msgid) {
             case MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS:
                 _handleCaptureStatus(message);

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -69,15 +69,21 @@ void
 QGCCameraManager::_mavlinkMessageReceived(const mavlink_message_t& message)
 {
     if(message.sysid == _vehicle->id()) {
+        if (message.msgid == MAVLINK_MSG_ID_HEARTBEAT) {
+            _handleHeartbeat(message);
+            return;
+        }
+
+        if (!_cameraInfoRequest.contains(QString::number(message.compid))) {
+            return;
+        }
+
         switch (message.msgid) {
             case MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS:
                 _handleCaptureStatus(message);
                 break;
             case MAVLINK_MSG_ID_STORAGE_INFORMATION:
                 _handleStorageInfo(message);
-                break;
-            case MAVLINK_MSG_ID_HEARTBEAT:
-                _handleHeartbeat(message);
                 break;
             case MAVLINK_MSG_ID_CAMERA_INFORMATION:
                 _handleCameraInfo(message);


### PR DESCRIPTION
as @dogmaphobic pointed out in PR  #7998, the recent addition of BatteryStatus message handling to the CameraManager was buggy in that it would produce a stream of errors when also other sources of BatteryStatus messages such as an autopilot are present.

That's my fault to not have noticed it in my testing (I unfortunately had my autopilot configured such to not emit a BatteryStatus message). So I feel responsible for also suggesting a correction :).

This PR corrects this and might be a proper replacement for PR #7998. It adds a proper filter to the function _mavlinkMessageReceived(), which allows only those componentIds which were recognized before as cameras to be handled. The determination of the valid IDs is done by the heartbeat handler. This way the implementation remains fully conform to the Mavlink spec, since it also filters by mav_type and not by componentId.

sorry for that.

Cheers, Olli

**Testing:**

1. For info, this is the error the previous implementation produces:
![qgc-idfilter-000](https://user-images.githubusercontent.com/6089567/68526506-fa159300-02dc-11ea-8e47-9522fcce055f.jpg)
It happens because the autopilots BatteryStatus message is also digested by the CameraManager in the function _mavlinkMessageReceived(), which is incorrect.
For that test I had the autopilot enabled to emit a BaterryStatus message, and used camera model which doesn't emit a BatteryStatus message itself.

2. Here the result with the same configuration (autopilot emits BatteryStatus, the camera doesn't):
The MAVLink inspector shows the autopilots BatteryStatus, but there are no errors.
![qgc-idfilter](https://user-images.githubusercontent.com/6089567/68526541-760fdb00-02dd-11ea-9132-e467525e308f.jpg)
![qgc-idfilter-002](https://user-images.githubusercontent.com/6089567/68526543-790acb80-02dd-11ea-8e44-d66afa156aee.jpg)

3. Here the result where I changed to a different camera model, which does emit a BatteryStatus (i.e., both autopilot and camera emit a BatteryStatus):
The MAVLink inspector shows both the autopilots and cameras BatteryStatus, but there are no errors (only the battery status reports from the CameraManager logging are seen).
![qgc-idfilter-003](https://user-images.githubusercontent.com/6089567/68526561-b66f5900-02dd-11ea-9ba5-b7e7baea3c2f.jpg)
![qgc-idfilter-004](https://user-images.githubusercontent.com/6089567/68526562-b8d1b300-02dd-11ea-82bc-70f85d5ea131.jpg)

4. I finally tried to test the situation where the camera disappears and reappears, i.e., if the code handles the resetting of the recognized componentIds correctly. This I did by disconnecting the camera from the autopilot with the autopilot and QGC still running, changing it's componentID, and reconnecting it to the autopilot. The behavior is fully as expected:
![qgc-idfilter-005](https://user-images.githubusercontent.com/6089567/68526612-431a1700-02de-11ea-865b-697f2740ceb6.jpg)
![qgc-idfilter-006](https://user-images.githubusercontent.com/6089567/68526615-457c7100-02de-11ea-9b16-cabc810b8274.jpg)
![qgc-idfilter-007](https://user-images.githubusercontent.com/6089567/68526616-47463480-02de-11ea-84da-cd4ac285e6a4.jpg)


