### PR TITLE
Remove deprecated QTime::start function and use QELapsedTimer

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -15,6 +15,7 @@
 #include "RadioComponentController.h"
 #include "QGCApplication.h"
 
+#include <QElapsedTimer>
 #include <QSettings>
 
 QGC_LOGGING_CATEGORY(RadioComponentControllerLog, "RadioComponentControllerLog")

--- a/src/AutoPilotPlugins/Common/RadioComponentController.h
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.h
@@ -310,7 +310,7 @@ private:
     int     _stickDetectInitialValue;
     int     _stickDetectValue;
     bool    _stickDetectSettleStarted;
-    QTime   _stickDetectSettleElapsed;
+    QElapsedTimer   _stickDetectSettleElapsed;
     static const int _stickDetectSettleMSecs;
 
     bool        _unitTestMode   = false;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <QElapsedTimer>
 #include <QObject>
 #include <QVariantList>
 #include <QGeoCoordinate>
@@ -1515,7 +1516,7 @@ private:
     QString _gitHash;
     quint64 _uid;
 
-    QTime   _lastBatteryAnnouncement;
+    QElapsedTimer   _lastBatteryAnnouncement;
     int     _lastAnnouncedLowBatteryPercent;
 
     SharedLinkInterfacePointer _priorityLink;  // We always keep a reference to the priority link to manage shutdown ordering

--- a/src/VehicleSetup/Bootloader.cc
+++ b/src/VehicleSetup/Bootloader.cc
@@ -18,7 +18,7 @@
 #include <QFile>
 #include <QSerialPortInfo>
 #include <QDebug>
-#include <QTime>
+#include <QElapsedTimer>
 
 #include "QGC.h"
 
@@ -54,9 +54,9 @@ bool Bootloader::_write(QSerialPort* port, const uint8_t byte)
 bool Bootloader::_read(QSerialPort* port, uint8_t* data, qint64 maxSize, int readTimeout)
 {
     qint64 bytesAlreadyRead = 0;
-    
+
     while (bytesAlreadyRead < maxSize) {
-        QTime timeout;
+        QElapsedTimer timeout;
         timeout.start();
         while (port->bytesAvailable() < 1) {
             if (timeout.elapsed() > readTimeout) {

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -14,7 +14,7 @@
 #ifndef JoystickConfigController_H
 #define JoystickConfigController_H
 
-#include <QTimer>
+#include <QElapsedTimer>
 
 #include "FactPanelController.h"
 #include "QGCLoggingCategory.h"
@@ -273,7 +273,7 @@ private:
     int     _stickDetectInitialValue;
     int     _stickDetectValue;
     bool    _stickDetectSettleStarted;
-    QTime   _stickDetectSettleElapsed;
+    QElapsedTimer   _stickDetectSettleElapsed;
 
     static const int _stickDetectSettleMSecs;
 


### PR DESCRIPTION
Warning message:
```
 warning: 'start' is deprecated: Use QElapsedTimer instead
```