### PR TITLE
UX improvements around MAVLink Console

### DIFF
--- a/src/AnalyzeView/MavlinkConsoleController.cc
+++ b/src/AnalyzeView/MavlinkConsoleController.cc
@@ -256,6 +256,15 @@ MavlinkConsoleController::writeLine(int line, const QByteArray &text)
     auto rc = rowCount();
     if (line >= rc) {
         insertRows(rc, 1 + line - rc);
+        if (rowCount() > _max_num_lines) {
+            int count = rowCount() - _max_num_lines;
+            removeRows(0, count);
+            line -= count;
+            _cursor -= count;
+            _cursor_home_pos -= count;
+            if (_cursor_home_pos < 0)
+                _cursor_home_pos = -1;
+        }
     }
     auto idx = index(line);
     setData(idx, data(idx, Qt::DisplayRole).toString() + text);

--- a/src/AnalyzeView/MavlinkConsoleController.h
+++ b/src/AnalyzeView/MavlinkConsoleController.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "QmlObjectListModel.h"
+#include "QGCPalette.h"
 #include "Fact.h"
 #include "FactMetaData.h"
 #include <QObject>
@@ -34,6 +35,15 @@ public:
     Q_INVOKABLE QString historyUp(const QString& current);
     Q_INVOKABLE QString historyDown(const QString& current);
 
+    /**
+     * Get clipboard data and if it has N lines, execute first N-1 commands
+     * @param command_pre prefix to data from clipboard
+     * @return last line of the clipboard data
+     */
+    Q_INVOKABLE QString handleClipboard(const QString& command_pre);
+
+    Q_PROPERTY(QString text                     READ getText                    CONSTANT)
+
 private slots:
     void _setActiveVehicle  (Vehicle* vehicle);
     void _receiveData(uint8_t device, uint8_t flags, uint16_t timeout, uint32_t baudrate, QByteArray data);
@@ -42,6 +52,10 @@ private:
     bool _processANSItext(QByteArray &line);
     void _sendSerialData(QByteArray, bool close = false);
     void writeLine(int line, const QByteArray &text);
+
+    QString transformLineForRichText(const QString& line) const;
+
+    QString getText() const;
 
     class CommandHistory
     {
@@ -61,5 +75,5 @@ private:
     Vehicle*      _vehicle;
     QList<QMetaObject::Connection> _uas_connections;
     CommandHistory _history;
-
+    QGCPalette     _palette;
 };

--- a/src/AnalyzeView/MavlinkConsoleController.h
+++ b/src/AnalyzeView/MavlinkConsoleController.h
@@ -69,6 +69,8 @@ private:
         int _index = 0;
     };
 
+    static constexpr int _max_num_lines = 500; ///< history size (affects CPU load)
+
     int           _cursor_home_pos;
     int           _cursor;
     QByteArray    _incoming_buffer;

--- a/src/AnalyzeView/MavlinkConsoleController.h
+++ b/src/AnalyzeView/MavlinkConsoleController.h
@@ -71,10 +71,11 @@ private:
 
     static constexpr int _max_num_lines = 500; ///< history size (affects CPU load)
 
-    int           _cursor_home_pos;
-    int           _cursor;
+    int           _cursor_home_pos{-1};
+    int           _cursorY{0};
+    int           _cursorX{0};
     QByteArray    _incoming_buffer;
-    Vehicle*      _vehicle;
+    Vehicle*      _vehicle{nullptr};
     QList<QMetaObject::Connection> _uas_connections;
     CommandHistory _history;
     QGCPalette     _palette;

--- a/src/AnalyzeView/MavlinkConsolePage.qml
+++ b/src/AnalyzeView/MavlinkConsolePage.qml
@@ -8,7 +8,8 @@
  ****************************************************************************/
 
 import QtQuick          2.3
-import QtQuick.Controls 1.2
+import QtQuick.Controls 1.3
+import QtQuick.Controls.Styles  1.4
 import QtQuick.Dialogs  1.2
 import QtQuick.Layouts      1.2
 
