### PR TITLE
Stable: Fix Qt environment style in linux systems

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -250,6 +250,7 @@ QT += \
     positioning \
     qml \
     quick \
+    quickcontrols2 \
     quickwidgets \
     sql \
     svg \

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -28,6 +28,7 @@
 #include <QFontDatabase>
 #include <QQuickWindow>
 #include <QQuickImageProvider>
+#include <QQuickStyle>
 
 #ifdef QGC_ENABLE_BLUETOOTH
 #include <QBluetoothLocalDevice>
@@ -213,6 +214,11 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
                 }
             }
             permFile.close();
+        }
+
+        // Set default QtQuick style if not configured
+        if (QString(getenv("QT_QUICK_CONTROLS_STYLE")).isEmpty()) {
+            QQuickStyle::setStyle("Universal");
         }
     }
 #endif


### PR DESCRIPTION
Just backporting @patrickelectric 's changes to stable. This fixes at least the first issue in #8484 (text not fitting in the widget)

![Screenshot from 2020-05-07 17-50-37](https://user-images.githubusercontent.com/4013804/81343484-740bb680-908b-11ea-9c2b-447098907713.png)
