### PR TITLE
Debian doc updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ jobs:
           sudo: required
         - stage: "Build"
           name: "Android 32 bit"
-          dist: trusty
+          dist: xenial
           language: android
           env: SPEC=android-clang CONFIG=installer BITNESS=32 GSTREAMER_NAME=armv7
           sudo: false
         - stage: "Build"
           name: "Android 64 bit"
-          dist: trusty
+          dist: xenial
           language: android
           env: SPEC=android-clang CONFIG=installer BITNESS=64 GSTREAMER_NAME=arm64
           sudo: false

--- a/doc/README
+++ b/doc/README
@@ -12,3 +12,10 @@ $doxygen Doxyfile
 
 The html file index.html should be in doc/html. 
 
+Debian
+=====================
+#To build documentation first install dependencies (doxygen, doxyqml and dot):
+sudo apt install doxygen graphviz doxyqml
+
+#Then build documentation in the doc/ directory
+doxygen ./Doxyfile

--- a/doc/dot
+++ b/doc/dot
@@ -34,4 +34,13 @@ do
   fi
 done
 
-/usr/local/bin/dot ${ARGS}
+if [[ -x "/usr/local/bin/dot" ]]  
+then
+  /usr/local/bin/dot ${ARGS}
+elif [[ -x "/usr/bin/dot" ]]
+then 
+  /usr/bin/dot ${ARGS}
+else
+  echo "Program dot not found: See file doc/dot"
+  exit 1
+fi


### PR DESCRIPTION
Updated the documentation to indicate correct packages for "apt" to import to build documentation.

Fixed dot errors (hardcoded path for dot)  in script building doxygen docs on Ubuntu 

Fixes TravisCI errors since Trusty has been replaced with xenial. 