### PR TITLE
COMPONENT_INFORMATION change ftp spec

### DIFF
--- a/src/Vehicle/ComponentInformationManager.h
+++ b/src/Vehicle/ComponentInformationManager.h
@@ -49,7 +49,7 @@ private:
     static void _stateRequestMetaDataJson       (StateMachine* stateMachine);
     static void _stateRequestTranslationJson    (StateMachine* stateMachine);
     static void _stateRequestComplete           (StateMachine* stateMachine);
-    static bool _uriIsFTP                       (const QString& uri);
+    static bool _uriIsMAVLinkFTP                (const QString& uri);
 
 
     ComponentInformationManager*    _compMgr                    = nullptr;

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -32,11 +32,14 @@ public:
     FTPManager(Vehicle* vehicle);
 
 	/// Downloads the specified file.
-    ///     @param from     File to download from vehicle, fully qualified path. May be in the format mavlinkftp://...
+    ///     @param fromURI  File to download from vehicle, fully qualified path. May be in the format "mftp://[;comp=<id>]..." where the component id is specified.
+    ///                     If component id is not specified MAV_COMP_ID_AUTOPILOT1 is used.
     ///     @param toDir    Local directory to download file to
     /// @return true: download has started, false: error, no download
     /// Signals downloadComplete, commandError, commandProgress
-    bool download(const QString& from, const QString& toDir);
+    bool download(const QString& fromURI, const QString& toDir);
+
+    static const char* mavlinkFTPScheme;
 
 signals:
     void downloadComplete(const QString& file, const QString& errorMsg);
@@ -120,8 +123,10 @@ private:
     void    _fillRequestDataWithString(MavlinkFTP::Request* request, const QString& str);
     void    _fillMissingBlocksWorker    (bool firstRequest);
     void    _burstReadFileWorker        (bool firstRequest);
+    bool    _parseURI                   (const QString& uri, QString& parsedURI, uint8_t& compId);
 
     Vehicle*                _vehicle;
+    uint8_t                 _ftpCompId;
     QList<StateFunctions_t> _rgStateMachine;
     DownloadState_t         _downloadState;
     QTimer                  _ackOrNakTimeoutTimer;

--- a/src/Vehicle/VehicleLinkManagerTest.cc
+++ b/src/Vehicle/VehicleLinkManagerTest.cc
@@ -47,7 +47,7 @@ void VehicleLinkManagerTest::cleanup(void)
         QCOMPARE(_linkManager->links().count(),         0);
     }
 
-    _multiVehicleMgr    = nullptr;
+    _multiVehicleMgr = nullptr;
 
     UnitTest::cleanup();
 }
@@ -73,12 +73,14 @@ void VehicleLinkManagerTest::_simpleLinkTest(void)
     Vehicle* vehicle = _multiVehicleMgr->activeVehicle();
     QVERIFY(vehicle);
     QSignalSpy spyVehicleDelete(vehicle, &QObject::destroyed);
+    QSignalSpy spyVehicleInitialConnectComplete(vehicle, &Vehicle::initialConnectComplete);
 
     QCOMPARE(mockConfig.use_count(),    2); // Refs: This method, MockLink
     QCOMPARE(mockLink.use_count(),      3); // Refs: This method, LinkManager, Vehicle
 
-    // We explicitly don't wait for the Vehicle to finish it's startup sequence before we disconnect.
-    // This helps to wring out possible crashing when the link goes down before the startup sequence is complete.
+    // We wait for the full initial connect sequence to complete to catch anby ComponentInformationManager bugs
+    QCOMPARE(spyVehicleInitialConnectComplete.wait(3000), true);
+
     mockLink->disconnect();
 
     // Vehicle should go away due to disconnect
@@ -113,6 +115,8 @@ void VehicleLinkManagerTest::_simpleCommLossTest(void)
     QCOMPARE(_multiVehicleMgr->vehicles()->count(), 1);
     Vehicle* vehicle = _multiVehicleMgr->activeVehicle();
     QVERIFY(vehicle);
+    QSignalSpy spyVehicleInitialConnectComplete(vehicle, &Vehicle::initialConnectComplete);
+    QCOMPARE(spyVehicleInitialConnectComplete.wait(3000), true);
 
     QSignalSpy spyCommLostChanged(vehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged);
     pMockLink->setCommLost(true);
@@ -157,6 +161,8 @@ void VehicleLinkManagerTest::_multiLinkSingleVehicleTest(void)
     VehicleLinkManager* vehicleLinkManager = vehicle->vehicleLinkManager();
     QVERIFY(vehicle);
     QVERIFY(vehicleLinkManager);
+    QSignalSpy spyVehicleInitialConnectComplete(vehicle, &Vehicle::initialConnectComplete);
+    QCOMPARE(spyVehicleInitialConnectComplete.wait(3000), true);
 
     QCOMPARE(mockLink1.get(), vehicleLinkManager->primaryLink().lock().get());
 
@@ -239,6 +245,8 @@ void VehicleLinkManagerTest::_connectionRemovedTest(void)
     QCOMPARE(spyVehicleCreate.wait(1000), true);
     Vehicle* vehicle = _multiVehicleMgr->activeVehicle();
     QVERIFY(vehicle);
+    QSignalSpy spyVehicleInitialConnectComplete(vehicle, &Vehicle::initialConnectComplete);
+    QCOMPARE(spyVehicleInitialConnectComplete.wait(3000), true);
 
     QSignalSpy spyCommLostChanged(vehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged);
 

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -1619,7 +1619,7 @@ void MockLink::_sendVersionMetaData(void)
 {
     mavlink_message_t   responseMsg;
 #if 1
-    char                metaDataURI[MAVLINK_MSG_COMPONENT_INFORMATION_FIELD_METADATA_URI_LEN]       = "mavlinkftp://version.json.gz";
+    char                metaDataURI[MAVLINK_MSG_COMPONENT_INFORMATION_FIELD_METADATA_URI_LEN]       = "mftp://[;comp=1]version.json.gz";
 #else
     char                metaDataURI[MAVLINK_MSG_COMPONENT_INFORMATION_FIELD_METADATA_URI_LEN]       = "https://bit.ly/31nm0fs";
 #endif
@@ -1642,7 +1642,7 @@ void MockLink::_sendParameterMetaData(void)
 {
     mavlink_message_t   responseMsg;
 #if 1
-    char                metaDataURI[MAVLINK_MSG_COMPONENT_INFORMATION_FIELD_METADATA_URI_LEN]       = "mavlinkftp://parameter.json";
+    char                metaDataURI[MAVLINK_MSG_COMPONENT_INFORMATION_FIELD_METADATA_URI_LEN]       = "mftp://[;comp=1]parameter.json";
 #else
     char                metaDataURI[MAVLINK_MSG_COMPONENT_INFORMATION_FIELD_METADATA_URI_LEN]       = "https://bit.ly/2ZKRIRE";
 #endif


### PR DESCRIPTION
* From `mavlinkftp://` to `mftp://` to save characters in message packet
* Add support for specifying component id in uri. Format `mftp://[;comp=<id>]<path>`. This allows the component which delivers the metadata files to differ from the component you are requesting it from. So for example you could store all the metadata on a companion computer.