### PR TITLE
Plan: Fix gimbal yaw visual problems

### DIFF
--- a/src/MissionManager/CameraSection.cc
+++ b/src/MissionManager/CameraSection.cc
@@ -543,9 +543,7 @@ double CameraSection::specifiedGimbalPitch(void) const
 
 void CameraSection::_updateSpecifiedGimbalYaw(void)
 {
-    if (_specifyGimbal) {
-        emit specifiedGimbalYawChanged(specifiedGimbalYaw());
-    }
+    emit specifiedGimbalYawChanged(specifiedGimbalYaw());
 }
 
 void CameraSection::_updateSpecifiedGimbalPitch(void)

--- a/src/MissionManager/CameraSection.cc
+++ b/src/MissionManager/CameraSection.cc
@@ -67,8 +67,6 @@ CameraSection::CameraSection(Vehicle* vehicle, QObject* parent)
     connect(this,                               &CameraSection::specifyGimbalChanged,       this, &CameraSection::_setDirty);
     connect(this,                               &CameraSection::specifyCameraModeChanged,   this, &CameraSection::_setDirty);
 
-    connect(this,                               &CameraSection::specifyGimbalChanged,       this, &CameraSection::_updateSpecifiedGimbalYaw);
-    connect(this,                               &CameraSection::specifyGimbalChanged,       this, &CameraSection::_updateSpecifiedGimbalPitch);
     connect(&_gimbalYawFact,                    &Fact::valueChanged,                        this, &CameraSection::_updateSpecifiedGimbalYaw);
     connect(&_gimbalPitchFact,                  &Fact::valueChanged,                        this, &CameraSection::_updateSpecifiedGimbalPitch);
 }
@@ -78,6 +76,8 @@ void CameraSection::setSpecifyGimbal(bool specifyGimbal)
     if (specifyGimbal != _specifyGimbal) {
         _specifyGimbal = specifyGimbal;
         emit specifyGimbalChanged(specifyGimbal);
+        emit specifiedGimbalYawChanged(specifiedGimbalYaw());
+        emit specifiedGimbalPitchChanged(specifiedGimbalPitch());
     }
 }
 
@@ -543,7 +543,9 @@ double CameraSection::specifiedGimbalPitch(void) const
 
 void CameraSection::_updateSpecifiedGimbalYaw(void)
 {
-    emit specifiedGimbalYawChanged(specifiedGimbalYaw());
+    if (_specifyGimbal) {
+        emit specifiedGimbalYawChanged(specifiedGimbalYaw());
+    }
 }
 
 void CameraSection::_updateSpecifiedGimbalPitch(void)

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1419,7 +1419,21 @@ void MissionController::_recalcMissionFlightStatus()
             _missionFlightStatus.vehicleSpeed = newSpeed;
         }
 
-        // Look for gimbal change
+        // ROI commands cancel out previous gimbal yaw/pitch
+        if (simpleItem) {
+            switch (simpleItem->command()) {
+            case MAV_CMD_NAV_ROI:
+            case MAV_CMD_DO_SET_ROI_LOCATION:
+            case MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET:
+                _missionFlightStatus.gimbalYaw = std::numeric_limits<double>::quiet_NaN();
+                _missionFlightStatus.gimbalPitch = std::numeric_limits<double>::quiet_NaN();
+                break;
+            default:
+                break;
+            }
+        }
+
+        // Look for specific gimbal changes
         double gimbalYaw = item->specifiedGimbalYaw();
         if (!qIsNaN(gimbalYaw)) {
             _missionFlightStatus.gimbalYaw = gimbalYaw;

--- a/src/MissionManager/MissionItemTest.cc
+++ b/src/MissionManager/MissionItemTest.cc
@@ -39,12 +39,11 @@ void MissionItemTest::init(void)
                                   MAV_TYPE_QUADROTOR,
                                   qgcApp()->toolbox()->firmwarePluginManager(),
                                   this);
-
 }
 
 void MissionItemTest::cleanup(void)
 {
-    delete _offlineVehicle;
+    _offlineVehicle->deleteLater();
     UnitTest::cleanup();
 }
 

--- a/src/MissionManager/VisualMissionItemTest.cc
+++ b/src/MissionManager/VisualMissionItemTest.cc
@@ -54,7 +54,7 @@ void VisualMissionItemTest::init(void)
 
 void VisualMissionItemTest::cleanup(void)
 {
-    delete _offlineVehicle;
+    _offlineVehicle->deleteLater();
     UnitTest::cleanup();
 }
 


### PR DESCRIPTION
Fixes for #8033:
* Unchecking gimbal yaw changes will correctly update gimbal visuals
* ROI commands will cancel the display of gimbal visuals. Note: This leads to some quirky behavior. Specifically that the waypoint item prior to the ROI command will continue to show gimbal angle display. Which technically is correct, but from and end user standpoint may be confusing.