### PR TITLE
MAVLinkInspector: Button fields too short

### DIFF
--- a/src/AnalyzeView/MAVLinkInspectorPage.qml
+++ b/src/AnalyzeView/MAVLinkInspectorPage.qml
@@ -94,7 +94,7 @@ Item {
                         selectionValid  = true
                         curMessageIndex = index
                     }
-                    Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 40
+                    Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 43
                 }
             }
         }


### PR DESCRIPTION
The fields in the mavlink inspector were too short for displaying also well when the message frequencies are >= 10 Hz.

This PR widens them by 3 default pixel widths, which - on my screen - is sufficient to also display frequencies above 100 Hz well. 
(I don't really understand the math, since the minimum width for the id and name is 3+28 = 31, and 100.0Hz would be another 7, so that a minimum width of the button of 40 sounds OK, but the math is obviously not as simple, and above my paygrade. Empirically 43 appears to be good).

cheers, Olli

Before:
note the missalignement on the right edge
![qgc-mavinspectorwidth-001](https://user-images.githubusercontent.com/6089567/68527320-e0c51480-02e5-11ea-9961-7e88a5b7cbf8.jpg)

After:
(taken during connection where e.g. the autopilots PARAM_VALUE comes whith high frequency)
![qgc-mavinspectorwidth-002](https://user-images.githubusercontent.com/6089567/68527328-f33f4e00-02e5-11ea-9714-e732e6da0e0e.jpg)

