### PR TITLE
Refactor CameraControl

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -108,6 +108,10 @@ WindowsBuild {
     QMAKE_TARGET_PRODUCT        = "$${QGC_APP_NAME}"
 }
 
+MacBuild {
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.12
+}
+
 #-------------------------------------------------------------------------------------
 # iOS
 
@@ -424,6 +428,10 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 #
 
 HEADERS += \
+    src/Camera/QGCCameraDefinitionFileHandler.h \
+    src/Camera/QGCCameraHttpDownloader.h \
+    src/Camera/QGCCameraOption.h \
+    src/Camera/QGCVideoStreamInfo.h \
     src/QmlControls/QmlUnitsConversion.h \
     src/Vehicle/VehicleEscStatusFactGroup.h \
     src/api/QGCCorePlugin.h \
@@ -438,6 +446,10 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 }
 
 SOURCES += \
+    src/Camera/QGCCameraDefinitionFileHandler.cc \
+    src/Camera/QGCCameraHttpDownloader.cc \
+    src/Camera/QGCCameraOption.cc \
+    src/Camera/QGCVideoStreamInfo.cc \
     src/Vehicle/VehicleEscStatusFactGroup.cc \
     src/api/QGCCorePlugin.cc \
     src/api/QGCOptions.cc \

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -10,7 +10,10 @@
 #include "SettingsManager.h"
 #include "VideoManager.h"
 #include "QGCMapEngine.h"
+
 #include "QGCCameraManager.h"
+#include "QGCVideoStreamInfo.h"
+#include "QGCCameraOption.h"
 
 #include <QDir>
 #include <QStandardPaths>
@@ -19,41 +22,6 @@
 
 QGC_LOGGING_CATEGORY(CameraControlLog, "CameraControlLog")
 QGC_LOGGING_CATEGORY(CameraControlVerboseLog, "CameraControlVerboseLog")
-
-static const char* kCondition       = "condition";
-static const char* kControl         = "control";
-static const char* kDefault         = "default";
-static const char* kDefnition       = "definition";
-static const char* kDescription     = "description";
-static const char* kExclusion       = "exclude";
-static const char* kExclusions      = "exclusions";
-static const char* kLocale          = "locale";
-static const char* kLocalization    = "localization";
-static const char* kMax             = "max";
-static const char* kMin             = "min";
-static const char* kModel           = "model";
-static const char* kName            = "name";
-static const char* kOption          = "option";
-static const char* kOptions         = "options";
-static const char* kOriginal        = "original";
-static const char* kParameter       = "parameter";
-static const char* kParameterrange  = "parameterrange";
-static const char* kParameterranges = "parameterranges";
-static const char* kParameters      = "parameters";
-static const char* kReadOnly        = "readonly";
-static const char* kWriteOnly       = "writeonly";
-static const char* kRoption         = "roption";
-static const char* kStep            = "step";
-static const char* kDecimalPlaces   = "decimalPlaces";
-static const char* kStrings         = "strings";
-static const char* kTranslated      = "translated";
-static const char* kType            = "type";
-static const char* kUnit            = "unit";
-static const char* kUpdate          = "update";
-static const char* kUpdates         = "updates";
-static const char* kValue           = "value";
-static const char* kVendor          = "vendor";
-static const char* kVersion         = "version";
 
 static const char* kPhotoMode       = "PhotoMode";
 static const char* kPhotoLapse      = "PhotoLapse";
@@ -71,86 +39,7 @@ const char* QGCCameraControl::kCAM_APERTURE    = "CAM_APERTURE";
 const char* QGCCameraControl::kCAM_WBMODE      = "CAM_WBMODE";
 const char* QGCCameraControl::kCAM_MODE        = "CAM_MODE";
 
-//-----------------------------------------------------------------------------
-QGCCameraOptionExclusion::QGCCameraOptionExclusion(QObject* parent, QString param_, QString value_, QStringList exclusions_)
-    : QObject(parent)
-    , param(param_)
-    , value(value_)
-    , exclusions(exclusions_)
-{
-}
 
-//-----------------------------------------------------------------------------
-QGCCameraOptionRange::QGCCameraOptionRange(QObject* parent, QString param_, QString value_, QString targetParam_, QString condition_, QStringList optNames_, QStringList optValues_)
-    : QObject(parent)
-    , param(param_)
-    , value(value_)
-    , targetParam(targetParam_)
-    , condition(condition_)
-    , optNames(optNames_)
-    , optValues(optValues_)
-{
-}
-
-//-----------------------------------------------------------------------------
-static bool
-read_attribute(QDomNode& node, const char* tagName, bool& target)
-{
-    QDomNamedNodeMap attrs = node.attributes();
-    if(!attrs.count()) {
-        return false;
-    }
-    QDomNode subNode = attrs.namedItem(tagName);
-    if(subNode.isNull()) {
-        return false;
-    }
-    target = subNode.nodeValue() != "0";
-    return true;
-}
-
-//-----------------------------------------------------------------------------
-static bool
-read_attribute(QDomNode& node, const char* tagName, int& target)
-{
-    QDomNamedNodeMap attrs = node.attributes();
-    if(!attrs.count()) {
-        return false;
-    }
-    QDomNode subNode = attrs.namedItem(tagName);
-    if(subNode.isNull()) {
-        return false;
-    }
-    target = subNode.nodeValue().toInt();
-    return true;
-}
-
-//-----------------------------------------------------------------------------
-static bool
-read_attribute(QDomNode& node, const char* tagName, QString& target)
-{
-    QDomNamedNodeMap attrs = node.attributes();
-    if(!attrs.count()) {
-        return false;
-    }
-    QDomNode subNode = attrs.namedItem(tagName);
-    if(subNode.isNull()) {
-        return false;
-    }
-    target = subNode.nodeValue();
-    return true;
-}
-
-//-----------------------------------------------------------------------------
-static bool
-read_value(QDomNode& element, const char* tagName, QString& target)
-{
-    QDomElement de = element.firstChildElement(tagName);
-    if(de.isNull()) {
-        return false;
-    }
-    target = de.text();
-    return true;
-}
 
 //-----------------------------------------------------------------------------
 QGCCameraControl::QGCCameraControl(const mavlink_camera_information_t *info, Vehicle* vehicle, int compID, QObject* parent)
