### PR TITLE
Fix MPEG-2 TS support on Android and iOS

### DIFF
--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -356,9 +356,17 @@ VideoReceiver::_makeSource(const QString& uri)
             break;
         }
 
-        if ((parser = gst_element_factory_make("parsebin", "parser")) == nullptr) {
-            qCritical() << "VideoReceiver::_makeSource() failed. Error with gst_element_factory_make('parsebin')";
-            break;
+        // FIXME: AV: Android does not determine MPEG2-TS via parsebin - have to explicitly state which demux to use
+        if (isTcpMPEGTS || isUdpMPEGTS) {
+            if ((parser = gst_element_factory_make("tsdemux", "parser")) == nullptr) {
+                qCritical(VideoReceiverLog) << "gst_element_factory_make('tsdemux') failed";
+                break;
+            }
+        } else {
+            if ((parser = gst_element_factory_make("parsebin", "parser")) == nullptr) {
+                qCritical() << "VideoReceiver::_makeSource() failed. Error with gst_element_factory_make('parsebin')";
+                break;
+            }
         }
 
         if ((bin = gst_bin_new("sourcebin")) == nullptr) {

--- a/src/VideoStreaming/VideoStreaming.cc
+++ b/src/VideoStreaming/VideoStreaming.cc
@@ -89,6 +89,7 @@ static void qt_gst_log(GstDebugCategory * category,
     GST_PLUGIN_STATIC_DECLARE(rtpmanager);
     GST_PLUGIN_STATIC_DECLARE(isomp4);
     GST_PLUGIN_STATIC_DECLARE(matroska);
+    GST_PLUGIN_STATIC_DECLARE(mpegtsdemux);
     GST_PLUGIN_STATIC_DECLARE(opengl);
 #if defined(__android__)
     GST_PLUGIN_STATIC_DECLARE(androidmedia);
@@ -162,6 +163,7 @@ void initializeVideoStreaming(int &argc, char* argv[], int gstDebuglevel)
     GST_PLUGIN_STATIC_REGISTER(rtpmanager);
     GST_PLUGIN_STATIC_REGISTER(isomp4);
     GST_PLUGIN_STATIC_REGISTER(matroska);
+    GST_PLUGIN_STATIC_REGISTER(mpegtsdemux);
     GST_PLUGIN_STATIC_REGISTER(opengl);
 
 #if defined(__android__)

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -89,6 +89,7 @@ LinuxBuild {
             -lgstrtpmanager \
             -lgstisomp4 \
             -lgstmatroska \
+            -lgstmpegtsdemux \
             -lgstandroidmedia \
             -lgstopengl
 
@@ -102,7 +103,7 @@ LinuxBuild {
             -lgstreamer-1.0 -lgstrtp-1.0 -lgstpbutils-1.0 -lgstrtsp-1.0 -lgsttag-1.0 \
             -lgstvideo-1.0 -lavformat -lavcodec -lavutil -lx264 -lavfilter -lswresample \
             -lgstriff-1.0 -lgstcontroller-1.0 -lgstapp-1.0 \
-            -lgstsdp-1.0 -lbz2 -lgobject-2.0 \
+            -lgstsdp-1.0 -lbz2 -lgobject-2.0 -lgstmpegts-1.0 \
             -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lorc-0.4 -liconv -lffi -lintl \
 
         INCLUDEPATH += \


### PR DESCRIPTION
This is critical to get MPEG-2 TS support on Android and iOS (bug in latest 3.x stable).