### PR TITLE
Fix PreFlightBatteryCheck issue with NaN

### DIFF
--- a/src/FlightDisplay/PreFlightBatteryCheck.qml
+++ b/src/FlightDisplay/PreFlightBatteryCheck.qml
@@ -25,6 +25,7 @@ PreFlightCheckButton {
 
     property int    failurePercent:                 40
     property bool   allowFailurePercentOverride:    false
-    property var    _batPercentRemaining:           activeVehicle ? activeVehicle.battery.percentRemaining.value : 0
+    property var    batteryValue:                   activeVehicle ? activeVehicle.battery.percentRemaining.value : 0
+    property var    _batPercentRemaining:           batteryValue ? batteryValue : 0
     property bool   _batLow:                        _batPercentRemaining < failurePercent
 }

--- a/src/FlightDisplay/PreFlightBatteryCheck.qml
+++ b/src/FlightDisplay/PreFlightBatteryCheck.qml
@@ -25,7 +25,7 @@ PreFlightCheckButton {
 
     property int    failurePercent:                 40
     property bool   allowFailurePercentOverride:    false
-    property var    batteryValue:                   activeVehicle ? activeVehicle.battery.percentRemaining.value : 0
-    property var    _batPercentRemaining:           batteryValue ? batteryValue : 0
+    property var    _batteryValue:                  activeVehicle ? activeVehicle.battery.percentRemaining.value : 0
+    property var    _batPercentRemaining:           isNaN(_batteryValue) ? 0 : _batteryValue
     property bool   _batLow:                        _batPercentRemaining < failurePercent
 }


### PR DESCRIPTION
When no battery is connected PX4 reports NaN as the battery percent remaining. This causes the preflight battery check to pass when it shouldn't. This fixes it.