### PR TITLE
Split into Views and Tools

### DIFF
--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -82,15 +82,6 @@ Rectangle {
                 }
             }
 
-            QGCLabel {
-                anchors.left:           parent.left
-                anchors.right:          parent.right
-                text:                   qsTr("Analyze")
-                wrapMode:               Text.WordWrap
-                horizontalAlignment:    Text.AlignHCenter
-                visible:                !ScreenTools.isShortScreen
-            }
-
             Repeater {
                 id:                     buttonRepeater
                 model:                  QGroundControl.corePlugin ? QGroundControl.corePlugin.analyzePages : []

--- a/src/FlightDisplay/FlyViewToolStripActionList.qml
+++ b/src/FlightDisplay/FlyViewToolStripActionList.qml
@@ -18,6 +18,11 @@ ToolStripActionList {
     signal displayPreFlightChecklist
 
     model: [
+        ToolStripAction {
+            text:           qsTr("Plan")
+            iconSource:     "/qmlimages/Plan.svg"
+            onTriggered:    mainWindow.showPlanView()
+        },
         PreFlightCheckListShowAction { onTriggered: displayPreFlightChecklist() },
         GuidedActionTakeoff { },
         GuidedActionLand { },

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -624,14 +624,14 @@ Item {
             maxHeight:          parent.height - toolStrip.y
             title:              qsTr("Plan")
 
-            //readonly property int flyButtonIndex:       0
-            readonly property int fileButtonIndex:      0
-            readonly property int takeoffButtonIndex:   1
-            readonly property int waypointButtonIndex:  2
-            readonly property int roiButtonIndex:       3
-            readonly property int patternButtonIndex:   4
-            readonly property int landButtonIndex:      5
-            readonly property int centerButtonIndex:    6
+            readonly property int flyButtonIndex:       0
+            readonly property int fileButtonIndex:      1
+            readonly property int takeoffButtonIndex:   2
+            readonly property int waypointButtonIndex:  3
+            readonly property int roiButtonIndex:       4
+            readonly property int patternButtonIndex:   5
+            readonly property int landButtonIndex:      6
+            readonly property int centerButtonIndex:    7
 
             property bool _isRallyLayer:    _editingLayer == _layerRallyPoints
             property bool _isMissionLayer:  _editingLayer == _layerMission
@@ -639,6 +639,11 @@ Item {
             ToolStripActionList {
                 id: toolStripActionList
                 model: [
+                    ToolStripAction {
+                        text:           qsTr("Fly")
+                        iconSource:     "/qmlimages/PaperPlane.svg"
+                        onTriggered:    mainWindow.showFlyView()
+                    },
                     ToolStripAction {
                         text:                   qsTr("File")
                         enabled:                !_planMasterController.syncInProgress

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -205,14 +205,6 @@ Rectangle {
             id:         buttonColumn
             spacing:    _defaultTextHeight / 2
 
-            QGCLabel {
-                Layout.fillWidth:       true
-                text:                   qsTr("Vehicle Setup")
-                wrapMode:               Text.WordWrap
-                horizontalAlignment:    Text.AlignHCenter
-                visible:                !ScreenTools.isShortScreen
-            }
-
             Repeater {
                 model:                  _corePlugin ? _corePlugin.settingsPages : []
                 visible:                _corePlugin && _corePlugin.options.combineSettingsAndSetup

--- a/src/ui/AppSettings.qml
+++ b/src/ui/AppSettings.qml
@@ -57,14 +57,6 @@ Rectangle {
 
             property real _maxButtonWidth: 0
 
-            QGCLabel {
-                Layout.fillWidth:       true
-                text:                   qsTr("Application Settings")
-                wrapMode:               Text.WordWrap
-                horizontalAlignment:    Text.AlignHCenter
-                visible:                !ScreenTools.isShortScreen
-            }
-
             Repeater {
                 model:  QGroundControl.corePlugin.settingsPages
                 QGCButton {

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -33,28 +33,6 @@ Rectangle {
     property bool   _communicationLost: _activeVehicle ? _activeVehicle.connectionLost : false
     property color  _mainStatusBGColor: qgcPal.brandingPurple
 
-    Component.onCompleted: toolbar.viewButtonClicked(flyButton)
-
-    function viewButtonClicked(button) {
-        if (mainWindow.preventViewSwitch()) {
-            return false
-        }
-        viewSelectDrawer.visible = false
-        currentButton.icon.source = button.imageResource
-        currentButton.logo = button.imageColor == "transparent"
-        return true
-    }
-
-    //-- Setup can be invoked from c++ side
-    Connections {
-        target: setupWindow
-        onVisibleChanged: {
-            if (setupWindow.visible) {
-                toolbar.viewButtonClicked(setupButton)
-            }
-        }
-    }
-
     QGCPalette { id: qgcPal }
 
     /// Bottom single pixel divider
@@ -89,7 +67,9 @@ Rectangle {
         QGCToolBarButton {
             id:                     currentButton
             Layout.preferredHeight: viewButtonRow.height
-            onClicked:              viewSelectDrawer.visible = true
+            icon.source:            "/res/QGCLogoFull"
+            logo:                   true
+            onClicked:              toolSelectDrawer.visible = true
         }
 
         MainStatusIndicator {


### PR DESCRIPTION
Views:
* Fly
* Plan
* You change views using the Fly/Plan button at the top of the left toolstrip

Tools:
* Application Settings
* Vehicle Setup
* Analyze Tools
* You show a tool by clicking the "Q" and picking it from the Tool drawer
* Selecting a tool has no effect on the current view. When you close the tool, the view you were looking at before is still there.
* Tools are full window and slide out from the left edge. Close button to close.

Note the "Plan" button in the top of the toolstrip:
![Screen Shot 2020-08-09 at 11 53 40 AM](https://user-images.githubusercontent.com/5876851/89739794-683be180-da38-11ea-93c3-c3fe1b97cf23.png)

Tool Drawer:
![Screen Shot 2020-08-09 at 11 54 05 AM](https://user-images.githubusercontent.com/5876851/89739815-a33e1500-da38-11ea-8a8b-07a28165448e.png)

Application Settings tool:
![Screen Shot 2020-08-09 at 11 52 31 AM](https://user-images.githubusercontent.com/5876851/89739807-8f92ae80-da38-11ea-9d28-23b311eeb00d.png)



