### PR TITLE
Remove RC_CHANNELS_RAW support

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -732,9 +732,6 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_RC_CHANNELS:
         _handleRCChannels(message);
         break;
-    case MAVLINK_MSG_ID_RC_CHANNELS_RAW:
-        _handleRCChannelsRaw(message);
-        break;
     case MAVLINK_MSG_ID_BATTERY_STATUS:
         _handleBatteryStatus(message);
         break;
@@ -1876,51 +1873,6 @@ void Vehicle::_handleRCChannels(mavlink_message_t& message)
 
     emit remoteControlRSSIChanged(channels.rssi);
     emit rcChannelsChanged(channels.chancount, pwmValues);
-}
-
-void Vehicle::_handleRCChannelsRaw(mavlink_message_t& message)
-{
-    // We handle both RC_CHANNLES and RC_CHANNELS_RAW since different firmware will only
-    // send one or the other.
-
-    mavlink_rc_channels_raw_t channels;
-
-    mavlink_msg_rc_channels_raw_decode(&message, &channels);
-
-    uint16_t* _rgChannelvalues[cMaxRcChannels] = {
-        &channels.chan1_raw,
-        &channels.chan2_raw,
-        &channels.chan3_raw,
-        &channels.chan4_raw,
-        &channels.chan5_raw,
-        &channels.chan6_raw,
-        &channels.chan7_raw,
-        &channels.chan8_raw,
-    };
-
-    int pwmValues[cMaxRcChannels];
-    int channelCount = 0;
-
-    for (int i=0; i<cMaxRcChannels; i++) {
-        pwmValues[i] = -1;
-    }
-
-    for (int i=0; i<8; i++) {
-        uint16_t channelValue = *_rgChannelvalues[i];
-
-        if (channelValue == UINT16_MAX) {
-            pwmValues[i] = -1;
-        } else {
-            channelCount = i + 1;
-            pwmValues[i] = channelValue;
-        }
-    }
-    for (int i=9; i<18; i++) {
-        pwmValues[i] = -1;
-    }
-
-    emit remoteControlRSSIChanged(channels.rssi);
-    emit rcChannelsChanged(channelCount, pwmValues);
 }
 
 // Pop warnings ignoring for mavlink headers for both GCC/Clang and MSVC

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1232,7 +1232,7 @@ signals:
     void gitHashChanged                 (QString hash);
     void vehicleUIDChanged              ();
 
-    /// New RC channel values
+    /// New RC channel values coming from RC_CHANNELS message
     ///     @param channelCount Number of available channels, cMaxRcChannels max
     ///     @param pwmValues -1 signals channel not available
     void rcChannelsChanged              (int channelCount, int pwmValues[cMaxRcChannels]);
@@ -1317,7 +1317,6 @@ private:
     void _handleHeartbeat               (mavlink_message_t& message);
     void _handleRadioStatus             (mavlink_message_t& message);
     void _handleRCChannels              (mavlink_message_t& message);
-    void _handleRCChannelsRaw           (mavlink_message_t& message);
     void _handleBatteryStatus           (mavlink_message_t& message);
     void _handleSysStatus               (mavlink_message_t& message);
     void _handleWindCov                 (mavlink_message_t& message);

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
@@ -90,12 +90,11 @@ void PX4FirmwareUpgradeThreadWorker::_findBoardOnce(void)
                         emit foundBoardInfo(bootloaderVersion, boardId, flashSize);
                     } else {
                         emit error(_bootloader->errorString());
-                        return;
                     }
                 } else {
                     emit error(_bootloader->errorString());
-                    return;
                 }
+                return;
             }
         }
     } else {


### PR DESCRIPTION
* Remove handling of `RC_CHANNELS_RAW` relying o n`RC_CHANNELS` only. Handling both was causing incorrect channel counts to be sent to Radio Cal. This fixes *#8853 
* Fixed flash find board loop 