### PR TITLE
Remove missing support for QGCView fact missing overlays

### DIFF
--- a/src/FactSystem/FactControls/FactPanelController.cc
+++ b/src/FactSystem/FactControls/FactPanelController.cc
@@ -35,30 +35,6 @@ FactPanelController::FactPanelController()
     connect(&_missingParametersTimer, &QTimer::timeout, this, &FactPanelController::_checkForMissingParameters);
 }
 
-void FactPanelController::_notifyPanelMissingParameter(const QString& missingParam)
-{
-    if (qgcApp()->mainRootWindow()) {
-        QVariant returnedValue;
-        QMetaObject::invokeMethod(
-            qgcApp()->mainRootWindow(),
-            "showMissingParameterOverlay",
-            Q_RETURN_ARG(QVariant, returnedValue),
-            Q_ARG(QVariant, missingParam));
-    }
-}
-
-void FactPanelController::_notifyPanelErrorMsg(const QString& errorMsg)
-{
-    if(qgcApp()->mainRootWindow()) {
-        QVariant returnedValue;
-        QMetaObject::invokeMethod(
-            qgcApp()->mainRootWindow(),
-            "showFactError",
-            Q_RETURN_ARG(QVariant, returnedValue),
-            Q_ARG(QVariant, errorMsg));
-    }
-}
-
 void FactPanelController::_reportMissingParameter(int componentId, const QString& name)
 {
     if (componentId == FactSystem::defaultComponentId) {
@@ -66,20 +42,7 @@ void FactPanelController::_reportMissingParameter(int componentId, const QString
     }
 
     qgcApp()->reportMissingParameter(componentId, name);
-
-    QString missingParam = QString("%1:%2").arg(componentId).arg(name);
-
-    qCWarning(FactPanelControllerLog) << "Missing parameter:" << missingParam;
-
-    // If missing parameters a reported from the constructor of a derived class we
-    // will not have access to _factPanel yet. Just record list of missing facts
-    // in that case instead of notify. Once _factPanel is available they will be
-    // send out for real.
-    if (qgcApp()->mainRootWindow()) {
-        _notifyPanelMissingParameter(missingParam);
-    } else {
-        _delayedMissingParams += missingParam;
-    }
+    qCWarning(FactPanelControllerLog) << "Missing parameter:" << QString("%1:%2").arg(componentId).arg(name);
 }
 
 bool FactPanelController::_allParametersExists(int componentId, QStringList names)
@@ -114,13 +77,6 @@ Fact* FactPanelController::getParameterFact(int componentId, const QString& name
 bool FactPanelController::parameterExists(int componentId, const QString& name)
 {
     return _vehicle ? _vehicle->parameterManager()->parameterExists(componentId, name) : false;
-}
-
-void FactPanelController::_showInternalError(const QString& errorMsg)
-{
-    _notifyPanelErrorMsg(tr("Internal Error: %1").arg(errorMsg));
-    qCWarning(FactPanelControllerLog) << "Internal Error" << errorMsg;
-    qgcApp()->showAppMessage(errorMsg);
 }
 
 void FactPanelController::getMissingParameters(QStringList rgNames)

--- a/src/FactSystem/FactControls/FactPanelController.h
+++ b/src/FactSystem/FactControls/FactPanelController.h
@@ -57,11 +57,6 @@ private slots:
     void _checkForMissingParameters(void);
 
 private:
-    void _notifyPanelMissingParameter(const QString& missingParam);
-    void _notifyPanelErrorMsg(const QString& errorMsg);
-    void _showInternalError(const QString& errorMsg);
-
-    QStringList _delayedMissingParams;
     QStringList _missingParameterWaitList;
     QTimer      _missingParametersTimer;
 };

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -532,14 +532,6 @@ ApplicationWindow {
         }
     }
 
-    function showMissingParameterOverlay(missingParamName) {
-        showError(qsTr("Parameters missing: %1").arg(missingParamName))
-    }
-
-    function showFactError(errorMsg) {
-        showError(qsTr("Fact error: %1").arg(errorMsg))
-    }
-
     Popup {
         id:                 systemMessageArea
         y:                  ScreenTools.defaultFontPixelHeight


### PR DESCRIPTION
With the change to full QML QGCView support was removed. That had support to show an overlay over the window which listed missing parameters. But the code to put this support back was only half fixed up. So it no longer worked. Instead of making it work again I removed the support from the overlay display completely. The users still gets message popups about missing parameters which is good enough.