### PR TITLE
Change Tool Drawer to Dialog

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -329,55 +329,50 @@ ApplicationWindow {
         visible: QGroundControl.settingsManager.flyViewSettings.showLogReplayStatusBar.rawValue
     }
 
-    Drawer {
-        id:             toolSelectDrawer
-        height:         mainWindow.height
-        edge:           Qt.LeftEdge
-        interactive:    true
-        dragMargin:     0
-        visible:        false
+    function showToolSelectDialog() {
+        if (!mainWindow.preventViewSwitch()) {
+            showPopupDialogFromComponent(toolSelectDialogComponent)
+        }
+    }
 
-        property var    _mainWindow:       mainWindow
-        property real   _toolButtonHeight: ScreenTools.defaultFontPixelHeight * 3
+    Component {
+        id: toolSelectDialogComponent
 
-        Rectangle {
-            width:  mainLayout.width + (mainLayout.anchors.margins * 2)
-            height: parent.height
-            color:  qgcPal.window
+        QGCPopupDialog {
+            id:         toolSelectDialog
+            title:      qsTr("Select Tool")
+            buttons:    StandardButton.Close
 
-            QGCFlickable {
-                anchors.top:        parent.top
-                anchors.bottom:     qgcVersionLayout.top
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                contentHeight:      mainLayout.height + (mainLayout.anchors.margins * 2)
-                flickableDirection: QGCFlickable.VerticalFlick
+            property real _toolButtonHeight:    ScreenTools.defaultFontPixelHeight * 3
+            property real _margins:             ScreenTools.defaultFontPixelWidth
+
+            ColumnLayout {
+                width:  innerLayout.width + (_margins * 2)
+                height: innerLayout.height + (_margins * 2)
 
                 ColumnLayout {
-                    id:                 mainLayout
-                    anchors.margins:    ScreenTools.defaultFontPixelWidth
-                    anchors.left:       parent.left
-                    anchors.top:        parent.top
-                    spacing:            ScreenTools.defaultFontPixelWidth
+                    id:             innerLayout
+                    Layout.margins: _margins
+                    spacing:        ScreenTools.defaultFontPixelWidth
 
                     SubMenuButton {
                         id:                 setupButton
-                        height:             toolSelectDrawer._toolButtonHeight
+                        height:             _toolButtonHeight
                         Layout.fillWidth:   true
                         text:               qsTr("Vehicle Setup")
                         imageColor:         qgcPal.text
                         imageResource:      "/qmlimages/Gears.svg"
                         onClicked: {
                             if (!mainWindow.preventViewSwitch()) {
+                                toolSelectDialog.hideDialog()
                                 mainWindow.showSetupTool()
-                                toolSelectDrawer.visible = false
                             }
                         }
                     }
 
                     SubMenuButton {
                         id:                 analyzeButton
-                        height:             toolSelectDrawer._toolButtonHeight
+                        height:             _toolButtonHeight
                         Layout.fillWidth:   true
                         text:               qsTr("Analyze Tools")
                         imageResource:      "/qmlimages/Analyze.svg"
@@ -385,15 +380,15 @@ ApplicationWindow {
                         visible:            QGroundControl.corePlugin.showAdvancedUI
                         onClicked: {
                             if (!mainWindow.preventViewSwitch()) {
+                                toolSelectDialog.hideDialog()
                                 mainWindow.showAnalyzeTool()
-                                toolSelectDrawer.visible = false
                             }
                         }
                     }
 
                     SubMenuButton {
                         id:                 settingsButton
-                        height:             toolSelectDrawer._toolButtonHeight
+                        height:             _toolButtonHeight
                         Layout.fillWidth:   true
                         text:               qsTr("Application Settings")
                         imageResource:      "/res/QGCLogoFull"
@@ -401,65 +396,61 @@ ApplicationWindow {
                         visible:            !QGroundControl.corePlugin.options.combineSettingsAndSetup
                         onClicked: {
                             if (!mainWindow.preventViewSwitch()) {
+                                toolSelectDialog.hideDialog()
                                 mainWindow.showSettingsTool()
-                                toolSelectDrawer.visible = false
                             }
                         }
                     }
-                }
-            }
 
-            ColumnLayout {
-                id:             qgcVersionLayout
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                anchors.bottom: parent.bottom
-                spacing:        0
+                    ColumnLayout {
+                        width:      innerLayout.width
+                        spacing:    0
 
-                QGCLabel {
-                    text:                   qsTr("%1 Version").arg(QGroundControl.appName)
-                    font.pointSize:         ScreenTools.smallFontPointSize
-                    wrapMode:               QGCLabel.WordWrap
-                    Layout.maximumWidth:    parent.width
-                    Layout.alignment:       Qt.AlignHCenter
-                }
-                QGCLabel {
-                    text:                   QGroundControl.qgcVersion
-                    font.pointSize:         ScreenTools.smallFontPointSize
-                    wrapMode:               QGCLabel.WrapAnywhere
-                    Layout.maximumWidth:    parent.width
-                    Layout.alignment:       Qt.AlignHCenter
-                }
-            }
-
-            DeadMouseArea {
-                anchors.fill: easterEggMouseArea
-            }
-
-            QGCMouseArea {
-                id:             easterEggMouseArea
-                anchors.fill:   qgcVersionLayout
-
-                onClicked: {
-                    if (mouse.modifiers & Qt.ControlModifier) {
-                        QGroundControl.corePlugin.showTouchAreas = !QGroundControl.corePlugin.showTouchAreas
-                    } else if (mouse.modifiers & Qt.ShiftModifier) {
-                        if(!QGroundControl.corePlugin.showAdvancedUI) {
-                            advancedModeConfirmation.open()
-                        } else {
-                            QGroundControl.corePlugin.showAdvancedUI = false
+                        QGCLabel {
+                            id:                     versionLabel
+                            text:                   qsTr("%1 Version").arg(QGroundControl.appName)
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                            wrapMode:               QGCLabel.WordWrap
+                            Layout.maximumWidth:    parent.width
+                            Layout.alignment:       Qt.AlignHCenter
                         }
-                    }
-                }
 
-                MessageDialog {
-                    id:                 advancedModeConfirmation
-                    title:              qsTr("Advanced Mode")
-                    text:               QGroundControl.corePlugin.showAdvancedUIMessage
-                    standardButtons:    StandardButton.Yes | StandardButton.No
-                    onYes: {
-                        QGroundControl.corePlugin.showAdvancedUI = true
-                        advancedModeConfirmation.close()
+                        QGCLabel {
+                            text:                   QGroundControl.qgcVersion
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                            wrapMode:               QGCLabel.WrapAnywhere
+                            Layout.maximumWidth:    parent.width
+                            Layout.alignment:       Qt.AlignHCenter
+
+                            QGCMouseArea {
+                                id:                 easterEggMouseArea
+                                anchors.topMargin:  -versionLabel.height
+                                anchors.fill:       parent
+
+                                onClicked: {
+                                    if (mouse.modifiers & Qt.ControlModifier) {
+                                        QGroundControl.corePlugin.showTouchAreas = !QGroundControl.corePlugin.showTouchAreas
+                                    } else if (mouse.modifiers & Qt.ShiftModifier) {
+                                        if(!QGroundControl.corePlugin.showAdvancedUI) {
+                                            advancedModeConfirmation.open()
+                                        } else {
+                                            QGroundControl.corePlugin.showAdvancedUI = false
+                                        }
+                                    }
+                                }
+
+                                MessageDialog {
+                                    id:                 advancedModeConfirmation
+                                    title:              qsTr("Advanced Mode")
+                                    text:               QGroundControl.corePlugin.showAdvancedUIMessage
+                                    standardButtons:    StandardButton.Yes | StandardButton.No
+                                    onYes: {
+                                        QGroundControl.corePlugin.showAdvancedUI = true
+                                        advancedModeConfirmation.close()
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -69,7 +69,7 @@ Rectangle {
             Layout.preferredHeight: viewButtonRow.height
             icon.source:            "/res/QGCLogoFull"
             logo:                   true
-            onClicked:              toolSelectDrawer.visible = true
+            onClicked:              mainWindow.showToolSelectDialog()
         }
 
         MainStatusIndicator {


### PR DESCRIPTION
* Using a Drawer to select Tools after clicking the Q icon was quirky from a user model standpoint. See #9396 for various problems.
* Changed to just use a regular dialog. I'm not super happy with that either but it is way less quirky and obvious as to how it works. I'll get back to this at some point when I get back to looking at the toolbar.

![Screen Shot 2021-02-16 at 3 30 56 PM](https://user-images.githubusercontent.com/5876851/108135072-4cab3680-706c-11eb-8751-2529a0ea1073.png)
