### PR TITLE
PX4 MC PID tuning page

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
@@ -12,9 +12,24 @@
 #include "PX4AutoPilotPlugin.h"
 #include "AirframeComponent.h"
 
+static bool isCopter(MAV_TYPE type) {
+    switch (type) {
+        case MAV_TYPE_QUADROTOR:
+        case MAV_TYPE_COAXIAL:
+        case MAV_TYPE_HELICOPTER:
+        case MAV_TYPE_HEXAROTOR:
+        case MAV_TYPE_OCTOROTOR:
+        case MAV_TYPE_TRICOPTER:
+            return true;
+        default:
+            break;
+    }
+    return false;
+}
+
 PX4TuningComponent::PX4TuningComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)
-    , _name(tr("Tuning"))
+    , _name(isCopter(vehicle->vehicleType()) ? tr("PID Tuning") : tr("Tuning"))
 {
 }
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -72,26 +72,86 @@ SetupPage {
             Component {
                 id: advancePageComponent
 
+
                 PIDTuning {
+                    property var rollList: ListModel {
+                        ListElement {
+                            title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
+                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                            param:          "MC_ROLLRATE_K"
+                            min:            0.3
+                            max:            3
+                            step:           0.05
+                        }
+                        ListElement {
+                            title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
+                            description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                            param:          "MC_ROLLRATE_D"
+                            min:            0.0004
+                            max:            0.01
+                            step:           0.0002
+                        }
+                        ListElement {
+                            title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
+                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                            param:          "MC_ROLLRATE_I"
+                            min:            0.1
+                            max:            0.5
+                            step:           0.025
+                        }
+                    }
+                    property var pitchList: ListModel {
+                        ListElement {
+                            title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
+                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                            param:          "MC_PITCHRATE_K"
+                            min:            0.3
+                            max:            3
+                            step:           0.05
+                        }
+                        ListElement {
+                            title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
+                            description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                            param:          "MC_PITCHRATE_D"
+                            min:            0.0004
+                            max:            0.01
+                            step:           0.0002
+                        }
+                        ListElement {
+                            title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
+                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                            param:          "MC_PITCHRATE_I"
+                            min:            0.1
+                            max:            0.5
+                            step:           0.025
+                        }
+                    }
+                    property var yawList: ListModel {
+                        ListElement {
+                            title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
+                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                            param:          "MC_YAWRATE_K"
+                            min:            0.3
+                            max:            3
+                            step:           0.05
+                        }
+                        ListElement {
+                            title:          qsTr("Integral Gain (MC_YAWRATE_I)")
+                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                            param:          "MC_YAWRATE_I"
+                            min:            0.04
+                            max:            0.4
+                            step:           0.02
+                        }
+                    }
                     anchors.left:   parent.left
                     anchors.right:  parent.right
                     tuneList:            [ qsTr("Roll"), qsTr("Pitch"), qsTr("Yaw") ]
                     params:              [
-                        [ controller.getParameterFact(-1, "MC_ROLL_P"),
-                         controller.getParameterFact(-1, "MC_ROLLRATE_P"),
-                         controller.getParameterFact(-1, "MC_ROLLRATE_I"),
-                         controller.getParameterFact(-1, "MC_ROLLRATE_D"),
-                         controller.getParameterFact(-1, "MC_ROLLRATE_FF") ],
-                        [ controller.getParameterFact(-1, "MC_PITCH_P"),
-                         controller.getParameterFact(-1, "MC_PITCHRATE_P"),
-                         controller.getParameterFact(-1, "MC_PITCHRATE_I"),
-                         controller.getParameterFact(-1, "MC_PITCHRATE_D"),
-                         controller.getParameterFact(-1, "MC_PITCHRATE_FF") ],
-                        [ controller.getParameterFact(-1, "MC_YAW_P"),
-                         controller.getParameterFact(-1, "MC_YAWRATE_P"),
-                         controller.getParameterFact(-1, "MC_YAWRATE_I"),
-                         controller.getParameterFact(-1, "MC_YAWRATE_D"),
-                         controller.getParameterFact(-1, "MC_YAWRATE_FF") ] ]
+                        rollList,
+                        pitchList,
+                        yawList
+                    ]
                 }
             } // Component - Advanced Page
         } // Column

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -28,132 +28,91 @@ SetupPage {
         Column {
             width: availableWidth
 
-            Component.onCompleted: {
-                // We use QtCharts only on Desktop platforms
-                showAdvanced = !ScreenTools.isMobile
-            }
-
             FactPanelController {
                 id:         controller
             }
 
-            // Standard tuning page
-            FactSliderPanel {
-                width:          availableWidth
-                visible:        !advanced
-
-                sliderModel: ListModel {
+            PIDTuning {
+                width: availableWidth
+                property var rollList: ListModel {
                     ListElement {
-                        title:          qsTr("Hover Throttle")
-                        description:    qsTr("Adjust throttle so hover is at mid-throttle. Slide to the left if hover is lower than throttle center. Slide to the right if hover is higher than throttle center.")
-                        param:          "MPC_THR_HOVER"
-                        min:            20
-                        max:            80
-                        step:           1
+                        title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
+                        description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                        param:          "MC_ROLLRATE_K"
+                        min:            0.3
+                        max:            3
+                        step:           0.05
                     }
-
                     ListElement {
-                        title:          qsTr("Manual minimum throttle")
-                        description:    qsTr("Slide to the left to start the motors with less idle power. Slide to the right if descending in manual flight becomes unstable.")
-                        param:          "MPC_MANTHR_MIN"
-                        min:            0
-                        max:            15
-                        step:           1
+                        title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
+                        description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                        param:          "MC_ROLLRATE_D"
+                        min:            0.0004
+                        max:            0.01
+                        step:           0.0002
+                    }
+                    ListElement {
+                        title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
+                        description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                        param:          "MC_ROLLRATE_I"
+                        min:            0.1
+                        max:            0.5
+                        step:           0.025
                     }
                 }
-            }
-
-            Loader {
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                sourceComponent:    advanced ? advancePageComponent : undefined
-            }
-
-            Component {
-                id: advancePageComponent
-
-
-                PIDTuning {
-                    property var rollList: ListModel {
-                        ListElement {
-                            title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
-                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                            param:          "MC_ROLLRATE_K"
-                            min:            0.3
-                            max:            3
-                            step:           0.05
-                        }
-                        ListElement {
-                            title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
-                            description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
-                            param:          "MC_ROLLRATE_D"
-                            min:            0.0004
-                            max:            0.01
-                            step:           0.0002
-                        }
-                        ListElement {
-                            title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
-                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                            param:          "MC_ROLLRATE_I"
-                            min:            0.1
-                            max:            0.5
-                            step:           0.025
-                        }
+                property var pitchList: ListModel {
+                    ListElement {
+                        title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
+                        description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                        param:          "MC_PITCHRATE_K"
+                        min:            0.3
+                        max:            3
+                        step:           0.05
                     }
-                    property var pitchList: ListModel {
-                        ListElement {
-                            title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
-                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                            param:          "MC_PITCHRATE_K"
-                            min:            0.3
-                            max:            3
-                            step:           0.05
-                        }
-                        ListElement {
-                            title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
-                            description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
-                            param:          "MC_PITCHRATE_D"
-                            min:            0.0004
-                            max:            0.01
-                            step:           0.0002
-                        }
-                        ListElement {
-                            title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
-                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                            param:          "MC_PITCHRATE_I"
-                            min:            0.1
-                            max:            0.5
-                            step:           0.025
-                        }
+                    ListElement {
+                        title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
+                        description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                        param:          "MC_PITCHRATE_D"
+                        min:            0.0004
+                        max:            0.01
+                        step:           0.0002
                     }
-                    property var yawList: ListModel {
-                        ListElement {
-                            title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
-                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                            param:          "MC_YAWRATE_K"
-                            min:            0.3
-                            max:            3
-                            step:           0.05
-                        }
-                        ListElement {
-                            title:          qsTr("Integral Gain (MC_YAWRATE_I)")
-                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                            param:          "MC_YAWRATE_I"
-                            min:            0.04
-                            max:            0.4
-                            step:           0.02
-                        }
+                    ListElement {
+                        title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
+                        description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                        param:          "MC_PITCHRATE_I"
+                        min:            0.1
+                        max:            0.5
+                        step:           0.025
                     }
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    tuneList:            [ qsTr("Roll"), qsTr("Pitch"), qsTr("Yaw") ]
-                    params:              [
-                        rollList,
-                        pitchList,
-                        yawList
-                    ]
                 }
-            } // Component - Advanced Page
+                property var yawList: ListModel {
+                    ListElement {
+                        title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
+                        description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                        param:          "MC_YAWRATE_K"
+                        min:            0.3
+                        max:            3
+                        step:           0.05
+                    }
+                    ListElement {
+                        title:          qsTr("Integral Gain (MC_YAWRATE_I)")
+                        description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                        param:          "MC_YAWRATE_I"
+                        min:            0.04
+                        max:            0.4
+                        step:           0.02
+                    }
+                }
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                tuneList:            [ qsTr("Roll"), qsTr("Pitch"), qsTr("Yaw") ]
+                params:              [
+                    rollList,
+                    pitchList,
+                    yawList
+                ]
+            }
         } // Column
     } // Component - pageComponent
 } // SetupPage

--- a/src/QmlControls/FactSliderPanel.qml
+++ b/src/QmlControls/FactSliderPanel.qml
@@ -10,6 +10,8 @@
 
 import QtQuick              2.3
 import QtQuick.Controls     1.2
+import QtQuick.Controls.Styles 1.4
+import QtQuick.Layouts  1.2
 
 import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0
@@ -63,11 +65,14 @@ Column {
                     anchors.left:       parent.left
                     anchors.right:      parent.right
                     anchors.top:        sliderRect.top
-                    spacing:            _margins
 
                     QGCLabel {
                         text:           title
                         font.family:    ScreenTools.demiboldFontFamily
+                    }
+                    Item {
+                        width: 1
+                        height: _margins
                     }
 
                     Slider {
@@ -78,6 +83,8 @@ Column {
                         stepSize:           step
                         tickmarksEnabled:   true
                         value:              _fact.value
+                        id:                 slider
+                        property int handleWidth: 0
 
                         property Fact _fact: controller.getParameterFact(-1, param)
 
@@ -85,6 +92,63 @@ Column {
                             if (_loadComplete) {
                                 _fact.value = value
                             }
+                        }
+
+                        style: SliderStyle {
+                            tickmarks: Repeater {
+                                id: repeater
+                                model: control.stepSize > 0 ? 1 + (control.maximumValue - control.minimumValue) / control.stepSize : 0
+                                property int unused: get()
+                                function get() {
+                                    slider.handleWidth = styleData.handleWidth
+                                    return 0
+                                }
+
+                                Rectangle {
+                                    color: Qt.hsla(palette.text.hslHue, palette.text.hslSaturation, palette.text.hslLightness, 0.5)
+                                    width: 2
+                                    height: 4
+                                    y: repeater.height
+                                    x: styleData.handleWidth / 2 + index * ((repeater.width - styleData.handleWidth) / (repeater.count-1))
+                                }
+                            }
+                        }
+                    }
+
+                    Item { // spacing
+                        width: 1
+                        height: 4
+                    }
+
+                    RowLayout {
+                        anchors.left:       parent.left
+                        anchors.right:      parent.right
+                        QGCLabel {
+                            id: leftValueLabel
+                            text: slider.minimumValue
+                            horizontalAlignment: Text.AlignLeft
+                        }
+                        Item {
+                            QGCLabel {
+                                visible: slider.value != slider.minimumValue && slider.value != slider.maximumValue
+                                text: Math.round(slider._fact.value*100000)/100000
+                                x: getX()
+                                function getX() {
+                                    var span = slider.maximumValue - slider.minimumValue
+                                    var x = slider.handleWidth / 2 + (slider.value-slider.minimumValue)/span * (slider.width-slider.handleWidth) - width / 2
+                                    // avoid overlapping text
+                                    var minX = leftValueLabel.x + leftValueLabel.width + _margins/2
+                                    if (x < minX) x = minX
+                                    var maxX = rightValueLabel.x - _margins/2 - width
+                                    if (x > maxX) x = maxX
+                                    return x
+                                }
+                            }
+                        }
+                        QGCLabel {
+                            id: rightValueLabel
+                            text: slider.maximumValue
+                            Layout.alignment: Qt.AlignRight
                         }
                     }
 

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -38,6 +38,7 @@ RowLayout {
     property int    _msecs:             0
     property double _last_t:            0
     property var    _savedTuningParamValues:    [ ]
+    property bool   _showCharts: !ScreenTools.isMobile // TODO: test and enable on mobile
 
     // The following are set when getValues is called
     property real   _valueRate
@@ -190,7 +191,7 @@ RowLayout {
     Column {
         spacing:            _margins
         Layout.alignment:   Qt.AlignTop
-        width:          parent.width * 0.4
+        width:          parent.width * (_showCharts ? 0.4 : 1)
 
         Column {
             QGCLabel { text: qsTr("Tuning Axis:") }
@@ -267,53 +268,12 @@ RowLayout {
                 onClicked:  resetToSavedTuningParamValues()
             }
         }
-
-        Item { width: 1; height: 1 }
-
-        QGCLabel { text: qsTr("Chart:") }
-
-        RowLayout {
-            spacing: _margins
-
-            QGCButton {
-                text:       qsTr("Clear")
-                onClicked:  resetGraphs()
-            }
-
-            QGCButton {
-                text:       dataTimer.running ? qsTr("Stop") : qsTr("Start")
-                onClicked: {
-                    dataTimer.running = !dataTimer.running
-                    _last_t = 0
-                    if (autoModeChange.checked) {
-                        globals.activeVehicle.flightMode = dataTimer.running ? "Stabilized" : globals.activeVehicle.pauseFlightMode
-                    }
-                }
-            }
-        }
-
-        QGCCheckBox {
-            id:     autoModeChange
-            text:   qsTr("Automatic Flight Mode Switching")
-        }
-
-        Column {
-            visible: autoModeChange.checked
-            QGCLabel {
-                text:            qsTr("Switches to 'Stabilized' when you click Start.")
-                font.pointSize:     ScreenTools.smallFontPointSize
-            }
-
-            QGCLabel {
-                text:            qsTr("Switches to '%1' when you click Stop.").arg(globals.activeVehicle.pauseFlightMode)
-                font.pointSize:     ScreenTools.smallFontPointSize
-            }
-        }
     }
 
     Column {
         Layout.fillWidth: true
         Layout.alignment:   Qt.AlignTop
+        visible:            _showCharts
 
         ChartView {
             id:                 ratesChart
@@ -363,6 +323,46 @@ RowLayout {
                 onReleased: {
                     _startPoint = undefined
                 }
+            }
+        }
+
+        Item { width: 1; height: 1 }
+
+        RowLayout {
+            spacing: _margins
+
+            QGCButton {
+                text:       qsTr("Clear")
+                onClicked:  resetGraphs()
+            }
+
+            QGCButton {
+                text:       dataTimer.running ? qsTr("Stop") : qsTr("Start")
+                onClicked: {
+                    dataTimer.running = !dataTimer.running
+                    _last_t = 0
+                    if (autoModeChange.checked) {
+                        globals.activeVehicle.flightMode = dataTimer.running ? "Stabilized" : globals.activeVehicle.pauseFlightMode
+                    }
+                }
+            }
+        }
+
+        QGCCheckBox {
+            id:     autoModeChange
+            text:   qsTr("Automatic Flight Mode Switching")
+        }
+
+        Column {
+            visible: autoModeChange.checked
+            QGCLabel {
+                text:            qsTr("Switches to 'Stabilized' when you click Start.")
+                font.pointSize:     ScreenTools.smallFontPointSize
+            }
+
+            QGCLabel {
+                text:            qsTr("Switches to '%1' when you click Stop.").arg(globals.activeVehicle.pauseFlightMode)
+                font.pointSize:     ScreenTools.smallFontPointSize
             }
         }
     }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -94,10 +94,13 @@ const char* Vehicle::_windFactGroupName =               "wind";
 const char* Vehicle::_vibrationFactGroupName =          "vibration";
 const char* Vehicle::_temperatureFactGroupName =        "temperature";
 const char* Vehicle::_clockFactGroupName =              "clock";
+const char* Vehicle::_setpointFactGroupName =           "setpoint";
 const char* Vehicle::_distanceSensorFactGroupName =     "distanceSensor";
 const char* Vehicle::_escStatusFactGroupName =          "escStatus";
 const char* Vehicle::_estimatorStatusFactGroupName =    "estimatorStatus";
 const char* Vehicle::_terrainFactGroupName =            "terrain";
+
+const QList<int> Vehicle::_pidTuningMessages = {MAVLINK_MSG_ID_ATTITUDE_QUATERNION, MAVLINK_MSG_ID_ATTITUDE_TARGET};
 
 // Standard connected vehicle
 Vehicle::Vehicle(LinkInterface*             link,
@@ -144,6 +147,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _vibrationFactGroup           (this)
     , _temperatureFactGroup         (this)
     , _clockFactGroup               (this)
+    , _setpointFactGroup            (this)
     , _distanceSensorFactGroup      (this)
     , _escStatusFactGroup           (this)
     , _estimatorStatusFactGroup     (this)
@@ -192,8 +196,6 @@ Vehicle::Vehicle(LinkInterface*             link,
         }
     }
 #endif
-
-    _pidTuningMessages << MAVLINK_MSG_ID_ATTITUDE << MAVLINK_MSG_ID_ATTITUDE_TARGET;
 
     _autopilotPlugin = _firmwarePlugin->autopilotPlugin(this);
     _autopilotPlugin->setParent(this);
@@ -400,6 +402,7 @@ void Vehicle::_commonInit()
     _addFactGroup(&_vibrationFactGroup,         _vibrationFactGroupName);
     _addFactGroup(&_temperatureFactGroup,       _temperatureFactGroupName);
     _addFactGroup(&_clockFactGroup,             _clockFactGroupName);
+    _addFactGroup(&_setpointFactGroup,          _setpointFactGroupName);
     _addFactGroup(&_distanceSensorFactGroup,    _distanceSensorFactGroupName);
     _addFactGroup(&_escStatusFactGroup,         _escStatusFactGroupName);
     _addFactGroup(&_estimatorStatusFactGroup,   _estimatorStatusFactGroupName);
@@ -437,8 +440,6 @@ void Vehicle::_commonInit()
         }
     }
 #endif
-
-    _pidTuningMessages << MAVLINK_MSG_ID_ATTITUDE << MAVLINK_MSG_ID_ATTITUDE_TARGET;
 }
 
 Vehicle::~Vehicle()
@@ -2813,6 +2814,7 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
 #endif
 
     int entryIndex = _findMavCommandListEntryIndex(message.compid, static_cast<MAV_CMD>(ack.command));
+    bool commandInList = false;
     if (entryIndex != -1) {
         const MavCommandListEntry_t& commandEntry = _mavCommandList[entryIndex];
         if (commandEntry.command == ack.command) {
@@ -2862,11 +2864,26 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
             }
 
             _mavCommandList.removeAt(entryIndex);
-            return;
+            commandInList = true;
         }
     }
 
-    qCDebug(VehicleLog) << "_handleCommandAck Ack not in list" << rawCommandName;
+    if (!commandInList) {
+        qCDebug(VehicleLog) << "_handleCommandAck Ack not in list" << rawCommandName;
+    }
+
+    // advance PID tuning setup/teardown
+    if (ack.command == MAV_CMD_SET_MESSAGE_INTERVAL && _pidTuningNextAdjustIndex >= 0) {
+        _pidTuningAdjustRates();
+    }
+    if (ack.command == MAV_CMD_GET_MESSAGE_INTERVAL && _pidTuningWaitingForRates) {
+        if (_pidTuningMessageRatesUsecs.count() < _pidTuningMessages.count()) {
+            sendMavCommand(defaultComponentId(),
+                    MAV_CMD_GET_MESSAGE_INTERVAL,
+                    true,                        // show error
+                    _pidTuningMessages[_pidTuningMessageRatesUsecs.count()]);
+        }
+    }
 }
 
 void Vehicle::_waitForMavlinkMessage(WaitForMavlinkMessageResultHandler resultHandler, void* resultHandlerData, int messageId, int timeoutMsecs)
@@ -3537,7 +3554,8 @@ void Vehicle::_handleMessageInterval(const mavlink_message_t& message)
         if (_pidTuningMessageRatesUsecs.count() == _pidTuningMessages.count()) {
             // We have back all the rates we requested
             _pidTuningWaitingForRates = false;
-            _pidTuningAdjustRates(true);
+            _pidTuningNextAdjustIndex = 0;
+            _pidTuningAdjustRates();
         }
     }
 }
@@ -3550,12 +3568,10 @@ void Vehicle::setPIDTuningTelemetryMode(bool pidTuning)
             _pidTuningTelemetryMode = true;
             _pidTuningWaitingForRates = true;
             _pidTuningMessageRatesUsecs.clear();
-            for (int telemetry: _pidTuningMessages) {
-                sendMavCommand(defaultComponentId(),
-                               MAV_CMD_GET_MESSAGE_INTERVAL,
-                               true,                        // show error
-                               telemetry);
-            }
+            sendMavCommand(defaultComponentId(),
+                    MAV_CMD_GET_MESSAGE_INTERVAL,
+                    true,                        // show error
+                    _pidTuningMessages[0]);
         }
     } else {
         if (_pidTuningTelemetryMode) {
@@ -3564,29 +3580,37 @@ void Vehicle::setPIDTuningTelemetryMode(bool pidTuning)
                 // We never finished waiting for previous rates
                 _pidTuningWaitingForRates = false;
             } else {
-                _pidTuningAdjustRates(false);
+                _pidTuningNextAdjustIndex = 0;
+                _pidTuningAdjustRates();
             }
         }
     }
 }
 
