### PR TITLE
Plan: Remove display of incomplete item line connections

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1232,8 +1232,7 @@ void MissionController::_recalcWaypointLines(void)
     bool                foundRTL =                      false;
     bool                homePositionValid =             _settingsItem->coordinate().isValid();
     bool                roiActive =                     false;
-    bool                setupIncompleteItem =           false;
-    VisualMissionItem*  startVIForIncompleteItem =      nullptr;
+    bool                previousItemIsIncomplete =      false;
 
     qCDebug(MissionControllerLog) << "_recalcWaypointLines homePositionValid" << homePositionValid;
 
@@ -1241,6 +1240,10 @@ void MissionController::_recalcWaypointLines(void)
 
     _linesTable.clear();
     _waypointPath.clear();
+
+    // Note: Although visual support _incompleteComplexItemLines is still in the codebase. The support for populating the list is not.
+    // This is due to the initial implementation being buggy and incomplete with respect to correctly generating the line set.
+    // So for now we leave the code for displaying them in, but none are ever added until we have time to implement the correct support.
 
     _waypointLines.beginReset();
     _directionArrows.beginReset();
@@ -1296,22 +1299,17 @@ void MissionController::_recalcWaypointLines(void)
 
         if (visualItem->specifiesCoordinate() && !visualItem->isStandaloneCoordinate()) {
             // Incomplete items are complex items which are waiting for the user to complete setup before there visuals can become valid.
-            // For example a Survey which has no polygon set for it yet. For these cases we draw incomplete segment lines so that there
-            // isn't a hole in the flight path lines.
+            // They may not yet have valid entry/exit coordinates associated with them while in the incomplete state.
+            // For examples a Survey item which has no polygon set yet.
             if (complexItem && complexItem->isIncomplete()) {
-                setupIncompleteItem = true;
+                // We don't link lines from a valid item to an incomplete item
+                previousItemIsIncomplete = true;
+            } else if (previousItemIsIncomplete) {
+                // We also don't link lines from an incomplete item to a valid item.
+                previousItemIsIncomplete = false;
+                firstCoordinateNotFound = false;
+                lastCoordinateItemBeforeRTL = visualItem;
             } else {
-                if (setupIncompleteItem) {
-                    VisualItemPair viPair(startVIForIncompleteItem, visualItem);
-                    CoordinateVector* coordVector = _createCoordinateVectorWorker(viPair);
-
-                    _incompleteComplexItemLines.append(coordVector);
-                    startVIForIncompleteItem = nullptr;
-                    setupIncompleteItem = false;
-                } else {
-                    startVIForIncompleteItem = visualItem;
-                }
-
                 if (lastCoordinateItemBeforeRTL != _settingsItem || (homePositionValid && linkStartToHome)) {
                     bool addDirectionArrow = false;
                     if (i != 1) {

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -750,6 +750,9 @@ int TransectStyleComplexItem::lastSequenceNumber(void) const
     if (_loadedMissionItems.count()) {
         // We have stored mission items, just use those
         return _sequenceNumber + _loadedMissionItems.count() - 1;
+    } else if (_transects.count() == 0) {
+        // Polygon has not yet been set so we just return back a one item complex item for now
+        return _sequenceNumber;
     } else {
         // We have to determine from transects
         int itemCount = 0;


### PR DESCRIPTION
* This essentially backs out the change to fix #8023. The correct fix for this is way more complex than I originally thought. And the existing code was buggy and causing crashes. Not possible to deal with in current stable. Will have to wait for point release.
* Fixed item sequence numbering problem for incomplete items. This could cause more than one item to have the same sequence number. Which would in turn cause things like multiple items being marked as current at the same time.