### PR TITLE
Add debian documentation, fix for hardcoded dot path

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@ install:
       Write-Host "Installed" -ForegroundColor Green
 
 build_script:
-  - mkdir %SHADOW_BUILD_DIR% && cd %SHADOW_BUILD_DIR% && %QT_QMAKE_DIR%\qmake -r CONFIG+=%CONFIG% CONFIG+=WarningsAsErrorsOn %APPVEYOR_BUILD_FOLDER%\qgroundcontrol.pro
+  - mkdir %SHADOW_BUILD_DIR% && cd %SHADOW_BUILD_DIR% && %QT_QMAKE_DIR%\qmake -r CONFIG+=%CONFIG% %APPVEYOR_BUILD_FOLDER%\qgroundcontrol.pro
   - cd %SHADOW_BUILD_DIR% && %QT_JOM_DIR%\jom
   - if "%CONFIG%" EQU "installer" ( copy %SHADOW_BUILD_DIR%\release\QGroundControl-installer.exe %APPVEYOR_BUILD_FOLDER%\QGroundControl-installer.exe )
 # Generate the source server information to embed in the PDB

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ jobs:
           sudo: required
         - stage: "Build"
           name: "Android 32 bit"
-          dist: trusty
+          dist: xenial
           language: android
           env: SPEC=android-clang CONFIG=installer BITNESS=32 GSTREAMER_NAME=armv7
           sudo: false
         - stage: "Build"
           name: "Android 64 bit"
-          dist: trusty
+          dist: xenial
           language: android
           env: SPEC=android-clang CONFIG=installer BITNESS=64 GSTREAMER_NAME=arm64
           sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,12 +197,7 @@ script:
         echo "Daily build" &&
         export STABLE_OR_DAILY=DailyBuild;
     fi
-  # Due to possible bug in Qt 5.11 WarningsAsErrorsOn is off for Linux builds. Hopefully back on once that is resolved.
-  - if [ "${SPEC}" = "macx-clang" ]; then
-        qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG} CONFIG+=${STABLE_OR_DAILY} CONFIG+=WarningsAsErrorsOn -spec ${SPEC};
-    else
-        qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG} CONFIG+=${STABLE_OR_DAILY} -spec ${SPEC};
-    fi
+  - qmake -r ${TRAVIS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG} CONFIG+=${STABLE_OR_DAILY} -spec ${SPEC};
 
   # compile
   - if [ "${SPEC}" != "macx-ios-clang" ]; then

