### PR TITLE
Fixed typo in TerrainAirMapQuery::_parseCarpetData

### DIFF
--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -249,7 +249,7 @@ void TerrainAirMapQuery::_parseCarpetData(const QJsonValue& carpetJson)
 
     QJsonObject statsObject =   jsonObject["stats"].toObject();
     double      minHeight =     statsObject["min"].toDouble();
-    double      maxHeight =     statsObject["min"].toDouble();
+    double      maxHeight =     statsObject["max"].toDouble();
 
     QList<QList<double>> carpet;
     if (!_carpetStatsOnly) {


### PR DESCRIPTION
It seems there is a typo in TerrainAirMapQuery::_parseCarpetData, maxHeight should be initialized by the 'max' value from json.