### PR TITLE
Fix channel indexing bug in Flight Modes page for Ardupilot

### DIFF
--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
@@ -107,7 +107,7 @@ void APMFlightModesComponentController::_rcChannelsChanged(int channelCount, int
 
     for (int i=0; i<_cChannelOptions; i++) {
         _rgChannelOptionEnabled[i] = QVariant(false);
-        channelValue = pwmValues[i+6];
+        channelValue = pwmValues[i+5];
         if (channelValue > 1800) {
             _rgChannelOptionEnabled[i] = QVariant(true);
         }


### PR DESCRIPTION
This fixes an off by 1 error in the Flight Modes page in Ardupilot. It's obvious once you see it, but took me forever to figure out. The resultant effect was every channel was off by 1, so when channel 8 was active channel 7 would light up yellow.

![image](https://user-images.githubusercontent.com/37091262/103597630-32970980-4ead-11eb-932c-2c434211faf7.png)
