### PR TITLE
Allow plugin to add flight modes to joystick button actions

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -81,12 +81,13 @@ public:
     ///         free when no longer needed.
     virtual QList<VehicleComponent*> componentsForVehicle(AutoPilotPlugin* vehicle);
 
-    /// Returns the list of available flight modes. Flight modes can be different in normal/advanced ui mode.
+    /// Returns the list of available flight modes for the Fly View dropdown. This may or may not be the full
+    /// list available from the firmware. Call will be made again if advanced mode changes.
+    virtual QStringList flightModes(Vehicle* /*vehicle*/) { return QStringList(); }
+
+    /// Returns the list of additional flight modes to add to the list for joystick button actions.
     /// Call will be made again if advanced mode changes.
-    virtual QStringList flightModes(Vehicle* vehicle) {
-        Q_UNUSED(vehicle);
-        return QStringList();
-    }
+    virtual QStringList extraJoystickFlightModes(Vehicle* /*vehicle*/) { return QStringList(); }
 
     /// Returns the name for this flight mode. Flight mode names must be human readable as well as audio speakable.
     ///     @param base_mode Base mode from mavlink HEARTBEAT message

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -972,7 +972,7 @@ void Joystick::_executeButtonAction(const QString& action, bool buttonDown)
         if (buttonDown) emit setVtolInFwdFlight(true);
     } else if (action == _buttonActionVTOLMultiRotor) {
         if (buttonDown) emit setVtolInFwdFlight(false);
-    } else if (_activeVehicle->flightModes().contains(action)) {
+    } else if (_activeVehicle->flightModes().contains(action) || _activeVehicle->extraJoystickFlightModes().contains(action)) {
         if (buttonDown) emit setFlightMode(action);
     } else if(action == _buttonActionContinuousZoomIn || action == _buttonActionContinuousZoomOut) {
         if (buttonDown) {
@@ -1069,6 +1069,10 @@ void Joystick::_buildActionList(Vehicle* activeVehicle)
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionToggleArm));
     if (activeVehicle) {
         QStringList list = activeVehicle->flightModes();
+        foreach(auto mode, list) {
+            _assignableButtonActions.append(new AssignableButtonAction(this, mode));
+        }
+        list = activeVehicle->extraJoystickFlightModes();
         foreach(auto mode, list) {
             _assignableButtonActions.append(new AssignableButtonAction(this, mode));
         }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2375,6 +2375,11 @@ QStringList Vehicle::flightModes(void)
     return _firmwarePlugin->flightModes(this);
 }
 
+QStringList Vehicle::extraJoystickFlightModes(void)
+{
+    return _firmwarePlugin->extraJoystickFlightModes(this);
+}
+
 QString Vehicle::flightMode(void) const
 {
     return _firmwarePlugin->flightMode(_base_mode, _custom_mode);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -542,6 +542,7 @@ public:
     Q_PROPERTY(bool                 autoDisarm              READ autoDisarm                                             NOTIFY autoDisarmChanged)
     Q_PROPERTY(bool                 flightModeSetAvailable  READ flightModeSetAvailable                                 CONSTANT)
     Q_PROPERTY(QStringList          flightModes             READ flightModes                                            NOTIFY flightModesChanged)
+    Q_PROPERTY(QStringList          extraJoystickFlightModes READ extraJoystickFlightModes                              NOTIFY flightModesChanged)
     Q_PROPERTY(QString              flightMode              READ flightMode             WRITE setFlightMode             NOTIFY flightModeChanged)
     Q_PROPERTY(bool                 hilMode                 READ hilMode                WRITE setHilMode                NOTIFY hilModeChanged)
     Q_PROPERTY(TrajectoryPoints*    trajectoryPoints        MEMBER _trajectoryPoints                                    CONSTANT)
@@ -851,10 +852,11 @@ public:
     bool armed      () { return _armed; }
     void setArmed   (bool armed);
 
-    bool flightModeSetAvailable(void);
-    QStringList flightModes(void);
-    QString flightMode(void) const;
-    void setFlightMode(const QString& flightMode);
+    bool flightModeSetAvailable             (void);
+    QStringList flightModes                 (void);
+    QStringList extraJoystickFlightModes    (void);
+    QString flightMode                      (void) const;
+    void setFlightMode                      (const QString& flightMode);
 
     QString priorityLinkName(void) const;
     QVariantList links(void) const;


### PR DESCRIPTION
You can implement ```FirmwarePlugin::extraJoystickFlightModes``` to support this. The usage case is where a custom build limits the flight modes availbel to the user from the Fly View but wants to add more modes for joystick buttons. This typically happens for vehicles which normally fly without a controller. For the Fly View you don't want any flight modes shown which are controller oriented. But then when you use a Joystick you want some of those back