### PR TITLE
QGCMavlink: Add GCC version check to use address-of-packed-member

### DIFF
--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -22,8 +22,15 @@
 
 // Ignore warnings from mavlink headers for both GCC/Clang and MSVC
 #ifdef __GNUC__
+
+#if __GNUC__ > 8
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#endif
+
 #else
 #pragma warning(push, 0)
 #endif


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


