### PR TITLE
Vagrant updates

### DIFF
--- a/.vagrantconfig.yml
+++ b/.vagrantconfig.yml
@@ -1,13 +1,13 @@
 configs:
     dev:
         'qt_deps_tarball': 'Qt5.11.0-gcc_64-min.tar.bz2'
-        'qt_deps_unpack_parent_dir': '/tmp'
+        'qt_deps_unpack_parent_dir': '/home/vagrant'
 
-        'qt_deps_unpack_dir': '/tmp/Qt5.11-gcc_64/5.11.0'
-        'qt_deps_bin_unpack_dir': '/tmp/Qt5.11-gcc_64/5.11.0/gcc_64/bin'
-        'qt_deps_lib_unpack_dir': '/tmp/Qt5.11-gcc_64/5.11.0/gcc_64/lib'
-        'qt_deps_plugins_unpack_dir': '/tmp/Qt5.11-gcc_64/5.11.0/gcc_64/plugins'
-        'qt_deps_qml_unpack_dir': '/tmp/Qt5.11-gcc_64/5.11.0/gcc_64/qml'
+        'qt_deps_unpack_dir': '/home/vagrant/Qt5.11-gcc_64/5.11.0'
+        'qt_deps_bin_unpack_dir': '/home/vagrant/Qt5.11-gcc_64/5.11.0/gcc_64/bin'
+        'qt_deps_lib_unpack_dir': '/home/vagrant/Qt5.11-gcc_64/5.11.0/gcc_64/lib'
+        'qt_deps_plugins_unpack_dir': '/home/vagrant/Qt5.11-gcc_64/5.11.0/gcc_64/plugins'
+        'qt_deps_qml_unpack_dir': '/home/vagrant/Qt5.11-gcc_64/5.11.0/gcc_64/qml'
 
         'project_root_dir': '/vagrant'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,13 +20,13 @@ Vagrant.configure(2) do |config|
     override.vm.box = "tknerr/baseimage-ubuntu-16.04"
   end
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "4096"]
+    vb.customize ["modifyvm", :id, "--memory", "6144"]
     vb.customize ["modifyvm", :id, "--cpus", "1"]
     vb.gui = true
   end
   ["vmware_fusion", "vmware_workstation"].each do |p|
     config.vm.provider p do |v|
-      v.vmx["memsize"] = "4096"
+      v.vmx["memsize"] = "6144"
       v.vmx["numvcpus"] = "1"
       v.gui = true
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,7 +108,7 @@ MAKE
     :pro => yaml_config['pro'],
     :spec => yaml_config['spec'],
     :deps_url => yaml_config['deps_url'],
-    :apt_pkgs => (travisfile['addons']['apt']['packages']+['git', 'build-essential', 'fuse']).join(' '),
+    :apt_pkgs => (travisfile['addons']['apt']['packages']+['git', 'build-essential', 'fuse', 'libsdl2-dev']).join(' '),
     :build_env => travisfile['env']['global'].select { |item| item.is_a?(String) }.join(' '),
 
     :project_root_dir => yaml_config['project_root_dir'],


### PR DESCRIPTION
Big usability improvement is the writing out of scripts to do the install.

Running `./do-make.sh` allows easy incremental building for those that don't do it every day.


