### PR TITLE
LinkInterface/Vehicle uses mutexes to synchronize writing bytes

### DIFF
--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -478,7 +478,7 @@ LogDownloadController::_requestLogData(uint16_t id, uint32_t offset, uint32_t co
                     &msg,
                     qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->id(), qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->defaultComponentId(),
                     id, offset, count);
-        _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+        _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
     }
 }
 
@@ -508,7 +508,7 @@ LogDownloadController::_requestLogList(uint32_t start, uint32_t end)
                     _vehicle->defaultComponentId(),
                     start,
                     end);
-        _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+        _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
         //-- Wait 5 seconds before bitching about not getting anything
         _timer.start(5000);
     }
@@ -674,7 +674,7 @@ LogDownloadController::eraseAll(void)
                     _vehicle->priorityLink()->mavlinkChannel(),
                     &msg,
                     qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->id(), qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->defaultComponentId());
-        _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+        _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
         refresh();
     }
 }

--- a/src/AnalyzeView/MavlinkConsoleController.cc
+++ b/src/AnalyzeView/MavlinkConsoleController.cc
@@ -129,7 +129,7 @@ MavlinkConsoleController::_sendSerialData(QByteArray data, bool close)
                     0,
                     chunk.size(),
                     reinterpret_cast<uint8_t*>(chunk.data()));
-        _vehicle->sendMessageOnLink(priority_link, msg);
+        _vehicle->sendMessageOnLinkThreadSafe(priority_link, msg);
         data.remove(0, chunk.size());
     }
 }

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -704,7 +704,7 @@ void APMSensorsComponentController::nextClicked(void)
                                       0,    // target_system
                                       0);   // target_component
 
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
 
     if (_calTypeInProgress == CalTypeCompassMot) {
         _stopCalibration(StopCalibrationSuccess);

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1183,7 +1183,7 @@ QGCCameraControl::_requestAllParameters()
         &msg,
         static_cast<uint8_t>(_vehicle->id()),
         static_cast<uint8_t>(compID()));
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
     qCDebug(CameraControlVerboseLog) << "Request all parameters";
 }
 

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -191,7 +191,7 @@ QGCCameraParamIO::_sendParameter()
         _vehicle->priorityLink()->mavlinkChannel(),
         &msg,
         &p);
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
     _paramWriteTimer.start();
 }
 
@@ -364,6 +364,6 @@ QGCCameraParamIO::paramRequest(bool reset)
         static_cast<uint8_t>(_control->compID()),
         param_id,
         -1);
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
     _paramRequestTimer.start();
 }

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -526,7 +526,7 @@ void ParameterManager::refreshAllParameters(uint8_t componentId)
                                              &msg,
                                              _vehicle->id(),
                                              componentId);
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
 
     QString what = (componentId == MAV_COMP_ID_ALL) ? "MAV_COMP_ID_ALL" : QString::number(componentId);
     qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "Request to refresh all parameters for component ID:" << what;
@@ -831,7 +831,7 @@ void ParameterManager::_readParameterRaw(int componentId, const QString& paramNa
                                              componentId,                    // Target component id
                                              fixedParamName,                 // Named parameter being requested
                                              paramIndex);                    // Parameter index being requested, -1 for named
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
 }
 
 void ParameterManager::_writeParameterRaw(int componentId, const QString& paramName, const QVariant& value)
@@ -890,7 +890,7 @@ void ParameterManager::_writeParameterRaw(int componentId, const QString& paramN
                                       _vehicle->priorityLink()->mavlinkChannel(),
                                       &msg,
                                       &p);
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
 }
 
 void ParameterManager::_writeLocalParamCache(int vehicleId, int componentId)
@@ -997,7 +997,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, QVarian
                                           _vehicle->priorityLink()->mavlinkChannel(),
                                           &msg,
                                           &p);
-        _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+        _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
 
         // Give the user some feedback things loaded properly
         QVariantAnimation *ani = new QVariantAnimation(this);

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -945,7 +945,7 @@ void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
                 &msg,
                 &cmd);
 
-    vehicle->sendMessageOnLink(vehicle->priorityLink(), msg);
+    vehicle->sendMessageOnLinkThreadSafe(vehicle->priorityLink(), msg);
 }
 
 void APMFirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double altitudeRel)
@@ -1139,5 +1139,5 @@ void APMFirmwarePlugin::_sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMoti
                                           vehicle->priorityLink()->mavlinkChannel(),
                                           &message,
                                           &globalPositionInt);
-    vehicle->sendMessageOnLink(vehicle->priorityLink(), message);
+    vehicle->sendMessageOnLinkThreadSafe(vehicle->priorityLink(), message);
 }

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -93,7 +93,7 @@ public:
     void                guidedModeRTL                   (Vehicle* vehicle, bool smartRTL) override;
     void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeChange) override;
     bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) override;
-    void                adjustOutgoingMavlinkMessage    (Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message) override;
+    void                adjustOutgoingMavlinkMessageThreadSafe(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message) override;
     virtual void        initializeStreamRates           (Vehicle* vehicle);
     void                initializeVehicle               (Vehicle* vehicle) override;
     bool                sendHomePositionToVehicle       (void) override;
@@ -127,7 +127,7 @@ private:
     void _handleIncomingParamValue(Vehicle* vehicle, mavlink_message_t* message);
     bool _handleIncomingStatusText(Vehicle* vehicle, mavlink_message_t* message);
     void _handleIncomingHeartbeat(Vehicle* vehicle, mavlink_message_t* message);
