### PR TITLE
Fix double send of MAV_CMD_PREFLIGHT_CALIBRATION

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Note: This file only contains high level features or important fixes.
 
 ## 4.1
 
+### 4.1.2 - Not yet released
+* Bug: Radio setup - Fix double send of `MAV_CMD_PREFLIGHT_CALIBRATION` causing "Unable to send command" error.
+
 ### 4.1.1 - Stable
 * Fix TCP link comms
 

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -700,10 +700,6 @@ void RadioComponentController::_writeCalibration(void)
 {
     if (!_uas) return;
 
-    if (_px4Vehicle()) {
-        _vehicle->stopCalibration();
-    }
-
     if (!_px4Vehicle() && (_vehicle->vehicleType() == MAV_TYPE_HELICOPTER || _vehicle->multiRotor()) &&  _rgChannelInfo[_rgFunctionChannelMapping[rcCalFunctionThrottle]].reversed) {
         // A reversed throttle could lead to dangerous power up issues if the firmware doesn't handle it absolutely correctly in all places.
         // So in this case fail the calibration for anything other than PX4 which is known to be able to handle this correctly.


### PR DESCRIPTION
Fix for #9381