### PR TITLE
qmake: Adding QGC_ENABLE_UNIX_INSTALLATION

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1447,5 +1447,27 @@ contains (CONFIG, QGC_DISABLE_INSTALLER_SETUP) {
     include(QGCPostLinkInstaller.pri)
 }
 
+#
+# Unix installation
+#
+
+contains (CONFIG, QGC_ENABLE_UNIX_INSTALLATION) {
+    message("binary: $${OUT_PWD}/$${DESTDIR}/QGroundControl")
+
+    bin_qgroundcontrol.path = $${PREFIX}/bin/
+    bin_qgroundcontrol.files = $${OUT_PWD}/$${DESTDIR}/QGroundControl
+
+    share_qgroundcontrol.path = $${PREFIX}/share/qgroundcontrol/
+    share_qgroundcontrol.files = $${IN_PWD}/resources/
+
+    share_pixmaps.path = $${PREFIX}/share/pixmaps/
+    share_pixmaps.files = $${IN_PWD}/resources/icons/qgroundcontrol.png
+
+    share_applications.path = $${PREFIX}/share/applications/
+    share_applications.files = $${IN_PWD}/deploy/qgroundcontrol.desktop
+
+    INSTALLS += bin_qgroundcontrol share_qgroundcontrol share_pixmaps share_applications
+}
+
 DISTFILES += \
     src/QmlControls/QGroundControl/Specific/qmldir

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1447,27 +1447,22 @@ contains (CONFIG, QGC_DISABLE_INSTALLER_SETUP) {
     include(QGCPostLinkInstaller.pri)
 }
 
-#
-# Unix installation
-#
-
-contains (CONFIG, QGC_ENABLE_UNIX_INSTALLATION) {
-    message("binary: $${OUT_PWD}/$${DESTDIR}/QGroundControl")
-
-    bin_qgroundcontrol.path = $${PREFIX}/bin/
-    bin_qgroundcontrol.files = $${OUT_PWD}/$${DESTDIR}/QGroundControl
-
-    share_qgroundcontrol.path = $${PREFIX}/share/qgroundcontrol/
-    share_qgroundcontrol.files = $${IN_PWD}/resources/
-
-    share_pixmaps.path = $${PREFIX}/share/pixmaps/
-    share_pixmaps.files = $${IN_PWD}/resources/icons/qgroundcontrol.png
-
-    share_applications.path = $${PREFIX}/share/applications/
-    share_applications.files = $${IN_PWD}/deploy/qgroundcontrol.desktop
-
-    INSTALLS += bin_qgroundcontrol share_qgroundcontrol share_pixmaps share_applications
-}
-
 DISTFILES += \
     src/QmlControls/QGroundControl/Specific/qmldir
+
+#
+# "install" target
+#
+
+bin_qgroundcontrol.path = $${PREFIX}/bin/
+bin_qgroundcontrol.files = $${OUT_PWD}/$${DESTDIR}/QGroundControl
+
+share_qgroundcontrol.path = $${PREFIX}/share/qgroundcontrol/
+share_qgroundcontrol.files = $${IN_PWD}/resources/
+
+share_pixmaps.path = $${PREFIX}/share/pixmaps/
+share_pixmaps.files = $${IN_PWD}/resources/icons/qgroundcontrol.png
+share_applications.path = $${PREFIX}/share/applications/
+share_applications.files = $${IN_PWD}/deploy/qgroundcontrol.desktop
+
+INSTALLS += bin_qgroundcontrol share_qgroundcontrol share_pixmaps share_applications

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1454,15 +1454,14 @@ DISTFILES += \
 # "install" target
 #
 
-bin_qgroundcontrol.path = $${PREFIX}/bin/
-bin_qgroundcontrol.files = $${OUT_PWD}/$${DESTDIR}/QGroundControl
+target.path = $${PREFIX}/bin/
 
 share_qgroundcontrol.path = $${PREFIX}/share/qgroundcontrol/
 share_qgroundcontrol.files = $${IN_PWD}/resources/
 
-share_pixmaps.path = $${PREFIX}/share/pixmaps/
-share_pixmaps.files = $${IN_PWD}/resources/icons/qgroundcontrol.png
+share_icons.path = $${PREFIX}/share/icons/hicolor/128x128/apps/
+share_icons.files = $${IN_PWD}/resources/icons/qgroundcontrol.png
 share_applications.path = $${PREFIX}/share/applications/
 share_applications.files = $${IN_PWD}/deploy/qgroundcontrol.desktop
 
-INSTALLS += bin_qgroundcontrol share_qgroundcontrol share_pixmaps share_applications
+INSTALLS += target share_qgroundcontrol share_icons share_applications


### PR DESCRIPTION
So we can install via "make install" like normal people and don't need to rely on own post-build-script copying stuff from right to left.

I was working on this while trying to make qmake working with flatpak's builder.
However, there was an issue - I think the make build template is not bug-free - so I had to switch to CMake.
Eventually, this might be useful for someone of you. Therefore sharing it :)

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com>


