### PR TITLE
WIP: Support MAV_CMD_CONDITION_GATE [Do Not Merge]

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -297,6 +297,10 @@ QList<MAV_CMD> PX4FirmwarePlugin::supportedMissionCommands(void)
         MAV_CMD_IMAGE_START_CAPTURE, MAV_CMD_IMAGE_STOP_CAPTURE, MAV_CMD_VIDEO_START_CAPTURE, MAV_CMD_VIDEO_STOP_CAPTURE,
         MAV_CMD_NAV_DELAY,
         MAV_CMD_CONDITION_YAW,
+#if 1
+        // Turn on this ifdef for condition gate testing
+        MAV_CMD_CONDITION_GATE,
+#endif
     };
 }
 

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -1063,6 +1063,22 @@
                 "enumValues":       "3,4"
             }
         },
+        {
+            "id":                   4501,
+            "rawName":              "MAV_CMD_CONDITION_GATE",
+            "friendlyName":         "Delay gate",
+            "description":          "Delay mission until vehicle flies through gate.",
+            "specifiesCoordinate":  true,
+            "standaloneCoordinate": true,
+            "category":             "Conditionals",
+            "friendlyEdit":         true,
+            "param2": {
+                "label":            "Alt Mode",
+                "default":          0,
+                "enumStrings":      "Ignore Altitude,Use Altitude",
+                "enumValues":       "0,1"
+            }
+        },
         { "id": 30001, "rawName": "MAV_CMD_PAYLOAD_PREPARE_DEPLOY", "friendlyName": "Payload prepare deploy" },
         { "id": 30002, "rawName": "MAV_CMD_PAYLOAD_CONTROL_DEPLOY", "friendlyName": "Payload control deploy" }
     ]

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -685,6 +685,18 @@ void SurveyComplexItem::_buildAndAppendMissionItems(QList<MissionItem*>& items, 
                                            missionItemParent);
                     items.append(item);
                 }
+                // End of transect, stop triggering
+                item = new MissionItem(seqNum++,
+                                       MAV_CMD_DO_SET_CAM_TRIGG_DIST,
+                                       MAV_FRAME_MISSION,
+                                       0,           // stop triggering
+                                       0,           // shutter integration (ignore)
+                                       0,           // trigger immediately when starting
+                                       0, 0, 0, 0,  // param 4-7 unused
+                                       true,        // autoContinue
+                                       false,       // isCurrentItem
+                                       missionItemParent);
+                items.append(item);
             }
             item = new MissionItem(seqNum++,
                                    MAV_CMD_NAV_WAYPOINT,
@@ -767,19 +779,6 @@ void SurveyComplexItem::_buildAndAppendMissionItems(QList<MissionItem*>& items, 
                                            missionItemParent);
                     items.append(item);
                     transectEntry = false;
-                } else if (!imagesEverywhere && !transectEntry){
-                    // End of transect, stop triggering
-                    item = new MissionItem(seqNum++,
-                                           MAV_CMD_DO_SET_CAM_TRIGG_DIST,
-                                           MAV_FRAME_MISSION,
-                                           0,           // stop triggering
-                                           0,           // shutter integration (ignore)
-                                           0,           // trigger immediately when starting
-                                           0, 0, 0, 0,  // param 4-7 unused
-                                           true,        // autoContinue
-                                           false,       // isCurrentItem
-                                           missionItemParent);
-                    items.append(item);
                 }
             }
         }

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -16,6 +16,7 @@
 #include "SettingsManager.h"
 #include "AppSettings.h"
 #include "QGCQGeoCoordinate.h"
+#include "PlanMasterController.h"
 
 #include <QPolygonF>
 
@@ -48,6 +49,7 @@ TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterC
     , _cameraShots                      (0)
     , _cameraCalc                       (masterController, settingsGroup)
     , _followTerrain                    (false)
+    , _useMavCmdConditionGate           (masterController->controllerVehicle()->firmwarePlugin()->supportedMissionCommands().contains(MAV_CMD_CONDITION_GATE))
     , _loadedMissionItemsParent         (nullptr)
     , _metaDataMap                      (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/TransectStyle.SettingsGroup.json"), this))
     , _turnAroundDistanceFact           (settingsGroup, _metaDataMap[_controllerVehicle->multiRotor() ? turnAroundDistanceMultiRotorName : turnAroundDistanceName])
@@ -756,6 +758,10 @@ int TransectStyleComplexItem::lastSequenceNumber(void) const
             } else {
                 // Each transect will have a camera start and stop in it
                 itemCount += _transects.count() * 2;
+                if (_useMavCmdConditionGate) {
+                    // Each transect will have a condition gate at the entry/exit of the transect
+                    itemCount += _transects.count() * 2;
+                }
             }
         }
 

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -181,6 +181,7 @@ protected:
     double          _cruiseSpeed;
     CameraCalc      _cameraCalc;
     bool            _followTerrain;
+    bool            _useMavCmdConditionGate = false;
 
     QObject*            _loadedMissionItemsParent;	///< Parent for all items in _loadedMissionItems for simpler delete
     QList<MissionItem*> _loadedMissionItems;		///< Mission items loaded from plan file


### PR DESCRIPTION
Related to #8430. This has been tested to work correctly from a standpoint of building the correct set of mission items with a survey which has a turnaround and images in turnaround is turned off. The sequences of commands for each transest is:
* WAYPOINT - turnaround WP
* WAYPOINT - survey edge WP
* GATE
* TRIGGER
* WAYPOINT - survey edge WP
* GATE
* TRIGGER
* WAYPOINT - turnaround WP

Someone from the PX4 firmware side can use this to test MAV_CMD_CONDITION_GATE support.
