### PR TITLE
Fly View: Move business logic inside controls

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -194,6 +194,7 @@
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewMap.qml">src/FlightDisplay/FlightDisplayViewMap.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewVideo.qml">src/FlightDisplay/FlightDisplayViewVideo.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewWidgets.qml">src/FlightDisplay/FlightDisplayViewWidgets.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewToolStrip.qml">src/FlightDisplay/FlyViewToolStrip.qml</file>
         <file alias="QGroundControl/FlightDisplay/GuidedActionConfirm.qml">src/FlightDisplay/GuidedActionConfirm.qml</file>
         <file alias="QGroundControl/FlightDisplay/GuidedActionList.qml">src/FlightDisplay/GuidedActionList.qml</file>
         <file alias="QGroundControl/FlightDisplay/GuidedActionsController.qml">src/FlightDisplay/GuidedActionsController.qml</file>

--- a/src/FlightDisplay/FlyViewToolStrip.qml
+++ b/src/FlightDisplay/FlyViewToolStrip.qml
@@ -1,0 +1,107 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QGroundControl           1.0
+import QGroundControl.Controls  1.0
+
+ToolStrip {
+    title: qsTr("Fly")
+
+    property var guidedActionsController
+    property var guidedActionList
+    property var preFlightCheckList
+
+    property bool _anyActionAvailable: guidedActionsController.showStartMission || guidedActionsController.showResumeMission || guidedActionsController.showChangeAlt || guidedActionsController.showLandAbort
+    property var _actionModel: [
+        {
+            title:      guidedActionsController.startMissionTitle,
+            text:       guidedActionsController.startMissionMessage,
+            action:     guidedActionsController.actionStartMission,
+            visible:    guidedActionsController.showStartMission
+        },
+        {
+            title:      guidedActionsController.continueMissionTitle,
+            text:       guidedActionsController.continueMissionMessage,
+            action:     guidedActionsController.actionContinueMission,
+            visible:    guidedActionsController.showContinueMission
+        },
+        {
+            title:      guidedActionsController.changeAltTitle,
+            text:       guidedActionsController.changeAltMessage,
+            action:     guidedActionsController.actionChangeAlt,
+            visible:    guidedActionsController.showChangeAlt
+        },
+        {
+            title:      guidedActionsController.landAbortTitle,
+            text:       guidedActionsController.landAbortMessage,
+            action:     guidedActionsController.actionLandAbort,
+            visible:    guidedActionsController.showLandAbort
+        }
+    ]
+
+    model: [
+        {
+            name:               "Checklist",
+            iconSource:         "/qmlimages/check.svg",
+            buttonVisible:      _useChecklist,
+            buttonEnabled:      _useChecklist && activeVehicle && !activeVehicle.armed,
+        },
+        {
+            name:               guidedActionsController.takeoffTitle,
+            iconSource:         "/res/takeoff.svg",
+            buttonVisible:      guidedActionsController.showTakeoff || !guidedActionsController.showLand,
+            buttonEnabled:      guidedActionsController.showTakeoff,
+            action:             guidedActionsController.actionTakeoff
+        },
+        {
+            name:               guidedActionsController.landTitle,
+            iconSource:         "/res/land.svg",
+            buttonVisible:      guidedActionsController.showLand && !guidedActionsController.showTakeoff,
+            buttonEnabled:      guidedActionsController.showLand,
+            action:             guidedActionsController.actionLand
+        },
+        {
+            name:               guidedActionsController.rtlTitle,
+            iconSource:         "/res/rtl.svg",
+            buttonVisible:      true,
+            buttonEnabled:      guidedActionsController.showRTL,
+            action:             guidedActionsController.actionRTL
+        },
+        {
+            name:               guidedActionsController.pauseTitle,
+            iconSource:         "/res/pause-mission.svg",
+            buttonVisible:      guidedActionsController.showPause,
+            buttonEnabled:      guidedActionsController.showPause,
+            action:             guidedActionsController.actionPause
+        },
+        {
+            name:               qsTr("Action"),
+            iconSource:         "/res/action.svg",
+            buttonVisible:      _anyActionAvailable,
+            buttonEnabled:      true,
+            action:             -1
+        }
+    ]
+
+    onClicked: {
+        if(index === 0) {
+            preFlightCheckList.open()
+        } else {
+            guidedActionsController.closeAll()
+            var action = model[index].action
+            if (action === -1) {
+                guidedActionList.model   = _actionModel
+                guidedActionList.visible = true
+            } else {
+                guidedActionsController.confirmAction(action)
+            }
+        }
+
+    }
+}

