### PR TITLE
Much better VTOL support [Do Not Merge]

### DIFF
--- a/src/FirmwarePlugin/PX4/MavCmdInfoMultiRotor.json
+++ b/src/FirmwarePlugin/PX4/MavCmdInfoMultiRotor.json
@@ -26,7 +26,7 @@
             "id":           22,
             "comment":      "MAV_CMD_NAV_TAKEOFF",
             "paramRemove":  "1",
-            "description":  "Hover straight up to specified altitude. Then travel to specified position.",
+            "description":  "Hover straight up to specified altitude. Then travel to specified position."
         }
     ]
 }

--- a/src/FirmwarePlugin/PX4/MavCmdInfoMultiRotor.json
+++ b/src/FirmwarePlugin/PX4/MavCmdInfoMultiRotor.json
@@ -25,7 +25,8 @@
         {
             "id":           22,
             "comment":      "MAV_CMD_NAV_TAKEOFF",
-            "paramRemove":  "1"
+            "paramRemove":  "1",
+            "description":  "Hover straight up to specified altitude. Then travel to specified position.",
         }
     ]
 }

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -51,7 +51,7 @@
                 "decimalPlaces":    2
             },
             "param4": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
@@ -73,7 +73,7 @@
                 "decimalPlaces":    2
             },
             "param4": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
@@ -100,7 +100,7 @@
                 "decimalPlaces":    2
             },
             "param4": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
@@ -128,7 +128,7 @@
                 "decimalPlaces":    2
             },
             "param4": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
@@ -149,6 +149,7 @@
             "friendlyName":         "Land",
             "description":          "Land vehicle at the specified location.",
             "specifiesCoordinate":  true,
+            "isLandCommand":        true,
             "friendlyEdit":         true,
             "category":             "Basic",
             "param1": {
@@ -158,7 +159,7 @@
                 "decimalPlaces":    2
             },
             "param4": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
@@ -169,7 +170,7 @@
             "id":                   22,
             "rawName":              "MAV_CMD_NAV_TAKEOFF",
             "friendlyName":         "Takeoff",
-            "description":          "Take off from the ground and travel towards the specified position.",
+            "description":          "Launch from the ground and travel towards the specified takeoff position.",
             "specifiesCoordinate":  true,
             "friendlyEdit":         true,
             "category":             "Basic",
@@ -180,7 +181,7 @@
                 "decimalPlaces":    2
             },
             "param4": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
@@ -287,12 +288,12 @@
             "id":                   84,
             "rawName":              "MAV_CMD_NAV_VTOL_TAKEOFF",
             "friendlyName":         "VTOL takeoff",
-            "description":          "Takeoff in VTOL mode, transition to forward flight and fly to the specified location.",
+            "description":          "Hover straight up to specified altitude, transition to fixed-wing and fly to the specified takeoff location.",
             "specifiesCoordinate":  true,
             "friendlyEdit":         true,
-            "category":             "VTOL",
+            "category":             "Basic",
             "param4": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
