### PR TITLE
Virtual joystick defaults to auto-center

### DIFF
--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -20,6 +20,9 @@ Item {
     property bool   _processTouchPoints:    false
     property color  _fgColor:               QGroundControl.globalPalette.text
     property color  _bgColor:               QGroundControl.globalPalette.window
+    property real   _hatWidth:              ScreenTools.defaultFontPixelHeight
+    property real   _hatWidthHalf:          _hatWidth / 2
+
     property real   stickPositionX:         _centerXY
     property real   stickPositionY:         yAxisReCenter ? _centerXY : height
 
@@ -176,17 +179,14 @@ Item {
     }
 
     Rectangle {
-        width:          hatWidth
-        height:         hatWidth
-        radius:         hatWidthHalf
+        width:          _hatWidth
+        height:         _hatWidth
+        radius:         _hatWidthHalf
         border.color:   _fgColor
         border.width:   1
         color:          Qt.rgba(_fgColor.r, _fgColor.g, _fgColor.b, 0.5)
-        x:              stickPositionX - hatWidthHalf
-        y:              stickPositionY - hatWidthHalf
-
-        readonly property real hatWidth:        ScreenTools.defaultFontPixelHeight
-        readonly property real hatWidthHalf:    ScreenTools.defaultFontPixelHeight / 2
+        x:              stickPositionX - _hatWidthHalf
+        y:              stickPositionY - _hatWidthHalf
     }
 
     Connections {
@@ -205,11 +205,18 @@ Item {
     }
 
     MultiPointTouchArea {
-        anchors.fill:       parent
-        minimumTouchPoints: 1
-        maximumTouchPoints: 1
-        touchPoints:        [ TouchPoint { id: touchPoint } ]
-        onPressed:          _joyRoot.thumbDown(touchPoints)
-        onReleased:         _joyRoot.reCenter()
+        anchors.fill:           parent
+        anchors.bottomMargin:   yAxisReCenter ? 0 : -_hatWidthHalf
+        minimumTouchPoints:     1
+        maximumTouchPoints:     1
+        touchPoints:            [ TouchPoint { id: touchPoint } ]
+        onPressed:              _joyRoot.thumbDown(touchPoints)
+        onReleased:             _joyRoot.reCenter()
+
+        Rectangle {
+            border.color: "red"
+            color: "transparent"
+            anchors.fill: parent
+        }
     }
 }

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -119,7 +119,7 @@
     "shortDesc": "Auto-Center Throttle",
     "longDesc":  "If enabled the throttle stick will snap back to center when released.",
     "type":             "bool",
-    "default":     false
+    "default":     true
 },
 {
     "name":             "gstDebugLevel",


### PR DESCRIPTION
* This is a safer option for multi-rotor/rover/sub. It's isn't necessarily the best option for fixed wing, but I'd question the sanity of someone flying a fixed wing with their thumbs anyway. They can always turn it off.
* There is a problem with respect to arming the vehicle with auto-center which are firmware specific:
  * PX4: Allows you arm with the throttle centered in modes like Position. It does not allow it in Stabilize. To me this makes a lot of sense since most joysticks virtual or not auto-center both axes.
  * ArduPilot: Require throttle to be low no matter what if you try to arm. So for vehicles which don't support reverse throttle auto-center doesn't really work. The reason being you can't hold the virtual joystick throttle down and click in the toolbar to arm. I'm going to post an issue against ArduPilot asking for ability to arm in modes where a center throttle is a perfectly valid state to fly and start a takeoff with.
* Related to #5897