### PR TITLE
FlightMap: Add widget with gimbal orientation feedback

### DIFF
--- a/qgcimages.qrc
+++ b/qgcimages.qrc
@@ -195,5 +195,6 @@
         <file alias="Yield.svg">src/ui/toolbar/Images/Yield.svg</file>
         <file alias="ZoomMinus.svg">src/FlightMap/Images/ZoomMinus.svg</file>
         <file alias="ZoomPlus.svg">src/FlightMap/Images/ZoomPlus.svg</file>
+        <file alias="gimbalNavigator.svg">src/FlightMap/Images/gimbalNavigator.svg</file>
     </qresource>
 </RCC>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -178,7 +178,7 @@
         <file alias="QGroundControl/Controls/TerrainStatus.qml">src/PlanView/TerrainStatus.qml</file>
         <file alias="QGroundControl/Controls/TakeoffItemMapVisual.qml">src/PlanView/TakeoffItemMapVisual.qml</file>
         <file alias="QGroundControl/Controls/ToolStrip.qml">src/QmlControls/ToolStrip.qml</file>
-       	<file alias="QGroundControl/Controls/ToolStripHoverButton.qml">src/QmlControls/ToolStripHoverButton.qml</file>
+        <file alias="QGroundControl/Controls/ToolStripHoverButton.qml">src/QmlControls/ToolStripHoverButton.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemStats.qml">src/PlanView/TransectStyleComplexItemStats.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemTabBar.qml">src/PlanView/TransectStyleComplexItemTabBar.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemTerrainFollow.qml">src/PlanView/TransectStyleComplexItemTerrainFollow.qml</file>
@@ -275,6 +275,7 @@
         <file alias="VibrationPage.qml">src/AnalyzeView/VibrationPage.qml</file>
         <file alias="VirtualJoystick.qml">src/FlightDisplay/VirtualJoystick.qml</file>
         <file alias="VTOLLandingPatternEditor.qml">src/PlanView/VTOLLandingPatternEditor.qml</file>
+        <file alias="QGroundControl/FlightMap/GimbalControl.qml">src/FlightMap/Widgets/GimbalControl.qml</file>
     </qresource>
     <qresource prefix="/FirstRunPromptDialogs">
         <file alias="UnitsFirstRunPrompt.qml">src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml</file>

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -120,8 +120,18 @@ Item {
     }
 
     PhotoVideoControl {
+        id:                     photoVideoControl
         anchors.margins:        _toolsMargin
         anchors.verticalCenter: parent.verticalCenter
+        anchors.right:          parent.right
+        width:                  _rightPanelWidth
+    }
+
+    GimbalControl {
+        id:                     gimbalControl
+        anchors.top:            photoVideoControl.visible ? photoVideoControl.bottom : parent.verticalCenter
+        // anchors.verticalCenter: photoVideoControl.visible ? undefined : parent.verticalCenter
+        anchors.margins:        _toolsMargin
         anchors.right:          parent.right
         width:                  _rightPanelWidth
     }

