### PR TITLE
Make Toolstrip flickable, fix maxHeight, fix bunch of margins

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -54,6 +54,7 @@ Item {
     property real   _pipSize:                       mainWindow.width * 0.2
     property alias  _guidedController:              guidedActionsController
     property alias  _altitudeSlider:                altitudeSlider
+    property real   _toolsMargin:                   ScreenTools.defaultFontPixelWidth * 0.75
 
     readonly property var       _dynamicCameras:        activeVehicle ? activeVehicle.dynamicCameras : null
     readonly property bool      _isCamera:              _dynamicCameras ? _dynamicCameras.cameras.count > 0 : false
@@ -357,7 +358,7 @@ Item {
                     // Do anchors again after popup
                     anchors.left =       _mapAndVideo.left
                     anchors.bottom =     _mapAndVideo.bottom
-                    anchors.margins =    ScreenTools.defaultFontPixelHeight
+                    anchors.margins =    _toolsMargin
                 }
             }
 
@@ -365,8 +366,8 @@ Item {
                 State {
                     name:   "pipMode"
                     PropertyChanges {
-                        target: _flightVideo
-                        anchors.margins: ScreenTools.defaultFontPixelHeight
+                        target:             _flightVideo
+                        anchors.margins:    _toolsMargin
                     }
                     PropertyChanges {
                         target: _flightVideoPipControl
@@ -376,12 +377,12 @@ Item {
                 State {
                     name:   "fullMode"
                     PropertyChanges {
-                        target: _flightVideo
+                        target:             _flightVideo
                         anchors.margins:    0
                     }
                     PropertyChanges {
-                        target: _flightVideoPipControl
-                        inPopup: false
+                        target:     _flightVideoPipControl
+                        inPopup:    false
                     }
                 },
                 State {
@@ -404,9 +405,9 @@ Item {
                     ParentChange {
                         target: _flightVideo
                         parent: videoItem
-                        x: 0
-                        y: 0
-                        width: videoItem.width
+                        x:      0
+                        y:      0
+                        width:  videoItem.width
                         height: videoItem.height
                     }
                 },
@@ -473,8 +474,8 @@ Item {
 
         Row {
             id:                     singleMultiSelector
-            anchors.topMargin:      ScreenTools.toolbarHeight + _margins
-            anchors.rightMargin:    _margins
+            anchors.topMargin:      ScreenTools.toolbarHeight + _toolsMargin
+            anchors.rightMargin:    _toolsMargin
             anchors.right:          parent.right
             spacing:                ScreenTools.defaultFontPixelWidth
             z:                      _mapAndVideo.z + 4
@@ -496,7 +497,7 @@ Item {
         FlightDisplayViewWidgets {
             id:                 flightDisplayViewWidgets
             z:                  _mapAndVideo.z + 4
-            height:             availableHeight - (singleMultiSelector.visible ? singleMultiSelector.height + _margins : 0) - (ScreenTools.defaultFontPixelHeight * 0.5)
+            height:             availableHeight - (singleMultiSelector.visible ? singleMultiSelector.height + _toolsMargin : 0) - _toolsMargin
             anchors.left:       parent.left
             anchors.right:      altitudeSlider.visible ? altitudeSlider.left : parent.right
             anchors.bottom:     parent.bottom
@@ -519,7 +520,7 @@ Item {
         }
 
         MultiVehicleList {
-            anchors.margins:            _margins
+            anchors.margins:            _toolsMargin
             anchors.top:                singleMultiSelector.bottom
             anchors.right:              parent.right
             anchors.bottom:             parent.bottom
@@ -554,14 +555,14 @@ Item {
             visible:            (activeVehicle ? activeVehicle.guidedModeSupported : true) && !QGroundControl.videoManager.fullScreen
             id:                 toolStrip
 
-            anchors.leftMargin: isInstrumentRight() ? ScreenTools.defaultFontPixelWidth * 2 : undefined
+            anchors.leftMargin: isInstrumentRight() ? _toolsMargin : undefined
             anchors.left:       isInstrumentRight() ? _mapAndVideo.left : undefined
             anchors.rightMargin:isInstrumentRight() ? undefined : ScreenTools.defaultFontPixelWidth
             anchors.right:      isInstrumentRight() ? undefined : _mapAndVideo.right
-            anchors.topMargin:  ScreenTools.defaultFontPixelHeight * 0.5
+            anchors.topMargin:  _toolsMargin
             anchors.top:        parent.top
             z:                  _mapAndVideo.z + 4
-            maxHeight:          (_flightVideo.visible ? _flightVideo.y : parent.height) - toolStrip.y
+            maxHeight:          parent.height - toolStrip.y + (_flightVideo.visible ? (_flightVideo.y - parent.height) : 0)
 
             property bool _anyActionAvailable: _guidedController.showStartMission || _guidedController.showResumeMission || _guidedController.showChangeAlt || _guidedController.showLandAbort
             property var _actionModel: [

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -478,12 +478,11 @@ FlightMap {
     MapScale {
         id:                     mapScale
         anchors.right:          parent.right
-        anchors.margins:        ScreenTools.defaultFontPixelHeight * (0.33)
-        anchors.topMargin:      ScreenTools.defaultFontPixelHeight * (0.33) + state === "bottomMode" ? 0 : ScreenTools.toolbarHeight
-        anchors.bottomMargin:   ScreenTools.defaultFontPixelHeight * (0.33)
+        anchors.margins:        _toolsMargin
+        anchors.topMargin:      _toolsMargin + state === "bottomMode" ? 0 : ScreenTools.toolbarHeight
         mapControl:             flightMap
         buttonsOnLeft:          false
-        visible:                !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.enableMapScale
+        visible:                !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.enableMapScale && mainIsMap
         state:                  "bottomMode"
         states: [
             State {

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -170,8 +170,8 @@ Item {
         id:                     instrumentsColumn
         spacing:                ScreenTools.defaultFontPixelHeight * 0.25
         anchors.top:            parent.top
-        anchors.topMargin:      QGroundControl.corePlugin.options.instrumentWidget ? (QGroundControl.corePlugin.options.instrumentWidget.widgetTopMargin + (ScreenTools.defaultFontPixelHeight * 0.5)) : 0
-        anchors.margins:        ScreenTools.defaultFontPixelHeight * 0.5
+        anchors.topMargin:      QGroundControl.corePlugin.options.instrumentWidget ? (QGroundControl.corePlugin.options.instrumentWidget.widgetTopMargin + _toolsMargin) : 0
+        anchors.margins:        _toolsMargin
         anchors.right:          parent.right
         //-------------------------------------------------------
         // Airmap Airspace Control
@@ -185,7 +185,7 @@ Item {
         //-- Instrument Panel
         Loader {
             id:                         instrumentsLoader
-            anchors.margins:            ScreenTools.defaultFontPixelHeight * 0.5
+            anchors.margins:            _toolsMargin
             property real maxHeight:    widgetRoot ? widgetRoot.height - instrumentsColumn.y - airspaceControl.height - (ScreenTools.defaultFontPixelHeight * 4) : 0
             states: [
                 State {

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -34,7 +34,7 @@ Item {
 
     readonly property int   _decimalPlaces:             8
     readonly property real  _margin:                    ScreenTools.defaultFontPixelHeight * 0.5
-    readonly property real  _toolsTopMargin:            ScreenTools.defaultFontPixelHeight * 0.5
+    readonly property real  _toolsMargin:               ScreenTools.defaultFontPixelWidth * 0.75
     readonly property real  _radius:                    ScreenTools.defaultFontPixelWidth  * 0.5
     readonly property real  _rightPanelWidth:           Math.min(parent.width / 3, ScreenTools.defaultFontPixelWidth * 30)
     readonly property var   _defaultVehicleCoordinate:  QtPositioning.coordinate(37.803784, -122.462276)
@@ -367,7 +367,7 @@ Item {
             planView:                   true
 
             // This is the center rectangle of the map which is not obscured by tools
-            property rect centerViewport:   Qt.rect(_leftToolWidth + _margin, _toolsTopMargin, editorMap.width - _leftToolWidth - _rightToolWidth - (_margin * 2), mapScale.y - _margin - _toolsTopMargin)
+            property rect centerViewport:   Qt.rect(_leftToolWidth + _margin, _toolsMargin, editorMap.width - _leftToolWidth - _rightToolWidth - (_margin * 2), mapScale.y - _margin - _toolsMargin)
 
             property real _leftToolWidth:       toolStrip.x + toolStrip.width
             property real _rightToolWidth:      rightPanel.width + rightPanel.anchors.rightMargin
@@ -536,12 +536,11 @@ Item {
         // Left tool strip
         ToolStrip {
             id:                 toolStrip
-            anchors.leftMargin: ScreenTools.defaultFontPixelWidth * 2
+            anchors.margins:    _toolsMargin
             anchors.left:       parent.left
-            anchors.topMargin:  _toolsTopMargin
             anchors.top:        parent.top
             z:                  QGroundControl.zOrderWidgets
-            maxHeight:          mapScale.y - toolStrip.y
+            maxHeight:          parent.height - toolStrip.y
 
             readonly property int flyButtonIndex:       0
             readonly property int fileButtonIndex:      1
@@ -638,11 +637,16 @@ Item {
                     }
                     break
                 case roiButtonIndex:
-                    allAddClickBoolsOff()
-                    if (_missionController.isROIActive) {
-                        insertCancelROIAfterCurrent()
+                    if (_addROIOnClick) {
+                        allAddClickBoolsOff()
+                        setChecked(index, false)
                     } else {
-                        _addROIOnClick = checked
+                        allAddClickBoolsOff()
+                        if (_missionController.isROIActive) {
+                            insertCancelROIAfterCurrent()
+                        } else {
+                            _addROIOnClick = checked
+                        }
                     }
                     break
                 case patternButtonIndex:
@@ -673,13 +677,13 @@ Item {
             opacity:            planExpanded.visible ? 0.2 : 0
             anchors.bottom:     parent.bottom
             anchors.right:      parent.right
-            anchors.rightMargin: ScreenTools.defaultFontPixelWidth
+            anchors.rightMargin: _toolsMargin
         }
         //-------------------------------------------------------
         // Right Panel Controls
         Item {
             anchors.fill:           rightPanel
-            anchors.topMargin:      _toolsTopMargin
+            anchors.topMargin:      _toolsMargin
             DeadMouseArea {
                 anchors.fill:   parent
             }
@@ -857,34 +861,34 @@ Item {
             }
         }
 
-        MapScale {
-            id:                     mapScale
-            anchors.margins:        ScreenTools.defaultFontPixelHeight * (0.66)
-            anchors.bottom:         waypointValuesDisplay.visible ? waypointValuesDisplay.top : parent.bottom
-            anchors.left:           parent.left
-            mapControl:             editorMap
-            buttonsOnLeft:          true
-            terrainButtonVisible:   _editingLayer === _layerMission
-            visible:                _toolStripBottom < y
-            terrainButtonChecked:   waypointValuesDisplay.visible
-            onTerrainButtonClicked: waypointValuesDisplay.toggleVisible()
-        }
-
         MissionItemStatus {
             id:                 waypointValuesDisplay
-            anchors.margins:    ScreenTools.defaultFontPixelWidth
-            anchors.left:       parent.left
+            anchors.margins:    _toolsMargin
+            anchors.left:       toolStrip.right
+            anchors.bottom:     mapScale.top
             height:             ScreenTools.defaultFontPixelHeight * 7
-            maxWidth:           parent.width - rightPanel.width - x
-            anchors.bottom:     parent.bottom
+            maxWidth:           rightPanel.x - x - anchors.margins
             missionItems:       _missionController.visualItems
-            visible:            _internalVisible && _editingLayer === _layerMission && (_toolStripBottom + mapScale.height) < y && QGroundControl.corePlugin.options.showMissionStatus
+            visible:            _internalVisible && _editingLayer === _layerMission && QGroundControl.corePlugin.options.showMissionStatus
 
             property bool _internalVisible: false
 
             function toggleVisible() {
                 _internalVisible = !_internalVisible
             }
+        }
+
+
+        MapScale {
+            id:                     mapScale
+            anchors.margins:        _toolsMargin
+            anchors.bottom:         parent.bottom
+            anchors.left:           toolStrip.right
+            mapControl:             editorMap
+            buttonsOnLeft:          true
+            terrainButtonVisible:   _editingLayer === _layerMission
+            terrainButtonChecked:   waypointValuesDisplay.visible
+            onTerrainButtonClicked: waypointValuesDisplay.toggleVisible()
         }
     }
 

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -19,7 +19,7 @@ Rectangle {
     id:         _root
     color:      qgcPal.globalTheme === QGCPalette.Light ? QGroundControl.corePlugin.options.toolbarBackgroundLight : QGroundControl.corePlugin.options.toolbarBackgroundDark
     width:      _idealWidth < repeater.contentWidth ? repeater.contentWidth : _idealWidth
-    height:     toolStripColumn.height + (toolStripColumn.anchors.margins * 2)
+    height:     Math.min(maxHeight, toolStripColumn.height + (toolStripColumn.anchors.margins * 2))
     radius:     ScreenTools.defaultFontPixelWidth / 2
 
     property alias  model:              repeater.model
@@ -51,48 +51,60 @@ Rectangle {
         buttons:    toolStripColumn.children
     }
 
-    Column {
-        id:                 toolStripColumn
+    DeadMouseArea {
+        anchors.fill: parent
+    }
+
+    QGCFlickable {
         anchors.margins:    ScreenTools.defaultFontPixelWidth * 0.4
         anchors.top:        parent.top
         anchors.left:       parent.left
         anchors.right:      parent.right
-        spacing:            ScreenTools.defaultFontPixelWidth * 0.25
+        height:             parent.height
+        contentHeight:      toolStripColumn.height
+        flickableDirection: Flickable.VerticalFlick
 
-        Repeater {
-            id: repeater
+        Column {
+            id:             toolStripColumn
+            anchors.left:   parent.left
+            anchors.right:  parent.right
+            spacing:        ScreenTools.defaultFontPixelWidth * 0.25
 
-            QGCHoverButton {
-                id:             buttonTemplate
+            Repeater {
+                id: repeater
 
-                anchors.left:   toolStripColumn.left
-                anchors.right:  toolStripColumn.right
-                height:         width
-                radius:         ScreenTools.defaultFontPixelWidth / 2
-                fontPointSize:  ScreenTools.smallFontPointSize
-                autoExclusive:  true
+                QGCHoverButton {
+                    id:             buttonTemplate
 
-                enabled:        modelData.buttonEnabled
-                visible:        modelData.buttonVisible
-                imageSource:    modelData.showAlternateIcon ? modelData.alternateIconSource : modelData.iconSource
-                text:           modelData.name
-                checked:        modelData.checked !== undefined ? modelData.checked : checked
+                    anchors.left:   toolStripColumn.left
+                    anchors.right:  toolStripColumn.right
+                    height:         width
+                    radius:         ScreenTools.defaultFontPixelWidth / 2
+                    fontPointSize:  ScreenTools.smallFontPointSize
+                    autoExclusive:  true
 
-                ButtonGroup.group: buttonGroup
-                // Only drop panel and toggleable are checkable
-                checkable: modelData.dropPanelComponent !== undefined || (modelData.toggle !== undefined && modelData.toggle)
+                    enabled:        modelData.buttonEnabled
+                    visible:        modelData.buttonVisible
+                    imageSource:    modelData.showAlternateIcon ? modelData.alternateIconSource : modelData.iconSource
+                    text:           modelData.name
+                    checked:        modelData.checked !== undefined ? modelData.checked : checked
 
-                onClicked: {
-                    dropPanel.hide()    // DropPanel will call hide on "lastClickedButton"
-                    if (modelData.dropPanelComponent === undefined) {
-                        _root.clicked(index, checked)
-                    } else if (checked) {
-                        var panelEdgeTopPoint = mapToItem(_root, width, 0)
-                        dropPanel.show(panelEdgeTopPoint, height, modelData.dropPanelComponent)
-                        _root.dropped(index)
+                    ButtonGroup.group: buttonGroup
+                    // Only drop panel and toggleable are checkable
+                    checkable: modelData.dropPanelComponent !== undefined || (modelData.toggle !== undefined && modelData.toggle)
+
+                    onClicked: {
+                        dropPanel.hide()    // DropPanel will call hide on "lastClickedButton"
+                        if (modelData.dropPanelComponent === undefined) {
+                            _root.clicked(index, checked)
+                        } else if (checked) {
+                            var panelEdgeTopPoint = mapToItem(_root, width, 0)
+                            dropPanel.show(panelEdgeTopPoint, height, modelData.dropPanelComponent)
+                            _root.dropped(index)
+                        }
+                        if(_root && buttonTemplate)
+                            _root.lastClickedButton = buttonTemplate
                     }
-                    if(_root && buttonTemplate)
-                        _root.lastClickedButton = buttonTemplate
                 }
             }
         }


### PR DESCRIPTION
* Toolstrip is now flickable. Need this for PlanView since it was getting so tall. Would never fit on small laptops/tablet/... Fixed maxHeight values in Plan/Fly usage to make it work correctly.
* Fixed up a bunch of inconsistent margins for tools on the edge of views.
* Made the tool boundary margins a tad smaller
* Fixed #8103. Terrain and Map Scale panel now anchor to the right of the tool strip so they access to full height for visuals