### PR TITLE
PX4 PID tuning page continued

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -687,6 +687,7 @@ HEADERS += \
     src/Vehicle/GPSRTKFactGroup.h \
     src/Vehicle/InitialConnectStateMachine.h \
     src/Vehicle/MAVLinkLogManager.h \
+    src/Vehicle/MAVLinkStreamConfig.h \
     src/Vehicle/MultiVehicleManager.h \
     src/Vehicle/StateMachine.h \
     src/Vehicle/SysStatusSensorInfo.h \
@@ -918,6 +919,7 @@ SOURCES += \
     src/Vehicle/GPSRTKFactGroup.cc \
     src/Vehicle/InitialConnectStateMachine.cc \
     src/Vehicle/MAVLinkLogManager.cc \
+    src/Vehicle/MAVLinkStreamConfig.cc \
     src/Vehicle/MultiVehicleManager.cc \
     src/Vehicle/StateMachine.cc \
     src/Vehicle/SysStatusSensorInfo.cc \

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -700,6 +700,8 @@ HEADERS += \
     src/Vehicle/VehicleClockFactGroup.h \
     src/Vehicle/VehicleDistanceSensorFactGroup.h \
     src/Vehicle/VehicleEstimatorStatusFactGroup.h \
+    src/Vehicle/VehicleLocalPositionFactGroup.h \
+    src/Vehicle/VehicleLocalPositionSetpointFactGroup.h \
     src/Vehicle/VehicleGPSFactGroup.h \
     src/Vehicle/VehicleGPS2FactGroup.h \
     src/Vehicle/VehicleLinkManager.h \
@@ -932,6 +934,8 @@ SOURCES += \
     src/Vehicle/VehicleClockFactGroup.cc \
     src/Vehicle/VehicleDistanceSensorFactGroup.cc \
     src/Vehicle/VehicleEstimatorStatusFactGroup.cc \
+    src/Vehicle/VehicleLocalPositionFactGroup.cc \
+    src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc \
     src/Vehicle/VehicleGPSFactGroup.cc \
     src/Vehicle/VehicleGPS2FactGroup.cc \
     src/Vehicle/VehicleLinkManager.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -323,6 +323,8 @@
         <file alias="Vehicle/GPSFact.json">src/Vehicle/GPSFact.json</file>
         <file alias="Vehicle/GPSRTKFact.json">src/Vehicle/GPSRTKFact.json</file>
         <file alias="Vehicle/SetpointFact.json">src/Vehicle/SetpointFact.json</file>
