### PR TITLE
Fix location of Qt.inputMethod.hide()

### DIFF
--- a/src/QmlControls/QGCViewDialog.qml
+++ b/src/QmlControls/QGCViewDialog.qml
@@ -32,14 +32,12 @@ Item {
 
     function accept() {
         if (acceptAllowed) {
-            Qt.inputMethod.hide()
             hideDialog()
         }
     }
 
     function reject() {
         if (rejectAllowed) {
-            Qt.inputMethod.hide()
             hideDialog()
         }
     }

--- a/src/QmlControls/QGCViewDialogContainer.qml
+++ b/src/QmlControls/QGCViewDialogContainer.qml
@@ -86,6 +86,7 @@ Item {
     Connections {
         target: _dialogComponentLoader.item
         onHideDialog: {
+            Qt.inputMethod.hide()
             mainWindowDialog.close()
         }
     }


### PR DESCRIPTION
If a consumer created there on accept/reject functions which is common it would not be called