### PR TITLE
#9202 Bugfix : Only restoring saved window state if parameters make sense on current screen configuration

### DIFF
--- a/src/QmlControls/MainWindowSavedState.qml
+++ b/src/QmlControls/MainWindowSavedState.qml
@@ -32,12 +32,24 @@ Item {
     }
 
     Component.onCompleted: {
-        if (_enabled && s.width && s.height) {
-            window.x = s.x;
-            window.y = s.y;
-            window.width = s.width;
-            window.height = s.height;
-            window.visibility = s.visibility;
+        var isValidScreenGeometry =
+                (
+                    (s.x      >= 0                                         ) &&
+                    (s.y      >= 0                                         ) &&
+                    (s.width  >  0                                         ) &&
+                    (s.height >  0                                         ) &&
+                    (s.x      <=  Screen.desktopAvailableWidth  - s.width  ) &&
+                    (s.y      <=  Screen.desktopAvailableHeight - s.height ) &&
+                    (s.width  <=  Screen.desktopAvailableWidth             ) &&
+                    (s.height <=  Screen.desktopAvailableHeight            )
+                )
+
+        if (_enabled && isValidScreenGeometry) {
+            window.x            = s.x
+            window.y            = s.y
+            window.width        = s.width
+            window.height       = s.height
+            window.visibility   = s.visibility
         }
     }
 


### PR DESCRIPTION
`src/QmlControls/MainWindowSavedState.qml` used to restore window state if it finds saved parameters in `%AppData%/QGroundControl.org/QGroundControl.ini`
This leads to bugs if, for example, the saved window position is on a screen which is no longer connected.

This PR adds a simple `if` clause which lets the main window open with Qt default geometry in case the saved geometry is found to be invalid.