### PR TITLE
Set correct parameter type for signal

### DIFF
--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -194,7 +194,7 @@ signals:
     void altDifferenceChanged           (double altDifference);
     void altPercentChanged              (double altPercent);
     void terrainPercentChanged          (double terrainPercent);
-    void terrainCollisionChanged        (double terrainCollision);
+    void terrainCollisionChanged        (bool terrainCollision);
     void azimuthChanged                 (double azimuth);
     void commandDescriptionChanged      (void);
     void commandNameChanged             (void);


### PR DESCRIPTION
terrainCollision property is a boolean value, but signal's parameter is double - it has to be bool too.