### PR TITLE
Plan: More work on contextual Plan tools

### DIFF
--- a/src/MissionManager/MissionCommandTree.cc
+++ b/src/MissionManager/MissionCommandTree.cc
@@ -219,7 +219,7 @@ const MissionCommandUIInfo* MissionCommandTree::getUIInfo(Vehicle* vehicle, MAV_
     }
 }
 
-QVariantList MissionCommandTree::getCommandsForCategory(Vehicle* vehicle, const QString& category)
+QVariantList MissionCommandTree::getCommandsForCategory(Vehicle* vehicle, const QString& category, bool showFlyThroughCommands)
 {
     MAV_AUTOPILOT   baseFirmwareType;
     MAV_TYPE        baseVehicleType;
@@ -237,7 +237,8 @@ QVariantList MissionCommandTree::getCommandsForCategory(Vehicle* vehicle, const 
     for (MAV_CMD command: commandMap.keys()) {
         if (supportedCommands.contains(command)) {
             MissionCommandUIInfo* uiInfo = commandMap[command];
-            if (uiInfo->category() == category || category == _allCommandsCategory) {
+            if ((uiInfo->category() == category || category == _allCommandsCategory) &&
+                    (showFlyThroughCommands || !uiInfo->specifiesCoordinate() || uiInfo->isStandaloneCoordinate())) {
                 list.append(QVariant::fromValue(uiInfo));
             }
         }

--- a/src/MissionManager/MissionCommandTree.h
+++ b/src/MissionManager/MissionCommandTree.h
@@ -62,7 +62,8 @@ public:
 
     const MissionCommandUIInfo* getUIInfo(Vehicle* vehicle, MAV_CMD command);
 
-   Q_INVOKABLE QVariantList getCommandsForCategory(Vehicle* vehicle, const QString& category);
+    /// @param showFlyThroughCommands - true: al commands shows, false: filter out commands which the vehicle flies through (specifiedCoordinate=true, standaloneCoordinate=false)
+    Q_INVOKABLE QVariantList getCommandsForCategory(Vehicle* vehicle, const QString& category, bool showFlyThroughCommands);
 
     // Overrides from QGCTool
     virtual void setToolbox(QGCToolbox* toolbox);

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -92,8 +92,9 @@ public:
     Q_PROPERTY(QString              surveyComplexItemName           READ surveyComplexItemName          CONSTANT)
     Q_PROPERTY(QString              corridorScanComplexItemName     READ corridorScanComplexItemName    CONSTANT)
     Q_PROPERTY(QString              structureScanComplexItemName    READ structureScanComplexItemName   CONSTANT)
-    Q_PROPERTY(bool                 isInsertTakeoffValid            MEMBER _isInsertTakeoffValid        NOTIFY isInsertTakeoffValidChanged) ///< true: Takeoff tool should be enabled
-    Q_PROPERTY(bool                 isInsertLandValid               MEMBER _isInsertLandValid           NOTIFY isInsertLandValidChanged)    ///< true: Land tool should be enabled
+    Q_PROPERTY(bool                 isInsertTakeoffValid            MEMBER _isInsertTakeoffValid        NOTIFY isInsertTakeoffValidChanged)
+    Q_PROPERTY(bool                 isInsertLandValid               MEMBER _isInsertLandValid           NOTIFY isInsertLandValidChanged)
+    Q_PROPERTY(bool                 flyThroughCommandsAllowed       MEMBER _flyThroughCommandsAllowed   NOTIFY flyThroughCommandsAllowedChanged)
 
     Q_INVOKABLE void removeMissionItem(int index);
 
@@ -228,32 +229,33 @@ public:
     static const QString patternSurveyName;
 
 signals:
-    void visualItemsChanged             (void);
-    void waypointPathChanged            (void);
-    void splitSegmentChanged             (void);
-    void newItemsFromVehicle            (void);
-    void missionDistanceChanged         (double missionDistance);
-    void missionTimeChanged             (void);
-    void missionHoverDistanceChanged    (double missionHoverDistance);
-    void missionHoverTimeChanged        (void);
-    void missionCruiseDistanceChanged   (double missionCruiseDistance);
-    void missionCruiseTimeChanged       (void);
-    void missionMaxTelemetryChanged     (double missionMaxTelemetry);
-    void complexMissionItemNamesChanged (void);
-    void resumeMissionIndexChanged      (void);
-    void resumeMissionReady             (void);
-    void resumeMissionUploadFail        (void);
-    void batteryChangePointChanged      (int batteryChangePoint);
-    void batteriesRequiredChanged       (int batteriesRequired);
-    void plannedHomePositionChanged     (QGeoCoordinate plannedHomePosition);
-    void progressPctChanged             (double progressPct);
-    void currentMissionIndexChanged     (int currentMissionIndex);
-    void currentPlanViewIndexChanged    (void);
-    void currentPlanViewItemChanged     (void);
-    void missionBoundingCubeChanged     (void);
-    void missionItemCountChanged        (int missionItemCount);
-    void isInsertTakeoffValidChanged    (void);
-    void isInsertLandValidChanged       (void);
+    void visualItemsChanged                 (void);
+    void waypointPathChanged                (void);
+    void splitSegmentChanged                (void);
+    void newItemsFromVehicle                (void);
+    void missionDistanceChanged             (double missionDistance);
+    void missionTimeChanged                 (void);
+    void missionHoverDistanceChanged        (double missionHoverDistance);
+    void missionHoverTimeChanged            (void);
+    void missionCruiseDistanceChanged       (double missionCruiseDistance);
+    void missionCruiseTimeChanged           (void);
+    void missionMaxTelemetryChanged         (double missionMaxTelemetry);
+    void complexMissionItemNamesChanged     (void);
+    void resumeMissionIndexChanged          (void);
+    void resumeMissionReady                 (void);
+    void resumeMissionUploadFail            (void);
+    void batteryChangePointChanged          (int batteryChangePoint);
+    void batteriesRequiredChanged           (int batteriesRequired);
+    void plannedHomePositionChanged         (QGeoCoordinate plannedHomePosition);
+    void progressPctChanged                 (double progressPct);
+    void currentMissionIndexChanged         (int currentMissionIndex);
+    void currentPlanViewIndexChanged        (void);
+    void currentPlanViewItemChanged         (void);
+    void missionBoundingCubeChanged         (void);
+    void missionItemCountChanged            (int missionItemCount);
+    void isInsertTakeoffValidChanged        (void);
+    void isInsertLandValidChanged           (void);
+    void flyThroughCommandsAllowedChanged   (void);
 
 private slots:
     void _newMissionItemsAvailableFromVehicle(bool removeAllRequested);
@@ -330,8 +332,9 @@ private:
     QGCGeoBoundingCube      _travelBoundingCube;
     QGeoCoordinate          _takeoffCoordinate;
     CoordinateVector*       _splitSegment;
-    bool                    _isInsertTakeoffValid = true;
-    bool                    _isInsertLandValid = true;
+    bool                    _isInsertTakeoffValid =         true;
+    bool                    _isInsertLandValid =            true;
+    bool                    _flyThroughCommandsAllowed =    true;
 
     static const char*  _settingsGroup;
 

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -399,6 +399,7 @@ QString SimpleMissionItem::abbreviation() const
     case MAV_CMD_NAV_VTOL_LAND:
         return tr("VTOL Land");
     case MAV_CMD_DO_SET_ROI:
+    case MAV_CMD_DO_SET_ROI_LOCATION:
         return tr("ROI");
     default:
         return QString();

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -240,8 +240,9 @@ Rectangle {
             id: commandDialog
 
             MissionCommandDialog {
-                missionItem:    _root.missionItem
-                map:            _root.map
+                missionItem:                _root.missionItem
+                map:                        _root.map
+                flyThroughCommandsAllowed:  _missionController.flyThroughCommandsAllowed
             }
         }
 

--- a/src/QmlControls/MissionCommandDialog.qml
+++ b/src/QmlControls/MissionCommandDialog.qml
@@ -19,8 +19,9 @@ import QGroundControl.Palette       1.0
 QGCViewDialog {
     id: root
 
-    property var missionItem
-    property var map
+    property var    missionItem
+    property var    map
+    property bool   flyThroughCommandsAllowed
 
     property var _vehicle: QGroundControl.multiVehicleManager.activeVehicle
 
@@ -40,7 +41,7 @@ QGCViewDialog {
         model:              QGroundControl.missionCommandTree.categoriesForVehicle(_vehicle)
 
         function categorySelected(category) {
-            commandList.model = QGroundControl.missionCommandTree.getCommandsForCategory(_vehicle, category)
+            commandList.model = QGroundControl.missionCommandTree.getCommandsForCategory(_vehicle, category, flyThroughCommandsAllowed)
         }
 
         Component.onCompleted: {
@@ -97,7 +98,7 @@ QGCViewDialog {
             MouseArea {
                 anchors.fill:   parent
                 onClicked: {
-                        missionItem.setMapCenterHintForCommandChange(map.center)
+                    missionItem.setMapCenterHintForCommandChange(map.center)
                     missionItem.command = mavCmdInfo.command
                     root.reject()
                 }

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -36,6 +36,7 @@ Rectangle {
     property real _idealWidth: (ScreenTools.isMobile ? ScreenTools.minTouchPixels : ScreenTools.defaultFontPixelWidth * 8) + toolStripColumn.anchors.margins * 2
 
     signal clicked(int index, bool checked)
+    signal dropped(int index)
 
     function setChecked(idx, check) {
         repeater.itemAt(idx).checked = check
@@ -88,6 +89,7 @@ Rectangle {
                     } else if (checked) {
                         var panelEdgeTopPoint = mapToItem(_root, width, 0)
                         dropPanel.show(panelEdgeTopPoint, height, modelData.dropPanelComponent)
+                        _root.dropped(index)
                     }
                     if(_root && buttonTemplate)
                         _root.lastClickedButton = buttonTemplate


### PR DESCRIPTION
* Waypoint button is contexual and only enabled when appropriate
* Made ROI tool visible. This was always there but hidden behind a magic flag
* Fixed a bunch on other contextual enable/disable bugs
* Fixed a bunch of bugs which related to managing the check state on the Plan ToolStrip