### PR TITLE
Plan: Land tool

### DIFF
--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -36,7 +36,7 @@ Item {
     readonly property string emergencyStopTitle:            qsTr("EMERGENCY STOP")
     readonly property string armTitle:                      qsTr("Arm")
     readonly property string disarmTitle:                   qsTr("Disarm")
-    readonly property string rtlTitle:                      qsTr("RTL")
+    readonly property string rtlTitle:                      qsTr("Return")
     readonly property string takeoffTitle:                  qsTr("Takeoff")
     readonly property string landTitle:                     qsTr("Land")
     readonly property string startMissionTitle:             qsTr("Start Mission")

--- a/src/MissionManager/CorridorScanPlanCreator.cc
+++ b/src/MissionManager/CorridorScanPlanCreator.cc
@@ -22,15 +22,7 @@ void CorridorScanPlanCreator::createPlan(const QGeoCoordinate& mapCenterCoord)
 {
     _planMasterController->removeAll();
     VisualMissionItem* takeoffItem = _missionController->insertTakeoffItem(mapCenterCoord, -1);
-    takeoffItem->setWizardMode(true);
-    _missionController->insertComplexMissionItem(MissionController::patternCorridorScanName, mapCenterCoord, -1)->setWizardMode(true);
-    if (_planMasterController->managerVehicle()->fixedWing()) {
-        FixedWingLandingComplexItem* landingItem = qobject_cast<FixedWingLandingComplexItem*>(_missionController->insertComplexMissionItem(MissionController::patternFWLandingName, mapCenterCoord, -1));
-        landingItem->setWizardMode(true);
-        landingItem->setLoiterDragAngleOnly(true);
-    } else {
-        MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
-        settingsItem->setMissionEndRTL(true);
-    }
+    _missionController->insertComplexMissionItem(MissionController::patternCorridorScanName, mapCenterCoord, -1);
+    _missionController->insertLandItem(mapCenterCoord, -1);
     _missionController->setCurrentPlanViewIndex(takeoffItem->sequenceNumber(), true);
 }

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -93,6 +93,7 @@ public:
     Q_PROPERTY(QString              corridorScanComplexItemName     READ corridorScanComplexItemName    CONSTANT)
     Q_PROPERTY(QString              structureScanComplexItemName    READ structureScanComplexItemName   CONSTANT)
     Q_PROPERTY(bool                 isInsertTakeoffValid            MEMBER _isInsertTakeoffValid        NOTIFY isInsertTakeoffValidChanged) ///< true: Takeoff tool should be enabled
+    Q_PROPERTY(bool                 isInsertLandValid               MEMBER _isInsertLandValid           NOTIFY isInsertLandValidChanged)    ///< true: Land tool should be enabled
 
     Q_INVOKABLE void removeMissionItem(int index);
 
@@ -109,6 +110,13 @@ public:
     ///     @param makeCurrentItem: true: Make this item the current item
     /// @return Newly created item
     Q_INVOKABLE VisualMissionItem* insertTakeoffItem(QGeoCoordinate coordinate, int visualItemIndex, bool makeCurrentItem = false);
+
+    /// Add a new land item to the list
+    ///     @param coordinate: Coordinate for item
+    ///     @param visualItemIndex: index to insert at, -1 for end of list
+    ///     @param makeCurrentItem: true: Make this item the current item
+    /// @return Newly created item
+    Q_INVOKABLE VisualMissionItem* insertLandItem(QGeoCoordinate coordinate, int visualItemIndex, bool makeCurrentItem = false);
 
     /// Add a new ROI mission item to the list
     ///     @param coordinate: Coordinate for item
@@ -245,6 +253,7 @@ signals:
     void missionBoundingCubeChanged     (void);
     void missionItemCountChanged        (int missionItemCount);
     void isInsertTakeoffValidChanged    (void);
+    void isInsertLandValidChanged       (void);
 
 private slots:
     void _newMissionItemsAvailableFromVehicle(bool removeAllRequested);
@@ -296,6 +305,7 @@ private:
     void _initLoadedVisualItems(QmlObjectListModel* loadedVisualItems);
     CoordinateVector* _addWaypointLineSegment(CoordVectHashTable& prevItemPairHashTable, VisualItemPair& pair);
     void _addTimeDistance(bool vtolInHover, double hoverTime, double cruiseTime, double extraTime, double distance, int seqNum);
+    VisualMissionItem* _insertSimpleMissionItemWorker(QGeoCoordinate coordinate, MAV_CMD command, int visualItemIndex, bool makeCurrentItem);
     void _insertComplexMissionItemWorker(ComplexMissionItem* complexItem, int visualItemIndex, bool makeCurrentItem);
     void _warnIfTerrainFrameUsed(void);
 
@@ -321,6 +331,7 @@ private:
     QGeoCoordinate          _takeoffCoordinate;
     CoordinateVector*       _splitSegment;
     bool                    _isInsertTakeoffValid = true;
+    bool                    _isInsertLandValid = true;
 
     static const char*  _settingsGroup;
 

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -27,16 +27,12 @@ public:
     MissionSettingsItem(Vehicle* vehicle, bool flyView, QObject* parent);
 
     Q_PROPERTY(Fact*    plannedHomePositionAltitude READ plannedHomePositionAltitude                            CONSTANT)
-    Q_PROPERTY(bool     missionEndRTL               READ missionEndRTL                  WRITE setMissionEndRTL  NOTIFY missionEndRTLChanged)
     Q_PROPERTY(QObject* cameraSection               READ cameraSection                                          CONSTANT)
     Q_PROPERTY(QObject* speedSection                READ speedSection                                           CONSTANT)
 
     Fact*           plannedHomePositionAltitude (void) { return &_plannedHomePositionAltitudeFact; }
-    bool            missionEndRTL               (void) const { return _missionEndRTL; }
     CameraSection*  cameraSection               (void) { return &_cameraSection; }
     SpeedSection*   speedSection                (void) { return &_speedSection; }
-
-    void setMissionEndRTL(bool missionEndRTL);
 
     /// Scans the loaded items for settings items
     bool scanForMissionSettings(QmlObjectListModel* visualItems, int scanIndex);
@@ -96,7 +92,6 @@ public:
 
 signals:
     void specifyMissionFlightSpeedChanged   (bool specifyMissionFlightSpeed);
-    void missionEndRTLChanged               (bool missionEndRTL);
 
 private slots:
     void _setDirtyAndUpdateLastSequenceNumber   (void);
@@ -112,7 +107,6 @@ private:
     int             _sequenceNumber =                   0;
     bool            _plannedHomePositionFromVehicle =   false;
     bool            _plannedHomePositionMovedByUser =   false;
-    bool            _missionEndRTL =                    false;
     CameraSection   _cameraSection;
     SpeedSection    _speedSection;
 

--- a/src/MissionManager/StructureScanPlanCreator.cc
+++ b/src/MissionManager/StructureScanPlanCreator.cc
@@ -22,15 +22,7 @@ void StructureScanPlanCreator::createPlan(const QGeoCoordinate& mapCenterCoord)
 {
     _planMasterController->removeAll();
     VisualMissionItem* takeoffItem = _missionController->insertTakeoffItem(mapCenterCoord, -1);
-    takeoffItem->setWizardMode(true);
     _missionController->insertComplexMissionItem(MissionController::patternStructureScanName, mapCenterCoord, -1)->setWizardMode(true);
-    if (_planMasterController->managerVehicle()->fixedWing()) {
-        FixedWingLandingComplexItem* landingItem = qobject_cast<FixedWingLandingComplexItem*>(_missionController->insertComplexMissionItem(MissionController::patternFWLandingName, mapCenterCoord, -1));
-        landingItem->setWizardMode(true);
-        landingItem->setLoiterDragAngleOnly(true);
-    } else {
-        MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
-        settingsItem->setMissionEndRTL(true);
-    }
+    _missionController->insertLandItem(mapCenterCoord, -1);
     _missionController->setCurrentPlanViewIndex(takeoffItem->sequenceNumber(), true);
 }

--- a/src/MissionManager/SurveyPlanCreator.cc
+++ b/src/MissionManager/SurveyPlanCreator.cc
@@ -23,15 +23,7 @@ void SurveyPlanCreator::createPlan(const QGeoCoordinate& mapCenterCoord)
 {
     _planMasterController->removeAll();
     VisualMissionItem* takeoffItem = _missionController->insertTakeoffItem(mapCenterCoord, -1);
-    takeoffItem->setWizardMode(true);
-    _missionController->insertComplexMissionItem(MissionController::patternSurveyName, mapCenterCoord, -1)->setWizardMode(true);
-    if (_planMasterController->managerVehicle()->fixedWing()) {
-        FixedWingLandingComplexItem* landingItem = qobject_cast<FixedWingLandingComplexItem*>(_missionController->insertComplexMissionItem(MissionController::patternFWLandingName, mapCenterCoord, -1));
-        landingItem->setWizardMode(true);
-        landingItem->setLoiterDragAngleOnly(true);
-    } else {
-        MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
-        settingsItem->setMissionEndRTL(true);
-    }
+    _missionController->insertComplexMissionItem(MissionController::patternSurveyName, mapCenterCoord, -1);
+    _missionController->insertLandItem(mapCenterCoord, -1);
     _missionController->setCurrentPlanViewIndex(takeoffItem->sequenceNumber(), true);
 }

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -108,28 +108,6 @@ Rectangle {
             }
 
             SectionHeader {
-                id:             missionEndHeader
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                text:           qsTr("Mission End")
-                checked:        true
-            }
-
-            Column {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                spacing:        _margin
-                visible:        missionEndHeader.checked
-
-                QGCCheckBox {
-                    text:       qsTr("Return To Launch")
-                    checked:    missionItem.missionEndRTL
-                    onClicked:  missionItem.missionEndRTL = checked
-                }
-            }
-
-
-            SectionHeader {
                 id:             vehicleInfoSectionHeader
                 anchors.left:   parent.left
                 anchors.right:  parent.right

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -629,7 +629,8 @@ Item {
             readonly property int waypointButtonIndex:  3
             readonly property int roiButtonIndex:       4
             readonly property int patternButtonIndex:   5
-            readonly property int centerButtonIndex:    6
+            readonly property int landButtonIndex:      6
+            readonly property int centerButtonIndex:    7
 
             property bool _isRally:     _editingLayer == _layerRallyPoints
 
@@ -678,6 +679,12 @@ Item {
                     dropPanelComponent: _singleComplexItem ? undefined : patternDropPanel
                 },
                 {
+                    name:               _planMasterController.controllerVehicle.fixedWing ? qsTr("Land") : qsTr("Return"),
+                    iconSource:         "/res/rtl.svg",
+                    buttonEnabled:      _missionController.isInsertLandValid,
+                    buttonVisible:      _editingLayer == _layerMission
+                },
+                {
                     name:               qsTr("Center"),
                     iconSource:         "/qmlimages/MapCenter.svg",
                     buttonEnabled:      true,
@@ -713,6 +720,9 @@ Item {
                     if (_singleComplexItem) {
                         addComplexItem(_missionController.complexMissionItemNames[0])
                     }
+                    break
+                case landButtonIndex:
+                    _missionController.insertLandItem(mapCenter(), _missionController.currentMissionIndex, true /* makeCurrentItem */)
                     break
                 }
             }
@@ -1025,25 +1035,6 @@ Item {
                         addComplexItem(modelData)
                         dropPanel.hide()
                     }
-                }
-            }
-
-            Rectangle {
-                width:              parent.width * 0.8
-                height:             1
-                color:              qgcPal.text
-                opacity:            0.5
-                Layout.fillWidth:   true
-                Layout.columnSpan:  2
-            }
-
-            QGCButton {
-                text:               qsTr("Load KML/SHP...")
-                Layout.fillWidth:   true
-                enabled:            !_planMasterController.syncInProgress
-                onClicked: {
-                    _planMasterController.loadShapeFromSelectedFile()
-                    dropPanel.hide()
                 }
             }
         } // Column


### PR DESCRIPTION
* Add contextual Land tool
* For fixed wing it adds a Landing Pattern
* For anything else it adds an RTL
* Name is Land or RTL based on context
* FW Landing Pattern removed from Pattern drop down
* KML load removed from Pattern drop down
* Removed 'Mission End RTL' from Mission Start item
* Cleaned up a bunch of waypoint line calc code:
  * Rover lines will now link correctly to home as appropriate
  * No more waypoint lines after an RTL
  * Various link start/end to home fixes