### PR TITLE
Battery status fixes

### DIFF
--- a/src/Vehicle/BatteryFact.json
+++ b/src/Vehicle/BatteryFact.json
@@ -9,21 +9,21 @@
 {
     "name":             "percentRemaining",
     "shortDescription": "Percent",
-    "type":             "int32",
+    "type":             "double",
     "decimalPlaces":    0,
     "units":            "%"
 },
 {
     "name":             "mahConsumed",
     "shortDescription": "Consumed",
-    "type":             "int32",
-     "decimalPlaces":    0,
-     "units":            "mAh"
+    "type":             "double",
+    "decimalPlaces":    0,
+    "units":            "mAh"
 },
 {
     "name":             "current",
     "shortDescription": "Current",
-    "type":             "float",
+    "type":             "double",
     "decimalPlaces":    2,
     "units":            "A"
 },
@@ -37,27 +37,29 @@
 {
     "name":             "cellCount",
     "shortDescription": "Cell Count",
-    "type":             "int32",
+    "type":             "double",
+    "decimalPlaces":    0,
     "decimalPlaces":    0
 },
 {
     "name":             "instantPower",
     "shortDescription": "Watts",
-    "type":             "float",
+    "type":             "double",
     "decimalPlaces":    2,
     "units":            "W"
 },
 {
     "name":             "timeRemaining",
     "shortDescription": "Time Remaining",
-    "type":             "int32",
+    "type":             "double",
+    "decimalPlaces":    0,
     "units":            "s"
 },
 {
     "name":             "chargeState",
     "shortDescription": "Charge State",
     "type":             "uint8",
-    "enumStrings":      "Low Battery State Not Provided,Normal Operation,Low Battery State,Critical Battery State,Emergency Battery State,Battery Failed,Battery Unhealthy",
+    "enumStrings":      "N/A,Normal Operation,Low Battery State,Critical Battery State,Emergency Battery State,Battery Failed,Battery Unhealthy",
     "enumValues":       "0,1,2,3,4,5,6",
     "decimalPlaces":    0
 }

--- a/src/Vehicle/BatteryFact.json
+++ b/src/Vehicle/BatteryFact.json
@@ -59,7 +59,7 @@
     "name":             "chargeState",
     "shortDescription": "Charge State",
     "type":             "uint8",
-    "enumStrings":      "N/A,Normal Operation,Low Battery State,Critical Battery State,Emergency Battery State,Battery Failed,Battery Unhealthy",
+    "enumStrings":      "n/a,Normal Operation,Low Battery State,Critical Battery State,Emergency Battery State,Battery Failed,Battery Unhealthy",
     "enumValues":       "0,1,2,3,4,5,6",
     "decimalPlaces":    0
 }

--- a/src/Vehicle/BatteryFact.json
+++ b/src/Vehicle/BatteryFact.json
@@ -35,13 +35,6 @@
     "units":            "C"
 },
 {
-    "name":             "cellCount",
-    "shortDescription": "Cell Count",
-    "type":             "double",
-    "decimalPlaces":    0,
-    "decimalPlaces":    0
-},
-{
     "name":             "instantPower",
     "shortDescription": "Watts",
     "type":             "double",

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1613,22 +1613,18 @@ void Vehicle::_handleBatteryStatus(mavlink_message_t& message)
         return;
     }
 
-    int cellCount = 0;
     double voltage = qQNaN();
     for (int i=0; i<10; i++) {
         double cellVoltage = bat_status.voltages[i] == UINT16_MAX ? qQNaN() : static_cast<double>(bat_status.voltages[i]) / 1000.0;
         if (qIsNaN(cellVoltage)) {
             break;
         }
-        cellCount++;
         if (i == 0) {
             voltage = cellVoltage;
         } else {
             voltage += cellVoltage;
         }
     }
-    pBatteryFactGroup->cellCount()->setRawValue(cellCount == 0 ? qQNaN() : cellCount);
-
 
     pBatteryFactGroup->temperature()->setRawValue(bat_status.temperature == INT16_MAX ? qQNaN() : static_cast<double>(bat_status.temperature) / 100.0);
     pBatteryFactGroup->mahConsumed()->setRawValue(bat_status.current_consumed == -1  ? qQNaN() : bat_status.current_consumed);
@@ -4265,7 +4261,6 @@ const char* VehicleBatteryFactGroup::_percentRemainingFactName =            "per
 const char* VehicleBatteryFactGroup::_mahConsumedFactName =                 "mahConsumed";
 const char* VehicleBatteryFactGroup::_currentFactName =                     "current";
 const char* VehicleBatteryFactGroup::_temperatureFactName =                 "temperature";
-const char* VehicleBatteryFactGroup::_cellCountFactName =                   "cellCount";
 const char* VehicleBatteryFactGroup::_instantPowerFactName =                "instantPower";
 const char* VehicleBatteryFactGroup::_timeRemainingFactName =               "timeRemaining";
 const char* VehicleBatteryFactGroup::_chargeStateFactName =                 "chargeState";
