### PR TITLE
Fix disappearing flight mode button assignments

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -279,7 +279,7 @@ void Joystick::_loadSettings()
 
     for (int button = 0; button < _totalButtonCount; button++) {
         QString a = settings.value(QString(_buttonActionNameKey).arg(button), QString()).toString();
-        if(!a.isEmpty() && _findAssignableButtonAction(a) >= 0 && a != _buttonActionNone) {
+        if(!a.isEmpty() && a != _buttonActionNone) {
             if(_buttonActionArray[button]) {
                 _buttonActionArray[button]->deleteLater();
             }

--- a/src/VehicleSetup/JoystickConfigButtons.qml
+++ b/src/VehicleSetup/JoystickConfigButtons.qml
@@ -69,13 +69,17 @@ Item {
                     onActivated: {
                         _activeJoystick.setButtonAction(modelData, textAt(index))
                     }
-                    Component.onCompleted: {
+
+                    function _findCurrentButtonAction() {
                         if(_activeJoystick) {
                             var i = find(_activeJoystick.buttonActions[modelData])
                             if(i < 0) i = 0
                             currentIndex = i
                         }
                     }
+
+                    Component.onCompleted:  _findCurrentButtonAction()
+                    onModelChanged:         _findCurrentButtonAction()
                 }
                 QGCCheckBox {
                     id:                         repeatCheck


### PR DESCRIPTION
The load settings for joystick buttons was validating the action against the currently known set of available actions. Tossing the actions which were not in the list. At the time load settings is called there isn't a vehicle yet hence the flight modes aren't in the list. Hence all flight mode assignments were being dropped.

I think it's better to just leave these in there in any case. It is possible to set up joystick for Vehicle A which has a different set of flight modes available than Vehicle B. It's better to have the flight mode change just fail with an error in that case.

The new way it works from a ui perspective is that if a button is truly assigned to a flight mode which currently does not exist then it shows "No Action" which isn't quite correct. But good enough I think then trying to get fancy.

Fix for #8746