### PR TITLE
Fix primaryLink null reference problems

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -504,22 +504,27 @@ void APMSensorsComponentController::cancelCalibration(void)
 
 void APMSensorsComponentController::nextClicked(void)
 {
-    mavlink_message_t       msg;
-    mavlink_msg_command_ack_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
-                                      qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
-                                      _vehicle->vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                      &msg,
-                                      0,    // command
-                                      1,    // result
-                                      0,    // progress
-                                      0,    // result_param2
-                                      0,    // target_system
-                                      0);   // target_component
+    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+    if (!weakLink.expired()) {
+        mavlink_message_t       msg;
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
-    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->vehicleLinkManager()->primaryLink(), msg);
+        mavlink_msg_command_ack_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
+                                          qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
+                                          sharedLink->mavlinkChannel(),
+                                          &msg,
+                                          0,    // command
+                                          1,    // result
+                                          0,    // progress
+                                          0,    // result_param2
+                                          0,    // target_system
+                                          0);   // target_component
 
-    if (_calTypeInProgress == CalTypeCompassMot) {
-        _stopCalibration(StopCalibrationSuccess);
+        _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+
+        if (_calTypeInProgress == CalTypeCompassMot) {
+            _stopCalibration(StopCalibrationSuccess);
+        }
     }
 }
 
@@ -535,7 +540,13 @@ bool APMSensorsComponentController::accelSetupNeeded(void) const
 
 bool APMSensorsComponentController::usingUDPLink(void)
 {
-    return _vehicle->vehicleLinkManager()->primaryLink()->linkConfiguration()->type() == LinkConfiguration::TypeUdp;
+    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+    if (weakLink.expired()) {
+        return false;
+    } else {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+        return sharedLink->linkConfiguration()->type() == LinkConfiguration::TypeUdp;
+    }
 }
 
 void APMSensorsComponentController::_handleCommandAck(mavlink_message_t& message)

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -65,7 +65,13 @@ SensorsComponentController::SensorsComponentController(void)
 
 bool SensorsComponentController::usingUDPLink(void)
 {
-    return _vehicle->vehicleLinkManager()->primaryLink()->linkConfiguration()->type() == LinkConfiguration::TypeUdp;
+    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+    if (weakLink.expired()) {
+        return false;
+    } else {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+        return sharedLink->linkConfiguration()->type() == LinkConfiguration::TypeUdp;
+    }
 }
 
 /// Appends the specified text to the status log area in the ui

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1171,17 +1171,22 @@ QGCCameraControl::_requestAllParameters()
             qCritical() << "QGCParamIO is NULL" << paramName;
         }
     }
-    MAVLinkProtocol* mavlink = qgcApp()->toolbox()->mavlinkProtocol();
-    mavlink_message_t msg;
-    mavlink_msg_param_ext_request_list_pack_chan(
-                static_cast<uint8_t>(mavlink->getSystemId()),
-                static_cast<uint8_t>(mavlink->getComponentId()),
-                _vehicle->vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                &msg,
-                static_cast<uint8_t>(_vehicle->id()),
-                static_cast<uint8_t>(compID()),
-                0);                                                 // trimmed messages = false
-    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->vehicleLinkManager()->primaryLink(), msg);
+    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+
+        MAVLinkProtocol* mavlink = qgcApp()->toolbox()->mavlinkProtocol();
+        mavlink_message_t msg;
+        mavlink_msg_param_ext_request_list_pack_chan(
+                    static_cast<uint8_t>(mavlink->getSystemId()),
+                    static_cast<uint8_t>(mavlink->getComponentId()),
+                    sharedLink->mavlinkChannel(),
+                    &msg,
+                    static_cast<uint8_t>(_vehicle->id()),
+                    static_cast<uint8_t>(compID()),
+                    0);                                                 // trimmed messages = false
+        _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    }
     qCDebug(CameraControlVerboseLog) << "Request all parameters";
 }
 

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -131,13 +131,17 @@ QGCCameraParamIO::sendParameter(bool updateUI)
 void
 QGCCameraParamIO::_sendParameter()
 {
-    mavlink_param_ext_set_t p;
-    memset(&p, 0, sizeof(mavlink_param_ext_set_t));
-    param_ext_union_t   union_value;
-    mavlink_message_t   msg;
-    FactMetaData::ValueType_t factType = _fact->type();
-    p.param_type = _mavParamType;
-    switch (factType) {
+    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+
+        mavlink_param_ext_set_t p;
+        memset(&p, 0, sizeof(mavlink_param_ext_set_t));
+        param_ext_union_t   union_value;
+        mavlink_message_t   msg;
+        FactMetaData::ValueType_t factType = _fact->type();
+        p.param_type = _mavParamType;
+        switch (factType) {
         case FactMetaData::valueTypeUint8:
         case FactMetaData::valueTypeBool:
             union_value.param_uint8 = static_cast<uint8_t>(_fact->rawValue().toUInt());
@@ -169,10 +173,10 @@ QGCCameraParamIO::_sendParameter()
             //-- String and custom are the same for now
         case FactMetaData::valueTypeString:
         case FactMetaData::valueTypeCustom:
-            {
-                QByteArray custom = _fact->rawValue().toByteArray();
-                memcpy(union_value.bytes, custom.data(), static_cast<size_t>(std::max(custom.size(), MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN)));
-            }
+        {
+            QByteArray custom = _fact->rawValue().toByteArray();
+            memcpy(union_value.bytes, custom.data(), static_cast<size_t>(std::max(custom.size(), MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN)));
+        }
             break;
         default:
             qCritical() << "Unsupported fact type" << factType << "for" << _fact->name();
@@ -180,18 +184,19 @@ QGCCameraParamIO::_sendParameter()
         case FactMetaData::valueTypeInt32:
             union_value.param_int32 = static_cast<int32_t>(_fact->rawValue().toInt());
             break;
+        }
+        memcpy(&p.param_value[0], &union_value.bytes[0], MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN);
+        p.target_system     = static_cast<uint8_t>(_vehicle->id());
+        p.target_component  = static_cast<uint8_t>(_control->compID());
+        strncpy(p.param_id, _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_ID_LEN);
+        mavlink_msg_param_ext_set_encode_chan(
+                    static_cast<uint8_t>(_pMavlink->getSystemId()),
+                    static_cast<uint8_t>(_pMavlink->getComponentId()),
+                    sharedLink->mavlinkChannel(),
+                    &msg,
+                    &p);
+        _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
-    memcpy(&p.param_value[0], &union_value.bytes[0], MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN);
-    p.target_system     = static_cast<uint8_t>(_vehicle->id());
-    p.target_component  = static_cast<uint8_t>(_control->compID());
-    strncpy(p.param_id, _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_ID_LEN);
-    mavlink_msg_param_ext_set_encode_chan(
-        static_cast<uint8_t>(_pMavlink->getSystemId()),
-        static_cast<uint8_t>(_pMavlink->getComponentId()),
-        _vehicle->vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-        &msg,
-        &p);
-    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->vehicleLinkManager()->primaryLink(), msg);
     _paramWriteTimer.start();
 }
 
