### PR TITLE
Update QGCExternalLibs.pri

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -110,7 +110,7 @@ SOURCES += \
 
 #
 # [REQUIRED] zlib library
-Windows {
+WindowsBuild {
     INCLUDEPATH +=  $$SOURCE_DIR/libs/zlib/windows/include
     LIBS += -L$$SOURCE_DIR/libs/zlib/windows/lib
 }


### PR DESCRIPTION
It does not build on windows. QGCExternalLibs.pri must fix Windows to WindowsBuild.


