### PR TITLE
linux_appimage: canonicalize release_dir argument

### DIFF
--- a/deploy/create_linux_appimage.sh
+++ b/deploy/create_linux_appimage.sh
@@ -88,5 +88,6 @@ chmod a+x ./appimagetool-x86_64.AppImage
 
 ./appimagetool-x86_64.AppImage ./$APP.AppDir/ ${TMPDIR}/$APP".AppImage"
 
+mkdir -p ${OUTPUT_DIR}
 cp ${TMPDIR}/$APP".AppImage" ${OUTPUT_DIR}/$APP".AppImage"
 

--- a/deploy/create_linux_appimage.sh
+++ b/deploy/create_linux_appimage.sh
@@ -8,7 +8,7 @@ if [[ $# -eq 0 ]]; then
   exit 1
 fi
 
-QGC_SRC=$1
+QGC_SRC=$(readlink -f $1)
 
 QGC_CUSTOM_APP_NAME="${QGC_CUSTOM_APP_NAME:-QGroundControl}"
 QGC_CUSTOM_GENERIC_NAME="${QGC_CUSTOM_GENERIC_NAME:-Ground Control Station}"
@@ -29,6 +29,7 @@ if [ ! -f ${QGC_RELEASE_DIR}/${QGC_CUSTOM_BINARY_NAME} ]; then
 fi
 
 OUTPUT_DIR=${3-`pwd`}
+OUTPUT_DIR=$(readlink -f $OUTPUT_DIR)
 echo "Output directory:" ${OUTPUT_DIR}
 
 # Generate AppImage using the binaries currently provided by the project.

--- a/deploy/create_linux_appimage.sh
+++ b/deploy/create_linux_appimage.sh
@@ -22,7 +22,7 @@ if [ ! -f ${QGC_SRC}/qgroundcontrol.pro ]; then
   exit 1
 fi
 
-QGC_RELEASE_DIR=$2
+QGC_RELEASE_DIR=$(readlink -f $2)
 if [ ! -f ${QGC_RELEASE_DIR}/${QGC_CUSTOM_BINARY_NAME} ]; then
   echo "please specify path to ${QGC_CUSTOM_BINARY_NAME} release as the 2nd argument"
   exit 1


### PR DESCRIPTION
When running the script and providing a local path as an argument for the release directory, the `rsync` command would fail, because `rsync` changes the directory and the relative path no longer applies. This only happens when `rsync` is ran inside the script. If I run the exact same command in the command line, it works. I'm not a bash ninja, so I don't know why. But canonicalizing the path fixes the problem :smile: 

- fixes errors when providing path arguments as local paths
- fixes error when output directory does not already exist