### PR TITLE
Rework reverse/center throttle support. Fix right stick centering bug.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Note: This file only contains high level features or important fixes.
 ## 4.0.7 - Not yet released
 
 * Fix video page sizing
+* Virtual Joystick: Fix right stick centering. Fix/add support for rover/sub reverse throttle support.
 
 ### 4.0.6 - Stable
 

--- a/src/FlightDisplay/FlightDisplayView.qml
+++ b/src/FlightDisplay/FlightDisplayView.qml
@@ -544,19 +544,17 @@ Item {
             z:                          _mapAndVideo.z + 5
             width:                      parent.width  - (_flightVideoPipControl.width / 2)
             height:                     Math.min(mainWindow.height * 0.25, ScreenTools.defaultFontPixelWidth * 16)
-            visible:                    (_virtualJoystick ? _virtualJoystick.value : false) && !QGroundControl.videoManager.fullScreen && !(activeVehicle ? activeVehicle.highLatencyLink : false)
+            visible:                    _virtualJoystickEnabled && !QGroundControl.videoManager.fullScreen && !(activeVehicle ? activeVehicle.highLatencyLink : false)
             anchors.bottom:             _flightVideoPipControl.top
             anchors.bottomMargin:       ScreenTools.defaultFontPixelHeight * 2
             anchors.horizontalCenter:   flightDisplayViewWidgets.horizontalCenter
             source:                     "qrc:/qml/VirtualJoystick.qml"
-            active:                     (_virtualJoystick ? _virtualJoystick.value : false) && !(activeVehicle ? activeVehicle.highLatencyLink : false)
+            active:                     _virtualJoystickEnabled && !(activeVehicle ? activeVehicle.highLatencyLink : false)
 
-            property bool useLightColors: isBackgroundDark
-            // The default behaviour is not centralized throttle
-            property bool centralizeThrottle: _virtualJoystickCentralized ? _virtualJoystickCentralized.value : false
+            property bool useLightColors:       isBackgroundDark
+            property bool autoCenterThrottle:   QGroundControl.settingsManager.appSettings.virtualJoystickAutoCenterThrottle.rawValue
 
-            property Fact _virtualJoystick: QGroundControl.settingsManager.appSettings.virtualJoystick
-            property Fact _virtualJoystickCentralized: QGroundControl.settingsManager.appSettings.virtualJoystickCentralized
+            property bool _virtualJoystickEnabled: QGroundControl.settingsManager.appSettings.virtualJoystick.rawValue
         }
 
         ToolStrip {

--- a/src/FlightDisplay/FlightDisplayViewWidgets.qml
+++ b/src/FlightDisplay/FlightDisplayViewWidgets.qml
@@ -95,10 +95,6 @@ Item {
         target:         QGroundControl.settingsManager.appSettings.virtualJoystick
         onValueChanged: _setInstrumentWidget()
     }
-    Connections {
-        target:         QGroundControl.settingsManager.appSettings.virtualJoystickCentralized
-        onValueChanged: _setInstrumentWidget()
-    }
 
     Connections {
         target:         QGroundControl.settingsManager.appSettings.showLargeCompass

--- a/src/FlightDisplay/VirtualJoystick.qml
+++ b/src/FlightDisplay/VirtualJoystick.qml
@@ -17,15 +17,19 @@ import QGroundControl.Palette       1.0
 import QGroundControl.Vehicle       1.0
 
 Item {
-    //property bool useLightColors - Must be passed in from loaded
-    //property bool centralizeThrottle - Must be passed in from loaded
+    // The following properties must be passed in from the Loader
+    // property bool useLightColors
+    // property bool autoCenterThrottle - true: throttle will snap back to center when released
+
+    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
     Timer {
         interval:   40  // 25Hz, same as real joystick rate
         running:    QGroundControl.settingsManager.appSettings.virtualJoystick.value && activeVehicle
         repeat:     true
         onTriggered: {
             if (activeVehicle) {
-                activeVehicle.virtualTabletJoystickValue(rightStick.xAxis, rightStick.yAxis, leftStick.xAxis, leftStick.yAxis)
+                activeVehicle.virtualTabletJoystickValue(rightStick.xAxis, -rightStick.yAxis, leftStick.xAxis, leftStick.yAxis)
             }
         }
     }
@@ -38,8 +42,8 @@ Item {
         anchors.bottom:         parent.bottom
         width:                  parent.height
         height:                 parent.height
-        yAxisThrottle:          true
-        yAxisThrottleCentered:  centralizeThrottle
+        yAxisPositiveRangeOnly: _activeVehicle && !_activeVehicle.rover && !_activeVehicle.sub
+        yAxisReCenter:          autoCenterThrottle
         lightColors:            useLightColors
     }
 

--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -7,26 +7,26 @@ import QGroundControl.ScreenTools   1.0
 Item {
     id:             _joyRoot
 
-    property alias  lightColors:    mapPal.lightColors  ///< true: use light colors from QGCMapPalette for drawing
-    property real   xAxis:          0                   ///< Value range [-1,1], negative values left stick, positive values right stick
-    property real   yAxis:          0                   ///< Value range [-1,1], negative values up stick, positive values down stick
-    property bool   yAxisThrottle:  false               ///< true: yAxis used for throttle, range [1,0], positive value are stick up
-    property bool   yAxisThrottleCentered: false        ///< false: center yAxis in throttle for reverser and forward
-    property real   xPositionDelta: 0                   ///< Amount to move the control on x axis
-    property real   yPositionDelta: 0                   ///< Amount to move the control on y axis
-    property bool   springYToCenter:true                ///< true: Spring Y to center on release
+    property alias  lightColors:            mapPal.lightColors  ///< true: use light colors from QGCMapPalette for drawing
+    property real   xAxis:                  0                   ///< Value range [-1,1], negative values left stick, positive values right stick
+    property real   yAxis:                  0                   ///< Value range [-1,1], negative values down stick, positive values up stick
+    property bool   yAxisPositiveRangeOnly: false               ///< true: value range [0,1], false: value range [-1,1]
+    property bool   yAxisReCenter:          true                ///< true: snaps back to center on release, false: stays at current position on release
+    property real   xPositionDelta:         0                   ///< Amount to move the control on x axis
+    property real   yPositionDelta:         0                   ///< Amount to move the control on y axis
 
     property real   _centerXY:              width / 2
     property bool   _processTouchPoints:    false
     property real   stickPositionX:         _centerXY
-    property real   stickPositionY:         yAxisThrottleCentered ? _centerXY : height
+    property real   stickPositionY:         yAxisReCenter ? _centerXY : height
 
     QGCMapPalette { id: mapPal }
 
-    onWidthChanged: calculateXAxis()
-    onStickPositionXChanged: calculateXAxis()
-    onHeightChanged: calculateYAxis()
-    onStickPositionYChanged: calculateYAxis()
+    onWidthChanged:                     calculateXAxis()
+    onStickPositionXChanged:            calculateXAxis()
+    onHeightChanged:                    calculateYAxis()
+    onStickPositionYChanged:            calculateYAxis()
+    onYAxisPositiveRangeOnlyChanged:    calculateYAxis()
 
     function calculateXAxis() {
         if(!_joyRoot.visible) {
@@ -42,13 +42,13 @@ Item {
         if(!_joyRoot.visible) {
             return;
         }
-        var yAxisTemp = stickPositionY / height
-        yAxisTemp *= 2.0
-        yAxisTemp -= 1.0
-        if (yAxisThrottle) {
-            yAxisTemp = ((yAxisTemp * -1.0) / 2.0) + 0.5
+        var fullRange = yAxisPositiveRangeOnly ? 1 : 2
+        var pctUp = 1.0 - (stickPositionY / height)
+        var rangeUp = pctUp * fullRange
+        if (!yAxisPositiveRangeOnly) {
+            rangeUp -= 1
         }
-        yAxis = yAxisTemp
+        yAxis = rangeUp
     }
 
     function reCenter() {
@@ -58,9 +58,9 @@ Item {
         xPositionDelta = 0
         yPositionDelta = 0
 
-        // Center sticks
+        // Re-Center sticks as needed
         stickPositionX = _centerXY
-        if (yAxisThrottleCentered) {
+        if (yAxisReCenter) {
             stickPositionY = _centerXY
         }
     }
@@ -68,7 +68,7 @@ Item {
     function thumbDown(touchPoints) {
         // Position the control around the initial thumb position
         xPositionDelta = touchPoints[0].x - _centerXY
-        if (yAxisThrottle) {
+        if (yAxisPositiveRangeOnly) {
             yPositionDelta = touchPoints[0].y - stickPositionY
         } else {
             yPositionDelta = touchPoints[0].y - _centerXY
@@ -94,7 +94,7 @@ Item {
 
     QGCColoredImage {
         color:                      lightColors ? "white" : "black"
-        visible:                    yAxisThrottle
+        visible:                    yAxisPositiveRangeOnly
         height:                     ScreenTools.defaultFontPixelHeight
         width:                      height
         sourceSize.height:          height
@@ -108,7 +108,7 @@ Item {
 
     QGCColoredImage {
         color:                      lightColors ? "white" : "black"
-        visible:                    yAxisThrottle
+        visible:                    yAxisPositiveRangeOnly
         height:                     ScreenTools.defaultFontPixelHeight
         width:                      height
         sourceSize.height:          height
@@ -122,7 +122,7 @@ Item {
 
     QGCColoredImage {
         color:                      lightColors ? "white" : "black"
-        visible:                    yAxisThrottle
+        visible:                    yAxisPositiveRangeOnly
         height:                     ScreenTools.defaultFontPixelHeight
         width:                      height
         sourceSize.height:          height
@@ -136,7 +136,7 @@ Item {
 
     QGCColoredImage {
         color:                      lightColors ? "white" : "black"
-        visible:                    yAxisThrottle
+        visible:                    yAxisPositiveRangeOnly
         height:                     ScreenTools.defaultFontPixelHeight
         width:                      height
         sourceSize.height:          height
@@ -200,9 +200,6 @@ Item {
         maximumTouchPoints: 1
         touchPoints:        [ TouchPoint { id: touchPoint } ]
         onPressed:          _joyRoot.thumbDown(touchPoints)
-        onReleased: {
-            if(springYToCenter)
-                _joyRoot.reCenter()
-        }
+        onReleased:         _joyRoot.reCenter()
     }
 }

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -111,9 +111,9 @@
     "defaultValue":     false
 },
 {
-    "name":             "virtualJoystickCentralized",
-    "shortDescription": "Set virtual joystick to be centralize throttle (spring-loaded).",
-    "longDescription":  "If this option is enabled the virtual joystick throttle stick will be centralized.",
+    "name":             "virtualJoystickAutoCenterThrottle",
+    "shortDescription": "Auto-Center Throttle",
+    "longDescription":  "If enabled the throttle stick will snap back to center when released.",
     "type":             "bool",
     "defaultValue":     false
 },

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -39,6 +39,15 @@ DECLARE_SETTINGGROUP(App, "")
     qmlRegisterUncreatableType<AppSettings>("QGroundControl.SettingsManager", 1, 0, "AppSettings", "Reference only");
     QGCPalette::setGlobalTheme(indoorPalette()->rawValue().toBool() ? QGCPalette::Dark : QGCPalette::Light);
 
+    // virtualJoystickCentralized -> virtualJoystickAutoCenterThrottle
+    QSettings settings;
+    settings.beginGroup(_settingsGroup);
+    QString deprecatedVirtualJoystickCentralizedKey("virtualJoystickCentralized");
+    if (settings.contains(deprecatedVirtualJoystickCentralizedKey)) {
+        settings.setValue(virtualJoystickAutoCenterThrottleName, settings.value(deprecatedVirtualJoystickCentralizedKey));
+        settings.remove(deprecatedVirtualJoystickCentralizedKey);
+    }
+
     // Instantiate savePath so we can check for override and setup default path if needed
 
     SettingsFact* savePathFact = qobject_cast<SettingsFact*>(savePath());
@@ -85,7 +94,7 @@ DECLARE_SETTINGSFACT(AppSettings, telemetrySaveNotArmed)
 DECLARE_SETTINGSFACT(AppSettings, audioMuted)
 DECLARE_SETTINGSFACT(AppSettings, checkInternet)
 DECLARE_SETTINGSFACT(AppSettings, virtualJoystick)
-DECLARE_SETTINGSFACT(AppSettings, virtualJoystickCentralized)
+DECLARE_SETTINGSFACT(AppSettings, virtualJoystickAutoCenterThrottle)
 DECLARE_SETTINGSFACT(AppSettings, appFontPointSize)
 DECLARE_SETTINGSFACT(AppSettings, showLargeCompass)
 DECLARE_SETTINGSFACT(AppSettings, savePath)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -39,7 +39,7 @@ public:
     DEFINE_SETTINGFACT(audioMuted)
     DEFINE_SETTINGFACT(checkInternet)
     DEFINE_SETTINGFACT(virtualJoystick)
-    DEFINE_SETTINGFACT(virtualJoystickCentralized)
+    DEFINE_SETTINGFACT(virtualJoystickAutoCenterThrottle)
     DEFINE_SETTINGFACT(appFontPointSize)
     DEFINE_SETTINGFACT(indoorPalette)
     DEFINE_SETTINGFACT(showLargeCompass)

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -30,11 +30,14 @@ Rectangle {
     anchors.fill:       parent
     anchors.margins:    ScreenTools.defaultFontPixelWidth
 
-    property Fact _percentRemainingAnnounce:    QGroundControl.settingsManager.appSettings.batteryPercentRemainingAnnounce
-    property Fact _savePath:                    QGroundControl.settingsManager.appSettings.savePath
-    property Fact _appFontPointSize:            QGroundControl.settingsManager.appSettings.appFontPointSize
-    property Fact _userBrandImageIndoor:        QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoor
-    property Fact _userBrandImageOutdoor:       QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoor
+    property Fact _percentRemainingAnnounce:            QGroundControl.settingsManager.appSettings.batteryPercentRemainingAnnounce
+    property Fact _savePath:                            QGroundControl.settingsManager.appSettings.savePath
+    property Fact _appFontPointSize:                    QGroundControl.settingsManager.appSettings.appFontPointSize
+    property Fact _userBrandImageIndoor:                QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoor
+    property Fact _userBrandImageOutdoor:               QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoor
+    property Fact _virtualJoystick:                     QGroundControl.settingsManager.appSettings.virtualJoystick
+    property Fact _virtualJoystickAutoCenterThrottle:   QGroundControl.settingsManager.appSettings.virtualJoystickAutoCenterThrottle
+
     property real _labelWidth:                  ScreenTools.defaultFontPixelWidth * 20
     property real _comboFieldWidth:             ScreenTools.defaultFontPixelWidth * 30
     property real _valueFieldWidth:             ScreenTools.defaultFontPixelWidth * 10
@@ -512,22 +515,23 @@ Rectangle {
                                 property Fact _showLogReplayStatusBar: QGroundControl.settingsManager.flyViewSettings.showLogReplayStatusBar
                             }
 
-                            FactCheckBox {
-                                text:       qsTr("Virtual Joystick")
-                                visible:    _virtualJoystick.visible
-                                fact:       _virtualJoystick
+                            RowLayout {
+                                spacing: ScreenTools.defaultFontPixelWidth
 
-                                property Fact _virtualJoystick: QGroundControl.settingsManager.appSettings.virtualJoystick
+                                FactCheckBox {
+                                    text:       qsTr("Virtual Joystick")
+                                    visible:    _virtualJoystick.visible
+                                    fact:       _virtualJoystick
+                                }
+
+                                FactCheckBox {
+                                    text:       qsTr("Auto-Center Throttle")
+                                    visible:    _virtualJoystickAutoCenterThrottle.visible
+                                    enabled:    _virtualJoystick.rawValue
+                                    fact:       _virtualJoystickAutoCenterThrottle
+                                }
                             }
 
-                            FactCheckBox {
-                                text:       qsTr("Auto-Center throttle")
-                                visible:    _virtualJoystickCentralized.visible && activeVehicle && (activeVehicle.sub || activeVehicle.rover)
-                                fact:       _virtualJoystickCentralized
-                                Layout.leftMargin: _margins
-
-                                property Fact _virtualJoystickCentralized: QGroundControl.settingsManager.appSettings.virtualJoystickCentralized
-                            }
                             FactCheckBox {
                                 text:       qsTr("Use Vertical Instrument Panel")
                                 visible:    _alternateInstrumentPanel.visible


### PR DESCRIPTION
* Fix for #8774. Related to #7375
* Fixes right stick auto-center
* Adds reverse support for rover/sub which sends correct negative thrust values for reverse
* Fixes throttle auto-center with respect to reverse as well