### PR TITLE
Fix Segfault on vehicle reboot

### DIFF
--- a/src/FactSystem/FactGroup.h
+++ b/src/FactSystem/FactGroup.h
@@ -49,6 +49,7 @@ public:
     QStringList factNames           (void) const { return _factNames; }
     QStringList factGroupNames      (void) const { return _nameToFactGroupMap.keys(); }
     bool        telemetryAvailable  (void) const { return _telemetryAvailable; }
+    const QMap<QString, FactGroup*>& factGroups() const { return _nameToFactGroupMap; }
 
     /// Allows a FactGroup to parse incoming messages and fill in values
     virtual void handleMessage(Vehicle* vehicle, mavlink_message_t& message);

--- a/src/TerrainTile.cc
+++ b/src/TerrainTile.cc
@@ -47,9 +47,9 @@ TerrainTile::~TerrainTile()
 {
     if (_data) {
         for (int i = 0; i < _gridSizeLat; i++) {
-            delete _data[i];
+            delete[] _data[i];
         }
-        delete _data;
+        delete[] _data;
         _data = nullptr;
     }
 }

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -105,7 +105,7 @@ void FTPManager::_downloadComplete(const QString& errorMsg)
 
 void FTPManager::_mavlinkMessageReceived(const mavlink_message_t& message)
 {
-    if (message.msgid != MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL && message.compid != _ftpCompId) {
+    if (message.msgid != MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL || message.compid != _ftpCompId) {
         return;
     }
 

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -182,7 +182,7 @@ QString FTPManager::_errorMsgFromNak(const MavlinkFTP::Request* nak)
 
 void FTPManager::_openFileROBegin(void)
 {
-    MavlinkFTP::Request request;
+    MavlinkFTP::Request request{};
     request.hdr.session = 0;
     request.hdr.opcode  = MavlinkFTP::kCmdOpenFileRO;
     request.hdr.offset  = 0;
@@ -241,7 +241,7 @@ void FTPManager::_burstReadFileWorker(bool firstRequest)
 {
     qCDebug(FTPManagerLog) << "_burstReadFileWorker: starting burst at offset:firstRequest:retryCount" << _downloadState.expectedOffset << firstRequest << _downloadState.retryCount;
 
-    MavlinkFTP::Request request;
+    MavlinkFTP::Request request{};
     request.hdr.session = _downloadState.sessionId;
     request.hdr.opcode  = MavlinkFTP::kCmdBurstReadFile;
     request.hdr.offset  = _downloadState.expectedOffset;
@@ -357,7 +357,7 @@ void FTPManager::_burstReadFileTimeout(void)
 void FTPManager::_fillMissingBlocksWorker(bool firstRequest)
 {
     if (_downloadState.rgMissingData.count()) {
-        MavlinkFTP::Request request;
+        MavlinkFTP::Request request{};
         MissingData_t&      missingData = _downloadState.rgMissingData.first();
 
         uint32_t cBytesToRead = qMin((uint32_t)sizeof(request.data), missingData.cBytesMissing);
@@ -483,7 +483,7 @@ void FTPManager::_fillMissingBlocksTimeout(void)
 
 void FTPManager::_resetSessionsBegin(void)
 {
-    MavlinkFTP::Request request;
+    MavlinkFTP::Request request{};
     request.hdr.opcode  = MavlinkFTP::kCmdResetSessions;
     request.hdr.size    = 0;
     _sendRequestExpectAck(&request);

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -126,7 +126,7 @@ private:
     bool    _parseURI                   (const QString& uri, QString& parsedURI, uint8_t& compId);
 
     Vehicle*                _vehicle;
-    uint8_t                 _ftpCompId;
+    uint8_t                 _ftpCompId = MAV_COMP_ID_AUTOPILOT1;
     QList<StateFunctions_t> _rgStateMachine;
     DownloadState_t         _downloadState;
     QTimer                  _ackOrNakTimeoutTimer;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -609,9 +609,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     VehicleBatteryFactGroup::handleMessageForFactGroupCreation(this, message);
 
     // Let the fact groups take a whack at the mavlink traffic
-    QStringList groupNames = factGroupNames();
-    for (int i=0; i<groupNames.count(); i++) {
-        FactGroup* factGroup = getFactGroup(groupNames[i]);
+    for (FactGroup* factGroup : factGroups()) {
         factGroup->handleMessage(this, message);
     }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1006,7 +1006,7 @@ private:
     unsigned        _mavlinkProtocolRequestMaxProtoVersion  = 0;
     unsigned        _maxProtoVersion                        = 0;
     bool            _capabilityBitsKnown                    = false;
-    uint64_t        _capabilityBits;
+    uint64_t        _capabilityBits                         = 0;
     bool            _receivingAttitudeQuaternion = false;
     CheckList       _checkListState                         = CheckListNotSetup;
     bool            _readyToFlyAvailable                    = false;

--- a/src/comm/BluetoothLink.h
+++ b/src/comm/BluetoothLink.h
@@ -119,11 +119,9 @@ class BluetoothLink : public LinkInterface
 {
     Q_OBJECT
 
-    friend class BluetoothConfiguration;
-    friend class LinkManager;
-
 public:
-    ~BluetoothLink();
+    BluetoothLink(SharedLinkConfigurationPtr& config);
+    virtual ~BluetoothLink();
 
     // Overrides from QThread
     void run(void) override;
@@ -147,7 +145,6 @@ private slots:
     void _writeBytes(const QByteArray bytes) override;
 
 private:
-    BluetoothLink(SharedLinkConfigurationPtr& config);
 
     // LinkInterface overrides
     bool _connect(void) override;

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -567,6 +567,7 @@ void LinkManager::_updateAutoConnectLinks(void)
                         pSerialConfig->setBaud      (boardType == QGCSerialPortInfo::BoardTypeSiKRadio ? 57600 : 115200);
                         pSerialConfig->setDynamic   (true);
                         pSerialConfig->setPortName  (portInfo.systemLocation());
+                        pSerialConfig->setAutoConnect(true);
 
                         SharedLinkConfigurationPtr  sharedConfig(pSerialConfig);
                         createConnectedLink(sharedConfig, boardType == QGCSerialPortInfo::BoardTypePX4Flow);

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -103,40 +103,38 @@ void LinkManager::createConnectedLink(LinkConfiguration* config)
 
 bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr& config, bool isPX4Flow)
 {
-    LinkInterface* link = nullptr;
+    SharedLinkInterfacePtr link = nullptr;
 
     switch(config->type()) {
 #ifndef NO_SERIAL_LINK
     case LinkConfiguration::TypeSerial:
-        link = new SerialLink(config, isPX4Flow);
+        link = std::make_shared<SerialLink>(config, isPX4Flow);
         break;
 #else
     Q_UNUSED(isPX4Flow)
 #endif
     case LinkConfiguration::TypeUdp:
-        link = new UDPLink(config);
+        link = std::make_shared<UDPLink>(config);
         break;
     case LinkConfiguration::TypeTcp:
-        link = new TCPLink(config);
+        link = std::make_shared<TCPLink>(config);
         break;
 #ifdef QGC_ENABLE_BLUETOOTH
     case LinkConfiguration::TypeBluetooth:
-        link = new BluetoothLink(config);
+        link = std::make_shared<BluetoothLink>(config);
         break;
 #endif
     case LinkConfiguration::TypeLogReplay:
-        link = new LogReplayLink(config);
+        link = std::make_shared<LogReplayLink>(config);
         break;
 #ifdef QT_DEBUG
     case LinkConfiguration::TypeMock:
-        link = new MockLink(config);
+        link = std::make_shared<MockLink>(config);
         break;
 #endif
     case LinkConfiguration::TypeLast:
         break;
     }
-
-    QScopedPointer<LinkInterface> scopedLink(link);
 
     if (link) {
 
@@ -148,24 +146,25 @@ bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr& config, bool i
             return false;
         }
 
-        SharedLinkInterfacePtr sharedLink(link);
-        _rgLinks.append(sharedLink);
-        config->setLink(sharedLink);
+        _rgLinks.append(link);
+        config->setLink(link);
 
-        connect(link, &LinkInterface::communicationError,  _app,                &QGCApplication::criticalMessageBoxOnMainThread);
-        connect(link, &LinkInterface::bytesReceived,       _mavlinkProtocol,    &MAVLinkProtocol::receiveBytes);
-        connect(link, &LinkInterface::bytesSent,           _mavlinkProtocol,    &MAVLinkProtocol::logSentBytes);
-        connect(link, &LinkInterface::disconnected,        this,                &LinkManager::_linkDisconnected);
+        connect(link.get(), &LinkInterface::communicationError,  _app,                &QGCApplication::criticalMessageBoxOnMainThread);
+        connect(link.get(), &LinkInterface::bytesReceived,       _mavlinkProtocol,    &MAVLinkProtocol::receiveBytes);
+        connect(link.get(), &LinkInterface::bytesSent,           _mavlinkProtocol,    &MAVLinkProtocol::logSentBytes);
+        connect(link.get(), &LinkInterface::disconnected,        this,                &LinkManager::_linkDisconnected);
 
-        _mavlinkProtocol->resetMetadataForLink(link);
+        _mavlinkProtocol->resetMetadataForLink(link.get());
         _mavlinkProtocol->setVersion(_mavlinkProtocol->getCurrentVersion());
 
         if (!link->_connect()) {
             return false;
         }
+
+        return true;
     }
 
-    return scopedLink.take() ? true : false;
+    return false;
 }
 
 SharedLinkInterfacePtr LinkManager::mavlinkForwardingLink()

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -212,7 +212,7 @@ void LinkManager::_linkDisconnected(void)
     }
 }
 
-SharedLinkInterfacePtr LinkManager::sharedLinkInterfacePointerForLink(LinkInterface* link)
+SharedLinkInterfacePtr LinkManager::sharedLinkInterfacePointerForLink(LinkInterface* link, bool ignoreNull)
 {
     for (int i=0; i<_rgLinks.count(); i++) {
         if (_rgLinks[i].get() == link) {
@@ -220,7 +220,8 @@ SharedLinkInterfacePtr LinkManager::sharedLinkInterfacePointerForLink(LinkInterf
         }
     }
 
-    qWarning() << "LinkManager::sharedLinkInterfaceForLink returning nullptr";
+    if (!ignoreNull)
+        qWarning() << "LinkManager::sharedLinkInterfaceForLink returning nullptr";
     return SharedLinkInterfacePtr(nullptr);
 }
 

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -117,7 +117,7 @@ public:
 
     /// If you are going to hold a reference to a LinkInterface* in your object you must reference count it
     /// by using this method to get access to the shared pointer.
-    SharedLinkInterfacePtr sharedLinkInterfacePointerForLink(LinkInterface* link);
+    SharedLinkInterfacePtr sharedLinkInterfacePointerForLink(LinkInterface* link, bool ignoreNull=false);
 
     bool containsLink(LinkInterface* link);
 

--- a/src/comm/LogReplayLink.h
+++ b/src/comm/LogReplayLink.h
@@ -52,10 +52,9 @@ class LogReplayLink : public LinkInterface
 {
     Q_OBJECT
 
-    friend class LinkManager;
-
 public:
-    ~LogReplayLink();
+    LogReplayLink(SharedLinkConfigurationPtr& config);
+    virtual ~LogReplayLink();
 
     /// @return true: log is currently playing, false: log playback is paused
     bool isPlaying(void) { return _readTickTimer.isActive(); }
@@ -96,8 +95,6 @@ private slots:
     void _setPlaybackSpeed  (qreal playbackSpeed);
 
 private:
-    // Links are only created/destroyed by LinkManager so constructor/destructor is not public
-    LogReplayLink(SharedLinkConfigurationPtr& config);
 
     // LinkInterface overrides
     bool _connect(void) override;

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -95,7 +95,7 @@ class MockLink : public LinkInterface
 
 public:
     MockLink(SharedLinkConfigurationPtr& config);
-    ~MockLink(void);
+    virtual ~MockLink();
 
     int             vehicleId           (void)                                          { return _vehicleSystemId; }
     MAV_AUTOPILOT   getFirmwareType     (void)                                          { return _firmwareType; }

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -109,10 +109,10 @@ class SerialLink : public LinkInterface
 {
     Q_OBJECT
 
-    friend class SerialConfiguration;
-    friend class LinkManager;
-
 public:
+    SerialLink(SharedLinkConfigurationPtr& config, bool isPX4Flow = false);
+    virtual ~SerialLink();
+
     // LinkInterface overrides
     bool isConnected(void) const override;
     void disconnect (void) override;
@@ -130,9 +130,6 @@ private slots:
     void _readBytes     (void);
 
 private:
-    // Links are only created/destroyed by LinkManager so constructor/destructor is not public
-    SerialLink(SharedLinkConfigurationPtr& config, bool isPX4Flow = false);
-    ~SerialLink();
 
     // LinkInterface overrides
     bool _connect(void) override;

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -70,12 +70,9 @@ class TCPLink : public LinkInterface
 {
     Q_OBJECT
 
-    friend class TCPLinkTest;
-    friend class TCPConfiguration;
-    friend class LinkManager;
-
 public:
-    ~TCPLink();
+    TCPLink(SharedLinkConfigurationPtr& config);
+    virtual ~TCPLink();
 
     QTcpSocket* getSocket           (void) { return _socket; }
     void        signalBytesWritten  (void);
@@ -101,7 +98,6 @@ private slots:
     void _writeBytes(const QByteArray data) override;
 
 private:
-    TCPLink(SharedLinkConfigurationPtr& config);
 
     // LinkInterface overrides
     bool _connect(void) override;

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -96,11 +96,9 @@ class UDPLink : public LinkInterface
 {
     Q_OBJECT
 
-    friend class UDPConfiguration;
-    friend class LinkManager;
-
 public:
-    ~UDPLink();
+    UDPLink(SharedLinkConfigurationPtr& config);
+    virtual ~UDPLink();
 
     // LinkInterface overrides
     bool isConnected(void) const override;
@@ -117,8 +115,6 @@ private slots:
     void _writeBytes(const QByteArray data) override;
 
 private:
-    // Links are only created/destroyed by LinkManager so constructor/destructor is not public
-    UDPLink(SharedLinkConfigurationPtr& config);
 
     // LinkInterface overrides
     bool _connect(void) override;


### PR DESCRIPTION
When rebooting the vehicle from param editor, the vehicle would call `VehicleLinkManager::closeVehicle()` from `Vehicle::_mavlinkMessageReceived`. The link was then removed, and deleted as the ref count went to 0. If `MAVLinkProtocol::receiveBytes` was then parsing further messages, the same link was accessed again, leading to invalid memory access.
This PR fixes it by checking the validity of the link object after message handling. It could be solved differently, e.g. by closing the connection outside of the `MAVLinkProtocol::receiveBytes` call.

See individual commits for details.

Fixes #9260

Debugging output:
```
VehicleLinkManagerLog: _removeLink: "5b59370"
LinkManagerLog: LinkManager::_linkDisconnected "PX4 FMU V5 on ttyACM0 (AutoConnect)" 3

Thread 1 "QGroundControl" received signal SIGSEGV, Segmentation fault.
```
With the stack trace:
```
#0  0x000000000044d05c in QString::QString(QString const&) (this=0x7fffffffbd58, other=...)
    at /opt/install/qt/5.12.5/gcc_64/include/QtCore/qstring.h:957
#1  0x000000000054d08f in LinkConfiguration::name() const (this=0x0)
    at /home/beat/px4/src/qgroundcontrol/src/comm/LinkConfiguration.h:39
#2  0x00000000007358fb in VehicleLinkManager::_addLink(LinkInterface*)
    (this=0x4f899e0, link=0x5b59370)
    at /home/beat/px4/src/qgroundcontrol/src/Vehicle/VehicleLinkManager.cc:174
#3  0x00000000007345b8 in VehicleLinkManager::mavlinkMessageReceived(LinkInterface*, __mavlink_message) (this=0x4f899e0, link=0x5b59370, message=...)
    at /home/beat/px4/src/qgroundcontrol/src/Vehicle/VehicleLinkManager.cc:36
#4  0x000000000070dd96 in Vehicle::_mavlinkMessageReceived(LinkInterface*, __mavlink_message)
    (this=0x55367a0, link=0x5b59370, message=...)
    at /home/beat/px4/src/qgroundcontrol/src/Vehicle/Vehicle.cc:562
#5  0x0000000000727e28 in QtPrivate::FunctorCall<QtPrivate::IndexesList<0, 1>, QtPrivate::List<LinkInterface*, __mavlink_message>, void, void (Vehicle::*)(LinkInterface*, __mavlink_message)>::call(void (Vehicle::*)(LinkInterface*, __mavlink_message), Vehicle*, void**) (f=
    (void (Vehicle::*)(Vehicle * const, LinkInterface *, __mavlink_message)) 0x70dbd0 <Vehicle::_mavlinkMessageReceived(LinkInterface*, __mavlink_message)>, o=0x55367a0, arg=0x7fffffffc340)
    at /opt/install/qt/5.12.5/gcc_64/include/QtCore/qobjectdefs_impl.h:152
#6  0x0000000000726865 in QtPrivate::FunctionPointer<void (Vehicle::*)(LinkInterface*, __mavlink_message)>::call<QtPrivate::List<LinkInterface*, __mavlink_message>, void>(void (Vehicle::*)(LinkInterface*, __mavlink_message), Vehicle*, void**) (f=
    (void (Vehicle::*)(Vehicle * const, LinkInterface *, __mavlink_message)) 0x70dbd0 <Vehicle::_mavlinkMessageReceived(LinkInterface*, __mavlink_message)>, o=0x55367a0, arg=0x7fffffffc340)
    at /opt/install/qt/5.12.5/gcc_64/include/QtCore/qobjectdefs_impl.h:185
#7  0x0000000000724a20 in QtPrivate::QSlotObject<void (Vehicle::*)(LinkInterface*, __mavlink_message), QtPrivate::List<LinkInterface*, __mavlink_message>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*)
    (which=1, this_=0x65a2bf0, r=0x55367a0, a=0x7fffffffc340, ret=0x0)
    at /opt/install/qt/5.12.5/gcc_64/include/QtCore/qobjectdefs_impl.h:414
#8  0x00007ffff2873df6 in QMetaObject::activate(QObject*, int, int, void**) ()
    at /opt/install/qt/5.12.5/gcc_64/lib/libQt5Core.so.5
#9  0x000000000095eb85 in MAVLinkProtocol::messageReceived(LinkInterface*, __mavlink_message)
    (this=0x7ffff7fa9010, _t1=0x5b59370, _t2=...) at moc_MAVLinkProtocol.cpp:346
#10 0x00000000007583a4 in MAVLinkProtocol::receiveBytes(LinkInterface*, QByteArray)
```