### PR TITLE
Support for mavlink GPS2_RAW message

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -700,6 +700,7 @@ HEADERS += \
     src/Vehicle/VehicleDistanceSensorFactGroup.h \
     src/Vehicle/VehicleEstimatorStatusFactGroup.h \
     src/Vehicle/VehicleGPSFactGroup.h \
+    src/Vehicle/VehicleGPS2FactGroup.h \
     src/Vehicle/VehicleLinkManager.h \
     src/Vehicle/VehicleSetpointFactGroup.h \
     src/Vehicle/VehicleTemperatureFactGroup.h \
@@ -930,6 +931,7 @@ SOURCES += \
     src/Vehicle/VehicleDistanceSensorFactGroup.cc \
     src/Vehicle/VehicleEstimatorStatusFactGroup.cc \
     src/Vehicle/VehicleGPSFactGroup.cc \
+    src/Vehicle/VehicleGPS2FactGroup.cc \
     src/Vehicle/VehicleLinkManager.cc \
     src/Vehicle/VehicleSetpointFactGroup.cc \
     src/Vehicle/VehicleTemperatureFactGroup.cc \

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -57,6 +57,8 @@ add_library(Vehicle
 	VehicleEstimatorStatusFactGroup.h
 	VehicleGPSFactGroup.cc
 	VehicleGPSFactGroup.h
+	VehicleGPS2FactGroup.cc
+	VehicleGPS2FactGroup.h
 	Vehicle.h
 	VehicleLinkManager.cc
 	VehicleLinkManager.h

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -29,6 +29,7 @@
 #include "VehicleDistanceSensorFactGroup.h"
 #include "VehicleWindFactGroup.h"
 #include "VehicleGPSFactGroup.h"
+#include "VehicleGPS2FactGroup.h"
 #include "VehicleSetpointFactGroup.h"
 #include "VehicleTemperatureFactGroup.h"
 #include "VehicleVibrationFactGroup.h"
@@ -280,6 +281,7 @@ public:
     Q_PROPERTY(Fact* throttlePct        READ throttlePct        CONSTANT)
 
     Q_PROPERTY(FactGroup*           gps             READ gpsFactGroup               CONSTANT)
+    Q_PROPERTY(FactGroup*           gps2            READ gps2FactGroup              CONSTANT)
     Q_PROPERTY(FactGroup*           wind            READ windFactGroup              CONSTANT)
     Q_PROPERTY(FactGroup*           vibration       READ vibrationFactGroup         CONSTANT)
     Q_PROPERTY(FactGroup*           temperature     READ temperatureFactGroup       CONSTANT)
@@ -601,6 +603,7 @@ public:
     Fact* throttlePct                       () { return &_throttlePctFact; }
 
     FactGroup* gpsFactGroup                 () { return &_gpsFactGroup; }
+    FactGroup* gps2FactGroup                () { return &_gps2FactGroup; }
     FactGroup* windFactGroup                () { return &_windFactGroup; }
     FactGroup* vibrationFactGroup           () { return &_vibrationFactGroup; }
     FactGroup* temperatureFactGroup         () { return &_temperatureFactGroup; }
@@ -907,6 +910,7 @@ private:
     void _handleExtendedSysState        (mavlink_message_t& message);
     void _handleCommandAck              (mavlink_message_t& message);
     void _handleGpsRawInt               (mavlink_message_t& message);
+    void _handleGps2Raw                 (mavlink_message_t& message);
     void _handleGlobalPositionInt       (mavlink_message_t& message);
     void _handleAltitude                (mavlink_message_t& message);
     void _handleVfrHud                  (mavlink_message_t& message);
@@ -993,6 +997,7 @@ private:
     uint32_t        _onboardControlSensorsHealth = 0;
     uint32_t        _onboardControlSensorsUnhealthy = 0;
     bool            _gpsRawIntMessageAvailable              = false;
+    bool            _gps2RawMessageAvailable                = false;
     bool            _globalPositionIntMessageAvailable      = false;
     bool            _altitudeMessageAvailable               = false;
     double          _defaultCruiseSpeed = qQNaN();
@@ -1206,6 +1211,7 @@ private:
     Fact _throttlePctFact;
 
     VehicleGPSFactGroup             _gpsFactGroup;
+    VehicleGPS2FactGroup            _gps2FactGroup;
     VehicleWindFactGroup            _windFactGroup;
     VehicleVibrationFactGroup       _vibrationFactGroup;
     VehicleTemperatureFactGroup     _temperatureFactGroup;
@@ -1248,6 +1254,7 @@ private:
     static const char* _throttlePctFactName;
 
     static const char* _gpsFactGroupName;
+    static const char* _gps2FactGroupName;
     static const char* _windFactGroupName;
     static const char* _vibrationFactGroupName;
     static const char* _temperatureFactGroupName;

--- a/src/Vehicle/VehicleGPS2FactGroup.cc
+++ b/src/Vehicle/VehicleGPS2FactGroup.cc
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "VehicleGPS2FactGroup.h"
+#include "Vehicle.h"
+#include "QGCGeo.h"
+
+VehicleGPS2FactGroup::VehicleGPS2FactGroup(QObject* parent)
+    : VehicleGPSFactGroup(parent) {}
+
+void VehicleGPS2FactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
+{
+    switch (message.msgid) {
+    case MAVLINK_MSG_ID_GPS2_RAW:
+        _handleGps2Raw(message);
+        break;
+    default:
+        break;
+    }
+}
+
+void VehicleGPS2FactGroup::_handleGps2Raw(mavlink_message_t& message)
+{
+    mavlink_gps2_raw_t gps2Raw;
+    mavlink_msg_gps2_raw_decode(&message, &gps2Raw);
+
+    lat()->setRawValue              (gps2Raw.lat * 1e-7);
+    lon()->setRawValue              (gps2Raw.lon * 1e-7);
+    mgrs()->setRawValue             (convertGeoToMGRS(QGeoCoordinate(gps2Raw.lat * 1e-7, gps2Raw.lon * 1e-7)));
+    count()->setRawValue            (gps2Raw.satellites_visible == 255 ? 0 : gps2Raw.satellites_visible);
+    hdop()->setRawValue             (gps2Raw.eph == UINT16_MAX ? qQNaN() : gps2Raw.eph / 100.0);
+    vdop()->setRawValue             (gps2Raw.epv == UINT16_MAX ? qQNaN() : gps2Raw.epv / 100.0);
+    courseOverGround()->setRawValue (gps2Raw.cog == UINT16_MAX ? qQNaN() : gps2Raw.cog / 100.0);
+    lock()->setRawValue             (gps2Raw.fix_type);
+}

--- a/src/Vehicle/VehicleGPS2FactGroup.h
+++ b/src/Vehicle/VehicleGPS2FactGroup.h
@@ -1,0 +1,27 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "VehicleGPSFactGroup.h"
+#include "QGCMAVLink.h"
+
+class VehicleGPS2FactGroup : public VehicleGPSFactGroup
+{
+    Q_OBJECT
+
+public:
+    VehicleGPS2FactGroup(QObject* parent = nullptr);
+
+    // Overrides from VehicleGPSFactGroup
+    void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
+
+private:
+    void _handleGps2Raw(mavlink_message_t& message);
+};

--- a/src/Vehicle/VehicleGPSFactGroup.h
+++ b/src/Vehicle/VehicleGPSFactGroup.h
@@ -38,7 +38,7 @@ public:
     Fact* lock              () { return &_lockFact; }
 
     // Overrides from FactGroup
-    void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
+    virtual void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
     static const char* _latFactName;
     static const char* _lonFactName;
@@ -49,7 +49,7 @@ public:
     static const char* _countFactName;
     static const char* _lockFactName;
 
-private:
+protected:
     void _handleGpsRawInt   (mavlink_message_t& message);
     void _handleHighLatency (mavlink_message_t& message);
     void _handleHighLatency2(mavlink_message_t& message);


### PR DESCRIPTION
This PR adds support for GPS2_RAW messages, implemented within the factgroup system so the new field GPS2 can be selected in the main custom telemetry widget.

I've inherited vehicleGPSfactgroup totally and reimplemented the handle message function. This has been tested in v4.1.1, master isn't compiling to me right now. For the PR I rebased to master.

It has been tested with Ardupilot SITL and it works fine.

This PR addresses part of #9435, the airspeed part probably requires development of autopilot firmware as well, I can't see where mavlink is sending the second airspeed values.