### PR TITLE
Plan: Incomplete visuals, Polygon/line toolbar

### DIFF
--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -516,10 +516,11 @@ Item {
         id: toolbarComponent
 
         PlanEditToolbar {
-            x:          mapControl.centerViewport.left
-            y:          mapControl.centerViewport.top
-            width:      mapControl.centerViewport.width
-            z:          QGroundControl.zOrderMapItems + 2
+            anchors.horizontalCenter:       mapControl.left
+            anchors.horizontalCenterOffset: mapControl.centerViewport.left + (mapControl.centerViewport.width / 2)
+            y:                              mapControl.centerViewport.top
+            z:                              QGroundControl.zOrderMapItems + 2
+            availableWidth:                 mapControl.centerViewport.width
 
             QGCButton {
                 _horizontalPadding: 0

--- a/src/MissionManager/QGCMapPolylineVisuals.qml
+++ b/src/MissionManager/QGCMapPolylineVisuals.qml
@@ -314,10 +314,11 @@ Item {
         id: toolbarComponent
 
         PlanEditToolbar {
-            x:          mapControl.centerViewport.left
-            y:          mapControl.centerViewport.top
-            width:      mapControl.centerViewport.width
-            z:          QGroundControl.zOrderMapItems + 2
+            anchors.horizontalCenter:       mapControl.left
+            anchors.horizontalCenterOffset: mapControl.centerViewport.left + (mapControl.centerViewport.width / 2)
+            y:                              mapControl.centerViewport.top
+            z:                              QGroundControl.zOrderMapItems + 2
+            availableWidth:                 mapControl.centerViewport.width
 
             QGCButton {
                 _horizontalPadding: 0

--- a/src/PlanView/PlanEditToolbar.qml
+++ b/src/PlanView/PlanEditToolbar.qml
@@ -14,14 +14,18 @@ import QtQuick.Layouts      1.2
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0
+import QGroundControl.Palette       1.0
 
 /// Toolbar used for things like Polygon editing tools
 Item {
+    width:  Math.min(toolsRowLayout.width + (_margins * 2), availableWidth)
     height: toolsFlickable.y + toolsFlickable.height + _margins
     z:      QGroundControl.zOrderMapItems + 2
 
-    property real   _radius:            ScreenTools.defaultFontPixelWidth / 2
-    property real   _margins:   ScreenTools.defaultFontPixelWidth / 2
+    property real availableWidth
+
+    property real _radius:  ScreenTools.defaultFontPixelWidth / 2
+    property real _margins: ScreenTools.defaultFontPixelWidth / 2
 
     Component.onCompleted: {
         // Move the child controls from consumer into the layout control
@@ -39,8 +43,7 @@ Item {
     Rectangle {
         anchors.fill:    parent
         radius:         _radius
-        color:          "white"
-        opacity:        0.75
+        color:          qgcPal.globalTheme === QGCPalette.Light ? QGroundControl.corePlugin.options.toolbarBackgroundLight : QGroundControl.corePlugin.options.toolbarBackgroundDark
     }
 
     QGCFlickable {
@@ -64,10 +67,8 @@ Item {
         id: instructionComponent
 
         QGCLabel {
-            id:                     instructionLabel
-            color:                  "black"
-            text:                   _instructionText
-            Layout.fillWidth:       true
+            id:             instructionLabel
+            text:           _instructionText
         }
     }
 }


### PR DESCRIPTION
* Polygon/line toolbar changes
  * Centered
  * Only as big as it needs to be
  * Same background coloring as left toolstrip
* Incomplete data indication changes
  * Entire item is borded in red if incomplete
  * Text to explain why incomplete

Shows new toolbar and incomplete data visuals:
![Screen Shot 2019-11-09 at 4 35 30 AM](https://user-images.githubusercontent.com/5876851/68528721-6081bd80-02ab-11ea-8db3-9147a24bdc35.png)

Incomplete due to terrain data:
![Screen Shot 2019-11-09 at 4 34 24 AM](https://user-images.githubusercontent.com/5876851/68528723-6a0b2580-02ab-11ea-80ff-250a52154c6b.png)

Related to #7957