### PR TITLE
Linux: Move to Qt 5.15.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -221,6 +221,7 @@ script:
     	mkdir -p ~/.config/QtProject/ &&
         cp ${TRAVIS_BUILD_DIR}/test/qtlogging.ini ~/.config/QtProject/ &&
         export QT_FATAL_WARNINGS=1 &&
+        export QT_DEBUG_PLUGINS=1 &&
         ./staging/qgroundcontrol-start.sh --unittest;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -225,7 +225,8 @@ script:
 
   # unit tests linux
   - if [[ "${SPEC}" = "linux-g++-64" && "${CONFIG}" = "debug" ]]; then
-    	mkdir -p ~/.config/QtProject/ &&
+        sudo apt-get install -qq libegl1-mesa &&
+    	  mkdir -p ~/.config/QtProject/ &&
         cp ${TRAVIS_BUILD_DIR}/test/qtlogging.ini ~/.config/QtProject/ &&
         export QT_FATAL_WARNINGS=1 &&
         cd ${SHADOW_BUILD_DIR}/package &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ addons:
     - libgstreamer1.0-0:amd64
     - libgstreamer1.0-dev
     - libudev-dev
-    - libxcb-xinerama0
     - wget
 
 before_install:
@@ -217,13 +216,20 @@ script:
     fi
   #- ccache -s
 
+  # create debug linux appimage for unit testing
+  - cd ${TRAVIS_BUILD_DIR}
+  - if [[ "${SPEC}" = "linux-g++-64" && "${CONFIG}" = "debug" ]]; then
+        ./deploy/create_linux_appimage.sh ${TRAVIS_BUILD_DIR} ${SHADOW_BUILD_DIR}/staging ${SHADOW_BUILD_DIR}/package;
+    fi
+
   # unit tests linux
   - if [[ "${SPEC}" = "linux-g++-64" && "${CONFIG}" = "debug" ]]; then
     	mkdir -p ~/.config/QtProject/ &&
         cp ${TRAVIS_BUILD_DIR}/test/qtlogging.ini ~/.config/QtProject/ &&
         export QT_FATAL_WARNINGS=1 &&
-        ldd ./staging/Qt/plugins/platforms/libqxcb.so &&
-        ./staging/qgroundcontrol-start.sh --unittest;
+        cd ${SHADOW_BUILD_DIR}/package &&
+        chmod +x QGroundControl.AppImage
+        ./QGroundControl.AppImage --unittest;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ jobs:
           sudo: required
         - stage: "Build"
           name: "Android 32 bit"
-          dist: bionic
+          dist: xenial
           language: android
           env: SPEC=android-clang CONFIG=installer BITNESS=32 GSTREAMER_NAME=armv7
           sudo: false
         - stage: "Build"
           name: "Android 64 bit"
-          dist: bionic
+          dist: xenial
           language: android
           env: SPEC=android-clang CONFIG=installer BITNESS=64 GSTREAMER_NAME=arm64
           sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,6 +219,7 @@ script:
   # create debug linux appimage for unit testing
   - cd ${TRAVIS_BUILD_DIR}
   - if [[ "${SPEC}" = "linux-g++-64" && "${CONFIG}" = "debug" ]]; then
+        mkdir ${SHADOW_BUILD_DIR}/package
         ./deploy/create_linux_appimage.sh ${TRAVIS_BUILD_DIR} ${SHADOW_BUILD_DIR}/staging ${SHADOW_BUILD_DIR}/package;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ jobs:
           sudo: required
         - stage: "Build"
           name: "Android 32 bit"
-          dist: xenial
+          dist: bionic
           language: android
           env: SPEC=android-clang CONFIG=installer BITNESS=32 GSTREAMER_NAME=armv7
           sudo: false
         - stage: "Build"
           name: "Android 64 bit"
-          dist: xenial
+          dist: bionic
           language: android
           env: SPEC=android-clang CONFIG=installer BITNESS=64 GSTREAMER_NAME=arm64
           sudo: false
