### PR TITLE
Terrain Profile: Fix off by 1 on terrain collision detection

### DIFF
--- a/src/QmlControls/FlightPathSegment.cc
+++ b/src/QmlControls/FlightPathSegment.cc
@@ -153,16 +153,14 @@ void FlightPathSegment::_updateTerrainCollision(void)
             newTerrainCollision = true;
             break;
         }
-        if (i > 0) {
-            if (i == _amslTerrainHeights.count() - 1) {
-                x += _finalDistanceBetween;
-            } else {
-                x += _distanceBetween;
-            }
+        if (i == _amslTerrainHeights.count() - 2) {
+            x += _finalDistanceBetween;
+        } else {
+            x += _distanceBetween;
         }
     }
 
-    qCDebug(FlightPathSegmentLog) << this << "_updateTerrainCollision" << newTerrainCollision;
+    qCDebug(FlightPathSegmentLog) << this << "_updateTerrainCollision new:old" << newTerrainCollision << _terrainCollision;
 
     if (newTerrainCollision != _terrainCollision) {
         _terrainCollision = newTerrainCollision;


### PR DESCRIPTION
* This could cause FW takeoff to show incorrect collision right at takeoff point
* Fix #9273