### PR TITLE
FollowMe: Fix "Always" settings for streaming GCS position

### DIFF
--- a/src/FollowMe/FollowMe.cc
+++ b/src/FollowMe/FollowMe.cc
@@ -151,7 +151,7 @@ void FollowMe::_sendGCSMotionReport()
 
     for (int i=0; i<vehicles->count(); i++) {
         Vehicle* vehicle = vehicles->value<Vehicle*>(i);
-        if (_isFollowFlightMode(vehicle, vehicle->flightMode())) {
+        if (_currentMode == MODE_ALWAYS || _isFollowFlightMode(vehicle, vehicle->flightMode())) {
             qCDebug(FollowMeLog) << "sendGCSMotionReport latInt:lonInt:altMetersAMSL" << motionReport.lat_int << motionReport.lon_int << motionReport.altMetersAMSL;
             vehicle->firmwarePlugin()->sendGCSMotionReport(vehicle, motionReport, estimatation_capabilities);
         }


### PR DESCRIPTION
Currently it looks like GCS motion reports will only be sent to vehicles that are in the appropriate "Follow" mode even when the "Stream GCS Position" setting is "Always". I've confirmed that GCS motion reports (FOLLOW_TARGET mavlink messages) aren't received using 4.0.4, whereas they were in version 3.5.6, when in a non-follow mode.

This PR should fix the issue. I haven't been able to fully test it as I'm not set up to build on Android and don't have a GPS I can use on my development machine. 


