### PR TITLE
libs/shapelib: Skip installing executables

### DIFF
--- a/libs/shapelib/CMakeLists.txt
+++ b/libs/shapelib/CMakeLists.txt
@@ -189,7 +189,7 @@ foreach(executable ${executables})
     get_target_property(${executable}_LOC ${executable} LOCATION)
     file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/script.sed "s?\\./${executable}?${${executable}_LOC}?\n")
   endif(BUILD_TEST)
-  install(TARGETS ${executable} DESTINATION ${CMAKE_INSTALL_BINDIR})
+  # install(TARGETS ${executable} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endforeach(executable ${executables})
 
 # Install header


### PR DESCRIPTION
.. which don't exist. The whole CMake file is a mess actually.
It would be much more elegant to add an option to turn it off.
Best of all in the upstream project and then adding it as a submodule here.

Anyway, this will workaround an error when running "make install".

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>