-    void _handleOutgoingParamSet(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message);
+    void _handleOutgoingParamSetThreadSafe(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message);
     void _soloVideoHandshake(Vehicle* vehicle, bool originalSoloFirmware);
     bool _guidedModeTakeoff(Vehicle* vehicle, double altitudeRel);
     void _handleRCChannels(Vehicle* vehicle, mavlink_message_t* message);
@@ -140,6 +140,8 @@ private:
 
     QList<APMCustomMode>    _supportedModes;
     QMap<int /* vehicle id */, QMap<int /* componentId */, bool /* true: component is part of ArduPilot stack */>> _ardupilotComponentMap;
+
+    QMutex _adjustOutgoingMavlinkMutex;
 
     static const char*      _artooIP;
     static const int        _artooVideoHandshakePort;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -156,11 +156,8 @@ bool FirmwarePlugin::adjustIncomingMavlinkMessage(Vehicle* vehicle, mavlink_mess
     return true;
 }
 
-void FirmwarePlugin::adjustOutgoingMavlinkMessage(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message)
+void FirmwarePlugin::adjustOutgoingMavlinkMessageThreadSafe(Vehicle* /*vehicle*/, LinkInterface* /*outgoingLink*/, mavlink_message_t* /*message*/)
 {
-    Q_UNUSED(vehicle);
-    Q_UNUSED(outgoingLink);
-    Q_UNUSED(message);
     // Generic plugin does no message adjustment
 }
 

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -947,5 +947,5 @@ void FirmwarePlugin::sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMotionRe
                                           vehicle->priorityLink()->mavlinkChannel(),
                                           &message,
                                           &follow_target);
-    vehicle->sendMessageOnLink(vehicle->priorityLink(), message);
+    vehicle->sendMessageOnLinkThreadSafe(vehicle->priorityLink(), message);
 }

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -193,10 +193,13 @@ public:
     /// Called before any mavlink message is sent to the Vehicle so plugin can adjust any message characteristics.
     /// This is handy to adjust or differences in mavlink spec implementations such that the base code can remain
     /// mavlink generic.
+    ///
+    /// This method must be thread safe.
+    ///
     ///     @param vehicle Vehicle message came from
     ///     @param outgoingLink Link that messae is going out on
     ///     @param message[in,out] Mavlink message to adjust if needed.
-    virtual void adjustOutgoingMavlinkMessage(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message);
+    virtual void adjustOutgoingMavlinkMessageThreadSafe(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message);
 
     /// Determines how to handle the first item of the mission item list. Internally to QGC the first item
     /// is always the home position.

--- a/src/FlightDisplay/VirtualJoystick.qml
+++ b/src/FlightDisplay/VirtualJoystick.qml
@@ -28,7 +28,7 @@ Item {
         repeat:     true
         onTriggered: {
             if (activeVehicle) {
-                activeVehicle.virtualTabletJoystickValue(rightStick.xAxis, -rightStick.yAxis, leftStick.xAxis, leftStick.yAxis)
+                activeVehicle.virtualTabletJoystickValue(rightStick.xAxis, rightStick.yAxis, leftStick.xAxis, leftStick.yAxis)
             }
         }
     }

--- a/src/GPS/RTCM/RTCMMavlink.cc
+++ b/src/GPS/RTCM/RTCMMavlink.cc
@@ -72,6 +72,6 @@ void RTCMMavlink::sendMessageToVehicle(const mavlink_gps_rtcm_data_t& msg)
                                               vehicle->priorityLink()->mavlinkChannel(),
                                               &message,
                                               &msg);
-        vehicle->sendMessageOnLink(vehicle->priorityLink(), message);
+        vehicle->sendMessageOnLinkThreadSafe(vehicle->priorityLink(), message);
     }
 }

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -193,18 +193,8 @@ signals:
     void accumulatorChanged         (bool accumulator);
     void enabledChanged             (bool enabled);
     void circleCorrectionChanged    (bool circleCorrection);
-
-    /// Signal containing new joystick information
-    ///     @param roll:            Range is -1:1, negative meaning roll left, positive meaning roll right
-    ///     @param pitch:           Range i -1:1, negative meaning pitch down, positive meaning pitch up
-    ///     @param yaw:             Range is -1:1, negative meaning yaw left, positive meaning yaw right
-    ///     @param throttle:        Range is 0:1, 0 meaning no throttle, 1 meaning full throttle
-    ///     @param buttons:         Button bitmap
-    ///     @param joystickMmode:   Current joystick mode
-    void manualControl              (float roll, float pitch, float yaw, float throttle, quint16 buttons, int joystickMmode);
+    void axisValues                 (float roll, float pitch, float yaw, float throttle);
     void manualControlGimbal        (float gimbalPitch, float gimbalYaw);
-
-    void buttonActionTriggered      (int action);
 
     void gimbalEnabledChanged       ();
     void axisFrequencyChanged       ();

--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -69,7 +69,7 @@ void MissionManager::writeArduPilotGuidedMissionItem(const QGeoCoordinate& gotoC
                                          &messageOut,
                                          &missionItem);
 
-    _vehicle->sendMessageOnLink(_dedicatedLink, messageOut);
+    _vehicle->sendMessageOnLinkThreadSafe(_dedicatedLink, messageOut);
     _startAckTimeout(AckGuidedItem);
     emit inProgressChanged(true);
 }

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -119,7 +119,7 @@ void PlanManager::_writeMissionCount(void)
                                         _writeMissionItems.count(),
                                         _planType);
 
-    _vehicle->sendMessageOnLink(_dedicatedLink, message);
+    _vehicle->sendMessageOnLinkThreadSafe(_dedicatedLink, message);
     _startAckTimeout(AckMissionRequest);
 }
 
