### PR TITLE
Plan - Terrain Status: Vertical index display. Click anywhere in bar.

### DIFF
--- a/src/PlanView/MissionItemStatus.qml
+++ b/src/PlanView/MissionItemStatus.qml
@@ -99,12 +99,32 @@ Rectangle {
                 checked:                    object.isCurrentItem
                 label:                      object.abbreviation.charAt(0)
                 index:                      object.abbreviation.charAt(0) > 'A' && object.abbreviation.charAt(0) < 'z' ? -1 : object.sequenceNumber
-                showSequenceNumbers:        true
-                visible:                    true
-                onClicked:                  root.setCurrentSeqNum(object.sequenceNumber)
+                showSequenceNumbers:        false
+            }
+
+            Rectangle {
+                id:                     indexBackground
+                anchors.leftMargin:     -2
+                anchors.rightMargin:    -2
+                anchors.fill:           indexLabel
+                color:                  qgcPal.window
+                opacity:                0.3
+                visible:                indexLabel.visible
+                transform:              Rotation { angle: 90; origin.x: indexBackground.width / 2; origin.y: indexBackground.height / 2 }
+            }
+
+            QGCLabel {
+                id:                 indexLabel
+                anchors.centerIn:   parent
+                text:               object.sequenceNumber
+                visible:            indicator.index != -1
+                transform:          Rotation { angle: 90; origin.x: indexLabel.width / 2; origin.y: indexLabel.height / 2 }
+            }
+
+            MouseArea {
+                anchors.fill:   parent
+                onClicked:      root.setCurrentSeqNum(object.sequenceNumber)
             }
         }
     }
 }
-
-


### PR DESCRIPTION
![Screen Shot 2020-03-15 at 12 12 58 PM](https://user-images.githubusercontent.com/5876851/76708763-a960dd00-66b6-11ea-9476-d5c148fed85b.png)

Been meaning to do this for ages:
* Item indices are vertical so they don't overlap
* You can click anywhere in vertical area to select item
* Fix for #8559