### PR TITLE
Mission flight status

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -353,7 +353,7 @@ CorridorScanComplexItem::ReadyForSaveState CorridorScanComplexItem::readyForSave
 
 double CorridorScanComplexItem::timeBetweenShots(void)
 {
-    return _cruiseSpeed == 0 ? 0 : _cameraCalc.adjustedFootprintFrontal()->rawValue().toDouble() / _cruiseSpeed;
+    return _vehicleSpeed == 0 ? 0 : _cameraCalc.adjustedFootprintFrontal()->rawValue().toDouble() / _vehicleSpeed;
 }
 
 double CorridorScanComplexItem::_calcTransectSpacing(void) const

--- a/src/MissionManager/CorridorScanComplexItemTest.cc
+++ b/src/MissionManager/CorridorScanComplexItemTest.cc
@@ -32,11 +32,6 @@ void CorridorScanComplexItemTest::init(void)
     int expectedTransectCount = _expectedTransectCount;
     QCOMPARE(_corridorItem->_transectCount(), expectedTransectCount);
 
-    // vehicleSpeed need for terrain calcs
-    MissionController::MissionFlightStatus_t missionFlightStatus;
-    missionFlightStatus.vehicleSpeed = 5;
-    _corridorItem->setMissionFlightStatus(missionFlightStatus);
-
     _corridorItem->setDirty(false);
 
     _rgCorridorPolygonSignals[corridorPolygonPathChangedIndex] = SIGNAL(pathChanged());

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -331,7 +331,6 @@ VisualMissionItem* MissionController::_insertSimpleMissionItemWorker(QGeoCoordin
             }
         }
     }
