### PR TITLE
Add a timer in between low battery warning messages.

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1507,7 +1507,8 @@ private:
     QString _gitHash;
     quint64 _uid;
 
-    int _lastAnnouncedLowBatteryPercent;
+    QTime   _lastBatteryAnnouncement;
+    int     _lastAnnouncedLowBatteryPercent;
 
     SharedLinkInterfacePointer _priorityLink;  // We always keep a reference to the priority link to manage shutdown ordering
     bool _priorityLinkCommanded;


### PR DESCRIPTION
QGC will now wait 30 seconds before issuing a new (spoken) low battery warning. When the low battery reaches 50% of the threshold, the delays go down to every 15 seconds.

The original code had the announcement go out for every percentage change, which could turn into a stream of spoken messages on top of each other.

Closes #8232 