### PR TITLE
Change gradient indicator calculation from degrees to percent

### DIFF
--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -38,7 +38,7 @@ Item {
     property real   _rowSpacing:                ScreenTools.isMobile ? 1 : 0
     property real   _distance:                  _statusValid && _currentMissionItem ? _currentMissionItem.distance : NaN
     property real   _altDifference:             _statusValid && _currentMissionItem ? _currentMissionItem.altDifference : NaN
-    property real   _gradient:                  _statusValid && _currentMissionItem && _currentMissionItem.distance > 0 ? (Math.atan(_currentMissionItem.altDifference / _currentMissionItem.distance) * (180.0/Math.PI)) : NaN
+    property real   _gradient:                  _statusValid && _currentMissionItem && _currentMissionItem.distance > 0 ? 100 * _currentMissionItem.altDifference / _currentMissionItem.distance : NaN
     property real   _azimuth:                   _statusValid && _currentMissionItem ? _currentMissionItem.azimuth : NaN
     property real   _heading:                   _statusValid && _currentMissionItem ? _currentMissionItem.missionVehicleYaw : NaN
     property real   _missionDistance:           _missionValid ? missionDistance : NaN


### PR DESCRIPTION
Came across this as we copied some of the indicator logic to a new AMC widget. If my understanding is correct and "gradient" is basically the same as "slope" and we want to display it in percent, I think the calculation should be `100 * altDifference / distance`.

Alternatively the `_gradientText` unit [on line 55](https://github.com/mavlink/qgroundcontrol/blob/master/src/PlanView/PlanToolBarIndicators.qml#L55) could be changed to degrees.