### PR TITLE
Migrated to new Mapbox provider API

### DIFF
--- a/src/QtLocationPlugin/MapboxMapProvider.cpp
+++ b/src/QtLocationPlugin/MapboxMapProvider.cpp
@@ -3,7 +3,7 @@
 #include "QGCMapEngine.h"
 #include "SettingsManager.h"
 
-static const QString MapBoxUrl = QStringLiteral("https://api.mapbox.com/v4/%1/%2/%3/%4.jpg80?access_token=%5");
+static const QString MapBoxUrl = QStringLiteral("https://api.mapbox.com/styles/v1/mapbox/%1/tiles/%2/%3/%4?access_token=%5");
 static const QString MapBoxUrlCustom = QStringLiteral("https://api.mapbox.com/styles/v1/%1/%2/tiles/256/%3/%4/%5?access_token=%6");
 
 MapboxMapProvider::MapboxMapProvider(const QString &mapName, const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject* parent)

--- a/src/QtLocationPlugin/MapboxMapProvider.h
+++ b/src/QtLocationPlugin/MapboxMapProvider.h
@@ -31,7 +31,7 @@ class MapboxStreetMapProvider : public MapboxMapProvider {
 
 public:
     MapboxStreetMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.streets"), AVERAGE_MAPBOX_STREET_MAP,
+        : MapboxMapProvider(QStringLiteral("streets-v10"), AVERAGE_MAPBOX_STREET_MAP,
                             QGeoMapType::StreetMap, parent) {}
 };
 
@@ -40,7 +40,7 @@ class MapboxLightMapProvider : public MapboxMapProvider {
 
 public:
     MapboxLightMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.light"), AVERAGE_TILE_SIZE,
+        : MapboxMapProvider(QStringLiteral("light-v9"), AVERAGE_TILE_SIZE,
                             QGeoMapType::CustomMap, parent) {}
 };
 
@@ -49,7 +49,7 @@ class MapboxDarkMapProvider : public MapboxMapProvider {
 
 public:
     MapboxDarkMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.dark"), AVERAGE_TILE_SIZE,
+        : MapboxMapProvider(QStringLiteral("dark-v9"), AVERAGE_TILE_SIZE,
                             QGeoMapType::CustomMap, parent) {}
 };
 
@@ -58,7 +58,7 @@ class MapboxSatelliteMapProvider : public MapboxMapProvider {
 
 public:
     MapboxSatelliteMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.satellite"), AVERAGE_MAPBOX_SAT_MAP,
+        : MapboxMapProvider(QStringLiteral("satellite-v9"), AVERAGE_MAPBOX_SAT_MAP,
                             QGeoMapType::SatelliteMapDay, parent) {}
 };
 
@@ -67,16 +67,16 @@ class MapboxHybridMapProvider : public MapboxMapProvider {
 
 public:
     MapboxHybridMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.streets-satellite"), AVERAGE_MAPBOX_SAT_MAP,
+        : MapboxMapProvider(QStringLiteral("satellite-streets-v10"), AVERAGE_MAPBOX_SAT_MAP,
                             QGeoMapType::HybridMap, parent) {}
 };
 
-class MapboxWheatPasteMapProvider : public MapboxMapProvider {
+class MapboxBrightMapProvider : public MapboxMapProvider {
     Q_OBJECT
 
 public:
-    MapboxWheatPasteMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.wheatpaste"), AVERAGE_TILE_SIZE,
+    MapboxBrightMapProvider(QObject* parent = nullptr)
+        : MapboxMapProvider(QStringLiteral("bright-v9"), AVERAGE_TILE_SIZE,
                             QGeoMapType::CustomMap, parent) {}
 };
 
@@ -85,17 +85,8 @@ class MapboxStreetsBasicMapProvider : public MapboxMapProvider {
 
 public:
     MapboxStreetsBasicMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.streets-basic"), AVERAGE_TILE_SIZE,
+        : MapboxMapProvider(QStringLiteral("basic-v9"), AVERAGE_TILE_SIZE,
                             QGeoMapType::StreetMap, parent) {}
-};
-
-class MapboxComicMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxComicMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.comic"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
 };
 
 class MapboxOutdoorsMapProvider : public MapboxMapProvider {
@@ -103,52 +94,7 @@ class MapboxOutdoorsMapProvider : public MapboxMapProvider {
 
 public:
     MapboxOutdoorsMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.outdoors"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
-};
-
-class MapboxRunBikeHikeMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxRunBikeHikeMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.run-bike-hike"), AVERAGE_MAPBOX_STREET_MAP,
-                            QGeoMapType::CycleMap, parent) {}
-};
-
-class MapboxPencilMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxPencilMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.pencil"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
-};
-
-class MapboxPiratesMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxPiratesMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.pirates"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
-};
-
-class MapboxEmeraldMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxEmeraldMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.emerald"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
-};
-
-class MapboxHighContrastMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxHighContrastMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.high-contrast"), AVERAGE_TILE_SIZE,
+        : MapboxMapProvider(QStringLiteral("outdoors-v10"), AVERAGE_TILE_SIZE,
                             QGeoMapType::CustomMap, parent) {}
 };
 

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -65,8 +65,7 @@ UrlFactory::UrlFactory() : _timeout(5 * 1000) {
     _providersTable["Mapbox Hybrid"]       = new MapboxHybridMapProvider(this);
     _providersTable["Mapbox StreetsBasic"] = new MapboxStreetsBasicMapProvider(this);
     _providersTable["Mapbox Outdoors"]     = new MapboxOutdoorsMapProvider(this);
-    _providersTable["Mapbox RunBikeHike"]  = new MapboxRunBikeHikeMapProvider(this);
-    _providersTable["Mapbox HighContrast"] = new MapboxHighContrastMapProvider(this);
+    _providersTable["Mapbox Bright"]       = new MapboxBrightMapProvider(this);
     _providersTable["Mapbox Custom"]       = new MapboxCustomMapProvider(this);
 
     //_providersTable["MapQuest Map"] = new MapQuestMapMapProvider(this);


### PR DESCRIPTION
Since **1st of June 2020** Mapbox migrated to new API and no longer supports requests to Legacy Maps and Legacy Static Images APIs. See blog post and deprecated style list as well as new map styles: 
- https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4
- https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/#which-classic-styles-are-being-deprecated
- https://docs.mapbox.com/api/maps/styles/#mapbox-styles

So since June all Mapbox maps show blank tiles. This PR fixes this.