--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -250,7 +250,8 @@ WindowsBuild {
         /wd4996 \   # silence warnings about deprecated strcpy and whatnot, these come from the shapefile code with is external
         /wd4005 \   # silence warnings about macro redefinition, these come from the shapefile code with is external
         /wd4290 \   # ignore exception specifications
-        /wd4267     # silence conversion from 'size_t' to 'int', possible loss of data, these come from gps drivers shared with px4
+        /wd4267 \   # silence conversion from 'size_t' to 'int', possible loss of data, these come from gps drivers shared with px4
+        /wd4100     # gst-plugins-good has this error
     WarningsAsErrorsOn {
         QMAKE_CXXFLAGS_WARN_ON += /WX
     }

--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -17,6 +17,8 @@
 # the project file.
 
 CONFIG -= debug_and_release
+CONFIG += warn_on
+
 linux {
     linux-g++ | linux-g++-64 | linux-g++-32 | linux-clang {
         message("Linux build")
@@ -25,12 +27,14 @@ linux {
         DEFINES += QGC_GST_TAISYNC_ENABLED
         DEFINES += QGC_GST_MICROHARD_ENABLED 
         DEFINES += QGC_ENABLE_MAVLINK_INSPECTOR
-        QMAKE_CXXFLAGS += -Wno-address-of-packed-member
         linux-clang {
             message("Linux clang")
             QMAKE_CXXFLAGS += -Qunused-arguments -fcolor-diagnostics
         } else {
-            QMAKE_CXXFLAGS += -Wno-deprecated-copy
+            QMAKE_CXXFLAGS_WARN_ON += -Werror \
+                -Wno-deprecated-copy \      # These come from mavlink headers
+                -Wno-unused-parameter \     # gst_plugins-good has these errors
+                -Wno-implicit-fallthrough   # gst_plugins-good has these errors
         }
     } else : linux-rasp-pi2-g++ {
         message("Linux R-Pi2 build")
@@ -45,9 +49,14 @@ linux {
         DEFINES += QGC_ENABLE_BLUETOOTH
         DEFINES += QGC_GST_TAISYNC_ENABLED
         DEFINES += QGC_GST_MICROHARD_ENABLED 
-        QMAKE_CXXFLAGS += -Wno-address-of-packed-member
-        QMAKE_CXXFLAGS += -Wno-unused-command-line-argument
-        QMAKE_CFLAGS += -Wno-unused-command-line-argument
+        QMAKE_CXXFLAGS_WARN_ON += -Werror \
+            -Wno-address-of-packed-member \     # Mavlink headers
+            -Wno-unused-parameter \             # gst_plugins-good has these errors
+            -Wno-implicit-fallthrough \         # gst_plugins-good has these errors
+            -Wno-unused-command-line-argument \ # from somewhere in Qt generated build files
+            -Wno-parentheses-equality           # android gstreamer header files
+        QMAKE_CFLAGS_WARN_ON += \
+            -Wno-unused-command-line-argument   # from somewhere in Qt generated build files
         QMAKE_LINK += -nostdlib++ # Hack fix?: https://forum.qt.io/topic/103713/error-cannot-find-lc-qt-5-12-android
         target.path = $$DESTDIR
         equals(ANDROID_TARGET_ARCH, armeabi-v7a)  {
@@ -72,11 +81,22 @@ linux {
     contains(QMAKE_TARGET.arch, x86_64) {
         message("Windows build")
         CONFIG += WindowsBuild
-        CONFIG += WarningsAsErrorsOn
         DEFINES += __STDC_LIMIT_MACROS
         DEFINES += QGC_GST_TAISYNC_ENABLED
         DEFINES += QGC_GST_MICROHARD_ENABLED 
         DEFINES += QGC_ENABLE_MAVLINK_INSPECTOR
+        QMAKE_CFLAGS -= -Zc:strictStrings
+        QMAKE_CFLAGS_RELEASE -= -Zc:strictStrings
+        QMAKE_CFLAGS_RELEASE_WITH_DEBUGINFO -= -Zc:strictStrings
+        QMAKE_CXXFLAGS -= -Zc:strictStrings
+        QMAKE_CXXFLAGS_RELEASE -= -Zc:strictStrings
+        QMAKE_CXXFLAGS_RELEASE_WITH_DEBUGINFO -= -Zc:strictStrings
+        QMAKE_CXXFLAGS += /std:c++17
+        QMAKE_CXXFLAGS_WARN_ON += /WX /W3 \
+            /wd4005 \   # silence warnings about macro redefinition, these come from the shapefile code with is external
+            /wd4290 \   # ignore exception specifications
+            /wd4267 \   # silence conversion from 'size_t' to 'int', possible loss of data, these come from gps drivers shared with px4
+            /wd4100     # unreferenced formal parameter - gst-plugins-good
     } else {
         error("Unsupported Windows toolchain, only Visual Studio 2017 64 bit is supported")
     }
@@ -95,10 +115,11 @@ linux {
                 QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.6
         }
         #-- Not forcing anything. Let qmake find the latest, installed SDK.
-        #QMAKE_MAC_SDK = macosx10.12
+        #QMAKE_MAC_SDK = macosx10.15
         QMAKE_CXXFLAGS += -fvisibility=hidden
-        #-- Disable annoying warnings comming from mavlink.h
-        QMAKE_CXXFLAGS += -Wno-address-of-packed-member
+        QMAKE_CXXFLAGS_WARN_ON += -Werror \
+            -Wno-address-of-packed-member \ # Mavlink headers
+            -Wno-unused-parameter           # gst-plugins-good
     } else {
         error("Unsupported Mac toolchain, only 64-bit LLVM+clang is supported")
     }
@@ -224,37 +245,11 @@ LOCATION_PLUGIN_NAME    = QGeoServiceProviderFactoryQGC
 # Turn off serial port warnings
 DEFINES += _TTY_NOWARN_
 
-MacBuild | LinuxBuild {
-    QMAKE_CXXFLAGS_WARN_ON += -Wall
-    WarningsAsErrorsOn {
-        QMAKE_CXXFLAGS_WARN_ON += -Werror
-    }
-    MacBuild {
-        # Latest clang version has a buggy check for this which cause Qt headers to throw warnings on qmap.h
-        QMAKE_CXXFLAGS_WARN_ON += -Wno-return-stack-address
-        # Xcode 8.3 has issues on how MAVLink accesses (packed) message structure members.
-        # Note that this will fail when Xcode version reaches 10.x.x
-        XCODE_VERSION = $$system($$PWD/tools/get_xcode_version.sh)
-        greaterThan(XCODE_VERSION, 8.2.0): QMAKE_CXXFLAGS_WARN_ON += -Wno-address-of-packed-member
-    }
-}
-
-WindowsBuild {
-    QMAKE_CFLAGS -= -Zc:strictStrings
-    QMAKE_CFLAGS_RELEASE -= -Zc:strictStrings
-    QMAKE_CFLAGS_RELEASE_WITH_DEBUGINFO -= -Zc:strictStrings
-    QMAKE_CXXFLAGS -= -Zc:strictStrings
-    QMAKE_CXXFLAGS_RELEASE -= -Zc:strictStrings
-    QMAKE_CXXFLAGS_RELEASE_WITH_DEBUGINFO -= -Zc:strictStrings
-    QMAKE_CXXFLAGS_WARN_ON += /W3 \
-        /wd4996 \   # silence warnings about deprecated strcpy and whatnot, these come from the shapefile code with is external
-        /wd4005 \   # silence warnings about macro redefinition, these come from the shapefile code with is external
-        /wd4290 \   # ignore exception specifications
-        /wd4267 \   # silence conversion from 'size_t' to 'int', possible loss of data, these come from gps drivers shared with px4
-        /wd4100     # gst-plugins-good has this error
-    WarningsAsErrorsOn {
-        QMAKE_CXXFLAGS_WARN_ON += /WX
-    }
+MacBuild {
+    # Xcode 8.3 has issues on how MAVLink accesses (packed) message structure members.
+    # Note that this will fail when Xcode version reaches 10.x.x
+    XCODE_VERSION = $$system($$PWD/tools/get_xcode_version.sh)
+    greaterThan(XCODE_VERSION, 8.2.0): QMAKE_CXXFLAGS_WARN_ON += -Wno-address-of-packed-member
 }
 
 #

--- a/doc/README
+++ b/doc/README
@@ -12,3 +12,10 @@ $doxygen Doxyfile
 
 The html file index.html should be in doc/html. 
 
+Debian
+=====================
+#To build documentation first install dependencies (doxygen, doxyqml and dot):
+sudo apt install doxygen graphviz doxyqml
+
+#Then build documentation in the doc/ directory
+doxygen ./Doxyfile

--- a/doc/dot
+++ b/doc/dot
@@ -34,4 +34,13 @@ do
   fi
 done
 
-/usr/local/bin/dot ${ARGS}
+if [[ -x "/usr/local/bin/dot" ]]  
+then
+  /usr/local/bin/dot ${ARGS}
+elif [[ -x "/usr/bin/dot" ]]
+then 
+  /usr/bin/dot ${ARGS}
+else
+  echo "Program dot not found: See file doc/dot"
+  exit 1
+fi

--- a/qmlglsink.pri
+++ b/qmlglsink.pri
@@ -1,6 +1,3 @@
-# FIXME: will be fixed after converting qmlglsink into .pro#static lib
-QMAKE_CXXFLAGS_WARN_ON =
-
 LinuxBuild {
     DEFINES += HAVE_QT_X11 HAVE_QT_EGLFS HAVE_QT_WAYLAND
 } else:MacBuild {

--- a/src/AutoPilotPlugins/APM/APMCompassCal.cc
+++ b/src/AutoPilotPlugins/APM/APMCompassCal.cc
@@ -180,10 +180,7 @@ CalWorkerThread::calibrate_return CalWorkerThread::mag_calibration_worker(detect
             break;
         }
 
-        int prev_count[max_mags];
         for (size_t cur_mag=0; cur_mag<max_mags; cur_mag++) {
-            prev_count[cur_mag] = worker_data->calibration_counter_total[cur_mag];
-
             if (!rgCompassAvailable[cur_mag]) {
                 continue;
             }

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -76,7 +76,7 @@ QGCCameraParamIO::QGCCameraParamIO(QGCCameraControl *control, Fact* fact, Vehicl
             break;
         default:
             qWarning() << "Unsupported fact type" << _fact->type() << "for" << _fact->name();
-            //-- Fall Through (screw clang)
+            [[fallthrough]];
         case FactMetaData::valueTypeInt32:
             _mavParamType = MAV_PARAM_EXT_TYPE_INT32;
             break;
@@ -176,7 +176,7 @@ QGCCameraParamIO::_sendParameter()
             break;
         default:
             qCritical() << "Unsupported fact type" << factType << "for" << _fact->name();
-            //-- Fall Through (screw clang)
+            [[fallthrough]];
         case FactMetaData::valueTypeInt32:
             union_value.param_int32 = static_cast<int32_t>(_fact->rawValue().toInt());
             break;

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -377,6 +377,7 @@ bool APMFirmwarePlugin::_handleIncomingStatusText(Vehicle* vehicle, mavlink_mess
                 case MAV_TYPE_QUADROTOR:
                     // Start TCP video handshake with ARTOO in case it's a Solo running ArduPilot firmware
                     _soloVideoHandshake(vehicle, false /* originalSoloFirmware */);
+                    [[fallthrough]];
                 case MAV_TYPE_COAXIAL:
                 case MAV_TYPE_HELICOPTER:
                 case MAV_TYPE_SUBMARINE:

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -1008,6 +1008,9 @@ double SimpleMissionItem::amslEntryAlt(void) const
         return _missionItem.param7();
     case QGroundControlQmlGlobal::AltitudeModeRelative:
         return _missionItem.param7() + _masterController->missionController()->plannedHomePosition().altitude();
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qWarning() << "Internal Error SimpleMissionItem::amslEntryAlt: Invalid altitudeMode:AltitudeModeNone";
+        return qQNaN();
     }
 
     qWarning() << "Internal Error SimpleMissionItem::amslEntryAlt: Invalid altitudeMode:" << _altitudeMode;

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -1008,8 +1008,8 @@ double SimpleMissionItem::amslEntryAlt(void) const
         return _missionItem.param7();
     case QGroundControlQmlGlobal::AltitudeModeRelative:
         return _missionItem.param7() + _masterController->missionController()->plannedHomePosition().altitude();
-    case QGroundControlQmlGlobal::AltitudeModeNone:
-        qWarning() << "Internal Error SimpleMissionItem::amslEntryAlt: Invalid altitudeMode == AltitudeModeNone";
-        return qQNaN();
     }
+
+    qWarning() << "Internal Error SimpleMissionItem::amslEntryAlt: Invalid altitudeMode:" << _altitudeMode;
+    return qQNaN();
 }


### PR DESCRIPTION
Updated the documentation to indicate correct packages for "apt" to import to build documentation. 

Fixed hardcoded path for dot command which caused doxygen command to fail on stock debian OS. 