--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -24,7 +24,6 @@ Rectangle {
     color:          qgcPal.window
     border.color:   _emergencyAction ? "red" : qgcPal.windowShade
     border.width:   _emergencyAction ? 4 : 1
-    z:              guidedController.z
     visible:        false
 
     property var    guidedController

--- a/src/FlightDisplay/GuidedActionList.qml
+++ b/src/FlightDisplay/GuidedActionList.qml
@@ -24,7 +24,6 @@ Rectangle {
     radius:     _margins / 2
     color:      qgcPal.window
     opacity:    0.9
-    z:          guidedController.z
     visible:    false
 
     property var    guidedController

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -190,12 +190,18 @@ Item {
             console.log("showStartMission", showStartMission)
         }
         _outputState()
+        if (showStartMission) {
+            confirmAction(actionStartMission)
+        }
     }
     onShowContinueMissionChanged: {
         if (_corePlugin.guidedActionsControllerLogging()) {
             console.log("showContinueMission", showContinueMission)
         }
         _outputState()
+        if (showContinueMission) {
+            confirmAction(actionContinueMission)
+        }
     }
     onShowRTLChanged: {
         if (_corePlugin.guidedActionsControllerLogging()) {
@@ -208,6 +214,11 @@ Item {
             console.log("showChangeAlt", showChangeAlt)
         }
         _outputState()
+    }
+    onShowLandAbortChanged: {
+        if (showLandAbort) {
+            confirmAction(actionLandAbort)
+        }
     }
 
     on_VehicleFlyingChanged: {
@@ -226,6 +237,12 @@ Item {
         _vehicleInRTLMode =     activeVehicle ? _flightMode === activeVehicle.rtlFlightMode || _flightMode === activeVehicle.smartRTLFlightMode : false
         _vehicleInLandMode =    activeVehicle ? _flightMode === activeVehicle.landFlightMode : false
         _vehicleInMissionMode = activeVehicle ? _flightMode === activeVehicle.missionFlightMode : false // Must be last to get correct signalling for showStartMission popups
+    }
+
+    function closeAll() {
+        confirmDialog.visible =     false
+        actionList.visible =        false
+        altitudeSlider.visible =    false
     }
 
     // Called when an action is about to be executed in order to confirm

--- a/src/QmlControls/QGroundControl/FlightDisplay/qmldir
+++ b/src/QmlControls/QGroundControl/FlightDisplay/qmldir
@@ -4,6 +4,7 @@ FlightDisplayView           1.0 FlightDisplayView.qml
 FlightDisplayViewMap        1.0 FlightDisplayViewMap.qml
 FlightDisplayViewVideo      1.0 FlightDisplayViewVideo.qml
 FlightDisplayViewWidgets    1.0 FlightDisplayViewWidgets.qml
+FlyViewToolStrip            1.0 FlyViewToolStrip.qml
 GuidedActionConfirm         1.0 GuidedActionConfirm.qml
 GuidedActionList            1.0 GuidedActionList.qml
 GuidedActionsController     1.0 GuidedActionsController.qml


### PR DESCRIPTION
This is a cleanup of FlightDisplayView.qml and the control within it. The goal is to move the business logic out of the main FlightDisplayView.qml file and into the controls use within that ui. That in turn should make this ui more easily customizable.