### PR TITLE
Improve survey presets drop down

### DIFF
--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -37,7 +37,11 @@ QStringList ComplexMissionItem::presetNames(void)
 
     settings.beginGroup(presetsSettingsGroup());
     settings.beginGroup(_presetSettingsKey);
-    return settings.childKeys();
+
+    names << "Select a preset";
+    names += settings.childKeys();
+
+    return names;
 }
 
 void ComplexMissionItem::loadPreset(const QString& name)

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -30,7 +30,7 @@ Rectangle {
     property real   _cameraMinTriggerInterval:  missionItem.cameraCalc.minTriggerInterval.rawValue
     property bool   _polygonDone:               false
     property string _doneAdjusting:             qsTr("Done Adjusting")
-    property bool   _presetsAvailable:          missionItem.presetNames.length !== 0
+    property bool   _presetsAvailable:          missionItem.presetNames.length > 1
 
     function polygonCaptureStarted() {
         missionItem.clearPolygon()
@@ -107,13 +107,11 @@ Rectangle {
                     id:                 wizardPresetCombo
                     Layout.fillWidth:   true
                     model:              missionItem.presetNames
-                }
-
-                QGCButton {
-                    Layout.fillWidth:   true
-                    text:               qsTr("Apply Preset")
-                    enabled:            missionItem.presetNames.length != 0
-                    onClicked:          missionItem.loadPreset(wizardPresetCombo.textAt(wizardPresetCombo.currentIndex))
+                    onActivated: {
+                        if (currentIndex > 0) {
+                            missionItem.loadPreset(textAt(currentIndex))
+                        }
+                    }
                 }
 
                 SectionHeader {
@@ -424,6 +422,12 @@ Rectangle {
                     id:                 presetCombo
                     Layout.fillWidth:   true
                     model:              missionItem.presetNames
+
+                    onActivated: {
+                        if (currentIndex > 0) {
+                            missionItem.loadPreset(textAt(currentIndex))
+                        }
+                    }
                 }
 
                 RowLayout {
@@ -431,15 +435,8 @@ Rectangle {
 
                     QGCButton {
                         Layout.fillWidth:   true
-                        text:               qsTr("Apply Preset")
-                        enabled:            missionItem.presetNames.length != 0
-                        onClicked:          missionItem.loadPreset(presetCombo.textAt(presetCombo.currentIndex))
-                    }
-
-                    QGCButton {
-                        Layout.fillWidth:   true
                         text:               qsTr("Delete Preset")
-                        enabled:            missionItem.presetNames.length != 0
+                        enabled:            presetCombo.currentIndex > 0
                         onClicked:          missionItem.deletePreset(presetCombo.textAt(presetCombo.currentIndex))
                     }
 


### PR DESCRIPTION
This PR implements the suggested improvements to the Survey Presets UI as discussed in 
https://github.com/mavlink/qgroundcontrol/issues/8347

![survey_presets](https://user-images.githubusercontent.com/37091262/75203456-5a64ff00-572b-11ea-9324-80d18ed8fe70.PNG)

And the wizard as well
![survey_presets_wizard](https://user-images.githubusercontent.com/37091262/75204078-225ebb80-572d-11ea-9097-6c06f48b9a80.PNG)

