### PR TITLE
Support for checklist status text color

### DIFF
--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -77,6 +77,9 @@ void QGCPalette::_buildMap()
     DECLARE_QGC_COLOR(alertText,            "#000000", "#000000", "#000000", "#000000")
     DECLARE_QGC_COLOR(missionItemEditor,    "#585858", "#dbfef8", "#585858", "#585d83")
     DECLARE_QGC_COLOR(hoverColor,           "#585858", "#dbfef8", "#585858", "#585d83")
+    DECLARE_QGC_COLOR(statusFailedText,     "#9d9d9d", "#000000", "#707070", "#ffffff")
+    DECLARE_QGC_COLOR(statusPassedText,     "#9d9d9d", "#000000", "#707070", "#ffffff")
+    DECLARE_QGC_COLOR(statusPendingText,    "#9d9d9d", "#000000", "#707070", "#ffffff")
 
     // Colors are not affecting by theming
     DECLARE_QGC_COLOR(mapWidgetBorderLight, "#ffffff", "#ffffff", "#ffffff", "#ffffff")

--- a/src/QGCPalette.h
+++ b/src/QGCPalette.h
@@ -115,6 +115,9 @@ public:
     DEFINE_QGC_COLOR(alertText,             setAlertText)
     DEFINE_QGC_COLOR(missionItemEditor,     setMissionItemEditor)
     DEFINE_QGC_COLOR(hoverColor,            setHoverColor)
+    DEFINE_QGC_COLOR(statusFailedText,      setstatusFailedText)
+    DEFINE_QGC_COLOR(statusPassedText,      setstatusPassedText)
+    DEFINE_QGC_COLOR(statusPendingText,     setstatusPendingText)
 
      QGCPalette(QObject* parent = nullptr);
     ~QGCPalette();

--- a/src/QmlControls/PreFlightCheckButton.qml
+++ b/src/QmlControls/PreFlightCheckButton.qml
@@ -32,6 +32,7 @@ QGCButton {
     property bool   telemetryFailure:               false   ///< true: telemetry check failing, false: telemetry check passing
     property bool   allowTelemetryFailureOverride:  false   ///< true: user can click past telemetry failure
     property bool   passed:                         _manualState === _statePassed && _telemetryState === _statePassed
+    property bool   failed:                         _manualState === _stateFailed || _telemetryState === _stateFailed
 
     property int _manualState:          manualText === "" ? _statePassed : _statePending
     property int _telemetryState:       _statePassed

--- a/src/QmlControls/PreFlightCheckGroup.qml
+++ b/src/QmlControls/PreFlightCheckGroup.qml
@@ -16,10 +16,6 @@ import QGroundControl.ScreenTools   1.0
 /// A PreFlightCheckGroup manages a set of PreFlightCheckButtons as a single entity.
 Column  {
     property string name
-    property string passedTextColor: "black"
-    property string failedTextColor: "black"
-    property string pendingTextColor: "black"
-
     property bool   passed: false
     property bool   failed: false
 
@@ -52,7 +48,7 @@ Column  {
         anchors.left:   parent.left
         anchors.right:  parent.right
         text:           name + (passed ? qsTr(" (passed)") : "")
-        color:          failed ? failedTextColor : (passed ? passedTextColor : pendingTextColor)
+        color:          failed ? qgcPal.statusFailedText : (passed ? qgcPal.statusPassedText : qgcPal.statusPendingText)
     }
 
     Column {

--- a/src/QmlControls/PreFlightCheckGroup.qml
+++ b/src/QmlControls/PreFlightCheckGroup.qml
@@ -16,7 +16,12 @@ import QGroundControl.ScreenTools   1.0
 /// A PreFlightCheckGroup manages a set of PreFlightCheckButtons as a single entity.
 Column  {
     property string name
+    property string passedTextColor: "black"
+    property string failedTextColor: "black"
+    property string pendingTextColor: "black"
+
     property bool   passed: false
+    property bool   failed: false
 
     spacing: ScreenTools.defaultFontPixelHeight / 2
 
@@ -47,6 +52,7 @@ Column  {
         anchors.left:   parent.left
         anchors.right:  parent.right
         text:           name + (passed ? qsTr(" (passed)") : "")
+        color:          failed ? failedTextColor : (passed ? passedTextColor : pendingTextColor)
     }
 
     Column {
@@ -58,9 +64,11 @@ Column  {
             for (var i=0; i<children.length; i++) {
                 if (!children[i].passed) {
                     passed = false
+                    failed = children[i].failed
                     return
                 }
             }
+            failed = false
             passed = true
         }
     }

--- a/src/QmlControls/SectionHeader.qml
+++ b/src/QmlControls/SectionHeader.qml
@@ -10,6 +10,7 @@ FocusScope {
     id:     _root
     height: column.height
 
+    property alias          color:          label.color
     property alias          text:           label.text
     property bool           checked:        true
     property bool           showSpacer:     true


### PR DESCRIPTION
This PR adds 3 new colors to the QGC palette:
- statusFailedText
- statusPassedText
- statusPendingText

These colors default to the standard `text` color, but are provided such that a custom build can override them. This PR also adds a small amount of logic to differentiate passed, failed, and pending checklist groups by introducing a `failed` property to the `PreFlightCheckGroup` QML type.