### PR TITLE
Gzip ArduPilot manifest support

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -110,6 +110,10 @@ SOURCES += \
 
 #
 # [REQUIRED] zlib library
+Windows {
+    INCLUDEPATH +=  $$SOURCE_DIR/libszlib/windows/include
+    LIBS += -L$$SOURCE_DIR/libszlib/windows/lib
+}
 LIBS += -lz
 
 #
@@ -147,7 +151,7 @@ contains(DEFINES, QGC_ENABLE_PAIRING) {
         exists(/usr/local/Cellar/openssl/1.0.2t/include) {
             INCLUDEPATH += /usr/local/Cellar/openssl/1.0.2t/include
             LIBS += -L/usr/local/Cellar/openssl/1.0.2t/lib
-            LIBS += -lcrypto -lz
+            LIBS += -lcrypto
         } else {
             # There is some circular reference settings going on between QGCExternalLibs.pri and gqgroundcontrol.pro.
             # So this duplicates some of the enable/disable logic which would normally be in qgroundcontrol.pro.
@@ -157,7 +161,7 @@ contains(DEFINES, QGC_ENABLE_PAIRING) {
         #- Pairing is not supported on Windows
         DEFINES -= QGC_ENABLE_PAIRING
     } else {
-        LIBS += -lcrypto -lz
+        LIBS += -lcrypto
         AndroidBuild {
             contains(QT_ARCH, arm) {
                 LIBS += $$ANDROID_EXTRA_LIBS

--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -109,6 +109,10 @@ SOURCES += \
     libs/shapelib/safileio.c
 
 #
+# [REQUIRED] zlib library
+LIBS += -lz
+
+#
 # [REQUIRED] SDL dependency. Provides joystick/gamepad support.
 # The SDL is packaged with QGC for the Mac and Windows. Linux support requires installing the SDL
 # library (development libraries and static binaries).

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -900,17 +900,17 @@ void FirmwareUpgradeController::_ardupilotManifestDownloadFinished(QString remot
     }
 
     int             ret;
-    int             cBuffer = 1024 * 5;
+    const int       cBuffer = 1024 * 5;
     unsigned char   inputBuffer[cBuffer];
     unsigned char   outputBuffer[cBuffer];
     z_stream        strm;
     QByteArray      jsonBytes;
 
-    strm.zalloc     = Z_NULL;
-    strm.zfree      = Z_NULL;
-    strm.opaque     = Z_NULL;
+    strm.zalloc     = nullptr;
+    strm.zfree      = nullptr;
+    strm.opaque     = nullptr;
     strm.avail_in   = 0;
-    strm.next_in    = Z_NULL;
+    strm.next_in    = nullptr;
 
     ret = inflateInit2(&strm, 16+MAX_WBITS);
     if (ret != Z_OK) {
@@ -920,7 +920,7 @@ void FirmwareUpgradeController::_ardupilotManifestDownloadFinished(QString remot
     }
 
     do {
-        strm.avail_in = inputFile.read((char *)inputBuffer, cBuffer);
+        strm.avail_in = static_cast<unsigned>(inputFile.read((char*)inputBuffer, cBuffer));
         if (strm.avail_in == 0) {
             break;
         }
@@ -939,7 +939,7 @@ void FirmwareUpgradeController::_ardupilotManifestDownloadFinished(QString remot
             }
 
             unsigned cBytesInflated = cBuffer - strm.avail_out;
-            jsonBytes.append((char*)outputBuffer, cBytesInflated);
+            jsonBytes.append((char*)outputBuffer, static_cast<int>(cBytesInflated));
         } while (strm.avail_out == 0);
     } while (ret != Z_STREAM_END);
 


### PR DESCRIPTION
* Get zlib support working on all platforms
* Switch to using gzip version of ArduPilot manifest

This is the first test case of inflating a gzip file. I will now turn this into a more generic gzip decompress and use for COMPONENT_INFORMATION gzipped json as wlel.