### PR TITLE
UI Scaling

### DIFF
--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -21,6 +21,8 @@ T.ComboBox {
     id:             control
     padding:        ScreenTools.comboBoxPadding
     spacing:        ScreenTools.defaultFontPixelWidth
+    font.pointSize: ScreenTools.defaultFontPointSize
+    font.family:    ScreenTools.normalFontFamily
     implicitWidth:  Math.max(background ? background.implicitWidth : 0,
                              contentItem.implicitWidth + leftPadding + rightPadding + padding)
     implicitHeight: Math.max(background ? background.implicitHeight : 0,
@@ -37,13 +39,13 @@ T.ComboBox {
     property real   _popupWidth:       sizeToContents ? _largestTextWidth + leftPadding + rightPadding : control.width
 
     TextMetrics {
-        id: textMetrics
+        id:         textMetrics
+        font:       control.font
     }
 
     onModelChanged: {
         if (sizeToContents) {
             _largestTextWidth = 0
-            textMetrics.font = control.font
             for (var i = 0; i < model.length; i++){
                 textMetrics.text = model[i]
                 _largestTextWidth = Math.max(textMetrics.width, _largestTextWidth)
@@ -59,8 +61,9 @@ T.ComboBox {
         property string _text: control.textRole ? (Array.isArray(control.model) ? modelData[control.textRole] : model[control.textRole]) : modelData
 
         TextMetrics {
-            id:    popupItemMetrics
-            text:  _text
+            id:             popupItemMetrics
+            font:           control.font
+            text:           _text
         }
 
         contentItem: Text {

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -146,8 +146,7 @@
     "units":                "pt",
     "min":                  6,
     "max":                  48,
-    "defaultValue":         0,
-    "qgcRebootRequired":    true
+    "defaultValue":         0
 },
 {
     "name":             "indoorPalette",

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -36,7 +36,7 @@ Rectangle {
     property Fact _userBrandImageIndoor:        QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoor
     property Fact _userBrandImageOutdoor:       QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoor
     property real _labelWidth:                  ScreenTools.defaultFontPixelWidth * 20
-    property real _comboFieldWidth:             ScreenTools.defaultFontPixelWidth * 28
+    property real _comboFieldWidth:             ScreenTools.defaultFontPixelWidth * 30
     property real _valueFieldWidth:             ScreenTools.defaultFontPixelWidth * 10
     property string _mapProvider:               QGroundControl.settingsManager.flightMapSettings.mapProvider.value
     property string _mapType:                   QGroundControl.settingsManager.flightMapSettings.mapType.value
@@ -197,14 +197,62 @@ Rectangle {
                                 }
 
                                 QGCLabel {
-                                    text:       qsTr("Stream GCS Position")
-                                    visible:    _followTarget.visible
+                                    text:                   qsTr("Stream GCS Position")
+                                    visible:                _followTarget.visible
                                 }
                                 FactComboBox {
                                     Layout.preferredWidth:  _comboFieldWidth
                                     fact:                   _followTarget
                                     indexModel:             false
                                     visible:                _followTarget.visible
+                                }
+                                QGCLabel {
+                                    text:                           qsTr("UI Scaling")
+                                    visible:                        _appFontPointSize.visible
+                                    Layout.alignment:               Qt.AlignVCenter
+                                }
+                                Item {
+                                    width:                          _comboFieldWidth
+                                    height:                         baseFontEdit.height * 1.5
+                                    visible:                        _appFontPointSize.visible
+                                    Layout.alignment:               Qt.AlignVCenter
+                                    Row {
+                                        spacing:                    ScreenTools.defaultFontPixelWidth
+                                        anchors.verticalCenter:     parent.verticalCenter
+                                        QGCButton {
+                                            width:                  height
+                                            height:                 baseFontEdit.height * 1.5
+                                            text:                   "-"
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            onClicked: {
+                                                if (_appFontPointSize.value > _appFontPointSize.min) {
+                                                    _appFontPointSize.value = _appFontPointSize.value - 1
+                                                }
+                                            }
+                                        }
+                                        QGCLabel {
+                                            id:                     baseFontEdit
+                                            width:                  ScreenTools.defaultFontPixelWidth * 6
+                                            text:                   (QGroundControl.settingsManager.appSettings.appFontPointSize.value / ScreenTools.platformFontPointSize * 100).toFixed(0) + "%"
+                                            horizontalAlignment:    Text.AlignHCenter
+                                            anchors.verticalCenter: parent.verticalCenter
+                                        }
+                                        Text {
+
+                                        }
+
+                                        QGCButton {
+                                            width:                  height
+                                            height:                 baseFontEdit.height * 1.5
+                                            text:                   "+"
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            onClicked: {
+                                                if (_appFontPointSize.value < _appFontPointSize.max) {
+                                                    _appFontPointSize.value = _appFontPointSize.value + 1
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -215,47 +263,13 @@ Rectangle {
                             anchors.left:       parent.left
                             anchors.right:      parent.right
                             anchors.top:        comboGridItem.bottom
+                            anchors.topMargin:  ScreenTools.defaultFontPixelHeight
                             height:             miscCol.height
 
                             ColumnLayout {
                                 id:                         miscCol
                                 anchors.horizontalCenter:   parent.horizontalCenter
                                 spacing:                    _margins
-
-                                RowLayout {
-                                    Layout.fillWidth:   false
-                                    Layout.alignment:   Qt.AlignHCenter
-                                    visible:             _appFontPointSize.visible
-
-                                    QGCLabel {
-                                        text:   qsTr("Font Size:")
-                                    }
-                                    QGCButton {
-                                        Layout.preferredWidth:  height
-                                        Layout.preferredHeight: baseFontEdit.height
-                                        text:                   "-"
-                                        onClicked: {
-                                            if (_appFontPointSize.value > _appFontPointSize.min) {
-                                                _appFontPointSize.value = _appFontPointSize.value - 1
-                                            }
-                                        }
-                                    }
-                                    FactTextField {
-                                        id:                     baseFontEdit
-                                        Layout.preferredWidth:  _valueFieldWidth
-                                        fact:                   QGroundControl.settingsManager.appSettings.appFontPointSize
-                                    }
-                                    QGCButton {
-                                        Layout.preferredWidth:  height
-                                        Layout.preferredHeight: baseFontEdit.height
-                                        text:                   "+"
-                                        onClicked: {
-                                            if (_appFontPointSize.value < _appFontPointSize.max) {
-                                                _appFontPointSize.value = _appFontPointSize.value + 1
-                                            }
-                                        }
-                                    }
-                                }
 
                                 FactCheckBox {
                                     text:       qsTr("Use Vehicle Pairing")


### PR DESCRIPTION
All sizing in QGC is based off the size of a single character using the system default font. The logic being that the size, in pixels of a same letter using a same font should be equivalently readable in all platforms.

Under General Settings, you can change this value, which in turn scales the entire UI up or down. The original entry under General Settings was "Font Size". From a user perspective, that doesn't make a whole lot of sense as nobody knows the intrinsic relationship between the font size and UI size.

This PR changes the terminology from _Font Size_ to _UI Scaling_. It also changes what the user sees. Instead of changing the font size (one integer at a time), the UI now shows a percentage value. When the current font size matches the default (for that given platform), you will now see 100% (instead of 13px for instance). As you increase the value, the code underneath is still adding/subtracting the size by one but the UI reflects the change using percentage.

* Change setting from _Font Size_ to _UI Scaling_.
* Change UI to show scaling percentage instead of the actual font point size.
* Allow changes to happen in real time (it used to require a restart to take effect)
* Fixed QGCComboBox where it was not specifying the font (the control was using the system default font) and using text metrics to compute intrinsic sizes.

<img width="1026" alt="Screen Shot 2020-01-23 at 3 57 19 PM" src="https://user-images.githubusercontent.com/749243/73019152-6d697400-3df9-11ea-914f-4e240f01ea5e.png">

<img width="1026" alt="Screen Shot 2020-01-23 at 3 57 12 PM" src="https://user-images.githubusercontent.com/749243/73019151-6cd0dd80-3df9-11ea-9433-9e69e7e461bc.png">

<img width="1026" alt="Screen Shot 2020-01-23 at 3 57 29 PM" src="https://user-images.githubusercontent.com/749243/73019153-6d697400-3df9-11ea-9c0d-31efbfbcfe02.png">
