### PR TITLE
Rework handling of fw/vehicle type with respect to conflicts with actual vehicle

### DIFF
--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -33,9 +33,10 @@ Item {
     id: _root
 
     PlanMasterController {
-        id: _planController
+        id:         _planController
+        flyView:    true
         Component.onCompleted: {
-            start(true /* flyView */)
+            start()
             mainWindow.planMasterControllerFlyView = _planController
         }
     }

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -167,6 +167,16 @@ public:
     ///     @param sequenceNumber - index for new item, -1 to clear current item
     Q_INVOKABLE void setCurrentPlanViewSeqNum(int sequenceNumber, bool force);
 
+    enum SendToVehiclePreCheckState {
+        SendToVehiclePreCheckStateOk,                       // Ok to send plan to vehicle
+        SendToVehiclePreCheckStateNoActiveVehicle,          // There is no active vehicle
+        SendToVehiclePreCheckStateFirwmareVehicleMismatch,  // Firmware/Vehicle type for plan mismatch with actual vehicle
+        SendToVehiclePreCheckStateActiveMission,            // Vehicle is currently flying a mission
+    };
+    Q_ENUM(SendToVehiclePreCheckState)
+
+    Q_INVOKABLE SendToVehiclePreCheckState sendToVehiclePreCheck(void);
+
     /// Determines if the mission has all data needed to be saved or sent to the vehicle.
     /// IMPORTANT NOTE: The return value is a VisualMissionItem::ReadForSaveState value. It is an int here to work around
     /// a nightmare of circular header dependency problems.
@@ -328,6 +338,8 @@ private:
     bool                    _isROIBeginItem                     (SimpleMissionItem* simpleItem);
     bool                    _isROICancelItem                    (SimpleMissionItem* simpleItem);
     FlightPathSegment*      _createFlightPathSegmentWorker      (VisualItemPair& pair);
+    void                    _allItemsRemoved                    (void);
+    void                    _firstItemAdded                     (void);
 
     static double           _calcDistanceToHome                 (VisualMissionItem* currentItem, VisualMissionItem* homeItem);
     static double           _normalizeLat                       (double lat);

--- a/src/MissionManager/MissionControllerTest.cc
+++ b/src/MissionManager/MissionControllerTest.cc
@@ -52,13 +52,14 @@ void MissionControllerTest::_initForFirmwareType(MAV_AUTOPILOT firmwareType)
     // Master controller pulls offline vehicle info from settings
     qgcApp()->toolbox()->settingsManager()->appSettings()->offlineEditingFirmwareType()->setRawValue(firmwareType);
     _masterController = new PlanMasterController(this);
+    _masterController->setFlyView(false);
     _missionController = _masterController->missionController();
 
     _multiSpyMissionController = new MultiSignalSpy();
     Q_CHECK_PTR(_multiSpyMissionController);
     QCOMPARE(_multiSpyMissionController->init(_missionController, _rgMissionControllerSignals, _cMissionControllerSignals), true);
 
-    _masterController->start(false /* flyView */);
+    _masterController->start();
 
     // All signals should some through on start
     QCOMPARE(_multiSpyMissionController->checkOnlySignalsByMask(visualItemsChangedSignalMask), true);

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -39,11 +39,7 @@ const char* PlanMasterController::kJsonRallyPointsObjectKey =   "rallyPoints";
 PlanMasterController::PlanMasterController(QObject* parent)
     : QObject               (parent)
     , _multiVehicleMgr      (qgcApp()->toolbox()->multiVehicleManager())
-    , _controllerVehicle    (new Vehicle(
-                                 static_cast<MAV_AUTOPILOT>(qgcApp()->toolbox()->settingsManager()->appSettings()->offlineEditingFirmwareType()->rawValue().toInt()),
-                                 static_cast<MAV_TYPE>(qgcApp()->toolbox()->settingsManager()->appSettings()->offlineEditingVehicleType()->rawValue().toInt()),
-                                 qgcApp()->toolbox()->firmwarePluginManager(),
-                                 this))
+    , _controllerVehicle    (new Vehicle(Vehicle::MAV_AUTOPILOT_TRACK, Vehicle::MAV_TYPE_TRACK, qgcApp()->toolbox()->firmwarePluginManager(), this))
     , _managerVehicle       (_controllerVehicle)
     , _missionController    (this)
     , _geoFenceController   (this)
@@ -94,12 +90,11 @@ PlanMasterController::~PlanMasterController()
 
 }
 