--- a/src/FlightMap/Images/gimbalNavigator.svg
+++ b/src/FlightMap/Images/gimbalNavigator.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 2208 2206" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+    <g transform="matrix(1,0,0,1,-5034.85,-4755.69)">
+        <g transform="matrix(1,0,0,1,250.314,-42.4226)">
+            <path d="M5560.71,5286.52C5656.05,5240.49 6127.64,5236.61 6222.13,5286.52C6239.05,5295.46 6150.12,4820.37 6127.64,4814.08C6066.59,4796.99 5702.17,4794.19 5655.2,4814.08C5628.67,4825.31 5549.48,5291.94 5560.71,5286.52Z" style="fill:rgb(36,107,0);stroke:rgb(35,31,32);stroke-width:4.17px;"/>
+            <g transform="matrix(0.973048,0,0,0.945818,2065.36,461.616)">
+                <path d="M4174.8,4601.8C4116.76,4584.7 3742.18,4581.43 3689.28,4601.8C3790.92,4805.06 3794.75,4956 3786.38,5201.2C3783.21,5294.13 3543.62,5301.1 3543.62,5301.1L3932.04,5700.71L4320.46,5301.1C4320.46,5301.1 4077.09,5300.39 4077.7,5201.2C4079.22,4953.5 4079.34,4800.2 4174.8,4601.8Z" style="fill:url(#_Linear1);stroke:rgb(35,31,32);stroke-width:4.34px;"/>
+            </g>
+        </g>
+        <g transform="matrix(6.12323e-17,1,-1,6.12323e-17,12040,-32.0953)">
+            <path d="M5560.71,5286.52C5656.05,5240.49 6127.64,5236.61 6222.13,5286.52C6239.05,5295.46 6150.12,4820.37 6127.64,4814.08C6066.59,4796.99 5702.17,4794.19 5655.2,4814.08C5628.67,4825.31 5549.48,5291.94 5560.71,5286.52Z" style="fill:rgb(107,36,0);stroke:rgb(35,31,32);stroke-width:4.17px;"/>
+            <g transform="matrix(0.973048,0,0,0.945818,2065.36,461.616)">
+                <path d="M4174.8,4601.8C4116.76,4584.7 3742.18,4581.43 3689.28,4601.8C3790.92,4805.06 3794.75,4956 3786.38,5201.2C3783.21,5294.13 3543.62,5301.1 3543.62,5301.1L3932.04,5700.71L4320.46,5301.1C4320.46,5301.1 4077.09,5300.39 4077.7,5201.2C4079.22,4953.5 4079.34,4800.2 4174.8,4601.8Z" style="fill:url(#_Linear2);stroke:rgb(35,31,32);stroke-width:4.34px;"/>
+            </g>
+        </g>
+        <g transform="matrix(6.12323e-17,-1,1,6.12323e-17,236.743,11750.7)">
+            <path d="M5560.71,5286.52C5656.05,5240.49 6127.64,5236.61 6222.13,5286.52C6239.05,5295.46 6150.12,4820.37 6127.64,4814.08C6066.59,4796.99 5702.17,4794.19 5655.2,4814.08C5628.67,4825.31 5549.48,5291.94 5560.71,5286.52Z" style="fill:rgb(107,36,0);stroke:rgb(35,31,32);stroke-width:4.17px;"/>
+            <g transform="matrix(0.973048,0,0,0.945818,2065.36,461.616)">
+                <path d="M4174.8,4601.8C4116.76,4584.7 3742.18,4581.43 3689.28,4601.8C3790.92,4805.06 3794.75,4956 3786.38,5201.2C3783.21,5294.13 3543.62,5301.1 3543.62,5301.1L3932.04,5700.71L4320.46,5301.1C4320.46,5301.1 4077.09,5300.39 4077.7,5201.2C4079.22,4953.5 4079.34,4800.2 4174.8,4601.8Z" style="fill:url(#_Linear3);stroke:rgb(35,31,32);stroke-width:4.34px;"/>
+            </g>
+        </g>
+        <g transform="matrix(-1,-1.22465e-16,1.22465e-16,-1,12033.2,11759.2)">
+            <path d="M5560.71,5286.52C5656.05,5240.49 6127.64,5236.61 6222.13,5286.52C6239.05,5295.46 6150.12,4820.37 6127.64,4814.08C6066.59,4796.99 5702.17,4794.19 5655.2,4814.08C5628.67,4825.31 5549.48,5291.94 5560.71,5286.52Z" style="fill:rgb(36,107,0);stroke:rgb(35,31,32);stroke-width:4.17px;"/>
+            <g transform="matrix(0.973048,0,0,0.945818,2065.36,461.616)">
+                <path d="M4174.8,4601.8C4116.76,4584.7 3742.18,4581.43 3689.28,4601.8C3790.92,4805.06 3794.75,4956 3786.38,5201.2C3783.21,5294.13 3543.62,5301.1 3543.62,5301.1L3932.04,5700.71L4320.46,5301.1C4320.46,5301.1 4077.09,5300.39 4077.7,5201.2C4079.22,4953.5 4079.34,4800.2 4174.8,4601.8Z" style="fill:url(#_Linear4);stroke:rgb(35,31,32);stroke-width:4.34px;"/>
+            </g>
+        </g>
+    </g>
+    <defs>
+        <linearGradient id="_Linear1" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.536407,-887.001,862.178,-0.55185,3932.58,5542.99)"><stop offset="0" style="stop-color:rgb(0,199,65);stop-opacity:1"/><stop offset="0.2" style="stop-color:rgb(0,180,70);stop-opacity:1"/><stop offset="0.42" style="stop-color:rgb(0,161,75);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(0,152,77);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear2" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.536407,-887.001,862.178,-0.55185,3932.58,5542.99)"><stop offset="0" style="stop-color:rgb(199,0,65);stop-opacity:1"/><stop offset="0.2" style="stop-color:rgb(180,0,70);stop-opacity:1"/><stop offset="0.42" style="stop-color:rgb(161,0,75);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(152,0,77);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear3" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.536407,-887.001,862.178,-0.55185,3932.58,5542.99)"><stop offset="0" style="stop-color:rgb(199,0,65);stop-opacity:1"/><stop offset="0.2" style="stop-color:rgb(180,0,70);stop-opacity:1"/><stop offset="0.42" style="stop-color:rgb(161,0,75);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(152,0,77);stop-opacity:1"/></linearGradient>
+        <linearGradient id="_Linear4" x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-0.536407,-887.001,862.178,-0.55185,3932.58,5542.99)"><stop offset="0" style="stop-color:rgb(0,199,65);stop-opacity:1"/><stop offset="0.2" style="stop-color:rgb(0,180,70);stop-opacity:1"/><stop offset="0.42" style="stop-color:rgb(0,161,75);stop-opacity:1"/><stop offset="1" style="stop-color:rgb(0,152,77);stop-opacity:1"/></linearGradient>
+    </defs>
+</svg>

