### PR TITLE
Don't show GCS heading unless it comes from plugin

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -35,7 +35,7 @@ Map {
     property string mapName:                        'defaultMap'
     property bool   isSatelliteMap:                 activeMapType.name.indexOf("Satellite") > -1 || activeMapType.name.indexOf("Hybrid") > -1
     property var    gcsPosition:                    QGroundControl.qgcPositionManger.gcsPosition
-    property int    gcsHeading:                     QGroundControl.qgcPositionManger.gcsHeading
+    property real   gcsHeading:                     QGroundControl.qgcPositionManger.gcsHeading
     property bool   userPanned:                     false   ///< true: the user has manually panned the map
     property bool   allowGCSLocationCenter:         false   ///< true: map will center/zoom to gcs location one time
     property bool   allowVehicleLocationCenter:     false   ///< true: map will center/zoom to vehicle location one time

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -13,12 +13,6 @@
 
 QGCPositionManager::QGCPositionManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool           (app, toolbox)
-    , _updateInterval   (0)
-    , _gcsHeading       (NAN)
-    , _currentSource    (nullptr)
-    , _defaultSource    (nullptr)
-    , _nmeaSource       (nullptr)
-    , _simulatedSource  (nullptr)
 {
 
 }
@@ -34,6 +28,9 @@ void QGCPositionManager::setToolbox(QGCToolbox *toolbox)
    QGCTool::setToolbox(toolbox);
    //-- First see if plugin provides a position source
    _defaultSource = toolbox->corePlugin()->createPositionSource(this);
+   if (_defaultSource) {
+       _usingPluginSource = true;
+   }
 
    if (qgcApp()->runningUnitTests()) {
        // Units test on travis fail due to lack of position source
@@ -91,7 +88,14 @@ void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
         _gcsPosition = newGCSPosition;
         emit gcsPositionChanged(_gcsPosition);
     }
-    if (newGCSHeading != _gcsHeading) {
+
+    // At this point only plugins support gcs heading. The reason is that the quality of heading information from a local
+    // position device (not a compass) is unknown. In many cases it can only be trusted if the GCS location is moving above
+    // a certain rate of speed. When it is not, or the gcs is standing still the heading is just random. We don't want these
+    // random heading to be shown on the fly view. So until we can get a true compass based heading or some smarted heading quality
+    // information which takes into account the speed of movement we normally don't set a heading. We do use the heading though
+    // if the plugin overrides the position source. In that case we assume that it hopefully know what it is doing.
+    if (_usingPluginSource && newGCSHeading != _gcsHeading) {
         _gcsHeading = newGCSHeading;
         emit gcsHeadingChanged(_gcsHeading);
     }

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -56,13 +56,14 @@ signals:
     void positionInfoUpdated(QGeoPositionInfo update);
 
 private:
-    int                 _updateInterval;
+    int                 _updateInterval =   0;
     QGeoPositionInfo    _geoPositionInfo;
     QGeoCoordinate      _gcsPosition;
-    qreal               _gcsHeading;
+    qreal               _gcsHeading =       qQNaN();
 
-    QGeoPositionInfoSource*     _currentSource;
-    QGeoPositionInfoSource*     _defaultSource;
-    QNmeaPositionInfoSource*    _nmeaSource;
-    QGeoPositionInfoSource*     _simulatedSource;
+    QGeoPositionInfoSource*     _currentSource =        nullptr;
+    QGeoPositionInfoSource*     _defaultSource =        nullptr;
+    QNmeaPositionInfoSource*    _nmeaSource =           nullptr;
+    QGeoPositionInfoSource*     _simulatedSource =      nullptr;
+    bool                        _usingPluginSource =    false;
 };


### PR DESCRIPTION
The quality of a GCS heading which comes from a calculated location and/or an internal GPS is low quality unless the GCS is moving position above a certain speed. When below that heading is just random. We don't want to random gcs headings to be displayed on the Fly view.

This will eventually be fixed to do possibly both of these things:
* Detect movement speed above a certain threshold at which point the heading is valid.
* Use a devices compass (if available) for gcs heading