@@ -302,13 +303,14 @@
         {
             "id":                   85,
             "rawName":              "MAV_CMD_NAV_VTOL_LAND",
-            "friendlyName":         "VTOL transition and land",
-            "description":          "Transition to VTOL mode and land.",
+            "friendlyName":         "VTOL land",
+            "description":          "Fly to specified location at current altitude, transition to multi-rotor and land.",
             "specifiesCoordinate":  true,
+            "isLandCommand":        true,
             "friendlyEdit":         true,
-            "category":             "VTOL",
+            "category":             "Basic",
             "param4": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "nanUnchanged":     true,
                 "default":          null,
@@ -400,11 +402,11 @@
         {
             "id":           115,
             "rawName":      "MAV_CMD_CONDITION_YAW",
-            "friendlyName": "Wait for Heading",
-            "description":  "Delay the mission until the specified heading is reached.",
+            "friendlyName": "Wait for Yaw",
+            "description":  "Delay the mission until the specified yaw is reached.",
             "category":     "Conditionals",
             "param1": {
-                "label":            "Heading",
+                "label":            "Yaw",
                 "units":            "deg",
                 "default":          0,
                 "decimalPlaces":    1

--- a/src/MissionManager/MissionCommandUIInfo.cc
+++ b/src/MissionManager/MissionCommandUIInfo.cc
@@ -37,6 +37,7 @@ const char* MissionCommandUIInfo::_rawNameJsonKey               = "rawName";
 const char* MissionCommandUIInfo::_standaloneCoordinateJsonKey  = "standaloneCoordinate";
 const char* MissionCommandUIInfo::_specifiesCoordinateJsonKey   = "specifiesCoordinate";
 const char* MissionCommandUIInfo::_specifiesAltitudeOnlyJsonKey = "specifiesAltitudeOnly";
+const char* MissionCommandUIInfo::_isLandCommandJsonKey         = "isLandCommand";
 const char* MissionCommandUIInfo::_unitsJsonKey                 = "units";
 const char* MissionCommandUIInfo::_commentJsonKey               = "comment";
 const char* MissionCommandUIInfo::_advancedCategory             = "Advanced";
@@ -164,6 +165,15 @@ bool MissionCommandUIInfo::specifiesAltitudeOnly(void) const
     }
 }
 
+bool MissionCommandUIInfo::isLandCommand(void) const
+{
+    if (_infoMap.contains(_isLandCommandJsonKey)) {
+        return _infoMap[_isLandCommandJsonKey].toBool();
+    } else {
+        return false;
+    }
+}
+
 void MissionCommandUIInfo::_overrideInfo(MissionCommandUIInfo* uiInfo)
 {
     // Override info values
@@ -199,7 +209,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
     QStringList allKeys;
     allKeys << _idJsonKey << _rawNameJsonKey << _friendlyNameJsonKey << _descriptionJsonKey << _standaloneCoordinateJsonKey << _specifiesCoordinateJsonKey
             <<_friendlyEditJsonKey << _param1JsonKey << _param2JsonKey << _param3JsonKey << _param4JsonKey << _param5JsonKey << _param6JsonKey << _param7JsonKey
-            << _paramRemoveJsonKey << _categoryJsonKey << _specifiesAltitudeOnlyJsonKey;
+            << _paramRemoveJsonKey << _categoryJsonKey << _specifiesAltitudeOnlyJsonKey << _isLandCommandJsonKey;
 
     // Look for unknown keys in top level object
     for (const QString& key: jsonObject.keys()) {
@@ -231,7 +241,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
     QList<QJsonValue::Type> types;
     types << QJsonValue::Double << QJsonValue::String << QJsonValue::String<< QJsonValue::String << QJsonValue::Bool << QJsonValue::Bool << QJsonValue::Bool
           << QJsonValue::Object << QJsonValue::Object << QJsonValue::Object << QJsonValue::Object << QJsonValue::Object << QJsonValue::Object << QJsonValue::Object
-          << QJsonValue::String << QJsonValue::String << QJsonValue::Bool;
+          << QJsonValue::String << QJsonValue::String << QJsonValue::Bool << QJsonValue::Bool;
     if (!JsonHelper::validateKeyTypes(jsonObject, allKeys, types, internalError)) {
         errorString = _loadErrorString(internalError);
         return false;
@@ -262,6 +272,9 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
     if (jsonObject.contains(_specifiesAltitudeOnlyJsonKey)) {
         _infoMap[_specifiesAltitudeOnlyJsonKey] = jsonObject.value(_specifiesAltitudeOnlyJsonKey).toBool();
     }
+    if (jsonObject.contains(_isLandCommandJsonKey)) {
+        _infoMap[_isLandCommandJsonKey] = jsonObject.value(_isLandCommandJsonKey).toBool();
+    }
     if (jsonObject.contains(_friendlyEditJsonKey)) {
         _infoMap[_friendlyEditJsonKey] = jsonObject.value(_friendlyEditJsonKey).toVariant();
     }
@@ -288,6 +301,9 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
         }
         if (!_infoAvailable(_specifiesCoordinateJsonKey)) {
             _setInfoValue(_specifiesCoordinateJsonKey, false);
+        }
+        if (!_infoAvailable(_isLandCommandJsonKey)) {
+            _setInfoValue(_isLandCommandJsonKey, false);
         }
         if (!_infoAvailable(_friendlyEditJsonKey)) {
             _setInfoValue(_friendlyEditJsonKey, false);

--- a/src/MissionManager/MissionCommandUIInfo.h
+++ b/src/MissionManager/MissionCommandUIInfo.h
@@ -96,6 +96,7 @@ private:
 /// specifiesCoordinate     bool    false       true: Command specifies a lat/lon/alt coordinate
 /// specifiesAltitudeOnly   bool    false       true: Command specifies an altitude only (no coordinate)
 /// standaloneCoordinate    bool    false       true: Vehicle does not fly through coordinate associated with command (exampl: ROI)
+/// isLandCommand           bool    false       true: Command specifies a land command (LAND, VTOL_LAND, ...)
 /// friendlyEdit            bool    false       true: Command supports friendly editing dialog, false: Command supports 'Show all values" style editing only
 /// category                string  Advanced    Category which this command belongs to
 /// paramRemove             string              Used by an override to remove params, example: "1,3" will remove params 1 and 3 on the override
@@ -118,6 +119,7 @@ public:
     Q_PROPERTY(bool     isStandaloneCoordinate  READ isStandaloneCoordinate CONSTANT)
     Q_PROPERTY(bool     specifiesCoordinate     READ specifiesCoordinate    CONSTANT)
     Q_PROPERTY(bool     specifiesAltitudeOnly   READ specifiesAltitudeOnly  CONSTANT)
+    Q_PROPERTY(bool     isLandCommand           READ isLandCommand          CONSTANT)
     Q_PROPERTY(int      command                 READ intCommand             CONSTANT)
 
     MAV_CMD command(void) const { return _command; }
@@ -131,6 +133,7 @@ public:
     bool    isStandaloneCoordinate  (void) const;
     bool    specifiesCoordinate     (void) const;
     bool    specifiesAltitudeOnly   (void) const;
+    bool    isLandCommand           (void) const;
 
     /// Load the data in the object from the specified json
     ///     @param jsonObject Json object to load from
@@ -190,6 +193,7 @@ private:
     static const char* _standaloneCoordinateJsonKey;
     static const char* _specifiesCoordinateJsonKey;
     static const char* _specifiesAltitudeOnlyJsonKey;
+    static const char* _isLandCommandJsonKey;
     static const char* _unitsJsonKey;
     static const char* _commentJsonKey;    
     static const char* _advancedCategory;

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -362,12 +362,15 @@ VisualMissionItem* MissionController::_insertSimpleMissionItemWorker(QGeoCoordin
     _initVisualItem(newItem);
 
     if (newItem->specifiesAltitude()) {
-        double  prevAltitude;
-        int     prevAltitudeMode;
+        const MissionCommandUIInfo* uiInfo = qgcApp()->toolbox()->missionCommandTree()->getUIInfo(_controllerVehicle, command);
+        if (!uiInfo->isLandCommand()) {
+            double  prevAltitude;
+            int     prevAltitudeMode;
 
-        if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltitudeMode)) {
-            newItem->altitude()->setRawValue(prevAltitude);
-            newItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltitudeMode>(prevAltitudeMode));
+            if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltitudeMode)) {
+                newItem->altitude()->setRawValue(prevAltitude);
+                newItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltitudeMode>(prevAltitudeMode));
+            }
         }
     }
     newItem->setMissionFlightStatus(_missionFlightStatus);
