### PR TITLE
Add option to ignore camel case in FactGroup.

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -154,7 +154,7 @@ read_value(QDomNode& element, const char* tagName, QString& target)
 
 //-----------------------------------------------------------------------------
 QGCCameraControl::QGCCameraControl(const mavlink_camera_information_t *info, Vehicle* vehicle, int compID, QObject* parent)
-    : FactGroup(0, parent)
+    : FactGroup(0, parent, true /* ignore camel case */)
     , _vehicle(vehicle)
     , _compID(compID)
 {

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -20,17 +20,19 @@
 
 QGC_LOGGING_CATEGORY(FactGroupLog, "FactGroupLog")
 
-FactGroup::FactGroup(int updateRateMsecs, const QString& metaDataFile, QObject* parent)
+FactGroup::FactGroup(int updateRateMsecs, const QString& metaDataFile, QObject* parent, bool ignoreCamelCase)
     : QObject(parent)
     , _updateRateMSecs(updateRateMsecs)
+    , _ignoreCamelCase(ignoreCamelCase)
 {
     _setupTimer();
     _nameToFactMetaDataMap = FactMetaData::createMapFromJsonFile(metaDataFile, this);
 }
 
-FactGroup::FactGroup(int updateRateMsecs, QObject* parent)
+FactGroup::FactGroup(int updateRateMsecs, QObject* parent, bool ignoreCamelCase)
     : QObject(parent)
     , _updateRateMSecs(updateRateMsecs)
+    , _ignoreCamelCase(ignoreCamelCase)
 {
     _setupTimer();
 }
@@ -70,7 +72,7 @@ Fact* FactGroup::getFact(const QString& name)
     }
 
     Fact*   fact =          nullptr;
-    QString camelCaseName = _camelCase(name);
+    QString camelCaseName = _ignoreCamelCase ? name : _camelCase(name);
 
     if (_nameToFactMap.contains(camelCaseName)) {
         fact = _nameToFactMap[camelCaseName];
@@ -85,7 +87,7 @@ Fact* FactGroup::getFact(const QString& name)
 FactGroup* FactGroup::getFactGroup(const QString& name)
 {
     FactGroup*  factGroup = nullptr;
-    QString     camelCaseName = _camelCase(name);
+    QString     camelCaseName = _ignoreCamelCase ? name : _camelCase(name);
 
     if (_nameToFactGroupMap.contains(camelCaseName)) {
         factGroup = _nameToFactGroupMap[camelCaseName];

--- a/src/FactSystem/FactGroup.h
+++ b/src/FactSystem/FactGroup.h
@@ -26,8 +26,8 @@ class FactGroup : public QObject
     Q_OBJECT
     
 public:
-    FactGroup(int updateRateMsecs, const QString& metaDataFile, QObject* parent = nullptr);
-    FactGroup(int updateRateMsecs, QObject* parent = nullptr);
+    FactGroup(int updateRateMsecs, const QString& metaDataFile, QObject* parent = nullptr, bool ignoreCamelCase = false);
+    FactGroup(int updateRateMsecs, QObject* parent = nullptr, bool ignoreCamelCase = false);
 
     Q_PROPERTY(QStringList factNames        READ factNames      CONSTANT)
     Q_PROPERTY(QStringList factGroupNames   READ factGroupNames CONSTANT)
@@ -63,6 +63,7 @@ private:
     void    _setupTimer (void);
     QString _camelCase  (const QString& text);
 
+    bool    _ignoreCamelCase = false;
     QTimer  _updateTimer;
 };
 


### PR DESCRIPTION
The camera module uses PARAM_EXT, which is case sensitive. Changing the case at runtime causes the parameters not to be found.