### PR TITLE
Add Flir Duo R config

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -671,6 +671,19 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle*)
             this);              // parent
         _cameraList.append(QVariant::fromValue(metaData));
 
+        metaData = new CameraMetaData(
+            tr("Flir Duo R"),
+            160,                // sensorWidth
+            120,                // sensorHeight
+            1920,               // imageWidth
+            1080,               // imageHeight
+            1.9,                // focalLength
+            true,               // true: landscape orientation
+            true,               // true: camera is fixed orientation
+            0,                  // minimum trigger interval
+            this);              // parent
+        _cameraList.append(QVariant::fromValue(metaData));
+
     }
 
     return _cameraList;


### PR DESCRIPTION
I added Flir Duo R as an option for survey (https://www.flir.com/support/products/duo-r/#Overview).
I got values from its spec listed on the guide (https://www.flir.com/globalassets/imported-assets/document/flir-duo-user-guide.pdf) and asked the Flir customer support team for the focal length.