### PR TITLE
Component specific handling of mavlink messages

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -818,13 +818,14 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     _messagesReceived++;
     emit messagesReceivedChanged();
     if(!_heardFrom) {
-        if(message.msgid == MAVLINK_MSG_ID_HEARTBEAT) {
+        if (message.msgid == MAVLINK_MSG_ID_HEARTBEAT) {
+            // This first hearbeat which comes through the vehicle is always the main autopilot component.
             _heardFrom = true;
-            _compID = message.compid;
+            _mainCompID = message.compid;
             _messageSeq = message.seq + 1;
         }
     } else {
-        if(_compID == message.compid) {
+        if(_mainCompID == message.compid) {
             uint16_t seq_received = static_cast<uint16_t>(message.seq);
             uint16_t packet_lost_count = 0;
             //-- Account for overflow during packet loss
@@ -850,7 +851,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         return;
     }
 
-    if (message.compid == MAV_COMP_ID_AUTOPILOT1) {
+    if (message.compid == _mainCompID) {
         _mavlinkMessageFromAutopilotOnly(link, message);
     } else {
         _mavlinkMessageFromAnyComponent(link, message);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1335,6 +1335,8 @@ private:
     void _writeCsvLine();
     void _flightTimerStart(void);
     void _flightTimerStop(void);
+    void _mavlinkMessageFromAutopilotOnly(LinkInterface* link, mavlink_message_t message);
+    void _mavlinkMessageFromAnyComponent(LinkInterface* link, mavlink_message_t message);
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1484,7 +1484,7 @@ private:
     uint                _messagesSent;
     uint                _messagesLost;
     uint8_t             _messageSeq;
-    uint8_t             _compID;
+    uint8_t             _mainCompID;
     bool                _heardFrom;
 
     float               _curGimbalRoll  = 0.0f;


### PR DESCRIPTION
Replacement for #8108

This splits Vehicle based mavlink message handling into two categories:
```
    void _mavlinkMessageFromAutopilotOnly(LinkInterface* link, mavlink_message_t message);
    void _mavlinkMessageFromAnyComponent(LinkInterface* link, mavlink_message_t message);
```


The import thing to look at is what message is in each category. This current breakout is a safe guess at what I think makes sense. It leans towards putting things in AnyComponent for safety. The goal is to keep the values which should only be vehicle associated in the AutopilotOnly handling. 

But in reality this is a significant mavlink spec problem in that how do you know which of these messages should come from where? And if the same messages comes from multiple components which one of them applies to the Vehicle itself.

@olliw42, @dogmaphobic Can you guys both take a look a this?

@hamishwillee FYI