### PR TITLE
Sub: Add fact for roll/pitch toggle, remove spaces from fact names

### DIFF
--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -135,7 +135,7 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void):
         _remapParamNameIntialized = true;
     }
 
-    _nameToFactGroupMap.insert("APMSubInfo", &_infoFactGroup);
+    _nameToFactGroupMap.insert("apmSubInfo", &_infoFactGroup);
 
     _factRenameMap[QStringLiteral("altitudeRelative")] = QStringLiteral("Depth");
     _factRenameMap[QStringLiteral("flightTime")] = QStringLiteral("Dive Time");

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -241,19 +241,19 @@ void ArduSubFirmwarePlugin::_handleNamedValueFloat(mavlink_message_t* message)
     QString name = QString(value.name);
 
     if (name == "CamTilt") {
-        _infoFactGroup.getFact("camera tilt")->setRawValue(value.value * 100);
+        _infoFactGroup.getFact("cameraTilt")->setRawValue(value.value * 100);
     } else if (name == "TetherTrn") {
-        _infoFactGroup.getFact("tether turns")->setRawValue(value.value);
+        _infoFactGroup.getFact("tetherTurns")->setRawValue(value.value);
     } else if (name == "Lights1") {
-        _infoFactGroup.getFact("lights 1")->setRawValue(value.value * 100);
+        _infoFactGroup.getFact("lights1")->setRawValue(value.value * 100);
     } else if (name == "Lights2") {
-        _infoFactGroup.getFact("lights 2")->setRawValue(value.value * 100);
+        _infoFactGroup.getFact("lights2")->setRawValue(value.value * 100);
     } else if (name == "PilotGain") {
-        _infoFactGroup.getFact("pilot gain")->setRawValue(value.value * 100);
+        _infoFactGroup.getFact("pilotGain")->setRawValue(value.value * 100);
     } else if (name == "InputHold") {
-        _infoFactGroup.getFact("input hold")->setRawValue(value.value);
+        _infoFactGroup.getFact("inputHold")->setRawValue(value.value);
     } else if (name == "RollPitch") {
-        _infoFactGroup.getFact("roll pitch toggle")->setRawValue(value.value);
+        _infoFactGroup.getFact("rollPitchToggle")->setRawValue(value.value);
     }
 }
 
@@ -267,7 +267,7 @@ void ArduSubFirmwarePlugin::_handleMavlinkMessage(mavlink_message_t* message)
     {
         mavlink_rangefinder_t msg;
         mavlink_msg_rangefinder_decode(message, &msg);
-        _infoFactGroup.getFact("rangefinder distance")->setRawValue(msg.distance);
+        _infoFactGroup.getFact("rangefinderDistance")->setRawValue(msg.distance);
         break;
     }
     }
@@ -283,14 +283,14 @@ QMap<QString, FactGroup*>* ArduSubFirmwarePlugin::factGroups(void) {
     return &_nameToFactGroupMap;
 }
 