@@ -351,20 +356,25 @@ QGCCameraParamIO::paramRequest(bool reset)
         _forceUIUpdate  = true;
     }
     qCDebug(CameraIOLog) << "Request parameter:" << _fact->name();
-    char param_id[MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN + 1];
-    memset(param_id, 0, sizeof(param_id));
-    strncpy(param_id, _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN);
-    mavlink_message_t msg;
-    mavlink_msg_param_ext_request_read_pack_chan(
-                static_cast<uint8_t>(_pMavlink->getSystemId()),
-                static_cast<uint8_t>(_pMavlink->getComponentId()),
-                _vehicle->vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                &msg,
-                static_cast<uint8_t>(_vehicle->id()),
-                static_cast<uint8_t>(_control->compID()),
-                param_id,
-                -1,
-                0);                                                 // trimmed messages = false
-    _vehicle->sendMessageOnLinkThreadSafe(_vehicle->vehicleLinkManager()->primaryLink(), msg);
+    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+
+        char param_id[MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN + 1];
+        memset(param_id, 0, sizeof(param_id));
+        strncpy(param_id, _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN);
+        mavlink_message_t msg;
+        mavlink_msg_param_ext_request_read_pack_chan(
+                    static_cast<uint8_t>(_pMavlink->getSystemId()),
+                    static_cast<uint8_t>(_pMavlink->getComponentId()),
+                    sharedLink->mavlinkChannel(),
+                    &msg,
+                    static_cast<uint8_t>(_vehicle->id()),
+                    static_cast<uint8_t>(_control->compID()),
+                    param_id,
+                    -1,
+                    0);                                                 // trimmed messages = false
+        _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    }
     _paramRequestTimer.start();
 }

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -1034,25 +1034,28 @@ QString FirmwarePlugin::gotoFlightMode(void) const
 
 void FirmwarePlugin::sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMotionReport& motionReport, uint8_t estimationCapabilities)
 {
-    MAVLinkProtocol* mavlinkProtocol = qgcApp()->toolbox()->mavlinkProtocol();
+    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
+    if (!weakLink.expired()) {
+        MAVLinkProtocol*        mavlinkProtocol = qgcApp()->toolbox()->mavlinkProtocol();
+        mavlink_follow_target_t follow_target   = {};
+        SharedLinkInterfacePtr  sharedLink      = weakLink.lock();
 
-    mavlink_follow_target_t follow_target = {};
+        follow_target.timestamp =           qgcApp()->msecsSinceBoot();
+        follow_target.est_capabilities =    estimationCapabilities;
+        follow_target.position_cov[0] =     static_cast<float>(motionReport.pos_std_dev[0]);
+        follow_target.position_cov[2] =     static_cast<float>(motionReport.pos_std_dev[2]);
+        follow_target.alt =                 static_cast<float>(motionReport.altMetersAMSL);
+        follow_target.lat =                 motionReport.lat_int;
+        follow_target.lon =                 motionReport.lon_int;
+        follow_target.vel[0] =              static_cast<float>(motionReport.vxMetersPerSec);
+        follow_target.vel[1] =              static_cast<float>(motionReport.vyMetersPerSec);
 
-    follow_target.timestamp =           qgcApp()->msecsSinceBoot();
-    follow_target.est_capabilities =    estimationCapabilities;
-    follow_target.position_cov[0] =     static_cast<float>(motionReport.pos_std_dev[0]);
-    follow_target.position_cov[2] =     static_cast<float>(motionReport.pos_std_dev[2]);
-    follow_target.alt =                 static_cast<float>(motionReport.altMetersAMSL);
-    follow_target.lat =                 motionReport.lat_int;
-    follow_target.lon =                 motionReport.lon_int;
-    follow_target.vel[0] =              static_cast<float>(motionReport.vxMetersPerSec);
-    follow_target.vel[1] =              static_cast<float>(motionReport.vyMetersPerSec);
-
-    mavlink_message_t message;
-    mavlink_msg_follow_target_encode_chan(static_cast<uint8_t>(mavlinkProtocol->getSystemId()),
-                                          static_cast<uint8_t>(mavlinkProtocol->getComponentId()),
-                                          vehicle->vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                          &message,
-                                          &follow_target);
-    vehicle->sendMessageOnLinkThreadSafe(vehicle->vehicleLinkManager()->primaryLink(), message);
+        mavlink_message_t message;
+        mavlink_msg_follow_target_encode_chan(static_cast<uint8_t>(mavlinkProtocol->getSystemId()),
+                                              static_cast<uint8_t>(mavlinkProtocol->getComponentId()),
+                                              sharedLink->mavlinkChannel(),
+                                              &message,
+                                              &follow_target);
+        vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+    }
 }

--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -39,33 +39,38 @@ void MissionManager::writeArduPilotGuidedMissionItem(const QGeoCoordinate& gotoC
 
     _connectToMavlink();
 
-    mavlink_message_t       messageOut;
-    mavlink_mission_item_t  missionItem;
+    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
 
-    memset(&missionItem, 0, sizeof(missionItem));
-    missionItem.target_system =     _vehicle->id();
-    missionItem.target_component =  _vehicle->defaultComponentId();
-    missionItem.seq =               0;
-    missionItem.command =           MAV_CMD_NAV_WAYPOINT;
-    missionItem.param1 =            0;
-    missionItem.param2 =            0;
-    missionItem.param3 =            0;
-    missionItem.param4 =            0;
-    missionItem.x =                 gotoCoord.latitude();
-    missionItem.y =                 gotoCoord.longitude();
-    missionItem.z =                 gotoCoord.altitude();
-    missionItem.frame =             MAV_FRAME_GLOBAL_RELATIVE_ALT;
-    missionItem.current =           altChangeOnly ? 3 : 2;
-    missionItem.autocontinue =      true;
 
-    _dedicatedLink = _vehicle->vehicleLinkManager()->primaryLink();
-    mavlink_msg_mission_item_encode_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
-                                         qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
-                                         _dedicatedLink->mavlinkChannel(),
-                                         &messageOut,
-                                         &missionItem);
+        mavlink_message_t       messageOut;
+        mavlink_mission_item_t  missionItem;
 
