### PR TITLE
Parallels build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ pkg_check_modules(GST
     gstreamer-1.0>=1.14
     gstreamer-video-1.0>=1.14
     gstreamer-gl-1.0>=1.14
+    egl
 )
 
 if (GST_FOUND)

--- a/src/VideoStreaming/VideoStreaming.pri
+++ b/src/VideoStreaming/VideoStreaming.pri
@@ -15,7 +15,7 @@ LinuxBuild {
     QT += x11extras waylandclient
     CONFIG += link_pkgconfig
     packagesExist(gstreamer-1.0) {
-        PKGCONFIG   += gstreamer-1.0  gstreamer-video-1.0 gstreamer-gl-1.0
+        PKGCONFIG   += gstreamer-1.0  gstreamer-video-1.0 gstreamer-gl-1.0 egl
         CONFIG      += VideoEnabled
     }
 } else:MacBuild {


### PR DESCRIPTION
This small patch fixes https://github.com/mavlink/qgroundcontrol/issues/8282

Also updated cmake files - works for me on Linux but not sure about something else like Windows - IMO they won't work without full msys environment.