### PR TITLE
update Gstreamer version in readme to 1.18.1

### DIFF
--- a/src/VideoReceiver/README.md
+++ b/src/VideoReceiver/README.md
@@ -2,7 +2,7 @@
 
 ## Video Streaming
 
-For supported platforms, QGroundControl implements an UDP RTP and RSTP video streaming receiver in its Main Flight Display. It uses GStreamer and a stripped down version of QtGstreamer. We've standardized on **GStreamer 1.14.4**. It has been reliable and we will be using it until a good reason to change it surfaces. Newer versions of GStreamer may break the build as some dependent libraries may change.
+For supported platforms, QGroundControl implements an UDP RTP and RSTP video streaming receiver in its Main Flight Display. It uses GStreamer and a stripped down version of QtGstreamer. We've standardized on **GStreamer 1.18.1**. It has been reliable and we will be using it until a good reason to change it surfaces. Newer versions of GStreamer may break the build as some dependent libraries may change.
 To build video streaming support, you will need to install the GStreamer development packages for the desired target platform.
 
 If you do have the proper GStreamer development libraries installed where QGC looks for it, the QGC build system will automatically use it and build video streaming support. If you would like to disable video streaming support, you can add **DISABLE_VIDEOSTREAMING** to the **DEFINES** build variable.
@@ -64,7 +64,7 @@ The build system is setup to use pkgconfig and it will find the necessary header
 
 ### Mac OS
 
-Download the gstreamer framework from here: http://gstreamer.freedesktop.org/data/pkg/osx. Supported version is 1.14.4. QGC may work with newer version, but it is untested.
+Download the gstreamer framework from here: http://gstreamer.freedesktop.org/data/pkg/osx. Supported version is 1.18.1. QGC may work with newer version, but it is untested.
 
 You need two packages:
 - [gstreamer-1.0-devel-1.18.1-x86_64.pkg](https://gstreamer.freedesktop.org/data/pkg/osx/1.18.1/gstreamer-1.0-devel-1.18.1-x86_64.pkg)
@@ -102,16 +102,16 @@ qgroundcontrol
 ```
 ### Windows
 
-Download the gstreamer framework from here: http://gstreamer.freedesktop.org/data/pkg/windows. Supported version is 1.4.14. QGC may work with newer version, but it is untested.
+Download the gstreamer framework from here: http://gstreamer.freedesktop.org/data/pkg/windows. Supported version is 1.18.1. QGC may work with newer version, but it is untested.
 
 You need two packages:
 
 #### 32-Bit: 
-- [gstreamer-1.0-devel-x86-1.14.4.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.14.4/gstreamer-1.0-devel-x86-1.14.4.msi)
-- [gstreamer-1.0-x86-1.14.4.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.14.4/gstreamer-1.0-x86-1.14.4.msi)
+- [gstreamer-1.0-devel-msvc-x86-1.18.1.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.18.1/msvc/gstreamer-1.0-devel-msvc-x86-1.18.1.msi)
+- [gstreamer-1.0-msvc-x86-1.18.1.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.18.1/msvc/gstreamer-1.0-msvc-x86-1.18.1.msi)
 
 #### 64-Bit: 
-- [gstreamer-1.0-devel-x86_64-1.14.4.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.14.4/gstreamer-1.0-devel-x86_64-1.14.4.msi)
-- [gstreamer-1.0-x86_64-1.14.4.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.14.4/gstreamer-1.0-x86_64-1.14.4.msi)
+- [gstreamer-1.0-devel-msvc-x86_64-1.18.1.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.18.1/msvc/gstreamer-1.0-devel-msvc-x86_64-1.18.1.msi)
+- [gstreamer-1.0-msvc-x86_64-1.18.1.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.18.1/msvc/gstreamer-1.0-msvc-x86_64-1.18.1.msi)
 
 Make sure you select "Complete" installation instead of "Typical" installation during the install process. The installer places them under c:\gstreamer, which is where the QGC build system will look for it.


### PR DESCRIPTION
Fix doc issue of commit 6afd4178d46a181bc3bcfdf9197179b478c193fc  and 465836c4bcd5e61be1b9c9aa4220b53a6552adba

NOTE: Since there are no update to gstreamer in IOS, i'm keeping the doc of IOS section remain still.

