### PR TITLE
Add a hill region to testable TerrainQueries.

### DIFF
--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -911,7 +911,7 @@ QList<double> UnitTestTerrainQuery::_requestCoordinateHeights(const QList<QGeoCo
             double fraction = 1.0 * x / dx;
             result.append(std::round(UnitTestTerrainQuery::LinearSlopeRegion::minAMSLElevation + (fraction * UnitTestTerrainQuery::LinearSlopeRegion::totalElevationChange)));
         } else if (hillRegion.contains(coordinate)) {
-            double arc_second_meters = (6371000. / 3600.) * (M_PI / 180);
+            double arc_second_meters = (earths_radius_mts * one_second_deg) * (M_PI / 180);
             double x = (coordinate.latitude() - hillRegion.center().latitude()) * arc_second_meters / one_second_deg;
             double y = (coordinate.longitude() - hillRegion.center().longitude()) * arc_second_meters / one_second_deg;
             double x2y2 = pow(x, 2) + pow(y, 2);

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -828,6 +828,15 @@ const double UnitTestTerrainQuery::LinearSlopeRegion::minAMSLElevation  = -100;
 const double UnitTestTerrainQuery::LinearSlopeRegion::maxAMSLElevation  = 1000;
 const double UnitTestTerrainQuery::LinearSlopeRegion::totalElevationChange     = maxAMSLElevation - minAMSLElevation;
 
+const UnitTestTerrainQuery::HillRegion UnitTestTerrainQuery::hillRegion{{
+    linearSlopeRegion.topRight(),
+    QGeoCoordinate{
+        linearSlopeRegion.topRight().latitude() - UnitTestTerrainQuery::regionSizeDeg,
+        linearSlopeRegion.topRight().longitude() + UnitTestTerrainQuery::regionSizeDeg
+    }
+}};
+const double UnitTestTerrainQuery::HillRegion::radius = UnitTestTerrainQuery::regionSizeDeg / UnitTestTerrainQuery::one_second_deg;
+
 UnitTestTerrainQuery::UnitTestTerrainQuery(TerrainQueryInterface* parent)
     :TerrainQueryInterface(parent)
 {
@@ -892,6 +901,8 @@ QList<double> UnitTestTerrainQuery::_requestCoordinateHeights(const QList<QGeoCo
 {
     QList<double> result;
 
+    std::cout.precision(17);
+
     for (const auto& coordinate : coordinates) {
         if (flat10Region.contains(coordinate)) {
             result.append(UnitTestTerrainQuery::Flat10Region::amslElevation);
@@ -901,6 +912,19 @@ QList<double> UnitTestTerrainQuery::_requestCoordinateHeights(const QList<QGeoCo
             long dx = regionSizeDeg/one_second_deg;
             double fraction = 1.0 * x / dx;
             result.append(std::round(UnitTestTerrainQuery::LinearSlopeRegion::minAMSLElevation + (fraction * UnitTestTerrainQuery::LinearSlopeRegion::totalElevationChange)));
+        } else if (hillRegion.contains(coordinate)) {
+            double arc_second_meters = (6371000. / 3600.) * (M_PI / 180);
+            double x = (coordinate.latitude() - hillRegion.center().latitude()) * arc_second_meters / one_second_deg;
+            double y = (coordinate.longitude() - hillRegion.center().longitude()) * arc_second_meters / one_second_deg;
+            double x2y2 = pow(x, 2) + pow(y, 2);
+            double r2 = pow(UnitTestTerrainQuery::HillRegion::radius, 2);
+            double z;
+            if (x2y2 <= r2) {
+                z = sqrt(r2 - x2y2);
+            } else {
+                z = UnitTestTerrainQuery::Flat10Region::amslElevation;
+            }
+            result.append(z);
         } else {
             result.clear();
             break;

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -901,8 +901,6 @@ QList<double> UnitTestTerrainQuery::_requestCoordinateHeights(const QList<QGeoCo
 {
     QList<double> result;
 
-    std::cout.precision(17);
-
     for (const auto& coordinate : coordinates) {
         if (flat10Region.contains(coordinate)) {
             result.append(UnitTestTerrainQuery::Flat10Region::amslElevation);

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -21,6 +21,8 @@
 #include <QTimer>
 #include <QtLocation/private/qgeotiledmapreply_p.h>
 
+#include <iostream>
+
 Q_DECLARE_LOGGING_CATEGORY(TerrainQueryLog)
 Q_DECLARE_LOGGING_CATEGORY(TerrainQueryVerboseLog)
 
@@ -338,6 +340,18 @@ public:
         static const double totalElevationChange;
     };
     static const LinearSlopeRegion linearSlopeRegion;
+
+    /// Region with a hill (top half of a sphere) in the center.
+    struct HillRegion : public QGeoRectangle
+    {
+        HillRegion(const QGeoRectangle& region)
+            : QGeoRectangle(region)
+        {
+        }
+
+        static const double radius;
+    };
+    static const HillRegion hillRegion;
 
     UnitTestTerrainQuery(TerrainQueryInterface* parent = nullptr);
 

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -21,8 +21,6 @@
 #include <QTimer>
 #include <QtLocation/private/qgeotiledmapreply_p.h>
 
-#include <iostream>
-
 Q_DECLARE_LOGGING_CATEGORY(TerrainQueryLog)
 Q_DECLARE_LOGGING_CATEGORY(TerrainQueryVerboseLog)
 

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -305,8 +305,9 @@ private:
 class UnitTestTerrainQuery : public TerrainQueryInterface {
 public:
 
-    static constexpr double regionSizeDeg   = 0.1;      // all regions are 0.1deg (~11km) square
-    static constexpr double one_second_deg  = 1.0/3600;
+    static constexpr double regionSizeDeg     = 0.1;      // all regions are 0.1deg (~11km) square
+    static constexpr double one_second_deg    = 1.0/3600;
+    static constexpr double earths_radius_mts = 6371000.;
 
     /// Point Nemo is a point on Earth furthest from land
     static const QGeoCoordinate pointNemo;


### PR DESCRIPTION
`TerrainQueries` typically don't work in the test cycle, but a while back i have contributed [special areas around Point Nemo](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.h#L301) where testing terrain-following `TransectStyleComplexItems` works.

Yet, we were missing a hill to verify transects are breaking on its top as expected and for LoS analysis. This only adds another useful region next to ones that are already there.