@@ -28,6 +29,10 @@ AnalyzePage {
 
     property bool isLoaded: false
 
+    // Key input on mobile is handled differently, so use a separate command input text field.
+    // E.g. for android see https://bugreports.qt.io/browse/QTBUG-40803
+    readonly property bool _separateCommandInput: ScreenTools.isMobile
+
     MavlinkConsoleController {
         id: conController
     }
@@ -44,54 +49,230 @@ AnalyzePage {
                 target: conController
 
                 onDataChanged: {
-                    // Keep the view in sync if the button is checked
                     if (isLoaded) {
-                        if (followTail.checked) {
-                            listview.positionViewAtEnd();
+                        // rate-limit updates to reduce CPU load
+                        updateTimer.start();
+                    }
+                }
+            }
+
+            property int _consoleOutputLen: 0
+
+            function scrollToBottom() {
+                var flickable = textConsole.flickableItem
+                if (flickable.contentHeight > flickable.height)
+                    flickable.contentY = flickable.contentHeight-flickable.height
+            }
+            function getCommand() {
+                return textConsole.getText(_consoleOutputLen, textConsole.length)
+            }
+            function getCommandAndClear() {
+                var command = getCommand()
+                textConsole.remove(_consoleOutputLen, textConsole.length)
+                return command
+            }
+
+            function pasteFromClipboard() {
+                // we need to handle a few cases here:
+                // in the general form we have: <command_pre><cursor><command_post>
+                // and the clipboard may contain newlines
+                var cursor = textConsole.cursorPosition - _consoleOutputLen
+                var command = getCommandAndClear()
+                var command_pre = ""
+                var command_post = command
+                if (cursor > 0) {
+                    command_pre = command.substr(0, cursor)
+                    command_post = command.substr(cursor)
+                }
+                var command_leftover = conController.handleClipboard(command_pre) + command_post
+                textConsole.insert(textConsole.length, command_leftover)
+                textConsole.cursorPosition = textConsole.length - command_post.length
+            }
+
+            Timer {
+                id: updateTimer
+                interval: 30
+                running: false
+                repeat: false
+                onTriggered: {
+                    // only update if scroll bar is at the bottom
+                    if (textConsole.flickableItem.atYEnd) {
+                        // backup & restore cursor & command
+                        var command = getCommand()
+                        var cursor = textConsole.cursorPosition - _consoleOutputLen
+                        textConsole.text = conController.text
+                        _consoleOutputLen = textConsole.length
+                        textConsole.insert(textConsole.length, command)
+                        textConsole.cursorPosition = textConsole.length
+                        scrollToBottom()
+                        if (cursor >= 0) {
+                            // We could restore the selection here too...
+                            textConsole.cursorPosition = _consoleOutputLen + cursor
+                        }
+                    } else {
+                        updateTimer.start();
+                    }
+                }
+            }
+
+            TextArea {
+                Component.onCompleted: {
+                    isLoaded = true
+                    _consoleOutputLen = textConsole.length
+                    textConsole.cursorPosition = _consoleOutputLen
+                    if (!_separateCommandInput)
+                        textConsole.forceActiveFocus()
+                }
+                id:                      textConsole
+                wrapMode:                Text.NoWrap
+                Layout.preferredWidth:   parent.width
+                Layout.fillHeight:       true
+                readOnly:                _separateCommandInput
+                frameVisible:            false
+                textFormat:              TextEdit.RichText
+                inputMethodHints:        Qt.ImhNoAutoUppercase | Qt.ImhMultiLine
+                text:                    "> "
+                focus:                   true
+
+                menu: Menu {
+                    id: contextMenu
+                    MenuItem {
+                        text: qsTr("Copy")
+                        onTriggered: {
+                            textConsole.copy()
+                        }
+                    }
+                    MenuItem {
+                        text: qsTr("Paste")
+                        onTriggered: {
+                            pasteFromClipboard()
                         }
                     }
                 }
-            }
 
-            Component {
-                id: delegateItem
-                Rectangle {
-                    color:  qgcPal.windowShade
-                    height: Math.round(ScreenTools.defaultFontPixelHeight * 0.1 + field.height)
-                    width:  listview.width
+                style: TextAreaStyle {
+                    textColor:          qgcPal.text
+                    backgroundColor:    qgcPal.windowShade
+                    selectedTextColor:  qgcPal.windowShade
+                    selectionColor:     qgcPal.text
+                    font.pointSize:     ScreenTools.defaultFontPointSize
+                    font.family:        ScreenTools.fixedFontFamily
+                }
 
-                    QGCLabel {
-                        id:          field
-                        text:        display
-                        width:       parent.width
-                        wrapMode:    Text.NoWrap
-                        font.family: ScreenTools.fixedFontFamily
-                        anchors.verticalCenter: parent.verticalCenter
+                Keys.onPressed: {
+                    if (event.key == Qt.Key_Tab) { // ignore tabs
+                        event.accepted = true
+                    }
+                    if (event.matches(StandardKey.Cut)) {
+                        // ignore for now
+                        event.accepted = true
+                    }
+
+                    if (!event.matches(StandardKey.Copy) &&
+                        event.key != Qt.Key_Escape &&
+                        event.key != Qt.Key_Insert &&
+                        event.key != Qt.Key_Pause &&
+                        event.key != Qt.Key_Print &&
+                        event.key != Qt.Key_SysReq &&
+                        event.key != Qt.Key_Clear &&
+                        event.key != Qt.Key_Home &&
+                        event.key != Qt.Key_End &&
+                        event.key != Qt.Key_Left &&
+                        event.key != Qt.Key_Up &&
+                        event.key != Qt.Key_Right &&
+                        event.key != Qt.Key_Down &&
+                        event.key != Qt.Key_PageUp &&
+                        event.key != Qt.Key_PageDown &&
+                        event.key != Qt.Key_Shift &&
+                        event.key != Qt.Key_Control &&
+                        event.key != Qt.Key_Meta &&
+                        event.key != Qt.Key_Alt &&
+                        event.key != Qt.Key_AltGr &&
+                        event.key != Qt.Key_CapsLock &&
+                        event.key != Qt.Key_NumLock &&
+                        event.key != Qt.Key_ScrollLock &&
+                        event.key != Qt.Key_Super_L &&
+                        event.key != Qt.Key_Super_R &&
+                        event.key != Qt.Key_Menu &&
+                        event.key != Qt.Key_Hyper_L &&
+                        event.key != Qt.Key_Hyper_R &&
+                        event.key != Qt.Key_Direction_L &&
+                        event.key != Qt.Key_Direction_R) {
+                        // Note: dead keys do not generate keyPressed event on linux, see
+                        // https://bugreports.qt.io/browse/QTBUG-79216
+
+                        scrollToBottom()
+
+                        // ensure cursor position is at an editable region
+                        if (textConsole.selectionStart < _consoleOutputLen) {
+                            textConsole.select(_consoleOutputLen, textConsole.selectionEnd)
+                        }
+                        if (textConsole.cursorPosition < _consoleOutputLen) {
+                            textConsole.cursorPosition = textConsole.length
+                        }
+                    }
+
+                    if (event.key == Qt.Key_Left) {
+                        // don't move beyond current command
+                        if (textConsole.cursorPosition == _consoleOutputLen) {
+                            event.accepted = true
+                        }
+                    }
+                    if (event.key == Qt.Key_Backspace) {
+                        if (textConsole.cursorPosition <= _consoleOutputLen) {
+                            event.accepted = true
+                        }
+                    }
+                    if (event.key == Qt.Key_Enter || event.key == Qt.Key_Return) {
+                        conController.sendCommand(getCommandAndClear())
+                        event.accepted = true
+                    }
+
+                    if (event.matches(StandardKey.Paste)) {
+                        pasteFromClipboard()
+                        event.accepted = true
+                    }
+
+                    // command history
+                    if (event.modifiers == Qt.NoModifier && event.key == Qt.Key_Up) {
+                        var command = conController.historyUp(getCommandAndClear())
+                        textConsole.insert(textConsole.length, command)
+                        textConsole.cursorPosition = textConsole.length
+                        event.accepted = true
+                    } else if (event.modifiers == Qt.NoModifier && event.key == Qt.Key_Down) {
+                        var command = conController.historyDown(getCommandAndClear())
+                        textConsole.insert(textConsole.length, command)
+                        textConsole.cursorPosition = textConsole.length
+                        event.accepted = true
                     }
                 }
-            }
 
-            QGCListView {
-                Component.onCompleted: {
-                    isLoaded = true
-                }
-                Layout.fillHeight: true
-                Layout.fillWidth:  true
-                clip:              true
-                id:                listview
-                model:             conController
-                delegate:          delegateItem
-
-                // Unsync the view if the user interacts
-                onMovementStarted: {
-                    followTail.checked = false
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.MiddleButton
+                    onClicked: {
+                        // disable middle-click pasting (we could add support for that if needed)
+                    }
+                    onWheel: {
+                        // increase scrolling speed (the default is a single line)
+                        var numLines = 4
+                        var flickable = textConsole.flickableItem
+                        var dy = wheel.angleDelta.y * numLines / 120 * textConsole.font.pixelSize
+                        flickable.contentY = Math.max(0, Math.min(flickable.contentHeight - flickable.height, flickable.contentY - dy))
+                        if (wheel.angleDelta.x != 0) {
+                            var dx = wheel.angleDelta.x * numLines / 120 * textConsole.font.pixelSize
+                            flickable.contentX = Math.max(0, Math.min(flickable.contentWidth - flickable.width, flickable.contentX - dx))
+                        }
+                        wheel.accepted = true
+                    }
                 }
             }
 
             RowLayout {
                 Layout.fillWidth:   true
+                visible:            _separateCommandInput
                 QGCTextField {
-                    id:               command
+                    id:               commandInput
                     Layout.fillWidth: true
                     placeholderText:  "Enter Commands here..."
                     inputMethodHints: Qt.ImhNoAutoUppercase
@@ -99,39 +280,15 @@ AnalyzePage {
                     function sendCommand() {
                         conController.sendCommand(text)
                         text = ""
+                        scrollToBottom()
                     }
                     onAccepted: sendCommand()
-
-                    Keys.onPressed: {
-                        if (event.key === Qt.Key_Up) {
-                            text = conController.historyUp(text);
-                            event.accepted = true;
-                        } else if (event.key === Qt.Key_Down) {
-                            text = conController.historyDown(text);
-                            event.accepted = true;
-                        }
-                    }
                 }
 
                 QGCButton {
                     id:        sendButton
                     text:      qsTr("Send")
-                    visible:   ScreenTools.isMobile
-
-                    onClicked: command.sendCommand()
-                }
-
-                QGCButton {
-                    id:        followTail
-                    text:      qsTr("Show Latest")
-                    checkable: true
-                    checked:   true
-
-                    onCheckedChanged: {
-                        if (checked && isLoaded) {
-                            listview.positionViewAtEnd();
-                        }
-                    }
+                    onClicked: commandInput.sendCommand()
                 }
             }
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/281593/102776708-87a42d00-438f-11eb-9482-0adeccc67afd.png)

Changes:
- revolutionary feature: user can select & copy output (to be fair there is a caveat, see below)
- auto-scrolling: update is paused when scrolling up, any key input will scroll to the bottom
- feel is more like a shell w/o extra text field.
  (on mobile there's still a separate text field as input is handled differently)
- handle multi-line commands from clipboard
- coloring of ERROR's and WARNing's
- set text focus to shell input on init
- some fixes around cursor + newline handling (see commits)

### Performance
The use of a `TextArea` is quite slow when the output grows. This is mitigated by:
- limit update rate to 30hz
- limit history to 500 lines

With this I'm seeing a CPU load increase for QGC from idle ~22% to ~28% with continous updates (running `top`), vs. 22% to 24% on master.
The only alternative to getting this faster I see is to do a custom QML element in C++.

Tested on Linux and Android. Would be good to give a quick test on MacOS and Windows as well (I don't have the setup).