### PR TITLE
Fixed 5.15 build on Android (removed deprecated API)

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -57,7 +57,6 @@ linux {
             -Wno-parentheses-equality           # android gstreamer header files
         QMAKE_CFLAGS_WARN_ON += \
             -Wno-unused-command-line-argument   # from somewhere in Qt generated build files
-        QMAKE_LINK += -nostdlib++ # Hack fix?: https://forum.qt.io/topic/103713/error-cannot-find-lc-qt-5-12-android
         target.path = $$DESTDIR
         equals(ANDROID_TARGET_ARCH, armeabi-v7a)  {
             DEFINES += __androidArm32__

--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -231,13 +231,6 @@ CONFIG(debug, debug|release) {
 
 SOURCE_DIR = $$IN_PWD
 
-!iOSBuild {
-    OBJECTS_DIR  = $${OUT_PWD}/obj
-    MOC_DIR      = $${OUT_PWD}/moc
-    UI_DIR       = $${OUT_PWD}/ui
-    RCC_DIR      = $${OUT_PWD}/rcc
-}
-
 LANGUAGE = C++
 
 LOCATION_PLUGIN_DESTDIR = $${OUT_PWD}/src/QtLocationPlugin

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -7,11 +7,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED"/>
-                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
-                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED"/>
+                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED"/>
                 <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"/>
             </intent-filter>
-
             <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
             <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_DEVICE_DETACHED"/>
             <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"/>
@@ -36,13 +35,11 @@
             <meta-data android:value="@string/ministro_needed_msg" android:name="android.app.ministro_needed_msg"/>
             <meta-data android:value="@string/fatal_error_msg" android:name="android.app.fatal_error_msg"/>
             <!--  Messages maps -->
-
             <!-- Splash screen -->
             <!--
             <meta-data android:name="android.app.splash_screen_drawable" android:resource="@drawable/logo"/>
             -->
             <!-- Splash screen -->
-
             <!-- Background running -->
             <!-- Warning: changing this value to true may cause unexpected crashes if the
                           application still try to draw after
@@ -52,7 +49,7 @@
             <!-- Background running -->
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28"/>
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="28"/>
 
     <!-- Needed to keep working while 'asleep' -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
@@ -63,20 +60,20 @@
 
     <!-- Support devices without USB host mode since there are other connection types -->
     <uses-feature android:name="android.hardware.usb.host" android:required="false"/>
-	
+
     <!-- Support devices without Bluetooth since there are other connection types -->
     <uses-feature android:name="android.hardware.bluetooth" android:required="false"/>
-	
+
     <!-- Support devices that don't have location services -->
-    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false"/>
     <uses-feature android:name="android.hardware.location.network" android:required="false"/>
     <uses-feature android:name="android.hardware.location" android:required="false"/>
     <uses-feature android:name="android.hardware.usb.accessory"/>
-	
-	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-	
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->
     <!-- %%INSERT_FEATURES -->

--- a/src/AnalyzeView/ULogParser.cc
+++ b/src/AnalyzeView/ULogParser.cc
@@ -14,25 +14,25 @@ ULogParser::~ULogParser()
 
 int ULogParser::sizeOfType(QString& typeName)
 {
-    if (typeName == QLatin1Literal("int8_t") || typeName == QLatin1Literal("uint8_t")) {
+    if (typeName == QLatin1String("int8_t") || typeName == QLatin1String("uint8_t")) {
         return 1;
 
-    } else if (typeName == QLatin1Literal("int16_t") || typeName == QLatin1Literal("uint16_t")) {
+    } else if (typeName == QLatin1String("int16_t") || typeName == QLatin1String("uint16_t")) {
         return 2;
 
-    } else if (typeName == QLatin1Literal("int32_t") || typeName == QLatin1Literal("uint32_t")) {
+    } else if (typeName == QLatin1String("int32_t") || typeName == QLatin1String("uint32_t")) {
         return 4;
 
-    } else if (typeName == QLatin1Literal("int64_t") || typeName == QLatin1Literal("uint64_t")) {
+    } else if (typeName == QLatin1String("int64_t") || typeName == QLatin1String("uint64_t")) {
         return 8;
 
-    } else if (typeName == QLatin1Literal("float")) {
+    } else if (typeName == QLatin1String("float")) {
         return 4;
 
-    } else if (typeName == QLatin1Literal("double")) {
+    } else if (typeName == QLatin1String("double")) {
         return 8;
 
-    } else if (typeName == QLatin1Literal("char") || typeName == QLatin1Literal("bool")) {
+    } else if (typeName == QLatin1String("char") || typeName == QLatin1String("bool")) {
         return 1;
     }
 
@@ -74,7 +74,7 @@ bool ULogParser::parseFieldFormat(QString& fields)
             QString typeNameFull = fields.mid(prevFieldEnd, spacePos - prevFieldEnd);
             QString fieldName = fields.mid(spacePos + 1, fieldEnd - spacePos - 1);
 
-            if (!fieldName.contains(QLatin1Literal("_padding"))) {
+            if (!fieldName.contains(QLatin1String("_padding"))) {
                 _cameraCaptureOffsets.insert(fieldName, offset);
                 offset += sizeOfFullType(typeNameFull);
             }
@@ -117,7 +117,7 @@ bool ULogParser::getTagsFromLog(QByteArray& log, QList<GeoTagWorker::cameraFeedb
                 QString messageName = fmt.left(posSeparator);
                 QString messageFields = fmt.mid(posSeparator + 1, header.msgSize - posSeparator - 1);
 
-                if(messageName == QLatin1Literal("camera_capture")) {
+                if(messageName == QLatin1String("camera_capture")) {
                     parseFieldFormat(messageFields);
                 }
                 break;
@@ -131,7 +131,7 @@ bool ULogParser::getTagsFromLog(QByteArray& log, QList<GeoTagWorker::cameraFeedb
 
                 QString messageName(addLoggedMsg.msgName);
 
-                if(messageName.contains(QLatin1Literal("camera_capture"))) {
+                if(messageName.contains(QLatin1String("camera_capture"))) {
                     _cameraCaptureMsgID = addLoggedMsg.msgID;
                     geotagFound = true;
                 }

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -246,7 +246,7 @@ void APMAirframeComponentController::_githubJsonDownloadComplete(QString /*remot
 
         QGCFileDownload* downloader = new QGCFileDownload(this);
         connect(downloader, &QGCFileDownload::downloadComplete, this, &APMAirframeComponentController::_paramFileDownloadComplete);
-        downloader->download(json[QLatin1Literal("download_url")].toString());
+        downloader->download(json[QLatin1String("download_url")].toString());
     } else {
         qgcApp()->showAppMessage(tr("Param file github json download failed: %1").arg(errorMsg));
         qgcApp()->restoreOverrideCursor();


### PR DESCRIPTION
Fixed 5.15 build on Android - removed deprecated API: `QLatin1Literal() -> QLatin1String()`.

**P.S. BTW**, Why Android build on 5.15 have multiple link errors? Any ideas how to fix? Update AndroidManifest.xml, @patrickelectric : https://wiki.qt.io/Qt_for_Android_known_issues ?