### PR TITLE
Fix CameraCalc loading

### DIFF
--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -241,6 +241,11 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
 
     _distanceToSurfaceRelative = v1Json[distanceToSurfaceRelativeName].toBool();
 
+    _cameraNameFact.setRawValue                 (v1Json[cameraNameName].toString());
+    _adjustedFootprintSideFact.setRawValue      (v1Json[adjustedFootprintSideName].toDouble());
+    _adjustedFootprintFrontalFact.setRawValue   (v1Json[adjustedFootprintFrontalName].toDouble());
+    _distanceToSurfaceFact.setRawValue          (v1Json[distanceToSurfaceName].toDouble());
+
     if (!isManualCamera()) {
         QList<JsonHelper::KeyValidateInfo> keyInfoList2 = {
             { valueSetIsDistanceName,   QJsonValue::Bool,   true },
@@ -256,14 +261,7 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
         _valueSetIsDistanceFact.setRawValue (v1Json[valueSetIsDistanceName].toBool());
         _frontalOverlapFact.setRawValue     (v1Json[frontalOverlapName].toDouble());
         _sideOverlapFact.setRawValue        (v1Json[sideOverlapName].toDouble());
-    }
-
-    _cameraNameFact.setRawValue                 (v1Json[cameraNameName].toString());
-    _adjustedFootprintSideFact.setRawValue      (v1Json[adjustedFootprintSideName].toDouble());
-    _adjustedFootprintFrontalFact.setRawValue   (v1Json[adjustedFootprintFrontalName].toDouble());
-    _distanceToSurfaceFact.setRawValue          (v1Json[distanceToSurfaceName].toDouble());
-    if (!isManualCamera()) {
-        _imageDensityFact.setRawValue(v1Json[imageDensityName].toDouble());
+        _imageDensityFact.setRawValue       (v1Json[imageDensityName].toDouble());
 
         if (!CameraSpec::load(v1Json, errorString)) {
             _disableRecalc = false;

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -141,7 +141,9 @@ void SurveyComplexItem::loadPreset(const QString& name)
     QString errorString;
 
     QJsonObject presetObject = _loadPresetJson(name);
-    _loadV4V5(presetObject, 0, errorString, 5, true /* forPresets */);
+    if (!_loadV4V5(presetObject, 0, errorString, 5, true /* forPresets */)) {
+        qgcApp()->showMessage(QStringLiteral("Internal Error: Preset load failed. Name: %1 Error: %2").arg(name).arg(errorString));
+    }
     _rebuildTransects();
 }
 


### PR DESCRIPTION
* Call was made to isManualCamera before the camera name was loaded. Causing it to base decisions on previous camera name. Which would in turn cause Manual camera Preset load to fail.
* Added Internal Error message display for preset load failures.
* Fix for #8398