### PR TITLE
QGCFileDialog remove separate mobile fileExtension properties

### DIFF
--- a/HackAndroidFileDialog.qrc
+++ b/HackAndroidFileDialog.qrc
@@ -1,5 +1,0 @@
-<RCC>
-    <qresource prefix="/qml">
-        <file alias="QGroundControl/Controls/HackFileDialog.qml">src/QmlControls/HackAndroidFileDialog.qml</file>
-    </qresource>
-</RCC>

--- a/HackFileDialog.qrc
+++ b/HackFileDialog.qrc
@@ -1,5 +1,0 @@
-<RCC>
-    <qresource prefix="/qml">
-        <file alias="QGroundControl/Controls/HackFileDialog.qml">src/QmlControls/HackFileDialog.qml</file>
-    </qresource>
-</RCC>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -362,15 +362,6 @@ CustomBuild {
         $$PWD/resources/InstrumentValueIcons/InstrumentValueIcons.qrc \
 }
 
-# On Qt 5.9 android versions there is the following bug: https://bugreports.qt.io/browse/QTBUG-61424
-# This prevents FileDialog from being used. So we have a temp hack workaround for it which just no-ops
-# the FileDialog fallback mechanism on android 5.9 builds.
-equals(QT_MAJOR_VERSION, 5):equals(QT_MINOR_VERSION, 9):AndroidBuild {
-    RESOURCES += $$PWD/HackAndroidFileDialog.qrc
-} else {
-    RESOURCES += $$PWD/HackFileDialog.qrc
-}
-
 #
 # Main QGroundControl portion of project file
 #