-    newItem->setMissionFlightStatus(_missionFlightStatus);
     if (visualItemIndex == -1) {
         _visualItems->append(newItem);
     } else {
@@ -372,7 +371,6 @@ VisualMissionItem* MissionController::insertTakeoffItem(QGeoCoordinate /*coordin
             newItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltitudeMode>(prevAltitudeMode));
         }
     }
-    newItem->setMissionFlightStatus(_missionFlightStatus);
     if (visualItemIndex == -1) {
         _visualItems->append(newItem);
     } else {

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -44,7 +44,7 @@ public:
     MissionController(PlanMasterController* masterController, QObject* parent = nullptr);
     ~MissionController();
 
-    typedef struct _MissionFlightStatus_t {
+    typedef struct {
         double  maxTelemetryDistance;
         double  totalDistance;
         double  totalTime;

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -935,7 +935,7 @@ void SimpleMissionItem::applyNewAltitude(double newAltitude)
 
 void SimpleMissionItem::setMissionFlightStatus(MissionController::MissionFlightStatus_t& missionFlightStatus)
 {
-    // If user has not already set speed/gimbal, set defaults from previous items.
+    // If speed and/or gimbal are not specifically set on this item. Then use the flight status values as initial defaults should a user turn them on.
     VisualMissionItem::setMissionFlightStatus(missionFlightStatus);
     if (_speedSection->available() && !_speedSection->specifyFlightSpeed() && !qFuzzyCompare(_speedSection->flightSpeed()->rawValue().toDouble(), missionFlightStatus.vehicleSpeed)) {
         _speedSection->flightSpeed()->setRawValue(missionFlightStatus.vehicleSpeed);

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -474,8 +474,8 @@ int StructureScanComplexItem::cameraShots(void) const
 void StructureScanComplexItem::setMissionFlightStatus(MissionController::MissionFlightStatus_t& missionFlightStatus)
 {
     ComplexMissionItem::setMissionFlightStatus(missionFlightStatus);
-    if (!qFuzzyCompare(_cruiseSpeed, missionFlightStatus.vehicleSpeed)) {
-        _cruiseSpeed = missionFlightStatus.vehicleSpeed;
+    if (!qFuzzyCompare(_vehicleSpeed, missionFlightStatus.vehicleSpeed)) {
+        _vehicleSpeed = missionFlightStatus.vehicleSpeed;
         emit timeBetweenShotsChanged();
     }
 }
@@ -499,7 +499,7 @@ void StructureScanComplexItem::_polygonDirtyChanged(bool dirty)
 
 double StructureScanComplexItem::timeBetweenShots(void)
 {
-    return _cruiseSpeed == 0 ? 0 : _cameraCalc.adjustedFootprintSide()->rawValue().toDouble() / _cruiseSpeed;
+    return _vehicleSpeed == 0 ? 0 : _cameraCalc.adjustedFootprintSide()->rawValue().toDouble() / _vehicleSpeed;
 }
 
 QGeoCoordinate StructureScanComplexItem::coordinate(void) const

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -151,7 +151,7 @@ private:
     double          _scanDistance;
     int             _cameraShots;
     double          _timeBetweenShots;
-    double          _cruiseSpeed;
+    double          _vehicleSpeed;
     CameraCalc      _cameraCalc;
 
 

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1416,7 +1416,7 @@ void SurveyComplexItem::rotateEntryPoint(void)
 
 double SurveyComplexItem::timeBetweenShots(void)
 {
-    return _cruiseSpeed == 0 ? 0 : triggerDistance() / _cruiseSpeed;
+    return _vehicleSpeed == 0 ? 0 : triggerDistance() / _vehicleSpeed;
 }
 
 double SurveyComplexItem::additionalTimeDelay (void) const

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -327,8 +327,10 @@ double TransectStyleComplexItem::greatestDistanceTo(const QGeoCoordinate &other)
 void TransectStyleComplexItem::setMissionFlightStatus(MissionController::MissionFlightStatus_t& missionFlightStatus)
 {
     ComplexMissionItem::setMissionFlightStatus(missionFlightStatus);
-    if (!qFuzzyCompare(_cruiseSpeed, missionFlightStatus.vehicleSpeed)) {
-        _cruiseSpeed = missionFlightStatus.vehicleSpeed;
+    if (!qFuzzyCompare(_vehicleSpeed, missionFlightStatus.vehicleSpeed)) {
+        _vehicleSpeed = missionFlightStatus.vehicleSpeed;
+        // Vehicle speed change affects max climb/descent rates calcs for terrain so we need to re-adjust
+        _rebuildTransects();
         emit timeBetweenShotsChanged();
     }
 }
@@ -707,9 +709,9 @@ int TransectStyleComplexItem::_maxPathHeight(const TerrainPathQuery::PathHeightI
 
 void TransectStyleComplexItem::_adjustForMaxRates(QList<CoordInfo_t>& transect)
 {
-    double maxClimbRate = _terrainAdjustMaxClimbRateFact.rawValue().toDouble();
-    double maxDescentRate = _terrainAdjustMaxDescentRateFact.rawValue().toDouble();
-    double flightSpeed = _missionFlightStatus.vehicleSpeed;
+    double maxClimbRate     = _terrainAdjustMaxClimbRateFact.rawValue().toDouble();
+    double maxDescentRate   = _terrainAdjustMaxDescentRateFact.rawValue().toDouble();
+    double flightSpeed      = _vehicleSpeed;
 
     if (qIsNaN(flightSpeed) || (maxClimbRate == 0 && maxDescentRate == 0)) {
         if (qIsNaN(flightSpeed)) {

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -185,7 +185,7 @@ protected:
     double          _complexDistance =  qQNaN();
     int             _cameraShots =      0;
     double          _timeBetweenShots = 0;
-    double          _cruiseSpeed =      0;
+    double          _vehicleSpeed =     5;
     CameraCalc      _cameraCalc;
     bool            _followTerrain =    false;
     double          _minAMSLAltitude =  qQNaN();

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -152,12 +152,11 @@ void VisualMissionItem::setAzimuth(double azimuth)
 
 void VisualMissionItem::setMissionFlightStatus(MissionController::MissionFlightStatus_t& missionFlightStatus)
 {
-    _missionFlightStatus = missionFlightStatus;
-    if (qIsNaN(_missionFlightStatus.gimbalYaw) && qIsNaN(_missionGimbalYaw)) {
+    if (qIsNaN(missionFlightStatus.gimbalYaw) && qIsNaN(_missionGimbalYaw)) {
         return;
     }
-    if (!qFuzzyCompare(_missionFlightStatus.gimbalYaw, _missionGimbalYaw)) {
-        _missionGimbalYaw = _missionFlightStatus.gimbalYaw;
+    if (!qFuzzyCompare(missionFlightStatus.gimbalYaw, _missionGimbalYaw)) {
+        _missionGimbalYaw = missionFlightStatus.gimbalYaw;
         emit missionGimbalYawChanged(_missionGimbalYaw);
     }
 }

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -271,8 +271,6 @@ protected:
     VisualMissionItem*      _parentItem =               nullptr;
     QGCGeoBoundingCube      _boundingCube;                          ///< The bounding "cube" of this element.
 
-    MissionController::MissionFlightStatus_t    _missionFlightStatus;
-
     /// This is used to reference any subsequent mission items which do not specify a coordinate.
     QmlObjectListModel  _childItems;
 


### PR DESCRIPTION
* No need to call setMissionFlightStatus on newly created items. Correct handling will happen during recalc
* TransectStyleCompleteItem now correctly rebuilds transects when vehicle speed changes. Terrain calc is specific to vehicle speed to do climb/descent rate based calc.
* Related to #8846