### PR TITLE
Mobile Log Replay: Fix file dialog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Note: This file only contains high level features or important fixes.
 ## 4.0.8 - Not yet released
 
 * iOS: Modify QGC file storage location to support new Files app
+* Mobile: Fix Log Replay status bar file selection
 
 ## 4.0.7 - Stable
 

--- a/src/QmlControls/LogReplayStatusBar.qml
+++ b/src/QmlControls/LogReplayStatusBar.qml
@@ -28,13 +28,16 @@ Rectangle {
     QGCFileDialog {
         id:                 filePicker
         title:              qsTr("Select Telemetery Log")
-        nameFilters:        [qsTr("Telemetry Logs (*.%1)").arg(QGroundControl.settingsManager.appSettings.telemetryFileExtension), qsTr("All Files (*)")]
+        nameFilters:        [qsTr("Telemetry Logs (*.%1)").arg(_logFileExtension), qsTr("All Files (*)")]
+        fileExtension:      _logFileExtension
         selectExisting:     true
         folder:             QGroundControl.settingsManager.appSettings.telemetrySavePath
         onAcceptedForLoad: {
             controller.link = QGroundControl.linkManager.startLogReplay(file)
             close()
         }
+
+        property string _logFileExtension: QGroundControl.settingsManager.appSettings.telemetryFileExtension
     }
 
     LogReplayLinkController {

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -39,8 +39,8 @@ CheckBox {
             implicitHeight: implicitWidth
             Rectangle {
                 anchors.fill:   parent
-                color:          control.enabled ? "white" : "gray"
-                border.color:   qgcPal.text
+                color:          control.enabled ? "white" : _qgcPal.text
+                border.color:   _qgcPal.text
                 border.width:   1
                 opacity:        control.checkedState === Qt.PartiallyChecked ? 0.5 : 1
                 QGCColoredImage {


### PR DESCRIPTION
Wasn't showing the list of telemetry files even though they were there in the file system