-void PlanMasterController::start(bool flyView)
+void PlanMasterController::start(void)
 {
-    _flyView = flyView;
-    _missionController.start(_flyView);
-    _geoFenceController.start(_flyView);
-    _rallyPointController.start(_flyView);
+    _missionController.start    (_flyView);
+    _geoFenceController.start   (_flyView);
+    _rallyPointController.start (_flyView);
 
     _activeVehicleChanged(_multiVehicleMgr->activeVehicle());
     connect(_multiVehicleMgr, &MultiVehicleManager::activeVehicleChanged, this, &PlanMasterController::_activeVehicleChanged);

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -35,6 +35,7 @@ public:
 
     ~PlanMasterController();
 
+    Q_PROPERTY(bool                     flyView                 MEMBER _flyView)
     Q_PROPERTY(Vehicle*                 controllerVehicle       READ controllerVehicle                      CONSTANT)                       ///< Offline controller vehicle
     Q_PROPERTY(Vehicle*                 managerVehicle          READ managerVehicle                         NOTIFY managerVehicleChanged)   ///< Either active vehicle or _controllerVehicle if no active vehicle
     Q_PROPERTY(MissionController*       missionController       READ missionController                      CONSTANT)
@@ -53,7 +54,7 @@ public:
     Q_PROPERTY(bool                     supportsTerrain         READ supportsTerrain                        NOTIFY supportsTerrainChanged)
 
     /// Should be called immediately upon Component.onCompleted.
-    Q_INVOKABLE void start(bool flyView);
+    Q_INVOKABLE void start(void);
 
     /// Starts the controller using a single static active vehicle. Will not track global active vehicle changes.
     ///     @param deleteWhenSendCmplete The PlanMasterController object should be deleted after the first send is completed.
@@ -94,6 +95,8 @@ public:
     QStringList saveNameFilters (void) const;
     bool        isEmpty         (void) const;
     bool        supportsTerrain (void) const { return _supportsTerrain; }
+
+    void        setFlyView(bool flyView) { _flyView = flyView; }
 
     QJsonDocument saveToJson    ();
 

--- a/src/MissionManager/PlanMasterControllerTest.cc
+++ b/src/MissionManager/PlanMasterControllerTest.cc
@@ -27,7 +27,8 @@ void PlanMasterControllerTest::init(void)
     UnitTest::init();
 
     _masterController = new PlanMasterController(this);
-    _masterController->start(false /* flyView */);
+    _masterController->setFlyView(false);
+    _masterController->start();
 }
 
 void PlanMasterControllerTest::cleanup(void)

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -22,12 +22,11 @@ Rectangle {
 
     property var    _masterControler:               masterController
     property var    _missionController:             _masterControler.missionController
-    property var    _missionVehicle:                _masterControler.controllerVehicle
-    property bool   _vehicleHasHomePosition:        _missionVehicle.homePosition.isValid
-    property bool   _offlineEditing:                _missionVehicle.isOfflineEditingVehicle
-    property bool   _enableOfflineVehicleCombos:    _offlineEditing && _noMissionItemsAdded
-    property bool   _showCruiseSpeed:               !_missionVehicle.multiRotor
-    property bool   _showHoverSpeed:                _missionVehicle.multiRotor || _missionVehicle.vtol
+    property var    _controllerVehicle:             _masterControler.controllerVehicle
+    property bool   _vehicleHasHomePosition:        _controllerVehicle.homePosition.isValid
+    property bool   _enableOfflineVehicleCombos:    _noMissionItemsAdded
+    property bool   _showCruiseSpeed:               !_controllerVehicle.multiRotor
+    property bool   _showHoverSpeed:                _controllerVehicle.multiRotor || _controllerVehicle.vtol
     property bool   _multipleFirmware:              QGroundControl.supportedFirmwareCount > 2
     property bool   _multipleVehicleTypes:          QGroundControl.supportedVehicleCount > 1
     property real   _fieldWidth:                    ScreenTools.defaultFontPixelWidth * 16
@@ -36,9 +35,9 @@ Rectangle {
     property var    _fileExtension:                 QGroundControl.settingsManager.appSettings.missionFileExtension
     property var    _appSettings:                   QGroundControl.settingsManager.appSettings
     property bool   _waypointsOnlyMode:             QGroundControl.corePlugin.options.missionWaypointsOnly
-    property bool   _showCameraSection:             (_waypointsOnlyMode || QGroundControl.corePlugin.showAdvancedUI) && !_missionVehicle.apmFirmware
+    property bool   _showCameraSection:             (_waypointsOnlyMode || QGroundControl.corePlugin.showAdvancedUI) && !_controllerVehicle.apmFirmware
     property bool   _simpleMissionStart:            QGroundControl.corePlugin.options.showSimpleMissionStart
-    property bool   _showFlightSpeed:               !_missionVehicle.vtol && !_simpleMissionStart && !_missionVehicle.apmFirmware
+    property bool   _showFlightSpeed:               !_controllerVehicle.vtol && !_simpleMissionStart && !_controllerVehicle.apmFirmware
 
     readonly property string _firmwareLabel:    qsTr("Firmware")
     readonly property string _vehicleLabel:     qsTr("Vehicle")
@@ -112,7 +111,7 @@ Rectangle {
                 anchors.left:   parent.left
                 anchors.right:  parent.right
                 text:           qsTr("Vehicle Info")
-                visible:        _offlineEditing && !_waypointsOnlyMode
+                visible:        !_waypointsOnlyMode
                 checked:        false
             }
 
@@ -133,8 +132,11 @@ Rectangle {
                     fact:                   QGroundControl.settingsManager.appSettings.offlineEditingFirmwareType
                     indexModel:             false
                     Layout.preferredWidth:  _fieldWidth
-                    visible:                _multipleFirmware
-                    enabled:                _enableOfflineVehicleCombos
+                    visible:                _multipleFirmware && _enableOfflineVehicleCombos
+                }
+                QGCLabel {
+                    text:       _controllerVehicle.firmwareTypeString
+                    visible:    _multipleFirmware && !_enableOfflineVehicleCombos
                 }
 
                 QGCLabel {
@@ -146,8 +148,11 @@ Rectangle {
                     fact:                   QGroundControl.settingsManager.appSettings.offlineEditingVehicleType
                     indexModel:             false
                     Layout.preferredWidth:  _fieldWidth
-                    visible:                _multipleVehicleTypes
-                    enabled:                _enableOfflineVehicleCombos
+                    visible:                _multipleVehicleTypes && _enableOfflineVehicleCombos
+                }
+                QGCLabel {
+                    text:       _controllerVehicle.vehicleTypeString
+                    visible:    _multipleVehicleTypes && !_enableOfflineVehicleCombos
                 }
 
                 QGCLabel {

--- a/src/QmlControls/QGCViewDialog.qml
+++ b/src/QmlControls/QGCViewDialog.qml
@@ -43,5 +43,4 @@ Item {
             hideDialog()
         }
     }
-
 }

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -64,11 +64,7 @@ void MultiVehicleManager::setToolbox(QGCToolbox *toolbox)
 
     connect(_mavlinkProtocol, &MAVLinkProtocol::vehicleHeartbeatInfo, this, &MultiVehicleManager::_vehicleHeartbeatInfo);
 
-    SettingsManager* settingsManager = toolbox->settingsManager();
-    _offlineEditingVehicle = new Vehicle(static_cast<MAV_AUTOPILOT>(settingsManager->appSettings()->offlineEditingFirmwareType()->rawValue().toInt()),
-                                         static_cast<MAV_TYPE>(settingsManager->appSettings()->offlineEditingVehicleType()->rawValue().toInt()),
-                                         _firmwarePluginManager,
-                                         this);
+    _offlineEditingVehicle = new Vehicle(Vehicle::MAV_AUTOPILOT_TRACK, Vehicle::MAV_TYPE_TRACK, _firmwarePluginManager, this);
 }
 
 void MultiVehicleManager::_vehicleHeartbeatInfo(LinkInterface* link, int vehicleId, int componentId, int vehicleFirmwareType, int vehicleType)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -430,16 +430,29 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
 {
     _commonInit();
 
-    // Offline editing vehicle tracks settings changes for offline editing settings
-    connect(_settingsManager->appSettings()->offlineEditingFirmwareType(),  &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
-    connect(_settingsManager->appSettings()->offlineEditingVehicleType(),   &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
+    if (_firmwareType == MAV_AUTOPILOT_TRACK) {
+        trackFirmwareVehicleTypeChanges();
+    }
     connect(_settingsManager->appSettings()->offlineEditingCruiseSpeed(),   &Fact::rawValueChanged, this, &Vehicle::_offlineCruiseSpeedSettingChanged);
     connect(_settingsManager->appSettings()->offlineEditingHoverSpeed(),    &Fact::rawValueChanged, this, &Vehicle::_offlineHoverSpeedSettingChanged);
 
-    // This add correct terrain capability bit
-    _offlineFirmwareTypeSettingChanged(_firmwareType);
-
+    _offlineFirmwareTypeSettingChanged(_firmwareType);  // This adds correct terrain capability bit
     _firmwarePlugin->initializeVehicle(this);
+}
+
+void Vehicle::trackFirmwareVehicleTypeChanges(void)
+{
+    connect(_settingsManager->appSettings()->offlineEditingFirmwareType(),  &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
+    connect(_settingsManager->appSettings()->offlineEditingVehicleType(),   &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
+
+    _offlineFirmwareTypeSettingChanged(_settingsManager->appSettings()->offlineEditingFirmwareType()->rawValue());
+    _offlineVehicleTypeSettingChanged(_settingsManager->appSettings()->offlineEditingVehicleType()->rawValue());
+}
+
+void Vehicle::stopTrackingFirmwareVehicleTypeChanges(void)
+{
+    disconnect(_settingsManager->appSettings()->offlineEditingFirmwareType(),  &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
+    disconnect(_settingsManager->appSettings()->offlineEditingVehicleType(),   &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
 }
 
 void Vehicle::_commonInit()

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -487,6 +487,10 @@ public:
             FirmwarePluginManager*  firmwarePluginManager,
             JoystickManager*        joystickManager);
 
+    // Pass these into the offline constructor to create an offline vehicle which tracks the offline vehicle settings
+    static const MAV_AUTOPILOT    MAV_AUTOPILOT_TRACK = static_cast<MAV_AUTOPILOT>(-1);
+    static const MAV_TYPE         MAV_TYPE_TRACK = static_cast<MAV_TYPE>(-1);
+
     // The following is used to create a disconnected Vehicle for use while offline editing.
     Vehicle(MAV_AUTOPILOT           firmwareType,
             MAV_TYPE                vehicleType,
@@ -907,6 +911,10 @@ public:
     ///     @param sendMultiple Send multiple time to guarantee Vehicle reception
     void requestDataStream(MAV_DATA_STREAM stream, uint16_t rate, bool sendMultiple = true);
 
+    // The follow method are used to turn on/off the tracking of settings updates for firmware/vehicle type on offline vehicles.
+    void trackFirmwareVehicleTypeChanges(void);
+    void stopTrackingFirmwareVehicleTypeChanges(void);
+
     typedef enum {
         MessageNone,
         MessageNormal,
@@ -1130,7 +1138,9 @@ public:
     void        setCheckListState       (CheckList cl)  { _checkListState = cl; emit checkListStateChanged(); }
 
 public slots:
-    void setVtolInFwdFlight             (bool vtolInFwdFlight);
+    void setVtolInFwdFlight                 (bool vtolInFwdFlight);
+    void _offlineFirmwareTypeSettingChanged (QVariant value);       // Should only be used by MissionControler to set firmware from Plan file
+    void _offlineVehicleTypeSettingChanged  (QVariant value);       // Should only be used by MissionController to set vehicle type from Plan file
 
 signals:
     void allLinksInactive               (Vehicle* vehicle);
@@ -1254,8 +1264,6 @@ private slots:
     void _remoteControlRSSIChanged      (uint8_t rssi);
     void _handleFlightModeChanged       (const QString& flightMode);
     void _announceArmedChanged          (bool armed);
-    void _offlineFirmwareTypeSettingChanged(QVariant value);
-    void _offlineVehicleTypeSettingChanged(QVariant value);
     void _offlineCruiseSpeedSettingChanged(QVariant value);
     void _offlineHoverSpeedSettingChanged(QVariant value);
     void _updateHighLatencyLink         (bool sendCommand = true);


### PR DESCRIPTION
Problem: 
* A Plan in QGC is targeted to a specific firmware/vehicle type due to differences in command support/implementations.
* Things can get out of sync with respect to what the Plan file was created for and the vehicle it is being uploaded to

Fixes:
* Warn the user if they are uploading a plan created for a different firmware/vehicle type combination
* Fix all the bug related to fw/vehicle type associated with a Plan and then a vehicle showing up on the fly with different types

Related to #8819

