### PR TITLE
ArduPilot: Change follow to work above home altitude only

### DIFF
--- a/src/AutoPilotPlugins/APM/APMFollowComponent.FactMetaData.json
+++ b/src/AutoPilotPlugins/APM/APMFollowComponent.FactMetaData.json
@@ -20,7 +20,7 @@
 },
 {
     "name":             "height",
-    "shortDescription": "Vertical distance from ground station to vehicle",
+    "shortDescription": "Vertical distance from Launch (home) position to vehicle",
     "type":             "double",
     "min":              0,
     "decimalPlaces":    1,

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -1136,15 +1136,16 @@ void APMFirmwarePlugin::_sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMoti
     mavlink_global_position_int_t globalPositionInt;
     memset(&globalPositionInt, 0, sizeof(globalPositionInt));
 
+    // Important note: QGC only supports sending the constant GCS home position altitude for follow me.
     globalPositionInt.time_boot_ms =    static_cast<uint32_t>(qgcApp()->msecsSinceBoot());
     globalPositionInt.lat =             motionReport.lat_int;
     globalPositionInt.lon =             motionReport.lon_int;
-    globalPositionInt.alt =             static_cast<int32_t>(motionReport.altMetersAMSL * 1000);                                        // mm
-    globalPositionInt.relative_alt =    static_cast<int32_t>((motionReport.altMetersAMSL - vehicle->homePosition().altitude()) * 1000); // mm
-    globalPositionInt.vx =              static_cast<int16_t>(motionReport.vxMetersPerSec * 100);                                        // cm/sec
-    globalPositionInt.vy =              static_cast<int16_t>(motionReport.vyMetersPerSec * 100);                                        // cm/sec
-    globalPositionInt.vy =              static_cast<int16_t>(motionReport.vzMetersPerSec * 100);                                        // cm/sec
-    globalPositionInt.hdg =             static_cast<uint16_t>(motionReport.headingDegrees * 100.0);                                     // centi-degrees
+    globalPositionInt.alt =             static_cast<int32_t>(vehicle->homePosition().altitude() * 1000);    // mm
+    globalPositionInt.relative_alt =    static_cast<int32_t>(0);                                            // mm
+    globalPositionInt.vx =              static_cast<int16_t>(motionReport.vxMetersPerSec * 100);            // cm/sec
+    globalPositionInt.vy =              static_cast<int16_t>(motionReport.vyMetersPerSec * 100);            // cm/sec
+    globalPositionInt.vy =              static_cast<int16_t>(motionReport.vzMetersPerSec * 100);            // cm/sec
+    globalPositionInt.hdg =             static_cast<uint16_t>(motionReport.headingDegrees * 100.0);         // centi-degrees
 
     mavlink_message_t message;
     mavlink_msg_global_position_int_encode_chan(static_cast<uint8_t>(mavlinkProtocol->getSystemId()),


### PR DESCRIPTION
Initial starting point is this:
![Screen Shot 2020-02-17 at 12 06 33 PM](https://user-images.githubusercontent.com/5876851/74684090-cd94d100-517f-11ea-9cc3-35744511c624.png)

When you click Enable for the first time you get this:
![Screen Shot 2020-02-17 at 12 06 40 PM](https://user-images.githubusercontent.com/5876851/74684115-e3a29180-517f-11ea-9fc0-233b379460dd.png)
This is due to the fact that the default value set by the firmware are not usable by QGC setup. You can also end up here if you futz parameters in the parameter editor and then to go this page. Clicking 'Reset To Supported Settings' will set things up to a decent set of workable defaults.

Which then gets you here:
![Screen Shot 2020-02-17 at 12 17 02 PM](https://user-images.githubusercontent.com/5876851/74684197-219fb580-5180-11ea-885c-e48cb4447826.png)
I'm hoping this is all self explaining.

Then to active Follow Me you change to Follow Me flight mode.

Some important things to note:
* The height you are specifying is a relative height above launch/home position.
* If you are using a mode which requires a heading from the gcs then you may need to walk in a specific direction for a short distance such that the gcs gps has a valid heading to send.

Related to #8711

@hamishwillee Hoping this is enough details for you to help with docs.