@@ -160,7 +49,15 @@ QGCCameraControl::QGCCameraControl(const mavlink_camera_information_t *info, Veh
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
     memcpy(&_info, info, sizeof(mavlink_camera_information_t));
+
+     _definitionFileHandler = new QGCCameraDefinitionFileHandler(this);
+     connect(_definitionFileHandler, &QGCCameraDefinitionFileHandler::constantsUpdated, this, &QGCCameraControl::_processConstants);
+     connect(_definitionFileHandler, &QGCCameraDefinitionFileHandler::factsUpdated, this, &QGCCameraControl::_processFacts);
+
+    _downloader = new QGCCameraHttpDownloader(this);
+    connect(_downloader, &QGCCameraHttpDownloader::dataReady, this, &QGCCameraControl::_dataReady);
     connect(this, &QGCCameraControl::dataReady, this, &QGCCameraControl::_dataReady);
+
     _vendor = QString(reinterpret_cast<const char*>(info->vendor_name));
     _modelName = QString(reinterpret_cast<const char*>(info->model_name));
     int ver = static_cast<int>(_info.cam_definition_version);
@@ -186,11 +83,7 @@ QGCCameraControl::QGCCameraControl(const mavlink_camera_information_t *info, Veh
     connect(&_recTimer, &QTimer::timeout, this, &QGCCameraControl::_recTimerHandler);
 }
 
-//-----------------------------------------------------------------------------
-QGCCameraControl::~QGCCameraControl()
-{
-    delete _netManager;
-    _netManager = nullptr;
+QGCCameraControl::~QGCCameraControl() {
 }
 
 //-----------------------------------------------------------------------------
@@ -216,9 +109,6 @@ QGCCameraControl::_initWhenReady()
     QTimer::singleShot(2500, this, &QGCCameraControl::_requestStorageInfo);
     _captureStatusTimer.start(2750);
     emit infoChanged();
-
-    delete _netManager;
-    _netManager = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -661,6 +551,7 @@ void
 QGCCameraControl::_requestCaptureStatus()
 {
     qCDebug(CameraControlLog) << "_requestCaptureStatus()";
+
     _vehicle->sendMavCommand(
         _compID,                                // target component
         MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS,  // command id
@@ -794,370 +685,7 @@ QGCCameraControl::_setPhotoStatus(PhotoStatus status)
     }
 }
 
-//-----------------------------------------------------------------------------
-bool
-QGCCameraControl::_loadCameraDefinitionFile(QByteArray& bytes)
-{
-    QByteArray originalData(bytes);
-    //-- Handle localization
-    if(!_handleLocalization(bytes)) {
-        return false;
-    }
-    int errorLine;
-    QString errorMsg;
-    QDomDocument doc;
-    if(!doc.setContent(bytes, false, &errorMsg, &errorLine)) {
-        qCritical() << "Unable to parse camera definition file on line:" << errorLine;
-        qCritical() << errorMsg;
-        return false;
-    }
-    //-- Load camera constants
-    QDomNodeList defElements = doc.elementsByTagName(kDefnition);
-    if(!defElements.size() || !_loadConstants(defElements)) {
-        qWarning() <<  "Unable to load camera constants from camera definition";
-        return false;
-    }
-    //-- Load camera parameters
-    QDomNodeList paramElements = doc.elementsByTagName(kParameters);
-    if(!paramElements.size() || !_loadSettings(paramElements)) {
-        qWarning() <<  "Unable to load camera parameters from camera definition";
-        return false;
-    }
-    //-- If this is new, cache it
-    if(!_cached) {
-        qCDebug(CameraControlLog) << "Saving camera definition file" << _cacheFile;
-        QFile file(_cacheFile);
-        if (!file.open(QIODevice::WriteOnly)) {
-            qWarning() << QString("Could not save cache file %1. Error: %2").arg(_cacheFile).arg(file.errorString());
-        } else {
-            file.write(originalData);
-        }
-    }
-    return true;
-}
 
-//-----------------------------------------------------------------------------
-bool
-QGCCameraControl::_loadConstants(const QDomNodeList nodeList)
-{
-    QDomNode node = nodeList.item(0);
-    if(!read_attribute(node, kVersion, _version)) {
-        return false;
-    }
-    if(!read_value(node, kModel, _modelName)) {
-        return false;
-    }
-    if(!read_value(node, kVendor, _vendor)) {
-        return false;
-    }
-    return true;
-}
-
-//-----------------------------------------------------------------------------
-bool
-QGCCameraControl::_loadSettings(const QDomNodeList nodeList)
-{
-    QDomNode node = nodeList.item(0);
-    QDomElement elem = node.toElement();
-    QDomNodeList parameters = elem.elementsByTagName(kParameter);
-    //-- Pre-process settings (maintain order and skip non-controls)
-    for(int i = 0; i < parameters.size(); i++) {
-        QDomNode parameterNode = parameters.item(i);
-        QString name;
-        if(read_attribute(parameterNode, kName, name)) {
-            bool control = true;
-            read_attribute(parameterNode, kControl, control);
-            if(control) {
-                _settings << name;
-            }
-        } else {
-            qCritical() << "Parameter entry missing parameter name";
-            return false;
-        }
-    }
-    //-- Load parameters
-    for(int i = 0; i < parameters.size(); i++) {
-        QDomNode parameterNode = parameters.item(i);
-        QString factName;
-        read_attribute(parameterNode, kName, factName);
-        QString type;
-        if(!read_attribute(parameterNode, kType, type)) {
-            qCritical() << QString("Parameter %1 missing parameter type").arg(factName);
-            return false;
-        }
-        //-- Does it have a control?
-        bool control = true;
-        read_attribute(parameterNode, kControl, control);
-        //-- Is it read only?
-        bool readOnly = false;
-        read_attribute(parameterNode, kReadOnly, readOnly);
-        //-- Is it write only?
-        bool writeOnly = false;
-        read_attribute(parameterNode, kWriteOnly, writeOnly);
-        //-- It can't be both
-        if(readOnly && writeOnly) {
-            qCritical() << QString("Parameter %1 cannot be both read only and write only").arg(factName);
-        }
-        //-- Param type
-        bool unknownType;
-        FactMetaData::ValueType_t factType = FactMetaData::stringToType(type, unknownType);
-        if (unknownType) {
-            qCritical() << QString("Unknown type for parameter %1").arg(factName);
-            return false;
-        }
-        //-- By definition, custom types do not have control
-        if(factType == FactMetaData::valueTypeCustom) {
-            control = false;
-        }
-        //-- Description
-        QString description;
-        if(!read_value(parameterNode, kDescription, description)) {
-            qCritical() << QString("Parameter %1 missing parameter description").arg(factName);
-            return false;
-        }
-        //-- Check for updates
-        QStringList updates = _loadUpdates(parameterNode);
-        if(updates.size()) {
-            qCDebug(CameraControlVerboseLog) << "Parameter" << factName << "requires updates for:" << updates;
-            _requestUpdates[factName] = updates;
-        }
-        //-- Build metadata
-        FactMetaData* metaData = new FactMetaData(factType, factName, this);
-        QQmlEngine::setObjectOwnership(metaData, QQmlEngine::CppOwnership);
-        metaData->setShortDescription(description);
-        metaData->setLongDescription(description);
-        metaData->setHasControl(control);
-        metaData->setReadOnly(readOnly);
-        metaData->setWriteOnly(writeOnly);
-        //-- Options (enums)
-        QDomElement optionElem = parameterNode.toElement();
-        QDomNodeList optionsRoot = optionElem.elementsByTagName(kOptions);
-        if(optionsRoot.size()) {
-            //-- Iterate options
-            QDomNode node = optionsRoot.item(0);
-            QDomElement elem = node.toElement();
-            QDomNodeList options = elem.elementsByTagName(kOption);
-            for(int i = 0; i < options.size(); i++) {
-                QDomNode option = options.item(i);
-                QString optName;
-                QString optValue;
-                QVariant optVariant;
-                if(!_loadNameValue(option, factName, metaData, optName, optValue, optVariant)) {
-                    delete metaData;
-                    return false;
-                }
-                metaData->addEnumInfo(optName, optVariant);
-                _originalOptNames[factName]  << optName;
-                _originalOptValues[factName] << optVariant;
-                //-- Check for exclusions
-                QStringList exclusions = _loadExclusions(option);
-                if(exclusions.size()) {
-                    qCDebug(CameraControlVerboseLog) << "New exclusions:" << factName << optValue << exclusions;
-                    QGCCameraOptionExclusion* pExc = new QGCCameraOptionExclusion(this, factName, optValue, exclusions);
-                    QQmlEngine::setObjectOwnership(pExc, QQmlEngine::CppOwnership);
-                    _valueExclusions.append(pExc);
-                }
-                //-- Check for range rules
-                if(!_loadRanges(option, factName, optValue)) {
-                    delete metaData;
-                    return false;
-                }
-            }
-        }
-        QString defaultValue;
-        if(read_attribute(parameterNode, kDefault, defaultValue)) {
-            QVariant defaultVariant;
-            QString  errorString;
-            if (metaData->convertAndValidateRaw(defaultValue, false, defaultVariant, errorString)) {
-                metaData->setRawDefaultValue(defaultVariant);
-            } else {
-                qWarning() << "Invalid default value for" << factName
-                           << " type:"  << metaData->type()
-                           << " value:" << defaultValue
-                           << " error:" << errorString;
-            }
-        }
-        //-- Set metadata and Fact
-        if (_nameToFactMetaDataMap.contains(factName)) {
-            qWarning() << QStringLiteral("Duplicate fact name:") << factName;
-            delete metaData;
-        } else {
-            {
-                //-- Check for Min Value
-                QString attr;
-                if(read_attribute(parameterNode, kMin, attr)) {
-                    QVariant typedValue;
-                    QString  errorString;
-                    if (metaData->convertAndValidateRaw(attr, true /* convertOnly */, typedValue, errorString)) {
-                        metaData->setRawMin(typedValue);
-                    } else {
-                        qWarning() << "Invalid min value for" << factName
-                                   << " type:"  << metaData->type()
-                                   << " value:" << attr
-                                   << " error:" << errorString;
-                    }
-                }
-            }
-            {
-                //-- Check for Max Value
-                QString attr;
-                if(read_attribute(parameterNode, kMax, attr)) {
-                    QVariant typedValue;
-                    QString  errorString;
-                    if (metaData->convertAndValidateRaw(attr, true /* convertOnly */, typedValue, errorString)) {
-                        metaData->setRawMax(typedValue);
-                    } else {
-                        qWarning() << "Invalid max value for" << factName
-                                   << " type:"  << metaData->type()
-                                   << " value:" << attr
-                                   << " error:" << errorString;
-                    }
-                }
-            }
-            {
-                //-- Check for Step Value
-                QString attr;
-                if(read_attribute(parameterNode, kStep, attr)) {
-                    QVariant typedValue;
-                    QString  errorString;
-                    if (metaData->convertAndValidateRaw(attr, true /* convertOnly */, typedValue, errorString)) {
-                        metaData->setRawIncrement(typedValue.toDouble());
-                    } else {
-                        qWarning() << "Invalid step value for" << factName
-                                   << " type:"  << metaData->type()
-                                   << " value:" << attr
-                                   << " error:" << errorString;
-                    }
-                }
-            }
-            {
-                //-- Check for Decimal Places
-                QString attr;
-                if(read_attribute(parameterNode, kDecimalPlaces, attr)) {
-                    QVariant typedValue;
-                    QString  errorString;
-                    if (metaData->convertAndValidateRaw(attr, true /* convertOnly */, typedValue, errorString)) {
-                        metaData->setDecimalPlaces(typedValue.toInt());
-                    } else {
-                        qWarning() << "Invalid decimal places value for" << factName
-                                   << " type:"  << metaData->type()
-                                   << " value:" << attr
-                                   << " error:" << errorString;
-                    }
-                }
-            }
-            {
-                //-- Check for Units
-                QString attr;
-                if(read_attribute(parameterNode, kUnit, attr)) {
-                    metaData->setRawUnits(attr);
-                }
-            }
-            qCDebug(CameraControlLog) << "New parameter:" << factName << (readOnly ? "ReadOnly" : "Writable") << (writeOnly ? "WriteOnly" : "Readable");
-            _nameToFactMetaDataMap[factName] = metaData;
-            Fact* pFact = new Fact(_compID, factName, factType, this);
-            QQmlEngine::setObjectOwnership(pFact, QQmlEngine::CppOwnership);
-            pFact->setMetaData(metaData);
-            pFact->_containerSetRawValue(metaData->rawDefaultValue());
-            QGCCameraParamIO* pIO = new QGCCameraParamIO(this, pFact, _vehicle);
-            QQmlEngine::setObjectOwnership(pIO, QQmlEngine::CppOwnership);
-            _paramIO[factName] = pIO;
-            _addFact(pFact, factName);
-        }
-    }
-    if(_nameToFactMetaDataMap.size() > 0) {
-        _addFactGroup(this, "camera");
-        _processRanges();
-        _activeSettings = _settings;
-        emit activeSettingsChanged();
-        return true;
-    }
-    return false;
-}
-
-//-----------------------------------------------------------------------------
-bool
-QGCCameraControl::_handleLocalization(QByteArray& bytes)
-{
-    QString errorMsg;
-    int errorLine;
-    QDomDocument doc;
-    if(!doc.setContent(bytes, false, &errorMsg, &errorLine)) {
-        qCritical() << "Unable to parse camera definition file on line:" << errorLine;
-        qCritical() << errorMsg;
-        return false;
-    }
-    //-- Find out where we are
-    QLocale locale = QLocale::system();
-#if defined (Q_OS_MAC)
-    locale = QLocale(locale.name());
-#endif
-    QString localeName = locale.name().toLower().replace("-", "_");
-    qCDebug(CameraControlLog) << "Current locale:" << localeName;
-    if(localeName == "en_us") {
-        // Nothing to do
-        return true;
-    }
-    QDomNodeList locRoot = doc.elementsByTagName(kLocalization);
-    if(!locRoot.size()) {
-        // Nothing to do
-        return true;
-    }
-    //-- Iterate locales
-    QDomNode node = locRoot.item(0);
-    QDomElement elem = node.toElement();
-    QDomNodeList locales = elem.elementsByTagName(kLocale);
-    for(int i = 0; i < locales.size(); i++) {
-        QDomNode locale = locales.item(i);
-        QString name;
-        if(!read_attribute(locale, kName, name)) {
-            qWarning() << "Localization entry is missing its name attribute";
-            continue;
-        }
-        // If we found a direct match, deal with it now
-        if(localeName == name.toLower().replace("-", "_")) {
-            return _replaceLocaleStrings(locale, bytes);
-        }
-    }
-    //-- No direct match. Pick first matching language (if any)
-    localeName = localeName.left(3);
-    for(int i = 0; i < locales.size(); i++) {
-        QDomNode locale = locales.item(i);
-        QString name;
-        read_attribute(locale, kName, name);
-        if(name.toLower().startsWith(localeName)) {
-            return _replaceLocaleStrings(locale, bytes);
-        }
-    }
-    //-- Could not find a language to use
-    qWarning() <<  "No match for" << QLocale::system().name() << "in camera definition file";
-    //-- Just use default, en_US
-    return true;
-}
-
-//-----------------------------------------------------------------------------
-bool
-QGCCameraControl::_replaceLocaleStrings(const QDomNode node, QByteArray& bytes)
-{
-    QDomElement stringElem = node.toElement();
-    QDomNodeList strings = stringElem.elementsByTagName(kStrings);
-    for(int i = 0; i < strings.size(); i++) {
-        QDomNode stringNode = strings.item(i);
-        QString original;
-        QString translated;
-        if(read_attribute(stringNode, kOriginal, original)) {
-            if(read_attribute(stringNode, kTranslated, translated)) {
-                QString o; o = "\"" + original + "\"";
-                QString t; t = "\"" + translated + "\"";
-                bytes.replace(o.toUtf8(), t.toUtf8());
-                o = ">" + original + "<";
-                t = ">" + translated + "<";
-                bytes.replace(o.toUtf8(), t.toUtf8());
-            }
-        }
-    }
-    return true;
-}
 
 //-----------------------------------------------------------------------------
 void
@@ -1813,98 +1341,61 @@ QGCCameraControl::_streamStatusTimeout()
     }
 }
 
