### PR TITLE
Disable SiK Radio mavlink 1 downgrade code

### DIFF
--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -319,6 +319,11 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                 emit vehicleHeartbeatInfo(link, _message.sysid, _message.compid, highLatency2.autopilot, highLatency2.type);
             }
 
+#if 0
+            // Given the current state of SiK Radio firmwares there is no way to make the code below work.
+            // The ArduPilot implementation of SiK Radio firmware always sends MAVLINK_MSG_ID_RADIO_STATUS as a mavlink 1
+            // packet even if the vehicle is sending Mavlink 2.
+
             // Detect if we are talking to an old radio not supporting v2
             mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(mavlinkChannel);
             if (_message.msgid == MAVLINK_MSG_ID_RADIO_STATUS && _radio_version_mismatch_count != -1) {
@@ -337,6 +342,7 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                 qDebug() << "Switching outbound to mavlink 1.0 due to incoming mavlink 1.0 packet:" << mavlinkStatus << mavlinkChannel << mavlinkStatus->flags;
                 mavlinkStatus->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
             }
+#endif
 
             // Update MAVLink status on every 32th packet
             if ((totalReceiveCounter[mavlinkChannel] & 0x1F) == 0) {


### PR DESCRIPTION
Fix for #8203

MAVLinkProtocol had code which would downgrade the link to mavlink 1 based on the firmware of the MAVLINK_MSG_ID_RADIO_STATUS packet. This doesn't work because ArduPilot SiK Radio firmware always sends MAVLINK_MSG_ID_RADIO_STATUS as a mavlink 1 packet, even if the vehicle is sending mavlink 2.