### PR TITLE
Enable and configure hardware decode priority 

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -709,6 +709,18 @@ void FactMetaData::addEnumInfo(const QString& name, const QVariant& value)
     _enumValues << value;
 }
 
+void FactMetaData::removeEnumInfo(const QVariant& value)
+{
+    const int index = _enumValues.indexOf(value);
+    if (index < 0) {
+        qWarning() << "Value does not exist in fact:" << value;
+        return;
+    }
+
+    _enumValues.removeAt(index);
+    _enumStrings.removeAt(index);
+}
+
 void FactMetaData::setTranslators(Translator rawTranslator, Translator cookedTranslator)
 {
     _rawTranslator = rawTranslator;

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -148,6 +148,9 @@ public:
     /// Used to add new values to the enum lists after the meta data has been loaded
     void addEnumInfo(const QString& name, const QVariant& value);
 
+    /// Used to remove values from the enum lists after the meta data has been loaded
+    void removeEnumInfo(const QVariant& value);
+
     void setDecimalPlaces           (int decimalPlaces)                 { _decimalPlaces = decimalPlaces; }
     void setRawDefaultValue         (const QVariant& rawDefaultValue);
     void setBitmaskInfo             (const QStringList& strings, const QVariantList& values);

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -81,6 +81,7 @@ Item {
     property bool isWindows:                        ScreenToolsController.isWindows
     property bool isDebug:                          ScreenToolsController.isDebug
     property bool isMac:                            ScreenToolsController.isMacOS
+    property bool isLinux:                          ScreenToolsController.isLinux
     property bool isTinyScreen:                     (Screen.width / realPixelDensity) < 120 // 120mm
     property bool isShortScreen:                    ((Screen.height / realPixelDensity) < 120) || (ScreenToolsController.isMobile && ((Screen.height / Screen.width) < 0.6))
     property bool isHugeScreen:                     (Screen.width / realPixelDensity) >= (23.5 * 25.4) // 27" monitor

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -133,8 +133,10 @@
     "name":             "forceVideoDecoder",
     "shortDesc":        "Force specific category of video decode",
     "longDesc":         "Force the change of prioritization between video decode methods, allowing the user to force some video hardware decode plugins if necessary.",
-    "type":             "string",
-    "default":          "",
+    "type":             "uint32",
+    "enumStrings":      "Default,Force software decoder,Force NVIDIA decoder,Force VA-API decoder,Force DirectX3D 11 decoder",
+    "enumValues":       "0,1,2,3,4",
+    "default":           0,
     "qgcRebootRequired": true
 }
 ]

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -128,6 +128,14 @@
     "longDesc":  "If this option is enabled, the rtpjitterbuffer is removed and the video sink is set to assynchronous mode, reducing the latency by about 200 ms.",
     "type":             "bool",
     "default":     false
+},
+{
+    "name":             "forceVideoDecoder",
+    "shortDesc":        "Force specific category of video decode",
+    "longDesc":         "Force the change of prioritization between video decode methods, allowing the user to force some video hardware decode plugins if necessary.",
+    "type":             "string",
+    "default":          "",
+    "qgcRebootRequired": true
 }
 ]
 }

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -29,12 +29,6 @@ const char* VideoSettings::videoSourceMPEGTS            = "MPEG-TS (h.264) Video
 const char* VideoSettings::videoSource3DRSolo           = "3DR Solo (requires restart)";
 const char* VideoSettings::videoSourceParrotDiscovery   = "Parrot Discovery";
 
-const char* VideoSettings::forceVideoDecoderDefault = "Default";
-const char* VideoSettings::forceVideoDecoderSoftware = "Force software decoder";
-const char* VideoSettings::forceVideoDecoderNVIDIA = "Force NVIDIA decoder";
-const char* VideoSettings::forceVideoDecoderVAAPI = "Force VA-API decoder";
-const char* VideoSettings::forceVideoDecoderD3D11 = "Force DirectX3D 11 decoder";
-
 DECLARE_SETTINGGROUP(Video, "Video")
 {
     qmlRegisterUncreatableType<VideoSettings>("QGroundControl.SettingsManager", 1, 0, "VideoSettings", "Reference only");
@@ -70,22 +64,18 @@ DECLARE_SETTINGGROUP(Video, "Video")
     }
     _nameToMetaDataMap[videoSourceName]->setEnumInfo(videoSourceList, videoSourceVarList);
 
