### PR TITLE
QGCCameraControl.c: Streamline and add some Logs

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -768,6 +768,7 @@ void
 QGCCameraControl::_setVideoStatus(VideoStatus status)
 {
     if(_video_status != status) {
+        qCDebug(CameraControlLog) << "_setVideoStatus()" << status;
         _video_status = status;
         emit videoStatusChanged();
         if(status == VIDEO_CAPTURE_STATUS_RUNNING) {
@@ -795,7 +796,7 @@ void
 QGCCameraControl::_setPhotoStatus(PhotoStatus status)
 {
     if(_photo_status != status) {
-        qCDebug(CameraControlLog) << "Set Photo Status:" << status;
+        qCDebug(CameraControlLog) << "_setPhotoStatus()" << status;
         _photo_status = status;
         emit photoStatusChanged();
     }
@@ -1463,7 +1464,7 @@ QGCCameraControl::_requestStorageInfo()
 void
 QGCCameraControl::handleSettings(const mavlink_camera_settings_t& settings)
 {
-    qCDebug(CameraControlLog) << "handleSettings() Mode:" << settings.mode_id;
+    qCDebug(CameraControlLog) << "handleSettings()" << settings.mode_id << settings.zoomLevel << settings.focusLevel;
     _setCameraMode(static_cast<CameraMode>(settings.mode_id));
     qreal z = static_cast<qreal>(settings.zoomLevel);
     qreal f = static_cast<qreal>(settings.focusLevel);
@@ -1481,7 +1482,7 @@ QGCCameraControl::handleSettings(const mavlink_camera_settings_t& settings)
 void
 QGCCameraControl::handleStorageInfo(const mavlink_storage_information_t& st)
 {
-    qCDebug(CameraControlLog) << "handleStorageInfo:" << st.available_capacity << st.status << st.storage_count << st.storage_id << st.total_capacity << st.used_capacity;
+    qCDebug(CameraControlLog) << "handleStorageInfo()" << st.available_capacity << st.status << st.storage_count << st.storage_id << st.total_capacity << st.used_capacity;
     if(st.status == STORAGE_STATUS_READY) {
         uint32_t t = static_cast<uint32_t>(st.total_capacity);
         if(_storageTotal != t) {
@@ -1504,7 +1505,7 @@ QGCCameraControl::handleStorageInfo(const mavlink_storage_information_t& st)
 void
 QGCCameraControl::handleBatteryStatus(const mavlink_battery_status_t& bs)
 {
-    qCDebug(CameraControlLog) << "handleBatteryStatus:" << bs.battery_remaining;
+    qCDebug(CameraControlLog) << "handleBatteryStatus()" << bs.battery_remaining;
     if(bs.battery_remaining >= 0 && _batteryRemaining != static_cast<int>(bs.battery_remaining)) {
         _batteryRemaining = static_cast<int>(bs.battery_remaining);
         emit batteryRemainingChanged();
@@ -1516,7 +1517,7 @@ void
 QGCCameraControl::handleCaptureStatus(const mavlink_camera_capture_status_t& cap)
 {
     //-- This is a response to MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS
-    qCDebug(CameraControlLog) << "handleCaptureStatus:" << cap.available_capacity << cap.image_interval << cap.image_status << cap.recording_time_ms << cap.video_status;
+    qCDebug(CameraControlLog) << "handleCaptureStatus()" << cap.available_capacity << cap.image_interval << cap.image_status << cap.recording_time_ms << cap.video_status;
     //-- Disk Free Space
     uint32_t a = static_cast<uint32_t>(cap.available_capacity);
     if(_storageFree != a) {
@@ -1557,7 +1558,7 @@ QGCCameraControl::handleCaptureStatus(const mavlink_camera_capture_status_t& cap
 void
 QGCCameraControl::handleVideoInfo(const mavlink_video_stream_information_t* vi)
 {
-    qCDebug(CameraControlLog) << "handleVideoInfo:" << vi->stream_id << vi->uri;
+    qCDebug(CameraControlLog) << "handleVideoInfo()" << vi->stream_id << vi->uri;
     _expectedCount = vi->count;
     if(!_findStream(vi->stream_id, false)) {
         qCDebug(CameraControlLog) << "Create stream handler for stream ID:" << vi->stream_id;
@@ -1590,7 +1591,7 @@ void
 QGCCameraControl::handleVideoStatus(const mavlink_video_stream_status_t* vs)
 {
     _streamStatusTimer.stop();
-    qCDebug(CameraControlLog) << "handleVideoStatus:" << vs->stream_id;
+    qCDebug(CameraControlLog) << "handleVideoStatus()" << vs->stream_id;
     QGCVideoStreamInfo* pInfo = _findStream(vs->stream_id);
     if(pInfo) {
         pInfo->update(vs);
@@ -1705,7 +1706,7 @@ QGCCameraControl::thermalStreamInstance()
 void
 QGCCameraControl::_requestStreamInfo(uint8_t streamID)
 {
-    qCDebug(CameraControlLog) << "Requesting video stream info for:" << streamID;
+    qCDebug(CameraControlLog) << "_requestStreamInfo()" << streamID;
     _vehicle->sendMavCommand(
         _compID,                                            // Target component
         MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION,           // Command id
@@ -1717,7 +1718,7 @@ QGCCameraControl::_requestStreamInfo(uint8_t streamID)
 void
 QGCCameraControl::_requestStreamStatus(uint8_t streamID)
 {
-    qCDebug(CameraControlLog) << "Requesting video stream status for:" << streamID;
+    qCDebug(CameraControlLog) << "_requestStreamStatus()" << streamID;
     _vehicle->sendMavCommand(
         _compID,                                            // Target component
         MAV_CMD_REQUEST_VIDEO_STREAM_STATUS,                // Command id
@@ -1973,7 +1974,7 @@ QGCCameraControl::_handleDefinitionFile(const QString &url)
 void
 QGCCameraControl::_httpRequest(const QString &url)
 {
-    qCDebug(CameraControlLog) << "Request camera definition:" << url;
+    qCDebug(CameraControlLog) << "_httpRequest()" << url;
     if(!_netManager) {
         _netManager = new QNetworkAccessManager(this);
     }
@@ -2081,7 +2082,7 @@ QGCCameraControl::validateParameter(Fact* pFact, QVariant& newValue)
 QStringList
 QGCCameraControl::activeSettings()
 {
-    qCDebug(CameraControlLog) << "Active:" << _activeSettings;
+    qCDebug(CameraControlLog) << "activeSettings()" << _activeSettings;
     return _activeSettings;
 }
 

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1237,6 +1237,7 @@ QGCCameraControl::handleParamValue(const mavlink_param_ext_value_t& value)
 void
 QGCCameraControl::_updateActiveList()
 {
+    qCDebug(CameraControlVerboseLog) << "_updateActiveList()";
     //-- Clear out excluded parameters based on exclusion rules
     QStringList exclusionList;
     for(QGCCameraOptionExclusion* param: _valueExclusions) {
@@ -1347,6 +1348,7 @@ QGCCameraControl::_processCondition(const QString condition)
 void
 QGCCameraControl::_updateRanges(Fact* pFact)
 {
+    qCDebug(CameraControlVerboseLog) << "_updateRanges()" << pFact->name();
     QMap<Fact*, QGCCameraOptionRange*> rangesSet;
     QMap<Fact*, QString> rangesReset;
     QStringList changedList;
@@ -1899,6 +1901,7 @@ QGCCameraControl::_loadRanges(QDomNode option, const QString factName, QString p
 void
 QGCCameraControl::_processRanges()
 {
+    qCDebug(CameraControlVerboseLog) << "_processRanges()";
     //-- After all parameter are loaded, process parameter ranges
     for(QGCCameraOptionRange* pRange: _optionRanges) {
         Fact* pRFact = getFact(pRange->targetParam);


### PR DESCRIPTION
This is really NFC. This PR 
* streamlines some log outputs to make the logs easier to interpret: Whenever an output is at the beginning of a function it outputs the function name (this format is used in many of the other outputs)
* adds a video status log output
* adds three more outputs to the verbose logs

_**NOTE:** This PR is NOT rebased on latest master, since the tool chain appears to have changed and I thus get an error, and the wiki has (understandably !) not yet been updated and I don't know exactly what to do. I have however tested that this PR can be merged/rebased without any merge conflicts, so this shouldn't be a big issue, and it's really not a complicated PR. If desired I can do the rebase, but could then not compile and test the PR. Sorry for the inconvenience._