+        <file alias="Vehicle/LocalPositionFact.json">src/Vehicle/LocalPositionFact.json</file>
+        <file alias="Vehicle/LocalPositionSetpointFact.json">src/Vehicle/LocalPositionFact.json</file>
         <file alias="Vehicle/SubmarineFact.json">src/Vehicle/SubmarineFact.json</file>
         <file alias="Vehicle/TemperatureFact.json">src/Vehicle/TemperatureFact.json</file>
         <file alias="Vehicle/TerrainFactGroup.json">src/Vehicle/TerrainFactGroup.json</file>

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
@@ -54,7 +54,7 @@ QUrl PX4TuningComponent::setupSource(void) const
 
     switch (_vehicle->vehicleType()) {
         case MAV_TYPE_FIXED_WING:
-            qmlFile = "qrc:/qml/PX4TuningComponentPlane.qml";
+            qmlFile = ""; // TODO: "qrc:/qml/PX4TuningComponentPlane.qml";
             break;
         case MAV_TYPE_QUADROTOR:
         case MAV_TYPE_COAXIAL:

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
@@ -12,8 +12,9 @@
 #include "PX4AutoPilotPlugin.h"
 #include "AirframeComponent.h"
 
-static bool isCopter(MAV_TYPE type) {
+static bool isCopterOrFW(MAV_TYPE type) {
     switch (type) {
+        case MAV_TYPE_FIXED_WING:
         case MAV_TYPE_QUADROTOR:
         case MAV_TYPE_COAXIAL:
         case MAV_TYPE_HELICOPTER:
@@ -29,7 +30,7 @@ static bool isCopter(MAV_TYPE type) {
 
 PX4TuningComponent::PX4TuningComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)
-    , _name(isCopter(vehicle->vehicleType()) ? tr("PID Tuning") : tr("Tuning"))
+    , _name(isCopterOrFW(vehicle->vehicleType()) ? tr("PID Tuning") : tr("Tuning"))
 {
 }
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
@@ -12,25 +12,9 @@
 #include "PX4AutoPilotPlugin.h"
 #include "AirframeComponent.h"
 
-static bool isCopterOrFW(MAV_TYPE type) {
-    switch (type) {
-        case MAV_TYPE_FIXED_WING:
-        case MAV_TYPE_QUADROTOR:
-        case MAV_TYPE_COAXIAL:
-        case MAV_TYPE_HELICOPTER:
-        case MAV_TYPE_HEXAROTOR:
-        case MAV_TYPE_OCTOROTOR:
-        case MAV_TYPE_TRICOPTER:
-            return true;
-        default:
-            break;
-    }
-    return false;
-}
-
 PX4TuningComponent::PX4TuningComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)
-    , _name(isCopterOrFW(vehicle->vehicleType()) ? tr("PID Tuning") : tr("Tuning"))
+    , _name(tr("PID Tuning"))
 {
 }
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -9,14 +9,10 @@
 
 import QtQuick          2.3
 import QtQuick.Controls 1.2
-import QtCharts         2.2
 import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0
-import QGroundControl.FactSystem    1.0
-import QGroundControl.FactControls  1.0
-import QGroundControl.ScreenTools   1.0
 
 SetupPage {
     id:             tuningPage
@@ -25,43 +21,7 @@ SetupPage {
     Component {
         id: pageComponent
 
-        Item {
-            width: availableWidth
-
-            FactPanelController {
-                id:         controller
-            }
-
-            QGCTabBar {
-                id:             bar
-                width:          parent.width
-                anchors.top:    parent.top
-                QGCTabButton {
-                    text:       qsTr("Rate Controller")
-                }
-                QGCTabButton {
-                    text:       qsTr("Attitude Controller")
-                }
-                QGCTabButton {
-                    text:       qsTr("Velocity Controller")
-                }
-                QGCTabButton {
-                    text:       qsTr("Position Controller")
-                }
-            }
-
-            property var pages:  [
-                "PX4TuningComponentCopterRate.qml",
-                "PX4TuningComponentCopterAttitude.qml",
-                "PX4TuningComponentCopterVelocity.qml",
-                "PX4TuningComponentCopterPosition.qml"
-            ]
-
-            Loader {
-                source:         pages[bar.currentIndex]
-                width:          parent.width
-                anchors.top:    bar.bottom
-            }
+        PX4TuningComponentCopterAll {
         }
     } // Component - pageComponent
 } // SetupPage

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -40,13 +40,21 @@ SetupPage {
                     text:       qsTr("Rate Controller")
                 }
                 QGCTabButton {
+                    text:       qsTr("Attitude Controller")
+                }
+                QGCTabButton {
                     text:       qsTr("Velocity Controller")
+                }
+                QGCTabButton {
+                    text:       qsTr("Position Controller")
                 }
             }
 
             property var pages:  [
                 "PX4TuningComponentCopterRate.qml",
-                "PX4TuningComponentCopterVelocity.qml"
+                "PX4TuningComponentCopterAttitude.qml",
+                "PX4TuningComponentCopterVelocity.qml",
+                "PX4TuningComponentCopterPosition.qml"
             ]
 
             Loader {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -25,113 +25,35 @@ SetupPage {
     Component {
         id: pageComponent
 
-        Column {
+        Item {
             width: availableWidth
 
             FactPanelController {
                 id:         controller
             }
 
-            PIDTuning {
-                width: availableWidth
-
-                property var roll: QtObject {
-                    property string name: qsTr("Roll")
-                    property var plot: [
-                        { name: "Response", value: globals.activeVehicle.rollRate.value },
-                        { name: "Setpoint", value: globals.activeVehicle.setpoint.rollRate.value }
-                    ]
-                    property var params: ListModel {
-                        ListElement {
-                            title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
-                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                            param:          "MC_ROLLRATE_K"
-                            min:            0.3
-                            max:            3
-                            step:           0.05
-                        }
-                        ListElement {
-                            title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
-                            description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
-                            param:          "MC_ROLLRATE_D"
-                            min:            0.0004
-                            max:            0.01
-                            step:           0.0002
-                        }
-                        ListElement {
-                            title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
-                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                            param:          "MC_ROLLRATE_I"
-                            min:            0.1
-                            max:            0.5
-                            step:           0.025
-                        }
-                    }
+            QGCTabBar {
+                id:             bar
+                width:          parent.width
+                anchors.top:    parent.top
+                QGCTabButton {
+                    text:       qsTr("Rate Controller")
                 }
-                property var pitch: QtObject {
-                    property string name: qsTr("Pitch")
-                    property var plot: [
-                        { name: "Response", value: globals.activeVehicle.pitchRate.value },
-                        { name: "Setpoint", value: globals.activeVehicle.setpoint.pitchRate.value }
-                    ]
-                    property var params: ListModel {
-                        ListElement {
-                            title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
-                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                            param:          "MC_PITCHRATE_K"
-                            min:            0.3
-                            max:            3
-                            step:           0.05
-                        }
-                        ListElement {
-                            title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
-                            description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
-                            param:          "MC_PITCHRATE_D"
-                            min:            0.0004
-                            max:            0.01
-                            step:           0.0002
-                        }
-                        ListElement {
-                            title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
-                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                            param:          "MC_PITCHRATE_I"
-                            min:            0.1
-                            max:            0.5
-                            step:           0.025
-                        }
-                    }
+                QGCTabButton {
+                    text:       qsTr("Velocity Controller")
                 }
-                property var yaw: QtObject {
-                    property string name: qsTr("Yaw")
-                    property var plot: [
-                        { name: "Response", value: globals.activeVehicle.yawRate.value },
-                        { name: "Setpoint", value: globals.activeVehicle.setpoint.yawRate.value }
-                    ]
-                    property var params: ListModel {
-                        ListElement {
-                            title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
-                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                            param:          "MC_YAWRATE_K"
-                            min:            0.3
-                            max:            3
-                            step:           0.05
-                        }
-                        ListElement {
-                            title:          qsTr("Integral Gain (MC_YAWRATE_I)")
-                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                            param:          "MC_YAWRATE_I"
-                            min:            0.04
-                            max:            0.4
-                            step:           0.02
-                        }
-                    }
-                }
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                title: "Rate"
-                unit: "deg/s"
-                axis: [ roll, pitch, yaw ]
             }
-        } // Column
+
+            property var pages:  [
+                "PX4TuningComponentCopterRate.qml",
+                "PX4TuningComponentCopterVelocity.qml"
+            ]
+
+            Loader {
+                source:         pages[bar.currentIndex]
+                width:          parent.width
+                anchors.top:    bar.bottom
+            }
+        }
     } // Component - pageComponent
 } // SetupPage

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -22,6 +22,7 @@ SetupPage {
         id: pageComponent
 
         PX4TuningComponentCopterAll {
+            height: availableHeight
         }
     } // Component - pageComponent
 } // SetupPage

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -34,84 +34,103 @@ SetupPage {
 
             PIDTuning {
                 width: availableWidth
-                property var rollList: ListModel {
-                    ListElement {
-                        title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
-                        description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                        param:          "MC_ROLLRATE_K"
-                        min:            0.3
-                        max:            3
-                        step:           0.05
-                    }
-                    ListElement {
-                        title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
-                        description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
-                        param:          "MC_ROLLRATE_D"
-                        min:            0.0004
-                        max:            0.01
-                        step:           0.0002
-                    }
-                    ListElement {
-                        title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
-                        description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                        param:          "MC_ROLLRATE_I"
-                        min:            0.1
-                        max:            0.5
-                        step:           0.025
-                    }
-                }
-                property var pitchList: ListModel {
-                    ListElement {
-                        title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
-                        description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                        param:          "MC_PITCHRATE_K"
-                        min:            0.3
-                        max:            3
-                        step:           0.05
-                    }
-                    ListElement {
-                        title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
-                        description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
-                        param:          "MC_PITCHRATE_D"
-                        min:            0.0004
-                        max:            0.01
-                        step:           0.0002
-                    }
-                    ListElement {
-                        title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
-                        description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                        param:          "MC_PITCHRATE_I"
-                        min:            0.1
-                        max:            0.5
-                        step:           0.025
+
+                property var roll: QtObject {
+                    property string name: qsTr("Roll")
+                    property var plot: [
+                        { name: "Response", value: globals.activeVehicle.rollRate.value },
+                        { name: "Setpoint", value: globals.activeVehicle.setpoint.rollRate.value }
+                    ]
+                    property var params: ListModel {
+                        ListElement {
+                            title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
+                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                            param:          "MC_ROLLRATE_K"
+                            min:            0.3
+                            max:            3
+                            step:           0.05
+                        }
+                        ListElement {
+                            title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
+                            description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                            param:          "MC_ROLLRATE_D"
+                            min:            0.0004
+                            max:            0.01
+                            step:           0.0002
+                        }
+                        ListElement {
+                            title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
+                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                            param:          "MC_ROLLRATE_I"
+                            min:            0.1
+                            max:            0.5
+                            step:           0.025
+                        }
                     }
                 }
-                property var yawList: ListModel {
-                    ListElement {
-                        title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
-                        description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                        param:          "MC_YAWRATE_K"
-                        min:            0.3
-                        max:            3
-                        step:           0.05
+                property var pitch: QtObject {
+                    property string name: qsTr("Pitch")
+                    property var plot: [
+                        { name: "Response", value: globals.activeVehicle.pitchRate.value },
+                        { name: "Setpoint", value: globals.activeVehicle.setpoint.pitchRate.value }
+                    ]
+                    property var params: ListModel {
+                        ListElement {
+                            title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
+                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                            param:          "MC_PITCHRATE_K"
+                            min:            0.3
+                            max:            3
+                            step:           0.05
+                        }
+                        ListElement {
+                            title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
+                            description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                            param:          "MC_PITCHRATE_D"
+                            min:            0.0004
+                            max:            0.01
+                            step:           0.0002
+                        }
+                        ListElement {
+                            title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
+                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                            param:          "MC_PITCHRATE_I"
+                            min:            0.1
+                            max:            0.5
+                            step:           0.025
+                        }
                     }
-                    ListElement {
-                        title:          qsTr("Integral Gain (MC_YAWRATE_I)")
-                        description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                        param:          "MC_YAWRATE_I"
-                        min:            0.04
-                        max:            0.4
-                        step:           0.02
+                }
+                property var yaw: QtObject {
+                    property string name: qsTr("Yaw")
+                    property var plot: [
+                        { name: "Response", value: globals.activeVehicle.yawRate.value },
+                        { name: "Setpoint", value: globals.activeVehicle.setpoint.yawRate.value }
+                    ]
+                    property var params: ListModel {
+                        ListElement {
+                            title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
+                            description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                            param:          "MC_YAWRATE_K"
+                            min:            0.3
+                            max:            3
+                            step:           0.05
+                        }
+                        ListElement {
+                            title:          qsTr("Integral Gain (MC_YAWRATE_I)")
+                            description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                            param:          "MC_YAWRATE_I"
+                            min:            0.04
+                            max:            0.4
+                            step:           0.02
+                        }
                     }
                 }
                 anchors.left:   parent.left
                 anchors.right:  parent.right
-                tuneList:            [ qsTr("Roll"), qsTr("Pitch"), qsTr("Yaw") ]
-                params:              [
-                    rollList,
-                    pitchList,
-                    yawList
-                ]
+                title: "Rate"
+                unit: "deg/s"
+                axis: [ roll, pitch, yaw ]
             }
         } // Column
     } // Component - pageComponent

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
@@ -1,0 +1,57 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.ScreenTools   1.0
+
+Item {
+    width: availableWidth
+
+    FactPanelController {
+        id:         controller
+    }
+
+    QGCTabBar {
+        id:             bar
+        width:          parent.width
+        anchors.top:    parent.top
+        QGCTabButton {
+            text:       qsTr("Rate Controller")
+        }
+        QGCTabButton {
+            text:       qsTr("Attitude Controller")
+        }
+        QGCTabButton {
+            text:       qsTr("Velocity Controller")
+        }
+        QGCTabButton {
+            text:       qsTr("Position Controller")
+        }
+    }
+
+    property var pages:  [
+        "PX4TuningComponentCopterRate.qml",
+        "PX4TuningComponentCopterAttitude.qml",
+        "PX4TuningComponentCopterVelocity.qml",
+        "PX4TuningComponentCopterPosition.qml"
+    ]
+
+    Loader {
+        source:            pages[bar.currentIndex]
+        width:             parent.width
+        anchors.top:       bar.bottom
+        anchors.topMargin: ScreenTools.defaultFontPixelWidth
+    }
+}

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
@@ -53,5 +53,6 @@ Item {
         width:             parent.width
         anchors.top:       bar.bottom
         anchors.topMargin: ScreenTools.defaultFontPixelWidth
+        anchors.bottom:    parent.bottom
     }
 }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
@@ -1,0 +1,87 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+Column {
+    width: availableWidth
+
+    PIDTuning {
+        width: availableWidth
+
+        property var roll: QtObject {
+            property string name: qsTr("Roll")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.roll.value },
+                { name: "Setpoint", value: globals.activeVehicle.setpoint.roll.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Proportional Gain (MC_ROLL_P)")
+                    description:    qsTr("Increase for more responsiveness, reduce if the attitude overshoots.")
+                    param:          "MC_ROLL_P"
+                    min:            1
+                    max:            14
+                    step:           0.5
+                }
+            }
+        }
+        property var pitch: QtObject {
+            property string name: qsTr("Pitch")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.pitch.value },
+                { name: "Setpoint", value: globals.activeVehicle.setpoint.pitch.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Proportional Gain (MC_PITCH_P)")
+                    description:    qsTr("Increase for more responsiveness, reduce if the attitude overshoots.")
+                    param:          "MC_PITCH_P"
+                    min:            1
+                    max:            14
+                    step:           0.5
+                }
+            }
+        }
+        property var yaw: QtObject {
+            property string name: qsTr("Yaw")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.heading.value },
+                { name: "Setpoint", value: globals.activeVehicle.setpoint.yaw.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Proportional Gain (MC_YAW_P)")
+                    description:    qsTr("Increase for more responsiveness, reduce if the attitude overshoots (there is only a setpoint when yaw is fixed, i.e. when centering the stick).")
+                    param:          "MC_YAW_P"
+                    min:            1
+                    max:            5
+                    step:           0.1
+                }
+            }
+        }
+        anchors.left:   parent.left
+        anchors.right:  parent.right
+        title: "Attitude"
+        tuningMode: Vehicle.ModeRateAndAttitude
+        unit: "deg"
+        axis: [ roll, pitch, yaw ]
+        showAutoModeChange: true
+    }
+}
+

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
@@ -18,8 +18,9 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 
-Column {
+ColumnLayout {
     width: availableWidth
+    anchors.fill: parent
 
     PIDTuning {
         width: availableWidth
@@ -75,8 +76,6 @@ Column {
                 }
             }
         }
-        anchors.left:   parent.left
-        anchors.right:  parent.right
         title: "Attitude"
         tuningMode: Vehicle.ModeRateAndAttitude
         unit: "deg"

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+Column {
+    width: availableWidth
+    property Fact _mcPosMode:       controller.getParameterFact(-1, "MPC_POS_MODE", false)
+
+    GridLayout {
+        columns: 2
+
+        QGCLabel {
+            text:               qsTr("Position control mode (set this to 'simple' during tuning):")
+            visible:            _mcPosMode
+        }
+        FactComboBox {
+            fact:               _mcPosMode
+            indexModel:         false
+            visible:            _mcPosMode
+        }
+    }
+
+    PIDTuning {
+        width: availableWidth
+        property var horizontal: QtObject {
+            property string name: qsTr("Horizontal")
+            property string plotTitle: qsTr("Horizontal (Y direction, sidewards)")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.localPosition.y.value },
+                { name: "Setpoint", value: globals.activeVehicle.localPositionSetpoint.y.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Proportional gain (MPC_XY_P)")
+                    description:    qsTr("Increase for more responsiveness, reduce if the position overshoots (there is only a setpoint when hovering, i.e. when centering the stick).")
+                    param:          "MPC_XY_P"
+                    min:            0
+                    max:            2
+                    step:           0.05
+                }
+            }
+        }
+        property var vertical: QtObject {
+            property string name: qsTr("Vertical")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.localPosition.z.value },
+                { name: "Setpoint", value: globals.activeVehicle.localPositionSetpoint.z.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Proportional gain (MPC_Z_P)")
+                    description:    qsTr("Increase for more responsiveness, reduce if the position overshoots (there is only a setpoint when hovering, i.e. when centering the stick).")
+                    param:          "MPC_Z_P"
+                    min:            0
+                    max:            2
+                    step:           0.05
+                }
+            }
+        }
+        anchors.left:   parent.left
+        anchors.right:  parent.right
+        title: "Position"
+        tuningMode: Vehicle.ModeVelocityAndPosition
+        unit: "m"
+        axis: [ horizontal, vertical ]
+        chartDisplaySec: 50
+    }
+}
+
+

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
@@ -18,8 +18,9 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 
-Column {
+ColumnLayout {
     width: availableWidth
+    anchors.fill: parent
     property Fact _mcPosMode:       controller.getParameterFact(-1, "MPC_POS_MODE", false)
 
     GridLayout {
@@ -73,8 +74,6 @@ Column {
                 }
             }
         }
-        anchors.left:   parent.left
-        anchors.right:  parent.right
         title: "Position"
         tuningMode: Vehicle.ModeVelocityAndPosition
         unit: "m"

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
@@ -18,106 +18,138 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 
-PIDTuning {
+Column {
     width: availableWidth
+    property Fact _airmode:           controller.getParameterFact(-1, "MC_AIRMODE", false)
+    property Fact _thrustModelFactor: controller.getParameterFact(-1, "THR_MDL_FAC", false)
 
-    property var roll: QtObject {
-        property string name: qsTr("Roll")
-        property var plot: [
-            { name: "Response", value: globals.activeVehicle.rollRate.value },
-            { name: "Setpoint", value: globals.activeVehicle.setpoint.rollRate.value }
-        ]
-        property var params: ListModel {
-            ListElement {
-                title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
-                description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                param:          "MC_ROLLRATE_K"
-                min:            0.3
-                max:            3
-                step:           0.05
-            }
-            ListElement {
-                title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
-                description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
-                param:          "MC_ROLLRATE_D"
-                min:            0.0004
-                max:            0.01
-                step:           0.0002
-            }
-            ListElement {
-                title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
-                description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                param:          "MC_ROLLRATE_I"
-                min:            0.1
-                max:            0.5
-                step:           0.025
-            }
+    GridLayout {
+        columns: 2
+
+        QGCLabel {
+            textFormat:         Text.RichText
+            text:               qsTr("Airmode (disable during tuning) <b><a href=\"https://docs.px4.io/master/en/config_mc/pid_tuning_guide_multicopter.html#airmode-mixer-saturation\">?</a></b>:")
+            onLinkActivated:    Qt.openUrlExternally(link)
+            visible:            _airmode
+        }
+        FactComboBox {
+            fact:               _airmode
+            indexModel:         false
+            visible:            _airmode
+        }
+
+        QGCLabel {
+            textFormat:         Text.RichText
+            text:               qsTr("Thrust curve <b><a href=\"https://docs.px4.io/master/en/config_mc/pid_tuning_guide_multicopter.html#thrust-curve\">?</a></b>:")
+            onLinkActivated:    Qt.openUrlExternally(link)
+            visible:            _thrustModelFactor
+        }
+        FactTextField {
+            fact:               _thrustModelFactor
+            visible:            _thrustModelFactor
         }
     }
-    property var pitch: QtObject {
-        property string name: qsTr("Pitch")
-        property var plot: [
-            { name: "Response", value: globals.activeVehicle.pitchRate.value },
-            { name: "Setpoint", value: globals.activeVehicle.setpoint.pitchRate.value }
-        ]
-        property var params: ListModel {
-            ListElement {
-                title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
-                description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                param:          "MC_PITCHRATE_K"
-                min:            0.3
-                max:            3
-                step:           0.05
-            }
-            ListElement {
-                title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
-                description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
-                param:          "MC_PITCHRATE_D"
-                min:            0.0004
-                max:            0.01
-                step:           0.0002
-            }
-            ListElement {
-                title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
-                description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                param:          "MC_PITCHRATE_I"
-                min:            0.1
-                max:            0.5
-                step:           0.025
-            }
-        }
-    }
-    property var yaw: QtObject {
-        property string name: qsTr("Yaw")
-        property var plot: [
-            { name: "Response", value: globals.activeVehicle.yawRate.value },
-            { name: "Setpoint", value: globals.activeVehicle.setpoint.yawRate.value }
-        ]
-        property var params: ListModel {
-            ListElement {
-                title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
-                description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
-                param:          "MC_YAWRATE_K"
-                min:            0.3
-                max:            3
-                step:           0.05
-            }
-            ListElement {
-                title:          qsTr("Integral Gain (MC_YAWRATE_I)")
-                description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
-                param:          "MC_YAWRATE_I"
-                min:            0.04
-                max:            0.4
-                step:           0.02
+    PIDTuning {
+        width: availableWidth
+
+        property var roll: QtObject {
+            property string name: qsTr("Roll")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.rollRate.value },
+                { name: "Setpoint", value: globals.activeVehicle.setpoint.rollRate.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
+                    description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                    param:          "MC_ROLLRATE_K"
+                    min:            0.3
+                    max:            3
+                    step:           0.05
+                }
+                ListElement {
+                    title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
+                    description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                    param:          "MC_ROLLRATE_D"
+                    min:            0.0004
+                    max:            0.01
+                    step:           0.0002
+                }
+                ListElement {
+                    title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
+                    description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                    param:          "MC_ROLLRATE_I"
+                    min:            0.1
+                    max:            0.5
+                    step:           0.025
+                }
             }
         }
+        property var pitch: QtObject {
+            property string name: qsTr("Pitch")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.pitchRate.value },
+                { name: "Setpoint", value: globals.activeVehicle.setpoint.pitchRate.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
+                    description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                    param:          "MC_PITCHRATE_K"
+                    min:            0.3
+                    max:            3
+                    step:           0.05
+                }
+                ListElement {
+                    title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
+                    description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                    param:          "MC_PITCHRATE_D"
+                    min:            0.0004
+                    max:            0.01
+                    step:           0.0002
+                }
+                ListElement {
+                    title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
+                    description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                    param:          "MC_PITCHRATE_I"
+                    min:            0.1
+                    max:            0.5
+                    step:           0.025
+                }
+            }
+        }
+        property var yaw: QtObject {
+            property string name: qsTr("Yaw")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.yawRate.value },
+                { name: "Setpoint", value: globals.activeVehicle.setpoint.yawRate.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
+                    description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                    param:          "MC_YAWRATE_K"
+                    min:            0.3
+                    max:            3
+                    step:           0.05
+                }
+                ListElement {
+                    title:          qsTr("Integral Gain (MC_YAWRATE_I)")
+                    description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                    param:          "MC_YAWRATE_I"
+                    min:            0.04
+                    max:            0.4
+                    step:           0.02
+                }
+            }
+        }
+        anchors.left:   parent.left
+        anchors.right:  parent.right
+        title: "Rate"
+        tuningMode: Vehicle.ModeRateAndAttitude
+        unit: "deg/s"
+        axis: [ roll, pitch, yaw ]
+        chartDisplaySec: 3
     }
-    anchors.left:   parent.left
-    anchors.right:  parent.right
-    title: "Rate"
-    tuningMode: Vehicle.ModeRateAndAttitude
-    unit: "deg/s"
-    axis: [ roll, pitch, yaw ]
-    chartDisplaySec: 3
 }
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
@@ -18,8 +18,9 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 
-Column {
+ColumnLayout {
     width: availableWidth
+    anchors.fill: parent
     property Fact _airmode:           controller.getParameterFact(-1, "MC_AIRMODE", false)
     property Fact _thrustModelFactor: controller.getParameterFact(-1, "THR_MDL_FAC", false)
 
@@ -143,8 +144,6 @@ Column {
                 }
             }
         }
-        anchors.left:   parent.left
-        anchors.right:  parent.right
         title: "Rate"
         tuningMode: Vehicle.ModeRateAndAttitude
         unit: "deg/s"

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
@@ -1,0 +1,123 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+PIDTuning {
+    width: availableWidth
+
+    property var roll: QtObject {
+        property string name: qsTr("Roll")
+        property var plot: [
+            { name: "Response", value: globals.activeVehicle.rollRate.value },
+            { name: "Setpoint", value: globals.activeVehicle.setpoint.rollRate.value }
+        ]
+        property var params: ListModel {
+            ListElement {
+                title:          qsTr("Overall Multiplier (MC_ROLLRATE_K)")
+                description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                param:          "MC_ROLLRATE_K"
+                min:            0.3
+                max:            3
+                step:           0.05
+            }
+            ListElement {
+                title:          qsTr("Differential Gain (MC_ROLLRATE_D)")
+                description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                param:          "MC_ROLLRATE_D"
+                min:            0.0004
+                max:            0.01
+                step:           0.0002
+            }
+            ListElement {
+                title:          qsTr("Integral Gain (MC_ROLLRATE_I)")
+                description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                param:          "MC_ROLLRATE_I"
+                min:            0.1
+                max:            0.5
+                step:           0.025
+            }
+        }
+    }
+    property var pitch: QtObject {
+        property string name: qsTr("Pitch")
+        property var plot: [
+            { name: "Response", value: globals.activeVehicle.pitchRate.value },
+            { name: "Setpoint", value: globals.activeVehicle.setpoint.pitchRate.value }
+        ]
+        property var params: ListModel {
+            ListElement {
+                title:          qsTr("Overall Multiplier (MC_PITCHRATE_K)")
+                description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                param:          "MC_PITCHRATE_K"
+                min:            0.3
+                max:            3
+                step:           0.05
+            }
+            ListElement {
+                title:          qsTr("Differential Gain (MC_PITCHRATE_D)")
+                description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
+                param:          "MC_PITCHRATE_D"
+                min:            0.0004
+                max:            0.01
+                step:           0.0002
+            }
+            ListElement {
+                title:          qsTr("Integral Gain (MC_PITCHRATE_I)")
+                description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                param:          "MC_PITCHRATE_I"
+                min:            0.1
+                max:            0.5
+                step:           0.025
+            }
+        }
+    }
+    property var yaw: QtObject {
+        property string name: qsTr("Yaw")
+        property var plot: [
+            { name: "Response", value: globals.activeVehicle.yawRate.value },
+            { name: "Setpoint", value: globals.activeVehicle.setpoint.yawRate.value }
+        ]
+        property var params: ListModel {
+            ListElement {
+                title:          qsTr("Overall Multiplier (MC_YAWRATE_K)")
+                description:    qsTr("Multiplier for P, I and D gains: increase for more responsiveness, reduce if the rates overshoot (and increasing D does not help).")
+                param:          "MC_YAWRATE_K"
+                min:            0.3
+                max:            3
+                step:           0.05
+            }
+            ListElement {
+                title:          qsTr("Integral Gain (MC_YAWRATE_I)")
+                description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                param:          "MC_YAWRATE_I"
+                min:            0.04
+                max:            0.4
+                step:           0.02
+            }
+        }
+    }
+    anchors.left:   parent.left
+    anchors.right:  parent.right
+    title: "Rate"
+    tuningMode: Vehicle.ModeRateAndAttitude
+    unit: "deg/s"
+    axis: [ roll, pitch, yaw ]
+    chartDisplaySec: 3
+}
+

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
@@ -150,6 +150,7 @@ Column {
         unit: "deg/s"
         axis: [ roll, pitch, yaw ]
         chartDisplaySec: 3
+        showAutoModeChange: true
     }
 }
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
@@ -18,82 +18,100 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 
-PIDTuning {
+Column {
     width: availableWidth
+    property Fact _mcPosMode:       controller.getParameterFact(-1, "MPC_POS_MODE", false)
 
-    property var horizontal: QtObject {
-        property string name: qsTr("Horizontal")
-        property string plotTitle: qsTr("Horizontal (Y direction, sidewards)")
-        property var plot: [
-            { name: "Response", value: globals.activeVehicle.localPosition.vy.value },
-            { name: "Setpoint", value: globals.activeVehicle.localPositionSetpoint.vy.value }
-        ]
-        property var params: ListModel {
-            ListElement {
-                title:          qsTr("Proportional gain (MPC_XY_VEL_P_ACC)")
-                description:    qsTr("TODO")
-                param:          "MPC_XY_VEL_P_ACC"
-                min:            1.2
-                max:            5
-                step:           0.05
-            }
-            ListElement {
-                title:          qsTr("Integral gain (MPC_XY_VEL_I_ACC)")
-                description:    qsTr("TODO")
-                param:          "MPC_XY_VEL_I_ACC"
-                min:            0.2
-                max:            10
-                step:           0.2
-            }
-            ListElement {
-                title:          qsTr("Differential gain (MPC_XY_VEL_D_ACC)")
-                description:    qsTr("TODO")
-                param:          "MPC_XY_VEL_D_ACC"
-                min:            0.1
-                max:            2
-                step:           0.05
-            }
+    GridLayout {
+        columns: 2
+
+        QGCLabel {
+            text:               qsTr("Position control mode (set this to 'simple' during tuning):")
+            visible:            _mcPosMode
+        }
+        FactComboBox {
+            fact:               _mcPosMode
+            indexModel:         false
+            visible:            _mcPosMode
         }
     }
-    property var vertical: QtObject {
-        property string name: qsTr("Vertical")
-        property var plot: [
-            { name: "Response", value: globals.activeVehicle.localPosition.vz.value },
-            { name: "Setpoint", value: globals.activeVehicle.localPositionSetpoint.vz.value }
-        ]
-        property var params: ListModel {
-            ListElement {
-                title:          qsTr("Proportional gain (MPC_Z_VEL_P_ACC)")
-                description:    qsTr("TODO")
-                param:          "MPC_Z_VEL_P_ACC"
-                min:            2
-                max:            15
-                step:           0.5
-            }
-            ListElement {
-                title:          qsTr("Integral gain (MPC_Z_VEL_I_ACC)")
-                description:    qsTr("TODO")
-                param:          "MPC_Z_VEL_I_ACC"
-                min:            0.2
-                max:            3
-                step:           0.05
-            }
-            ListElement {
-                title:          qsTr("Differential gain (MPC_Z_VEL_D_ACC)")
-                description:    qsTr("TODO")
-                param:          "MPC_Z_VEL_D_ACC"
-                min:            0
-                max:            2
-                step:           0.05
+
+    PIDTuning {
+        width: availableWidth
+        property var horizontal: QtObject {
+            property string name: qsTr("Horizontal")
+            property string plotTitle: qsTr("Horizontal (Y direction, sidewards)")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.localPosition.vy.value },
+                { name: "Setpoint", value: globals.activeVehicle.localPositionSetpoint.vy.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Proportional gain (MPC_XY_VEL_P_ACC)")
+                    description:    qsTr("TODO")
+                    param:          "MPC_XY_VEL_P_ACC"
+                    min:            1.2
+                    max:            5
+                    step:           0.05
+                }
+                ListElement {
+                    title:          qsTr("Integral gain (MPC_XY_VEL_I_ACC)")
+                    description:    qsTr("TODO")
+                    param:          "MPC_XY_VEL_I_ACC"
+                    min:            0.2
+                    max:            10
+                    step:           0.2
+                }
+                ListElement {
+                    title:          qsTr("Differential gain (MPC_XY_VEL_D_ACC)")
+                    description:    qsTr("TODO")
+                    param:          "MPC_XY_VEL_D_ACC"
+                    min:            0.1
+                    max:            2
+                    step:           0.05
+                }
             }
         }
+        property var vertical: QtObject {
+            property string name: qsTr("Vertical")
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.localPosition.vz.value },
+                { name: "Setpoint", value: globals.activeVehicle.localPositionSetpoint.vz.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Proportional gain (MPC_Z_VEL_P_ACC)")
+                    description:    qsTr("TODO")
+                    param:          "MPC_Z_VEL_P_ACC"
+                    min:            2
+                    max:            15
+                    step:           0.5
+                }
+                ListElement {
+                    title:          qsTr("Integral gain (MPC_Z_VEL_I_ACC)")
+                    description:    qsTr("TODO")
+                    param:          "MPC_Z_VEL_I_ACC"
+                    min:            0.2
+                    max:            3
+                    step:           0.05
+                }
+                ListElement {
+                    title:          qsTr("Differential gain (MPC_Z_VEL_D_ACC)")
+                    description:    qsTr("TODO")
+                    param:          "MPC_Z_VEL_D_ACC"
+                    min:            0
+                    max:            2
+                    step:           0.05
+                }
+            }
+        }
+        anchors.left:   parent.left
+        anchors.right:  parent.right
+        title: "Velocity"
+        tuningMode: Vehicle.ModeVelocityAndPosition
+        unit: "m/s"
+        axis: [ horizontal, vertical ]
     }
-    anchors.left:   parent.left
-    anchors.right:  parent.right
-    title: "Velocity"
-    tuningMode: Vehicle.ModeVelocityAndPosition
-    unit: "m/s"
-    axis: [ horizontal, vertical ]
 }
 
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
@@ -18,8 +18,9 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 
-Column {
+ColumnLayout {
     width: availableWidth
+    anchors.fill: parent
     property Fact _mcPosMode:       controller.getParameterFact(-1, "MPC_POS_MODE", false)
 
     GridLayout {
@@ -105,8 +106,6 @@ Column {
                 }
             }
         }
-        anchors.left:   parent.left
-        anchors.right:  parent.right
         title: "Velocity"
         tuningMode: Vehicle.ModeVelocityAndPosition
         unit: "m/s"

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
@@ -1,0 +1,99 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+PIDTuning {
+    width: availableWidth
+
+    property var horizontal: QtObject {
+        property string name: qsTr("Horizontal")
+        property string plotTitle: qsTr("Horizontal (Y direction, sidewards)")
+        property var plot: [
+            { name: "Response", value: globals.activeVehicle.localPosition.vy.value },
+            { name: "Setpoint", value: globals.activeVehicle.localPositionSetpoint.vy.value }
+        ]
+        property var params: ListModel {
+            ListElement {
+                title:          qsTr("Proportional gain (MPC_XY_VEL_P_ACC)")
+                description:    qsTr("TODO")
+                param:          "MPC_XY_VEL_P_ACC"
+                min:            1.2
+                max:            5
+                step:           0.05
+            }
+            ListElement {
+                title:          qsTr("Integral gain (MPC_XY_VEL_I_ACC)")
+                description:    qsTr("TODO")
+                param:          "MPC_XY_VEL_I_ACC"
+                min:            0.2
+                max:            10
+                step:           0.2
+            }
+            ListElement {
+                title:          qsTr("Differential gain (MPC_XY_VEL_D_ACC)")
+                description:    qsTr("TODO")
+                param:          "MPC_XY_VEL_D_ACC"
+                min:            0.1
+                max:            2
+                step:           0.05
+            }
+        }
+    }
+    property var vertical: QtObject {
+        property string name: qsTr("Vertical")
+        property var plot: [
+            { name: "Response", value: globals.activeVehicle.localPosition.vz.value },
+            { name: "Setpoint", value: globals.activeVehicle.localPositionSetpoint.vz.value }
+        ]
+        property var params: ListModel {
+            ListElement {
+                title:          qsTr("Proportional gain (MPC_Z_VEL_P_ACC)")
+                description:    qsTr("TODO")
+                param:          "MPC_Z_VEL_P_ACC"
+                min:            2
+                max:            15
+                step:           0.5
+            }
+            ListElement {
+                title:          qsTr("Integral gain (MPC_Z_VEL_I_ACC)")
+                description:    qsTr("TODO")
+                param:          "MPC_Z_VEL_I_ACC"
+                min:            0.2
+                max:            3
+                step:           0.05
+            }
+            ListElement {
+                title:          qsTr("Differential gain (MPC_Z_VEL_D_ACC)")
+                description:    qsTr("TODO")
+                param:          "MPC_Z_VEL_D_ACC"
+                min:            0
+                max:            2
+                step:           0.05
+            }
+        }
+    }
+    anchors.left:   parent.left
+    anchors.right:  parent.right
+    title: "Velocity"
+    tuningMode: Vehicle.ModeVelocityAndPosition
+    unit: "m/s"
+    axis: [ horizontal, vertical ]
+}
+
+

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
@@ -48,7 +48,7 @@ Column {
             property var params: ListModel {
                 ListElement {
                     title:          qsTr("Proportional gain (MPC_XY_VEL_P_ACC)")
-                    description:    qsTr("TODO")
+                    description:    qsTr("Increase for more responsiveness, reduce if the velocity overshoots (and increasing D does not help).")
                     param:          "MPC_XY_VEL_P_ACC"
                     min:            1.2
                     max:            5
@@ -56,7 +56,7 @@ Column {
                 }
                 ListElement {
                     title:          qsTr("Integral gain (MPC_XY_VEL_I_ACC)")
-                    description:    qsTr("TODO")
+                    description:    qsTr("Increase to reduce steady-state error (e.g. wind)")
                     param:          "MPC_XY_VEL_I_ACC"
                     min:            0.2
                     max:            10
@@ -64,7 +64,7 @@ Column {
                 }
                 ListElement {
                     title:          qsTr("Differential gain (MPC_XY_VEL_D_ACC)")
-                    description:    qsTr("TODO")
+                    description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
                     param:          "MPC_XY_VEL_D_ACC"
                     min:            0.1
                     max:            2
@@ -81,7 +81,7 @@ Column {
             property var params: ListModel {
                 ListElement {
                     title:          qsTr("Proportional gain (MPC_Z_VEL_P_ACC)")
-                    description:    qsTr("TODO")
+                    description:    qsTr("Increase for more responsiveness, reduce if the velocity overshoots (and increasing D does not help).")
                     param:          "MPC_Z_VEL_P_ACC"
                     min:            2
                     max:            15
@@ -89,7 +89,7 @@ Column {
                 }
                 ListElement {
                     title:          qsTr("Integral gain (MPC_Z_VEL_I_ACC)")
-                    description:    qsTr("TODO")
+                    description:    qsTr("Increase to reduce steady-state error")
                     param:          "MPC_Z_VEL_I_ACC"
                     min:            0.2
                     max:            3
@@ -97,7 +97,7 @@ Column {
                 }
                 ListElement {
                     title:          qsTr("Differential gain (MPC_Z_VEL_D_ACC)")
-                    description:    qsTr("TODO")
+                    description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
                     param:          "MPC_Z_VEL_D_ACC"
                     min:            0
                     max:            2

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
@@ -9,14 +9,10 @@
 
 import QtQuick          2.3
 import QtQuick.Controls 1.2
-import QtCharts         2.2
 import QtQuick.Layouts  1.2
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0
-import QGroundControl.FactSystem    1.0
-import QGroundControl.FactControls  1.0
-import QGroundControl.ScreenTools   1.0
 
 SetupPage {
     id:             tuningPage
@@ -25,31 +21,7 @@ SetupPage {
     Component {
         id: pageComponent
 
-        Item {
-            width: availableWidth
-
-            FactPanelController {
-                id:         controller
-            }
-
-            QGCTabBar {
-                id:             bar
-                width:          parent.width
-                anchors.top:    parent.top
-                QGCTabButton {
-                    text:       qsTr("TECS")
-                }
-            }
-
-            property var pages:  [
-                "PX4TuningComponentPlaneTECS.qml",
-            ]
-
-            Loader {
-                source:         pages[bar.currentIndex]
-                width:          parent.width
-                anchors.top:    bar.bottom
-            }
+        PX4TuningComponentPlaneAll {
         }
     } // Component - pageComponent
 } // SetupPage

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
@@ -22,6 +22,7 @@ SetupPage {
         id: pageComponent
 
         PX4TuningComponentPlaneAll {
+            height: availableHeight
         }
     } // Component - pageComponent
 } // SetupPage

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml
@@ -25,61 +25,31 @@ SetupPage {
     Component {
         id: pageComponent
 
-        Column {
+        Item {
             width: availableWidth
-
-            Component.onCompleted: {
-                // We use QtCharts only on Desktop platforms
-                showAdvanced = !ScreenTools.isMobile
-            }
 
             FactPanelController {
                 id:         controller
             }
 
-            // Standard tuning page
-            FactSliderPanel {
-                width:          availableWidth
-                visible:        !advanced
-                sliderModel: ListModel {
-                    ListElement {
-                        title:          qsTr("Cruise throttle")
-                        description:    qsTr("This is the throttle setting required to achieve the desired cruise speed. Most planes need 50-60%.")
-                        param:          "FW_THR_CRUISE"
-                        min:            20
-                        max:            80
-                        step:           1
-                    }
+            QGCTabBar {
+                id:             bar
+                width:          parent.width
+                anchors.top:    parent.top
+                QGCTabButton {
+                    text:       qsTr("TECS")
                 }
             }
+
+            property var pages:  [
+                "PX4TuningComponentPlaneTECS.qml",
+            ]
 
             Loader {
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                sourceComponent:    advanced ? advancePageComponent : undefined
+                source:         pages[bar.currentIndex]
+                width:          parent.width
+                anchors.top:    bar.bottom
             }
-
-            Component {
-                id: advancePageComponent
-
-                PIDTuning {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    tuneList:            [ qsTr("Roll"), qsTr("Pitch"), qsTr("Yaw") ]
-                    params:              [
-                        [ controller.getParameterFact(-1, "FW_RR_P"),
-                         controller.getParameterFact(-1, "FW_RR_I"),
-                         controller.getParameterFact(-1, "FW_RR_FF"),
-                         controller.getParameterFact(-1, "FW_R_TC"),],
-                        [ controller.getParameterFact(-1, "FW_PR_P"),
-                         controller.getParameterFact(-1, "FW_PR_I"),
-                         controller.getParameterFact(-1, "FW_PR_FF"),
-                         controller.getParameterFact(-1, "FW_P_TC") ],
-                        [ controller.getParameterFact(-1, "FW_YR_P"),
-                         controller.getParameterFact(-1, "FW_YR_I"),
-                         controller.getParameterFact(-1, "FW_YR_FF") ] ]
-                }
-            } // Component - Advanced Page
-        } // Column
+        }
     } // Component - pageComponent
 } // SetupPage

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
@@ -1,0 +1,45 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.ScreenTools   1.0
+
+Item {
+    width: availableWidth
+
+    FactPanelController {
+        id:         controller
+    }
+
+    QGCTabBar {
+        id:             bar
+        width:          parent.width
+        anchors.top:    parent.top
+        QGCTabButton {
+            text:       qsTr("TECS")
+        }
+    }
+
+    property var pages:  [
+        "PX4TuningComponentPlaneTECS.qml",
+    ]
+
+    Loader {
+        source:            pages[bar.currentIndex]
+        width:             parent.width
+        anchors.top:       bar.bottom
+        anchors.topMargin: ScreenTools.defaultFontPixelWidth
+    }
+}

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
@@ -41,5 +41,6 @@ Item {
         width:             parent.width
         anchors.top:       bar.bottom
         anchors.topMargin: ScreenTools.defaultFontPixelWidth
+        anchors.bottom:    parent.bottom
     }
 }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml
@@ -18,8 +18,9 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Vehicle       1.0
 
-Column {
+ColumnLayout {
     width: availableWidth
+    anchors.fill: parent
 
     PIDTuning {
         width: availableWidth
@@ -43,8 +44,6 @@ Column {
             }
             // TODO: add other params
         }
-        anchors.left:   parent.left
-        anchors.right:  parent.right
         title: "TECS"
         tuningMode: Vehicle.ModeAltitudeAndAirspeed
         unit: ""

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml
@@ -1,0 +1,56 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+Column {
+    width: availableWidth
+
+    PIDTuning {
+        width: availableWidth
+        property var data: QtObject {
+            property string name: qsTr("Altitude & Airspeed")
+            property var plot: [
+                { name: "Airspeed", value: globals.activeVehicle.airSpeed.value },
+                { name: "Airspeed Setpoint", value: globals.activeVehicle.airSpeedSetpoint.value },
+                { name: "Altitide (Rel)", value: globals.activeVehicle.altitudeTuning.value },
+                { name: "Altitude Setpoint", value: globals.activeVehicle.altitudeTuningSetpoint.value }
+            ]
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Height rate feed forward (FW_T_HRATE_FF)")
+                    description:    qsTr("TODO")
+                    param:          "FW_T_HRATE_FF"
+                    min:            0
+                    max:            1
+                    step:           0.05
+                }
+            }
+            // TODO: add other params
+        }
+        anchors.left:   parent.left
+        anchors.right:  parent.right
+        title: "TECS"
+        tuningMode: Vehicle.ModeAltitudeAndAirspeed
+        unit: ""
+        axis: [ data ]
+    }
+}
+
+
+

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
@@ -11,7 +11,9 @@
 import QtQuick              2.3
 import QtQuick.Controls     1.2
 
-import QGroundControl.Controls  1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.ScreenTools   1.0
 
 SetupPage {
     id:             tuningPage
@@ -20,64 +22,37 @@ SetupPage {
     Component {
         id: pageComponent
 
-        FactSliderPanel {
-            width:          availableWidth
-            sliderModel: ListModel {
+        Item {
+            width: availableWidth
 
-                ListElement {
-                    title:          qsTr("Plane Roll sensitivity")
-                    description:    qsTr("Slide to the left to make roll control faster and more accurate. Slide to the right if roll oscillates or is too twitchy.")
-                    param:          "FW_R_TC"
-                    min:            0.2
-                    max:            0.8
-                    step:           0.01
+            FactPanelController {
+                id:         controller
+            }
+
+            QGCTabBar {
+                id:             bar
+                width:          parent.width
+                anchors.top:    parent.top
+
+                QGCTabButton {
+                    text:       qsTr("Multirotor")
                 }
-
-                ListElement {
-                    title:          qsTr("Plane Pitch sensitivity")
-                    description:    qsTr("Slide to the left to make pitch control faster and more accurate. Slide to the right if pitch oscillates or is too twitchy.")
-                    param:          "FW_P_TC"
-                    min:            0.2
-                    max:            0.8
-                    step:           0.01
-                }
-
-                ListElement {
-                    title:          qsTr("Plane Cruise throttle")
-                    description:    qsTr("This is the throttle setting required to achieve the desired cruise speed. Most planes need 50-60%.")
-                    param:          "FW_THR_CRUISE"
-                    min:            20
-                    max:            80
-                    step:           1
-                }
-
-                ListElement {
-                    title:          qsTr("Hover Throttle")
-                    description:    qsTr("Adjust throttle so hover is at mid-throttle. Slide to the left if hover is lower than throttle center. Slide to the right if hover is higher than throttle center.")
-                    param:          "MPC_THR_HOVER"
-                    min:            20
-                    max:            80
-                    step:           1
-                }
-
-                ListElement {
-                    title:          qsTr("Hover manual minimum throttle")
-                    description:    qsTr("Slide to the left to start the motors with less idle power. Slide to the right if descending in manual flight becomes unstable.")
-                    param:          "MPC_MANTHR_MIN"
-                    min:            0
-                    max:            15
-                    step:           1
-                }
-
-                ListElement {
-                    title:          qsTr("Plane Mission mode sensitivity")
-                    description:    qsTr("Slide to the left to make position control more accurate and more aggressive. Slide to the right to make flight in mission mode smoother and less twitchy.")
-                    param:          "FW_L1_PERIOD"
-                    min:            12
-                    max:            50
-                    step:           0.5
+                QGCTabButton {
+                    text:       qsTr("Fixedwing")
                 }
             }
+
+            property var pages:  [
+                "PX4TuningComponentCopterAll.qml",
+                "PX4TuningComponentPlaneAll.qml"
+            ]
+
+            Loader {
+                source:            pages[bar.currentIndex]
+                width:             parent.width
+                anchors.top:       bar.bottom
+                anchors.topMargin: ScreenTools.defaultFontPixelWidth
+            }
         }
-    }
+    } // Component - pageComponent
 }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
@@ -38,14 +38,14 @@ SetupPage {
                 QGCTabButton {
                     text:       qsTr("Multirotor")
                 }
-                QGCTabButton {
-                    text:       qsTr("Fixedwing")
-                }
+                //QGCTabButton {
+                //    text:       qsTr("Fixedwing")
+                //}
             }
 
             property var pages:  [
                 "PX4TuningComponentCopterAll.qml",
-                "PX4TuningComponentPlaneAll.qml"
+                //"PX4TuningComponentPlaneAll.qml"
             ]
 
             Loader {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
@@ -24,6 +24,7 @@ SetupPage {
 
         Item {
             width: availableWidth
+            height: availableHeight
 
             FactPanelController {
                 id:         controller
@@ -52,6 +53,7 @@ SetupPage {
                 width:             parent.width
                 anchors.top:       bar.bottom
                 anchors.topMargin: ScreenTools.defaultFontPixelWidth
+                anchors.bottom:    parent.bottom
             }
         }
     } // Component - pageComponent

--- a/src/FirmwarePlugin/PX4/PX4Resources.qrc
+++ b/src/FirmwarePlugin/PX4/PX4Resources.qrc
@@ -13,11 +13,13 @@
         <file alias="PX4SimpleFlightModes.qml">../../AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml</file>
         <file alias="PX4FlightBehaviorCopter.qml">../../AutoPilotPlugins/PX4/PX4FlightBehaviorCopter.qml</file>
         <file alias="PX4TuningComponentCopter.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml</file>
+        <file alias="PX4TuningComponentCopterAll.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml</file>
         <file alias="PX4TuningComponentCopterAttitude.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml</file>
         <file alias="PX4TuningComponentCopterRate.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml</file>
         <file alias="PX4TuningComponentCopterVelocity.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml</file>
         <file alias="PX4TuningComponentCopterPosition.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml</file>
         <file alias="PX4TuningComponentPlane.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml</file>
+        <file alias="PX4TuningComponentPlaneAll.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml</file>
         <file alias="PX4TuningComponentPlaneTECS.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml</file>
         <file alias="PX4TuningComponentVTOL.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml</file>
         <file alias="SafetyComponent.qml">../../AutoPilotPlugins/PX4/SafetyComponent.qml</file>

--- a/src/FirmwarePlugin/PX4/PX4Resources.qrc
+++ b/src/FirmwarePlugin/PX4/PX4Resources.qrc
@@ -16,6 +16,7 @@
         <file alias="PX4TuningComponentCopterRate.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml</file>
         <file alias="PX4TuningComponentCopterVelocity.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml</file>
         <file alias="PX4TuningComponentPlane.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml</file>
+        <file alias="PX4TuningComponentPlaneTECS.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml</file>
         <file alias="PX4TuningComponentVTOL.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml</file>
         <file alias="SafetyComponent.qml">../../AutoPilotPlugins/PX4/SafetyComponent.qml</file>
         <file alias="SafetyComponentSummary.qml">../../AutoPilotPlugins/PX4/SafetyComponentSummary.qml</file>

--- a/src/FirmwarePlugin/PX4/PX4Resources.qrc
+++ b/src/FirmwarePlugin/PX4/PX4Resources.qrc
@@ -13,6 +13,8 @@
         <file alias="PX4SimpleFlightModes.qml">../../AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml</file>
         <file alias="PX4FlightBehaviorCopter.qml">../../AutoPilotPlugins/PX4/PX4FlightBehaviorCopter.qml</file>
         <file alias="PX4TuningComponentCopter.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml</file>
+        <file alias="PX4TuningComponentCopterRate.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml</file>
+        <file alias="PX4TuningComponentCopterVelocity.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml</file>
         <file alias="PX4TuningComponentPlane.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml</file>
         <file alias="PX4TuningComponentVTOL.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml</file>
         <file alias="SafetyComponent.qml">../../AutoPilotPlugins/PX4/SafetyComponent.qml</file>

--- a/src/FirmwarePlugin/PX4/PX4Resources.qrc
+++ b/src/FirmwarePlugin/PX4/PX4Resources.qrc
@@ -13,8 +13,10 @@
         <file alias="PX4SimpleFlightModes.qml">../../AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml</file>
         <file alias="PX4FlightBehaviorCopter.qml">../../AutoPilotPlugins/PX4/PX4FlightBehaviorCopter.qml</file>
         <file alias="PX4TuningComponentCopter.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml</file>
+        <file alias="PX4TuningComponentCopterAttitude.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml</file>
         <file alias="PX4TuningComponentCopterRate.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml</file>
         <file alias="PX4TuningComponentCopterVelocity.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml</file>
+        <file alias="PX4TuningComponentCopterPosition.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml</file>
         <file alias="PX4TuningComponentPlane.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlane.qml</file>
         <file alias="PX4TuningComponentPlaneTECS.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml</file>
         <file alias="PX4TuningComponentVTOL.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml</file>

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -153,6 +153,11 @@ RowLayout {
                         adjustYAxisMin(_yAxis, value)
                         adjustYAxisMax(_yAxis, value)
                     }
+                    // limit history
+                    var minSec = _msecs/1000 - 3*60
+                    while (chart.series(i).count > 0 && chart.series(i).at(0).x < minSec) {
+                        chart.series(i).remove(0)
+                    }
                 }
             }
 

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -254,6 +254,13 @@ RowLayout {
                     var next = chart.mapToValue(Qt.point(mouse.x+1, mouse.y+1))
                     _scaling = next.x - start.x
                 }
+                onWheel: {
+                    if (wheel.angleDelta.y > 0)
+                        chartDisplaySec /= 1.2
+                    else
+                        chartDisplaySec *= 1.2
+                    _xAxis.min = _xAxis.max - chartDisplaySec
+                }
                 onPositionChanged: {
                     if(_startPoint != undefined) {
                         dataTimer.running = false

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -139,13 +139,20 @@ RowLayout {
             _xAxis.max = _msecs / 1000
             _xAxis.min = _msecs / 1000 - chartDisplaySec
 
+            var firstPoint = _msecs == 0
+
             var len = axis[_currentAxis].plot.length
             for (var i = 0; i < len; ++i) {
                 var value = axis[_currentAxis].plot[i].value
                 if (!isNaN(value)) {
                     chart.series(i).append(_msecs/1000, value)
-                    adjustYAxisMin(_yAxis, value)
-                    adjustYAxisMax(_yAxis, value)
+                    if (firstPoint) {
+                        _yAxis.min = value
+                        _yAxis.max = value
+                    } else {
+                        adjustYAxisMin(_yAxis, value)
+                        adjustYAxisMax(_yAxis, value)
+                    }
                 }
             }
 

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -307,6 +307,15 @@ RowLayout {
                     }
                 }
             }
+            Connections {
+                target: globals.activeVehicle
+                onArmedChanged: {
+                    if (armed && !dataTimer.running) { // start plotting on arming if not already running
+                        dataTimer.running = true
+                        _last_t = 0
+                    }
+                }
+            }
         }
 
         QGCCheckBox {

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -165,92 +165,98 @@ RowLayout {
         property int _maxPointCount:    10000 / interval
     }
 
-    Column {
-        spacing:            _margins
-        Layout.alignment:   Qt.AlignTop
-        width:          parent.width * (_showCharts ? 0.4 : 1)
-
+    QGCFlickable {
+        contentWidth:           parent.width * (_showCharts ? 0.4 : 1)
+        contentHeight:          rightColumn.height
+        Layout.fillHeight:      true
+        Layout.minimumWidth:    contentWidth
+        Layout.maximumWidth:    contentWidth
+        Layout.alignment:       Qt.AlignTop
         Column {
+            spacing:            _margins
+            Layout.alignment:   Qt.AlignTop
+            width:          parent.width
+            id:             rightColumn
 
-            RowLayout {
-                spacing: _margins
-                visible: axis.length > 1
+            Column {
 
-                QGCLabel { text: qsTr("Select Tuning:") }
+                RowLayout {
+                    spacing: _margins
+                    visible: axis.length > 1
 
-                Repeater {
-                    model: axis
-                    QGCRadioButton {
-                        text:           modelData.name
-                        checked:        index == _currentAxis
-                        onClicked: _currentAxis = index
+                    QGCLabel { text: qsTr("Select Tuning:") }
+
+                    Repeater {
+                        model: axis
+                        QGCRadioButton {
+                            text:           modelData.name
+                            checked:        index == _currentAxis
+                            onClicked: _currentAxis = index
+                        }
                     }
                 }
             }
-        }
 
-        // Instantiate all sliders (instead of switching the model), so that
-        // values are not changed unexpectedly if they do not match with a tick
-        // value
-        Repeater {
-            model: axis
-            FactSliderPanel {
-                width:       parent.width
-                visible:     _currentAxis === index
-                sliderModel: axis[index].params
-            }
-        }
-
-        Column {
-            QGCLabel { text: qsTr("Clipboard Values:") }
-
-            GridLayout {
-                rows:           savedRepeater.model.length
-                flow:           GridLayout.TopToBottom
-                rowSpacing:     0
-                columnSpacing:  _margins
-
-                Repeater {
-                    model: axis[_currentAxis].params
-
-                    QGCLabel { text: param }
-                }
-
-                Repeater {
-                    id: savedRepeater
-
-                    QGCLabel { text: modelData }
+            // Instantiate all sliders (instead of switching the model), so that
+            // values are not changed unexpectedly if they do not match with a tick
+            // value
+            Repeater {
+                model: axis
+                FactSliderPanel {
+                    width:       parent.width
+                    visible:     _currentAxis === index
+                    sliderModel: axis[index].params
                 }
             }
-        }
 
-        RowLayout {
-            spacing: _margins
+            Column {
+                QGCLabel { text: qsTr("Clipboard Values:") }
 
-            QGCButton {
-                text:       qsTr("Save To Clipboard")
-                onClicked:  saveTuningParamValues()
+                GridLayout {
+                    rows:           savedRepeater.model.length
+                    flow:           GridLayout.TopToBottom
+                    rowSpacing:     0
+                    columnSpacing:  _margins
+
+                    Repeater {
+                        model: axis[_currentAxis].params
+
+                        QGCLabel { text: param }
+                    }
+
+                    Repeater {
+                        id: savedRepeater
+
+                        QGCLabel { text: modelData }
+                    }
+                }
             }
 
-            QGCButton {
-                text:       qsTr("Restore From Clipboard")
-                onClicked:  resetToSavedTuningParamValues()
+            RowLayout {
+                spacing: _margins
+
+                QGCButton {
+                    text:       qsTr("Save To Clipboard")
+                    onClicked:  saveTuningParamValues()
+                }
+
+                QGCButton {
+                    text:       qsTr("Restore From Clipboard")
+                    onClicked:  resetToSavedTuningParamValues()
+                }
             }
         }
     }
 
-    Column {
-        Layout.fillWidth: true
-        Layout.alignment:   Qt.AlignTop
+    ColumnLayout {
         visible:            _showCharts
 
         ChartView {
             id:                 chart
-            anchors.left:       parent.left
-            anchors.right:      parent.right
-            height:             availableHeight * 0.75
             antialiasing:       true
             legend.alignment:   Qt.AlignBottom
+            Layout.fillHeight:  true
+            Layout.fillWidth:   true
 
             // enable mouse dragging
             MouseArea {

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -167,6 +167,7 @@ RowLayout {
 
             RowLayout {
                 spacing: _margins
+                visible: axis.length > 1
 
                 QGCLabel { text: qsTr("Select Tuning:") }
 

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -27,6 +27,7 @@ RowLayout {
     property string title
     property var    tuningMode
     property double chartDisplaySec:     8 // number of seconds to display
+    property bool   showAutoModeChange:  false
 
     property real   _margins:           ScreenTools.defaultFontPixelHeight / 2
     property int    _currentAxis:       0
@@ -293,7 +294,7 @@ RowLayout {
                 onClicked: {
                     dataTimer.running = !dataTimer.running
                     _last_t = 0
-                    if (autoModeChange.checked) {
+                    if (showAutoModeChange && autoModeChange.checked) {
                         globals.activeVehicle.flightMode = dataTimer.running ? "Stabilized" : globals.activeVehicle.pauseFlightMode
                     }
                 }
@@ -301,8 +302,13 @@ RowLayout {
         }
 
         QGCCheckBox {
+            visible: showAutoModeChange
             id:     autoModeChange
             text:   qsTr("Automatic Flight Mode Switching")
+            onClicked: {
+                if (checked)
+                    dataTimer.running = false
+            }
         }
 
         Column {

--- a/src/Vehicle/LocalPositionFact.json
+++ b/src/Vehicle/LocalPositionFact.json
@@ -1,0 +1,49 @@
+{
+    "version":      1,
+    "fileType":  "FactMetaData",
+    "QGC.MetaData.Facts":
+[
+{
+    "name":             "x",
+    "shortDesc": "X",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m"
+},
+{
+    "name":             "y",
+    "shortDesc": "Y",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m"
+},
+{
+    "name":             "z",
+    "shortDesc": "Z",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m"
+},
+{
+    "name":             "vx",
+    "shortDesc": "VX",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m/s"
+},
+{
+    "name":             "vy",
+    "shortDesc": "Vy",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m/s"
+},
+{
+    "name":             "vz",
+    "shortDesc": "Vz",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "m/s"
+}
+]
+}

--- a/src/Vehicle/MAVLinkStreamConfig.cc
+++ b/src/Vehicle/MAVLinkStreamConfig.cc
@@ -29,6 +29,26 @@ void MAVLinkStreamConfig::setHighRateRateAndAttitude()
     setNextState(State::Configuring);
 }
 
+void MAVLinkStreamConfig::setHighRateVelAndPos()
+{
+    int requestedRate = (int)(1000000.0 / 100.0);
+    _nextDesiredRates = QVector<DesiredStreamRate>{{
+        {MAVLINK_MSG_ID_LOCAL_POSITION_NED, requestedRate},
+        {MAVLINK_MSG_ID_POSITION_TARGET_LOCAL_NED, requestedRate},
+    }};
+    setNextState(State::Configuring);
+}
+
+void MAVLinkStreamConfig::setHighRateAltAirspeed()
+{
+    int requestedRate = (int)(1000000.0 / 100.0);
+    _nextDesiredRates = QVector<DesiredStreamRate>{{
+        {MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT, requestedRate},
+        {MAVLINK_MSG_ID_VFR_HUD, requestedRate},
+    }};
+    setNextState(State::Configuring);
+}
+
 void MAVLinkStreamConfig::gotSetMessageIntervalAck()
 {
     switch (_state) {

--- a/src/Vehicle/MAVLinkStreamConfig.cc
+++ b/src/Vehicle/MAVLinkStreamConfig.cc
@@ -1,0 +1,104 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "MAVLinkStreamConfig.h"
+#include "QGCMAVLink.h"
+
+MAVLinkStreamConfig::MAVLinkStreamConfig(const SetMessageIntervalCb &messageIntervalCb)
+    : _messageIntervalCb(messageIntervalCb)
+{
+}
+
+void MAVLinkStreamConfig::setHighRateRateAndAttitude()
+{
+    int requestedRate = (int)(1000000.0 / 100.0); // 100 Hz in usecs (better set this a bit higher than actually needed,
+    // to give it more priority in case of exceeding link bandwidth)
+
+    _nextDesiredRates = QVector<DesiredStreamRate>{{
+        {MAVLINK_MSG_ID_ATTITUDE_QUATERNION, requestedRate},
+        {MAVLINK_MSG_ID_ATTITUDE_TARGET, requestedRate},
+    }};
+    // we could check if we're already configured as requested
+
+    setNextState(State::Configuring);
+}
+
+void MAVLinkStreamConfig::gotSetMessageIntervalAck()
+{
+    switch (_state) {
+        case State::Configuring:
+            nextDesiredRate();
+            break;
+        case State::RestoringDefaults:
+            restoreNextDefault();
+            break;
+        default:
+            break;
+    }
+}
+
+void MAVLinkStreamConfig::setNextState(State state)
+{
+    _nextState = state;
+    if (_state == State::Idle) {
+        // first restore defaults no matter what the next state is
+        _state = State::RestoringDefaults;
+        restoreNextDefault();
+    }
+}
+
+void MAVLinkStreamConfig::nextDesiredRate()
+{
+    if (_nextState != State::Idle) { // allow state to be interrupted by a new request
+        _desiredRates.clear();
+        _state = State::RestoringDefaults;
+        restoreNextDefault();
+        return;
+    }
+
+    if (_desiredRates.empty()) {
+        _state = State::Idle;
+        return;
+    }
+    const DesiredStreamRate& rate = _desiredRates.last();
+    _changedIds.push_back(rate.messageId);
+    _messageIntervalCb(rate.messageId, rate.rate);
+    _desiredRates.pop_back();
+}
+
+void MAVLinkStreamConfig::restoreDefaults()
+{
+    setNextState(State::RestoringDefaults);
+}
+
+void MAVLinkStreamConfig::restoreNextDefault()
+{
+    if (_changedIds.empty()) {
+        // do we have a pending request?
+        switch (_nextState) {
+            case State::Configuring:
+                _state = _nextState;
+                _desiredRates = _nextDesiredRates;
+                _nextDesiredRates.clear();
+                _nextState = State::Idle;
+                nextDesiredRate();
+                break;
+            case State::RestoringDefaults:
+            case State::Idle:
+                _nextState = State::Idle; // nothing to do, we just finished restoring
+                _state = State::Idle;
+                break;
+        }
+        return;
+    }
+
+    int id = _changedIds.last();
+    _messageIntervalCb(id, 0); // restore the default rate
+    _changedIds.pop_back();
+}

--- a/src/Vehicle/MAVLinkStreamConfig.h
+++ b/src/Vehicle/MAVLinkStreamConfig.h
@@ -27,6 +27,8 @@ public:
     MAVLinkStreamConfig(const SetMessageIntervalCb& messageIntervalCb);
 
     void setHighRateRateAndAttitude();
+    void setHighRateVelAndPos();
+    void setHighRateAltAirspeed();
 
     void restoreDefaults();
 

--- a/src/Vehicle/MAVLinkStreamConfig.h
+++ b/src/Vehicle/MAVLinkStreamConfig.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QVector>
+
+#include <functional>
+
+/**
+ * @class MAVLinkStreamConfig
+ * Allows to configure a set of mavlink streams to a specific rate,
+ * and restore back to default.
+ * Note that only one set is active at a time.
+ */
+class MAVLinkStreamConfig
+{
+public:
+    using SetMessageIntervalCb = std::function<void(int messageId, int rate)>;
+
+    MAVLinkStreamConfig(const SetMessageIntervalCb& messageIntervalCb);
+
+    void setHighRateRateAndAttitude();
+
+    void restoreDefaults();
+
+    void gotSetMessageIntervalAck();
+private:
+    enum class State {
+        Idle,
+        RestoringDefaults,
+        Configuring
+    };
+
+    struct DesiredStreamRate {
+        int messageId;
+        int rate;
+    };
+
+    void restoreNextDefault();
+    void nextDesiredRate();
+    void setNextState(State state);
+
+    State _state{State::Idle};
+    QVector<DesiredStreamRate> _desiredRates;
+    QVector<int> _changedIds;
+
+    State _nextState{State::Idle};
+    QVector<DesiredStreamRate> _nextDesiredRates;
+
+    const SetMessageIntervalCb _messageIntervalCb;
+};

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -97,6 +97,8 @@ const char* Vehicle::_temperatureFactGroupName =        "temperature";
 const char* Vehicle::_clockFactGroupName =              "clock";
 const char* Vehicle::_setpointFactGroupName =           "setpoint";
 const char* Vehicle::_distanceSensorFactGroupName =     "distanceSensor";
+const char* Vehicle::_localPositionFactGroupName =      "localPosition";
+const char* Vehicle::_localPositionSetpointFactGroupName ="localPositionSetpoint";
 const char* Vehicle::_escStatusFactGroupName =          "escStatus";
 const char* Vehicle::_estimatorStatusFactGroupName =    "estimatorStatus";
 const char* Vehicle::_terrainFactGroupName =            "terrain";
@@ -150,6 +152,8 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _clockFactGroup               (this)
     , _setpointFactGroup            (this)
     , _distanceSensorFactGroup      (this)
+    , _localPositionFactGroup       (this)
+    , _localPositionSetpointFactGroup(this)
     , _escStatusFactGroup           (this)
     , _estimatorStatusFactGroup     (this)
     , _terrainFactGroup             (this)
@@ -296,6 +300,8 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _vibrationFactGroup               (this)
     , _clockFactGroup                   (this)
     , _distanceSensorFactGroup          (this)
+    , _localPositionFactGroup           (this)
+    , _localPositionSetpointFactGroup   (this)
 {
     _linkManager = _toolbox->linkManager();
 
@@ -408,6 +414,8 @@ void Vehicle::_commonInit()
     _addFactGroup(&_clockFactGroup,             _clockFactGroupName);
     _addFactGroup(&_setpointFactGroup,          _setpointFactGroupName);
     _addFactGroup(&_distanceSensorFactGroup,    _distanceSensorFactGroupName);
+    _addFactGroup(&_localPositionFactGroup,     _localPositionFactGroupName);
+    _addFactGroup(&_localPositionSetpointFactGroup,_localPositionSetpointFactGroupName);
     _addFactGroup(&_escStatusFactGroup,         _escStatusFactGroupName);
     _addFactGroup(&_estimatorStatusFactGroup,   _estimatorStatusFactGroupName);
     _addFactGroup(&_terrainFactGroup,           _terrainFactGroupName);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3555,14 +3555,27 @@ int  Vehicle::versionCompare(int major, int minor, int patch)
     return _firmwarePlugin->versionCompare(this, major, minor, patch);
 }
 
-void Vehicle::setPIDTuningTelemetryMode(bool pidTuning)
+void Vehicle::setPIDTuningTelemetryMode(PIDTuningTelemetryMode mode)
 {
-    setLiveUpdates(pidTuning);
-    _setpointFactGroup.setLiveUpdates(pidTuning);
-    if (pidTuning) {
-        _mavlinkStreamConfig.setHighRateRateAndAttitude();
-    } else {
-        _mavlinkStreamConfig.restoreDefaults();
+    bool liveUpdate = mode != ModeDisabled;
+    setLiveUpdates(liveUpdate);
+    _setpointFactGroup.setLiveUpdates(liveUpdate);
+    _localPositionFactGroup.setLiveUpdates(liveUpdate);
+    _localPositionSetpointFactGroup.setLiveUpdates(liveUpdate);
+
+    switch (mode) {
+        case ModeDisabled:
+            _mavlinkStreamConfig.restoreDefaults();
+            break;
+        case ModeRateAndAttitude:
+            _mavlinkStreamConfig.setHighRateRateAndAttitude();
+            break;
+        case ModeVelocityAndPosition:
+            _mavlinkStreamConfig.setHighRateVelAndPos();
+            break;
+        case ModeAltitudeAndAirspeed:
+            _mavlinkStreamConfig.setHighRateAltAirspeed();
+            break;
     }
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -20,6 +20,7 @@
 #include "QGCMAVLink.h"
 #include "QmlObjectListModel.h"
 #include "MAVLinkProtocol.h"
+#include "MAVLinkStreamConfig.h"
 #include "UASMessageHandler.h"
 #include "SettingsFact.h"
 #include "QGCMapCircle.h"
@@ -924,7 +925,6 @@ private:
     void _handleAttitudeQuaternion      (mavlink_message_t& message);
     void _handleStatusText              (mavlink_message_t& message);
     void _handleOrbitExecutionStatus    (const mavlink_message_t& message);
-    void _handleMessageInterval         (const mavlink_message_t& message);
     void _handleGimbalOrientation       (const mavlink_message_t& message);
     void _handleObstacleDistance        (const mavlink_message_t& message);
     // ArduPilot dialect messages
@@ -946,13 +946,13 @@ private:
     void _setCapabilities               (uint64_t capabilityBits);
     void _updateArmed                   (bool armed);
     bool _apmArmingNotRequired          ();
-    void _pidTuningAdjustRates          ();
     void _initializeCsv                 ();
     void _writeCsvLine                  ();
     void _flightTimerStart              ();
     void _flightTimerStop               ();
     void _chunkedStatusTextTimeout      (void);
     void _chunkedStatusTextCompleted    (uint8_t compId);
+    void _setMessageInterval            (int messageId, int rate);
 
     static void _rebootCommandResultHandler(void* resultHandlerData, int compId, MAV_RESULT commandResult, MavCmdResultFailureCode_t failureCode);
 
@@ -1112,12 +1112,7 @@ private:
     QTimer          _orbitTelemetryTimer;
     static const int _orbitTelemetryTimeoutMsecs = 3000; // No telemetry for this amount and orbit will go inactive
 
-    // PID Tuning telemetry mode
-    bool            _pidTuningTelemetryMode = false;
-    bool            _pidTuningWaitingForRates = false;
-    int             _pidTuningNextAdjustIndex = -1;
-    QMap<int, int>  _pidTuningMessageRatesUsecs;
-    static const QList<int> _pidTuningMessages;
+    MAVLinkStreamConfig _mavlinkStreamConfig;
 
     // Chunked status text support
     typedef struct {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -272,9 +272,12 @@ public:
     Q_PROPERTY(Fact* yawRate            READ yawRate            CONSTANT)
     Q_PROPERTY(Fact* groundSpeed        READ groundSpeed        CONSTANT)
     Q_PROPERTY(Fact* airSpeed           READ airSpeed           CONSTANT)
+    Q_PROPERTY(Fact* airSpeedSetpoint   READ airSpeedSetpoint   CONSTANT)
     Q_PROPERTY(Fact* climbRate          READ climbRate          CONSTANT)
     Q_PROPERTY(Fact* altitudeRelative   READ altitudeRelative   CONSTANT)
     Q_PROPERTY(Fact* altitudeAMSL       READ altitudeAMSL       CONSTANT)
+    Q_PROPERTY(Fact* altitudeTuning     READ altitudeTuning     CONSTANT)
+    Q_PROPERTY(Fact* altitudeTuningSetpoint READ altitudeTuningSetpoint CONSTANT)
     Q_PROPERTY(Fact* flightDistance     READ flightDistance     CONSTANT)
     Q_PROPERTY(Fact* distanceToHome     READ distanceToHome     CONSTANT)
     Q_PROPERTY(Fact* missionItemIndex   READ missionItemIndex   CONSTANT)
@@ -605,10 +608,13 @@ public:
     Fact* pitchRate                         () { return &_pitchRateFact; }
     Fact* yawRate                           () { return &_yawRateFact; }
     Fact* airSpeed                          () { return &_airSpeedFact; }
+    Fact* airSpeedSetpoint                  () { return &_airSpeedSetpointFact; }
     Fact* groundSpeed                       () { return &_groundSpeedFact; }
     Fact* climbRate                         () { return &_climbRateFact; }
     Fact* altitudeRelative                  () { return &_altitudeRelativeFact; }
     Fact* altitudeAMSL                      () { return &_altitudeAMSLFact; }
+    Fact* altitudeTuning                    () { return &_altitudeTuningFact; }
+    Fact* altitudeTuningSetpoint            () { return &_altitudeTuningSetpointFact; }
     Fact* flightDistance                    () { return &_flightDistanceFact; }
     Fact* distanceToHome                    () { return &_distanceToHomeFact; }
     Fact* missionItemIndex                  () { return &_missionItemIndexFact; }
@@ -932,6 +938,7 @@ private:
     void _handleGlobalPositionInt       (mavlink_message_t& message);
     void _handleAltitude                (mavlink_message_t& message);
     void _handleVfrHud                  (mavlink_message_t& message);
+    void _handleNavControllerOutput     (mavlink_message_t& message);
     void _handleHighLatency             (mavlink_message_t& message);
     void _handleHighLatency2            (mavlink_message_t& message);
     void _handleAttitudeWorker          (double rollRadians, double pitchRadians, double yawRadians);
@@ -1199,6 +1206,8 @@ private:
 
     QMap<uint8_t /* batteryId */, uint8_t /* MAV_BATTERY_CHARGE_STATE_OK */> _lowestBatteryChargeStateAnnouncedMap;
 
+    float _altitudeTuningOffset = qQNaN(); // altitude offset, so the plotted value is around 0
+
     // FactGroup facts
 
     Fact _rollFact;
@@ -1209,9 +1218,12 @@ private:
     Fact _yawRateFact;
     Fact _groundSpeedFact;
     Fact _airSpeedFact;
+    Fact _airSpeedSetpointFact;
     Fact _climbRateFact;
     Fact _altitudeRelativeFact;
     Fact _altitudeAMSLFact;
+    Fact _altitudeTuningFact;
+    Fact _altitudeTuningSetpointFact;
     Fact _flightDistanceFact;
     Fact _flightTimeFact;
     Fact _distanceToHomeFact;
@@ -1254,9 +1266,12 @@ private:
     static const char* _yawRateFactName;
     static const char* _groundSpeedFactName;
     static const char* _airSpeedFactName;
+    static const char* _airSpeedSetpointFactName;
     static const char* _climbRateFactName;
     static const char* _altitudeRelativeFactName;
     static const char* _altitudeAMSLFactName;
+    static const char* _altitudeTuningFactName;
+    static const char* _altitudeTuningSetpointFactName;
     static const char* _flightDistanceFactName;
     static const char* _flightTimeFactName;
     static const char* _distanceToHomeFactName;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -384,7 +384,15 @@ public:
     ///     @param timeoutSec Disabled motor after this amount of time
     Q_INVOKABLE void motorTest(int motor, int percent, int timeoutSecs, bool showError);
 
-    Q_INVOKABLE void setPIDTuningTelemetryMode(bool pidTuning);
+    enum PIDTuningTelemetryMode {
+        ModeDisabled,
+        ModeRateAndAttitude,
+        ModeVelocityAndPosition,
+        ModeAltitudeAndAirspeed,
+    };
+    Q_ENUM(PIDTuningTelemetryMode)
+
+    Q_INVOKABLE void setPIDTuningTelemetryMode(PIDTuningTelemetryMode mode);
 
     Q_INVOKABLE void gimbalControlValue (double pitch, double yaw);
     Q_INVOKABLE void gimbalPitchStep    (int direction);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -28,6 +28,8 @@
 #include "SysStatusSensorInfo.h"
 #include "VehicleClockFactGroup.h"
 #include "VehicleDistanceSensorFactGroup.h"
+#include "VehicleLocalPositionFactGroup.h"
+#include "VehicleLocalPositionSetpointFactGroup.h"
 #include "VehicleWindFactGroup.h"
 #include "VehicleGPSFactGroup.h"
 #include "VehicleGPS2FactGroup.h"
@@ -293,6 +295,8 @@ public:
     Q_PROPERTY(FactGroup*           estimatorStatus READ estimatorStatusFactGroup   CONSTANT)
     Q_PROPERTY(FactGroup*           terrain         READ terrainFactGroup           CONSTANT)
     Q_PROPERTY(FactGroup*           distanceSensors READ distanceSensorFactGroup    CONSTANT)
+    Q_PROPERTY(FactGroup*           localPosition   READ localPositionFactGroup     CONSTANT)
+    Q_PROPERTY(FactGroup*           localPositionSetpoint READ localPositionSetpointFactGroup CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  batteries       READ batteries                  CONSTANT)
 
     Q_PROPERTY(int      firmwareMajorVersion        READ firmwareMajorVersion       NOTIFY firmwareVersionChanged)
@@ -614,6 +618,8 @@ public:
     FactGroup* clockFactGroup               () { return &_clockFactGroup; }
     FactGroup* setpointFactGroup            () { return &_setpointFactGroup; }
     FactGroup* distanceSensorFactGroup      () { return &_distanceSensorFactGroup; }
+    FactGroup* localPositionFactGroup       () { return &_localPositionFactGroup; }
+    FactGroup* localPositionSetpointFactGroup() { return &_localPositionSetpointFactGroup; }
     FactGroup* escStatusFactGroup           () { return &_escStatusFactGroup; }
     FactGroup* estimatorStatusFactGroup     () { return &_estimatorStatusFactGroup; }
     FactGroup* terrainFactGroup             () { return &_terrainFactGroup; }
@@ -1216,6 +1222,8 @@ private:
     VehicleClockFactGroup           _clockFactGroup;
     VehicleSetpointFactGroup        _setpointFactGroup;
     VehicleDistanceSensorFactGroup  _distanceSensorFactGroup;
+    VehicleLocalPositionFactGroup   _localPositionFactGroup;
+    VehicleLocalPositionSetpointFactGroup _localPositionSetpointFactGroup;
     VehicleEscStatusFactGroup       _escStatusFactGroup;
     VehicleEstimatorStatusFactGroup _estimatorStatusFactGroup;
     TerrainFactGroup                _terrainFactGroup;
@@ -1259,6 +1267,8 @@ private:
     static const char* _clockFactGroupName;
     static const char* _setpointFactGroupName;
     static const char* _distanceSensorFactGroupName;
+    static const char* _localPositionFactGroupName;
+    static const char* _localPositionSetpointFactGroupName;
     static const char* _escStatusFactGroupName;
     static const char* _estimatorStatusFactGroupName;
     static const char* _terrainFactGroupName;

--- a/src/Vehicle/VehicleLocalPositionFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionFactGroup.cc
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "VehicleLocalPositionFactGroup.h"
+#include "Vehicle.h"
+
+#include <QtMath>
+
+const char* VehicleLocalPositionFactGroup::_xFactName =     "x";
+const char* VehicleLocalPositionFactGroup::_yFactName =     "y";
+const char* VehicleLocalPositionFactGroup::_zFactName =     "z";
+const char* VehicleLocalPositionFactGroup::_vxFactName =    "vx";
+const char* VehicleLocalPositionFactGroup::_vyFactName =    "vy";
+const char* VehicleLocalPositionFactGroup::_vzFactName =    "vz";
+
+VehicleLocalPositionFactGroup::VehicleLocalPositionFactGroup(QObject* parent)
+    : FactGroup     (1000, ":/json/Vehicle/LocalPositionFact.json", parent)
+    , _xFact    (0, _xFactName,     FactMetaData::valueTypeDouble)
+    , _yFact    (0, _yFactName,     FactMetaData::valueTypeDouble)
+    , _zFact    (0, _zFactName,     FactMetaData::valueTypeDouble)
+    , _vxFact   (0, _vxFactName,    FactMetaData::valueTypeDouble)
+    , _vyFact   (0, _vyFactName,    FactMetaData::valueTypeDouble)
+    , _vzFact   (0, _vzFactName,    FactMetaData::valueTypeDouble)
+{
+    _addFact(&_xFact,      _xFactName);
+    _addFact(&_yFact,      _yFactName);
+    _addFact(&_zFact,      _zFactName);
+    _addFact(&_vxFact,     _vxFactName);
+    _addFact(&_vyFact,     _vyFactName);
+    _addFact(&_vzFact,     _vzFactName);
+
+    // Start out as not available "--.--"
+    _xFact.setRawValue(qQNaN());
+    _yFact.setRawValue(qQNaN());
+    _zFact.setRawValue(qQNaN());
+    _vxFact.setRawValue(qQNaN());
+    _vyFact.setRawValue(qQNaN());
+    _vzFact.setRawValue(qQNaN());
+}
+
+void VehicleLocalPositionFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
+{
+    if (message.msgid != MAVLINK_MSG_ID_LOCAL_POSITION_NED) {
+        return;
+    }
+
+    mavlink_local_position_ned_t localPosition;
+    mavlink_msg_local_position_ned_decode(&message, &localPosition);
+
+    x()->setRawValue(localPosition.x);
+    y()->setRawValue(localPosition.y);
+    z()->setRawValue(localPosition.z);
+
+    vx()->setRawValue(localPosition.vx);
+    vy()->setRawValue(localPosition.vy);
+    vz()->setRawValue(localPosition.vz);
+
+    _setTelemetryAvailable(true);
+}

--- a/src/Vehicle/VehicleLocalPositionFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionFactGroup.h
@@ -1,0 +1,53 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "FactGroup.h"
+#include "QGCMAVLink.h"
+
+class VehicleLocalPositionFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+public:
+    VehicleLocalPositionFactGroup(QObject* parent = nullptr);
+
+    Q_PROPERTY(Fact* x     READ x    CONSTANT)
+    Q_PROPERTY(Fact* y     READ y    CONSTANT)
+    Q_PROPERTY(Fact* z     READ z    CONSTANT)
+    Q_PROPERTY(Fact* vx    READ vx   CONSTANT)
+    Q_PROPERTY(Fact* vy    READ vy   CONSTANT)
+    Q_PROPERTY(Fact* vz    READ vz   CONSTANT)
+
+    Fact* x    () { return &_xFact; }
+    Fact* y    () { return &_yFact; }
+    Fact* z    () { return &_zFact; }
+    Fact* vx   () { return &_vxFact; }
+    Fact* vy   () { return &_vyFact; }
+    Fact* vz   () { return &_vzFact; }
+
+    // Overrides from FactGroup
+    void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
+
+    static const char* _xFactName;
+    static const char* _yFactName;
+    static const char* _zFactName;
+    static const char* _vxFactName;
+    static const char* _vyFactName;
+    static const char* _vzFactName;
+
+private:
+    Fact _xFact;
+    Fact _yFact;
+    Fact _zFact;
+    Fact _vxFact;
+    Fact _vyFact;
+    Fact _vzFact;
+};

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "VehicleLocalPositionSetpointFactGroup.h"
+#include "Vehicle.h"
+
+#include <QtMath>
+
+const char* VehicleLocalPositionSetpointFactGroup::_xFactName =     "x";
+const char* VehicleLocalPositionSetpointFactGroup::_yFactName =     "y";
+const char* VehicleLocalPositionSetpointFactGroup::_zFactName =     "z";
+const char* VehicleLocalPositionSetpointFactGroup::_vxFactName =    "vx";
+const char* VehicleLocalPositionSetpointFactGroup::_vyFactName =    "vy";
+const char* VehicleLocalPositionSetpointFactGroup::_vzFactName =    "vz";
+
+VehicleLocalPositionSetpointFactGroup::VehicleLocalPositionSetpointFactGroup(QObject* parent)
+    : FactGroup     (1000, ":/json/Vehicle/LocalPositionSetpointFact.json", parent)
+    , _xFact    (0, _xFactName,     FactMetaData::valueTypeDouble)
+    , _yFact    (0, _yFactName,     FactMetaData::valueTypeDouble)
+    , _zFact    (0, _zFactName,     FactMetaData::valueTypeDouble)
+    , _vxFact   (0, _vxFactName,    FactMetaData::valueTypeDouble)
+    , _vyFact   (0, _vyFactName,    FactMetaData::valueTypeDouble)
+    , _vzFact   (0, _vzFactName,    FactMetaData::valueTypeDouble)
+{
+    _addFact(&_xFact,      _xFactName);
+    _addFact(&_yFact,      _yFactName);
+    _addFact(&_zFact,      _zFactName);
+    _addFact(&_vxFact,     _vxFactName);
+    _addFact(&_vyFact,     _vyFactName);
+    _addFact(&_vzFact,     _vzFactName);
+
+    // Start out as not available "--.--"
+    _xFact.setRawValue(qQNaN());
+    _yFact.setRawValue(qQNaN());
+    _zFact.setRawValue(qQNaN());
+    _vxFact.setRawValue(qQNaN());
+    _vyFact.setRawValue(qQNaN());
+    _vzFact.setRawValue(qQNaN());
+}
+
+void VehicleLocalPositionSetpointFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
+{
+    if (message.msgid != MAVLINK_MSG_ID_POSITION_TARGET_LOCAL_NED) {
+        return;
+    }
+
+    mavlink_position_target_local_ned_t localPosition;
+    mavlink_msg_position_target_local_ned_decode(&message, &localPosition);
+
+    x()->setRawValue(localPosition.x);
+    y()->setRawValue(localPosition.y);
+    z()->setRawValue(localPosition.z);
+
+    vx()->setRawValue(localPosition.vx);
+    vy()->setRawValue(localPosition.vy);
+    vz()->setRawValue(localPosition.vz);
+
+    _setTelemetryAvailable(true);
+}

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
@@ -1,0 +1,53 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "FactGroup.h"
+#include "QGCMAVLink.h"
+
+class VehicleLocalPositionSetpointFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+public:
+    VehicleLocalPositionSetpointFactGroup(QObject* parent = nullptr);
+
+    Q_PROPERTY(Fact* x     READ x    CONSTANT)
+    Q_PROPERTY(Fact* y     READ y    CONSTANT)
+    Q_PROPERTY(Fact* z     READ z    CONSTANT)
+    Q_PROPERTY(Fact* vx    READ vx   CONSTANT)
+    Q_PROPERTY(Fact* vy    READ vy   CONSTANT)
+    Q_PROPERTY(Fact* vz    READ vz   CONSTANT)
+
+    Fact* x    () { return &_xFact; }
+    Fact* y    () { return &_yFact; }
+    Fact* z    () { return &_zFact; }
+    Fact* vx   () { return &_vxFact; }
+    Fact* vy   () { return &_vyFact; }
+    Fact* vz   () { return &_vzFact; }
+
+    // Overrides from FactGroup
+    void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
+
+    static const char* _xFactName;
+    static const char* _yFactName;
+    static const char* _zFactName;
+    static const char* _vxFactName;
+    static const char* _vyFactName;
+    static const char* _vzFactName;
+
+private:
+    Fact _xFact;
+    Fact _yFact;
+    Fact _zFact;
+    Fact _vxFact;
+    Fact _vyFact;
+    Fact _vzFact;
+};

--- a/src/Vehicle/VehicleSetpointFactGroup.cc
+++ b/src/Vehicle/VehicleSetpointFactGroup.cc
@@ -59,6 +59,7 @@ void VehicleSetpointFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_mes
 
     this->roll()->setRawValue   (qRadiansToDegrees(roll));
     this->pitch()->setRawValue  (qRadiansToDegrees(pitch));
+    if (yaw < 0.f) yaw += 2.f * (float)M_PI; // bring to range [0, 2pi] to match the heading angle
     this->yaw()->setRawValue    (qRadiansToDegrees(yaw));
 
     rollRate()->setRawValue (qRadiansToDegrees(attitudeTarget.body_roll_rate));


### PR DESCRIPTION
This continues the work from #9256:
- makes the plots + mavlink streams more generic
- adds mouse wheel zooming
- adds all MC controllers (attitude, velocity + position)
- adds MC_AIRMODE + THR_MDL_FAC params
  - with links to docs (opening the external link did not work for me though, due to a Qt vs. system lib mismatch)
- adds MPC_POS_MODE for velocity + position controllers (this could possibly be set automatically, but we need to avoid user confusion and ensure it's always restored)
- adds vtol
- adds fw (not finished yet)

This is the MC rate controller page for a VTOL:
![qgc_pid_tuning_vtol_rate](https://user-images.githubusercontent.com/281593/106147537-41a16c80-6178-11eb-8cc1-dfa93bf31528.png)

Basic FW TECS plot:
![qgc_pid_tuning_plane_tecs](https://user-images.githubusercontent.com/281593/106147876-ad83d500-6178-11eb-80a4-7ffcdc1803a8.png)

~Known issue: there is no scrollbar shown when the page overflows the vertical window size. @DonLakeFlyer I'd appreciate if you can have a look.~ fixed

Thanks to @dagar @MaEtUgR @RomanBapst for your inputs