### PR TITLE
Add indexes to prevent Query Blocking with full search for Big offline map.

### DIFF
--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -1061,6 +1061,8 @@ QGCCacheWorker::_createDB(QSqlDatabase* db, bool createDefault)
     {
         qWarning() << "Map Cache SQL error (create Tiles db):" << query.lastError().text();
     } else {
+        query.exec("CREATE INDEX hash ON Tiles ( hash, size, type ) ");
+             
         if(!query.exec(
             "CREATE TABLE IF NOT EXISTS TileSets ("
             "setID INTEGER PRIMARY KEY NOT NULL, "

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -1061,7 +1061,7 @@ QGCCacheWorker::_createDB(QSqlDatabase* db, bool createDefault)
     {
         qWarning() << "Map Cache SQL error (create Tiles db):" << query.lastError().text();
     } else {
-        query.exec("CREATE INDEX hash ON Tiles ( hash, size, type ) ");
+        query.exec("CREATE INDEX IF NOT EXISTS hash ON Tiles ( hash, size, type ) ");
              
         if(!query.exec(
             "CREATE TABLE IF NOT EXISTS TileSets ("


### PR DESCRIPTION
If TileDB is bigger than 2GB, 
--- sq = QString("SELECT COUNT(size), SUM(size) FROM Tiles WHERE tileID IN (SELECT A.tileID FROM SetTiles A join SetTiles B on A.tileID = B.tileID WHERE B.setID  ---
This query holds so long time QGCTileCache Worker.
I solved my problems with adding an index like that.

