### PR TITLE
Fly: Fix Drawer closePolicy/interactive

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -333,7 +333,6 @@ ApplicationWindow {
         edge:           Qt.LeftEdge
         interactive:    true
         dragMargin:     0
-        closePolicy:    Drawer.NoAutoClose
         visible:        false
 
         property var    _mainWindow:       mainWindow
@@ -482,6 +481,8 @@ ApplicationWindow {
         height:         mainWindow.height
         edge:           Qt.LeftEdge
         dragMargin:     0
+        closePolicy:    Drawer.NoAutoClose
+        interactive:    false
         visible:        false
 
         property alias title:   toolbarDrawerText.text


### PR DESCRIPTION
* Tool select drawer supports escape, click outside, switch right to close
* Tool drawer should not support interactive close methods, just the Close button