### PR TITLE
Remove unnecessary pointer check before delete 

### DIFF
--- a/src/AirspaceManagement/AirspaceManager.cc
+++ b/src/AirspaceManagement/AirspaceManager.cc
@@ -48,21 +48,16 @@ AirspaceManager::AirspaceManager(QGCApplication* app, QGCToolbox* toolbox)
 //-----------------------------------------------------------------------------
 AirspaceManager::~AirspaceManager()
 {
-    if(_advisories) {
-        delete _advisories;
-    }
-    if(_weatherProvider) {
-        delete _weatherProvider;
-    }
-    if(_ruleSetsProvider) {
-        delete _ruleSetsProvider;
-    }
-    if(_airspaces) {
-        delete _airspaces;
-    }
-    if(_flightPlan) {
-        delete _flightPlan;
-    }
+    delete _advisories;
+    _advisories = nullptr;
+    delete _weatherProvider;
+    _weatherProvider = nullptr;
+    delete _ruleSetsProvider;
+    _ruleSetsProvider = nullptr;
+    delete _airspaces;
+    _airspaces = nullptr;
+    delete _flightPlan;
+    _flightPlan = nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -527,10 +527,9 @@ void LogDownloadController::downloadToDirectory(const QString& dir)
     //-- Stop listing just in case
     _receivedAllEntries();
     //-- Reset downloads, again just in case
-    if(_downloadData) {
-        delete _downloadData;
-        _downloadData = 0;
-    }
+    delete _downloadData;
+    _downloadData = nullptr;
+
     _downloadPath = dir;
     if(!_downloadPath.isEmpty()) {
         if(!_downloadPath.endsWith(QDir::separator()))
@@ -573,10 +572,9 @@ LogDownloadController::_getNextSelected()
 bool
 LogDownloadController::_prepareLogDownload()
 {
-    if(_downloadData) {
-        delete _downloadData;
-        _downloadData = nullptr;
-    }
+    delete _downloadData;
+    _downloadData = nullptr;
+
     QGCLogEntry* entry = _getNextSelected();
     if(!entry) {
         return false;

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -189,9 +189,8 @@ QGCCameraControl::QGCCameraControl(const mavlink_camera_information_t *info, Veh
 //-----------------------------------------------------------------------------
 QGCCameraControl::~QGCCameraControl()
 {
-    if(_netManager) {
-        delete _netManager;
-    }
+    delete _netManager;
+    _netManager = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -217,10 +216,9 @@ QGCCameraControl::_initWhenReady()
     QTimer::singleShot(2500, this, &QGCCameraControl::_requestStorageInfo);
     _captureStatusTimer.start(2750);
     emit infoChanged();
-    if(_netManager) {
-        delete _netManager;
-        _netManager = nullptr;
-    }
+
+    delete _netManager;
+    _netManager = nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -39,12 +39,10 @@ VideoManager::VideoManager(QGCApplication* app, QGCToolbox* toolbox)
 //-----------------------------------------------------------------------------
 VideoManager::~VideoManager()
 {
-    if(_videoReceiver) {
-        delete _videoReceiver;
-    }
-    if(_thermalVideoReceiver) {
-        delete _thermalVideoReceiver;
-    }
+    delete _videoReceiver;
+    _videoReceiver = nullptr;
+    delete _thermalVideoReceiver;
+    _thermalVideoReceiver = nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -60,10 +60,8 @@ getQGCMapEngine()
 void
 destroyMapEngine()
 {
-    if(kMapEngine) {
-        delete kMapEngine;
-        kMapEngine = nullptr;
-    }
+    delete kMapEngine;
+    kMapEngine = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -105,8 +103,8 @@ QGCMapEngine::~QGCMapEngine()
 {
     _worker.quit();
     _worker.wait();
-    if(_urlFactory)
-        delete _urlFactory;
+    delete _urlFactory;
+    _urlFactory = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -373,8 +371,8 @@ int
 QGCMapEngine::concurrentDownloads(QString type)
 {
     Q_UNUSED(type);
-    // TODO : We may want different values depending on 
-    // the provider here, let it like this as all provider are set to 12 
+    // TODO : We may want different values depending on
+    // the provider here, let it like this as all provider are set to 12
     // at the moment
     return 12;
 }
@@ -408,4 +406,3 @@ QGCMapEngine::_internetStatus(bool active)
 }
 
 // Resolution math: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Resolution_and_Scale
-

--- a/src/QtLocationPlugin/QGCMapEngineData.h
+++ b/src/QtLocationPlugin/QGCMapEngineData.h
@@ -243,8 +243,8 @@ public:
 
     ~QGCSaveTileTask()
     {
-        if(_tile)
-            delete _tile;
+        delete _tile;
+        _tile = nullptr;
     }
 
     QGCCacheTile*   tile() { return _tile; }

--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -61,9 +61,8 @@ QGCCachedTileSet::QGCCachedTileSet(const QString& name)
 //-----------------------------------------------------------------------------
 QGCCachedTileSet::~QGCCachedTileSet()
 {
-    if(_networkManager) {
-        delete _networkManager;
-    }
+    delete _networkManager;
+    _networkManager = nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -688,9 +688,8 @@ MAVLinkLogManager::_sendLog(const QString& logFile)
     }
     QFile* file = new QFile(logFile);
     if(!file || !file->open(QIODevice::ReadOnly)) {
-        if(file) {
-            delete file;
-        }
+        delete file;
+        file = nullptr;
         qCWarning(MAVLinkLogManagerLog) << "Could not open log file:" << logFile;
         return false;
     }
@@ -929,10 +928,7 @@ MAVLinkLogManager::_discardLog()
 bool
 MAVLinkLogManager::_createNewLog()
 {
-    if(_logProcessor) {
-        delete _logProcessor;
-        _logProcessor = nullptr;
-    }
+    delete _logProcessor;
     _logProcessor = new MAVLinkLogProcessor;
     if(_logProcessor->create(this, _logPath, static_cast<uint8_t>(_vehicle->id()))) {
         _insertNewLog(_logProcessor->record());

--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -140,10 +140,9 @@ void
 VideoReceiver::_tcp_timeout()
 {
     //-- If socket is live, we got no connection nor a socket error
-    if(_socket) {
-        delete _socket;
-        _socket = nullptr;
-    }
+    delete _socket;
+    _socket = nullptr;
+
     if(_videoSettings->streamEnabled()->rawValue().toBool()) {
         //-- RTSP will try to connect to the server. If it cannot connect,
         //   it will simply give up and never try again. Instead, we keep


### PR DESCRIPTION
Fix #8247 
> The C++ language guarantees that delete p will do nothing if p is null. Since you might get the test backwards, and since most testing methodologies force you to explicitly test every branch point, you should not put in the redundant if test.