### PR TITLE
Fix incorrect units of gradient on planner screen.

### DIFF
--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -52,7 +52,7 @@ Item {
 
     property string _distanceText:              isNaN(_distance) ?              "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_distance).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
     property string _altDifferenceText:         isNaN(_altDifference) ?         "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_altDifference).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
-    property string _gradientText:              isNaN(_gradient) ?              "-.-" : _gradient.toFixed(0) + " %"
+    property string _gradientText:              isNaN(_gradient) ?              "-.-" : _gradient.toFixed(0) + "\u00B0"
     property string _azimuthText:               isNaN(_azimuth) ?               "-.-" : Math.round(_azimuth) % 360
     property string _headingText:               isNaN(_azimuth) ?               "-.-" : Math.round(_heading) % 360
     property string _missionDistanceText:       isNaN(_missionDistance) ?       "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_missionDistance).toFixed(0) + " " + QGroundControl.appSettingsDistanceUnitsString

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -52,7 +52,7 @@ Item {
 
     property string _distanceText:              isNaN(_distance) ?              "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_distance).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
     property string _altDifferenceText:         isNaN(_altDifference) ?         "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_altDifference).toFixed(1) + " " + QGroundControl.appSettingsDistanceUnitsString
-    property string _gradientText:              isNaN(_gradient) ?              "-.-" : _gradient.toFixed(0) + "\u00B0"
+    property string _gradientText:              isNaN(_gradient) ?              "-.-" : _gradient.toFixed(0) + " deg"
     property string _azimuthText:               isNaN(_azimuth) ?               "-.-" : Math.round(_azimuth) % 360
     property string _headingText:               isNaN(_azimuth) ?               "-.-" : Math.round(_heading) % 360
     property string _missionDistanceText:       isNaN(_missionDistance) ?       "-.-" : QGroundControl.metersToAppSettingsDistanceUnits(_missionDistance).toFixed(0) + " " + QGroundControl.appSettingsDistanceUnitsString


### PR DESCRIPTION
The gradient was displayed with "%" as the unit, whereas it is actually degrees.