### PR TITLE
Bring back non-coordinate display and waypoint sequence number

### DIFF
--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -32,6 +32,7 @@ MapQuickItem {
             id:                 _label
             checked:            _isCurrentItem
             label:              missionItem ? missionItem.abbreviation : ""
+            index:              missionItem ? missionItem.sequenceNumber : 0
             gimbalYaw:          missionItem.missionGimbalYaw
             vehicleYaw:         missionItem.missionVehicleYaw
             showGimbalYaw:      !isNaN(missionItem.missionGimbalYaw)

--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -110,6 +110,22 @@ Item {
             missionItem:    _missionItem
             sequenceNumber: _missionItem.sequenceNumber
             onClicked:      _root.clicked(_missionItem.sequenceNumber)
+            // These are the non-coordinate child mission items attached to this item
+            Row {
+                anchors.top:    parent.top
+                anchors.left:   parent.right
+                Repeater {
+                    model: _missionItem.childItems
+                    delegate: MissionItemIndexLabel {
+                        z:                      2
+                        label:                  object.abbreviation.length === 0 ? object.sequenceNumber : object.abbreviation.charAt(0)
+                        checked:                object.isCurrentItem
+                        child:                  true
+                        specifiesCoordinate:    false
+                        onClicked:              _root.clicked(object.sequenceNumber)
+                    }
+                }
+            }
         }
     }
 }

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -25,7 +25,7 @@ Canvas {
     property real   gimbalYaw
     property real   vehicleYaw
     property bool   showGimbalYaw:          false
-    property bool   showSequenceNumbers:    false
+    property bool   showSequenceNumbers:    true
 
     property real   _width:             showGimbalYaw ? Math.max(_gimbalYawWidth, labelControl.visible ? labelControl.width : indicator.width) : (labelControl.visible ? labelControl.width : indicator.width)
     property real   _height:            showGimbalYaw ? _gimbalYawWidth : (labelControl.visible ? labelControl.height : indicator.height)


### PR DESCRIPTION
The `Jump to` mission waypoint doesn't make sense without knowing the item numbers, therefore, bring back waypoint numbers and display of non-position waypoints like "Jump to". Hiding the non-position waypoints hides important mission actions.

Removed by the following PRs:
 - Remove non-coordinate items: #7771
 - Hide sequence numbers: #7830

This PR:
![Screenshot from 2020-01-28 21-09-03](https://user-images.githubusercontent.com/47554641/73301206-a26b3180-4212-11ea-9f83-8779b6c53110.png)

Current master:
![Screenshot from 2020-01-28 21-10-08](https://user-images.githubusercontent.com/47554641/73301207-a26b3180-4212-11ea-837c-c2a67b937345.png)
