### PR TITLE
Drive Plan view ROI support from firmware capability bits

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -48,7 +48,7 @@ public:
         GuidedModeCapability =              1 << 2, ///< Vehicle supports guided mode commands
         OrbitModeCapability =               1 << 3, ///< Vehicle supports orbit mode
         TakeoffVehicleCapability =          1 << 4, ///< Vehicle supports guided takeoff
-        ROIModeCapability =                 1 << 5, ///< Vehicle supports ROI
+        ROIModeCapability =                 1 << 5, ///< Vehicle supports ROI (both in Fly guided mode and from Plan creation)
     } FirmwareCapabilities;
 
     /// Maps from on parameter name to another

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -617,7 +617,7 @@ Item {
                     name:               _missionController.isROIActive ? qsTr("Cancel ROI") : qsTr("ROI"),
                     iconSource:         "/qmlimages/MapAddMission.svg",
                     buttonEnabled:      true,
-                    buttonVisible:      _isMissionLayer,
+                    buttonVisible:      _isMissionLayer && _planMasterController.controllerVehicle.roiModeSupported,
                     toggle:             !_missionController.isROIActive
                 },
                 {


### PR DESCRIPTION
This makes Plan view using the same capability bit as Fly view for ROI support. I've left the bit set on only for multi-rotor which isn't technically correct. But closer to vehicle majority usage.

Replacement for #8337.

@dakejahl So to turn off ROI support fully in Sentera custom you remove the ROI capability in the Sentera firmware plugin override.