### PR TITLE
Windows build fix

### DIFF
--- a/qmlglsink.cmake
+++ b/qmlglsink.cmake
@@ -41,7 +41,7 @@ elseif(APPLE)
 elseif(IOS)
 	target_compile_definitions(gst_plugins_good PUBLIC HAVE_QT_MAC)
 elseif(WIN32)
-	target_compile_definitions(gst_plugins_good PUBLIC HAVE_QT_WIN32)
+	target_compile_definitions(gst_plugins_good PUBLIC HAVE_QT_WIN32 HAVE_QT_QPA_HEADER)
 
 	# TODO: use FindOpenGL?
 	target_link_libraries(gst_plugins_good PUBLIC opengl32.lib user32.lib)

--- a/qmlglsink.pri
+++ b/qmlglsink.pri
@@ -8,7 +8,7 @@ LinuxBuild {
 } else:iOSBuild {
     DEFINES += HAVE_QT_IOS
 } else:WindowsBuild {
-    DEFINES += HAVE_QT_WIN32
+    DEFINES += HAVE_QT_WIN32 HAVE_QT_QPA_HEADER
     LIBS += opengl32.lib user32.lib
 } else:AndroidBuild {
     DEFINES += HAVE_QT_ANDROID


### PR DESCRIPTION
This patch fixes https://github.com/mavlink/qgroundcontrol/issues/8309 qmlglsink build issue for Windows (missed during qmlglsink re-sync with upstream).

@kshahar - thanks for all your help!
