### PR TITLE
Use QtBluetooth enums from their namespace

### DIFF
--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -113,7 +113,7 @@ bool BluetoothLink::_hardwareConnect()
     _discoveryAgent->start();
 #else
     _createSocket();
-    _targetSocket->connectToService(QBluetoothAddress(qobject_cast<BluetoothConfiguration*>(_config.get())->device().address), QBluetoothUuid(QBluetoothUuid::SerialPort));
+    _targetSocket->connectToService(QBluetoothAddress(qobject_cast<BluetoothConfiguration*>(_config.get())->device().address), QBluetoothUuid(QBluetoothUuid::ServiceClassUuid::SerialPort));
 #endif
     return true;
 }


### PR DESCRIPTION
For increased type safety, some enums have been changed to
scoped enums in Qt 6.2, see
https://codereview.qt-project.org/c/qt/qtconnectivity/+/336678
This patch adapts qgroundcontrol to this change.
Since C++11, enums inject their symbols in both their own
and their parent namespace, so this patch can be merged right
now.

Signed-off-by: Andreas Buhr <andreas.buhr@qt.io>