### PR TITLE
Terrain Profile: Fix min amsl alt calculation

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1505,7 +1505,7 @@ void MissionController::_recalcMissionFlightStatus()
     lastFlyThroughVI->setDistance(0);
     lastFlyThroughVI->setDistanceFromStart(0);
 
-    _minAMSLAltitude = _maxAMSLAltitude = _settingsItem->coordinate().altitude();
+    _minAMSLAltitude = _maxAMSLAltitude = qQNaN();
 
     _resetMissionFlightStatus();
 
@@ -1582,14 +1582,14 @@ void MissionController::_recalcMissionFlightStatus()
                 // Keep track of the min/max AMSL altitude for entire mission so we can calculate altitude percentages in terrain status display
                 if (simpleItem) {
                     double amslAltitude = item->amslEntryAlt();
-                    _minAMSLAltitude = std::min(_minAMSLAltitude, amslAltitude);
-                    _maxAMSLAltitude = std::max(_maxAMSLAltitude, amslAltitude);
+                    _minAMSLAltitude = std::fmin(_minAMSLAltitude, amslAltitude);
+                    _maxAMSLAltitude = std::fmax(_maxAMSLAltitude, amslAltitude);
                 } else {
                     // Complex item
                     double complexMinAMSLAltitude = complexItem->minAMSLAltitude();
                     double complexMaxAMSLAltitude = complexItem->maxAMSLAltitude();
-                    _minAMSLAltitude = std::min(_minAMSLAltitude, complexMinAMSLAltitude);
-                    _maxAMSLAltitude = std::max(_maxAMSLAltitude, complexMaxAMSLAltitude);
+                    _minAMSLAltitude = std::fmin(_minAMSLAltitude, complexMinAMSLAltitude);
+                    _maxAMSLAltitude = std::fmax(_maxAMSLAltitude, complexMaxAMSLAltitude);
                 }
 
                 if (!item->isStandaloneCoordinate()) {

--- a/src/QmlControls/TerrainProfile.cc
+++ b/src/QmlControls/TerrainProfile.cc
@@ -16,6 +16,8 @@
 
 #include <QSGSimpleRectNode>
 
+QGC_LOGGING_CATEGORY(TerrainProfileLog, "TerrainProfileLog")
+
 TerrainProfile::TerrainProfile(QQuickItem* parent)
     : QQuickItem(parent)
 {
@@ -209,10 +211,9 @@ QSGNode* TerrainProfile::updatePaintNode(QSGNode* oldNode, QQuickItem::UpdatePai
 
     double amslAltRange = qMax(_missionController->maxAMSLAltitude(), maxTerrainHeight) - _missionController->minAMSLAltitude();
 
-#if 0
     static int counter = 0;
-    qDebug() << "updatePaintNode" << counter++ << cFlightProfileSegments << cTerrainProfilePoints << cMissingTerrainSegments << cTerrainCollisionSegments;
-#endif
+    qCDebug(TerrainProfileLog) << QStringLiteral("updatePaintNode counter:%1 cFlightProfileSegments:%2 cTerrainProfilePoints:%3 cMissingTerrainSegments:%4 cTerrainCollisionSegments:%5 minAMSLAlt:%6 maxTerrainHeight:%7")
+                               .arg(counter++).arg(cFlightProfileSegments).arg(cTerrainProfilePoints).arg(cMissingTerrainSegments).arg(cTerrainCollisionSegments).arg(minAMSLAlt()).arg(maxTerrainHeight);
 
     _pixelsPerMeter = (_visibleWidth - (_horizontalMargin * 2)) / _missionController->missionDistance();
 

--- a/src/QmlControls/TerrainProfile.h
+++ b/src/QmlControls/TerrainProfile.h
@@ -14,6 +14,10 @@
 #include <QSGGeometryNode>
 #include <QSGGeometry>
 
+#include "QGCLoggingCategory.h"
+
+Q_DECLARE_LOGGING_CATEGORY(TerrainProfileLog)
+
 class MissionController;
 class QmlObjectListModel;
 class FlightPathSegment;


### PR DESCRIPTION
This would lead to confusing differences in the Terrain Profile display depending in what happened before a Plan was loaded.