### PR TITLE
Altitude Text fields: Don't show (Rel) additional units label all the time

### DIFF
--- a/src/FactSystem/FactControls/AltitudeFactTextField.qml
+++ b/src/FactSystem/FactControls/AltitudeFactTextField.qml
@@ -38,7 +38,8 @@ FactTextField {
         if (altitudeMode === QGroundControl.AltitudeModeNone) {
             _altitudeModeExtraUnits = _altModeNoneExtraUnits
         } else if (altitudeMode === QGroundControl.AltitudeModeRelative) {
-            _altitudeModeExtraUnits = _altModeRelativeExtraUnits
+            //_altitudeModeExtraUnits = _altModeRelativeExtraUnits
+            _altitudeModeExtraUnits = "" // Showing (rel) all the time is too noisy
         } else if (altitudeMode === QGroundControl.AltitudeModeAbsolute) {
             _altitudeModeExtraUnits = _altModeAbsoluteExtraUnits
         } else if (altitudeMode === QGroundControl.AltitudeModeAboveTerrain) {

--- a/src/PlanView/CorridorScanEditor.qml
+++ b/src/PlanView/CorridorScanEditor.qml
@@ -118,7 +118,7 @@ Rectangle {
                     distanceToSurfaceLabel:         qsTr("Altitude")
                     distanceToSurfaceAltitudeMode:  missionItem.followTerrain ?
                                                         QGroundControl.AltitudeModeAboveTerrain :
-                                                        missionItem.cameraCalc.distanceToSurfaceRelative
+                                                        (missionItem.cameraCalc.distanceToSurfaceRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute)
                     frontalDistanceLabel:           qsTr("Trigger Dist")
                     sideDistanceLabel:              qsTr("Spacing")
                 }

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -211,7 +211,7 @@ Rectangle {
                     distanceToSurfaceLabel:         qsTr("Altitude")
                     distanceToSurfaceAltitudeMode:  missionItem.followTerrain ?
                                                         QGroundControl.AltitudeModeAboveTerrain :
-                                                        missionItem.cameraCalc.distanceToSurfaceRelative
+                                                        (missionItem.cameraCalc.distanceToSurfaceRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute)
                     frontalDistanceLabel:           qsTr("Trigger Dist")
                     sideDistanceLabel:              qsTr("Spacing")
                 }


### PR DESCRIPTION
* Most folks live in relative altitudes. So it's very noisy to show that all the time.
* Now only the non relative modes will show a special label.
* Fixed bugs in Survey/Corridor with respect to correctly setting altitude mode