@@ -432,7 +435,7 @@ VisualMissionItem* MissionController::insertLandItem(QGeoCoordinate coordinate, 
         fwLanding->setLoiterDragAngleOnly(true);
         return fwLanding;
     } else {
-        return _insertSimpleMissionItemWorker(coordinate, MAV_CMD_NAV_RETURN_TO_LAUNCH, visualItemIndex, makeCurrentItem);
+        return _insertSimpleMissionItemWorker(coordinate, _managerVehicle->vtol() ? MAV_CMD_NAV_VTOL_LAND : MAV_CMD_NAV_RETURN_TO_LAUNCH, visualItemIndex, makeCurrentItem);
     }
 }
 

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -192,6 +192,7 @@ void SimpleMissionItem::_connectSignals(void)
     connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::specifiesCoordinateChanged);
     connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::specifiesAltitudeOnlyChanged);
     connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::isStandaloneCoordinateChanged);
+    connect(&_missionItem._commandFact, &Fact::valueChanged, this, &SimpleMissionItem::isLandCommandChanged);
 
     // Whenever these properties change the ui model changes as well
     connect(this, &SimpleMissionItem::commandChanged,       this, &SimpleMissionItem::_rebuildFacts);
@@ -752,21 +753,13 @@ void SimpleMissionItem::_setDefaultsForCommand(void)
         }
     }
 
