### PR TITLE
QGCMAVLink: add missing class for Sub

### DIFF
--- a/src/comm/QGCMAVLink.cc
+++ b/src/comm/QGCMAVLink.cc
@@ -110,6 +110,8 @@ QGCMAVLink::VehicleClass_t QGCMAVLink::vehicleClass(MAV_TYPE mavType)
     case MAV_TYPE_GROUND_ROVER:
     case MAV_TYPE_SURFACE_BOAT:
         return VehicleClassRoverBoat;
+    case MAV_TYPE_SUBMARINE:
+        return VehicleClassSub;
     case MAV_TYPE_QUADROTOR:
     case MAV_TYPE_COAXIAL:
     case MAV_TYPE_HELICOPTER:


### PR DESCRIPTION
This fixes features that check for a sub not working, such as the "lights" and "frame" tabs in vehicle setup