### PR TITLE
CameraManager: Adds basic zoom slider to Camera Widget

### DIFF
--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -199,6 +199,7 @@ public:
     Q_INVOKABLE virtual bool toggleVideo    ();
     Q_INVOKABLE virtual void resetSettings  ();
     Q_INVOKABLE virtual void formatCard     (int id = 1);
+    Q_INVOKABLE virtual void setZoom        (int level){ setZoomLevel(level); } //invokable wrapper to setZoomLevel()
     Q_INVOKABLE virtual void stepZoom       (int direction);
     Q_INVOKABLE virtual void startZoom      (int direction);
     Q_INVOKABLE virtual void stopZoom       ();


### PR DESCRIPTION
Some cameras support zoom. Currently it seems a ZOOM capability is only supported when there is a stream. This PR adds a slider to the "normal" CameraPageWidget.

_**NOTE:** This PR is NOT rebased on latest master, since the tool chain appears to have changed and I thus get an error, and the wiki has (understandably !) not yet been updated and I don't know exactly what to do. I have however tested that this PR can be merged/rebased without any merge conflicts, so this shouldn't be a big issue. If desired I can do the rebase, but could then not compile and test the PR. Sorry for the inconvenience._

![qgc-zoom-01](https://user-images.githubusercontent.com/6089567/71320392-e009cb80-24aa-11ea-9fd0-ccbbc5cd51be.jpg)
![qgc-zoom-02](https://user-images.githubusercontent.com/6089567/71320393-e13af880-24aa-11ea-8abc-e4f60aac349d.jpg)

Pain points:
* Using a Slider is convenient from a user perspective but has the problem that - at least as far as I could determine - it's value cannot be set without emitting a value changed (a onMove doesn't appear to exist), which leads to a recursive loop. Therefore, the current implementation breaks the loop by not updating the slider's value, but only using the slider to emit the new zoom level. On the web I found "solutions" like to disconnect and reconnect signals, but I think that's not proper.
* I don't have a stream and could not test interaction and potential conflicts with the already existing zoom support.

I'm thus not sure this PR as is has any change. I certainly would wish so. :):)