### PR TITLE
Switch gstreamer to use Qt log API by default

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -319,27 +319,12 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 #endif
 
     // Gstreamer debug settings
-#if defined(__ios__) || defined(__android__)
-    // Initialize Video Streaming
-    initializeVideoStreaming(argc, argv, nullptr, nullptr);
-#else
-    QString savePath, gstDebugLevel;
-    if (settings.contains(AppSettings::savePathName)) {
-        savePath = settings.value(AppSettings::savePathName).toString();
-    }
-    if(savePath.isEmpty()) {
-        savePath = "/tmp";
-    }
-    savePath = savePath + "/Logs/gst";
-    if (!QDir(savePath).exists()) {
-        QDir().mkpath(savePath);
-    }
+    int gstDebugLevel = 0;
     if (settings.contains(AppSettings::gstDebugLevelName)) {
-        gstDebugLevel = "*:" + settings.value(AppSettings::gstDebugLevelName).toString();
+        gstDebugLevel = settings.value(AppSettings::gstDebugLevelName).toInt();
     }
     // Initialize Video Streaming
-    initializeVideoStreaming(argc, argv, savePath.toUtf8().data(), gstDebugLevel.toUtf8().data());
-#endif
+    initializeVideoStreaming(argc, argv, gstDebugLevel);
 
     _toolbox = new QGCToolbox(this);
     _toolbox->setChildToolboxes();

--- a/src/VideoStreaming/README.md
+++ b/src/VideoStreaming/README.md
@@ -7,6 +7,10 @@ To build video streaming support, you will need to install the GStreamer develop
 
 If you do have the proper GStreamer development libraries installed where QGC looks for it, the QGC build system will automatically use it and build video streaming support. If you would like to disable video streaming support, you can add **DISABLE_VIDEOSTREAMING** to the **DEFINES** build variable.
 
+### Gstreamer logs
+
+For cases, when it is need to have more control over gstreamer logging than is availabe via QGroundControl's UI, it is possible to configure gstreamer logging via environment variables. Please see https://developer.gnome.org/gstreamer/stable/gst-running.html for details.
+
 ### UDP Pipeline
 
 For the time being, the RTP UDP pipeline is somewhat hardcoded, using h.264 or h.265. It's best to use a camera capable of hardware encoding either h.264 (such as the Logitech C920) or h.265. On the sender end, for RTP (UDP Streaming) you would run something like this:

--- a/src/VideoStreaming/VideoStreaming.h
+++ b/src/VideoStreaming/VideoStreaming.h
@@ -16,4 +16,4 @@
 
 #pragma once
 
-extern void initializeVideoStreaming    (int &argc, char *argv[], char* filename, char* debuglevel);
+extern void initializeVideoStreaming    (int &argc, char *argv[], int gstDebuglevel);


### PR DESCRIPTION
Trying to make VideoReceiver stuff more QGC-like/consistent - switched gstreamer to use QT logging system if GST_DEBUG and other debug related environment variables are not set (also works on Android/iOS without any extra efforts - just use UI to tweak logging).

If GST_DEBUG is set then gstreamer can be configured to log in its native way. This mode is useful for these who work with gstreamer or who is helping to trace gtsreamer issue.
