### PR TITLE
Fix text overlay for recorded videos

### DIFF
--- a/src/VideoManager/SubtitleWriter.cc
+++ b/src/VideoManager/SubtitleWriter.cc
@@ -39,7 +39,8 @@ void SubtitleWriter::startCapturingTelemetry(const QString& videoFile)
     _values = settings.value("large").toStringList().replaceInStrings(QStringLiteral("Vehicle."), QString());
     _values += settings.value("small").toStringList().replaceInStrings(QStringLiteral("Vehicle."), QString());
 
-    _startTime = QDateTime::currentDateTime();
+    // One subtitle always starts where the previous ended
+    _lastEndTime = QTime(0, 0);
 
     QFileInfo videoFileInfo(videoFile);
     QString subtitleFilePath = QStringLiteral("%1/%2.ass").arg(videoFileInfo.path(), videoFileInfo.completeBaseName());
@@ -108,10 +109,11 @@ void SubtitleWriter::_captureTelemetry()
     }
 
     // The time to start displaying this subtitle text
-    QTime start = QTime(0, 0).addMSecs(_startTime.time().msecsTo(QDateTime::currentDateTime().time()));
+    QTime start = _lastEndTime;
 
     // The time to stop displaying this subtitle text
     QTime end = start.addMSecs(1000/_sampleRate);
+    _lastEndTime = end;
 
     // This splits the screen in N parts and uses the N-1 internal parts to align the subtitles to.
     // Should we try to get the resolution from the pipeline? This seems to work fine with other resolutions too.

--- a/src/VideoManager/SubtitleWriter.h
+++ b/src/VideoManager/SubtitleWriter.h
@@ -43,7 +43,7 @@ private slots:
 private:
     QTimer _timer;
     QStringList _values;
-    QDateTime _startTime;
+    QTime _lastEndTime;
     QFile _file;
 
     static const int _sampleRate;

--- a/src/VideoManager/SubtitleWriter.h
+++ b/src/VideoManager/SubtitleWriter.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "QGCLoggingCategory.h"
+#include "Fact.h"
 #include <QObject>
 #include <QTimer>
 #include <QDateTime>
@@ -42,9 +43,9 @@ private slots:
 
 private:
     QTimer _timer;
-    QStringList _values;
+    QList<Fact*> _facts;
     QTime _lastEndTime;
     QFile _file;
 
-    static const int _sampleRate;
+    static const int _sampleRate; // Sample rate in Hz for getting telemetry data, most players do weird stuff when > 1Hz
 };


### PR DESCRIPTION
First commit fixes #8766 and the second updates the code to work with the new values widget.