### PR TITLE
FactMetaData: Add custom validator support

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -424,6 +424,13 @@ bool FactMetaData::convertAndValidateCooked(const QVariant& cookedValue, bool co
 
     errorString.clear();
 
+    if (!convertOnly && _customCookedValidator) {
+        errorString = _customCookedValidator(cookedValue);
+        if (!errorString.isEmpty()) {
+            return false;
+        }
+    }
+
     switch (type()) {
     case FactMetaData::valueTypeInt8:
     case FactMetaData::valueTypeInt16:

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -43,6 +43,10 @@ public:
 
     typedef QVariant (*Translator)(const QVariant& from);
 
+    // Custom function to validate a cooked value.
+    //  @return Error string for failed validation explanation to user. Empty string indicates no error.
+    typedef QString (*CustomCookedValidator)(const QVariant& cookedValue);
+
     FactMetaData(QObject* parent = nullptr);
     FactMetaData(ValueType_t type, QObject* parent = nullptr);
     FactMetaData(ValueType_t type, const QString name, QObject* parent = nullptr);
@@ -179,6 +183,10 @@ public:
     /// @returns false: Convertion failed
     bool clampValue(const QVariant& cookedValue, QVariant& typedValue);
 
+    /// Sets a custom cooked validator function for this metadata. The custom validator will be called
+    /// prior to the standard validator when convertAndValidateCooked is called.
+    void setCustomCookedValidator(CustomCookedValidator customValidator) { _customCookedValidator = customValidator; }
+
     static const int kDefaultDecimalPlaces = 3;  ///< Default value for decimal places if not specified/known
     static const int kUnknownDecimalPlaces = -1; ///< Number of decimal places to specify is not known
 
@@ -285,6 +293,7 @@ private:
     bool            _readOnly;
     bool            _writeOnly;
     bool            _volatile;
+    CustomCookedValidator _customCookedValidator = nullptr;
 
     // Exact conversion constants
     static const struct UnitConsts_s {


### PR DESCRIPTION
FactMetaData:
```
    // Custom function to validate a cooked value.
    //  @return Error string for failed validation explanation to user. Empty string indicates no error.
    typedef QString (*CustomCookedValidator)(const QVariant& cookedValue);
```

```
    /// Sets a custom cooked validator function for this metadata. The custom validator will be called
    /// prior to the standard validator when convertAndValidateCooked is called.
    void setCustomCookedValidator(CustomCookedValidator customValidator) { _customCookedValidator = customValidator; }
```

This then ties into the normal Fact validation system. Such that the users get an explanation and an error popup dialog when validation fails.

Related to #8721