### PR TITLE
[NEW] - Configure branding logo margins

### DIFF
--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -155,6 +155,7 @@
 		<file alias="QGroundControl/Controls/QGCTabBar.qml">../src/QmlControls/QGCTabBar.qml</file>
 		<file alias="QGroundControl/Controls/QGCTabButton.qml">../src/QmlControls/QGCTabButton.qml</file>
 		<file alias="QGroundControl/Controls/QGCTextField.qml">../src/QmlControls/QGCTextField.qml</file>
+		<file alias="QGroundControl/Controls/QGCSpinBox.qml">../src/QmlControls/QGCSpinBox.qml</file>
 		<file alias="QGroundControl/Controls/QGCToolBarButton.qml">../src/QmlControls/QGCToolBarButton.qml</file>
 		<file alias="QGroundControl/Controls/QGCToolInsets.qml">../src/QmlControls/QGCToolInsets.qml</file>
 		<file alias="QGroundControl/Controls/QGCViewDialog.qml">../src/QmlControls/QGCViewDialog.qml</file>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -156,6 +156,7 @@
         <file alias="QGroundControl/Controls/QGCTabBar.qml">src/QmlControls/QGCTabBar.qml</file>
         <file alias="QGroundControl/Controls/QGCTabButton.qml">src/QmlControls/QGCTabButton.qml</file>
         <file alias="QGroundControl/Controls/QGCTextField.qml">src/QmlControls/QGCTextField.qml</file>
