### PR TITLE
Fixed misspelled Parrot Sequoia

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -416,8 +416,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            //tr("Parrot Sequoia RGB"),
-            tr("Parrot Sequioa RGB"),
+            tr("Parrot Sequoia RGB"),
             6.17,               // sensorWidth
             4.63,               // sendsorHeight
             4608,               // imageWidth
@@ -430,8 +429,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle* vehicle)
         _cameraList.append(QVariant::fromValue(metaData));
 
         metaData = new CameraMetaData(
-            //tr("Parrot Sequoia Monochrome"),
-            tr("Parrot Sequioa Monochrome"),
+            tr("Parrot Sequoia Monochrome"),
             4.8,                // sensorWidth
             3.6,                // sendsorHeight
             1280,               // imageWidth


### PR DESCRIPTION
Parrot Sequoia was misspelled.
https://www.parrot.com/business-solutions-us/parrot-professional/parrot-sequoia