### PR TITLE
Work around for random rectangles over maps

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -30,6 +30,9 @@ Map {
     gesture.flickDeceleration:  3000
     plugin:                     Plugin { name: "QGroundControl" }
 
+    // https://bugreports.qt.io/browse/QTBUG-82185
+    opacity:                    0.99
+
     property string mapName:                        'defaultMap'
     property bool   isSatelliteMap:                 activeMapType.name.indexOf("Satellite") > -1 || activeMapType.name.indexOf("Hybrid") > -1
     property var    gcsPosition:                    QGroundControl.qgcPositionManger.gcsPosition


### PR DESCRIPTION
This happens when using some QtQuick.Controls 2.x controls. I filed a bug with Qt and got a "work around" from it:

https://bugreports.qt.io/browse/QTBUG-82185

Fixes https://github.com/mavlink/qgroundcontrol/issues/7976
Fixes https://github.com/mavlink/qgroundcontrol/issues/8293

I'm starting with this PR alone. Subsequent to this I will be pushing another PR restoring proper QtQuick versions to something more current.
