### PR TITLE
Level horizon indicator

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -443,7 +443,7 @@ Item {
                 id:             levelButton
                 width:          _buttonWidth
                 text:           qsTr("Level Horizon")
-                indicatorGreen: sens_board_x_off.value !== 0 || sens_board_y_off.value !== 0 | sens_board_z_off.value !== 0
+                indicatorGreen: true
                 enabled:        cal_acc0_id.value !== 0 && cal_gyro0_id.value !== 0
                 visible:        QGroundControl.corePlugin.options.showSensorCalibrationLevel && showSensorCalibrationLevel
 

--- a/src/QmlControls/IndicatorButton.qml
+++ b/src/QmlControls/IndicatorButton.qml
@@ -1,3 +1,12 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
 import QtQuick          2.3
 import QtQuick.Controls 1.2
 
@@ -5,11 +14,9 @@ import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.ScreenTools   1.0
 
-// An IndicatorButton works just like q QGCButton with the additional support or a red/green
-// indicator on the right edge.
-
+/// Works just like a regular button but it can have a red indicator on the right side displayed
 QGCButton {
-    property bool indicatorGreen: false
+    property bool indicatorGreen: false ///< true: no indicator shown, false: red indicator shown
 
     Rectangle {
         anchors.rightMargin:    ScreenTools.defaultFontPixelWidth / 3
@@ -18,6 +25,7 @@ QGCButton {
         width:                  radius * 2
         height:                 width
         radius:                 (ScreenTools.defaultFontPixelHeight * .75) / 2
-        color:                  indicatorGreen ? "#00d932" : "red"
+        color:                  "red"
+        visible:                enabled && !indicatorGreen
     }
 }


### PR DESCRIPTION
* Sensor setup indicators only show when red. This is a better user model for buttons which are either red or show no indicator since they are fine. It also matches how the Setup page buttons works in that they go red when setup is needed and then just normal buttons when setup is good.
* PX4 Level Horizon never shows a red indicator
* Replacement for #9283