-void Vehicle::_pidTuningAdjustRates(bool setRatesForTuning)
+void Vehicle::_pidTuningAdjustRates()
 {
-    int requestedRate = (int)(1000000.0 / 30.0); // 30 Hz in usecs
+    int requestedRate = (int)(1000000.0 / 100.0); // 100 Hz in usecs (better set this a bit higher than actually needed,
+    // to give it more priority in case of exceeing link bandwidth)
 
-    for (int telemetry: _pidTuningMessages) {
+    if (_pidTuningNextAdjustIndex >= _pidTuningMessages.size()) {
+        _pidTuningNextAdjustIndex = -1;
+        return;
+    }
+    int telemetry = _pidTuningMessages[_pidTuningNextAdjustIndex];
 
-        if (requestedRate < _pidTuningMessageRatesUsecs[telemetry]) {
-            sendMavCommand(defaultComponentId(),
-                           MAV_CMD_SET_MESSAGE_INTERVAL,
-                           true,                        // show error
-                           telemetry,
-                           setRatesForTuning ? requestedRate : _pidTuningMessageRatesUsecs[telemetry]);
-        }
+    if (requestedRate < _pidTuningMessageRatesUsecs[telemetry] || _pidTuningMessageRatesUsecs[telemetry] == 0) {
+        sendMavCommand(defaultComponentId(),
+                MAV_CMD_SET_MESSAGE_INTERVAL,
+                true,                        // show error
+                telemetry,
+                _pidTuningTelemetryMode ? requestedRate : _pidTuningMessageRatesUsecs[telemetry]);
     }
 
-    setLiveUpdates(setRatesForTuning);
-    _setpointFactGroup.setLiveUpdates(setRatesForTuning);
+    if (_pidTuningNextAdjustIndex == 0) {
+        setLiveUpdates(_pidTuningTelemetryMode);
+        _setpointFactGroup.setLiveUpdates(_pidTuningTelemetryMode);
+    }
+    ++_pidTuningNextAdjustIndex;
 }
 
 void Vehicle::_initializeCsv()

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2656,11 +2656,10 @@ void Vehicle::_sendMavCommandWorker(bool commandInt, bool requestMessage, bool s
         return;
     }
 
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
 
-    if (!weakLink.expired()) {
+    if (sharedLink) {
         MavCommandListEntry_t   entry;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
         entry.useCommandInt     = commandInt;
         entry.targetCompId      = targetCompId;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -937,7 +937,7 @@ private:
     void _setCapabilities               (uint64_t capabilityBits);
     void _updateArmed                   (bool armed);
     bool _apmArmingNotRequired          ();
-    void _pidTuningAdjustRates          (bool setRatesForTuning);
+    void _pidTuningAdjustRates          ();
     void _initializeCsv                 ();
     void _writeCsvLine                  ();
     void _flightTimerStart              ();
@@ -1105,8 +1105,9 @@ private:
     // PID Tuning telemetry mode
     bool            _pidTuningTelemetryMode = false;
     bool            _pidTuningWaitingForRates = false;
-    QList<int>      _pidTuningMessages;
+    int             _pidTuningNextAdjustIndex = -1;
     QMap<int, int>  _pidTuningMessageRatesUsecs;
+    static const QList<int> _pidTuningMessages;
 
     // Chunked status text support
     typedef struct {
@@ -1249,6 +1250,7 @@ private:
     static const char* _vibrationFactGroupName;
     static const char* _temperatureFactGroupName;
     static const char* _clockFactGroupName;
+    static const char* _setpointFactGroupName;
     static const char* _distanceSensorFactGroupName;
     static const char* _escStatusFactGroupName;
     static const char* _estimatorStatusFactGroupName;


### PR DESCRIPTION
This brings the PID tuning page into a minimally working state.

![qgc_pid_tuning_wifi](https://user-images.githubusercontent.com/281593/102354319-b0e94580-3faa-11eb-8d07-197c7d1ffdf2.png)

And over a telemetry link:
![qgc_pid_tuning_telem](https://user-images.githubusercontent.com/281593/102354339-b9418080-3faa-11eb-9787-69e6d9353df2.png)
Unfortunately the update rate is not sufficient (around 10Hz) for it to be useful.

I removed the attitude, since that is generally not required to be tuned for MC.

### TODO
Before merging:
-  [x] make the advanced the default, remove hover & min throttle sliders
-  [x] make sure things are still corrrect for other vehicle types
-  [x] fix overlapping text for slider
-  [ ] descriptions can probably be improved

For later:
- disable graph over telemetry link (e.g. if update rate is < 20Hz)
- keep data when switching between axis (graph + clipboard)
- add ability to lock roll+pitch sliders together
- start graph on arming if not already running
- mouse zooming might be useful
- potentially show `MC_ROLLRATE_MAX` in the graph

Apart from tuning, I think an additional behavior tab would be useful, with sliders for max velocity and responsiveness (jerk limits, max acceleration, which ideally is a combined slider).

@DonLakeFlyer feel free to push the branch for further changes/improvements.