### PR TITLE
FTPManager: Fix struct definition

### DIFF
--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -63,18 +63,18 @@ private:
     typedef void (FTPManager::*StateAckNakFn)    (const MavlinkFTP::Request* ackOrNak);
     typedef void (FTPManager::*StateTimeoutFn)          (void);
 
-    typedef struct {
+    struct StateFunctions_t {
         StateBeginFn    beginFn;
         StateAckNakFn   ackNakFn;
         StateTimeoutFn  timeoutFn;
-    } StateFunctions_t;
+    };
 
-    typedef struct  {
+    struct MissingData_t {
         uint32_t offset;
         uint32_t cBytesMissing;
-    } MissingData_t;
+    };
 
-    typedef struct {
+    struct DownloadState_t {
         uint8_t                 sessionId;
         uint32_t                expectedOffset;         ///< offset which should be coming next
         uint32_t                bytesWritten;
@@ -97,7 +97,7 @@ private:
             rgMissingData.clear();
             file.close();
         }
-    } DownloadState_t;
+    };
 
 
     void    _mavlinkMessageReceived     (const mavlink_message_t& message);


### PR DESCRIPTION
This fix a warning message in clang 11.
Moves from C struct definition to C++ standard style.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


