### PR TITLE
Re-architect toolbar for better customization, features, real estate

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -177,6 +177,7 @@
         <file alias="QGroundControl/Controls/SurveyMapVisual.qml">src/PlanView/SurveyMapVisual.qml</file>
         <file alias="QGroundControl/Controls/TerrainStatus.qml">src/PlanView/TerrainStatus.qml</file>
         <file alias="QGroundControl/Controls/TakeoffItemMapVisual.qml">src/PlanView/TakeoffItemMapVisual.qml</file>
+        <file alias="QGroundControl/Controls/ToolBarBase.qml">src/ui/toolbar/ToolBarBase.qml</file>
         <file alias="QGroundControl/Controls/ToolStrip.qml">src/QmlControls/ToolStrip.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemStats.qml">src/PlanView/TransectStyleComplexItemStats.qml</file>
         <file alias="QGroundControl/Controls/VehicleRotationCal.qml">src/QmlControls/VehicleRotationCal.qml</file>

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -217,20 +217,31 @@ bool ArduSubFirmwarePlugin::supportsMotorInterference(void)
     return false;
 }
 
-const QVariantList& ArduSubFirmwarePlugin::toolBarIndicators(const Vehicle* vehicle)
+const QVariantList& ArduSubFirmwarePlugin::toolIndicators(const Vehicle* vehicle)
 {
     Q_UNUSED(vehicle);
     //-- Sub specific list of indicators (Enter your modified list here)
-    if(_toolBarIndicators.size() == 0) {
-        _toolBarIndicators = QVariantList({
+    if(_toolIndicators.size() == 0) {
+        _toolIndicators = QVariantList({
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/JoystickIndicator.qml")),
+        });
+    }
+    return _toolIndicators;
+}
+
+const QVariantList& ArduSubFirmwarePlugin::modeIndicators(const Vehicle* vehicle)
+{
+    Q_UNUSED(vehicle);
+    //-- Sub specific list of indicators (Enter your modified list here)
+    if(_modeIndicators.size() == 0) {
+        _modeIndicators = QVariantList({
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ModeIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ArmedIndicator.qml")),
         });
     }
-    return _toolBarIndicators;
+    return _modeIndicators;
 }
 
 void ArduSubFirmwarePlugin::_handleNamedValueFloat(mavlink_message_t* message)

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -136,14 +136,16 @@ public:
     QString brandImageOutdoor(const Vehicle* vehicle) const final { Q_UNUSED(vehicle); return QStringLiteral("/qmlimages/APM/BrandImageSub"); }
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     int remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const final;
-    const QVariantList& toolBarIndicators(const Vehicle* vehicle) final;
+    const QVariantList& toolIndicators(const Vehicle* vehicle) final;
+    const QVariantList& modeIndicators(const Vehicle* vehicle) final;
     bool  adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_message_t* message) final;
     virtual QMap<QString, FactGroup*>* factGroups(void) final;
     void adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData) override final;
 
 
 private:
-    QVariantList _toolBarIndicators;
+    QVariantList _toolIndicators;
+    QVariantList _modeIndicators;
     static bool _remapParamNameIntialized;
     QMap<QString, QString> _factRenameMap;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -304,17 +304,26 @@ QString FirmwarePlugin::vehicleImageCompass(const Vehicle*) const
     return QStringLiteral("/qmlimages/compassInstrumentArrow.svg");
 }
 
