### PR TITLE
Don't report missing parameter FRAME_CLASS

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -139,7 +139,7 @@ static QString s_findImageResourceRover(int frameClass, int frameType)
 }
 
 APMAirframeComponentController::APMAirframeComponentController(void)
-    : _frameClassFact   (getParameterFact(FactSystem::defaultComponentId, QStringLiteral("FRAME_CLASS")))
+    : _frameClassFact   (getParameterFact(FactSystem::defaultComponentId, QStringLiteral("FRAME_CLASS"), false /* reportMissing */))
     , _frameTypeFact    (getParameterFact(FactSystem::defaultComponentId, QStringLiteral("FRAME_TYPE"), false /* reportMissing */))
     , _frameClassModel  (new QmlObjectListModel(this))
 {


### PR DESCRIPTION
ArduSub doesn't have this parameter, this gets rid of the "missing param" warning.

Fix #8319 