### PR TITLE
Start Mission slider appears when checklist is complete

### DIFF
--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -70,6 +70,12 @@ Item {
     readonly property string    _mainIsMapKey:          "MainFlyWindowIsMap"
     readonly property string    _PIPVisibleKey:         "IsPIPVisible"
 
+    on_CanArmChanged: {
+        if (_guidedController.showStartMission && _canArm) {
+            _guidedController.confirmAction(_guidedController.actionStartMission)
+        }
+    }
+
     function setStates() {
         QGroundControl.saveBoolGlobalSetting(_mainIsMapKey, mainIsMap)
         if(mainIsMap) {

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -76,6 +76,12 @@ Item {
         }
     }
 
+    onVisibleChanged: {
+        if (visible && activeVehicle && !_canArm) {
+            checklistDropPanel.open()
+        }
+    }
+
     function setStates() {
         QGroundControl.saveBoolGlobalSetting(_mainIsMapKey, mainIsMap)
         if(mainIsMap) {


### PR DESCRIPTION
When not using the preflight checklist, if a vehicle has a mission the **Start Mission** slider will pop up as soon as the vehicle connects.  This PR now provides the same behavior when using the checklist, as soon as the checklist is complete the **Start Mission** slider will appear