### PR TITLE
Don't add RTL for VTOLs and FixedWings

### DIFF
--- a/src/MissionManager/CorridorScanPlanCreator.cc
+++ b/src/MissionManager/CorridorScanPlanCreator.cc
@@ -23,6 +23,9 @@ void CorridorScanPlanCreator::createPlan(const QGeoCoordinate& mapCenterCoord)
     _planMasterController->removeAll();
     VisualMissionItem* takeoffItem = _missionController->insertTakeoffItem(mapCenterCoord, -1);
     _missionController->insertComplexMissionItem(MissionController::patternCorridorScanName, mapCenterCoord, -1);
-    _missionController->insertLandItem(mapCenterCoord, -1);
+    // We want the operator to coordinate his landing for VTOL and Fixed Wing. An RTL is not really predictable.
+    if(!_planMasterController->managerVehicle()->vtol() && !_planMasterController->managerVehicle()->fixedWing()) {
+        _missionController->insertLandItem(mapCenterCoord, -1);
+    }
     _missionController->setCurrentPlanViewSeqNum(takeoffItem->sequenceNumber(), true);
 }

--- a/src/MissionManager/StructureScanPlanCreator.cc
+++ b/src/MissionManager/StructureScanPlanCreator.cc
@@ -23,6 +23,9 @@ void StructureScanPlanCreator::createPlan(const QGeoCoordinate& mapCenterCoord)
     _planMasterController->removeAll();
     VisualMissionItem* takeoffItem = _missionController->insertTakeoffItem(mapCenterCoord, -1);
     _missionController->insertComplexMissionItem(MissionController::patternStructureScanName, mapCenterCoord, -1)->setWizardMode(true);
-    _missionController->insertLandItem(mapCenterCoord, -1);
+    // We want the operator to coordinate his landing for VTOL and Fixed Wing. An RTL is not really predictable.
+    if(!_planMasterController->managerVehicle()->vtol() && !_planMasterController->managerVehicle()->fixedWing()) {
+        _missionController->insertLandItem(mapCenterCoord, -1);
+    }
     _missionController->setCurrentPlanViewSeqNum(takeoffItem->sequenceNumber(), true);
 }

--- a/src/MissionManager/SurveyPlanCreator.cc
+++ b/src/MissionManager/SurveyPlanCreator.cc
@@ -24,6 +24,9 @@ void SurveyPlanCreator::createPlan(const QGeoCoordinate& mapCenterCoord)
     _planMasterController->removeAll();
     VisualMissionItem* takeoffItem = _missionController->insertTakeoffItem(mapCenterCoord, -1);
     _missionController->insertComplexMissionItem(MissionController::patternSurveyName, mapCenterCoord, -1);
-    _missionController->insertLandItem(mapCenterCoord, -1);
+    // We want the operator to coordinate his landing for VTOL and Fixed Wing. An RTL is not really predictable.
+    if(!_planMasterController->managerVehicle()->vtol() && !_planMasterController->managerVehicle()->fixedWing()) {
+        _missionController->insertLandItem(mapCenterCoord, -1);
+    }
     _missionController->setCurrentPlanViewSeqNum(takeoffItem->sequenceNumber(), true);
 }


### PR DESCRIPTION
This change removes the automatically added RTL waypoint for VTOL and FixedWing when autogenerating plans from templates.

"We want the operator to coordinate his landing. An RTL is not really predictable. That's why we want operators to work with land start markers, loiter to altitude, and land as a planned mission landing" @Yannick
