### PR TITLE
Mapbox hybrid map name API fix

### DIFF
--- a/src/QtLocationPlugin/MapboxMapProvider.h
+++ b/src/QtLocationPlugin/MapboxMapProvider.h
@@ -67,7 +67,7 @@ class MapboxHybridMapProvider : public MapboxMapProvider {
 
 public:
     MapboxHybridMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.hybrid"), AVERAGE_MAPBOX_SAT_MAP,
+        : MapboxMapProvider(QStringLiteral("mapbox.streets-satellite"), AVERAGE_MAPBOX_SAT_MAP,
                             QGeoMapType::HybridMap, parent) {}
 };
 


### PR DESCRIPTION
Selecting map type as "Mapbox Hybrid" produces error and map is not shown:

> Fetch tile error: "Error transferring https://api.mapbox.com/v4/mapbox.hybrid/8/147/87.jpg80?access_token=pk.eyJ1IjoiYWlybWFwIiwiYSI6InhIMVMxeHcifQ.-5KWsUSR1cTbqUhTRpGkgQ - server replied: Not Found"
> QGeoTileRequestManager: Failed to fetch tile (147,87,8) 5 times, giving up. Last error message was: 'Error transferring https://api.mapbox.com/v4/mapbox.hybrid/8/147/87.jpg80?access_token=pk.eyJ1IjoiYWlybWFwIiwiYSI6InhIMVMxeHcifQ.-5KWsUSR1cTbqUhTRpGkgQ - server replied: Not Found'

This PR fixes this.