@@ -161,7 +161,7 @@ void PlanManager::_requestList(void)
                                                MAV_COMP_ID_AUTOPILOT1,
                                                _planType);
 
-    _vehicle->sendMessageOnLink(_dedicatedLink, message);
+    _vehicle->sendMessageOnLinkThreadSafe(_dedicatedLink, message);
     _startAckTimeout(AckMissionCount);
 }
 
@@ -301,7 +301,7 @@ void PlanManager::_readTransactionComplete(void)
                                       MAV_MISSION_ACCEPTED,
                                       _planType);
     
-    _vehicle->sendMessageOnLink(_dedicatedLink, message);
+    _vehicle->sendMessageOnLinkThreadSafe(_dedicatedLink, message);
 
     _finishTransaction(true);
 }
@@ -369,7 +369,7 @@ void PlanManager::_requestNextMissionItem(void)
                 _planType);
     }
     
-    _vehicle->sendMessageOnLink(_dedicatedLink, message);
+    _vehicle->sendMessageOnLinkThreadSafe(_dedicatedLink, message);
     _startAckTimeout(AckMissionItem);
 }
 
@@ -586,7 +586,7 @@ void PlanManager::_handleMissionRequest(const mavlink_message_t& message, bool m
                                            _planType);
     }
     
-    _vehicle->sendMessageOnLink(_dedicatedLink, messageOut);
+    _vehicle->sendMessageOnLinkThreadSafe(_dedicatedLink, messageOut);
     _startAckTimeout(AckMissionRequest);
 }
 
@@ -928,7 +928,7 @@ void PlanManager::_removeAllWorker(void)
                                             _vehicle->id(),
                                             MAV_COMP_ID_AUTOPILOT1,
                                             _planType);
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), message);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), message);
     _startAckTimeout(AckMissionClearAll);
 }
 

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -387,8 +387,7 @@ void MultiVehicleManager::_sendGCSHeartbeat(void)
 
             uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
             int len = mavlink_msg_to_send_buffer(buffer, &message);
-
-            link->writeBytesSafe((const char*)buffer, len);
+            link->writeBytesThreadSafe((const char*)buffer, len);
         }
     }
 }

--- a/src/Vehicle/TerrainProtocolHandler.cc
+++ b/src/Vehicle/TerrainProtocolHandler.cc
@@ -146,7 +146,7 @@ void TerrainProtocolHandler::_sendTerrainData(const QGeoCoordinate& swCorner, ui
                         _currentTerrainRequest.grid_spacing,
                         gridBit,
                         terrainData);
-            _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+            _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
         }
     }
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -59,7 +59,6 @@ QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
 const QString guided_mode_not_supported_by_vehicle = QObject::tr("Guided mode not supported by Vehicle.");
 
 const char* Vehicle::_settingsGroup =               "Vehicle%1";        // %1 replaced with mavlink system id
-const char* Vehicle::_joystickModeSettingsKey =     "JoystickMode";
 const char* Vehicle::_joystickEnabledSettingsKey =  "JoystickEnabled";
 
 const char* Vehicle::_rollFactName =                "roll";
@@ -116,7 +115,6 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _soloFirmware(false)
     , _toolbox(qgcApp()->toolbox())
     , _settingsManager(_toolbox->settingsManager())
-    , _joystickMode(JoystickModeRC)
     , _joystickEnabled(false)
     , _uas(nullptr)
     , _mav(nullptr)
@@ -235,7 +233,6 @@ Vehicle::Vehicle(LinkInterface*             link,
 
     _addLink(link);
 
-    connect(this, &Vehicle::_sendMessageOnLinkOnThread, this, &Vehicle::_sendMessageOnLink, Qt::QueuedConnection);
     connect(this, &Vehicle::flightModeChanged,          this, &Vehicle::_handleFlightModeChanged);
     connect(this, &Vehicle::armedChanged,               this, &Vehicle::_announceArmedChanged);
 
@@ -328,7 +325,6 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _soloFirmware(false)
     , _toolbox(qgcApp()->toolbox())
     , _settingsManager(_toolbox->settingsManager())
-    , _joystickMode(JoystickModeRC)
     , _joystickEnabled(false)
     , _uas(nullptr)
     , _mav(nullptr)
@@ -1846,7 +1842,7 @@ void Vehicle::_handlePing(LinkInterface* link, mavlink_message_t& message)
                                ping.seq,
                                message.sysid,
                                message.compid);
-    sendMessageOnLink(link, msg);
+    sendMessageOnLinkThreadSafe(link, msg);
 }
 
 void Vehicle::_handleHeartbeat(mavlink_message_t& message)
@@ -2104,29 +2100,13 @@ void Vehicle::_linkInactiveOrDeleted(LinkInterface* link)
     }
 }
 
