### PR TITLE
Fixed interactions between PreFlightCheckList and the FlightView

### DIFF
--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -96,13 +96,17 @@ Item {
     readonly property int actionVtolTransitionToMRFlight:   21
     readonly property int actionROI:                        22
 
+    property bool   _useChecklist:              QGroundControl.settingsManager.appSettings.useChecklist.rawValue && QGroundControl.corePlugin.options.preFlightChecklistUrl.toString().length
+    property bool   _enforceChecklist:          _useChecklist && QGroundControl.settingsManager.appSettings.enforceChecklist.rawValue
+    property bool   _canArm:                    activeVehicle ? (_useChecklist ? (_enforceChecklist ? activeVehicle.checkListState === Vehicle.CheckListPassed : true) : true) : false
+
     property bool showEmergenyStop:     _guidedActionsEnabled && !_hideEmergenyStop && _vehicleArmed && _vehicleFlying
-    property bool showArm:              _guidedActionsEnabled && !_vehicleArmed
+    property bool showArm:              _guidedActionsEnabled && !_vehicleArmed && _canArm
     property bool showDisarm:           _guidedActionsEnabled && _vehicleArmed && !_vehicleFlying
     property bool showRTL:              _guidedActionsEnabled && _vehicleArmed && activeVehicle.guidedModeSupported && _vehicleFlying && !_vehicleInRTLMode
-    property bool showTakeoff:          _guidedActionsEnabled && activeVehicle.takeoffVehicleSupported && !_vehicleFlying
+    property bool showTakeoff:          _guidedActionsEnabled && activeVehicle.takeoffVehicleSupported && !_vehicleFlying && _canArm
     property bool showLand:             _guidedActionsEnabled && activeVehicle.guidedModeSupported && _vehicleArmed && !activeVehicle.fixedWing && !_vehicleInLandMode
-    property bool showStartMission:     _guidedActionsEnabled && _missionAvailable && !_missionActive && !_vehicleFlying
+    property bool showStartMission:     _guidedActionsEnabled && _missionAvailable && !_missionActive && !_vehicleFlying && _canArm
     property bool showContinueMission:  _guidedActionsEnabled && _missionAvailable && !_missionActive && _vehicleArmed && _vehicleFlying && (_currentMissionIndex < _missionItemCount - 1)
     property bool showPause:            _guidedActionsEnabled && _vehicleArmed && activeVehicle.pauseVehicleSupported && _vehicleFlying && !_vehiclePaused && !_fixedWingOnApproach
     property bool showChangeAlt:        _guidedActionsEnabled && _vehicleFlying && activeVehicle.guidedModeSupported && _vehicleArmed && !_missionActive

--- a/src/FlightDisplay/PreFlightCheckList.qml
+++ b/src/FlightDisplay/PreFlightCheckList.qml
@@ -30,7 +30,15 @@ Rectangle {
         source: "/checklists/DefaultChecklist.qml"
     }
 
-    property bool _passed:  false
+    property bool allChecksPassed:  false
+
+    onAllChecksPassedChanged: {
+        if (allChecksPassed) {
+            activeVehicle.checkListState = Vehicle.CheckListPassed
+        } else {
+            activeVehicle.checkListState = Vehicle.CheckListFailed
+        }
+    }
 
     function _handleGroupPassedChanged(index, passed) {
         if (passed) {
@@ -53,7 +61,7 @@ Rectangle {
                 break
             }
         }
-        _passed = allPassed;
+        allChecksPassed = allPassed;
     }
 
     //-- Pick a checklist model that matches the current airframe type (if any)
@@ -85,12 +93,6 @@ Rectangle {
         if(activeVehicle) {
             if(visible) {
                 _updateModel()
-            } else {
-                if(modelContainer.item.model.isPassed()) {
-                    activeVehicle.checkListState = Vehicle.CheckListPassed
-                } else {
-                    activeVehicle.checkListState = Vehicle.CheckListFailed
-                }
             }
         }
     }
@@ -139,7 +141,7 @@ Rectangle {
                 height:     1.75 * ScreenTools.defaultFontPixelHeight
 
                 QGCLabel {
-                    text:                   qsTr("Pre-Flight Checklist %1").arg(_passed ? qsTr("(passed)") : "")
+                    text:                   qsTr("Pre-Flight Checklist %1").arg(allChecksPassed ? qsTr("(passed)") : "")
                     anchors.left:           parent.left
                     anchors.verticalCenter: parent.verticalCenter
                     font.pointSize:         ScreenTools.mediumFontPointSize


### PR DESCRIPTION
This PR accomplishes 3 things:

1. Checklist logic for `_canArm` when using **enforceChecklist** has moved to the GuidedActionsController. This allows the Flight View to properly catch the signals that depend on the preflight checklist (canArm, startMission, etc)

2. Updating of the `Vehicle.checkListState` in the PreFlightCheckList from the `onAllChecksPassedChanged` signal, as opposed to the `onVisibleChanged` signal. 

3. Added a timer with a 1 second delay to forcing opening the checklist when navigating to the Flight View if using **enforceChecklist**. This timer also triggers closing the checklist once complete.