### PR TITLE
Set initial values for sliders in PhotoVideoControl from underlying fact

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -466,6 +466,7 @@ Rectangle {
                                 minimumValue:               parent._fact.min
                                 stepSize:                   parent._fact.increment
                                 visible:                    parent._isSlider
+                                value:                      parent._fact.value
                                 updateValueWhileDragging:   false
                                 onValueChanged:             parent._fact.value = value
                                 Component.onCompleted:      value = parent._fact.value


### PR DESCRIPTION
Before this fix, sliders with camera settings in PhotoVideoControl would all be set to their minimum values (see below) everytime the popup dialog is displayed. After the fix, these sliders will have their initial value set based on the underlying fact

![Screenshot_20210205-161943](https://user-images.githubusercontent.com/29304159/107054154-0b936680-67d0-11eb-91ba-a20debf07cae.jpg)
