### PR TITLE
Microservice versioning Proof of Concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,7 @@ Qt*-linux*.tar.*
 .vs/
 
 libs/airmapd/include/boost
+
+# Jetbrains IDEs
+.idea/
+cmake-build-debug/

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -22,7 +22,7 @@
 // TODO microservice versioning: Figure out how to actually configure these
 #define SERVICE_ID 1
 constexpr uint16_t SERVICE_MIN_VERSION = 1;
-constexpr uint16_t SERVICE_MAX_VERSION = 3;
+constexpr uint16_t SERVICE_MAX_VERSION = 1;
 
 QGC_LOGGING_CATEGORY(PlanManagerLog, "PlanManagerLog")
 
@@ -381,7 +381,8 @@ void PlanManager::_requestNextMissionItem(void)
     qCDebug(PlanManagerLog) << QStringLiteral("_requestNextMissionItem %1 sequenceNumber:retry").arg(_planTypeString()) << _itemIndicesToRead[0] << _retryCount;
 
     mavlink_message_t message;
-    if (_vehicle->capabilityBits() & MAV_PROTOCOL_CAPABILITY_MISSION_INT) {
+    //if (_vehicle->capabilityBits() & MAV_PROTOCOL_CAPABILITY_MISSION_INT) {
+    if (_serviceVersion > 1) {
         mavlink_msg_mission_request_int_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
                                                   qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
                                                   _dedicatedLink->mavlinkChannel(),
@@ -574,7 +575,7 @@ void PlanManager::_handleMissionRequest(const mavlink_message_t& message, bool m
     qCDebug(PlanManagerLog) << QStringLiteral("_handleMissionRequest %1 sequenceNumber:command").arg(_planTypeString()) << missionRequestSeq << item->command();
 
     mavlink_message_t   messageOut;
-    if (missionItemInt || _vehicle->apmFirmware() /* ArduPilot always expects to get MISSION_ITEM_INT no matter what */) {
+    if (_serviceVersion > 1 || _vehicle->apmFirmware() /* ArduPilot always expects to get MISSION_ITEM_INT no matter what */) {
         mavlink_msg_mission_item_int_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
                                                qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
                                                _dedicatedLink->mavlinkChannel(),

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -91,6 +91,7 @@ signals:
 private slots:
     void _mavlinkMessageReceived(const mavlink_message_t& message);
     void _ackTimeout(void);
+    void _serviceVersionReceived(uint16_t serviceID, uint16_t serviceVersion);
 
 protected:
     typedef enum {
@@ -100,6 +101,7 @@ protected:
         AckMissionRequest,  ///< MISSION_REQUEST is expected, or MISSION_ACK to end sequence
         AckMissionClearAll, ///< MISSION_CLEAR_ALL sent, MISSION_ACK is expected
         AckGuidedItem,      ///< MISSION_ACK expected in response to ArduPilot guided mode single item send
+        AckServiceVersion,  ///< Expecting to receive microservice version
     } AckType_t;
 
     typedef enum {
@@ -154,8 +156,20 @@ protected:
     int                 _currentMissionIndex;
     int                 _lastCurrentIndex;
 
+    bool                _connectedToMavlink;
+    uint16_t            _serviceVersion;
+
 private:
     void _setTransactionInProgress(TransactionType_t type);
+    /**
+     * Performs the following actions:
+     *  - Set _retry_count to 0
+     *  - Connect to Mavlink (if not already done)
+     *  - Request the microservice version
+     * Once the microservice version is received, the actual transaction begins.
+     * @param type
+     */
+    void _startTransaction(TransactionType_t type);
 };
 
 #endif

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -4047,9 +4047,8 @@ void Vehicle::requestMicroserviceVersion(uint16_t serviceID, uint16_t minVersion
     if(iter == _microserviceVersions.end()){
         sendMavCommand(
                 defaultComponentId(),
-                MAV_CMD_REQUEST_MESSAGE,
+                MAV_CMD_REQUEST_SERVICE_VERSION,
                 false,
-                MAVLINK_MSG_ID_MAVLINK_SERVICE_VERSION,
                 serviceID,
                 minVersion,
                 maxVersion

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -4037,18 +4037,17 @@ int  Vehicle::versionCompare(int major, int minor, int patch)
     return _firmwarePlugin->versionCompare(this, major, minor, patch);
 }
 
-void Vehicle::requestMicroserviceVersion(uint16_t serviceID) {
+void Vehicle::requestMicroserviceVersion(uint16_t serviceID, uint16_t minVersion, uint16_t maxVersion) {
     auto iter = _microserviceVersions.find(serviceID);
     if(iter == _microserviceVersions.end()){
-        // TODO microservice version: Where to get supported range of versions for QGC?
         sendMavCommand(
                 defaultComponentId(),
                 MAV_CMD_REQUEST_MESSAGE,
                 false,
                 MAVLINK_MSG_ID_MAVLINK_SERVICE_VERSION,
                 serviceID,
-                0,
-                9999
+                minVersion,
+                maxVersion
                 );
     }else{
         uint16_t version = iter.value();

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -822,6 +822,9 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_OBSTACLE_DISTANCE:
         _handleObstacleDistance(message);
         break;
+    case MAVLINK_MSG_ID_MAVLINK_SERVICE_VERSION:
+        _handleServiceVersion(message);
+        break;
 
     case MAVLINK_MSG_ID_SERIAL_CONTROL:
     {
@@ -2835,6 +2838,8 @@ void Vehicle::_linkActiveChanged(LinkInterface *link, bool active, int vehicleID
         } else if (multiVehicle) {
             qgcApp()->showMessage(tr("Communication lost to vehicle %1").arg(_id));
         }
+        // Communication loss might be because the vehicle rebooted, and hence lost all microservice version information
+        _microserviceVersions.clear();
     }
     if (multiVehicle && (communicationLost || communicationRegained)) {
         commSpeech.append(tr(" to vehicle %1").arg(_id));
@@ -4270,6 +4275,8 @@ void Vehicle::updateFlightDistance(double distance)
 void Vehicle::_handleServiceVersion(const mavlink_message_t &message) {
     mavlink_mavlink_service_version_t serviceVersion;
     mavlink_msg_mavlink_service_version_decode(&message, &serviceVersion);
+
+    qDebug() << "Service ID: " << serviceVersion.service_id << ", selected version: " << serviceVersion.selected_version;
 
     // TODO microservice version: Should I do anything special here to handle unsupported service?
     // I don't think so, because every service will have to handle on its own the case when it just is not

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3410,7 +3410,17 @@ void Vehicle::_protocolVersionTimeOut()
     _startPlanRequest();
 }
 
-void Vehicle::_handleUnsupportedRequestAutopilotCapabilities()
+void Vehicle::_serviceVersionTimeout (uint16_t serviceID)
+{
+    qDebug("===== _serviceVersionTimeout ===");
+    auto iter = _microserviceVersions.find(serviceID);
+    if(iter == _microserviceVersions.end()){
+        _microserviceVersions.insert(serviceID, 0);
+        emit serviceVersionReceived(serviceID, 0);
+    }
+}
+
+void Vehicle::_handleUnsupportedRequestAutopilotCapabilities(void)
 {
     // We end up here if either the vehicle does not support the MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES command or if
     // we never received an Ack back for the command.
@@ -4053,6 +4063,7 @@ void Vehicle::requestMicroserviceVersion(uint16_t serviceID, uint16_t minVersion
                 minVersion,
                 maxVersion
                 );
+        QTimer::singleShot(1000, this, [serviceID, this](){this->_serviceVersionTimeout(serviceID);});
     }else{
         uint16_t version = iter.value();
         emit serviceVersionReceived(serviceID, version);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1183,9 +1183,15 @@ signals:
     void checkListStateChanged          ();
     /**
      * Emitted when the microservice version handshake is complete. To initiate this handshake,
-     * see Vehicle::requestMicroserviceVersion
+     * see Vehicle::requestMicroserviceVersion.
+     *
+     * This signal will be emitted even if the vehicle has not implemented microservice versioning! In that case,
+     * after using requestMicroserviceVersion, the response will never be received, so there will be a timeout
+     * after some amount of time. Then, this signal will be emitted with serviceVersion = 0.
+     *
      * @param serviceID ID of the service
      * @param serviceVersion The version of the service which was agreed upon, OR 0 if no compatible versions were found
+     *     or if the message was never received from the vehicle.
      */
     void serviceVersionReceived         (uint16_t serviceID, uint16_t serviceVersion);
 
@@ -1299,6 +1305,7 @@ private slots:
     void _trafficUpdate                 (bool alert, QString traffic_id, QString vehicle_id, QGeoCoordinate location, float heading);
     void _orbitTelemetryTimeout         ();
     void _protocolVersionTimeOut        ();
+    void _serviceVersionTimeout         (uint16_t serviceID);
     void _updateFlightTime              ();
 
 private:

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -776,13 +776,15 @@ public:
     Q_INVOKABLE int versionCompare(int major, int minor, int patch);
 
     /// Asynchronously requests the version of the given microservice.
-    /// After calling this function, a microserviceVersion signal will be emitted.
+    /// After calling this function, a microserviceVersion signal will eventually be emitted.
     /// If the version of this particular microservice was never requested, then this function sends out the
     /// request message over MAVLink. When it gets the result, it caches it locally and emits the signal.
     /// If the version is already cached, then this function will immediately emit the signal without
     /// any communication over MAVLink.
     /// @param serviceID the ID of the service to request, or 0 to request all services supported by the system.
-    Q_INVOKABLE void requestMicroserviceVersion(uint16_t serviceID);
+    /// @param minVersion The minimum version of this microservice supported by this version of QGC
+    /// @param maxVersion The maximum version of this microservice supported by this version of QGC
+    Q_INVOKABLE void requestMicroserviceVersion(uint16_t serviceID, uint16_t minVersion, uint16_t maxVersion);
 
     /// Test motor
     ///     @param motor Motor number, 1-based
@@ -1179,6 +1181,12 @@ signals:
     void linksPropertiesChanged         ();
     void textMessageReceived            (int uasid, int componentid, int severity, QString text);
     void checkListStateChanged          ();
+    /**
+     * Emitted when the microservice version handshake is complete. To initiate this handshake,
+     * see Vehicle::requestMicroserviceVersion
+     * @param serviceID ID of the service
+     * @param serviceVersion The version of the service which was agreed upon, OR 0 if no compatible versions were found
+     */
     void serviceVersionReceived         (uint16_t serviceID, uint16_t serviceVersion);
 
     void messagesReceivedChanged        ();

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -775,6 +775,15 @@ public:
     Q_INVOKABLE int versionCompare(QString& compare);
     Q_INVOKABLE int versionCompare(int major, int minor, int patch);
 
+    /// Asynchronously requests the version of the given microservice.
+    /// After calling this function, a microserviceVersion signal will be emitted.
+    /// If the version of this particular microservice was never requested, then this function sends out the
+    /// request message over MAVLink. When it gets the result, it caches it locally and emits the signal.
+    /// If the version is already cached, then this function will immediately emit the signal without
+    /// any communication over MAVLink.
+    /// @param serviceID the ID of the service to request, or 0 to request all services supported by the system.
+    Q_INVOKABLE void requestMicroserviceVersion(uint16_t serviceID);
+
     /// Test motor
     ///     @param motor Motor number, 1-based
     ///     @param percent 0-no power, 100-full power
@@ -1170,6 +1179,7 @@ signals:
     void linksPropertiesChanged         ();
     void textMessageReceived            (int uasid, int componentid, int severity, QString text);
     void checkListStateChanged          ();
+    void serviceVersionReceived         (uint16_t serviceID, uint16_t serviceVersion);
 
     void messagesReceivedChanged        ();
     void messagesSentChanged            ();
@@ -1325,6 +1335,7 @@ private:
     void _handleMessageInterval         (const mavlink_message_t& message);
     void _handleGimbalOrientation       (const mavlink_message_t& message);
     void _handleObstacleDistance        (const mavlink_message_t& message);
+    void _handleServiceVersion          (const mavlink_message_t& message);
     // ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)
     void _handleCameraFeedback          (const mavlink_message_t& message);
@@ -1424,6 +1435,9 @@ private:
     bool            _highLatencyLink;
     bool            _receivingAttitudeQuaternion;
     CheckList       _checkListState = CheckListNotSetup;
+
+    // TODO microservice version: Make sure there's not some specific data type for service IDs
+    QHash<uint16_t, uint16_t> _microserviceVersions;
 
     QGCCameraManager* _cameras;
 


### PR DESCRIPTION
Related:

 - [Microservice versioning document](https://docs.google.com/document/d/1zK_JcJbhtbRA3W0MgnXSNWMUxOcBu6vXocrjZVMXki4/edit#)
 - https://github.com/PX4/Firmware/pull/13565
 - https://github.com/PX4/Devguide/pull/945

This PR uses [this common.xml](https://github.com/ItsTimmy/mavlink/blob/pr-microservice-versioning/message_definitions/v1.0/common.xml), and [this C library](https://github.com/ItsTimmy/c_library_v2) generated from it.

This is still a work in progress, because the exact API for microservice versioning has not been finalized. In addition, there is still work to be done on this code:

- [x] Clean up old code that is currently commented out
- [x] Determine how the mission microservice should act with systems that do not perform the microservice version handshake
- [x] Update comments in the Mission microservice to reflect the changes
- [ ] Update MAVLink module to include new auto-generated constants for service IDs and new messages
- [ ] Thorough testing

This is currently a minimum functioning prototype. Work is now being done in PX4 and MAVSDK to reach the same state, while the specifications are finalized and MAVLink is updated.

More context: https://docs.google.com/document/d/1zK_JcJbhtbRA3W0MgnXSNWMUxOcBu6vXocrjZVMXki4/