### PR TITLE
Plan: New wizard done model

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -41,18 +41,19 @@ CorridorScanComplexItem::CorridorScanComplexItem(PlanMasterController* masterCon
         _cameraCalc.distanceToSurface()->setRawValue(qgcApp()->toolbox()->settingsManager()->appSettings()->defaultMissionItemAltitude()->rawValue());
     }
 
-    connect(&_corridorWidthFact,    &Fact::valueChanged,                                this, &CorridorScanComplexItem::_setDirty);
-    connect(&_corridorPolyline,     &QGCMapPolyline::pathChanged,                       this, &CorridorScanComplexItem::_setDirty);
+    connect(&_corridorWidthFact,    &Fact::valueChanged,                            this, &CorridorScanComplexItem::_setDirty);
+    connect(&_corridorPolyline,     &QGCMapPolyline::pathChanged,                   this, &CorridorScanComplexItem::_setDirty);
 
-    connect(&_cameraCalc,           &CameraCalc::distanceToSurfaceRelativeChanged, this, &CorridorScanComplexItem::coordinateHasRelativeAltitudeChanged);
-    connect(&_cameraCalc,           &CameraCalc::distanceToSurfaceRelativeChanged, this, &CorridorScanComplexItem::exitCoordinateHasRelativeAltitudeChanged);
+    connect(&_cameraCalc,           &CameraCalc::distanceToSurfaceRelativeChanged,  this, &CorridorScanComplexItem::coordinateHasRelativeAltitudeChanged);
+    connect(&_cameraCalc,           &CameraCalc::distanceToSurfaceRelativeChanged,  this, &CorridorScanComplexItem::exitCoordinateHasRelativeAltitudeChanged);
 
-    connect(&_corridorPolyline,     &QGCMapPolyline::dirtyChanged,  this, &CorridorScanComplexItem::_polylineDirtyChanged);
+    connect(&_corridorPolyline,     &QGCMapPolyline::dirtyChanged,                  this, &CorridorScanComplexItem::_polylineDirtyChanged);
 
-    connect(&_corridorPolyline,     &QGCMapPolyline::pathChanged,   this, &CorridorScanComplexItem::_rebuildCorridorPolygon);
-    connect(&_corridorWidthFact,    &Fact::valueChanged,            this, &CorridorScanComplexItem::_rebuildCorridorPolygon);
+    connect(&_corridorPolyline,     &QGCMapPolyline::pathChanged,                   this, &CorridorScanComplexItem::_rebuildCorridorPolygon);
+    connect(&_corridorWidthFact,    &Fact::valueChanged,                            this, &CorridorScanComplexItem::_rebuildCorridorPolygon);
 
-    connect(&_corridorPolyline,     &QGCMapPolyline::isValidChanged,this, &CorridorScanComplexItem::readyForSaveStateChanged);
+    connect(&_corridorPolyline,     &QGCMapPolyline::isValidChanged,                this, &CorridorScanComplexItem::_updateWizardMode);
+    connect(&_corridorPolyline,     &QGCMapPolyline::traceModeChanged,              this, &CorridorScanComplexItem::_updateWizardMode);
 
     if (!kmlFile.isEmpty()) {
         _corridorPolyline.loadKMLFile(kmlFile);
@@ -383,4 +384,11 @@ double CorridorScanComplexItem::_calcTransectSpacing(void) const
     }
 
     return transectSpacing;
+}
+
+void CorridorScanComplexItem::_updateWizardMode(void)
+{
+    if (_corridorPolyline.isValid() && !_corridorPolyline.traceMode()) {
+        setWizardMode(false);
+    }
 }

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -58,8 +58,9 @@ public:
     static const char* corridorWidthName;
 
 private slots:
-    void _polylineDirtyChanged      (bool dirty);
-    void _rebuildCorridorPolygon    (void);
+    void _polylineDirtyChanged          (bool dirty);
+    void _rebuildCorridorPolygon        (void);
+    void _updateWizardMode              (void);
 
     // Overrides from TransectStyleComplexItem
     void _rebuildTransectsPhase1    (void) final;