@@ -45,7 +45,7 @@ jobs:
           sudo: required
         - stage: "Google Play Upload"
           name: "Google Play Upload"
-          dist: trusty
+          dist: bionic
           language: android
           env: SPEC=google-play-upload
           sudo: false
@@ -104,9 +104,9 @@ before_install:
 install:
   # linux dependencies: qt
   - if [ "${SPEC}" = "linux-g++-64" ]; then
-        wget --quiet https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.12.6-gcc_64-min.tar.bz2 &&
-        tar jxf Qt5.12.6-gcc_64-min.tar.bz2 -C /tmp &&
-        export PATH=/tmp/Qt5.12-gcc_64/5.12.6/gcc_64/bin:$PATH
+        wget --quiet https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/Qt5.15.1-gcc_64-min.tar.bz2 &&
+        tar jxf Qt5.15.1-gcc_64-min.tar.bz2 -C /tmp &&
+        export PATH=/tmp/Qt5.15-gcc_64/5.15.1/gcc_64/bin:$PATH
         ;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -221,7 +221,7 @@ script:
     	mkdir -p ~/.config/QtProject/ &&
         cp ${TRAVIS_BUILD_DIR}/test/qtlogging.ini ~/.config/QtProject/ &&
         export QT_FATAL_WARNINGS=1 &&
-        export QT_DEBUG_PLUGINS=1 &&
+        ldd ./staging/Qt/plugins/platforms/libqxcb.so &&
         ./staging/qgroundcontrol-start.sh --unittest;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ addons:
     - libgstreamer1.0-0:amd64
     - libgstreamer1.0-dev
     - libudev-dev
+    - libxcb-xinerama0
     - wget
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,7 +219,7 @@ script:
   # create debug linux appimage for unit testing
   - cd ${TRAVIS_BUILD_DIR}
   - if [[ "${SPEC}" = "linux-g++-64" && "${CONFIG}" = "debug" ]]; then
-        mkdir ${SHADOW_BUILD_DIR}/package
+        mkdir ${SHADOW_BUILD_DIR}/package &&
         ./deploy/create_linux_appimage.sh ${TRAVIS_BUILD_DIR} ${SHADOW_BUILD_DIR}/staging ${SHADOW_BUILD_DIR}/package;
     fi
 
@@ -229,7 +229,7 @@ script:
         cp ${TRAVIS_BUILD_DIR}/test/qtlogging.ini ~/.config/QtProject/ &&
         export QT_FATAL_WARNINGS=1 &&
         cd ${SHADOW_BUILD_DIR}/package &&
-        chmod +x QGroundControl.AppImage
+        chmod +x QGroundControl.AppImage &&
         ./QGroundControl.AppImage --unittest;
     fi
 

--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -89,6 +89,7 @@ LinuxBuild {
         libQt5PositioningQuick.so.5 \
         libQt5PrintSupport.so.5 \
         libQt5Qml.so.5 \
+        libQt5QmlModels.so.5 \
         libQt5Quick.so.5 \
         libQt5QuickControls2.so.5 \
         libQt5QuickTemplates2.so.5 \

--- a/src/QGCLoggingCategory.cc
+++ b/src/QGCLoggingCategory.cc
@@ -69,6 +69,9 @@ void QGCLoggingCategoryRegister::setFilterRulesFromSettings(const QString& comma
     }
     QString filterRules;
 
+    // Disable the ridiculous "QML Connections: Implicitly defined onFoo properties in Connections are deprecated..." spew
+    filterRules += "qt.qml.connections=false\n";
+
     filterRules += "*Log.debug=false\n";
 
     // Set up filters defined in settings


### PR DESCRIPTION
* First step of moving all OS to Qt 5.15.1 which will be the supported Qt for upcoming Stable 4.1
* Getting it in early enough to get some bake time on it while working towards Stable