### PR TITLE
TelemetryValuesBar: custom transparency by settings

### DIFF
--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -7,22 +7,23 @@
  *
  ****************************************************************************/
 
-import QtQuick                      2.12
-import QtQuick.Layouts              1.12
+import QtQuick                        2.12
+import QtQuick.Layouts                1.12
 
-import QGroundControl               1.0
-import QGroundControl.ScreenTools   1.0
-import QGroundControl.Vehicle       1.0
-import QGroundControl.Controls      1.0
-import QGroundControl.Palette       1.0
+import QGroundControl                 1.0
+import QGroundControl.ScreenTools     1.0
+import QGroundControl.Vehicle         1.0
+import QGroundControl.Controls        1.0
+import QGroundControl.Palette         1.0
 
 Rectangle {
     id:                 telemetryPanel
     height:             telemetryLayout.height + (_toolsMargin * 2)
     width:              telemetryLayout.width + (_toolsMargin * 2)
-    color:              Qt.hsla(_baseBGColor.hslHue, _baseBGColor.hslSaturation, _baseBGColor.hslLightness, 0.5)
+    color:              Qt.hsla(_baseBGColor.hslHue, _baseBGColor.hslSaturation, _baseBGColor.hslLightness, _telemetryPanelAlpha)
     radius:             ScreenTools.defaultFontPixelWidth / 2
 
+    property real  _telemetryPanelAlpha: QGroundControl.settingsManager.appSettings.instrumentWidgetAlpha.value
     property color _baseBGColor: qgcPal.window
 
     DeadMouseArea { anchors.fill: parent }

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -316,6 +316,15 @@
     "shortDesc":    "Use COMPONENT_INFORMATION query (beta)",
     "type":         "bool",
     "default":      false
+},
+{
+    "name":          "instrumentWidgetAlpha",
+    "shortDesc":     "Intrument widget opacity",
+    "type":          "float",
+    "units":         "pt",
+    "min":           0,
+    "max":           1,
+    "default":       0.5
 }
 ]
 }

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -137,6 +137,7 @@ DECLARE_SETTINGSFACT(AppSettings, firstRunPromptIdsShown)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlink)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlinkHostName)
 DECLARE_SETTINGSFACT(AppSettings, useComponentInformationQuery)
+DECLARE_SETTINGSFACT(AppSettings, instrumentWidgetAlpha)
 
 DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
 {

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -64,6 +64,7 @@ public:
     DEFINE_SETTINGFACT(forwardMavlink)
     DEFINE_SETTINGFACT(forwardMavlinkHostName)
     DEFINE_SETTINGFACT(useComponentInformationQuery)
+    DEFINE_SETTINGFACT(instrumentWidgetAlpha)
 
     // Although this is a global setting it only affects ArduPilot vehicle since PX4 automatically starts the stream from the vehicle side
     DEFINE_SETTINGFACT(apmStartMavlinkStreams)

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -32,6 +32,7 @@ Rectangle {
 
     property Fact _savePath:                            QGroundControl.settingsManager.appSettings.savePath
     property Fact _appFontPointSize:                    QGroundControl.settingsManager.appSettings.appFontPointSize
+    property Fact _instrumentWidetAlpha:                QGroundControl.settingsManager.appSettings.instrumentWidgetAlpha
     property Fact _userBrandImageIndoor:                QGroundControl.settingsManager.brandImageSettings.userBrandImageIndoor
     property Fact _userBrandImageOutdoor:               QGroundControl.settingsManager.brandImageSettings.userBrandImageOutdoor
     property Fact _virtualJoystick:                     QGroundControl.settingsManager.appSettings.virtualJoystick
@@ -578,6 +579,54 @@ Rectangle {
                                             onClicked: {
                                                 if (_appFontPointSize.value < _appFontPointSize.max) {
                                                     _appFontPointSize.value = _appFontPointSize.value + 1
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                QGCLabel {
+                                    text:                           qsTr("Telemetry widget opacity")
+                                    visible:                        _instrumentWidetAlpha.visible
+                                    Layout.alignment:               Qt.AlignVCenter
+                                }
+                                Item {
+                                    width:                          _comboFieldWidth
+                                    height:                         instrumentWidgetEdit.height * 1.5
+                                    visible:                        _instrumentWidetAlpha.visible
+                                    Layout.alignment:               Qt.AlignVCenter
+                                    Row {
+                                        spacing:                    ScreenTools.defaultFontPixelWidth
+                                        anchors.verticalCenter:     parent.verticalCenter
+                                        QGCButton {
+                                            width:                  height
+                                            height:                 instrumentWidgetEdit.height * 1.5
+                                            text:                   "-"
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            onClicked: {
+                                                if (_instrumentWidetAlpha.value > _instrumentWidetAlpha.min) {
+                                                    _instrumentWidetAlpha.value = _instrumentWidetAlpha.value - 0.05
+                                                }
+                                            }
+                                        }
+                                        QGCLabel {
+                                            id:                     instrumentWidgetEdit
+                                            width:                  ScreenTools.defaultFontPixelWidth * 6
+                                            text:                   (QGroundControl.settingsManager.appSettings.instrumentWidgetAlpha.value * 100).toFixed(0) + "%"
+                                            horizontalAlignment:    Text.AlignHCenter
+                                            anchors.verticalCenter: parent.verticalCenter
+                                        }
+                                        Text {
+
+                                        }
+
+                                        QGCButton {
+                                            width:                  height
+                                            height:                 instrumentWidgetEdit.height * 1.5
+                                            text:                   "+"
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            onClicked: {
+                                                if (_instrumentWidetAlpha.value < _instrumentWidetAlpha.max) {
+                                                    _instrumentWidetAlpha.value = _instrumentWidetAlpha.value + 0.05
                                                 }
                                             }
                                         }


### PR DESCRIPTION
Under some basemaps the default alpha value for this panel was too transparent for the user to see clearly the values. This commit makes this alpha channel variable by a setting under appsettings.

This addresses the issue #9433