-    _vehicle->sendMessageOnLinkThreadSafe(_dedicatedLink, messageOut);
+        memset(&missionItem, 0, sizeof(missionItem));
+        missionItem.target_system =     _vehicle->id();
+        missionItem.target_component =  _vehicle->defaultComponentId();
+        missionItem.seq =               0;
+        missionItem.command =           MAV_CMD_NAV_WAYPOINT;
+        missionItem.param1 =            0;
+        missionItem.param2 =            0;
+        missionItem.param3 =            0;
+        missionItem.param4 =            0;
+        missionItem.x =                 gotoCoord.latitude();
+        missionItem.y =                 gotoCoord.longitude();
+        missionItem.z =                 gotoCoord.altitude();
+        missionItem.frame =             MAV_FRAME_GLOBAL_RELATIVE_ALT;
+        missionItem.current =           altChangeOnly ? 3 : 2;
+        missionItem.autocontinue =      true;
+
+        mavlink_msg_mission_item_encode_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
+                                             qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
+                                             sharedLink->mavlinkChannel(),
+                                             &messageOut,
+                                             &missionItem);
+
+        _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), messageOut);
+    }
     _startAckTimeout(AckGuidedItem);
     emit inProgressChanged(true);
 }

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -137,7 +137,6 @@ protected:
     Vehicle*            _vehicle =              nullptr;
     MissionCommandTree* _missionCommandTree =   nullptr;
     MAV_MISSION_TYPE    _planType;
-    LinkInterface*      _dedicatedLink =        nullptr;
 
     QTimer*             _ackTimeoutTimer =      nullptr;
     AckType_t           _expectedAck;

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -213,9 +213,16 @@ void PlanMasterController::_activeVehicleChanged(Vehicle* activeVehicle)
 
 void PlanMasterController::loadFromVehicle(void)
 {
-    if (_managerVehicle->vehicleLinkManager()->primaryLink()->linkConfiguration()->isHighLatency()) {
-        qgcApp()->showAppMessage(tr("Download not supported on high latency links."));
+    WeakLinkInterfacePtr weakLink = _managerVehicle->vehicleLinkManager()->primaryLink();
+    if (weakLink.expired()) {
+        // Vehicle is shutting down
         return;
+    } else {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+        if (sharedLink->linkConfiguration()->isHighLatency()) {
+            qgcApp()->showAppMessage(tr("Download not supported on high latency links."));
+            return;
+        }
     }
 
     if (offline()) {
@@ -320,9 +327,16 @@ void PlanMasterController::_startFlightPlanning(void) {
 
 void PlanMasterController::sendToVehicle(void)
 {
-    if (_managerVehicle->vehicleLinkManager()->primaryLink()->linkConfiguration()->isHighLatency()) {
-        qgcApp()->showAppMessage(tr("Upload not supported on high latency links."));
+    WeakLinkInterfacePtr weakLink = _managerVehicle->vehicleLinkManager()->primaryLink();
+    if (weakLink.expired()) {
+        // Vehicle is shutting down
         return;
+    } else {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+        if (sharedLink->linkConfiguration()->isHighLatency()) {
+            qgcApp()->showAppMessage(tr("Upload not supported on high latency links."));
+            return;
+        }
     }
 
     if (offline()) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1428,19 +1428,25 @@ void Vehicle::_updateArmed(bool armed)
 
 void Vehicle::_handlePing(LinkInterface* link, mavlink_message_t& message)
 {
-    mavlink_ping_t      ping;
-    mavlink_message_t   msg;
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-    mavlink_msg_ping_decode(&message, &ping);
-    mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                               static_cast<uint8_t>(_mavlink->getComponentId()),
-                               vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                               &msg,
-                               ping.time_usec,
-                               ping.seq,
-                               message.sysid,
-                               message.compid);
-    sendMessageOnLinkThreadSafe(link, msg);
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+
+        mavlink_ping_t      ping;
+        mavlink_message_t   msg;
+
+        mavlink_msg_ping_decode(&message, &ping);
+        mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                   static_cast<uint8_t>(_mavlink->getComponentId()),
+                                   sharedLink->mavlinkChannel(),
+                                   &msg,
+                                   ping.time_usec,
+                                   ping.seq,
+                                   message.sysid,
+                                   message.compid);
+        sendMessageOnLinkThreadSafe(link, msg);
+    }
 }
 
 void Vehicle::_handleHeartbeat(mavlink_message_t& message)
@@ -1889,20 +1895,26 @@ void Vehicle::setFlightMode(const QString& flightMode)
     uint32_t    custom_mode;
 
     if (_firmwarePlugin->setFlightMode(flightMode, &base_mode, &custom_mode)) {
-        // setFlightMode will only set MAV_MODE_FLAG_CUSTOM_MODE_ENABLED in base_mode, we need to move back in the existing
-        // states.
-        uint8_t newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
-        newBaseMode |= base_mode;
+        WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-        mavlink_message_t msg;
-        mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
-                                       _mavlink->getComponentId(),
-                                       vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                       &msg,
-                                       id(),
-                                       newBaseMode,
-                                       custom_mode);
-        sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), msg);
+        if (!weakLink.expired()) {
+            uint8_t                 newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
+            SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+
+            // setFlightMode will only set MAV_MODE_FLAG_CUSTOM_MODE_ENABLED in base_mode, we need to move back in the existing
+            // states.
+            newBaseMode |= base_mode;
+
+            mavlink_message_t msg;
+            mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
+                                           _mavlink->getComponentId(),
+                                           sharedLink->mavlinkChannel(),
+                                           &msg,
+                                           id(),
+                                           newBaseMode,
+                                           custom_mode);
+            sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+        }
     } else {
         qWarning() << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
     }