+        <file alias="QGroundControl/Controls/QGCSpinBox.qml">src/QmlControls/QGCSpinBox.qml</file>
         <file alias="QGroundControl/Controls/QGCToolBarButton.qml">src/QmlControls/QGCToolBarButton.qml</file>
         <file alias="QGroundControl/Controls/QGCToolInsets.qml">src/QmlControls/QGCToolInsets.qml</file>
         <file alias="QGroundControl/Controls/QGCViewDialog.qml">src/QmlControls/QGCViewDialog.qml</file>

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -112,6 +112,7 @@ add_custom_target(QmlControlsQml
 		QGCTabBar.qml
 		QGCTabButton.qml
 		QGCTextField.qml
+		QGCSpinBox.qml
 		QGCToolBarButton.qml
 		QGCToolInsets.qml
 		QGCViewDialogContainer.qml

--- a/src/QmlControls/QGCSpinBox.qml
+++ b/src/QmlControls/QGCSpinBox.qml
@@ -1,0 +1,29 @@
+import QtQuick                  2.3
+import QtQuick.Controls         1.2
+import QtQuick.Controls.Styles  1.4
+import QtQuick.Layouts          1.2
+
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+
+SpinBox {
+    id:                 root
+    implicitHeight:     ScreenTools.implicitTextFieldHeight
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
+    onEditingFinished: {
+        if (ScreenTools.isMobile) {
+            // Toss focus on mobile after Done on virtual keyboard. Prevent strange interactions.
+            focus = false
+        }
+    }
+
+    style: SpinBoxStyle {
+        id:             sbs
+        textColor:      qgcPal.textFieldText
+        font.pointSize: ScreenTools.defaultFontPointSize
+        font.family:    ScreenTools.normalFontFamily
+        renderType:     ScreenTools.isWindows ? Text.QtRendering : sbs.renderType   // This works around font rendering problems on windows
+    }
+}

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -82,6 +82,7 @@ QGCSwitch                               1.0 QGCSwitch.qml
 QGCTabBar                               1.0 QGCTabBar.qml
 QGCTabButton                            1.0 QGCTabButton.qml
 QGCTextField                            1.0 QGCTextField.qml
+QGCSpinBox                              1.0 QGCSpinBox.qml
 QGCToolBarButton                        1.0 QGCToolBarButton.qml
 QGCToolInsets                           1.0 QGCToolInsets.qml
 QGCViewDialog                           1.0 QGCViewDialog.qml

--- a/src/QmlControls/QmlTest.qml
+++ b/src/QmlControls/QmlTest.qml
@@ -586,6 +586,23 @@ Rectangle {
                             enabled: false
                         }
 
+                        // QGCSpinBox
+                        Loader {
+                            sourceComponent: ctlRowHeader
+                            property string text: "QGCSpinBox"
+                        }
+                        QGCSpinBox {
+                            width: ctlPrevColumn._colWidth
+                            height: ctlPrevColumn._height
+                            value: 123
+                        }
+                        QGCSpinBox {
+                            width: ctlPrevColumn._colWidth
+                            height: ctlPrevColumn._height
+                            text: 123
+                            enabled: false
+                        }
+
                         // QGCComboBox
                         Loader {
                             sourceComponent: ctlRowHeader

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -183,25 +183,11 @@
     "default":     ""
 },
 {
-    "name":             "userBrandImageIndoorMargin",
-    "shortDesc": "User-selected brand image margin",
-    "longDesc":  "Define the margin for the indoor image",
-    "type":             "double",
-    "default":     0
-},
-{
     "name":             "userBrandImageOutdoor",
     "shortDesc": "User-selected brand image",
     "longDesc":  "Location in file system of user-selected brand image (outdoor)",
     "type":             "string",
     "default":     ""
-},
-{
-    "name":             "userBrandImageOutdoorMargin",
-    "shortDesc": "User-selected brand image margin",
-    "longDesc":  "Define the margin for the outdoor image",
-    "type":             "double",
-    "default":     0
 },
 {
     "name":             "mapboxToken",

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -187,7 +187,7 @@
     "shortDesc": "User-selected brand image margin",
     "longDesc":  "Define the margin for the indoor image",
     "type":             "double",
-    "default":     ""
+    "default":     0
 },
 {
     "name":             "userBrandImageOutdoor",
@@ -201,7 +201,7 @@
     "shortDesc": "User-selected brand image margin",
     "longDesc":  "Define the margin for the outdoor image",
     "type":             "double",
-    "default":     ""
+    "default":     0
 },
 {
     "name":             "mapboxToken",

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -183,10 +183,24 @@
     "default":     ""
 },
 {
+    "name":             "userBrandImageIndoorMargin",
+    "shortDesc": "User-selected brand image margin",
+    "longDesc":  "Define the margin for the indoor image",
+    "type":             "double",
+    "default":     ""
+},
+{
     "name":             "userBrandImageOutdoor",
     "shortDesc": "User-selected brand image",
     "longDesc":  "Location in file system of user-selected brand image (outdoor)",
     "type":             "string",
+    "default":     ""
+},
+{
+    "name":             "userBrandImageOutdoorMargin",
+    "shortDesc": "User-selected brand image margin",
+    "longDesc":  "Define the margin for the outdoor image",
+    "type":             "double",
     "default":     ""
 },
 {

--- a/src/Settings/BrandImage.SettingsGroup.json
+++ b/src/Settings/BrandImage.SettingsGroup.json
@@ -14,8 +14,8 @@
     "name":             "userBrandImageIndoorMargin",
     "shortDesc": "User-selected brand image margin",
     "longDesc":  "Define the margin for the indoor image",
-    "type":             "uint32",
-    "default":     ""
+    "type":             "double",
+    "default":     "0"
 },
 {
     "name":             "userBrandImageOutdoor",
@@ -28,8 +28,8 @@
     "name":             "userBrandImageOutdoorMargin",
     "shortDesc": "User-selected brand image margin",
     "longDesc":  "Define the margin for the outdoor image",
-    "type":             "uint32",
-    "default":     ""
+    "type":             "double",
+    "default":     "0"
 }
 ]
 }

--- a/src/Settings/BrandImage.SettingsGroup.json
+++ b/src/Settings/BrandImage.SettingsGroup.json
@@ -11,10 +11,24 @@
     "default":     ""
 },
 {
+    "name":             "userBrandImageIndoorMargin",
+    "shortDesc": "User-selected brand image margin",
+    "longDesc":  "Define the margin for the indoor image",
+    "type":             "uint32",
+    "default":     ""
+},
+{
     "name":             "userBrandImageOutdoor",
     "shortDesc": "User-selected brand image",
     "longDesc":  "Location in file system of user-selected brand image (outdoor)",
     "type":             "string",
+    "default":     ""
+},
+{
+    "name":             "userBrandImageOutdoorMargin",
+    "shortDesc": "User-selected brand image margin",
+    "longDesc":  "Define the margin for the outdoor image",
+    "type":             "uint32",
     "default":     ""
 }
 ]

