### PR TITLE
Softlock workaround fix

### DIFF
--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -218,7 +218,10 @@ Rectangle {
                 QGCMenuItem {
                     text:           qsTr("Edit position...")
                     visible:        missionItem.specifiesCoordinate
-                    onTriggered:    mainWindow.showComponentDialog(editPositionDialog, qsTr("Edit Position"), mainWindow.showDialogDefaultWidth, StandardButton.Close)
+                    onTriggered:    mainWindow.showComponentDialog2(editPositionDialog, qsTr("Edit Position"), mainWindow.showDialogDefaultWidth, StandardButton.Close)
+                    // EditPositionDialog uses a second instance of showComponentDialog to use a second drawer/dialog combination. This is to get around the soft-lock
+                    // issue you can enter, when a dialog is opened inside a dialog. (Eg. EditPositionDialog can open a ParameterEditorDialog through a FactTextField's help button/validation.
+                    // Once in this screen, you lose the ability to close the dialog, and cannot proceed without restarting the application.
                 }
 
                 QGCMenuSeparator {

--- a/src/QmlControls/QGCViewDialogContainer.qml
+++ b/src/QmlControls/QGCViewDialogContainer.qml
@@ -20,11 +20,12 @@ Item {
 
     property real   _defaultTextHeight: _textMeasure.contentHeight
     property real   _defaultTextWidth:  _textMeasure.contentWidth
+    property var _dialogWindow
 
     function setupDialogButtons() {
         _acceptButton.visible = false
         _rejectButton.visible = false
-        var buttons = mainWindowDialog.dialogButtons
+        var buttons = _dialogWindow.dialogButtons
         // Accept role buttons
         if (buttons & StandardButton.Ok) {
             _acceptButton.text = qsTr("Ok")
@@ -87,7 +88,8 @@ Item {
         target: _dialogComponentLoader.item
         onHideDialog: {
             Qt.inputMethod.hide()
-            mainWindowDialog.close()
+            if(_dialogWindow)
+                _dialogWindow.close()
         }
     }
 
@@ -105,7 +107,7 @@ Item {
             QGCLabel {
                 id:                 titleLabel
                 x:                  _defaultTextWidth
-                text:               mainWindowDialog.dialogTitle
+                text:               _dialogWindow ? _dialogWindow.dialogTitle : ""
                 height:             parent.height
                 verticalAlignment:	Text.AlignVCenter
             }
@@ -136,7 +138,7 @@ Item {
             anchors.right:      parent.right
             anchors.top:        _spacer.bottom
             anchors.bottom:     parent.bottom
-            sourceComponent:    mainWindowDialog.dialogComponent
+            sourceComponent:    _dialogWindow ? _dialogWindow.dialogComponent : ""
             focus:              true
             property bool acceptAllowed: _acceptButton.visible
             property bool rejectAllowed: _rejectButton.visible


### PR DESCRIPTION
This allows any dialog component to nest itself up to twice.

The simplest example is.
* Drop a way point
* On the right, click the hamburger
* Click Edit Position
* Click the "**?**" button on one of the facts (eg. Lat / Lon)

Prior to #8826, this would have resulted in a soft lock.

The current implementation on master results in the "ParamaterEditorDialog" not being shown.

This proposed implementation allows to display a dialog within a dialog (which appears to be the maximum nesting I have found)