### PR TITLE
Set the first waypoint for the VTOL missions as VTOL takeoff

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -390,6 +390,10 @@ VisualMissionItem* MissionController::_insertSimpleMissionItemWorker(QGeoCoordin
 
 VisualMissionItem* MissionController::insertSimpleMissionItem(QGeoCoordinate coordinate, int visualItemIndex, bool makeCurrentItem)
 {
+    // In case of VTOL insert a take off waypoint as the first waypoint
+    if(_visualItems->count() == 1 && _controllerVehicle->vtol()) {
+        return insertTakeoffItem(coordinate, visualItemIndex, makeCurrentItem);
+    }
     return _insertSimpleMissionItemWorker(coordinate, MAV_CMD_NAV_WAYPOINT, visualItemIndex, makeCurrentItem);
 }
 

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -66,7 +66,7 @@ Rectangle {
             visible:            missionItem.isTakeoffItem && missionItem.wizardMode // Hack special case for takeoff item
 
             QGCLabel {
-                text:               qsTr("Move 'T' Takeoff to the climbout location.")
+                text:               qsTr("Move '%1' Takeoff to the climbout location.").arg(missionItem.commandName.charAt(0))
                 Layout.fillWidth:   true
                 wrapMode:           Text.WordWrap
                 visible:            !initialClickLabel.visible


### PR DESCRIPTION
In the case of VTOL vehicle, the first Waypoint added will be a VTOL Takeoff and transition 

![Screenshot from 2020-01-21 18-26-46](https://user-images.githubusercontent.com/47554641/72827808-c01d2180-3c7b-11ea-9cc0-146c0b337179.png)

Clarify the message icon when we don't have a home location. The Takeoff point was hardcoded to `T` even in the case of VTOL which will be displayed as `V`
![Screenshot from 2020-01-21 18-46-37](https://user-images.githubusercontent.com/47554641/72829136-7aae2380-3c7e-11ea-8bc8-6c489b8d9fac.png)