### PR TITLE
fix mavlink shell: weakLink.expired() logic was inverted

### DIFF
--- a/src/AnalyzeView/MavlinkConsoleController.cc
+++ b/src/AnalyzeView/MavlinkConsoleController.cc
@@ -110,11 +110,10 @@ MavlinkConsoleController::_sendSerialData(QByteArray data, bool close)
         return;
     }
 
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
         return;
     }
-    SharedLinkInterfacePtr sharedLink = weakLink.lock();
 
     // Send maximum sized chunks until the complete buffer is transmitted
     while(data.size()) {


### PR DESCRIPTION
And removes the extra expired() call (less atomic ops).