### PR TITLE
Replaced not equal operator for double values to qFuzzyCompare

### DIFF
--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -146,7 +146,7 @@ void VisualMissionItem::setMissionFlightStatus(MissionController::MissionFlightS
     if (qIsNaN(_missionFlightStatus.gimbalYaw) && qIsNaN(_missionGimbalYaw)) {
         return;
     }
-    if (_missionFlightStatus.gimbalYaw != _missionGimbalYaw) {
+    if (!qFuzzyCompare(_missionFlightStatus.gimbalYaw, _missionGimbalYaw)) {
         _missionGimbalYaw = _missionFlightStatus.gimbalYaw;
         emit missionGimbalYawChanged(_missionGimbalYaw);
     }


### PR DESCRIPTION
Using != operator is not a way to go for comparing double values. Moreover, qFuzzyCompare is already widely used in the file, so the fix would be good for keeping consistency too.