### PR TITLE
Clang 12 compile error fixes

### DIFF
--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -61,7 +61,7 @@ void AutoPilotPlugin::parametersReadyPreChecks(void)
     _recalcSetupComplete();
 
     // Connect signals in order to keep setupComplete up to date
-    for(const QVariant componentVariant: vehicleComponents()) {
+    for(QVariant componentVariant: vehicleComponents()) {
         VehicleComponent* component = qobject_cast<VehicleComponent*>(qvariant_cast<QObject *>(componentVariant));
         if (component) {
             connect(component, &VehicleComponent::setupCompleteChanged, this, &AutoPilotPlugin::_recalcSetupComplete);

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -241,7 +241,7 @@ void TerrainAirMapQuery::_parsePathData(const QJsonValue& pathJson)
     double lonStep = stepArray[1].toDouble();
 
     QList<double> heights;
-    for (const QJsonValue& profileValue: profileArray) {
+    for (QJsonValue profileValue: profileArray) {
         heights.append(profileValue.toDouble());
     }
 

--- a/src/Vehicle/CompInfoParam.cc
+++ b/src/Vehicle/CompInfoParam.cc
@@ -67,7 +67,7 @@ void CompInfoParam::setJson(const QString& metadataJsonFileName, const QString& 
     }
 
     QJsonArray rgParameters = jsonObj[_jsonParametersKey].toArray();
-    for (const QJsonValue& parameterValue: rgParameters) {
+    for (QJsonValue parameterValue: rgParameters) {
         QMap<QString, QString> emptyDefineMap;
 
         if (!parameterValue.isObject()) {

--- a/src/Vehicle/CompInfoVersion.cc
+++ b/src/Vehicle/CompInfoVersion.cc
@@ -59,7 +59,7 @@ void CompInfoVersion::setJson(const QString& metadataJsonFileName, const QString
     }
 
     QJsonArray rgSupportedTypes = jsonObj[_jsonSupportedCompMetadataTypesKey].toArray();
-    for (const QJsonValue& typeValue: rgSupportedTypes) {
+    for (QJsonValue typeValue: rgSupportedTypes) {
         _supportedTypes.append(static_cast<COMP_METADATA_TYPE>(typeValue.toInt()));
     }
 }


### PR DESCRIPTION
These are necessary to get master to compile with Clang 12. At first sight it might look like a naive fix - what was initially a reference is now a copy. However, if you trace the code path in the inner loop, you will find that in all of these cases either the inner loop already created a local copy, and/or discarded the const modifier (which requires again taking a copy).

So based on my quick assessment the new compiler version keeps us more honest about the invariants.