### PR TITLE
Default state of VTOL in mission

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1544,6 +1544,8 @@ void MissionController::_recalcMissionFlightStatus()
         }
 
         // Update VTOL state
+        //VTOL default state is criuse 
+        vtolInHover = false;
         if (simpleItem && _controllerVehicle->vtol()) {
             switch (simpleItem->command()) {
             case MAV_CMD_NAV_TAKEOFF:


### PR DESCRIPTION
The default state of most VTOLs in mission (for example survey ) is cruise. so cruise speed must be used for flight time. 

https://github.com/mavlink/qgroundcontrol/issues/7662