--- a/src/MissionManager/QGCMapPolygon.cc
+++ b/src/MissionManager/QGCMapPolygon.cc
@@ -598,3 +598,11 @@ QDomElement QGCMapPolygon::kmlPolygonElement(KMLDomDocument& domDocument)
 
     return polygonElement;
 }
+
+void QGCMapPolygon::setTraceMode(bool traceMode)
+{
+    if (traceMode != _traceMode) {
+        _traceMode = traceMode;
+        emit traceModeChanged(traceMode);
+    }
+}

--- a/src/MissionManager/QGCMapPolygon.h
+++ b/src/MissionManager/QGCMapPolygon.h
@@ -39,7 +39,7 @@ public:
     Q_PROPERTY(bool                 interactive READ interactive    WRITE setInteractive    NOTIFY interactiveChanged)
     Q_PROPERTY(bool                 isValid     READ isValid                                NOTIFY isValidChanged)
     Q_PROPERTY(bool                 empty       READ empty                                  NOTIFY isEmptyChanged)
-    Q_PROPERTY(bool                 traceMode   MEMBER _traceMode                           NOTIFY traceModeChanged)
+    Q_PROPERTY(bool                 traceMode   READ traceMode      WRITE setTraceMode      NOTIFY traceModeChanged)
 
     Q_INVOKABLE void clear(void);
     Q_INVOKABLE void appendVertex(const QGeoCoordinate& coordinate);
@@ -105,6 +105,7 @@ public:
     bool            interactive (void) const { return _interactive; }
     bool            isValid     (void) const { return _polygonModel.count() >= 3; }
     bool            empty       (void) const { return _polygonModel.count() == 0; }
+    bool            traceMode   (void) const { return _traceMode; }
 
     QVariantList        path        (void) const { return _polygonPath; }
     QmlObjectListModel* qmlPathModel(void) { return &_polygonModel; }
@@ -115,6 +116,7 @@ public:
     void setCenter      (QGeoCoordinate newCenter);
     void setCenterDrag  (bool centerDrag);
     void setInteractive (bool interactive);
+    void setTraceMode   (bool traceMode);
 
     static const char* jsonPolygonKey;
 

--- a/src/MissionManager/QGCMapPolyline.cc
+++ b/src/MissionManager/QGCMapPolyline.cc
@@ -431,3 +431,11 @@ void QGCMapPolyline::_endResetIfNotActive(void)
         endReset();
     }
 }
+
+void QGCMapPolyline::setTraceMode(bool traceMode)
+{
+    if (traceMode != _traceMode) {
+        _traceMode = traceMode;
+        emit traceModeChanged(traceMode);
+    }
+}

--- a/src/MissionManager/QGCMapPolyline.h
+++ b/src/MissionManager/QGCMapPolyline.h
@@ -32,7 +32,7 @@ public:
     Q_PROPERTY(bool                 interactive READ interactive    WRITE setInteractive    NOTIFY interactiveChanged)
     Q_PROPERTY(bool                 isValid     READ isValid                                NOTIFY isValidChanged)
     Q_PROPERTY(bool                 empty       READ empty                                  NOTIFY isEmptyChanged)
-    Q_PROPERTY(bool                 traceMode   MEMBER _traceMode                           NOTIFY traceModeChanged)
+    Q_PROPERTY(bool                 traceMode   READ traceMode      WRITE setTraceMode      NOTIFY traceModeChanged)
 
     Q_INVOKABLE void clear(void);
     Q_INVOKABLE void appendVertex(const QGeoCoordinate& coordinate);
@@ -89,6 +89,7 @@ public:
     QVariantList    path        (void) const { return _polylinePath; }
     bool            isValid     (void) const { return _polylineModel.count() >= 2; }
     bool            empty       (void) const { return _polylineModel.count() == 0; }
+    bool            traceMode   (void) const { return _traceMode; }
 
     QmlObjectListModel* qmlPathModel(void) { return &_polylineModel; }
     QmlObjectListModel& pathModel   (void) { return _polylineModel; }
@@ -96,6 +97,7 @@ public:
     void setPath        (const QList<QGeoCoordinate>& path);
     void setPath        (const QVariantList& path);
     void setInteractive (bool interactive);
