### PR TITLE
Avoid QGC to shutdown connecting to a flying Ardupilot

### DIFF
--- a/src/Vehicle/TrajectoryPoints.cc
+++ b/src/Vehicle/TrajectoryPoints.cc
@@ -27,7 +27,7 @@ void TrajectoryPoints::_vehicleCoordinateChanged(QGeoCoordinate coordinate)
                 _lastPoint = coordinate;
                 _points.append(QVariant::fromValue(coordinate));
                 emit pointAdded(coordinate);
-            } else {
+            } else if(_points.count()>0){
                 _lastPoint = coordinate;
                 _points[_points.count() - 1] = QVariant::fromValue(coordinate);
                 emit updateLastPoint(coordinate);


### PR DESCRIPTION
I have noticed that master crash when I connect to a flying Ardupilot simulator. 
After investigation, it's an 'index out of range' on TrajectoryPoints because we try to access `_points[points.count()-1]` and `point.count()=0`. 
Here a proposal for a fix, this needs to be checked though! :-)