### PR TITLE
Fix Qt environment style in linux systems

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -250,6 +250,7 @@ QT += \
     positioning \
     qml \
     quick \
+    quickcontrols2 \
     quickwidgets \
     sql \
     svg \

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -28,6 +28,7 @@
 #include <QFontDatabase>
 #include <QQuickWindow>
 #include <QQuickImageProvider>
+#include <QQuickStyle>
 
 #ifdef QGC_ENABLE_BLUETOOTH
 #include <QBluetoothLocalDevice>
@@ -217,6 +218,11 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
                 }
             }
             permFile.close();
+        }
+
+        // Set default QtQuick style if not configured
+        if (QString(getenv("QT_QUICK_CONTROLS_STYLE")).isEmpty()) {
+            QQuickStyle::setStyle("Universal");
         }
     }
 #endif


### PR DESCRIPTION
QGC appears broken when compiled in linux environment that does not provide QT_QUICK_CONTROLS_STYLE
Without this patch, that is what I have here:
![image](https://user-images.githubusercontent.com/1215497/79900838-3f3e0500-83e5-11ea-8ec6-2689dc87498f.png)
