### PR TITLE
ScreenTools.qml: decouple font from default width/height

### DIFF
--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -162,7 +162,7 @@ Item {
     Text {
         id:     _textMeasure
         text:   "X"
-        font.family:    normalFontFamily
+        font.family:    "opensans"
         property real   fontWidth:    contentWidth
         property real   fontHeight:   contentHeight
         Component.onCompleted: {


### PR DESCRIPTION
I realized when changing the fonts in QGC all the proportions in the GUI go nuts. This is because screentools takes the base measurement from the font we are using.

This PR decouples the basic units of GUI from font used, so a change in font doesn't mess up with GUI proportions. I left hardcoded "opensans" which is the default until now.

I've tested adding new fonts and now the dimensions of the GUI are unaffected. 

I am not sure if this is the best way to approach this, let me know your thoughts please. Thanks!