### PR TITLE
fix warning C5208 on windows(stop the build process)

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1133,7 +1133,7 @@ private:
     void _waitForMavlinkMessageMessageReceived(const mavlink_message_t& message);
 
     // requestMessage handling
-    typedef struct {
+    typedef struct RequestMessageInfo {
         bool                        commandAckReceived; // We keep track of the ack/message being received since the order in which this will come in is random
         bool                        messageReceived;    // We only delete the allocated RequestMessageInfo_t when both happen (or the message wait times out)
         int                         msgId;
@@ -1145,7 +1145,7 @@ private:
     static void _requestMessageCmdResultHandler             (void* resultHandlerData, int compId, MAV_RESULT result, MavCmdResultFailureCode_t failureCode);
     static void _requestMessageWaitForMessageResultHandler  (void* resultHandlerData, bool noResponsefromVehicle, const mavlink_message_t& message);
 
-    typedef struct {
+    typedef struct MavCommandListEntry {
         int                 targetCompId        = MAV_COMP_ID_AUTOPILOT1;
         bool                useCommandInt       = false;
         MAV_CMD             command;

--- a/src/Vehicle/VehicleLinkManager.h
+++ b/src/Vehicle/VehicleLinkManager.h
@@ -77,7 +77,7 @@ private:
     LinkInterface*  _bestActivePrimaryLink  (void);
     void            _commRegainedOnLink     (LinkInterface*  link);
 
-    typedef struct {
+    typedef struct LinkInfo {
         SharedLinkInterfacePtr  link;
         bool                    commLost = false;
         QElapsedTimer           heartbeatElapsedTimer;


### PR DESCRIPTION
Building QGC with visual studio 2019 ver 16.6(with x86-windows-msvc2017-64bit)(not vs2017) on Windows 10, it stop with warning C5208.

As state in Microsoft doc(https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=vs-2019), the  fix is simple: add a name to struct typedef.