### PR TITLE
qgroundcontrol: Remove print support

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -263,7 +263,6 @@ AndroidBuild || iOSBuild {
     # Android and iOS don't unclude these
 } else {
     QT += \
-        printsupport \
         serialport \
 }
 


### PR DESCRIPTION
Project is not using QPrint* classes or QPageSetupDialog and QAbstractPrintDialog

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