--- a/src/FlightMap/Widgets/GimbalControl.qml
+++ b/src/FlightMap/Widgets/GimbalControl.qml
@@ -103,7 +103,7 @@ Rectangle {
                 ColumnLayout {
                     QGCLabel {
                         Layout.alignment:   Qt.AlignLeft
-                        text:               "Pitch"
+                        text:               "Tilt"
                         font.pointSize:     ScreenTools.smallFontPointSize
 
                     }
@@ -117,7 +117,7 @@ Rectangle {
 
                     QGCLabel {
                         Layout.alignment:   Qt.AlignLeft
-                        text:               "Yaw"
+                        text:               "Pan"
                         font.pointSize:     ScreenTools.smallFontPointSize
 
                     }

--- a/src/FlightMap/Widgets/GimbalControl.qml
+++ b/src/FlightMap/Widgets/GimbalControl.qml
@@ -1,0 +1,180 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick                  2.4
+import QtPositioning            5.2
+import QtQuick.Layouts          1.2
+import QtQuick.Controls         1.4
+import QtQuick.Dialogs          1.2
+import QtGraphicalEffects       1.0
+
+import QGroundControl                   1.0
+import QGroundControl.ScreenTools       1.0
+import QGroundControl.Controls          1.0
+import QGroundControl.Palette           1.0
+import QGroundControl.Vehicle           1.0
+import QGroundControl.Controllers       1.0
+import QGroundControl.FactSystem        1.0
+import QGroundControl.FactControls      1.0
+
+Rectangle {
+    id: rectangle
+    height:     baseLayout.height + (_margins * 2)
+    color:      "#80000000"
+    radius:     _margins
+    visible:    !QGroundControl.settingsManager.flyViewSettings.alternateInstrumentPanel.rawValue && hasGimbal() && multiVehiclePanelSelector.showSingleVehiclePanel
+
+    property real   _margins:                                   ScreenTools.defaultFontPixelHeight / 2
+    property var    _activeVehicle:                             QGroundControl.multiVehicleManager.activeVehicle
+
+    function hasGimbal() {
+        return _activeVehicle ? _activeVehicle.gimbalData : false
+    }
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
+    QGCColoredImage {
+        anchors.margins:    _margins
+        anchors.top:        parent.top
+        anchors.right:      parent.right
+        source:             "/res/gear-black.svg"
+        mipmap:             true
+        height:             ScreenTools.defaultFontPixelHeight
+        width:              height
+        sourceSize.height:  height
+        color:              qgcPal.text
+        fillMode:           Image.PreserveAspectFit
+        visible:            true
+
+        QGCMouseArea {
+            fillItem:   parent
+            onClicked:  mainWindow.showPopupDialogFromComponent(gimbalSettingsDialogComponent)
+        }
+    }
+
+    ColumnLayout {
+        id:                         baseLayout
+        spacing:                    10
+        anchors.margins:            _margins
+        anchors.top:                parent.top
+        anchors.horizontalCenter:   parent.horizontalCenter
+
+        ColumnLayout {
+            id:                         titleLayout
+            spacing:                    ScreenTools.defaultFontPixelHeight / 2
+            height:                     parent.width
+            Layout.alignment:           Qt.AlignHCenter
+
+
+            RowLayout {
+                Layout.alignment:       Qt.AlignHCenter
+
+                Image {
+                    id:                 navigatorImage
+                    source:             "/qmlimages/gimbalNavigator.svg"
+                    height:             ScreenTools.defaultFontPixelHeight
+                    mipmap:             true
+                    fillMode:           Image.PreserveAspectFit
+                    sourceSize.height:  height
+                    width:              height
+                }
+
+                QGCLabel {
+                    Layout.alignment:   Qt.AlignLeft
+                    text:               "Gimbal Orientation"
+                    font.pointSize:     ScreenTools.defaultFontPointSize
+
+                }
+
+            }
+
+            RowLayout {
+                id:                         contentLayout
+                spacing:                    ScreenTools.defaultFontPixelHeight / 2
+                height:                     parent.width
+                Layout.alignment:           Qt.AlignHCenter
+
+                ColumnLayout {
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignLeft
+                        text:               "Pitch"
+                        font.pointSize:     ScreenTools.smallFontPointSize
+
+                    }
+
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignLeft
+                        text:               "Roll"
+                        font.pointSize:     ScreenTools.smallFontPointSize
+
+                    }
+
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignLeft
+                        text:               "Yaw"
+                        font.pointSize:     ScreenTools.smallFontPointSize
+
+                    }
+                }
+                ColumnLayout {
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignRight
+                        text:               _activeVehicle != null ? (_activeVehicle.gimbalPitch  / 100).toFixed(1) + "°" : "---°"
+                        font.pointSize:     ScreenTools.smallFontPointSize
+
+                    }
+
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignRight
+                        text:               _activeVehicle != null ? (_activeVehicle.gimbalRoll / 100).toFixed(1) + "°" : "---°"
+                        font.pointSize:     ScreenTools.smallFontPointSize
+
+                    }
+
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignRight
+                        text:               _activeVehicle != null ? (_activeVehicle.gimbalYaw / 100).toFixed(1) + "°" : "---°"
+                        font.pointSize:     ScreenTools.smallFontPointSize
+
+                    }
+                }
+            }
+        } // mainLayout
+
+
+    } // ColumnLayout
+
+    Component {
+        id: gimbalSettingsDialogComponent
+
+        QGCPopupDialog {
+            title:      qsTr("Settings")
+            buttons:    StandardButton.Close
+
+            RowLayout {
+                QGCLabel {
+                    Layout.alignment: Qt.AlignLeft
+                    text: "Change Gimbal mode (WIP):"
+                    font.pointSize: ScreenTools.smallFontPointSize
+                }
+
+                QGCComboBox {
+                    Layout.fillWidth:   true
+                    sizeToContents:     true
+                    model:              [ "---", "Retracted", "Neutral", "MAVLink targetting", "Rc Targetting", "GPS Point" ]
+                    currentIndex:       0
+                    visible:            true
+                    // TODO This should send a MAVLINK_MSG_ID_MOUNT_CONTROL possibly taking arguments from settings or a ROI on screen
+                    // onActivated:        _activeVehicle.gimbalMode(index)
+                }
+            }
+
+        }
+    }
+}

