### PR TITLE
comm: Add missing QObject include for QGCMAVLink

### DIFF
--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <QObject>
 #include <QString>
 #include <QList>
 


### PR DESCRIPTION
It's necessary to include QOBject to inherit

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


