### PR TITLE
Remove QGCApplication and VideoSettings from the VideoReceiver

### DIFF
--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -71,7 +71,7 @@ public:
     void reportMissingParameter(int componentId, const QString& name);
 
     /// Show a non-modal message to the user
-    void showMessage(const QString& message);
+    Q_SLOT void showMessage(const QString& message);
 
     /// @return true: Fake ui into showing mobile interface
     bool fakeMobile(void) const { return _fakeMobile; }

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -167,5 +167,5 @@ bool VideoSettings::streamConfigured(void)
 
 void VideoSettings::_configChanged(QVariant)
 {
-    emit streamConfiguredChanged();
+    emit streamConfiguredChanged(streamConfigured());
 }

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -60,7 +60,7 @@ public:
     static const char* videoSourceMPEGTS;
 
 signals:
-    void streamConfiguredChanged    ();
+    void streamConfiguredChanged    (bool configured);
 
 private slots:
     void _configChanged             (QVariant value);

--- a/src/VideoStreaming/VideoManager.h
+++ b/src/VideoStreaming/VideoManager.h
@@ -67,6 +67,9 @@ public:
     virtual VideoReceiver*  videoReceiver           () { return _videoReceiver; }
     virtual VideoReceiver*  thermalVideoReceiver    () { return _thermalVideoReceiver; }
 
+    QStringList videoExtensions();
+    QStringList videoMuxes();
+
 #if defined(QGC_DISABLE_UVC)
     virtual bool        uvcEnabled          () { return false; }
 #else
@@ -81,6 +84,8 @@ public:
 
     Q_INVOKABLE void startVideo     ();
     Q_INVOKABLE void stopVideo      ();
+
+    void cleanupOldVideos();
 
 signals:
     void hasVideoChanged            ();

--- a/src/VideoStreaming/VideoReceiver.h
+++ b/src/VideoStreaming/VideoReceiver.h
@@ -45,10 +45,8 @@ public:
     Q_PROPERTY(bool             showFullScreen      READ    showFullScreen      WRITE   setShowFullScreen     NOTIFY showFullScreenChanged)
     Q_PROPERTY(bool             streamEnabled       READ    streamEnabled       WRITE   setStreamEnabled      NOTIFY streamEnabledChanged)
     Q_PROPERTY(bool             streamConfigured    READ    streamConfigured    WRITE   setStreamConfigured   NOTIFY streamConfiguredChanged)
-    Q_PROPERTY(bool             storageLimit        READ    storageLimit        WRITE   setStorageLimit       NOTIFY storageLimitChanged)
     Q_PROPERTY(bool             isTaisync           READ    isTaisync           WRITE   setIsTaysinc          NOTIFY isTaisyncChanged)
 
-    Q_PROPERTY(int              maxVideoSize        READ    maxVideoSize        WRITE   setMaxVideoSize       NOTIFY maxVideoSizeChanged)
     Q_PROPERTY(int              recordingFormatId   READ    recordingFormatId   WRITE   setRecordingFormatId  NOTIFY recordingFormatIdChanged)
     Q_PROPERTY(int              rtspTimeout         READ    rtspTimeout         WRITE   setRtspTimeout        NOTIFY rtspTimeoutChanged)
 
@@ -63,10 +61,6 @@ public:
     Q_SLOT void setStreamConfigured(bool enabled);
     Q_SIGNAL void streamConfiguredChanged();
 
-    bool storageLimit() const;
-    Q_SLOT void setStorageLimit(bool enabled);
-    Q_SIGNAL void storageLimitChanged();
-
     bool isTaisync() const;
     Q_SLOT void setIsTaysinc(bool value);
     Q_SIGNAL void isTaisyncChanged();
@@ -79,10 +73,6 @@ public:
     Q_SLOT void setImagePath(const QString& path);
     Q_SIGNAL void imagePathChanged();
 
-    int maxVideoSize() const;
-    Q_SLOT void setMaxVideoSize(int value);
-    Q_SIGNAL void maxVideoSizeChanged();
-
     int recordingFormatId() const;
     Q_SLOT void setRecordingFormatId(int value);
     Q_SIGNAL void recordingFormatIdChanged();
@@ -94,6 +84,8 @@ public:
     Q_SIGNAL void restartTimeout();
     Q_SIGNAL void sendMessage(const QString& message);
 
+    // Emitted before recording starts.
+    Q_SIGNAL void beforeRecording();
     void setUnittestMode(bool runUnitTests);
 #if defined(QGC_GST_STREAMING)
     virtual bool            recording       () { return _recording; }
@@ -172,7 +164,6 @@ protected:
     virtual void                _unlinkRecordingBranch  (GstPadProbeInfo* info);
     virtual void                _shutdownRecordingBranch();
     virtual void                _shutdownPipeline       ();
-    virtual void                _cleanupOldVideos       ();
 
     GstElement*     _pipeline;
     GstElement*     _videoSink;
@@ -201,7 +192,6 @@ protected:
     bool            _storageLimit;
     bool            _unittTestMode;
     bool            _isTaisync;
-    int            _maxVideoSize; // in mbs.
     int            _recordingFormatId; // 0 - 2, defined in VideoReceiver.cc / kVideoExtensions. TODO: use a better representation.
     int            _rtspTimeout;
 