@@ -1921,28 +1933,33 @@ QVariantList Vehicle::links() const {
 
 void Vehicle::requestDataStream(MAV_DATA_STREAM stream, uint16_t rate, bool sendMultiple)
 {
-    mavlink_message_t               msg;
-    mavlink_request_data_stream_t   dataStream;
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-    memset(&dataStream, 0, sizeof(dataStream));
+    if (!weakLink.expired()) {
+        mavlink_message_t               msg;
+        mavlink_request_data_stream_t   dataStream;
+        SharedLinkInterfacePtr          sharedLink = weakLink.lock();
 
-    dataStream.req_stream_id = stream;
-    dataStream.req_message_rate = rate;
-    dataStream.start_stop = 1;  // start
-    dataStream.target_system = id();
-    dataStream.target_component = _defaultComponentId;
+        memset(&dataStream, 0, sizeof(dataStream));
 
-    mavlink_msg_request_data_stream_encode_chan(_mavlink->getSystemId(),
-                                                _mavlink->getComponentId(),
-                                                vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                                &msg,
-                                                &dataStream);
+        dataStream.req_stream_id = stream;
+        dataStream.req_message_rate = rate;
+        dataStream.start_stop = 1;  // start
+        dataStream.target_system = id();
+        dataStream.target_component = _defaultComponentId;
 
-    if (sendMultiple) {
-        // We use sendMessageMultiple since we really want these to make it to the vehicle
-        sendMessageMultiple(msg);
-    } else {
-        sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), msg);
+        mavlink_msg_request_data_stream_encode_chan(_mavlink->getSystemId(),
+                                                    _mavlink->getComponentId(),
+                                                    sharedLink->mavlinkChannel(),
+                                                    &msg,
+                                                    &dataStream);
+
+        if (sendMultiple) {
+            // We use sendMessageMultiple since we really want these to make it to the vehicle
+            sendMessageMultiple(msg);
+        } else {
+            sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+        }
     }
 }
 
@@ -1951,7 +1968,11 @@ void Vehicle::_sendMessageMultipleNext()
     if (_nextSendMessageMultipleIndex < _sendMessageMultipleList.count()) {
         qCDebug(VehicleLog) << "_sendMessageMultipleNext:" << _sendMessageMultipleList[_nextSendMessageMultipleIndex].message.msgid;
 
-        sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
+        WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+
+        if (!weakLink.expired()) {
+            sendMessageOnLinkThreadSafe(weakLink.lock().get(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
+        }
 
         if (--_sendMessageMultipleList[_nextSendMessageMultipleIndex].retryCount <= 0) {
             _sendMessageMultipleList.removeAt(_nextSendMessageMultipleIndex);
@@ -2053,20 +2074,25 @@ void Vehicle::_parametersReady(bool parametersReady)
 
 void Vehicle::_sendQGCTimeToVehicle()
 {
-    mavlink_message_t       msg;
-    mavlink_system_time_t   cmd;
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-    // Timestamp of the master clock in microseconds since UNIX epoch.
-    cmd.time_unix_usec = QDateTime::currentDateTime().currentMSecsSinceEpoch()*1000;
-    // Timestamp of the component clock since boot time in milliseconds (Not necessary).
-    cmd.time_boot_ms = 0;
-    mavlink_msg_system_time_encode_chan(_mavlink->getSystemId(),
-                                        _mavlink->getComponentId(),
-                                        vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                        &msg,
-                                        &cmd);
+    if (!weakLink.expired()) {
+        mavlink_message_t       msg;
+        mavlink_system_time_t   cmd;
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
-    sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), msg);
+        // Timestamp of the master clock in microseconds since UNIX epoch.
+        cmd.time_unix_usec = QDateTime::currentDateTime().currentMSecsSinceEpoch()*1000;
+        // Timestamp of the component clock since boot time in milliseconds (Not necessary).
+        cmd.time_boot_ms = 0;
+        mavlink_msg_system_time_encode_chan(_mavlink->getSystemId(),
+                                            _mavlink->getComponentId(),
+                                            sharedLink->mavlinkChannel(),
+                                            &msg,
+                                            &cmd);
+
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    }
 }
 
 void Vehicle::_imageReady(UASInterface*)
@@ -2488,19 +2514,25 @@ void Vehicle::emergencyStop()
 
 void Vehicle::setCurrentMissionSequence(int seq)
 {
-    if (!_firmwarePlugin->sendHomePositionToVehicle()) {
-        seq--;
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+
+    if (!weakLink.expired()) {
+        mavlink_message_t       msg;
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+
+        if (!_firmwarePlugin->sendHomePositionToVehicle()) {
+            seq--;
+        }
+        mavlink_msg_mission_set_current_pack_chan(
+                    static_cast<uint8_t>(_mavlink->getSystemId()),
+                    static_cast<uint8_t>(_mavlink->getComponentId()),
+                    sharedLink->mavlinkChannel(),
+                    &msg,
+                    static_cast<uint8_t>(id()),
+                    _compID,
+                    static_cast<uint16_t>(seq));
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
-    mavlink_message_t msg;
-    mavlink_msg_mission_set_current_pack_chan(
-                static_cast<uint8_t>(_mavlink->getSystemId()),
-                static_cast<uint8_t>(_mavlink->getComponentId()),
-                vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                &msg,
-                static_cast<uint8_t>(id()),
-                _compID,
-                static_cast<uint16_t>(seq));
-    sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), msg);
 }
 
 void Vehicle::sendMavCommand(int compId, MAV_CMD command, bool showError, float param1, float param2, float param3, float param4, float param5, float param6, float param7)
@@ -2623,29 +2655,34 @@ void Vehicle::_sendMavCommandWorker(bool commandInt, bool requestMessage, bool s
         return;
     }
 
-    MavCommandListEntry_t entry;
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-    entry.useCommandInt     = commandInt;
-    entry.targetCompId      = targetCompId;
-    entry.command           = command;
-    entry.frame             = frame;
-    entry.showError         = showError;
-    entry.requestMessage    = requestMessage;
-    entry.resultHandler     = resultHandler;
-    entry.resultHandlerData = resultHandlerData;
-    entry.rgParam[0]        = param1;
-    entry.rgParam[1]        = param2;
-    entry.rgParam[2]        = param3;
-    entry.rgParam[3]        = param4;
-    entry.rgParam[4]        = param5;
-    entry.rgParam[5]        = param6;
-    entry.rgParam[6]        = param7;
-    entry.maxTries          = _sendMavCommandShouldRetry(command) ? _mavCommandMaxRetryCount : 1;
-    entry.ackTimeoutMSecs   = _vehicleLinkManager->primaryLink()->linkConfiguration()->isHighLatency() ? _mavCommandAckTimeoutMSecsHighLatency : _mavCommandAckTimeoutMSecs;
-    entry.elapsedTimer.start();
+    if (!weakLink.expired()) {
+        MavCommandListEntry_t   entry;
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
-    _mavCommandList.append(entry);
-    _sendMavCommandFromList(_mavCommandList.last());
+        entry.useCommandInt     = commandInt;
+        entry.targetCompId      = targetCompId;
+        entry.command           = command;
+        entry.frame             = frame;
+        entry.showError         = showError;
+        entry.requestMessage    = requestMessage;
+        entry.resultHandler     = resultHandler;
+        entry.resultHandlerData = resultHandlerData;
+        entry.rgParam[0]        = param1;
+        entry.rgParam[1]        = param2;
+        entry.rgParam[2]        = param3;
+        entry.rgParam[3]        = param4;
+        entry.rgParam[4]        = param5;
+        entry.rgParam[5]        = param6;
+        entry.rgParam[6]        = param7;
+        entry.maxTries          = _sendMavCommandShouldRetry(command) ? _mavCommandMaxRetryCount : 1;
+        entry.ackTimeoutMSecs   = sharedLink->linkConfiguration()->isHighLatency() ? _mavCommandAckTimeoutMSecsHighLatency : _mavCommandAckTimeoutMSecs;
+        entry.elapsedTimer.start();
+
+        _mavCommandList.append(entry);
+        _sendMavCommandFromList(_mavCommandList.last());
+    }
 }
 
 void Vehicle::_sendMavCommandFromList(MavCommandListEntry_t& commandEntry)
@@ -2679,50 +2716,56 @@ void Vehicle::_sendMavCommandFromList(MavCommandListEntry_t& commandEntry)
 
     qCDebug(VehicleLog) << "_sendMavCommandFromList command:tryCount" << rawCommandName << commandEntry.tryCount;
 
-    mavlink_message_t       msg;
-    if (commandEntry.useCommandInt) {
-        mavlink_command_int_t  cmd;
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-        memset(&cmd, 0, sizeof(cmd));
-        cmd.target_system =     _id;
-        cmd.target_component =  commandEntry.targetCompId;
-        cmd.command =           commandEntry.command;
-        cmd.frame =             commandEntry.frame;
-        cmd.param1 =            commandEntry.rgParam[0];
-        cmd.param2 =            commandEntry.rgParam[1];
-        cmd.param3 =            commandEntry.rgParam[2];
-        cmd.param4 =            commandEntry.rgParam[3];
-        cmd.x =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[4] : commandEntry.rgParam[4] * 1e7;
-        cmd.y =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[5] : commandEntry.rgParam[5] * 1e7;
-        cmd.z =                 commandEntry.rgParam[6];
-        mavlink_msg_command_int_encode_chan(_mavlink->getSystemId(),
-                                            _mavlink->getComponentId(),
-                                            vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                            &msg,
-                                            &cmd);
-    } else {
-        mavlink_command_long_t  cmd;
+    if (!weakLink.expired()) {
+        mavlink_message_t       msg;
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
-        memset(&cmd, 0, sizeof(cmd));
-        cmd.target_system =     _id;
-        cmd.target_component =  commandEntry.targetCompId;
-        cmd.command =           commandEntry.command;
-        cmd.confirmation =      0;
-        cmd.param1 =            commandEntry.rgParam[0];
-        cmd.param2 =            commandEntry.rgParam[1];
-        cmd.param3 =            commandEntry.rgParam[2];
-        cmd.param4 =            commandEntry.rgParam[3];
-        cmd.param5 =            commandEntry.rgParam[4];
-        cmd.param6 =            commandEntry.rgParam[5];
-        cmd.param7 =            commandEntry.rgParam[6];
-        mavlink_msg_command_long_encode_chan(_mavlink->getSystemId(),
-                                             _mavlink->getComponentId(),
-                                             vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                             &msg,
-                                             &cmd);
+        if (commandEntry.useCommandInt) {
+            mavlink_command_int_t  cmd;
+
+            memset(&cmd, 0, sizeof(cmd));
+            cmd.target_system =     _id;
+            cmd.target_component =  commandEntry.targetCompId;
+            cmd.command =           commandEntry.command;
+            cmd.frame =             commandEntry.frame;
+            cmd.param1 =            commandEntry.rgParam[0];
+            cmd.param2 =            commandEntry.rgParam[1];
+            cmd.param3 =            commandEntry.rgParam[2];
+            cmd.param4 =            commandEntry.rgParam[3];
+            cmd.x =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[4] : commandEntry.rgParam[4] * 1e7;
+            cmd.y =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[5] : commandEntry.rgParam[5] * 1e7;
+            cmd.z =                 commandEntry.rgParam[6];
+            mavlink_msg_command_int_encode_chan(_mavlink->getSystemId(),
+                                                _mavlink->getComponentId(),
+                                                sharedLink->mavlinkChannel(),
+                                                &msg,
+                                                &cmd);
+        } else {
+            mavlink_command_long_t  cmd;
+
+            memset(&cmd, 0, sizeof(cmd));
+            cmd.target_system =     _id;
+            cmd.target_component =  commandEntry.targetCompId;
+            cmd.command =           commandEntry.command;
+            cmd.confirmation =      0;
+            cmd.param1 =            commandEntry.rgParam[0];
+            cmd.param2 =            commandEntry.rgParam[1];
+            cmd.param3 =            commandEntry.rgParam[2];
+            cmd.param4 =            commandEntry.rgParam[3];
+            cmd.param5 =            commandEntry.rgParam[4];
+            cmd.param6 =            commandEntry.rgParam[5];
+            cmd.param7 =            commandEntry.rgParam[6];
+            mavlink_msg_command_long_encode_chan(_mavlink->getSystemId(),
+                                                 _mavlink->getComponentId(),
+                                                 sharedLink->mavlinkChannel(),
+                                                 &msg,
+                                                 &cmd);
+        }
+
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
-
-    sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), msg);
 }
 
 void Vehicle::_sendMavCommandResponseTimeoutCheck(void)
