### PR TITLE
main.cc: Different runguard names for custom builds

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -223,7 +223,14 @@ bool checkAndroidWritePermission() {
 int main(int argc, char *argv[])
 {
 #ifndef __mobile__
-    RunGuard guard("QGroundControlRunGuardKey");
+    // We make the runguard key different for custom and non custom
+    // builds, so they can be executed together in the same device.
+    // Stable and Daily have same QGC_APPLICATION_NAME so they would
+    // not be able to run at the same time
+    QString runguardString(QGC_APPLICATION_NAME);
+    runguardString.append("RunGuardKey");
+
+    RunGuard guard(runguardString);
     if (!guard.tryToRun()) {
         // QApplication is necessary to use QMessageBox
         QApplication errorApp(argc, argv);


### PR DESCRIPTION
This way we can run at the same time regular QGC and custom QGC and runguard will not block the execution of each other.

This was talked in slack a few months back, and it was suggested to use the executable name for the runguard. This way the runguards of daily and stable will block each other, but custom builds would be able to run independently.

I wasn't able to get the executable name, but with the approach of this commit we have the same effect, only Custom will be compatible with non custom, but stable and daily will still have same runguard and thus won't be able to run at the same time.


