### PR TITLE
Separate daily build settings space

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -139,6 +139,13 @@ MobileBuild {
     DEFINES += __mobile__
 }
 
+StableBuild {
+    message("Stable Build")
+} else {
+    message("Daily Build")
+    DEFINES += DAILY_BUILD
+}
+
 # set the QGC version from git
 
 exists ($$PWD/.git) {

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -156,14 +156,15 @@ public:
     bool _checkTelemetrySavePath(bool useMessageBox);
 
 private slots:
-    void _missingParamsDisplay(void);
+    void _missingParamsDisplay          (void);
     void _currentVersionDownloadFinished(QString remoteFile, QString localFile);
-    void _currentVersionDownloadError(QString errorMsg);
-    bool _parseVersionText(const QString& versionString, int& majorVersion, int& minorVersion, int& buildVersion);
-    void _onGPSConnect();
-    void _onGPSDisconnect();
-    void _gpsSurveyInStatus(float duration, float accuracyMM,  double latitude, double longitude, float altitude, bool valid, bool active);
-    void _gpsNumSatellites(int numSatellites);
+    void _currentVersionDownloadError   (QString errorMsg);
+    bool _parseVersionText              (const QString& versionString, int& majorVersion, int& minorVersion, int& buildVersion);
+    void _onGPSConnect                  (void);
+    void _onGPSDisconnect               (void);
+    void _gpsSurveyInStatus             (float duration, float accuracyMM,  double latitude, double longitude, float altitude, bool valid, bool active);
+    void _gpsNumSatellites              (int numSatellites);
+    void _showDelayedAppMessages        (void);
 
 private:
     QObject*    _rootQmlObject          ();
@@ -193,6 +194,8 @@ private:
     QLocale             _locale;
     bool                _error                  = false;
     QElapsedTimer       _msecsElapsedTime;
+
+    QList<QPair<QString /* title */, QString /* message */>> _delayedAppMessages;
 
     static const char* _settingsVersionKey;             ///< Settings key which hold settings version
     static const char* _deleteAllSettingsKey;           ///< If this settings key is set on boot, all settings will be deleted

--- a/src/QmlControls/InstrumentValueArea.cc
+++ b/src/QmlControls/InstrumentValueArea.cc
@@ -176,7 +176,7 @@ void InstrumentValueArea::_checkForDeprecatedSettings(void)
 
     if (settings.childGroups().contains(_deprecatedGroupKey)) {
         settings.remove(_deprecatedGroupKey);
-        qgcApp()->showAppMessage(tr("Instrument Values"), tr("The support for custom instrument values display has changed. Because of this the display will be reset to the new default setup. You will need to modify it again to suit your needs."));
+        qgcApp()->showAppMessage(tr("The support for custom instrument value display has changed. The display will be reset to the new default setup. You will need to modify it again to suit your needs."), tr("Instrument Values"));
     }
 }
 


### PR DESCRIPTION
* This allows you to better use Daily Builds side by side with Stable builds on the same machine without the Daily Build trashing your Stable settings.
* There is a new define DAILY_BUILD which is triggered by the StableBuild CONFIG option being missing.
* CI builds will set StableBuild to on for tagged builds. All other builds have it off, hence daily builds creation.