### PR TITLE
Various fixes

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -367,11 +367,11 @@ Item {
                     name:   "pipMode"
                     PropertyChanges {
                         target:             _flightVideo
-                        anchors.margins:    _toolsMargin
+                        anchors.margins:    ScreenTools.defaultFontPixelHeight
                     }
                     PropertyChanges {
-                        target: _flightVideoPipControl
-                        inPopup: false
+                        target:             _flightVideoPipControl
+                        inPopup:            false
                     }
                 },
                 State {
@@ -381,8 +381,8 @@ Item {
                         anchors.margins:    0
                     }
                     PropertyChanges {
-                        target:     _flightVideoPipControl
-                        inPopup:    false
+                        target:             _flightVideoPipControl
+                        inPopup:            false
                     }
                 },
                 State {
@@ -396,19 +396,19 @@ Item {
                         }
                     }
                     PropertyChanges {
-                        target: _flightVideoPipControl
-                        inPopup: true
+                        target:             _flightVideoPipControl
+                        inPopup:            true
                     }
                 },
                 State {
                     name: "popup-finished"
                     ParentChange {
-                        target: _flightVideo
-                        parent: videoItem
-                        x:      0
-                        y:      0
-                        width:  videoItem.width
-                        height: videoItem.height
+                        target:             _flightVideo
+                        parent:             videoItem
+                        x:                  0
+                        y:                  0
+                        width:              videoItem.width
+                        height:             videoItem.height
                     }
                 },
                 State {
@@ -420,12 +420,12 @@ Item {
                         }
                     }
                     ParentChange {
-                        target: _flightVideo
-                        parent: _mapAndVideo
+                        target:             _flightVideo
+                        parent:             _mapAndVideo
                     }
                     PropertyChanges {
-                        target: _flightVideoPipControl
-                        inPopup: false
+                        target:             _flightVideoPipControl
+                        inPopup:             false
                     }
                 }
             ]

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -390,7 +390,7 @@ Item {
                     StateChangeScript {
                         script: {
                             // Stop video, restart it again with Timer
-                            // Avoiding crashs if ParentChange is not yet done
+                            // Avoiding crashes if ParentChange is not yet done
                             QGroundControl.videoManager.stopVideo()
                             videoPopUpTimer.running = true
                         }

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -49,7 +49,6 @@ Item {
     property var    _rallyPointController:          _planController.rallyPointController
     property bool   _isPipVisible:                  QGroundControl.videoManager.hasVideo ? QGroundControl.loadBoolGlobalSetting(_PIPVisibleKey, true) : false
     property bool   _useChecklist:                  QGroundControl.settingsManager.appSettings.useChecklist.rawValue && QGroundControl.corePlugin.options.preFlightChecklistUrl.toString().length
-    property real   _savedZoomLevel:                0
     property real   _margins:                       ScreenTools.defaultFontPixelWidth / 2
     property real   _pipSize:                       mainWindow.width * 0.2
     property alias  _guidedController:              guidedActionsController
@@ -75,25 +74,10 @@ Item {
             //-- Adjust Margins
             _flightMapContainer.state   = "fullMode"
             _flightVideo.state          = "pipMode"
-            //-- Save/Restore Map Zoom Level
-            if(_savedZoomLevel != 0) {
-                if(mainWindow.flightDisplayMap) {
-                    mainWindow.flightDisplayMap.zoomLevel = _savedZoomLevel
-                }
-            } else {
-                if(mainWindow.flightDisplayMap) {
-                    _savedZoomLevel = mainWindow.flightDisplayMap.zoomLevel
-                }
-            }
         } else {
             //-- Adjust Margins
             _flightMapContainer.state   = "pipMode"
             _flightVideo.state          = "fullMode"
-            //-- Set Map Zoom Level
-            if(mainWindow.flightDisplayMap) {
-                _savedZoomLevel = mainWindow.flightDisplayMap.zoomLevel
-                mainWindow.flightDisplayMap.zoomLevel = _savedZoomLevel - 3
-            }
         }
     }
 
@@ -335,6 +319,7 @@ Item {
                 scaleState:                 (mainIsMap && flyViewOverlay.item) ? (flyViewOverlay.item.scaleState ? flyViewOverlay.item.scaleState : "bottomMode") : "bottomMode"
                 Component.onCompleted: {
                     mainWindow.flightDisplayMap = _fMap
+                    _fMap.adjustMapSize()
                 }
             }
         }
@@ -459,6 +444,7 @@ Item {
             onActivated: {
                 mainIsMap = !mainIsMap
                 setStates()
+                _fMap.adjustMapSize()
             }
             onHideIt: {
                 setPipVisibility(!state)

--- a/src/FlightDisplay/FlightDisplayViewMap.qml
+++ b/src/FlightDisplay/FlightDisplayViewMap.qml
@@ -30,6 +30,8 @@ FlightMap {
     allowGCSLocationCenter:     !userPanned
     allowVehicleLocationCenter: !_keepVehicleCentered
     planView:                   false
+    zoomLevel:                  QGroundControl.flightMapZoom
+    center:                     QGroundControl.flightMapPosition
 
     property alias  scaleState: mapScale.state
 
@@ -52,6 +54,7 @@ FlightMap {
 
     property bool   _disableVehicleTracking:    false
     property bool   _keepVehicleCentered:       mainIsMap ? false : true
+    property bool   _pipping:                   false
 
     function updateAirspace(reset) {
         if(_airspaceEnabled) {
@@ -63,11 +66,41 @@ FlightMap {
         }
     }
 
+    function pipIn() {
+        if(QGroundControl.flightMapZoom > 3) {
+            _pipping = true;
+            zoomLevel = QGroundControl.flightMapZoom - 3
+            _pipping = false;
+        }
+    }
+
+    function pipOut() {
+        _pipping = true;
+        zoomLevel = QGroundControl.flightMapZoom
+        _pipping = false;
+    }
+
+    function adjustMapSize() {
+        if(mainIsMap)
+            pipOut()
+        else
+            pipIn()
+    }
+
     // Track last known map position and zoom from Fly view in settings
 
+    onVisibleChanged: {
+        if(visible) {
+            adjustMapSize()
+            center    = QGroundControl.flightMapPosition
+        }
+    }
+
     onZoomLevelChanged: {
-        QGroundControl.flightMapZoom = zoomLevel
-        updateAirspace(false)
+        if(!_pipping) {
+            QGroundControl.flightMapZoom = zoomLevel
+            updateAirspace(false)
+        }
     }
     onCenterChanged: {
         QGroundControl.flightMapPosition = center

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -78,7 +78,10 @@ Map {
     onGcsPositionChanged: {
         if (gcsPosition.isValid && allowGCSLocationCenter && !firstGCSPositionReceived && !firstVehiclePositionReceived) {
             firstGCSPositionReceived = true
-            center = gcsPosition
+            //-- Only center on gsc if we have no vehicle (and we are supposed to do so)
+            var activeVehicleCoordinate = activeVehicle ? activeVehicle.coordinate : QtPositioning.coordinate()
+            if(QGroundControl.settingsManager.flyViewSettings.keepMapCenteredOnVehicle.rawValue || !activeVehicleCoordinate.isValid)
+                center = gcsPosition
         }
     }
 

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -25,8 +25,6 @@ import QGroundControl.QGCPositionManager    1.0
 Map {
     id: _map
 
-    zoomLevel:                  QGroundControl.flightMapZoom
-    center:                     QGroundControl.flightMapPosition
     //-- Qt 5.9 has rotation gesture enabled by default. Here we limit the possible gestures.
     gesture.acceptedGestures:   MapGestureArea.PinchGesture | MapGestureArea.PanGesture | MapGestureArea.FlickGesture
     gesture.flickDeceleration:  3000
@@ -81,7 +79,6 @@ Map {
         if (gcsPosition.isValid && allowGCSLocationCenter && !firstGCSPositionReceived && !firstVehiclePositionReceived) {
             firstGCSPositionReceived = true
             center = gcsPosition
-            zoomLevel = QGroundControl.flightMapInitialZoom
         }
     }
 

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -105,8 +105,12 @@ Item {
     }
 
     onVisibleChanged: {
-        if (visible && !_planMasterController.containsItems) {
-            toolStrip.simulateClick(toolStrip.fileButtonIndex)
+        if(visible) {
+            editorMap.zoomLevel = QGroundControl.flightMapZoom
+            editorMap.center    = QGroundControl.flightMapPosition
+            if (!_planMasterController.containsItems) {
+                toolStrip.simulateClick(toolStrip.fileButtonIndex)
+            }
         }
     }
 
@@ -367,28 +371,28 @@ Item {
             allowVehicleLocationCenter: true
             planView:                   true
 
+            zoomLevel:                  QGroundControl.flightMapZoom
+            center:                     QGroundControl.flightMapPosition
+
             // This is the center rectangle of the map which is not obscured by tools
             property rect centerViewport:   Qt.rect(_leftToolWidth + _margin, _toolsMargin, editorMap.width - _leftToolWidth - _rightToolWidth - (_margin * 2), mapScale.y - _margin - _toolsMargin)
 
             property real _leftToolWidth:       toolStrip.x + toolStrip.width
             property real _rightToolWidth:      rightPanel.width + rightPanel.anchors.rightMargin
 
-            readonly property real animationDuration: 500
-
             // Initial map position duplicates Fly view position
             Component.onCompleted: editorMap.center = QGroundControl.flightMapPosition
 
-            Behavior on zoomLevel {
-                NumberAnimation {
-                    duration:       editorMap.animationDuration
-                    easing.type:    Easing.InOutQuad
-                }
-            }
-
             QGCMapPalette { id: mapPal; lightColors: editorMap.isSatelliteMap }
 
-            onZoomLevelChanged: updateAirspace(false)
-            onCenterChanged:    updateAirspace(false)
+            onZoomLevelChanged: {
+                QGroundControl.flightMapZoom = zoomLevel
+                updateAirspace(false)
+            }
+            onCenterChanged: {
+                QGroundControl.flightMapPosition = center
+                updateAirspace(false)
+            }
 
             MouseArea {
                 anchors.fill: parent

--- a/src/QmlControls/QGCSlider.qml
+++ b/src/QmlControls/QGCSlider.qml
@@ -68,7 +68,7 @@ Slider {
             radius:         _radius
             property real _radius: Math.round(ScreenTools.defaultFontPixelHeight * 0.75)
             Label {
-                text:               _root.value.toFixed(0)
+                text:               _root.value.toFixed( _root.maximumValue <= 1 ? 1 : 0)
                 visible:            _root.displayValue
                 anchors.centerIn:   parent
                 font.family:        ScreenTools.normalFontFamily

--- a/src/VehicleSetup/VehicleSummary.qml
+++ b/src/VehicleSetup/VehicleSummary.qml
@@ -132,7 +132,7 @@ Rectangle {
                             }
 
                             onClicked : {
-                                console.log(modelData.setupSource)
+                                //console.log(modelData.setupSource)
                                 if (modelData.setupSource !== "") {
                                     setupView.showVehicleComponentPanel(modelData)
                                 }

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -207,7 +207,7 @@ ApplicationWindow {
             dlgLoader.source = "QGCViewDialogContainer.qml"
         }
         onClosed: {
-            console.log("View switch ok")
+            //console.log("View switch ok")
             mainWindow.popPreventViewSwitch()
             dlgLoader.source = ""
         }


### PR DESCRIPTION
Little things that have been annoying me but never got around to dig into them and fix them:

* Tackled map zoom sync. There were (and still are) way too many places setting the map zoom level, all using different methods to keep track of what the setting should be. I think I got all the obvious offenders but I still see things that I'm not sure what they are doing or how to even test them.

* Fix video margins when video is in PIP mode. For some reason, someone changed the margin for video and it wasn't using the full available space (it was smaller than the map size when the map is in PIP mode).

* QGC had this annoying habit of switching the map center to the GCS location if the GCS started receiving GPS data after the vehicle. If we have vehicle GPS data and QGC is set to track the vehicle's position, don't change the map.

* Silence a few spurious debug output (all from the QML side).