### PR TITLE
MissionItemStatus: Show seq nums, clickable selection

### DIFF
--- a/src/PlanView/MissionItemStatus.qml
+++ b/src/PlanView/MissionItemStatus.qml
@@ -25,9 +25,11 @@ Rectangle {
     opacity:    0.80
     clip:       true
 
-    property var missionItems                ///< List of all available mission items
+    property var    missionItems                    ///< List of all available mission items
+    property real   maxWidth:          parent.width
 
-    property real maxWidth:          parent.width
+    signal setCurrentSeqNum(int seqNum)
+
     readonly property real _margins: ScreenTools.defaultFontPixelWidth
 
     onMaxWidthChanged: {
@@ -97,7 +99,9 @@ Rectangle {
                 checked:                    object.isCurrentItem
                 label:                      object.abbreviation.charAt(0)
                 index:                      object.abbreviation.charAt(0) > 'A' && object.abbreviation.charAt(0) < 'z' ? -1 : object.sequenceNumber
+                showSequenceNumbers:        true
                 visible:                    true
+                onClicked:                  root.setCurrentSeqNum(object.sequenceNumber)
             }
         }
     }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -884,6 +884,8 @@ Item {
             missionItems:       _missionController.visualItems
             visible:            _internalVisible && _editingLayer === _layerMission && QGroundControl.corePlugin.options.showMissionStatus
 
+            onSetCurrentSeqNum: _missionController.setCurrentPlanViewSeqNum(seqNum, true)
+
             property bool _internalVisible: false
 
             function toggleVisible() {

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -25,6 +25,7 @@ Canvas {
     property real   gimbalYaw
     property real   vehicleYaw
     property bool   showGimbalYaw:          false
+    property bool   showSequenceNumbers:    false
 
     property real   _width:             showGimbalYaw ? Math.max(_gimbalYawWidth, labelControl.visible ? labelControl.width : indicator.width) : (labelControl.visible ? labelControl.width : indicator.width)
     property real   _height:            showGimbalYaw ? _gimbalYawWidth : (labelControl.visible ? labelControl.height : indicator.height)
@@ -37,7 +38,7 @@ Canvas {
     property real   _labelMargin:       2
     property real   _labelRadius:       _indicatorRadius + _labelMargin
     property string _label:             label.length > 1 ? label : ""
-    property string _index:             index === 0 || index === -1 ? label.charAt(0) : "" /*index*/
+    property string _index:             index === 0 || index === -1 ? label.charAt(0) : (showSequenceNumbers ? index : "")
 
     onColorChanged:         requestPaint()
     onShowGimbalYawChanged: requestPaint()


### PR DESCRIPTION
* The bottom status panel in the Plan View shows sequence number. This can be used if you get a warning about a specific item number to know which one it is.
* You can click on the items in the panel to set the current item

Related to #8098, #8119