### PR TITLE
MissionManager: get currentMissionIndex from High_lat messages

### DIFF
--- a/src/MissionManager/MissionManager.h
+++ b/src/MissionManager/MissionManager.h
@@ -40,7 +40,10 @@ private slots:
     void _mavlinkMessageReceived(const mavlink_message_t& message);
 
 private:
+    void _handleHighLatency(const mavlink_message_t& message);
+    void _handleHighLatency2(const mavlink_message_t& message);
     void _handleMissionCurrent(const mavlink_message_t& message);
+    void _updateMissionIndex(int index);
     void _handleHeartbeat(const mavlink_message_t& message);
 
     int _cachedLastCurrentIndex;


### PR DESCRIPTION
High latency messages provide wp_num field, which is meant to be used instead of MISSION_CURRENT when we are under high latency link. 

This PR provides support in mission manager so it takes the currentMissionIndex from high latency as well, so the highlighting of the active Waypoint over the map works under High latency as well.