### PR TITLE
VTOL Takeoff should be considered a transition to FW

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1548,11 +1548,9 @@ void MissionController::_recalcMissionFlightStatus()
         // Update VTOL state
         if (simpleItem && _controllerVehicle->vtol()) {
             switch (simpleItem->command()) {
-            case MAV_CMD_NAV_TAKEOFF:
+            case MAV_CMD_NAV_TAKEOFF:       // This will do a fixed wing style takeoff
+            case MAV_CMD_NAV_VTOL_TAKEOFF:  // Vehicle goes straight up and then transitions to FW
                 vtolInHover = false;
-                break;
-            case MAV_CMD_NAV_VTOL_TAKEOFF:
-                vtolInHover = true;
                 break;
             case MAV_CMD_NAV_LAND:
                 vtolInHover = false;


### PR DESCRIPTION
* VTOL_TAKEOFF command wasn't considered as a transition to FW
* Fix for #8735

Also keep in mind for time calcs that in general QGC doesn't consider vertical distance in calcs, only horizontal distance. Except for takeoff which is special cased and will account for the takeoff from ground to straight up in hover. Land doesn't do this, which is odd, but it is what is is for now.