### PR TITLE
View switch prevention support

### DIFF
--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -14,20 +14,25 @@ import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
 
+// Important Note: Toolbar buttons must manage their checked state manually in order to support
+// view switch prevention. This means they can't be checkable or autoExclusive.
+
 Button {
     id:                 button
     height:             ScreenTools.defaultFontPixelHeight * 3
     leftPadding:        _horizontalMargin
     rightPadding:       _horizontalMargin
-    autoExclusive:      true
+    checkable:          false
 
     property bool logo: false
 
     property real _horizontalMargin: ScreenTools.defaultFontPixelWidth
 
+    onCheckedChanged: checkable = false
+
     background: Rectangle {
         anchors.fill: parent
-        color:  logo ? qgcPal.brandingPurple : (checked ? qgcPal.buttonHighlight : Qt.rgba(0,0,0,0))
+        color:  logo ? qgcPal.brandingPurple : (button.checked ? qgcPal.buttonHighlight : Qt.rgba(0,0,0,0))
     }
 
     contentItem: Row {

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -6,6 +6,9 @@ import QtGraphicalEffects       1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
 
+// Important Note: SubMenuButtons must manage their checked state manually in order to support
+// view switch prevention. This means they can't be checkable or autoExclusive.
+
 Button {
     id:             _rootButton
     property bool   setupComplete:  true                                    ///< true: setup complete indicator shows as completed
@@ -13,11 +16,13 @@ Button {
     property string imageResource:  "/qmlimages/subMenuButtonImage.png"     ///< Button image
     property size   sourceSize:     Qt.size(ScreenTools.defaultFontPixelHeight * 2, ScreenTools.defaultFontPixelHeight * 2)
 
-    text: "Button"  ///< Pass in your own button text
+    text:               "Button"  ///< Pass in your own button text
+    activeFocusOnPress: true
 
-    checkable:      true
     implicitHeight: ScreenTools.isTinyScreen ? ScreenTools.defaultFontPixelHeight * 3.5 : ScreenTools.defaultFontPixelHeight * 2.5
     implicitWidth:  __panel.implicitWidth
+
+    onCheckedChanged: checkable = false
 
     style: ButtonStyle {
         id: buttonStyle

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -41,6 +41,9 @@ Rectangle {
 
     function showSummaryPanel()
     {
+        if (mainWindow.preventViewSwitch) {
+            return
+        }
         if (_fullParameterVehicleAvailable) {
             if (QGroundControl.multiVehicleManager.activeVehicle.autopilot.vehicleComponents.length === 0) {
                 panelLoader.setSourceComponent(noComponentsVehicleSummaryComponent)
@@ -54,30 +57,19 @@ Rectangle {
         }
     }
 
-    function showFirmwarePanel()
-    {
-        if (!ScreenTools.isMobile) {
-            panelLoader.setSource("FirmwareUpgrade.qml")
+    function showPanel(button, qmlSource) {
+        if (mainWindow.preventViewSwitch) {
+            return
         }
-    }
-
-    function showJoystickPanel()
-    {
-        panelLoader.setSource("JoystickConfig.qml")
-    }
-
-    function showParametersPanel()
-    {
-        panelLoader.setSource("SetupParameterEditor.qml")
-    }
-
-    function showPX4FlowPanel()
-    {
-        panelLoader.setSource("PX4FlowSensor.qml")
+        button.checked = true
+        panelLoader.setSource(qmlSource)
     }
 
     function showVehicleComponentPanel(vehicleComponent)
     {
+        if (mainWindow.preventViewSwitch) {
+            return
+        }
         var autopilotPlugin = QGroundControl.multiVehicleManager.activeVehicle.autopilot
         var prereq = autopilotPlugin.prerequisiteSetup(vehicleComponent)
         if (prereq !== "") {
@@ -229,7 +221,7 @@ Rectangle {
                     exclusiveGroup:     setupButtonGroup
                     text:               modelData.title
                     visible:            _corePlugin && _corePlugin.options.combineSettingsAndSetup
-                    onClicked:          panelLoader.setSource(modelData.url)
+                    onClicked:          showPanel(this, modelData.url)
                     Layout.fillWidth:   true
                 }
             }
@@ -255,7 +247,7 @@ Rectangle {
                 text:               qsTr("Firmware")
                 Layout.fillWidth:   true
 
-                onClicked: showFirmwarePanel()
+                onClicked: showPanel(this, "FirmwareUpgrade.qml")
             }
 
             SubMenuButton {
@@ -265,8 +257,7 @@ Rectangle {
                 setupIndicator:     false
                 text:               qsTr("PX4Flow")
                 Layout.fillWidth:   true
-
-                onClicked:      showPX4FlowPanel()
+                onClicked:          showPX4FlowPanel(this, "PX4FlowSensor.qml")
             }
 
             SubMenuButton {
@@ -277,8 +268,7 @@ Rectangle {
                 visible:            _fullParameterVehicleAvailable && joystickManager.joysticks.length !== 0
                 text:               qsTr("Joystick")
                 Layout.fillWidth:   true
-
-                onClicked: showJoystickPanel()
+                onClicked:          showJoystickPanel(this, "JoystickConfig.qml")
             }
 
             Repeater {
@@ -293,8 +283,7 @@ Rectangle {
                     text:               modelData.name
                     visible:            modelData.setupSource.toString() !== ""
                     Layout.fillWidth:   true
-
-                    onClicked: showVehicleComponentPanel(modelData)
+                    onClicked:          showVehicleComponentPanel(modelData)
                 }
             }
 
@@ -306,8 +295,7 @@ Rectangle {
                                     _corePlugin.showAdvancedUI
                 text:               qsTr("Parameters")
                 Layout.fillWidth:   true
-
-                onClicked: showParametersPanel()
+                onClicked:          showPanel(this, "SetupParameterEditor.qml")
             }
 
         }

--- a/src/ui/AppSettings.qml
+++ b/src/ui/AppSettings.qml
@@ -74,7 +74,10 @@ Rectangle {
                     Layout.fillWidth:   true
 
                     onClicked: {
-                        if(__rightPanel.source !== modelData.url) {
+                        if (mainWindow.preventViewSwitch) {
+                            return
+                        }
+                        if (__rightPanel.source !== modelData.url) {
                             __rightPanel.source = modelData.url
                         }
                         checked = true

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -49,6 +49,7 @@ ApplicationWindow {
     property bool               communicationLost:          activeVehicle ? activeVehicle.connectionLost : false
     property string             formatedMessage:            activeVehicle ? activeVehicle.formatedMessage : ""
     property real               availableHeight:            mainWindow.height - mainWindow.header.height - mainWindow.footer.height
+    property bool               preventViewSwitch:          false
 
     property var                currentPlanMissionItem:     planMasterControllerPlan ? planMasterControllerPlan.missionController.currentPlanViewItem : null
     property var                planMasterControllerPlan:   null
@@ -151,8 +152,10 @@ ApplicationWindow {
         mainWindowDialog.dialogComponent = component
         mainWindowDialog.dialogTitle = title
         mainWindowDialog.dialogButtons = buttons
+        console.log("Prevent view switch")
+        mainWindow.preventViewSwitch = true
         mainWindowDialog.open()
-        if(buttons & StandardButton.Cancel || buttons & StandardButton.Close || buttons & StandardButton.Discard || buttons & StandardButton.Abort || buttons & StandardButton.Ignore) {
+        if (buttons & StandardButton.Cancel || buttons & StandardButton.Close || buttons & StandardButton.Discard || buttons & StandardButton.Abort || buttons & StandardButton.Ignore) {
             mainWindowDialog.closePolicy = Popup.NoAutoClose;
             mainWindowDialog.interactive = false;
         } else {
@@ -184,6 +187,8 @@ ApplicationWindow {
             dlgLoader.source = "QGCViewDialogContainer.qml"
         }
         onClosed: {
+            console.log("View switch ok")
+            mainWindow.preventViewSwitch = false
             dlgLoader.source = ""
         }
     }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -98,16 +98,24 @@ Item {
             anchors.bottom:         parent.bottom
             spacing:                ScreenTools.defaultFontPixelWidth / 2
 
-            ButtonGroup {
-                buttons:            viewRow.children
-            }
+            // Important Note: Toolbar buttons must manage their checked state manually in order to support
+            // view switch prevention. There doesn't seem to be a way to make this work if they are in a
+            // ButtonGroup.
 
             //---------------------------------------------
             // Toolbar Row
             RowLayout {
-                id:                 viewRow
+                id:                 buttonRow
                 Layout.fillHeight:  true
                 spacing:            0
+
+                function clearAllChecks() {
+                    for (var i=0; i<buttonRow.children.length; i++) {
+                        if (buttonRow.children[i].toString().startsWith("QGCToolBarButton")) {
+                            buttonRow.children[i].checked = false
+                        }
+                    }
+                }
 
                 QGCToolBarButton {
                     id:                 settingsButton
@@ -116,6 +124,10 @@ Item {
                     logo:               true
                     visible:            !QGroundControl.corePlugin.options.combineSettingsAndSetup
                     onClicked: {
+                        if (mainWindow.preventViewSwitch) {
+                            return
+                        }
+                        buttonRow.clearAllChecks()
                         checked = true
                         mainWindow.showSettingsView()
                     }
@@ -126,6 +138,10 @@ Item {
                     Layout.fillHeight:  true
                     icon.source:        "/qmlimages/Gears.svg"
                     onClicked: {
+                        if (mainWindow.preventViewSwitch) {
+                            return
+                        }
+                        buttonRow.clearAllChecks()
                         checked = true
                         mainWindow.showSetupView()
                     }
@@ -136,6 +152,10 @@ Item {
                     Layout.fillHeight:  true
                     icon.source:        "/qmlimages/Plan.svg"
                     onClicked: {
+                        if (mainWindow.preventViewSwitch) {
+                            return
+                        }
+                        buttonRow.clearAllChecks()
                         checked = true
                         mainWindow.showPlanView()
                     }
@@ -146,6 +166,10 @@ Item {
                     Layout.fillHeight:  true
                     icon.source:        "/qmlimages/PaperPlane.svg"
                     onClicked: {
+                        if (mainWindow.preventViewSwitch) {
+                            return
+                        }
+                        buttonRow.clearAllChecks()
                         checked = true
                         mainWindow.showFlyView()
                     }
@@ -157,6 +181,10 @@ Item {
                     icon.source:        "/qmlimages/Analyze.svg"
                     visible:            QGroundControl.corePlugin.showAdvancedUI
                     onClicked: {
+                        if (mainWindow.preventViewSwitch) {
+                            return
+                        }
+                        buttonRow.clearAllChecks()
                         checked = true
                         mainWindow.showAnalyzeView()
                     }


### PR DESCRIPTION
Previously the right side dialogs were parented to the child window the came from. Now they are parented to the main window. This causes a new problem when the right dialog pops up from a validation error. The same basic problem has always existed though when changing pages within a view like Settings pages. The nice thing is that the new way right dialogs are rooted to mainWindow makes it way easier to fix.  For example this sequence:
* App Settings/General
* Type -10 into Default Mission Altitude. Don't move focus away
* Click on any other App Settings button (or switch views from the toolbar)
* The view will switch and you will be left with a either a screwed up validation dialog or a validation dialog showing over the wrong view

In order to fix this there is a new mainWindow.preventViewSwitch bool which dictates whether a view switch should be allowed. This is automatically kept up to date by the right hand dialog code. But anything which wants to do a view switch needs to respect it. 

Currently the App Settings tabs and the Toolbar buttons respect it. And I just realized I need to hook it up to the Setup pages as well. I'll do that in a follow on commit.