### PR TITLE
Fix vehicle map item opacity

### DIFF
--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -31,6 +31,7 @@ MapQuickItem {
     anchorPoint.y:  vehicleItem.height / 2
     visible:        coordinate.isValid
 
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property bool   _adsbVehicle:   vehicle ? false : true
     property real   _uavSize:       ScreenTools.defaultFontPixelHeight * 5
     property real   _adsbSize:      ScreenTools.defaultFontPixelHeight * 2.5
@@ -41,7 +42,7 @@ MapQuickItem {
         id:         vehicleItem
         width:      vehicleIcon.width
         height:     vehicleIcon.height
-        opacity:    vehicle ? (vehicle.active ? 1.0 : 0.5) : 1.0
+        opacity:    (vehicle && _activeVehicle) ? ((vehicle === _activeVehicle) ? 1.0 : 0.5) : 1.0
 
         Rectangle {
             id:                 vehicleShadow

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -42,7 +42,7 @@ MapQuickItem {
         id:         vehicleItem
         width:      vehicleIcon.width
         height:     vehicleIcon.height
-        opacity:    (vehicle && _activeVehicle) ? ((vehicle === _activeVehicle) ? 1.0 : 0.5) : 1.0
+        opacity:    _adsbVehicle || vehicle === _activeVehicle ? 1.0 : 0.5
 
         Rectangle {
             id:                 vehicleShadow


### PR DESCRIPTION
Noticed at some point the active vehicle map icon kept being transparent instead of fully opaque. After investigating found that it relied on an old property `Vehicle.active` which got removed in 66753e2111b1b7139664f8e354f2919c5b2e37f2

This PR fixes that and brings back the opaque icon.

# Screenshots

Current:

![Screenshot from 2021-03-31 22-37-30](https://user-images.githubusercontent.com/9222431/113241793-fe956f80-9274-11eb-8f56-3234d3d087af.png)

Fix:

![Screenshot from 2021-03-31 22-38-29](https://user-images.githubusercontent.com/9222431/113241783-f89f8e80-9274-11eb-89f3-c073b985b4bc.png)

Fix (with mutliple vehicles):

![Screenshot from 2021-03-31 22-51-48](https://user-images.githubusercontent.com/9222431/113241759-ee7d9000-9274-11eb-9669-743279905b33.png)
