### PR TITLE
Fix APM PowerComponent to use the battery FactGroups

### DIFF
--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -130,8 +130,9 @@ SetupPage {
                         property Fact battMonitor:      controller.getParameterFact(-1, "BATT_MONITOR", false /* reportMissing */)
                         property Fact battVoltMult:     controller.getParameterFact(-1, "BATT_VOLT_MULT", false /* reportMissing */)
                         property Fact battVoltPin:      controller.getParameterFact(-1, "BATT_VOLT_PIN", false /* reportMissing */)
-                        property Fact vehicleVoltage:   controller.vehicle.battery.voltage
-                        property Fact vehicleCurrent:   controller.vehicle.battery.current
+                        property FactGroup  _batteryFactGroup:  controller.vehicle.getFactGroup("battery0")
+                        property Fact vehicleVoltage:   _batteryFactGroup.voltage
+                        property Fact vehicleCurrent:   _batteryFactGroup.current
                     }
                 }
             }
@@ -215,8 +216,9 @@ SetupPage {
                         property Fact battMonitor:      controller.getParameterFact(-1, "BATT2_MONITOR", false /* reportMissing */)
                         property Fact battVoltMult:     controller.getParameterFact(-1, "BATT2_VOLT_MULT", false /* reportMissing */)
                         property Fact battVoltPin:      controller.getParameterFact(-1, "BATT2_VOLT_PIN", false /* reportMissing */)
-                        property Fact vehicleVoltage:   controller.vehicle.battery2.voltage
-                        property Fact vehicleCurrent:   controller.vehicle.battery2.current
+                        property FactGroup  _batteryFactGroup:  controller.vehicle.getFactGroup("battery1")
+                        property Fact vehicleVoltage:   _batteryFactGroup.voltage
+                        property Fact vehicleCurrent:   _batteryFactGroup.current
                     }
                 }
             }


### PR DESCRIPTION
The power screen in the APM vehicle setup didn't properly show the current voltage and current.

I'm not much of a Qt developer, but looking at other pieces of the code i found something that seems to fix the problem.

Please advice if this is the correct way to fix this. Happy to adjust the PR if needed.

Environment:
* Mac OS X Big Sur
* Drone running ArduCopter 4.0.5
* Single battery installed in Drone