-const char* APMSubmarineFactGroup::_camTiltFactName             = "camera tilt";
-const char* APMSubmarineFactGroup::_tetherTurnsFactName         = "tether turns";
-const char* APMSubmarineFactGroup::_lightsLevel1FactName        = "lights 1";
-const char* APMSubmarineFactGroup::_lightsLevel2FactName        = "lights 2";
-const char* APMSubmarineFactGroup::_pilotGainFactName           = "pilot gain";
-const char* APMSubmarineFactGroup::_inputHoldFactName           = "input hold";
-const char* APMSubmarineFactGroup::_rollPitchToggleFactName     = "roll pitch toggle";
-const char* APMSubmarineFactGroup::_rangefinderDistanceFactName = "rangefinder distance";
+const char* APMSubmarineFactGroup::_camTiltFactName             = "cameraTilt";
+const char* APMSubmarineFactGroup::_tetherTurnsFactName         = "tetherTurns";
+const char* APMSubmarineFactGroup::_lightsLevel1FactName        = "lights1";
+const char* APMSubmarineFactGroup::_lightsLevel2FactName        = "lights2";
+const char* APMSubmarineFactGroup::_pilotGainFactName           = "pilotGain";
+const char* APMSubmarineFactGroup::_inputHoldFactName           = "inputHold";
+const char* APMSubmarineFactGroup::_rollPitchToggleFactName     = "rollPitchToggle";
+const char* APMSubmarineFactGroup::_rangefinderDistanceFactName = "rangefinderDistance";
 
 APMSubmarineFactGroup::APMSubmarineFactGroup(QObject* parent)
     : FactGroup(300, ":/json/Vehicle/SubmarineFact.json", parent)

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -252,6 +252,8 @@ void ArduSubFirmwarePlugin::_handleNamedValueFloat(mavlink_message_t* message)
         _infoFactGroup.getFact("pilot gain")->setRawValue(value.value * 100);
     } else if (name == "InputHold") {
         _infoFactGroup.getFact("input hold")->setRawValue(value.value);
+    } else if (name == "RollPitch") {
+        _infoFactGroup.getFact("roll pitch toggle")->setRawValue(value.value);
     }
 }
 
@@ -287,6 +289,7 @@ const char* APMSubmarineFactGroup::_lightsLevel1FactName        = "lights 1";
 const char* APMSubmarineFactGroup::_lightsLevel2FactName        = "lights 2";
 const char* APMSubmarineFactGroup::_pilotGainFactName           = "pilot gain";
 const char* APMSubmarineFactGroup::_inputHoldFactName           = "input hold";
+const char* APMSubmarineFactGroup::_rollPitchToggleFactName     = "roll pitch toggle";
 const char* APMSubmarineFactGroup::_rangefinderDistanceFactName = "rangefinder distance";
 
 APMSubmarineFactGroup::APMSubmarineFactGroup(QObject* parent)
@@ -297,6 +300,7 @@ APMSubmarineFactGroup::APMSubmarineFactGroup(QObject* parent)
     , _lightsLevel2Fact        (0, _lightsLevel2FactName,        FactMetaData::valueTypeDouble)
     , _pilotGainFact           (0, _pilotGainFactName,           FactMetaData::valueTypeDouble)
     , _inputHoldFact           (0, _inputHoldFactName,           FactMetaData::valueTypeDouble)
+    , _rollPitchToggleFact     (0, _rollPitchToggleFactName,     FactMetaData::valueTypeDouble)
     , _rangefinderDistanceFact (0, _rangefinderDistanceFactName, FactMetaData::valueTypeDouble)
 {
     _addFact(&_camTiltFact,             _camTiltFactName);
@@ -305,6 +309,7 @@ APMSubmarineFactGroup::APMSubmarineFactGroup(QObject* parent)
     _addFact(&_lightsLevel2Fact,        _lightsLevel2FactName);
     _addFact(&_pilotGainFact,           _pilotGainFactName);
     _addFact(&_inputHoldFact,           _inputHoldFactName);
+    _addFact(&_rollPitchToggleFact    , _rollPitchToggleFactName);
     _addFact(&_rangefinderDistanceFact, _rangefinderDistanceFactName);
 
     // Start out as not available "--.--"
@@ -314,6 +319,7 @@ APMSubmarineFactGroup::APMSubmarineFactGroup(QObject* parent)
     _lightsLevel2Fact.setRawValue        (std::numeric_limits<float>::quiet_NaN());
     _pilotGainFact.setRawValue           (std::numeric_limits<float>::quiet_NaN());
     _inputHoldFact.setRawValue           (std::numeric_limits<float>::quiet_NaN());
+    _rollPitchToggleFact.setRawValue     (2); // 2 shows "Unavailable" in older firmwares
     _rangefinderDistanceFact.setRawValue (std::numeric_limits<float>::quiet_NaN());
 
 }

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -57,6 +57,7 @@ public:
     static const char* _lightsLevel2FactName;
     static const char* _pilotGainFactName;
     static const char* _inputHoldFactName;
