### PR TITLE
Set Rally Point default value to 0.0 and get it from Fact's default

### DIFF
--- a/src/MissionManager/RallyPoint.FactMetaData.json
+++ b/src/MissionManager/RallyPoint.FactMetaData.json
@@ -12,10 +12,11 @@
     "decimalPlaces":    7
 },
 {
-    "name":             "Altitude",
+    "name":             "Relative Altitude",
     "shortDescription": "Altitude of rally point position (home relative)",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "m"
+    "units":            "m",
+    "defaultValue":     0.0
 }
 ]

--- a/src/MissionManager/RallyPoint.cc
+++ b/src/MissionManager/RallyPoint.cc
@@ -15,7 +15,7 @@
 
 const char* RallyPoint::_longitudeFactName =    "Longitude";
 const char* RallyPoint::_latitudeFactName =     "Latitude";
-const char* RallyPoint::_altitudeFactName =     "Altitude";
+const char* RallyPoint::_altitudeFactName =     "Relative Altitude";
 
 QMap<QString, FactMetaData*> RallyPoint::_metaDataMap;
 
@@ -63,9 +63,7 @@ RallyPoint::~RallyPoint()
 
 void RallyPoint::_factSetup(void)
 {
-    if (_metaDataMap.isEmpty()) {
-        _metaDataMap = FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/RallyPoint.FactMetaData.json"), nullptr /* metaDataParent */);
-    }
+    _cacheFactMetadata();
 
     _longitudeFact.setMetaData(_metaDataMap[_longitudeFactName]);
     _latitudeFact.setMetaData(_metaDataMap[_latitudeFactName]);
@@ -78,6 +76,12 @@ void RallyPoint::_factSetup(void)
     connect(&_longitudeFact, &Fact::valueChanged, this, &RallyPoint::_sendCoordinateChanged);
     connect(&_latitudeFact, &Fact::valueChanged, this, &RallyPoint::_sendCoordinateChanged);
     connect(&_altitudeFact, &Fact::valueChanged, this, &RallyPoint::_sendCoordinateChanged);
+}
+
+void RallyPoint::_cacheFactMetadata() {
+    if (_metaDataMap.isEmpty()) {
+        _metaDataMap = FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/RallyPoint.FactMetaData.json"), nullptr /* metaDataParent */);
+    }
 }
 
 void RallyPoint::setCoordinate(const QGeoCoordinate& coordinate)
@@ -97,6 +101,15 @@ void RallyPoint::setDirty(bool dirty)
         _dirty = dirty;
         emit dirtyChanged(dirty);
     }
+}
+
+double RallyPoint::getDefaultFactAltitude() {
+    _cacheFactMetadata();
+    auto it = _metaDataMap.find(QString(_altitudeFactName));
+    if(it != _metaDataMap.end() && (*it)->defaultValueAvailable()) {
+        return (*it)->rawDefaultValue().toDouble();
+    }
+    return 0.0;
 }
 
 QGeoCoordinate RallyPoint::coordinate(void) const

--- a/src/MissionManager/RallyPoint.h
+++ b/src/MissionManager/RallyPoint.h
@@ -39,6 +39,8 @@ public:
     bool dirty(void) const { return _dirty; }
     void setDirty(bool dirty);
 
+    static double getDefaultFactAltitude();
+
 signals:
     void coordinateChanged      (const QGeoCoordinate& coordinate);
     void dirtyChanged           (bool dirty);
@@ -48,6 +50,7 @@ private slots:
 
 private:
     void _factSetup(void);
+    static void _cacheFactMetadata();
 
     bool _dirty;
     Fact _longitudeFact;

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -243,7 +243,7 @@ void RallyPointController::addPoint(QGeoCoordinate point)
     if (_points.count()) {
         defaultAlt = qobject_cast<RallyPoint*>(_points[_points.count() - 1])->coordinate().altitude();
     } else {
-        defaultAlt = qgcApp()->toolbox()->settingsManager()->appSettings()->defaultMissionItemAltitude()->rawValue().toDouble();
+        defaultAlt = RallyPoint::getDefaultFactAltitude();
     }
     point.setAltitude(defaultAlt);
     RallyPoint* newPoint = new RallyPoint(point, this);

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -243,7 +243,12 @@ void RallyPointController::addPoint(QGeoCoordinate point)
     if (_points.count()) {
         defaultAlt = qobject_cast<RallyPoint*>(_points[_points.count() - 1])->coordinate().altitude();
     } else {
-        defaultAlt = RallyPoint::getDefaultFactAltitude();
+        if(_masterController->controllerVehicle()->fixedWing()) {
+            defaultAlt = qgcApp()->toolbox()->settingsManager()->appSettings()->defaultMissionItemAltitude()->rawValue().toDouble();
+        }
+        else {
+            defaultAlt = RallyPoint::getDefaultFactAltitude();
+        }
     }
     point.setAltitude(defaultAlt);
     RallyPoint* newPoint = new RallyPoint(point, this);


### PR DESCRIPTION
The Rally Point default value is taken from user settings `Default Mission Altitude`.
This PR does the following:
 - Take the default value from the `Fact`'s default value if NOT fixed wing. Otherwise use the same behaviour `Default Mission Altitude`
 - Rename the misleading `Altitude` to `Relative Altitude` (relative to home altitude)
 - Set the default value to `0.0` (use home altitude by default)
