### PR TITLE
QtLocationPlugin: Add Japan Map

### DIFF
--- a/src/QtLocationPlugin/GenericMapProvider.cpp
+++ b/src/QtLocationPlugin/GenericMapProvider.cpp
@@ -8,6 +8,41 @@
  ****************************************************************************/
 #include "GenericMapProvider.h"
 
+static const QString JapanStdMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/std/%1/%2/%3.png");
+
+QString JapanStdMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
+    Q_UNUSED(networkManager)
+    return JapanStdMapUrl.arg(zoom).arg(x).arg(y);
+}
+
+static const QString JapanSeamlessMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/%1/%2/%3.jpg");
+
+QString JapanSeamlessMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
+    Q_UNUSED(networkManager)
+    return JapanSeamlessMapUrl.arg(zoom).arg(x).arg(y);
+}
+
+static const QString JapanAnaglyphMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/anaglyphmap_color/%1/%2/%3.png");
+
+QString JapanAnaglyphMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
+    Q_UNUSED(networkManager)
+    return JapanAnaglyphMapUrl.arg(zoom).arg(x).arg(y);
+}
+
+static const QString JapanSlopeMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/slopemap/%1/%2/%3.png");
+
+QString JapanSlopeMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
+    Q_UNUSED(networkManager)
+    return JapanSlopeMapUrl.arg(zoom).arg(x).arg(y);
+}
+
+static const QString JapanReliefMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/relief/%1/%2/%3.png");
+
+QString JapanReliefMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
+    Q_UNUSED(networkManager)
+    return JapanReliefMapUrl.arg(zoom).arg(x).arg(y);
+}
+
 static const QString StatkartMapUrl = QStringLiteral("http://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo4&zoom=%1&x=%2&y=%3");
 
 QString StatkartMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {

--- a/src/QtLocationPlugin/GenericMapProvider.h
+++ b/src/QtLocationPlugin/GenericMapProvider.h
@@ -10,6 +10,56 @@
 
 #include "MapProvider.h"
 
+class JapanStdMapProvider : public MapProvider {
+    Q_OBJECT
+  public:
+    JapanStdMapProvider(QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/std"), QStringLiteral("png"),
+                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+
+    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+};
+
+class JapanSeamlessMapProvider : public MapProvider {
+    Q_OBJECT
+  public:
+    JapanSeamlessMapProvider(QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto"), QStringLiteral("jpg"),
+                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+
+    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+};
+
+class JapanAnaglyphMapProvider : public MapProvider {
+    Q_OBJECT
+  public:
+    JapanAnaglyphMapProvider(QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/anaglyphmap_color"), QStringLiteral("png"),
+                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+
+    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+};
+
+class JapanSlopeMapProvider : public MapProvider {
+    Q_OBJECT
+  public:
+    JapanSlopeMapProvider(QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/slopemap"), QStringLiteral("png"),
+                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+
+    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+};
+
+class JapanReliefMapProvider : public MapProvider {
+    Q_OBJECT
+  public:
+    JapanReliefMapProvider(QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/relief"), QStringLiteral("png"),
+                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+
+    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+};
+
 class StatkartMapProvider : public MapProvider {
     Q_OBJECT
   public:

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -75,6 +75,12 @@ UrlFactory::UrlFactory() : _timeout(5 * 1000) {
     _providersTable["VWorld Satellite Map"] = new VWorldSatMapProvider(this);
 
     _providersTable["Airmap Elevation"] = new AirmapElevationProvider(this);
+
+    _providersTable["Japan-GSI Contour"] = new JapanStdMapProvider(this);
+    _providersTable["Japan-GSI Seamless"] = new JapanSeamlessMapProvider(this);
+    _providersTable["Japan-GSI Anaglyph"] = new JapanAnaglyphMapProvider(this);
+    _providersTable["Japan-GSI Slope"] = new JapanSlopeMapProvider(this);
+    _providersTable["Japan-GSI Relief"] = new JapanReliefMapProvider(this);
 }
 
 void UrlFactory::registerProvider(QString name, MapProvider* provider) {


### PR DESCRIPTION
I am a QGC customer in Japan.
I would like to use the maps provided by the Geographical Survey Institute of Japan.
I would add five different types of maps.

standard map
![Screenshot from 2020-05-02 10-46-51](https://user-images.githubusercontent.com/646194/80854800-02d89780-8c76-11ea-804b-d7d2b2ca7e28.png)

photo map
![Screenshot from 2020-05-02 11-40-47](https://user-images.githubusercontent.com/646194/80854805-0d932c80-8c76-11ea-9f5a-8d68a97d3024.png)

elevation map by color
![Screenshot from 2020-05-02 12-25-15](https://user-images.githubusercontent.com/646194/80854813-1ab01b80-8c76-11ea-8377-bd2a09752239.png)

anaglyph
![Screenshot from 2020-05-02 11-55-59](https://user-images.githubusercontent.com/646194/80854818-213e9300-8c76-11ea-99e3-9eeeaaf9b9e9.png)

inclination diagram
![Screenshot from 2020-05-02 12-24-34](https://user-images.githubusercontent.com/646194/80854826-2f8caf00-8c76-11ea-88f6-cc5fd7fbe8f7.png)