### PR TITLE
Fix plan load fallback for unknown file type

### DIFF
--- a/src/AnalyzeView/GeoTagPage.qml
+++ b/src/AnalyzeView/GeoTagPage.qml
@@ -75,7 +75,7 @@ AnalyzePage {
                     id:             openLogFile
                     title:          qsTr("Select log file")
                     folder:         shortcuts.home
-                    nameFilters:    [qsTr("ULog file (*.ulg)"), qsTr("PX4 log file (*.px4log)"), qsTr("All Files (*.*)")]
+                    nameFilters:    [qsTr("ULog file (*.ulg)"), qsTr("PX4 log file (*.px4log)"), qsTr("All Files (*)")]
                     defaultSuffix:  "ulg"
                     selectExisting: true
                     onAccepted: {

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -370,7 +370,19 @@ void PlanMasterController::loadFromFile(const QString& filename)
     }
 
     bool success = false;
-    if(fileInfo.suffix() == AppSettings::planFileExtension) {
+    if (fileInfo.suffix() == AppSettings::missionFileExtension) {
+        if (!_missionController.loadJsonFile(file, errorString)) {
+            qgcApp()->showAppMessage(errorMessage.arg(errorString));
+        } else {
+            success = true;
+        }
+    } else if (fileInfo.suffix() == AppSettings::waypointsFileExtension || fileInfo.suffix() == QStringLiteral("txt")) {
+        if (!_missionController.loadTextFile(file, errorString)) {
+            qgcApp()->showAppMessage(errorMessage.arg(errorString));
+        } else {
+            success = true;
+        }
+    } else {
         QJsonDocument   jsonDoc;
         QByteArray      bytes = file.readAll();
 
@@ -408,20 +420,6 @@ void PlanMasterController::loadFromFile(const QString& filename)
             qgcApp()->toolbox()->corePlugin()->postLoadFromJson(this, json);
             success = true;
         }
-    } else if (fileInfo.suffix() == AppSettings::missionFileExtension) {
-        if (!_missionController.loadJsonFile(file, errorString)) {
-            qgcApp()->showAppMessage(errorMessage.arg(errorString));
-        } else {
-            success = true;
-        }
-    } else if (fileInfo.suffix() == AppSettings::waypointsFileExtension || fileInfo.suffix() == QStringLiteral("txt")) {
-        if (!_missionController.loadTextFile(file, errorString)) {
-            qgcApp()->showAppMessage(errorMessage.arg(errorString));
-        } else {
-            success = true;
-        }
-    } else {
-        //-- TODO: What then?
     }
 
     if(success){
@@ -584,7 +582,7 @@ QStringList PlanMasterController::loadNameFilters(void) const
     QStringList filters;
 
     filters << tr("Supported types (*.%1 *.%2 *.%3 *.%4)").arg(AppSettings::planFileExtension).arg(AppSettings::missionFileExtension).arg(AppSettings::waypointsFileExtension).arg("txt") <<
-               tr("All Files (*.*)");
+               tr("All Files (*)");
     return filters;
 }
 
@@ -593,7 +591,7 @@ QStringList PlanMasterController::saveNameFilters(void) const
 {
     QStringList filters;
 
-    filters << tr("Plan Files (*.%1)").arg(fileExtension()) << tr("All Files (*.*)");
+    filters << tr("Plan Files (*.%1)").arg(fileExtension()) << tr("All Files (*)");
     return filters;
 }
 

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -281,7 +281,7 @@ Item {
     QGCFileDialog {
         id:             fileDialog
         folder:         _appSettings.parameterSavePath
-        nameFilters:    [ qsTr("Parameter Files (*.%1)").arg(_appSettings.parameterFileExtension) , qsTr("All Files (*.*)") ]
+        nameFilters:    [ qsTr("Parameter Files (*.%1)").arg(_appSettings.parameterFileExtension) , qsTr("All Files (*)") ]
 
         onAcceptedForSave: {
             controller.saveToFile(file)


### PR DESCRIPTION
* If we don't know the file type by extension we attempt a json load. Fix for #9164
* Fixed "All Files" wildcard specification in file pickers from `*.*` to * which actually catches "all" files!