### PR TITLE
Create field for manual Magnetic Declination setup for Submarines

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -446,6 +446,37 @@ SetupPage {
                                 model:      _orientationsDialogShowCompass ? 3 : 0
                                 delegate:   singleCompassSettingsComponent
                             }
+
+                            QGCLabel {
+                                id:         magneticDeclinationLabel
+                                width:      parent.width
+                                visible:    globals.activeVehicle.sub && _orientationsDialogShowCompass
+                                text:       qsTr("Magnetic Declination")
+                            }
+
+                            Column {
+                                visible:            magneticDeclinationLabel.visible
+                                anchors.margins:    ScreenTools.defaultFontPixelWidth
+                                anchors.left:       parent.left
+                                anchors.right:      parent.right
+                                spacing:            ScreenTools.defaultFontPixelHeight
+
+                                QGCCheckBox {
+                                    id:                           manualMagneticDeclinationCheckBox
+                                    text:                         qsTr("Manual Magnetic Declination")
+                                    property Fact autoDecFact:    controller.getParameterFact(-1, "COMPASS_AUTODEC")
+                                    property int manual:          0
+                                    property int automatic:       1
+
+                                    checked:    autoDecFact.rawValue === manual
+                                    onClicked:  autoDecFact.value = (checked ? manual : automatic)
+                                }
+
+                                FactTextField {
+                                    fact:       sensorParams.declinationFact
+                                    enabled:    manualMagneticDeclinationCheckBox.checked
+                                }
+                            }
                         } // Column
                     } // QGCFlickable
                 } // QGCViewDialog

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -57,6 +57,7 @@ const char* FactMetaData::_enumBitmaskArrayDescriptionJsonKey   = "description";
 const FactMetaData::BuiltInTranslation_s FactMetaData::_rgBuiltInTranslations[] = {
     { "centi-degrees",  "deg",  FactMetaData::_centiDegreesToDegrees,                   FactMetaData::_degreesToCentiDegrees },
     { "radians",        "deg",  FactMetaData::_radiansToDegrees,                        FactMetaData::_degreesToRadians },
+    { "rad",            "deg",  FactMetaData::_radiansToDegrees,                        FactMetaData::_degreesToRadians },
     { "gimbal-degrees", "deg",  FactMetaData::_mavlinkGimbalDegreesToUserGimbalDegrees, FactMetaData::_userGimbalDegreesToMavlinkGimbalDegrees },
     { "norm",           "%",    FactMetaData::_normToPercent,                           FactMetaData::_percentToNorm },
 };

--- a/src/FirmwarePlugin/APM/APMSensorParams.qml
+++ b/src/FirmwarePlugin/APM/APMSensorParams.qml
@@ -92,4 +92,6 @@ Item {
     property bool compass2Calibrated:               compass2Available ? compass2OfsXFact.value != 0.0  && compass2OfsYFact.value != 0.0  &&compass2OfsZFact.value != 0.0 : false
     property bool compass3Calibrated:               compass3Available ? compass3OfsXFact.value != 0.0  && compass3OfsYFact.value != 0.0  &&compass3OfsZFact.value != 0.0 : false
     property var  rgCompassCalibrated:              [ compass1Calibrated, compass2Calibrated, compass3Calibrated ]
+
+    property Fact declinationFact:                  factPanelController.getParameterFact(-1, "COMPASS_DEC")
 }


### PR DESCRIPTION
This introduces a Magnetic Declination field for Subs:
![declination](https://user-images.githubusercontent.com/4013804/103784409-abff3b00-5018-11eb-8e51-a4e4c3913e8c.gif)

Two possible discussion points:

 - ~Should we show it as degrees instead of radians ? Is something already there in the fact system that could help with the conversion?~
 - Having the checkbox inverted (user clicks "Manual declination" instead of "Automatic Declination") makes more sense from a user perspective. This could be done by adding an "inverted" property to FactCheckBox, but [this binding](https://github.com/mavlink/qgroundcontrol/blob/master/src/FactSystem/FactControls/FactCheckBox.qml#L18) would double in size.
 
Fix #7310