--- a/src/Settings/BrandImageSettings.cc
+++ b/src/Settings/BrandImageSettings.cc
@@ -18,4 +18,6 @@ DECLARE_SETTINGGROUP(BrandImage, "Branding")
 }
 
 DECLARE_SETTINGSFACT(BrandImageSettings, userBrandImageIndoor)
+DECLARE_SETTINGSFACT(BrandImageSettings, userBrandImageIndoorMargin)
 DECLARE_SETTINGSFACT(BrandImageSettings, userBrandImageOutdoor)
+DECLARE_SETTINGSFACT(BrandImageSettings, userBrandImageOutdoorMargin)

--- a/src/Settings/BrandImageSettings.h
+++ b/src/Settings/BrandImageSettings.h
@@ -22,5 +22,7 @@ public:
     BrandImageSettings(QObject* parent = nullptr);
     DEFINE_SETTING_NAME_GROUP()
     DEFINE_SETTINGFACT(userBrandImageIndoor)
+    DEFINE_SETTINGFACT(userBrandImageIndoorMargin)
     DEFINE_SETTINGFACT(userBrandImageOutdoor)
+    DEFINE_SETTINGFACT(userBrandImageOutdoorMargin)
 };

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -33,7 +33,9 @@ Rectangle {
     property Fact _savePath:                            QGroundControl.settingsManager.appSettings.savePath
     property Fact _appFontPointSize:                    QGroundControl.settingsManager.appSettings.appFontPointSize
     property Fact _userBrandImageIndoor:                QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoor
+    property Fact _userBrandImageIndoorMargin:          QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoorMargin
     property Fact _userBrandImageOutdoor:               QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoor
+    property Fact _userBrandImageOutdoorMargin:         QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoorMargin
     property Fact _virtualJoystick:                     QGroundControl.settingsManager.appSettings.virtualJoystick
     property Fact _virtualJoystickAutoCenterThrottle:   QGroundControl.settingsManager.appSettings.virtualJoystickAutoCenterThrottle
 
@@ -61,6 +63,7 @@ Rectangle {
 
     property string gpsDisabled: "Disabled"
     property string gpsUdpPort:  "UDP Port"
+
 
     readonly property real _internalWidthRatio: 0.8
 
@@ -1058,6 +1061,24 @@ Rectangle {
                             }
 
                             QGCLabel {
+                                text:           qsTr("Indoor Image Margin")
+                                visible:        userBrandImageIndoorMargin.visible
+                            }
+                            SpinBox {
+                                id:                     userBrandImageIndoorMargin
+                                decimals:               0
+                                value:                  _userBrandImageIndoorMargin.value > 0 ? _userBrandImageIndoorMargin.value : ScreenTools.defaultFontPixelHeight * 0.66
+                                minimumValue: 1
+                                maximumValue: 20
+                                onValueChanged:  {
+                                    _userBrandImageIndoorMargin.value = value
+                                    userBrandImageIndoorMargin.value = value
+                                }
+                                Layout.columnSpan: 2
+                            }
+                            
+
+                            QGCLabel {
                                 text:       qsTr("Outdoor Image")
                                 visible:    _userBrandImageOutdoor.visible
                             }
@@ -1078,6 +1099,25 @@ Rectangle {
                                     onAcceptedForLoad:  _userBrandImageOutdoor.rawValue = "file:///" + file
                                 }
                             }
+
+
+                            QGCLabel {
+                                text:           qsTr("Outdoor Image Margin")
+                                visible:        userBrandImageOutdoorMargin.visible
+                            }
+                            SpinBox {
+                                id:                     userBrandImageOutdoorMargin
+                                decimals:               0
+                                value:                  _userBrandImageOutdoorMargin.value > 0 ? _userBrandImageOutdoorMargin.value : ScreenTools.defaultFontPixelHeight * 0.66
+                                minimumValue: 1
+                                maximumValue: 20
+                                onValueChanged:  {
+                                    _userBrandImageOutdoorMargin.value = value
+                                    userBrandImageOutdoorMargin.value = value
+                                }
+                                Layout.columnSpan: 2
+                            }
+
                             QGCButton {
                                 text:               qsTr("Reset Default Brand Image")
                                 Layout.columnSpan:  3
@@ -1085,6 +1125,8 @@ Rectangle {
                                 onClicked:  {
                                     _userBrandImageIndoor.rawValue = ""
                                     _userBrandImageOutdoor.rawValue = ""
+                                    userBrandImageIndoorMargin.value = ScreenTools.defaultFontPixelHeight * 0.66
+                                    userBrandImageOutdoorMargin.value = ScreenTools.defaultFontPixelHeight * 0.66
                                 }
                             }
                         }

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -1064,7 +1064,7 @@ Rectangle {
                                 text:           qsTr("Indoor Image Margin")
                                 visible:        userBrandImageIndoorMargin.visible
                             }
-                            SpinBox {
+                            QGCSpinBox {
                                 id:                     userBrandImageIndoorMargin
                                 decimals:               0
                                 value:                  _userBrandImageIndoorMargin.value > 0 ? _userBrandImageIndoorMargin.value : ScreenTools.defaultFontPixelHeight * 0.66
@@ -1105,7 +1105,7 @@ Rectangle {
                                 text:           qsTr("Outdoor Image Margin")
                                 visible:        userBrandImageOutdoorMargin.visible
                             }
-                            SpinBox {
+                            QGCSpinBox {
                                 id:                     userBrandImageOutdoorMargin
                                 decimals:               0
                                 value:                  _userBrandImageOutdoorMargin.value > 0 ? _userBrandImageOutdoorMargin.value : ScreenTools.defaultFontPixelHeight * 0.66

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -114,7 +114,7 @@ Rectangle {
         anchors.right:          parent.right
         anchors.top:            parent.top
         anchors.bottom:         parent.bottom
-        anchors.margins:        ScreenTools.defaultFontPixelHeight * 0.66
+        anchors.margins:        _brandImageMargin
         visible:                currentToolbar !== planViewToolbar && _activeVehicle && !_communicationLost && x > (toolsFlickable.x + toolsFlickable.contentWidth + ScreenTools.defaultFontPixelWidth)
         fillMode:               Image.PreserveAspectFit
         source:                 _outdoorPalette ? _brandImageOutdoor : _brandImageIndoor
@@ -123,11 +123,14 @@ Rectangle {
         property bool   _outdoorPalette:        qgcPal.globalTheme === QGCPalette.Light
         property bool   _corePluginBranding:    QGroundControl.corePlugin.brandImageIndoor.length != 0
         property string _userBrandImageIndoor:  QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoor.value
+        property double _userBrandImageIndoorMargin:  QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoorMargin.value > 0 ? QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoorMargin.value : ScreenTools.defaultFontPixelHeight * 0.66
         property string _userBrandImageOutdoor: QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoor.value
+        property double _userBrandImageOutdoorMargin: QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoorMargin.value > 0 ? QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoorMargin.value : ScreenTools.defaultFontPixelHeight * 0.66
         property bool   _userBrandingIndoor:    _userBrandImageIndoor.length != 0
         property bool   _userBrandingOutdoor:   _userBrandImageOutdoor.length != 0
         property string _brandImageIndoor:      brandImageIndoor()
         property string _brandImageOutdoor:     brandImageOutdoor()
+        property string _brandImageMargin:      brandImageMargin()
 
         function brandImageIndoor() {
             if (_userBrandingIndoor) {
@@ -146,6 +149,30 @@ Rectangle {
         }
 
         function brandImageOutdoor() {
+            if (_userBrandingOutdoor) {
+                return _userBrandingOutdoor
+            } else {
+                if (_userBrandingIndoor) {
+                    return _userBrandingIndoor
+                } else {
+                    if (_corePluginBranding) {
+                        return QGroundControl.corePlugin.brandImageOutdoor
+                    } else {
+                        return _activeVehicle ? _activeVehicle.brandImageOutdoor : ""
+                    }
+                }
+            }
+        }  
+        
+        function brandImageMargin() {
+            if (_userBrandingIndoor) {
+                return _userBrandImageIndoorMargin
+            } else {
+                return _userBrandImageOutdoorMargin
+            }
+        }
+
+        function brandImageOutdoorMargin() {
             if (_userBrandingOutdoor) {
                 return _userBrandingOutdoor
             } else {


### PR DESCRIPTION
Some logos that have an image together with text become not readable or not recognizable at all with the default margins. So I just added in settings the possibility to change that logo margins for a custom ones.

By default I left the ones already configured.

Thanks