### PR TITLE
PLan: Takeoff item user model changes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ Note: This file only contains high level features or important fixes.
 
 ### 3.6.0 - Daily Build
 
-* ADSB: Added support for connecting to SBS server. Adds support for ADSB data from USB SDR Dongle running 'dump190 --net' for example.
+* ADSB: Added support for connecting to SBS server. Adds support for ADSB data from USB SDR Dongle running 'dump1090 --net' for example.
 * Toolbar: Scrollable left/right on small screens like phones
 * Plan View: New create plan UI for initial plan creation
 * New Corridor editing tools ui. Includes ability to trace polyline by clicking.

--- a/src/FlightMap/MapItems/MissionLineView.qml
+++ b/src/FlightMap/MapItems/MissionLineView.qml
@@ -17,8 +17,6 @@ import QGroundControl.Palette   1.0
 
 /// The MissionLineView control is used to add lines between mission items
 MapItemView {
-    property bool homePositionValid: true   ///< true: show home position, false: don't show home position
-
     delegate: MapPolyline {
         line.width: 3
         line.color: "#be781c"                           // Hack, can't get palette to work in here

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -395,9 +395,8 @@ VisualMissionItem* MissionController::insertSimpleMissionItem(QGeoCoordinate coo
 VisualMissionItem* MissionController::insertTakeoffItem(QGeoCoordinate /*coordinate*/, int visualItemIndex, bool makeCurrentItem)
 {
     int sequenceNumber = _nextSequenceNumber();
-    TakeoffMissionItem * newItem = new TakeoffMissionItem(_controllerVehicle->vtol() ? MAV_CMD_NAV_VTOL_TAKEOFF : MAV_CMD_NAV_TAKEOFF, _controllerVehicle, _flyView, _settingsItem, this);
+    TakeoffMissionItem * newItem = new TakeoffMissionItem(_controllerVehicle->vtol() ? MAV_CMD_NAV_VTOL_TAKEOFF : MAV_CMD_NAV_TAKEOFF, _managerVehicle, _flyView, _settingsItem, this);
     newItem->setSequenceNumber(sequenceNumber);
-    newItem->setWizardMode(true);
     _initVisualItem(newItem);
 
     if (newItem->specifiesAltitude()) {
@@ -1705,8 +1704,6 @@ void MissionController::_initAllVisualItems(void)
         }
     }
 
-    _settingsItem->setHomePositionFromVehicle(_managerVehicle);
-
     connect(_settingsItem, &MissionSettingsItem::coordinateChanged,     this, &MissionController::_recalcAll);
     connect(_settingsItem, &MissionSettingsItem::coordinateChanged,     this, &MissionController::plannedHomePositionChanged);
 
@@ -1831,7 +1828,7 @@ bool MissionController::_findPreviousAltitude(int newIndex, double* prevAltitude
 {
     bool        found = false;
     double      foundAltitude = 0;
-    int         foundAltitudeMode;
+    int         foundAltitudeMode = QGroundControlQmlGlobal::AltitudeModeNone;
 
     if (newIndex > _visualItems->count()) {
         return false;
@@ -1879,9 +1876,8 @@ MissionSettingsItem* MissionController::_addMissionSettings(QmlObjectListModel* 
 {
     qCDebug(MissionControllerLog) << "_addMissionSettings";
 
-    MissionSettingsItem* settingsItem = new MissionSettingsItem(_controllerVehicle, _flyView, visualItems);
+    MissionSettingsItem* settingsItem = new MissionSettingsItem(_managerVehicle, _flyView, visualItems);
     visualItems->insert(0, settingsItem);
-    settingsItem->setHomePositionFromVehicle(_managerVehicle);
 
     if (visualItems == _visualItems) {
         _settingsItem = settingsItem;

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -377,7 +377,7 @@ VisualMissionItem* MissionController::_insertSimpleMissionItemWorker(QGeoCoordin
     }
 
     // We send the click coordinate through here to be able to set the planned home position from the user click location if needed
-    _recalcAllWithClickCoordinate(coordinate);
+    _recalcAllWithCoordinate(coordinate);
 
     if (makeCurrentItem) {
         setCurrentPlanViewIndex(newItem->sequenceNumber(), true);
@@ -392,14 +392,11 @@ VisualMissionItem* MissionController::insertSimpleMissionItem(QGeoCoordinate coo
     return _insertSimpleMissionItemWorker(coordinate, MAV_CMD_NAV_WAYPOINT, visualItemIndex, makeCurrentItem);
 }
 
-VisualMissionItem* MissionController::insertTakeoffItem(QGeoCoordinate coordinate, int visualItemIndex, bool makeCurrentItem)
+VisualMissionItem* MissionController::insertTakeoffItem(QGeoCoordinate /*coordinate*/, int visualItemIndex, bool makeCurrentItem)
 {
     int sequenceNumber = _nextSequenceNumber();
     TakeoffMissionItem * newItem = new TakeoffMissionItem(_controllerVehicle->vtol() ? MAV_CMD_NAV_VTOL_TAKEOFF : MAV_CMD_NAV_TAKEOFF, _controllerVehicle, _flyView, _settingsItem, this);
     newItem->setSequenceNumber(sequenceNumber);
-    if (!newItem->coordinate().isValid()) {
-        newItem->setCoordinate(coordinate);
-    }
     newItem->setWizardMode(true);
     _initVisualItem(newItem);
 
@@ -419,8 +416,7 @@ VisualMissionItem* MissionController::insertTakeoffItem(QGeoCoordinate coordinat
         _visualItems->insert(visualItemIndex, newItem);
     }
 
-    // We send the click coordinate through here to be able to set the planned home position from the user click location if needed
-    _recalcAllWithClickCoordinate(coordinate);
+    _recalcAll();
 
     if (makeCurrentItem) {
         setCurrentPlanViewIndex(newItem->sequenceNumber(), true);
@@ -466,7 +462,7 @@ VisualMissionItem* MissionController::insertComplexMissionItem(QString itemName,
         return nullptr;
     }
 
-    _insertComplexMissionItemWorker(newItem, visualItemIndex, makeCurrentItem);
+    _insertComplexMissionItemWorker(mapCenterCoordinate, newItem, visualItemIndex, makeCurrentItem);
 
     return newItem;
 }
@@ -486,12 +482,12 @@ VisualMissionItem* MissionController::insertComplexMissionItemFromKMLOrSHP(QStri
         return nullptr;
     }
 
-    _insertComplexMissionItemWorker(newItem, visualItemIndex, makeCurrentItem);
+    _insertComplexMissionItemWorker(QGeoCoordinate(), newItem, visualItemIndex, makeCurrentItem);
 
     return newItem;
 }
 
-void MissionController::_insertComplexMissionItemWorker(ComplexMissionItem* complexItem, int visualItemIndex, bool makeCurrentItem)
+void MissionController::_insertComplexMissionItemWorker(const QGeoCoordinate& mapCenterCoordinate, ComplexMissionItem* complexItem, int visualItemIndex, bool makeCurrentItem)
 {
     int sequenceNumber = _nextSequenceNumber();
     bool surveyStyleItem = qobject_cast<SurveyComplexItem*>(complexItem) ||
@@ -538,7 +534,7 @@ void MissionController::_insertComplexMissionItemWorker(ComplexMissionItem* comp
     if(!complexItem->isSimpleItem()) {
         connect(complexItem, &ComplexMissionItem::boundingCubeChanged, this, &MissionController::_complexBoundingBoxChanged);
     }
-    _recalcAll();
+    _recalcAllWithCoordinate(mapCenterCoordinate);
 
     if (makeCurrentItem) {
         setCurrentPlanViewIndex(complexItem->sequenceNumber(), true);
@@ -1649,6 +1645,7 @@ void MissionController::_recalcChildItems(void)
 
 void MissionController::_setPlannedHomePositionFromFirstCoordinate(const QGeoCoordinate& clickCoordinate)
 {
+    bool foundFirstCoordinate = false;
     QGeoCoordinate firstCoordinate;
 
     if (_settingsItem->coordinate().isValid()) {
@@ -1659,14 +1656,15 @@ void MissionController::_setPlannedHomePositionFromFirstCoordinate(const QGeoCoo
     for (int i=1; i<_visualItems->count(); i++) {
         VisualMissionItem* item = _visualItems->value<VisualMissionItem*>(i);
 
-        if (item->specifiesCoordinate()) {
+        if (item->specifiesCoordinate() && item->coordinate().isValid()) {
+            foundFirstCoordinate = true;
             firstCoordinate = item->coordinate();
             break;
         }
     }
 
     // No item specifying a coordinate was found, in this case it we have a clickCoordinate use that
-    if (!firstCoordinate.isValid()) {
+    if (!foundFirstCoordinate) {
         firstCoordinate = clickCoordinate;
     }
 
@@ -1677,11 +1675,10 @@ void MissionController::_setPlannedHomePositionFromFirstCoordinate(const QGeoCoo
     }
 }
 
-/// @param clickCoordinate The location of the user click when inserting a new item
-void MissionController::_recalcAllWithClickCoordinate(QGeoCoordinate& clickCoordinate)
+void MissionController::_recalcAllWithCoordinate(const QGeoCoordinate& coordinate)
 {
     if (!_flyView) {
-        _setPlannedHomePositionFromFirstCoordinate(clickCoordinate);
+        _setPlannedHomePositionFromFirstCoordinate(coordinate);
     }
     _recalcSequence();
     _recalcChildItems();
@@ -1692,7 +1689,7 @@ void MissionController::_recalcAllWithClickCoordinate(QGeoCoordinate& clickCoord
 void MissionController::_recalcAll(void)
 {
     QGeoCoordinate emptyCoord;
-    _recalcAllWithClickCoordinate(emptyCoord);
+    _recalcAllWithCoordinate(emptyCoord);
 }
 
 /// Initializes a new set of mission items
@@ -1817,37 +1814,12 @@ void MissionController::managerVehicleChanged(Vehicle* managerVehicle)
     connect(_missionManager, &MissionManager::lastCurrentIndexChanged,  this, &MissionController::resumeMissionIndexChanged);
     connect(_missionManager, &MissionManager::resumeMissionReady,       this, &MissionController::resumeMissionReady);
     connect(_missionManager, &MissionManager::resumeMissionUploadFail,  this, &MissionController::resumeMissionUploadFail);
-    connect(_managerVehicle, &Vehicle::homePositionChanged,             this, &MissionController::_managerVehicleHomePositionChanged);
     connect(_managerVehicle, &Vehicle::defaultCruiseSpeedChanged,       this, &MissionController::_recalcMissionFlightStatus);
     connect(_managerVehicle, &Vehicle::defaultHoverSpeedChanged,        this, &MissionController::_recalcMissionFlightStatus);
     connect(_managerVehicle, &Vehicle::vehicleTypeChanged,              this, &MissionController::complexMissionItemNamesChanged);
 
-    if (!_masterController->offline()) {
-        _managerVehicleHomePositionChanged();
-    }
-
     emit complexMissionItemNamesChanged();
     emit resumeMissionIndexChanged();
-}
-
-void MissionController::_managerVehicleHomePositionChanged(void)
-{
-    if (_visualItems) {
-        bool currentDirtyBit = dirty();
-
-        MissionSettingsItem* settingsItem = qobject_cast<MissionSettingsItem*>(_visualItems->get(0));
-        if (settingsItem) {
-            settingsItem->setHomePositionFromVehicle(_managerVehicle);
-        } else {
-            qWarning() << "First item is not MissionSettingsItem";
-        }
-
-        if (!currentDirtyBit) {
-            // Don't let this trip the dirty bit. Otherwise plan will keep getting marked dirty if vehicle home
-            // changes.
-            _visualItems->setDirty(false);
-        }
-    }
 }
 
 void MissionController::_inProgressChanged(bool inProgress)
@@ -1858,7 +1830,7 @@ void MissionController::_inProgressChanged(bool inProgress)
 bool MissionController::_findPreviousAltitude(int newIndex, double* prevAltitude, int* prevAltitudeMode)
 {
     bool        found = false;
-    double      foundAltitude;
+    double      foundAltitude = 0;
     int         foundAltitudeMode;
 
     if (newIndex > _visualItems->count()) {

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -260,7 +260,6 @@ signals:
 private slots:
     void _newMissionItemsAvailableFromVehicle(bool removeAllRequested);
     void _itemCommandChanged(void);
-    void _managerVehicleHomePositionChanged(void);
     void _inProgressChanged(bool inProgress);
     void _currentMissionIndexChanged(int sequenceNumber);
     void _recalcWaypointLines(void);
@@ -278,7 +277,7 @@ private:
     void _init(void);
     void _recalcSequence(void);
     void _recalcChildItems(void);
-    void _recalcAllWithClickCoordinate(QGeoCoordinate& clickCoordinate);
+    void _recalcAllWithCoordinate(const QGeoCoordinate& coordinate);
     void _initAllVisualItems(void);
     void _deinitAllVisualItems(void);
     void _initVisualItem(VisualMissionItem* item);
@@ -308,7 +307,7 @@ private:
     CoordinateVector* _addWaypointLineSegment(CoordVectHashTable& prevItemPairHashTable, VisualItemPair& pair);
     void _addTimeDistance(bool vtolInHover, double hoverTime, double cruiseTime, double extraTime, double distance, int seqNum);
     VisualMissionItem* _insertSimpleMissionItemWorker(QGeoCoordinate coordinate, MAV_CMD command, int visualItemIndex, bool makeCurrentItem);
-    void _insertComplexMissionItemWorker(ComplexMissionItem* complexItem, int visualItemIndex, bool makeCurrentItem);
+    void _insertComplexMissionItemWorker(const QGeoCoordinate& mapCenterCoordinate, ComplexMissionItem* complexItem, int visualItemIndex, bool makeCurrentItem);
     void _warnIfTerrainFrameUsed(void);
 
 private:

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -47,17 +47,16 @@ MissionSettingsItem::MissionSettingsItem(Vehicle* vehicle, bool flyView, QObject
     connect(this,               &MissionSettingsItem::specifyMissionFlightSpeedChanged, this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
     connect(&_cameraSection,    &CameraSection::itemCountChanged,                       this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
     connect(&_speedSection,     &CameraSection::itemCountChanged,                       this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
-
     connect(this,               &MissionSettingsItem::terrainAltitudeChanged,           this, &MissionSettingsItem::_setHomeAltFromTerrain);
-
+    connect(&_cameraSection,    &CameraSection::dirtyChanged,                           this, &MissionSettingsItem::_sectionDirtyChanged);
+    connect(&_speedSection,     &SpeedSection::dirtyChanged,                            this, &MissionSettingsItem::_sectionDirtyChanged);
+    connect(&_cameraSection,    &CameraSection::specifiedGimbalYawChanged,              this, &MissionSettingsItem::specifiedGimbalYawChanged);
+    connect(&_cameraSection,    &CameraSection::specifiedGimbalPitchChanged,            this, &MissionSettingsItem::specifiedGimbalPitchChanged);
+    connect(&_speedSection,     &SpeedSection::specifiedFlightSpeedChanged,             this, &MissionSettingsItem::specifiedFlightSpeedChanged);
+    connect(_vehicle,           &Vehicle::homePositionChanged,                          this, &MissionSettingsItem::_updateHomePosition);
     connect(&_plannedHomePositionAltitudeFact,  &Fact::rawValueChanged,                 this, &MissionSettingsItem::_updateAltitudeInCoordinate);
 
-    connect(&_cameraSection,    &CameraSection::dirtyChanged,   this, &MissionSettingsItem::_sectionDirtyChanged);
-    connect(&_speedSection,     &SpeedSection::dirtyChanged,    this, &MissionSettingsItem::_sectionDirtyChanged);
-
-    connect(&_cameraSection,    &CameraSection::specifiedGimbalYawChanged,      this, &MissionSettingsItem::specifiedGimbalYawChanged);
-    connect(&_cameraSection,    &CameraSection::specifiedGimbalPitchChanged,    this, &MissionSettingsItem::specifiedGimbalPitchChanged);
-    connect(&_speedSection,     &SpeedSection::specifiedFlightSpeedChanged,     this, &MissionSettingsItem::specifiedFlightSpeedChanged);
+    _updateHomePosition(_vehicle->homePosition());
 }
 
 int MissionSettingsItem::lastSequenceNumber(void) const
@@ -284,4 +283,11 @@ void MissionSettingsItem::_setHomeAltFromTerrain(double terrainAltitude)
 QString MissionSettingsItem::abbreviation(void) const
 {
     return _flyView ? tr("H") : tr("Launch");
+}
+
+void MissionSettingsItem::_updateHomePosition(const QGeoCoordinate& homePosition)
+{
+    if (_flyView) {
+        setCoordinate(homePosition);
+    }
 }

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -100,6 +100,7 @@ private slots:
     void _updateAltitudeInCoordinate            (QVariant value);
     void _setHomeAltFromTerrain                 (double terrainAltitude);
     void _setCoordinateWorker                   (const QGeoCoordinate& coordinate);
+    void _updateHomePosition                    (const QGeoCoordinate& homePosition);
 
 private:
     QGeoCoordinate  _plannedHomePositionCoordinate;     // Does not include altitude

--- a/src/MissionManager/TakeoffMissionItem.cc
+++ b/src/MissionManager/TakeoffMissionItem.cc
@@ -58,6 +58,13 @@ void TakeoffMissionItem::_init(void)
 
     _initLaunchTakeoffAtSameLocation();
 
+    if (_launchTakeoffAtSameLocation && homePosition.isValid()) {
+        _wizardMode = false;
+        SimpleMissionItem::setCoordinate(homePosition);
+    } else {
+        _wizardMode = true;
+    }
+
     setDirty(false);
 }
 

--- a/src/MissionManager/TakeoffMissionItem.h
+++ b/src/MissionManager/TakeoffMissionItem.h
@@ -29,7 +29,7 @@ public:
     QGeoCoordinate  launchCoordinate            (void) const { return _settingsItem->coordinate(); }
     bool            launchTakeoffAtSameLocation (void) const { return _launchTakeoffAtSameLocation; }
 
-    void setLaunchCoordinate            (const QGeoCoordinate& launchCoordinate) { _settingsItem->setCoordinate(launchCoordinate); }
+    void setLaunchCoordinate            (const QGeoCoordinate& launchCoordinate);
     void setLaunchTakeoffAtSameLocation (bool launchTakeoffAtSameLocation);
 
     static bool isTakeoffCommand(MAV_CMD command);

--- a/src/PlanView/FWLandingPatternMapVisual.qml
+++ b/src/PlanView/FWLandingPatternMapVisual.qml
@@ -179,6 +179,8 @@ Item {
             anchors.fill:   map
             z:              QGroundControl.zOrderMapItems + 1   // Over item indicators
 
+            readonly property int   _decimalPlaces:             8
+
             onClicked: {
                 var coordinate = map.toCoordinate(Qt.point(mouse.x, mouse.y), false /* clipToViewPort */)
                 coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -38,8 +38,7 @@ Item {
     property real   _rowSpacing:                ScreenTools.isMobile ? 1 : 0
     property real   _distance:                  _statusValid && _currentMissionItem ? _currentMissionItem.distance : NaN
     property real   _altDifference:             _statusValid && _currentMissionItem ? _currentMissionItem.altDifference : NaN
-    property real   _gradient:                  _statusValid && _currentMissionItem && _currentMissionItem.distance > 0 ? Math.atan(_currentMissionItem.altDifference / _currentMissionItem.distance) : NaN
-    property real   _gradientPercent:           isNaN(_gradient) ? NaN : _gradient * 100
+    property real   _gradient:                  _statusValid && _currentMissionItem && _currentMissionItem.distance > 0 ? (Math.atan(_currentMissionItem.altDifference / _currentMissionItem.distance) * (180.0/Math.PI)) : NaN
     property real   _azimuth:                   _statusValid && _currentMissionItem ? _currentMissionItem.azimuth : NaN
     property real   _heading:                   _statusValid && _currentMissionItem ? _currentMissionItem.missionVehicleYaw : NaN
     property real   _missionDistance:           _missionValid ? missionDistance : NaN
@@ -53,7 +52,7 @@ Item {
 
     property string _distanceText:              isNaN(_distance) ?              "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_distance).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
     property string _altDifferenceText:         isNaN(_altDifference) ?         "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_altDifference).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
-    property string _gradientText:              isNaN(_gradient) ?              "-.-" : _gradientPercent.toFixed(0) + " %"
+    property string _gradientText:              isNaN(_gradient) ?              "-.-" : _gradient.toFixed(0) + " %"
     property string _azimuthText:               isNaN(_azimuth) ?               "-.-" : Math.round(_azimuth) % 360
     property string _headingText:               isNaN(_azimuth) ?               "-.-" : Math.round(_heading) % 360
     property string _missionDistanceText:       isNaN(_missionDistance) ?       "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_missionDistance).toFixed(0) + " " + QGroundControl.appSettingsDistanceUnitsString

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -63,24 +63,29 @@ Rectangle {
             anchors.left:       parent.left
             anchors.right:      parent.right
             spacing:            _margin
-            visible:            missionItem.wizardMode
+            visible:            missionItem.isTakeoffItem && missionItem.wizardMode // Hack special case for takeoff item
 
             QGCLabel {
-                text:               qsTr("Adjust the initial launch location by dragging 'L' indicator to the desired location.")
+                id:                 initialClickLabel
+                text:               missionItem.launchTakeoffAtSameLocation ?
+                                        qsTr("Click in map to set Takeoff location.") :
+                                        qsTr("Click in map to set Launch location.")
                 Layout.fillWidth:   true
                 wrapMode:           Text.WordWrap
-                visible:            !missionItem.launchTakeoffAtSameLocation
+                visible:            missionItem.isTakeoffItem && !missionItem.launchCoordinate.isValid
             }
 
             QGCLabel {
-                text:               qsTr("Adjust the takeoff %1 location by dragging 'T' indicator to the desired location.").arg(missionItem.launchTakeoffAtSameLocation ? "" : qsTr("completion "))
+                text:               qsTr("Adjust the takeoff completion location by dragging 'T' indicator to the desired location.")
                 Layout.fillWidth:   true
                 wrapMode:           Text.WordWrap
+                visible:            !initialClickLabel.visible
             }
 
             QGCButton {
                 text:               qsTr("Done Adjusting")
                 Layout.fillWidth:   true
+                visible:            !initialClickLabel.visible
                 onClicked: {
                     missionItem.wizardMode = false
                     editorRoot.selectNextNotReadyItem()


### PR DESCRIPTION
Given how different firmwares and vehicles deal with takeoff items which do or don't include a location. Trying to explain how this all works now is next to impossible since it's so complicated. The simplest way to explain how it works now is:
* The user is asked to click in the map to set initial location when appropriate. Sometimes that sets launch location, sometimes takeoff location, sometime both!
* The editor drops in/out of wizard mode appropriately
* A fixed wing takeoff which requires a coordinate sets the takeoff item coordinate to be at a 30% climb out from the launch location