### PR TITLE
Simple mission item: Fix add/remove of drag area onSpecifiesCoordinateChanged

### DIFF
--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -57,17 +57,23 @@ Item {
     }
 
     function showDragArea() {
-        if (!_dragAreaShowing && _missionItem.specifiesCoordinate) {
+        if (!_dragAreaShowing) {
             _dragArea = dragAreaComponent.createObject(map)
             _dragAreaShowing = true
         }
     }
 
+    function updateDragArea() {
+        if (_missionItem.isCurrentItem && map.planView && _missionItem.specifiesCoordinate) {
+            showDragArea()
+        } else {
+            hideDragArea()
+        }
+    }
+
     Component.onCompleted: {
         showItemVisuals()
-        if (_missionItem.isCurrentItem && map.planView) {
-            showDragArea()
-        }
+        updateDragArea()
     }
 
     Component.onDestruction: {
@@ -79,13 +85,8 @@ Item {
     Connections {
         target: _missionItem
 
-        onIsCurrentItemChanged: {
-            if (_missionItem.isCurrentItem && map.planView) {
-                showDragArea()
-            } else {
-                hideDragArea()
-            }
-        }
+        onIsCurrentItemChanged:         updateDragArea()
+        onSpecifiesCoordinateChanged:   updateDragArea()
     }
 
     // Control which is used to drag items


### PR DESCRIPTION
* If the command was changed from a command which specified a coordinate to a command which did not it was not tracked correctly. This caused param5/6 to get screwed up on the mission item.
* Fix #9468