### PR TITLE
Prevent view switching apis support a stack

### DIFF
--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -41,7 +41,7 @@ Rectangle {
 
     function showSummaryPanel()
     {
-        if (mainWindow.preventViewSwitch) {
+        if (mainWindow.preventViewSwitch()) {
             return
         }
         if (_fullParameterVehicleAvailable) {
@@ -58,7 +58,7 @@ Rectangle {
     }
 
     function showPanel(button, qmlSource) {
-        if (mainWindow.preventViewSwitch) {
+        if (mainWindow.preventViewSwitch()) {
             return
         }
         button.checked = true
@@ -67,7 +67,7 @@ Rectangle {
 
     function showVehicleComponentPanel(vehicleComponent)
     {
-        if (mainWindow.preventViewSwitch) {
+        if (mainWindow.preventViewSwitch()) {
             return
         }
         var autopilotPlugin = QGroundControl.multiVehicleManager.activeVehicle.autopilot

--- a/src/ui/AppSettings.qml
+++ b/src/ui/AppSettings.qml
@@ -74,7 +74,7 @@ Rectangle {
                     Layout.fillWidth:   true
 
                     onClicked: {
-                        if (mainWindow.preventViewSwitch) {
+                        if (mainWindow.preventViewSwitch()) {
                             return
                         }
                         if (__rightPanel.source !== modelData.url) {

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -38,6 +38,9 @@ ApplicationWindow {
         }
     }
 
+    property var                _rgPreventViewSwitch:       [ false ]
+
+
     readonly property real      _topBottomMargins:          ScreenTools.defaultFontPixelHeight * 0.5
     readonly property string    _mainToolbar:               QGroundControl.corePlugin.options.mainToolbarUrl
     readonly property string    _planToolbar:               QGroundControl.corePlugin.options.planToolbarUrl
@@ -49,7 +52,6 @@ ApplicationWindow {
     property bool               communicationLost:          activeVehicle ? activeVehicle.connectionLost : false
     property string             formatedMessage:            activeVehicle ? activeVehicle.formatedMessage : ""
     property real               availableHeight:            mainWindow.height - mainWindow.header.height - mainWindow.footer.height
-    property bool               preventViewSwitch:          false
 
     property var                currentPlanMissionItem:     planMasterControllerPlan ? planMasterControllerPlan.missionController.currentPlanViewItem : null
     property var                planMasterControllerPlan:   null
@@ -72,6 +74,25 @@ ApplicationWindow {
 
     //-------------------------------------------------------------------------
     //-- Global Scope Functions
+
+    /// Prevent view switching
+    function pushPreventViewSwitch() {
+        _rgPreventViewSwitch.push(true)
+    }
+
+    /// Allow view switching
+    function popPreventViewSwitch() {
+        if (_rgPreventViewSwitch.length == 1) {
+            console.warning("mainWindow.popPreventViewSwitch called when nothing pushed")
+            return
+        }
+        _rgPreventViewSwitch.pop()
+    }
+
+    /// @return true: View switches are not currently allowed
+    function preventViewSwitch() {
+        return _rgPreventViewSwitch[_rgPreventViewSwitch.length - 1]
+    }
 
     function viewSwitch(isPlanView) {
         settingsWindow.visible  = false
@@ -152,8 +173,7 @@ ApplicationWindow {
         mainWindowDialog.dialogComponent = component
         mainWindowDialog.dialogTitle = title
         mainWindowDialog.dialogButtons = buttons
-        console.log("Prevent view switch")
-        mainWindow.preventViewSwitch = true
+        mainWindow.pushPreventViewSwitch()
         mainWindowDialog.open()
         if (buttons & StandardButton.Cancel || buttons & StandardButton.Close || buttons & StandardButton.Discard || buttons & StandardButton.Abort || buttons & StandardButton.Ignore) {
             mainWindowDialog.closePolicy = Popup.NoAutoClose;
@@ -188,7 +208,7 @@ ApplicationWindow {
         }
         onClosed: {
             console.log("View switch ok")
-            mainWindow.preventViewSwitch = false
+            mainWindow.popPreventViewSwitch()
             dlgLoader.source = ""
         }
     }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -124,7 +124,7 @@ Item {
                     logo:               true
                     visible:            !QGroundControl.corePlugin.options.combineSettingsAndSetup
                     onClicked: {
-                        if (mainWindow.preventViewSwitch) {
+                        if (mainWindow.preventViewSwitch()) {
                             return
                         }
                         buttonRow.clearAllChecks()
@@ -138,7 +138,7 @@ Item {
                     Layout.fillHeight:  true
                     icon.source:        "/qmlimages/Gears.svg"
                     onClicked: {
-                        if (mainWindow.preventViewSwitch) {
+                        if (mainWindow.preventViewSwitch()) {
                             return
                         }
                         buttonRow.clearAllChecks()
@@ -152,7 +152,7 @@ Item {
                     Layout.fillHeight:  true
                     icon.source:        "/qmlimages/Plan.svg"
                     onClicked: {
-                        if (mainWindow.preventViewSwitch) {
+                        if (mainWindow.preventViewSwitch()) {
                             return
                         }
                         buttonRow.clearAllChecks()
@@ -166,7 +166,7 @@ Item {
                     Layout.fillHeight:  true
                     icon.source:        "/qmlimages/PaperPlane.svg"
                     onClicked: {
-                        if (mainWindow.preventViewSwitch) {
+                        if (mainWindow.preventViewSwitch()) {
                             return
                         }
                         buttonRow.clearAllChecks()
@@ -181,7 +181,7 @@ Item {
                     icon.source:        "/qmlimages/Analyze.svg"
                     visible:            QGroundControl.corePlugin.showAdvancedUI
                     onClicked: {
-                        if (mainWindow.preventViewSwitch) {
+                        if (mainWindow.preventViewSwitch()) {
                             return
                         }
                         buttonRow.clearAllChecks()


### PR DESCRIPTION
The prevent view switching methods are all on mainWindow:
* pushPreventViewSwitch() - Call to prevent a view switch, should have a matched popPreventViewSwitch
* popPreventViewSwitch() - Matching call to pop the prevent view switch stack
* preventViewSwitch() - Return true if view switching should be prevented. This is already used in all the right places to prevent view switching. Implementors of things like individual setup pages shouldn't need to call this.

I've changed the current usage over to these new methods. But I have not used them inside any of the setup pages yet. Example usage would be:
* Radio Component
* When the user starts a calibration pushPreventViewSwitch() should be called
* When the user finishes/cancels the calibration popPreventViewSwitch() should be called

Support for fixing #7585 
