### PR TITLE
fix issue of read access violation exception(access nullptr)

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3729,7 +3729,8 @@ void Vehicle::clearAllParamMapRC(void)
 
 void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, float thrust, quint16 buttons)
 {
-    if (_vehicleLinkManager->primaryLink()->linkConfiguration()->isHighLatency()) {
+    LinkInterface* pPrimaryLink = vehicleLinkManager()->primaryLink();
+    if (pPrimaryLink == nullptr || pPrimaryLink->linkConfiguration()->isHighLatency()) {
         return;
     }
 
@@ -3745,7 +3746,7 @@ void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, flo
     mavlink_msg_manual_control_pack_chan(
                 static_cast<uint8_t>(_mavlink->getSystemId()),
                 static_cast<uint8_t>(_mavlink->getComponentId()),
-                vehicleLinkManager()->primaryLink()->mavlinkChannel(),
+                pPrimaryLink->mavlinkChannel(),
                 &message,
                 static_cast<uint8_t>(_id),
                 static_cast<int16_t>(newPitchCommand),
@@ -3753,5 +3754,5 @@ void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, flo
                 static_cast<int16_t>(newThrustCommand),
                 static_cast<int16_t>(newYawCommand),
                 buttons);
-    sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), message);
+    sendMessageOnLinkThreadSafe(pPrimaryLink, message);
 }


### PR DESCRIPTION
Step to reproduce:
(1) Connect QGC with PX4 and Airsim, wait until QGC show "Connected" on UI
(2) Shutting down PX4, wait until QGC show "Communication Lost" with a "Disconnect" button.
(3) Click on the button, the crash happened.

Crash:
<img width="509" alt="Screen Shot 2020-10-28 at 10 57 30" src="https://user-images.githubusercontent.com/5885946/97405545-cdfe8200-1932-11eb-8c4f-9469bc6f8a5f.png">

Debugging:
<img width="1114" alt="Screen Shot 2020-10-28 at 10 58 06" src="https://user-images.githubusercontent.com/5885946/97405607-e8d0f680-1932-11eb-92b8-47c82424147c.png">
<img width="570" alt="Screen Shot 2020-10-28 at 11 01 32" src="https://user-images.githubusercontent.com/5885946/97405615-eb335080-1932-11eb-9530-43fc639e4ae1.png">

Stack Trace:
```
1  std::_Ptr_base<LinkConfiguration>::_Incref                                 memory          767  0x7ff722c011ee 
2  std::_Ptr_base<LinkConfiguration>::_Copy_construct_from<LinkConfiguration> memory          728  0x7ff722c000b8 
3  std::shared_ptr<LinkConfiguration>::shared_ptr<LinkConfiguration>          memory          980  0x7ff722c00f27 
4  LinkInterface::linkConfiguration                                           LinkInterface.h 53   0x7ff722c016ac 
5  Vehicle::sendJoystickDataThreadSafe                                        Vehicle.cc      3732 0x7ff722d6b7fd 
6  Vehicle::virtualTabletJoystickValue                                        Vehicle.cc      2120 0x7ff722d692fc 
7  Vehicle::qt_static_metacall                                                moc_Vehicle.cpp 1454 0x7ff7230088c8 
8  Vehicle::qt_metacall                                                       moc_Vehicle.cpp 2366 0x7ff7230073cc 
9  QVariant::QVariant                                                         Qt5Cored             0x7fff4adc0254 
10 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff5367261b 
11 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff5342ac4e 
12 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff5342b966 
13 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff53427dea 
14 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff534278fb 
15 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff531ea181 
16 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff5346d928 
17 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff5346a770 
18 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff53396dc5 
19 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff536acb7b 
20 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff53607214 
21 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff53607919 
22 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff5367fda6 
23 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff535c5e9f 
24 QVariant::QVariant                                                         Qt5Cored             0x7fff4ae08350 
25 QVariant::QVariant                                                         Qt5Cored             0x7fff4ae08288 
26 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff537bacd1 
27 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff537baf6e 
28 QQmlJS::AST::DeleteExpression::~DeleteExpression                           Qt5Qmld              0x7fff537baba2 
29 QGraphicsView::inputMethodQuery                                            Qt5Widgetsd          0x7fff59c2c218 
30 QGraphicsView::inputMethodQuery                                            Qt5Widgetsd          0x7fff59c26c9f 
31 QVariant::QVariant                                                         Qt5Cored             0x7fff4adb1536 
32 QVariant::QVariant                                                         Qt5Cored             0x7fff4adaf2c2 
33 QVariant::QVariant                                                         Qt5Cored             0x7fff4adb2efd 
34 QVariant::QVariant                                                         Qt5Cored             0x7fff4ae7492a 
35 FT_List_Up                                                                 qwindowsd            0x7fff59856084 
36 QVariant::QVariant                                                         Qt5Cored             0x7fff4ae726e9 
37 CallWindowProcW                                                            USER32               0x7fffe147e6d8 
38 DispatchMessageW                                                           USER32               0x7fffe147e119 
39 QVariant::QVariant                                                         Qt5Cored             0x7fff4ae72fea 
40 FT_List_Up                                                                 qwindowsd            0x7fff59856044 
41 QVariant::QVariant                                                         Qt5Cored             0x7fff4adab713 
42 QVariant::QVariant                                                         Qt5Cored             0x7fff4adab94e 
43 QVariant::QVariant                                                         Qt5Cored             0x7fff4adaf07f 
44 QOpenGLFunctions_4_2_Compatibility::glVertexAttrib4sv                      Qt5Guid              0x7fff4b7c0128 
45 QGraphicsView::inputMethodQuery                                            Qt5Widgetsd          0x7fff59c2664a 
46 main                                                                       main.cc         394  0x7ff722ddec6f 
47 invoke_main                                                                exe_common.inl  79   0x7ff72304dd79 
48 __scrt_common_main_seh                                                     exe_common.inl  288  0x7ff72304dc5e 
49 __scrt_common_main                                                         exe_common.inl  331  0x7ff72304db1e 
50 mainCRTStartup                                                             exe_main.cpp    17   0x7ff72304de09 
51 BaseThreadInitThunk                                                        KERNEL32             0x7fffe13c7034 
52 RtlUserThreadStart                                                         ntdll                0x7fffe1f3cec1 
```

