### PR TITLE
CameraManager: Ensure that parameter ranges are respected

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1255,6 +1255,14 @@ QGCCameraControl::_updateActiveList()
     }
     if(active != _activeSettings) {
         qCDebug(CameraControlVerboseLog) << "Excluding" << exclusionList;
+        //-- Go through all active facts and respect parameterranges
+        for(QString param: active) {
+            Fact* pFact = getFact(param);
+            if(pFact) {
+                _updateRanges(pFact);
+            }
+        }
+        //-- Make them active
         _activeSettings = active;
         emit activeSettingsChanged();
         //-- Force validity of "Facts" based on active set


### PR DESCRIPTION
I've added <parameterranges> to a camera definition file and have found that they are NOT respected in the CameraManagerEdit window until the associated parameter is explicitly changed itself. For my case this actually can bring the camera into undefined states, and that's why I added the range limits in the first place.

The solution which works for me is to ensure correct ranges by going through all active parameters in _updateActiveList() and to call _updateRanges() for each.

_**NOTE:** This PR is NOT rebased on latest master, since the tool chain appears to have changed and I thus get an error, and the wiki has (understandably !) not yet been updated and I don't know exactly what to do. I have however tested that this PR can be merged/rebased without any merge conflicts, so this shouldn't be a big issue. If desired I can do the rebase, but could then not compile and test the PR. Sorry for the inconvenience._

To demonstrate the problem, these details:
In my case there are parameters "Aspect Ratio" and "Resolution", and the options available for "Resolution" need to be restricted according to the setting in "Aspect Ratio". In the original code the ranges are however not respected for "Resolution" for until I would make a change to "Aspect Ratio".

Original:

![qgc-ranges-01](https://user-images.githubusercontent.com/6089567/71319671-b4361800-24a1-11ea-9f58-8d4476331091.jpg)
![qgc-ranges-02](https://user-images.githubusercontent.com/6089567/71319674-b5ffdb80-24a1-11ea-8730-018b30ec61cf.jpg)

Note the range of available options for the parameter "Resolution". I could choose now e.g. 2.7K 4:3 which would bring the camera in an undefined state.

With this PR:

![qgc-ranges-03](https://user-images.githubusercontent.com/6089567/71319630-20644c00-24a1-11ea-857f-fdf2e3a94fb6.jpg)
![qgc-ranges-04](https://user-images.githubusercontent.com/6089567/71319631-235f3c80-24a1-11ea-89c0-1401aa92e81d.jpg)

The important piece to note is that there is a _processCondition("") in the log after the "Excluding(...)", which does the trick. The range of available options for the parameter "Resolution" is now as described in the camera definetion file.