--- a/src/VideoStreaming/VideoReceiver.h
+++ b/src/VideoStreaming/VideoReceiver.h
@@ -39,11 +39,62 @@ public:
     Q_PROPERTY(bool             videoRunning        READ    videoRunning        NOTIFY  videoRunningChanged)
     Q_PROPERTY(QString          imageFile           READ    imageFile           NOTIFY  imageFileChanged)
     Q_PROPERTY(QString          videoFile           READ    videoFile           NOTIFY  videoFileChanged)
+    Q_PROPERTY(QString          imagePath           READ    imagePath           NOTIFY  imagePathChanged)
+    Q_PROPERTY(QString          videoPath           READ    videoPath           NOTIFY  videoPathChanged)
+
     Q_PROPERTY(bool             showFullScreen      READ    showFullScreen      WRITE   setShowFullScreen     NOTIFY showFullScreenChanged)
+    Q_PROPERTY(bool             streamEnabled       READ    streamEnabled       WRITE   setStreamEnabled      NOTIFY streamEnabledChanged)
+    Q_PROPERTY(bool             streamConfigured    READ    streamConfigured    WRITE   setStreamConfigured   NOTIFY streamConfiguredChanged)
+    Q_PROPERTY(bool             storageLimit        READ    storageLimit        WRITE   setStorageLimit       NOTIFY storageLimitChanged)
+    Q_PROPERTY(bool             isTaisync           READ    isTaisync           WRITE   setIsTaysinc          NOTIFY isTaisyncChanged)
+
+    Q_PROPERTY(int              maxVideoSize        READ    maxVideoSize        WRITE   setMaxVideoSize       NOTIFY maxVideoSizeChanged)
+    Q_PROPERTY(int              recordingFormatId   READ    recordingFormatId   WRITE   setRecordingFormatId  NOTIFY recordingFormatIdChanged)
+    Q_PROPERTY(int              rtspTimeout         READ    rtspTimeout         WRITE   setRtspTimeout        NOTIFY rtspTimeoutChanged)
 
     explicit VideoReceiver(QObject* parent = nullptr);
     ~VideoReceiver();
 
+    bool streamEnabled() const;
+    Q_SLOT void setStreamEnabled(bool enabled);
+    Q_SIGNAL void streamEnabledChanged();
+
+    bool streamConfigured() const;
+    Q_SLOT void setStreamConfigured(bool enabled);
+    Q_SIGNAL void streamConfiguredChanged();
+
+    bool storageLimit() const;
+    Q_SLOT void setStorageLimit(bool enabled);
+    Q_SIGNAL void storageLimitChanged();
+
+    bool isTaisync() const;
+    Q_SLOT void setIsTaysinc(bool value);
+    Q_SIGNAL void isTaisyncChanged();
+
+    QString videoPath() const;
+    Q_SLOT void setVideoPath(const QString& path);
+    Q_SIGNAL void videoPathChanged();
+
+    QString imagePath() const;
+    Q_SLOT void setImagePath(const QString& path);
+    Q_SIGNAL void imagePathChanged();
+
+    int maxVideoSize() const;
+    Q_SLOT void setMaxVideoSize(int value);
+    Q_SIGNAL void maxVideoSizeChanged();
+
+    int recordingFormatId() const;
+    Q_SLOT void setRecordingFormatId(int value);
+    Q_SIGNAL void recordingFormatIdChanged();
+
+    int rtspTimeout() const;
+    Q_SLOT void setRtspTimeout(int value);
+    Q_SIGNAL void rtspTimeoutChanged();
+
+    Q_SIGNAL void restartTimeout();
+    Q_SIGNAL void sendMessage(const QString& message);
+
+    void setUnittestMode(bool runUnitTests);
 #if defined(QGC_GST_STREAMING)
     virtual bool            recording       () { return _recording; }
 #endif
@@ -86,7 +137,6 @@ protected slots:
 #if defined(QGC_GST_STREAMING)
     GstElement*  _makeSource                (const QString& uri);
     GstElement*  _makeFileSink              (const QString& videoFile, unsigned format);
-    virtual void _restart_timeout           ();
     virtual void _handleError               ();
     virtual void _handleEOS                 ();
     virtual void _handleStateChanged        ();
@@ -141,8 +191,19 @@ protected:
     QString         _uri;
     QString         _imageFile;
     QString         _videoFile;
+    QString         _videoPath;
+    QString         _imagePath;
+
     bool            _videoRunning;
     bool            _showFullScreen;
-    VideoSettings*  _videoSettings;
+    bool            _streamEnabled;
+    bool            _streamConfigured;
+    bool            _storageLimit;
+    bool            _unittTestMode;
+    bool            _isTaisync;
+    int            _maxVideoSize; // in mbs.
+    int            _recordingFormatId; // 0 - 2, defined in VideoReceiver.cc / kVideoExtensions. TODO: use a better representation.
+    int            _rtspTimeout;
+
 };
 


### PR DESCRIPTION
The VideoReceiver should work 'as is', without depending on the
whole application or in the settings. This patch removes all the
hard dependencies on QGroundControl, FactSystem and Settings system
so it's easier to isolate and test the code.


