### PR TITLE
Move to BATTERY_STATUS only for info. Don't assume first battery is id=0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,11 @@ Note: This file only contains high level features or important fixes.
 
 ## 4.0
 
-## 4.0.10 - Not yet released
+## 4.0.11 - Not yet release
+* Fix battery id handling for multiple batteries
+
+## 4.0.10 - Stable
+* Fix crashes in UDPLink
 
 ## 4.0.9 - Stable
 

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -79,9 +79,10 @@ SetupPage {
 
                             QGCLabel { text: qsTr("Battery1 monitor:") }
                             FactComboBox {
-                                id:         monitor1Combo
-                                fact:       _batt1Monitor
-                                indexModel: false
+                                id:             monitor1Combo
+                                fact:           _batt1Monitor
+                                indexModel:     false
+                                sizeToContents: true
                             }
                         }
 
@@ -164,9 +165,10 @@ SetupPage {
 
                             QGCLabel { text: qsTr("Battery2 monitor:") }
                             FactComboBox {
-                                id:         monitor2Combo
-                                fact:       _batt2Monitor
-                                indexModel: false
+                                id:             monitor2Combo
+                                fact:           _batt2Monitor
+                                indexModel:     false
+                                sizeToContents: true
                             }
                         }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1346,7 +1346,6 @@ private:
     void _writeCsvLine                  ();
     void _flightTimerStart              ();
     void _flightTimerStop               ();
-    void _batteryStatusWorker           (int batteryId, double voltage, double current, double batteryRemainingPct);
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
@@ -1578,6 +1577,8 @@ private:
     VehicleSetpointFactGroup        _setpointFactGroup;
     VehicleDistanceSensorFactGroup  _distanceSensorFactGroup;
     VehicleEstimatorStatusFactGroup _estimatorStatusFactGroup;
+
+    int _lowestBatteryIdSeen = -1;
 
     static const char* _rollFactName;
     static const char* _pitchFactName;


### PR DESCRIPTION
This fixes problems on boards which support multiple power modules and the power module that is in use isn't the first one.
