### PR TITLE
Don't show GCS heading

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -35,7 +35,7 @@ Map {
     property string mapName:                        'defaultMap'
     property bool   isSatelliteMap:                 activeMapType.name.indexOf("Satellite") > -1 || activeMapType.name.indexOf("Hybrid") > -1
     property var    gcsPosition:                    QGroundControl.qgcPositionManger.gcsPosition
-    property int    gcsHeading:                     QGroundControl.qgcPositionManger.gcsHeading
+    property double gcsHeading:                     NaN // QGroundControl.qgcPositionManger.gcsHeading - Note: This is NaN because the quality of gcsHeading is generally crap. Which means it shows bad values.
     property bool   userPanned:                     false   ///< true: the user has manually panned the map
     property bool   allowGCSLocationCenter:         false   ///< true: map will center/zoom to gcs location one time
     property bool   allowVehicleLocationCenter:     false   ///< true: map will center/zoom to vehicle location one time


### PR DESCRIPTION
99% of the time the heading value is random since it comes from the location information and/or or device GPS. And that heading value is only valid if it is moving fairly rapidly in a direction.