### PR TITLE
Terrain Profile: Fix bugs relating to incorrect complex item min/max amsl alt

### DIFF
--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -107,8 +107,8 @@ signals:
     void greatestDistanceToChanged  (void);
     void presetNamesChanged         (void);
     void isIncompleteChanged        (void);
-    void minAMSLAltitudeChanged     (double minAMSLAltitude);
-    void maxAMSLAltitudeChanged     (double maxAMSLAltitude);
+    void minAMSLAltitudeChanged     (void);
+    void maxAMSLAltitudeChanged     (void);
     void terrainCollisionChanged    (bool terrainCollision);
 
 protected slots:

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -114,12 +114,8 @@ void MissionSettingsItem::setSequenceNumber(int sequenceNumber)
     }
 }
 
-bool MissionSettingsItem::load(const QJsonObject& complexObject, int sequenceNumber, QString& errorString)
+bool MissionSettingsItem::load(const QJsonObject& /*complexObject*/, int /*sequenceNumber*/, QString& /*errorString*/)
 {
-    Q_UNUSED(complexObject);
-    Q_UNUSED(sequenceNumber);
-    Q_UNUSED(errorString);
-
     return true;
 }
 

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -99,14 +99,14 @@ StructureScanComplexItem::StructureScanComplexItem(PlanMasterController* masterC
     connect(&_entranceAltFact,  &Fact::valueChanged,                                this, &StructureScanComplexItem::_amslEntryAltChanged);
     connect(this,               &StructureScanComplexItem::amslEntryAltChanged,     this, &StructureScanComplexItem::amslExitAltChanged);
 
-    connect(_missionController, &MissionController::plannedHomePositionChanged,     this, &StructureScanComplexItem::_minAMSLAltChanged);
-    connect(_missionController, &MissionController::plannedHomePositionChanged,     this, &StructureScanComplexItem::_maxAMSLAltChanged);
-    connect(this,               &StructureScanComplexItem::topFlightAltChanged,     this, &StructureScanComplexItem::_minAMSLAltChanged);
-    connect(this,               &StructureScanComplexItem::topFlightAltChanged,     this, &StructureScanComplexItem::_maxAMSLAltChanged);
-    connect(this,               &StructureScanComplexItem::bottomFlightAltChanged,  this, &StructureScanComplexItem::_minAMSLAltChanged);
-    connect(this,               &StructureScanComplexItem::bottomFlightAltChanged,  this, &StructureScanComplexItem::_maxAMSLAltChanged);
-    connect(&_entranceAltFact,  &Fact::valueChanged,                                this, &StructureScanComplexItem::_minAMSLAltChanged);
-    connect(&_entranceAltFact,  &Fact::valueChanged,                                this, &StructureScanComplexItem::_maxAMSLAltChanged);
+    connect(_missionController, &MissionController::plannedHomePositionChanged,     this, &StructureScanComplexItem::minAMSLAltitudeChanged);
+    connect(_missionController, &MissionController::plannedHomePositionChanged,     this, &StructureScanComplexItem::maxAMSLAltitudeChanged);
+    connect(this,               &StructureScanComplexItem::topFlightAltChanged,     this, &StructureScanComplexItem::minAMSLAltitudeChanged);
+    connect(this,               &StructureScanComplexItem::topFlightAltChanged,     this, &StructureScanComplexItem::maxAMSLAltitudeChanged);
+    connect(this,               &StructureScanComplexItem::bottomFlightAltChanged,  this, &StructureScanComplexItem::minAMSLAltitudeChanged);
+    connect(this,               &StructureScanComplexItem::bottomFlightAltChanged,  this, &StructureScanComplexItem::maxAMSLAltitudeChanged);
+    connect(&_entranceAltFact,  &Fact::valueChanged,                                this, &StructureScanComplexItem::minAMSLAltitudeChanged);
+    connect(&_entranceAltFact,  &Fact::valueChanged,                                this, &StructureScanComplexItem::maxAMSLAltitudeChanged);
 
     connect(&_flightPolygon,                        &QGCMapPolygon::pathChanged,                    this, &StructureScanComplexItem::_updateFlightPathSegmentsSignal);
     connect(&_startFromTopFact,                     &Fact::valueChanged,                            this, &StructureScanComplexItem::_updateFlightPathSegmentsSignal);
@@ -269,7 +269,7 @@ bool StructureScanComplexItem::load(const QJsonObject& complexObject, int sequen
 
 void StructureScanComplexItem::_flightPathChanged(void)
 {
-    // Calc bounding cube
+    // Calc bounding cubetopFlightAlt
     double north = 0.0;
     double south = 180.0;
     double east  = 0.0;
@@ -762,16 +762,6 @@ double StructureScanComplexItem::maxAMSLAltitude(void) const
 {
     double maxAlt = qMax(topFlightAlt(), _entranceAltFact.rawValue().toDouble());
     return maxAlt + _missionController->plannedHomePosition().altitude();
-}
-
-void StructureScanComplexItem::_minAMSLAltChanged(void)
-{
-    emit minAMSLAltitudeChanged(minAMSLAltitude());
-}
-
-void StructureScanComplexItem::_maxAMSLAltChanged(void)
-{
-    emit maxAMSLAltitudeChanged(maxAMSLAltitude());
 }
 
 void StructureScanComplexItem::_segmentTerrainCollisionChanged(bool terrainCollision)

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -134,8 +134,6 @@ private slots:
     void _recalcScanDistance                        (void);
     void _updateWizardMode                          (void);
     void _updateFlightPathSegmentsDontCallDirectly  (void);
-    void _minAMSLAltChanged                         (void);
-    void _maxAMSLAltChanged                         (void);
 
 private:
     void    _setCameraShots                 (int cameraShots);

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -111,8 +111,8 @@ public:
     void                setSequenceNumber           (int sequenceNumber) final;
     double              amslEntryAlt                (void) const final;
     double              amslExitAlt                 (void) const final;
-    double              minAMSLAltitude             (void) const final { return _minAMSLAltitude; }
-    double              maxAMSLAltitude             (void) const final { return _maxAMSLAltitude; }
+    double              minAMSLAltitude             (void) const final;
+    double              maxAMSLAltitude             (void) const final;
 
     static const char* turnAroundDistanceName;
     static const char* turnAroundDistanceMultiRotorName;


### PR DESCRIPTION
* Fixed more bug relating to the terrain profile clipping the flight path since min/max alt was incorrect
* Found while trying to reproduce #9272