-    QStringList forceVideoDecoderList{
-        forceVideoDecoderDefault,
-        forceVideoDecoderSoftware,
-        forceVideoDecoderNVIDIA,
+    const QVariantList removeForceVideoDecodeList{
 #ifdef Q_OS_LINUX
-        forceVideoDecoderVAAPI,
+        VideoDecoderOptions::ForceVideoDecoderDirectX3D,
 #endif
 #ifdef Q_OS_WIN
-        forceVideoDecoderD3D11,
+        VideoDecoderOptions::ForceVideoDecoderVAAPI,
 #endif
     };
-    QVariantList forceVideoDecoderVarList;
-    for (const QString& forceVideoDecode: forceVideoDecoderList) {
-        forceVideoDecoderVarList.append(QVariant::fromValue(forceVideoDecode));
+
+    for(const auto& value : removeForceVideoDecodeList) {
+        _nameToMetaDataMap[forceVideoDecoderName]->removeEnumInfo(value);
     }
-    _nameToMetaDataMap[forceVideoDecoderName]->setEnumInfo(forceVideoDecoderList, forceVideoDecoderVarList);
 
     // Set default value for videoSource
     _setDefaults();
@@ -98,8 +88,6 @@ void VideoSettings::_setDefaults()
     } else {
         _nameToMetaDataMap[videoSourceName]->setRawDefaultValue(videoDisabled);
     }
-
-    _nameToMetaDataMap[forceVideoDecoderName]->setRawDefaultValue(forceVideoDecoderDefault);
 }
 
 DECLARE_SETTINGSFACT(VideoSettings, aspectRatio)

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -35,6 +35,7 @@ public:
     DEFINE_SETTINGFACT(streamEnabled)
     DEFINE_SETTINGFACT(disableWhenDisarmed)
     DEFINE_SETTINGFACT(lowLatencyMode)
+    DEFINE_SETTINGFACT(forceVideoDecoder)
 
     Q_PROPERTY(bool     streamConfigured        READ streamConfigured       NOTIFY streamConfiguredChanged)
     Q_PROPERTY(QString  rtspVideoSource         READ rtspVideoSource        CONSTANT)
@@ -44,6 +45,12 @@ public:
     Q_PROPERTY(QString  mpegtsVideoSource       READ mpegtsVideoSource      CONSTANT)
     Q_PROPERTY(QString  disabledVideoSource     READ disabledVideoSource    CONSTANT)
 
+    Q_PROPERTY(QString  defaultVideoDecoder     READ defaultVideoDecoder    CONSTANT)
+    Q_PROPERTY(QString  softwareVideoDecoder    READ softwareVideoDecoder   CONSTANT)
+    Q_PROPERTY(QString  nvidiaVideoDecoder      READ nvidiaVideoDecoder     CONSTANT)
+    Q_PROPERTY(QString  vaapiVideoDecoder       READ vaapiVideoDecoder      CONSTANT)
+    Q_PROPERTY(QString  d3d11VideoDecoder       READ d3d11VideoDecoder      CONSTANT)
+
     bool     streamConfigured       ();
     QString  rtspVideoSource        () { return videoSourceRTSP; }
     QString  udp264VideoSource      () { return videoSourceUDPH264; }
@@ -51,6 +58,12 @@ public:
     QString  tcpVideoSource         () { return videoSourceTCP; }
     QString  mpegtsVideoSource      () { return videoSourceMPEGTS; }
     QString  disabledVideoSource    () { return videoDisabled; }
+
+    QString defaultVideoDecoder     () { return forceVideoDecoderDefault; }
+    QString softwareVideoDecoder    () { return forceVideoDecoderSoftware; }
+    QString nvidiaVideoDecoder      () { return forceVideoDecoderNVIDIA; }
+    QString vaapiVideoDecoder       () { return forceVideoDecoderVAAPI; }
+    QString d3d11VideoDecoder       () { return forceVideoDecoderD3D11; }
 
     static const char* videoSourceNoVideo;
     static const char* videoDisabled;
@@ -61,6 +74,12 @@ public:
     static const char* videoSourceMPEGTS;
     static const char* videoSource3DRSolo;
     static const char* videoSourceParrotDiscovery;
+
+    static const char* forceVideoDecoderDefault;
+    static const char* forceVideoDecoderSoftware;
+    static const char* forceVideoDecoderNVIDIA;
+    static const char* forceVideoDecoderVAAPI;
+    static const char* forceVideoDecoderD3D11;
 
 signals:
     void streamConfiguredChanged    (bool configured);

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -37,6 +37,15 @@ public:
     DEFINE_SETTINGFACT(lowLatencyMode)
     DEFINE_SETTINGFACT(forceVideoDecoder)
 
+    enum VideoDecoderOptions {
+        ForceVideoDecoderDefault = 0,
+        ForceVideoDecoderSoftware,
+        ForceVideoDecoderNVIDIA,
+        ForceVideoDecoderVAAPI,
+        ForceVideoDecoderDirectX3D,
+    };
+    Q_ENUM(VideoDecoderOptions)
+
     Q_PROPERTY(bool     streamConfigured        READ streamConfigured       NOTIFY streamConfiguredChanged)
     Q_PROPERTY(QString  rtspVideoSource         READ rtspVideoSource        CONSTANT)
     Q_PROPERTY(QString  udp264VideoSource       READ udp264VideoSource      CONSTANT)
