### PR TITLE
Value edit dialog

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -142,6 +142,8 @@
         <file alias="QGroundControl/Controls/QGCMenuSeparator.qml">src/QmlControls/QGCMenuSeparator.qml</file>
         <file alias="QGroundControl/Controls/QGCMouseArea.qml">src/QmlControls/QGCMouseArea.qml</file>
         <file alias="QGroundControl/Controls/QGCMovableItem.qml">src/QmlControls/QGCMovableItem.qml</file>
+        <file alias="QGroundControl/Controls/QGCPopupDialog.qml">src/QmlControls/QGCPopupDialog.qml</file>
+        <file alias="QGroundControl/Controls/QGCPopupDialogContainer.qml">src/QmlControls/QGCPopupDialogContainer.qml</file>
         <file alias="QGroundControl/Controls/QGCPipable.qml">src/QmlControls/QGCPipable.qml</file>
         <file alias="QGroundControl/Controls/QGCRadioButton.qml">src/QmlControls/QGCRadioButton.qml</file>
         <file alias="QGroundControl/Controls/QGCSlider.qml">src/QmlControls/QGCSlider.qml</file>

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -53,8 +53,6 @@ void FactGroup::_setupTimer()
 
 Fact* FactGroup::getFact(const QString& name)
 {
-    Fact* fact = nullptr;
-
     if (name.contains(".")) {
         QStringList parts = name.split(".");
         if (parts.count() != 2) {
@@ -71,11 +69,14 @@ Fact* FactGroup::getFact(const QString& name)
         return factGroup->getFact(parts[1]);
     }
 
-    if (_nameToFactMap.contains(name)) {
-        fact = _nameToFactMap[name];
+    Fact*   fact =          nullptr;
+    QString camelCaseName = _camelCase(name);
+
+    if (_nameToFactMap.contains(camelCaseName)) {
+        fact = _nameToFactMap[camelCaseName];
         QQmlEngine::setObjectOwnership(fact, QQmlEngine::CppOwnership);
     } else {
-        qWarning() << "Unknown Fact" << name;
+        qWarning() << "Unknown Fact" << camelCaseName;
     }
 
     return fact;
@@ -83,13 +84,14 @@ Fact* FactGroup::getFact(const QString& name)
 
 FactGroup* FactGroup::getFactGroup(const QString& name)
 {
-    FactGroup* factGroup = nullptr;
+    FactGroup*  factGroup = nullptr;
+    QString     camelCaseName = _camelCase(name);
 
-    if (_nameToFactGroupMap.contains(name)) {
-        factGroup = _nameToFactGroupMap[name];
+    if (_nameToFactGroupMap.contains(camelCaseName)) {
+        factGroup = _nameToFactGroupMap[camelCaseName];
         QQmlEngine::setObjectOwnership(factGroup, QQmlEngine::CppOwnership);
     } else {
-        qWarning() << "Unknown FactGroup" << name;
+        qWarning() << "Unknown FactGroup" << camelCaseName;
     }
 
     return factGroup;
@@ -141,4 +143,10 @@ void FactGroup::setLiveUpdates(bool liveUpdates)
     for(Fact* fact: _nameToFactMap) {
         fact->setSendValueChangedSignals(liveUpdates);
     }
+}
+
+
+QString FactGroup::_camelCase(const QString& text)
+{
+    return text[0].toLower() + text.right(text.length() - 1);
 }

--- a/src/FactSystem/FactGroup.h
+++ b/src/FactSystem/FactGroup.h
@@ -44,25 +44,26 @@ public:
     QStringList factNames(void) const { return _factNames; }
     QStringList factGroupNames(void) const { return _nameToFactGroupMap.keys(); }
 
-protected:
-    void _addFact(Fact* fact, const QString& name);
-    void _addFactGroup(FactGroup* factGroup, const QString& name);
-    void _loadFromJsonArray(const QJsonArray jsonArray);
-
-    int _updateRateMSecs;   ///< Update rate for Fact::valueChanged signals, 0: immediate update
-
 protected slots:
     virtual void _updateAllValues(void);
 
-private:
-    void _setupTimer();
-    QTimer _updateTimer;
-
 protected:
+    void _addFact           (Fact* fact, const QString& name);
+    void _addFactGroup      (FactGroup* factGroup, const QString& name);
+    void _loadFromJsonArray (const QJsonArray jsonArray);
+
+    int  _updateRateMSecs;   ///< Update rate for Fact::valueChanged signals, 0: immediate update
+
     QMap<QString, Fact*>            _nameToFactMap;
     QMap<QString, FactGroup*>       _nameToFactGroupMap;
     QMap<QString, FactMetaData*>    _nameToFactMetaDataMap;
     QStringList                     _factNames;
+
+private:
+    void    _setupTimer (void);
+    QString _camelCase  (const QString& text);
+
+    QTimer  _updateTimer;
 };
 
 #endif

--- a/src/FlightMap/Widgets/ValuesWidgetController.h
+++ b/src/FlightMap/Widgets/ValuesWidgetController.h
@@ -38,7 +38,10 @@ public:
 
     InstrumentValue(Vehicle* activeVehicle, FontSize fontSize, QmlObjectListModel* rowModel);
 
+    Q_PROPERTY(QStringList  factGroupNames      MEMBER  _factGroupNames                             NOTIFY factGroupNamesChanged)
+    Q_PROPERTY(QStringList  factValueNames      MEMBER  _factValueNames                             NOTIFY factValueNamesChanged)
     Q_PROPERTY(QString      factGroupName       MEMBER  _factGroupName                              NOTIFY factGroupNameChanged)
+    Q_PROPERTY(QString      factName            MEMBER  _factName                                   NOTIFY factNameChanged)
     Q_PROPERTY(Fact*        fact                READ    fact                                        NOTIFY factChanged)
     Q_PROPERTY(QString      label               READ    label               WRITE setLabel          NOTIFY labelChanged)
     Q_PROPERTY(QString      icon                READ    icon                WRITE setIcon           NOTIFY iconChanged)             ///< If !isEmpty icon will be show instead of label
@@ -49,8 +52,8 @@ public:
     Q_PROPERTY(QStringList  fontSizeNames       MEMBER _fontSizeNames                               CONSTANT)
     Q_PROPERTY(bool         showUnits           READ    showUnits           WRITE setShowUnits      NOTIFY showUnitsChanged)
 
-    Q_INVOKABLE void setFact(QString factGroupName, QString factName, QString label);
-    Q_INVOKABLE void clearFact(void);
+    Q_INVOKABLE void    setFact(const QString& factGroupName, const QString& factName);
+    Q_INVOKABLE void    clearFact(void);
 
     Fact*           fact                    (void) { return _fact; }
     FontSize        fontSize                (void) const { return _fontSize; }
@@ -76,6 +79,8 @@ signals:
     void showUnitsChanged       (bool showUnits);
     void iconChanged            (const QString& icon);
     void iconPositionChanged    (IconPosition iconPosition);
+    void factGroupNamesChanged  (const QStringList& factGroupNames);
+    void factValueNamesChanged  (const QStringList& factValueNames);
 
 private:
     void _setFontSize           (FontSize fontSize);
@@ -90,6 +95,8 @@ private:
     FontSize            _fontSize =         DefaultFontSize;
     QString             _icon;
     IconPosition        _iconPosition =     IconLeft;
+    QStringList         _factGroupNames;
+    QStringList         _factValueNames;
 
     static const QStringList _iconPositionNames;
     static       QStringList _iconNames;
@@ -102,6 +109,7 @@ private:
     static const char*  _showUnitsKey;
     static const char*  _iconKey;
     static const char*  _iconPositionKey;
+    static const char*  _vehicleFactGroupName;
 };
 
 Q_DECLARE_METATYPE(InstrumentValue::FontSize)
@@ -146,7 +154,7 @@ private:
     InstrumentValue*    _createNewInstrumentValueWorker     (Vehicle* activeVehicle, InstrumentValue::FontSize fontSize, QmlObjectListModel* rowModel);
     void                _loadSettings                       (void);
     void                _connectSignalsToController         (InstrumentValue* value, ValuesWidgetController* controller);
-
+    QString             _pascalCase                         (const QString& text);
 
     MultiVehicleManager*    _multiVehicleMgr =      nullptr;
     QmlObjectListModel*     _valuesModel =          nullptr;

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick 2.12
+
+Item {
+    width:  childrenRect.width
+    height: childrenRect.height
+
+    signal hideDialog
+
+    Keys.onReleased: {
+        if (event.key === Qt.Key_Escape) {
+            reject()
+            event.accepted = true
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            accept()
+            event.accepted = true
+        }
+    }
+
+    function accept() {
+        if (acceptAllowed) {
+            Qt.inputMethod.hide()
+            hideDialog()
+        }
+    }
+
+    function reject() {
+        if (rejectAllowed) {
+            Qt.inputMethod.hide()
+            hideDialog()
+        }
+    }
+}

--- a/src/QmlControls/QGCPopupDialogContainer.qml
+++ b/src/QmlControls/QGCPopupDialogContainer.qml
@@ -1,0 +1,174 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick                      2.12
+import QtQuick.Controls             2.4
+import QtQuick.Layouts              1.12
+import QtQuick.Dialogs              1.3
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+
+Popup {
+    anchors.centerIn:   parent
+    width:              mainFlickable.width
+    height:             mainFlickable.height
+    padding:            0
+    modal:              true
+    focus:              true
+
+    background: Rectangle {
+        color: QGroundControl.globalPalette.window
+    }
+
+    property string title
+    property var    buttons
+    property var    dialogComponent
+
+    property real _contentMargin:       ScreenTools.defaultFontPixelHeight / 2
+    property real _popupDoubleInset:    ScreenTools.defaultFontPixelHeight * 2
+    property real _maxAvailableWidth:   parent.width - _popupDoubleInset
+    property real _maxAvailableHeight:  parent.height - _popupDoubleInset
+
+    Component.onCompleted: setupDialogButtons()
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: parent.enabled }
+
+    function setupDialogButtons() {
+        acceptButton.visible = false
+        rejectButton.visible = false
+        // Accept role buttons
+        if (buttons & StandardButton.Ok) {
+            acceptButton.text = qsTr("Ok")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.Open) {
+            acceptButton.text = qsTr("Open")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.Save) {
+            acceptButton.text = qsTr("Save")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.Apply) {
+            acceptButton.text = qsTr("Apply")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.Open) {
+            acceptButton.text = qsTr("Open")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.SaveAll) {
+            acceptButton.text = qsTr("Save All")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.Yes) {
+            acceptButton.text = qsTr("Yes")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.YesToAll) {
+            acceptButton.text = qsTr("Yes to All")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.Retry) {
+            acceptButton.text = qsTr("Retry")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.Reset) {
+            acceptButton.text = qsTr("Reset")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.RestoreToDefaults) {
+            acceptButton.text = qsTr("Restore to Defaults")
+            acceptButton.visible = true
+        } else if (buttons & StandardButton.Ignore) {
+            acceptButton.text = qsTr("Ignore")
+            acceptButton.visible = true
+        }
+
+        // Reject role buttons
+        if (buttons & StandardButton.Cancel) {
+            rejectButton.text = qsTr("Cancel")
+            rejectButton.visible = true
+        } else if (buttons & StandardButton.Close) {
+            rejectButton.text = qsTr("Close")
+            rejectButton.visible = true
+        } else if (buttons & StandardButton.No) {
+            rejectButton.text = qsTr("No")
+            rejectButton.visible = true
+        } else if (buttons & StandardButton.NoToAll) {
+            rejectButton.text = qsTr("No to All")
+            rejectButton.visible = true
+        } else if (buttons & StandardButton.Abort) {
+            rejectButton.text = qsTr("Abort")
+            rejectButton.visible = true
+        }
+
+        if (rejectButton.visible) {
+            closePolicy = Popup.NoAutoClose | Popup.CloseOnEscape
+        } else {
+            closePolicy = Popup.NoAutoClose
+        }
+    }
+
+    Connections {
+        target:         dialogComponentLoader.item
+        onHideDialog:   close()
+    }
+
+    QGCFlickable {
+        id:             mainFlickable
+        width:          Math.min(mainColumnLayout.width, _maxAvailableWidth)
+        height:         Math.min(mainColumnLayout.height, _maxAvailableHeight)
+        contentWidth:   mainColumnLayout.width
+        contentHeight:  mainColumnLayout.height
+
+        Rectangle {
+            width:  titleRowLayout.width
+            height: titleRowLayout.height
+            color:  qgcPal.windowShade
+        }
+
+        ColumnLayout {
+            id:         mainColumnLayout
+            spacing:    _contentMargin
+
+            RowLayout {
+                id:                 titleRowLayout
+                Layout.fillWidth:   true
+
+                QGCLabel {
+                    Layout.leftMargin:  ScreenTools.defaultFontPixelWidth
+                    Layout.fillWidth:   true
+                    text:               title
+                    height:             parent.height
+                    verticalAlignment:	Text.AlignVCenter
+                }
+
+                QGCButton {
+                    id:         rejectButton
+                    onClicked:  dialogComponentLoader.item.reject()
+                }
+
+                QGCButton {
+                    id:         acceptButton
+                    primary:    true
+                    onClicked:  dialogComponentLoader.item.accept()
+                }
+            }
+
+            Item {
+                id: item
+                width:  dialogComponentLoader.width + (_contentMargin * 2)
+                height: dialogComponentLoader.height + _contentMargin
+
+                Loader {
+                    id:                 dialogComponentLoader
+                    x:                  _contentMargin
+                    sourceComponent:    dialogComponent
+                    focus:              true
+                    property bool acceptAllowed: acceptButton.visible
+                    property bool rejectAllowed: rejectButton.visible
+                }
+            }
+        }
+    }
+}

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -64,6 +64,8 @@ QGCMouseArea            1.0 QGCMouseArea.qml
 QGCMovableItem          1.0 QGCMovableItem.qml
 QGCOptionsComboBox      1.0 QGCOptionsComboBox.qml
 QGCPipable              1.0 QGCPipable.qml
+QGCPopupDialog          1.0 QGCPopupDialog.qml
+QGCPopupDialogContainer 1.0 QGCPopupDialogContainer.qml
 QGCRadioButton          1.0 QGCRadioButton.qml
 QGCSlider               1.0 QGCSlider.qml
 QGCSwitch               1.0 QGCSwitch.qml

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -417,21 +417,21 @@ QmlObjectListModel* QGCCorePlugin::valuesWidgetDefaultSettings(ValuesWidgetContr
 
     QmlObjectListModel* columnModel = controller.appendRow();
     InstrumentValue* colValue = columnModel->value<InstrumentValue*>(0);
-    colValue->setFact("Vehicle", "altitudeRelative", QString());
+    colValue->setFact("Vehicle", "AltitudeRelative");
     colValue->setLabel(colValue->fact()->shortDescription());
     colValue->setShowUnits(true);
     colValue->setFontSize(InstrumentValue::LargeFontSize);
 
     columnModel = controller.appendRow();
     colValue = columnModel->value<InstrumentValue*>(0);
-    colValue->setFact("Vehicle", "groundSpeed", QString());
+    colValue->setFact("Vehicle", "GroundSpeed");
     colValue->setLabel(colValue->fact()->shortDescription());
     colValue->setShowUnits(true);
     colValue->setFontSize(InstrumentValue::DefaultFontSize);
 
     columnModel = controller.appendRow();
     colValue = columnModel->value<InstrumentValue*>(0);
-    colValue->setFact("Vehicle", "flightTime", QString());
+    colValue->setFact("Vehicle", "FlightTime");
     colValue->setLabel(colValue->fact()->shortDescription());
     colValue->setShowUnits(false);
     colValue->setFontSize(InstrumentValue::DefaultFontSize);

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -223,6 +223,16 @@ ApplicationWindow {
         }
     }
 
+    function showPopupDialog(component, title, buttons) {
+        var popup = popupDialogContainterComponent.createObject(mainWindow, { "title": title, "buttons": buttons, "dialogComponent": component})
+        popup.open()
+    }
+
+    Component {
+        id: popupDialogContainterComponent
+        QGCPopupDialogContainer { }
+    }
+
     property bool _forceClose: false
 
     function finishCloseProcess() {


### PR DESCRIPTION
New QGCPopupDialog support:
* Works just like right hand QGCViewDialog except creates a centered modal Popup
* Popup is centered on the screen
* Popup is ensured to not exceed window bounds
* Size of Popup is determined by size of inner QGCPopupDialog content
* Flickable is automatically included for scrolling when QGCPopupDialog content exceeds main window bounds
* Create using mainWindow.showPopupDialog(...)
* mainWindow.showPopupDialog can be called from within QGCPopupDialog content to stack dialogs

New value editing dialogs for Instrument Values using the new capability above:
![Screen Shot 2020-04-11 at 2 48 15 PM](https://user-images.githubusercontent.com/5876851/79055803-af3dd580-7c04-11ea-95c1-2b504cddde92.png)
* Since the new dialogs don't overlap the instrument display you can see the effects of your changes as you make them. 
* Still some quirks on right side margins, but tired of fighting with Qt Layout bugs. I'll get back to it.
* Visuals are dirt simple now for dialog container just like the old right side dialog visuals. But I may take a look at improving them.

Icon Picker:
![Screen Shot 2020-04-11 at 2 48 23 PM](https://user-images.githubusercontent.com/5876851/79055812-b95fd400-7c04-11ea-8485-d685a1f36a79.png)

If you used a daily build from the last couple days and edited the instrument panel. You'll have to reset and do it over. I found a problem with previous persistence format. And it wasn't worth writing code for back compat for something which lived for only a few days.
