### PR TITLE
Adjust minimum application window size

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -25,8 +25,8 @@ import QGroundControl.FlightMap     1.0
 /// All properties defined here are visible to all QML pages.
 ApplicationWindow {
     id:             mainWindow
-    minimumWidth:   ScreenTools.isMobile ? Screen.width  : Math.min(215 * Screen.pixelDensity, Screen.width)
-    minimumHeight:  ScreenTools.isMobile ? Screen.height : Math.min(120 * Screen.pixelDensity, Screen.height)
+    minimumWidth:   ScreenTools.isMobile ? Screen.width  : Math.min(ScreenTools.defaultFontPixelWidth * 100, Screen.width)
+    minimumHeight:  ScreenTools.isMobile ? Screen.height : Math.min(ScreenTools.defaultFontPixelWidth * 50, Screen.height)
     visible:        true
 
     Component.onCompleted: {


### PR DESCRIPTION
In response to https://github.com/mavlink/qgroundcontrol/issues/8486

I'm using an arbitrary minimum size where the UI _mostly_ fits. Needs testing on other platforms. Especially when connected to low DPI monitors.

<img width="912" alt="Screen Shot 2020-03-23 at 5 23 39 PM" src="https://user-images.githubusercontent.com/749243/77360303-e159c700-6d2b-11ea-9a68-92ec184d6497.png">

Closes #8486