+    void setTraceMode   (bool traceMode);
 
     static const char* jsonPolylineKey;
 

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -71,6 +71,8 @@ StructureScanComplexItem::StructureScanComplexItem(PlanMasterController* masterC
     connect(&_structurePolygon, &QGCMapPolygon::dirtyChanged,   this, &StructureScanComplexItem::_polygonDirtyChanged);
     connect(&_structurePolygon, &QGCMapPolygon::pathChanged,    this, &StructureScanComplexItem::_rebuildFlightPolygon);
     connect(&_structurePolygon, &QGCMapPolygon::isValidChanged, this, &StructureScanComplexItem::readyForSaveStateChanged);
+    connect(&_structurePolygon, &QGCMapPolygon::isValidChanged,     this, &StructureScanComplexItem::_updateWizardMode);
+    connect(&_structurePolygon, &QGCMapPolygon::traceModeChanged,   this, &StructureScanComplexItem::_updateWizardMode);
 
     connect(&_structurePolygon, &QGCMapPolygon::countChanged,   this, &StructureScanComplexItem::_updateLastSequenceNumber);
     connect(&_layersFact,       &Fact::valueChanged,            this, &StructureScanComplexItem::_updateLastSequenceNumber);
@@ -625,4 +627,11 @@ void StructureScanComplexItem::_recalcScanDistance()
 StructureScanComplexItem::ReadyForSaveState StructureScanComplexItem::readyForSaveState(void) const
 {
     return _structurePolygon.isValid() && !_wizardMode ? ReadyForSave : NotReadyForSaveData;
+}
+
+void StructureScanComplexItem::_updateWizardMode(void)
+{
+    if (_structurePolygon.isValid() && !_structurePolygon.traceMode()) {
+        setWizardMode(false);
+    }
 }

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -117,17 +117,18 @@ signals:
 
 private slots:
     void _setDirty(void);
-    void _polygonDirtyChanged       (bool dirty);
-    void _flightPathChanged         (void);
-    void _clearInternal             (void);
-    void _updateCoordinateAltitudes (void);
-    void _rebuildFlightPolygon      (void);
-    void _recalcCameraShots         (void);
-    void _recalcLayerInfo           (void);
-    void _updateLastSequenceNumber  (void);
-    void _updateGimbalPitch         (void);
-    void _signalTopBottomAltChanged (void);
-    void _recalcScanDistance        (void);
+    void _polygonDirtyChanged           (bool dirty);
+    void _flightPathChanged             (void);
+    void _clearInternal                 (void);
+    void _updateCoordinateAltitudes     (void);
+    void _rebuildFlightPolygon          (void);
+    void _recalcCameraShots             (void);
+    void _recalcLayerInfo               (void);
+    void _updateLastSequenceNumber      (void);
+    void _updateGimbalPitch             (void);
+    void _signalTopBottomAltChanged     (void);
+    void _recalcScanDistance            (void);
+    void _updateWizardMode              (void);
 
 private:
     void _setCameraShots(int cameraShots);

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -99,6 +99,9 @@ SurveyComplexItem::SurveyComplexItem(PlanMasterController* masterController, boo
     connect(&_splitConcavePolygonsFact, &Fact::valueChanged,                        this, &SurveyComplexItem::_rebuildTransects);
     connect(this,                       &SurveyComplexItem::refly90DegreesChanged,  this, &SurveyComplexItem::_rebuildTransects);
 
+    connect(&_surveyAreaPolygon,        &QGCMapPolygon::isValidChanged,             this, &SurveyComplexItem::_updateWizardMode);
+    connect(&_surveyAreaPolygon,        &QGCMapPolygon::traceModeChanged,           this, &SurveyComplexItem::_updateWizardMode);
+
     // FIXME: Shouldn't these be in TransectStyleComplexItem? They are also in CorridorScanComplexItem constructur
     connect(&_cameraCalc, &CameraCalc::distanceToSurfaceRelativeChanged, this, &SurveyComplexItem::coordinateHasRelativeAltitudeChanged);
     connect(&_cameraCalc, &CameraCalc::distanceToSurfaceRelativeChanged, this, &SurveyComplexItem::exitCoordinateHasRelativeAltitudeChanged);
@@ -1427,4 +1430,11 @@ double SurveyComplexItem::additionalTimeDelay (void) const
     }
 
     return hoverTime;
+}
+
+void SurveyComplexItem::_updateWizardMode(void)
+{
+    if (_surveyAreaPolygon.isValid() && !_surveyAreaPolygon.traceMode()) {
+        setWizardMode(false);
+    }
 }

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -80,10 +80,12 @@ signals:
     void refly90DegreesChanged(bool refly90Degrees);
 
 private slots:
