### PR TITLE
create_linux_appimage.sh: stop trying to wget from not-found URL(s)

### DIFF
--- a/deploy/create_linux_appimage.sh
+++ b/deploy/create_linux_appimage.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -x
+#!/bin/bash
 
-#set +e
+set -Eeuxo pipefail # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
 
 if [[ $# -eq 0 ]]; then
   echo 'create_linux_appimage.sh QGC_SRC_DIR QGC_RELEASE_DIR'
@@ -41,8 +41,6 @@ APPDIR=${TMPDIR}/$APP".AppDir"
 mkdir -p ${APPDIR}
 
 cd ${TMPDIR}
-wget -c --quiet http://ftp.us.debian.org/debian/pool/main/u/udev/udev_175-7.2_amd64.deb
-wget -c --quiet http://ftp.us.debian.org/debian/pool/main/s/speech-dispatcher/speech-dispatcher_0.8.8-1_amd64.deb
 wget -c --quiet http://ftp.us.debian.org/debian/pool/main/libs/libsdl2/libsdl2-2.0-0_2.0.2%2bdfsg1-6_amd64.deb
 
 cd ${APPDIR}
@@ -56,12 +54,6 @@ dpkg -x libdirectfb-1.2-9_1.2.10.0-5.1_amd64.deb libdirectfb
 cp -L libdirectfb/usr/lib/x86_64-linux-gnu/libdirectfb-1.2.so.9 ${APPDIR}/usr/lib/x86_64-linux-gnu/
 cp -L libdirectfb/usr/lib/x86_64-linux-gnu/libfusion-1.2.so.9 ${APPDIR}/usr/lib/x86_64-linux-gnu/
 cp -L libdirectfb/usr/lib/x86_64-linux-gnu/libdirect-1.2.so.9 ${APPDIR}/usr/lib/x86_64-linux-gnu/
-
-# copy libts-0.0-0
-wget -c --quiet http://ftp.us.debian.org/debian/pool/main/t/tslib/libts-0.0-0_1.0-11_amd64.deb
-mkdir libts
-dpkg -x libts-0.0-0_1.0-11_amd64.deb libts
-cp -L libts/usr/lib/x86_64-linux-gnu/libts-0.0.so.0 ${APPDIR}/usr/lib/x86_64-linux-gnu/
 
 # copy QGroundControl release into appimage
 rsync -av --exclude=*.cpp --exclude=*.h --exclude=*.o --exclude="CMake*" --exclude="*.cmake" ${QGC_RELEASE_DIR}/* ${APPDIR}/


### PR DESCRIPTION
I discovered the issues with this script while using it to build an AppImage containing a modified application binary of [CustomQGC](https://github.com/mavlink/qgroundcontrol/blob/master/custom-example/custom.pri). I am working for one of several teams that got involved with [US Defense drone-related initiatives](https://www.defense.gov/Newsroom/Releases/Release/Article/2318799/defense-innovation-unit-announces-suas-product-availability-to-provide-secure-c/) recently.

For now, this issue is only pertinent to those who **deploy** QGC. That probably isn't even a majority of the developers. So this isn't affecting a lot of people.

However, I do think you should add `set -Eeuxo` to your bash script A.S.A.P.  The next time a depended-upon URL goes offline, it may not be as innocuous for your AppImages. Having an "early warning" (a script failure in CI) will help avoid the pain of publicly releasing an AppImage that could immediately be found to be unlaunchable by scores of users.

Now that I ran into the issue, I have subsequently discovered that it was previously reported as issue #7635 

I don't want to "spam" by posting my assessment in 2 places. Therefore, I will kindly request that anyone reading this take a look at what I said on the issue: https://github.com/mavlink/qgroundcontrol/issues/7635#issuecomment-744906359