### PR TITLE
main: Fix mac build when running Qt 5.15

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
 #ifndef __ios__
     // Prevent Apple's app nap from screwing us over
     // tip: the domain can be cross-checked on the command line with <defaults domains>
-    QProcess::execute("defaults write org.qgroundcontrol.qgroundcontrol NSAppSleepDisabled -bool YES");
+    QProcess::execute("defaults", {"write org.qgroundcontrol.qgroundcontrol NSAppSleepDisabled -bool YES"});
 #endif
 #endif
 


### PR DESCRIPTION
QProces::execute(QString) was deprecated, QProcess::execute(QString, QStringList) should be used

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


