### PR TITLE
Support for Vehicle and Firmware classes

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -752,23 +752,23 @@ QList<MAV_CMD> APMFirmwarePlugin::supportedMissionCommands(void)
     };
 }
 
-QString APMFirmwarePlugin::missionCommandOverrides(MAV_TYPE vehicleType) const
+QString APMFirmwarePlugin::missionCommandOverrides(QGCMAVLink::VehicleClass_t vehicleClass) const
 {
-    switch (vehicleType) {
-    case MAV_TYPE_GENERIC:
+    switch (vehicleClass) {
+    case QGCMAVLink::VehicleClassGeneric:
         return QStringLiteral(":/json/APM-MavCmdInfoCommon.json");
-    case MAV_TYPE_FIXED_WING:
+    case QGCMAVLink::VehicleClassFixedWing:
         return QStringLiteral(":/json/APM-MavCmdInfoFixedWing.json");
-    case MAV_TYPE_QUADROTOR:
+    case QGCMAVLink::VehicleClassMultiRotor:
         return QStringLiteral(":/json/APM-MavCmdInfoMultiRotor.json");
-    case MAV_TYPE_VTOL_QUADROTOR:
+    case QGCMAVLink::VehicleClassVTOL:
         return QStringLiteral(":/json/APM-MavCmdInfoVTOL.json");
-    case MAV_TYPE_SUBMARINE:
+    case QGCMAVLink::VehicleClassSub:
         return QStringLiteral(":/json/APM-MavCmdInfoSub.json");
-    case MAV_TYPE_GROUND_ROVER:
+    case QGCMAVLink::VehicleClassRoverBoat:
         return QStringLiteral(":/json/APM-MavCmdInfoRover.json");
     default:
-        qWarning() << "APMFirmwarePlugin::missionCommandOverrides called with bad MAV_TYPE:" << vehicleType;
+        qWarning() << "APMFirmwarePlugin::missionCommandOverrides called with bad VehicleClass_t:" << vehicleClass;
         return QString();
     }
 }

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -97,7 +97,7 @@ public:
     virtual void        initializeStreamRates           (Vehicle* vehicle);
     void                initializeVehicle               (Vehicle* vehicle) override;
     bool                sendHomePositionToVehicle       (void) override;
-    QString             missionCommandOverrides         (MAV_TYPE vehicleType) const override;
+    QString             missionCommandOverrides         (QGCMAVLink::VehicleClass_t vehicleClass) const override;
     QString             getVersionParam                 (void) override { return QStringLiteral("SYSID_SW_MREV"); }
     QString             _internalParameterMetaDataFile  (Vehicle* vehicle) override;
     FactMetaData*       _getMetaDataForFact             (QObject* parameterMetaData, const QString& name, FactMetaData::ValueType_t type, MAV_TYPE vehicleType) override;

--- a/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
@@ -24,11 +24,11 @@ APMFirmwarePluginFactory::APMFirmwarePluginFactory(void)
 
 }
 
-QList<MAV_AUTOPILOT> APMFirmwarePluginFactory::supportedFirmwareTypes(void) const
+QList<QGCMAVLink::FirmwareClass_t> APMFirmwarePluginFactory::supportedFirmwareClasses(void) const
 {
-    QList<MAV_AUTOPILOT> list;
+    QList<QGCMAVLink::FirmwareClass_t> list;
 
-    list.append(MAV_AUTOPILOT_ARDUPILOTMEGA);
+    list.append(QGCMAVLink::FirmwareClassArduPilot);
     return list;
 }
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.h
@@ -7,8 +7,7 @@
  *
  ****************************************************************************/
 
-#ifndef APMFirmwarePluginFactory_H
-#define APMFirmwarePluginFactory_H
+#pragma once
 
 #include "FirmwarePlugin.h"
 
@@ -24,8 +23,8 @@ class APMFirmwarePluginFactory : public FirmwarePluginFactory
 public:
     APMFirmwarePluginFactory(void);
 
-    QList<MAV_AUTOPILOT>    supportedFirmwareTypes      (void) const final;
-    FirmwarePlugin*         firmwarePluginForAutopilot  (MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType) final;
+    QList<QGCMAVLink::FirmwareClass_t>  supportedFirmwareClasses(void) const final;
+    FirmwarePlugin*                     firmwarePluginForAutopilot  (MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType) final;
 
 private:
     ArduCopterFirmwarePlugin*   _arduCopterPluginInstance;
@@ -33,5 +32,3 @@ private:
     ArduRoverFirmwarePlugin*    _arduRoverPluginInstance;
     ArduSubFirmwarePlugin*      _arduSubPluginInstance;
 };
-
-#endif

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -34,11 +34,9 @@ FirmwarePluginFactory::FirmwarePluginFactory(void)
     FirmwarePluginFactoryRegister::instance()->registerPluginFactory(this);
 }
 
-QList<MAV_TYPE> FirmwarePluginFactory::supportedVehicleTypes(void) const
+QList<QGCMAVLink::VehicleClass_t> FirmwarePluginFactory::supportedVehicleClasses(void) const
 {
-    QList<MAV_TYPE> vehicleTypes;
-    vehicleTypes << MAV_TYPE_FIXED_WING << MAV_TYPE_QUADROTOR << MAV_TYPE_VTOL_QUADROTOR << MAV_TYPE_GROUND_ROVER << MAV_TYPE_SUBMARINE;
-    return vehicleTypes;
+    return QGCMAVLink::allVehicleClasses();
 }
 
 FirmwarePluginFactoryRegister* FirmwarePluginFactoryRegister::instance(void)
@@ -182,23 +180,23 @@ QList<MAV_CMD> FirmwarePlugin::supportedMissionCommands(void)
     return QList<MAV_CMD>();
 }
 
-QString FirmwarePlugin::missionCommandOverrides(MAV_TYPE vehicleType) const
+QString FirmwarePlugin::missionCommandOverrides(QGCMAVLink::VehicleClass_t vehicleClass) const
 {
-    switch (vehicleType) {
-    case MAV_TYPE_GENERIC:
+    switch (vehicleClass) {
+    case QGCMAVLink::VehicleClassGeneric:
         return QStringLiteral(":/json/MavCmdInfoCommon.json");
-    case MAV_TYPE_FIXED_WING:
+    case QGCMAVLink::VehicleClassFixedWing:
         return QStringLiteral(":/json/MavCmdInfoFixedWing.json");
-    case MAV_TYPE_QUADROTOR:
+    case QGCMAVLink::VehicleClassMultiRotor:
         return QStringLiteral(":/json/MavCmdInfoMultiRotor.json");
-    case MAV_TYPE_VTOL_QUADROTOR:
+    case QGCMAVLink::VehicleClassVTOL:
         return QStringLiteral(":/json/MavCmdInfoVTOL.json");
-    case MAV_TYPE_SUBMARINE:
+    case QGCMAVLink::VehicleClassSub:
         return QStringLiteral(":/json/MavCmdInfoSub.json");
-    case MAV_TYPE_GROUND_ROVER:
+    case QGCMAVLink::VehicleClassRoverBoat:
         return QStringLiteral(":/json/MavCmdInfoRover.json");
     default:
-        qWarning() << "FirmwarePlugin::missionCommandOverrides called with bad MAV_TYPE:" << vehicleType;
+        qWarning() << "FirmwarePlugin::missionCommandOverrides called with bad VehicleClass_t:" << vehicleClass;
         return QString();
     }
 }
@@ -785,22 +783,6 @@ bool FirmwarePlugin::hasGimbal(Vehicle* vehicle, bool& rollSupported, bool& pitc
     pitchSupported = false;
     yawSupported = false;
     return false;
-}
-
-bool FirmwarePlugin::isVtol(const Vehicle* vehicle) const
-{
-    switch (vehicle->vehicleType()) {
-    case MAV_TYPE_VTOL_DUOROTOR:
-    case MAV_TYPE_VTOL_QUADROTOR:
-    case MAV_TYPE_VTOL_TILTROTOR:
-    case MAV_TYPE_VTOL_RESERVED2:
-    case MAV_TYPE_VTOL_RESERVED3:
-    case MAV_TYPE_VTOL_RESERVED4:
-    case MAV_TYPE_VTOL_RESERVED5:
-        return true;
-    default:
-        return false;
-    }
 }
 
 QGCCameraManager* FirmwarePlugin::createCameraManager(Vehicle* vehicle)

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -241,8 +241,8 @@ public:
     virtual QList<MAV_CMD> supportedMissionCommands(void);
 
     /// Returns the name of the mission command json override file for the specified vehicle type.
-    ///     @param vehicleType Vehicle type to return file for, MAV_TYPE_GENERIC is a request for overrides for all vehicle types
-    virtual QString missionCommandOverrides(MAV_TYPE vehicleType) const;
+    ///     @param vehicleClass Vehicle class to return file for, VehicleClassGeneric is a request for overrides for all vehicle types
+    virtual QString missionCommandOverrides(QGCMAVLink::VehicleClass_t vehicleClass) const;
 
     /// Returns the mapping structure which is used to map from one parameter name to another based on firmware version.
     virtual const remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const;
@@ -316,9 +316,6 @@ public:
     /// @return true: vehicle has gimbal, false: gimbal support unknown
     virtual bool hasGimbal(Vehicle* vehicle, bool& rollSupported, bool& pitchSupported, bool& yawSupported);
 
-    /// Returns true if the vehicle is a VTOL
-    virtual bool isVtol(const Vehicle* vehicle) const;
-
     /// Convert from HIGH_LATENCY2.custom_mode value to correct 32 bit value.
     virtual uint32_t highLatencyCustomModeTo32Bits(uint16_t hlCustomMode);
 
@@ -383,11 +380,11 @@ public:
     /// @return Singleton FirmwarePlugin instance for the specified MAV_AUTOPILOT.
     virtual FirmwarePlugin* firmwarePluginForAutopilot(MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType) = 0;
 
-    /// @return List of firmware types this plugin supports.
-    virtual QList<MAV_AUTOPILOT> supportedFirmwareTypes(void) const = 0;
+    /// @return List of firmware classes this plugin supports.
+    virtual QList<QGCMAVLink::FirmwareClass_t> supportedFirmwareClasses(void) const = 0;
 
-    /// @return List of vehicle types this plugin supports.
-    virtual QList<MAV_TYPE> supportedVehicleTypes(void) const;
+    /// @return List of vehicle classes this plugin supports.
+    virtual QList<QGCMAVLink::VehicleClass_t> supportedVehicleClasses(void) const;
 };
 
 class FirmwarePluginFactoryRegister : public QObject