-bool Vehicle::sendMessageOnLink(LinkInterface* link, mavlink_message_t message)
+bool Vehicle::sendMessageOnLinkThreadSafe(LinkInterface* link, mavlink_message_t message)
 {
-    if (!link || !_links.contains(link) || !link->isConnected()) {
+    QMutexLocker lock(&_sendMessageOnLinkMutex);
+
+    if (!link->isConnected()) {
         return false;
     }
-
-    emit _sendMessageOnLinkOnThread(link, message);
-
-    return true;
-}
-
-void Vehicle::_sendMessageOnLink(LinkInterface* link, mavlink_message_t message)
-{
-    // Make sure this is still a good link
-    if (!link || !_links.contains(link) || !link->isConnected()) {
-        return;
-    }
-
-#if 0
-    // Leaving in for ease in Mav 2.0 testing
-    mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(link->mavlinkChannel());
-    qDebug() << "_sendMessageOnLink" << mavlinkStatus << link->mavlinkChannel() << mavlinkStatus->flags << message.magic;
-#endif
 
     // Give the plugin a chance to adjust
     _firmwarePlugin->adjustOutgoingMavlinkMessage(this, link, &message);
@@ -2135,9 +2115,11 @@ void Vehicle::_sendMessageOnLink(LinkInterface* link, mavlink_message_t message)
     uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
     int len = mavlink_msg_to_send_buffer(buffer, &message);
 
-    link->writeBytesSafe((const char*)buffer, len);
+    link->writeBytesThreadSafe((const char*)buffer, len);
     _messagesSent++;
     emit messagesSentChanged();
+
+    return true;
 }
 
 void Vehicle::_updatePriorityLink(bool updateActive, bool sendCommand)
@@ -2426,11 +2408,6 @@ void Vehicle::_loadSettings()
     }
     QSettings settings;
     settings.beginGroup(QString(_settingsGroup).arg(_id));
-    bool convertOk;
-    _joystickMode = static_cast<JoystickMode_t>(settings.value(_joystickModeSettingsKey, JoystickModeRC).toInt(&convertOk));
-    if (!convertOk) {
-        _joystickMode = JoystickModeRC;
-    }
     // Joystick enabled is a global setting so first make sure there are any joysticks connected
     if (_toolbox->joystickManager()->joysticks().count()) {
         setJoystickEnabled(settings.value(_joystickEnabledSettingsKey, false).toBool());
@@ -2441,42 +2418,13 @@ void Vehicle::_loadSettings()
 void Vehicle::_saveSettings()
 {
     QSettings settings;
-
     settings.beginGroup(QString(_settingsGroup).arg(_id));
-
-    settings.setValue(_joystickModeSettingsKey, _joystickMode);
 
     // The joystick enabled setting should only be changed if a joystick is present
     // since the checkbox can only be clicked if one is present
     if (_toolbox->joystickManager()->joysticks().count()) {
         settings.setValue(_joystickEnabledSettingsKey, _joystickEnabled);
     }
-}
-
-int Vehicle::joystickMode()
-{
-    return _joystickMode;
-}
-
-void Vehicle::setJoystickMode(int mode)
-{
-    if (mode < 0 || mode >= JoystickModeMax) {
-        qCWarning(VehicleLog) << "Invalid joystick mode" << mode;
-        return;
-    }
-
-    _joystickMode = (JoystickMode_t)mode;
-    _saveSettings();
-    emit joystickModeChanged(mode);
-}
-
-QStringList Vehicle::joystickModes()
-{
-    QStringList list;
-
-    list << "Normal" << "Attitude" << "Position" << "Force" << "Velocity";
-
-    return list;
 }
 
 bool Vehicle::joystickEnabled()
@@ -2571,7 +2519,7 @@ void Vehicle::setFlightMode(const QString& flightMode)
                                        id(),
                                        newBaseMode,
                                        custom_mode);
-        sendMessageOnLink(priorityLink(), msg);
+        sendMessageOnLinkThreadSafe(priorityLink(), msg);
     } else {
         qWarning() << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
     }
@@ -2647,7 +2595,7 @@ void Vehicle::requestDataStream(MAV_DATA_STREAM stream, uint16_t rate, bool send
         // We use sendMessageMultiple since we really want these to make it to the vehicle
         sendMessageMultiple(msg);
     } else {
-        sendMessageOnLink(priorityLink(), msg);
+        sendMessageOnLinkThreadSafe(priorityLink(), msg);
     }
 }
 
@@ -2656,7 +2604,7 @@ void Vehicle::_sendMessageMultipleNext()
     if (_nextSendMessageMultipleIndex < _sendMessageMultipleList.count()) {
         qCDebug(VehicleLog) << "_sendMessageMultipleNext:" << _sendMessageMultipleList[_nextSendMessageMultipleIndex].message.msgid;
 
-        sendMessageOnLink(priorityLink(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
+        sendMessageOnLinkThreadSafe(priorityLink(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
 
         if (--_sendMessageMultipleList[_nextSendMessageMultipleIndex].retryCount <= 0) {
             _sendMessageMultipleList.removeAt(_nextSendMessageMultipleIndex);
@@ -2826,7 +2774,7 @@ void Vehicle::_sendQGCTimeToVehicle()
                                         &msg,
                                         &cmd);
 
-    sendMessageOnLink(priorityLink(), msg);
+    sendMessageOnLinkThreadSafe(priorityLink(), msg);
 }
 
 void Vehicle::disconnectInactiveVehicle()
@@ -2884,13 +2832,13 @@ void Vehicle::_remoteControlRSSIChanged(uint8_t rssi)
 void Vehicle::virtualTabletJoystickValue(double roll, double pitch, double yaw, double thrust)
 {
     // The following if statement prevents the virtualTabletJoystick from sending values if the standard joystick is enabled
-    if ( !_joystickEnabled && !_highLatencyLink) {
-        _uas->setExternalControlSetpoint(
+    if (!_joystickEnabled) {
+        sendJoystickDataThreadSafe(
             static_cast<float>(roll),
             static_cast<float>(pitch),
             static_cast<float>(yaw),
             static_cast<float>(thrust),
-            0, JoystickModeRC);
+            0);
     }
 }
 
@@ -3362,7 +3310,7 @@ void Vehicle::setCurrentMissionSequence(int seq)
         static_cast<uint8_t>(id()),
         _compID,
         static_cast<uint16_t>(seq));
-    sendMessageOnLink(priorityLink(), msg);
+    sendMessageOnLinkThreadSafe(priorityLink(), msg);
 }
 
 void Vehicle::sendMavCommand(int component, MAV_CMD command, bool showError, float param1, float param2, float param3, float param4, float param5, float param6, float param7)
@@ -3500,7 +3448,7 @@ void Vehicle::_sendMavCommandAgain()
                                              &cmd);
     }
 
-    sendMessageOnLink(priorityLink(), msg);
+    sendMessageOnLinkThreadSafe(priorityLink(), msg);
 }
 
 void Vehicle::_sendNextQueuedMavCommand()
