### PR TITLE
Vehicle: fix removal of hashtag in statustext

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1000,8 +1000,17 @@ void Vehicle::_chunkedStatusTextCompleted(uint8_t compId)
 
     // If the message is NOTIFY or higher severity, or starts with a '#',
     // then read it aloud.
-    if (messageText.startsWith("#") || severity <= MAV_SEVERITY_NOTICE) {
+    bool readAloud = false;
+
+    if (messageText.startsWith("#")) {
         messageText.remove("#");
+        readAloud = true;
+    }
+    else if (severity <= MAV_SEVERITY_NOTICE) {
+        readAloud = true;
+    }
+
+    if (readAloud) {
         if (!skipSpoken) {
             qgcApp()->toolbox()->audioOutput()->say(messageText);
         }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1003,7 +1003,7 @@ void Vehicle::_chunkedStatusTextCompleted(uint8_t compId)
     bool readAloud = false;
 
     if (messageText.startsWith("#")) {
-        messageText.remove("#");
+        messageText.remove(0, 1);
         readAloud = true;
     }
     else if (severity <= MAV_SEVERITY_NOTICE) {


### PR DESCRIPTION
This fixes a bug where a URL containing a hashtag (#) was displayed without the hashtag.

This is untested, feed forward programming :smile:.