### PR TITLE
Enable QLineF::intersects on Qt version 5.14.0

### DIFF
--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -218,7 +218,7 @@ bool QGroundControlQmlGlobal::linesIntersect(QPointF line1A, QPointF line1B, QPo
 {
     QPointF intersectPoint;
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     auto intersect = QLineF(line1A, line1B).intersect(QLineF(line2A, line2B), &intersectPoint);
 #else
     auto intersect = QLineF(line1A, line1B).intersects(QLineF(line2A, line2B), &intersectPoint);


### PR DESCRIPTION
function "QLineF::IntersectionType QLineF::intersects(const QLineF &line, QPointF *intersectionPoint) const" was introduced in Qt 5.14, and QLineF::intersect is obsolete.

see also:
https://doc.qt.io/qt-5.14/qlinef-obsolete.html
https://doc.qt.io/qt-5.14/qlinef.html#intersects


