### PR TITLE
Bump settings version

### DIFF
--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -10,6 +10,6 @@
 
 // If you need to make an incompatible changes to stored settings, bump this version number
 // up by 1. This will caused store settings to be cleared on next boot.
-#define QGC_SETTINGS_VERSION 8
+#define QGC_SETTINGS_VERSION 9
 
 #endif // QGC_CONFIGURATION_H

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -173,6 +173,7 @@ Rectangle {
                                     }
                                     Component.onCompleted: {
                                         var index = mapCombo.find(_mapProvider)
+                                        if(index < 0) index = 0
                                         mapCombo.currentIndex = index
                                     }
                                 }
@@ -190,6 +191,7 @@ Rectangle {
                                     }
                                     Component.onCompleted: {
                                         var index = mapTypeCombo.find(_mapType)
+                                        if(index < 0) index = 0
                                         mapTypeCombo.currentIndex = index
                                     }
                                 }


### PR DESCRIPTION
This: https://github.com/mavlink/qgroundcontrol/commit/5683020f93611b0ed99f2ba8cde10087a1d0002f

It changed the map type from a number to a string. This causes QGC to not know what to load as a default map type when launching with an old settings file.