### PR TITLE
Use new tarballs for android gstreamer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ install:
   # android dependencies: qt, gstreamer, android-ndk
   - if [ "${SPEC}" = "android-clang" ]; then
         wget --quiet https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/gstreamer-1.0-android-${GSTREAMER_NAME}-1.14.4.tar.bz2 &&
-        tar jxf gstreamer-1.0-android-universal-1.14.4.tar.bz2 -C ${TRAVIS_BUILD_DIR} &&
+        tar jxf gstreamer-1.0-android-${GSTREAMER_NAME}-1.14.4.tar.bz2 -C ${TRAVIS_BUILD_DIR} &&
         wget --quiet https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip &&
         unzip android-ndk-r20-linux-x86_64.zip > /dev/null &&
         export ANDROID_NDK_ROOT=`pwd`/android-ndk-r20 &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,12 @@ matrix:
         - name: "Android 32 bit"
           dist: trusty
           language: android
-          env: SPEC=android-clang CONFIG=installer BITNESS=32
+          env: SPEC=android-clang CONFIG=installer BITNESS=32 GSTREAMER_NAME=armv7
           sudo: false
         - name: "Android 64 bit"
           dist: trusty
           language: android
-          env: SPEC=android-clang CONFIG=installer BITNESS=64
+          env: SPEC=android-clang CONFIG=installer BITNESS=64 GSTREAMER_NAME=arm64
           sudo: false
         - name: "OSX Installer"
           os: osx
@@ -96,7 +96,7 @@ install:
 
   # android dependencies: qt, gstreamer, android-ndk
   - if [ "${SPEC}" = "android-clang" ]; then
-        wget --quiet https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/gstreamer-1.0-android-universal-1.14.4.tar.bz2 &&
+        wget --quiet https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/gstreamer-1.0-android-${GSTREAMER_NAME}-1.14.4.tar.bz2 &&
         tar jxf gstreamer-1.0-android-universal-1.14.4.tar.bz2 -C ${TRAVIS_BUILD_DIR} &&
         wget --quiet https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip &&
         unzip android-ndk-r20-linux-x86_64.zip > /dev/null &&


### PR DESCRIPTION
* I created custom tarballs for armv7 and adm64 android gstreamer install and pushed them up to S3.
* Individual tarballs for each version speed up download times.
* There is a script to do this: https://qgroundcontrol.s3-us-west-2.amazonaws.com/dependencies/gstreamer-1.0-android-universal-1.14.4.tar.bz2
* Fix for #8283

Contents of script:
```
#!/bin/bash
# In order to support both 32 and 64 bit downloads with shorter download times we create our own variants of gstreamer-1.0-android-universal-1.14.4.tar.bz2.
# The normal version from gstreamer.freedesktop.org is a huge download since it includes all variants. This scripts creates custom versions
# of the tarball which only include a single variant. They continue to use the same 'universal' when expanded naming such that QGC builds
# continue to work with either the large standard version of the custom CI version.
#
# Note: https://qgroundcontrol.s3-us-west-2.amazonaws.com/dependencies/gstreamer-1.0-android-universal-1.14.4.tar.bz2 is no longer used by the built system.
# This custom variant had only the armv7 and x86 versions in it. It is kept on S3 for back compat with old builds.
#
set -e
mkdir gstreamer-1.0-android-universal-1.14.4
#wget https://gstreamer.freedesktop.org/data/pkg/android/1.14.4/gstreamer-1.0-android-universal-1.14.4.tar.bz2
tar -jxf gstreamer-1.0-android-universal-1.14.4.tar.bz2 -C gstreamer-1.0-android-universal-1.14.4
mkdir gstreamer-1.0-android-armv7-1.14.4
cp -r gstreamer-1.0-android-universal-1.14.4 gstreamer-1.0-android-armv7-1.14.4/.
rm -rf gstreamer-1.0-android-armv7-1.14.4/gstreamer-1.0-android-universal-1.14.4/arm
rm -rf gstreamer-1.0-android-armv7-1.14.4/gstreamer-1.0-android-universal-1.14.4/arm64
rm -rf gstreamer-1.0-android-armv7-1.14.4/gstreamer-1.0-android-universal-1.14.4/x86
rm -rf gstreamer-1.0-android-armv7-1.14.4/gstreamer-1.0-android-universal-1.14.4/x86_64
tar -jcvf gstreamer-1.0-android-armv7-1.14.4/gstreamer-1.0-android-armv7-1.14.4.tar.bz2 gstreamer-1.0-android-armv7-1.14.4/gstreamer-1.0-android-universal-1.14.4/
mkdir gstreamer-1.0-android-arm64-1.14.4
cp -r gstreamer-1.0-android-universal-1.14.4 gstreamer-1.0-android-arm64-1.14.4/.
rm -rf gstreamer-1.0-android-arm64-1.14.4/gstreamer-1.0-android-universal-1.14.4/arm
rm -rf gstreamer-1.0-android-arm64-1.14.4/gstreamer-1.0-android-universal-1.14.4/armv7
rm -rf gstreamer-1.0-android-arm64-1.14.4/gstreamer-1.0-android-universal-1.14.4/x86
rm -rf gstreamer-1.0-android-arm64-1.14.4/gstreamer-1.0-android-universal-1.14.4/x86_64
tar -jcvf gstreamer-1.0-android-arm64-1.14.4/gstreamer-1.0-android-arm64-1.14.4.tar.bz2 gstreamer-1.0-android-arm64-1.14.4/gstreamer-1.0-android-universal-1.14.4/
```