### PR TITLE
Fix QGCApplication::mainRootWindow()

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -748,7 +748,7 @@ void QGCApplication::showMessage(const QString& message)
 
 QQuickItem* QGCApplication::mainRootWindow()
 {
-    if(_mainRootWindow) {
+    if(!_mainRootWindow) {
         _mainRootWindow = reinterpret_cast<QQuickItem*>(_rootQmlObject());
     }
     return _mainRootWindow;


### PR DESCRIPTION
This little change allows QGCApplication::mainRootWindow() to return root window. Until now it was always returning NULL.