### PR TITLE
fixed typo in VirtualJoystick.qml

### DIFF
--- a/src/FlightDisplay/VirtualJoystick.qml
+++ b/src/FlightDisplay/VirtualJoystick.qml
@@ -24,7 +24,7 @@ Item {
 
     Timer {
         interval:   40  // 25Hz, same as real joystick rate
-        running:    QGroundControl.settingsManager.appSettings.virtualJoystick.value && activeVehicle
+        running:    QGroundControl.settingsManager.appSettings.virtualJoystick.value && _activeVehicle
         repeat:     true
         onTriggered: {
             if (_activeVehicle) {


### PR DESCRIPTION
activeVehicle - >_activeVehicle
caused the virtual joystick to malfunction