### PR TITLE
link against libicudata.so too

### DIFF
--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -107,6 +107,7 @@ LinuxBuild {
     !contains(DEFINES, __rasp_pi2__) {
         # Some Qt distributions link with *.so.56
         QT_LIB_LIST += \
+            libicudata.so \
             libicudata.so.56 \
             libicui18n.so.56 \
             libicuuc.so.56


### PR DESCRIPTION
Without this change the build of QGC fails in the link step on
Arch Linux machines.


