### PR TITLE
[WIP] QGCApplication: set style for all OS

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -223,14 +223,14 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
             }
             permFile.close();
         }
-
-        // Set default QtQuick style if not configured
-        if (QString(getenv("QT_QUICK_CONTROLS_STYLE")).isEmpty()) {
-            QQuickStyle::setStyle("Universal");
-        }
     }
 #endif
 #endif
+
+    // Set default QtQuick style if not configured
+    if (QString(getenv("QT_QUICK_CONTROLS_STYLE")).isEmpty()) {
+        QQuickStyle::setStyle("Universal");
+    }
 
     // Setup for network proxy support
     QNetworkProxyFactory::setUseSystemConfiguration(true);


### PR DESCRIPTION
Following up with https://github.com/mavlink/qgroundcontrol/pull/8736 in regard to https://github.com/mavlink/qgroundcontrol/issues/8484

This ui fix was previously applied to linux only, but windows was still demonstrating the same problem


