### PR TITLE
VideoReceiverApp: Fix gradle file and use https over http

### DIFF
--- a/VideoReceiverApp/android/build.gradle
+++ b/VideoReceiverApp/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
 
     repositories {
         maven  {
-            url "http://repo1.maven.org/maven2"
+            url "https://repo1.maven.org/maven2"
         }
     }
 


### PR DESCRIPTION
It's not possible to use http anymore, maven repository should use https.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