-    switch (command) {
-    case MAV_CMD_NAV_WAYPOINT:
+    if (command == MAV_CMD_NAV_WAYPOINT) {
         // We default all acceptance radius to 0. This allows flight controller to be in control of
         // accept radius.
         _missionItem.setParam2(0);
-        break;
-
-    case MAV_CMD_NAV_LAND:
-    case MAV_CMD_NAV_VTOL_LAND:
-    case MAV_CMD_DO_SET_ROI_LOCATION:
+    } else if (uiInfo->isLandCommand() || command == MAV_CMD_DO_SET_ROI_LOCATION) {
         _altitudeFact.setRawValue(0);
         _missionItem.setParam7(0);
-        break;
-    default:
-        break;
     }
 
     _missionItem.setAutoContinue(true);
@@ -994,4 +987,11 @@ void SimpleMissionItem::_possibleAdditionalTimeDelayChanged(void)
     }
 
     return;
+}
+
+bool SimpleMissionItem::isLandCommand(void) const
+{
+    MAV_CMD command = static_cast<MAV_CMD>(this->command());
+    const MissionCommandUIInfo* uiInfo = _commandTree->getUIInfo(_vehicle, command);
+    return uiInfo->isLandCommand();
 }

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -103,6 +103,7 @@ public:
     bool            dirty                   (void) const override { return _dirty; }
     bool            isSimpleItem            (void) const final { return true; }
     bool            isStandaloneCoordinate  (void) const final;
+    bool            isLandCommand           (void) const final;
     bool            specifiesCoordinate     (void) const final;
     bool            specifiesAltitudeOnly   (void) const final;
     QString         commandDescription      (void) const final;

