### PR TITLE
Don't allow user to enter a bad formed rtsp url

### DIFF
--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -45,6 +45,7 @@ QGCTextField {
             validate:       true
             validateValue:  _validateString
             fact:           _textField.fact
+            validator:      _textField.validator
         }
     }
 
@@ -52,6 +53,7 @@ QGCTextField {
         id: helpDialogComponent
         ParameterEditorDialog {
             fact: _textField.fact
+            validator:      _textField.validator
         }
     }
 }

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -29,6 +29,7 @@ QGCViewDialog {
     property bool   validate:       false
     property string validateValue
     property bool   setFocus:       true    ///< true: focus is set to text field on display, false: focus not set (works around strange virtual keyboard bug with FactValueSlider
+    property alias  validator:      valueField.validator
 
     signal valueChanged
 

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -1003,6 +1003,7 @@ Rectangle {
                                 Layout.preferredWidth:  _comboFieldWidth
                                 fact:                   QGroundControl.settingsManager.videoSettings.rtspUrl
                                 visible:                _isRTSP && QGroundControl.settingsManager.videoSettings.rtspUrl.visible
+                                validator:              RegExpValidator { regExp: /^(?:rtsp?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/ }
                             }
 
                             QGCLabel {


### PR DESCRIPTION
Add a regex validator to the RTSP URL textfield to match the allowed URL.
Gstreamer doesn't handle well the bad formated rstp urls. A space in front will break finding the stream
as it happened with some users.



