### PR TITLE
Show mission items in Geofence edit mode

### DIFF
--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -38,6 +38,7 @@ MapQuickItem {
             showGimbalYaw:      !isNaN(missionItem.missionGimbalYaw)
             highlightSelected:  true
             onClicked:          _item.clicked()
+            opacity:            _item.opacity
 
             property bool _isCurrentItem:   missionItem ? missionItem.isCurrentItem || missionItem.hasCurrentChildItem : false
         }

--- a/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
@@ -71,6 +71,7 @@ Rectangle {
         drag.maximumX:      itemDragger.parent.width - parent.width
         drag.maximumY:      itemDragger.parent.height - parent.height
         preventStealing:    true
+        enabled:            itemDragger.visible
 
         onClicked: {
             focus = true

--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -303,7 +303,7 @@ Item {
 
             sourceItem: SplitIndicator {
                 z:          _zorderSplitHandle
-                onClicked:  mapPolygon.splitPolygonSegment(mapQuickItem.vertexIndex)
+                onClicked:  if(_root.interactive) mapPolygon.splitPolygonSegment(mapQuickItem.vertexIndex)
             }
         }
     }
@@ -368,7 +368,7 @@ Item {
                 }
             }
 
-            onClicked: menu.popupVertex(polygonVertex)
+            onClicked: if(_root.interactive) menu.popupVertex(polygonVertex)
         }
     }
 
@@ -577,7 +577,7 @@ Item {
             z:                  QGroundControl.zOrderMapItems + 1   // Over item indicators
 
             onClicked: {
-                if (mouse.button === Qt.LeftButton) {
+                if (mouse.button === Qt.LeftButton && _root.interactive) {
                     mapPolygon.appendVertex(mapControl.toCoordinate(Qt.point(mouse.x, mouse.y), false /* clipToViewPort */))
                 }
             }
@@ -599,7 +599,7 @@ Item {
                 height:     width
                 radius:     width / 2
                 color:      "white"
-                opacity:    .90
+                opacity:    interiorOpacity * .90
             }
         }
     }

--- a/src/MissionManager/QGCMapPolylineVisuals.qml
+++ b/src/MissionManager/QGCMapPolylineVisuals.qml
@@ -175,6 +175,7 @@ Item {
             line.color: lineColor
             path:       mapPolyline.path
             visible:    _root.visible
+            opacity:    _root.opacity
         }
     }
 