--- a/src/FirmwarePlugin/FirmwarePluginManager.cc
+++ b/src/FirmwarePlugin/FirmwarePluginManager.cc
@@ -26,33 +26,35 @@ FirmwarePluginManager::~FirmwarePluginManager()
     delete _genericFirmwarePlugin;
 }
 
-QList<MAV_AUTOPILOT> FirmwarePluginManager::supportedFirmwareTypes(void)
+QList<QGCMAVLink::FirmwareClass_t> FirmwarePluginManager::supportedFirmwareClasses(void)
 {
-    if (_supportedFirmwareTypes.isEmpty()) {
+    if (_supportedFirmwareClasses.isEmpty()) {
         QList<FirmwarePluginFactory*> factoryList = FirmwarePluginFactoryRegister::instance()->pluginFactories();
         for (int i = 0; i < factoryList.count(); i++) {
-            _supportedFirmwareTypes.append(factoryList[i]->supportedFirmwareTypes());
+            _supportedFirmwareClasses.append(factoryList[i]->supportedFirmwareClasses());
         }
-        _supportedFirmwareTypes.append(MAV_AUTOPILOT_GENERIC);
+        _supportedFirmwareClasses.append(QGCMAVLink::FirmwareClassGeneric);
     }
-    return _supportedFirmwareTypes;
+    return _supportedFirmwareClasses;
 }
 
-QList<MAV_TYPE> FirmwarePluginManager::supportedVehicleTypes(MAV_AUTOPILOT firmwareType)
+QList<QGCMAVLink::VehicleClass_t> FirmwarePluginManager::supportedVehicleClasses(QGCMAVLink::FirmwareClass_t firmwareClass)
 {
-    QList<MAV_TYPE> vehicleTypes;
+    QList<QGCMAVLink::VehicleClass_t> vehicleClasses;
 
-    FirmwarePluginFactory* factory = _findPluginFactory(firmwareType);
+    FirmwarePluginFactory* factory = _findPluginFactory(firmwareClass);
 
     if (factory) {
-        vehicleTypes = factory->supportedVehicleTypes();
-    } else if (firmwareType == MAV_AUTOPILOT_GENERIC) {
-        vehicleTypes << MAV_TYPE_FIXED_WING << MAV_TYPE_QUADROTOR << MAV_TYPE_VTOL_QUADROTOR << MAV_TYPE_GROUND_ROVER << MAV_TYPE_SUBMARINE;
+        vehicleClasses = factory->supportedVehicleClasses();
+    } else if (firmwareClass == QGCMAVLink::FirmwareClassGeneric) {
+        // Generic supports all specific vehicle class
+        vehicleClasses = QGCMAVLink::allVehicleClasses();
+        vehicleClasses.removeOne(QGCMAVLink::VehicleClassGeneric);
     } else {
-        qWarning() << "Request for unknown firmware plugin factory" << firmwareType;
+        qWarning() << "Request for unknown firmware plugin factory" << firmwareClass;
     }
 
-    return vehicleTypes;
+    return vehicleClasses;
 }
 
 FirmwarePlugin* FirmwarePluginManager::firmwarePluginForAutopilot(MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType)
@@ -62,8 +64,6 @@ FirmwarePlugin* FirmwarePluginManager::firmwarePluginForAutopilot(MAV_AUTOPILOT 
 
     if (factory) {
         plugin = factory->firmwarePluginForAutopilot(firmwareType, vehicleType);
-    } else if (firmwareType != MAV_AUTOPILOT_GENERIC) {
-        qWarning() << "Request for unknown firmware plugin factory" << firmwareType;
     }
 
     if (!plugin) {
@@ -77,14 +77,14 @@ FirmwarePlugin* FirmwarePluginManager::firmwarePluginForAutopilot(MAV_AUTOPILOT 
     return plugin;
 }
 
-FirmwarePluginFactory* FirmwarePluginManager::_findPluginFactory(MAV_AUTOPILOT firmwareType)
+FirmwarePluginFactory* FirmwarePluginManager::_findPluginFactory(QGCMAVLink::FirmwareClass_t firmwareClass)
 {
     QList<FirmwarePluginFactory*> factoryList = FirmwarePluginFactoryRegister::instance()->pluginFactories();
 
     // Find the plugin which supports this vehicle
     for (int i=0; i<factoryList.count(); i++) {
         FirmwarePluginFactory* factory = factoryList[i];
-        if (factory->supportedFirmwareTypes().contains(firmwareType)) {
+        if (factory->supportedFirmwareClasses().contains(firmwareClass)) {
             return factory;
         }
     }

--- a/src/FirmwarePlugin/FirmwarePluginManager.h
+++ b/src/FirmwarePlugin/FirmwarePluginManager.h
@@ -7,12 +7,7 @@
  *
  ****************************************************************************/
 
-
-/// @file
-///     @author Don Gagne <don@thegagnes.com>
-
-#ifndef FirmwarePluginManager_H
-#define FirmwarePluginManager_H
+#pragma once
 
 #include <QObject>
 
@@ -33,10 +28,10 @@ public:
     ~FirmwarePluginManager();
 
     /// Returns list of firmwares which are supported by the system
-    QList<MAV_AUTOPILOT> supportedFirmwareTypes(void);
+    QList<QGCMAVLink::FirmwareClass_t> supportedFirmwareClasses(void);
 
     /// Returns the list of supported vehicle types for the specified firmware
-    QList<MAV_TYPE> supportedVehicleTypes(MAV_AUTOPILOT firmwareType);
+    QList<QGCMAVLink::VehicleClass_t> supportedVehicleClasses(QGCMAVLink::FirmwareClass_t firmwareClass);
 
     /// Returns appropriate plugin for autopilot type.
     ///     @param firmwareType Type of firmwware to return plugin for.
@@ -45,10 +40,8 @@ public:
     FirmwarePlugin* firmwarePluginForAutopilot(MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType);
 
 private:
-    FirmwarePluginFactory* _findPluginFactory(MAV_AUTOPILOT firmwareType);
+    FirmwarePluginFactory* _findPluginFactory(QGCMAVLink::FirmwareClass_t firmwareClass);
 
-    FirmwarePlugin*         _genericFirmwarePlugin;
-    QList<MAV_AUTOPILOT>    _supportedFirmwareTypes;
+    FirmwarePlugin*                     _genericFirmwarePlugin;
+    QList<QGCMAVLink::FirmwareClass_t>  _supportedFirmwareClasses;
 };
-
-#endif

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -297,23 +297,23 @@ QList<MAV_CMD> PX4FirmwarePlugin::supportedMissionCommands(void)
     return cmds;
 }
 
-QString PX4FirmwarePlugin::missionCommandOverrides(MAV_TYPE vehicleType) const
+QString PX4FirmwarePlugin::missionCommandOverrides(QGCMAVLink::VehicleClass_t vehicleClass) const
 {
-    switch (vehicleType) {
-    case MAV_TYPE_GENERIC:
+    switch (vehicleClass) {
+    case QGCMAVLink::VehicleClassGeneric:
         return QStringLiteral(":/json/PX4-MavCmdInfoCommon.json");
-    case MAV_TYPE_FIXED_WING:
+    case QGCMAVLink::VehicleClassFixedWing:
         return QStringLiteral(":/json/PX4-MavCmdInfoFixedWing.json");
-    case MAV_TYPE_QUADROTOR:
+    case QGCMAVLink::VehicleClassMultiRotor:
         return QStringLiteral(":/json/PX4-MavCmdInfoMultiRotor.json");
-    case MAV_TYPE_VTOL_QUADROTOR:
+    case QGCMAVLink::VehicleClassVTOL:
         return QStringLiteral(":/json/PX4-MavCmdInfoVTOL.json");
-    case MAV_TYPE_SUBMARINE:
+    case QGCMAVLink::VehicleClassSub:
         return QStringLiteral(":/json/PX4-MavCmdInfoSub.json");
-    case MAV_TYPE_GROUND_ROVER:
+    case QGCMAVLink::VehicleClassRoverBoat:
         return QStringLiteral(":/json/PX4-MavCmdInfoRover.json");
     default:
-        qWarning() << "PX4FirmwarePlugin::missionCommandOverrides called with bad MAV_TYPE:" << vehicleType;
+        qWarning() << "PX4FirmwarePlugin::missionCommandOverrides called with bad VehicleClass_t:" << vehicleClass;
         return QString();
     }
 }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -55,7 +55,7 @@ public:
     bool                isGuidedMode                    (const Vehicle* vehicle) const override;
     void                initializeVehicle               (Vehicle* vehicle) override;
     bool                sendHomePositionToVehicle       (void) override;
-    QString             missionCommandOverrides         (MAV_TYPE vehicleType) const override;
+    QString             missionCommandOverrides         (QGCMAVLink::VehicleClass_t vehicleClass) const override;
     QString             getVersionParam                 (void) override { return QString("SYS_PARAM_VER"); }
     FactMetaData*       _getMetaDataForFact             (QObject* parameterMetaData, const QString& name, FactMetaData::ValueType_t type, MAV_TYPE vehicleType) override;
     QString             _internalParameterMetaDataFile  (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QString(":/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml"); }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
@@ -7,10 +7,6 @@
  *
  ****************************************************************************/
 
-
-/// @file
-///     @author Don Gagne <don@thegagnes.com>
-
 #include "PX4FirmwarePluginFactory.h"
 #include "PX4/PX4FirmwarePlugin.h"
 
@@ -22,10 +18,10 @@ PX4FirmwarePluginFactory::PX4FirmwarePluginFactory(void)
 
 }
 
-QList<MAV_AUTOPILOT> PX4FirmwarePluginFactory::supportedFirmwareTypes(void) const
+QList<QGCMAVLink::FirmwareClass_t> PX4FirmwarePluginFactory::supportedFirmwareClasses(void) const
 {
-    QList<MAV_AUTOPILOT> list;
-    list.append(MAV_AUTOPILOT_PX4);
+    QList<QGCMAVLink::FirmwareClass_t> list;
+    list.append(QGCMAVLink::FirmwareClassPX4);
     return list;
 }
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.h
@@ -7,8 +7,7 @@
  *
  ****************************************************************************/
 
-#ifndef PX4FirmwarePluginFactory_H
-#define PX4FirmwarePluginFactory_H
+#pragma once
 
 #include "FirmwarePlugin.h"
 
@@ -21,11 +20,9 @@ class PX4FirmwarePluginFactory : public FirmwarePluginFactory
 public:
     PX4FirmwarePluginFactory(void);
 
-    QList<MAV_AUTOPILOT>    supportedFirmwareTypes      (void) const final;
-    FirmwarePlugin*         firmwarePluginForAutopilot  (MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType) final;
+    QList<QGCMAVLink::FirmwareClass_t>  supportedFirmwareClasses(void) const final;
+    FirmwarePlugin*                     firmwarePluginForAutopilot  (MAV_AUTOPILOT autopilotType, MAV_TYPE vehicleType) final;
 
 private:
     PX4FirmwarePlugin*  _pluginInstance;
 };
-
-#endif

--- a/src/FirstRunPromptDialogs/OfflineVehicleFirstRunPrompt.qml
+++ b/src/FirstRunPromptDialogs/OfflineVehicleFirstRunPrompt.qml
@@ -26,8 +26,8 @@ FirstRunPrompt {
     property var    _offlineVehicle:        QGroundControl.multiVehicleManager.offlineEditingVehicle
     property bool   _showCruiseSpeed:       !_offlineVehicle.multiRotor
     property bool   _showHoverSpeed:        _offlineVehicle.multiRotor || _offlineVehicle.vtol
-    property bool   _multipleFirmware:      QGroundControl.supportedFirmwareCount > 2
-    property bool   _multipleVehicleTypes:  QGroundControl.supportedVehicleCount > 1
+    property bool   _multipleFirmware:      !QGroundControl.singleFirmwareSupport
+    property bool   _multipleVehicleTypes:  !QGroundControl.singleVehicleSupport
     property real   _fieldWidth:            ScreenTools.defaultFontPixelWidth * 16
 
     ColumnLayout {
@@ -61,7 +61,7 @@ FirstRunPrompt {
                 }
                 FactComboBox {
                     Layout.preferredWidth:  _fieldWidth
-                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingFirmwareType
+                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingFirmwareClass
                     indexModel:             false
                     visible:                _multipleFirmware
                 }
@@ -73,7 +73,7 @@ FirstRunPrompt {
                 }
                 FactComboBox {
                     Layout.preferredWidth:  _fieldWidth
-                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingVehicleType
+                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingVehicleClass
                     indexModel:             false
                     visible:                _multipleVehicleTypes
                 }

--- a/src/MissionManager/MissionCommandList.h
+++ b/src/MissionManager/MissionCommandList.h
@@ -27,8 +27,7 @@ class MissionCommandList : public QObject
     Q_OBJECT
     
 public:
-    /// @param jsonFilename Json file which contains commands
-    /// @param baseCommandList true: bottomost level of mission command hierarchy (partial not allowed), false: mid-level of command hierarchy
+    /// @param baseCommandList true: bottomost level of mission command hierarchy (partial spec allowed), false: override level of hierarchy
     MissionCommandList(const QString& jsonFilename, bool baseCommandList, QObject* parent = nullptr);
 
     /// Returns list of categories in this list

--- a/src/MissionManager/MissionCommandTree.cc
+++ b/src/MissionManager/MissionCommandTree.cc
@@ -1,4 +1,3 @@
-
 /****************************************************************************
  *
  * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
@@ -7,7 +6,6 @@
  * COPYING.md in the root of the source code directory.
  *
  ****************************************************************************/
-
 
 #include "MissionCommandTree.h"
 #include "FactMetaData.h"
@@ -21,10 +19,10 @@
 #include <QQmlEngine>
 
 MissionCommandTree::MissionCommandTree(QGCApplication* app, QGCToolbox* toolbox, bool unitTest)
-    : QGCTool(app, toolbox)
-    , _allCommandsCategory(tr("All commands"))
-    , _settingsManager(nullptr)
-    , _unitTest(unitTest)
+    : QGCTool               (app, toolbox)
+    , _allCommandsCategory  (tr("All commands"))
+    , _settingsManager      (nullptr)
+    , _unitTest             (unitTest)
 {
 }
 
@@ -37,25 +35,22 @@ void MissionCommandTree::setToolbox(QGCToolbox* toolbox)
 #ifdef UNITTEST_BUILD
     if (_unitTest) {
         // Load unit testing tree
-        _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_GENERIC] =           new MissionCommandList(":/unittest/UT-MavCmdInfoCommon.json", true, this);
-        _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_FIXED_WING] =        new MissionCommandList(":/unittest/UT-MavCmdInfoFixedWing.json", false, this);
-        _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_QUADROTOR] =         new MissionCommandList(":/unittest/UT-MavCmdInfoMultiRotor.json", false, this);
-        _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_VTOL_QUADROTOR] =    new MissionCommandList(":/unittest/UT-MavCmdInfoVTOL.json", false, this);
-        _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_SUBMARINE] =         new MissionCommandList(":/unittest/UT-MavCmdInfoSub.json", false, this);
-        _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_GROUND_ROVER] =      new MissionCommandList(":/unittest/UT-MavCmdInfoRover.json", false, this);
+        _staticCommandTree[MAV_AUTOPILOT_GENERIC][QGCMAVLink::VehicleClassGeneric]      = new MissionCommandList(":/unittest/UT-MavCmdInfoCommon.json", true, this);
+        _staticCommandTree[MAV_AUTOPILOT_GENERIC][QGCMAVLink::VehicleClassFixedWing]    = new MissionCommandList(":/unittest/UT-MavCmdInfoFixedWing.json", false, this);
+        _staticCommandTree[MAV_AUTOPILOT_GENERIC][QGCMAVLink::VehicleClassMultiRotor]   = new MissionCommandList(":/unittest/UT-MavCmdInfoMultiRotor.json", false, this);
+        _staticCommandTree[MAV_AUTOPILOT_GENERIC][QGCMAVLink::VehicleClassVTOL]         = new MissionCommandList(":/unittest/UT-MavCmdInfoVTOL.json", false, this);
+        _staticCommandTree[MAV_AUTOPILOT_GENERIC][QGCMAVLink::VehicleClassSub]          = new MissionCommandList(":/unittest/UT-MavCmdInfoSub.json", false, this);
+        _staticCommandTree[MAV_AUTOPILOT_GENERIC][QGCMAVLink::VehicleClassRoverBoat]    = new MissionCommandList(":/unittest/UT-MavCmdInfoRover.json", false, this);
     } else {
 #endif
         // Load all levels of hierarchy
-        for (MAV_AUTOPILOT firmwareType: _toolbox->firmwarePluginManager()->supportedFirmwareTypes()) {
-            FirmwarePlugin* plugin = _toolbox->firmwarePluginManager()->firmwarePluginForAutopilot(firmwareType, MAV_TYPE_QUADROTOR);
+        for (const QGCMAVLink::FirmwareClass_t firmwareClass: _toolbox->firmwarePluginManager()->supportedFirmwareClasses()) {
+            FirmwarePlugin* plugin = _toolbox->firmwarePluginManager()->firmwarePluginForAutopilot(QGCMAVLink::firmwareClassToAutopilot(firmwareClass), MAV_TYPE_QUADROTOR);
 
-            QList<MAV_TYPE> vehicleTypes;
-            vehicleTypes << MAV_TYPE_GENERIC << MAV_TYPE_FIXED_WING << MAV_TYPE_QUADROTOR << MAV_TYPE_VTOL_QUADROTOR << MAV_TYPE_GROUND_ROVER << MAV_TYPE_SUBMARINE;
-
-            for(MAV_TYPE vehicleType: vehicleTypes) {
-                QString overrideFile = plugin->missionCommandOverrides(vehicleType);
+            for (const QGCMAVLink::VehicleClass_t vehicleClass: QGCMAVLink::allVehicleClasses()) {
+                QString overrideFile = plugin->missionCommandOverrides(vehicleClass);
                 if (!overrideFile.isEmpty()) {
-                    _staticCommandTree[firmwareType][vehicleType] = new MissionCommandList(overrideFile, firmwareType == MAV_AUTOPILOT_GENERIC && vehicleType == MAV_TYPE_GENERIC /* baseCommandList */, this);
+                    _staticCommandTree[firmwareClass][vehicleClass] = new MissionCommandList(overrideFile, firmwareClass == QGCMAVLink::FirmwareClassGeneric && vehicleClass == QGCMAVLink::VehicleClassGeneric /* baseCommandList */, this);
                 }
             }
         }
@@ -64,45 +59,15 @@ void MissionCommandTree::setToolbox(QGCToolbox* toolbox)
 #endif
 }
 
-MAV_AUTOPILOT MissionCommandTree::_baseFirmwareType(MAV_AUTOPILOT firmwareType) const
-{
-    if (qgcApp()->toolbox()->firmwarePluginManager()->supportedFirmwareTypes().contains(firmwareType)) {
-        return firmwareType;
-    } else {
-        return MAV_AUTOPILOT_GENERIC;
-    }
-
-}
-
-MAV_TYPE MissionCommandTree::_baseVehicleType(MAV_TYPE mavType) const
-{
-    if (QGCMAVLink::isFixedWing(mavType)) {
-        return MAV_TYPE_FIXED_WING;
-    } else if (QGCMAVLink::isMultiRotor(mavType)) {
-        return MAV_TYPE_QUADROTOR;
-    } else if (QGCMAVLink::isVTOL(mavType)) {
-        return MAV_TYPE_VTOL_QUADROTOR;
-    } else if (QGCMAVLink::isRover(mavType)) {
-        return MAV_TYPE_GROUND_ROVER;
-    } else if (QGCMAVLink::isSub(mavType)) {
-        return MAV_TYPE_SUBMARINE;
-    } else {
-        return MAV_TYPE_GENERIC;
-    }
-}
-
 /// Add the next level of the hierarchy to a collapsed tree.
-///     @param vehicle Collapsed tree is for this vehicle
-///     @param cmdList List of mission commands to collapse into ui info
-///     @param collapsedTree Tree we are collapsing into
-void MissionCommandTree::_collapseHierarchy(Vehicle*                                vehicle,
-                                            const MissionCommandList*               cmdList,
+///     @param cmdList          List of mission commands to collapse into ui info
+///     @param collapsedTree    Tree we are collapsing into
+void MissionCommandTree::_collapseHierarchy(const MissionCommandList*               cmdList,
                                             QMap<MAV_CMD, MissionCommandUIInfo*>&   collapsedTree)
 {
-    MAV_AUTOPILOT   baseFirmwareType;
-    MAV_TYPE        baseVehicleType;
-
-    _baseVehicleInfo(vehicle, baseFirmwareType, baseVehicleType);
+    if (!cmdList) {
+        return;
+    }
 
     for (MAV_CMD command: cmdList->commandIds()) {
         MissionCommandUIInfo* uiInfo = cmdList->getUIInfo(command);
@@ -118,34 +83,33 @@ void MissionCommandTree::_collapseHierarchy(Vehicle*                            
 
 void MissionCommandTree::_buildAllCommands(Vehicle* vehicle)
 {
-    MAV_AUTOPILOT   baseFirmwareType;
-    MAV_TYPE        baseVehicleType;
+    QGCMAVLink::FirmwareClass_t firmwareClass;
+    QGCMAVLink::VehicleClass_t  vehicleClass;
 
-    _baseVehicleInfo(vehicle, baseFirmwareType, baseVehicleType);
+    _firmwareAndVehicleClassInfo(vehicle, firmwareClass, vehicleClass);
 
-    if (_allCommands.contains(baseFirmwareType) &&
-            _allCommands[baseFirmwareType].contains(baseVehicleType)) {
+    if (_allCommands.contains(firmwareClass) && _allCommands[firmwareClass].contains(vehicleClass)) {
         // Already built
         return;
     }
 
-    QMap<MAV_CMD, MissionCommandUIInfo*>& collapsedTree = _allCommands[baseFirmwareType][baseVehicleType];
+    QMap<MAV_CMD, MissionCommandUIInfo*>& collapsedTree = _allCommands[firmwareClass][vehicleClass];
 
-    // Any Firmware, Any Vehicle
-    _collapseHierarchy(vehicle, _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_GENERIC], collapsedTree);
+    // Base of the tree is all commands
+    _collapseHierarchy(_staticCommandTree[MAV_AUTOPILOT_GENERIC][QGCMAVLink::VehicleClassGeneric], collapsedTree);
 
-    // Any Firmware, Specific Vehicle
-    if (baseVehicleType != MAV_TYPE_GENERIC) {
-        _collapseHierarchy(vehicle, _staticCommandTree[MAV_AUTOPILOT_GENERIC][baseVehicleType], collapsedTree);
+    // Add the overrides for specific vehicle types
+    if (vehicleClass != QGCMAVLink::VehicleClassGeneric) {
+        _collapseHierarchy(_staticCommandTree[QGCMAVLink::FirmwareClassGeneric][vehicleClass], collapsedTree);
     }
 
-    // Known Firmware, Any Vehicle
-    if (baseFirmwareType != MAV_AUTOPILOT_GENERIC) {
-        _collapseHierarchy(vehicle, _staticCommandTree[baseFirmwareType][MAV_TYPE_GENERIC], collapsedTree);
+    // Add the overrides for specific firmware class, all vehicles
+    if (firmwareClass != QGCMAVLink::FirmwareClassGeneric) {
+        _collapseHierarchy(_staticCommandTree[firmwareClass][QGCMAVLink::VehicleClassGeneric], collapsedTree);
 
-        // Known Firmware, Specific Vehicle
-        if (baseVehicleType != MAV_TYPE_GENERIC) {
-            _collapseHierarchy(vehicle, _staticCommandTree[baseFirmwareType][baseVehicleType], collapsedTree);
+        // Add overrides for specific vehicle class
+        if (vehicleClass != QGCMAVLink::VehicleClassGeneric) {
+            _collapseHierarchy(_staticCommandTree[firmwareClass][vehicleClass], collapsedTree);
         }
     }
 
@@ -154,28 +118,28 @@ void MissionCommandTree::_buildAllCommands(Vehicle* vehicle)
     for (MAV_CMD cmd: collapsedTree.keys()) {
         if (supportedCommands.contains(cmd)) {
             QString newCategory = collapsedTree[cmd]->category();
-            if (!_supportedCategories[baseFirmwareType][baseVehicleType].contains(newCategory)) {
-                _supportedCategories[baseFirmwareType][baseVehicleType].append(newCategory);
+            if (!_supportedCategories[firmwareClass][vehicleClass].contains(newCategory)) {
+                _supportedCategories[firmwareClass][vehicleClass].append(newCategory);
             }
         }
     }
-    _supportedCategories[baseFirmwareType][baseVehicleType].append(_allCommandsCategory);
+    _supportedCategories[firmwareClass][vehicleClass].append(_allCommandsCategory);
 }
 
 QStringList MissionCommandTree::_availableCategoriesForVehicle(Vehicle* vehicle)
 {
-    MAV_AUTOPILOT   baseFirmwareType;
-    MAV_TYPE        baseVehicleType;
+    QGCMAVLink::FirmwareClass_t firmwareClass;
+    QGCMAVLink::VehicleClass_t  vehicleClass;
 
-    _baseVehicleInfo(vehicle, baseFirmwareType, baseVehicleType);
+    _firmwareAndVehicleClassInfo(vehicle, firmwareClass, vehicleClass);
     _buildAllCommands(vehicle);
 
-    return _supportedCategories[baseFirmwareType][baseVehicleType];
+    return _supportedCategories[firmwareClass][vehicleClass];
 }
 
 QString MissionCommandTree::friendlyName(MAV_CMD command)
 {
-    MissionCommandList *    commandList =   _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_GENERIC];
+    MissionCommandList *    commandList =   _staticCommandTree[QGCMAVLink::FirmwareClassGeneric][QGCMAVLink::VehicleClassGeneric];
     MissionCommandUIInfo*   uiInfo =        commandList->getUIInfo(command);
 
     if (uiInfo) {
@@ -187,7 +151,7 @@ QString MissionCommandTree::friendlyName(MAV_CMD command)
 
 QString MissionCommandTree::rawName(MAV_CMD command)
 {
-    MissionCommandList *    commandList =   _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_GENERIC];
+    MissionCommandList *    commandList =   _staticCommandTree[QGCMAVLink::FirmwareClassGeneric][QGCMAVLink::VehicleClassGeneric];
     MissionCommandUIInfo*   uiInfo =        commandList->getUIInfo(command);
 
     if (uiInfo) {
@@ -199,18 +163,18 @@ QString MissionCommandTree::rawName(MAV_CMD command)
 
 const QList<MAV_CMD>& MissionCommandTree::allCommandIds(void) const
 {
-    return _staticCommandTree[MAV_AUTOPILOT_GENERIC][MAV_TYPE_GENERIC]->commandIds();
+    return _staticCommandTree[QGCMAVLink::FirmwareClassGeneric][QGCMAVLink::VehicleClassGeneric]->commandIds();
 }
 
 const MissionCommandUIInfo* MissionCommandTree::getUIInfo(Vehicle* vehicle, MAV_CMD command)
 {
-    MAV_AUTOPILOT   baseFirmwareType;
-    MAV_TYPE        baseVehicleType;
+    QGCMAVLink::FirmwareClass_t firmwareClass;
+    QGCMAVLink::VehicleClass_t  vehicleClass;
 
-    _baseVehicleInfo(vehicle, baseFirmwareType, baseVehicleType);
+    _firmwareAndVehicleClassInfo(vehicle, firmwareClass, vehicleClass);
     _buildAllCommands(vehicle);
 
-    const QMap<MAV_CMD, MissionCommandUIInfo*>& infoMap = _allCommands[baseFirmwareType][baseVehicleType];
+    const QMap<MAV_CMD, MissionCommandUIInfo*>& infoMap = _allCommands[firmwareClass][vehicleClass];
     if (infoMap.contains(command)) {
         return infoMap[command];
     } else {
@@ -220,19 +184,19 @@ const MissionCommandUIInfo* MissionCommandTree::getUIInfo(Vehicle* vehicle, MAV_
 
 QVariantList MissionCommandTree::getCommandsForCategory(Vehicle* vehicle, const QString& category, bool showFlyThroughCommands)
 {
-    MAV_AUTOPILOT   baseFirmwareType;
-    MAV_TYPE        baseVehicleType;
+    QGCMAVLink::FirmwareClass_t firmwareClass;
+    QGCMAVLink::VehicleClass_t  vehicleClass;
 
-    _baseVehicleInfo(vehicle, baseFirmwareType, baseVehicleType);
+    _firmwareAndVehicleClassInfo(vehicle, firmwareClass, vehicleClass);
     _buildAllCommands(vehicle);
 
-    // vehicle can be null in which case _baseVehicleInfo will tell of the firmware/vehicle type for the offline editing vehicle.
+    // vehicle can be null in which case _firmwareAndVehicleClassInfo will tell of the firmware/vehicle type for the offline editing vehicle.
     // We then use that to get a firmware plugin so we can get the list of supported commands.
-    FirmwarePlugin* firmwarePlugin = qgcApp()->toolbox()->firmwarePluginManager()->firmwarePluginForAutopilot(baseFirmwareType, baseVehicleType);
+    FirmwarePlugin* firmwarePlugin = qgcApp()->toolbox()->firmwarePluginManager()->firmwarePluginForAutopilot(QGCMAVLink::firmwareClassToAutopilot(firmwareClass), QGCMAVLink::vehicleClassToMavType(vehicleClass));
     QList<MAV_CMD>  supportedCommands = firmwarePlugin->supportedMissionCommands();
 
     QVariantList list;
-    QMap<MAV_CMD, MissionCommandUIInfo*> commandMap = _allCommands[baseFirmwareType][baseVehicleType];
+    QMap<MAV_CMD, MissionCommandUIInfo*> commandMap = _allCommands[firmwareClass][vehicleClass];
     for (MAV_CMD command: commandMap.keys()) {
         if (supportedCommands.contains(command)) {
             MissionCommandUIInfo* uiInfo = commandMap[command];
@@ -246,14 +210,8 @@ QVariantList MissionCommandTree::getCommandsForCategory(Vehicle* vehicle, const 
     return list;
 }
 
-void MissionCommandTree::_baseVehicleInfo(Vehicle* vehicle, MAV_AUTOPILOT& baseFirmwareType, MAV_TYPE& baseVehicleType) const
+void MissionCommandTree::_firmwareAndVehicleClassInfo(Vehicle* vehicle, QGCMAVLink::FirmwareClass_t& firmwareClass, QGCMAVLink::VehicleClass_t& vehicleClass) const
 {
-    if (vehicle) {
-        baseFirmwareType = _baseFirmwareType(vehicle->firmwareType());
-        baseVehicleType = _baseVehicleType(vehicle->vehicleType());
-    } else {
-        // No Vehicle means offline editing
-        baseFirmwareType = _baseFirmwareType((MAV_AUTOPILOT)_settingsManager->appSettings()->offlineEditingFirmwareType()->rawValue().toInt());
-        baseVehicleType = _baseVehicleType((MAV_TYPE)_settingsManager->appSettings()->offlineEditingVehicleType()->rawValue().toInt());
-    }
+    firmwareClass = QGCMAVLink::firmwareClass(vehicle->firmwareType());
+    vehicleClass = QGCMAVLink::vehicleClass(vehicle->vehicleType());
 }

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -725,16 +725,16 @@ bool MissionController::_loadJsonMissionFileV2(const QJsonObject& json, QmlObjec
 
     // Get the firmware/vehicle type from the plan file
     MAV_AUTOPILOT   planFileFirmwareType =  static_cast<MAV_AUTOPILOT>(json[_jsonFirmwareTypeKey].toInt());
-    MAV_TYPE        planFileVehicleType =   static_cast<MAV_TYPE>       (appSettings->offlineEditingVehicleType()->rawValue().toInt());
+    MAV_TYPE        planFileVehicleType =   static_cast<MAV_TYPE>     (QGCMAVLink::vehicleClassToMavType(appSettings->offlineEditingVehicleClass()->rawValue().toInt()));
     if (json.contains(_jsonVehicleTypeKey)) {
         planFileVehicleType = static_cast<MAV_TYPE>(json[_jsonVehicleTypeKey].toInt());
     }
 
     // Update firmware/vehicle offline settings if we aren't connect to a vehicle
     if (_masterController->offline()) {
-        appSettings->offlineEditingFirmwareType()->setRawValue(AppSettings::offlineEditingFirmwareTypeFromFirmwareType(static_cast<MAV_AUTOPILOT>(json[_jsonFirmwareTypeKey].toInt())));
+        appSettings->offlineEditingFirmwareClass()->setRawValue(QGCMAVLink::firmwareClass(static_cast<MAV_AUTOPILOT>(json[_jsonFirmwareTypeKey].toInt())));
         if (json.contains(_jsonVehicleTypeKey)) {
-            appSettings->offlineEditingVehicleType()->setRawValue(AppSettings::offlineEditingVehicleTypeFromVehicleType(static_cast<MAV_TYPE>(json[_jsonVehicleTypeKey].toInt())));
+            appSettings->offlineEditingVehicleClass()->setRawValue(QGCMAVLink::vehicleClass(planFileVehicleType));
         }
     }
 

--- a/src/MissionManager/MissionControllerTest.cc
+++ b/src/MissionManager/MissionControllerTest.cc
@@ -50,7 +50,7 @@ void MissionControllerTest::_initForFirmwareType(MAV_AUTOPILOT firmwareType)
     _rgMissionControllerSignals[visualItemsChangedSignalIndex] =    SIGNAL(visualItemsChanged());
 
     // Master controller pulls offline vehicle info from settings
-    qgcApp()->toolbox()->settingsManager()->appSettings()->offlineEditingFirmwareType()->setRawValue(firmwareType);
+    qgcApp()->toolbox()->settingsManager()->appSettings()->offlineEditingFirmwareClass()->setRawValue(QGCMAVLink::firmwareClass(firmwareType));
     _masterController = new PlanMasterController(this);
     _masterController->setFlyView(false);
     _missionController = _masterController->missionController();

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -143,8 +143,8 @@ void PlanMasterController::_activeVehicleChanged(Vehicle* activeVehicle)
 
         // Update controllerVehicle to the currently connected vehicle
         AppSettings* appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
-        appSettings->offlineEditingFirmwareType()->setRawValue(AppSettings::offlineEditingFirmwareTypeFromFirmwareType(_managerVehicle->firmwareType()));
-        appSettings->offlineEditingVehicleType()->setRawValue(AppSettings::offlineEditingVehicleTypeFromVehicleType(_managerVehicle->vehicleType()));
+        appSettings->offlineEditingFirmwareClass()->setRawValue(QGCMAVLink::firmwareClass(_managerVehicle->firmwareType()));
+        appSettings->offlineEditingVehicleClass()->setRawValue(QGCMAVLink::vehicleClass(_managerVehicle->vehicleType()));
 
         // We use these signals to sequence upload and download to the multiple controller/managers
         connect(_managerVehicle->missionManager(),      &MissionManager::newMissionItemsAvailable,  this, &PlanMasterController::_loadMissionComplete);

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -40,7 +40,6 @@ Rectangle {
     property real   _sectionSpacer:             ScreenTools.defaultFontPixelWidth / 2  // spacing between section headings
     property bool   _singleComplexItem:         _missionController.complexMissionItemNames.length === 1
     property bool   _readyForSave:              missionItem.readyForSaveState === VisualMissionItem.ReadyForSave
-    property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
 
     readonly property real  _editFieldWidth:    Math.min(width - _innerMargin * 2, ScreenTools.defaultFontPixelWidth * 12)
     readonly property real  _margin:            ScreenTools.defaultFontPixelWidth / 2
@@ -160,6 +159,7 @@ Rectangle {
                 id: commandDialog
 
                 MissionCommandDialog {
+                    vehicle:                    masterController.controllerVehicle
                     missionItem:                _root.missionItem
                     map:                        _root.map
                     // FIXME: Disabling fly through commands doesn't work since you may need to change from an RTL to something else
@@ -207,6 +207,8 @@ Rectangle {
                     visible:        missionItem.specifiesCoordinate
                     enabled:        _activeVehicle
                     onTriggered:    missionItem.coordinate = _activeVehicle.coordinate
+
+                    property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
                 }
 
                 QGCMenuItem {

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -26,8 +26,8 @@ Rectangle {
     property bool   _vehicleHasHomePosition:        _controllerVehicle.homePosition.isValid
     property bool   _showCruiseSpeed:               !_controllerVehicle.multiRotor
     property bool   _showHoverSpeed:                _controllerVehicle.multiRotor || _controllerVehicle.vtol
-    property bool   _multipleFirmware:              QGroundControl.supportedFirmwareCount > 2
-    property bool   _multipleVehicleTypes:          QGroundControl.supportedVehicleCount > 1
+    property bool   _multipleFirmware:              !QGroundControl.singleFirmwareSupport
+    property bool   _multipleVehicleTypes:          !QGroundControl.singleVehicleSupport
     property real   _fieldWidth:                    ScreenTools.defaultFontPixelWidth * 16
     property bool   _mobile:                        ScreenTools.isMobile
     property var    _savePath:                      QGroundControl.settingsManager.appSettings.missionSavePath
@@ -194,7 +194,7 @@ Rectangle {
                     visible:            _multipleFirmware
                 }
                 FactComboBox {
-                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingFirmwareType
+                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingFirmwareClass
                     indexModel:             false
                     Layout.preferredWidth:  _fieldWidth
                     visible:                _multipleFirmware && _noMissionItemsAdded
@@ -210,7 +210,7 @@ Rectangle {
                     visible:            _multipleVehicleTypes
                 }
                 FactComboBox {
-                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingVehicleType
+                    fact:                   QGroundControl.settingsManager.appSettings.offlineEditingVehicleClass
                     indexModel:             false
                     Layout.preferredWidth:  _fieldWidth
                     visible:                _multipleVehicleTypes && _noMissionItemsAdded

--- a/src/QmlControls/MissionCommandDialog.qml
+++ b/src/QmlControls/MissionCommandDialog.qml
@@ -19,11 +19,10 @@ import QGroundControl.Palette       1.0
 QGCViewDialog {
     id: root
 
+    property var    vehicle
     property var    missionItem
     property var    map
     property bool   flyThroughCommandsAllowed
-
-    property var _vehicle: QGroundControl.multiVehicleManager.activeVehicle
 
     QGCPalette { id: qgcPal }
 
@@ -38,10 +37,10 @@ QGCViewDialog {
         anchors.margins:    ScreenTools.defaultFontPixelWidth
         anchors.left:       categoryLabel.right
         anchors.right:      parent.right
-        model:              QGroundControl.missionCommandTree.categoriesForVehicle(_vehicle)
+        model:              QGroundControl.missionCommandTree.categoriesForVehicle(vehicle)
 
         function categorySelected(category) {
-            commandList.model = QGroundControl.missionCommandTree.getCommandsForCategory(_vehicle, category, flyThroughCommandsAllowed)
+            commandList.model = QGroundControl.missionCommandTree.getCommandsForCategory(vehicle, category, flyThroughCommandsAllowed)
         }
 
         Component.onCompleted: {

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -190,31 +190,28 @@ void QGroundControlQmlGlobal::setMavlinkSystemID(int id)
     emit mavlinkSystemIDChanged(id);
 }
 
-int QGroundControlQmlGlobal::supportedFirmwareCount()
+bool QGroundControlQmlGlobal::singleFirmwareSupport(void)
 {
-    return _firmwarePluginManager->supportedFirmwareTypes().count();
+    return _firmwarePluginManager->supportedFirmwareClasses().count() == 1;
 }
 
-int QGroundControlQmlGlobal::supportedVehicleCount()
+bool QGroundControlQmlGlobal::singleVehicleSupport(void)
 {
-    int count = 0;
-    QList<MAV_AUTOPILOT> list = _firmwarePluginManager->supportedFirmwareTypes();
-    foreach(auto firmware, list) {
-        if(firmware != MAV_AUTOPILOT_GENERIC) {
-            count += _firmwarePluginManager->supportedVehicleTypes(firmware).count();
-        }
+    if (singleFirmwareSupport()) {
+        return _firmwarePluginManager->supportedVehicleClasses(_firmwarePluginManager->supportedFirmwareClasses()[0]).count() == 1;
     }
-    return count;
+
+    return false;
 }
 
 bool QGroundControlQmlGlobal::px4ProFirmwareSupported()
 {
-    return _firmwarePluginManager->supportedFirmwareTypes().contains(MAV_AUTOPILOT_PX4);
+    return _firmwarePluginManager->supportedFirmwareClasses().contains(QGCMAVLink::FirmwareClassPX4);
 }
 
 bool QGroundControlQmlGlobal::apmFirmwareSupported()
 {
-    return _firmwarePluginManager->supportedFirmwareTypes().contains(MAV_AUTOPILOT_ARDUPILOTMEGA);
+    return _firmwarePluginManager->supportedFirmwareClasses().contains(QGCMAVLink::FirmwareClassArduPilot);
 }
 
 bool QGroundControlQmlGlobal::linesIntersect(QPointF line1A, QPointF line1B, QPointF line2A, QPointF line2B)

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -7,12 +7,7 @@
  *
  ****************************************************************************/
 
-
-/// @file
-///     @author Don Gagne <don@thegagnes.com>
-
-#ifndef QGroundControlQmlGlobal_H
-#define QGroundControlQmlGlobal_H
+#pragma once
 
 #include "QGCToolbox.h"
 #include "QGCApplication.h"
@@ -62,35 +57,41 @@ public:
     };
     Q_ENUM(AltitudeMode)
 
-    Q_PROPERTY(QString              appName             READ appName                CONSTANT)
+    Q_PROPERTY(QString              appName                 READ    appName                 CONSTANT)
+    Q_PROPERTY(LinkManager*         linkManager             READ    linkManager             CONSTANT)
+    Q_PROPERTY(MultiVehicleManager* multiVehicleManager     READ    multiVehicleManager     CONSTANT)
+    Q_PROPERTY(QGCMapEngineManager* mapEngineManager        READ    mapEngineManager        CONSTANT)
+    Q_PROPERTY(QGCPositionManager*  qgcPositionManger       READ    qgcPositionManger       CONSTANT)
+    Q_PROPERTY(VideoManager*        videoManager            READ    videoManager            CONSTANT)
+    Q_PROPERTY(MAVLinkLogManager*   mavlinkLogManager       READ    mavlinkLogManager       CONSTANT)
+    Q_PROPERTY(SettingsManager*     settingsManager         READ    settingsManager         CONSTANT)
+    Q_PROPERTY(AirspaceManager*     airspaceManager         READ    airspaceManager         CONSTANT)
+    Q_PROPERTY(ADSBVehicleManager*  adsbVehicleManager      READ    adsbVehicleManager      CONSTANT)
+    Q_PROPERTY(QGCCorePlugin*       corePlugin              READ    corePlugin              CONSTANT)
+    Q_PROPERTY(MissionCommandTree*  missionCommandTree      READ    missionCommandTree      CONSTANT)
+    Q_PROPERTY(FactGroup*           gpsRtk                  READ    gpsRtkFactGroup         CONSTANT)
+    Q_PROPERTY(bool                 airmapSupported         READ    airmapSupported         CONSTANT)
+    Q_PROPERTY(TaisyncManager*      taisyncManager          READ    taisyncManager          CONSTANT)
+    Q_PROPERTY(bool                 taisyncSupported        READ    taisyncSupported        CONSTANT)
+    Q_PROPERTY(MicrohardManager*    microhardManager        READ    microhardManager        CONSTANT)
+    Q_PROPERTY(bool                 microhardSupported      READ    microhardSupported      CONSTANT)
+    Q_PROPERTY(bool                 supportsPairing         READ    supportsPairing         CONSTANT)
+    Q_PROPERTY(QGCPalette*          globalPalette           MEMBER  _globalPalette          CONSTANT)   ///< This palette will always return enabled colors
+    Q_PROPERTY(QmlUnitsConversion*  unitsConversion         READ    unitsConversion         CONSTANT)
+    Q_PROPERTY(bool                 singleFirmwareSupport   READ    singleFirmwareSupport   CONSTANT)
+    Q_PROPERTY(bool                 singleVehicleSupport    READ    singleVehicleSupport    CONSTANT)
+    Q_PROPERTY(bool                 px4ProFirmwareSupported READ    px4ProFirmwareSupported CONSTANT)
+    Q_PROPERTY(int                  apmFirmwareSupported    READ    apmFirmwareSupported    CONSTANT)
+    Q_PROPERTY(QGeoCoordinate       flightMapPosition       READ    flightMapPosition       WRITE setFlightMapPosition  NOTIFY flightMapPositionChanged)
+    Q_PROPERTY(double               flightMapZoom           READ    flightMapZoom           WRITE setFlightMapZoom      NOTIFY flightMapZoomChanged)
+    Q_PROPERTY(double               flightMapInitialZoom    MEMBER  _flightMapInitialZoom   CONSTANT)   ///< Zoom level to use when either gcs or vehicle shows up for first time
 
-    Q_PROPERTY(LinkManager*         linkManager         READ linkManager            CONSTANT)
-    Q_PROPERTY(MultiVehicleManager* multiVehicleManager READ multiVehicleManager    CONSTANT)
-    Q_PROPERTY(QGCMapEngineManager* mapEngineManager    READ mapEngineManager       CONSTANT)
-    Q_PROPERTY(QGCPositionManager*  qgcPositionManger   READ qgcPositionManger      CONSTANT)
-    Q_PROPERTY(MissionCommandTree*  missionCommandTree  READ missionCommandTree     CONSTANT)
-    Q_PROPERTY(VideoManager*        videoManager        READ videoManager           CONSTANT)
-    Q_PROPERTY(MAVLinkLogManager*   mavlinkLogManager   READ mavlinkLogManager      CONSTANT)
-    Q_PROPERTY(QGCCorePlugin*       corePlugin          READ corePlugin             CONSTANT)
-    Q_PROPERTY(SettingsManager*     settingsManager     READ settingsManager        CONSTANT)
-    Q_PROPERTY(FactGroup*           gpsRtk              READ gpsRtkFactGroup        CONSTANT)
-    Q_PROPERTY(AirspaceManager*     airspaceManager     READ airspaceManager        CONSTANT)
-    Q_PROPERTY(ADSBVehicleManager*  adsbVehicleManager  READ adsbVehicleManager     CONSTANT)
-    Q_PROPERTY(bool                 airmapSupported     READ airmapSupported        CONSTANT)
-    Q_PROPERTY(TaisyncManager*      taisyncManager      READ taisyncManager         CONSTANT)
-    Q_PROPERTY(bool                 taisyncSupported    READ taisyncSupported       CONSTANT)
-    Q_PROPERTY(MicrohardManager*    microhardManager    READ microhardManager       CONSTANT)
-    Q_PROPERTY(bool                 microhardSupported  READ microhardSupported     CONSTANT)
-    Q_PROPERTY(bool                 supportsPairing     READ supportsPairing        CONSTANT)
-    Q_PROPERTY(QGCPalette*          globalPalette       MEMBER _globalPalette       CONSTANT)   // This palette will always return enabled colors
-    Q_PROPERTY(QmlUnitsConversion*  unitsConversion     READ unitsConversion        CONSTANT)
-#if defined(QGC_ENABLE_PAIRING)
-    Q_PROPERTY(PairingManager*      pairingManager      READ pairingManager         CONSTANT)
-#endif
-    Q_PROPERTY(int      supportedFirmwareCount          READ supportedFirmwareCount CONSTANT)
-    Q_PROPERTY(int      supportedVehicleCount           READ supportedVehicleCount  CONSTANT)
-    Q_PROPERTY(bool     px4ProFirmwareSupported         READ px4ProFirmwareSupported CONSTANT)
-    Q_PROPERTY(int      apmFirmwareSupported            READ apmFirmwareSupported   CONSTANT)
+    Q_PROPERTY(QString  parameterFileExtension  READ parameterFileExtension CONSTANT)
+    Q_PROPERTY(QString  missionFileExtension    READ missionFileExtension   CONSTANT)
+    Q_PROPERTY(QString  telemetryFileExtension  READ telemetryFileExtension CONSTANT)
+
+    Q_PROPERTY(QString qgcVersion       READ qgcVersion         CONSTANT)
+    Q_PROPERTY(bool    skipSetupPage    READ skipSetupPage      WRITE setSkipSetupPage NOTIFY skipSetupPageChanged)
 
     Q_PROPERTY(qreal zOrderTopMost              READ zOrderTopMost              CONSTANT) ///< z order for top most items, toolbar, main window sub view
     Q_PROPERTY(qreal zOrderWidgets              READ zOrderWidgets              CONSTANT) ///< z order value to widgets, for example: zoom controls, hud widgetss
@@ -99,7 +100,6 @@ public:
     Q_PROPERTY(qreal zOrderWaypointIndicators   READ zOrderWaypointIndicators   CONSTANT)
     Q_PROPERTY(qreal zOrderTrajectoryLines      READ zOrderTrajectoryLines      CONSTANT)
     Q_PROPERTY(qreal zOrderWaypointLines        READ zOrderWaypointLines        CONSTANT)
-
     //-------------------------------------------------------------------------
     // MavLink Protocol
     Q_PROPERTY(bool     isVersionCheckEnabled   READ isVersionCheckEnabled      WRITE setIsVersionCheckEnabled      NOTIFY isVersionCheckEnabledChanged)
@@ -107,16 +107,10 @@ public:
     Q_PROPERTY(bool     hasAPMSupport           READ hasAPMSupport              CONSTANT)
     Q_PROPERTY(bool     hasMAVLinkInspector     READ hasMAVLinkInspector        CONSTANT)
 
-    Q_PROPERTY(QGeoCoordinate flightMapPosition     READ flightMapPosition      WRITE setFlightMapPosition          NOTIFY flightMapPositionChanged)
-    Q_PROPERTY(double         flightMapZoom         READ flightMapZoom          WRITE setFlightMapZoom              NOTIFY flightMapZoomChanged)
-    Q_PROPERTY(double         flightMapInitialZoom  MEMBER _flightMapInitialZoom                                    CONSTANT)                               ///< Zoom level to use when either gcs or vehicle shows up for first time
 
-    Q_PROPERTY(QString  parameterFileExtension  READ parameterFileExtension CONSTANT)
-    Q_PROPERTY(QString  missionFileExtension    READ missionFileExtension   CONSTANT)
-    Q_PROPERTY(QString  telemetryFileExtension  READ telemetryFileExtension CONSTANT)
-
-    Q_PROPERTY(QString qgcVersion       READ qgcVersion         CONSTANT)
-    Q_PROPERTY(bool    skipSetupPage    READ skipSetupPage      WRITE setSkipSetupPage NOTIFY skipSetupPageChanged)
+#if defined(QGC_ENABLE_PAIRING)
+    Q_PROPERTY(PairingManager*      pairingManager          READ pairingManager         CONSTANT)
+#endif
 
     Q_INVOKABLE void    saveGlobalSetting       (const QString& key, const QString& value);
     Q_INVOKABLE QString loadGlobalSetting       (const QString& key, const QString& defaultValue);
@@ -212,8 +206,8 @@ public:
     bool    hasMAVLinkInspector     () { return false; }
 #endif
 
-    int     supportedFirmwareCount  ();
-    int     supportedVehicleCount   ();
+    bool    singleFirmwareSupport   ();
+    bool    singleVehicleSupport    ();
     bool    px4ProFirmwareSupported ();
     bool    apmFirmwareSupported    ();
     bool    skipSetupPage           () { return _skipSetupPage; }
@@ -281,5 +275,3 @@ private:
     static QGeoCoordinate   _coord;
     static double           _zoom;
 };
-
-#endif

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -4,19 +4,19 @@
     "QGC.MetaData.Facts":
 [
 {
-    "name":             "offlineEditingFirmwareType",
-    "shortDescription": "Offline editing firmware type",
+    "name":             "offlineEditingFirmwareClass",
+    "shortDescription": "Offline editing firmware class",
     "type":             "uint32",
     "enumStrings":      "ArduPilot,PX4 Pro,Mavlink Generic",
     "enumValues":       "3,12,0",
     "defaultValue":     12
 },
 {
-    "name":             "offlineEditingVehicleType",
-    "shortDescription": "Offline editing vehicle type",
+    "name":             "offlineEditingVehicleClass",
+    "shortDescription": "Offline editing vehicle class",
     "type":             "uint32",
-    "enumStrings":      "Fixed Wing,Multi-Rotor,VTOL,Rover,Sub",
-    "enumValues":       "1,2,20,10,12",
+    "enumStrings":      "Fixed Wing,Multi-Rotor,VTOL,Rover,Sub,Mavlink Generic",
+    "enumValues":       "1,2,20,10,12,0",
     "defaultValue":     2
 },
 {

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -26,8 +26,8 @@ public:
 
     DEFINE_SETTING_NAME_GROUP()
 
-    DEFINE_SETTINGFACT(offlineEditingFirmwareType)
-    DEFINE_SETTINGFACT(offlineEditingVehicleType)
+    DEFINE_SETTINGFACT(offlineEditingFirmwareClass)
+    DEFINE_SETTINGFACT(offlineEditingVehicleClass)
     DEFINE_SETTINGFACT(offlineEditingCruiseSpeed)
     DEFINE_SETTINGFACT(offlineEditingHoverSpeed)
     DEFINE_SETTINGFACT(offlineEditingAscentSpeed)
@@ -93,9 +93,6 @@ public:
     static QList<int> firstRunPromptsIdsVariantToList   (const QVariant& firstRunPromptIds);
     static QVariant   firstRunPromptsIdsListToVariant   (const QList<int>& rgIds);
     Q_INVOKABLE void  firstRunPromptIdsMarkIdAsShown    (int id);
-
-    static MAV_AUTOPILOT    offlineEditingFirmwareTypeFromFirmwareType  (MAV_AUTOPILOT firmwareType);
-    static MAV_TYPE         offlineEditingVehicleTypeFromVehicleType    (MAV_TYPE vehicleType);
 
     // Application wide file extensions
     static const char* parameterFileExtension;

--- a/src/Vehicle/CompInfoParam.cc
+++ b/src/Vehicle/CompInfoParam.cc
@@ -103,7 +103,7 @@ bool CompInfoParam::_isParameterVolatile(const QString& name)
 FirmwarePlugin* CompInfoParam::_anyVehicleTypeFirmwarePlugin(MAV_AUTOPILOT firmwareType)
 {
     FirmwarePluginManager*  pluginMgr               = qgcApp()->toolbox()->firmwarePluginManager();
-    MAV_TYPE                anySupportedVehicleType = pluginMgr->supportedVehicleTypes(firmwareType)[0];
+    MAV_TYPE                anySupportedVehicleType = QGCMAVLink::vehicleClassToMavType(pluginMgr->supportedVehicleClasses(QGCMAVLink::firmwareClass(firmwareType))[0]);
 
     return pluginMgr->firmwarePluginForAutopilot(firmwareType, anySupportedVehicleType);
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -424,17 +424,17 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
 
 void Vehicle::trackFirmwareVehicleTypeChanges(void)
 {
-    connect(_settingsManager->appSettings()->offlineEditingFirmwareType(),  &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
-    connect(_settingsManager->appSettings()->offlineEditingVehicleType(),   &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
+    connect(_settingsManager->appSettings()->offlineEditingFirmwareClass(), &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
+    connect(_settingsManager->appSettings()->offlineEditingVehicleClass(),  &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
 
-    _offlineFirmwareTypeSettingChanged(_settingsManager->appSettings()->offlineEditingFirmwareType()->rawValue());
-    _offlineVehicleTypeSettingChanged(_settingsManager->appSettings()->offlineEditingVehicleType()->rawValue());
+    _offlineFirmwareTypeSettingChanged(_settingsManager->appSettings()->offlineEditingFirmwareClass()->rawValue());
+    _offlineVehicleTypeSettingChanged(_settingsManager->appSettings()->offlineEditingVehicleClass()->rawValue());
 }
 
 void Vehicle::stopTrackingFirmwareVehicleTypeChanges(void)
 {
-    disconnect(_settingsManager->appSettings()->offlineEditingFirmwareType(),  &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
-    disconnect(_settingsManager->appSettings()->offlineEditingVehicleType(),   &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
+    disconnect(_settingsManager->appSettings()->offlineEditingFirmwareClass(),  &Fact::rawValueChanged, this, &Vehicle::_offlineFirmwareTypeSettingChanged);
+    disconnect(_settingsManager->appSettings()->offlineEditingVehicleClass(),  &Fact::rawValueChanged, this, &Vehicle::_offlineVehicleTypeSettingChanged);
 }
 
 void Vehicle::_commonInit()
@@ -588,9 +588,9 @@ void Vehicle::prepareDelete()
     }
 }
 
-void Vehicle::_offlineFirmwareTypeSettingChanged(QVariant value)
+void Vehicle::_offlineFirmwareTypeSettingChanged(QVariant varFirmwareType)
 {
-    _firmwareType = static_cast<MAV_AUTOPILOT>(value.toInt());
+    _firmwareType = static_cast<MAV_AUTOPILOT>(varFirmwareType.toInt());
     _firmwarePlugin = _firmwarePluginManager->firmwarePluginForAutopilot(_firmwareType, _vehicleType);
     if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
         _capabilityBits |= MAV_PROTOCOL_CAPABILITY_TERRAIN;
@@ -601,9 +601,9 @@ void Vehicle::_offlineFirmwareTypeSettingChanged(QVariant value)
     emit capabilityBitsChanged(_capabilityBits);
 }
 
-void Vehicle::_offlineVehicleTypeSettingChanged(QVariant value)
+void Vehicle::_offlineVehicleTypeSettingChanged(QVariant varVehicleType)
 {
-    _vehicleType = static_cast<MAV_TYPE>(value.toInt());
+    _vehicleType = static_cast<MAV_TYPE>(varVehicleType.toInt());
     emit vehicleTypeChanged();
 }
 
@@ -2721,7 +2721,7 @@ bool Vehicle::fixedWing() const
 
 bool Vehicle::rover() const
 {
-    return QGCMAVLink::isRover(vehicleType());
+    return QGCMAVLink::isRoverBoat(vehicleType());
 }
 
 bool Vehicle::sub() const
@@ -2736,7 +2736,7 @@ bool Vehicle::multiRotor() const
 
 bool Vehicle::vtol() const
 {
-    return _firmwarePlugin->isVtol(this);
+    return QGCMAVLink::isVTOL(vehicleType());
 }
 
 bool Vehicle::supportsThrottleModeCenterZero() const

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1159,8 +1159,8 @@ public:
 
 public slots:
     void setVtolInFwdFlight                 (bool vtolInFwdFlight);
-    void _offlineFirmwareTypeSettingChanged (QVariant value);       // Should only be used by MissionControler to set firmware from Plan file
-    void _offlineVehicleTypeSettingChanged  (QVariant value);       // Should only be used by MissionController to set vehicle type from Plan file
+    void _offlineFirmwareTypeSettingChanged (QVariant varFirmwareType); // Should only be used by MissionControler to set firmware from Plan file
+    void _offlineVehicleTypeSettingChanged  (QVariant varVehicleType);  // Should only be used by MissionController to set vehicle type from Plan file
 
 signals:
     void allLinksInactive               (Vehicle* vehicle);

--- a/src/comm/QGCMAVLink.cc
+++ b/src/comm/QGCMAVLink.cc
@@ -9,45 +9,91 @@
 
 #include "QGCMAVLink.h"
 
-bool QGCMAVLink::isFixedWing(MAV_TYPE mavType)
+constexpr QGCMAVLink::FirmwareClass_t QGCMAVLink::FirmwareClassPX4;
+constexpr QGCMAVLink::FirmwareClass_t QGCMAVLink::FirmwareClassArduPilot;
+constexpr QGCMAVLink::FirmwareClass_t QGCMAVLink::FirmwareClassGeneric;
+
+constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassFixedWing;
+constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassRoverBoat;
+constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassSub;
+constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassMultiRotor;
+constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassVTOL;
+constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassGeneric;
+
+QList<QGCMAVLink::FirmwareClass_t> QGCMAVLink::allFirmwareClasses(void)
 {
-    return mavType == MAV_TYPE_FIXED_WING;
+    static const QList<QGCMAVLink::FirmwareClass_t> classes = {
+        FirmwareClassPX4,
+        FirmwareClassArduPilot,
+        FirmwareClassGeneric
+    };
+
+    return classes;
 }
 
-bool QGCMAVLink::isRover(MAV_TYPE mavType)
+QList<QGCMAVLink::VehicleClass_t> QGCMAVLink::allVehicleClasses(void)
 {
-    switch (mavType) {
-    case MAV_TYPE_GROUND_ROVER:
-    case MAV_TYPE_SURFACE_BOAT:
-        return true;
-    default:
-        return false;
+    static const QList<QGCMAVLink::VehicleClass_t> classes = {
+        VehicleClassFixedWing,
+        VehicleClassRoverBoat,
+        VehicleClassSub,
+        VehicleClassMultiRotor,
+        VehicleClassVTOL,
+        VehicleClassGeneric,
+    };
+
+    return classes;
+}
+
+QGCMAVLink::FirmwareClass_t QGCMAVLink::firmwareClass(MAV_AUTOPILOT autopilot)
+{
+    if (isPX4FirmwareClass(autopilot)) {
+        return FirmwareClassPX4;
+    } else if (isArduPilotFirmwareClass(autopilot)) {
+        return FirmwareClassArduPilot;
+    } else {
+        return FirmwareClassGeneric;
     }
+}
+
+bool QGCMAVLink::isFixedWing(MAV_TYPE mavType)
+{
+    return vehicleClass(mavType) == VehicleClassFixedWing;
+}
+
+bool QGCMAVLink::isRoverBoat(MAV_TYPE mavType)
+{
+    return vehicleClass(mavType) == VehicleClassRoverBoat;
 }
 
 bool QGCMAVLink::isSub(MAV_TYPE mavType)
 {
-    return mavType == MAV_TYPE_SUBMARINE;
+    return vehicleClass(mavType) == VehicleClassSub;
 }
 
 bool QGCMAVLink::isMultiRotor(MAV_TYPE mavType)
 {
+    return vehicleClass(mavType) == VehicleClassMultiRotor;
+}
+
+bool QGCMAVLink::isVTOL(MAV_TYPE mavType)
+{
+    return vehicleClass(mavType) == VehicleClassVTOL;
+}
+
+QGCMAVLink::VehicleClass_t QGCMAVLink::vehicleClass(MAV_TYPE mavType)
+{
     switch (mavType) {
+    case MAV_TYPE_GROUND_ROVER:
+    case MAV_TYPE_SURFACE_BOAT:
+        return VehicleClassRoverBoat;
     case MAV_TYPE_QUADROTOR:
     case MAV_TYPE_COAXIAL:
     case MAV_TYPE_HELICOPTER:
     case MAV_TYPE_HEXAROTOR:
     case MAV_TYPE_OCTOROTOR:
     case MAV_TYPE_TRICOPTER:
-        return true;
-    default:
-        return false;
-    }
-}
-
-bool QGCMAVLink::isVTOL(MAV_TYPE mavType)
-{
-    switch (mavType) {
+        return VehicleClassMultiRotor;
     case MAV_TYPE_VTOL_DUOROTOR:
     case MAV_TYPE_VTOL_QUADROTOR:
     case MAV_TYPE_VTOL_TILTROTOR:
@@ -55,27 +101,12 @@ bool QGCMAVLink::isVTOL(MAV_TYPE mavType)
     case MAV_TYPE_VTOL_RESERVED3:
     case MAV_TYPE_VTOL_RESERVED4:
     case MAV_TYPE_VTOL_RESERVED5:
-        return true;
+        return VehicleClassVTOL;
+    case MAV_TYPE_FIXED_WING:
+        return VehicleClassFixedWing;
     default:
-        return false;
+        return VehicleClassGeneric;
     }
-}
-
-MAV_TYPE QGCMAVLink::vehicleClass(MAV_TYPE mavType)
-{
-    if (isFixedWing(mavType)) {
-        return MAV_TYPE_FIXED_WING;
-    } else if (isRover(mavType)) {
-        return MAV_TYPE_GROUND_ROVER;
-    } else if (isSub(mavType)) {
-        return MAV_TYPE_SUBMARINE;
-    } else if (isMultiRotor(mavType)) {
-        return MAV_TYPE_QUADROTOR;
-    } else if (isVTOL(mavType)) {
-        return MAV_TYPE_VTOL_QUADROTOR;
-    }
-
-    return MAV_TYPE_GENERIC;
 }
 
 QString  QGCMAVLink::mavResultToString(MAV_RESULT result)

--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <QString>
+#include <QList>
 
 #define MAVLINK_USE_MESSAGE_INFO
 #define MAVLINK_EXTERNAL_RX_STATUS  // Single m_mavlink_status instance is in QGCApplication.cc
@@ -48,13 +49,37 @@ extern mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
 
 class QGCMAVLink {
 public:
-    static bool     isFixedWing         (MAV_TYPE mavType);
-    static bool     isRover             (MAV_TYPE mavType);
-    static bool     isSub               (MAV_TYPE mavType);
-    static bool     isMultiRotor        (MAV_TYPE mavType);
-    static bool     isVTOL              (MAV_TYPE mavType);
-    static MAV_TYPE vehicleClass        (MAV_TYPE mavType);
-    static QString  mavResultToString   (MAV_RESULT result);
+    typedef int FirmwareClass_t;
+    typedef int VehicleClass_t;
+
+    static constexpr FirmwareClass_t FirmwareClassPX4       = MAV_AUTOPILOT_PX4;
+    static constexpr FirmwareClass_t FirmwareClassArduPilot = MAV_AUTOPILOT_ARDUPILOTMEGA;
+    static constexpr FirmwareClass_t FirmwareClassGeneric   = MAV_AUTOPILOT_GENERIC;
+
+    static constexpr VehicleClass_t VehicleClassFixedWing   = MAV_TYPE_FIXED_WING;
+    static constexpr VehicleClass_t VehicleClassRoverBoat   = MAV_TYPE_GROUND_ROVER;
+    static constexpr VehicleClass_t VehicleClassSub         = MAV_TYPE_SUBMARINE;
+    static constexpr VehicleClass_t VehicleClassMultiRotor  = MAV_TYPE_QUADROTOR;
+    static constexpr VehicleClass_t VehicleClassVTOL        = MAV_TYPE_VTOL_QUADROTOR;
+    static constexpr VehicleClass_t VehicleClassGeneric     = MAV_TYPE_GENERIC;
+
+    static bool                     isPX4FirmwareClass      (MAV_AUTOPILOT autopilot) { return autopilot == MAV_AUTOPILOT_PX4; }
+    static bool                     isArduPilotFirmwareClass(MAV_AUTOPILOT autopilot) { return autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA; }
+    static bool                     isGenericFirmwareClass  (MAV_AUTOPILOT autopilot) { return !isPX4FirmwareClass(autopilot) && ! isArduPilotFirmwareClass(autopilot); }
+    static FirmwareClass_t          firmwareClass           (MAV_AUTOPILOT autopilot);
+    static MAV_AUTOPILOT            firmwareClassToAutopilot(FirmwareClass_t firmwareClass) { return static_cast<MAV_AUTOPILOT>(firmwareClass); }
+    static QList<FirmwareClass_t>   allFirmwareClasses      (void);
+
+    static bool                     isFixedWing             (MAV_TYPE mavType);
+    static bool                     isRoverBoat             (MAV_TYPE mavType);
+    static bool                     isSub                   (MAV_TYPE mavType);
+    static bool                     isMultiRotor            (MAV_TYPE mavType);
+    static bool                     isVTOL                  (MAV_TYPE mavType);
+    static VehicleClass_t           vehicleClass            (MAV_TYPE mavType);
+    static MAV_TYPE                 vehicleClassToMavType   (VehicleClass_t vehicleClass) { return static_cast<MAV_TYPE>(vehicleClass); }
+    static QList<VehicleClass_t>    allVehicleClasses       (void);
+
+    static QString          mavResultToString       (MAV_RESULT result);
 };
 
 class MavlinkFTP {

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -110,8 +110,8 @@ void UnitTest::init(void)
 
     // Force offline vehicle back to defaults
     AppSettings* appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
-    appSettings->offlineEditingFirmwareType()->setRawValue(appSettings->offlineEditingFirmwareType()->rawDefaultValue());
-    appSettings->offlineEditingVehicleType()->setRawValue(appSettings->offlineEditingVehicleType()->rawDefaultValue());
+    appSettings->offlineEditingFirmwareClass()->setRawValue(appSettings->offlineEditingFirmwareClass()->rawDefaultValue());
+    appSettings->offlineEditingVehicleClass()->setRawValue(appSettings->offlineEditingVehicleClass()->rawDefaultValue());
     
     _messageBoxRespondedTo = false;
     _missedMessageBoxCount = 0;


### PR DESCRIPTION
* First step in cleaning up MissionCommandTree and friends with respect to correct support for VTOL plan creation
* Internally QGC has always had the concept of firmware and vehicle "classes". For example although there are a million different MAV_TYPEs which are VTOL, QGC treats them all as a "vtol" class vehicle.  And doesn't really care about the specific VTOL MAV_TYPE.
* This change formalizes those relationships into stronger typing of firmware and vehicle classes instead of just using MAV_AUTOPILOT/MAV_TYPE in special ways in certain places.
* Related to #8923