### PR TITLE
ShapeFileHelper: Fix incomplete type QVariant error

### DIFF
--- a/src/ShapeFileHelper.cc
+++ b/src/ShapeFileHelper.cc
@@ -13,7 +13,6 @@
 #include "SHPFileHelper.h"
 
 #include <QFile>
-#include <QVariant>
 
 const char* ShapeFileHelper::_errorPrefix = QT_TR_NOOP("Shape file load failed. %1");
 

--- a/src/ShapeFileHelper.h
+++ b/src/ShapeFileHelper.h
@@ -12,6 +12,7 @@
 #include <QObject>
 #include <QList>
 #include <QGeoCoordinate>
+#include <QVariant>
 
 /// Routines for loading polygons or polylines from KML or SHP files.
 class ShapeFileHelper : public QObject


### PR DESCRIPTION
Got this error while compiling master branch with Qt 5.14.0 in macOS

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


