### PR TITLE
Set default landing heading to takeoff heading

### DIFF
--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -14,6 +14,7 @@
 #include "SimpleMissionItem.h"
 #include "PlanMasterController.h"
 #include "FlightPathSegment.h"
+#include "TakeoffMissionItem.h"
 
 #include <QPolygonF>
 
@@ -27,6 +28,15 @@ LandingComplexItem::LandingComplexItem(PlanMasterController* masterController, b
     // The follow is used to compress multiple recalc calls in a row to into a single call.
     connect(this, &LandingComplexItem::_updateFlightPathSegmentsSignal, this, &LandingComplexItem::_updateFlightPathSegmentsDontCallDirectly,   Qt::QueuedConnection);
     qgcApp()->addCompressedSignal(QMetaMethod::fromSignal(&LandingComplexItem::_updateFlightPathSegmentsSignal));
+}
+
+void LandingComplexItem::setLandingHeadingToTakeoffHeading()
+{
+    TakeoffMissionItem* takeoffMissionItem = _missionController->takeoffMissionItem();
+    if (takeoffMissionItem && takeoffMissionItem->specifiesCoordinate()) {
+        qreal heading = takeoffMissionItem->launchCoordinate().azimuthTo(takeoffMissionItem->coordinate());
+        landingHeading()->setRawValue(heading);
+    }
 }
 
 double LandingComplexItem::complexDistance(void) const

--- a/src/MissionManager/LandingComplexItem.h
+++ b/src/MissionManager/LandingComplexItem.h
@@ -40,6 +40,8 @@ public:
     Q_PROPERTY(QGeoCoordinate   landingCoordinate       READ    landingCoordinate           WRITE setLandingCoordinate      NOTIFY landingCoordinateChanged)
     Q_PROPERTY(bool             landingCoordSet         MEMBER _landingCoordSet                                             NOTIFY landingCoordSetChanged)
 
+    Q_INVOKABLE void setLandingHeadingToTakeoffHeading();
+
     virtual Fact* loiterAltitude          (void) = 0;
     virtual Fact* loiterRadius            (void) = 0;
     virtual Fact* landingAltitude         (void) = 0;

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -22,12 +22,12 @@
 class FlightPathSegment;
 class VisualMissionItem;
 class MissionItem;
-class MissionSettingsItem;
 class AppSettings;
 class MissionManager;
 class SimpleMissionItem;
 class ComplexMissionItem;
 class MissionSettingsItem;
+class TakeoffMissionItem;
 class QDomDocument;
 class PlanViewSettings;
 
@@ -86,6 +86,7 @@ public:
     Q_PROPERTY(int                  currentPlanViewSeqNum           READ currentPlanViewSeqNum          NOTIFY currentPlanViewSeqNumChanged)
     Q_PROPERTY(int                  currentPlanViewVIIndex          READ currentPlanViewVIIndex         NOTIFY currentPlanViewVIIndexChanged)
     Q_PROPERTY(VisualMissionItem*   currentPlanViewItem             READ currentPlanViewItem            NOTIFY currentPlanViewItemChanged)
+    Q_PROPERTY(TakeoffMissionItem*  takeoffMissionItem              READ takeoffMissionItem             NOTIFY takeoffMissionItemChanged)
     Q_PROPERTY(double               missionDistance                 READ missionDistance                NOTIFY missionDistanceChanged)
     Q_PROPERTY(double               missionTime                     READ missionTime                    NOTIFY missionTimeChanged)
     Q_PROPERTY(double               missionHoverDistance            READ missionHoverDistance           NOTIFY missionHoverDistanceChanged)
@@ -225,6 +226,7 @@ public:
     QStringList         complexMissionItemNames     (void) const;
     QGeoCoordinate      plannedHomePosition         (void) const;
     VisualMissionItem*  currentPlanViewItem         (void) const { return _currentPlanViewItem; }
+    TakeoffMissionItem* takeoffMissionItem          (void) const { return _takeoffMissionItem; }
     double              progressPct                 (void) const { return _progressPct; }
     QString             surveyComplexItemName       (void) const;
     QString             corridorScanComplexItemName (void) const;
@@ -280,6 +282,7 @@ signals:
     void currentPlanViewSeqNumChanged       (void);
     void currentPlanViewVIIndexChanged      (void);
     void currentPlanViewItemChanged         (void);
+    void takeoffMissionItemChanged          (void);
     void missionBoundingCubeChanged         (void);
     void missionItemCountChanged            (int missionItemCount);
     void onlyInsertTakeoffValidChanged      (void);
@@ -379,6 +382,7 @@ private:
     int                         _currentPlanViewSeqNum =        -1;
     int                         _currentPlanViewVIIndex =       -1;
     VisualMissionItem*          _currentPlanViewItem =          nullptr;
+    TakeoffMissionItem*         _takeoffMissionItem =           nullptr;
     QTimer                      _updateTimer;
     QGCGeoBoundingCube          _travelBoundingCube;
     QGeoCoordinate              _takeoffCoordinate;

--- a/src/PlanView/FWLandingPatternEditor.qml
+++ b/src/PlanView/FWLandingPatternEditor.qml
@@ -289,6 +289,7 @@ Rectangle {
                 onClicked: {
                     missionItem.landingCoordinate = activeVehicle.coordinate
                     missionItem.landingHeading.rawValue = activeVehicle.heading.rawValue
+                    missionItem.setLandingHeadingToTakeoffHeading()
                 }
             }
         }

--- a/src/PlanView/FWLandingPatternMapVisual.qml
+++ b/src/PlanView/FWLandingPatternMapVisual.qml
@@ -189,6 +189,7 @@ Item {
                 coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
                 coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
                 _missionItem.landingCoordinate = coordinate
+                _missionItem.setLandingHeadingToTakeoffHeading()
             }
         }
     }

--- a/src/PlanView/VTOLLandingPatternEditor.qml
+++ b/src/PlanView/VTOLLandingPatternEditor.qml
@@ -276,6 +276,7 @@ Rectangle {
                 onClicked: {
                     missionItem.landingCoordinate = activeVehicle.coordinate
                     missionItem.landingHeading.rawValue = activeVehicle.heading.rawValue
+                    missionItem.setLandingHeadingToTakeoffHeading()
                 }
             }
         }

--- a/src/PlanView/VTOLLandingPatternMapVisual.qml
+++ b/src/PlanView/VTOLLandingPatternMapVisual.qml
@@ -159,6 +159,7 @@ Item {
                 coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)
                 coordinate.altitude = coordinate.altitude.toFixed(_decimalPlaces)
                 _missionItem.landingCoordinate = coordinate
+                _missionItem.setLandingHeadingToTakeoffHeading()
             }
         }
     }


### PR DESCRIPTION
For **VTOL** and **FW** set default landing heading to takeoff heading when `TakeoffMissionItem` is added in `PlanView`.

VTOL:

![Screenshot from 2020-08-14 20-50-07](https://user-images.githubusercontent.com/2475093/90304009-b73aaa00-de70-11ea-9eeb-80d9b50f12d1.png)

FW:

![Screenshot from 2020-08-14 20-48-03](https://user-images.githubusercontent.com/2475093/90304013-bbff5e00-de70-11ea-94c3-9bf8be731a55.png)

@DonLakeFlyer, please take a look and let me know if anything is missing.