### PR TITLE
Emit sensorHilChanged signal only if it was really changed

### DIFF
--- a/src/comm/QGCJSBSimLink.h
+++ b/src/comm/QGCJSBSimLink.h
@@ -94,9 +94,10 @@ public slots:
     }
 
     void enableSensorHIL(bool enable) {
-        if (enable != _sensorHilEnabled)
+        if (enable != _sensorHilEnabled) {
             _sensorHilEnabled = enable;
             emit sensorHilChanged(enable);
+        }
     }
 
     void readBytes();

--- a/src/comm/QGCXPlaneLink.h
+++ b/src/comm/QGCXPlaneLink.h
@@ -131,9 +131,10 @@ public slots:
     void setVersion(unsigned int version);
 
     void enableSensorHIL(bool enable) {
-        if (enable != _sensorHilEnabled)
+        if (enable != _sensorHilEnabled) {
             _sensorHilEnabled = enable;
             emit sensorHilChanged(enable);
+        }
     }
 
     void enableHilActuatorControls(bool enable);


### PR DESCRIPTION
Originally sensorHilChanged() was emitted every time enableSensorHIL() was called.
However, we need to emit signal only when the value was changed.