### PR TITLE
Remove altitude mode warning dialog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ Note: This file only contains high level features or important fixes.
 
 ## 4.0.9 - Not yet released
 
+* Fix bug which could prevent view switching from working after altitude mode warning dialog would pop up
+
 ## 4.0.8 - Stable
 
 * iOS: Modify QGC file storage location to support new Files app

--- a/src/FactSystem/FactControls/AltitudeFactTextField.qml
+++ b/src/FactSystem/FactControls/AltitudeFactTextField.qml
@@ -29,8 +29,7 @@ FactTextField {
     readonly property string _altModeAboveTerrainExtraUnits:    qsTr("(Abv Terr)")
     readonly property string _altModeTerrainFrameExtraUnits:    qsTr("(TerrF)")
 
-    property string _altitudeModeExtraUnits:    _altModeNoneExtraUnits
-    property Fact   _aboveTerrainWarning:       QGroundControl.settingsManager.planViewSettings.aboveTerrainWarning
+    property string _altitudeModeExtraUnits: _altModeNoneExtraUnits
 
     onAltitudeModeChanged: updateAltitudeModeExtraUnits()
 
@@ -44,36 +43,11 @@ FactTextField {
             _altitudeModeExtraUnits = _altModeAbsoluteExtraUnits
         } else if (altitudeMode === QGroundControl.AltitudeModeAboveTerrain) {
             _altitudeModeExtraUnits = _altModeAboveTerrainExtraUnits
-            if (!_aboveTerrainWarning.rawValue) {
-                mainWindow.showComponentDialog(aboveTerrainWarning, qsTr("Warning"), mainWindow.showDialogDefaultWidth, StandardButton.Ok)
-            }
         } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame) {
             _altitudeModeExtraUnits = _altModeTerrainFrameExtraUnits
         } else {
             console.log("AltitudeFactTextField Internal error: Unknown altitudeMode", altitudeMode)
             _altitudeModeExtraUnits = ""
-        }
-    }
-
-    Component {
-        id: aboveTerrainWarning
-        QGCViewDialog {
-            ColumnLayout {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                spacing:        ScreenTools.defaultFontPixelHeight
-
-                QGCLabel {
-                    Layout.fillWidth:   true
-                    wrapMode:           Text.WordWrap
-                    text:               qsTr("'Above Terrain' will set an absolute altitude for the item based on the terrain height at the location and the requested altitude above terrain. It does not send terrain heights to the vehicle.")
-                }
-
-                FactCheckBox {
-                    text: qsTr("Don't show again")
-                    fact: _aboveTerrainWarning
-                }
-            }
         }
     }
 }

--- a/src/Settings/PlanView.SettingsGroup.json
+++ b/src/Settings/PlanView.SettingsGroup.json
@@ -6,12 +6,6 @@
     "defaultValue":     false
 },
 {
-    "name":             "aboveTerrainWarning",
-    "shortDescription": "Don't warn user about 'Above Terrain' usage",
-    "type":             "bool",
-    "defaultValue":     false
-},
-{
     "name":             "showMissionItemStatus",
     "shortDescription": "Show/Hide the mission item status display",
     "type":             "bool",

--- a/src/Settings/PlanViewSettings.cc
+++ b/src/Settings/PlanViewSettings.cc
@@ -18,6 +18,5 @@ DECLARE_SETTINGGROUP(PlanView, "PlanView")
 }
 
 DECLARE_SETTINGSFACT(PlanViewSettings, displayPresetsTabFirst)
-DECLARE_SETTINGSFACT(PlanViewSettings, aboveTerrainWarning)
 DECLARE_SETTINGSFACT(PlanViewSettings, showMissionItemStatus)
 DECLARE_SETTINGSFACT(PlanViewSettings, takeoffItemNotRequired)

--- a/src/Settings/PlanViewSettings.h
+++ b/src/Settings/PlanViewSettings.h
@@ -21,7 +21,6 @@ public:
     // Most individual settings related to PlanView are still in AppSettings due to historical reasons.
 
     DEFINE_SETTINGFACT(displayPresetsTabFirst)
-    DEFINE_SETTINGFACT(aboveTerrainWarning)
     DEFINE_SETTINGFACT(showMissionItemStatus)
     DEFINE_SETTINGFACT(takeoffItemNotRequired)
 };

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -178,6 +178,10 @@ ApplicationWindow {
     readonly property int showDialogDefaultWidth:   40  ///< Use for default dialog width
 
     function showComponentDialog(component, title, charWidth, buttons) {
+        if (mainWindowDialog.visible) {
+            console.warn(("showComponentDialog called while dialog is already visible"))
+            return
+        }
         var dialogWidth = charWidth === showDialogFullWidth ? mainWindow.width : ScreenTools.defaultFontPixelWidth * charWidth
         mainWindowDialog.width = dialogWidth
         mainWindowDialog.dialogComponent = component


### PR DESCRIPTION
* The altitude mode warning dialog was popping up while it was already popped up
* This would cause the view switch prevention code to get confused
* Prevent MainRoowWindow.showComponentDialog from getting screwed up if called while a dialog is already showing
* Get rid of the altitude mode warning since it's not critical and making it work correctly isn't worth the effort
* Fix for #8812

