### PR TITLE
fix warning C4334(lead to error 2220) on debug build with vs comipiler

### DIFF
--- a/src/qgcunittest/MultiSignalSpyV2.cc
+++ b/src/qgcunittest/MultiSignalSpyV2.cc
@@ -268,7 +268,7 @@ quint64 MultiSignalSpyV2::signalNameToMask(const char* signalName)
     for (int i=0; i<_rgSignalNames.count(); i++) {
         qDebug() << "signalNameToMask" << signalName << _rgSignalNames[i];
         if (_rgSignalNames[i] == signalName) {
-            return 1 << i;
+            return 1ULL << i;
         }
     }
 


### PR DESCRIPTION
Wonder if 'unsigned long long' is proper here, since quint64 may be defined to other type on other platform.

Maybe should use static_cast to convert the shift result ?