+    void _updateWizardMode              (void);
+
     // Overrides from TransectStyleComplexItem
-    void _rebuildTransectsPhase1    (void) final;
-    void _recalcComplexDistance     (void) final;
-    void _recalcCameraShots         (void) final;
+    void _rebuildTransectsPhase1        (void) final;
+    void _recalcComplexDistance         (void) final;
+    void _recalcCameraShots             (void) final;
 
 private:
     enum CameraTriggerCode {

--- a/src/PlanView/CorridorScanEditor.qml
+++ b/src/PlanView/CorridorScanEditor.qml
@@ -68,15 +68,19 @@ Rectangle {
                 text:               qsTr("Use the Polyline Tools to create the polyline which defines the corridor.")
             }
 
+            /*
+              Trial of new "done" model so leaving for now in case it comes back
             QGCButton {
                 text:               qsTr("Done With Polyline")
                 Layout.fillWidth:   true
                 enabled:            missionItem.corridorPolyline.isValid && !missionItem.corridorPolyline.traceMode
                 onClicked: {
                     missionItem.wizardMode = false
-                    editorRoot.selectNextNotReadyItem()
+                    // Trial of no auto select next item
+                    //editorRoot.selectNextNotReadyItem()
                 }
             }
+            */
         }
 
         Column {

--- a/src/PlanView/FWLandingPatternEditor.qml
+++ b/src/PlanView/FWLandingPatternEditor.qml
@@ -312,12 +312,13 @@ Rectangle {
             }
 
             QGCButton {
-                text:               qsTr("Done Adjusting")
+                text:               qsTr("Done")
                 Layout.fillWidth:   true
                 onClicked: {
                     missionItem.wizardMode = false
                     missionItem.landingDragAngleOnly = false
-                    editorRoot.selectNextNotReadyItem()
+                    // Trial of no auto select next item
+                    //editorRoot.selectNextNotReadyItem()
                 }
             }
         }

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -20,7 +20,7 @@ Rectangle {
     color:          _currentItem ? qgcPal.missionItemEditor : qgcPal.windowShade
     radius:         _radius
     opacity:        _currentItem ? 1.0 : 0.7
-    border.width:   _readyForSave ? 0 : 1
+    border.width:   _readyForSave ? 0 : 2
     border.color:   qgcPal.warningText
 
     property var    map                 ///< Map control
@@ -87,7 +87,7 @@ Rectangle {
         Rectangle {
             id:                     notReadyForSaveIndicator
             anchors.verticalCenter: parent.verticalCenter
-            width:                  readyForSaveLabel.contentHeight
+            width:                  _hamburgerSize
             height:                 width
             border.width:           1
             border.color:           qgcPal.warningText

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -91,12 +91,13 @@ Rectangle {
             }
 
             QGCButton {
-                text:               qsTr("Done Adjusting")
+                text:               qsTr("Done")
                 Layout.fillWidth:   true
                 visible:            !initialClickLabel.visible
                 onClicked: {
                     missionItem.wizardMode = false
-                    editorRoot.selectNextNotReadyItem()
+                    // Trial of no auto select next item
+                    //editorRoot.selectNextNotReadyItem()
                 }
             }
 

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -69,15 +69,19 @@ Rectangle {
                 text:               qsTr("Use the Polygon Tools to create the polygon which outlines the structure.")
             }
 
+            /*
+              Trial of new "done" model so leaving for now in case it comes back
             QGCButton {
                 text:               qsTr("Done With Polygon")
                 Layout.fillWidth:   true
                 enabled:            missionItem.structurePolygon.isValid && !missionItem.structurePolygon.traceMode
                 onClicked: {
                     missionItem.wizardMode = false
-                    editorRoot.selectNextNotReadyItem()
+                    // Trial of no auto select next item
+                    //editorRoot.selectNextNotReadyItem()
                 }
             }
+            */
         }
 
         Column {

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -29,7 +29,7 @@ Rectangle {
     property var    _vehicle:                   QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
     property real   _cameraMinTriggerInterval:  missionItem.cameraCalc.minTriggerInterval.rawValue
     property bool   _polygonDone:               false
-    property string _doneAdjusting:             qsTr("Done Adjusting")
+    property string _doneAdjusting:             qsTr("Done")
     property bool   _presetsAvailable:          missionItem.presetNames.length !== 0
 
     function polygonCaptureStarted() {
@@ -77,6 +77,8 @@ Rectangle {
                     text:                   qsTr("Use the Polygon Tools to create the polygon which outlines your survey area.")
                 }
 
+                /*
+                  Trial of new "done" model so leaving for now in case it comes back
                 QGCButton {
                     text:               qsTr("Done With Polygon")
                     Layout.fillWidth:   true
@@ -84,13 +86,17 @@ Rectangle {
                     onClicked: {
                         if (!_presetsAvailable) {
                             missionItem.wizardMode = false
-                            editorRoot.selectNextNotReadyItem()
+                            // Trial of no auto select next item
+                            //editorRoot.selectNextNotReadyItem()
                         }
                         _polygonDone = true
                     }
                 }
+                */
             }
 
+            /*
+            Trial of new "done" model so leaving for now in case it comes back
             ColumnLayout {
                 Layout.fillWidth:   true
                 spacing:            _margin
@@ -166,10 +172,12 @@ Rectangle {
                     enabled:            missionItem.surveyAreaPolygon.isValid
                     onClicked: {
                         missionItem.wizardMode = false
-                        editorRoot.selectNextNotReadyItem()
+                        // Trial of no auto select next item
+                        //editorRoot.selectNextNotReadyItem()
                     }
                 }
             }
+            */
         }
 
         Column {


### PR DESCRIPTION
How things used to work:
* When you created a plan from a template say like survey...
* You would get a red Takeoff item (and others) which indicated it was incomplete. It told you what to futz and then to click "Done Adjusting" when done. At which point the editor switches back to normal editing mode.
* Same thing for items which required you to set up a Polygon/Polyline. 
* When you clicked "Done Adjusting" it would automatically move you to the next incomplete item as well. In this case that would be the Survey item

Problems:
* When you clicked to position the takeoff item. You then clicked "Done Adjusting" which in fact wasn't correct. You may need to still adjust the altitude for example. So you aren't really "Done Adjusting".
* Also the fact that when you clicked "Done Adjusting" it automatically moved you to the next incomplete item could cause you to miss the fact that there were other important things you really needed to take care of before you were "Done".
* In the case where the incomplete item was due to no Polygon/Polyline yet set for the item. When you added a Polygon say by tracing and clicked Done Tracing. You still needed to the click Done Adjusting which is a pain.
* Red highlights for incomplete were not quite strong enough visually.

To deal with the above I changed the user model for how these incomplete items work:
* Changed visuals to make incomplete items more prominent.
* Changed the "Done Adjusting" wording to just "Done"
* For items which just need a valid Polygon/Polyline to be completed there is no "Done" button. Finishing the add of the Polygon/Polyline will mark the item as no longer incomplete.
* When an item transitions away from incomplete it no longer automatically selects the next incomplete item.

Here you can see the new visuals for items which have a Done button:
![Screen Shot 2020-03-31 at 10 57 30 AM](https://user-images.githubusercontent.com/5876851/78062569-b7179300-7343-11ea-84bb-0df08bea5ca8.png)

Here you can see the new visuals for items which only have Polygon/Polyline requirement:
![Screen Shot 2020-03-31 at 10 57 52 AM](https://user-images.githubusercontent.com/5876851/78062574-bb43b080-7343-11ea-9acb-faa37cbd0db5.png)
