### PR TITLE
Vagrant: move to bionic64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox"
   config.vm.provider "vmware_fusion"
 
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
   config.vm.provider :docker do |docker, override|
     override.vm.box = "tknerr/baseimage-ubuntu-16.04"
   end


### PR DESCRIPTION
xenial fails with this error:

    default: Project ERROR: gstreamer-gl-1.0 development package not found

bionic64 just works.  So move to it :-)


