### PR TITLE
Fix Takeoff.Pitch/Yaw usage by vehicle type

### DIFF
--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -196,20 +196,7 @@
             "specifiesCoordinate":  true,
             "isTakeoffCommand":     true,
             "friendlyEdit":         true,
-            "category":             "Basic",
-            "param1": {
-                "label":            "Pitch",
-                "units":            "deg",
-                "default":          15,
-                "decimalPlaces":    2
-            },
-            "param4": {
-                "label":            "Yaw",
-                "units":            "deg",
-                "nanUnchanged":     true,
-                "default":          null,
-                "decimalPlaces":    2
-            }
+            "category":             "Basic"
         },
         { "id": 23, "rawName": "MAV_CMD_NAV_LAND_LOCAL", "friendlyName": "Land local" },
         { "id": 24, "rawName": "MAV_CMD_NAV_TAKEOFF_LOCAL", "friendlyName": "Takeoff local" },

--- a/src/MissionManager/MavCmdInfoFixedWing.json
+++ b/src/MissionManager/MavCmdInfoFixedWing.json
@@ -22,7 +22,12 @@
         {
             "id":           22,
             "comment":      "MAV_CMD_NAV_TAKEOFF",
-            "paramRemove":  "4"
+            "param1": {
+                "label":            "Pitch",
+                "units":            "deg",
+                "default":          15,
+                "decimalPlaces":    2
+            }
         }
     ]
 }

--- a/src/MissionManager/MavCmdInfoMultiRotor.json
+++ b/src/MissionManager/MavCmdInfoMultiRotor.json
@@ -22,7 +22,13 @@
         {
             "id":           22,
             "comment":      "MAV_CMD_NAV_TAKEOFF",
-            "paramRemove":  "1"
+            "param4": {
+                "label":            "Yaw",
+                "units":            "deg",
+                "nanUnchanged":     true,
+                "default":          null,
+                "decimalPlaces":    2
+            }
         },
         {
             "id":           31,


### PR DESCRIPTION
* Default Takeoff.Pitch value of 15 will only be set for Fixed Wing vehicles
* Adjust json command tree for correct usages of Pitch/Yaw by vehicle type
* Related to #9443