### PR TITLE
Fixed suspicious if-expression

### DIFF
--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -167,14 +167,10 @@ void VisualMissionItem::_updateTerrainAltitude(void)
         return;
     }
     if (!_flyView && specifiesCoordinate() && coordinate().isValid()) {
-        if (specifiesCoordinate()) {
-            if (coordinate().isValid()) {
-                // We use a timer so that any additional requests before the timer fires result in only a single request
-                _updateTerrainTimer.start();
-            }
-        } else {
-            _terrainAltitude = qQNaN();
-        }
+        // We use a timer so that any additional requests before the timer fires result in only a single request
+        _updateTerrainTimer.start();
+    } else {
+        _terrainAltitude = qQNaN();
     }
 }
 


### PR DESCRIPTION
In existing code there is no need to check specifiesCoordinate() and coordinate().isValid(), because they are always true. I assume the correct logic should be like that (start timer if expression is true or set _terrainAltitude to NaN otherwise).
