### PR TITLE
Reworked Warnings As Errors mechanism

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -106,13 +106,18 @@ linux {
         QMAKE_CXXFLAGS_RELEASE -= -Zc:strictStrings
         QMAKE_CXXFLAGS_RELEASE_WITH_DEBUGINFO -= -Zc:strictStrings
         QMAKE_CXXFLAGS += /std:c++17
+        QMAKE_CXXFLAGS_WARN_ON -= -w34100 # Qt insanity which prevents /wd from working correctly
         QMAKE_CXXFLAGS += /W3 \
-            /wd4005 \   # silence warnings about macro redefinition, these come from the shapefile code with is external
             /wd4290 \   # ignore exception specifications
             /wd4267 \   # silence conversion from 'size_t' to 'int', possible loss of data, these come from gps drivers shared with px4
             /wd4100     # unreferenced formal parameter - gst-plugins-good
+        QMAKE_CFLAGS += /W3 \
+            /wd4005 \   # all of these come from shape file code
+            /wd4267 \
+            /wd4996
         !WarningsAsErrorsOff {
             QMAKE_CXXFLAGS += /WX
+            QMAKE_CFLAGS += /WX
         }
     } else {
         error("Unsupported Windows toolchain, only Visual Studio 2017 64 bit is supported")

--- a/src/AutoPilotPlugins/APM/APMCompassCal.cc
+++ b/src/AutoPilotPlugins/APM/APMCompassCal.cc
@@ -249,8 +249,8 @@ CalWorkerThread::calibrate_return CalWorkerThread::calibrate_from_orientation(
 
         for (unsigned int cur_orientation=0; cur_orientation<detect_orientation_side_count; cur_orientation++) {
             if (!side_data_collected[cur_orientation]) {
-                strcat(pendingStr, " ");
-                strcat(pendingStr, detect_orientation_str((enum detect_orientation_return)cur_orientation));
+                strcat_s(pendingStr, sizeof(pendingStr), " ");
+                strcat_s(pendingStr, sizeof(pendingStr), detect_orientation_str((enum detect_orientation_return)cur_orientation));
             }
         }
         _emitVehicleTextMessage(QStringLiteral("[cal] pending:%1").arg(pendingStr));

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
@@ -101,7 +101,7 @@ ESP8266ComponentController::setWifiSSID(QString ssid)
     char tmp[20];
     memset(tmp, 0, sizeof(tmp));
     std::string	sid = ssid.toStdString();
-    strncpy(tmp, sid.c_str(), sizeof(tmp));
+    strncpy_s(tmp, sizeof(tmp), sid.c_str(), sizeof(tmp));
     Fact* f1 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_SSID1"));
     Fact* f2 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_SSID2"));
     Fact* f3 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_SSID3"));
@@ -140,7 +140,7 @@ ESP8266ComponentController::setWifiPassword(QString password)
     char tmp[20];
     memset(tmp, 0, sizeof(tmp));
     std::string	pwd = password.toStdString();
-    strncpy(tmp, pwd.c_str(), sizeof(tmp));
+    strncpy_s(tmp, sizeof(tmp), pwd.c_str(), sizeof(tmp));
     Fact* f1 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_PASSWORD1"));
     Fact* f2 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_PASSWORD2"));
     Fact* f3 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_PASSWORD3"));
@@ -183,7 +183,7 @@ ESP8266ComponentController::setWifiSSIDSta(QString ssid)
         char tmp[20];
         memset(tmp, 0, sizeof(tmp));
         std::string	sid = ssid.toStdString();
-        strncpy(tmp, sid.c_str(), sizeof(tmp));
+        strncpy_s(tmp, sizeof(tmp), sid.c_str(), sizeof(tmp));
         Fact* f1 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_SSIDSTA1"));
         Fact* f2 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_SSIDSTA2"));
         Fact* f3 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_SSIDSTA3"));
@@ -227,7 +227,7 @@ ESP8266ComponentController::setWifiPasswordSta(QString password)
         char tmp[20];
         memset(tmp, 0, sizeof(tmp));
         std::string	pwd = password.toStdString();
-        strncpy(tmp, pwd.c_str(), sizeof(tmp));
+        strncpy_s(tmp, sizeof(tmp), pwd.c_str(), sizeof(tmp));
         Fact* f1 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_PWDSTA1"));
         Fact* f2 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_PWDSTA2"));
         Fact* f3 = getParameterFact(MAV_COMP_ID_UDP_BRIDGE, QStringLiteral("WIFI_PWDSTA3"));

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -184,7 +184,7 @@ QGCCameraParamIO::_sendParameter()
     memcpy(&p.param_value[0], &union_value.bytes[0], MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN);
     p.target_system     = static_cast<uint8_t>(_vehicle->id());
     p.target_component  = static_cast<uint8_t>(_control->compID());
-    strncpy(p.param_id, _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_ID_LEN);
+    strncpy_s(p.param_id, sizeof(p.param_id), _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_ID_LEN);
     mavlink_msg_param_ext_set_encode_chan(
         static_cast<uint8_t>(_pMavlink->getSystemId()),
         static_cast<uint8_t>(_pMavlink->getComponentId()),
@@ -353,7 +353,7 @@ QGCCameraParamIO::paramRequest(bool reset)
     qCDebug(CameraIOLog) << "Request parameter:" << _fact->name();
     char param_id[MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN + 1];
     memset(param_id, 0, sizeof(param_id));
-    strncpy(param_id, _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN);
+    strncpy_s(param_id, sizeof(param_id), _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN);
     mavlink_message_t msg;
     mavlink_msg_param_ext_request_read_pack_chan(
         static_cast<uint8_t>(_pMavlink->getSystemId()),

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -822,7 +822,7 @@ void ParameterManager::_readParameterRaw(int componentId, const QString& paramNa
     mavlink_message_t msg;
     char fixedParamName[MAVLINK_MSG_PARAM_REQUEST_READ_FIELD_PARAM_ID_LEN];
 
-    strncpy(fixedParamName, paramName.toStdString().c_str(), sizeof(fixedParamName));
+    strncpy_s(fixedParamName, sizeof(fixedParamName), paramName.toStdString().c_str(), sizeof(fixedParamName));
     mavlink_msg_param_request_read_pack_chan(_mavlink->getSystemId(),   // QGC system id
                                              _mavlink->getComponentId(),     // QGC component id
                                              _vehicle->priorityLink()->mavlinkChannel(),
@@ -882,7 +882,7 @@ void ParameterManager::_writeParameterRaw(int componentId, const QString& paramN
     p.target_system = (uint8_t)_vehicle->id();
     p.target_component = (uint8_t)componentId;
 
-    strncpy(p.param_id, paramName.toStdString().c_str(), sizeof(p.param_id));
+    strncpy_s(p.param_id, sizeof(p.param_id), paramName.toStdString().c_str(), sizeof(p.param_id));
 
     mavlink_message_t msg;
     mavlink_msg_param_set_encode_chan(_mavlink->getSystemId(),
@@ -986,7 +986,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, QVarian
         mavlink_param_union_t   union_value;
         memset(&p, 0, sizeof(p));
         p.param_type = MAV_PARAM_TYPE_UINT32;
-        strncpy(p.param_id, "_HASH_CHECK", sizeof(p.param_id));
+        strncpy_s(p.param_id, sizeof(p.param_id), "_HASH_CHECK", sizeof(p.param_id));
         union_value.param_uint32 = crc32_value;
         p.param_value = union_value.param_float;
         p.target_system = (uint8_t)_vehicle->id();

--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -155,7 +155,8 @@ MAVLinkLogProcessor::create(MAVLinkLogManager* manager, const QString path, uint
                       id,
                       QDateTime::currentDateTime().toString("yyyy-MM-dd-hh-mm-ss-zzz").toLocal8Bit().data(),
                       manager->logExtension().toLocal8Bit().data());
-    _fd = fopen(_fileName.toLocal8Bit().data(), "wb");
+    _fd = nullptr;
+    fopen_s(&_fd, _fileName.toLocal8Bit().data(), "wb");
     if(_fd) {
         _record = new MAVLinkLogFiles(manager, _fileName, true);
         _record->setWriting(true);
@@ -801,7 +802,8 @@ MAVLinkLogManager::_uploadFinished()
                 //-- Write side-car file to flag it as uploaded
                 QString sideCar = _makeFilename(_currentLogfile->name());
                 sideCar.replace(_ulogExtension, kSidecarExtension);
-                FILE* f = fopen(sideCar.toLatin1().data(), "wb");
+                FILE* f = nullptr;
+                fopen_s(&f, sideCar.toLatin1().data(), "wb");
                 if(f) {
                     fclose(f);
                 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1031,7 +1031,7 @@ void Vehicle::_handleStatusText(mavlink_message_t& message)
     uint8_t compId = message.compid;
 
     b.resize(MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1);
-    strncpy(b.data(), statustext.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
+    strncpy_s(b.data(), MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN, statustext.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
     b[b.length()-1] = '\0';
     messageText = QString(b);
     bool includesNullTerminator = messageText.length() < MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN;
@@ -1479,7 +1479,7 @@ void Vehicle::_handleAutopilotVersion(LinkInterface *link, mavlink_message_t& me
     } else {
         // APM Firmware stores the first 8 characters of the git hash as an ASCII character string
         char nullStr[9];
-        strncpy(nullStr, (char*)autopilotVersion.flight_custom_version, 8);
+        strncpy_s(nullStr, sizeof(nullStr), (char*)autopilotVersion.flight_custom_version, 8);
         nullStr[8] = 0;
         _gitHash = nullStr;
     }

--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -236,13 +236,7 @@ void TCPLink::_restartConnection()
 
 static bool is_ip(const QString& address)
 {
-    int a,b,c,d;
-    if (sscanf(address.toStdString().c_str(), "%d.%d.%d.%d", &a, &b, &c, &d) != 4
-            && strcmp("::1", address.toStdString().c_str())) {
-        return false;
-    } else {
-        return true;
-    }
+    return !QHostAddress(address).isNull();
 }
 
 static QString get_ip_address(const QString& address)

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -37,13 +37,7 @@ static const char* kZeroconfRegistration = "_qgroundcontrol._udp";
 
 static bool is_ip(const QString& address)
 {
-    int a,b,c,d;
-    if (sscanf(address.toStdString().c_str(), "%d.%d.%d.%d", &a, &b, &c, &d) != 4
-            && strcmp("::1", address.toStdString().c_str())) {
-        return false;
-    } else {
-        return true;
-    }
+    return !QHostAddress(address).isNull();
 }
 
 static QString get_ip_address(const QString& address)

--- a/src/uas/FileManager.cc
+++ b/src/uas/FileManager.cc
@@ -538,7 +538,7 @@ void FileManager::listDirectory(const QString& dirPath)
 
 void FileManager::_fillRequestWithString(Request* request, const QString& str)
 {
-    strncpy((char *)&request->data[0], str.toStdString().c_str(), sizeof(request->data));
+    strncpy_s((char *)&request->data[0], sizeof(request->data), str.toStdString().c_str(), sizeof(request->data));
     request->hdr.size = static_cast<uint8_t>(strnlen((const char *)&request->data[0], sizeof(request->data)));
 }
 


### PR DESCRIPTION
You can now turn off warnings as errors using CONFIG+=WarningsAsErrorsOff on private builds. This should only be used temporarily if for some reason your compiler is newer than what QGC CI users and is popping new errors. For that you should submit specific code fixes or if absolutely needed warnings off fixes. Can also be helpful it you are using version of Qt which are not the current supported version as well.