@@ -2998,69 +3041,75 @@ void Vehicle::rebootVehicle()
 
 void Vehicle::startCalibration(Vehicle::CalibrationType calType)
 {
-    float param1 = 0;
-    float param2 = 0;
-    float param3 = 0;
-    float param4 = 0;
-    float param5 = 0;
-    float param6 = 0;
-    float param7 = 0;
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-    switch (calType) {
-    case CalibrationGyro:
-        param1 = 1;
-        break;
-    case CalibrationMag:
-        param2 = 1;
-        break;
-    case CalibrationRadio:
-        param4 = 1;
-        break;
-    case CalibrationCopyTrims:
-        param4 = 2;
-        break;
-    case CalibrationAccel:
-        param5 = 1;
-        break;
-    case CalibrationLevel:
-        param5 = 2;
-        break;
-    case CalibrationEsc:
-        param7 = 1;
-        break;
-    case CalibrationPX4Airspeed:
-        param6 = 1;
-        break;
-    case CalibrationPX4Pressure:
-        param3 = 1;
-        break;
-    case CalibrationAPMCompassMot:
-        param6 = 1;
-        break;
-    case CalibrationAPMPressureAirspeed:
-        param3 = 1;
-        break;
-    case CalibrationAPMPreFlight:
-        param3 = 1; // GroundPressure/Airspeed
-        if (multiRotor() || rover()) {
-            // Gyro cal for ArduCopter only
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+
+        float param1 = 0;
+        float param2 = 0;
+        float param3 = 0;
+        float param4 = 0;
+        float param5 = 0;
+        float param6 = 0;
+        float param7 = 0;
+
+        switch (calType) {
+        case CalibrationGyro:
             param1 = 1;
+            break;
+        case CalibrationMag:
+            param2 = 1;
+            break;
+        case CalibrationRadio:
+            param4 = 1;
+            break;
+        case CalibrationCopyTrims:
+            param4 = 2;
+            break;
+        case CalibrationAccel:
+            param5 = 1;
+            break;
+        case CalibrationLevel:
+            param5 = 2;
+            break;
+        case CalibrationEsc:
+            param7 = 1;
+            break;
+        case CalibrationPX4Airspeed:
+            param6 = 1;
+            break;
+        case CalibrationPX4Pressure:
+            param3 = 1;
+            break;
+        case CalibrationAPMCompassMot:
+            param6 = 1;
+            break;
+        case CalibrationAPMPressureAirspeed:
+            param3 = 1;
+            break;
+        case CalibrationAPMPreFlight:
+            param3 = 1; // GroundPressure/Airspeed
+            if (multiRotor() || rover()) {
+                // Gyro cal for ArduCopter only
+                param1 = 1;
+            }
         }
-    }
 
-    // We can't use sendMavCommand here since we have no idea how long it will be before the command returns a result. This in turn
-    // causes the retry logic to break down.
-    mavlink_message_t msg;
-    mavlink_msg_command_long_pack_chan(_mavlink->getSystemId(),
-                                       _mavlink->getComponentId(),
-                                       vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                       &msg,
-                                       id(),
-                                       defaultComponentId(),            // target component
-                                       MAV_CMD_PREFLIGHT_CALIBRATION,    // command id
-                                       0,                                // 0=first transmission of command
-                                       param1, param2, param3, param4, param5, param6, param7);
-    sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), msg);
+        // We can't use sendMavCommand here since we have no idea how long it will be before the command returns a result. This in turn
+        // causes the retry logic to break down.
+        mavlink_message_t msg;
+        mavlink_msg_command_long_pack_chan(_mavlink->getSystemId(),
+                                           _mavlink->getComponentId(),
+                                           sharedLink->mavlinkChannel(),
+                                           &msg,
+                                           id(),
+                                           defaultComponentId(),            // target component
+                                           MAV_CMD_PREFLIGHT_CALIBRATION,    // command id
+                                           0,                                // 0=first transmission of command
+                                           param1, param2, param3, param4, param5, param6, param7);
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    }
 }
 
 void Vehicle::stopCalibration(void)