@@ -45,12 +54,6 @@ public:
     Q_PROPERTY(QString  mpegtsVideoSource       READ mpegtsVideoSource      CONSTANT)
     Q_PROPERTY(QString  disabledVideoSource     READ disabledVideoSource    CONSTANT)
 
-    Q_PROPERTY(QString  defaultVideoDecoder     READ defaultVideoDecoder    CONSTANT)
-    Q_PROPERTY(QString  softwareVideoDecoder    READ softwareVideoDecoder   CONSTANT)
-    Q_PROPERTY(QString  nvidiaVideoDecoder      READ nvidiaVideoDecoder     CONSTANT)
-    Q_PROPERTY(QString  vaapiVideoDecoder       READ vaapiVideoDecoder      CONSTANT)
-    Q_PROPERTY(QString  d3d11VideoDecoder       READ d3d11VideoDecoder      CONSTANT)
-
     bool     streamConfigured       ();
     QString  rtspVideoSource        () { return videoSourceRTSP; }
     QString  udp264VideoSource      () { return videoSourceUDPH264; }
@@ -58,12 +61,6 @@ public:
     QString  tcpVideoSource         () { return videoSourceTCP; }
     QString  mpegtsVideoSource      () { return videoSourceMPEGTS; }
     QString  disabledVideoSource    () { return videoDisabled; }
-
-    QString defaultVideoDecoder     () { return forceVideoDecoderDefault; }
-    QString softwareVideoDecoder    () { return forceVideoDecoderSoftware; }
-    QString nvidiaVideoDecoder      () { return forceVideoDecoderNVIDIA; }
-    QString vaapiVideoDecoder       () { return forceVideoDecoderVAAPI; }
-    QString d3d11VideoDecoder       () { return forceVideoDecoderD3D11; }
 
     static const char* videoSourceNoVideo;
     static const char* videoDisabled;
@@ -74,12 +71,6 @@ public:
     static const char* videoSourceMPEGTS;
     static const char* videoSource3DRSolo;
     static const char* videoSourceParrotDiscovery;
-
-    static const char* forceVideoDecoderDefault;
-    static const char* forceVideoDecoderSoftware;
-    static const char* forceVideoDecoderNVIDIA;
-    static const char* forceVideoDecoderVAAPI;
-    static const char* forceVideoDecoderD3D11;
 
 signals:
     void streamConfiguredChanged    (bool configured);

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -30,6 +30,7 @@
 
 #if defined(QGC_GST_STREAMING)
 #include "GStreamer.h"
+#include "VideoSettings.h"
 #else
 #include "GLVideoItemStub.h"
 #endif
@@ -104,6 +105,11 @@ VideoManager::setToolbox(QGCToolbox *toolbox)
    connect(pVehicleMgr, &MultiVehicleManager::activeVehicleChanged, this, &VideoManager::_setActiveVehicle);
 
 #if defined(QGC_GST_STREAMING)
+    bool forceSoftware = _videoSettings->forceVideoDecoder()->rawValue() == VideoSettings::VideoDecoderOptions::ForceVideoDecoderSoftware;
+    bool forceNVIDIA = _videoSettings->forceVideoDecoder()->rawValue() == VideoSettings::VideoDecoderOptions::ForceVideoDecoderNVIDIA;
+    bool forceVAAPI = _videoSettings->forceVideoDecoder()->rawValue() == VideoSettings::VideoDecoderOptions::ForceVideoDecoderVAAPI;
+    bool forceD3D11 = _videoSettings->forceVideoDecoder()->rawValue() == VideoSettings::VideoDecoderOptions::ForceVideoDecoderDirectX3D;
+    GStreamer::blacklist(forceSoftware, forceVAAPI, forceNVIDIA, forceD3D11);
 #ifndef QGC_DISABLE_UVC
    // If we are using a UVC camera setup the device name
    _updateUVC();

