### PR TITLE
Fix YUV 4:2:0 plane rendering in certain cases

### DIFF
--- a/src/VideoStreaming/gstqtvideosink/painters/videomaterial.h
+++ b/src/VideoStreaming/gstqtvideosink/painters/videomaterial.h
@@ -50,14 +50,16 @@ public:
 protected:
     VideoMaterial();
     void initRgbTextureInfo(GLenum internalFormat, GLuint format,
-                            GLenum type, const QSize &size);
-    void initYuv420PTextureInfo(bool uvSwapped, const QSize &size);
+                            GLenum type, const GstVideoInfo& videoInfo);
+    void initYuv420PTextureInfo(const GstVideoInfo& videoInfo);
+    void updateYuv420PTextureInfo(const GstVideoInfo& videoInfo);
     void init(GstVideoColorMatrix colorMatrixType);
 
 private:
     void bindTexture(int i, const quint8 *data);
 
-
+    GstVideoInfo m_videoInfo;
+    GstBufferPool* m_bufferPool;
     GstBuffer *m_frame;
     QMutex m_frameMutex;
 
@@ -67,7 +69,8 @@ private:
     int m_textureWidths[Num_Texture_IDs];
     int m_textureHeights[Num_Texture_IDs];
     int m_textureOffsets[Num_Texture_IDs];
-    QSize m_textureSize;
+    int m_textureStrides[Num_Texture_IDs];
+    bool m_textureAllocated[Num_Texture_IDs];
 
     GLenum m_textureFormat;
     GLuint m_textureInternalFormat;


### PR DESCRIPTION
This patch fixes YUV 4:2:0 buffer layout handling issue which is visible as green or colored bars on the screen in certain cases. On my side it is easy to reproduce if VA API H.264 decoder is used in 1080p mode (Ubuntu 18.04/Qt 5.11.3/Gstreamer 1.14.5).