--- a/src/QGCLoggingCategory.cc
+++ b/src/QGCLoggingCategory.cc
@@ -38,6 +38,10 @@ QGCLoggingCategoryRegister* QGCLoggingCategoryRegister::instance(void)
     if (!_instance) {
         _instance = new QGCLoggingCategoryRegister();
         Q_CHECK_PTR(_instance);
+
+        // Built in categories that have the output of console.log in qml
+        _instance->registerCategory("qml");
+        _instance->registerCategory("js");
     }
     
     return _instance;

--- a/src/QmlControls/QGroundControl/FlightMap/qmldir
+++ b/src/QmlControls/QGroundControl/FlightMap/qmldir
@@ -17,6 +17,7 @@ QGCAttitudeHUD              1.0 QGCAttitudeHUD.qml
 QGCAttitudeWidget           1.0 QGCAttitudeWidget.qml
 QGCCompassWidget            1.0 QGCCompassWidget.qml
 QGCPitchIndicator           1.0 QGCPitchIndicator.qml
+GimbalControl               1.0 GimbalControl.qml
 
 # Map items
 CameraTriggerIndicator      1.0 CameraTriggerIndicator.qml

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3742,7 +3742,7 @@ void Vehicle::_handleGimbalOrientation(const mavlink_message_t& message)
     mavlink_mount_orientation_t o;
     mavlink_msg_mount_orientation_decode(&message, &o);
 
-    _handleGimbalUpdate(o.roll, o.pitch, o.yaw);
+    _handleGimbalUpdate(o.pitch, o.roll, o.yaw);
 }
 
 #if !defined(NO_ARDUPILOT_DIALECT)
@@ -3755,7 +3755,7 @@ void Vehicle::_handleGimbalStatus(const mavlink_message_t& message)
 }
 #endif
 
