### PR TITLE
QGCMAVLink: Remove mavlink warnings

### DIFF
--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -19,9 +19,18 @@
 #define MAVLINK_USE_MESSAGE_INFO
 #define MAVLINK_EXTERNAL_RX_STATUS  // Single m_mavlink_status instance is in QGCApplication.cc
 #include <stddef.h>                 // Hack workaround for Mav 2.0 header problem with respect to offsetof usage
+
+// Ignore warnings from mavlink headers for both GCC/Clang and MSVC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#pragma warning(push, 0)
+
 #include <mavlink_types.h>
 extern mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
 #include <mavlink.h>
+
+#pragma GCC diagnostic pop
+#pragma warning(pop, 0)
 
 class QGCMAVLink {
 public:


### PR DESCRIPTION
mavlink as submodule contains more warnings than particles in the universe.
This results in a terrible experience for developers, since it makes harder to find
real warning messages for QGC.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


