### PR TITLE
Fix possibility of AUTOPILOT_VERSION message crashing QGC

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -79,8 +79,9 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
                 _components.append(QVariant::fromValue((VehicleComponent*)_radioComponent));
             }
 
+            FwVersion vehicleVersion(_vehicle->firmwareMajorVersion(), _vehicle->firmwareMinorVersion(), _vehicle->firmwarePatchVersion());
             // No flight modes component for Sub versions 3.5 and up
-            if (!_vehicle->sub() || (_vehicle->versionCompare(3, 5, 0) < 0)) {
+            if (!_vehicle->sub() || (vehicleVersion.compare(FwVersion(3, 5, 0)) < 0)) {
                 _flightModesComponent = new APMFlightModesComponent(_vehicle, this);
                 _flightModesComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_flightModesComponent));
@@ -94,7 +95,7 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
             _powerComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue((VehicleComponent*)_powerComponent));
 
-            if (!_vehicle->sub() || (_vehicle->sub() && _vehicle->versionCompare(3, 5, 3) >= 0)) {
+            if (!_vehicle->sub() || (_vehicle->sub() && vehicleVersion.compare(FwVersion(3, 5, 3)) >= 0)) {
                 _motorComponent = new APMMotorComponent(_vehicle, this);
                 _motorComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_motorComponent));
@@ -111,7 +112,7 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
                 _components.append(QVariant::fromValue((VehicleComponent*)_followComponent));
             }
 
-            if (_vehicle->vehicleType() == MAV_TYPE_HELICOPTER && (_vehicle->versionCompare(4, 0, 0) >= 0)) {
+            if (_vehicle->vehicleType() == MAV_TYPE_HELICOPTER && (vehicleVersion.compare(FwVersion(4, 0, 0)) >= 0)) {
                 _heliComponent = new APMHeliComponent(_vehicle, this);
                 _heliComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_heliComponent));
@@ -130,7 +131,7 @@ const QVariantList& APMAutoPilotPlugin::vehicleComponents(void)
                 _lightsComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue((VehicleComponent*)_lightsComponent));
 
-                if(_vehicle->versionCompare(3, 5, 0) >= 0) {
+                if(vehicleVersion.compare(FwVersion(3, 5, 0)) >= 0) {
                     _subFrameComponent = new APMSubFrameComponent(_vehicle, this);
                     _subFrameComponent->setupTriggerSignals();
                     _components.append(QVariant::fromValue((VehicleComponent*)_subFrameComponent));

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -827,6 +827,7 @@ void APMFirmwarePlugin::_artooSocketError(QAbstractSocket::SocketError socketErr
 
 QString APMFirmwarePlugin::internalParameterMetaDataFile(Vehicle* vehicle)
 {
+    FwVersion vehicleVersion(vehicle->firmwareMajorVersion(), vehicle->firmwareMinorVersion(), vehicle->firmwarePatchVersion());
     switch (vehicle->vehicleType()) {
     case MAV_TYPE_QUADROTOR:
     case MAV_TYPE_HEXAROTOR:
@@ -834,13 +835,13 @@ QString APMFirmwarePlugin::internalParameterMetaDataFile(Vehicle* vehicle)
     case MAV_TYPE_TRICOPTER:
     case MAV_TYPE_COAXIAL:
     case MAV_TYPE_HELICOPTER:
-        if (vehicle->versionCompare(4, 0, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(4, 0, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.4.0.xml");
         }
-        if (vehicle->versionCompare(3, 7, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(3, 7, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.7.xml");
         }
-        if (vehicle->versionCompare(3, 6, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(3, 6, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.6.xml");
         }
         return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Copter.3.5.xml");
@@ -853,38 +854,38 @@ QString APMFirmwarePlugin::internalParameterMetaDataFile(Vehicle* vehicle)
     case MAV_TYPE_VTOL_RESERVED4:
     case MAV_TYPE_VTOL_RESERVED5:
     case MAV_TYPE_FIXED_WING:
-        if (vehicle->versionCompare(4, 0, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(4, 0, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.4.0.xml");
         }
-        if (vehicle->versionCompare(3, 10, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(3, 10, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.10.xml");
         }
-        if (vehicle->versionCompare(3, 9, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(3, 9, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.9.xml");
         }
         return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Plane.3.8.xml");
 
     case MAV_TYPE_GROUND_ROVER:
     case MAV_TYPE_SURFACE_BOAT:
-        if (vehicle->versionCompare(4, 0, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(4, 0, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.4.0.xml");
         }
-        if (vehicle->versionCompare(3, 6, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(3, 6, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.6.xml");
         }
-        if (vehicle->versionCompare(3, 5, 0) >= 0) {
+        if (vehicleVersion.compare(FwVersion(3, 5, 0)) >= 0) {
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.5.xml");
         }
         return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Rover.3.4.xml");
 
     case MAV_TYPE_SUBMARINE:
-        if (vehicle->versionCompare(4, 0, 0) >= 0) { // 4.0.x
+        if (vehicleVersion.compare(FwVersion(4, 0, 0)) >= 0) { // 4.0.x
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.4.0.xml");
         }
-        if (vehicle->versionCompare(3, 6, 0) >= 0) { // 3.6.x
+        if (vehicleVersion.compare(FwVersion(3, 6, 0)) >= 0) { // 3.6.x
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.6.xml");
         }
-        if (vehicle->versionCompare(3, 5, 0) >= 0) { // 3.5.x
+        if (vehicleVersion.compare(FwVersion(3, 5, 0)) >= 0) { // 3.5.x
             return QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.Sub.3.5.xml");
         }
         // up to 3.4.x

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -18,6 +18,9 @@
 #include "ParameterManager.h"
 #include "PX4ParameterMetaData.h"
 
+/**
+ * Single ton instance used for handling firmware related information. Most of the functionality requires a Vehicle instance
+*/
 class PX4FirmwarePlugin : public FirmwarePlugin
 {
     Q_OBJECT

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -4030,16 +4030,6 @@ void Vehicle::_mavlinkMessageStatus(int uasId, uint64_t totalSent, uint64_t tota
     }
 }
 
-int  Vehicle::versionCompare(QString& compare)
-{
-    return _firmwarePlugin->versionCompare(this, compare);
-}
-
-int  Vehicle::versionCompare(int major, int minor, int patch)
-{
-    return _firmwarePlugin->versionCompare(this, major, minor, patch);
-}
-
 void Vehicle::_handleMessageInterval(const mavlink_message_t& message)
 {
     if (_pidTuningWaitingForRates) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -758,11 +758,6 @@ public:
     Q_INVOKABLE void triggerCamera();
     Q_INVOKABLE void sendPlan(QString planFile);
 
-    /// Used to check if running current version is equal or higher than the one being compared.
-    //  returns 1 if current > compare, 0 if current == compare, -1 if current < compare
-    Q_INVOKABLE int versionCompare(QString& compare);
-    Q_INVOKABLE int versionCompare(int major, int minor, int patch);
-
     /// Test motor
     ///     @param motor Motor number, 1-based
     ///     @param percent 0-no power, 100-full power


### PR DESCRIPTION
`FirmwarePlugin::checkIfIsLatestStable` is executed on every `AUTOPILOT_VERSION` message received from the vehicle which starts a file download to check the latest stable version. There were cases reported by autopilot sending too much of these and breaking QGC. Also on a failed attempt, we leave the object hanging.
This PR limits the firmware version file fetch to one instance only and logs the error reports as debug.


