### PR TITLE
Windows uninstall race condition

### DIFF
--- a/deploy/qgroundcontrol_installer.nsi
+++ b/deploy/qgroundcontrol_installer.nsi
@@ -71,8 +71,7 @@ check64BitUninstall:
   StrCmp $R0 "" doInstall
 
 doUninstall:
-  DetailPrint "Uninstalling previous version..."  
-  ExecWait "$R0 /S -LEAVE_DATA=1"
+  DetailPrint "Uninstalling previous version..."  ExecWait "$R0 /S -LEAVE_DATA=1 _?=$INSTDIR"
   IntCmp $0 0 doInstall
 
   MessageBox MB_OK|MB_ICONEXCLAMATION \


### PR DESCRIPTION
The uninstall step prior to install was not waiting to complete. Which led to the uninstaller running at the same time as the installer. Which could lead to some files missing from the install.