### PR TITLE
Only accept sufficiently accurate location updates

### DIFF
--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -82,7 +82,7 @@ void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
         // Note that gcsPosition filters out possible crap values
         if (qAbs(update.coordinate().latitude()) > 0.001 &&
             qAbs(update.coordinate().longitude()) > 0.001 &&
-            update.attribute(QGeoPositionInfo::HorizontalAccuracy) <= MinHorizonalAccuracyMetres) {
+            update.attribute(QGeoPositionInfo::HorizontalAccuracy) <= MinHorizonalAccuracyMeters) {
             newGCSPosition = update.coordinate();
         }
     }

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -78,9 +78,11 @@ void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
     QGeoCoordinate newGCSPosition = QGeoCoordinate();
     qreal newGCSHeading = update.attribute(QGeoPositionInfo::Direction);
 
-    if (update.isValid()) {
+    if (update.isValid() && update.hasAttribute(QGeoPositionInfo::HorizontalAccuracy)) {
         // Note that gcsPosition filters out possible crap values
-        if (qAbs(update.coordinate().latitude()) > 0.001 && qAbs(update.coordinate().longitude()) > 0.001) {
+        if (qAbs(update.coordinate().latitude()) > 0.001 &&
+            qAbs(update.coordinate().longitude()) > 0.001 &&
+            update.attribute(QGeoPositionInfo::HorizontalAccuracy) <= MinHorizonalAccuracyMetres) {
             newGCSPosition = update.coordinate();
         }
     }

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -21,7 +21,7 @@ class QGCPositionManager : public QGCTool {
     Q_OBJECT
 
 public:
-
+    static constexpr size_t MinHorizonalAccuracyMetres = 100;
     QGCPositionManager(QGCApplication* app, QGCToolbox* toolbox);
     ~QGCPositionManager();
 

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -21,7 +21,7 @@ class QGCPositionManager : public QGCTool {
     Q_OBJECT
 
 public:
-    static constexpr size_t MinHorizonalAccuracyMetres = 100;
+    static constexpr size_t MinHorizonalAccuracyMeters = 100;
     QGCPositionManager(QGCApplication* app, QGCToolbox* toolbox);
     ~QGCPositionManager();
 


### PR DESCRIPTION
Addresses: https://github.com/mavlink/qgroundcontrol/issues/9471

Ubuntu location services are powered by [geoclue](https://gitlab.freedesktop.org/geoclue/geoclue/-/wikis/home), a service and framework that doesn't radiate with an aura of maturity:
```
$ cat /var/log/syslog | grep geoclue
...
Feb 24 07:17:35 remek-XPS-2 geoclue[6935]: Failed to query location: Forbidden
Feb 24 07:18:23 remek-XPS-2 systemd[1]: geoclue.service: Succeeded.
Feb 24 07:18:54 remek-XPS-2 dbus-daemon[1205]: [system] Activating via systemd: service name='org.freedesktop.GeoClue2' unit='geoclue.service' requested by ':1.43' (uid=125 pid=1688 comm="/usr/bin/gnome-shell " label="unconfined")
Feb 24 07:19:00 remek-XPS-2 whoopsie-upload-all[2637]: /var/crash/_usr_libexec_geoclue.122.crash already marked for upload, skipping
...
Feb 24 07:41:31 remek-XPS-2 systemd[1]: geoclue.service: Succeeded.
Feb 24 07:41:54 remek-XPS-2 kernel: [  435.218728] geoclue[7398]: segfault at 8 ip 000055a07d1c3697 sp 00007ffd5616abd0 error 4 in geoclue[55a07d1a5000+29000]
Feb 24 07:41:54 remek-XPS-2 geoclue[7398]: soup_message_set_request: assertion 'SOUP_IS_MESSAGE (msg)' failed
Feb 24 07:41:54 remek-XPS-2 systemd[1]: geoclue.service: Main process exited, code=dumped, status=11/SEGV
Feb 24 07:41:54 remek-XPS-2 systemd[1]: geoclue.service: Failed with result 'core-dump'.
Feb 24 07:42:18 remek-XPS-2 dbus-daemon[1278]: [system] Activating via systemd: service name='org.freedesktop.GeoClue2' unit='geoclue.service' requested by ':1.146' (uid=1001 pid=7525 comm="/usr/bin/gjs /usr/bin/gnome-maps " label="unconfined")
Feb 24 07:42:22 remek-XPS-2 geoclue[7546]: soup_message_set_request: assertion 'SOUP_IS_MESSAGE (msg)' failed
Feb 24 07:42:22 remek-XPS-2 kernel: [  463.701454] geoclue[7546]: segfault at 8 ip 000055fec4772697 sp 00007fff5c45cd70 error 4 in geoclue[55fec4754000+29000]
```
By default it comes shipped configured against the Mozilla backend
```
url=https://location.services.mozilla.com/v1/geolocate?key=geoclue
```
which, on gps-less systems (like our dev laptops) runs the query against Mozilla's database of wifi hotspots and tries to determine the host system whereabouts. The database is crowd-sourced and, judging from what Firefox ships with:
![ff](https://user-images.githubusercontent.com/8327961/109007799-d4b4c000-76ac-11eb-931a-e24fc2627ff8.png)
the quality gap to google is sadly broad.

geoclue can be configured against google backend, but i failed trying to acomplish this.
```
Feb 24 07:19:04 remek-XPS-2 geoclue[1985]: Failed to query location: Forbidden
```
The net result is that QGC (via geoclue) can show a position that is inaccurate beyond useful. 
![wrong-posi](https://user-images.githubusercontent.com/8327961/109008160-4725a000-76ad-11eb-91a3-a708a58e5591.png)

This PR demands that the OS offered position is accurate enough, the treshold for which has been determined watching my Android 10 mobile phone:
```
D QGroundControl Daily: QDateTime(2021-02-24 14:37:30.637 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 13.936 AGE (sec): 0
D QGroundControl Daily: QDateTime(2021-02-24 14:37:31.298 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 16.08 AGE (sec): 0
D QGroundControl Daily: QDateTime(2021-02-24 14:37:32.303 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 21.44 AGE (sec): 0
D QGroundControl Daily: QDateTime(2021-02-24 14:37:33.298 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 21.44 AGE (sec): 0
D QGroundControl Daily: QDateTime(2021-02-24 14:37:34.298 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 21.44 AGE (sec): 0
D QGroundControl Daily: QDateTime(2021-02-24 14:37:35.315 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 45.024 AGE (sec): 0
D QGroundControl Daily: QDateTime(2021-02-24 14:37:36.303 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 70.752 AGE (sec): 0
D QGroundControl Daily: QDateTime(2021-02-24 14:37:37.311 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20.368 AGE (sec): 0
D QGroundControl Daily: QDateTime(2021-02-24 14:37:38.303 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 19.296 AGE (sec): 0
```
(location update every second)

and my dev Ubuntu 20.04 laptop:
```
QDateTime(2021-02-24 13:56:48.144 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): nan AGE (sec): 53
QDateTime(2021-02-24 13:56:53.589 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 13:57:38.033 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 13:58:14.880 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 13:59:04.237 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 13:59:37.228 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 14:03:47.798 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 14:04:07.766 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 14:04:41.688 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 14:04:56.713 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 14:12:38.555 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 14:13:09.628 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 14:15:02.341 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
QDateTime(2021-02-24 14:15:36.396 CET Qt::LocalTime) HORIZONTAL ACCURACY (metres): 20000 AGE (sec): 0
``` 
The first update reports the last seen location, so it can be quite old and horizontal accuracy is absent - see where this happens [here](https://code.qt.io/cgit/qt/qtlocation.git/tree/src/plugins/position/geoclue/qgeopositioninfosource_geocluemaster.cpp?h=dev#n299). The following updates do feature horizontal accuracy and thus appear to come from `geoclue` (not its Qt shim). They are quite irregular but two of them come roughly each minute. 20km horizontal accuracy is what `gnome-maps` shows on my system:
![gnome-maps](https://user-images.githubusercontent.com/8327961/109011872-af768080-76b1-11eb-876c-c8f5b30e05f6.png)
So i am led to believe it is presented with the same datapoint as QGC. QGC just chooses not to interpret the accuracy.

Conclusion: Horizontal Accuracy can be counted on on both Ubuntu and Android. I have no access to Windows or MacOS to repeat these experiments. I would be prudent to do that.

And of course i have verified i continue to see the lock on my android phone:
![IMG_20210224_134856](https://user-images.githubusercontent.com/8327961/109010444-1135eb00-76b0-11eb-9774-9884787a449a.jpg)
