### PR TITLE
PX4 Config: Horizon level fix

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -443,7 +443,7 @@ Item {
                 id:             levelButton
                 width:          _buttonWidth
                 text:           qsTr("Level Horizon")
-                indicatorGreen: sens_board_x_off.value !== 0 || sens_board_y_off.value !== 0 | sens_board_z_off.value !== 0
+                indicatorGreen: true
                 enabled:        cal_acc0_id.value !== 0 && cal_gyro0_id.value !== 0
                 visible:        QGroundControl.corePlugin.options.showSensorCalibrationLevel && showSensorCalibrationLevel
 


### PR DESCRIPTION
Leveling the horizon is not a requirement and can cause more harm than good. We are defaulting now to a green indicator to suggest to average users that they do not need to do anything.

There are likely more fixes coming, so I've kept this as draft.