### PR TITLE
Correctly set parent of QGCCorePlugin

### DIFF
--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -134,13 +134,13 @@ void QGCToolbox::_scanAndLoadPlugins(QGCApplication* app)
 {
 #if defined (QGC_CUSTOM_BUILD)
     //-- Create custom plugin (Static)
-    _corePlugin = (QGCCorePlugin*) new CUSTOMCLASS(app, app->toolbox());
+    _corePlugin = (QGCCorePlugin*) new CUSTOMCLASS(app, this);
     if(_corePlugin) {
         return;
     }
 #endif
     //-- No plugins found, use default instance
-    _corePlugin = new QGCCorePlugin(app, app->toolbox());
+    _corePlugin = new QGCCorePlugin(app, this);
 }
 
 QGCTool::QGCTool(QGCApplication* app, QGCToolbox* toolbox)


### PR DESCRIPTION
`QGCCorePlugin` is currently constructed with a `QGCToolbox* toolbox` parameter of null. This is because at the time `QGCCorePlugin` (or an actual custom plugin) is constructed app->toolbox() is null.
`QGCCorePlugin` is created in `_scanAndLoadPlugins()`, which is called as part of the QGCToolbox constructor where all toolbox classes use the same format:

`_class = new Class(app, this);`

The creation of `QGCCorePlugin `should follow the same pattern.

The practical issue I had with this is that because the parent is not set correctly, `QGCCorePlugin `is not destructed when the app is closed. This means any code in the destructor is not run. (QGCCorePlugin itself has as a destructor which is currently not being called).