+
+
 //-----------------------------------------------------------------------------
-QStringList
-QGCCameraControl::_loadExclusions(QDomNode option)
+void
+QGCCameraControl::_processConstants()
 {
-    QStringList exclusionList;
-    QDomElement optionElem = option.toElement();
-    QDomNodeList excRoot = optionElem.elementsByTagName(kExclusions);
-    if(excRoot.size()) {
-        //-- Iterate exclusions
-        QDomNode node = excRoot.item(0);
-        QDomElement elem = node.toElement();
-        QDomNodeList exclusions = elem.elementsByTagName(kExclusion);
-        for(int i = 0; i < exclusions.size(); i++) {
-            QString exclude = exclusions.item(i).toElement().text();
-            if(!exclude.isEmpty()) {
-                exclusionList << exclude;
-            }
-        }
-    }
-    return exclusionList;
+    qCDebug(CameraControlLog) << "Updating contants with input from definition file";
+    _vendor = _definitionFileHandler->_vendor;
+    _modelName = _definitionFileHandler->_modelName;
+    _version = _definitionFileHandler->_version;
 }
 
 //-----------------------------------------------------------------------------
-QStringList
-QGCCameraControl::_loadUpdates(QDomNode option)
+void
+QGCCameraControl::_processFacts()
 {
-    QStringList updateList;
-    QDomElement optionElem = option.toElement();
-    QDomNodeList updateRoot = optionElem.elementsByTagName(kUpdates);
-    if(updateRoot.size()) {
-        //-- Iterate updates
-        QDomNode node = updateRoot.item(0);
-        QDomElement elem = node.toElement();
-        QDomNodeList updates = elem.elementsByTagName(kUpdate);
-        for(int i = 0; i < updates.size(); i++) {
-            QString update = updates.item(i).toElement().text();
-            if(!update.isEmpty()) {
-                updateList << update;
-            }
-        }
-    }
-    return updateList;
-}
+    qCDebug(CameraControlLog) << "Updating lists and maps with parsed data";
+    _valueExclusions.append(_definitionFileHandler->_valueExclusions);
+    _optionRanges.append(_definitionFileHandler->_optionRanges);
+    _settings.append(_definitionFileHandler->_settings);
+    _requestUpdates = QMap<QString, QStringList>(_definitionFileHandler->_requestUpdates);
+    _originalOptNames = QMap<QString, QStringList>(_definitionFileHandler->_originalOptNames);
+    _originalOptValues = QMap<QString, QVariantList>(_definitionFileHandler->_originalOptValues);
 
