### PR TITLE
Bring back visual sequence number in map item indicators

### DIFF
--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -31,7 +31,8 @@ MapQuickItem {
         MissionItemIndexLabel {
             id:                 _label
             checked:            _isCurrentItem
-            label:              missionItem ? missionItem.abbreviation : ""
+            label:              missionItem.abbreviation
+            index:              missionItem.abbreviation.charAt(0) > 'A' && missionItem.abbreviation.charAt(0) < 'z' ? -1 : missionItem.sequenceNumber
             gimbalYaw:          missionItem.missionGimbalYaw
             vehicleYaw:         missionItem.missionVehicleYaw
             showGimbalYaw:      !isNaN(missionItem.missionGimbalYaw)

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -25,7 +25,7 @@ Canvas {
     property real   gimbalYaw
     property real   vehicleYaw
     property bool   showGimbalYaw:          false
-    property bool   showSequenceNumbers:    false
+    property bool   showSequenceNumbers:    true
 
     property real   _width:             showGimbalYaw ? Math.max(_gimbalYawWidth, labelControl.visible ? labelControl.width : indicator.width) : (labelControl.visible ? labelControl.width : indicator.width)
     property real   _height:            showGimbalYaw ? _gimbalYawWidth : (labelControl.visible ? labelControl.height : indicator.height)


### PR DESCRIPTION
* After feedback from multiple sources on the reason why sequence numbers need to be shown in the map items I brought them back. They now show like they used to for items in the map. 
* The main complaint which isn't solvable in some other way it that the numbering is needed for discussion around
* The Plan item editors continue to not show item numbers.