### PR TITLE
Compiler switch for Survey Preset JSON generation

### DIFF
--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -80,22 +80,6 @@ void ComplexMissionItem::_savePresetJson(const QString& name, QJsonObject& prese
     // Use this to save a survey preset as a JSON file to be included in the build
     // as a built-in survey preset that cannot be deleted.
     #if 0
-    _saveSettingsValueAsJson(settings, name);
-    #endif
-
-    emit presetNamesChanged();
-}
-
-QJsonObject ComplexMissionItem::_loadPresetJson(const QString& name)
-{
-    QSettings settings;
-    settings.beginGroup(presetsSettingsGroup());
-    settings.beginGroup(_presetSettingsKey);
-    return QJsonDocument::fromBinaryData(settings.value(name).toByteArray()).object();
-}
-
-void ComplexMissionItem::_saveSettingsValueAsJson(const QSettings& settings, const QString& name)
-{
     QString savePath = _settingsManager->appSettings()->missionSavePath();
     QDir saveDir(savePath);
 
@@ -108,8 +92,17 @@ void ComplexMissionItem::_saveSettingsValueAsJson(const QSettings& settings, con
     }
 
     qDebug() << "Saving survey preset to JSON";
-    QJsonObject jsonObj = QJsonDocument::fromBinaryData(settings.value(name).toByteArray()).object();
     auto jsonDoc = QJsonDocument(jsonObj);
-
     jsonFile.write(jsonDoc.toJson());
+    #endif
+
+    emit presetNamesChanged();
+}
+
+QJsonObject ComplexMissionItem::_loadPresetJson(const QString& name)
+{
+    QSettings settings;
+    settings.beginGroup(presetsSettingsGroup());
+    settings.beginGroup(_presetSettingsKey);
+    return QJsonDocument::fromBinaryData(settings.value(name).toByteArray()).object();
 }

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -86,8 +86,6 @@ protected:
     void        _savePresetJson (const QString& name, QJsonObject& presetObject);
     QJsonObject _loadPresetJson (const QString& name);
 
-    void        _saveSettingsValueAsJson(const QSettings& settings, const QString& name);
-
     bool _isIncomplete = true;
 
     QMap<QString, FactMetaData*> _metaDataMap;

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -15,6 +15,10 @@
 
 #include <QSettings>
 
+#include <QGCToolbox.h>
+#include <SettingsManager.h>
+
+
 class ComplexMissionItem : public VisualMissionItem
 {
     Q_OBJECT
@@ -82,11 +86,16 @@ protected:
     void        _savePresetJson (const QString& name, QJsonObject& presetObject);
     QJsonObject _loadPresetJson (const QString& name);
 
+    void        _saveSettingsValueAsJson(const QSettings& settings, const QString& name);
+
     bool _isIncomplete = true;
 
     QMap<QString, FactMetaData*> _metaDataMap;
 
     static const char* _presetSettingsKey;
+
+    QGCToolbox* _toolbox;
+    SettingsManager* _settingsManager;
 };
 
 #endif


### PR DESCRIPTION
This allows developers to optionally save a Survey Preset as a JSON file when selecting "Save preset" in the Survey Plan. 

This JSON files end up in the "Missions" directory, where you can just copy/paste them into your source tree and include them in your custom build.

```
<qresource prefix="/foo">
        <file alias="bar.json">patch/bar.json</file>
</qresource>
```

The from C++ file load code is `":/foo/bar.json"`