### PR TITLE
Fix map scale behaviour

### DIFF
--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -49,6 +49,7 @@ FlightMap {
     property var    _rallyPointController:      planMasterController.rallyPointController
     property var    _activeVehicleCoordinate:   _activeVehicle ? _activeVehicle.coordinate : QtPositioning.coordinate()
     property real   _toolButtonTopMargin:       parent.height - mainWindow.height + (ScreenTools.defaultFontPixelHeight / 2)
+    property real   _toolsMargin:               ScreenTools.defaultFontPixelWidth * 0.75
     property bool   _airspaceEnabled:           QGroundControl.airmapSupported ? (QGroundControl.settingsManager.airMapSettings.enableAirMap.rawValue && QGroundControl.airspaceManager.connected): false
     property var    _flyViewSettings:           QGroundControl.settingsManager.flyViewSettings
     property bool   _keepMapCenteredOnVehicle:  _flyViewSettings.keepMapCenteredOnVehicle.rawValue
@@ -570,6 +571,18 @@ FlightMap {
             border.color:   object.lineColor
             border.width:   object.lineWidth
         }
+    }
+
+    MapScale {
+        id:                 mapScale
+        anchors.margins:    _toolsMargin
+        anchors.left:       parent.left
+        anchors.top:        parent.top
+        mapControl:         _root
+        buttonsOnLeft:      false
+        visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && mapControl.pipState.state === mapControl.pipState.windowState
+
+        property real centerInset: visible ? parent.height - y : 0
     }
 
 }

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -203,7 +203,7 @@ Item {
         anchors.top:        parent.top
         mapControl:         _mapControl
         buttonsOnLeft:      false
-        visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && mapControl.pipState.state !== mapControl.pipState.pipState
+        visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && mapControl.pipState.state === mapControl.pipState.fullState
 
         property real centerInset: visible ? parent.height - y : 0
     }


### PR DESCRIPTION
- Fix scale showing in video when map is in windowState
- Show scale when map is in windowState

old version:
![Screen Capture_QGroundControl_20201118152907](https://user-images.githubusercontent.com/1215497/99572060-e2beba80-29b2-11eb-8a93-27a84a4e957d.gif)


new version:
![Screen Capture_QGroundControl_20201118152721](https://user-images.githubusercontent.com/1215497/99571877-a55a2d00-29b2-11eb-81f4-f64f549406f9.gif)
