### PR TITLE
Fix "Pause" behaviour for ArduPilot

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -912,7 +912,10 @@ void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
         return;
     }
 
-    setGuidedMode(vehicle, true);
+    // Only set guided mode if altitude change has been requested.
+    if (abs(altitudeChange)>0.01) {
+        setGuidedMode(vehicle, true);
+    }
 
     mavlink_message_t msg;
     mavlink_set_position_target_local_ned_t cmd;

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -217,7 +217,7 @@ Item {
     property var _actionData
 
     on_FlightModeChanged: {
-        _vehiclePaused =        activeVehicle ? _flightMode === activeVehicle.pauseFlightMode : false
+        _vehiclePaused =        activeVehicle ? _flightMode === activeVehicle.pauseFlightMode || activeVehicle.guidedMode: false
         _vehicleInRTLMode =     activeVehicle ? _flightMode === activeVehicle.rtlFlightMode || _flightMode === activeVehicle.smartRTLFlightMode : false
         _vehicleInLandMode =    activeVehicle ? _flightMode === activeVehicle.landFlightMode : false
         _vehicleInMissionMode = activeVehicle ? _flightMode === activeVehicle.missionFlightMode : false // Must be last to get correct signalling for showStartMission popups


### PR DESCRIPTION
Pausing the mission via the "Pause" button on the Fly screen sets the vehicle to the relevant flight mode (LOITER, HOLD or BRAKE depending on type) but then the mode is immediately set to GUIDED so that the altitude can be set via the slider. This causes the "Resume Mission" and "Change Alt" actions to be unavailable.

This change causes the mode to change to GUIDED if the altitude change requested is more than 1cm, and also recognises the mission as paused when in GUIDED mode so that the "Resume Mission" and "Change Alt" actions are shown.