### PR TITLE
Fix view visible property toggle on redundant click

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -99,42 +99,49 @@ ApplicationWindow {
         return _rgPreventViewSwitch[_rgPreventViewSwitch.length - 1]
     }
 
-    function viewSwitch(isPlanView) {
+    function showFlyView() {
+        settingsWindow.visible  = false
+        setupWindow.visible     = false
+        analyzeWindow.visible   = false
+        planViewLoader.visible  = false
+        flightView.visible      = true
+        toolbar.source          = _mainToolbar
+    }
+
+    function showPlanView() {
         settingsWindow.visible  = false
         setupWindow.visible     = false
         analyzeWindow.visible   = false
         flightView.visible      = false
-        planViewLoader.visible  = false
-        if(isPlanView) {
-            toolbar.source  = _planToolbar
-        } else {
-            toolbar.source  = _mainToolbar
-        }
-    }
-
-    function showFlyView() {
-        viewSwitch(false)
-        flightView.visible = true
-    }
-
-    function showPlanView() {
-        viewSwitch(true)
-        planViewLoader.visible = true
+        planViewLoader.visible  = true
+        toolbar.source          = _planToolbar
     }
 
     function showAnalyzeView() {
-        viewSwitch(false)
-        analyzeWindow.visible = true
+        settingsWindow.visible  = false
+        setupWindow.visible     = false
+        flightView.visible      = false
+        planViewLoader.visible  = false
+        analyzeWindow.visible   = true
+        toolbar.source          = _mainToolbar
     }
 
     function showSetupView() {
-        viewSwitch(false)
-        setupWindow.visible = true
+        settingsWindow.visible  = false
+        analyzeWindow.visible   = false
+        flightView.visible      = false
+        planViewLoader.visible  = false
+        setupWindow.visible     = true
+        toolbar.source          = _mainToolbar
     }
 
     function showSettingsView() {
-        viewSwitch(false)
-        settingsWindow.visible = true
+        setupWindow.visible     = false
+        analyzeWindow.visible   = false
+        flightView.visible      = false
+        planViewLoader.visible  = false
+        settingsWindow.visible  = true
+        toolbar.source          = _mainToolbar
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
Fixes an issue where if clicking the view button in the main toolbar for a view you're already in, the view will toggle the `visible` property causing the `onVisibleChanged` handler to run. This is an issue for code that relies on that signal, i.e https://github.com/mavlink/qgroundcontrol/pull/8358/files


