### PR TITLE
Cube orange yellow

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ Note: This file only contains high level features or important fixes.
 
 ## 4.0.9 - Not yet released
 
+* Don't auto-connect to second Cube Orange/Yellow composite port
 * Plan: Fix bugs associated with mission commands which specify and altitude but no lat/lon
 * Fix bug which could prevent view switching from working after altitude mode warning dialog would pop up
 

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -294,10 +294,33 @@ QString QGCSerialPortInfo::_boardTypeToString(BoardType_t boardType)
 
 QList<QGCSerialPortInfo> QGCSerialPortInfo::availablePorts(void)
 {
+    // Cube Orange/Yellow are composite devices which expose two usb ports over a single usb connection.
+    // The first port is the mavlink connection, the second is the SLCAN connection by default.
+    // We don't expose the second port as being available to QGC.
+
+    static const int hexCubeVID = 11694;
+    static const int hexCubeOrangePID = 4118;
+    static const int hexCubeYellowPID = 4114;
+
+    bool cubeOrangeAlreadySeen = false;
+    bool cubeYellowAlreadySeen = false;
+
     QList<QGCSerialPortInfo>    list;
 
     for(QSerialPortInfo portInfo: QSerialPortInfo::availablePorts()) {
         if (!isSystemPort(&portInfo)) {
+            if (portInfo.vendorIdentifier() == hexCubeVID && portInfo.productIdentifier() == hexCubeOrangePID) {
+                if (cubeOrangeAlreadySeen) {
+                    continue;
+                }
+                cubeOrangeAlreadySeen = true;
+            }
+            if (portInfo.vendorIdentifier() == hexCubeVID && portInfo.productIdentifier() == hexCubeYellowPID) {
+                if (cubeYellowAlreadySeen) {
+                    continue;
+                }
+                cubeYellowAlreadySeen = true;
+            }
             list << *((QGCSerialPortInfo*)&portInfo);
         }
     }

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -313,12 +313,14 @@ QList<QGCSerialPortInfo> QGCSerialPortInfo::availablePorts(void)
                 if (cubeOrangeAlreadySeen) {
                     continue;
                 }
+                qCDebug(QGCSerialPortInfoLog) << "Skipping secondary port on Cube Orange" << portInfo.portName();
                 cubeOrangeAlreadySeen = true;
             }
             if (portInfo.vendorIdentifier() == hexCubeVID && portInfo.productIdentifier() == hexCubeYellowPID) {
                 if (cubeYellowAlreadySeen) {
                     continue;
                 }
+                qCDebug(QGCSerialPortInfoLog) << "Skipping secondary port on Cube Yellow" << portInfo.portName();
                 cubeYellowAlreadySeen = true;
             }
             list << *((QGCSerialPortInfo*)&portInfo);


### PR DESCRIPTION
The Orange and Yellow Cubes expose a composite usb device over a single usb physical connections. The first of the ports is the mavlink connection. The second connection by default is SLCAN and QGC should not auto-connect to it.