### PR TITLE
Feature request: Save hostnames instead of host addresses for TCP/UDP links

### DIFF
--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -80,10 +80,16 @@ public:
     /*!
      * @brief The host address
      *
-     * @return Host address
+     * @return Resolved host address, or a null QHostAddress if hostname can't be resolved
      */
-    const QHostAddress& address   () { return _address; }
-    const QString       host      () { return _address.toString(); }
+    const QHostAddress  address   ();
+
+    /*!
+     * @brief The host name
+     *
+     * @return Stored host name
+     */
+    const QString       host      () { return _hostname; }
 
     /*!
      * @brief Set the host address
@@ -91,7 +97,13 @@ public:
      * @param[in] address Host address
      */
     void setAddress (const QHostAddress& address);
-    void setHost    (const QString host);
+
+    /*!
+     * @brief Set the host name
+     *
+     * @param[in] host Host name
+     */
+    void setHost    (const QString& host);
 
     /// From LinkConfiguration
     LinkType    type            () { return LinkConfiguration::TypeTcp; }
@@ -108,7 +120,7 @@ signals:
     void hostChanged();
 
 private:
-    QHostAddress _address;
+    QString _hostname;
     quint16 _port;
 };
 

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -33,18 +33,27 @@
 #include "QGCConfig.h"
 #include "LinkManager.h"
 
-class UDPCLient {
+class UDPClient {
 public:
-    UDPCLient(const QHostAddress& address_, quint16 port_)
-        : address(address_)
-        , port(port_)
+    UDPClient(const QHostAddress& address_, quint16 port_)
+        : _hostname(address_.toString())
+        , _address(address_)
+        , _port(port_)
     {}
-    UDPCLient(const UDPCLient* other)
-        : address(other->address)
-        , port(other->port)
+    UDPClient(const QString& hostname_, quint16 port_);
+    UDPClient(const UDPClient* other)
+        : _hostname(other->hostname())
+        , _address(other->address())
+        , _port(other->port())
     {}
-    QHostAddress    address;
-    quint16         port;
+    QString         hostname()  const   { return _hostname; };
+    QHostAddress    address()   const   { return _address; };
+    quint16         port()      const   { return _port; };
+
+private:
+    QString         _hostname;
+    QHostAddress    _address;
+    quint16         _port;
 };
 
 class UDPConfiguration : public LinkConfiguration
@@ -116,7 +125,7 @@ public:
      */
     QStringList hostList    () { return _hostList; }
 
-    const QList<UDPCLient*> targetHosts() { return _targetHosts; }
+    const QList<UDPClient*> targetHosts() { return _targetHosts; }
 
     /// From LinkConfiguration
     LinkType    type                 () { return LinkConfiguration::TypeUdp; }
@@ -139,7 +148,7 @@ private:
     void _copyFrom          (LinkConfiguration *source);
 
 private:
-    QList<UDPCLient*>   _targetHosts;
+    QList<UDPClient*>   _targetHosts;
     QStringList         _hostList;      ///< Exposed to QML
     quint16             _localPort;
 };
@@ -189,7 +198,7 @@ private:
     void    _restartConnection      ();
     void    _registerZeroconf       (uint16_t port, const std::string& regType);
     void    _deregisterZeroconf     ();
-    void    _writeDataGram          (const QByteArray data, const UDPCLient* target);
+    void    _writeDataGram          (const QByteArray data, const UDPClient* target);
 
 #if defined(QGC_ZEROCONF_ENABLED)
     DNSServiceRef  _dnssServiceRef;
@@ -199,7 +208,7 @@ private:
     QUdpSocket*             _socket;
     UDPConfiguration*       _udpConfig;
     bool                    _connectState;
-    QList<UDPCLient*>       _sessionTargets;
+    QList<UDPClient*>       _sessionTargets;
     QList<QHostAddress>     _localAddress;
 
 };


### PR DESCRIPTION
**Background**: This mainly concerns drones that are used for indoor flights. We are using QGroundControl to connect to vehicles that are in a local wireless network. The vehicles themselves are equipped with an onboard computer running ROS, with `mavros` serving as, among other things, a MAVLink proxy.

**The problem**: The drones may connect to different networks and may be given different IP addresses. Name resolution inside the network is handled by `avahi`, dropping the requirement to configure the network's DHCP/DNS servers. Thus, a drone with a single hostname may have different IP addresses in different networks, during different runs, etc.

This is not a big problem for ssh, ROS, and other tools, since the drone may be accessed by its hostname, but QGroundControl seems to only store IP addresses and resolve them at link configuration time.

**Proposed solution**: I suggest storing unresolved hostnames for TCP and UDP connections and resolve them at a later time (ideally when the connection is established). This seems to be easier for TCP connections (where address is only used when connection is established), UDP probably requires more thought.

Right now having an unresolvable hostname in a UDP link results in several seconds of blank window upon starting QGroundControl. Changing networks while QGroundControl is running is not handled as well.

Addresses #6866