--- a/src/MissionManager/QGCMapPolylineVisuals.qml
+++ b/src/MissionManager/QGCMapPolylineVisuals.qml
@@ -128,7 +128,6 @@ Item {
         title:          qsTr("Select KML File")
         selectExisting: true
         nameFilters:    ShapeFileHelper.fileDialogKMLFilters
-        fileExtension:  QGroundControl.settingsManager.appSettings.kmlFileExtension
 
         onAcceptedForLoad: {
             mapPolyline.loadKMLFile(file)

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -271,8 +271,6 @@ Item {
             fileDialog.planFiles =      true
             fileDialog.selectExisting = true
             fileDialog.nameFilters =    _planMasterController.loadNameFilters
-            fileDialog.fileExtension =  _appSettings.planFileExtension
-            fileDialog.fileExtension2 = _appSettings.missionFileExtension
             fileDialog.openForLoad()
         }
 
@@ -284,8 +282,6 @@ Item {
             fileDialog.planFiles =      true
             fileDialog.selectExisting = false
             fileDialog.nameFilters =    _planMasterController.saveNameFilters
-            fileDialog.fileExtension =  _appSettings.planFileExtension
-            fileDialog.fileExtension2 = _appSettings.missionFileExtension
             fileDialog.openForSave()
         }
 
@@ -301,8 +297,6 @@ Item {
             fileDialog.planFiles =      false
             fileDialog.selectExisting = false
             fileDialog.nameFilters =    ShapeFileHelper.fileDialogKMLFilters
-            fileDialog.fileExtension =  _appSettings.kmlFileExtension
-            fileDialog.fileExtension2 = ""
             fileDialog.openForSave()
         }
     }

--- a/src/QmlControls/AppMessages.qml
+++ b/src/QmlControls/AppMessages.qml
@@ -162,7 +162,6 @@ Item {
                 id:             writeDialog
                 folder:         QGroundControl.settingsManager.appSettings.logSavePath
                 nameFilters:    [qsTr("Log files (*.txt)"), qsTr("All Files (*)")]
-                fileExtension:  qsTr("txt")
                 selectExisting: false
                 title:          qsTr("Select log save file")
                 onAcceptedForSave: {

--- a/src/QmlControls/HackFileDialog.qml
+++ b/src/QmlControls/HackFileDialog.qml
@@ -1,9 +1,0 @@
-import QtQuick          2.3
-import QtQuick.Dialogs  1.2
-
-// On Qt 5.9 android versions there is the following bug: https://bugreports.qt.io/browse/QTBUG-61424
-// This prevents FileDialog from being used. So we have a temp hack workaround for it which just no-ops
-// the FileDialog fallback mechanism on android 5.9 builds.
-
-FileDialog {
-}

--- a/src/QmlControls/KMLOrSHPFileDialog.qml
+++ b/src/QmlControls/KMLOrSHPFileDialog.qml
@@ -19,6 +19,4 @@ QGCFileDialog {
     title:          qsTr("Select Polygon File")
     selectExisting: true
     nameFilters:    ShapeFileHelper.fileDialogKMLOrSHPFilters
-    fileExtension:  QGroundControl.settingsManager.appSettings.kmlFileExtension
-    fileExtension2: QGroundControl.settingsManager.appSettings.shpFileExtension
 }

--- a/src/QmlControls/LogReplayStatusBar.qml
+++ b/src/QmlControls/LogReplayStatusBar.qml
@@ -28,8 +28,7 @@ Rectangle {
     QGCFileDialog {
         id:                 filePicker
         title:              qsTr("Select Telemetery Log")
-        nameFilters:        [qsTr("Telemetry Logs (*.%1)").arg(_logFileExtension), qsTr("All Files (*)")]
-        fileExtension:      _logFileExtension
+        nameFilters:        [ qsTr("Telemetry Logs (*.%1)").arg(_logFileExtension), qsTr("All Files (*)") ]
         selectExisting:     true
         folder:             QGroundControl.settingsManager.appSettings.telemetrySavePath
         onAcceptedForLoad: {

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -287,7 +287,6 @@ Item {
     QGCFileDialog {
         id:             fileDialog
         folder:         _appSettings.parameterSavePath
-        fileExtension:  _appSettings.parameterFileExtension
         nameFilters:    [ qsTr("Parameter Files (*.%1)").arg(_appSettings.parameterFileExtension) , qsTr("All Files (*.*)") ]
 
         onAcceptedForSave: {

--- a/src/QmlControls/QGCFileDialogController.h
+++ b/src/QmlControls/QGCFileDialogController.h
@@ -24,13 +24,11 @@ class QGCFileDialogController : public QObject
 
 public:
     /// Return all file in the specified path which match the specified extension
-    Q_INVOKABLE QStringList getFiles(const QString& directoryPath, const QStringList& fileExtensions);
+    Q_INVOKABLE QStringList getFiles(const QString& directoryPath, const QStringList& nameFilters);
 
-    /// Returns the specified file name with the extension added it needed
-    Q_INVOKABLE QString filenameWithExtension(const QString& filename, const QStringList& rgFileExtensions);
-
-    /// Returns the fully qualified file name from the specified parts
-    Q_INVOKABLE QString fullyQualifiedFilename(const QString& directoryPath, const QString& filename, const QStringList& rgFileExtensions);
+    /// Returns the fully qualified file name from the specified parts.
+    /// If filename has no file extension the first file extension is nameFilters is added to the filename.
+    Q_INVOKABLE QString fullyQualifiedFilename(const QString& directoryPath, const QString& filename, const QStringList& nameFilters = QStringList());
 
     /// Check for file existence of specified fully qualified file name
     Q_INVOKABLE bool fileExists(const QString& filename);

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -210,7 +210,6 @@ Item {
         id:             fileDialog
         folder:         QGroundControl.settingsManager.appSettings.missionSavePath
         nameFilters:    ["Tile Sets (*.qgctiledb)"]
-        fileExtension:  "qgctiledb"
 
         onAcceptedForSave: {
             if (QGroundControl.mapEngineManager.exportSets(file)) {


### PR DESCRIPTION
* These were causing bugs when they got out of sync with `nameFilters`
* Now mobile works from `nameFilters` as well