### PR TITLE
Replace qFuzzyCompare with better functioning QGC::fuzzyCompare

### DIFF
--- a/src/ADSB/ADSBVehicle.cc
+++ b/src/ADSB/ADSBVehicle.cc
@@ -9,6 +9,7 @@
 
 #include "ADSBVehicle.h"
 #include "QGCLoggingCategory.h"
+#include "QGC.h"
 
 #include <QDebug>
 #include <QtMath>
@@ -42,13 +43,13 @@ void ADSBVehicle::update(const VehicleInfo_t& vehicleInfo)
         }
     }
     if (vehicleInfo.availableFlags & AltitudeAvailable) {
-        if (!(qIsNaN(vehicleInfo.altitude) && qIsNaN(_altitude)) && !qFuzzyCompare(vehicleInfo.altitude, _altitude)) {
+        if (!QGC::fuzzyCompare(vehicleInfo.altitude, _altitude)) {
             _altitude = vehicleInfo.altitude;
             emit altitudeChanged();
         }
     }
     if (vehicleInfo.availableFlags & HeadingAvailable) {
-        if (!(qIsNaN(vehicleInfo.heading) && qIsNaN(_heading)) && !qFuzzyCompare(vehicleInfo.heading, _heading)) {
+        if (!QGC::fuzzyCompare(vehicleInfo.heading, _heading)) {
             _heading = vehicleInfo.heading;
             emit headingChanged();
         }

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2236,7 +2236,7 @@ void MissionController::applyDefaultMissionAltitude(void)
 
 void MissionController::_progressPctChanged(double progressPct)
 {
-    if (!qFuzzyCompare(progressPct, _progressPct)) {
+    if (!QGC::fuzzyCompare(progressPct, _progressPct)) {
         _progressPct = progressPct;
         emit progressPctChanged(progressPct);
     }

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -266,7 +266,7 @@ void MissionSettingsItem::_updateAltitudeInCoordinate(QVariant value)
 {
     double newAltitude = value.toDouble();
 
-    if (!qFuzzyCompare(_plannedHomePositionCoordinate.altitude(), newAltitude)) {
+    if (QGC::fuzzyCompare(_plannedHomePositionCoordinate.altitude(), newAltitude)) {
         _plannedHomePositionCoordinate.setAltitude(newAltitude);
         emit coordinateChanged(_plannedHomePositionCoordinate);
         emit exitCoordinateChanged(_plannedHomePositionCoordinate);

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -686,7 +686,7 @@ void SimpleMissionItem::_terrainAltChanged(void)
         } else {
             double newAboveTerrain = terrainAltitude() + _altitudeFact.rawValue().toDouble();
             double oldAboveTerrain = _amslAltAboveTerrainFact.rawValue().toDouble();
-            if (qIsNaN(oldAboveTerrain) || !qFuzzyCompare(newAboveTerrain, oldAboveTerrain)) {
+            if (!QGC::fuzzyCompare(newAboveTerrain, oldAboveTerrain)) {
                 _missionItem._param7Fact.setRawValue(newAboveTerrain);
                 _amslAltAboveTerrainFact.setRawValue(newAboveTerrain);
             }
@@ -941,14 +941,14 @@ void SimpleMissionItem::setMissionFlightStatus(MissionController::MissionFlightS
     VisualMissionItem::setMissionFlightStatus(missionFlightStatus);
 
     // If speed and/or gimbal are not specifically set on this item. Then use the flight status values as initial defaults should a user turn them on.
-    if (_speedSection->available() && !_speedSection->specifyFlightSpeed() && !qFuzzyCompare(_speedSection->flightSpeed()->rawValue().toDouble(), missionFlightStatus.vehicleSpeed)) {
+    if (_speedSection->available() && !_speedSection->specifyFlightSpeed() && !QGC::fuzzyCompare(_speedSection->flightSpeed()->rawValue().toDouble(), missionFlightStatus.vehicleSpeed)) {
         _speedSection->flightSpeed()->setRawValue(missionFlightStatus.vehicleSpeed);
     }
     if (_cameraSection->available() && !_cameraSection->specifyGimbal()) {
-        if (!qIsNaN(missionFlightStatus.gimbalYaw) && !qFuzzyCompare(_cameraSection->gimbalYaw()->rawValue().toDouble(), missionFlightStatus.gimbalYaw)) {
+        if (!qIsNaN(missionFlightStatus.gimbalYaw) && !QGC::fuzzyCompare(_cameraSection->gimbalYaw()->rawValue().toDouble(), missionFlightStatus.gimbalYaw)) {
             _cameraSection->gimbalYaw()->setRawValue(missionFlightStatus.gimbalYaw);
         }
-        if (!qIsNaN(missionFlightStatus.gimbalPitch) && !qFuzzyCompare(_cameraSection->gimbalPitch()->rawValue().toDouble(), missionFlightStatus.gimbalPitch)) {
+        if (!qIsNaN(missionFlightStatus.gimbalPitch) && !QGC::fuzzyCompare(_cameraSection->gimbalPitch()->rawValue().toDouble(), missionFlightStatus.gimbalPitch)) {
             _cameraSection->gimbalPitch()->setRawValue(missionFlightStatus.gimbalPitch);
         }
     }

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -474,7 +474,7 @@ int StructureScanComplexItem::cameraShots(void) const
 void StructureScanComplexItem::setMissionFlightStatus(MissionController::MissionFlightStatus_t& missionFlightStatus)
 {
     ComplexMissionItem::setMissionFlightStatus(missionFlightStatus);
-    if (!qFuzzyCompare(_vehicleSpeed, missionFlightStatus.vehicleSpeed)) {
+    if (!QGC::fuzzyCompare(_vehicleSpeed, missionFlightStatus.vehicleSpeed)) {
         _vehicleSpeed = missionFlightStatus.vehicleSpeed;
         emit timeBetweenShotsChanged();
     }
@@ -645,7 +645,7 @@ void StructureScanComplexItem::_recalcScanDistance()
                                              << " scanDistance: " << _scanDistance;
     }
 
-    if (!qFuzzyCompare(_scanDistance, scanDistance)) {
+    if (!QGC::fuzzyCompare(_scanDistance, scanDistance)) {
         _scanDistance = scanDistance;
         emit complexDistanceChanged();
     }

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -327,7 +327,7 @@ double TransectStyleComplexItem::greatestDistanceTo(const QGeoCoordinate &other)
 void TransectStyleComplexItem::setMissionFlightStatus(MissionController::MissionFlightStatus_t& missionFlightStatus)
 {
     ComplexMissionItem::setMissionFlightStatus(missionFlightStatus);
-    if (!qFuzzyCompare(_vehicleSpeed, missionFlightStatus.vehicleSpeed)) {
+    if (!QGC::fuzzyCompare(_vehicleSpeed, missionFlightStatus.vehicleSpeed)) {
         _vehicleSpeed = missionFlightStatus.vehicleSpeed;
         // Vehicle speed change affects max climb/descent rates calcs for terrain so we need to re-adjust
         _rebuildTransects();

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -96,7 +96,7 @@ void VisualMissionItem::setHasCurrentChildItem(bool hasCurrentChildItem)
 
 void VisualMissionItem::setDistance(double distance)
 {
-    if (!qFuzzyCompare(_distance, distance)) {
+    if (!QGC::fuzzyCompare(_distance, distance)) {
         _distance = distance;
         emit distanceChanged(_distance);
     }
@@ -104,7 +104,7 @@ void VisualMissionItem::setDistance(double distance)
 
 void VisualMissionItem::setDistanceFromStart(double distanceFromStart)
 {
-    if (!qFuzzyCompare(_distanceFromStart, distanceFromStart)) {
+    if (!QGC::fuzzyCompare(_distanceFromStart, distanceFromStart)) {
         _distanceFromStart = distanceFromStart;
         emit distanceFromStartChanged(_distanceFromStart);
     }
@@ -112,7 +112,7 @@ void VisualMissionItem::setDistanceFromStart(double distanceFromStart)
 
 void VisualMissionItem::setAltDifference(double altDifference)
 {
-    if (!qFuzzyCompare(_altDifference, altDifference)) {
+    if (!QGC::fuzzyCompare(_altDifference, altDifference)) {
         _altDifference = altDifference;
         emit altDifferenceChanged(_altDifference);
     }
@@ -120,7 +120,7 @@ void VisualMissionItem::setAltDifference(double altDifference)
 
 void VisualMissionItem::setAltPercent(double altPercent)
 {
-    if (!qFuzzyCompare(_altPercent, altPercent)) {
+    if (!QGC::fuzzyCompare(_altPercent, altPercent)) {
         _altPercent = altPercent;
         emit altPercentChanged(_altPercent);
     }
@@ -128,7 +128,7 @@ void VisualMissionItem::setAltPercent(double altPercent)
 
 void VisualMissionItem::setTerrainPercent(double terrainPercent)
 {
-    if (!qFuzzyCompare(_terrainPercent, terrainPercent)) {
+    if (!QGC::fuzzyCompare(_terrainPercent, terrainPercent)) {
         _terrainPercent = terrainPercent;
         emit terrainPercentChanged(terrainPercent);
     }
@@ -144,7 +144,7 @@ void VisualMissionItem::setTerrainCollision(bool terrainCollision)
 
 void VisualMissionItem::setAzimuth(double azimuth)
 {
-    if (!qFuzzyCompare(_azimuth, azimuth)) {
+    if (!QGC::fuzzyCompare(_azimuth, azimuth)) {
         _azimuth = azimuth;
         emit azimuthChanged(_azimuth);
     }
@@ -164,7 +164,7 @@ void VisualMissionItem::setMissionFlightStatus(MissionController::MissionFlightS
 
 void VisualMissionItem::setMissionVehicleYaw(double vehicleYaw)
 {
-    if (!qFuzzyCompare(_missionVehicleYaw, vehicleYaw)) {
+    if (!QGC::fuzzyCompare(_missionVehicleYaw, vehicleYaw)) {
         _missionVehicleYaw = vehicleYaw;
         emit missionVehicleYawChanged(_missionVehicleYaw);
     }
@@ -189,7 +189,7 @@ void VisualMissionItem::_updateTerrainAltitude(void)
 void VisualMissionItem::_reallyUpdateTerrainAltitude(void)
 {
     QGeoCoordinate coord = coordinate();
-    if (specifiesCoordinate() && coord.isValid() && (qIsNaN(_terrainAltitude) || !qFuzzyCompare(_lastLatTerrainQuery, coord.latitude()) || qFuzzyCompare(_lastLonTerrainQuery, coord.longitude()))) {
+    if (specifiesCoordinate() && coord.isValid() && (qIsNaN(_terrainAltitude) || !QGC::fuzzyCompare(_lastLatTerrainQuery, coord.latitude()) || QGC::fuzzyCompare(_lastLonTerrainQuery, coord.longitude()))) {
         _lastLatTerrainQuery = coord.latitude();
         _lastLonTerrainQuery = coord.longitude();
         if (_currentTerrainAtCoordinateQuery) {

--- a/src/QmlControls/FlightPathSegment.cc
+++ b/src/QmlControls/FlightPathSegment.cc
@@ -8,6 +8,7 @@
  ****************************************************************************/
 
 #include "FlightPathSegment.h"
+#include "QGC.h"
 
 QGC_LOGGING_CATEGORY(FlightPathSegmentLog, "FlightPathSegmentLog")
 
@@ -51,7 +52,7 @@ void FlightPathSegment::setCoordinate2(const QGeoCoordinate &coordinate)
 
 void FlightPathSegment::setCoord1AMSLAlt(double alt)
 {
-    if (!qFuzzyCompare(alt, _coord1AMSLAlt)) {
+    if (!QGC::fuzzyCompare(alt, _coord1AMSLAlt)) {
         _coord1AMSLAlt = alt;
         emit coord1AMSLAltChanged();
         _updateTerrainCollision();
@@ -60,7 +61,7 @@ void FlightPathSegment::setCoord1AMSLAlt(double alt)
 
 void FlightPathSegment::setCoord2AMSLAlt(double alt)
 {
-    if (!qFuzzyCompare(alt, _coord2AMSLAlt)) {
+    if (!QGC::fuzzyCompare(alt, _coord2AMSLAlt)) {
         _coord2AMSLAlt = alt;
         emit coord2AMSLAltChanged();
         _updateTerrainCollision();
@@ -104,11 +105,11 @@ void FlightPathSegment::_terrainDataReceived(bool success, const TerrainPathQuer
 {
     qCDebug(FlightPathSegmentLog) << this << "_terrainDataReceived" << success << pathHeightInfo.heights.count();
     if (success) {
-        if (!qFuzzyCompare(pathHeightInfo.distanceBetween, _distanceBetween)) {
+        if (!QGC::fuzzyCompare(pathHeightInfo.distanceBetween, _distanceBetween)) {
             _distanceBetween = pathHeightInfo.distanceBetween;
             emit distanceBetweenChanged(_distanceBetween);
         }
-        if (!qFuzzyCompare(pathHeightInfo.finalDistanceBetween, _finalDistanceBetween)) {
+        if (!QGC::fuzzyCompare(pathHeightInfo.finalDistanceBetween, _finalDistanceBetween)) {
             _finalDistanceBetween = pathHeightInfo.finalDistanceBetween;
             emit finalDistanceBetweenChanged(_finalDistanceBetween);
         }
@@ -133,7 +134,7 @@ void FlightPathSegment::_updateTotalDistance(void)
         newTotalDistance = _coord1.distanceTo(_coord2);
     }
 
-    if (!qFuzzyCompare(newTotalDistance, _totalDistance)) {
+    if (!QGC::fuzzyCompare(newTotalDistance, _totalDistance)) {
         _totalDistance = newTotalDistance;
         emit totalDistanceChanged(_totalDistance);
     }

--- a/src/QmlControls/InstrumentValueData.cc
+++ b/src/QmlControls/InstrumentValueData.cc
@@ -327,7 +327,7 @@ void InstrumentValueData::_updateOpacity(void)
         newOpacity = _rangeOpacities[rangeIndex].toDouble();
     }
 
-    if (!qFuzzyCompare(newOpacity, _currentOpacity)) {
+    if (!QGC::fuzzyCompare(newOpacity, _currentOpacity)) {
         _currentOpacity = newOpacity;
         emit currentOpacityChanged(newOpacity);
     }

--- a/src/QmlControls/TerrainProfile.cc
+++ b/src/QmlControls/TerrainProfile.cc
@@ -309,7 +309,8 @@ QSGNode* TerrainProfile::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePai
     emit widthChanged();
     emit pixelsPerMeterChanged();
 
-    double newMaxAMSLAlt = qMax(_missionController->maxAMSLAltitude(), maxTerrainHeight);    if (!qFuzzyCompare(newMaxAMSLAlt, _maxAMSLAlt)) {
+    double newMaxAMSLAlt = qMax(_missionController->maxAMSLAltitude(), maxTerrainHeight);
+    if (!QGC::fuzzyCompare(newMaxAMSLAlt, _maxAMSLAlt)) {
         _maxAMSLAlt = newMaxAMSLAlt;
         emit maxAMSLAltChanged();
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -880,7 +880,7 @@ void Vehicle::_handleOrbitExecutionStatus(const mavlink_message_t& message)
     mavlink_msg_orbit_execution_status_decode(&message, &orbitStatus);
 
     double newRadius =  qAbs(static_cast<double>(orbitStatus.radius));
-    if (!qFuzzyCompare(_orbitMapCircle.radius()->rawValue().toDouble(), newRadius)) {
+    if (!QGC::fuzzyCompare(_orbitMapCircle.radius()->rawValue().toDouble(), newRadius)) {
         _orbitMapCircle.radius()->setRawValue(newRadius);
     }
 

--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -494,19 +494,6 @@ bool UnitTest::fileCompare(const QString& file1, const QString& file2)
     return true;
 }
 
-bool UnitTest::doubleNaNCompare(double value1, double value2)
-{
-    if (qIsNaN(value1) && qIsNaN(value2)) {
-        return true;
-    } else {
-        bool ret = qFuzzyCompare(value1, value2);
-        if (!ret) {
-            qDebug() << value1 << value2;
-        }
-        return ret;
-    }
-}
-
 void UnitTest::changeFactValue(Fact* fact,double increment)
 {
     if (fact->typeIsBool()) {
@@ -525,13 +512,13 @@ void UnitTest::_missionItemsEqual(MissionItem& actual, MissionItem& expected)
     QCOMPARE(static_cast<int>(actual.frame()),      static_cast<int>(expected.frame()));
     QCOMPARE(actual.autoContinue(),                 expected.autoContinue());
 
-    QVERIFY(UnitTest::doubleNaNCompare(actual.param1(), expected.param1()));
-    QVERIFY(UnitTest::doubleNaNCompare(actual.param2(), expected.param2()));
-    QVERIFY(UnitTest::doubleNaNCompare(actual.param3(), expected.param3()));
-    QVERIFY(UnitTest::doubleNaNCompare(actual.param4(), expected.param4()));
-    QVERIFY(UnitTest::doubleNaNCompare(actual.param5(), expected.param5()));
-    QVERIFY(UnitTest::doubleNaNCompare(actual.param6(), expected.param6()));
-    QVERIFY(UnitTest::doubleNaNCompare(actual.param7(), expected.param7()));
+    QVERIFY(QGC::fuzzyCompare(actual.param1(), expected.param1()));
+    QVERIFY(QGC::fuzzyCompare(actual.param2(), expected.param2()));
+    QVERIFY(QGC::fuzzyCompare(actual.param3(), expected.param3()));
+    QVERIFY(QGC::fuzzyCompare(actual.param4(), expected.param4()));
+    QVERIFY(QGC::fuzzyCompare(actual.param5(), expected.param5()));
+    QVERIFY(QGC::fuzzyCompare(actual.param6(), expected.param6()));
+    QVERIFY(QGC::fuzzyCompare(actual.param7(), expected.param7()));
 }
 
 bool UnitTest::fuzzyCompareLatLon(const QGeoCoordinate& coord1, const QGeoCoordinate& coord2)

--- a/src/qgcunittest/UnitTest.h
+++ b/src/qgcunittest/UnitTest.h
@@ -96,10 +96,6 @@ public:
     /// @return true: files are alike, false: files differ
     static bool fileCompare(const QString& file1, const QString& file2);
 
-    /// Fuzzy compare on two doubles, where NaN is a possible value
-    /// @return true: equal
-    static bool doubleNaNCompare(double value1, double value2);
-
     /// Changes the Facts rawValue such that it emits a valueChanged signal.
     ///     @param increment 0 use standard increment, other increment by specified amount if double value
     void changeFactValue(Fact* fact, double increment = 0);


### PR DESCRIPTION
Qt's qFuzzyCompare has all sort of quirks:
* Double values cannot be NaN. This was known and handled with extra code in most places.
* Nor can they be 0. This was unknown and still seems incorrect. But whatever...

In those cases it doesn't work correctly. There were a pile of places in QGC code using it and due to the above problems I create a new QGC::fuzzyCompare which can be used on double which works in all cases.