### PR TITLE
cmake updates and fixes

### DIFF
--- a/cmake/Qt5QGCConfiguration.cmake
+++ b/cmake/Qt5QGCConfiguration.cmake
@@ -3,8 +3,15 @@ if(DEFINED ENV{QT_VERSION})
 endif()
 
 if(NOT QT_VERSION)
-	# try Qt 5.12.0 if none specified, last LTS.
-	set(QT_VERSION "5.12.5")
+	# if QT version not specified then use any available version (5.12 or 5.15 only)
+	file(GLOB FOUND_QT_VERSIONS
+		LIST_DIRECTORIES true
+		$ENV{HOME}/Qt/5.12.*
+		$ENV{HOME}/Qt/5.15.*
+	)
+	list(SORT FOUND_QT_VERSIONS) # prefer 5.12
+	list(GET FOUND_QT_VERSIONS 0 QT_VERSION_PATH)
+	get_filename_component(QT_VERSION ${QT_VERSION_PATH} NAME)	
 endif()
 
 if(DEFINED ENV{QT_MKSPEC})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,8 +119,6 @@ add_library(qgc
 	QGCTemporaryFile.h
 	QGCToolbox.cc
 	QGCToolbox.h
-	QGCZlib.cc
-	QGCZlib.h
 	RunGuard.cc
 	RunGuard.h
 	ShapeFileHelper.cc
@@ -144,6 +142,7 @@ add_subdirectory(Audio)
 add_subdirectory(AutoPilotPlugins)
 add_subdirectory(Camera)
 add_subdirectory(comm)
+add_subdirectory(Compression)
 add_subdirectory(FactSystem)
 add_subdirectory(FirmwarePlugin)
 add_subdirectory(FlightDisplay)

--- a/src/Compression/CMakeLists.txt
+++ b/src/Compression/CMakeLists.txt
@@ -1,0 +1,36 @@
+
+set(XZ_EMBEDDED_DIR ${CMAKE_SOURCE_DIR}/libs/xz-embedded)
+
+add_library(compression
+	QGCLZMA.cc
+	QGCLZMA.h
+	QGCZlib.cc
+	QGCZlib.h
+	
+	${XZ_EMBEDDED_DIR}/linux/include/linux/xz.h
+	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_lzma2.h
+	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_private.h
+	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_stream.h
+	${XZ_EMBEDDED_DIR}/userspace/xz_config.h
+	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_crc32.c
+	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_crc64.c
+	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_dec_lzma2.c
+	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_dec_stream.c
+)
+
+target_compile_definitions(compression PRIVATE XZ_DEC_ANY_CHECK XZ_USE_CRC64)
+
+target_link_libraries(compression
+	Qt5::Core
+
+	qgc
+)
+
+target_include_directories(compression
+	INTERFACE
+		${CMAKE_CURRENT_SOURCE_DIR}
+	PRIVATE
+		${XZ_EMBEDDED_DIR}/userspace
+		${XZ_EMBEDDED_DIR}/linux/include/linux
+)
+

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(Vehicle
 target_link_libraries(Vehicle
 	PRIVATE
 		ui
+		compression
 	PUBLIC
 		qgc
 )

--- a/src/VehicleSetup/CMakeLists.txt
+++ b/src/VehicleSetup/CMakeLists.txt
@@ -29,6 +29,8 @@ add_custom_target(VehicleSetupQml
 )
 
 target_link_libraries(VehicleSetup
+	PRIVATE
+		compression
 	PUBLIC
 		qgc
 )

--- a/src/VideoReceiver/CMakeLists.txt
+++ b/src/VideoReceiver/CMakeLists.txt
@@ -2,7 +2,15 @@ set(EXTRA_SOURCES)
 set(EXTRA_LIBRARIES)
 
 if (GST_FOUND)
-    set(EXTRA_SOURCES gstqgc.c gstqgcvideosinkbin.c GStreamer.cc GStreamer.h GstVideoReceiver.cc GstVideoReceiver.h)
+    set(EXTRA_SOURCES
+    	gstqgc.c
+    	gstqgcvideosinkbin.c
+    	GStreamer.cc
+    	GStreamer.h
+    	GstVideoReceiver.cc
+    	GstVideoReceiver.h
+    )
+   
     set(EXTRA_LIBRARIES qmlglsink ${GST_LIBRARIES})
 endif()
 
@@ -17,6 +25,7 @@ target_link_libraries(VideoReceiver
         Qt5::OpenGL
         Qt5::Quick
         ${EXTRA_LIBRARIES}
+        Settings
 )
 
 target_include_directories(VideoReceiver INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
 - use any Qt 5.12.x or 5.15.x version found
    - prefers 5.12 over 5.15
    - overridden by setting QT_VERSION
 - add Compression (and XZ_EMBEDDED) to build