### PR TITLE
Allow to move/reorder objects within QmlObjectListModel

### DIFF
--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -125,6 +125,22 @@ bool QmlObjectListModel::removeRows(int position, int rows, const QModelIndex& p
     return true;
 }
 
+void QmlObjectListModel::move(int from, int to)
+{
+    if(0 <= from && from < count() && 0 <= to && to < count() && from != to) {
+        // Workaround to allow move item to the bottom. Done according to
+        // beginMoveRows() documentation and implementation specificity:
+        // https://doc.qt.io/qt-5/qabstractitemmodel.html#beginMoveRows
+        // (see 3rd picture explanation there)
+        if(from == to - 1) {
+            to = from++;
+        }
+        beginMoveRows(QModelIndex(), from, from, QModelIndex(), to);
+        _objectList.move(from, to);
+        endMoveRows();
+    }
+}
+
 QObject* QmlObjectListModel::operator[](int index)
 {
     if (index < 0 || index >= _objectList.count()) {

--- a/src/QmlControls/QmlObjectListModel.h
+++ b/src/QmlControls/QmlObjectListModel.h
@@ -46,6 +46,9 @@ public:
     bool        contains            (QObject* object) { return _objectList.indexOf(object) != -1; }
     int         indexOf             (QObject* object) { return _objectList.indexOf(object); }
 
+    /// Moves an item to a new position
+    void move(int from, int to);
+
     QObject*    operator[]          (int i);
     const QObject* operator[]       (int i) const;
     template<class T> T value       (int index) { return qobject_cast<T>(_objectList[index]); }


### PR DESCRIPTION
Often necessary to move/reorder objects within the list for example in ListView dragging, waypoints reordering, etc etc. And `move()` method should be added and organized properly to allow above and work correctly.