### PR TITLE
Sub motor test fixes

### DIFF
--- a/src/AutoPilotPlugins/APM/APMMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMMotorComponent.qml
@@ -69,7 +69,7 @@ SetupPage {
                             updateValueWhileDragging:   false
 
                             onValueChanged: {
-                                controller.vehicle.motorTest(index + 1, value, value == 0 ? 0 : _motorTimeoutSecs)
+                                controller.vehicle.motorTest(index + 1, value, value == 0 ? 0 : _motorTimeoutSecs, true)
                                 if (value != 0) {
                                     motorTimer.restart()
                                 }

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
@@ -279,7 +279,7 @@ SetupPage {
                 id: timer
                 interval:       50
                 repeat:         true
-                running:        canRunManualTest
+                running:        canRunManualTest && shouldRunManualTest
 
                 onTriggered: {
                     if (controller.vehicle.armed) {

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
@@ -288,9 +288,9 @@ SetupPage {
                             var reversed = controller.getParameterFact(-1, "MOT_" + (_lastIndex + 1) + "_DIRECTION").value == -1
 
                             if (reversed) {
-                                controller.vehicle.motorTest(_lastIndex, 100 - slider.motorSlider.value, 0)
+                                controller.vehicle.motorTest(_lastIndex, 100 - slider.motorSlider.value, 0, false)
                             } else {
-                                controller.vehicle.motorTest(_lastIndex, slider.motorSlider.value, 0)
+                                controller.vehicle.motorTest(_lastIndex, slider.motorSlider.value, 0, false)
                             }
                     }
                 }

--- a/src/AutoPilotPlugins/Common/MotorComponent.qml
+++ b/src/AutoPilotPlugins/Common/MotorComponent.qml
@@ -69,7 +69,7 @@ SetupPage {
                             updateValueWhileDragging:   false
 
                             onValueChanged: {
-                                controller.vehicle.motorTest(index + 1, value, value == 0 ? 0 : _motorTimeoutSecs)
+                                controller.vehicle.motorTest(index + 1, value, value == 0 ? 0 : _motorTimeoutSecs, true)
                                 if (value != 0) {
                                     motorTimer.restart()
                                 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3150,9 +3150,9 @@ void Vehicle::setSoloFirmware(bool soloFirmware)
     }
 }
 
-void Vehicle::motorTest(int motor, int percent, int timeoutSecs)
+void Vehicle::motorTest(int motor, int percent, int timeoutSecs, bool showError)
 {
-    sendMavCommand(_defaultComponentId, MAV_CMD_DO_MOTOR_TEST, true, motor, MOTOR_TEST_THROTTLE_PERCENT, percent, timeoutSecs, 0, MOTOR_TEST_ORDER_BOARD);
+    sendMavCommand(_defaultComponentId, MAV_CMD_DO_MOTOR_TEST, showError, motor, MOTOR_TEST_THROTTLE_PERCENT, percent, timeoutSecs, 0, MOTOR_TEST_ORDER_BOARD);
 }
 
 QString Vehicle::brandImageIndoor() const

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -372,7 +372,7 @@ public:
     ///     @param motor Motor number, 1-based
     ///     @param percent 0-no power, 100-full power
     ///     @param timeoutSec Disabled motor after this amount of time
-    Q_INVOKABLE void motorTest(int motor, int percent, int timeoutSecs);
+    Q_INVOKABLE void motorTest(int motor, int percent, int timeoutSecs, bool showError);
 
     Q_INVOKABLE void setPIDTuningTelemetryMode(bool pidTuning);
 


### PR DESCRIPTION
 - Stops the timer when it shouldn't be sending motor tests messages. This fixes some "motor test command failed" after user clicked the motor test toggle to stop the test/disarm, but the vehicle state in qgc hasn't received a disarmed heartbet yet

 - Disables showError for sub, fixing #9234 