### PR TITLE
Toolbar indicators: Change order, Change VTOL indicator

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -329,9 +329,9 @@ const QVariantList &FirmwarePlugin::toolBarIndicators(const Vehicle* vehicle)
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSRTKIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ArmedIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ModeIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/VTOLModeIndicator.qml")),
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ArmedIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MultiVehicleSelector.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/LinkIndicator.qml")),
         });

--- a/src/ui/toolbar/VTOLModeIndicator.qml
+++ b/src/ui/toolbar/VTOLModeIndicator.qml
@@ -19,21 +19,29 @@ import QGroundControl.Palette               1.0
 
 //-------------------------------------------------------------------------
 //-- VTOL Mode Indicator
-QGCLabel {
+QGCComboBox {
     anchors.verticalCenter: parent.verticalCenter
-    verticalAlignment:      Text.AlignVCenter
-    text:                   _fwdFlight ? qsTr("VTOL: Fixed Wing") : qsTr("VTOL: Multi-Rotor")
+    alternateText:          _fwdFlight ? qsTr("VTOL: FW") : qsTr("VTOL: MR")
+    model:                  [ qsTr("VTOL: Multi-Rotor"), qsTr("VTOL: Fixed Wing")  ]
     font.pointSize:         ScreenTools.mediumFontPointSize
-    color:                  qgcPal.buttonText
-    width:                  implicitWidth
+    currentIndex:           -1
+    sizeToContents:         true
 
     property bool showIndicator: _activeVehicle.vtol && _activeVehicle.px4Firmware
 
-    property var  _activeVehicle:   QGroundControl.multiVehicleManager.activeVehicle
-    property bool _fwdFlight:       _activeVehicle.vtolInFwdFlight
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property bool   _fwdFlight:     _activeVehicle.vtolInFwdFlight
 
-    QGCMouseArea {
-        fillItem: parent
-        onClicked: activeVehicle.vtolInFwdFlight ? toolBar.vtolTransitionToMRFlight() : toolBar.vtolTransitionToFwdFlight()
+    onActivated: {
+        if (index == 0) {
+            if (_fwdFlight) {
+                mainWindow.vtolTransitionToMRFlight()
+            }
+        } else {
+            if (!_fwdFlight) {
+                mainWindow.vtolTransitionToFwdFlight()
+            }
+        }
+        currentIndex = -1
     }
 }


### PR DESCRIPTION
* Order is now Arm/Disarm, Flight Mode, VTOL, ...
* VTOL Indicator is changed to be a combo to match other controls. Also changed wording to use less space.
<img width="480" alt="Screen Shot 2019-12-11 at 8 38 42 AM" src="https://user-images.githubusercontent.com/5876851/70594568-0cdbfa00-1bf2-11ea-985e-81e76fc4b6e4.png">

Fix for #8085 