### PR TITLE
Introduce weight unit and separate distance unit from altitude

### DIFF
--- a/custom-example/res/CustomFlyViewOverlay.qml
+++ b/custom-example/res/CustomFlyViewOverlay.qml
@@ -66,7 +66,7 @@ Item {
             if (activeVehicle && gcsPosition.latitude && Math.abs(gcsPosition.latitude)  > 0.001 && gcsPosition.longitude && Math.abs(gcsPosition.longitude)  > 0.001) {
                 var gcs = QtPositioning.coordinate(gcsPosition.latitude, gcsPosition.longitude)
                 var veh = activeVehicle.coordinate;
-                _distance = QGroundControl.metersToAppSettingsDistanceUnits(gcs.distanceTo(veh));
+                _distance = QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(gcs.distanceTo(veh));
                 //-- Ignore absurd values
                 if(_distance > 99999)
                     _distance = 0;

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -434,6 +434,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 #
 
 HEADERS += \
+    src/QmlControls/QmlUnitsConversion.h \
     src/api/QGCCorePlugin.h \
     src/api/QGCOptions.h \
     src/api/QGCSettings.h \

--- a/src/AutoPilotPlugins/APM/APMFollowComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFollowComponent.qml
@@ -151,7 +151,7 @@ SetupPage {
             }
 
             function _radiansToHeading(radians) {
-                var geometricAngle = QGroundControl.radiansToDegrees(radians)
+                var geometricAngle = QGroundControl.unitsConversion.radiansToDegrees(radians)
                 var headingAngle = 90 - geometricAngle
                 if (headingAngle < 0) {
                     headingAngle += 360
@@ -163,7 +163,7 @@ SetupPage {
 
             function _headingToRadians(heading) {
                 var geometricAngle = -(heading - 90)
-                return QGroundControl.degreesToRadians(geometricAngle)
+                return QGroundControl.unitsConversion.degreesToRadians(geometricAngle)
             }
 
             APMFollowComponentController {
@@ -419,7 +419,7 @@ SetupPage {
                         QGCLabel {
                             id:                 distanceLabel
                             anchors.centerIn:   distanceLine
-                            text:               controller.distance.valueString + " " + QGroundControl.appSettingsDistanceUnitsString
+                            text:               controller.distance.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
 
                             transform: Rotation {
                                 origin.x:       distanceLabel.width  / 2
@@ -497,7 +497,7 @@ SetupPage {
                         QGCLabel {
                             id:                 heightValueLabel
                             anchors.centerIn:   parent
-                            text:               controller.height.valueString + " " + QGroundControl.appSettingsDistanceUnitsString
+                            text:               controller.height.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
                         }
                     }
 

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -198,7 +198,7 @@ SetupPage {
                             }
 
                             QGCLabel {
-                                text:               qsTr("Minimum Distance: (") + QGroundControl.appSettingsDistanceUnitsString + ")"
+                                text:               qsTr("Minimum Distance: (") + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString + ")"
                                 Layout.fillWidth:   true
                                 Layout.alignment:   Qt.AlignVCenter
                             }
@@ -209,15 +209,15 @@ SetupPage {
                                 Layout.minimumHeight:   ScreenTools.defaultFontPixelHeight * 2
                                 Layout.fillWidth:   true
                                 Layout.fillHeight:  true
-                                maximumValue:       QGroundControl.metersToAppSettingsDistanceUnits(15)
-                                minimumValue:       QGroundControl.metersToAppSettingsDistanceUnits(1)
+                                maximumValue:       QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(15)
+                                minimumValue:       QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(1)
                                 stepSize:           1
                                 displayValue:       true
                                 updateValueWhileDragging:   false
                                 Layout.alignment:   Qt.AlignVCenter
                                 value: {
                                     if (_collisionPrevention && _collisionPrevention.rawValue > 0) {
-                                        return QGroundControl.metersToAppSettingsDistanceUnits(_collisionPrevention.rawValue)
+                                        return QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_collisionPrevention.rawValue)
                                     } else {
                                         return 1;
                                     }
@@ -226,7 +226,7 @@ SetupPage {
                                     if(_collisionPrevention) {
                                         //-- Negative means disabled
                                         if(_collisionPrevention.rawValue >= 0) {
-                                            _collisionPrevention.rawValue = QGroundControl.appSettingsDistanceUnitsToMeters(value)
+                                            _collisionPrevention.rawValue = QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsToMeters(value)
                                         }
                                     }
                                 }

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -32,6 +32,11 @@ const qreal FactMetaData::UnitConsts_s::milesToMeters =         1609.344;
 const qreal FactMetaData::UnitConsts_s::feetToMeters =          0.3048;
 const qreal FactMetaData::UnitConsts_s::inchesToCentimeters =   2.54;
 
+//Weight
+const qreal FactMetaData::UnitConsts_s::ouncesToGrams =         28.3495;
+const qreal FactMetaData::UnitConsts_s::poundsToGrams =         453.592;
+
+
 static const char* kDefaultCategory = QT_TRANSLATE_NOOP("FactMetaData", "Other");
 static const char* kDefaultGroup    = QT_TRANSLATE_NOOP("FactMetaData", "Misc");
 
@@ -51,24 +56,31 @@ const FactMetaData::AppSettingsTranslation_s FactMetaData::_rgAppSettingsTransla
     { "m",      "m",        FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "meter",  "meter",    FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "meters", "meters",   FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    //NOTE: we've coined an artificial "raw unit" of "altitude metre" to separate it from the distance metre - a bit awkward but this is all the design permits
+    { "alt m",  "m",        FactMetaData::UnitAltitude,    UnitsSettings::AltitudeUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "cm/px",  "cm/px",    FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "m/s",    "m/s",      FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsMetersPerSecond,   FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "C",      "C",        FactMetaData::UnitTemperature, UnitsSettings::TemperatureUnitsCelsius,     FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "m^2",    "m^2",      FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareMeters,       FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "m^2",    "m\u00B2",  FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareMeters,       FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
     { "m",      "ft",       FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsFeet,           FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
     { "meter",  "ft",       FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsFeet,           FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
     { "meters", "ft",       FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsFeet,           FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
+    { "alt m",  "ft",       FactMetaData::UnitAltitude,    UnitsSettings::AltitudeUnitsFeet,           FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
     { "cm/px",  "in/px",    FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsFeet,           FactMetaData::_centimetersToInches,                 FactMetaData::_inchesToCentimeters },
-    { "m^2",    "km^2",     FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareKilometers,   FactMetaData::_squareMetersToSquareKilometers,      FactMetaData::_squareKilometersToSquareMeters },
+    { "m^2",    "km\u00B2", FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareKilometers,   FactMetaData::_squareMetersToSquareKilometers,      FactMetaData::_squareKilometersToSquareMeters },
     { "m^2",    "ha",       FactMetaData::UnitArea,        UnitsSettings::AreaUnitsHectares,           FactMetaData::_squareMetersToHectares,              FactMetaData::_hectaresToSquareMeters },
-    { "m^2",    "ft^2",     FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareFeet,         FactMetaData::_squareMetersToSquareFeet,            FactMetaData::_squareFeetToSquareMeters },
+    { "m^2",    "ft\u00B2", FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareFeet,         FactMetaData::_squareMetersToSquareFeet,            FactMetaData::_squareFeetToSquareMeters },
     { "m^2",    "ac",       FactMetaData::UnitArea,        UnitsSettings::AreaUnitsAcres,              FactMetaData::_squareMetersToAcres,                 FactMetaData::_acresToSquareMeters },
-    { "m^2",    "mi^2",     FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareMiles,        FactMetaData::_squareMetersToSquareMiles,           FactMetaData::_squareMilesToSquareMeters },
+    { "m^2",    "mi\u00B2", FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareMiles,        FactMetaData::_squareMetersToSquareMiles,           FactMetaData::_squareMilesToSquareMeters },
     { "m/s",    "ft/s",     FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsFeetPerSecond,     FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
     { "m/s",    "mph",      FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsMilesPerHour,      FactMetaData::_metersPerSecondToMilesPerHour,       FactMetaData::_milesPerHourToMetersPerSecond },
     { "m/s",    "km/h",     FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsKilometersPerHour, FactMetaData::_metersPerSecondToKilometersPerHour,  FactMetaData::_kilometersPerHourToMetersPerSecond },
     { "m/s",    "kn",       FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsKnots,             FactMetaData::_metersPerSecondToKnots,              FactMetaData::_knotsToMetersPerSecond },
     { "C",      "F",        FactMetaData::UnitTemperature, UnitsSettings::TemperatureUnitsFarenheit,   FactMetaData::_celsiusToFarenheit,                  FactMetaData::_farenheitToCelsius },
+    { "g",      "g",        FactMetaData::UnitWeight,      UnitsSettings::WeightUnitsGrams,            FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "g",      "kg",       FactMetaData::UnitWeight,      UnitsSettings::WeightUnitsKg,               FactMetaData::_gramsToKilograms,                    FactMetaData::_kilogramsToGrams },
+    { "g",      "oz",       FactMetaData::UnitWeight,      UnitsSettings::WeightUnitsOz,               FactMetaData::_gramsToOunces,                       FactMetaData::_ouncesToGrams },
+    { "g",      "lbs",      FactMetaData::UnitWeight,      UnitsSettings::WeightUnitsLbs,              FactMetaData::_gramsToPunds,                        FactMetaData::_poundsToGrams },
 };
 
 const char* FactMetaData::_decimalPlacesJsonKey =       "decimalPlaces";
@@ -790,6 +802,30 @@ QVariant FactMetaData::_farenheitToCelsius(const QVariant& farenheit)
     return QVariant((farenheit.toDouble() - 32) * (5.0 / 9.0));
 }
 
+QVariant FactMetaData::_kilogramsToGrams(const QVariant& kg) {
+    return QVariant(kg.toDouble() * 1000);
+}
+
+QVariant FactMetaData::_ouncesToGrams(const QVariant& oz) {
+    return QVariant(oz.toDouble() * constants.ouncesToGrams);
+}
+
+QVariant FactMetaData::_poundsToGrams(const QVariant& lbs) {
+    return QVariant(lbs.toDouble() * constants.poundsToGrams);
+}
+
+QVariant FactMetaData::_gramsToKilograms(const QVariant& g) {
+    return QVariant(g.toDouble() / 1000);
+}
+
+QVariant FactMetaData::_gramsToOunces(const QVariant& g) {
+    return QVariant(g.toDouble() / constants.ouncesToGrams);
+}
+
+QVariant FactMetaData::_gramsToPunds(const QVariant& g) {
+    return QVariant(g.toDouble() / constants.poundsToGrams);
+}
+
 void FactMetaData::setRawUnits(const QString& rawUnits)
 {
     _rawUnits = rawUnits;
@@ -895,6 +931,9 @@ void FactMetaData::_setAppSettingsTranslators(void)
             case UnitDistance:
                 settingsUnits = settings->distanceUnits()->rawValue().toUInt();
                 break;
+            case UnitAltitude:
+                settingsUnits = settings->altitudeUnits()->rawValue().toUInt();
+                break;
             case UnitSpeed:
                 settingsUnits = settings->speedUnits()->rawValue().toUInt();
                 break;
@@ -903,6 +942,9 @@ void FactMetaData::_setAppSettingsTranslators(void)
                 break;
             case UnitTemperature:
                 settingsUnits = settings->temperatureUnits()->rawValue().toUInt();
+                break;
+            case UnitWeight:
+                settingsUnits = settings->weightUnits()->rawValue().toUInt();
                 break;
             default:
                 break;
@@ -929,6 +971,44 @@ const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsDist
         uint settingsUnits = qgcApp()->toolbox()->settingsManager()->unitsSettings()->distanceUnits()->rawValue().toUInt();
 
         if (pAppSettingsTranslation->unitType == UnitDistance
+                && pAppSettingsTranslation->unitOption == settingsUnits) {
+            return pAppSettingsTranslation;
+        }
+    }
+    return nullptr;
+}
+
+const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsAltitudeUnitsTranslation(const QString& rawUnits)
+{
+    for (size_t i=0; i<sizeof(_rgAppSettingsTranslations)/sizeof(_rgAppSettingsTranslations[0]); i++) {
+        const AppSettingsTranslation_s* pAppSettingsTranslation = &_rgAppSettingsTranslations[i];
+
+        if (rawUnits.toLower() != pAppSettingsTranslation->rawUnits.toLower()) {
+            continue;
+        }
+
+        uint settingsUnits = qgcApp()->toolbox()->settingsManager()->unitsSettings()->altitudeUnits()->rawValue().toUInt();
+
+        if (pAppSettingsTranslation->unitType == UnitAltitude
+                && pAppSettingsTranslation->unitOption == settingsUnits) {
+            return pAppSettingsTranslation;
+        }
+    }
+    return nullptr;
+}
+
+const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsWeightUnitsTranslation(const QString& rawUnits)
+{
+    for (size_t i=0; i<sizeof(_rgAppSettingsTranslations)/sizeof(_rgAppSettingsTranslations[0]); i++) {
+        const AppSettingsTranslation_s* pAppSettingsTranslation = &_rgAppSettingsTranslations[i];
+
+        if (rawUnits.toLower() != pAppSettingsTranslation->rawUnits.toLower()) {
+            continue;
+        }
+
+        uint settingsUnits = qgcApp()->toolbox()->settingsManager()->unitsSettings()->weightUnits()->rawValue().toUInt();
+
+        if (pAppSettingsTranslation->unitType == UnitWeight
                 && pAppSettingsTranslation->unitOption == settingsUnits) {
             return pAppSettingsTranslation;
         }
@@ -966,9 +1046,29 @@ QVariant FactMetaData::metersToAppSettingsDistanceUnits(const QVariant& meters)
     }
 }
 
+QVariant FactMetaData::metersToAppSettingsAltitudeUnits(const QVariant& meters)
+{
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAltitudeUnitsTranslation("alt m");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->rawTranslator(meters);
+    } else {
+        return meters;
+    }
+}
+
 QVariant FactMetaData::appSettingsDistanceUnitsToMeters(const QVariant& distance)
 {
     const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsDistanceUnitsTranslation("m");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->cookedTranslator(distance);
+    } else {
+        return distance;
+    }
+}
+
+QVariant FactMetaData::appSettingsAltitudeUnitsToMeters(const QVariant& distance)
+{
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAltitudeUnitsTranslation("alt m");
     if (pAppSettingsTranslation) {
         return pAppSettingsTranslation->cookedTranslator(distance);
     } else {
@@ -983,6 +1083,26 @@ QString FactMetaData::appSettingsDistanceUnitsString(void)
         return pAppSettingsTranslation->cookedUnits;
     } else {
         return QStringLiteral("m");
+    }
+}
+
+QString FactMetaData::appSettingsAltitudeUnitsString(void)
+{
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAltitudeUnitsTranslation("alt m");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->cookedUnits;
+    } else {
+        return QStringLiteral("m");
+    }
+}
+
+QString FactMetaData::appSettingsWeightUnitsString(void)
+{
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsWeightUnitsTranslation("g");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->cookedUnits;
+    } else {
+        return QStringLiteral("g");
     }
 }
 
@@ -1015,6 +1135,25 @@ QString FactMetaData::appSettingsAreaUnitsString(void)
         return QStringLiteral("m^2");
     }
 }
+
+QVariant FactMetaData::gramsToAppSettingsWeightUnits(const QVariant& grams) {
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsWeightUnitsTranslation("g");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->rawTranslator(grams);
+    } else {
+        return grams;
+    }
+}
+
+QVariant FactMetaData::appSettingsWeightUnitsToGrams(const QVariant& weight) {
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsWeightUnitsTranslation("g");
+    if (pAppSettingsTranslation) {
+        return pAppSettingsTranslation->cookedTranslator(weight);
+    } else {
+        return weight;
+    }
+}
+
 
 double FactMetaData::cookedIncrement(void) const
 {

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -53,34 +53,34 @@ const FactMetaData::BuiltInTranslation_s FactMetaData::_rgBuiltInTranslations[] 
 
 // Translations driven by app settings
 const FactMetaData::AppSettingsTranslation_s FactMetaData::_rgAppSettingsTranslations[] = {
-    { "m",      "m",        FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "meter",  "meter",    FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "meters", "meters",   FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    //NOTE: we've coined an artificial "raw unit" of "altitude metre" to separate it from the distance metre - a bit awkward but this is all the design permits
-    { "alt m",  "m",        FactMetaData::UnitAltitude,    UnitsSettings::AltitudeUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "cm/px",  "cm/px",    FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "m/s",    "m/s",      FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsMetersPerSecond,   FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "C",      "C",        FactMetaData::UnitTemperature, UnitsSettings::TemperatureUnitsCelsius,     FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "m^2",    "m\u00B2",  FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareMeters,       FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "m",      "ft",       FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsFeet,           FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
-    { "meter",  "ft",       FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsFeet,           FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
-    { "meters", "ft",       FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsFeet,           FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
-    { "alt m",  "ft",       FactMetaData::UnitAltitude,    UnitsSettings::AltitudeUnitsFeet,           FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
-    { "cm/px",  "in/px",    FactMetaData::UnitDistance,    UnitsSettings::DistanceUnitsFeet,           FactMetaData::_centimetersToInches,                 FactMetaData::_inchesToCentimeters },
-    { "m^2",    "km\u00B2", FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareKilometers,   FactMetaData::_squareMetersToSquareKilometers,      FactMetaData::_squareKilometersToSquareMeters },
-    { "m^2",    "ha",       FactMetaData::UnitArea,        UnitsSettings::AreaUnitsHectares,           FactMetaData::_squareMetersToHectares,              FactMetaData::_hectaresToSquareMeters },
-    { "m^2",    "ft\u00B2", FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareFeet,         FactMetaData::_squareMetersToSquareFeet,            FactMetaData::_squareFeetToSquareMeters },
-    { "m^2",    "ac",       FactMetaData::UnitArea,        UnitsSettings::AreaUnitsAcres,              FactMetaData::_squareMetersToAcres,                 FactMetaData::_acresToSquareMeters },
-    { "m^2",    "mi\u00B2", FactMetaData::UnitArea,        UnitsSettings::AreaUnitsSquareMiles,        FactMetaData::_squareMetersToSquareMiles,           FactMetaData::_squareMilesToSquareMeters },
-    { "m/s",    "ft/s",     FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsFeetPerSecond,     FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
-    { "m/s",    "mph",      FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsMilesPerHour,      FactMetaData::_metersPerSecondToMilesPerHour,       FactMetaData::_milesPerHourToMetersPerSecond },
-    { "m/s",    "km/h",     FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsKilometersPerHour, FactMetaData::_metersPerSecondToKilometersPerHour,  FactMetaData::_kilometersPerHourToMetersPerSecond },
-    { "m/s",    "kn",       FactMetaData::UnitSpeed,       UnitsSettings::SpeedUnitsKnots,             FactMetaData::_metersPerSecondToKnots,              FactMetaData::_knotsToMetersPerSecond },
-    { "C",      "F",        FactMetaData::UnitTemperature, UnitsSettings::TemperatureUnitsFarenheit,   FactMetaData::_celsiusToFarenheit,                  FactMetaData::_farenheitToCelsius },
-    { "g",      "g",        FactMetaData::UnitWeight,      UnitsSettings::WeightUnitsGrams,            FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
-    { "g",      "kg",       FactMetaData::UnitWeight,      UnitsSettings::WeightUnitsKg,               FactMetaData::_gramsToKilograms,                    FactMetaData::_kilogramsToGrams },
-    { "g",      "oz",       FactMetaData::UnitWeight,      UnitsSettings::WeightUnitsOz,               FactMetaData::_gramsToOunces,                       FactMetaData::_ouncesToGrams },
-    { "g",      "lbs",      FactMetaData::UnitWeight,      UnitsSettings::WeightUnitsLbs,              FactMetaData::_gramsToPunds,                        FactMetaData::_poundsToGrams },
+    { "m",      "m",        FactMetaData::UnitHorizontalDistance,    UnitsSettings::HorizontalDistanceUnitsMeters, FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "meter",  "meter",    FactMetaData::UnitHorizontalDistance,    UnitsSettings::HorizontalDistanceUnitsMeters, FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "meters", "meters",   FactMetaData::UnitHorizontalDistance,    UnitsSettings::HorizontalDistanceUnitsMeters, FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    //NOTE: we've coined an artificial "raw unit" of "vertical metre" to separate it from the horizontal metre - a bit awkward but this is all the design permits
+    { "vertical m",  "m",   FactMetaData::UnitVerticalDistance,      UnitsSettings::VerticalDistanceUnitsMeters,   FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "cm/px",  "cm/px",    FactMetaData::UnitHorizontalDistance,    UnitsSettings::HorizontalDistanceUnitsMeters, FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "m/s",    "m/s",      FactMetaData::UnitSpeed,                 UnitsSettings::SpeedUnitsMetersPerSecond,     FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "C",      "C",        FactMetaData::UnitTemperature,           UnitsSettings::TemperatureUnitsCelsius,       FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "m^2",    "m\u00B2",  FactMetaData::UnitArea,                  UnitsSettings::AreaUnitsSquareMeters,         FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "m",      "ft",       FactMetaData::UnitHorizontalDistance,    UnitsSettings::HorizontalDistanceUnitsFeet,   FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
+    { "meter",  "ft",       FactMetaData::UnitHorizontalDistance,    UnitsSettings::HorizontalDistanceUnitsFeet,   FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
+    { "meters", "ft",       FactMetaData::UnitHorizontalDistance,    UnitsSettings::HorizontalDistanceUnitsFeet,   FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
+    { "alt m",  "ft",       FactMetaData::UnitVerticalDistance,      UnitsSettings::VerticalDistanceUnitsFeet,     FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
+    { "cm/px",  "in/px",    FactMetaData::UnitHorizontalDistance,    UnitsSettings::HorizontalDistanceUnitsFeet,   FactMetaData::_centimetersToInches,                 FactMetaData::_inchesToCentimeters },
+    { "m^2",    "km\u00B2", FactMetaData::UnitArea,                  UnitsSettings::AreaUnitsSquareKilometers,     FactMetaData::_squareMetersToSquareKilometers,      FactMetaData::_squareKilometersToSquareMeters },
+    { "m^2",    "ha",       FactMetaData::UnitArea,                  UnitsSettings::AreaUnitsHectares,             FactMetaData::_squareMetersToHectares,              FactMetaData::_hectaresToSquareMeters },
+    { "m^2",    "ft\u00B2", FactMetaData::UnitArea,                  UnitsSettings::AreaUnitsSquareFeet,           FactMetaData::_squareMetersToSquareFeet,            FactMetaData::_squareFeetToSquareMeters },
+    { "m^2",    "ac",       FactMetaData::UnitArea,                  UnitsSettings::AreaUnitsAcres,                FactMetaData::_squareMetersToAcres,                 FactMetaData::_acresToSquareMeters },
+    { "m^2",    "mi\u00B2", FactMetaData::UnitArea,                  UnitsSettings::AreaUnitsSquareMiles,          FactMetaData::_squareMetersToSquareMiles,           FactMetaData::_squareMilesToSquareMeters },
+    { "m/s",    "ft/s",     FactMetaData::UnitSpeed,                 UnitsSettings::SpeedUnitsFeetPerSecond,       FactMetaData::_metersToFeet,                        FactMetaData::_feetToMeters },
+    { "m/s",    "mph",      FactMetaData::UnitSpeed,                 UnitsSettings::SpeedUnitsMilesPerHour,        FactMetaData::_metersPerSecondToMilesPerHour,       FactMetaData::_milesPerHourToMetersPerSecond },
+    { "m/s",    "km/h",     FactMetaData::UnitSpeed,                 UnitsSettings::SpeedUnitsKilometersPerHour,   FactMetaData::_metersPerSecondToKilometersPerHour,  FactMetaData::_kilometersPerHourToMetersPerSecond },
+    { "m/s",    "kn",       FactMetaData::UnitSpeed,                 UnitsSettings::SpeedUnitsKnots,               FactMetaData::_metersPerSecondToKnots,              FactMetaData::_knotsToMetersPerSecond },
+    { "C",      "F",        FactMetaData::UnitTemperature,           UnitsSettings::TemperatureUnitsFarenheit,     FactMetaData::_celsiusToFarenheit,                  FactMetaData::_farenheitToCelsius },
+    { "g",      "g",        FactMetaData::UnitWeight,                UnitsSettings::WeightUnitsGrams,              FactMetaData::_defaultTranslator,                   FactMetaData::_defaultTranslator },
+    { "g",      "kg",       FactMetaData::UnitWeight,                UnitsSettings::WeightUnitsKg,                 FactMetaData::_gramsToKilograms,                    FactMetaData::_kilogramsToGrams },
+    { "g",      "oz",       FactMetaData::UnitWeight,                UnitsSettings::WeightUnitsOz,                 FactMetaData::_gramsToOunces,                       FactMetaData::_ouncesToGrams },
+    { "g",      "lbs",      FactMetaData::UnitWeight,                UnitsSettings::WeightUnitsLbs,                FactMetaData::_gramsToPunds,                        FactMetaData::_poundsToGrams },
 };
 
 const char* FactMetaData::_decimalPlacesJsonKey =       "decimalPlaces";
@@ -928,11 +928,11 @@ void FactMetaData::_setAppSettingsTranslators(void)
             uint settingsUnits = 0;
 
             switch (pAppSettingsTranslation->unitType) {
-            case UnitDistance:
-                settingsUnits = settings->distanceUnits()->rawValue().toUInt();
+            case UnitHorizontalDistance:
+                settingsUnits = settings->horizontalDistanceUnits()->rawValue().toUInt();
                 break;
-            case UnitAltitude:
-                settingsUnits = settings->altitudeUnits()->rawValue().toUInt();
+            case UnitVerticalDistance:
+                settingsUnits = settings->verticalDistanceUnits()->rawValue().toUInt();
                 break;
             case UnitSpeed:
                 settingsUnits = settings->speedUnits()->rawValue().toUInt();
@@ -959,7 +959,7 @@ void FactMetaData::_setAppSettingsTranslators(void)
     }
 }
 
-const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsDistanceUnitsTranslation(const QString& rawUnits)
+const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsHorizontalDistanceUnitsTranslation(const QString& rawUnits)
 {
     for (size_t i=0; i<sizeof(_rgAppSettingsTranslations)/sizeof(_rgAppSettingsTranslations[0]); i++) {
         const AppSettingsTranslation_s* pAppSettingsTranslation = &_rgAppSettingsTranslations[i];
@@ -968,9 +968,9 @@ const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsDist
             continue;
         }
 
-        uint settingsUnits = qgcApp()->toolbox()->settingsManager()->unitsSettings()->distanceUnits()->rawValue().toUInt();
+        uint settingsUnits = qgcApp()->toolbox()->settingsManager()->unitsSettings()->horizontalDistanceUnits()->rawValue().toUInt();
 
-        if (pAppSettingsTranslation->unitType == UnitDistance
+        if (pAppSettingsTranslation->unitType == UnitHorizontalDistance
                 && pAppSettingsTranslation->unitOption == settingsUnits) {
             return pAppSettingsTranslation;
         }
@@ -978,7 +978,7 @@ const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsDist
     return nullptr;
 }
 
-const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsAltitudeUnitsTranslation(const QString& rawUnits)
+const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsVerticalDistanceUnitsTranslation(const QString& rawUnits)
 {
     for (size_t i=0; i<sizeof(_rgAppSettingsTranslations)/sizeof(_rgAppSettingsTranslations[0]); i++) {
         const AppSettingsTranslation_s* pAppSettingsTranslation = &_rgAppSettingsTranslations[i];
@@ -987,9 +987,9 @@ const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsAlti
             continue;
         }
 
-        uint settingsUnits = qgcApp()->toolbox()->settingsManager()->unitsSettings()->altitudeUnits()->rawValue().toUInt();
+        uint settingsUnits = qgcApp()->toolbox()->settingsManager()->unitsSettings()->verticalDistanceUnits()->rawValue().toUInt();
 
-        if (pAppSettingsTranslation->unitType == UnitAltitude
+        if (pAppSettingsTranslation->unitType == UnitVerticalDistance
                 && pAppSettingsTranslation->unitOption == settingsUnits) {
             return pAppSettingsTranslation;
         }
@@ -1036,9 +1036,9 @@ const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsArea
     return nullptr;
 }
 
-QVariant FactMetaData::metersToAppSettingsDistanceUnits(const QVariant& meters)
+QVariant FactMetaData::metersToAppSettingsHorizontalDistanceUnits(const QVariant& meters)
 {
-    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsDistanceUnitsTranslation("m");
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsHorizontalDistanceUnitsTranslation("m");
     if (pAppSettingsTranslation) {
         return pAppSettingsTranslation->rawTranslator(meters);
     } else {
@@ -1046,9 +1046,9 @@ QVariant FactMetaData::metersToAppSettingsDistanceUnits(const QVariant& meters)
     }
 }
 
-QVariant FactMetaData::metersToAppSettingsAltitudeUnits(const QVariant& meters)
+QVariant FactMetaData::metersToAppSettingsVerticalDistanceUnits(const QVariant& meters)
 {
-    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAltitudeUnitsTranslation("alt m");
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsVerticalDistanceUnitsTranslation("vertical m");
     if (pAppSettingsTranslation) {
         return pAppSettingsTranslation->rawTranslator(meters);
     } else {
@@ -1056,9 +1056,9 @@ QVariant FactMetaData::metersToAppSettingsAltitudeUnits(const QVariant& meters)
     }
 }
 
-QVariant FactMetaData::appSettingsDistanceUnitsToMeters(const QVariant& distance)
+QVariant FactMetaData::appSettingsHorizontalDistanceUnitsToMeters(const QVariant& distance)
 {
-    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsDistanceUnitsTranslation("m");
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsHorizontalDistanceUnitsTranslation("m");
     if (pAppSettingsTranslation) {
         return pAppSettingsTranslation->cookedTranslator(distance);
     } else {
@@ -1066,9 +1066,9 @@ QVariant FactMetaData::appSettingsDistanceUnitsToMeters(const QVariant& distance
     }
 }
 
-QVariant FactMetaData::appSettingsAltitudeUnitsToMeters(const QVariant& distance)
+QVariant FactMetaData::appSettingsVerticalDistanceUnitsToMeters(const QVariant& distance)
 {
-    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAltitudeUnitsTranslation("alt m");
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsVerticalDistanceUnitsTranslation("alt m");
     if (pAppSettingsTranslation) {
         return pAppSettingsTranslation->cookedTranslator(distance);
     } else {
@@ -1076,9 +1076,9 @@ QVariant FactMetaData::appSettingsAltitudeUnitsToMeters(const QVariant& distance
     }
 }
 
-QString FactMetaData::appSettingsDistanceUnitsString(void)
+QString FactMetaData::appSettingsHorizontalDistanceUnitsString(void)
 {
-    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsDistanceUnitsTranslation("m");
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsHorizontalDistanceUnitsTranslation("m");
     if (pAppSettingsTranslation) {
         return pAppSettingsTranslation->cookedUnits;
     } else {
@@ -1086,9 +1086,9 @@ QString FactMetaData::appSettingsDistanceUnitsString(void)
     }
 }
 
-QString FactMetaData::appSettingsAltitudeUnitsString(void)
+QString FactMetaData::appSettingsVerticalDistanceUnitsString(void)
 {
-    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsAltitudeUnitsTranslation("alt m");
+    const AppSettingsTranslation_s* pAppSettingsTranslation = _findAppSettingsVerticalDistanceUnitsTranslation("alt m");
     if (pAppSettingsTranslation) {
         return pAppSettingsTranslation->cookedUnits;
     } else {

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -60,29 +60,29 @@ public:
 
     const FactMetaData& operator=(const FactMetaData& other);
 
-    /// Converts from meters to the user specified distance unit
-    static QVariant metersToAppSettingsDistanceUnits(const QVariant& meters);
+    /// Converts from meters to the user specified horizontal distance unit
+    static QVariant metersToAppSettingsHorizontalDistanceUnits(const QVariant& meters);
 
-    /// Converts from user specified distance unit to meters
-    static QVariant appSettingsDistanceUnitsToMeters(const QVariant& distance);
+    /// Converts from user specified horizontal distance unit to meters
+    static QVariant appSettingsHorizontalDistanceUnitsToMeters(const QVariant& distance);
 
-    /// Returns the string for distance units which has configued by user
-    static QString appSettingsDistanceUnitsString(void);
+    /// Returns the string for horizontal distance units which has configued by user
+    static QString appSettingsHorizontalDistanceUnitsString(void);
 
-    /// Converts from meters to the user specified altitude unit
-    static QVariant metersToAppSettingsAltitudeUnits(const QVariant& meters);
+    /// Converts from meters to the user specified vertical distance unit
+    static QVariant metersToAppSettingsVerticalDistanceUnits(const QVariant& meters);
 
-    /// Converts from user specified altitude unit to meters
-    static QVariant appSettingsAltitudeUnitsToMeters(const QVariant& distance);
+    /// Converts from user specified vertical distance unit to meters
+    static QVariant appSettingsVerticalDistanceUnitsToMeters(const QVariant& distance);
 
-    /// Returns the string for altitude units which has configued by user
-    static QString appSettingsAltitudeUnitsString(void);
+    /// Returns the string for vertical distance units which has configued by user
+    static QString appSettingsVerticalDistanceUnitsString(void);
 
     /// Converts from grams to the user specified weight unit
-    static QVariant gramsToAppSettingsWeightUnits(const QVariant& meters);
+    static QVariant gramsToAppSettingsWeightUnits(const QVariant& grams);
 
     /// Converts from user specified weight unit to grams
-    static QVariant appSettingsWeightUnitsToGrams(const QVariant& distance);
+    static QVariant appSettingsWeightUnitsToGrams(const QVariant& weight);
 
     /// Returns the string for weight units which has configued by user
     static QString appSettingsWeightUnitsString(void);
@@ -236,8 +236,8 @@ private:
 
 
     enum UnitTypes {
-        UnitDistance = 0,
-        UnitAltitude,
+        UnitHorizontalDistance = 0,
+        UnitVerticalDistance,
         UnitArea,
         UnitSpeed,
         UnitTemperature,
@@ -245,16 +245,16 @@ private:
     };
 
     struct AppSettingsTranslation_s {
-        QString     rawUnits;
-        const char*     cookedUnits;
-        UnitTypes       unitType;
-        uint32_t        unitOption;
-        Translator      rawTranslator;
-        Translator      cookedTranslator;
+        QString       rawUnits;
+        const char*   cookedUnits;
+        UnitTypes     unitType;
+        uint32_t      unitOption;
+        Translator    rawTranslator;
+        Translator    cookedTranslator;
     };
 
-    static const AppSettingsTranslation_s* _findAppSettingsDistanceUnitsTranslation(const QString& rawUnits);
-    static const AppSettingsTranslation_s* _findAppSettingsAltitudeUnitsTranslation(const QString& rawUnits);
+    static const AppSettingsTranslation_s* _findAppSettingsHorizontalDistanceUnitsTranslation(const QString& rawUnits);
+    static const AppSettingsTranslation_s* _findAppSettingsVerticalDistanceUnitsTranslation(const QString& rawUnits);
     static const AppSettingsTranslation_s* _findAppSettingsAreaUnitsTranslation(const QString& rawUnits);
     static const AppSettingsTranslation_s* _findAppSettingsWeightUnitsTranslation(const QString& rawUnits);
 

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -69,6 +69,24 @@ public:
     /// Returns the string for distance units which has configued by user
     static QString appSettingsDistanceUnitsString(void);
 
+    /// Converts from meters to the user specified altitude unit
+    static QVariant metersToAppSettingsAltitudeUnits(const QVariant& meters);
+
+    /// Converts from user specified altitude unit to meters
+    static QVariant appSettingsAltitudeUnitsToMeters(const QVariant& distance);
+
+    /// Returns the string for altitude units which has configued by user
+    static QString appSettingsAltitudeUnitsString(void);
+
+    /// Converts from grams to the user specified weight unit
+    static QVariant gramsToAppSettingsWeightUnits(const QVariant& meters);
+
+    /// Converts from user specified weight unit to grams
+    static QVariant appSettingsWeightUnitsToGrams(const QVariant& distance);
+
+    /// Returns the string for weight units which has configued by user
+    static QString appSettingsWeightUnitsString(void);
+
     /// Converts from meters to the user specified distance unit
     static QVariant squareMetersToAppSettingsAreaUnits(const QVariant& squareMeters);
 
@@ -209,12 +227,21 @@ private:
     static QVariant _inchesToCentimeters(const QVariant& inches);
     static QVariant _celsiusToFarenheit(const QVariant& celsius);
     static QVariant _farenheitToCelsius(const QVariant& farenheit);
+    static QVariant _kilogramsToGrams(const QVariant& kg);
+    static QVariant _ouncesToGrams(const QVariant& oz);
+    static QVariant _poundsToGrams(const QVariant& lbs);
+    static QVariant _gramsToKilograms(const QVariant& g);
+    static QVariant _gramsToOunces(const QVariant& g);
+    static QVariant _gramsToPunds(const QVariant& g);
+
 
     enum UnitTypes {
         UnitDistance = 0,
+        UnitAltitude,
         UnitArea,
         UnitSpeed,
-        UnitTemperature
+        UnitTemperature,
+        UnitWeight
     };
 
     struct AppSettingsTranslation_s {
@@ -227,7 +254,9 @@ private:
     };
 
     static const AppSettingsTranslation_s* _findAppSettingsDistanceUnitsTranslation(const QString& rawUnits);
+    static const AppSettingsTranslation_s* _findAppSettingsAltitudeUnitsTranslation(const QString& rawUnits);
     static const AppSettingsTranslation_s* _findAppSettingsAreaUnitsTranslation(const QString& rawUnits);
+    static const AppSettingsTranslation_s* _findAppSettingsWeightUnitsTranslation(const QString& rawUnits);
 
     static void _loadJsonDefines(const QJsonObject& jsonDefinesObject, QMap<QString, QString>& defineMap);
 
@@ -267,6 +296,8 @@ private:
         static const qreal milesToMeters;
         static const qreal feetToMeters;
         static const qreal inchesToCentimeters;
+        static const qreal ouncesToGrams;
+        static const qreal poundsToGrams;
     } constants;
 
     struct BuiltInTranslation_s {

--- a/src/FlightDisplay/GuidedAltitudeSlider.qml
+++ b/src/FlightDisplay/GuidedAltitudeSlider.qml
@@ -67,14 +67,14 @@ Rectangle {
         QGCLabel {
             id:                         altField
             anchors.horizontalCenter:   parent.horizontalCenter
-            text:                       newAltitudeAppUnits + " " + QGroundControl.appSettingsDistanceUnitsString
+            text:                       newAltitudeAppUnits + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
 
             property real   altGainRange:           Math.max(_sliderMaxAlt - _vehicleAltitude, 0)
             property real   altLossRange:           Math.max(_vehicleAltitude - _sliderMinAlt, 0)
             property real   altExp:                 Math.pow(altSlider.value, 3)
             property real   altLossGain:            altExp * (altSlider.value > 0 ? altGainRange : altLossRange)
             property real   newAltitudeMeters:      _vehicleAltitude + altLossGain
-            property string newAltitudeAppUnits:    QGroundControl.metersToAppSettingsDistanceUnits(newAltitudeMeters).toFixed(1)
+            property string newAltitudeAppUnits:    QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(newAltitudeMeters).toFixed(1)
 
             function setToMinimumTakeoff() {
                 altSlider.value = Math.pow(activeVehicle.minimumTakeoffAltitude() / altGainRange, 1.0/3.0)

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -84,7 +84,7 @@ MapQuickItem {
             visible:                    _adsbVehicle ? !isNaN(altitude) : _multiVehicle
             property string vehicleLabelText: visible ?
                                                   (_adsbVehicle ?
-                                                       QGroundControl.metersToAppSettingsDistanceUnits(altitude).toFixed(0) + " " + QGroundControl.appSettingsDistanceUnitsString :
+                                                       QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(altitude).toFixed(0) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString :
                                                        (_multiVehicle ? qsTr("Vehicle %1").arg(vehicle.id) : "")) :
                                                   ""
 

--- a/src/FlightMap/MapScale.qml
+++ b/src/FlightMap/MapScale.qml
@@ -121,7 +121,7 @@ Item {
             var leftCoord  = mapControl.toCoordinate(Qt.point(0, scale.y), false /* clipToViewPort */)
             var rightCoord = mapControl.toCoordinate(Qt.point(scaleLinePixelLength, scale.y), false /* clipToViewPort */)
             var scaleLineMeters = Math.round(leftCoord.distanceTo(rightCoord))
-            if (QGroundControl.settingsManager.unitsSettings.distanceUnits.value === UnitsSettings.DistanceUnitsFeet) {
+            if (QGroundControl.settingsManager.unitsSettings.horizontalDistanceUnits.value === UnitsSettings.HorizontalDistanceUnitsFeet) {
                 calculateFeetRatio(scaleLineMeters, scaleLinePixelLength)
             } else {
                 calculateMetersRatio(scaleLineMeters, scaleLinePixelLength)

--- a/src/MissionManager/KMLPlanDomDocument.cc
+++ b/src/MissionManager/KMLPlanDomDocument.cc
@@ -84,8 +84,8 @@ void KMLPlanDomDocument::_addFlightPath(Vehicle* vehicle, QList<MissionItem*> rg
                 QString htmlString;
                 htmlString += QStringLiteral("Index: %1\n").arg(item->sequenceNumber());
                 htmlString += uiInfo->friendlyName() + "\n";
-                htmlString += QStringLiteral("Alt AMSL: %1 %2\n").arg(QString::number(FactMetaData::metersToAppSettingsDistanceUnits(coord.altitude()).toDouble(), 'f', 2)).arg(FactMetaData::appSettingsDistanceUnitsString());
-                htmlString += QStringLiteral("Alt Rel: %1 %2\n").arg(QString::number(FactMetaData::metersToAppSettingsDistanceUnits(coord.altitude() - homeCoord.altitude()).toDouble(), 'f', 2)).arg(FactMetaData::appSettingsDistanceUnitsString());
+                htmlString += QStringLiteral("Alt AMSL: %1 %2\n").arg(QString::number(FactMetaData::metersToAppSettingsHorizontalDistanceUnits(coord.altitude()).toDouble(), 'f', 2)).arg(FactMetaData::appSettingsHorizontalDistanceUnitsString());
+                htmlString += QStringLiteral("Alt Rel: %1 %2\n").arg(QString::number(FactMetaData::metersToAppSettingsHorizontalDistanceUnits(coord.altitude() - homeCoord.altitude()).toDouble(), 'f', 2)).arg(FactMetaData::appSettingsHorizontalDistanceUnitsString());
                 htmlString += QStringLiteral("Lat: %1\n").arg(QString::number(coord.latitude(), 'f', 7));
                 htmlString += QStringLiteral("Lon: %1\n").arg(QString::number(coord.longitude(), 'f', 7));
                 QDomCDATASection cdataSection = createCDATASection(htmlString);

--- a/src/PlanView/FWLandingPatternMapVisual.qml
+++ b/src/PlanView/FWLandingPatternMapVisual.qml
@@ -460,8 +460,8 @@ Item {
 
             sourceItem: HeightIndicator {
                 map:        _root.map
-                heightText: Math.floor(QGroundControl.metersToAppSettingsDistanceUnits(_transitionAltitudeMeters)) +
-                            QGroundControl.appSettingsDistanceUnitsString + "<sup>*</sup>"
+                heightText: Math.floor(QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_transitionAltitudeMeters)) +
+                            QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString + "<sup>*</sup>"
             }
 
             function recalc() {
@@ -492,8 +492,8 @@ Item {
 
             sourceItem: HeightIndicator {
                 map:        _root.map
-                heightText: Math.floor(QGroundControl.metersToAppSettingsDistanceUnits(_midSlopeAltitudeMeters)) +
-                            QGroundControl.appSettingsDistanceUnitsString + "<sup>*</sup>"
+                heightText: Math.floor(QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_midSlopeAltitudeMeters)) +
+                            QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString + "<sup>*</sup>"
             }
 
             function recalc() {
@@ -527,7 +527,7 @@ Item {
 
             sourceItem: HeightIndicator {
                 map:        _root.map
-                heightText: _missionItem.loiterAltitude.value.toFixed(1) + QGroundControl.appSettingsDistanceUnitsString
+                heightText: _missionItem.loiterAltitude.value.toFixed(1) + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
             }
         }
     }

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -50,13 +50,13 @@ Item {
     property real   _controllerProgressPct:     _controllerValid ? _planMasterController.missionController.progressPct : 0
     property bool   _syncInProgress:            _controllerValid ? _planMasterController.missionController.syncInProgress : false
 
-    property string _distanceText:              isNaN(_distance) ?              "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_distance).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
-    property string _altDifferenceText:         isNaN(_altDifference) ?         "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_altDifference).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
+    property string _distanceText:              isNaN(_distance) ?              "-.-" : QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_distance).toFixed(1) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+    property string _altDifferenceText:         isNaN(_altDifference) ?         "-.-" : QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_altDifference).toFixed(1) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
     property string _gradientText:              isNaN(_gradient) ?              "-.-" : _gradient.toFixed(0) + " %"
     property string _azimuthText:               isNaN(_azimuth) ?               "-.-" : Math.round(_azimuth) % 360
     property string _headingText:               isNaN(_azimuth) ?               "-.-" : Math.round(_heading) % 360
-    property string _missionDistanceText:       isNaN(_missionDistance) ?       "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_missionDistance).toFixed(0) + " " + QGroundControl.appSettingsDistanceUnitsString
-    property string _missionMaxTelemetryText:   isNaN(_missionMaxTelemetry) ?   "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_missionMaxTelemetry).toFixed(0) + " " + QGroundControl.appSettingsDistanceUnitsString
+    property string _missionDistanceText:       isNaN(_missionDistance) ?       "-.-" : QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_missionDistance).toFixed(0) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+    property string _missionMaxTelemetryText:   isNaN(_missionMaxTelemetry) ?   "-.-" : QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_missionMaxTelemetry).toFixed(0) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
     property string _batteryChangePointText:    _batteryChangePoint < 0 ?       "N/A" : _batteryChangePoint
     property string _batteriesRequiredText:     _batteriesRequired < 0 ?        "N/A" : _batteriesRequired
 

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -221,13 +221,13 @@ Rectangle {
                     QGCLabel { text: missionItem.layers.valueString }
 
                     QGCLabel { text: qsTr("Layer Height") }
-                    QGCLabel { text: missionItem.cameraCalc.adjustedFootprintFrontal.valueString + " " + QGroundControl.appSettingsDistanceUnitsString }
+                    QGCLabel { text: missionItem.cameraCalc.adjustedFootprintFrontal.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString }
 
                     QGCLabel { text: qsTr("Top Layer Alt") }
-                    QGCLabel { text: QGroundControl.metersToAppSettingsDistanceUnits(missionItem.topFlightAlt).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString }
+                    QGCLabel { text: QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(missionItem.topFlightAlt).toFixed(1) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString }
 
                     QGCLabel { text: qsTr("Bottom Layer Alt") }
-                    QGCLabel { text: QGroundControl.metersToAppSettingsDistanceUnits(missionItem.bottomFlightAlt).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString }
+                    QGCLabel { text: QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(missionItem.bottomFlightAlt).toFixed(1) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString }
 
                     QGCLabel { text: qsTr("Photo Count") }
                     QGCLabel { text: missionItem.cameraShots }
@@ -236,7 +236,7 @@ Rectangle {
                     QGCLabel { text: missionItem.timeBetweenShots.toFixed(1) + " " + qsTr("secs") }
 
                     QGCLabel { text: qsTr("Trigger Distance") }
-                    QGCLabel { text: missionItem.cameraCalc.adjustedFootprintSide.valueString + " " + QGroundControl.appSettingsDistanceUnitsString }
+                    QGCLabel { text: missionItem.cameraCalc.adjustedFootprintSide.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString }
                 }
             } // Grid Column
 

--- a/src/PlanView/TerrainStatus.qml
+++ b/src/PlanView/TerrainStatus.qml
@@ -48,7 +48,9 @@ Rectangle {
         anchors.top:            parent.bottom
         width:                  parent.height
         font.pointSize:         ScreenTools.smallFontPointSize
-        text:                   qsTr("Height AMSL (%1)").arg(QGroundControl.appSettingsDistanceUnitsString)
+        text:                   qsTr("Height AMSL (%1)").arg(
+                                    QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+                                )
         horizontalAlignment:    Text.AlignHCenter
         rotation:               -90
         transformOrigin:        Item.TopLeft

--- a/src/PlanView/TransectStyleComplexItemStats.qml
+++ b/src/PlanView/TransectStyleComplexItemStats.qml
@@ -14,7 +14,7 @@ Grid {
     columnSpacing:  ScreenTools.defaultFontPixelWidth
 
     QGCLabel { text: qsTr("Survey Area") }
-    QGCLabel { text: QGroundControl.squareMetersToAppSettingsAreaUnits(missionItem.coveredArea).toFixed(2) + " " + QGroundControl.appSettingsAreaUnitsString }
+    QGCLabel { text: QGroundControl.unitsConversion.squareMetersToAppSettingsAreaUnits(missionItem.coveredArea).toFixed(2) + " " + QGroundControl.unitsConversion.appSettingsAreaUnitsString }
 
     QGCLabel { text: qsTr("Photo Count") }
     QGCLabel { text: missionItem.cameraShots }

--- a/src/QmlControls/QGroundControl/Specific/UnitsWizardPage.qml
+++ b/src/QmlControls/QGroundControl/Specific/UnitsWizardPage.qml
@@ -57,18 +57,18 @@ BaseStartupWizardPage {
                     model: [qsTr("Metric System"), qsTr("Imperial System")]
                     Layout.preferredWidth:  _comboFieldWidth
 
-                    currentIndex: QGroundControl.settingsManager.unitsSettings.distanceUnits.value === UnitsSettings.DistanceUnitsMeters ? 0 : 1
+                    currentIndex: QGroundControl.settingsManager.unitsSettings.horizontalDistanceUnits.value === UnitsSettings.HorizontalDistanceUnitsMeters ? 0 : 1
 
                     onActivated: {
                         var metric = (currentIndex === 0);
-                        QGroundControl.settingsManager.unitsSettings.distanceUnits.value = metric ? UnitsSettings.DistanceUnitsMeters : UnitsSettings.DistanceUnitsFeet
+                        QGroundControl.settingsManager.unitsSettings.horizontalDistanceUnits.value = metric ? UnitsSettings.HorizontalDistanceUnitsMeters : UnitsSettings.HorizontalDistanceUnitsFeet
                         QGroundControl.settingsManager.unitsSettings.areaUnits.value = metric ? UnitsSettings.AreaUnitsSquareMeters : UnitsSettings.AreaUnitsSquareFeet
                         QGroundControl.settingsManager.unitsSettings.speedUnits.value = metric ? UnitsSettings.SpeedUnitsMetersPerSecond : UnitsSettings.SpeedUnitsFeetPerSecond
                         QGroundControl.settingsManager.unitsSettings.temperatureUnits.value = metric ? UnitsSettings.TemperatureUnitsCelsius : UnitsSettings.TemperatureUnitsFarenheit
                     }
                 }
                 Repeater {
-                    model:  [ QGroundControl.settingsManager.unitsSettings.distanceUnits, QGroundControl.settingsManager.unitsSettings.areaUnits, QGroundControl.settingsManager.unitsSettings.speedUnits, QGroundControl.settingsManager.unitsSettings.temperatureUnits ]
+                    model:  [ QGroundControl.settingsManager.unitsSettings.horizontalDistanceUnits, QGroundControl.settingsManager.unitsSettings.areaUnits, QGroundControl.settingsManager.unitsSettings.speedUnits, QGroundControl.settingsManager.unitsSettings.temperatureUnits ]
                     FactComboBox {
                         Layout.preferredWidth:  _comboFieldWidth
                         fact:                   modelData

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -18,13 +18,13 @@
 #include "QGCApplication.h"
 #include "LinkManager.h"
 #include "SettingsFact.h"
-#include "FactMetaData.h"
 #include "SimulatedPosition.h"
 #include "QGCLoggingCategory.h"
 #include "AppSettings.h"
 #include "AirspaceManager.h"
 #include "ADSBVehicleManager.h"
 #include "QGCPalette.h"
+#include "QmlUnitsConversion.h"
 #if defined(QGC_ENABLE_PAIRING)
 #include "PairingManager.h"
 #endif
@@ -83,6 +83,7 @@ public:
     Q_PROPERTY(bool                 microhardSupported  READ microhardSupported     CONSTANT)
     Q_PROPERTY(bool                 supportsPairing     READ supportsPairing        CONSTANT)
     Q_PROPERTY(QGCPalette*          globalPalette       MEMBER _globalPalette       CONSTANT)   // This palette will always return enabled colors
+    Q_PROPERTY(QmlUnitsConversion*  unitsConversion     READ unitsConversion        CONSTANT)
 #if defined(QGC_ENABLE_PAIRING)
     Q_PROPERTY(PairingManager*      pairingManager      READ pairingManager         CONSTANT)
 #endif
@@ -114,10 +115,6 @@ public:
     Q_PROPERTY(QString  missionFileExtension    READ missionFileExtension   CONSTANT)
     Q_PROPERTY(QString  telemetryFileExtension  READ telemetryFileExtension CONSTANT)
 
-    /// Returns the string for distance units which has configued by user
-    Q_PROPERTY(QString appSettingsDistanceUnitsString READ appSettingsDistanceUnitsString CONSTANT)
-    Q_PROPERTY(QString appSettingsAreaUnitsString READ appSettingsAreaUnitsString CONSTANT)
-
     Q_PROPERTY(QString qgcVersion       READ qgcVersion         CONSTANT)
     Q_PROPERTY(bool    skipSetupPage    READ skipSetupPage      WRITE setSkipSetupPage NOTIFY skipSetupPageChanged)
 
@@ -137,38 +134,6 @@ public:
     Q_INVOKABLE void    startAPMArduRoverMockLink   (bool sendStatusText);
     Q_INVOKABLE void    stopOneMockLink             (void);
 
-    /// Converts from meters to the user specified distance unit
-    Q_INVOKABLE QVariant metersToAppSettingsDistanceUnits(const QVariant& meters) const { return FactMetaData::metersToAppSettingsDistanceUnits(meters); }
-
-    /// Converts from user specified distance unit to meters
-    Q_INVOKABLE QVariant appSettingsDistanceUnitsToMeters(const QVariant& distance) const { return FactMetaData::appSettingsDistanceUnitsToMeters(distance); }
-
-    QString appSettingsDistanceUnitsString(void) const { return FactMetaData::appSettingsDistanceUnitsString(); }
-
-    /// Converts from meters to the user specified distance unit
-    Q_INVOKABLE QVariant metersToAppSettingsAltitudeUnits(const QVariant& meters) const { return FactMetaData::metersToAppSettingsAltitudeUnits(meters); }
-
-    /// Converts from user specified distance unit to meters
-    Q_INVOKABLE QVariant appSettingsAltitudeUnitsToMeters(const QVariant& distance) const { return FactMetaData::appSettingsAltitudeUnitsToMeters(distance); }
-
-    QString appSettingsAltitudeUnitsString(void) const { return FactMetaData::appSettingsAltitudeUnitsString(); }
-
-    /// Converts from grams to the user specified weight unit
-    Q_INVOKABLE QVariant gramsToAppSettingsWeightUnits(const QVariant& meters) const { return FactMetaData::gramsToAppSettingsWeightUnits(meters); }
-
-    /// Converts from user specified weight unit to grams
-    Q_INVOKABLE QVariant appSettingsWeightUnitsToGrams(const QVariant& distance) const { return FactMetaData::appSettingsWeightUnitsToGrams(distance); }
-
-    QString appSettingsWeightUnitsString(void) const { return FactMetaData::appSettingsWeightUnitsString(); }
-
-    /// Converts from square meters to the user specified area unit
-    Q_INVOKABLE QVariant squareMetersToAppSettingsAreaUnits(const QVariant& meters) const { return FactMetaData::squareMetersToAppSettingsAreaUnits(meters); }
-
-    /// Converts from user specified area unit to square meters
-    Q_INVOKABLE QVariant appSettingsAreaUnitsToSquareMeters(const QVariant& area) const { return FactMetaData::appSettingsAreaUnitsToSquareMeters(area); }
-
-    QString appSettingsAreaUnitsString(void) const { return FactMetaData::appSettingsAreaUnitsString(); }
-
     /// Returns the list of available logging category names.
     Q_INVOKABLE QStringList loggingCategories(void) const { return QGCLoggingCategoryRegister::instance()->registeredCategories(); }
 
@@ -182,9 +147,6 @@ public:
     Q_INVOKABLE void updateLoggingFilterRules(void) { QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(QString()); }
 
     Q_INVOKABLE bool linesIntersect(QPointF xLine1, QPointF yLine1, QPointF xLine2, QPointF yLine2);
-
-    Q_INVOKABLE double degreesToRadians(double degrees) { return qDegreesToRadians(degrees); }
-    Q_INVOKABLE double radiansToDegrees(double radians) { return qRadiansToDegrees(radians); }
 
     // Property accesors
 
@@ -201,6 +163,7 @@ public:
     FactGroup*              gpsRtkFactGroup     ()  { return _gpsRtkFactGroup; }
     AirspaceManager*        airspaceManager     ()  { return _airspaceManager; }
     ADSBVehicleManager*     adsbVehicleManager  ()  { return _adsbVehicleManager; }
+    QmlUnitsConversion*     unitsConversion     ()  { return &_unitsConversion; }
 #if defined(QGC_ENABLE_PAIRING)
     bool                    supportsPairing     ()  { return true; }
     PairingManager*         pairingManager      ()  { return _pairingManager; }
@@ -299,6 +262,7 @@ private:
     MicrohardManager*       _microhardManager       = nullptr;
     ADSBVehicleManager*     _adsbVehicleManager     = nullptr;
     QGCPalette*             _globalPalette          = nullptr;
+    QmlUnitsConversion      _unitsConversion;
 #if defined(QGC_ENABLE_PAIRING)
     PairingManager*         _pairingManager         = nullptr;
 #endif

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -145,6 +145,22 @@ public:
 
     QString appSettingsDistanceUnitsString(void) const { return FactMetaData::appSettingsDistanceUnitsString(); }
 
+    /// Converts from meters to the user specified distance unit
+    Q_INVOKABLE QVariant metersToAppSettingsAltitudeUnits(const QVariant& meters) const { return FactMetaData::metersToAppSettingsAltitudeUnits(meters); }
+
+    /// Converts from user specified distance unit to meters
+    Q_INVOKABLE QVariant appSettingsAltitudeUnitsToMeters(const QVariant& distance) const { return FactMetaData::appSettingsAltitudeUnitsToMeters(distance); }
+
+    QString appSettingsAltitudeUnitsString(void) const { return FactMetaData::appSettingsAltitudeUnitsString(); }
+
+    /// Converts from grams to the user specified weight unit
+    Q_INVOKABLE QVariant gramsToAppSettingsWeightUnits(const QVariant& meters) const { return FactMetaData::gramsToAppSettingsWeightUnits(meters); }
+
+    /// Converts from user specified weight unit to grams
+    Q_INVOKABLE QVariant appSettingsWeightUnitsToGrams(const QVariant& distance) const { return FactMetaData::appSettingsWeightUnitsToGrams(distance); }
+
+    QString appSettingsWeightUnitsString(void) const { return FactMetaData::appSettingsWeightUnitsString(); }
+
     /// Converts from square meters to the user specified area unit
     Q_INVOKABLE QVariant squareMetersToAppSettingsAreaUnits(const QVariant& meters) const { return FactMetaData::squareMetersToAppSettingsAreaUnits(meters); }
 

--- a/src/QmlControls/QmlUnitsConversion.h
+++ b/src/QmlControls/QmlUnitsConversion.h
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#ifndef QMLUNITSCONVERSION_H
+#define QMLUNITSCONVERSION_H
+
+#include <QObject>
+#include <qmath.h>
+#include "FactMetaData.h"
+
+class QmlUnitsConversion : public QObject
+{
+    Q_OBJECT
+public:
+    QmlUnitsConversion(QObject *parent=nullptr): QObject(parent) {}
+    ~QmlUnitsConversion() = default;
+
+    Q_PROPERTY(QString appSettingsHorizontalDistanceUnitsString READ appSettingsHorizontalDistanceUnitsString CONSTANT)
+    Q_PROPERTY(QString appSettingsVerticalDistanceUnitsString   READ appSettingsVerticalDistanceUnitsString   CONSTANT)
+    Q_PROPERTY(QString appSettingsAreaUnitsString               READ appSettingsAreaUnitsString               CONSTANT)
+    Q_PROPERTY(QString appSettingsWeightUnitsString             READ appSettingsWeightUnitsString             CONSTANT)
+
+    /// Converts from meters to the user specified distance unit
+    Q_INVOKABLE QVariant metersToAppSettingsHorizontalDistanceUnits(const QVariant& meters) const { return FactMetaData::metersToAppSettingsHorizontalDistanceUnits(meters); }
+
+    /// Converts from user specified distance unit to meters
+    Q_INVOKABLE QVariant appSettingsHorizontalDistanceUnitsToMeters(const QVariant& distance) const { return FactMetaData::appSettingsHorizontalDistanceUnitsToMeters(distance); }
+
+    QString appSettingsHorizontalDistanceUnitsString(void) const { return FactMetaData::appSettingsHorizontalDistanceUnitsString(); }
+
+    /// Converts from meters to the user specified distance unit
+    Q_INVOKABLE QVariant metersToAppSettingsVerticalDistanceUnits(const QVariant& meters) const { return FactMetaData::metersToAppSettingsVerticalDistanceUnits(meters); }
+
+    /// Converts from user specified distance unit to meters
+    Q_INVOKABLE QVariant appSettingsVerticalDistanceUnitsToMeters(const QVariant& distance) const { return FactMetaData::appSettingsVerticalDistanceUnitsToMeters(distance); }
+
+    QString appSettingsVerticalDistanceUnitsString(void) const { return FactMetaData::appSettingsVerticalDistanceUnitsString(); }
+
+    /// Converts from grams to the user specified weight unit
+    Q_INVOKABLE QVariant gramsToAppSettingsWeightUnits(const QVariant& meters) const { return FactMetaData::gramsToAppSettingsWeightUnits(meters); }
+
+    /// Converts from user specified weight unit to grams
+    Q_INVOKABLE QVariant appSettingsWeightUnitsToGrams(const QVariant& distance) const { return FactMetaData::appSettingsWeightUnitsToGrams(distance); }
+
+    QString appSettingsWeightUnitsString(void) const { return FactMetaData::appSettingsWeightUnitsString(); }
+
+    /// Converts from square meters to the user specified area unit
+    Q_INVOKABLE QVariant squareMetersToAppSettingsAreaUnits(const QVariant& meters) const { return FactMetaData::squareMetersToAppSettingsAreaUnits(meters); }
+
+    /// Converts from user specified area unit to square meters
+    Q_INVOKABLE QVariant appSettingsAreaUnitsToSquareMeters(const QVariant& area) const { return FactMetaData::appSettingsAreaUnitsToSquareMeters(area); }
+
+    QString appSettingsAreaUnitsString(void) const { return FactMetaData::appSettingsAreaUnitsString(); }
+
+    Q_INVOKABLE double degreesToRadians(double degrees) { return qDegreesToRadians(degrees); }
+    Q_INVOKABLE double radiansToDegrees(double radians) { return qRadiansToDegrees(radians); }
+};
+
+#endif // QMLUNITSCONVERSION_H

--- a/src/Settings/UnitsSettings.cc
+++ b/src/Settings/UnitsSettings.cc
@@ -17,63 +17,65 @@ DECLARE_SETTINGGROUP(Units, "Units")
     qmlRegisterUncreatableType<UnitsSettings>("QGroundControl.SettingsManager", 1, 0, "UnitsSettings", "Reference only");
 }
 
-DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, distanceUnits)
+DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, horizontalDistanceUnits)
 {
-    if (!_distanceUnitsFact) {
+    if (!_horizontalDistanceUnitsFact) {
         // Distance/Area/Speed units settings can't be loaded from json since it creates an infinite loop of meta data loading.
         QStringList     enumStrings;
         QVariantList    enumValues;
         enumStrings << "Feet" << "Meters";
-        enumValues << QVariant::fromValue(static_cast<uint32_t>(DistanceUnitsFeet)) << QVariant::fromValue(static_cast<uint32_t>(DistanceUnitsMeters));
+        enumValues << QVariant::fromValue(static_cast<uint32_t>(HorizontalDistanceUnitsFeet))
+                   << QVariant::fromValue(static_cast<uint32_t>(HorizontalDistanceUnitsMeters));
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
-        metaData->setName(distanceUnitsName);
+        metaData->setName(horizontalDistanceUnitsName);
         metaData->setShortDescription("Distance units");
         metaData->setEnumInfo(enumStrings, enumValues);
 
-        DistanceUnits defaultDistanceUnit = DistanceUnitsMeters;
+        HorizontalDistanceUnits defaultHorizontalDistanceUnit = HorizontalDistanceUnitsMeters;
         switch(QLocale::system().measurementSystem()) {
             case QLocale::MetricSystem: {
-                defaultDistanceUnit = DistanceUnitsMeters;
+                defaultHorizontalDistanceUnit = HorizontalDistanceUnitsMeters;
             } break;
             case QLocale::ImperialUSSystem:
             case QLocale::ImperialUKSystem:
-                defaultDistanceUnit = DistanceUnitsFeet;
+                defaultHorizontalDistanceUnit = HorizontalDistanceUnitsFeet;
                 break;
         }
-        metaData->setRawDefaultValue(defaultDistanceUnit);
+        metaData->setRawDefaultValue(defaultHorizontalDistanceUnit);
         metaData->setQGCRebootRequired(true);
-        _distanceUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
+        _horizontalDistanceUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
-    return _distanceUnitsFact;
+    return _horizontalDistanceUnitsFact;
 }
 
-DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, altitudeUnits)
+DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, verticalDistanceUnits)
 {
-    if (!_altitudeUnitsFact) {
+    if (!_verticalDistanceUnitsFact) {
         // Distance/Area/Speed units settings can't be loaded from json since it creates an infinite loop of meta data loading.
         QStringList     enumStrings;
         QVariantList    enumValues;
         enumStrings << "Feet" << "Meters";
-        enumValues << QVariant::fromValue(static_cast<uint32_t>(DistanceUnitsFeet)) << QVariant::fromValue(static_cast<uint32_t>(DistanceUnitsMeters));
+        enumValues << QVariant::fromValue(static_cast<uint32_t>(VerticalDistanceUnitsFeet))
+                   << QVariant::fromValue(static_cast<uint32_t>(VerticalDistanceUnitsMeters));
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
-        metaData->setName(altitudeUnitsName);
+        metaData->setName(verticalDistanceUnitsName);
         metaData->setShortDescription("Altitude units");
         metaData->setEnumInfo(enumStrings, enumValues);
-        AltitudeUnits defaultAltitudeUnit = AltitudeUnitsMeters;
+        VerticalDistanceUnits defaultVerticalAltitudeUnit = VerticalDistanceUnitsMeters;
         switch(QLocale::system().measurementSystem()) {
             case QLocale::MetricSystem: {
-                defaultAltitudeUnit = AltitudeUnitsMeters;
+                defaultVerticalAltitudeUnit = VerticalDistanceUnitsMeters;
             } break;
             case QLocale::ImperialUSSystem:
             case QLocale::ImperialUKSystem:
-                defaultAltitudeUnit = AltitudeUnitsFeet;
+                defaultVerticalAltitudeUnit = VerticalDistanceUnitsFeet;
                 break;
         }
-        metaData->setRawDefaultValue(defaultAltitudeUnit);
+        metaData->setRawDefaultValue(defaultVerticalAltitudeUnit);
         metaData->setQGCRebootRequired(true);
-        _altitudeUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
+        _verticalDistanceUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
-    return _altitudeUnitsFact;
+    return _verticalDistanceUnitsFact;
 }
 
 DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, areaUnits)

--- a/src/Settings/UnitsSettings.cc
+++ b/src/Settings/UnitsSettings.cc
@@ -47,6 +47,35 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, distanceUnits)
     return _distanceUnitsFact;
 }
 
+DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, altitudeUnits)
+{
+    if (!_altitudeUnitsFact) {
+        // Distance/Area/Speed units settings can't be loaded from json since it creates an infinite loop of meta data loading.
+        QStringList     enumStrings;
+        QVariantList    enumValues;
+        enumStrings << "Feet" << "Meters";
+        enumValues << QVariant::fromValue(static_cast<uint32_t>(DistanceUnitsFeet)) << QVariant::fromValue(static_cast<uint32_t>(DistanceUnitsMeters));
+        FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
+        metaData->setName(altitudeUnitsName);
+        metaData->setShortDescription("Altitude units");
+        metaData->setEnumInfo(enumStrings, enumValues);
+        AltitudeUnits defaultAltitudeUnit = AltitudeUnitsMeters;
+        switch(QLocale::system().measurementSystem()) {
+            case QLocale::MetricSystem: {
+                defaultAltitudeUnit = AltitudeUnitsMeters;
+            } break;
+            case QLocale::ImperialUSSystem:
+            case QLocale::ImperialUKSystem:
+                defaultAltitudeUnit = AltitudeUnitsFeet;
+                break;
+        }
+        metaData->setRawDefaultValue(defaultAltitudeUnit);
+        metaData->setQGCRebootRequired(true);
+        _altitudeUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
+    }
+    return _altitudeUnitsFact;
+}
+
 DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, areaUnits)
 {
     if (!_areaUnitsFact) {
@@ -146,4 +175,37 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, temperatureUnits)
         _temperatureUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
     return _temperatureUnitsFact;
+}
+
+DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, weightUnits)
+{
+    if (!_weightUnitsFact) {
+        // Units settings can't be loaded from json since it creates an infinite loop of meta data loading.
+        QStringList     enumStrings;
+        QVariantList    enumValues;
+        enumStrings << "Grams" << "Kilograms" << "Ounces" << "Pounds";
+        enumValues
+            << QVariant::fromValue(static_cast<uint32_t>(WeightUnitsGrams))
+            << QVariant::fromValue(static_cast<uint32_t>(WeightUnitsKg))
+            << QVariant::fromValue(static_cast<uint32_t>(WeightUnitsOz))
+            << QVariant::fromValue(static_cast<uint32_t>(WeightUnitsLbs));
+        FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
+        metaData->setName(weightUnitsName);
+        metaData->setShortDescription(tr("Weight units"));
+        metaData->setEnumInfo(enumStrings, enumValues);
+        WeightUnits defaultWeightUnit = WeightUnitsGrams;
+        switch(QLocale::system().measurementSystem()) {
+            case QLocale::MetricSystem:
+            case QLocale::ImperialUKSystem: {
+                defaultWeightUnit = WeightUnitsGrams;
+            } break;
+            case QLocale::ImperialUSSystem:
+                defaultWeightUnit = WeightUnitsOz;
+                break;
+        }
+        metaData->setRawDefaultValue(defaultWeightUnit);
+        metaData->setQGCRebootRequired(true);
+        _weightUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
+    }
+    return _weightUnitsFact;
 }

--- a/src/Settings/UnitsSettings.h
+++ b/src/Settings/UnitsSettings.h
@@ -24,6 +24,11 @@ public:
         DistanceUnitsMeters
     };
 
+    enum AltitudeUnits {
+        AltitudeUnitsFeet = 0,
+        AltitudeUnitsMeters
+    };
+
     enum AreaUnits {
         AreaUnitsSquareFeet = 0,
         AreaUnitsSquareMeters,
@@ -46,17 +51,28 @@ public:
         TemperatureUnitsFarenheit,
     };
 
+    enum WeightUnits {
+        WeightUnitsGrams = 0,
+        WeightUnitsKg,
+        WeightUnitsOz,
+        WeightUnitsLbs
+    };
+
     Q_ENUM(DistanceUnits)
     Q_ENUM(AreaUnits)
+    Q_ENUM(AltitudeUnits)
     Q_ENUM(SpeedUnits)
     Q_ENUM(TemperatureUnits)
+    Q_ENUM(WeightUnits)
 
     DEFINE_SETTING_NAME_GROUP()
 
     DEFINE_SETTINGFACT(distanceUnits)
+    DEFINE_SETTINGFACT(altitudeUnits)
     DEFINE_SETTINGFACT(areaUnits)
     DEFINE_SETTINGFACT(speedUnits)
     DEFINE_SETTINGFACT(temperatureUnits)
+    DEFINE_SETTINGFACT(weightUnits)
 };
 
 #endif

--- a/src/Settings/UnitsSettings.h
+++ b/src/Settings/UnitsSettings.h
@@ -19,14 +19,14 @@ class UnitsSettings : public SettingsGroup
 public:
     UnitsSettings(QObject* parent = nullptr);
 
-    enum DistanceUnits {
-        DistanceUnitsFeet = 0,
-        DistanceUnitsMeters
+    enum HorizontalDistanceUnits {
+        HorizontalDistanceUnitsFeet = 0,
+        HorizontalDistanceUnitsMeters
     };
 
-    enum AltitudeUnits {
-        AltitudeUnitsFeet = 0,
-        AltitudeUnitsMeters
+    enum VerticalDistanceUnits {
+        VerticalDistanceUnitsFeet = 0,
+        VerticalDistanceUnitsMeters
     };
 
     enum AreaUnits {
@@ -58,17 +58,17 @@ public:
         WeightUnitsLbs
     };
 
-    Q_ENUM(DistanceUnits)
+    Q_ENUM(HorizontalDistanceUnits)
+    Q_ENUM(VerticalDistanceUnits)
     Q_ENUM(AreaUnits)
-    Q_ENUM(AltitudeUnits)
     Q_ENUM(SpeedUnits)
     Q_ENUM(TemperatureUnits)
     Q_ENUM(WeightUnits)
 
     DEFINE_SETTING_NAME_GROUP()
 
-    DEFINE_SETTINGFACT(distanceUnits)
-    DEFINE_SETTINGFACT(altitudeUnits)
+    DEFINE_SETTINGFACT(horizontalDistanceUnits)
+    DEFINE_SETTINGFACT(verticalDistanceUnits)
     DEFINE_SETTINGFACT(areaUnits)
     DEFINE_SETTINGFACT(speedUnits)
     DEFINE_SETTINGFACT(temperatureUnits)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3150,7 +3150,7 @@ void Vehicle::guidedModeGotoLocation(const QGeoCoordinate& gotoCoord)
     }
     double maxDistance = _settingsManager->flyViewSettings()->maxGoToLocationDistance()->rawValue().toDouble();
     if (coordinate().distanceTo(gotoCoord) > maxDistance) {
-        qgcApp()->showAppMessage(QString("New location is too far. Must be less than %1 %2.").arg(qRound(FactMetaData::metersToAppSettingsDistanceUnits(maxDistance).toDouble())).arg(FactMetaData::appSettingsDistanceUnitsString()));
+        qgcApp()->showAppMessage(QString("New location is too far. Must be less than %1 %2.").arg(qRound(FactMetaData::metersToAppSettingsHorizontalDistanceUnits(maxDistance).toDouble())).arg(FactMetaData::appSettingsHorizontalDistanceUnitsString()));
         return;
     }
     _firmwarePlugin->guidedModeGotoLocation(this, gotoCoord);

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -99,7 +99,7 @@ Rectangle {
                                 QGCLabel { text: modelData }
                             }
                             Repeater {
-                                model:  [ QGroundControl.settingsManager.unitsSettings.distanceUnits, QGroundControl.settingsManager.unitsSettings.areaUnits, QGroundControl.settingsManager.unitsSettings.speedUnits, QGroundControl.settingsManager.unitsSettings.temperatureUnits ]
+                                model:  [ QGroundControl.settingsManager.unitsSettings.horizontalDistanceUnits, QGroundControl.settingsManager.unitsSettings.areaUnits, QGroundControl.settingsManager.unitsSettings.speedUnits, QGroundControl.settingsManager.unitsSettings.temperatureUnits ]
                                 FactComboBox {
                                     Layout.preferredWidth:  _comboFieldWidth
                                     fact:                   modelData
@@ -162,7 +162,7 @@ Rectangle {
                                     text:       qsTr("Map Provider")
                                     width:      _labelWidth
                                 }
-                                
+
                                 QGCComboBox {
                                     id:             mapCombo
                                     model:          QGroundControl.mapEngineManager.mapProviderList

--- a/src/ui/toolbar/GPSRTKIndicator.qml
+++ b/src/ui/toolbar/GPSRTKIndicator.qml
@@ -71,7 +71,7 @@ Item {
                         visible: QGroundControl.gpsRtk.currentAccuracy.value > 0
                         }
                     QGCLabel {
-                        text: QGroundControl.gpsRtk.currentAccuracy.valueString + " " + QGroundControl.appSettingsDistanceUnitsString
+                        text: QGroundControl.gpsRtk.currentAccuracy.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
                         visible: QGroundControl.gpsRtk.currentAccuracy.value > 0
                         }
                     QGCLabel { text: qsTr("Satellites:") }


### PR DESCRIPTION
Sooner or later drones will start carrying payload and this PR introduces units of weight.
It also separates distance units from altitude units as this is often a practice (e.g.: US military always measures altitude in feet, but often measure distance in "km" - we've all seen in Hollywood movies when they say "clicks" - it's true).