### PR TITLE
Video widget

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,9 @@ Note: This file only contains high level features or important fixes.
 
 ## 4.0
 
-## 4.0.7 - Not yet releases
+## 4.0.7 - Not yet released
+
+* Fix video page sizing
 
 ### 4.0.6 - Stable
 

--- a/src/FlightMap/Widgets/VideoPageWidget.qml
+++ b/src/FlightMap/Widgets/VideoPageWidget.qml
@@ -26,7 +26,7 @@ import QGroundControl.FactControls      1.0
 /// Video streaming page for Instrument Panel PageView
 Item {
     width:              pageWidth
-    height:             videoGrid.height + (ScreenTools.defaultFontPixelHeight * 2)
+    height:             videoGrid.y + videoGrid.height + _margins
     anchors.margins:    ScreenTools.defaultFontPixelWidth * 2
     anchors.centerIn:   parent
 
@@ -39,15 +39,19 @@ Item {
     property int    _curCameraIndex:        _dynamicCameras ? _dynamicCameras.currentCamera : 0
     property bool   _isCamera:              _dynamicCameras ? _dynamicCameras.cameras.count > 0 : false
     property var    _camera:                _isCamera ? (_dynamicCameras.cameras.get(_curCameraIndex) && _dynamicCameras.cameras.get(_curCameraIndex).paramComplete ? _dynamicCameras.cameras.get(_curCameraIndex) : null) : null
+    property real   _margins:               ScreenTools.defaultFontPixelWidth / 2
 
     QGCPalette { id:qgcPal; colorGroupEnabled: true }
 
     GridLayout {
         id:                 videoGrid
+        anchors.margins:    _margins
+        anchors.top:        parent.top
+        anchors.left:       parent.left
+        anchors.right:      parent.right
         columns:            2
-        columnSpacing:      ScreenTools.defaultFontPixelWidth * 2
+        columnSpacing:      _margins
         rowSpacing:         ScreenTools.defaultFontPixelHeight
-        anchors.centerIn:   parent
         Connections {
             // For some reason, the normal signal is not reflected in the control below
             target: QGroundControl.settingsManager.videoSettings.streamEnabled
@@ -57,7 +61,7 @@ Item {
         }
         // Enable/Disable Video Streaming
         QGCLabel {
-           text:                qsTr("Enable Stream")
+           text:                qsTr("Enable")
            font.pointSize:      ScreenTools.smallFontPointSize
            visible:             !_camera || !_camera.autoStream
         }
@@ -98,7 +102,7 @@ Item {
         }
         //-- Video Fit
         QGCLabel {
-            text:               qsTr("Video Screen Fit")
+            text:               qsTr("Video Fit")
             visible:            QGroundControl.videoManager.isGStreamer
             font.pointSize:     ScreenTools.smallFontPointSize
         }
@@ -109,13 +113,14 @@ Item {
             Layout.alignment:   Qt.AlignHCenter
         }
         QGCLabel {
-            text: qsTr("File Name");
-            visible: QGroundControl.videoManager.isGStreamer
+            text:               qsTr("File Name");
+            font.pointSize:     ScreenTools.smallFontPointSize
+            visible:            QGroundControl.videoManager.isGStreamer
         }
-        TextField {
-            id: videoFileName
-            visible: QGroundControl.videoManager.isGStreamer
-            width: 100
+        QGCTextField {
+            id:                 videoFileName
+            Layout.fillWidth:   true
+            visible:            QGroundControl.videoManager.isGStreamer
         }
         //-- Video Recording
         QGCLabel {

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -216,10 +216,8 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
             permFile.close();
         }
 
-        // Set default QtQuick style if not configured
-        if (QString(getenv("QT_QUICK_CONTROLS_STYLE")).isEmpty()) {
-            QQuickStyle::setStyle("Universal");
-        }
+        // Always set style to default, this way QT_QUICK_CONTROLS_STYLE environment variable doesn't cause random changes in ui
+        QQuickStyle::setStyle("Default");
     }
 #endif
 #endif


### PR DESCRIPTION
* Fix video page widget control usage and sizing
* Always apply "Default" style to Qml Controls. In general this shouldn't be needed since we have our own custom control set. But there are a few like sliders which use the vanilla control. By forcing to Default style it prevents the QT_QUICK_CONTROLS_STYLE from randomly changing the QGC ui.

![Screen Shot 2020-05-13 at 12 52 09 PM](https://user-images.githubusercontent.com/5876851/81858689-f6c3c400-9518-11ea-89eb-67653fb2278b.png)

Replacement for #8747 and friends.