### PR TITLE
Only accept ATTITUDE messages from the vehicle

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1112,6 +1112,11 @@ void Vehicle::_handleAttitudeWorker(double rollRadians, double pitchRadians, dou
 
 void Vehicle::_handleAttitude(mavlink_message_t& message)
 {
+    // only accept the attitude message from the vehicle's flight controller
+    if (message.sysid != _id || message.compid != _compID) {
+        return;
+    }
+
     if (_receivingAttitudeQuaternion) {
         return;
     }
@@ -1124,6 +1129,11 @@ void Vehicle::_handleAttitude(mavlink_message_t& message)
 
 void Vehicle::_handleAttitudeQuaternion(mavlink_message_t& message)
 {
+    // only accept the attitude message from the vehicle's flight controller
+    if (message.sysid != _id || message.compid != _compID) {
+        return;
+    }
+
     _receivingAttitudeQuaternion = true;
 
     mavlink_attitude_quaternion_t attitudeQuaternion;


### PR DESCRIPTION
In a system there might be more than one component emitting a MAVLink ATTITUDE message, for instance a flight controller and a gimbal.

Currently the code is not discriminating against the different sources, with the result that the instrument widget gets confused, i.e. will appear to wildly flip around, as it shows the attitudes of the various sources as they arrive.

This PR adds a check for the sysid and compid of the message and rejects it if they don't match the vehicles IDs.

Works great for my setup.