### PR TITLE
fix too many fail message box when failed to start mission

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -718,7 +718,7 @@ bool FirmwarePlugin::_armVehicleAndValidate(Vehicle* vehicle)
 
     // We try arming 3 times
     for (int retries=0; retries<3; retries++) {
-        vehicle->setArmed(true);
+        vehicle->setArmedMsg(true, false);
 
         // Wait for vehicle to return armed state for 3 seconds
         for (int i=0; i<30; i++) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2481,10 +2481,15 @@ QGeoCoordinate Vehicle::homePosition()
 
 void Vehicle::setArmed(bool armed)
 {
+    setArmedMsg(armed, true);
+}
+
+void Vehicle::setArmedMsg(bool armed, bool showError)
+{
     // We specifically use COMMAND_LONG:MAV_CMD_COMPONENT_ARM_DISARM since it is supported by more flight stacks.
     sendMavCommand(_defaultComponentId,
                    MAV_CMD_COMPONENT_ARM_DISARM,
-                   true,    // show error if fails
+                   showError,    // show error if fails
                    armed ? 1.0f : 0.0f);
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -864,6 +864,7 @@ public:
 
     bool armed      () { return _armed; }
     void setArmed   (bool armed);
+    void setArmedMsg   (bool armed, bool showError);
 
     bool flightModeSetAvailable             ();
     QStringList flightModes                 ();


### PR DESCRIPTION
it's too many error message boxs when failed to start mission，like the below picture:
![image](https://user-images.githubusercontent.com/19259642/82114913-19144680-9792-11ea-80e4-1a87ae8aad3a.png)

it's caused by the 3 time arming tries so I add a function to set vehicle armed  with no arm fail message, after fixed like:

![image](https://user-images.githubusercontent.com/19259642/82114601-43fd9b00-9790-11ea-8c8c-94afdafe03f1.png)
