### PR TITLE
Continue work on MAVLink Graphing

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -50,6 +50,7 @@ linux {
         target.path = $$DESTDIR
         equals(ANDROID_TARGET_ARCH, armeabi-v7a)  {
             DEFINES += __androidArm32__
+            DEFINES += QGC_ENABLE_MAVLINK_INSPECTOR
             message("Android Arm 32 bit build")
         } else:equals(ANDROID_TARGET_ARCH, arm64-v8a)  {
             DEFINES += __androidArm64__

--- a/src/AnalyzeView/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspectorController.h
@@ -91,8 +91,10 @@ public:
     Q_PROPERTY(quint64              count           READ count          NOTIFY messageChanged)
     Q_PROPERTY(QmlObjectListModel*  fields          READ fields         NOTIFY indexChanged)
     Q_PROPERTY(bool                 fieldSelected   READ fieldSelected  NOTIFY fieldSelectedChanged)
+    Q_PROPERTY(bool                 selected        READ selected       NOTIFY selectedChanged)
 
-    QGCMAVLinkMessage(QObject* parent, mavlink_message_t* message);
+    QGCMAVLinkMessage   (QObject* parent, mavlink_message_t* message);
+    ~QGCMAVLinkMessage  ();
 
     quint32             id              () { return _message.msgid;  }
     quint8              cid             () { return _message.compid; }
@@ -102,16 +104,19 @@ public:
     quint64             lastCount       () { return _lastCount; }
     QmlObjectListModel* fields          () { return &_fields; }
     bool                fieldSelected   () { return _fieldSelected; }
+    bool                selected        () { return _selected; }
 
     void                updateFieldSelection();
     void                update          (mavlink_message_t* message);
     void                updateFreq      ();
+    void                setSelected     (bool sel) { _selected = sel; }
 
 signals:
     void messageChanged                 ();
     void freqChanged                    ();
     void indexChanged                   ();
     void fieldSelectedChanged           ();
+    void selectedChanged                ();
 
 private:
     QmlObjectListModel  _fields;
@@ -121,6 +126,7 @@ private:
     uint64_t            _lastCount  = 0;
     mavlink_message_t   _message;   //-- List of QGCMAVLinkMessageField
     bool                _fieldSelected   = false;
+    bool                _selected   = false;
 };
 
 //-----------------------------------------------------------------------------
@@ -134,7 +140,8 @@ public:
 
     Q_PROPERTY(int                  selected        READ selected       WRITE setSelected   NOTIFY selectedChanged)
 
-    QGCMAVLinkVehicle(QObject* parent, quint8 id);
+    QGCMAVLinkVehicle   (QObject* parent, quint8 id);
+    ~QGCMAVLinkVehicle  ();
 
     quint8              id              () { return _id; }
     QmlObjectListModel* messages        () { return &_messages; }
@@ -154,6 +161,7 @@ signals:
 
 private:
     void _checkCompID                   (QGCMAVLinkMessage *message);
+    void _resetSelection                ();
 
 private:
     quint8              _id;


### PR DESCRIPTION
* Enable charting on Android 32-bit
* Skip message parsing if the message is not being consumed.
* Work around message disassembly issue on ARM 32-bit.
* Fix memory leaks.

Two charts, six series running on a 6-year-old, dual core Nexus 9 (Android 32-bit):
![screen](https://user-images.githubusercontent.com/749243/71722615-74532700-2df7-11ea-99a3-d9245345b7b1.png)
