### PR TITLE
fix joystick: avoid accessing invalid pointer after vehicle is destroyed

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -459,6 +459,10 @@ Vehicle::~Vehicle()
     delete _mav;
     _mav = nullptr;
 
+    if (_joystickManager) {
+        _startJoystick(false);
+    }
+
 #if defined(QGC_AIRMAP_ENABLED)
     if (_airspaceVehicleManager) {
         delete _airspaceVehicleManager;
@@ -1876,6 +1880,7 @@ void Vehicle::_startJoystick(bool start)
             joystick->startPolling(this);
         } else {
             joystick->stopPolling();
+            joystick->wait(500);
         }
     }
 }


### PR DESCRIPTION
Joystick::_activeVehicle was still pointing to a vehicle after it got destroyed (e.g. on disconnect) and the thread continued to access it.

Ideally Joystick::_activeVehicle would be changed to a weak pointer.

@DonLakeFlyer your assessment in https://github.com/mavlink/qgroundcontrol/issues/9263 is correct, there was no protection. I did not see a crash, but I saw the pointer being dereferenced after free.

This should fix https://github.com/mavlink/qgroundcontrol/issues/9263
