### PR TITLE
Remove unused function

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -455,7 +455,6 @@ void QGCApplication::_shutdown()
     // Close out all Qml before we delete toolbox. This way we don't get all sorts of null reference complaints from Qml.
     delete _qmlAppEngine;
 
-    shutdownVideoStreaming();
     delete _toolbox;
 }
 

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -173,19 +173,3 @@ void initializeVideoStreaming(int &argc, char* argv[], char* logpath, char* debu
     qmlRegisterType<VideoItem>              ("QGroundControl.QgcQtGStreamer", 1, 0, "VideoItem");
     qmlRegisterUncreatableType<VideoSurface>("QGroundControl.QgcQtGStreamer", 1, 0, "VideoSurface", QStringLiteral("VideoSurface from QML is not supported"));
 }
-
-void shutdownVideoStreaming()
-{
-    /* From: http://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/gstreamer-Gst.html#gst-deinit
-     *
-     * "It is normally not needed to call this function in a normal application as the resources will automatically
-     * be freed when the program terminates. This function is therefore mostly used by testsuites and other memory
-     * profiling tools."
-     *
-     * It's causing a hang on exit. It hangs while deleting some thread.
-     *
-#if defined(QGC_GST_STREAMING)
-     gst_deinit();
-#endif
-    */
-}

--- a/src/VideoStreaming/VideoStreaming.h
+++ b/src/VideoStreaming/VideoStreaming.h
@@ -17,5 +17,5 @@
 #pragma once
 
 extern void initializeVideoStreaming    (int &argc, char *argv[], char* filename, char* debuglevel);
-extern void shutdownVideoStreaming      ();
+
 


### PR DESCRIPTION
Every single line of this function is commented out, and the
documentation of GStreamer says that it's uneeded.


