### PR TITLE
QGCLocationPlugin.pri: remove unused condition for old workaround:

### DIFF
--- a/src/QtLocationPlugin/QGCLocationPlugin.pri
+++ b/src/QtLocationPlugin/QGCLocationPlugin.pri
@@ -9,14 +9,7 @@
 
 QT  += location-private positioning-private network
 
-contains(QT_VERSION, 5.5.1) {
-    message(Using Local QtLocation headers for Qt 5.5.1)
-    INCLUDEPATH += \
-        $$PWD/qtlocation/include \
-} else {
-    message(Using Default QtLocation headers)
-    INCLUDEPATH += $$QT.location.includes
-}
+INCLUDEPATH += $$QT.location.includes
 
 HEADERS += \
     $$PWD/QGCMapEngine.h \


### PR DESCRIPTION
apparently when QGC used qt 5.5.1 there was some issue with qtlocation and this was included here as a workaround for that qt bug. We've been out of that conflicting version for a long time, so it should be safe to remove this now. I haven't removed the actual folder that instruction was pointing to, I don't know if it is interesting to keep it for code navigation purposes. Let me know if you consider that should be removed as well and I will add it to this PR. Thanks!


