### PR TITLE
Support for CustomSettings 

### DIFF
--- a/custom-example/custom.pri
+++ b/custom-example/custom.pri
@@ -35,6 +35,9 @@ CONFIG  += QGC_DISABLE_PX4_PLUGIN_FACTORY
 DEFINES += CUSTOMHEADER=\"\\\"CustomPlugin.h\\\"\"
 DEFINES += CUSTOMCLASS=CustomPlugin
 
+DEFINES += CUSTOMSETTINGSHEADER=\"\\\"CustomSettings.h\\\"\"
+DEFINES += CUSTOMSETTINGSCLASS=CustomSettings
+
 TARGET   = CustomQGroundControl
 DEFINES += QGC_APPLICATION_NAME='"\\\"Custom QGroundControl\\\""'
 
@@ -59,21 +62,25 @@ QML_IMPORT_PATH += \
 # Our own, custom sources
 SOURCES += \
     $$PWD/src/CustomPlugin.cc \
+    $$PWD/src/Settings/CustomSettings.cc \
 
 HEADERS += \
     $$PWD/src/CustomPlugin.h \
+    $$PWD/src/Settings/CustomSettings.h \
 
 INCLUDEPATH += \
     $$PWD/src \
+    $$PWD/src/Settings \
+
 
 #-------------------------------------------------------------------------------------
 # Custom Firmware/AutoPilot Plugin
 
 INCLUDEPATH += \
     $$PWD/src/FirmwarePlugin \
-    $$PWD/src/AutoPilotPlugin
+    $$PWD/src/AutoPilotPlugin \
 
-HEADERS+= \
+HEADERS += \
     $$PWD/src/AutoPilotPlugin/CustomAutoPilotPlugin.h \
     $$PWD/src/FirmwarePlugin/CustomFirmwarePlugin.h \
     $$PWD/src/FirmwarePlugin/CustomFirmwarePluginFactory.h \

--- a/custom-example/custom.qrc
+++ b/custom-example/custom.qrc
@@ -31,4 +31,7 @@
     <qresource prefix="/qml">
         <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">res/CustomFlyViewOverlay.qml</file>
     </qresource>
+    <qresource prefix="/json">
+        <file alias="Custom.SettingsGroup.json">src/Settings/Custom.SettingsGroup.json</file>
+    </qresource>
 </RCC>

--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -88,6 +88,8 @@ void CustomPlugin::setToolbox(QGCToolbox* toolbox)
 
     // Allows us to be notified when the user goes in/out out advanced mode
     connect(qgcApp()->toolbox()->corePlugin(), &QGCCorePlugin::showAdvancedUIChanged, this, &CustomPlugin::_advancedChanged);
+
+    _customSettings = qgcApp()->toolbox()->settingsManager()->customSettings();
 }
 
 void CustomPlugin::_advancedChanged(bool changed)

--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -15,6 +15,7 @@
 #include "QGCOptions.h"
 #include "QGCLoggingCategory.h"
 #include "SettingsManager.h"
+#include "CustomSettings.h"
 
 #include <QTranslator>
 
@@ -77,4 +78,5 @@ private:
 private:
     CustomOptions*  _options = nullptr;
     QVariantList    _customSettingsList; // Not to be mixed up with QGCCorePlugin implementation
+    CustomSettings* _customSettings;
 };

--- a/custom-example/src/Settings/Custom.SettingsGroup.json
+++ b/custom-example/src/Settings/Custom.SettingsGroup.json
@@ -1,0 +1,19 @@
+{
+    "version":      1,
+    "fileType":  "FactMetaData",
+    "QGC.MetaData.Facts":
+[
+{
+    "name":             "customSetting1",
+    "shortDesc":        "Just an example",
+    "type":             "string",
+    "default":          ""
+},
+{
+    "name":             "customSetting2",
+    "shortDesc":        "Another example",
+    "type":             "bool",
+    "default":          false
+}
+]
+}

--- a/custom-example/src/Settings/CustomSettings.cc
+++ b/custom-example/src/Settings/CustomSettings.cc
@@ -1,0 +1,21 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "CustomSettings.h"
+
+#include <QQmlEngine>
+#include <QtQml>
+
+DECLARE_SETTINGGROUP(Custom, "Custom")
+{
+    qmlRegisterUncreatableType<CustomSettings>("QGroundControl.SettingsManager", 1, 0, "CustomSettings", "Reference only");
+}
+
+DECLARE_SETTINGSFACT(CustomSettings, customSetting1)
+DECLARE_SETTINGSFACT(CustomSettings, customSetting2)