@@ -3691,7 +3639,7 @@ void Vehicle::rebootVehicle()
                                          priorityLink()->mavlinkChannel(),
                                          &msg,
                                          &cmd);
-    sendMessageOnLink(priorityLink(), msg);
+    sendMessageOnLinkThreadSafe(priorityLink(), msg);
 }
 
 void Vehicle::setSoloFirmware(bool soloFirmware)
@@ -3857,7 +3805,7 @@ void Vehicle::_ackMavlinkLogData(uint16_t sequence)
                 priorityLink()->mavlinkChannel(),
                 &msg,
                 &ack);
-    sendMessageOnLink(priorityLink(), msg);
+    sendMessageOnLinkThreadSafe(priorityLink(), msg);
 }
 
 void Vehicle::_handleMavlinkLoggingData(mavlink_message_t& message)
@@ -4426,7 +4374,7 @@ void Vehicle::sendParamMapRC(const QString& paramName, double scale, double cent
                                        static_cast<float>(centerValue),
                                        static_cast<float>(minValue),
                                        static_cast<float>(maxValue));
-    sendMessageOnLink(priorityLink(), message);
+    sendMessageOnLinkThreadSafe(priorityLink(), message);
 }
 
 void Vehicle::clearAllParamMapRC(void)
@@ -4445,8 +4393,37 @@ void Vehicle::clearAllParamMapRC(void)
                                            -2,                                                  // Disable map for specified tuning id
                                            i,                                                   // tuning id
                                            0, 0, 0, 0);                                         // unused
-        sendMessageOnLink(priorityLink(), message);
+        sendMessageOnLinkThreadSafe(priorityLink(), message);
     }
