### PR TITLE
cmake enable mavlink inspector by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,11 @@ if (GST_FOUND)
 
     include(qmlglsink.cmake)
 endif()
+
+add_definitions(
+    -DQGC_ENABLE_MAVLINK_INSPECTOR
+)
+
 #=============================================================================
 # Qt5
 #


### PR DESCRIPTION
Should this be tied to actual requirements?