### PR TITLE
ParameterEditor: mention that it resets sensors calibration and frame setup

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -315,7 +315,7 @@ Item {
             QGCLabel {
                 width:              parent.width
                 wrapMode:           Text.WordWrap
-                text:               qsTr("Select Reset to reset all parameters to their defaults.\n\nNote that this will also completely reset everything, including UAVCAN nodes.")
+                text:               qsTr("Select Reset to reset all parameters to their defaults.\n\nNote that this will also completely reset everything, including UAVCAN nodes, all vehicle settings, setup and calibrations.")
             }
         }
     }


### PR DESCRIPTION
We had users pressing that and hoping the vehicle would still be operational. This makes it a little clearer that it won't.

