### PR TITLE
JoystickThumbPad: remove red virtual joystick border

### DIFF
--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -212,11 +212,5 @@ Item {
         touchPoints:            [ TouchPoint { id: touchPoint } ]
         onPressed:              _joyRoot.thumbDown(touchPoints)
         onReleased:             _joyRoot.reCenter()
-
-        Rectangle {
-            border.color: "red"
-            color: "transparent"
-            anchors.fill: parent
-        }
     }
 }


### PR DESCRIPTION
It looks quite strange and was probably added for debugging purposes.

Before:
![image](https://user-images.githubusercontent.com/4668506/108853543-26931280-75e7-11eb-9d26-0361e60afebb.png)

After:
![image](https://user-images.githubusercontent.com/4668506/108853134-a8367080-75e6-11eb-8e69-1944607e9549.png)