### PR TITLE
CameraTriggerIndicator: use a qml based icon instead:

### DIFF
--- a/src/FlightMap/MapItems/CameraTriggerIndicator.qml
+++ b/src/FlightMap/MapItems/CameraTriggerIndicator.qml
@@ -29,13 +29,39 @@ MapQuickItem {
 
         readonly property real _radius: ScreenTools.defaultFontPixelHeight * 0.6
 
-        QGCColoredImage {
-            anchors.margins:    3
-            anchors.fill:       parent
-            color:              "white"
-            mipmap:             true
-            fillMode:           Image.PreserveAspectFit
-            source:             "/qmlimages/camera.svg"
+        // Bigger rectangle of camera icon
+        Rectangle {
+            id:                       cameraIconFrameRectangle
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter:   parent.verticalCenter
+            height:                   width * 0.6
+            width:                    parent.width * 0.6
+            color:                    qgcPal.window
+            radius:                   4
+
+            // Little rectangle on top indicating viewfinder
+            Rectangle {
+                id:                       cameraIconViewFinderRectangle
+                anchors.horizontalCenter: cameraIconFrameRectangle.horizontalCenter
+                anchors.bottom:           cameraIconFrameRectangle.top
+                width:                    cameraIconFrameRectangle.width * 0.5
+                height:                   cameraIconFrameRectangle.height * 0.3
+                color:                    qgcPal.window
+                radius:                   2
+            }
+        }
+
+        // Circunference indicating the lens
+        Rectangle {
+            id:                      cameraIconLens
+            anchors.centerIn:        cameraIconFrameRectangle
+            height:                  width
+            width:                   cameraIconFrameRectangle.height * 0.9
+            color:                   "transparent"
+            border.color:            "black"
+            opacity:                 0.9
+            border.width:            2
+            radius:                  width * 0.5
         }
     }
 }


### PR DESCRIPTION
There were performance issues when too many icons of this kind were displayed on the map, probably because of the old image based nature of the icon. This commit changes it to a qml rectangles based icon. 

As discussed in issue #9501, the optimal way of addressing this would be by openGL shaders. This commit paints a camera icon based on qml rectangles instead, I am not familiarized with the openGL shaders approach right now, and I thought this could be a nice provisional fix.

The performance of QGC is not affected apparently anymore with this new icon. Some screenshots of the change:

Old icon:
![old](https://user-images.githubusercontent.com/18221398/110007891-737b9500-7d1b-11eb-9a4b-8a8ff11a9fff.jpg)

New icon:
![new](https://user-images.githubusercontent.com/18221398/110007903-77a7b280-7d1b-11eb-8b2e-066d6f663ca6.jpg)

Let me know your thoughts, I will be happy to change the PR if needed. Thanks!



