### PR TITLE
support mRo Control Zero with PX4

### DIFF
--- a/src/VehicleSetup/Bootloader.h
+++ b/src/VehicleSetup/Bootloader.h
@@ -52,6 +52,7 @@ public:
     static const int boardIDFMUK66V3    = 28;       ///< FMUK66V3 board, as from USB PID
     static const int boardIDKakuteF7    = 123;      ///< Holybro KakuteF7 board, as from USB PID
     static const int boardIDDurandalV1  = 139;      ///< Holybro Durandal-v1 board, as from USB PID
+    static const int boardIDmRoCtrlZeroF7 = 141;    ///< mRo Control Zero F7 board, as from USB PID
     static const int boardIDModalFCV1   = 41775;    ///< ModalAI FC V1 board, as from USB PID
     static const int boardIDUVifyCore   = 20;       ///< UVify Core board, as from USB PID
 

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -336,6 +336,14 @@ void FirmwareUpgradeController::_initFirmwareHash()
         { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/modalai_fc-v1_default.px4"},
         { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/modalai_fc-v1_default.px4"},
     };
+
+    //////////////////////////////////// mRo Control Zero firmwares //////////////////////////////////////////////////
+    FirmwareToUrlElement_t rgmRoCtrlZero[] = {
+        { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/mro_ctrl-zero-f7_default.px4"},
+        { AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/beta/mro_ctrl-zero-f7_default.px4"},
+        { AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/master/mro_ctrl-zero-f7_default.px4"},
+    };
+
     //////////////////////////////////// UVify FC firmwares //////////////////////////////////////////////////
     FirmwareToUrlElement_t rgUVifyCoreFirmwareArray[] = {
         { AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/Firmware/stable/uvify_core_default.px4"},
@@ -448,6 +456,12 @@ void FirmwareUpgradeController::_initFirmwareHash()
         _rgModalFCV1Firmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
     }
 
+    size = sizeof(rgmRoCtrlZero)/sizeof(rgmRoCtrlZero[0]);
+    for (int i = 0; i < size; i++) {
+        const FirmwareToUrlElement_t& element = rgmRoCtrlZero[i];
+        _rgmRoCtrlZeroF7Firmware.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
+    }
+
     size = sizeof(rgUVifyCoreFirmwareArray)/sizeof(rgUVifyCoreFirmwareArray[0]);
     for (int i = 0; i < size; i++) {
         const FirmwareToUrlElement_t& element = rgUVifyCoreFirmwareArray[i];
@@ -536,6 +550,9 @@ QHash<FirmwareUpgradeController::FirmwareIdentifier, QString>* FirmwareUpgradeCo
         break;
     case Bootloader::boardIDModalFCV1:
         _rgFirmwareDynamic = _rgModalFCV1Firmware;
+        break;
+    case Bootloader::boardIDmRoCtrlZeroF7:
+        _rgFirmwareDynamic = _rgmRoCtrlZeroF7Firmware;
         break;
     case Bootloader::boardIDUVifyCore:
         _rgFirmwareDynamic = _rgUVifyCoreFirmware;

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -220,6 +220,7 @@ private:
     QHash<FirmwareIdentifier, QString> _rgDurandalV1Firmware;
     QHash<FirmwareIdentifier, QString> _rgFMUK66V3Firmware;
     QHash<FirmwareIdentifier, QString> _rgModalFCV1Firmware;
+    QHash<FirmwareIdentifier, QString> _rgmRoCtrlZeroF7Firmware;
     QHash<FirmwareIdentifier, QString> _rgUVifyCoreFirmware;
     QHash<FirmwareIdentifier, QString> _rgPX4FLowFirmware;
     QHash<FirmwareIdentifier, QString> _rg3DRRadioFirmware;

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -68,6 +68,7 @@
         { "regExp": "^Crazyflie BL",        "boardClass": "Pixhawk" },
         { "regExp": "^PX4 OmnibusF4SD",     "boardClass": "Pixhawk" },
         { "regExp": "^fmuv[2345]$",         "boardClass": "Pixhawk" },
+        { "regExp": "^mRoControlZeroF7",    "boardClass": "Pixhawk" },
         { "regExp": "PX4.*Flow",            "boardClass": "PX4 Flow" },
         { "regExp": "^FT231X USB UART$",    "boardClass": "SiK Radio" },
         { "regExp": "USB UART$",            "boardClass": "SiK Radio",  "androidOnly": true, "comment": "Very broad fallback, too dangerous for non-android" }


### PR DESCRIPTION
I forgot how awful this was, we should add support for a manifest file.