### PR TITLE
Mavlink Inspector: Support displaying messages from multiple systems

### DIFF
--- a/src/AnalyzeView/AnalyzePage.qml
+++ b/src/AnalyzeView/AnalyzePage.qml
@@ -26,7 +26,7 @@ Item {
     property alias  headerComponent:    headerLoader.sourceComponent
     property real   availableWidth:     width  - pageLoader.x
     property real   availableHeight:    height - mainContent.y
-    property bool   poped:              false
+    property bool   popped:             false
     property real   _margins:           ScreenTools.defaultFontPixelHeight * 0.5
 
     signal popout()
@@ -47,13 +47,13 @@ Item {
         anchors.top:            parent.top
         anchors.left:           parent.left
         anchors.rightMargin:    _margins
-        anchors.right:          floatIcon.left
+        anchors.right:          floatIcon.visible ? floatIcon.left : parent.right
         spacing:                _margins
         visible:                !ScreenTools.isShortScreen && headerLoader.sourceComponent === null
         QGCLabel {
             id:                 pageNameLabel
             font.pointSize:     ScreenTools.largeFontPointSize
-            visible:            !poped
+            visible:            !popped
         }
         QGCLabel {
             id:                 pageDescriptionLabel
@@ -86,13 +86,10 @@ Item {
         source:                 "/qmlimages/FloatingWindow.svg"
         fillMode:               Image.PreserveAspectFit
         color:                  qgcPal.text
-        visible:                !poped && !ScreenTools.isMobile
+        visible:                !popped && !ScreenTools.isMobile
         MouseArea {
-            anchors.fill: parent
-            onClicked: {
-                popout()
-            }
+            anchors.fill:   parent
+            onClicked:      popout()
         }
     }
-
 }

--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -7,11 +7,6 @@
  *
  ****************************************************************************/
 
-
-/// @file
-///     @brief Setup View
-///     @author Don Gagne <don@thegagnes.com>
-
 import QtQuick          2.3
 import QtQuick.Window   2.2
 import QtQuick.Controls 1.2
@@ -23,9 +18,11 @@ import QGroundControl.Controllers   1.0
 import QGroundControl.ScreenTools   1.0
 
 Rectangle {
-    id:     setupView
+    id:     _root
     color:  qgcPal.window
     z:      QGroundControl.zOrderTopMost
+
+    signal popout()
 
     ExclusiveGroup { id: setupButtonGroup }
 
@@ -147,7 +144,8 @@ Rectangle {
             panelLoader.source = ""
             buttonRepeater.itemAt(_curIndex).loader.source = source
             buttonRepeater.itemAt(_curIndex).visible = false
-            buttonRepeater.itemAt(_curIndex).loader.item.poped = true
+            buttonRepeater.itemAt(_curIndex).loader.item.popped = true
+            _root.popout()
         }
     }
 

--- a/src/AnalyzeView/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspectorController.h
@@ -27,7 +27,7 @@ Q_DECLARE_LOGGING_CATEGORY(MAVLinkInspectorLog)
 QT_CHARTS_USE_NAMESPACE
 
 class QGCMAVLinkMessage;
-class QGCMAVLinkVehicle;
+class QGCMAVLinkSystem;
 class MAVLinkChartController;
 class MAVLinkInspectorController;
 
@@ -137,7 +137,7 @@ private:
 
 //-----------------------------------------------------------------------------
 /// Vehicle MAVLink message belongs to
-class QGCMAVLinkVehicle : public QObject {
+class QGCMAVLinkSystem : public QObject {
     Q_OBJECT
 public:
     Q_PROPERTY(quint8               id              READ id             CONSTANT)
@@ -147,8 +147,8 @@ public:
 
     Q_PROPERTY(int                  selected        READ selected       WRITE setSelected   NOTIFY selectedChanged)
 
-    QGCMAVLinkVehicle   (QObject* parent, quint8 id);
-    ~QGCMAVLinkVehicle  ();
+    QGCMAVLinkSystem   (QObject* parent, quint8 id);
+    ~QGCMAVLinkSystem  ();
 
     quint8              id              () { return _id; }
     QmlObjectListModel* messages        () { return &_messages; }
@@ -248,22 +248,23 @@ public:
     MAVLinkInspectorController();
     ~MAVLinkInspectorController();
 
-    Q_PROPERTY(QStringList          vehicleNames        READ vehicleNames           NOTIFY vehiclesChanged)
-    Q_PROPERTY(QmlObjectListModel*  vehicles            READ vehicles               NOTIFY vehiclesChanged)
-    Q_PROPERTY(QmlObjectListModel*  charts              READ charts                 NOTIFY chartsChanged)
-    Q_PROPERTY(QGCMAVLinkVehicle*   activeVehicle       READ activeVehicle          NOTIFY activeVehiclesChanged)
-    Q_PROPERTY(QStringList          timeScales          READ timeScales             NOTIFY timeScalesChanged)
-    Q_PROPERTY(QStringList          rangeList           READ rangeList              NOTIFY rangeListChanged)
+    Q_PROPERTY(QStringList          systemNames     READ systemNames    NOTIFY systemsChanged)
+    Q_PROPERTY(QmlObjectListModel*  systems         READ systems       NOTIFY systemsChanged)
+    Q_PROPERTY(QmlObjectListModel*  charts          READ charts         NOTIFY chartsChanged)
+    Q_PROPERTY(QGCMAVLinkSystem*    activeSystem    READ activeSystem   NOTIFY activeSystemChanged)
+    Q_PROPERTY(QStringList          timeScales      READ timeScales     NOTIFY timeScalesChanged)
+    Q_PROPERTY(QStringList          rangeList       READ rangeList      NOTIFY rangeListChanged)
 
     Q_INVOKABLE MAVLinkChartController* createChart     ();
     Q_INVOKABLE void                    deleteChart     (MAVLinkChartController* chart);
+    Q_INVOKABLE void                    setActiveSystem (int systemId);
 
-    QmlObjectListModel*             vehicles            () { return &_vehicles;     }
-    QmlObjectListModel*             charts              () { return &_charts;       }
-    QGCMAVLinkVehicle*              activeVehicle       () { return _activeVehicle; }
-    QStringList                     vehicleNames        () { return _vehicleNames;  }
-    QStringList                     timeScales          ();
-    QStringList                     rangeList           ();
+    QmlObjectListModel* systems     () { return &_systems;     }
+    QmlObjectListModel* charts      () { return &_charts;       }
+    QGCMAVLinkSystem*   activeSystem() { return _activeSystem; }
+    QStringList         systemNames () { return _systemNames;  }
+    QStringList         timeScales  ();
+    QStringList         rangeList   ();
 
     class TimeScale_st : public QObject {
     public:
@@ -283,33 +284,33 @@ public:
     const QList<Range_st*>&         rangeSt             () { return _rangeSt; }
 
 signals:
-    void vehiclesChanged            ();
-    void chartsChanged              ();
-    void activeVehiclesChanged      ();
-    void timeScalesChanged          ();
-    void rangeListChanged           ();
+    void systemsChanged     ();
+    void chartsChanged      ();
+    void activeSystemChanged();
+    void timeScalesChanged  ();
+    void rangeListChanged   ();
 
 private slots:
-    void _receiveMessage            (LinkInterface* link, mavlink_message_t message);
-    void _vehicleAdded              (Vehicle* vehicle);
-    void _vehicleRemoved            (Vehicle* vehicle);
-    void _setActiveVehicle          (Vehicle* vehicle);
-    void _refreshFrequency          ();
+    void _receiveMessage    (LinkInterface* link, mavlink_message_t message);
+    void _vehicleAdded      (Vehicle* vehicle);
+    void _vehicleRemoved    (Vehicle* vehicle);
+    void _setActiveVehicle  (Vehicle* vehicle);
+    void _refreshFrequency  ();
 
 private:
-    QGCMAVLinkVehicle* _findVehicle (uint8_t id);
+    QGCMAVLinkSystem* _findVehicle (uint8_t id);
 
 private:
 
-    int                 _selectedSystemID       = 0;                    ///< Currently selected system
-    int                 _selectedComponentID    = 0;                    ///< Currently selected component
+    int                 _selectedSystemID       = 0;        ///< Currently selected system
+    int                 _selectedComponentID    = 0;        ///< Currently selected component
     QStringList         _timeScales;
     QStringList         _rangeList;
-    QGCMAVLinkVehicle*  _activeVehicle          = nullptr;
+    QGCMAVLinkSystem*   _activeSystem           = nullptr;
     QTimer              _updateFrequencyTimer;
-    QStringList         _vehicleNames;
-    QmlObjectListModel  _vehicles;                                      ///< List of QGCMAVLinkVehicle
-    QmlObjectListModel  _charts;                                        ///< List of MAVLinkCharts
+    QStringList         _systemNames;
+    QmlObjectListModel  _systems;                           ///< List of QGCMAVLinkSystem
+    QmlObjectListModel  _charts;                            ///< List of MAVLinkCharts
     QList<TimeScale_st*>_timeScaleSt;
     QList<Range_st*>    _rangeSt;
 

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -522,6 +522,12 @@ ApplicationWindow {
             anchors.right:  parent.right
             anchors.top:    toolDrawerToolbar.bottom
             anchors.bottom: parent.bottom
+
+            Connections {
+                target:                 toolDrawerLoader.item
+                ignoreUnknownSignals:   true
+                onPopout:               toolDrawer.visible = false
+            }
         }
     }
 


### PR DESCRIPTION
* Here is an example of a log replay. You can see the system combo shows up with two entries. 255 is QGC outgoing telemetry, and 1 is the incoming vehicle telemetry.
![Screen Shot 2020-08-14 at 3 10 57 PM](https://user-images.githubusercontent.com/5876851/90296534-a07c5f00-de40-11ea-8da6-6da6f24c48fe.png)
* Also fixed a problem where values for a message were not updated unless the message was selected in the ui. This made analyzing logs not super useful. Since you couldn't see the last value for the message. And in fact if you selected a message, new values came in for that message, selected some other message, new values came in on the previous message and then you went back to select the previous message it would show you stale data with no indicator of that.
