### PR TITLE
Give up on getting AUTOPILOT_VERSION based on time now retry count.

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -703,7 +703,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
                 _capabilitiesRetryElapsed.start();
             } else if (_capabilitiesRetryElapsed.elapsed() > 10000){
                 qCDebug(VehicleLog) << "Giving up on getting AUTOPILOT_VERSION after 10 seconds";
-                qgcApp()->showMessage(QStringLiteral("Vehicle failed to send AUTOPILOT_VERSION"));
+                qgcApp()->showMessage(QStringLiteral("Vehicle failed to send AUTOPILOT_VERSION after waiting/retrying for 10 seconds"));
                 _handleUnsupportedRequestAutopilotCapabilities();
             } else {
                 // Vehicle never sent us AUTOPILOT_VERSION response. Try again.

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -12,6 +12,7 @@
 #include <QObject>
 #include <QVariantList>
 #include <QGeoCoordinate>
+#include <QTime>
 
 #include "FactGroup.h"
 #include "LinkInterface.h"
@@ -1431,6 +1432,7 @@ private:
     QTimer                          _mavCommandAckTimer;
     int                             _mavCommandRetryCount;
     int                             _capabilitiesRetryCount =               0;
+    QTime                           _capabilitiesRetryElapsed;
     static const int                _mavCommandMaxRetryCount =              3;
     static const int                _mavCommandAckTimeoutMSecs =            3000;
     static const int                _mavCommandAckTimeoutMSecsHighLatency = 120000;


### PR DESCRIPTION
ArduPilot takes a full 5 seconds before it will send AUTOPILOT_VERSION. Previous code used a retry count which wasn't high enough hence it would fail out. Change to wait for 10 seconds and then fail.