### PR TITLE
deply: create_linux_appimage: Fix usage of QGC_CUSTOM_APP_NAME

### DIFF
--- a/deploy/create_linux_appimage.sh
+++ b/deploy/create_linux_appimage.sh
@@ -18,7 +18,7 @@ QGC_CUSTOM_APP_ICON="${QGC_CUSTOM_APP_ICON:-${QGC_SRC}/resources/icons/qgroundco
 QGC_CUSTOM_APP_ICON_NAME="${QGC_CUSTOM_APP_ICON_NAME:-QGroundControl}"
 
 if [ ! -f ${QGC_SRC}/qgroundcontrol.pro ]; then
-  echo "please specify path to $(QGC_CUSTOM_APP_NAME) source as the 1st argument"
+  echo "please specify path to ${QGC_CUSTOM_APP_NAME} source as the 1st argument"
   exit 1
 fi
 


### PR DESCRIPTION
`$(_)` is used for commands, for variables the correct is `${_}`

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


