### PR TITLE
Change unit test to use MISSION_ITEM_INT to catch bugs

### DIFF
--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -395,7 +395,7 @@ void PlanManager::_handleMissionItem(const mavlink_message_t& message, bool miss
         param3 =        missionItem.param3;
         param4 =        missionItem.param4;
         param5 =        missionItem.frame == MAV_FRAME_MISSION ? (double)missionItem.x : (double)missionItem.x * 1e-7;
-        param6 =        missionItem.frame == MAV_FRAME_MISSION ? (double)missionItem.y : (double)missionItem.x * 1e-7;
+        param6 =        missionItem.frame == MAV_FRAME_MISSION ? (double)missionItem.y : (double)missionItem.y * 1e-7;
         param7 =        (double)missionItem.z;
         autoContinue =  missionItem.autocontinue;
         isCurrentItem = missionItem.current;

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -1129,11 +1129,14 @@ void MockLink::_respondWithAutopilotVersion(void)
 #if !defined(NO_ARDUPILOT_DIALECT)
     }
 #endif
+    uint64_t capabilities = MAV_PROTOCOL_CAPABILITY_MAVLINK2 | MAV_PROTOCOL_CAPABILITY_MISSION_FENCE | MAV_PROTOCOL_CAPABILITY_MISSION_RALLY | MAV_PROTOCOL_CAPABILITY_MISSION_INT |
+            (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA ? MAV_PROTOCOL_CAPABILITY_TERRAIN : 0);
+
     mavlink_msg_autopilot_version_pack_chan(_vehicleSystemId,
                                             _vehicleComponentId,
                                             _mavlinkChannel,
                                             &msg,
-                                            MAV_PROTOCOL_CAPABILITY_MAVLINK2 | MAV_PROTOCOL_CAPABILITY_MISSION_FENCE | MAV_PROTOCOL_CAPABILITY_MISSION_RALLY | (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA ? MAV_PROTOCOL_CAPABILITY_TERRAIN : 0),
+                                            capabilities,
                                             flightVersion,                   // flight_sw_version,
                                             0,                               // middleware_sw_version,
                                             0,                               // os_sw_version,

--- a/src/comm/MockLinkMissionItemHandler.h
+++ b/src/comm/MockLinkMissionItemHandler.h
@@ -84,14 +84,14 @@ private slots:
     void _missionItemResponseTimeout(void);
 
 private:
-    void _handleMissionRequestList(const mavlink_message_t& msg);
-    void _handleMissionRequest(const mavlink_message_t& msg);
-    void _handleMissionItem(const mavlink_message_t& msg, bool missionItemInt);
-    void _handleMissionCount(const mavlink_message_t& msg);
-    void _handleMissionClearAll(const mavlink_message_t& msg);
-    void _requestNextMissionItem(int sequenceNumber);
-    void _sendAck(MAV_MISSION_RESULT ackType);
-    void _startMissionItemResponseTimer(void);
+    void _handleMissionRequestList      (const mavlink_message_t& msg);
+    void _handleMissionRequest          (const mavlink_message_t& msg);
+    void _handleMissionItem             (const mavlink_message_t& msg);
+    void _handleMissionCount            (const mavlink_message_t& msg);
+    void _handleMissionClearAll         (const mavlink_message_t& msg);
+    void _requestNextMissionItem        (int sequenceNumber);
+    void _sendAck                       (MAV_MISSION_RESULT ackType);
+    void _startMissionItemResponseTimer (void);
 
 private:
     MockLink* _mockLink;
@@ -99,15 +99,7 @@ private:
     int _writeSequenceCount;    ///< Numbers of items about to be written
     int _writeSequenceIndex;    ///< Current index being reqested
 
-    typedef struct {
-        bool isIntItem;
-        union {
-            mavlink_mission_item_t      missionItem;
-            mavlink_mission_item_int_t  missionItemInt;
-        };
-    } MissionItemBoth_t;
-    
-    typedef QMap<uint16_t, MissionItemBoth_t> MissionItemList_t;
+    typedef QMap<uint16_t, mavlink_mission_item_int_t> MissionItemList_t;
 
     MAV_MISSION_TYPE    _requestType;
     MissionItemList_t   _missionItems;


### PR DESCRIPTION
* MockLink is now always MISSION_ITEM_INT
* Unit tests now catch this bug: https://github.com/mavlink/qgroundcontrol/pull/9150#pullrequestreview-521211041
* Fix PlanManager MISSION_ITEM_INT bug