### PR TITLE
Control main window size/position save/restore.

### DIFF
--- a/src/QmlControls/MainWindowSavedState.qml
+++ b/src/QmlControls/MainWindowSavedState.qml
@@ -12,10 +12,13 @@ import QtQuick.Window   2.11
 import QtQuick.Controls 2.4
 import Qt.labs.settings 1.0
 
-import QGroundControl.ScreenTools 1.0
+import QGroundControl               1.0
+import QGroundControl.ScreenTools   1.0
 
 Item {
     property Window window
+
+    property bool _enabled: !ScreenTools.isMobile && QGroundControl.corePlugin.options.enableSaveMainWindowPosition
 
     Settings {
         id:         s
@@ -29,7 +32,7 @@ Item {
     }
 
     Component.onCompleted: {
-        if (!ScreenTools.isMobile && s.width && s.height) {
+        if (_enabled && s.width && s.height) {
             window.x = s.x;
             window.y = s.y;
             window.width = s.width;
@@ -39,12 +42,12 @@ Item {
     }
 
     Connections {
-        target:                 ScreenTools.isMobile ? null : window
-        onXChanged:             saveSettingsTimer.restart()
-        onYChanged:             saveSettingsTimer.restart()
-        onWidthChanged:         saveSettingsTimer.restart()
-        onHeightChanged:        saveSettingsTimer.restart()
-        onVisibilityChanged:    saveSettingsTimer.restart()
+        target:                 window
+        onXChanged:             if(_enabled) saveSettingsTimer.restart()
+        onYChanged:             if(_enabled) saveSettingsTimer.restart()
+        onWidthChanged:         if(_enabled) saveSettingsTimer.restart()
+        onHeightChanged:        if(_enabled) saveSettingsTimer.restart()
+        onVisibilityChanged:    if(_enabled) saveSettingsTimer.restart()
     }
 
     Timer {
@@ -55,20 +58,22 @@ Item {
     }
 
     function saveSettings() {
-        switch(window.visibility) {
-        case ApplicationWindow.Windowed:
-            s.x = window.x;
-            s.y = window.y;
-            s.width = window.width;
-            s.height = window.height;
-            s.visibility = window.visibility;
-            break;
-        case ApplicationWindow.FullScreen:
-            s.visibility = window.visibility;
-            break;
-        case ApplicationWindow.Maximized:
-            s.visibility = window.visibility;
-            break;
+        if(_enabled) {
+            switch(window.visibility) {
+            case ApplicationWindow.Windowed:
+                s.x = window.x;
+                s.y = window.y;
+                s.width = window.width;
+                s.height = window.height;
+                s.visibility = window.visibility;
+                break;
+            case ApplicationWindow.FullScreen:
+                s.visibility = window.visibility;
+                break;
+            case ApplicationWindow.Maximized:
+                s.visibility = window.visibility;
+                break;
+            }
         }
     }
 }

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -66,6 +66,7 @@ public:
     Q_PROPERTY(bool                     showMavlinkLogOptions           READ showMavlinkLogOptions          CONSTANT)
     Q_PROPERTY(bool                     enableMultiVehicleList          READ enableMultiVehicleList         CONSTANT)
     Q_PROPERTY(bool                     enableMapScale                  READ enableMapScale                 CONSTANT)
+    Q_PROPERTY(bool                     enableSaveMainWindowPosition    READ enableSaveMainWindowPosition   CONSTANT)
 
     /// Should QGC hide its settings menu and colapse it into one single menu (Settings and Vehicle Setup)?
     /// @return true if QGC should consolidate both menus into one.
@@ -127,6 +128,8 @@ public:
     virtual bool    showMavlinkLogOptions           () const { return true; }
     virtual bool    enableMultiVehicleList          () const { return true; }
     virtual bool    enableMapScale                  () const { return true; }
+    /// Desktop builds save the main application size and position on close (and restore it on open)
+    virtual bool    enableSaveMainWindowPosition    () const { return true; }
 
 #if defined(__mobile__)
     virtual bool    useMobileFileDialog             () const { return true;}


### PR DESCRIPTION
Expose API to prevent QGC from saving the application window size and position on close (or restoring it on open). This is used on custom builds where the window position and size is controlled elsewhere (running Linux on a tablet for instance).


