### PR TITLE
Links: Prevent stale readBytes signalling to call into deleted objects

### DIFF
--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -86,6 +86,8 @@ void BluetoothLink::disconnect(void)
     }
 #endif
     if(_targetSocket) {
+        // This prevents stale signals from calling the link after it has been deleted
+        QObject::connect(_targetSocket, &QBluetoothSocket::readyRead, this, &BluetoothLink::readBytes);
         _targetSocket->deleteLater();
         _targetSocket = nullptr;
         emit disconnected();

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -79,6 +79,8 @@ void SerialLink::_writeBytes(const QByteArray data)
 void SerialLink::disconnect(void)
 {
     if (_port) {
+        // This prevents stale signals from calling the link after it has been deleted
+        QObject::disconnect(_port, &QIODevice::readyRead, this, &SerialLink::_readBytes);
         _port->close();
         _port->deleteLater();
         _port = nullptr;

--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -106,6 +106,8 @@ void TCPLink::disconnect(void)
     quit();
     wait();
     if (_socket) {
+        // This prevents stale signal from calling the link after it has been deleted
+        QObject::connect(_socket, &QTcpSocket::readyRead, this, &TCPLink::readBytes);
         _socketIsConnected = false;
         _socket->disconnectFromHost(); // Disconnect tcp
         _socket->waitForDisconnected();        

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -222,6 +222,8 @@ void UDPLink::disconnect(void)
     quit();
     wait();
     if (_socket) {
+        // This prevents stale signal from calling the link after it has been deleted
+        QObject::disconnect(_socket, &QUdpSocket::readyRead, this, &UDPLink::readBytes);
         // Make sure delete happen on correct thread
         _socket->deleteLater();
         _socket = nullptr;


### PR DESCRIPTION
This fixes various crashes where slots are called on deleted objects. In reality all of the LinkInterface, FooLinks and MAVLinkProtocol code needs to be thrown out re-written using a proper consistent threading model. But I don't have time for that right now so I'm just sticking fingers in the dyke.