--- a/src/MissionManager/TakeoffMissionItem.cc
+++ b/src/MissionManager/TakeoffMissionItem.cc
@@ -118,7 +118,7 @@ void TakeoffMissionItem::_initLaunchTakeoffAtSameLocation(void)
         if (_vehicle->fixedWing() || _vehicle->vtol()) {
             setLaunchTakeoffAtSameLocation(false);
         } else {
-            // PX4 specifies a coordinate for takeoff even for non fixed wing. But it makes more sense to not have a coordinate
+            // PX4 specifies a coordinate for takeoff even for multi-rotor. But it makes more sense to not have a coordinate
             // from and end user standpoint. So even for PX4 we try to keep launch and takeoff at the same position. Unless the
             // user has moved/loaded launch at a different location than takeoff.
             if (coordinate().isValid() && _settingsItem->coordinate().isValid()) {

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -68,6 +68,7 @@ public:
     Q_PROPERTY(bool             specifiesAltitudeOnly               READ specifiesAltitudeOnly                                              NOTIFY specifiesAltitudeOnlyChanged)                ///< true: Item has altitude only, no full coordinate
     Q_PROPERTY(bool             isSimpleItem                        READ isSimpleItem                                                       NOTIFY isSimpleItemChanged)                         ///< Simple or Complex MissionItem
     Q_PROPERTY(bool             isTakeoffItem                       READ isTakeoffItem                                                      NOTIFY isTakeoffItemChanged)                        ///< true: Takeoff item special case
+    Q_PROPERTY(bool             isLandCommand                       READ isLandCommand                                                      NOTIFY isLandCommandChanged)                        ///< true: Takeoff item special case
     Q_PROPERTY(QString          editorQml                           MEMBER _editorQml                                                       CONSTANT)                                           ///< Qml code for editing this item
     Q_PROPERTY(QString          mapVisualQML                        READ mapVisualQML                                                       CONSTANT)                                           ///< QMl code for map visuals
     Q_PROPERTY(QmlObjectListModel* childItems                       READ childItems                                                         CONSTANT)
@@ -130,6 +131,7 @@ public:
     virtual bool            dirty                   (void) const = 0;
     virtual bool            isSimpleItem            (void) const = 0;
     virtual bool            isTakeoffItem           (void) const { return false; }
+    virtual bool            isLandCommand           (void) const { return false; }
     virtual bool            isStandaloneCoordinate  (void) const = 0;
     virtual bool            specifiesCoordinate     (void) const = 0;
     virtual bool            specifiesAltitudeOnly   (void) const = 0;
@@ -207,6 +209,7 @@ signals:
     void sequenceNumberChanged          (int sequenceNumber);
     void isSimpleItemChanged            (bool isSimpleItem);
     void isTakeoffItemChanged           (bool isTakeoffItem);
+    void isLandCommandChanged           (void);
     void specifiesCoordinateChanged     (void);
     void isStandaloneCoordinateChanged  (void);
     void specifiesAltitudeOnlyChanged   (void);

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -629,7 +629,7 @@ Item {
                     dropPanelComponent: _singleComplexItem ? undefined : patternDropPanel
                 },
                 {
-                    name:               _planMasterController.controllerVehicle.fixedWing ? qsTr("Land") : qsTr("Return"),
+                    name:               _planMasterController.controllerVehicle.multiRotor ? qsTr("Return") : qsTr("Land"),
                     iconSource:         "/res/rtl.svg",
                     buttonEnabled:      _missionController.isInsertLandValid,
                     buttonVisible:      _isMissionLayer

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -58,6 +58,16 @@ Rectangle {
         anchors.left:       parent.left
         anchors.right:      parent.right
         anchors.top:        parent.top
+        spacing:            _margin
+
+        QGCLabel {
+            width:          parent.width
+            wrapMode:       Text.WordWrap
+            font.pointSize: ScreenTools.smallFontPointSize
+            text:           missionItem.rawEdit ?
+                                qsTr("Provides advanced access to all commands/parameters. Be very careful!") :
+                                missionItem.commandDescription
+        }
 
         ColumnLayout {
             anchors.left:       parent.left
@@ -66,7 +76,7 @@ Rectangle {
             visible:            missionItem.isTakeoffItem && missionItem.wizardMode // Hack special case for takeoff item
 
             QGCLabel {
-                text:               qsTr("Move 'T' Takeoff to the %1 location.").arg(missionItem.vehicle.vtol ? qsTr("desired") : qsTr("climbout"))
+                text:               qsTr("Move '%1' Takeoff to the %2 location.").arg(missionItem.vehicle.vtol ? qsTr("V") : qsTr("T")).arg(missionItem.vehicle.vtol ? qsTr("desired") : qsTr("climbout"))
                 Layout.fillWidth:   true
                 wrapMode:           Text.WordWrap
                 visible:            !initialClickLabel.visible
@@ -76,7 +86,7 @@ Rectangle {
                 text:               qsTr("Ensure clear of obstacles and into the wind.")
                 Layout.fillWidth:   true
                 wrapMode:           Text.WordWrap
-                visible:            !initialClickLabel.visible && !missionItem.vehicle.vtol
+                visible:            !initialClickLabel.visible
             }
 
             QGCButton {
@@ -105,15 +115,6 @@ Rectangle {
             anchors.right:      parent.right
             spacing:            _margin
             visible:            !missionItem.wizardMode
-
-            QGCLabel {
-                width:          parent.width
-                wrapMode:       Text.WordWrap
-                font.pointSize: ScreenTools.smallFontPointSize
-                text:           missionItem.rawEdit ?
-                                    qsTr("Provides advanced access to all commands/parameters. Be very careful!") :
-                                    missionItem.commandDescription
-            }
 
             GridLayout {
                 anchors.left:   parent.left
@@ -160,6 +161,14 @@ Rectangle {
                     anchors.left:       parent.left
                     anchors.right:      parent.right
                     spacing:            _margin
+
+                    QGCLabel {
+                        width:          parent.width
+                        wrapMode:       Text.WordWrap
+                        font.pointSize: ScreenTools.smallFontPointSize
+                        text:           qsTr("Altitude below specifies the approximate altitude of the ground. Normally 0 for landing back at original launch location.")
+                        visible:        missionItem.isLandCommand
+                    }
 
                     Item {
                         width:  altHamburger.x + altHamburger.width


### PR DESCRIPTION
VTOL support was in a state of very unhelpful mess.

![Screen Shot 2020-03-05 at 12 55 42 PM](https://user-images.githubusercontent.com/5876851/76025023-f4256c80-5ee0-11ea-91af-dc23fe0019e7.png)

Screenshot shows multiple changes, some specific to VTOL, some generic:
* VTOL Takeoff now works like Fixed Wing takeoff in that it positions the Takeoff item away from the Launch location. And it asks the user to futz both, warning them about wind and so forth.
* The command description is now shown all the time even when in incomplete/wizard mode. This helps explain a bit about the move this thing to here, move that thing to there.
* A number of the command description help texts were updated to better reflect what they do and or make more sense with respect to the QGC planning ui terminology.
* A number of commands were using the word "Heading" for labels when they should have been "Yaw".
* The Tooltrip Return/Land button now says "Land" for a VTOL and when you click it a VTOL_LAND command is added.
* Fix some bugs where the family of land commands did not have their altitude correctly defaulted to 0.
* Land commands have an altitude value associated with them. Differing from almost all other commands this altitude is the altitude of the ground. Which can be quite confusion. So in those cases be a little more wordy on what the altitude is actually for.

![Screen Shot 2020-03-05 at 1 03 17 PM](https://user-images.githubusercontent.com/5876851/76025444-cf7dc480-5ee1-11ea-8cf4-e11fa67982a6.png)
