### PR TITLE
[FIX for issue 8654] Add form validation for survey preset names

### DIFF
--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -373,8 +373,12 @@ Rectangle {
 
             QGCViewDialog {
                 function accept() {
-                    if (presetNameField.text != "") {
-                        _missionItem.savePreset(presetNameField.text)
+                    if (presetNameField.text.includes("/")){  // form validation because savePreset will fail silently if presetNameField includes "/"
+                        presetNameError.text = "/ is not allowed in preset names"
+                    } else if(presetNameField.text === ""){
+                        presetNameError.text = "Preset name must not be empty"
+                    } else {
+                        missionItem.savePreset(presetNameField.text)
                         hideDialog()
                     }
                 }
@@ -397,6 +401,10 @@ Rectangle {
                     QGCTextField {
                         id:                 presetNameField
                         Layout.fillWidth:   true
+                    }
+                    QGCLabel {
+                        id:                 presetNameError
+                        color:              "red"
                     }
                 }
             }


### PR DESCRIPTION
When trying to add a preset name with a disallowed character we would fail silently which is a confusing experience for the user. Instead it should tell the user they cannot use that character and allow them to choose a different preset name. 

Original issue: 
https://github.com/mavlink/qgroundcontrol/issues/8654