+    static const char* _rollPitchToggleFactName;
     static const char* _rangefinderDistanceFactName;
 
     static const char* _settingsGroup;
@@ -68,6 +69,7 @@ private:
     Fact            _lightsLevel2Fact;
     Fact            _pilotGainFact;
     Fact            _inputHoldFact;
+    Fact            _rollPitchToggleFact;
     Fact            _rangefinderDistanceFact;
 };
 

--- a/src/MissionManager/RallyPoint.FactMetaData.json
+++ b/src/MissionManager/RallyPoint.FactMetaData.json
@@ -16,7 +16,7 @@
     "decimalPlaces":    7
 },
 {
-    "name":             "Relative Altitude",
+    "name":             "RelativeAltitude",
     "shortDescription": "Altitude of rally point position (home relative)",
     "type":             "double",
     "decimalPlaces":    2,

--- a/src/MissionManager/RallyPoint.cc
+++ b/src/MissionManager/RallyPoint.cc
@@ -15,7 +15,7 @@
 
 const char* RallyPoint::_longitudeFactName =    "Longitude";
 const char* RallyPoint::_latitudeFactName =     "Latitude";
-const char* RallyPoint::_altitudeFactName =     "Relative Altitude";
+const char* RallyPoint::_altitudeFactName =     "RelativeAltitude";
 
 QMap<QString, FactMetaData*> RallyPoint::_metaDataMap;
 

--- a/src/Vehicle/SubmarineFact.json
+++ b/src/Vehicle/SubmarineFact.json
@@ -45,6 +45,12 @@
     "type":             "float",
     "decimalPlaces":    2,
     "units":            "meters"
+},
+{   "name":             "roll pitch toggle",
+    "shortDescription": "Roll/Pitch Toggle",
+    "type":             "int16",
+    "enumStrings":      "Disabled,Enabled,Unavailable",
+    "enumValues":       "0,1,2"
 }
 ]
 }

--- a/src/Vehicle/SubmarineFact.json
+++ b/src/Vehicle/SubmarineFact.json
@@ -4,49 +4,49 @@
     "QGC.MetaData.Facts":
 [
 {
-    "name":             "camera tilt",
+    "name":             "cameraTilt",
     "shortDescription": "Camera Tilt",
     "type":             "int16",
     "units":            "%"
 },
 {
-    "name":             "tether turns",
+    "name":             "tetherTurns",
     "shortDescription": "Tether Turns",
     "type":             "int16",
     "units":            "clockwise"
 },
 {
-    "name":             "lights 1",
+    "name":             "lights1",
     "shortDescription": "Lights 1 level",
     "type":             "int16",
     "units":            "%"
 },
 {
-    "name":             "lights 2",
+    "name":             "lights2",
     "shortDescription": "Lights 2 level",
     "type":             "int16",
     "units":            "%"
 },
 {
-    "name":             "pilot gain",
+    "name":             "pilotGain",
     "shortDescription": "Pilot Gain",
     "type":             "int16",
     "units":            "%"
 },
 {
-    "name":             "input hold",
+    "name":             "inputHold",
     "shortDescription": "Input Hold",
     "type":             "int16",
     "enumStrings":      "Disabled,Enabled",
     "enumValues":       "0,1"
 },
-{    "name":             "rangefinder distance",
+{    "name":            "rangefinderDistance",
     "shortDescription": "Rangefinder",
     "type":             "float",
     "decimalPlaces":    2,
     "units":            "meters"
 },
-{   "name":             "roll pitch toggle",
+{   "name":             "rollPitchToggle",
     "shortDescription": "Roll/Pitch Toggle",
     "type":             "int16",
     "enumStrings":      "Disabled,Enabled,Unavailable",


### PR DESCRIPTION
This will allow sub users to see if the ROV is in the Roll/pitch toggle
mode using the APMSubInfo section in the info widget

needs to wait for https://github.com/ArduPilot/ardupilot/pull/13630

Fix #8360 
Fix #8705