### PR TITLE
Warn about Above Terrain usage

### DIFF
--- a/src/FactSystem/FactControls/AltitudeFactTextField.qml
+++ b/src/FactSystem/FactControls/AltitudeFactTextField.qml
@@ -1,6 +1,19 @@
-import QtQuick                      2.3
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+import QtQuick          2.3
+import QtQuick.Dialogs  1.2
+import QtQuick.Layouts  1.2
+
 import QGroundControl               1.0
 import QGroundControl.FactSystem    1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
 
 FactTextField {
     unitsLabel:         fact ? fact.units : ""
@@ -16,7 +29,8 @@ FactTextField {
     readonly property string _altModeAboveTerrainExtraUnits:    qsTr("(Abv Terr)")
     readonly property string _altModeTerrainFrameExtraUnits:    qsTr("(TerrF)")
 
-    property string _altitudeModeExtraUnits: _altModeNoneExtraUnits
+    property string _altitudeModeExtraUnits:    _altModeNoneExtraUnits
+    property Fact   _aboveTerrainWarning:       QGroundControl.settingsManager.planViewSettings.aboveTerrainWarning
 
     onAltitudeModeChanged: updateAltitudeModeExtraUnits()
 
@@ -29,11 +43,36 @@ FactTextField {
             _altitudeModeExtraUnits = _altModeAbsoluteExtraUnits
         } else if (altitudeMode === QGroundControl.AltitudeModeAboveTerrain) {
             _altitudeModeExtraUnits = _altModeAboveTerrainExtraUnits
+            if (!_aboveTerrainWarning.rawValue) {
+                mainWindow.showComponentDialog(aboveTerrainWarning, qsTr("Warning"), mainWindow.showDialogDefaultWidth, StandardButton.Ok)
+            }
         } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame) {
             _altitudeModeExtraUnits = _altModeTerrainFrameExtraUnits
         } else {
             console.log("AltitudeFactTextField Internal error: Unknown altitudeMode", altitudeMode)
             _altitudeModeExtraUnits = ""
+        }
+    }
+
+    Component {
+        id: aboveTerrainWarning
+        QGCViewDialog {
+            ColumnLayout {
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                spacing:        ScreenTools.defaultFontPixelHeight
+
+                QGCLabel {
+                    Layout.fillWidth:   true
+                    wrapMode:           Text.WordWrap
+                    text:               qsTr("'Above Terrain' will set an absolute altitude for the item based on the terrain height at the location and the requested altitude above terrain. It does not send terrain heights to the vehicle.")
+                }
+
+                FactCheckBox {
+                    text: qsTr("Don't show again")
+                    fact: _aboveTerrainWarning
+                }
+            }
         }
     }
 }

--- a/src/Settings/PlanView.SettingsGroup.json
+++ b/src/Settings/PlanView.SettingsGroup.json
@@ -4,5 +4,11 @@
     "shortDescription": "Display the presets tab at start",
     "type":             "bool",
     "defaultValue":     false
+},
+{
+    "name":             "aboveTerrainWarning",
+    "shortDescription": "Don't warn user about 'Above Terrain' usage",
+    "type":             "bool",
+    "defaultValue":     false
 }
 ]

--- a/src/Settings/PlanViewSettings.cc
+++ b/src/Settings/PlanViewSettings.cc
@@ -18,3 +18,4 @@ DECLARE_SETTINGGROUP(PlanView, "PlanView")
 }
 
 DECLARE_SETTINGSFACT(PlanViewSettings, displayPresetsTabFirst)
+DECLARE_SETTINGSFACT(PlanViewSettings, aboveTerrainWarning)

--- a/src/Settings/PlanViewSettings.h
+++ b/src/Settings/PlanViewSettings.h
@@ -21,4 +21,5 @@ public:
     // Most individual settings related to PlanView are still in AppSettings due to historical reasons.
 
     DEFINE_SETTINGFACT(displayPresetsTabFirst)
+    DEFINE_SETTINGFACT(aboveTerrainWarning)
 };


### PR DESCRIPTION
Reduce confusion with vehicle based terrain following mavlink support:
<img width="339" alt="Screen Shot 2019-12-10 at 3 10 38 PM" src="https://user-images.githubusercontent.com/5876851/70528581-98587b00-1b5f-11ea-8e39-5f5c4f2d5fc2.png">

Related to #8087.