### PR TITLE
Support colored text for checklist section headers

### DIFF
--- a/src/QmlControls/PreFlightCheckButton.qml
+++ b/src/QmlControls/PreFlightCheckButton.qml
@@ -32,6 +32,7 @@ QGCButton {
     property bool   telemetryFailure:               false   ///< true: telemetry check failing, false: telemetry check passing
     property bool   allowTelemetryFailureOverride:  false   ///< true: user can click past telemetry failure
     property bool   passed:                         _manualState === _statePassed && _telemetryState === _statePassed
+    property bool   failed:                         _manualState === _stateFailed || _telemetryState === _stateFailed
 
     property int _manualState:          manualText === "" ? _statePassed : _statePending
     property int _telemetryState:       _statePassed

--- a/src/QmlControls/PreFlightCheckGroup.qml
+++ b/src/QmlControls/PreFlightCheckGroup.qml
@@ -16,7 +16,12 @@ import QGroundControl.ScreenTools   1.0
 /// A PreFlightCheckGroup manages a set of PreFlightCheckButtons as a single entity.
 Column  {
     property string name
+    property string passedTextColor: "black"
+    property string failedTextColor: "black"
+    property string pendingTextColor: "black"
+
     property bool   passed: false
+    property bool   failed: false
 
     spacing: ScreenTools.defaultFontPixelHeight / 2
 
@@ -47,6 +52,7 @@ Column  {
         anchors.left:   parent.left
         anchors.right:  parent.right
         text:           name + (passed ? qsTr(" (passed)") : "")
+        color:          failed ? failedTextColor : (passed ? passedTextColor : pendingTextColor)
     }
 
     Column {
@@ -58,9 +64,11 @@ Column  {
             for (var i=0; i<children.length; i++) {
                 if (!children[i].passed) {
                     passed = false
+                    failed = children[i].failed
                     return
                 }
             }
+            failed = false
             passed = true
         }
     }

--- a/src/QmlControls/SectionHeader.qml
+++ b/src/QmlControls/SectionHeader.qml
@@ -10,6 +10,7 @@ FocusScope {
     id:     _root
     height: column.height
 
+    property alias          color:          label.color
     property alias          text:           label.text
     property bool           checked:        true
     property bool           showSpacer:     true


### PR DESCRIPTION
Added properties to enable changing the color of the checklist section headers based on the pass/fail status of the checklist items.

If any item in the group fails, the group header will display the `failedTextColor`. Once all items pass, the color will be the `passedTextColor`. Otherwise, the color will remain `pendingTextColor`


