### PR TITLE
QtLocationPlugin: Maximize the map to 21.

### DIFF
--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -24,7 +24,7 @@
 #include "MapboxMapProvider.h"
 #include "ElevationMapProvider.h"
 
-#define MAX_MAP_ZOOM (20.0)
+#define MAX_MAP_ZOOM (21.0)
 
 class UrlFactory : public QObject {
     Q_OBJECT


### PR DESCRIPTION
I use Google's satellite maps.
I tend to fly my multicopters in areas where the area is small.
Google supports up to ZOOM size 21.
I would change the maximum from 20 to 21.

![Screenshot from 2020-04-24 19-02-16](https://user-images.githubusercontent.com/646194/80204278-85a09780-8663-11ea-8982-75534835b868.png)