@@ -4279,7 +4274,6 @@ VehicleBatteryFactGroup::VehicleBatteryFactGroup(QObject* parent)
     , _mahConsumedFact              (0, _mahConsumedFactName,               FactMetaData::valueTypeDouble)
     , _currentFact                  (0, _currentFactName,                   FactMetaData::valueTypeDouble)
     , _temperatureFact              (0, _temperatureFactName,               FactMetaData::valueTypeDouble)
-    , _cellCountFact                (0, _cellCountFactName,                 FactMetaData::valueTypeDouble)
     , _instantPowerFact             (0, _instantPowerFactName,              FactMetaData::valueTypeDouble)
     , _timeRemainingFact            (0, _timeRemainingFactName,             FactMetaData::valueTypeDouble)
     , _chargeStateFact              (0, _chargeStateFactName,               FactMetaData::valueTypeUint8)
@@ -4289,7 +4283,6 @@ VehicleBatteryFactGroup::VehicleBatteryFactGroup(QObject* parent)
     _addFact(&_mahConsumedFact,             _mahConsumedFactName);
     _addFact(&_currentFact,                 _currentFactName);
     _addFact(&_temperatureFact,             _temperatureFactName);
-    _addFact(&_cellCountFact,               _cellCountFactName);
     _addFact(&_instantPowerFact,            _instantPowerFactName);
     _addFact(&_timeRemainingFact,           _timeRemainingFactName);
     _addFact(&_chargeStateFact,             _chargeStateFactName);
@@ -4300,7 +4293,6 @@ VehicleBatteryFactGroup::VehicleBatteryFactGroup(QObject* parent)
     _mahConsumedFact.setRawValue        (qQNaN());
     _currentFact.setRawValue            (qQNaN());
     _temperatureFact.setRawValue        (qQNaN());
-    _cellCountFact.setRawValue          (qQNaN());
     _instantPowerFact.setRawValue       (qQNaN());
     _timeRemainingFact.setRawValue      (qQNaN());
     _chargeStateFact.setRawValue        (MAV_BATTERY_CHARGE_STATE_UNDEFINED);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -256,7 +256,6 @@ public:
     Q_PROPERTY(Fact* mahConsumed        READ mahConsumed        CONSTANT)
     Q_PROPERTY(Fact* current            READ current            CONSTANT)
     Q_PROPERTY(Fact* temperature        READ temperature        CONSTANT)
-    Q_PROPERTY(Fact* cellCount          READ cellCount          CONSTANT)
     Q_PROPERTY(Fact* instantPower       READ instantPower       CONSTANT)
     Q_PROPERTY(Fact* timeRemaining      READ timeRemaining      CONSTANT)
     Q_PROPERTY(Fact* chargeState        READ chargeState        CONSTANT)
@@ -266,7 +265,6 @@ public:
     Fact* mahConsumed               () { return &_mahConsumedFact; }
     Fact* current                   () { return &_currentFact; }
     Fact* temperature               () { return &_temperatureFact; }
-    Fact* cellCount                 () { return &_cellCountFact; }
     Fact* instantPower              () { return &_instantPowerFact; }
     Fact* timeRemaining             () { return &_timeRemainingFact; }
     Fact* chargeState               () { return &_chargeStateFact; }
@@ -276,7 +274,6 @@ public:
     static const char* _mahConsumedFactName;
     static const char* _currentFactName;
     static const char* _temperatureFactName;
-    static const char* _cellCountFactName;
     static const char* _instantPowerFactName;
     static const char* _timeRemainingFactName;
     static const char* _chargeStateFactName;
@@ -289,7 +286,6 @@ private:
     Fact            _mahConsumedFact;
     Fact            _currentFact;
     Fact            _temperatureFact;
-    Fact            _cellCountFact;
     Fact            _instantPowerFact;
     Fact            _timeRemainingFact;
     Fact            _chargeStateFact;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -283,14 +283,6 @@ public:
 
     static const char* _settingsGroup;
 
-    static const double _voltageUnavailable;
-    static const int    _percentRemainingUnavailable;
-    static const int    _mahConsumedUnavailable;
-    static const int    _currentUnavailable;
-    static const double _temperatureUnavailable;
-    static const int    _cellCountUnavailable;
-    static const double _instantPowerUnavailable;
-
 private:
     Fact            _voltageFact;
     Fact            _percentRemainingFact;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1348,6 +1348,7 @@ private:
     void _writeCsvLine                  ();
     void _flightTimerStart              ();
     void _flightTimerStop               ();
+    void _batteryStatusWorker           (int batteryId, double voltage, double current, double batteryRemainingPct);
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;


### PR DESCRIPTION
This is a fix for #8190.

* Fixed support for usage of BATTERY_STATUS and SYS_STATUS messages to get correct battery 1 and battery 2 values.
* Remove cellCount as a value available to BatteryFactGroup since it can't be calculated correctly.