### PR TITLE
ArduPilot - Flight Mode Setup page: Fix multiple off by ones in channel function code

### DIFF
--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
@@ -211,7 +211,7 @@ SetupPage {
                                 QGCLabel {
                                     anchors.baseline:   optCombo.baseline
                                     text:               qsTr("Channel option %1 :").arg(index)
-                                    color:              controller.channelOptionEnabled[modelData] ? "yellow" : qgcPal.text
+                                    color:              controller.channelOptionEnabled[modelData + (_ch7OptAvailable ? 1 : 0)] ? "yellow" : qgcPal.text
                                 }
 
                                 FactComboBox {

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
@@ -107,7 +107,7 @@ void APMFlightModesComponentController::_rcChannelsChanged(int channelCount, int
 
     for (int i=0; i<_cChannelOptions; i++) {
         _rgChannelOptionEnabled[i] = QVariant(false);
-        channelValue = pwmValues[i+6];
+        channelValue = pwmValues[i+5];
         if (channelValue > 1800) {
             _rgChannelOptionEnabled[i] = QVariant(true);
         }

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
@@ -81,7 +81,7 @@ private:
     QVariantList    _superSimpleModeEnabled;
 
     static const uint8_t    _allSimpleBits =    0x3F;
-    static const int        _cChannelOptions =  10;
+    static const int        _cChannelOptions =  11;
     static const int        _cSimpleModeBits =  8;
     static const int        _cFltModes =        6;
 


### PR DESCRIPTION
* The ui indication for whether an rc channel switch function was triggered was off by one
* Channel 16 rc function would never show correct ui indicator
* Replacement for #9305