@@ -3148,19 +3197,25 @@ void Vehicle::stopMavlinkLog()
 
 void Vehicle::_ackMavlinkLogData(uint16_t sequence)
 {
-    mavlink_message_t msg;
-    mavlink_logging_ack_t ack;
-    memset(&ack, 0, sizeof(ack));
-    ack.sequence = sequence;
-    ack.target_component = _defaultComponentId;
-    ack.target_system = id();
-    mavlink_msg_logging_ack_encode_chan(
-                _mavlink->getSystemId(),
-                _mavlink->getComponentId(),
-                vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                &msg,
-                &ack);
-    sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), msg);
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+        mavlink_message_t       msg;
+        mavlink_logging_ack_t   ack;
+
+        memset(&ack, 0, sizeof(ack));
+        ack.sequence = sequence;
+        ack.target_component = _defaultComponentId;
+        ack.target_system = id();
+        mavlink_msg_logging_ack_encode_chan(
+                    _mavlink->getSystemId(),
+                    _mavlink->getComponentId(),
+                    sharedLink->mavlinkChannel(),
+                    &msg,
+                    &ack);
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    }
 }
 
 void Vehicle::_handleMavlinkLoggingData(mavlink_message_t& message)
@@ -3681,78 +3736,93 @@ void Vehicle::updateFlightDistance(double distance)
 
 void Vehicle::sendParamMapRC(const QString& paramName, double scale, double centerValue, int tuningID, double minValue, double maxValue)
 {
-    mavlink_message_t message;
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-    char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
-    // Copy string into buffer, ensuring not to exceed the buffer size
-    for (unsigned int i = 0; i < sizeof(param_id_cstr); i++) {
-        if ((int)i < paramName.length()) {
-            param_id_cstr[i] = paramName.toLatin1()[i];
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+        mavlink_message_t       message;
+
+        char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
+        // Copy string into buffer, ensuring not to exceed the buffer size
+        for (unsigned int i = 0; i < sizeof(param_id_cstr); i++) {
+            if ((int)i < paramName.length()) {
+                param_id_cstr[i] = paramName.toLatin1()[i];
+            }
         }
-    }
 
-    mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                                       static_cast<uint8_t>(_mavlink->getComponentId()),
-                                       vehicleLinkManager()->primaryLink()->mavlinkChannel(),
-                                       &message,
-                                       _id,
-                                       MAV_COMP_ID_AUTOPILOT1,
-                                       param_id_cstr,
-                                       -1,                                                  // parameter name specified as string in previous argument
-                                       static_cast<uint8_t>(tuningID),
-                                       static_cast<float>(scale),
-                                       static_cast<float>(centerValue),
-                                       static_cast<float>(minValue),
-                                       static_cast<float>(maxValue));
-    sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), message);
-}
-
-void Vehicle::clearAllParamMapRC(void)
-{
-    char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
-
-    for (int i = 0; i < 3; i++) {
-        mavlink_message_t message;
         mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
                                            static_cast<uint8_t>(_mavlink->getComponentId()),
-                                           vehicleLinkManager()->primaryLink()->mavlinkChannel(),
+                                           sharedLink->mavlinkChannel(),
                                            &message,
                                            _id,
                                            MAV_COMP_ID_AUTOPILOT1,
                                            param_id_cstr,
-                                           -2,                                                  // Disable map for specified tuning id
-                                           i,                                                   // tuning id
-                                           0, 0, 0, 0);                                         // unused
-        sendMessageOnLinkThreadSafe(vehicleLinkManager()->primaryLink(), message);
+                                           -1,                                                  // parameter name specified as string in previous argument
+                                           static_cast<uint8_t>(tuningID),
+                                           static_cast<float>(scale),
+                                           static_cast<float>(centerValue),
+                                           static_cast<float>(minValue),
+                                           static_cast<float>(maxValue));
+        sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+    }
+}
+
+void Vehicle::clearAllParamMapRC(void)
+{
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+        char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
+
+        for (int i = 0; i < 3; i++) {
+            mavlink_message_t message;
+            mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                               static_cast<uint8_t>(_mavlink->getComponentId()),
+                                               sharedLink->mavlinkChannel(),
+                                               &message,
+                                               _id,
+                                               MAV_COMP_ID_AUTOPILOT1,
+                                               param_id_cstr,
+                                               -2,                                                  // Disable map for specified tuning id
+                                               i,                                                   // tuning id
+                                               0, 0, 0, 0);                                         // unused
+            sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+        }
     }
 }
 
 void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, float thrust, quint16 buttons)
 {
-    LinkInterface* pPrimaryLink = vehicleLinkManager()->primaryLink();
-    if (pPrimaryLink == nullptr || pPrimaryLink->linkConfiguration()->isHighLatency()) {
-        return;
-    }
+    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
 
-    mavlink_message_t message;
-    
-    // Incoming values are in the range -1:1
-    float axesScaling =         1.0 * 1000.0;
-    float newRollCommand =      roll * axesScaling;
-    float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
-    float newYawCommand    =    yaw * axesScaling;
-    float newThrustCommand =    thrust * axesScaling;
-    
-    mavlink_msg_manual_control_pack_chan(
-                static_cast<uint8_t>(_mavlink->getSystemId()),
-                static_cast<uint8_t>(_mavlink->getComponentId()),
-                pPrimaryLink->mavlinkChannel(),
-                &message,
-                static_cast<uint8_t>(_id),
-                static_cast<int16_t>(newPitchCommand),
-                static_cast<int16_t>(newRollCommand),
-                static_cast<int16_t>(newThrustCommand),
-                static_cast<int16_t>(newYawCommand),
-                buttons);
-    sendMessageOnLinkThreadSafe(pPrimaryLink, message);
+    if (!weakLink.expired()) {
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+
+        if (sharedLink->linkConfiguration()->isHighLatency()) {
+            return;
+        }
+
+        mavlink_message_t message;
+
+        // Incoming values are in the range -1:1
+        float axesScaling =         1.0 * 1000.0;
+        float newRollCommand =      roll * axesScaling;
+        float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
+        float newYawCommand    =    yaw * axesScaling;
+        float newThrustCommand =    thrust * axesScaling;
+
+        mavlink_msg_manual_control_pack_chan(
+                    static_cast<uint8_t>(_mavlink->getSystemId()),
+                    static_cast<uint8_t>(_mavlink->getComponentId()),
+                    sharedLink->mavlinkChannel(),
+                    &message,
+                    static_cast<uint8_t>(_id),
+                    static_cast<int16_t>(newPitchCommand),
+                    static_cast<int16_t>(newRollCommand),
+                    static_cast<int16_t>(newThrustCommand),
+                    static_cast<int16_t>(newYawCommand),
+                    buttons);
+        sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+    }
 }

