### PR TITLE
Mobile: Turn off persistence of AppSettings::savePath

### DIFF
--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -77,3 +77,8 @@ void SettingsFact::_rawValueChanged(QVariant value)
 
     settings.setValue(_name, value);
 }
+
+void SettingsFact::setNoUpdate(void)
+{
+    disconnect(this, &Fact::rawValueChanged, this, &SettingsFact::_rawValueChanged);
+}

--- a/src/FactSystem/SettingsFact.h
+++ b/src/FactSystem/SettingsFact.h
@@ -26,6 +26,10 @@ public:
     Q_PROPERTY(bool visible MEMBER _visible CONSTANT)
 
     // Must be called before any references to fact
+    // Specifies that this fact will not update it's QSettings value when it changes
+    void setNoUpdate(void);
+
+    // Must be called before any references to fact
     void setVisible(bool visible) { _visible = visible; }
 
 private slots:

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -42,6 +42,12 @@ DECLARE_SETTINGGROUP(App, "")
     // Instantiate savePath so we can check for override and setup default path if needed
 
     SettingsFact* savePathFact = qobject_cast<SettingsFact*>(savePath());
+#ifdef __mobile__
+    // For mobile builds the default save path is invariant, sort of. For example on iOS it includes a UID for the app
+    // which can change. If we allow that to be saved back to settings, then subsequent installs of new version may cause
+    // the path to be invalid.
+    savePathFact->setNoUpdate();
+#endif
     QString appName = qgcApp()->applicationName();
     if (savePathFact->rawValue().toString().isEmpty() && _nameToMetaDataMap[savePathName]->rawDefaultValue().toString().isEmpty()) {
 #ifdef __mobile__


### PR DESCRIPTION
On iOS builds the mobile save path includes an application UID in it. If QGC persists this and then you install a newer version that UID can change. Which in turn will cause QGC to not be able to load data from the correct location.