### PR TITLE
Fix advanced tuning without side effects

### DIFF
--- a/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
@@ -64,8 +64,8 @@ SetupPage {
             ExclusiveGroup { id: returnAltRadioGroup }
 
             Component.onCompleted: {
-                // Advanced tuning is hacked out due to Qt crash with Qml Charts and a QGuiApplication
-                //showAdvanced = !ScreenTools.isMobile
+                // We use QtCharts only on Desktop platforms
+                showAdvanced = !ScreenTools.isMobile
 
                 // Qml Sliders have a strange behavior in which they first set Slider::value to some internal
                 // setting and then set Slider::value to the bound properties value. If you have an onValueChanged

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -29,8 +29,8 @@ SetupPage {
             width: availableWidth
 
             Component.onCompleted: {
-                // Advanced tuning is hacked out due to Qt crash with Qml Charts and a QGuiApplication
-                //showAdvanced = !ScreenTools.isMobile
+                // We use QtCharts only on Desktop platforms
+                showAdvanced = !ScreenTools.isMobile
             }
 
             FactPanelController {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
@@ -29,8 +29,8 @@ SetupPage {
             width: availableWidth
 
             Component.onCompleted: {
-                // Advanced tuning is hacked out due to Qt crash with Qml Charts and a QGuiApplication
-                //showAdvanced = !ScreenTools.isMobile
+                // We use QtCharts only on Desktop platforms
+                showAdvanced = !ScreenTools.isMobile
             }
 
             FactPanelController {

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -158,7 +158,11 @@ static QObject* shapeFileHelperSingletonFactory(QQmlEngine*, QJSEngine*)
 }
 
 QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
+  #if defined(__mobile__)
     : QGuiApplication       (argc, argv)
+  #else
+    : QApplication          (argc, argv)
+  #endif
     , _runningUnitTests     (unitTesting)
 {
     _app = this;
@@ -554,9 +558,6 @@ bool QGCApplication::_initForNormalAppBoot()
     }
 
     QSettings settings;
-
-    // Exit main application when last window is closed
-    connect(this, &QGCApplication::lastWindowClosed, this, QGCApplication::quit);
 
     _qmlAppEngine = toolbox()->corePlugin()->createRootWindow(this);
 

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -35,7 +35,25 @@ class QGCSingleton;
 class QGCToolbox;
 class QGCFileDownload;
 
-class QGCApplication : public QGuiApplication
+/**
+ * @brief The main application and management class.
+ *
+ * This class is started by the main method and provides
+ * the central management unit of the groundstation application.
+ *
+ * Needs QApplication base to support QtCharts module. This way
+ * we avoid application crashing on 5.12 when using the module.
+ * We don't have QtWidgets on mobile, avoid using it.
+ *
+ * Note: `lastWindowClosed` will be sent by MessageBox popups and other
+ * dialogs, that are spawned in QML, when they are closed
+**/
+class QGCApplication :
+      #if defined(__mobile__)
+        public QGuiApplication
+      #else
+        public QApplication
+      #endif
 {
     Q_OBJECT
 

--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -285,7 +285,7 @@ void QmlObjectListModel::clearAndDeleteContents()
     endResetModel();
 }
 
-void QmlObjectListModel::beginReset(void)
+void QmlObjectListModel::beginReset()
 {
     if (_externalBeginResetModel) {
         qWarning() << "QmlObjectListModel::beginReset already set";
@@ -294,7 +294,7 @@ void QmlObjectListModel::beginReset(void)
     beginResetModel();
 }
 
-void QmlObjectListModel::endReset(void)
+void QmlObjectListModel::endReset()
 {
     if (!_externalBeginResetModel) {
         qWarning() << "QmlObjectListModel::endReset begin not set";


### PR DESCRIPTION
Brings back fix for the advanced tuning crash without the side effect of application closing on MessageBox closing.
It seems that the `QGuiApplication::lastWindowClosed` signal is triggered in our QML application if we spawn an widget (DialogBox) from QML. This PR disconnects the signal from `QCoreApplication::quit` slot.
Also enable advanced tuning option that was removed temporary
Condition to keep using `QGuiApplication` on mobile is due to untested behaviour for some corner cases on mobile with `QApplication`. However, Advanced Tuning with charts works on mobile 

Original PR that had side effects: https://github.com/mavlink/qgroundcontrol/pull/7978
Fixed side effects: https://github.com/mavlink/qgroundcontrol/issues/7962