-const QVariantList &FirmwarePlugin::toolBarIndicators(const Vehicle*)
+const QVariantList& FirmwarePlugin::toolIndicators(const Vehicle*)
 {
     //-- Default list of indicators for all vehicles.
-    if(_toolBarIndicatorList.size() == 0) {
-        _toolBarIndicatorList = QVariantList({
+    if(_toolIndicatorList.size() == 0) {
+        _toolIndicatorList = QVariantList({
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")),
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSRTKIndicator.qml")),
+        });
+    }
+    return _toolIndicatorList;
+}
+
+const QVariantList& FirmwarePlugin::modeIndicators(const Vehicle*)
+{
+    //-- Default list of indicators for all vehicles.
+    if(_modeIndicatorList.size() == 0) {
+        _modeIndicatorList = QVariantList({
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ROIIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ArmedIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/ModeIndicator.qml")),
@@ -323,7 +332,7 @@ const QVariantList &FirmwarePlugin::toolBarIndicators(const Vehicle*)
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/LinkIndicator.qml")),
         });
     }
-    return _toolBarIndicatorList;
+    return _modeIndicatorList;
 }
 
 const QVariantList& FirmwarePlugin::cameraList(const Vehicle*)

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -267,10 +267,15 @@ public:
     /// Return the resource file which contains the vehicle icon used in the compass
     virtual QString vehicleImageCompass(const Vehicle* vehicle) const;
 
-    /// Allows the core plugin to override the toolbar indicators
-    ///     signals toolbarIndicatorsChanged
-    /// @return A list of QUrl with the indicators (see MainToolBarIndicators.qml)
-    virtual const QVariantList& toolBarIndicators(const Vehicle* vehicle);
+    /// Returns the list of toolbar tool indicators associated with a vehicle
+    ///     signals toolIndicatorsChanged
+    /// @return A list of QUrl with the indicators
+    virtual const QVariantList& toolIndicators(const Vehicle* vehicle);
+
+    /// Returns the list of toolbar mode indicators associated with a vehicle
+    ///     signals modeIndicatorsChanged
+    /// @return A list of QUrl with the indicators
+    virtual const QVariantList& modeIndicators(const Vehicle* vehicle);
 
     /// Returns a list of CameraMetaData objects for available cameras on the vehicle.
     /// TODO: This should go into QGCCameraManager
@@ -330,7 +335,8 @@ public:
     static const QString px4FollowMeFlightMode;
 
 signals:
-    void toolbarIndicatorsChanged(void);
+    void toolIndicatorsChanged(void);
+    void modeIndicatorsChanged(void);
 
 protected:
     // Arms the vehicle with validation and retries
@@ -351,7 +357,9 @@ protected:
     virtual QString _versionRegex() { return QString(); }
 
 private:
-    QVariantList _toolBarIndicatorList;
+    QVariantList _toolIndicatorList;
+    QVariantList _modeIndicatorList;
+
     static QVariantList _cameraList;    ///< Standard QGC camera list
 };
 

--- a/src/FlightDisplay/FlyViewCustomLayer.qml
+++ b/src/FlightDisplay/FlyViewCustomLayer.qml
@@ -34,8 +34,8 @@ import QGroundControl.Vehicle       1.0
 Item {
     id: _root
 
-    property var parentToolInsets             // These insets tell you what screen real estate is available for positioning the controls in your overlay
-    property var toolInsets:      _toolInsets // These are the insets for your custom overlay additions
+    property var parentToolInsets               // These insets tell you what screen real estate is available for positioning the controls in your overlay
+    property var totalToolInsets:   _toolInsets // These are the insets for your custom overlay additions
     property var mapControl
 
     QGCToolInsets {

--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -41,8 +41,8 @@ FlightMap {
     property var    guidedActionsController
     property var    rightPanelWidth
     property var    planMasterController
-    property bool   pipMode:                    false                           // true: map is shown in a small pip mode
-    property var    toolInsets                                                  // Insets for the center viewport area
+    property bool   pipMode:                    false   // true: map is shown in a small pip mode
+    property var    toolInsets                          // Insets for the center viewport area
 
     property var    _planMasterController:      planMasterController
     property var    _geoFenceController:        planMasterController.geoFenceController

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -33,9 +33,9 @@ import QGroundControl.Vehicle       1.0
 Item {
     id: _root
 
-    property var   parentToolInsets
-    property var   totalToolInsets:         _totalToolInsets
-    property var   mapControl
+    property var    parentToolInsets
+    property var    totalToolInsets:        _totalToolInsets
+    property var    mapControl
 
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property var    _planMasterController:  mainWindow.planMasterControllerPlanView

--- a/src/PlanView/PlanToolBar.qml
+++ b/src/PlanView/PlanToolBar.qml
@@ -32,7 +32,6 @@ Rectangle {
             id:                 settingsButton
             Layout.fillHeight:  true
             icon.source:        "/qmlimages/PaperPlane.svg"
-            logo:               true
             checked:            false
             onClicked: {
                 checked = false

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -11,7 +11,7 @@ import QGroundControl.Palette           1.0
 
 // Toolbar for Plan View
 Item {
-    anchors.fill:   parent
+    width: missionStats.width + _margins
 
     property var    _planMasterController:      mainWindow.planMasterControllerPlanView
     property var    _currentMissionItem:        mainWindow.currentPlanMissionItem          ///< Mission item to display status for
@@ -109,11 +109,9 @@ Item {
         anchors.top:            parent.top
         anchors.bottom:         parent.bottom
         anchors.leftMargin:     _margins
-        anchors.rightMargin:    _margins
         anchors.left:           parent.left
-        anchors.right:          uploadButton.visible ? uploadButton.left : parent.right
         columnSpacing:          0
-        columns:                3
+        columns:                4
 
         GridLayout {
             columns:                8
@@ -226,37 +224,25 @@ Item {
             }
 
             Item { width: 1; height: 1 }
-/*
-            FIXME: Swap point display is currently hidden since the code which calcs it doesn't work correctly
-            QGCLabel { text: qsTr("Swap waypoint:"); font.pointSize: _dataFontSize; }
-            QGCLabel {
-                text:                   _batteryChangePointText
-                font.pointSize:         _dataFontSize
-                Layout.minimumWidth:    _mediumValueWidth
-            }
-*/
         }
-    }
 
-    QGCButton {
-        id:                     uploadButton
-        anchors.rightMargin:    _margins
-        anchors.right:          parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        text:                   _controllerDirty ? qsTr("Upload Required") : qsTr("Upload")
-        enabled:                !_controllerSyncInProgress
-        visible:                !_controllerOffline && !_controllerSyncInProgress && !uploadCompleteText.visible
-        primary:                _controllerDirty
-        onClicked:              _planMasterController.upload()
+        QGCButton {
+            id:          uploadButton
+            text:        _controllerDirty ? qsTr("Upload Required") : qsTr("Upload")
+            enabled:     !_controllerSyncInProgress
+            visible:     !_controllerOffline && !_controllerSyncInProgress && !uploadCompleteText.visible
+            primary:     _controllerDirty
+            onClicked:   _planMasterController.upload()
 
-        PropertyAnimation on opacity {
-            easing.type:    Easing.OutQuart
-            from:           0.5
-            to:             1
-            loops:          Animation.Infinite
-            running:        _controllerDirty && !_controllerSyncInProgress
-            alwaysRunToEnd: true
-            duration:       2000
+            PropertyAnimation on opacity {
+                easing.type:    Easing.OutQuart
+                from:           0.5
+                to:             1
+                loops:          Animation.Infinite
+                running:        _controllerDirty && !_controllerSyncInProgress
+                alwaysRunToEnd: true
+                duration:       2000
+            }
         }
     }
 
@@ -276,16 +262,6 @@ Item {
             }
         }
     }
-
-    /*
-    Rectangle {
-        anchors.bottom: parent.bottom
-        height:         toolBar.height * 0.05
-        width:          activeVehicle ? activeVehicle.parameterManager.loadProgress * parent.width : 0
-        color:          qgcPal.colorGreen
-        visible:        !largeProgressBar.visible
-    }
-    */
 
     // Large mission download progress bar
     Rectangle {

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -32,7 +32,7 @@ Button {
 
     background: Rectangle {
         anchors.fill: parent
-        color:  logo ? qgcPal.brandingPurple : (button.checked ? qgcPal.buttonHighlight : Qt.rgba(0,0,0,0))
+        color:  button.checked ? qgcPal.buttonHighlight : Qt.rgba(0,0,0,0)
     }
 
     contentItem: Row {
@@ -44,7 +44,7 @@ Button {
             width:                  height
             sourceSize.height:      parent.height
             fillMode:               Image.PreserveAspectFit
-            color:                  logo ? "white" : (button.checked ? qgcPal.buttonHighlightText : qgcPal.buttonText)
+            color:                  logo ? "transparent" : (button.checked ? qgcPal.buttonHighlightText : qgcPal.buttonText)
             source:                 button.icon.source
             anchors.verticalCenter: parent.verticalCenter
         }

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -99,6 +99,7 @@ SurveyMapVisuals        1.0 SurveyMapVisuals.qml
 TerrainStatus           1.0 TerrainStatus.qml
 TransectStyleComplexItemStats 1.0 TransectStyleComplexItemStats.qml
 TransectStyleMapVisuals 1.0 TransectStyleMapVisuals.qml
+ToolBarBase             1.0 ToolBarBase.qml
 ToolStrip               1.0 ToolStrip.qml
 VehicleRotationCal      1.0 VehicleRotationCal.qml
 VehicleSummaryRow       1.0 VehicleSummaryRow.qml

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -414,8 +414,8 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _flightDistanceFact   (0, _flightDistanceFactName,    FactMetaData::valueTypeDouble)
     , _flightTimeFact       (0, _flightTimeFactName,        FactMetaData::valueTypeElapsedTimeInSeconds)
     , _distanceToHomeFact   (0, _distanceToHomeFactName,    FactMetaData::valueTypeDouble)
-    , _headingToNextWPFact  (0, _headingToNextWPFactName,   FactMetaData::valueTypeDouble)
     , _missionItemIndexFact (0, _missionItemIndexFactName,  FactMetaData::valueTypeUint16)
+    , _headingToNextWPFact  (0, _headingToNextWPFactName,   FactMetaData::valueTypeDouble)
     , _headingToHomeFact    (0, _headingToHomeFactName,     FactMetaData::valueTypeDouble)
     , _distanceToGCSFact    (0, _distanceToGCSFactName,     FactMetaData::valueTypeDouble)
     , _hobbsFact            (0, _hobbsFactName,             FactMetaData::valueTypeString)
@@ -446,7 +446,8 @@ void Vehicle::_commonInit()
 {
     _firmwarePlugin = _firmwarePluginManager->firmwarePluginForAutopilot(_firmwareType, _vehicleType);
 
-    connect(_firmwarePlugin, &FirmwarePlugin::toolbarIndicatorsChanged, this, &Vehicle::toolBarIndicatorsChanged);
+    connect(_firmwarePlugin, &FirmwarePlugin::toolIndicatorsChanged, this, &Vehicle::toolIndicatorsChanged);
+    connect(_firmwarePlugin, &FirmwarePlugin::modeIndicatorsChanged, this, &Vehicle::modeIndicatorsChanged);
 
     connect(this, &Vehicle::coordinateChanged,      this, &Vehicle::_updateDistanceHeadingToHome);
     connect(this, &Vehicle::coordinateChanged,      this, &Vehicle::_updateDistanceToGCS);
@@ -3902,10 +3903,19 @@ QString Vehicle::vehicleImageCompass() const
         return QString();
 }
 
-const QVariantList& Vehicle::toolBarIndicators()
+const QVariantList& Vehicle::toolIndicators()
 {
     if(_firmwarePlugin) {
-        return _firmwarePlugin->toolBarIndicators(this);
+        return _firmwarePlugin->toolIndicators(this);
+    }
+    static QVariantList emptyList;
+    return emptyList;
+}
+
+const QVariantList& Vehicle::modeIndicators()
+{
+    if(_firmwarePlugin) {
+        return _firmwarePlugin->modeIndicators(this);
     }
     static QVariantList emptyList;
     return emptyList;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -615,7 +615,8 @@ public:
     Q_PROPERTY(unsigned int         telemetryTXBuffer       READ telemetryTXBuffer                                      NOTIFY telemetryTXBufferChanged)
     Q_PROPERTY(int                  telemetryLNoise         READ telemetryLNoise                                        NOTIFY telemetryLNoiseChanged)
     Q_PROPERTY(int                  telemetryRNoise         READ telemetryRNoise                                        NOTIFY telemetryRNoiseChanged)
-    Q_PROPERTY(QVariantList         toolBarIndicators       READ toolBarIndicators                                      NOTIFY toolBarIndicatorsChanged)
+    Q_PROPERTY(QVariantList         toolIndicators          READ toolIndicators                                         NOTIFY toolIndicatorsChanged)
+    Q_PROPERTY(QVariantList         modeIndicators          READ modeIndicators                                         NOTIFY modeIndicatorsChanged)
     Q_PROPERTY(bool              initialPlanRequestComplete READ initialPlanRequestComplete                             NOTIFY initialPlanRequestCompleteChanged)
     Q_PROPERTY(QVariantList         staticCameraList        READ staticCameraList                                       CONSTANT)
     Q_PROPERTY(QGCCameraManager*    dynamicCameras          READ dynamicCameras                                         NOTIFY dynamicCamerasChanged)
@@ -1086,7 +1087,8 @@ public:
     QString vehicleImageOutline () const;
     QString vehicleImageCompass () const;
 
-    const QVariantList&         toolBarIndicators   ();
+    const QVariantList&         toolIndicators      ();
+    const QVariantList&         modeIndicators      ();
     const QVariantList&         staticCameraList    () const;
 
     bool capabilitiesKnown      () const { return _capabilityBitsKnown; }
@@ -1160,7 +1162,8 @@ signals:
     void capabilitiesKnownChanged       (bool capabilitiesKnown);
     void initialPlanRequestCompleteChanged(bool initialPlanRequestComplete);
     void capabilityBitsChanged          (uint64_t capabilityBits);
-    void toolBarIndicatorsChanged       ();
+    void toolIndicatorsChanged          ();
+    void modeIndicatorsChanged          ();
     void highLatencyLinkChanged         (bool highLatencyLink);
     void priorityLinkNameChanged        (const QString& priorityLinkName);
     void linksChanged                   ();

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -516,8 +516,18 @@ QString QGCCorePlugin::stableVersionCheckFileUrl() const
 #endif
 }
 
-QStringList
-QGCCorePlugin::startupPages()
+QStringList QGCCorePlugin::startupPages()
 {
     return { "/qml/QGroundControl/Specific/UnitsWizardPage.qml" };
+}
+
+const QVariantList &QGCCorePlugin::toolBarIndicators(void)
+{
+    //-- Default list of indicators for all vehicles.
+    if(_toolBarIndicatorList.size() == 0) {
+        _toolBarIndicatorList = QVariantList({
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSRTKIndicator.qml")),
+        });
+    }
+    return _toolBarIndicatorList;
 }

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -58,7 +58,7 @@ public:
     Q_PROPERTY(QString              brandImageOutdoor       READ brandImageOutdoor                              CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  customMapItems          READ customMapItems                                 CONSTANT)
     Q_PROPERTY(QStringList          startupPages            READ startupPages                                   NOTIFY startupPagesChanged)
-
+    Q_PROPERTY(QVariantList         toolBarIndicators       READ toolBarIndicators                              NOTIFY toolBarIndicatorsChanged)
 
     Q_INVOKABLE bool guidedActionsControllerLogging() const;
 
@@ -172,6 +172,11 @@ public:
     /// @return QML files paths that will be loaded using the StartupWizard control
     virtual QStringList startupPages();
 
+    /// Returns the list of toolbar indicators which are not related to a vehicle
+    ///     signals toolbarIndicatorsChanged
+    /// @return A list of QUrl with the indicators
+    virtual const QVariantList& toolBarIndicators(void);
+
     bool showTouchAreas() const { return _showTouchAreas; }
     bool showAdvancedUI() const { return _showAdvancedUI; }
     void setShowTouchAreas(bool show);
@@ -181,12 +186,13 @@ public:
     void                            setToolbox              (QGCToolbox* toolbox);
 
 signals:
-    void settingsPagesChanged   ();
-    void analyzePagesChanged    ();
-    void instrumentPagesChanged ();
-    void showTouchAreasChanged  (bool showTouchAreas);
-    void showAdvancedUIChanged  (bool showAdvancedUI);
-    void startupPagesChanged    ();
+    void settingsPagesChanged       ();
+    void analyzePagesChanged        ();
+    void instrumentPagesChanged     ();
+    void showTouchAreasChanged      (bool showTouchAreas);
+    void showAdvancedUIChanged      (bool showAdvancedUI);
+    void startupPagesChanged        ();
+    void toolBarIndicatorsChanged   ();
 
 protected slots:
     void _activeVehicleChanged  (Vehicle* activeVehicle);
@@ -203,6 +209,7 @@ protected:
     Vehicle*            _activeVehicle  = nullptr;
     QGCCameraManager*   _dynamicCameras = nullptr;
     QGCCameraControl*   _currentCamera  = nullptr;
+    QVariantList        _toolBarIndicatorList;
 
 private:
     QGCCorePlugin_p*    _p;

--- a/src/api/QGCOptions.cc
+++ b/src/api/QGCOptions.cc
@@ -21,16 +21,6 @@ QGCOptions::QGCOptions(QObject* parent)
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 }
 
-QUrl QGCOptions::mainToolbarUrl() const
-{
-    return QUrl(QStringLiteral("qrc:/toolbar/MainToolBar.qml"));
-}
-
-QUrl QGCOptions::planToolbarUrl() const
-{
-    return QUrl(QStringLiteral("qrc:/qml/PlanToolBar.qml"));
-}
-
 QColor QGCOptions::toolbarBackgroundLight() const
 {
     return QColor(255,255,255,204);
@@ -39,11 +29,6 @@ QColor QGCOptions::toolbarBackgroundLight() const
 QColor QGCOptions::toolbarBackgroundDark() const
 {
     return QColor(0,0,0,192);
-}
-
-QUrl QGCOptions::planToolbarIndicatorsUrl() const
-{
-    return QUrl(QStringLiteral("PlanToolBar.qml"));
 }
 
 QGCFlyViewOptions* QGCOptions::flyViewOptions(void)

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -55,11 +55,8 @@ public:
     Q_PROPERTY(double                   toolbarHeightMultiplier         READ toolbarHeightMultiplier        CONSTANT)
     Q_PROPERTY(bool                     enablePlanViewSelector          READ enablePlanViewSelector         CONSTANT)
     Q_PROPERTY(QUrl                     preFlightChecklistUrl           READ preFlightChecklistUrl          CONSTANT)
-    Q_PROPERTY(QUrl                     mainToolbarUrl                  READ mainToolbarUrl                 CONSTANT)
-    Q_PROPERTY(QUrl                     planToolbarUrl                  READ planToolbarUrl                 CONSTANT)
     Q_PROPERTY(QColor                   toolbarBackgroundLight          READ toolbarBackgroundLight         CONSTANT)
     Q_PROPERTY(QColor                   toolbarBackgroundDark           READ toolbarBackgroundDark          CONSTANT)
-    Q_PROPERTY(QUrl                     planToolbarIndicatorsUrl        READ planToolbarIndicatorsUrl       CONSTANT)
     Q_PROPERTY(bool                     showSensorCalibrationCompass    READ showSensorCalibrationCompass   NOTIFY showSensorCalibrationCompassChanged)
     Q_PROPERTY(bool                     showSensorCalibrationGyro       READ showSensorCalibrationGyro      NOTIFY showSensorCalibrationGyroChanged)
     Q_PROPERTY(bool                     showSensorCalibrationAccel      READ showSensorCalibrationAccel     NOTIFY showSensorCalibrationAccelChanged)
@@ -107,16 +104,10 @@ public:
     /// Provides an optional, custom preflight checklist
     virtual QUrl    preFlightChecklistUrl           () const { return QUrl::fromUserInput("qrc:/qml/PreFlightCheckList.qml"); }
 
-    /// Allows replacing the Main toolbar
-    virtual QUrl    mainToolbarUrl                  () const;
-    /// Allows replacing the Plan View toolbar
-    virtual QUrl    planToolbarUrl                  () const;
     /// Allows replacing the toolbar Light Theme color
     virtual QColor  toolbarBackgroundLight          () const;
     /// Allows replacing the toolbar Dark Theme color
     virtual QColor  toolbarBackgroundDark           () const;
-    /// Allows replacing the Plan View toolbar container
-    virtual QUrl    planToolbarIndicatorsUrl        () const;
     /// By returning false you can hide the following sensor calibration pages
     virtual bool    showSensorCalibrationCompass    () const { return true; }
     virtual bool    showSensorCalibrationGyro       () const { return true; }

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -49,10 +49,7 @@ ApplicationWindow {
 
     property var                _rgPreventViewSwitch:       [ false ]
 
-
     readonly property real      _topBottomMargins:          ScreenTools.defaultFontPixelHeight * 0.5
-    readonly property string    _mainToolbar:               QGroundControl.corePlugin.options.mainToolbarUrl
-    readonly property string    _planToolbar:               QGroundControl.corePlugin.options.planToolbarUrl
 
     //-------------------------------------------------------------------------
     //-- Global Scope Variables
@@ -107,44 +104,47 @@ ApplicationWindow {
         return _rgPreventViewSwitch[_rgPreventViewSwitch.length - 1]
     }
 
-    function viewSwitch(isPlanView) {
+    function viewSwitch(isPlanView, showModeIndicators) {
         settingsWindow.visible  = false
         setupWindow.visible     = false
         analyzeWindow.visible   = false
         flightView.visible      = false
         planViewLoader.visible  = false
-        if(isPlanView) {
-            toolbar.source  = _planToolbar
+        var indicatorSource
+        if (isPlanView) {
+            indicatorSource = "qrc:/qml/PlanToolBarIndicators.qml"
         } else {
-            toolbar.source  = _mainToolbar
+            indicatorSource = "qrc:/toolbar/MainToolBarIndicators.qml"
         }
+        toolbar.item.indicatorSource = indicatorSource
+        toolbar.item.showModeIndicators = showModeIndicators
     }
 
     function showFlyView() {
         if (!flightView.visible) {
             mainWindow.showPreFlightChecklistIfNeeded()
         }
-        viewSwitch(false)
+        viewSwitch(false, true)
         flightView.visible = true
     }
 
     function showPlanView() {
-        viewSwitch(true)
+        viewSwitch(true, false)
         planViewLoader.visible = true
     }
 
     function showAnalyzeView() {
-        viewSwitch(false)
+        viewSwitch(false, false)
         analyzeWindow.visible = true
     }
 
     function showSetupView() {
-        viewSwitch(false)
+        viewSwitch(false, false)
         setupWindow.visible = true
     }
 
     function showSettingsView() {
-        viewSwitch(false)
+        viewSwitch(false, false)
         settingsWindow.visible = true
     }
 
@@ -324,13 +324,13 @@ ApplicationWindow {
     header: ToolBar {
         height:         ScreenTools.toolbarHeight
         visible:        !QGroundControl.videoManager.fullScreen
-        background:     Rectangle {
+        background: Rectangle {
             color:      qgcPal.globalTheme === QGCPalette.Light ? QGroundControl.corePlugin.options.toolbarBackgroundLight : QGroundControl.corePlugin.options.toolbarBackgroundDark
         }
         Loader {
             id:             toolbar
             anchors.fill:   parent
-            source:         _mainToolbar
+            source:         "qrc:/toolbar/MainToolBar.qml"
             //-- Toggle Full Screen / Windowed
             MouseArea {
                 anchors.fill:   parent

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -7,15 +7,10 @@
  *
  ****************************************************************************/
 
-import QtQuick          2.11
-import QtQuick.Controls 2.4
-import QtQuick.Layouts  1.11
+import QtQuick 2.12
 
-import QGroundControl                       1.0
-import QGroundControl.Controls              1.0
-import QGroundControl.MultiVehicleManager   1.0
-import QGroundControl.ScreenTools           1.0
-import QGroundControl.Palette               1.0
+import QGroundControl               1.0
+import QGroundControl.ScreenTools   1.0
 
 //-------------------------------------------------------------------------
 //-- Toolbar Indicators
@@ -23,15 +18,41 @@ Row {
     id:                 indicatorRow
     anchors.top:        parent.top
     anchors.bottom:     parent.bottom
+    anchors.margins:    _toolIndicatorMargins
     spacing:            ScreenTools.defaultFontPixelWidth * 1.5
 
+    // This property should come in from the Loader
+    //property bool showModeIndicators: true
+
+    property var  _activeVehicle:           QGroundControl.multiVehicleManager.activeVehicle
+    property real _toolIndicatorMargins:    ScreenTools.defaultFontPixelHeight * 0.66
+
     Repeater {
-        model: activeVehicle ? activeVehicle.toolBarIndicators : []
+        id:     appRepeater
+        model:  QGroundControl.corePlugin.toolBarIndicators
         Loader {
-            id:                 indicatorLoader
             anchors.top:        parent.top
             anchors.bottom:     parent.bottom
-            anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.66
+            source:             modelData
+            visible:            item.showIndicator
+        }
+    }
+
+    Repeater {
+        model: _activeVehicle ? _activeVehicle.toolIndicators : []
+        Loader {
+            anchors.top:        parent.top
+            anchors.bottom:     parent.bottom
+            source:             modelData
+            visible:            item.showIndicator
+        }
+    }
+
+    Repeater {
+        model: _activeVehicle && showModeIndicators ? _activeVehicle.modeIndicators : []
+        Loader {
+            anchors.top:        parent.top
+            anchors.bottom:     parent.bottom
             source:             modelData
             visible:            item.showIndicator
         }


### PR DESCRIPTION
* Common base view toolbar for all views
* Branding and communication status information is consistent across all views
* If a vehicle is connected you can still see critical tool indicators like say battery even though you may be changing a parameter
* Ability to show tool indicators when not connected to a vehicle. A good example of this is RTK. If you have an RTK device connected you can now see survey in without a vehicle connected.
* Plan view now uses standard view switching mechanism instead of the "You only get to go back to the Fly View" thing.
* New view switching ui uses less real estate. Provide space for the next phase of work which is to add an instrument value section to the toolbar for critical values.
* I'll be writing up dev guide docs for how to customize.

RTK with no vehicle connected:
![Screen Shot 2020-05-06 at 6 30 36 PM](https://user-images.githubusercontent.com/5876851/81244932-883aaf80-8fc8-11ea-9102-dec8c3327f4d.png)

Full toolbar:
![Screen Shot 2020-05-06 at 6 30 54 PM](https://user-images.githubusercontent.com/5876851/81244935-896bdc80-8fc8-11ea-986e-a3566fda7309.png)

Click the view icon to change views:
![Screen Shot 2020-05-06 at 6 31 19 PM](https://user-images.githubusercontent.com/5876851/81244937-8a9d0980-8fc8-11ea-9d03-4a65b63904a0.png)

You can still see vehicle indicators from views other than Flu:
![Screen Shot 2020-05-06 at 6 31 31 PM](https://user-images.githubusercontent.com/5876851/81244939-8a9d0980-8fc8-11ea-987a-8f7673246bf6.png)

Plan View:
![Screen Shot 2020-05-06 at 6 31 42 PM](https://user-images.githubusercontent.com/5876851/81244940-8a9d0980-8fc8-11ea-8fb3-03b4f8a82984.png)
