### PR TITLE
Enforce checklist order property

### DIFF
--- a/src/QmlControls/PreFlightCheckModel.qml
+++ b/src/QmlControls/PreFlightCheckModel.qml
@@ -12,12 +12,17 @@ import QtQml.Models 2.1
 
 ObjectModel {
     id: _root
+    property bool enforceOrder: true
 
     function reset() {
         for (var i=0; i<_root.count; i++) {
             var group = _root.get(i)
             group.reset()
-            group.enabled = i === 0
+            if (enforceOrder) {
+                group.enabled = i === 0
+            } else {
+                group.enabled = true
+            }
             group._checked = i === 0
         }
     }


### PR DESCRIPTION
Added a property to the PreFlightCheckModel to enforce checklist order.

This can be set to `false` by a custom build that wishes to see all checklist subsections and complete them in any order.