-//-----------------------------------------------------------------------------
-bool
-QGCCameraControl::_loadRanges(QDomNode option, const QString factName, QString paramValue)
-{
-    QDomElement optionElem = option.toElement();
-    QDomNodeList rangeRoot = optionElem.elementsByTagName(kParameterranges);
-    if(rangeRoot.size()) {
-        QDomNode node = rangeRoot.item(0);
-        QDomElement elem = node.toElement();
-        QDomNodeList parameterRanges = elem.elementsByTagName(kParameterrange);
-        //-- Iterate parameter ranges
-        for(int i = 0; i < parameterRanges.size(); i++) {
-            QString param;
-            QString condition;
-            QDomNode paramRange = parameterRanges.item(i);
-            if(!read_attribute(paramRange, kParameter, param)) {
-                qCritical() << QString("Malformed option range for parameter %1").arg(factName);
-                return false;
-            }
-            read_attribute(paramRange, kCondition, condition);
-            QDomElement pelem = paramRange.toElement();
-            QDomNodeList rangeOptions = pelem.elementsByTagName(kRoption);
-            QStringList  optNames;
-            QStringList  optValues;
-            //-- Iterate options
-            for(int i = 0; i < rangeOptions.size(); i++) {
-                QString optName;
-                QString optValue;
-                QDomNode roption = rangeOptions.item(i);
-                if(!read_attribute(roption, kName, optName)) {
-                    qCritical() << QString("Malformed roption for parameter %1").arg(factName);
-                    return false;
-                }
-                if(!read_attribute(roption, kValue, optValue)) {
-                    qCritical() << QString("Malformed rvalue for parameter %1").arg(factName);
-                    return false;
-                }
-                optNames  << optName;
-                optValues << optValue;
-            }
-            if(optNames.size()) {
-                QGCCameraOptionRange* pRange = new QGCCameraOptionRange(this, factName, paramValue, param, condition, optNames, optValues);
-                _optionRanges.append(pRange);
-                qCDebug(CameraControlVerboseLog) << "New range limit:" << factName << paramValue << param << condition << optNames << optValues;
-            }
-        }
-    }
-    return true;
+     qCDebug(CameraControlLog) << "Updating contants with input from definition file";
+     for (int i=0; i < _definitionFileHandler->_parsedFacts.size(); i++) {
+         ParsedFact parsedfact = _definitionFileHandler->_parsedFacts[i];
+
+         if (!_nameToFactMetaDataMap.contains(parsedfact.name)) {
+             parsedfact.metaData->setParent(this);
+             QQmlEngine::setObjectOwnership(parsedfact.metaData, QQmlEngine::CppOwnership);
+
+             Fact* pFact = new Fact(_compID, parsedfact.name, parsedfact.type, this);
+             QQmlEngine::setObjectOwnership(pFact, QQmlEngine::CppOwnership);
+             pFact->setMetaData(parsedfact.metaData);
+             pFact->_containerSetRawValue(parsedfact.metaData->rawDefaultValue());
+
+             QGCCameraParamIO* pIO = new QGCCameraParamIO(this, pFact, _vehicle);
+             QQmlEngine::setObjectOwnership(pIO, QQmlEngine::CppOwnership);
+             _paramIO[parsedfact.name] = pIO;
+
+             _nameToFactMetaDataMap[parsedfact.name] = parsedfact.metaData;
+             _addFact(pFact, parsedfact.name);
+         } else {
+             qWarning() << QStringLiteral("Duplicate fact name:") << parsedfact.name;
+             delete parsedfact.metaData; // Cleanup
+         }
+     }
+
+     if(_nameToFactMetaDataMap.size() > 0) {
+         _addFactGroup(this, "camera");
+         _processRanges();
+         _activeSettings = _settings;
+         emit activeSettingsChanged();
+     }
 }
 
 //-----------------------------------------------------------------------------
@@ -1931,27 +1422,6 @@ QGCCameraControl::_processRanges()
     }
 }
 
-//-----------------------------------------------------------------------------
-bool
-QGCCameraControl::_loadNameValue(QDomNode option, const QString factName, FactMetaData* metaData, QString& optName, QString& optValue, QVariant& optVariant)
-{
-    if(!read_attribute(option, kName, optName)) {
-        qCritical() << QString("Malformed option for parameter %1").arg(factName);
-        return false;
-    }
-    if(!read_attribute(option, kValue, optValue)) {
-        qCritical() << QString("Malformed value for parameter %1").arg(factName);
-        return false;
-    }
-    QString  errorString;
-    if (!metaData->convertAndValidateRaw(optValue, false, optVariant, errorString)) {
-        qWarning() << "Invalid option value, name:" << factName
-                   << " type:"  << metaData->type()
-                   << " value:" << optValue
-                   << " error:" << errorString;
-    }
-    return true;
-}
 
 //-----------------------------------------------------------------------------
 void
@@ -1961,19 +1431,19 @@ QGCCameraControl::_handleDefinitionFile(const QString &url)
     QFile xmlFile(_cacheFile);
     if (!xmlFile.exists()) {
         qCDebug(CameraControlLog) << "No camera definition file cached";
-        _httpRequest(url);
+        _downloader->download(url);
         return;
     }
     if (!xmlFile.open(QIODevice::ReadOnly)) {
         qWarning() << "Could not read cached camera definition file:" << _cacheFile;
-        _httpRequest(url);
+        _downloader->download(url);
         return;
     }
     QByteArray bytes = xmlFile.readAll();
     QDomDocument doc;
     if(!doc.setContent(bytes, false)) {
         qWarning() << "Could not parse cached camera definition file:" << _cacheFile;
-        _httpRequest(url);
+        _downloader->download(url);
         return;
     }
     //-- We have it
@@ -1982,48 +1452,6 @@ QGCCameraControl::_handleDefinitionFile(const QString &url)
     emit dataReady(bytes);
 }
 
