### PR TITLE
Tweaks to Popup visuals

### DIFF
--- a/src/QmlControls/QGCPopupDialogContainer.qml
+++ b/src/QmlControls/QGCPopupDialogContainer.qml
@@ -18,15 +18,60 @@ import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
 
 Popup {
+    id:                 root
     anchors.centerIn:   parent
-    width:              mainFlickable.width
-    height:             mainFlickable.height
-    padding:            0
+    width:              mainFlickable.width + (padding * 2)
+    height:             mainFlickable.height + (padding * 2)
+    padding:            2
     modal:              true
     focus:              true
 
-    background: Rectangle {
-        color: QGroundControl.globalPalette.window
+    property var pal:           QGroundControl.globalPalette
+    property real frameSize:    ScreenTools.defaultFontPixelWidth
+
+    background: Item {
+
+        Rectangle {
+            anchors.left:   parent.left
+            anchors.top:    parent.top
+            width:          frameSize
+            height:         frameSize
+            color:          pal.text
+            visible:        enabled
+        }
+
+        Rectangle {
+            anchors.right:  parent.right
+            anchors.top:    parent.top
+            width:          frameSize
+            height:         frameSize
+            color:          pal.text
+            visible:        enabled
+        }
+
+        Rectangle {
+            anchors.left:   parent.left
+            anchors.bottom: parent.bottom
+            width:          frameSize
+            height:         frameSize
+            color:          pal.text
+            visible:        enabled
+        }
+
+        Rectangle {
+            anchors.right:  parent.right
+            anchors.bottom: parent.bottom
+            width:          frameSize
+            height:         frameSize
+            color:          pal.text
+            visible:        enabled
+        }
+
+        Rectangle {
+            anchors.margins:    root.padding
+            anchors.fill:       parent
+            color:              pal.window
+        }
     }
 
     property string title


### PR DESCRIPTION
Some minor visual tweaks to make the dialogs more visually distinct when you stack them.

<img width="413" alt="Screen Shot 2020-04-13 at 5 02 15 PM" src="https://user-images.githubusercontent.com/5876851/79172075-8fdfad80-7da8-11ea-8f28-6d19386ff712.png">
