### PR TITLE
Add cu.Bluetooth-Incoming-Port to system port list

### DIFF
--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -340,6 +340,7 @@ bool QGCSerialPortInfo::isSystemPort(QSerialPortInfo* port)
     // MAC OS
     if (port->systemLocation().contains("tty.MALS")
         || port->systemLocation().contains("tty.SOC")
+        || port->systemLocation().contains("cu.Bluetooth-Incoming-Port")
         || port->systemLocation().contains("tty.Bluetooth-Incoming-Port")
         // We open these by their cu.usbserial and cu.usbmodem handles
         // already. We don't want to open them twice and conflict


### PR DESCRIPTION
`tty.Bluetooth-Incoming-Port` is already counted as a MacOS system port that
QGC should ignore. This commit adds the related `cu.Bluetooth-Incoming-Port` to
the system port list as well.

Fixes https://github.com/mavlink/qgroundcontrol/issues/9081 by avoiding the
empty serial number collision.


