### PR TITLE
Updated AirMap Support

### DIFF
--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -141,7 +141,7 @@ LinuxBuild {
 
     # Airmap
     contains (DEFINES, QGC_AIRMAP_ENABLED) {
-        QMAKE_POST_LINK += && $$QMAKE_COPY $$PWD/libs/airmapd/linux/Qt.5.11.0/libairmap-qt.so.0.0.1 $$DESTDIR/Qt/libs/
+        QMAKE_POST_LINK += && $$QMAKE_COPY $$PWD/libs/airmapd/linux/$$AIRMAP_QT_PATH/libairmap-qt.so.0.0.1 $$DESTDIR/Qt/libs/
     }
 
     # QGroundControl start script

--- a/libs/airmapd/include/airmap/advisory.h
+++ b/libs/airmapd/include/airmap/advisory.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_ADVISORY_H_
 #define AIRMAP_ADVISORY_H_
 
@@ -11,6 +23,7 @@
 #include <airmap/outcome.h>
 #include <airmap/ruleset.h>
 #include <airmap/status.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <functional>
@@ -22,11 +35,11 @@ namespace airmap {
 
 /// Advisory provides functionality to query airspace and weather information about
 /// a geographic area.
-class Advisory : DoNotCopyOrMove {
+class AIRMAP_EXPORT Advisory : DoNotCopyOrMove {
  public:
   /// Advisory bundles together airspace information and its evaluation in terms
   /// good to fly/needs information or feedback/conflict.
-  struct AirspaceAdvisory {
+  struct AIRMAP_EXPORT AirspaceAdvisory {
     Status::Advisory advisory;  /// Airspace information.
     Status::Color color;        /// The evaluation of the airspace.
     std::uint32_t rule_id;      /// The id of the ruleset.
@@ -34,14 +47,14 @@ class Advisory : DoNotCopyOrMove {
   };
 
   /// Wind bundles up attributes describing a wind conditions.
-  struct Wind {
+  struct AIRMAP_EXPORT Wind {
     std::uint32_t heading = 0;    ///< The heading in [°].
     float speed           = 0.0;  ///< The speed in [°].
     std::uint32_t gusting = 0;
   };
 
   /// Weather bundles up attributes describing a weather condition.
-  struct Weather {
+  struct AIRMAP_EXPORT Weather {
     std::string condition;      ///< The overall weather condition.
     std::string icon;           ///< The icon or class of icon that should be used for display purposes.
     Wind wind;                  ///< The details about the current wind conditions.
@@ -57,7 +70,7 @@ class Advisory : DoNotCopyOrMove {
 
   /// ForId bundles up types to ease interaction
   /// with Advisory::for_id.
-  struct ForId {
+  struct AIRMAP_EXPORT ForId {
     /// Parameters bundles up input parameters.
     struct Parameters {
       Optional<DateTime> start;  ///< Search for advisories before this time.
@@ -73,7 +86,7 @@ class Advisory : DoNotCopyOrMove {
 
   /// Search bundles up types to ease interaction
   /// with Advisory::search.
-  struct Search {
+  struct AIRMAP_EXPORT Search {
     /// Parameters bundles up input parameters.
     struct Parameters {
       Required<Geometry> geometry;     ///< Evaluate rulesets intersecting this geometry.
@@ -90,7 +103,7 @@ class Advisory : DoNotCopyOrMove {
 
   /// ReportWeather bundles up types to ease interaction
   /// with Advisory::report_weather.
-  struct ReportWeather {
+  struct AIRMAP_EXPORT ReportWeather {
     /// Parameters bundles up input parameters.
     struct Parameters {
       float latitude;            ///< The latitude component of the takeoff point in [°].

--- a/libs/airmapd/include/airmap/aircraft.h
+++ b/libs/airmapd/include/airmap/aircraft.h
@@ -1,14 +1,28 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AIRCRAFT_H_
 #define AIRMAP_AIRCRAFT_H_
+
+#include <airmap/visibility.h>
 
 #include <string>
 
 namespace airmap {
 
 /// Aircraft describes an aircraft in terms of its model and its manufacturer.
-struct Aircraft {
+struct AIRMAP_EXPORT Aircraft {
   /// Model bundles up a model id and a product name.
-  struct Model {
+  struct AIRMAP_EXPORT Model {
     std::string id;    ///< The unique id of the model in the context of AirMap.
     std::string name;  ///< The human-readable name of the model.
   };
@@ -16,7 +30,7 @@ struct Aircraft {
   /// Manufacturer bundles up an id and a human-readable name.
   /// Please note that the id is only unique/relevant in the context of the
   /// AirMap services.
-  struct Manufacturer {
+  struct AIRMAP_EXPORT Manufacturer {
     std::string id;    ///< The unique id of the manufacturer in the context of AirMap.
     std::string name;  ///< The human-readable name of the manufacturer.
   };

--- a/libs/airmapd/include/airmap/aircrafts.h
+++ b/libs/airmapd/include/airmap/aircrafts.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AIRCRAFTS_H_
 #define AIRMAP_AIRCRAFTS_H_
 
@@ -6,6 +18,7 @@
 #include <airmap/error.h>
 #include <airmap/optional.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <functional>
 #include <string>
@@ -15,13 +28,13 @@ namespace airmap {
 
 /// Aircrafts models access to a database of aircraft models (specifically drones)
 /// and manufacturers.
-class Aircrafts : DoNotCopyOrMove {
+class AIRMAP_EXPORT Aircrafts : DoNotCopyOrMove {
  public:
   /// Manufacturers groups together types to ease interaction with
   /// Aircrafts::manufacturers.
-  struct Manufacturers {
+  struct AIRMAP_EXPORT Manufacturers {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> manufacturer_name;  ///< Search for the specific manufacturer with this name.
     };
 
@@ -34,9 +47,9 @@ class Aircrafts : DoNotCopyOrMove {
 
   /// Models groups together types to ease interaction with
   /// Aircrafts::models.
-  struct Models {
+  struct AIRMAP_EXPORT Models {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<Aircraft::Manufacturer> manufacturer;  ///< Only list models by this manufacturer.
       Optional<std::string> model_name;               ///< Search for the specific model with this name.
     };
@@ -50,7 +63,7 @@ class Aircrafts : DoNotCopyOrMove {
 
   /// ModelForId groups together types to ease interaction with
   /// Aircrafts::model_for_id.
-  struct ModelForId {
+  struct AIRMAP_EXPORT ModelForId {
     /// Parameters bundles up input parameters.
     struct Parameters {
       std::string id;  ///< Search for the model with this id.

--- a/libs/airmapd/include/airmap/airspace.h
+++ b/libs/airmapd/include/airmap/airspace.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AIRSPACE_H_
 #define AIRMAP_AIRSPACE_H_
 
@@ -5,6 +17,7 @@
 #include <airmap/optional.h>
 #include <airmap/rule.h>
 #include <airmap/timestamp.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <iosfwd>
@@ -16,13 +29,13 @@ namespace airmap {
 
 /// Airspace groups together general information about an airspace and
 /// in-depth information providing more details.
-class Airspace {
+class AIRMAP_EXPORT Airspace {
  public:
   /// Airport bundles up properties further describing an
   /// airspace around an airport.
-  struct Airport {
+  struct AIRMAP_EXPORT Airport {
     /// Runway describes an individual runway of an airport.
-    struct Runway {
+    struct AIRMAP_EXPORT Runway {
       std::string name;  ///< Commn name assigned to the runway in the context of a specific airport.
       float length;      ///< Lenght of the runway in [m].
       float bearing;     ///< Bearing of the runway in [°].
@@ -48,13 +61,13 @@ class Airspace {
 
   /// ControlledAirspace bundles up properties describing
   /// a controlled airspace.
-  struct ControlledAirspace {
+  struct AIRMAP_EXPORT ControlledAirspace {
     std::string airspace_classification;  ///< The classification of the ControlledAirspace.
   };
 
   /// SpecialUseAirspace bundles up properties describing
   /// a special use airspace.
-  struct SpecialUseAirspace {
+  struct AIRMAP_EXPORT SpecialUseAirspace {
     /// Type enumerates all known special-purpose types.
     enum class Type {};
     Type type;  ///< The type of the SpecialUseAirspace.
@@ -62,7 +75,7 @@ class Airspace {
 
   /// TemporaryFlightRestriction describes an airspace that
   /// modelling a temporary restriction of the airspace.
-  struct TemporaryFlightRestriction {
+  struct AIRMAP_EXPORT TemporaryFlightRestriction {
     /// Type enumerates all known types of temporary flight restrictions.
     enum class Type {};
     std::string url;     ///< The URL providing further information about the temporary flight restriction.
@@ -71,25 +84,25 @@ class Airspace {
   };
 
   /// Wildfire describes an airspace around a wildfire.
-  struct Wildfire {
+  struct AIRMAP_EXPORT Wildfire {
     std::string effective_date;
   };
 
   /// Park describes an airspace over a park.
-  struct Park {};
+  struct AIRMAP_EXPORT Park {};
   /// Prison describes an airspace over a prison.
-  struct Prison {};
+  struct AIRMAP_EXPORT Prison {};
   /// School describes an airspace over a school.
-  struct School {};
+  struct AIRMAP_EXPORT School {};
   /// Hospital describes an airspace over a hospital.
-  struct Hospital {};
+  struct AIRMAP_EXPORT Hospital {};
   /// Fire describes an airspace over a fire.
-  struct Fire {};
+  struct AIRMAP_EXPORT Fire {};
   /// Emergency describes an airspace over an emergency situation.
-  struct Emergency {};
+  struct AIRMAP_EXPORT Emergency {};
 
   /// Heliport describes an airspace around a heliport.
-  struct Heliport {
+  struct AIRMAP_EXPORT Heliport {
     /// Usage enumerates all known usages of a heliport.
     enum class Usage {};
     std::string faa_id;  ///< The FAA id of the heliport.
@@ -98,13 +111,13 @@ class Airspace {
   };
 
   /// PowerPlant describes the airspace around a power plant.
-  struct PowerPlant {
+  struct AIRMAP_EXPORT PowerPlant {
     std::string technology;  ///< The technology used by the power plant.
     std::uint64_t code;      ///< Official number of the power plant.
   };
 
   /// RelatedGeometry bundles up a geometry related to an airspace.
-  struct RelatedGeometry {
+  struct AIRMAP_EXPORT RelatedGeometry {
     std::string id;     ///< The unique id of the geometry in the context of AirMap.
     Geometry geometry;  ///< The actual geometry.
   };
@@ -318,9 +331,9 @@ class Airspace {
   void set_details(const Emergency &detail);
 
  private:
-  struct Invalid {};
+  struct AIRMAP_EXPORT Invalid {};
 
-  union Details {
+  union AIRMAP_EXPORT Details {
     Details();
     ~Details();
 
@@ -356,28 +369,29 @@ class Airspace {
 };
 
 /// @cond
-bool operator==(const Airspace::RelatedGeometry &lhs, const Airspace::RelatedGeometry &rhs);
-bool operator==(const Airspace::Airport &lhs, const Airspace::Airport &rhs);
-bool operator==(const Airspace::Airport::Runway &lhs, const Airspace::Airport::Runway &rhs);
-bool operator==(const Airspace::ControlledAirspace &lhs, const Airspace::ControlledAirspace &rhs);
-bool operator==(const Airspace::SpecialUseAirspace &lhs, const Airspace::SpecialUseAirspace &rhs);
-bool operator==(const Airspace::TemporaryFlightRestriction &lhs, const Airspace::TemporaryFlightRestriction &rhs);
-bool operator==(const Airspace::Wildfire &lhs, const Airspace::Wildfire &rhs);
-bool operator==(const Airspace::Park &lhs, const Airspace::Park &rhs);
-bool operator==(const Airspace::Prison &lhs, const Airspace::Prison &rhs);
-bool operator==(const Airspace::School &lhs, const Airspace::School &rhs);
-bool operator==(const Airspace::Hospital &lhs, const Airspace::Hospital &rhs);
-bool operator==(const Airspace::Fire &lhs, const Airspace::Fire &rhs);
-bool operator==(const Airspace::Emergency &lhs, const Airspace::Emergency &rhs);
-bool operator==(const Airspace::Heliport &lhs, const Airspace::Heliport &rhs);
-bool operator==(const Airspace::PowerPlant &lhs, const Airspace::PowerPlant &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::RelatedGeometry &lhs, const Airspace::RelatedGeometry &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Airport &lhs, const Airspace::Airport &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Airport::Runway &lhs, const Airspace::Airport::Runway &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::ControlledAirspace &lhs, const Airspace::ControlledAirspace &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::SpecialUseAirspace &lhs, const Airspace::SpecialUseAirspace &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::TemporaryFlightRestriction &lhs,
+                              const Airspace::TemporaryFlightRestriction &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Wildfire &lhs, const Airspace::Wildfire &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Park &lhs, const Airspace::Park &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Prison &lhs, const Airspace::Prison &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::School &lhs, const Airspace::School &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Hospital &lhs, const Airspace::Hospital &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Fire &lhs, const Airspace::Fire &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Emergency &lhs, const Airspace::Emergency &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::Heliport &lhs, const Airspace::Heliport &rhs);
+AIRMAP_EXPORT bool operator==(const Airspace::PowerPlant &lhs, const Airspace::PowerPlant &rhs);
 
-Airspace::Type operator~(Airspace::Type);
-Airspace::Type operator|(Airspace::Type, Airspace::Type);
-Airspace::Type operator&(Airspace::Type, Airspace::Type);
+AIRMAP_EXPORT Airspace::Type operator~(Airspace::Type);
+AIRMAP_EXPORT Airspace::Type operator|(Airspace::Type, Airspace::Type);
+AIRMAP_EXPORT Airspace::Type operator&(Airspace::Type, Airspace::Type);
 
-std::ostream &operator<<(std::ostream &, const Airspace &);
-std::ostream &operator<<(std::ostream &, Airspace::Type);
+AIRMAP_EXPORT std::ostream &operator<<(std::ostream &, const Airspace &);
+AIRMAP_EXPORT std::ostream &operator<<(std::ostream &, Airspace::Type);
 /// @endcond
 
 }  // namespace airmap

--- a/libs/airmapd/include/airmap/airspaces.h
+++ b/libs/airmapd/include/airmap/airspaces.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AIRSPACES_H_
 #define AIRMAP_AIRSPACES_H_
 
@@ -6,6 +18,7 @@
 #include <airmap/do_not_copy_or_move.h>
 #include <airmap/error.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <functional>
 #include <vector>
@@ -13,13 +26,13 @@
 namespace airmap {
 
 /// Airspaces provides functionality to query the airspace database.
-class Airspaces : DoNotCopyOrMove {
+class AIRMAP_EXPORT Airspaces : DoNotCopyOrMove {
  public:
   /// ForIds groups together types to ease interaction with
   /// Airspaces::ForIds.
-  struct ForIds {
+  struct AIRMAP_EXPORT ForIds {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Airspace::Id id;  ///< Search for the airspace with this id.
     };
 
@@ -32,9 +45,9 @@ class Airspaces : DoNotCopyOrMove {
 
   /// Search groups together types to ease interaction with
   /// Airspaces::Search.
-  struct Search {
+  struct AIRMAP_EXPORT Search {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<Airspace::Type> types;          ///< Search for airspaces with either one of these types.
       Optional<Airspace::Type> ignored_types;  ///< Ignore airspaces with either one of these types.
       Optional<bool> full;  ///< If true, the complete description of airspaces in the result set is requested.

--- a/libs/airmapd/include/airmap/authenticator.h
+++ b/libs/airmapd/include/airmap/authenticator.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_AUTHENTICATOR_H_
 #define AIRMAP_AUTHENTICATOR_H_
 
@@ -6,6 +18,7 @@
 #include <airmap/error.h>
 #include <airmap/outcome.h>
 #include <airmap/token.h>
+#include <airmap/visibility.h>
 
 #include <chrono>
 #include <functional>
@@ -15,7 +28,7 @@
 namespace airmap {
 
 /// Authenticator provides functionality to authenticate with the AirMap services.
-class Authenticator : DoNotCopyOrMove {
+class AIRMAP_EXPORT Authenticator : DoNotCopyOrMove {
  public:
   /// Scope enumerates all known authentication scopes.
   enum class Scope { access_token = 0, open_id = 1, open_id_offline_access = 2 };
@@ -31,9 +44,9 @@ class Authenticator : DoNotCopyOrMove {
 
   /// AuthenticateWithPassword groups together types to ease interaction with
   /// Authenticator::authenticate_with_password.
-  struct AuthenticateWithPassword {
+  struct AIRMAP_EXPORT AuthenticateWithPassword {
     /// Parameters bundles up input parameters.
-    struct Params {
+    struct AIRMAP_EXPORT Params {
       Credentials::OAuth oauth;                    ///< OAuth-specific credentials for this authentication request.
       GrantType grant_type{GrantType::password};   ///< The grant type of this authentication request.
       Scope scope{Scope::open_id_offline_access};  ///< The scope of this authentication request.
@@ -50,7 +63,7 @@ class Authenticator : DoNotCopyOrMove {
 
   /// AuthenticateAnonymously groups together types to ease interaction with
   /// Authenticator::authenticate_anonymously.
-  struct AuthenticateAnonymously {
+  struct AIRMAP_EXPORT AuthenticateAnonymously {
     /// The input parameters.
     using Params = Credentials::Anonymous;
     /// Result models the outcome of calling Authenticator::authenticate_anonymously.
@@ -62,9 +75,9 @@ class Authenticator : DoNotCopyOrMove {
 
   /// RenewAuthentication groups together types to ease interaction with
   /// Authenticator::renew_authentication.
-  struct RenewAuthentication {
+  struct AIRMAP_EXPORT RenewAuthentication {
     /// The input parameters.
-    struct Params {
+    struct AIRMAP_EXPORT Params {
       std::string client_id;                    ///< The app id for which authentication renewal is requested.
       std::string refresh_token;                ///< The refresh token for the authentication renewal request.
       GrantType grant_type{GrantType::bearer};  ///< The grant type of the authentication renewal request.

--- a/libs/airmapd/include/airmap/client.h
+++ b/libs/airmapd/include/airmap/client.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CLIENT_H_
 #define AIRMAP_CLIENT_H_
 
@@ -5,6 +17,7 @@
 #include <airmap/do_not_copy_or_move.h>
 #include <airmap/optional.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 
@@ -28,14 +41,14 @@ class Telemetry;
 class Traffic;
 
 /// Client enables applications to use the AirMap services and APIs.
-class Client : DoNotCopyOrMove {
+class AIRMAP_EXPORT Client : DoNotCopyOrMove {
  public:
   /// Version enumerates all known versions available to clients.
   enum class Version { production, staging };
 
   /// Configuration bundles up parameters enabling
   /// customization of a Client implementation behavior.
-  struct Configuration {
+  struct AIRMAP_EXPORT Configuration {
     std::string host;  ///< Address of the host exposing the AirMap services.
     Version version;   ///< The version of the AirMap services that should be used.
     struct {
@@ -77,11 +90,11 @@ class Client : DoNotCopyOrMove {
   ///     "port": 443
   ///   },
   ///   "telemetry": {
-  ///     "host": "api-udp-telemetry.airmap.com",
+  ///     "host": "telemetry.airmap.com",
   ///     "port": 16060
   ///   },
   ///   "traffic": {
-  ///     "host": "mqtt-prod.airmap.io",
+  ///     "host": "mqtt.airmap.com",
   ///     "port": 8883
   ///    },
   ///    "credentials": {
@@ -140,8 +153,8 @@ class Client : DoNotCopyOrMove {
 };
 
 /// @cond
-std::istream& operator>>(std::istream& in, Client::Version& version);
-std::ostream& operator<<(std::ostream& out, Client::Version version);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, Client::Version& version);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Client::Version version);
 /// @endcond
 
 }  // namespace airmap

--- a/libs/airmapd/include/airmap/context.h
+++ b/libs/airmapd/include/airmap/context.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CONTEXT_H_
 #define AIRMAP_CONTEXT_H_
 
@@ -8,6 +20,7 @@
 #include <airmap/logger.h>
 #include <airmap/monitor/client.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <functional>
 #include <unordered_set>
@@ -16,7 +29,7 @@ namespace airmap {
 
 /// Context consitutes the point-of-entry for interaction with the classes and interfaces
 /// in airmap::*.
-class Context : DoNotCopyOrMove {
+class AIRMAP_EXPORT Context : DoNotCopyOrMove {
  public:
   /// ReturnCode enumerates all known return values for a call to run or exec.
   enum class ReturnCode {

--- a/libs/airmapd/include/airmap/credentials.h
+++ b/libs/airmapd/include/airmap/credentials.h
@@ -1,7 +1,20 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_CREDENTIALS_H_
 #define AIRMAP_CREDENTIALS_H_
 
 #include <airmap/optional.h>
+#include <airmap/visibility.h>
 
 #include <iosfwd>
 #include <string>
@@ -10,7 +23,7 @@ namespace airmap {
 
 /// Credentials bundles up all credentials required
 /// to use the AirMap SDK and APIs.
-struct Credentials {
+struct AIRMAP_EXPORT Credentials {
   enum class Type { anonymous, oauth };
 
   /// Anonymous bundles up all attributes needed to
@@ -34,9 +47,9 @@ struct Credentials {
 };
 
 /// operator>> extracts type from in.
-std::istream& operator>>(std::istream& in, Credentials::Type& type);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, Credentials::Type& type);
 /// operator<< inserts type into out.
-std::ostream& operator<<(std::ostream& out, Credentials::Type type);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Credentials::Type type);
 
 }  // namespace airmap
 

--- a/libs/airmapd/include/airmap/date_time.h
+++ b/libs/airmapd/include/airmap/date_time.h
@@ -1,10 +1,26 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_DATE_TIME_H_
 #define AIRMAP_DATE_TIME_H_
+
+#include <airmap/visibility.h>
+#include <cstdint>
 
 #include <memory>
 #include <string>
 
 namespace airmap {
+
 class DateTime;
 template <typename Tag>
 class Duration;
@@ -15,11 +31,11 @@ class Duration;
 
 namespace tag {
 
-struct Hours {};
-struct Minutes {};
-struct Seconds {};
-struct Milliseconds {};
-struct Microseconds {};
+struct AIRMAP_EXPORT Hours {};
+struct AIRMAP_EXPORT Minutes {};
+struct AIRMAP_EXPORT Seconds {};
+struct AIRMAP_EXPORT Milliseconds {};
+struct AIRMAP_EXPORT Microseconds {};
 
 }  // namespace tag
 
@@ -30,7 +46,7 @@ using Milliseconds = Duration<tag::Milliseconds>;
 using Microseconds = Duration<tag::Microseconds>;
 
 /// Clock marks the reference for time measurements.
-class Clock {
+class AIRMAP_EXPORT Clock {
  public:
   static DateTime universal_time();
   static DateTime local_time();
@@ -38,13 +54,13 @@ class Clock {
 
 namespace boost_iso {
 
-DateTime datetime(const std::string &iso_time);
-std::string to_iso_string(const DateTime &);
+AIRMAP_EXPORT DateTime datetime(const std::string &iso_time);
+AIRMAP_EXPORT std::string to_iso_string(const DateTime &);
 
 }  // namespace boost_iso
 
 /// DateTime marks a specific point in time, in reference to Clock.
-class DateTime {
+class AIRMAP_EXPORT DateTime {
  public:
   DateTime();
   ~DateTime();
@@ -75,15 +91,15 @@ class DateTime {
   friend std::string boost_iso::to_iso_string(const DateTime &datetime);
 };
 
-Hours hours(int64_t raw);
-Minutes minutes(int64_t raw);
-Seconds seconds(int64_t raw);
-Milliseconds milliseconds(int64_t raw);
-Microseconds microseconds(int64_t raw);
+AIRMAP_EXPORT Hours hours(std::int64_t raw);
+AIRMAP_EXPORT Minutes minutes(std::int64_t raw);
+AIRMAP_EXPORT Seconds seconds(std::int64_t raw);
+AIRMAP_EXPORT Milliseconds milliseconds(std::int64_t raw);
+AIRMAP_EXPORT Microseconds microseconds(std::int64_t raw);
 
 namespace detail {
 
-class Duration {
+class AIRMAP_EXPORT Duration {
  public:
   Duration();
   ~Duration();
@@ -104,40 +120,42 @@ class Duration {
   friend Microseconds DateTime::operator-(const DateTime &) const;
   friend Microseconds DateTime::time_of_day() const;
 
-  friend Hours airmap::hours(int64_t raw);
-  friend Minutes airmap::minutes(int64_t raw);
-  friend Seconds airmap::seconds(int64_t raw);
-  friend Milliseconds airmap::milliseconds(int64_t raw);
-  friend Microseconds airmap::microseconds(int64_t raw);
+  friend Hours airmap::hours(std::int64_t raw);
+  friend Minutes airmap::minutes(std::int64_t raw);
+  friend Seconds airmap::seconds(std::int64_t raw);
+  friend Milliseconds airmap::milliseconds(std::int64_t raw);
+  friend Microseconds airmap::microseconds(std::int64_t raw);
 };
 
 }  // namespace detail
 
 template <typename Tag>
-class Duration : public detail::Duration {};
+class AIRMAP_EXPORT Duration : public detail::Duration {};
 
 /// milliseconds_since_epoch returns the milliseconds that elapsed since the UNIX epoch.
-uint64_t milliseconds_since_epoch(const DateTime &dt);
+AIRMAP_EXPORT uint64_t milliseconds_since_epoch(const DateTime &dt);
 /// microseconds_since_epoch returns the microseconds that elapsed since the UNIX epoch.
-uint64_t microseconds_since_epoch(const DateTime &dt);
+AIRMAP_EXPORT uint64_t microseconds_since_epoch(const DateTime &dt);
 /// from_seconds_since_epoch returns a DateTime.
-DateTime from_seconds_since_epoch(const Seconds &s);
+AIRMAP_EXPORT DateTime from_seconds_since_epoch(const Seconds &s);
 /// from_milliseconds_since_epoch returns a DateTime.
-DateTime from_milliseconds_since_epoch(const Milliseconds &ms);
+AIRMAP_EXPORT DateTime from_milliseconds_since_epoch(const Milliseconds &ms);
 /// from_microseconds_since_epoch returns a DateTime.
-DateTime from_microseconds_since_epoch(const Microseconds &us);
+AIRMAP_EXPORT DateTime from_microseconds_since_epoch(const Microseconds &us);
 
 // moves the datetime forward to the specified hour
-DateTime move_to_hour(const DateTime &dt, uint64_t hour);
+AIRMAP_EXPORT DateTime move_to_hour(const DateTime &dt, uint64_t hour);
 
 namespace iso8601 {
 
 /// parse parses a DateTime instance from the string s in iso8601 format.
-DateTime parse(const std::string &s);
+AIRMAP_EXPORT DateTime parse(const std::string &s);
 /// generate returns a string in iso8601 corresponding to 'dt'.
-std::string generate(const DateTime &dt);
+AIRMAP_EXPORT std::string generate(const DateTime &dt);
 
 }  // namespace iso8601
+
+AIRMAP_EXPORT std::ostream &operator<<(std::ostream &to, const detail::Duration &from);
 
 }  // namespace airmap
 

--- a/libs/airmapd/include/airmap/do_not_copy_or_move.h
+++ b/libs/airmapd/include/airmap/do_not_copy_or_move.h
@@ -1,10 +1,24 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_DO_NOT_COPY_OR_MOVE_H_
 #define AIRMAP_DO_NOT_COPY_OR_MOVE_H_
+
+#include <airmap/visibility.h>
 
 namespace airmap {
 
 /// @cond
-struct DoNotCopyOrMove {
+struct AIRMAP_EXPORT DoNotCopyOrMove {
   DoNotCopyOrMove()                       = default;
   DoNotCopyOrMove(const DoNotCopyOrMove&) = delete;
   DoNotCopyOrMove(DoNotCopyOrMove&&)      = delete;

--- a/libs/airmapd/include/airmap/error.h
+++ b/libs/airmapd/include/airmap/error.h
@@ -1,8 +1,21 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_ERROR_H_
 #define AIRMAP_ERROR_H_
 
 #include <airmap/do_not_copy_or_move.h>
 #include <airmap/optional.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 
@@ -15,10 +28,10 @@
 namespace airmap {
 
 /// Error models an error raised by an AirMap component.
-struct Error {
+struct AIRMAP_EXPORT Error {
   /// Value is a discriminated union type wrapping up multiple atomic types and
   /// their composition into a vector or a dictionary.
-  class Value {
+  class AIRMAP_EXPORT Value {
    public:
     /// Type enumerates all datatypes that can be wrapped in a Value.
     enum class Type {
@@ -86,7 +99,7 @@ struct Error {
     const std::vector<Value>& vector() const;
 
    private:
-    union Details {
+    union AIRMAP_EXPORT Details {
       Details();
       ~Details();
 
@@ -160,13 +173,13 @@ struct Error {
 };
 
 /// operator== returns true if both type and value of lhs and rhs compare equal.
-bool operator==(const Error::Value& lhs, const Error::Value& rhs);
+AIRMAP_EXPORT bool operator==(const Error::Value& lhs, const Error::Value& rhs);
 /// operator< returns true if type and value of lhs compare < than type and value of rhs.
-bool operator<(const Error::Value& lhs, const Error::Value& rhs);
+AIRMAP_EXPORT bool operator<(const Error::Value& lhs, const Error::Value& rhs);
 /// operator<< inserts 'value' into 'out'.
-std::ostream& operator<<(std::ostream& out, const Error::Value& value);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, const Error::Value& value);
 /// operator<< inserts 'error' into 'out'.
-std::ostream& operator<<(std::ostream& out, const Error& error);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, const Error& error);
 
 }  // namespace airmap
 

--- a/libs/airmapd/include/airmap/evaluation.h
+++ b/libs/airmapd/include/airmap/evaluation.h
@@ -1,9 +1,22 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_EVALUATION_H_
 #define AIRMAP_EVALUATION_H_
 
 #include <airmap/optional.h>
 #include <airmap/ruleset.h>
 #include <airmap/status.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <iosfwd>
@@ -14,15 +27,15 @@
 namespace airmap {
 
 /// Evaluation bundles together information regarding an airspace ruleset evaluation.
-struct Evaluation {
+struct AIRMAP_EXPORT Evaluation {
   /// Authority models an authority capable of authorizing flight plans.
-  struct Authority {
+  struct AIRMAP_EXPORT Authority {
     std::string id;    ///< The id of the authority.
     std::string name;  ///< The name of the authority.
   };
 
   /// Authorization bundles up the authorization status of a flight plan.
-  struct Authorization {
+  struct AIRMAP_EXPORT Authorization {
     /// Status enumerates all known states of an Authorization.
     enum class Status {
       accepted,                  ///< The flight plan is accepted.
@@ -38,7 +51,7 @@ struct Evaluation {
   };
 
   /// Validation bundles up the validation status of a flight plan.
-  struct Validation {
+  struct AIRMAP_EXPORT Validation {
     /// Status enumerates all known states of a Validation.
     enum class Status {
       valid,    ///< The validation succeeded.
@@ -47,7 +60,7 @@ struct Evaluation {
     };
 
     /// Feature describes a specific feature that requires validation.
-    struct Feature {
+    struct AIRMAP_EXPORT Feature {
       std::string code;         ///< The code of the feature.
       std::string description;  ///< The description of the feature.
     };
@@ -74,14 +87,14 @@ struct Evaluation {
 };
 
 /// @cond
-std::ostream& operator<<(std::ostream& out, Evaluation::Authorization::Status status);
-std::istream& operator>>(std::istream& in, Evaluation::Authorization::Status& status);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Evaluation::Authorization::Status status);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, Evaluation::Authorization::Status& status);
 
-std::ostream& operator<<(std::ostream& out, Evaluation::Validation::Status status);
-std::istream& operator>>(std::istream& in, Evaluation::Validation::Status& status);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Evaluation::Validation::Status status);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, Evaluation::Validation::Status& status);
 
-std::ostream& operator<<(std::ostream& out, Evaluation::Failure failure);
-std::istream& operator>>(std::istream& in, Evaluation::Failure& failure);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Evaluation::Failure failure);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, Evaluation::Failure& failure);
 /// @endcond
 
 }  // namespace airmap

--- a/libs/airmapd/include/airmap/flight.h
+++ b/libs/airmapd/include/airmap/flight.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_FLIGHT_H_
 #define AIRMAP_FLIGHT_H_
 
@@ -5,13 +17,14 @@
 #include <airmap/flight_plan.h>
 #include <airmap/geometry.h>
 #include <airmap/pilot.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 
 namespace airmap {
 
 /// Flight bundles together properties describing an individual flight.
-struct Flight {
+struct AIRMAP_EXPORT Flight {
   using Id = std::string;
 
   Id id;                                    ///< The unique identifier of a flight in the context of AirMap.

--- a/libs/airmapd/include/airmap/flight_plan.h
+++ b/libs/airmapd/include/airmap/flight_plan.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_FLIGHT_PLAN_H_
 #define AIRMAP_FLIGHT_PLAN_H_
 
@@ -8,6 +20,7 @@
 #include <airmap/pilot.h>
 #include <airmap/ruleset.h>
 #include <airmap/status.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <iosfwd>
@@ -18,16 +31,16 @@
 namespace airmap {
 
 /// FlightPlan bundles together properties describing a plan for a flight.
-struct FlightPlan {
+struct AIRMAP_EXPORT FlightPlan {
   /// Id models a unique identifier for a flight plan in the context of AirMap.
   using Id = std::string;
 
   /// Briefing bundles together information and data for a flight plan.
   /// The target audience is a hypothetical pilot or operator conducting
   /// the flight described in the flight plan.
-  struct Briefing {
+  struct AIRMAP_EXPORT Briefing {
     /// AdvisoryStatus summarizes the status of all advisories applying to a specific flight plan.
-    struct AdvisoryStatus {
+    struct AIRMAP_EXPORT AdvisoryStatus {
       Status::Color color;                       ///< The overall color of the status.
       std::vector<Status::Advisory> advisories;  ///< The collection of relevant advisories.
     };

--- a/libs/airmapd/include/airmap/flight_plans.h
+++ b/libs/airmapd/include/airmap/flight_plans.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_FLIGHT_PLANS_H_
 #define AIRMAP_FLIGHT_PLANS_H_
 
@@ -5,6 +17,7 @@
 #include <airmap/error.h>
 #include <airmap/flight_plan.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <functional>
@@ -13,13 +26,13 @@
 namespace airmap {
 
 /// FlightPlans provides functionality for managing flight plans.
-class FlightPlans : DoNotCopyOrMove {
+class AIRMAP_EXPORT FlightPlans : DoNotCopyOrMove {
  public:
   /// ForId bundles up types to ease interaction with
   /// FlightPlans::for_id.
-  struct ForId {
+  struct AIRMAP_EXPORT ForId {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       FlightPlan::Id id;                    ///< Search for the flight with this id.
     };
@@ -33,7 +46,7 @@ class FlightPlans : DoNotCopyOrMove {
 
   /// Create bundles up types to ease interaction with
   /// FlightPlans::create_by_point and FlightPlans::create_by_polygon.
-  struct Create {
+  struct AIRMAP_EXPORT Create {
     /// Parameters bundles up input parameters.
     struct Parameters {
       std::string authorization;           ///< Authorization token obtained by logging in to the AirMap services.
@@ -61,9 +74,9 @@ class FlightPlans : DoNotCopyOrMove {
 
   /// Update bundles up types to ease interaction with
   /// FlightPlans::update.
-  struct Update {
+  struct AIRMAP_EXPORT Update {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       FlightPlan flight_plan;  ///< The details of the plan that should be created with the AirMap services.
     };
@@ -76,15 +89,15 @@ class FlightPlans : DoNotCopyOrMove {
 
   /// Delete bundles up types to ease interaction with
   /// FlightPlans::delete_.
-  struct Delete {
+  struct AIRMAP_EXPORT Delete {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       FlightPlan::Id id;                    ///< Id of the flight plan that should be deleted.
     };
 
     /// Response models the response from the AirMap services.
-    struct Response {
+    struct AIRMAP_EXPORT Response {
       FlightPlan::Id id;  ///< Id of the flight plan that was deleted.
     };
 
@@ -97,9 +110,9 @@ class FlightPlans : DoNotCopyOrMove {
 
   /// RenderBriefing bundles up types to ease interaction with
   /// FlightPlans::render_briefing.
-  struct RenderBriefing {
+  struct AIRMAP_EXPORT RenderBriefing {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       FlightPlan::Id id;                    ///< Id of the flight plan that should be rendered as a briefing.
     };
@@ -112,9 +125,9 @@ class FlightPlans : DoNotCopyOrMove {
 
   /// Submit bundles up types to ease interaction with
   /// FlightPlans::submit.
-  struct Submit {
+  struct AIRMAP_EXPORT Submit {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       FlightPlan::Id id;                    ///< Id of the flight plan that should be submitted.
     };

--- a/libs/airmapd/include/airmap/flights.h
+++ b/libs/airmapd/include/airmap/flights.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_FLIGHTS_H_
 #define AIRMAP_FLIGHTS_H_
 
@@ -8,6 +20,7 @@
 #include <airmap/geometry.h>
 #include <airmap/optional.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <functional>
@@ -16,13 +29,13 @@
 namespace airmap {
 
 /// Flights provides functionality for managing flights.
-class Flights : DoNotCopyOrMove {
+class AIRMAP_EXPORT Flights : DoNotCopyOrMove {
  public:
   /// ForId bundles up types to ease interaction with
   /// Flights::for_id.
-  struct ForId {
+  struct AIRMAP_EXPORT ForId {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       Flight::Id id;                        ///< Search for the flight with this id.
       Optional<bool> enhance;               ///< If true, provides extended information per flight in the result set.
@@ -37,9 +50,9 @@ class Flights : DoNotCopyOrMove {
 
   /// Search bundles up types to ease interaction with
   /// Flights::search.
-  struct Search {
+  struct AIRMAP_EXPORT Search {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       Optional<std::uint32_t> limit;        ///< Limit the number of results to 'limit'.
       Optional<Geometry> geometry;          ///< Search for flights intersecting this geometry.
@@ -55,8 +68,8 @@ class Flights : DoNotCopyOrMove {
     };
 
     /// Response bundles up pagination and actual results for a call to Flights::search.
-    struct Response {
-      struct Paging {
+    struct AIRMAP_EXPORT Response {
+      struct AIRMAP_EXPORT Paging {
         std::uint32_t limit;        ///< The maximum number of results per page.
         std::uint32_t total;        ///< The total number of results.
       } paging;                     ///< Bundles up pagination information.
@@ -73,9 +86,9 @@ class Flights : DoNotCopyOrMove {
   /// CreateFlight bundles up types to ease interaction with
   /// Flights::create_flight_by_point, Flights::create_flight_by_path and
   /// Flights::create_flight_by_polygon.
-  struct CreateFlight {
+  struct AIRMAP_EXPORT CreateFlight {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;        ///< Authorization token obtained by logging in to the AirMap services.
       Required<float> latitude;         ///< Latitude of take-off point in [°].
       Required<float> longitude;        ///< Longitude of take-off point in [°].
@@ -97,15 +110,15 @@ class Flights : DoNotCopyOrMove {
 
   /// DeleteFlight bundles up types to ease interaction with
   /// Flights::delete_flight.
-  struct DeleteFlight {
+  struct AIRMAP_EXPORT DeleteFlight {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       Flight::Id id;              ///< Id of the flight that should be deleted.
     };
 
     /// Response models the response from the AirMap services.
-    struct Response {
+    struct AIRMAP_EXPORT Response {
       Flight::Id id;  ///< Id of the flight that was deleted.
     };
 
@@ -118,15 +131,15 @@ class Flights : DoNotCopyOrMove {
 
   /// EndFlight bundles up types to ease interaction with
   /// Flights::end_flight.
-  struct EndFlight {
+  struct AIRMAP_EXPORT EndFlight {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       Flight::Id id;              ///< Id of the flight that should be ended.
     };
 
     /// Response models the response from the AirMap services.
-    struct Response {
+    struct AIRMAP_EXPORT Response {
       DateTime end_time;  ///< Point in time when the flight was ended.
     };
 
@@ -139,15 +152,15 @@ class Flights : DoNotCopyOrMove {
 
   /// StartFlightCommunications bundles up types to ease interaction with
   /// Flights::start_flight_communications.
-  struct StartFlightCommunications {
+  struct AIRMAP_EXPORT StartFlightCommunications {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       Flight::Id id;              ///< Id of the flight for which flight comms should be started.
     };
 
     /// Response models the response from the AirMap services.
-    struct Response {
+    struct AIRMAP_EXPORT Response {
       std::string key;  ///< The encryption key that should be used to encrypt individual telemetry updates.
     };
 
@@ -160,15 +173,15 @@ class Flights : DoNotCopyOrMove {
 
   /// EndFlightCommunications bundles up types to ease interaction with
   /// Flights::end_flight_communications.
-  struct EndFlightCommunications {
+  struct AIRMAP_EXPORT EndFlightCommunications {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       Flight::Id id;              ///< Id of the flight for which flight comms should be ended.
     };
 
     /// Response models the response from the AirMap services.
-    struct Response {};
+    struct AIRMAP_EXPORT Response {};
 
     /// Result models the outcome of calling Flights::end_flight_communications.
     using Result = Outcome<Response, Error>;

--- a/libs/airmapd/include/airmap/geometry.h
+++ b/libs/airmapd/include/airmap/geometry.h
@@ -1,14 +1,27 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_GEOMETRY_H_
 #define AIRMAP_GEOMETRY_H_
 
 #include <airmap/optional.h>
+#include <airmap/visibility.h>
 
 #include <vector>
 
 namespace airmap {
 
 /// Geometry bundles up different types of geometries.
-class Geometry {
+class AIRMAP_EXPORT Geometry {
  public:
   /// Type enumerates all known geometry types.
   enum class Type {
@@ -23,7 +36,7 @@ class Geometry {
   };
 
   /// Coordinate marks a point in 3-dimensional space.
-  struct Coordinate {
+  struct AIRMAP_EXPORT Coordinate {
     double latitude;            /// The latitude component of this coordinate in [°].
     double longitude;           /// The longitude component of this coordinate in [°].
     Optional<double> altitude;  /// The altitude component of this coordinate in [m].
@@ -32,7 +45,7 @@ class Geometry {
 
   /// CoordinateVector is a collection of points in 3-dimensional space.
   template <Type tag>
-  struct CoordinateVector {
+  struct AIRMAP_EXPORT CoordinateVector {
     std::vector<Coordinate> coordinates;  ///< The individual coordinates.
   };
 
@@ -47,7 +60,7 @@ class Geometry {
   ///     the exterior ring, and any others MUST be interior rings.  The
   ///     exterior ring bounds the surface, and the interior rings (if
   ///     present) bound holes within the surface.
-  struct Polygon {
+  struct AIRMAP_EXPORT Polygon {
     CoordinateVector<Type::polygon> outer_ring;
     std::vector<CoordinateVector<Type::polygon>> inner_rings;
   };
@@ -100,9 +113,9 @@ class Geometry {
   const GeometryCollection details_for_geometry_collection() const;
 
  private:
-  struct Invalid {};
+  struct AIRMAP_EXPORT Invalid {};
 
-  union Data {
+  union AIRMAP_EXPORT Data {
     Data();
     ~Data();
 
@@ -131,12 +144,13 @@ class Geometry {
 };
 
 /// @cond
-bool operator==(const Geometry::Coordinate& lhs, const Geometry::Coordinate& rhs);
+AIRMAP_EXPORT bool operator==(const Geometry::Coordinate& lhs, const Geometry::Coordinate& rhs);
 
-bool operator==(const Geometry::Polygon& lhs, const Geometry::Polygon& rhs);
+AIRMAP_EXPORT bool operator==(const Geometry::Polygon& lhs, const Geometry::Polygon& rhs);
 
 template <Geometry::Type tag>
-bool operator==(const Geometry::CoordinateVector<tag>& lhs, const Geometry::CoordinateVector<tag>& rhs) {
+AIRMAP_EXPORT inline bool operator==(const Geometry::CoordinateVector<tag>& lhs,
+                                     const Geometry::CoordinateVector<tag>& rhs) {
   return lhs.coordinates == rhs.coordinates;
 }
 /// @endcond

--- a/libs/airmapd/include/airmap/logger.h
+++ b/libs/airmapd/include/airmap/logger.h
@@ -1,7 +1,20 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_LOGGER_H_
 #define AIRMAP_LOGGER_H_
 
 #include <airmap/do_not_copy_or_move.h>
+#include <airmap/visibility.h>
 
 #include <iostream>
 #include <memory>
@@ -10,7 +23,7 @@ namespace airmap {
 
 /// Logger abstracts logging of human-readable message
 /// providing details on the operation of the system.
-class Logger : DoNotCopyOrMove {
+class AIRMAP_EXPORT Logger : DoNotCopyOrMove {
  public:
   /// Severity enumerates all known levels of severity
   enum class Severity { debug = 0, info = 1, error = 2 };
@@ -41,22 +54,23 @@ class Logger : DoNotCopyOrMove {
 };
 
 /// operator< returns true iff the numeric value of lhs < rhs.
-bool operator<(Logger::Severity lhs, Logger::Severity rhs);
+AIRMAP_EXPORT bool operator<(Logger::Severity lhs, Logger::Severity rhs);
 
 /// operator>> parses severity from in.
-std::istream& operator>>(std::istream& in, Logger::Severity& severity);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, Logger::Severity& severity);
 
 /// create_default_logger returns a Logger implementation writing
 /// log messages to 'out'.
-std::shared_ptr<Logger> create_default_logger(std::ostream& out = std::cerr);
+AIRMAP_EXPORT std::shared_ptr<Logger> create_default_logger(std::ostream& out = std::cerr);
 
 /// create_filtering_logger returns a logger that filters out log entries
 /// with a severity smaller than the configurated severity.
-std::shared_ptr<Logger> create_filtering_logger(Logger::Severity severity, const std::shared_ptr<Logger>& logger);
+AIRMAP_EXPORT std::shared_ptr<Logger> create_filtering_logger(Logger::Severity severity,
+                                                              const std::shared_ptr<Logger>& logger);
 
 /// create_null_logger returns a logger that does the equivalent of
 /// > /dev/null.
-std::shared_ptr<Logger> create_null_logger();
+AIRMAP_EXPORT std::shared_ptr<Logger> create_null_logger();
 
 }  // namespace airmap
 

--- a/libs/airmapd/include/airmap/monitor/client.h
+++ b/libs/airmapd/include/airmap/monitor/client.h
@@ -1,9 +1,22 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_MONITOR_CLIENT_H_
 #define AIRMAP_MONITOR_CLIENT_H_
 
 #include <airmap/do_not_copy_or_move.h>
 #include <airmap/error.h>
 #include <airmap/traffic.h>
+#include <airmap/visibility.h>
 
 #include <memory>
 #include <vector>
@@ -14,24 +27,24 @@ namespace airmap {
 namespace monitor {
 
 /// Client provides access to the AirMap monitor service.
-class Client : DoNotCopyOrMove {
+class AIRMAP_EXPORT Client : DoNotCopyOrMove {
  public:
   /// Configuration bundles up creation-time parameters of a Client.
-  struct Configuration {
+  struct AIRMAP_EXPORT Configuration {
     std::string endpoint;            ///< The remote endpoint hosting the service.
     std::shared_ptr<Logger> logger;  ///< The logger instance.
   };
 
   /// Updates models updates delivered to clients.
-  struct Update {
+  struct AIRMAP_EXPORT Update {
     std::vector<Traffic::Update> traffic;  ///< Traffic updates.
   };
 
   /// UpdateStream abstracts a source of incoming updates.
-  class UpdateStream : DoNotCopyOrMove {
+  class AIRMAP_EXPORT UpdateStream : DoNotCopyOrMove {
    public:
     /// Reveiver models an entity interested in receiving updates.
-    class Receiver : DoNotCopyOrMove {
+    class AIRMAP_EXPORT Receiver : DoNotCopyOrMove {
      public:
       /// handle_update is invoked for every update sent out by the service.
       virtual void handle_update(const Update& update) = 0;
@@ -48,7 +61,7 @@ class Client : DoNotCopyOrMove {
   };
 
   /// ConnectToUpdates bundles up types for calls to Client::connect_to_updates.
-  struct ConnectToUpdates {
+  struct AIRMAP_EXPORT ConnectToUpdates {
     /// Result models the outcome of calling Client::connect_to_updates.
     using Result = Outcome<std::shared_ptr<UpdateStream>, Error>;
     /// Callback models the async receiver for a call to Client::connect_to_updates.

--- a/libs/airmapd/include/airmap/optional.h
+++ b/libs/airmapd/include/airmap/optional.h
@@ -1,5 +1,19 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_OPTIONAL_H_
 #define AIRMAP_OPTIONAL_H_
+
+#include <airmap/visibility.h>
 
 #include <iostream>
 #include <type_traits>
@@ -8,7 +22,7 @@ namespace airmap {
 
 /// Optional manages an optional contained value of type T.
 template <typename T>
-class Optional {
+class AIRMAP_EXPORT Optional {
  public:
   /// Optional initializes a new instance with no contained value.
   Optional() : has_value{false} {
@@ -109,7 +123,7 @@ class Optional {
 
  private:
   bool has_value;
-  union Storage {
+  union AIRMAP_EXPORT Storage {
     Storage() {
     }
     ~Storage() {
@@ -120,7 +134,7 @@ class Optional {
 
 /// operator<< inserts value into out.
 template <typename T>
-inline std::ostream& operator<<(std::ostream& out, const Optional<T>& value) {
+AIRMAP_EXPORT inline std::ostream& operator<<(std::ostream& out, const Optional<T>& value) {
   if (value)
     out << value.get();
   else

--- a/libs/airmapd/include/airmap/outcome.h
+++ b/libs/airmapd/include/airmap/outcome.h
@@ -1,5 +1,19 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_OUTCOME_H_
 #define AIRMAP_OUTCOME_H_
+
+#include <airmap/visibility.h>
 
 #include <type_traits>
 
@@ -8,7 +22,7 @@ namespace airmap {
 /// Outcome models a return value from a function XOR an error object
 /// describing the error condition if no value can be returned.
 template <typename Value, typename Error>
-class Outcome {
+class AIRMAP_EXPORT Outcome {
  public:
   /// @cond
   static_assert(not std::is_same<Value, Error>::value, "Value and Error must not be the same type");
@@ -153,7 +167,7 @@ class Outcome {
   enum class Type { value, error };
 
   Type type;
-  union Data {
+  union AIRMAP_EXPORT Data {
     Data() : value{} {
     }
 

--- a/libs/airmapd/include/airmap/pilot.h
+++ b/libs/airmapd/include/airmap/pilot.h
@@ -1,9 +1,22 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PILOT_H_
 #define AIRMAP_PILOT_H_
 
 #include <airmap/aircraft.h>
 #include <airmap/date_time.h>
 #include <airmap/optional.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 
@@ -13,9 +26,9 @@
 namespace airmap {
 
 /// Pilot bundles up all properties describing a pilot on the AirMap services.
-struct Pilot {
+struct AIRMAP_EXPORT Pilot {
   /// Aircraft describes a vehicle owned by a Pilot.
-  struct Aircraft {
+  struct AIRMAP_EXPORT Aircraft {
     std::string id;          ///< The unique id of the vehicle in the context of AirMap.
     std::string nick_name;   ///< The human-readable nickname of the vehicle.
     airmap::Aircraft model;  ///< The model of the aircraft.
@@ -25,12 +38,13 @@ struct Pilot {
   std::string id;                     ///< The unique id of the pilot in the context of AirMap.
   std::string first_name;             ///< The first name of the pilot.
   std::string last_name;              ///< The last name of the pilot.
-  std::string user_name;              ///< The AirMap username of this pilot.
+  std::string email;                  ///< The email AirMap recorded for this pilot.
+  Optional<std::string> user_name;    ///< The pilot's username used to connect to AirMap services.
   Optional<std::string> picture_url;  ///< The URL of a picture showing the pilot.
 
   /// VerificationStatus summarizes the
   /// status of contact detail verification.
-  struct VerificationStatus {
+  struct AIRMAP_EXPORT VerificationStatus {
     bool email;  ///< true iff the email address of the pilot has been verified
     bool phone;  ///< true iff the phone number of the pilot has been verified
   } verification_status;
@@ -38,19 +52,30 @@ struct Pilot {
   /// Statistics about the pilot and her
   /// flight experience as recorded by the
   /// AirMap services.
-  struct Statistics {
-    struct Flight {
+  struct AIRMAP_EXPORT Statistics {
+    struct AIRMAP_EXPORT Flight {
       std::uint64_t total;        ///< The total number of flights
       DateTime last_flight_time;  ///< Date and time of the last flight
     } flight;                     ///< Statistical details about flights conducted by a pilot.
-    struct Aircraft {
+    struct AIRMAP_EXPORT Aircraft {
       std::uint64_t total;  ///< The total number of aircrafts
     } aircraft;             ///< Statistical details about aircrafts owned by a pilot
   } statistics;
 
   /// App- and user-specific metadata.
-  struct Metadata {
-    std::map<std::string, std::string> app;   ///< App-specific meta-data.
+  struct AIRMAP_EXPORT Metadata {
+    struct AIRMAP_EXPORT App {
+      struct AIRMAP_EXPORT Legal {
+        struct AIRMAP_EXPORT PrivacyPolicy {
+          bool update_required;   ///< True iff user needs to accept updated privacy policy
+        } privacy_policy;
+        struct AIRMAP_EXPORT TermsOfService {
+          bool update_required;   ///< True iff user needs to accept updated terms of service
+        } terms_of_service;
+      } legal;
+      std::uint64_t total;        ///< The total number of flights
+      DateTime last_flight_time;  ///< Date and time of the last flight
+    } app;                        ///< App-specific metadata
     std::map<std::string, std::string> user;  ///< User-specific meta-data.
   } metadata;                                 ///< Metadata associated with a pilot.
   DateTime created_at;                        ///< Timestamp of the creation of this pilot in the AirMap system.

--- a/libs/airmapd/include/airmap/pilots.h
+++ b/libs/airmapd/include/airmap/pilots.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_PILOTS_H_
 #define AIRMAP_PILOTS_H_
 
@@ -7,6 +19,7 @@
 #include <airmap/optional.h>
 #include <airmap/outcome.h>
 #include <airmap/pilot.h>
+#include <airmap/visibility.h>
 
 #include <functional>
 #include <iosfwd>
@@ -16,7 +29,7 @@
 namespace airmap {
 
 /// Pilots provides functionality to manage (the authorized) pilot.
-class Pilots : DoNotCopyOrMove {
+class AIRMAP_EXPORT Pilots : DoNotCopyOrMove {
  public:
   /// Exclude enumerates fields that can be excluded when querying pilot and aircraft properties.
   enum class Exclude {
@@ -28,9 +41,9 @@ class Pilots : DoNotCopyOrMove {
 
   /// Authenticated bundles up types to ease interaction
   /// with Pilots::authenticated.
-  struct Authenticated {
+  struct AIRMAP_EXPORT Authenticated {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;        ///< Authorization token obtained by logging in to the AirMap services.
       Optional<Exclude> exclude{};      ///< Exclude these fields from results.
       bool retrieve_statistics{false};  ///< If true, statistics about flights and aircrafts are requested.
@@ -45,9 +58,9 @@ class Pilots : DoNotCopyOrMove {
 
   /// ForId bundles up types to ease interaction
   /// with Pilots::for_id.
-  struct ForId {
+  struct AIRMAP_EXPORT ForId {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;        ///< Authorization token obtained by logging in to the AirMap services.
       std::string id;                   ///< Searches for the specific pilot with this id.
       Optional<Exclude> exclude{};      ///< Exclude these fields from results.
@@ -63,9 +76,9 @@ class Pilots : DoNotCopyOrMove {
 
   /// UpdateForId bundles up types to ease interaction
   /// with Pilots::update_for_id.
-  struct UpdateForId {
+  struct AIRMAP_EXPORT UpdateForId {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       std::string id;             ///< Updates the specific pilot with this id.
       std::string first_name;     ///< The first name of the pilot.
@@ -85,14 +98,14 @@ class Pilots : DoNotCopyOrMove {
 
   /// StartVerifyPilotPhoneForId bundles up types to ease interaction
   /// with Pilots::start_verify_pilot_phone_for_id.
-  struct StartVerifyPilotPhoneForId {
+  struct AIRMAP_EXPORT StartVerifyPilotPhoneForId {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       std::string id;             ///< Verifies the phone number for the pilot with this id.
     };
 
-    struct Empty {};
+    struct AIRMAP_EXPORT Empty {};
 
     /// Result models the outcome of calling Pilots::start_verify_pilot_phone_for_id.
     using Result = Outcome<Empty, Error>;
@@ -103,15 +116,15 @@ class Pilots : DoNotCopyOrMove {
 
   /// FinishVerifyPilotPhoneForId bundles up types to ease interaction
   /// with Pilots::finish_verify_pilot_phone_for_id.
-  struct FinishVerifyPilotPhoneForId {
+  struct AIRMAP_EXPORT FinishVerifyPilotPhoneForId {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       std::string id;             ///< Verifies the phone number for the pilot with this id.
       std::uint32_t token;        ///< The token that was received on the pilot's phone.
     };
 
-    struct Empty {};
+    struct AIRMAP_EXPORT Empty {};
 
     /// Result models the outcome of calling Pilots::finish_verify_pilot_phone_for_id.
     using Result = Outcome<Empty, Error>;
@@ -122,9 +135,9 @@ class Pilots : DoNotCopyOrMove {
 
   /// Aircrafts bundles up types to ease interaction
   /// with Pilots::aircrafts.
-  struct Aircrafts {
+  struct AIRMAP_EXPORT Aircrafts {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       std::string id;             ///< Lists all aircrafts owned by the pilot with this id.
     };
@@ -138,9 +151,9 @@ class Pilots : DoNotCopyOrMove {
 
   /// AddAircraft bundles up types to ease interaction
   /// with Pilots::add_aircraft.
-  struct AddAircraft {
+  struct AIRMAP_EXPORT AddAircraft {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       std::string id;             ///< Adds an aircraft for the pilot with this id.
       std::string model_id;       ///< The id of the model of the aircraft.
@@ -156,15 +169,15 @@ class Pilots : DoNotCopyOrMove {
 
   /// DeleteAircraft bundles up types to ease interaction
   /// with Pilots::delete_aircraft.
-  struct DeleteAircraft {
+  struct AIRMAP_EXPORT DeleteAircraft {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       std::string id;             ///< Deletes an aircraft for the pilot with this id.
       std::string aircraft_id;    ///< Deletes the specific aircraft with this id.
     };
 
-    struct Empty {};
+    struct AIRMAP_EXPORT Empty {};
 
     /// Result models the outcome of calling Pilots::delete_aircraft.
     using Result = Outcome<Empty, Error>;
@@ -175,16 +188,16 @@ class Pilots : DoNotCopyOrMove {
 
   /// UpdateAircraft bundles up types to ease interaction
   /// with Pilots::update_aircraft.
-  struct UpdateAircraft {
+  struct AIRMAP_EXPORT UpdateAircraft {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       std::string authorization;  ///< Authorization token obtained by logging in to the AirMap services.
       std::string id;             ///< Updates an aircraft for the pilot with this id.
       std::string aircraft_id;    ///< Update the specific aircraft with this id.
       std::string nick_name;      ///< The new nick name for the aircraft.
     };
 
-    struct Empty {};
+    struct AIRMAP_EXPORT Empty {};
     /// Result models the outcome of calling Pilots::update_aircraft.
     using Result = Outcome<Empty, Error>;
     /// Callback describes the function signature of the callback that is
@@ -231,9 +244,9 @@ class Pilots : DoNotCopyOrMove {
 };
 
 /// @cond
-Pilots::Exclude operator|(Pilots::Exclude, Pilots::Exclude);
-Pilots::Exclude operator&(Pilots::Exclude, Pilots::Exclude);
-std::ostream& operator<<(std::ostream& out, Pilots::Exclude exclude);
+AIRMAP_EXPORT Pilots::Exclude operator|(Pilots::Exclude, Pilots::Exclude);
+AIRMAP_EXPORT Pilots::Exclude operator&(Pilots::Exclude, Pilots::Exclude);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Pilots::Exclude exclude);
 /// @endcond
 
 }  // namespace airmap

--- a/libs/airmapd/include/airmap/qt/client.h
+++ b/libs/airmapd/include/airmap/qt/client.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_CLIENT_H_
 #define AIRMAP_QT_CLIENT_H_
 
@@ -6,6 +18,7 @@
 #include <airmap/error.h>
 #include <airmap/logger.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <QObject>
 
@@ -19,7 +32,7 @@ namespace qt {
 ///
 /// All callback invocations that might happen in the context of a Client instance
 /// are dispatched to the Qt applications' main thread.
-class Client : public QObject, public airmap::Client {
+class AIRMAP_EXPORT Client : public QObject, public airmap::Client {
  public:
   using CreateResult   = Outcome<Client*, Error>;
   using CreateCallback = std::function<void(const CreateResult&)>;

--- a/libs/airmapd/include/airmap/qt/logger.h
+++ b/libs/airmapd/include/airmap/qt/logger.h
@@ -1,7 +1,20 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_LOGGER_H_
 #define AIRMAP_QT_LOGGER_H_
 
 #include <airmap/logger.h>
+#include <airmap/visibility.h>
 
 #include <QLoggingCategory>
 
@@ -12,7 +25,7 @@ namespace qt {
 
 /// Logger is an airmap::Logger implementation that uses to
 /// Qt's logging facilities.
-class Logger : public airmap::Logger {
+class AIRMAP_EXPORT Logger : public airmap::Logger {
  public:
   /// logging_category returns a QLoggingCategory instance
   /// that enables calling code to fine-tune logging behavior of a Logger instance.
@@ -34,7 +47,7 @@ class Logger : public airmap::Logger {
 
 /// DispatchingLogger is an airmap::Logger implementation that dispatches to Qt's main
 /// event loop for logger invocation
-class DispatchingLogger : public airmap::Logger {
+class AIRMAP_EXPORT DispatchingLogger : public airmap::Logger {
  public:
   /// DispatchingLogger initializes a new instance with 'next'.
   DispatchingLogger(const std::shared_ptr<airmap::Logger>& next);

--- a/libs/airmapd/include/airmap/qt/types.h
+++ b/libs/airmapd/include/airmap/qt/types.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_QT_TYPES_H_
 #define AIRMAP_QT_TYPES_H_
 
@@ -18,6 +30,7 @@
 #include <airmap/token.h>
 #include <airmap/traffic.h>
 #include <airmap/version.h>
+#include <airmap/visibility.h>
 
 #include <QMetaType>
 
@@ -58,7 +71,7 @@ namespace qt {
 ///
 /// This function has to be called at least once to be able to use airmap::*
 /// types in queued signal-slot connections.
-void register_types();
+AIRMAP_EXPORT void register_types();
 
 }  // namespace qt
 }  // namespace airmap

--- a/libs/airmapd/include/airmap/rule.h
+++ b/libs/airmapd/include/airmap/rule.h
@@ -1,11 +1,25 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_RULE_H_
 #define AIRMAP_RULE_H_
+
+#include <airmap/visibility.h>
 
 #include <string>
 
 namespace airmap {
 
-struct Rule {
+struct AIRMAP_EXPORT Rule {
   // TODO(tvoss): Fill in values once schema is known.
   enum class Type {};
   Type type;
@@ -16,7 +30,7 @@ struct Rule {
   // TODO(tvoss): Add requirements here.
 };
 
-bool operator==(const Rule& lhs, const Rule& rhs);
+AIRMAP_EXPORT bool operator==(const Rule& lhs, const Rule& rhs);
 
 }  // namespace airmap
 

--- a/libs/airmapd/include/airmap/ruleset.h
+++ b/libs/airmapd/include/airmap/ruleset.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_RULESET_H_
 #define AIRMAP_RULESET_H_
 
@@ -6,6 +18,7 @@
 #include <airmap/optional.h>
 #include <airmap/pilot.h>
 #include <airmap/status.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <iosfwd>
@@ -17,11 +30,11 @@
 namespace airmap {
 
 /// RuleSet bundles together properties describing a ruleset.
-struct RuleSet {
+struct AIRMAP_EXPORT RuleSet {
   // Feature describes a flight feature modelled by a particular rule.
   struct Feature;
   /// Rule models the individual result of a Rule evaluation.
-  struct Rule {
+  struct AIRMAP_EXPORT Rule {
     /// Status enumerates all known status codes of a rule.
     enum class Status {
       unknown,          ///< The status of the rule is unknown.
@@ -46,7 +59,7 @@ struct RuleSet {
   };
 
   /// Jurisdiction describes a jurisdiction in a geographical scope.
-  struct Jurisdiction {
+  struct AIRMAP_EXPORT Jurisdiction {
     /// Region enumerates all known regional scopes of a jurisdiction.
     enum class Region {
       national,  ///< The jurisdiction applies nation-wide.
@@ -76,12 +89,12 @@ struct RuleSet {
   std::vector<std::string> airspace_types;  ///< The layers that a RuleSet instance applies to.
   std::vector<Rule> rules;                  ///< The individual rules in the set.
 
-  struct Feature {
+  struct AIRMAP_EXPORT Feature {
     enum class Type { unknown, boolean, floating_point, string };
     enum class Measurement { unknown, speed, weight, distance };
     enum class Unit { unknown, kilograms, meters, meters_per_sec };
 
-    class Value {
+    class AIRMAP_EXPORT Value {
      public:
       Value();
       explicit Value(bool value);
@@ -107,7 +120,7 @@ struct RuleSet {
       Value& destruct();
 
       Type type_;
-      union Detail {
+      union AIRMAP_EXPORT Detail {
         Detail();
         ~Detail();
 
@@ -129,26 +142,27 @@ struct RuleSet {
     Type type{Type::unknown};
     Measurement measurement{Measurement::unknown};
     Unit unit{Unit::unknown};
+    bool is_calculated;
   };
 };
 
-std::ostream& operator<<(std::ostream& out, RuleSet::Feature::Type type);
-std::istream& operator>>(std::istream& in, RuleSet::Feature::Type& type);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, RuleSet::Feature::Type type);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, RuleSet::Feature::Type& type);
 
-std::ostream& operator<<(std::ostream& out, RuleSet::Feature::Measurement measurement);
-std::istream& operator>>(std::istream& in, RuleSet::Feature::Measurement& measurement);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, RuleSet::Feature::Measurement measurement);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, RuleSet::Feature::Measurement& measurement);
 
-std::ostream& operator<<(std::ostream& out, RuleSet::Feature::Unit unit);
-std::istream& operator>>(std::istream& in, RuleSet::Feature::Unit& unit);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, RuleSet::Feature::Unit unit);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, RuleSet::Feature::Unit& unit);
 
-std::ostream& operator<<(std::ostream& out, RuleSet::Jurisdiction::Region region);
-std::istream& operator>>(std::istream& in, RuleSet::Jurisdiction::Region& region);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, RuleSet::Jurisdiction::Region region);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, RuleSet::Jurisdiction::Region& region);
 
-std::ostream& operator<<(std::ostream& out, RuleSet::SelectionType type);
-std::istream& operator>>(std::istream& in, RuleSet::SelectionType& type);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, RuleSet::SelectionType type);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, RuleSet::SelectionType& type);
 
-std::ostream& operator<<(std::ostream& out, RuleSet::Rule::Status status);
-std::istream& operator>>(std::istream& in, RuleSet::Rule::Status& status);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, RuleSet::Rule::Status status);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, RuleSet::Rule::Status& status);
 
 }  // namespace airmap
 

--- a/libs/airmapd/include/airmap/rulesets.h
+++ b/libs/airmapd/include/airmap/rulesets.h
@@ -1,12 +1,26 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_RULESETS_H_
 #define AIRMAP_RULESETS_H_
 
 #include <airmap/do_not_copy_or_move.h>
 #include <airmap/error.h>
 #include <airmap/evaluation.h>
+#include <airmap/flight_plan.h>
 #include <airmap/geometry.h>
 #include <airmap/outcome.h>
 #include <airmap/ruleset.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <functional>
@@ -15,12 +29,12 @@
 namespace airmap {
 
 /// RuleSets provides functionality for managing contextual airspace.
-class RuleSets : DoNotCopyOrMove {
+class AIRMAP_EXPORT RuleSets : DoNotCopyOrMove {
  public:
   /// Search bundles up types to ease interaction with
   /// RuleSets::search.
-  struct Search {
-    struct Parameters {
+  struct AIRMAP_EXPORT Search {
+    struct AIRMAP_EXPORT Parameters {
       Required<Geometry> geometry;  ///< Search for rulesets intersecting this geometry.
     };
 
@@ -33,8 +47,8 @@ class RuleSets : DoNotCopyOrMove {
 
   /// ForId bundles up types to ease interaction with
   /// RuleSets::for_id.
-  struct ForId {
-    struct Parameters {
+  struct AIRMAP_EXPORT ForId {
+    struct AIRMAP_EXPORT Parameters {
       RuleSet::Id id;  ///< Search for the ruleset with this id.
     };
 
@@ -47,8 +61,8 @@ class RuleSets : DoNotCopyOrMove {
 
   /// FetchRules bundles up types to ease interaction with
   /// RuleSets::fetch_rules.
-  struct FetchRules {
-    struct Parameters {
+  struct AIRMAP_EXPORT FetchRules {
+    struct AIRMAP_EXPORT Parameters {
       Optional<std::string> rulesets;  ///< Fetch rules which apply to these rulesets.
     };
 
@@ -61,8 +75,8 @@ class RuleSets : DoNotCopyOrMove {
 
   /// EvaluateRules bundles up types to ease interaction with
   /// RuleSets::evaluate_rulesets.
-  struct EvaluateRules {
-    struct Parameters {
+  struct AIRMAP_EXPORT EvaluateRules {
+    struct AIRMAP_EXPORT Parameters {
       Required<Geometry> geometry;  ///< Evaluate rulesets intersecting this geometry.
       std::unordered_map<std::string, RuleSet::Feature::Value>
           features;                    ///< Additional properties of the planned flight.
@@ -70,6 +84,20 @@ class RuleSets : DoNotCopyOrMove {
     };
 
     /// Result models the outcome of calling RuleSets::evaluate_rulesets.
+    using Result = Outcome<Evaluation, Error>;
+    /// Callback describes the function signature of the callback that is invoked
+    /// when a call to RuleSets::evaluate_rulesets finishes.
+    using Callback = std::function<void(const Result&)>;
+  };
+
+  /// EvaluateFlightPlan bundles up types to ease interaction with
+  /// RuleSets::evaluate_flight_plan.
+  struct AIRMAP_EXPORT EvaluateFlightPlan {
+    struct AIRMAP_EXPORT Parameters {
+      FlightPlan::Id id;  ///< Id of the flight plan that should be submitted.
+    };
+
+    /// Result models the outcome of calling RuleSets::evaluate_flight_plan.
     using Result = Outcome<Evaluation, Error>;
     /// Callback describes the function signature of the callback that is invoked
     /// when a call to RuleSets::evaluate_rulesets finishes.
@@ -91,6 +119,10 @@ class RuleSets : DoNotCopyOrMove {
   /// evaluate_rulesets evaluates rulesets and geometry identified by 'parameters' and
   /// reports back results to 'cb'.
   virtual void evaluate_rulesets(const EvaluateRules::Parameters& parameters, const EvaluateRules::Callback& cb) = 0;
+
+  /// evaluate_flight_plan evaluates a flight plan identified by 'parameters' and
+  /// reports back results to 'cb'.
+  virtual void evaluate_flight_plan(const EvaluateFlightPlan::Parameters& parameters, const EvaluateFlightPlan::Callback& cb) = 0;
 
  protected:
   /// @cond

--- a/libs/airmapd/include/airmap/status.h
+++ b/libs/airmapd/include/airmap/status.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_STATUS_H_
 #define AIRMAP_STATUS_H_
 
@@ -8,6 +20,7 @@
 #include <airmap/geometry.h>
 #include <airmap/optional.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <functional>
@@ -19,27 +32,27 @@ namespace airmap {
 
 /// Status provides functionality to query airspace and weather information about
 /// a geographic area.
-class Status : DoNotCopyOrMove {
+class AIRMAP_EXPORT Status : DoNotCopyOrMove {
  public:
   /// Color enumerates known colors assigned to advisories.
   enum class Color { green = 0, yellow = 1, orange = 2, red = 3 };
 
   /// Advisory bundles together airspace information and its evaluation in terms
   /// good to fly/needs information or feedback/conflict.
-  struct Advisory {
+  struct AIRMAP_EXPORT Advisory {
     Airspace airspace;  /// The airspace that the advisory refers to.
     Color color;        /// The evaluation of the airspace.
   };
 
   /// Wind bundles up attributes describing a wind conditions.
-  struct Wind {
+  struct AIRMAP_EXPORT Wind {
     std::uint32_t heading = 0;  ///< The heading in [°].
     std::uint32_t speed   = 0;  ///< The speed in [°].
     std::uint32_t gusting = 0;
   };
 
   /// Weather bundles up attributes describing a weather condition.
-  struct Weather {
+  struct AIRMAP_EXPORT Weather {
     std::string condition;            ///< The overall weather condition.
     std::string icon;                 ///< The icon or class of icon that should be used for display purposes.
     Wind wind;                        ///< The details about the current wind conditions.
@@ -50,7 +63,7 @@ class Status : DoNotCopyOrMove {
   };
 
   /// Report summarizes information about a geographic area.
-  struct Report {
+  struct AIRMAP_EXPORT Report {
     std::uint32_t max_safe_distance = 0;  ///< The distance to the area that is considered safe in [m].
     Color advisory_color;                 ///< The overall evaluation of all advisories.
     std::vector<Advisory> advisories;     ///< All relevant advisories.
@@ -59,9 +72,9 @@ class Status : DoNotCopyOrMove {
 
   /// GetStatus bundles up types to ease interaction
   /// with Status::get_status*.
-  struct GetStatus {
+  struct AIRMAP_EXPORT GetStatus {
     /// Parameters bundles up input parameters.
-    struct Parameters {
+    struct AIRMAP_EXPORT Parameters {
       Required<float> latitude;                ///< The latitude of the center point of the query.
       Required<float> longitude;               ///< The longitude of the center point of the query.
       Optional<Airspace::Type> types;          ///< Query status information for these types of airspaces.
@@ -97,8 +110,8 @@ class Status : DoNotCopyOrMove {
 };
 
 /// @cond
-std::ostream& operator<<(std::ostream& out, Status::Color color);
-std::istream& operator>>(std::istream& in, Status::Color& color);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Status::Color color);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, Status::Color& color);
 /// @endcond
 
 }  // namespace airmap

--- a/libs/airmapd/include/airmap/telemetry.h
+++ b/libs/airmapd/include/airmap/telemetry.h
@@ -1,8 +1,21 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_TELEMETRY_H_
 #define AIRMAP_TELEMETRY_H_
 
 #include <airmap/do_not_copy_or_move.h>
 #include <airmap/error.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 #include <string>
@@ -14,10 +27,10 @@ struct Flight;
 
 /// Telemetry provides functionality to submit telemetry updates to the
 /// AirMap services during flight.
-class Telemetry : DoNotCopyOrMove {
+class AIRMAP_EXPORT Telemetry : DoNotCopyOrMove {
  public:
   /// Position describes a timestamped geographical position.
-  struct Position {
+  struct AIRMAP_EXPORT Position {
     std::uint64_t timestamp;     ///< Ingestion timestamp of the update.
     double latitude;             ///< The latitude of the position [°].
     double longitude;            ///< The longitude of the position in [°].
@@ -27,7 +40,7 @@ class Telemetry : DoNotCopyOrMove {
   };
 
   /// Speed describes the timestamped 3-dim velocity of a vehicle.
-  struct Speed {
+  struct AIRMAP_EXPORT Speed {
     std::uint64_t timestamp;  ///< Ingestion timestamp of the update.
     float velocity_x;         ///< The velocity of the vehicle in direction of the x axis in [m/s].
     float velocity_y;         ///< The velocity of the vehicle in direction of the y axis in [m/s].
@@ -35,7 +48,7 @@ class Telemetry : DoNotCopyOrMove {
   };
 
   /// Attitude describes the timestamped 3-dim orientation of a vehicle.
-  struct Attitude {
+  struct AIRMAP_EXPORT Attitude {
     std::uint64_t timestamp;  ///< Ingestion timestamp of the update.
     float yaw;                ///< The yaw of the vehicle in [°/s].
     float pitch;              ///< The pitch of the vehicle in [°/s].
@@ -43,7 +56,7 @@ class Telemetry : DoNotCopyOrMove {
   };
 
   /// Barometer describes the timestamped atmospheric pressurce conditions.
-  struct Barometer {
+  struct AIRMAP_EXPORT Barometer {
     std::uint64_t timestamp;  ///< Ingestion timestamp of the update.
     float pressure;           ///< The atmospheric pressure measurement in [Pa].
   };
@@ -57,7 +70,7 @@ class Telemetry : DoNotCopyOrMove {
 
   /// Update models an update of the current position, speed, attitude or atmospheric pressure
   /// measurement/estimate.
-  class Update {
+  class AIRMAP_EXPORT Update {
    public:
     /// Type enumerates all known update types.
     enum class Type : std::uint8_t {

--- a/libs/airmapd/include/airmap/timestamp.h
+++ b/libs/airmapd/include/airmap/timestamp.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_TIMESTAMP_H_
 #define AIRMAP_TIMESTAMP_H_
 

--- a/libs/airmapd/include/airmap/token.h
+++ b/libs/airmapd/include/airmap/token.h
@@ -1,7 +1,20 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_TOKEN_H_
 #define AIRMAP_TOKEN_H_
 
 #include <airmap/optional.h>
+#include <airmap/visibility.h>
 
 #include <chrono>
 #include <iosfwd>
@@ -10,7 +23,7 @@
 namespace airmap {
 
 /// Token models an authentication token required to access the AirMap services.
-class Token {
+class AIRMAP_EXPORT Token {
  public:
   /// Type enumerates all known token types.
   enum class Type {
@@ -21,12 +34,12 @@ class Token {
   };
 
   /// Anonymous models a token for an anonymous authentication with the AirMap services.
-  struct Anonymous {
+  struct AIRMAP_EXPORT Anonymous {
     std::string id;  ///< The authentication id.
   };
 
   /// OAuth models a token for an authentication with OAuth credentials with the AirMap services.
-  struct OAuth {
+  struct AIRMAP_EXPORT OAuth {
     enum class Type { bearer };
     Type type;            ///< The type of the OAuth token.
     std::string refresh;  ///< The refresh token for subsequent renewal requests.
@@ -35,7 +48,7 @@ class Token {
   };
 
   /// Refreshed models a token for a refreshed authentication with OAuth credentials with the AirMap services.
-  struct Refreshed {
+  struct AIRMAP_EXPORT Refreshed {
     OAuth::Type type;                 ///< The type of the Refreshed token.
     std::chrono::seconds expires_in;  ///< The token expires in 'expires_in' seconds.
     std::string id;                   ///< The id token.
@@ -63,6 +76,8 @@ class Token {
 
   /// type returns the Type of this Token instance.
   Type type() const;
+  /// pilot_id returns the pilot id of this Token instance.
+  const std::string pilot_id() const;
   /// id returns the common id of this Token instance.
   const std::string& id() const;
   /// anonymous returns the details for a Type::anonymous Token instance.
@@ -79,7 +94,7 @@ class Token {
   Refreshed& refreshed();
 
  private:
-  union Data {
+  union AIRMAP_EXPORT Data {
     Data();
     ~Data();
 
@@ -100,15 +115,15 @@ class Token {
 };
 
 /// operator<< inserts type into out.
-std::ostream& operator<<(std::ostream& out, Token::Type type);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Token::Type type);
 /// operator>> extracts type from in.
-std::istream& operator>>(std::istream& in, Token::Type& type);
+AIRMAP_EXPORT std::istream& operator>>(std::istream& in, Token::Type& type);
 /// operator== returns true iff lhs equals rhs.
-bool operator==(const Token::OAuth& lhs, const Token::OAuth& rhs);
+AIRMAP_EXPORT bool operator==(const Token::OAuth& lhs, const Token::OAuth& rhs);
 /// operator== returns true iff lhs equals rhs.
-bool operator==(Token::OAuth::Type lhs, Token::OAuth::Type rhs);
+AIRMAP_EXPORT bool operator==(Token::OAuth::Type lhs, Token::OAuth::Type rhs);
 /// operator== returns true iff lhs equals rhs.
-bool operator==(const Token::Refreshed& lhs, const Token::Refreshed& rhs);
+AIRMAP_EXPORT bool operator==(const Token::Refreshed& lhs, const Token::Refreshed& rhs);
 
 }  // namespace airmap
 

--- a/libs/airmapd/include/airmap/traffic.h
+++ b/libs/airmapd/include/airmap/traffic.h
@@ -1,3 +1,15 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_TRAFFIC_H_
 #define AIRMAP_TRAFFIC_H_
 
@@ -6,6 +18,7 @@
 #include <airmap/error.h>
 #include <airmap/logger.h>
 #include <airmap/outcome.h>
+#include <airmap/visibility.h>
 
 #include <functional>
 #include <iosfwd>
@@ -17,11 +30,11 @@ namespace airmap {
 
 /// Traffic provides access to the AirMap situational awareness
 /// and traffic alerts.
-class Traffic : DoNotCopyOrMove {
+class AIRMAP_EXPORT Traffic : DoNotCopyOrMove {
  public:
   /// Update bundles together information about aerial traffic
   /// relevant to a UAV flight.
-  struct Update {
+  struct AIRMAP_EXPORT Update {
     /// Type enumerates all known types of Traffic::Update.
     enum class Type {
       unknown,                ///< Marks the unknown type.
@@ -43,10 +56,10 @@ class Traffic : DoNotCopyOrMove {
 
   /// Monitor models handling of individual subscribers
   /// to per-flight alerts and awareness notices.
-  class Monitor : DoNotCopyOrMove {
+  class AIRMAP_EXPORT Monitor : DoNotCopyOrMove {
    public:
     /// Parameters bundles up input parameters.
-    struct Params {
+    struct AIRMAP_EXPORT Params {
       std::string flight_id;      ///< The id of the flight for which traffic udpates should be started.
       std::string authorization;  ///< The authorization token.
     };
@@ -58,9 +71,8 @@ class Traffic : DoNotCopyOrMove {
     using Callback = std::function<void(const Result&)>;
 
     /// Subscriber abstracts handling of batches of Update instances.
-    class Subscriber {
+    class AIRMAP_EXPORT Subscriber {
      public:
-     virtual ~Subscriber() = default;
       /// handle_update is invoked when a new batch of Update instances
       /// is available.
       virtual void handle_update(Update::Type type, const std::vector<Update>& update) = 0;
@@ -71,7 +83,7 @@ class Traffic : DoNotCopyOrMove {
 
     /// FunctionalSubscriber is a convenience class that dispatches
     /// to a function 'f' for handling batches of Update instances.
-    class FunctionalSubscriber : public Subscriber {
+    class AIRMAP_EXPORT FunctionalSubscriber : public Subscriber {
      public:
       /// FunctionalSubscriber initializes a new instance with 'f'.
       explicit FunctionalSubscriber(const std::function<void(Update::Type, const std::vector<Update>&)>& f);
@@ -84,7 +96,7 @@ class Traffic : DoNotCopyOrMove {
 
     /// LoggingSubscriber is a convenience class that logs incoming batches
     /// of Update instances.
-    class LoggingSubscriber : public Subscriber {
+    class AIRMAP_EXPORT LoggingSubscriber : public Subscriber {
      public:
       /// LoggingSubscriber initializes an instance with 'component', feeding
       /// log entries to 'logger'. Please note that no change of ownership takes
@@ -122,7 +134,7 @@ class Traffic : DoNotCopyOrMove {
 };
 
 /// operator<< inserts a textual representation of type into out.
-std::ostream& operator<<(std::ostream& out, Traffic::Update::Type type);
+AIRMAP_EXPORT std::ostream& operator<<(std::ostream& out, Traffic::Update::Type type);
 
 }  // namespace airmap
 

--- a/libs/airmapd/include/airmap/version.h
+++ b/libs/airmapd/include/airmap/version.h
@@ -1,8 +1,21 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #ifndef AIRMAP_VERSION_H_
 #define AIRMAP_VERSION_H_
 
 #include <airmap/date_time.h>
 #include <airmap/optional.h>
+#include <airmap/visibility.h>
 
 #include <cstdint>
 
@@ -10,7 +23,7 @@ namespace airmap {
 
 /// Version bundles up information describing a specific version of the AirMap
 /// client library. We follow semantic versioning guidelines (see https://semver.org).
-struct Version {
+struct AIRMAP_EXPORT Version {
   /// current returns an immutable reference to the version of the client library.
   static const Version& current();
 

--- a/libs/airmapd/include/airmap/visibility.h
+++ b/libs/airmapd/include/airmap/visibility.h
@@ -1,0 +1,25 @@
+// AirMap Platform SDK
+// Copyright © 2018 AirMap, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//   http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef AIRMAP_VISIBILITY_H_
+#define AIRMAP_VISIBILITY_H_
+
+#if defined(__GNUC__) || defined(__clang__)
+#define AIRMAP_EXPORT __attribute__((visibility("default")))
+#elif defined(_MSC_VER)
+#define AIRMAP_EXPORT __declspec(dllexport)
+#else
+#pragma message("unknown compiler - default AIRMAP_EXPORT to empty")
+#define AIRMAP_EXPORT
+#endif
+
+#endif  // AIRMAP_VISIBILITY_H_

--- a/libs/airmapd/linux/Qt.5.12/libairmap-cpp.so
+++ b/libs/airmapd/linux/Qt.5.12/libairmap-cpp.so
@@ -1,0 +1,1 @@
+libairmap-cpp.so.0.0.1

--- a/libs/airmapd/linux/Qt.5.12/libairmap-cpp.so.0.0.1
+++ b/libs/airmapd/linux/Qt.5.12/libairmap-cpp.so.0.0.1
@@ -1,0 +1,1 @@
+libairmap-cpp.so.0

--- a/libs/airmapd/linux/Qt.5.12/libairmap-qt.so
+++ b/libs/airmapd/linux/Qt.5.12/libairmap-qt.so
@@ -1,0 +1,1 @@
+libairmap-qt.so.0.0.1

--- a/libs/airmapd/linux/Qt.5.12/libairmap-qt.so.0.0.1
+++ b/libs/airmapd/linux/Qt.5.12/libairmap-qt.so.0.0.1
@@ -1,0 +1,1 @@
+libairmap-qt.so.0

--- a/src/Airmap/AirMapFlightPlanManager.cc
+++ b/src/Airmap/AirMapFlightPlanManager.cc
@@ -16,7 +16,6 @@
 
 #include "PlanMasterController.h"
 #include "QGCMAVLink.h"
-#include "VisualMissionItem.h"
 
 #include "airmap/date_time.h"
 #include "airmap/flight_plans.h"

--- a/src/Airmap/AirMapFlightPlanManager.cc
+++ b/src/Airmap/AirMapFlightPlanManager.cc
@@ -352,7 +352,7 @@ AirMapFlightPlanManager::_endFlight()
 
 //-----------------------------------------------------------------------------
 bool
-AirMapFlightPlanManager::_collectFlightDtata()
+AirMapFlightPlanManager::_collectFlightData()
 {
     if(!_planController || !_planController->missionController()) {
         return false;
@@ -364,17 +364,11 @@ AirMapFlightPlanManager::_collectFlightDtata()
         qCDebug(AirMapManagerLog) << "Not enough points for a flight plan.";
         return false;
     }
-    if (_planController->missionController()->readyForSaveState() != VisualMissionItem::ReadyForSave) {
-        qCDebug(AirMapManagerLog) << "No takeoff altitude";
-        return false;
-    }
-    float maxMissionAltitude    = static_cast<float>(fmax(bc.pointNW.altitude(), bc.pointSE.altitude()));
-    double takeoffAltitude      = _planController->missionController()->plannedHomePositionAltitude();
-    _flight.takeoffCoord        = _planController->missionController()->takeoffCoordinate();
-        // altitude reference for AirMap is takeoff altitude, so adjust if altitudes specified in absolute terms
-    _flight.maxAltitudeAboveTakeoff = (_planController->missionController()->globalAltitudeMode() == QGroundControlQmlGlobal::AltitudeModeRelative) ? maxMissionAltitude : maxMissionAltitude - takeoffAltitude;
-    _flight.coords              = bc.polygon2D();
-    _flight.bc                  = bc;
+    // altitude reference for AirMap is takeoff altitude & all altitudes provided in the bounding cube are relative to takeoff already
+    _flight.takeoffCoord            = _planController->missionController()->takeoffCoordinate();
+    _flight.maxAltitudeAboveTakeoff = static_cast<float>(fmax(bc.pointNW.altitude(), bc.pointSE.altitude()));
+    _flight.coords                  = bc.polygon2D();
+    _flight.bc                      = bc;
     emit missionAreaChanged();
     return true;
 }
@@ -386,7 +380,7 @@ AirMapFlightPlanManager::_createFlightPlan()
     _flight.reset();
 
     //-- Get flight data
-    if(!_collectFlightDtata()) {
+    if(!_collectFlightData()) {
         return;
     }
 
@@ -574,7 +568,7 @@ AirMapFlightPlanManager::_updateFlightPlan(bool interactive)
         return;
     }
     //-- Get flight data
-    if(!_collectFlightDtata()) {
+    if(!_collectFlightData()) {
         return;
     }
 

--- a/src/Airmap/AirMapFlightPlanManager.cc
+++ b/src/Airmap/AirMapFlightPlanManager.cc
@@ -363,10 +363,12 @@ AirMapFlightPlanManager::_collectFlightDtata()
         qCDebug(AirMapManagerLog) << "Not enough points for a flight plan.";
         return false;
     }
-    _flight.maxAltitude   = static_cast<float>(fmax(bc.pointNW.altitude(), bc.pointSE.altitude()));
-    _flight.takeoffCoord  = _planController->missionController()->takeoffCoordinate();
-    _flight.coords        = bc.polygon2D();
-    _flight.bc            = bc;
+    float maxMissionAltitude    = static_cast<float>(fmax(bc.pointNW.altitude(), bc.pointSE.altitude()));
+    _flight.takeoffCoord        = _planController->missionController()->takeoffCoordinate();
+        // altitude reference for AirMap is ground level, so adjust if altitudes specified in absolute terms
+    _flight.maxAltitude         = (_planController->missionController()->globalAltitudeMode() == QGroundControlQmlGlobal::AltitudeModeRelative) ? maxMissionAltitude : maxMissionAltitude - _flight.takeoffCoord.altitude();
+    _flight.coords              = bc.polygon2D();
+    _flight.bc                  = bc;
     emit missionAreaChanged();
     return true;
 }

--- a/src/Airmap/AirMapFlightPlanManager.h
+++ b/src/Airmap/AirMapFlightPlanManager.h
@@ -139,11 +139,11 @@ private:
         QGCGeoBoundingCube bc;
         QList<QGeoCoordinate> coords;
         QGeoCoordinate  takeoffCoord;
-        float maxAltitude = 0;
+        float maxAltitudeAboveTakeoff = 0;
         void reset() {
             bc.reset();
             coords.clear();
-            maxAltitude = 0;
+            maxAltitudeAboveTakeoff = 0;
         }
     };
 

--- a/src/Airmap/AirMapFlightPlanManager.h
+++ b/src/Airmap/AirMapFlightPlanManager.h
@@ -104,8 +104,8 @@ public:
     void                endFlight           (QString flightID) override;
 
 signals:
-    void            error                   (const QString& what, const QString& airmapdMessage, const QString& airmapdDetails);
-    void            flightIDChanged         (QString flightID);
+    void error                              (const QString& what, const QString& airmapdMessage, const QString& airmapdDetails);
+    void flightIDChanged                    (QString flightID);
 
 private slots:
     void _pollBriefing                      ();
@@ -116,12 +116,12 @@ private slots:
     void _loadFlightList                    ();
 
 private:
-    void _createFlightPlan                  ();
-    bool _collectFlightDtata                ();
-    void _updateFlightPlan                  (bool interactive = false);
-    bool _findBriefFeature                  (const QString& name);
-    void _updateFlightStartEndTime          (airmap::DateTime& start_time, airmap::DateTime& end_time);
-    void _updateRulesAndFeatures            (std::vector<airmap::RuleSet::Id>& rulesets, std::unordered_map<std::string, airmap::RuleSet::Feature::Value>& features, bool updateFeatures = false);
+    void    _createFlightPlan               ();
+    bool    _collectFlightData              ();
+    void    _updateFlightPlan               (bool interactive = false);
+    bool    _findBriefFeature               (const QString& name);
+    void    _updateFlightStartEndTime       (airmap::DateTime& start_time, airmap::DateTime& end_time);
+    void    _updateRulesAndFeatures         (std::vector<airmap::RuleSet::Id>& rulesets, std::unordered_map<std::string, airmap::RuleSet::Feature::Value>& features, bool updateFeatures = false);
 
 private:
     enum class State {

--- a/src/Airmap/AirMapManager.cc
+++ b/src/Airmap/AirMapManager.cc
@@ -168,7 +168,7 @@ AirMapManager::_settingsTimeout()
         auto credentials    = Credentials{};
         credentials.api_key = _shared.settings().apiKey.toStdString();
         auto configuration  = Client::default_production_configuration(credentials);
-        configuration.telemetry.host = "telemetry.airmap.com";
+        configuration.telemetry.host = _telemetryHost;
         configuration.telemetry.port = 16060;
         qt::Client::create(configuration, _dispatchingLogger, this, [this](const qt::Client::CreateResult& result) {
             if (result) {

--- a/src/Airmap/AirMapManager.cc
+++ b/src/Airmap/AirMapManager.cc
@@ -168,8 +168,8 @@ AirMapManager::_settingsTimeout()
         auto credentials    = Credentials{};
         credentials.api_key = _shared.settings().apiKey.toStdString();
         auto configuration  = Client::default_production_configuration(credentials);
-        configuration.telemetry.host = "udp.telemetry.k8s.airmap.io";
-        configuration.telemetry.port = 7070;
+        configuration.telemetry.host = "telemetry.airmap.com";
+        configuration.telemetry.port = 16060;
         qt::Client::create(configuration, _dispatchingLogger, this, [this](const qt::Client::CreateResult& result) {
             if (result) {
                 qCDebug(AirMapManagerLog) << "Successfully created airmap::qt::Client instance";

--- a/src/Airmap/AirMapManager.cc
+++ b/src/Airmap/AirMapManager.cc
@@ -169,7 +169,7 @@ AirMapManager::_settingsTimeout()
         credentials.api_key = _shared.settings().apiKey.toStdString();
         auto configuration  = Client::default_production_configuration(credentials);
         configuration.telemetry.host = _telemetryHost;
-        configuration.telemetry.port = 16060;
+        configuration.telemetry.port = _telemetryPort;
         qt::Client::create(configuration, _dispatchingLogger, this, [this](const qt::Client::CreateResult& result) {
             if (result) {
                 qCDebug(AirMapManagerLog) << "Successfully created airmap::qt::Client instance";

--- a/src/Airmap/AirMapManager.h
+++ b/src/Airmap/AirMapManager.h
@@ -66,6 +66,8 @@ private:
     std::shared_ptr<airmap::qt::Logger>             _logger;
     std::shared_ptr<airmap::qt::DispatchingLogger>  _dispatchingLogger;
     AirspaceManager::AuthStatus                     _authStatus;
+    const std::string                               _telemetryHost = "telemetry.airmap.com";
+    const uint16_t                                  _telemetryPort = 16060;
 };
 
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2509,14 +2509,18 @@ void MissionController::_updateTimeout()
                 case MAV_CMD_NAV_WAYPOINT:
                 case MAV_CMD_NAV_LAND:
                     if(pSimpleItem->coordinate().isValid()) {
+                        double alt = 0.0;
+                        if (!pSimpleItem->altitude()->rawValue().isNull()) {
+                            alt = pSimpleItem->altitude()->rawValue().toDouble();   // for some reason, the item's coordinate().altitude() is out of sync with the altitude()
+                        }
                         if((MAV_CMD)pSimpleItem->command() == MAV_CMD_NAV_TAKEOFF) {
                             takeoffCoordinate = pSimpleItem->coordinate();
+                            minAlt = maxAlt = alt;
                         } else if(!firstCoordinate.isValid()) {
                             firstCoordinate = pSimpleItem->coordinate();
                         }
                         double lat = pSimpleItem->coordinate().latitude()  + 90.0;
                         double lon = pSimpleItem->coordinate().longitude() + 180.0;
-                        double alt = pSimpleItem->coordinate().altitude();
                         north  = fmax(north, lat);
                         south  = fmin(south, lat);
                         east   = fmax(east,  lon);

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2511,10 +2511,11 @@ void MissionController::_updateTimeout()
                     if(pSimpleItem->coordinate().isValid()) {
                         double alt = 0.0;
                         if (!pSimpleItem->altitude()->rawValue().isNull()) {
-                            alt = pSimpleItem->altitude()->rawValue().toDouble();   // for some reason, the item's coordinate().altitude() is out of sync with the altitude()
+                            alt = pSimpleItem->altitude()->rawValue().toDouble();
                         }
                         if((MAV_CMD)pSimpleItem->command() == MAV_CMD_NAV_TAKEOFF) {
                             takeoffCoordinate = pSimpleItem->coordinate();
+                            takeoffCoordinate.setAltitude(alt);
                             minAlt = maxAlt = alt;
                         } else if(!firstCoordinate.isValid()) {
                             firstCoordinate = pSimpleItem->coordinate();

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2553,7 +2553,7 @@ void MissionController::_updateTimeout()
         }
     }
     //-- Figure out where this thing is taking off from
-     if(!takeoffCoordinate.isValid()) {
+    if(!takeoffCoordinate.isValid()) {
         if(firstCoordinate.isValid()) {
             takeoffCoordinate = firstCoordinate;
         } else {

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2652,7 +2652,3 @@ void MissionController::setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeM
         emit globalAltitudeModeChanged();
     }
 }
-
-double MissionController::plannedHomePositionAltitude() {
-    return _settingsItem->plannedHomePositionAltitude()->rawValue().toDouble();
-}

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2510,7 +2510,7 @@ void MissionController::_updateTimeout()
                 case MAV_CMD_NAV_LAND:
                     if(pSimpleItem->coordinate().isValid()) {
                         double alt = 0.0;
-                        if (!pSimpleItem->altitude()->rawValue().isNull()) {
+                        if (!pSimpleItem->altitude()->rawValue().isNull() && !qIsNaN(pSimpleItem->altitude()->rawValue().toDouble())) {
                             alt = pSimpleItem->altitude()->rawValue().toDouble();
                         }
                         if((MAV_CMD)pSimpleItem->command() == MAV_CMD_NAV_TAKEOFF) {
@@ -2553,7 +2553,7 @@ void MissionController::_updateTimeout()
         }
     }
     //-- Figure out where this thing is taking off from
-    if(!takeoffCoordinate.isValid()) {
+     if(!takeoffCoordinate.isValid()) {
         if(firstCoordinate.isValid()) {
             takeoffCoordinate = firstCoordinate;
         } else {
@@ -2651,4 +2651,8 @@ void MissionController::setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeM
         _globalAltMode = altMode;
         emit globalAltitudeModeChanged();
     }
+}
+
+double MissionController::plannedHomePositionAltitude() {
+    return _settingsItem->plannedHomePositionAltitude()->rawValue().toDouble();
 }

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -198,6 +198,8 @@ public:
     QGCGeoBoundingCube* travelBoundingCube  () { return &_travelBoundingCube; }
     QGeoCoordinate      takeoffCoordinate   () { return _takeoffCoordinate; }
 
+    double plannedHomePositionAltitude();
+
     // Overrides from PlanElementController
     bool supported                  (void) const final { return true; }
     void start                      (bool flyView) final;

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -198,8 +198,6 @@ public:
     QGCGeoBoundingCube* travelBoundingCube  () { return &_travelBoundingCube; }
     QGeoCoordinate      takeoffCoordinate   () { return _takeoffCoordinate; }
 
-    double plannedHomePositionAltitude();
-
     // Overrides from PlanElementController
     bool supported                  (void) const final { return true; }
     void start                      (bool flyView) final;

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -99,7 +99,7 @@ void PlanMasterController::start(void)
 
 #if defined(QGC_AIRMAP_ENABLED)
     //-- This assumes there is one single instance of PlanMasterController in edit mode.
-    if(!flyView) {
+    if(!_flyView) {
         // Wait for signal confirming AirMap client connection before starting flight planning
         connect(qgcApp()->toolbox()->airspaceManager(), &AirspaceManager::connectStatusChanged, this, &PlanMasterController::_startFlightPlanning);
     }

--- a/src/MissionManager/TakeoffMissionItem.cc
+++ b/src/MissionManager/TakeoffMissionItem.cc
@@ -66,6 +66,7 @@ void TakeoffMissionItem::_init(bool forLoad)
             homePosition = activeVehicle->homePosition();
             if (homePosition.isValid()) {
                 _settingsItem->setCoordinate(homePosition);
+                _settingsItem->coordinate().setAltitude(homePosition.altitude());
             }
         }
     }

--- a/src/MissionManager/TakeoffMissionItem.cc
+++ b/src/MissionManager/TakeoffMissionItem.cc
@@ -66,7 +66,6 @@ void TakeoffMissionItem::_init(bool forLoad)
             homePosition = activeVehicle->homePosition();
             if (homePosition.isValid()) {
                 _settingsItem->setCoordinate(homePosition);
-                _settingsItem->coordinate().setAltitude(homePosition.altitude());
             }
         }
     }


### PR DESCRIPTION
Resolves issues with AirMap's support in QGC to allow users to file flight plans, send telemetry and utilize AirMap's other services.

Also resolves an issue with altitude handling in creating the flight's bounding cube.

There is a related PR incoming that removes AirMap headers and libs from this repo in favor of downloading and installing the same at build time.