--- a/src/Vehicle/VehicleLinkManager.h
+++ b/src/Vehicle/VehicleLinkManager.h
@@ -34,7 +34,7 @@ class VehicleLinkManager : public QObject
 public:
     VehicleLinkManager(Vehicle* vehicle);
 
-    Q_PROPERTY(LinkInterface*   primaryLink                 READ primaryLink                                                    NOTIFY primaryLinkChanged)
+    Q_PROPERTY(bool             primaryLinkIsPX4Flow        READ primaryLinkIsPX4Flow                                           NOTIFY primaryLinkChanged)
     Q_PROPERTY(QString          primaryLinkName             READ primaryLinkName            WRITE setPrimaryLinkByName          NOTIFY primaryLinkChanged)
     Q_PROPERTY(QStringList      linkNames                   READ linkNames                                                      NOTIFY linkNamesChanged)
     Q_PROPERTY(QStringList      linkStatuses                READ linkStatuses                                                   NOTIFY linkStatusesChanged)
@@ -42,19 +42,18 @@ public:
     Q_PROPERTY(bool             communicationLostEnabled    READ communicationLostEnabled   WRITE setCommunicationLostEnabled   NOTIFY communicationLostEnabledChanged)
     Q_PROPERTY(bool             autoDisconnect              MEMBER _autoDisconnect                                              NOTIFY autoDisconnectChanged)
 
-    void            mavlinkMessageReceived      (LinkInterface* link, mavlink_message_t message);
-    bool            containsLink                (LinkInterface* link);
-    LinkInterface*  primaryLink                 (void) { return _primaryLink; }
-    QString         primaryLinkName             (void) const;
-    QStringList     linkNames                   (void) const;
-    QStringList     linkStatuses                (void) const;
-    bool            communicationLost           (void) const { return _communicationLost; }
-    bool            communicationLostEnabled    (void) const { return _communicationLostEnabled; }
-
-    void            setPrimaryLinkByName        (const QString& name);
-    void            setCommunicationLostEnabled (bool communicationLostEnabled);
-
-    void            closeVehicle                (void);
+    bool                    primaryLinkIsPX4Flow        (void) const;
+    void                    mavlinkMessageReceived      (LinkInterface* link, mavlink_message_t message);
+    bool                    containsLink                (LinkInterface* link);
+    WeakLinkInterfacePtr    primaryLink                 (void) { return _primaryLink; }
+    QString                 primaryLinkName             (void) const;
+    QStringList             linkNames                   (void) const;
+    QStringList             linkStatuses                (void) const;
+    bool                    communicationLost           (void) const { return _communicationLost; }
+    bool                    communicationLostEnabled    (void) const { return _communicationLostEnabled; }
+    void                    setPrimaryLinkByName        (const QString& name);
+    void                    setCommunicationLostEnabled (bool communicationLostEnabled);
+    void                    closeVehicle                (void);
 
 signals:
     void primaryLinkChanged             (void);
@@ -69,13 +68,13 @@ private slots:
     void _commLostCheck(void);
 
 private:
-    int             _containsLinkIndex      (LinkInterface* link);
-    void            _addLink                (LinkInterface* link);
-    void            _removeLink             (LinkInterface* link);
-    void            _linkDisconnected       (void);
-    bool            _updatePrimaryLink      (void);
-    LinkInterface*  _bestActivePrimaryLink  (void);
-    void            _commRegainedOnLink     (LinkInterface*  link);
+    int                     _containsLinkIndex      (LinkInterface* link);
+    void                    _addLink                (LinkInterface* link);
+    void                    _removeLink             (LinkInterface* link);
+    void                    _linkDisconnected       (void);
+    bool                    _updatePrimaryLink      (void);
+    WeakLinkInterfacePtr    _bestActivePrimaryLink  (void);
+    void                    _commRegainedOnLink     (LinkInterface*  link);
 
     typedef struct LinkInfo {
         SharedLinkInterfacePtr  link;
@@ -83,14 +82,14 @@ private:
         QElapsedTimer           heartbeatElapsedTimer;
     } LinkInfo_t;
 
