### PR TITLE
checks for gst.h file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,10 @@ endif()
 #
 find_package(PkgConfig)
 pkg_check_modules(GST
+	REQUIRED
     gstreamer-1.0>=1.14
     gstreamer-video-1.0>=1.14
-    gstreamer-gl-1.0>=1.14
+    gstreamer-gl-1.0>=1.14	
 )
 
 if (GST_FOUND)


### PR DESCRIPTION
The **build** fails because the package "gstream" was not found. This should be the required package and if not found then **cmake** should raise an error. This PR fixes that. 