### PR TITLE
Fix joystick reconnect bug - srr-qgc branch

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -265,6 +265,7 @@ Joystick::Joystick(const QString& name, int axisCount, int buttonCount, int hatC
         _buttonActionArray.append(nullptr);
     }
 
+    _activeVehicleChanged(_multiVehicleManager->activeVehicle());
     connect(_multiVehicleManager, &MultiVehicleManager::activeVehicleChanged, this, &Joystick::_activeVehicleChanged);
     emit buttonActionsChanged();
 }


### PR DESCRIPTION
When a joystick would be disconnected then reconnected none of the
settings would be set correctly.  Noticing this did not occur on the
upstream I tracked down the introduction of this bug to the commit
8cd3c085f81ccc20289ee0e46427bdc309acf1f5.  Upon further inspection I
found that we should be calling _loadSettings and the other
initialization methods in the constructor to account for the case when a
joystick is unplugged and reconnected without the connection to the
activeVechicle changing.


