### PR TITLE
Allow developers (or advanced users) to override gstreamer debug settings

### DIFF
--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -132,7 +132,7 @@ void initializeVideoStreaming(int &argc, char* argv[], char* logpath, char* debu
         gst_ios_init();
     #else
         //-- Generic initialization
-        if (logpath) {
+        if (qgetenv("GST_DEBUG").isEmpty() && logpath) {
             QString gstDebugFile = QString("%1/%2").arg(logpath).arg("gstreamer-log.txt");
             qDebug() << "GStreamer debug output:" << gstDebugFile;
             if (debuglevel) {


### PR DESCRIPTION
It is quite useful if you set your gstreamer debug settings in QtCreator or environment and do not want to depend on QGC settings state (they are reset to default sometimes, for example).

This small change greatly simplifies my life. If other guys find it useful too then why not to have that in master?