@@ -186,6 +187,7 @@ Item {
             anchorPoint.x:  sourceItem.width / 2
             anchorPoint.y:  sourceItem.height / 2
             z:              _zorderSplitHandle
+            opacity:        _root.opacity
 
             property int vertexIndex
 
@@ -204,6 +206,8 @@ Item {
             delegate: Item {
                 property var _splitHandle
                 property var _vertices:     mapPolyline.path
+
+                opacity:    _root.opacity
 
                 function _setHandlePosition() {
                     var nextIndex = index + 1
@@ -238,6 +242,7 @@ Item {
             mapControl: _root.mapControl
             id:         dragArea
             z:          _zorderDragHandle
+            opacity:    _root.opacity
 
             property int polylineVertex
 
@@ -267,6 +272,7 @@ Item {
             anchorPoint.x:  dragHandle.width / 2
             anchorPoint.y:  dragHandle.height / 2
             z:              _zorderDragHandle
+            opacity:        _root.opacity
 
             property int polylineVertex
 
@@ -291,6 +297,8 @@ Item {
 
             delegate: Item {
                 property var _visuals: [ ]
+
+                opacity:    _root.opacity
 
                 Component.onCompleted: {
                     var dragHandle = dragHandleComponent.createObject(mapControl)
@@ -366,7 +374,7 @@ Item {
             z:                  QGroundControl.zOrderMapItems + 1   // Over item indicators
 
             onClicked: {
-                if (mouse.button === Qt.LeftButton) {
+                if (mouse.button === Qt.LeftButton && _root.interactive) {
                     mapPolyline.appendVertex(mapControl.toCoordinate(Qt.point(mouse.x, mouse.y), false /* clipToViewPort */))
                 }
             }

--- a/src/PlanView/CorridorScanMapVisual.qml
+++ b/src/PlanView/CorridorScanMapVisual.qml
@@ -25,9 +25,10 @@ TransectStyleMapVisuals {
         id:             mapPolylineVisuals
         mapControl:     map
         mapPolyline:    object.corridorPolyline
-        interactive:    _currentItem
+        interactive:    _currentItem && parent.interactive
         lineWidth:      3
         lineColor:      "#be781c"
         visible:        _currentItem
+        opacity:        parent.opacity
     }
 }

--- a/src/PlanView/FWLandingPatternMapVisual.qml
+++ b/src/PlanView/FWLandingPatternMapVisual.qml
@@ -24,6 +24,7 @@ Item {
     id: _root
 
     property var map        ///< Map control to place item in
+    property bool interactive: true
 
     signal clicked(int sequenceNumber)
 
@@ -178,6 +179,7 @@ Item {
         MouseArea {
             anchors.fill:   map
             z:              QGroundControl.zOrderMapItems + 1   // Over item indicators
+            visible:        _root.interactive
 
             readonly property int   _decimalPlaces:             8
 
@@ -199,6 +201,7 @@ Item {
             mapControl:     _root.map
             itemIndicator:  _loiterPointObject
             itemCoordinate: _missionItem.loiterCoordinate
+            visible:        _root.interactive
 
             property bool _preventReentrancy: false
 
@@ -224,6 +227,7 @@ Item {
             mapControl:     _root.map
             itemIndicator:  _landingPointObject
             itemCoordinate: _missionItem.landingCoordinate
+            visible:        _root.interactive
 
             onItemCoordinateChanged: _missionItem.moveLandingPosition(itemCoordinate)
         }

--- a/src/PlanView/GeoFenceMapVisuals.qml
+++ b/src/PlanView/GeoFenceMapVisuals.qml
@@ -39,8 +39,8 @@ Item {
     property int    _borderWidthExclusion:      0
     property color  _interiorColorExclusion:    "orange"
     property color  _interiorColorInclusion:    "transparent"
-    property real   _interiorOpacityExclusion:  0.2
-    property real   _interiorOpacityInclusion:  1
+    property real   _interiorOpacityExclusion:  0.2 * opacity
+    property real   _interiorOpacityInclusion:  1 * opacity
 
     function addPolygon(inclusionPolygon) {
         // Initial polygon is inset to take 2/3rds space
@@ -104,6 +104,7 @@ Item {
             borderColor:        _borderColor
             interiorColor:      object.inclusion ? _interiorColorInclusion : _interiorColorExclusion
             interiorOpacity:    object.inclusion ? _interiorOpacityInclusion : _interiorOpacityExclusion
+            interactive:        _root.interactive && mapPolygon && mapPolygon.interactive
         }
     }
 
@@ -118,6 +119,7 @@ Item {
             borderColor:        _borderColor
             interiorColor:      object.inclusion ? _interiorColorInclusion : _interiorColorExclusion
             interiorOpacity:    object.inclusion ? _interiorOpacityInclusion : _interiorOpacityExclusion
+            interactive:         _root.interactive && mapCircle && mapCircle.interactive
         }
     }
 
@@ -146,7 +148,7 @@ Item {
         MissionItemIndicatorDrag {
             mapControl:     map
             itemCoordinate: myGeoFenceController.breachReturnPoint
-            //visible:        itemCoordinate.isValid
+            visible:        _root.interactive
 
             onItemCoordinateChanged: myGeoFenceController.breachReturnPoint = itemCoordinate
         }
@@ -162,6 +164,7 @@ Item {
             anchorPoint.y:  sourceItem.anchorPointY
             z:              QGroundControl.zOrderMapItems
             coordinate:     myGeoFenceController.breachReturnPoint
+            opacity:        _root.opacity
 
             sourceItem: MissionItemIndexLabel {
                 label:      qsTr("B", "Breach Return Point item indicator")

--- a/src/PlanView/MissionItemMapVisual.qml
+++ b/src/PlanView/MissionItemMapVisual.qml
@@ -23,6 +23,7 @@ Item {
 
     property var map        ///< Map control to place item in
     property var vehicle    ///< Vehicle associated with this item
+    property var interactive: true    ///< Vehicle associated with this item
 
     signal clicked(int sequenceNumber)
 
@@ -34,7 +35,7 @@ Item {
             if (component.status === Component.Error) {
                 console.log("Error loading Qml: ", object.mapVisualQML, component.errorString())
             }
-            _visualItem = component.createObject(map, { "map": _root.map, vehicle: _root.vehicle })
+            _visualItem = component.createObject(map, { "map": _root.map, vehicle: _root.vehicle, 'opacity': Qt.binding(function() { return _root.opacity }), 'interactive': Qt.binding(function() { return _root.interactive }) })
             _visualItem.clicked.connect(_root.clicked)
         }
     }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -390,6 +390,7 @@ Item {
 
             property real _leftToolWidth:       toolStrip.x + toolStrip.width
             property real _rightToolWidth:      rightPanel.width + rightPanel.anchors.rightMargin
+            property real _nonInteractiveOpacity:  0.5
 
             // Initial map position duplicates Fly view position
             Component.onCompleted: editorMap.center = QGroundControl.flightMapPosition
@@ -436,18 +437,20 @@ Item {
 
             // Add the mission item visuals to the map
             Repeater {
-                model: _editingLayer == _layerMission ? _missionController.visualItems : undefined
+                model: _missionController.visualItems
                 delegate: MissionItemMapVisual {
                     map:        editorMap
                     onClicked:  _missionController.setCurrentPlanViewSeqNum(sequenceNumber, false)
-                    visible:    _editingLayer == _layerMission
+                    opacity:    _editingLayer == _layerMission ? 1 : editorMap._nonInteractiveOpacity
+                    interactive: _editingLayer == _layerMission
                 }
             }
 
             // Add lines between waypoints
             MissionLineView {
                 showSpecialVisual:  _missionController.isROIBeginCurrentItem
-                model:              _editingLayer == _layerMission ? _missionController.waypointLines : undefined
+                model:              _missionController.waypointLines
+                opacity:            _editingLayer == _layerMission ? 1 : editorMap._nonInteractiveOpacity
             }
 
             // Direction arrows in waypoint lines
@@ -464,13 +467,14 @@ Item {
 
             // Incomplete segment lines
             MapItemView {
-                model: _editingLayer == _layerMission ? _missionController.incompleteComplexItemLines : undefined
+                model: _missionController.incompleteComplexItemLines
 
                 delegate: MapPolyline {
                     path:       [ object.coordinate1, object.coordinate2 ]
                     line.width: 1
                     line.color: "red"
                     z:          QGroundControl.zOrderWaypointLines
+                    opacity:    _editingLayer == _layerMission ? 1 : editorMap._nonInteractiveOpacity
                 }
             }
 
@@ -513,8 +517,7 @@ Item {
             // Add the vehicles to the map
             MapItemView {
                 model: QGroundControl.multiVehicleManager.vehicles
-                delegate:
-                    VehicleMapItem {
+                delegate: VehicleMapItem {
                     vehicle:        object
                     coordinate:     object.coordinate
                     map:            editorMap
@@ -529,6 +532,7 @@ Item {
                 interactive:            _editingLayer == _layerGeoFence
                 homePosition:           _missionController.plannedHomePosition
                 planView:               true
+                opacity:                _editingLayer != _layerGeoFence ? editorMap._nonInteractiveOpacity : 1
             }
 
             RallyPointMapVisuals {
@@ -536,6 +540,7 @@ Item {
                 myRallyPointController: _rallyPointController
                 interactive:            _editingLayer == _layerRallyPoints
                 planView:               true
+                opacity:                _editingLayer != _layerRallyPoints ? editorMap._nonInteractiveOpacity : 1
             }
 
             // Airspace overlap support
@@ -851,6 +856,7 @@ Item {
                 flightMap:              editorMap
                 visible:                _editingLayer == _layerGeoFence
             }
+
             // Rally Point Editor
             RallyPointEditorHeader {
                 id:                     rallyPointHeader

--- a/src/PlanView/RallyPointMapVisuals.qml
+++ b/src/PlanView/RallyPointMapVisuals.qml
@@ -47,7 +47,7 @@ Item {
         MissionItemIndicatorDrag {
             mapControl:     _root.map
             itemCoordinate: rallyPointObject.coordinate
-            visible:        rallyPointObject === myRallyPointController.currentRallyPoint
+            visible:        rallyPointObject === myRallyPointController.currentRallyPoint && _root.interactive
 
             property var rallyPointObject
 
@@ -63,6 +63,7 @@ Item {
             anchorPoint.x:  sourceItem.anchorPointX
             anchorPoint.y:  sourceItem.anchorPointY
             z:              QGroundControl.zOrderMapItems
+            opacity:        _root.opacity
 
             property var rallyPointObject
 
@@ -84,6 +85,7 @@ Item {
             model: _rallyPoints
 
             delegate: Item {
+                opacity:        _root.opacity
                 property var _visuals: [ ]
 
                 Component.onCompleted: {

--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -24,6 +24,7 @@ Item {
 
     property var map        ///< Map control to place item in
     property var vehicle    ///< Vehicle associated with this item
+    property bool interactive: true
 
     property var    _missionItem:       object
     property var    _itemVisual
@@ -95,6 +96,7 @@ Item {
             mapControl:     _root.map
             itemIndicator:  _itemVisual
             itemCoordinate: _missionItem.coordinate
+            visible:        _root.interactive
 
             onItemCoordinateChanged: _missionItem.coordinate = itemCoordinate
         }
@@ -109,7 +111,8 @@ Item {
             z:              QGroundControl.zOrderMapItems
             missionItem:    _missionItem
             sequenceNumber: _missionItem.sequenceNumber
-            onClicked:      _root.clicked(_missionItem.sequenceNumber)
+            onClicked:      if(_root.interactive)  _root.clicked(_missionItem.sequenceNumber)
+            opacity:        _root.opacity
         }
     }
 }

--- a/src/PlanView/StructureScanMapVisual.qml
+++ b/src/PlanView/StructureScanMapVisual.qml
@@ -27,6 +27,7 @@ Item {
     property var _missionItem:      object
     property var _structurePolygon: object.structurePolygon
     property var _flightPolygon:    object.flightPolygon
+    property bool interactive:      parent.interactive
 
     signal clicked(int sequenceNumber)
 
@@ -43,11 +44,11 @@ Item {
     QGCMapPolygonVisuals {
         mapControl:         map
         mapPolygon:         _structurePolygon
-        interactive:        _missionItem.isCurrentItem
+        interactive:        _missionItem.isCurrentItem && _root.interactive
         borderWidth:        1
         borderColor:        "black"
         interiorColor:      "green"
-        interiorOpacity:    0.25
+        interiorOpacity:    0.5 * _root.opacity
     }
 
     QGCMapPolygonVisuals {
@@ -56,6 +57,7 @@ Item {
         interactive:        false
         borderWidth:        2
         borderColor:        "white"
+        interiorOpacity:    _root.opacity
     }
 
     // Entry point
@@ -67,7 +69,7 @@ Item {
             anchorPoint.y:  sourceItem.anchorPointY
             z:              QGroundControl.zOrderMapItems
             coordinate:     _missionItem.coordinate
-            visible:        _missionItem.exitCoordinate.isValid
+            visible:        _missionItem.exitCoordinate.isValid && _root.interactive
 
             sourceItem: MissionItemIndexLabel {
                 index:      _missionItem.sequenceNumber
@@ -87,7 +89,7 @@ Item {
             anchorPoint.y:  sourceItem.anchorPointY
             z:              QGroundControl.zOrderMapItems
             coordinate:     _missionItem.exitCoordinate
-            visible:        _missionItem.exitCoordinate.isValid
+            visible:        _missionItem.exitCoordinate.isValid && _root.interactive
 
             sourceItem: MissionItemIndexLabel {
                 index:      _missionItem.lastSequenceNumber

--- a/src/PlanView/TakeoffItemMapVisual.qml
+++ b/src/PlanView/TakeoffItemMapVisual.qml
@@ -24,6 +24,7 @@ Item {
 
     property var map        ///< Map control to place item in
     property var vehicle    ///< Vehicle associated with this item
+    property bool interactive: true
 
     property var    _missionItem:           object
     property var    _takeoffIndicatorItem
@@ -78,6 +79,7 @@ Item {
             mapControl:     _root.map
             itemIndicator:  _takeoffIndicatorItem
             itemCoordinate: _missionItem.specifiesCoordinate ? _missionItem.coordinate : _missionItem.launchCoordinate
+            visible:        _root.interactive
 
             onItemCoordinateChanged: {
                 if (_missionItem.specifiesCoordinate) {
@@ -96,7 +98,7 @@ Item {
             mapControl:     _root.map
             itemIndicator:  _launchIndicatorItem
             itemCoordinate: _missionItem.launchCoordinate
-            visible:        !_missionItem.launchTakeoffAtSameLocation
+            visible:        !_missionItem.launchTakeoffAtSameLocation && _root.interactive
 
             onItemCoordinateChanged: _missionItem.launchCoordinate = itemCoordinate
         }
@@ -111,6 +113,7 @@ Item {
             missionItem:    _missionItem
             sequenceNumber: _missionItem.sequenceNumber
             onClicked:      _root.clicked(_missionItem.sequenceNumber)
+            opacity:        _root.opacity
         }
     }
 
@@ -121,7 +124,7 @@ Item {
             coordinate:     _missionItem.launchCoordinate
             anchorPoint.x:  sourceItem.anchorPointX
             anchorPoint.y:  sourceItem.anchorPointY
-            visible:        !_missionItem.launchTakeoffAtSameLocation
+            visible:        !_missionItem.launchTakeoffAtSameLocation && _root.interactive
 
             sourceItem:
                 MissionItemIndexLabel {
@@ -129,6 +132,7 @@ Item {
                     label:              qsTr("Launch")
                     highlightSelected:  true
                     onClicked:          _root.clicked(_missionItem.sequenceNumber)
+                    visible:            _root.interactive
                 }
         }
     }
@@ -140,7 +144,7 @@ Item {
         MouseArea {
             anchors.fill:   map
             z:              QGroundControl.zOrderMapItems + 1   // Over item indicators
-            visible:        !_missionItem.launchCoordinate.isValid
+            visible:        !_missionItem.launchCoordinate.isValid && _root.interactive
 
             readonly property int   _decimalPlaces: 8
 

--- a/src/PlanView/TransectStyleMapVisuals.qml
+++ b/src/PlanView/TransectStyleMapVisuals.qml
@@ -24,6 +24,7 @@ Item {
 
     property var    map                                                 ///< Map control to place item in
     property bool   polygonInteractive: true
+    property bool   interactive: true
 
     property var    _missionItem:               object
     property var    _mapPolygon:                object.surveyAreaPolygon
@@ -70,11 +71,11 @@ Item {
         id:                 mapPolygonVisuals
         mapControl:         map
         mapPolygon:         _mapPolygon
-        interactive:        polygonInteractive && _missionItem.isCurrentItem
+        interactive:        polygonInteractive && _missionItem.isCurrentItem && _root.interactive
         borderWidth:        1
         borderColor:        "black"
         interiorColor:      QGroundControl.globalPalette.surveyPolygonInterior
-        interiorOpacity:    0.5
+        interiorOpacity:    0.5 * _root.opacity
     }
 
     // Full set of transects lines. Shown when item is selected.
@@ -86,6 +87,7 @@ Item {
             line.width: 2
             path:       _transectPoints
             visible:    _currentItem
+            opacity:    _root.opacity
         }
     }
 
@@ -98,6 +100,7 @@ Item {
             line.width: 2
             path:       _showPartialEntryExit ? [ _transectPoints[0], _transectPoints[1] ] : []
             visible:    _showPartialEntryExit
+            opacity:    _root.opacity
         }
     }
     Component {
@@ -108,6 +111,7 @@ Item {
             line.width: 2
             path:       _showPartialEntryExit ? [ _transectPoints[_lastPointIndex - 1], _transectPoints[_lastPointIndex] ] : []
             visible:    _showPartialEntryExit
+            opacity:    _root.opacity
         }
     }
 
@@ -121,11 +125,12 @@ Item {
             z:              QGroundControl.zOrderMapItems
             coordinate:     _missionItem.coordinate
             visible:        _missionItem.exitCoordinate.isValid
+            opacity:        _root.opacity
 
             sourceItem: MissionItemIndexLabel {
                 index:      _missionItem.sequenceNumber
                 checked:    _missionItem.isCurrentItem
-                onClicked:  _root.clicked(_missionItem.sequenceNumber)
+                onClicked:  if(_root.interactive) _root.clicked(_missionItem.sequenceNumber)
             }
         }
     }
@@ -138,6 +143,7 @@ Item {
             toCoord:        _transectPoints[_firstTrueTransectIndex + 1]
             arrowPosition:  1
             visible:        _currentItem
+            opacity:        _root.opacity
         }
     }
 
@@ -149,6 +155,7 @@ Item {
             toCoord:        _transectPoints[nextTrueTransectIndex + 1]
             arrowPosition:  1
             visible:        _currentItem && _transectCount > 3
+            opacity:        _root.opacity
 
             property int nextTrueTransectIndex: _firstTrueTransectIndex + (_hasTurnaround ? 4 : 2)
         }
@@ -162,6 +169,7 @@ Item {
             toCoord:        _transectPoints[_lastTrueTransectIndex]
             arrowPosition:  3
             visible:        _currentItem
+            opacity:        _root.opacity
         }
     }
 
@@ -173,6 +181,7 @@ Item {
             toCoord:        _transectPoints[prevTrueTransectIndex]
             arrowPosition:  13
             visible:        _currentItem && _transectCount > 3
+            opacity:        _root.opacity
 
             property int prevTrueTransectIndex: _lastTrueTransectIndex - (_hasTurnaround ? 4 : 2)
         }
@@ -188,11 +197,12 @@ Item {
             z:              QGroundControl.zOrderMapItems
             coordinate:     _missionItem.exitCoordinate
             visible:        _missionItem.exitCoordinate.isValid
+            opacity:        _root.opacity
 
             sourceItem: MissionItemIndexLabel {
                 index:      _missionItem.lastSequenceNumber
                 checked:    _missionItem.isCurrentItem
-                onClicked:  _root.clicked(_missionItem.sequenceNumber)
+                onClicked:  if(_root.interactive) _root.clicked(_missionItem.sequenceNumber)
             }
         }
     }


### PR DESCRIPTION
Show mission items in geofence and rally edit mode.

Add interactive flag to the mission items that don't have it and disable interactions in Geofence and Rally edit mode.
Propagate transparency to the mission items in order to enable it in non-mission edit mode.

Mission edit mode
![mission_always](https://user-images.githubusercontent.com/47554641/80191310-c96cb000-8615-11ea-95eb-7001ca214d02.png)

Geofence edit mode
![fence_always](https://user-images.githubusercontent.com/47554641/80191326-cf629100-8615-11ea-80cc-2aea9f7ee84b.png)

Rally Points edit mode
![rally_always](https://user-images.githubusercontent.com/47554641/80191342-d5f10880-8615-11ea-8a08-27dacd194f40.png)

Mission from the screenshots
[geofence_test.zip](https://github.com/mavlink/qgroundcontrol/files/4527610/geofence_test.zip)


