### PR TITLE
Make telemetryvaluesbar opaque

### DIFF
--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -20,10 +20,8 @@ Rectangle {
     id:                 telemetryPanel
     height:             telemetryLayout.height + (_toolsMargin * 2)
     width:              telemetryLayout.width + (_toolsMargin * 2)
-    color:              Qt.hsla(_baseBGColor.hslHue, _baseBGColor.hslSaturation, _baseBGColor.hslLightness, 0.5)
+    color:              qgcPal.window
     radius:             ScreenTools.defaultFontPixelWidth / 2
-
-    property color _baseBGColor: qgcPal.window
 
     DeadMouseArea { anchors.fill: parent }
 


### PR DESCRIPTION
Following the discussion in https://github.com/mavlink/qgroundcontrol/issues/9433 this PR makes the panel opaque. It already includes the revert PR : https://github.com/mavlink/qgroundcontrol/pull/9450

Let me know if something additional is needed. Thanks!