### PR TITLE
Deploy tools: Make paths consistent and add QGStreamer

### DIFF
--- a/deploy/MakeQtTravisTarball.sh
+++ b/deploy/MakeQtTravisTarball.sh
@@ -11,16 +11,27 @@ if [ ! -d ${QT_DIRECTORY} ]; then
 	exit 1
 fi
 
-QT_FULL_VERSION=5.11.0
-QT_BASE_VERSION=5.11
+QT_FULL_VERSION=5.12.6
 
 QT_BUILD_TYPE=$2
 if [ ! -d ${QT_DIRECTORY}/${QT_FULL_VERSION}/${QT_BUILD_TYPE} ]; then
-        echo 'Qt build type directory not found. Specify example: clang_64'
+        echo 'Qt build type directory not found. Specify example: clang_64 or ios'
     exit 1
 fi
 
-mkdir -p Qt${QT_BASE_VERSION}-${QT_BUILD_TYPE}/${QT_FULL_VERSION}/${QT_BUILD_TYPE}
-cp -r ${QT_DIRECTORY}/${QT_FULL_VERSION}/${QT_BUILD_TYPE} Qt${QT_BASE_VERSION}-${QT_BUILD_TYPE}/${QT_FULL_VERSION}
-rm -rf Qt${QT_BASE_VERSION}-${QT_BUILD_TYPE}/${QT_FULL_VERSION}/${QT_BUILD_TYPE}/doc
-tar -jcvf Qt${QT_FULL_VERSION}-${QT_BUILD_TYPE}-min.tar.bz2 Qt${QT_BASE_VERSION}-${QT_BUILD_TYPE}/
+mkdir -p Qt${QT_FULL_VERSION}-${QT_BUILD_TYPE}/${QT_FULL_VERSION}/${QT_BUILD_TYPE}
+cp -r ${QT_DIRECTORY}/${QT_FULL_VERSION}/${QT_BUILD_TYPE} Qt${QT_FULL_VERSION}-${QT_BUILD_TYPE}/${QT_FULL_VERSION}
+rm -rf Qt${QT_FULL_VERSION}-${QT_BUILD_TYPE}/${QT_FULL_VERSION}/${QT_BUILD_TYPE}/doc
+tar -jcvf Qt${QT_FULL_VERSION}-${QT_BUILD_TYPE}-min.tar.bz2 --exclude='*_debug*' Qt${QT_FULL_VERSION}-${QT_BUILD_TYPE}/
+
+# Pull iOS GStreamer
+if [ -d ~/Library/Developer/GStreamer/iPhone.sdk ]; then
+    echo 'GStreamer for iOS found, archiving..'
+	tar -jcvf gstreamer-ios-min.tar.bz2 -C ~/Library/Developer GStreamer/iPhone.sdk
+fi
+
+# Pull Mac OS GStreamer
+if [ -d /Library/Frameworks/GStreamer ]; then
+	echo 'GStreamer for MacOS found, archiving..'
+	tar -jcvf gstreamer-macos-min.tar.bz2 /Library/Frameworks/GStreamer
+fi


### PR DESCRIPTION
This makes it easier to deploy on remote targets and also includes iOS for GStreamer.

@DonLakeFlyer I found the previous naming convention unnecessarily complex (two ways of specifying Qt versions, you never know which one was meant).

This will one-time break the Travis scripts as you need to add the last dot release, but that shouldn't be an issue once you update.