+}
+
+void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, float thrust, quint16 buttons)
+{
+    if (_highLatencyLink) {
+        return;
+    }
+
+    mavlink_message_t message;
+    
+    // Incoming values are in the range -1:1
+    float axesScaling =         1.0 * 1000.0;
+    float newRollCommand =      roll * axesScaling;
+    float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
+    float newYawCommand    =    yaw * axesScaling;
+    float newThrustCommand =    thrust * axesScaling;
+    
+    mavlink_msg_manual_control_pack_chan(
+        static_cast<uint8_t>(_mavlink->getSystemId()),
+        static_cast<uint8_t>(_mavlink->getComponentId()),
+        priorityLink()->mavlinkChannel(),
+        &message,
+        static_cast<uint8_t>(_id),
+        static_cast<int16_t>(newPitchCommand),
+        static_cast<int16_t>(newRollCommand),
+        static_cast<int16_t>(newThrustCommand),
+        static_cast<int16_t>(newYawCommand),
+        buttons);
+    sendMessageOnLinkThreadSafe(priorityLink(), message);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2102,14 +2102,12 @@ void Vehicle::_linkInactiveOrDeleted(LinkInterface* link)
 
 bool Vehicle::sendMessageOnLinkThreadSafe(LinkInterface* link, mavlink_message_t message)
 {
-    QMutexLocker lock(&_sendMessageOnLinkMutex);
-
     if (!link->isConnected()) {
         return false;
     }
 
     // Give the plugin a chance to adjust
-    _firmwarePlugin->adjustOutgoingMavlinkMessage(this, link, &message);
+    _firmwarePlugin->adjustOutgoingMavlinkMessageThreadSafe(this, link, &message);
 
     // Write message into buffer, prepending start sign
     uint8_t buffer[MAVLINK_MAX_PACKET_LEN];

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1412,7 +1412,6 @@ private:
     bool            _highLatencyLink;
     bool            _receivingAttitudeQuaternion;
     CheckList       _checkListState = CheckListNotSetup;
-    QMutex          _sendMessageOnLinkMutex;
 
     QGCCameraManager* _cameras;
 

--- a/src/VehicleSetup/JoystickConfigAdvanced.qml
+++ b/src/VehicleSetup/JoystickConfigAdvanced.qml
@@ -128,22 +128,6 @@ Item {
             }
         }
         //-----------------------------------------------------------------
-        //-- Mode
-        QGCLabel {
-            Layout.alignment:   Qt.AlignVCenter
-            text:               qsTr("Joystick mode:")
-            visible:            advancedSettings.checked
-        }
-        QGCComboBox {
-            enabled:            advancedSettings.checked
-            currentIndex:       activeVehicle.joystickMode
-            width:              ScreenTools.defaultFontPixelWidth * 20
-            model:              activeVehicle.joystickModes
-            onActivated:        activeVehicle.joystickMode = index
-            Layout.alignment:   Qt.AlignVCenter
-            visible:            advancedSettings.checked
-        }
-        //-----------------------------------------------------------------
         //-- Axis Message Frequency
         QGCLabel {
             text:               qsTr("Axis frequency (Hz):")

--- a/src/VehicleSetup/JoystickConfigGeneral.qml
+++ b/src/VehicleSetup/JoystickConfigGeneral.qml
@@ -200,7 +200,7 @@ Item {
 
                     Connections {
                         target:             _activeJoystick
-                        onManualControl: {
+                        onAxisValues: {
                             rollAxis.axisValue      = roll  * 32768.0
                             pitchAxis.axisValue     = pitch * 32768.0
                             yawAxis.axisValue       = yaw   * 32768.0

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -65,7 +65,6 @@ LinkInterface::LinkInterface(SharedLinkConfigurationPointer& config, bool isPX4F
     memset(_outDataWriteAmounts,0, sizeof(_outDataWriteAmounts));
     memset(_outDataWriteTimes,  0, sizeof(_outDataWriteTimes));
 
-    QObject::connect(this, &LinkInterface::_invokeWriteBytes, this, &LinkInterface::_writeBytes);
     qRegisterMetaType<LinkInterface*>("LinkInterface*");
 }
 
@@ -209,4 +208,12 @@ void LinkInterface::stopMavlinkMessagesTimer() {
     }
 
     _mavlinkMessagesTimers.clear();
+}
+
+void LinkInterface::writeBytesThreadSafe(const char *bytes, int length)
+{
+    QByteArray byteArray(bytes, length);
+    _writeBytesMutex.lock();
+    _writeBytes(byteArray);
+    _writeBytesMutex.unlock();
 }

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -136,33 +136,11 @@ public:
     bool connect(void);
     bool disconnect(void);
 
-public slots:
+    void writeBytesThreadSafe(const char *bytes, int length);
 
-    /**
-     * @brief This method allows to write bytes to the interface.
-     *
-     * If the underlying communication is packet oriented,
-     * one write command equals a datagram. In case of serial
-     * communication arbitrary byte lengths can be written. The method ensures
-     * thread safety regardless of the underlying LinkInterface implementation.
-     *
-     * @param bytes:  The pointer to the byte array containing the data
-     * @param length: The length of the data array
-     **/
-    void writeBytesSafe(const char *bytes, int length)
-    {
-        emit _invokeWriteBytes(QByteArray(bytes, length));
-    }
-
-private slots:
-    virtual void _writeBytes(const QByteArray) = 0;
-
-    void _activeChanged(bool active, int vehicle_id);
-    
 signals:
     void autoconnectChanged(bool autoconnect);
     void activeChanged(LinkInterface* link, bool active, int vehicle_id);
-    void _invokeWriteBytes(QByteArray);
     void highLatencyChanged(bool highLatency);
 
     /// Signalled when a link suddenly goes away due to it being removed by for example pulling the cable to the connection.
@@ -231,6 +209,9 @@ protected:
     SharedLinkConfigurationPointer _config;
     bool _highLatency;
 
+private slots:
+    void _activeChanged(bool active, int vehicle_id);
+
 private:
     /**
      * @brief logDataRateToBuffer Stores transmission times/amounts for statistics
@@ -288,6 +269,8 @@ private:
      */
     void stopMavlinkMessagesTimer();
 
+    virtual void _writeBytes(const QByteArray) = 0; // Not thread safe, only writeBytesThreadSafe is thread safe
+
     bool _mavlinkChannelSet;    ///< true: _mavlinkChannel has been set
     uint8_t _mavlinkChannel;    ///< mavlink channel to use for this link, as used by mavlink_parse_char
     
@@ -307,7 +290,8 @@ private:
     quint64 _outDataWriteAmounts[_dataRateBufferSize]; // In bytes
     qint64  _outDataWriteTimes[_dataRateBufferSize]; // in ms
     
-    mutable QMutex _dataRateMutex; // Mutex for accessing the data rate member variables
+    mutable QMutex _dataRateMutex;
+    mutable QMutex _writeBytesMutex;
 
     bool _enableRateCollection;
     bool _decodedFirstMavlinkPacket;    ///< true: link has correctly decoded it's first mavlink packet

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -969,7 +969,7 @@ void LinkManager::_activeLinkCheck(void)
     if (!found && link) {
         // See if we can get an NSH prompt on this link
         bool foundNSHPrompt = false;
-        link->writeBytesSafe("\r", 1);
+        link->writeBytesThreadSafe("\r", 1);
         QSignalSpy spy(link, SIGNAL(bytesReceived(LinkInterface*, QByteArray)));
         if (spy.wait(100)) {
             QList<QVariant> arguments = spy.takeFirst();

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -277,7 +277,7 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                 if (forwardingLink) {
                     uint8_t buf[MAVLINK_MAX_PACKET_LEN];
                     int len = mavlink_msg_to_send_buffer(buf, &_message);
-                    forwardingLink->writeBytesSafe((const char*)buf, len);
+                    forwardingLink->writeBytesThreadSafe((const char*)buf, len);
                 }
             }
 

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -160,8 +160,12 @@ public:
     static MockLink* startAPMArduSubMockLink     (bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink* startAPMArduRoverMockLink   (bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
 
+signals:
+    void writeBytesQueuedSignal(const QByteArray bytes);
+
 private slots:
-    virtual void _writeBytes(const QByteArray bytes);
+    void _writeBytes(const QByteArray bytes) final;
+    void _writeBytesQueued(const QByteArray bytes);
 
 private slots:
     void _run1HzTasks(void);

--- a/src/qgcunittest/TCPLinkTest.cc
+++ b/src/qgcunittest/TCPLinkTest.cc
@@ -125,7 +125,7 @@ void TCPLinkTest::_connectSucceed_test(void)
     const char* bytesWrittenSignal = SIGNAL(bytesWritten(qint64));
     MultiSignalSpy bytesWrittenSpy;
     QCOMPARE(bytesWrittenSpy.init(_link->getSocket(), &bytesWrittenSignal, 1), true);
-    _link->writeBytesSafe(bytesOut.data(), bytesOut.size());
+    _link->writeBytesThreadSafe(bytesOut.data(), bytesOut.size());
     _multiSpy->clearAllSignals();
     
     // We emit this signal such that it will be queued and run on the TCPLink thread. This in turn

--- a/src/uas/FileManager.cc
+++ b/src/uas/FileManager.cc
@@ -891,5 +891,5 @@ void FileManager::_sendRequestNoAck(Request* request)
                                                  0,                  // Target component
                                                  (uint8_t*)request); // Payload
     
-    _vehicle->sendMessageOnLink(link, message);
+    _vehicle->sendMessageOnLinkThreadSafe(link, message);
 }

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -424,7 +424,7 @@ void UAS::startCalibration(UASInterface::StartCalibrationType calType)
                                        accelCal,                         // accel cal
                                        airspeedCal,                      // PX4: airspeed cal, ArduPilot: compass mot
                                        escCal);                          // esc cal
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
 }
 
 void UAS::stopCalibration(void)
@@ -732,7 +732,7 @@ void UAS::requestImage()
                                                           &msg,
                                                           MAVLINK_DATA_STREAM_IMG_JPEG,
                                                           0, 0, 0, 0, 0, 50);
-        _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
+        _vehicle->sendMessageOnLinkThreadSafe(_vehicle->priorityLink(), msg);
     }
 }
 
@@ -810,196 +810,6 @@ void UAS::processParamValueMsg(mavlink_message_t& msg, const QString& paramName,
 
     emit parameterUpdate(uasId, compId, paramName, rawValue.param_count, rawValue.param_index, rawValue.param_type, paramValue);
 }
-
-/**
-* Set the manual control commands.
-* This can only be done if the system has manual inputs enabled and is armed.
-*/
-void UAS::setExternalControlSetpoint(float roll, float pitch, float yaw, float thrust, quint16 buttons, int joystickMode)
-{
-    if (!_vehicle || !_vehicle->priorityLink()) {
-        return;
-    }
-    mavlink_message_t message;
-    if (joystickMode == Vehicle::JoystickModeAttitude) {
-        // send an external attitude setpoint command (rate control disabled)
-        float attitudeQuaternion[4];
-        mavlink_euler_to_quaternion(roll, pitch, yaw, attitudeQuaternion);
-        uint8_t typeMask = 0x7; // disable rate control
-        mavlink_msg_set_attitude_target_pack_chan(
-            mavlink->getSystemId(),
-            mavlink->getComponentId(),
-            _vehicle->priorityLink()->mavlinkChannel(),
-            &message,
-            QGC::groundTimeUsecs(),
-            this->uasId,
-            0,
-            typeMask,
-            attitudeQuaternion,
-            0,
-            0,
-            0,
-            thrust);
-    } else if (joystickMode == Vehicle::JoystickModePosition) {
-        // Send the the local position setpoint (local pos sp external message)
-        static float px = 0;
-        static float py = 0;
-        static float pz = 0;
-        //XXX: find decent scaling
-        px -= pitch;
-        py += roll;
-        pz -= 2.0f*(thrust-0.5);
-        uint16_t typeMask = (1<<11)|(7<<6)|(7<<3); // select only POSITION control
-        mavlink_msg_set_position_target_local_ned_pack_chan(
-            mavlink->getSystemId(),
-            mavlink->getComponentId(),
-            _vehicle->priorityLink()->mavlinkChannel(),
-            &message,
-            QGC::groundTimeUsecs(),
-            this->uasId,
-            0,
-            MAV_FRAME_LOCAL_NED,
-            typeMask,
-            px,
-            py,
-            pz,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            yaw,
-            0);
-    } else if (joystickMode == Vehicle::JoystickModeForce) {
-        // Send the the force setpoint (local pos sp external message)
-        float dcm[3][3];
-        mavlink_euler_to_dcm(roll, pitch, yaw, dcm);
-        const float fx = -dcm[0][2] * thrust;
-        const float fy = -dcm[1][2] * thrust;
-        const float fz = -dcm[2][2] * thrust;
-        uint16_t typeMask = (3<<10)|(7<<3)|(7<<0)|(1<<9); // select only FORCE control (disable everything else)
-        mavlink_msg_set_position_target_local_ned_pack_chan(
-            mavlink->getSystemId(),
-            mavlink->getComponentId(),
-            _vehicle->priorityLink()->mavlinkChannel(),
-            &message,
-            QGC::groundTimeUsecs(),
-            this->uasId,
-            0,
-            MAV_FRAME_LOCAL_NED,
-            typeMask,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            fx,
-            fy,
-            fz,
-            0,
-            0);
-    } else if (joystickMode == Vehicle::JoystickModeVelocity) {
-        // Send the the local velocity setpoint (local pos sp external message)
-        static float vx = 0;
-        static float vy = 0;
-        static float vz = 0;
-        static float yawrate = 0;
-        //XXX: find decent scaling
-        vx -= pitch;
-        vy += roll;
-        vz -= 2.0f*(thrust-0.5);
-        yawrate += yaw; //XXX: not sure what scale to apply here
-        uint16_t typeMask = (1<<10)|(7<<6)|(7<<0); // select only VELOCITY control
-        mavlink_msg_set_position_target_local_ned_pack_chan(
-            mavlink->getSystemId(),
-            mavlink->getComponentId(),
-            _vehicle->priorityLink()->mavlinkChannel(),
-            &message,
-            QGC::groundTimeUsecs(),
-            this->uasId,
-            0,
-            MAV_FRAME_LOCAL_NED,
-            typeMask,
-            0,
-            0,
-            0,
-            vx,
-            vy,
-            vz,
-            0,
-            0,
-            0,
-            0,
-            yawrate);
-    } else if (joystickMode == Vehicle::JoystickModeRC) {
-        // Store scaling values for all 3 axes
-        static const float axesScaling = 1.0 * 1000.0;
-        // Calculate the new commands for roll, pitch, yaw, and thrust
-        const float newRollCommand = roll * axesScaling;
-        // negate pitch value because pitch is negative for pitching forward but mavlink message argument is positive for forward
-        const float newPitchCommand  = -pitch * axesScaling;
-        const float newYawCommand    = yaw * axesScaling;
-        const float newThrustCommand = thrust * axesScaling;
-        // Send the MANUAL_COMMAND message
-        mavlink_msg_manual_control_pack_chan(
-            static_cast<uint8_t>(mavlink->getSystemId()),
-            static_cast<uint8_t>(mavlink->getComponentId()),
-            _vehicle->priorityLink()->mavlinkChannel(),
-            &message,
-            static_cast<uint8_t>(this->uasId),
-            static_cast<int16_t>(newPitchCommand),
-            static_cast<int16_t>(newRollCommand),
-            static_cast<int16_t>(newThrustCommand),
-            static_cast<int16_t>(newYawCommand),
-            buttons);
-    }
-    _vehicle->sendMessageOnLink(_vehicle->priorityLink(), message);
-}
-
-#ifndef __mobile__
-void UAS::setManual6DOFControlCommands(double x, double y, double z, double roll, double pitch, double yaw)
-{
-    if (!_vehicle) {
-        return;
-    }
-    const uint8_t base_mode = _vehicle->baseMode();
-
-   // If system has manual inputs enabled and is armed
-    if(((base_mode & MAV_MODE_FLAG_DECODE_POSITION_MANUAL) && (base_mode & MAV_MODE_FLAG_DECODE_POSITION_SAFETY)) || (base_mode & MAV_MODE_FLAG_HIL_ENABLED))
-    {
-        mavlink_message_t message;
-        float q[4];
-        mavlink_euler_to_quaternion(roll, pitch, yaw, q);
-
-        float yawrate = 0.0f;
-
-        // Do not control rates and throttle
-        quint8 mask = (1 << 0) | (1 << 1) | (1 << 2); // ignore rates
-        mask |= (1 << 6); // ignore throttle
-        mavlink_msg_set_attitude_target_pack_chan(mavlink->getSystemId(),
-                                                  mavlink->getComponentId(),
-                                                  _vehicle->priorityLink()->mavlinkChannel(),
-                                                  &message,
-                                                  QGC::groundTimeMilliseconds(), this->uasId, _vehicle->defaultComponentId(),
-                                                  mask, q, 0, 0, 0, 0);
-        _vehicle->sendMessageOnLink(_vehicle->priorityLink(), message);
-        quint16 position_mask = (1 << 3) | (1 << 4) | (1 << 5) |
-            (1 << 6) | (1 << 7) | (1 << 8);
-        mavlink_msg_set_position_target_local_ned_pack_chan(mavlink->getSystemId(), mavlink->getComponentId(),
-                                                            _vehicle->priorityLink()->mavlinkChannel(),
-                                                            &message, QGC::groundTimeMilliseconds(), this->uasId, _vehicle->defaultComponentId(),
-                                                            MAV_FRAME_LOCAL_NED, position_mask, x, y, z, 0, 0, 0, 0, 0, 0, yaw, yawrate);
-        _vehicle->sendMessageOnLink(_vehicle->priorityLink(), message);
-        qDebug() << __FILE__ << __LINE__ << ": SENT 6DOF CONTROL MESSAGES: x" << x << " y: " << y << " z: " << z << " roll: " << roll << " pitch: " << pitch << " yaw: " << yaw;
-    }
-    else
-    {
-        qDebug() << "3DMOUSE/MANUAL CONTROL: IGNORING COMMANDS: Set mode to MANUAL to send 3DMouse commands first";
-    }
-}
-#endif
 
 /**
 * Order the robot to start receiver pairing

--- a/src/uas/UAS.h
+++ b/src/uas/UAS.h
@@ -193,14 +193,6 @@ public slots:
     /** @brief Order the robot to pair its receiver **/
     void pairRX(int rxType, int rxSubType);
 
-    /** @brief Set the values for the manual control of the vehicle */
-    void setExternalControlSetpoint(float roll, float pitch, float yaw, float thrust, quint16 buttons, int joystickMode);
-
-    /** @brief Set the values for the 6dof manual control of the vehicle */
-#ifndef __mobile__
-    void setManual6DOFControlCommands(double x, double y, double z, double roll, double pitch, double yaw);
-#endif
-
     /** @brief Receive a message from one of the communication links. */
     virtual void receiveMessage(mavlink_message_t message);
 


### PR DESCRIPTION
Previously writing bytes out to a link went through a sequence of multiple queued messages in Vehicle and LinkInterface to prevent thread safety issues. The problem is that doing it that way is dog slow. So slow that in cases where a joystick was being used on a device with a very slow CPU the MANUAL_CONTROL messages didn't make it through to the vehicle at a high enough frequency. It also chew more CPU than needed.

What happens now is that both Vehicle and LinkInterface use mutexes for thread safety in the following calls which are threadsafe:
* LinkInterface::writeBytesThreadSafe
* Vehicle::sendMessageOnLinkThreadSafe
* Vehicle::sendJoystickDataThreadSafe - Joystick calls this directly instead of posting queued signal

The end result is Mavlink message sending QGC->Vehicle which is measured in nanoseconds instead of 100s of milliseconds. And also when using a joystick a significant reduction in CPU usage.