### PR TITLE
Hold: Only use MISSION_ITEM_INT

### DIFF
--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -109,29 +109,29 @@ protected:
         TransactionRemoveAll
     } TransactionType_t;
 
-    void _startAckTimeout(AckType_t ack);
-    bool _checkForExpectedAck(AckType_t receivedAck);
-    void _readTransactionComplete(void);
-    void _handleMissionCount(const mavlink_message_t& message);
-    void _handleMissionItem(const mavlink_message_t& message, bool missionItemInt);
-    void _handleMissionRequest(const mavlink_message_t& message, bool missionItemInt);
-    void _handleMissionAck(const mavlink_message_t& message);
-    void _requestNextMissionItem(void);
-    void _clearMissionItems(void);
-    void _sendError(ErrorCode_t errorCode, const QString& errorMsg);
-    QString _ackTypeToString(AckType_t ackType);
-    QString _missionResultToString(MAV_MISSION_RESULT result);
-    void _finishTransaction(bool success, bool apmGuidedItemWrite = false);
-    void _requestList(void);
-    void _writeMissionCount(void);
-    void _writeMissionItemsWorker(void);
-    void _clearAndDeleteMissionItems(void);
-    void _clearAndDeleteWriteMissionItems(void);
-    QString _lastMissionReqestString(MAV_MISSION_RESULT result);
-    void _removeAllWorker(void);
-    void _connectToMavlink(void);
-    void _disconnectFromMavlink(void);
-    QString _planTypeString(void);
+    void    _startAckTimeout                (AckType_t ack);
+    bool    _checkForExpectedAck            (AckType_t receivedAck);
+    void    _readTransactionComplete        (void);
+    void    _handleMissionCount             (const mavlink_message_t& message);
+    void    _handleMissionItem              (const mavlink_message_t& message, bool missionItemInt);
+    void    _handleMissionRequest           (const mavlink_message_t& message);
+    void    _handleMissionAck               (const mavlink_message_t& message);
+    void    _requestNextMissionItem         (void);
+    void    _clearMissionItems              (void);
+    void    _sendError                      (ErrorCode_t errorCode, const QString& errorMsg);
+    QString _ackTypeToString                (AckType_t ackType);
+    QString _missionResultToString          (MAV_MISSION_RESULT result);
+    void    _finishTransaction              (bool success, bool apmGuidedItemWrite = false);
+    void    _requestList                    (void);
+    void    _writeMissionCount              (void);
+    void    _writeMissionItemsWorker        (void);
+    void    _clearAndDeleteMissionItems     (void);
+    void    _clearAndDeleteWriteMissionItems(void);
+    QString _lastMissionReqestString        (MAV_MISSION_RESULT result);
+    void    _removeAllWorker                (void);
+    void    _connectToMavlink               (void);
+    void    _disconnectFromMavlink          (void);
+    QString _planTypeString                 (void);
 
 protected:
     Vehicle*            _vehicle;


### PR DESCRIPTION
This pull request relates to a **breaking** mavlink mission protocol spec change I want to make which would need to be coordinate/testing across al major GCS makers. The change is basically to always use MISSION_ITEM_INT no matter what. I have tested this pull against PX4 and it works fine. Given discussion in #8086 I assume it will work fine for PX4 as well. But I won't be able to test that till next week.

Here it is:
* Mark MISSION_ITEM, MISSION_REQUEST and MAV_PROTOCOL_CAPABILITY_MISSION_INT as deprecated
* Change spec for MISSION_REQUEST to always respond with MISSION_ITEM_INT item **NOT** MISSION_ITEM. This is a breaking change.

Related to #8086