### PR TITLE
Fix gstreamer's deadlock on QGC exit

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -192,6 +192,7 @@ ApplicationWindow {
 
     function finishCloseProcess() {
         QGroundControl.linkManager.shutdown()
+        QGroundControl.videoManager.stopVideo();
         _forceClose = true
         mainWindow.close()
     }


### PR DESCRIPTION
In some cases QGC hangs at exit (on my side - with VA API H.264 decoder on Ubuntu 18.04/Qt 5.11.3/Gstreamer 1.14.5). This little fix changes video manager de-initialization context and that's enough to keep everything happy and working.