### PR TITLE
Don't unref _tee - we don't hold reference to this object, it is owned...

### DIFF
--- a/src/VideoStreaming/VideoReceiver.cc
+++ b/src/VideoStreaming/VideoReceiver.cc
@@ -659,8 +659,6 @@ VideoReceiver::_shutdownPipeline() {
     }
     gst_element_set_state(_pipeline, GST_STATE_NULL);
     gst_bin_remove(GST_BIN(_pipeline), _videoSink);
-    gst_bin_remove(GST_BIN(_pipeline), _tee);
-    gst_object_unref(_tee);
     _tee = nullptr;
     gst_object_unref(_pipeline);
     _pipeline = nullptr;


### PR DESCRIPTION
... by _pipeline

Need to slow down a bit - overlooked double free. This patch fixes issue introduced by https://github.com/mavlink/qgroundcontrol/pull/8406
