### PR TITLE
Remove deprecated QString::sprintf

### DIFF
--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -222,7 +222,7 @@ QGCMapEngine::cacheTile(QString type, const QString& hash, const QByteArray& ima
 QString
 QGCMapEngine::getTileHash(QString type, int x, int y, int z)
 {
-    return QString().sprintf("%010d%08d%08d%03d", getQGCMapEngine()->urlFactory()->getIdFromType(type), x, y, z);
+    return QString::asprintf("%010d%08d%08d%03d", getQGCMapEngine()->urlFactory()->getIdFromType(type), x, y, z);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -553,7 +553,7 @@ QGCMapEngineManager::getUniqueName()
     int count = 1;
     while (true) {
         name = test;
-        name += QString().sprintf("%03d", count++);
+        name += QString::asprintf("%03d", count++);
         if(!findName(name))
             return name;
     }

--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -57,7 +57,7 @@ void TCPLink::_writeDebugBytes(const QByteArray data)
     for (int i=0, size = data.size(); i<size; i++)
     {
         unsigned char v = data[i];
-        bytes.append(QString().sprintf("%02x ", v));
+        bytes.append(QString::asprintf("%02x ", v));
         if (data[i] > 31 && data[i] < 127)
         {
             ascii.append(data[i]);


### PR DESCRIPTION
from the warning message:
```
note: 'sprintf' has been explicitly marked deprecated here
    QT_DEPRECATED_X("Use asprintf(), arg() or QTextStream instead")
```