-void Vehicle::_handleGimbalUpdate(const float roll, const float pitch, const float yaw)
+void Vehicle::_handleGimbalUpdate(const float pitch, const float roll, const float yaw)
 {
     if(fabsf(_curGimbalRoll - roll) > 0.5f) {
         _curGimbalRoll = roll;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3713,15 +3713,15 @@ void Vehicle::gimbalPitchStep(int direction)
     if(_haveGimbalData) {
         //qDebug() << "Pitch:" << _curGimbalPitch << direction << (_curGimbalPitch + direction);
         double p = static_cast<double>(_curGimbalPitch + direction);
-        gimbalControlValue(p, static_cast<double>(_curGinmbalYaw));
+        gimbalControlValue(p, static_cast<double>(_curGimbalYaw));
     }
 }
 
 void Vehicle::gimbalYawStep(int direction)
 {
     if(_haveGimbalData) {
-        //qDebug() << "Yaw:" << _curGinmbalYaw << direction << (_curGinmbalYaw + direction);
-        double y = static_cast<double>(_curGinmbalYaw + direction);
+        //qDebug() << "Yaw:" << _curGimbalYaw << direction << (_curGimbalYaw + direction);
+        double y = static_cast<double>(_curGimbalYaw + direction);
         gimbalControlValue(static_cast<double>(_curGimbalPitch), y);
     }
 }
@@ -3745,8 +3745,8 @@ void Vehicle::_handleGimbalOrientation(const mavlink_message_t& message)
         _curGimbalPitch = o.pitch;
         emit gimbalPitchChanged();
     }
-    if(fabsf(_curGinmbalYaw - o.yaw) > 0.5f) {
-        _curGinmbalYaw = o.yaw;
+    if(fabsf(_curGimbalYaw - o.yaw) > 0.5f) {
+        _curGimbalYaw = o.yaw;
         emit gimbalYawChanged();
     }
     if(!_haveGimbalData) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -919,7 +919,7 @@ private:
     void _handleOrbitExecutionStatus    (const mavlink_message_t& message);
     void _handleMessageInterval         (const mavlink_message_t& message);
     void _handleGimbalOrientation       (const mavlink_message_t& message);
-    void _handleGimbalUpdate            (const float roll, const float pitch, const float yaw);
+    void _handleGimbalUpdate            (const float pitch, const float roll, const float yaw);
     void _handleObstacleDistance        (const mavlink_message_t& message);
     // ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -749,7 +749,7 @@ public:
 
     qreal       gimbalRoll              () { return static_cast<qreal>(_curGimbalRoll);}
     qreal       gimbalPitch             () { return static_cast<qreal>(_curGimbalPitch); }
-    qreal       gimbalYaw               () { return static_cast<qreal>(_curGinmbalYaw); }
+    qreal       gimbalYaw               () { return static_cast<qreal>(_curGimbalYaw); }
     bool        gimbalData              () { return _haveGimbalData; }
     bool        isROIEnabled            () { return _isROIEnabled; }
 
@@ -1074,7 +1074,7 @@ private:
 
     float               _curGimbalRoll  = 0.0f;
     float               _curGimbalPitch = 0.0f;
-    float               _curGinmbalYaw  = 0.0f;
+    float               _curGimbalYaw  = 0.0f;
     bool                _haveGimbalData = false;
     bool                _isROIEnabled   = false;
     Joystick*           _activeJoystick = nullptr;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -919,10 +919,12 @@ private:
     void _handleOrbitExecutionStatus    (const mavlink_message_t& message);
     void _handleMessageInterval         (const mavlink_message_t& message);
     void _handleGimbalOrientation       (const mavlink_message_t& message);
+    void _handleGimbalUpdate            (const float roll, const float pitch, const float yaw);
     void _handleObstacleDistance        (const mavlink_message_t& message);
     // ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)
     void _handleCameraFeedback          (const mavlink_message_t& message);
+    void _handleGimbalStatus            (const mavlink_message_t& message);
 #endif
     void _handleCameraImageCaptured     (const mavlink_message_t& message);
     void _handleADSBVehicle             (const mavlink_message_t& message);


### PR DESCRIPTION
I'm working on adding control for a gimbal mount in qgroundcontrol. This PR adds a simple widget that displays the current feedback provided by ArduPilot (MOUNT_STATUS) message.

Functionality:
 * Visual feedback on gimbal angles from ArduPilot in a widget on the FlyView screen
 * Option to change the gimbal mode from a settings popup from the widget
 * Option to click on a map location to set as GPS tracking target for the gimbal
 
<img width="379" alt="image" src="https://user-images.githubusercontent.com/792959/106730159-9167b400-660e-11eb-92fc-e30160333065.png">

<img width="352" alt="image" src="https://user-images.githubusercontent.com/792959/106730237-a3e1ed80-660e-11eb-8265-719b067d666c.png">

<img width="427" alt="image" src="https://user-images.githubusercontent.com/792959/106730853-1d79db80-660f-11eb-90ce-a57e84adb8dc.png">