-    Vehicle*            _vehicle                    = nullptr;
-    LinkManager*        _linkMgr                    = nullptr;
-    QTimer              _commLostCheckTimer;
-    QList<LinkInfo_t>   _rgLinkInfo;
-    LinkInterface*      _primaryLink                = nullptr;
-    bool                _communicationLost          = false;
-    bool                _communicationLostEnabled   = true;
-    bool                _autoDisconnect             = false;    ///< true: Automatically disconnect vehicle when last connection goes away or lost heartbeat
+    Vehicle*                _vehicle                    = nullptr;
+    LinkManager*            _linkMgr                    = nullptr;
+    QTimer                  _commLostCheckTimer;
+    QList<LinkInfo_t>       _rgLinkInfo;
+    WeakLinkInterfacePtr    _primaryLink;
+    bool                    _communicationLost          = false;
+    bool                    _communicationLostEnabled   = true;
+    bool                    _autoDisconnect             = false;    ///< true: Automatically disconnect vehicle when last connection goes away or lost heartbeat
 
     static const int _commLostCheckTimeoutMSecs     = 1000;  // Check for comm lost once a second
     static const int _heartbeatMaxElpasedMSecs      = 3500;  // No heartbeat for longer than this indicates comm loss

--- a/src/Vehicle/VehicleLinkManagerTest.cc
+++ b/src/Vehicle/VehicleLinkManagerTest.cc
@@ -158,7 +158,7 @@ void VehicleLinkManagerTest::_multiLinkSingleVehicleTest(void)
     QVERIFY(vehicle);
     QVERIFY(vehicleLinkManager);
 
-    QCOMPARE(mockLink1.get(), vehicleLinkManager->primaryLink());
+    QCOMPARE(mockLink1.get(), vehicleLinkManager->primaryLink().lock().get());
 
     QStringList rgNames = vehicleLinkManager->linkNames();
     QStringList rgStatus = vehicleLinkManager->linkStatuses();
@@ -202,7 +202,7 @@ void VehicleLinkManagerTest::_multiLinkSingleVehicleTest(void)
     QCOMPARE(multiSpy.waitForSignal (_primaryLinkChangedSignalName, VehicleLinkManager::_heartbeatMaxElpasedMSecs * 2), true);
     quint32 signalMask = multiSpy.signalNameToMask(_primaryLinkChangedSignalName) | multiSpy.signalNameToMask(_linkStatusesChangedSignalName);
     QVERIFY(multiSpy.checkOnlySignalByMask(signalMask));
-    QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink());
+    QCOMPARE(pMockLink2,vehicleLinkManager->primaryLink().lock().get());
 
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
@@ -216,7 +216,7 @@ void VehicleLinkManagerTest::_multiLinkSingleVehicleTest(void)
     pMockLink1->setCommLost(false);
     QCOMPARE(multiSpy.waitForSignal (_linkStatusesChangedSignalName, VehicleLinkManager::_heartbeatMaxElpasedMSecs * 2),    true);
     QVERIFY(multiSpy.checkOnlySignalByMask(multiSpy.signalNameToMask(_linkStatusesChangedSignalName)));
-    QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink());
+    QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink().lock().get());
 
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
@@ -282,7 +282,7 @@ void VehicleLinkManagerTest::_highLatencyLinkTest(void)
     MockLink* pMockLink2 = qobject_cast<MockLink*>(mockLink2.get());
 
     QCOMPARE(multiSpyVLM.waitForSignal(_primaryLinkChangedSignalName, 100), true);
-    QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink());
+    QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink().lock().get());
     QCOMPARE(spyTransmissionEnabledChanged.count(), 1);
     QCOMPARE(spyTransmissionEnabledChanged.takeFirst()[0].toBool(), false);
     multiSpyVLM.clearAllSignals();
@@ -294,7 +294,7 @@ void VehicleLinkManagerTest::_highLatencyLinkTest(void)
 
     pMockLink2->setCommLost(true);
     QCOMPARE(multiSpyVLM.waitForSignal(_primaryLinkChangedSignalName, VehicleLinkManager::_heartbeatMaxElpasedMSecs * 2), true);
-    QCOMPARE(pMockLink1, vehicleLinkManager->primaryLink());
+    QCOMPARE(pMockLink1, vehicleLinkManager->primaryLink().lock().get());
     QCOMPARE(spyTransmissionEnabledChanged.count(), 1);
     QCOMPARE(spyTransmissionEnabledChanged.takeFirst()[0].toBool(), true);
     spyTransmissionEnabledChanged.clear();

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -249,7 +249,7 @@ Rectangle {
             SubMenuButton {
                 id:                 px4FlowButton
                 exclusiveGroup:     setupButtonGroup
-                visible:            QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle.vehicleLinkManager.primaryLink.isPX4Flow : false
+                visible:            QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle.vehicleLinkManager.primaryLinkIsPX4Flow : false
                 setupIndicator:     false
                 text:               qsTr("PX4Flow")
                 Layout.fillWidth:   true

--- a/src/uas/UAS.cc
+++ b/src/uas/UAS.cc
@@ -473,19 +473,22 @@ void UAS::requestImage()
         return;
     }
 
-   qDebug() << "trying to get an image from the uas...";
+    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
+
+    qDebug() << "trying to get an image from the uas...";
 
     // check if there is already an image transmission going on
-    if (imagePacketsArrived == 0)
-    {
-        mavlink_message_t msg;
+    if (!weakLink.expired() && imagePacketsArrived == 0) {
+        mavlink_message_t       msg;
+        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+
         mavlink_msg_data_transmission_handshake_pack_chan(mavlink->getSystemId(),
                                                           mavlink->getComponentId(),
-                                                          _vehicle->vehicleLinkManager()->primaryLink()->mavlinkChannel(),
+                                                          sharedLink->mavlinkChannel(),
                                                           &msg,
                                                           MAVLINK_DATA_STREAM_IMG_JPEG,
                                                           0, 0, 0, 0, 0, 50);
-        _vehicle->sendMessageOnLinkThreadSafe(_vehicle->vehicleLinkManager()->primaryLink(), msg);
+        _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
 }
 


### PR DESCRIPTION
* There are race conditions with respect to a primary link going away before the Vehicle itself is fully destroyed. During this time primaryLink can be null.
* Change the method signature of VehicleLinkManager::primaryLink to return a weak reference. This makes it clearer that it is possible for this value to be null.
* Change all usage of VehicleLinkManager::primaryLink to correctly do null checks