### PR TITLE
Update PlanToolBarIndicators.qml

### DIFF
--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -69,7 +69,7 @@ Item {
     readonly property real _margins: ScreenTools.defaultFontPixelWidth
 
     function getMissionTime() {
-        if(isNaN(_missionTime)) {
+        if(isNaN(_missionTime || _missionTime == 0)) {
             return "00:00:00"
         }
         var t = new Date(0, 0, 0, 0, 0, Number(_missionTime))


### PR DESCRIPTION
For android devices, in Flight Plan tab, initial time value is 01:00:00. However in other devices no problem. In debug mode, i saw that _missionTime's value is NaN, but after click Flight Plan tab the _missionTime's value is 0.

I reported this as an issue before. https://github.com/mavlink/qgroundcontrol/issues/7416#issue-440324533


