### PR TITLE
Mac os build action

### DIFF
--- a/.github/workflows/buildQGCandDeploy.yml
+++ b/.github/workflows/buildQGCandDeploy.yml
@@ -1,0 +1,76 @@
+name: Build QGC and upload to release 
+
+on: 
+    push:
+      #Every time a tag with name v* (e.g: vX.Y.Z) is pushed,
+      #this action will trigger.
+      tags:
+        - v*
+      #If instead of a tag (or with both restricctions simultaniously)
+      #you prefer to trigger the action uppon push on a branch,
+      #remove the "tags:" flag and add the "branches:" one. E.g:
+      #push:
+        #branches:
+          #- your_branch
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  JOBS: 4
+  CONFIG: installer
+  ACTIONS_BUILD_DIR: ${{ github.workspace }}/../qgroundcontrol
+
+jobs:
+  build-job:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        #Only running MacOS right now, but we leave this options 
+        #for future builds of all distros
+        exclude:
+          - os: ubuntu-latest
+          - os: windows-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: install QT via action
+        uses: jurplel/install-qt-action@v2
+        with: 
+          version: '5.12.6'
+          host: 'mac'
+          target: 'desktop'
+          dir: '${{ runner.temp }}'
+          modules: 'qtcharts'
+          setup-python: 'false'
+
+      - name: Install Gstreamer
+        run:  |
+              wget --quiet https://qgroundcontrol.s3-us-west-2.amazonaws.com/dependencies/gstreamer-osx-1.18.1.tar.bz2
+              sudo tar -zxf gstreamer-osx-1.18.1.tar.bz2 -C /Library/Frameworks
+        
+      - name: mkdir directory shadow_build
+        run:  mkdir ${{ runner.temp }}/shadow_build_dir
+
+      - name: run qmake and build
+        working-directory: ${{ runner.temp }}/shadow_build_dir
+        run:  |
+              export JOBS=$((`sysctl -n hw.ncpu`+1))
+              qmake -r ${ACTIONS_BUILD_DIR}/qgroundcontrol.pro CONFIG+=${CONFIG}
+              make -j$JOBS
+
+      - name: Upload build artifacts to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ runner.temp }}/shadow_build_dir/package/QGroundControl.dmg
+          asset_name: QGroundControl.dmg
+          tag: ${{ github.ref }}
+          overwrite: true
+          body: "QGgroundControl ${{ steps.get_version.outputs.VERSION }} test"


### PR DESCRIPTION
**Problem**
We were having issues building and deploying for macOS via Travis.

**Solution**
Implement  build and deploy via Github Actions.

An action is created which triggers every time a tag is pushed. It will then proceed to build and deploy the artifacts generated by the build (in this case just the .dmg) as assets of the release of the same name as the tag pushed.

**Additional context**
Probably all deployments could be implemented in this same action, so every release could automatically create the assets for windows, android and macOS