### PR TITLE
Deploy custom start script for custom build

### DIFF
--- a/QGCSetup.pri
+++ b/QGCSetup.pri
@@ -90,7 +90,7 @@ LinuxBuild {
     QMAKE_POST_LINK += && mkdir -p $$DESTDIR/Qt/libs && mkdir -p $$DESTDIR/Qt/plugins
 
     # QT_INSTALL_LIBS
-    QT_LIB_LIST = \
+    QT_LIB_LIST += \
         libQt5Charts.so.5 \
         libQt5Core.so.5 \
         libQt5DBus.so.5 \
@@ -160,7 +160,11 @@ LinuxBuild {
     }
 
     # QGroundControl start script
-    QMAKE_POST_LINK += && $$QMAKE_COPY $$BASEDIR/deploy/qgroundcontrol-start.sh $$DESTDIR
-    QMAKE_POST_LINK += && $$QMAKE_COPY $$BASEDIR/deploy/qgroundcontrol.desktop $$DESTDIR
-    QMAKE_POST_LINK += && $$QMAKE_COPY $$BASEDIR/resources/icons/qgroundcontrol.png $$DESTDIR
+    contains (CONFIG, QGC_DISABLE_CUSTOM_BUILD) | !exists($$PWD/custom/custom.pri) {
+        QMAKE_POST_LINK += && $$QMAKE_COPY $$BASEDIR/deploy/qgroundcontrol-start.sh $$DESTDIR
+        QMAKE_POST_LINK += && $$QMAKE_COPY $$BASEDIR/deploy/qgroundcontrol.desktop $$DESTDIR
+        QMAKE_POST_LINK += && $$QMAKE_COPY $$BASEDIR/resources/icons/qgroundcontrol.png $$DESTDIR
+    } else {
+        include($$PWD/custom/custom_deploy.pri)
+    }
 }

--- a/custom-example/custom.pri
+++ b/custom-example/custom.pri
@@ -55,6 +55,14 @@ RESOURCES += \
 QML_IMPORT_PATH += \
    $$PWD/res
 
+LinuxBuild {
+
+    # Our QT_INSTALL_LIBS
+    QT_LIB_LIST += \
+        libQt5VirtualKeyboard.so.5 \
+
+}
+
 # Our own, custom sources
 SOURCES += \
     $$PWD/src/CustomPlugin.cc \

--- a/custom-example/custom_deploy.pri
+++ b/custom-example/custom_deploy.pri
@@ -1,0 +1,3 @@
+QMAKE_POST_LINK += && $$QMAKE_COPY $$PWD/deploy/qgroundcontrol-start.sh $$DESTDIR
+QMAKE_POST_LINK += && $$QMAKE_COPY $$PWD/deploy/qgroundcontrol.desktop $$DESTDIR
+QMAKE_POST_LINK += && $$QMAKE_COPY $$PWD/res/Images/CustomAppIcon.png $$DESTDIR

--- a/custom-example/deploy/qgroundcontrol-start.sh
+++ b/custom-example/deploy/qgroundcontrol-start.sh
@@ -3,8 +3,9 @@ HERE="$(dirname "$(readlink -f "${0}")")"
 export LD_LIBRARY_PATH="${HERE}/usr/lib/x86_64-linux-gnu":"${HERE}/Qt/libs":$LD_LIBRARY_PATH
 export QML2_IMPORT_PATH="${HERE}/Qt/qml"
 export QT_PLUGIN_PATH="${HERE}/Qt/plugins"
+export QT_IM_MODULE=qtvirtualkeyboard
 
 # hack until icon issue with AppImage is resolved
 mkdir -p ~/.icons && \cp -f ${HERE}/qgroundcontrol.png ~/.icons
 
-"${HERE}/CustomQGC" "$@"
+"${HERE}/CustomQGroundControl" "$@"

--- a/custom-example/deploy/qgroundcontrol.desktop
+++ b/custom-example/deploy/qgroundcontrol.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=CustomQGroundControl
+GenericName=Ground Control Station
+Comment=UAS ground control station
+Icon=CustomAppIcon
+Exec=qgroundcontrol-start.sh
+Terminal=false
+Categories=Utility;


### PR DESCRIPTION
2 fixes proposed for custom build:

- [x] Deploy custom start script for custom build
- [x] Add custom `QT_LIB_LIST` in custom build (prevent its overwriting in `QGCSetup.pri`)