--- a/custom-example/src/Settings/CustomSettings.h
+++ b/custom-example/src/Settings/CustomSettings.h
@@ -1,0 +1,23 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2016 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "SettingsGroup.h"
+
+class CustomSettings : public SettingsGroup
+{
+    Q_OBJECT
+
+public:
+    CustomSettings(QObject* parent = nullptr);
+    DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(customSetting1)
+    DEFINE_SETTINGFACT(customSetting2)
+};

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -32,6 +32,9 @@ SettingsManager::SettingsManager(QGCApplication* app, QGCToolbox* toolbox)
 #if !defined(NO_ARDUPILOT_DIALECT)
     , _apmMavlinkStreamRateSettings (nullptr)
 #endif
+#if defined (QGC_CUSTOM_BUILD) && defined (CUSTOMSETTINGSCLASS)
+    , _customSettings                (nullptr)
+#endif
 {
 
 }
@@ -58,6 +61,9 @@ void SettingsManager::setToolbox(QGCToolbox *toolbox)
     _apmMavlinkStreamRateSettings = new APMMavlinkStreamRateSettings(this);
 #endif
 #if defined(QGC_AIRMAP_ENABLED)
-    _airMapSettings =               new AirMapSettings          (this);
+    _airMapSettings =               new AirMapSettings              (this);
+#endif
+#if defined (QGC_CUSTOM_BUILD) && defined (CUSTOMSETTINGSCLASS)
+    _customSettings               = new CUSTOMSETTINGSCLASS         (this);
 #endif
 }

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -27,6 +27,9 @@
 #include "APMMavlinkStreamRateSettings.h"
 #include "FirmwareUpgradeSettings.h"
 #include "ADSBVehicleManagerSettings.h"
+#if defined (QGC_CUSTOM_BUILD) && defined (CUSTOMSETTINGSCLASS)
+#include CUSTOMSETTINGSHEADER
+#endif
 #if defined(QGC_AIRMAP_ENABLED)
 #include "AirMapSettings.h"
 #endif
@@ -36,7 +39,7 @@
 class SettingsManager : public QGCTool
 {
     Q_OBJECT
-    
+
 public:
     SettingsManager(QGCApplication* app, QGCToolbox* toolbox);
 
@@ -57,6 +60,9 @@ public:
     Q_PROPERTY(QObject* adsbVehicleManagerSettings      READ adsbVehicleManagerSettings     CONSTANT)
 #if !defined(NO_ARDUPILOT_DIALECT)
     Q_PROPERTY(QObject* apmMavlinkStreamRateSettings    READ apmMavlinkStreamRateSettings   CONSTANT)
+#endif
+#if defined (QGC_CUSTOM_BUILD) && defined (CUSTOMSETTINGSCLASS)
+    Q_PROPERTY(QObject* customSettings                  READ customSettings                 CONSTANT)
 #endif
     // Override from QGCTool
     virtual void setToolbox(QGCToolbox *toolbox);
@@ -79,6 +85,9 @@ public:
 #if !defined(NO_ARDUPILOT_DIALECT)
     APMMavlinkStreamRateSettings*   apmMavlinkStreamRateSettings(void) { return _apmMavlinkStreamRateSettings; }
 #endif
+#if defined (QGC_CUSTOM_BUILD) && defined (CUSTOMSETTINGSCLASS)
+    CUSTOMSETTINGSCLASS*                 customSettings              (void) { return _customSettings;}
+#endif
 private:
 #if defined(QGC_AIRMAP_ENABLED)
     AirMapSettings*         _airMapSettings;
@@ -97,6 +106,9 @@ private:
     ADSBVehicleManagerSettings*     _adsbVehicleManagerSettings;
 #if !defined(NO_ARDUPILOT_DIALECT)
     APMMavlinkStreamRateSettings*   _apmMavlinkStreamRateSettings;
+#endif
+#if defined (QGC_CUSTOM_BUILD) && defined (CUSTOMSETTINGSCLASS)
+    CUSTOMSETTINGSCLASS*                 _customSettings;
 #endif
 };
 


### PR DESCRIPTION
This PR adds the ability for custom plugin users to define their own SettingsGroup, which they can access via the SettingsManager. I've added it to the custom-example for reference on usage. 

I'll open a PR into master after this has passed review.