### PR TITLE
VideoReceiver: Remove low-latency mode and set rtpjitterbuffer to a shorter buffer

### DIFF
--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -123,13 +123,6 @@
     "default":     false
 },
 {
-    "name":             "lowLatencyMode",
-    "shortDesc": "Tweaks video for lower latency",
-    "longDesc":  "If this option is enabled, the rtpjitterbuffer is removed and the video sink is set to assynchronous mode, reducing the latency by about 200 ms.",
-    "type":             "bool",
-    "default":     false
-},
-{
     "name":             "forceVideoDecoder",
     "shortDesc":        "Force specific category of video decode",
     "longDesc":         "Force the change of prioritization between video decode methods, allowing the user to force some video hardware decode plugins if necessary.",

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -106,7 +106,6 @@ DECLARE_SETTINGSFACT(VideoSettings, enableStorageLimit)
 DECLARE_SETTINGSFACT(VideoSettings, rtspTimeout)
 DECLARE_SETTINGSFACT(VideoSettings, streamEnabled)
 DECLARE_SETTINGSFACT(VideoSettings, disableWhenDisarmed)
-DECLARE_SETTINGSFACT(VideoSettings, lowLatencyMode)
 
 DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, videoSource)
 {

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -34,7 +34,6 @@ public:
     DEFINE_SETTINGFACT(rtspTimeout)
     DEFINE_SETTINGFACT(streamEnabled)
     DEFINE_SETTINGFACT(disableWhenDisarmed)
-    DEFINE_SETTINGFACT(lowLatencyMode)
     DEFINE_SETTINGFACT(forceVideoDecoder)
 
     enum VideoDecoderOptions {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -185,7 +185,6 @@ Vehicle::Vehicle(LinkInterface*             link,
     // Set video stream to udp if running ArduSub and Video is disabled
     if (sub() && _settingsManager->videoSettings()->videoSource()->rawValue() == VideoSettings::videoDisabled) {
         _settingsManager->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceUDPH264);
-        _settingsManager->videoSettings()->lowLatencyMode()->setRawValue(true);
     }
 
     //-- Airspace Management
@@ -431,7 +430,6 @@ void Vehicle::_commonInit()
     // Set video stream to udp if running ArduSub and Video is disabled
     if (sub() && _settingsManager->videoSettings()->videoSource()->rawValue() == VideoSettings::videoDisabled) {
         _settingsManager->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceUDPH264);
-        _settingsManager->videoSettings()->lowLatencyMode()->setRawValue(true);
     }
 
     //-- Airspace Management

--- a/src/VideoManager/VideoManager.h
+++ b/src/VideoManager/VideoManager.h
@@ -132,7 +132,6 @@ protected slots:
     void _udpPortChanged            ();
     void _rtspUrlChanged            ();
     void _tcpUrlChanged             ();
-    void _lowLatencyModeChanged     ();
     void _updateUVC                 ();
     void _setActiveVehicle          (Vehicle* vehicle);
     void _aspectRatioChanged        ();
@@ -164,7 +163,6 @@ protected:
     // 3) Qt rendering thread (during video sink creation process which should happen in this thread)
     // It works for now but...
     bool                    _videoStarted[2]        = { false, false };
-    bool                    _lowLatencyStreaming[2] = { false, false };
     QAtomicInteger<bool>    _streaming              = false;
     QAtomicInteger<bool>    _decoding               = false;
     QAtomicInteger<bool>    _recording              = false;

--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -790,6 +790,7 @@ GstVideoReceiver::_makeSource(const QString& uri)
                     qCCritical(VideoReceiverLog) << "gst_element_factory_make('rtpjitterbuffer') failed";
                     break;
                 }
+                g_object_set(buffer, "latency", 70, NULL);
 
                 gst_bin_add(GST_BIN(bin), buffer);
 

--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -1088,8 +1088,6 @@ GstVideoReceiver::_addVideoSink(GstPad* pad)
 
     gst_element_sync_state_with_parent(_videoSink);
 
-    g_object_set(_videoSink, "sync", _buffer >= 0, NULL);
-
     GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-videosink");
 
     if (_decoderValve != nullptr) {

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -336,13 +336,6 @@ Rectangle {
 
                                 Item { width: 1; height: 1}
                                 FactCheckBox {
-                                    text:       qsTr("Low Latency Mode")
-                                    fact:       _videoSettings.lowLatencyMode
-                                    visible:    !_videoAutoStreamConfig && _isGst && fact.visible
-                                }
-
-                                Item { width: 1; height: 1}
-                                FactCheckBox {
                                     text:       qsTr("Auto-Delete Saved Recordings")
                                     fact:       _videoSettings.enableStorageLimit
                                     visible:    _showSaveVideoSettings && fact.visible


### PR DESCRIPTION
Potential fix for #9448 

This replaces the default 200ms in rtpjitterbuffer for 70ms.

We could allow the user to fine tune this value. but I don't think we should allow that much customization

Needs testing!