-//-----------------------------------------------------------------------------
-void
-QGCCameraControl::_httpRequest(const QString &url)
-{
-    qCDebug(CameraControlLog) << "Request camera definition:" << url;
-    if(!_netManager) {
-        _netManager = new QNetworkAccessManager(this);
-    }
-    QNetworkProxy savedProxy = _netManager->proxy();
-    QNetworkProxy tempProxy;
-    tempProxy.setType(QNetworkProxy::DefaultProxy);
-    _netManager->setProxy(tempProxy);
-    QNetworkRequest request(url);
-    request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
-    QNetworkReply* reply = _netManager->get(request);
-    connect(reply, &QNetworkReply::finished,  this, &QGCCameraControl::_downloadFinished);
-    _netManager->setProxy(savedProxy);
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCCameraControl::_downloadFinished()
-{
-    QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
-    if(!reply) {
-        return;
-    }
-    int err = reply->error();
-    int http_code = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
-    QByteArray data = reply->readAll();
-    if(err == QNetworkReply::NoError && http_code == 200) {
-        data.append("\n");
-    } else {
-        data.clear();
-        qWarning() << QString("Camera Definition download error: %1 status: %2").arg(reply->errorString(), reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toString());
-    }
-    emit dataReady(data);
-    //reply->deleteLater();
-}
 
 //-----------------------------------------------------------------------------
 void
@@ -2031,7 +1459,19 @@ QGCCameraControl::_dataReady(QByteArray data)
 {
     if(data.size()) {
         qCDebug(CameraControlLog) << "Parsing camera definition";
-        _loadCameraDefinitionFile(data);
+        _definitionFileHandler->parse(data);
+
+        //-- If this is new, cache it
+        if(!_cached) {
+            qCDebug(CameraControlLog) << "Saving camera definition file" << _cacheFile;
+            QFile file(_cacheFile);
+            if (!file.open(QIODevice::WriteOnly)) {
+                qWarning() << QString("Could not save cache file %1. Error: %2").arg(_cacheFile).arg(file.errorString());
+            } else {
+                file.write(data);
+            }
+        }
+
     } else {
         qCDebug(CameraControlLog) << "No camera definition";
     }
@@ -2147,59 +1587,3 @@ QGCCameraControl::mode()
     return _paramComplete && factExists(kCAM_MODE) ? getFact(kCAM_MODE) : nullptr;
 }
 
-//-----------------------------------------------------------------------------
-QGCVideoStreamInfo::QGCVideoStreamInfo(QObject* parent, const mavlink_video_stream_information_t *si)
-    : QObject(parent)
-{
-    memcpy(&_streamInfo, si, sizeof(mavlink_video_stream_information_t));
-}
-
-//-----------------------------------------------------------------------------
-qreal
-QGCVideoStreamInfo::aspectRatio()
-{
-    qreal ar = 1.0;
-    if(_streamInfo.resolution_h && _streamInfo.resolution_v) {
-        ar = static_cast<double>(_streamInfo.resolution_h) / static_cast<double>(_streamInfo.resolution_v);
-    }
-    return ar;
-}
-
-//-----------------------------------------------------------------------------
-bool
-QGCVideoStreamInfo::update(const mavlink_video_stream_status_t* vs)
-{
-    bool changed = false;
-    if(_streamInfo.hfov != vs->hfov) {
-        changed = true;
-        _streamInfo.hfov = vs->hfov;
-    }
-    if(_streamInfo.flags != vs->flags) {
-        changed = true;
-        _streamInfo.flags = vs->flags;
-    }
-    if(_streamInfo.bitrate != vs->bitrate) {
-        changed = true;
-        _streamInfo.bitrate = vs->bitrate;
-    }
-    if(_streamInfo.rotation != vs->rotation) {
-        changed = true;
-        _streamInfo.rotation = vs->rotation;
-    }
-    if(_streamInfo.framerate != vs->framerate) {
-        changed = true;
-        _streamInfo.framerate = vs->framerate;
-    }
-    if(_streamInfo.resolution_h != vs->resolution_h) {
-        changed = true;
-        _streamInfo.resolution_h = vs->resolution_h;
-    }
-    if(_streamInfo.resolution_v != vs->resolution_v) {
-        changed = true;
-        _streamInfo.resolution_v = vs->resolution_v;
-    }
-    if(changed) {
-        emit infoChanged();
-    }
-    return changed;
-}

--- a/src/Camera/QGCCameraDefinitionFileHandler.cc
+++ b/src/Camera/QGCCameraDefinitionFileHandler.cc
@@ -1,0 +1,588 @@
+/*!
+ *   @file
+ *   @brief Camera Definition File Parser
+ *   @author Gus Grubba <gus@auterion.com>
+ *   @author Hugo Trippaers <htrippaers@schubergphilis.com>
+ *
+ */
+
+#include "QGCCameraDefinitionFileHandler.h"
+
+QGC_LOGGING_CATEGORY(CameraDefinitionHandler, "CameraDefinitionHandler")
+
+static const char* kCondition       = "condition";
+static const char* kControl         = "control";
+static const char* kDefault         = "default";
+static const char* kDefnition       = "definition";
+static const char* kDescription     = "description";
+static const char* kExclusion       = "exclude";
+static const char* kExclusions      = "exclusions";
+static const char* kLocale          = "locale";
+static const char* kLocalization    = "localization";
+static const char* kMax             = "max";
+static const char* kMin             = "min";
+static const char* kModel           = "model";
+static const char* kName            = "name";
+static const char* kOption          = "option";
+static const char* kOptions         = "options";
+static const char* kOriginal        = "original";
+static const char* kParameter       = "parameter";
+static const char* kParameterrange  = "parameterrange";
+static const char* kParameterranges = "parameterranges";
+static const char* kParameters      = "parameters";
+static const char* kReadOnly        = "readonly";
+static const char* kWriteOnly       = "writeonly";
+static const char* kRoption         = "roption";
+static const char* kStep            = "step";
+static const char* kDecimalPlaces   = "decimalPlaces";
+static const char* kStrings         = "strings";
+static const char* kTranslated      = "translated";
+static const char* kType            = "type";
+static const char* kUnit            = "unit";
+static const char* kUpdate          = "update";
+static const char* kUpdates         = "updates";
+static const char* kValue           = "value";
+static const char* kVendor          = "vendor";
+static const char* kVersion         = "version";
+
+//static const char* kPhotoMode       = "PhotoMode";
+//static const char* kPhotoLapse      = "PhotoLapse";
+//static const char* kPhotoLapseCount = "PhotoLapseCount";
+//static const char* kThermalOpacity  = "ThermalOpacity";
+//static const char* kThermalMode     = "ThermalMode";
+
+//-----------------------------------------------------------------------------
+static bool
+read_attribute(QDomNode& node, const char* tagName, bool& target)
+{
+    QDomNamedNodeMap attrs = node.attributes();
+    if(!attrs.count()) {
+        return false;
+    }
+    QDomNode subNode = attrs.namedItem(tagName);
+    if(subNode.isNull()) {
+        return false;
+    }
+    target = subNode.nodeValue() != "0";
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+static bool
+read_attribute(QDomNode& node, const char* tagName, int& target)
+{
+    QDomNamedNodeMap attrs = node.attributes();
+    if(!attrs.count()) {
+        return false;
+    }
+    QDomNode subNode = attrs.namedItem(tagName);
+    if(subNode.isNull()) {
+        return false;
+    }
+    target = subNode.nodeValue().toInt();
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+static bool
+read_attribute(QDomNode& node, const char* tagName, QString& target)
+{
+    QDomNamedNodeMap attrs = node.attributes();
+    if(!attrs.count()) {
+        return false;
+    }
+    QDomNode subNode = attrs.namedItem(tagName);
+    if(subNode.isNull()) {
+        return false;
+    }
+    target = subNode.nodeValue();
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+static bool
+read_value(QDomNode& element, const char* tagName, QString& target)
+{
+    QDomElement de = element.firstChildElement(tagName);
+    if(de.isNull()) {
+        return false;
+    }
+    target = de.text();
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+QGCCameraDefinitionFileHandler::QGCCameraDefinitionFileHandler(QObject *parent)
+    : QObject(parent)
+{
+}
+
+//-----------------------------------------------------------------------------
+QGCCameraDefinitionFileHandler::~QGCCameraDefinitionFileHandler()
+{
+}
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+bool
+QGCCameraDefinitionFileHandler::parse(QByteArray& bytes)
+{
+    QByteArray originalData(bytes);
+    //-- Handle localization
+    if(!_handleLocalization(bytes)) {
+        return false;
+    }
+    int errorLine;
+    QString errorMsg;
+    QDomDocument doc;
+    if(!doc.setContent(bytes, false, &errorMsg, &errorLine)) {
+        qCritical() << "Unable to parse camera definition file on line:" << errorLine;
+        qCritical() << errorMsg;
+        return false;
+    }
+    //-- Load camera constants
+    QDomNodeList defElements = doc.elementsByTagName(kDefnition);
+    if(!defElements.size() || !_loadConstants(defElements)) {
+        qWarning() <<  "Unable to load camera constants from camera definition";
+        return false;
+    }
+    //-- Load camera parameters
+    QDomNodeList paramElements = doc.elementsByTagName(kParameters);
+    if(!paramElements.size() || !_loadSettings(paramElements)) {
+        qWarning() <<  "Unable to load camera parameters from camera definition";
+        return false;
+    }
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+bool
+QGCCameraDefinitionFileHandler::_handleLocalization(QByteArray& bytes)
+{
+    QString errorMsg;
+    int errorLine;
+    QDomDocument doc;
+    if(!doc.setContent(bytes, false, &errorMsg, &errorLine)) {
+        qCritical() << "Unable to parse camera definition file on line:" << errorLine;
+        qCritical() << errorMsg;
+        return false;
+    }
+    //-- Find out where we are
+    QLocale locale = QLocale::system();
+#if defined (Q_OS_MAC)
+    locale = QLocale(locale.name());
+#endif
+    QString localeName = locale.name().toLower().replace("-", "_");
+    qCDebug(CameraDefinitionHandler) << "Current locale:" << localeName;
+    if(localeName == "en_us") {
+        // Nothing to do
+        return true;
+    }
+    QDomNodeList locRoot = doc.elementsByTagName(kLocalization);
+    if(!locRoot.size()) {
+        // Nothing to do
+        return true;
+    }
+    //-- Iterate locales
+    QDomNode node = locRoot.item(0);
+    QDomElement elem = node.toElement();
+    QDomNodeList locales = elem.elementsByTagName(kLocale);
+    for(int i = 0; i < locales.size(); i++) {
+        QDomNode locale = locales.item(i);
+        QString name;
+        if(!read_attribute(locale, kName, name)) {
+            qWarning() << "Localization entry is missing its name attribute";
+            continue;
+        }
+        // If we found a direct match, deal with it now
+        if(localeName == name.toLower().replace("-", "_")) {
+            return _replaceLocaleStrings(locale, bytes);
+        }
+    }
+    //-- No direct match. Pick first matching language (if any)
+    localeName = localeName.left(3);
+    for(int i = 0; i < locales.size(); i++) {
+        QDomNode locale = locales.item(i);
+        QString name;
+        read_attribute(locale, kName, name);
+        if(name.toLower().startsWith(localeName)) {
+            return _replaceLocaleStrings(locale, bytes);
+        }
+    }
+    //-- Could not find a language to use
+    qWarning() <<  "No match for" << QLocale::system().name() << "in camera definition file";
+    //-- Just use default, en_US
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+bool
+QGCCameraDefinitionFileHandler::_replaceLocaleStrings(const QDomNode node, QByteArray& bytes)
+{
+    QDomElement stringElem = node.toElement();
+    QDomNodeList strings = stringElem.elementsByTagName(kStrings);
+    for(int i = 0; i < strings.size(); i++) {
+        QDomNode stringNode = strings.item(i);
+        QString original;
+        QString translated;
+        if(read_attribute(stringNode, kOriginal, original)) {
+            if(read_attribute(stringNode, kTranslated, translated)) {
+                QString o; o = "\"" + original + "\"";
+                QString t; t = "\"" + translated + "\"";
+                bytes.replace(o.toUtf8(), t.toUtf8());
+                o = ">" + original + "<";
+                t = ">" + translated + "<";
+                bytes.replace(o.toUtf8(), t.toUtf8());
+            }
+        }
+    }
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+bool
+QGCCameraDefinitionFileHandler::_loadConstants(const QDomNodeList nodeList)
+{
+    QDomNode node = nodeList.item(0);
+    if(!read_attribute(node, kVersion, _version)) {
+        return false;
+    }
+    if(!read_value(node, kModel, _modelName)) {
+        return false;
+    }
+    if(!read_value(node, kVendor, _vendor)) {
+        return false;
+    }
+
+    emit constantsUpdated();
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+bool
+QGCCameraDefinitionFileHandler::_loadSettings(const QDomNodeList nodeList)
+{
+    QDomNode node = nodeList.item(0);
+    QDomElement elem = node.toElement();
+    QDomNodeList parameters = elem.elementsByTagName(kParameter);
+    //-- Pre-process settings (maintain order and skip non-controls)
+    for(int i = 0; i < parameters.size(); i++) {
+        QDomNode parameterNode = parameters.item(i);
+        QString name;
+        if(read_attribute(parameterNode, kName, name)) {
+            bool control = true;
+            read_attribute(parameterNode, kControl, control);
+            if(control) {
+                _settings << name;
+            }
+        } else {
+            qCritical() << "Parameter entry missing parameter name";
+            return false;
+        }
+    }
+    //-- Load parameters
+    for(int i = 0; i < parameters.size(); i++) {
+        QDomNode parameterNode = parameters.item(i);
+        QString factName;
+        read_attribute(parameterNode, kName, factName);
+        QString type;
+        if(!read_attribute(parameterNode, kType, type)) {
+            qCritical() << QString("Parameter %1 missing parameter type").arg(factName);
+            return false;
+        }
+        //-- Does it have a control?
+        bool control = true;
+        read_attribute(parameterNode, kControl, control);
+        //-- Is it read only?
+        bool readOnly = false;
+        read_attribute(parameterNode, kReadOnly, readOnly);
+        //-- Is it write only?
+        bool writeOnly = false;
+        read_attribute(parameterNode, kWriteOnly, writeOnly);
+        //-- It can't be both
+        if(readOnly && writeOnly) {
+            qCritical() << QString("Parameter %1 cannot be both read only and write only").arg(factName);
+        }
+        //-- Param type
+        bool unknownType;
+        FactMetaData::ValueType_t factType = FactMetaData::stringToType(type, unknownType);
+        if (unknownType) {
+            qCritical() << QString("Unknown type for parameter %1").arg(factName);
+            return false;
+        }
+        //-- By definition, custom types do not have control
+        if(factType == FactMetaData::valueTypeCustom) {
+            control = false;
+        }
+        //-- Description
+        QString description;
+        if(!read_value(parameterNode, kDescription, description)) {
+            qCritical() << QString("Parameter %1 missing parameter description").arg(factName);
+            return false;
+        }
+        //-- Check for updates
+        QStringList updates = _loadUpdates(parameterNode);
+        if(updates.size()) {
+            qCDebug(CameraDefinitionHandler) << "Parameter" << factName << "requires updates for:" << updates;
+            _requestUpdates[factName] = updates;
+        }
+        //-- Build metadata
+        FactMetaData* metaData = new FactMetaData(factType, factName, nullptr);
+        metaData->setShortDescription(description);
+        metaData->setLongDescription(description);
+        metaData->setHasControl(control);
+        metaData->setReadOnly(readOnly);
+        metaData->setWriteOnly(writeOnly);
+        //-- Options (enums)
+        QDomElement optionElem = parameterNode.toElement();
+        QDomNodeList optionsRoot = optionElem.elementsByTagName(kOptions);
+        if(optionsRoot.size()) {
+            //-- Iterate options
+            QDomNode node = optionsRoot.item(0);
+            QDomElement elem = node.toElement();
+            QDomNodeList options = elem.elementsByTagName(kOption);
+            for(int i = 0; i < options.size(); i++) {
+                QDomNode option = options.item(i);
+                QString optName;
+                QString optValue;
+                QVariant optVariant;
+                if(!_loadNameValue(option, factName, metaData, optName, optValue, optVariant)) {
+                    delete metaData;
+                    return false;
+                }
+                metaData->addEnumInfo(optName, optVariant);
+                _originalOptNames[factName]  << optName;
+                _originalOptValues[factName] << optVariant;
+                //-- Check for exclusions
+                QStringList exclusions = _loadExclusions(option);
+                if(exclusions.size()) {
+                    qCDebug(CameraDefinitionHandler) << "New exclusions:" << factName << optValue << exclusions;
+                    QGCCameraOptionExclusion* pExc = new QGCCameraOptionExclusion(this, factName, optValue, exclusions);
+                    QQmlEngine::setObjectOwnership(pExc, QQmlEngine::CppOwnership);
+                    _valueExclusions.append(pExc);
+                }
+                //-- Check for range rules
+                if(!_loadRanges(option, factName, optValue)) {
+                    delete metaData;
+                    return false;
+                }
+            }
+        }
+        QString defaultValue;
+        if(read_attribute(parameterNode, kDefault, defaultValue)) {
+            QVariant defaultVariant;
+            QString  errorString;
+            if (metaData->convertAndValidateRaw(defaultValue, false, defaultVariant, errorString)) {
+                metaData->setRawDefaultValue(defaultVariant);
+            } else {
+                qWarning() << "Invalid default value for" << factName
+                           << " type:"  << metaData->type()
+                           << " value:" << defaultValue
+                           << " error:" << errorString;
+            }
+        }
+        //-- Set metadata and Fact
+
+        {
+            //-- Check for Min Value
+            QString attr;
+            if(read_attribute(parameterNode, kMin, attr)) {
+                QVariant typedValue;
+                QString  errorString;
+                if (metaData->convertAndValidateRaw(attr, true /* convertOnly */, typedValue, errorString)) {
+                    metaData->setRawMin(typedValue);
+                } else {
+                    qWarning() << "Invalid min value for" << factName
+                               << " type:"  << metaData->type()
+                               << " value:" << attr
+                               << " error:" << errorString;
+                }
+            }
+        }
+        {
+            //-- Check for Max Value
+            QString attr;
+            if(read_attribute(parameterNode, kMax, attr)) {
+                QVariant typedValue;
+                QString  errorString;
+                if (metaData->convertAndValidateRaw(attr, true /* convertOnly */, typedValue, errorString)) {
+                    metaData->setRawMax(typedValue);
+                } else {
+                    qWarning() << "Invalid max value for" << factName
+                               << " type:"  << metaData->type()
+                               << " value:" << attr
+                               << " error:" << errorString;
+                }
+            }
+        }
+        {
+            //-- Check for Step Value
+            QString attr;
+            if(read_attribute(parameterNode, kStep, attr)) {
+                QVariant typedValue;
+                QString  errorString;
+                if (metaData->convertAndValidateRaw(attr, true /* convertOnly */, typedValue, errorString)) {
+                    metaData->setRawIncrement(typedValue.toDouble());
+                } else {
+                    qWarning() << "Invalid step value for" << factName
+                               << " type:"  << metaData->type()
+                               << " value:" << attr
+                               << " error:" << errorString;
+                }
+            }
+        }
+        {
+            //-- Check for Decimal Places
+            QString attr;
+            if(read_attribute(parameterNode, kDecimalPlaces, attr)) {
+                QVariant typedValue;
+                QString  errorString;
+                if (metaData->convertAndValidateRaw(attr, true /* convertOnly */, typedValue, errorString)) {
+                    metaData->setDecimalPlaces(typedValue.toInt());
+                } else {
+                    qWarning() << "Invalid decimal places value for" << factName
+                               << " type:"  << metaData->type()
+                               << " value:" << attr
+                               << " error:" << errorString;
+                }
+            }
+        }
+        {
+            //-- Check for Units
+            QString attr;
+            if(read_attribute(parameterNode, kUnit, attr)) {
+                metaData->setRawUnits(attr);
+            }
+        }
+        qCDebug(CameraDefinitionHandler) << "New parameter:" << factName << (readOnly ? "ReadOnly" : "Writable") << (writeOnly ? "WriteOnly" : "Readable");
+
+        ParsedFactType newFact;
+        newFact.name = factName;
+        newFact.type = factType;
+        newFact.metaData = metaData;
+
+        _parsedFacts.append(newFact);
+    }
+
+    if(_parsedFacts.size() > 0) {
+        emit factsUpdated();
+        return true;
+    }
+    return false;
+}
+
+//-----------------------------------------------------------------------------
+bool
+QGCCameraDefinitionFileHandler::_loadNameValue(QDomNode option, const QString factName, FactMetaData* metaData, QString& optName, QString& optValue, QVariant& optVariant)
+{
+    if(!read_attribute(option, kName, optName)) {
+        qCritical() << QString("Malformed option for parameter %1").arg(factName);
+        return false;
+    }
+    if(!read_attribute(option, kValue, optValue)) {
+        qCritical() << QString("Malformed value for parameter %1").arg(factName);
+        return false;
+    }
+    QString  errorString;
+    if (!metaData->convertAndValidateRaw(optValue, false, optVariant, errorString)) {
+        qWarning() << "Invalid option value, name:" << factName
+                   << " type:"  << metaData->type()
+                   << " value:" << optValue
+                   << " error:" << errorString;
+    }
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+QStringList
+QGCCameraDefinitionFileHandler::_loadExclusions(QDomNode option)
+{
+    QStringList exclusionList;
+    QDomElement optionElem = option.toElement();
+    QDomNodeList excRoot = optionElem.elementsByTagName(kExclusions);
+    if(excRoot.size()) {
+        //-- Iterate exclusions
+        QDomNode node = excRoot.item(0);
+        QDomElement elem = node.toElement();
+        QDomNodeList exclusions = elem.elementsByTagName(kExclusion);
+        for(int i = 0; i < exclusions.size(); i++) {
+            QString exclude = exclusions.item(i).toElement().text();
+            if(!exclude.isEmpty()) {
+                exclusionList << exclude;
+            }
+        }
+    }
+    return exclusionList;
+}
+
+//-----------------------------------------------------------------------------
+QStringList
+QGCCameraDefinitionFileHandler::_loadUpdates(QDomNode option)
+{
+    QStringList updateList;
+    QDomElement optionElem = option.toElement();
+    QDomNodeList updateRoot = optionElem.elementsByTagName(kUpdates);
+    if(updateRoot.size()) {
+        //-- Iterate updates
+        QDomNode node = updateRoot.item(0);
+        QDomElement elem = node.toElement();
+        QDomNodeList updates = elem.elementsByTagName(kUpdate);
+        for(int i = 0; i < updates.size(); i++) {
+            QString update = updates.item(i).toElement().text();
+            if(!update.isEmpty()) {
+                updateList << update;
+            }
+        }
+    }
+    return updateList;
+}
+
+//-----------------------------------------------------------------------------
+bool
+QGCCameraDefinitionFileHandler::_loadRanges(QDomNode option, const QString factName, QString paramValue)
+{
+    QDomElement optionElem = option.toElement();
+    QDomNodeList rangeRoot = optionElem.elementsByTagName(kParameterranges);
+    if(rangeRoot.size()) {
+        QDomNode node = rangeRoot.item(0);
+        QDomElement elem = node.toElement();
+        QDomNodeList parameterRanges = elem.elementsByTagName(kParameterrange);
+        //-- Iterate parameter ranges
+        for(int i = 0; i < parameterRanges.size(); i++) {
+            QString param;
+            QString condition;
+            QDomNode paramRange = parameterRanges.item(i);
+            if(!read_attribute(paramRange, kParameter, param)) {
+                qCritical() << QString("Malformed option range for parameter %1").arg(factName);
+                return false;
+            }
+            read_attribute(paramRange, kCondition, condition);
+            QDomElement pelem = paramRange.toElement();
+            QDomNodeList rangeOptions = pelem.elementsByTagName(kRoption);
+            QStringList  optNames;
+            QStringList  optValues;
+            //-- Iterate options
+            for(int i = 0; i < rangeOptions.size(); i++) {
+                QString optName;
+                QString optValue;
+                QDomNode roption = rangeOptions.item(i);
+                if(!read_attribute(roption, kName, optName)) {
+                    qCritical() << QString("Malformed roption for parameter %1").arg(factName);
+                    return false;
+                }
+                if(!read_attribute(roption, kValue, optValue)) {
+                    qCritical() << QString("Malformed rvalue for parameter %1").arg(factName);
+                    return false;
+                }
+                optNames  << optName;
+                optValues << optValue;
+            }
+            if(optNames.size()) {
+                QGCCameraOptionRange* pRange = new QGCCameraOptionRange(this, factName, paramValue, param, condition, optNames, optValues);
+                _optionRanges.append(pRange);
+                qCDebug(CameraDefinitionHandler) << "New range limit:" << factName << paramValue << param << condition << optNames << optValues;
+            }
+        }
+    }
+    return true;
+}

--- a/src/Camera/QGCCameraDefinitionFileHandler.h
+++ b/src/Camera/QGCCameraDefinitionFileHandler.h
@@ -1,0 +1,62 @@
+/*!
+ *   @file
+ *   @brief Camera Definition File Parser
+ *   @author Gus Grubba <gus@auterion.com>
+ *   @author Hugo Trippaers <htrippaers@schubergphilis.com>
+ *
+ */
+
+#ifndef QGCCAMERADEFINITIONFILEHANDLER_H
+#define QGCCAMERADEFINITIONFILEHANDLER_H
+
+#include "QGCApplication.h"
+#include "QGCCameraOption.h"
+#include <QLoggingCategory>
+
+typedef struct ParsedFact {
+    QString name;
+    FactMetaData::ValueType_t type;
+    FactMetaData* metaData;
+} ParsedFactType;
+
+class QGCCameraDefinitionFileHandler : public QObject
+{
+    Q_OBJECT
+public:
+    QGCCameraDefinitionFileHandler(QObject *);
+    ~QGCCameraDefinitionFileHandler();
+
+    bool parse(QByteArray&);
+
+    // Constants read from the definition file and set on the CameraComponent
+    int _version;
+    QString _modelName;
+    QString _vendor;
+
+    // Everything parsed from the parameters
+    QList<QGCCameraOptionRange*> _optionRanges;
+    QStringList _settings;
+    QMap<QString, QStringList> _requestUpdates;
+    QMap<QString, QStringList> _originalOptNames;
+    QMap<QString, QVariantList> _originalOptValues;
+    QList<QGCCameraOptionExclusion*> _valueExclusions;
+
+    QList<ParsedFact> _parsedFacts;
+
+
+signals:
+    void constantsUpdated();
+    void factsUpdated();
+
+protected:
+    bool _handleLocalization(QByteArray&);
+    bool _replaceLocaleStrings(QDomNode, QByteArray&);
+    bool _loadConstants(const QDomNodeList nodeList);
+    bool _loadSettings(const QDomNodeList nodeList);
+    bool _loadNameValue(QDomNode, const QString factName, FactMetaData* metaData, QString& optName, QString& optValue, QVariant& optVariant);
+    QStringList _loadExclusions(QDomNode option);
+    QStringList _loadUpdates(QDomNode option);
+    bool _loadRanges(QDomNode option, const QString factName, QString paramValue);
+};
+
+#endif // QGCCAMERADEFINITIONFILEHANDLER_H

--- a/src/Camera/QGCCameraHttpDownloader.cc
+++ b/src/Camera/QGCCameraHttpDownloader.cc
@@ -1,0 +1,68 @@
+/*!
+ *   @file
+ *   @brief Http downloader, used to download camera definition files
+ *   @author Gus Grubba <gus@auterion.com>
+ *   @author Hugo Trippaers <htrippaers@schubergphilis.com>
+ *
+ */
+
+#include "QGCCameraHttpDownloader.h"
+
+QGC_LOGGING_CATEGORY(CameraHttpLog, "CameraHttpLog")
+
+
+//-----------------------------------------------------------------------------
+QGCCameraHttpDownloader::QGCCameraHttpDownloader(QObject *parent)
+    : QObject(parent)
+{
+}
+
+//-----------------------------------------------------------------------------
+QGCCameraHttpDownloader::~QGCCameraHttpDownloader()
+{
+    delete _netManager;
+    _netManager = nullptr;
+}
+
+void
+QGCCameraHttpDownloader::download(const QString &url) {
+    qCDebug(CameraHttpLog) << "Request camera definition:" << url;
+    if(!_netManager) {
+        _netManager = new QNetworkAccessManager(this);
+    }
+    QNetworkProxy savedProxy = _netManager->proxy();
+    QNetworkProxy tempProxy;
+    tempProxy.setType(QNetworkProxy::DefaultProxy);
+    _netManager->setProxy(tempProxy);
+    QNetworkRequest request(url);
+    request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    QSslConfiguration conf = request.sslConfiguration();
+    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
+    request.setSslConfiguration(conf);
+    QNetworkReply* reply = _netManager->get(request);
+    connect(reply, &QNetworkReply::finished,  this, &QGCCameraHttpDownloader::_downloadFinished);
+    _netManager->setProxy(savedProxy);
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCCameraHttpDownloader::_downloadFinished()
+{
+    QNetworkReply* reply = qobject_cast<QNetworkReply*>(sender());
+    if(!reply) {
+        return;
+    }
+    int err = reply->error();
+    int http_code = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    QByteArray data = reply->readAll();
+    if(err == QNetworkReply::NoError && http_code == 200) {
+        data.append("\n");
+        qCDebug(CameraHttpLog) << "Camera Definition download ok";
+    } else {
+        data.clear();
+        qWarning(CameraHttpLog) << QString("Camera Definition download error: %1 status: %2").arg(reply->errorString(), reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toString());
+    }
+    emit dataReady(data);
+    //reply->deleteLater();
+}
+

--- a/src/Camera/QGCCameraHttpDownloader.h
+++ b/src/Camera/QGCCameraHttpDownloader.h
@@ -1,0 +1,34 @@
+/*!
+ *   @file
+ *   @brief Camera Http Download Utility
+ *   @author Gus Grubba <gus@auterion.com>
+ *   @author Hugo Trippaers <htrippaers@schubergphilis.com>
+ *
+ */
+
+#ifndef QGCCAMERAHTTPDOWNLOADER_H
+#define QGCCAMERAHTTPDOWNLOADER_H
+
+#include "QGCApplication.h"
+#include <QLoggingCategory>
+
+class QGCCameraHttpDownloader : public QObject
+{
+    Q_OBJECT
+public:
+    explicit QGCCameraHttpDownloader(QObject *);
+    ~QGCCameraHttpDownloader();
+
+    void download(const QString &);
+
+protected:
+    QNetworkAccessManager*              _netManager         = nullptr;
+
+protected slots:
+    virtual void    _downloadFinished       ();
+
+signals:
+    void                                dataReady           (QByteArray);
+
+};
+#endif // QGCCAMERAHTTPDOWNLOADER_H

--- a/src/Camera/QGCCameraOption.cc
+++ b/src/Camera/QGCCameraOption.cc
@@ -1,0 +1,30 @@
+/*!
+ *   @file
+ *   @brief Camera Option Classes
+ *   @author Gus Grubba <gus@auterion.com>
+ *   @author Hugo Trippaers <htrippaers@schubergphilis.com>
+ *
+ */
+
+#include "QGCCameraOption.h"
+
+//-----------------------------------------------------------------------------
+QGCCameraOptionExclusion::QGCCameraOptionExclusion(QObject* parent, QString param_, QString value_, QStringList exclusions_)
+    : QObject(parent)
+    , param(param_)
+    , value(value_)
+    , exclusions(exclusions_)
+{
+}
+
+//-----------------------------------------------------------------------------
+QGCCameraOptionRange::QGCCameraOptionRange(QObject* parent, QString param_, QString value_, QString targetParam_, QString condition_, QStringList optNames_, QStringList optValues_)
+    : QObject(parent)
+    , param(param_)
+    , value(value_)
+    , targetParam(targetParam_)
+    , condition(condition_)
+    , optNames(optNames_)
+    , optValues(optValues_)
+{
+}

--- a/src/Camera/QGCCameraOption.h
+++ b/src/Camera/QGCCameraOption.h
@@ -1,0 +1,42 @@
+/*!
+ *   @file
+ *   @brief Camera Option Classes
+ *   @author Gus Grubba <gus@auterion.com>
+ *   @author Hugo Trippaers <htrippaers@schubergphilis.com>
+ *
+ */
+
+#ifndef QGCCAMERAOPTION_H
+#define QGCCAMERAOPTION_H
+
+#include "QGCApplication.h"
+
+//-----------------------------------------------------------------------------
+/// Camera option exclusions
+class QGCCameraOptionExclusion : public QObject
+{
+public:
+    QGCCameraOptionExclusion(QObject* parent, QString param_, QString value_, QStringList exclusions_);
+    QString param;
+    QString value;
+    QStringList exclusions;
+};
+
+//-----------------------------------------------------------------------------
+/// Camera option ranges
+class QGCCameraOptionRange : public QObject
+{
+public:
+    QGCCameraOptionRange(QObject* parent, QString param_, QString value_, QString targetParam_, QString condition_, QStringList optNames_, QStringList optValues_);
+    QString param;
+    QString value;
+    QString targetParam;
+    QString condition;
+    QStringList  optNames;
+    QStringList  optValues;
+    QVariantList optVariants;
+};
+
+
+
+#endif // QGCCAMERAOPTION_H

--- a/src/Camera/QGCVideoStreamInfo.cc
+++ b/src/Camera/QGCVideoStreamInfo.cc
@@ -1,0 +1,66 @@
+/*!
+ *   @file
+ *   @brief Camera Video Stream Info
+ *   @author Gus Grubba <gus@auterion.com>
+ *   @author Hugo Trippaers <htrippaers@schubergphilis.com>
+ *
+ */
+
+#include "QGCVideoStreamInfo.h"
+
+//-----------------------------------------------------------------------------
+QGCVideoStreamInfo::QGCVideoStreamInfo(QObject* parent, const mavlink_video_stream_information_t *si)
+    : QObject(parent)
+{
+    memcpy(&_streamInfo, si, sizeof(mavlink_video_stream_information_t));
+}
+
+//-----------------------------------------------------------------------------
+qreal
+QGCVideoStreamInfo::aspectRatio()
+{
+    qreal ar = 1.0;
+    if(_streamInfo.resolution_h && _streamInfo.resolution_v) {
+        ar = static_cast<double>(_streamInfo.resolution_h) / static_cast<double>(_streamInfo.resolution_v);
+    }
+    return ar;
+}
+
+//-----------------------------------------------------------------------------
+bool
+QGCVideoStreamInfo::update(const mavlink_video_stream_status_t* vs)
+{
+    bool changed = false;
+    if(_streamInfo.hfov != vs->hfov) {
+        changed = true;
+        _streamInfo.hfov = vs->hfov;
+    }
+    if(_streamInfo.flags != vs->flags) {
+        changed = true;
+        _streamInfo.flags = vs->flags;
+    }
+    if(_streamInfo.bitrate != vs->bitrate) {
+        changed = true;
+        _streamInfo.bitrate = vs->bitrate;
+    }
+    if(_streamInfo.rotation != vs->rotation) {
+        changed = true;
+        _streamInfo.rotation = vs->rotation;
+    }
+    if(_streamInfo.framerate != vs->framerate) {
+        changed = true;
+        _streamInfo.framerate = vs->framerate;
+    }
+    if(_streamInfo.resolution_h != vs->resolution_h) {
+        changed = true;
+        _streamInfo.resolution_h = vs->resolution_h;
+    }
+    if(_streamInfo.resolution_v != vs->resolution_v) {
+        changed = true;
+        _streamInfo.resolution_v = vs->resolution_v;
+    }
+    if(changed) {
+        emit infoChanged();
+    }
+    return changed;
+}

--- a/src/Camera/QGCVideoStreamInfo.h
+++ b/src/Camera/QGCVideoStreamInfo.h
@@ -1,0 +1,48 @@
+/*!
+ *   @file
+ *   @brief Camera Video Stream Info
+ *   @author Gus Grubba <gus@auterion.com>
+ *   @author Hugo Trippaers <htrippaers@schubergphilis.com>
+ *
+ */
+
+#ifndef QGCVIDEOSTREAMINFO_H
+#define QGCVIDEOSTREAMINFO_H
+
+#include "QGCApplication.h"
+
+/// Video Stream Info
+/// Encapsulates the contents of a [VIDEO_STREAM_INFORMATION](https://mavlink.io/en/messages/common.html#VIDEO_STREAM_INFORMATION) message
+class QGCVideoStreamInfo : public QObject
+{
+    Q_OBJECT
+public:
+    QGCVideoStreamInfo(QObject* parent, const mavlink_video_stream_information_t* si);
+
+    Q_PROPERTY(QString      uri                 READ uri                NOTIFY infoChanged)
+    Q_PROPERTY(QString      name                READ name               NOTIFY infoChanged)
+    Q_PROPERTY(int          streamID            READ streamID           NOTIFY infoChanged)
+    Q_PROPERTY(int          type                READ type               NOTIFY infoChanged)
+    Q_PROPERTY(qreal        aspectRatio         READ aspectRatio        NOTIFY infoChanged)
+    Q_PROPERTY(qreal        hfov                READ hfov               NOTIFY infoChanged)
+    Q_PROPERTY(bool         isThermal           READ isThermal          NOTIFY infoChanged)
+
+    QString uri             () { return QString(_streamInfo.uri);  }
+    QString name            () { return QString(_streamInfo.name); }
+    qreal   aspectRatio     ();
+    qreal   hfov            () { return _streamInfo.hfov; }
+    int     type            () { return _streamInfo.type; }
+    int     streamID        () { return _streamInfo.stream_id; }
+    bool    isThermal       () { return _streamInfo.flags & VIDEO_STREAM_STATUS_FLAGS_THERMAL; }
+
+    bool    update          (const mavlink_video_stream_status_t* vs);
+
+signals:
+    void    infoChanged     ();
+
+private:
+    mavlink_video_stream_information_t _streamInfo;
+};
+
+
+#endif // QGCVIDEOSTREAMINFO_H


### PR DESCRIPTION
Refactor CameraControl
- Separate Definition File Parsing to dedicated class
- Separate HTTP Downloading to dedicated class
- Move Video Stream Info class to own files
- Move Camera Options to own files

I was trying to understand how the Camera Component worked and refactored some of it in the meantime. If this is useful I'm happy to take feedback and spend some more time cleaning this up. If it isn't, no worries. The exercise was worth it :-) The idea was that this refactoring improves separation of concerns and makes testing of internal bits easier. Though no tests have been added yet by me.

The functional testing I did on this bit is with a ArduPilot and a camera component. Scenarios tested are with a definition file and without a definition file. 