--- a/src/VideoReceiver/GStreamer.cc
+++ b/src/VideoReceiver/GStreamer.cc
@@ -108,17 +108,38 @@ static void qgcputenv(const QString& key, const QString& root, const QString& pa
 static void
 blacklist()
 {
-    GstRegistry* reg;
+    GstRegistry* registry = gst_registry_get();
 
-    if ((reg = gst_registry_get()) == nullptr) {
+    if (registry == nullptr) {
+        qCCritical(GStreamerLog) << "Failed to get gstreamer registry.";
         return;
     }
 
-    GstPluginFeature* plugin;
+    auto changeRank = [registry](const char* featureName, uint16_t rank) {
+        GstPluginFeature* feature = gst_registry_lookup_feature(registry, featureName);
+        if (feature == nullptr) {
+            qCDebug(GStreamerLog) << "Failed to change ranking of feature:" << featureName;
+            return;
+        }
 
-    if ((plugin = gst_registry_lookup_feature(reg, "bcmdec")) != nullptr) {
-        qCCritical(GStreamerLog) << "Disable bcmdec";
-        gst_plugin_feature_set_rank(plugin, GST_RANK_NONE);
+        qCInfo(GStreamerLog) << "Changing feature (" << featureName << ") to use rank:" << rank;
+        gst_plugin_feature_set_rank(feature, rank);
+        gst_registry_add_feature(registry, feature);
+        gst_object_unref(feature);
+    };
+
+    // Set rank for specific features
+    changeRank("bcmdec", GST_RANK_NONE);
+    changeRank("avdec_h264", GST_RANK_MARGINAL + 1);
+
+    // Enable VAAPI drivers
+    for(auto name : {"vaapimpeg2dec", "vaapimpeg4dec", "vaapih263dec", "vaapih264dec", "vaapivc1dec", "vaapidecodebin"}) {
+        changeRank(name, GST_RANK_PRIMARY);
+    }
+
+    // Enable NVIDIA's proprietary APIs for hardware video acceleration
+    for(auto name : {"nvh265dec", "nvh265sldec", "nvh264dec", "nvh264sldec"}) {
+        changeRank(name, GST_RANK_PRIMARY);
     }
 }
 

--- a/src/VideoReceiver/GStreamer.h
+++ b/src/VideoReceiver/GStreamer.h
@@ -7,6 +7,7 @@
 
 class GStreamer {
 public:
+    static void blacklist(bool forceSoftware = false, bool forceVAAPI = false, bool forceNVIDIA = false, bool forceD3D11 = false);
     static void initialize(int argc, char* argv[], int debuglevel);
     static void* createVideoSink(QObject* parent, QQuickItem* widget);
     static void releaseVideoSink(void* sink);

--- a/src/VideoReceiver/GstVideoReceiver.h
+++ b/src/VideoReceiver/GstVideoReceiver.h
@@ -103,7 +103,7 @@ protected slots:
 
 protected:
     virtual GstElement* _makeSource(const QString& uri);
-    virtual GstElement* _makeDecoder(GstCaps* caps, GstElement* videoSink);
+    virtual GstElement* _makeDecoder(GstCaps* caps = nullptr, GstElement* videoSink = nullptr);
     virtual GstElement* _makeFileSink(const QString& videoFile, FILE_FORMAT format);
 
     virtual void _onNewSourcePad(GstPad* pad);
@@ -125,10 +125,6 @@ protected:
     static void _wrapWithGhostPad(GstElement* element, GstPad* pad, gpointer data);
     static void _linkPad(GstElement* element, GstPad* pad, gpointer data);
     static gboolean _padProbe(GstElement* element, GstPad* pad, gpointer user_data);
-    static gboolean _filterParserCaps(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data);
-    static gboolean _autoplugQueryCaps(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data);
-    static gboolean _autoplugQueryContext(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data);
-    static gboolean _autoplugQuery(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data);
     static GstPadProbeReturn _teeProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     static GstPadProbeReturn _videoSinkProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     static GstPadProbeReturn _eosProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -313,6 +313,19 @@ Rectangle {
                                     visible:                _showSaveVideoSettings && _videoSettings.enableStorageLimit.value && maxSavedVideoStorageLabel.visible
                                 }
 
+                                QGCLabel {
+                                    id:         videoDecodeLabel
+                                    text:       qsTr("Video decode priority")
+                                    visible:    forceVideoDecoderComboBox.visible
+                                }
+                                FactComboBox {
+                                    id:                     forceVideoDecoderComboBox
+                                    Layout.preferredWidth:  _comboFieldWidth
+                                    fact:                   _videoSettings.forceVideoDecoder
+                                    visible:                fact.visible
+                                    indexModel:             false
+                                }
+
                                 Item { width: 1; height: 1}
                                 FactCheckBox {
                                     text:       qsTr("Disable When Disarmed")


### PR DESCRIPTION
- nvidia's hardwre code - tested by me
- vaapi hardware decode AMD - tested by @Williangalvani 

The older video implementation was using a specific pipeline, with the new video backend, now QGC is hostage of `decodebin` to take the decisions about the pipeline construction. 
Moving to `decodebin3` and enabling the hardware decode creates a much better scenario with a modern `decodebin` alternative that can handle a better construction and decision about the pipeline and elements that is used.  

Fix #8631
Needs #9099 to work under windows