### PR TITLE
QGCPostLinkCommon: Remove duplicate echo

### DIFF
--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -72,7 +72,6 @@ WindowsBuild {
 }
 
 LinuxBuild {
-    QMAKE_POST_LINK += echo "Post Link Common"
     QMAKE_POST_LINK += && mkdir -p $$DESTDIR/Qt/libs && mkdir -p $$DESTDIR/Qt/plugins
 
     # QT_INSTALL_LIBS


### PR DESCRIPTION
We have `QMAKE_POST_LINK += echo "Post Link Common"` in line 12 already.


