### PR TITLE
Stability Fixes - Vehicle Link Manager Test

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -185,17 +185,25 @@ void APMFirmwarePlugin::_handleIncomingParamValue(Vehicle* vehicle, mavlink_mess
 
     paramValue.param_value = paramUnion.param_float;
 
-    // Re-Encoding is always done using mavlink 1.0 on channel 0
-    auto channel = LinkManager::reservedMavlinkChannel();
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
+    // Re-Encoding is always done using mavlink 1.0
+    auto mgr = qgcApp()->toolbox()->linkManager();
+    LinkInterface::Channel channel;
+    if (mgr) {
+        channel.reserve(*mgr);
+    }
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel.id());
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
 
     Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
     mavlink_msg_param_value_encode_chan(message->sysid,
                                         message->compid,
-                                        channel,
+                                        channel.id(),
                                         message,
                                         &paramValue);
+
+    if (mgr) {
+        channel.free(*mgr);
+    }
 }
 
 void APMFirmwarePlugin::_handleOutgoingParamSetThreadSafe(Vehicle* /*vehicle*/, LinkInterface* outgoingLink, mavlink_message_t* message)
@@ -356,9 +364,13 @@ QString APMFirmwarePlugin::_getMessageText(mavlink_message_t* message) const
 
 void APMFirmwarePlugin::_setInfoSeverity(mavlink_message_t* message) const
 {
-    // Re-Encoding is always done using mavlink 1.0 on channel 0
-    auto channel = LinkManager::reservedMavlinkChannel();
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
+    // Re-Encoding is always done using mavlink 1.0
+    auto mgr = qgcApp()->toolbox()->linkManager();
+    LinkInterface::Channel channel;
+    if (mgr) {
+        channel.reserve(*mgr);
+    }
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel.id());
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
 
     mavlink_statustext_t statusText;
@@ -369,9 +381,13 @@ void APMFirmwarePlugin::_setInfoSeverity(mavlink_message_t* message) const
     Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
     mavlink_msg_statustext_encode_chan(message->sysid,
                                        message->compid,
-                                       channel,
+                                       channel.id(),
                                        message,
                                        &statusText);
+
+    if (mgr) {
+        channel.free(*mgr);
+    }
 }
 
 void APMFirmwarePlugin::_adjustCalibrationMessageSeverity(mavlink_message_t* message) const
@@ -379,18 +395,26 @@ void APMFirmwarePlugin::_adjustCalibrationMessageSeverity(mavlink_message_t* mes
     mavlink_statustext_t statusText;
     mavlink_msg_statustext_decode(message, &statusText);
 
-    // Re-Encoding is always done using mavlink 1.0 on channel 0
-    auto channel = LinkManager::reservedMavlinkChannel();
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
+    // Re-Encoding is always done using mavlink 1.0
+    auto mgr = qgcApp()->toolbox()->linkManager();
+    LinkInterface::Channel channel;
+    if (mgr) {
+        channel.reserve(*mgr);
+    }
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel.id());
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
     statusText.severity = MAV_SEVERITY_INFO;
 
     Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
     mavlink_msg_statustext_encode_chan(message->sysid,
                                        message->compid,
-                                       channel,
+                                       channel.id(),
                                        message,
                                        &statusText);
+
+    if (mgr) {
+        channel.free(*mgr);
+    }
 }
 
 void APMFirmwarePlugin::initializeStreamRates(Vehicle* vehicle)

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -748,12 +748,10 @@ void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
 
     setGuidedMode(vehicle, true);
 
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t                       msg;
         mavlink_set_position_target_local_ned_t cmd;
-        SharedLinkInterfacePtr                  sharedLink = weakLink.lock();
-
 
         memset(&cmd, 0, sizeof(cmd));
 
@@ -893,10 +891,9 @@ QString APMFirmwarePlugin::_versionRegex() {
 
 void APMFirmwarePlugin::_handleRCChannels(Vehicle* vehicle, mavlink_message_t* message)
 {
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_rc_channels_t   channels;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
         mavlink_msg_rc_channels_decode(message, &channels);
         //-- Ardupilot uses 0-255 to indicate 0-100% where QGC expects 0-100
@@ -915,10 +912,9 @@ void APMFirmwarePlugin::_handleRCChannels(Vehicle* vehicle, mavlink_message_t* m
 
 void APMFirmwarePlugin::_handleRCChannelsRaw(Vehicle* vehicle, mavlink_message_t *message)
 {
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_rc_channels_raw_t   channels;
-        SharedLinkInterfacePtr      sharedLink = weakLink.lock();
 
         mavlink_msg_rc_channels_raw_decode(message, &channels);
         //-- Ardupilot uses 0-255 to indicate 0-100% where QGC expects 0-100
@@ -956,11 +952,10 @@ void APMFirmwarePlugin::_sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMoti
         return;
     }
 
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         MAVLinkProtocol*                mavlinkProtocol = qgcApp()->toolbox()->mavlinkProtocol();
         mavlink_global_position_int_t   globalPositionInt;
-        SharedLinkInterfacePtr          sharedLink = weakLink.lock();
 
         memset(&globalPositionInt, 0, sizeof(globalPositionInt));
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -120,6 +120,9 @@ private:
 
     static const char*      _artooIP;
     static const int        _artooVideoHandshakePort;
+
+    static uint8_t          _reencodeMavlinkChannel();
+    static QMutex&          _reencodeMavlinkChannelMutex();
 };
 
 #endif

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -97,12 +97,11 @@ void InitialConnectStateMachine::_stateRequestCapabilities(StateMachine* stateMa
     Vehicle*                    vehicle         = connectMachine->_vehicle;
     WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
 
+    SharedLinkInterfacePtr sharedLink = weakLink.lock();
     if (weakLink.expired()) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestCapabilities Skipping capability request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "Skipping capability request due to link type";
             connectMachine->advance();

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -95,10 +95,9 @@ void InitialConnectStateMachine::_stateRequestCapabilities(StateMachine* stateMa
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    SharedLinkInterfacePtr sharedLink = weakLink.lock();
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestCapabilities Skipping capability request due to no primary link";
         connectMachine->advance();
     } else {
@@ -206,14 +205,12 @@ void InitialConnectStateMachine::_stateRequestProtocolVersion(StateMachine* stat
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestProtocolVersion Skipping protocol version request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestProtocolVersion Skipping protocol version request due to link type";
             connectMachine->advance();
@@ -315,17 +312,15 @@ void InitialConnectStateMachine::_stateRequestMission(StateMachine* stateMachine
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
     disconnect(vehicle->_parameterManager, &ParameterManager::loadProgressChanged, connectMachine,
             &InitialConnectStateMachine::gotProgressUpdate);
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestMission: Skipping first mission load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestMission: Skipping first mission load request due to link type";
             vehicle->_firstMissionLoadComplete();
@@ -340,14 +335,12 @@ void InitialConnectStateMachine::_stateRequestGeoFence(StateMachine* stateMachin
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestGeoFence: Skipping first geofence load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestGeoFence: Skipping first geofence load request due to link type";
             vehicle->_firstGeoFenceLoadComplete();
@@ -367,14 +360,12 @@ void InitialConnectStateMachine::_stateRequestRallyPoints(StateMachine* stateMac
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestRallyPoints: Skipping first rally point load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestRallyPoints: Skipping first rally point load request due to link type";
             vehicle->_firstRallyPointLoadComplete();

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1477,7 +1477,7 @@ void Vehicle::_handlePing(LinkInterface* link, mavlink_message_t& message)
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog) << "_handlePing: primary link gone!";
+        qCDebug(VehicleLog) << "_handlePing: primary link gone!";
         return;
     }
 
@@ -1951,7 +1951,7 @@ void Vehicle::setFlightMode(const QString& flightMode)
     if (_firmwarePlugin->setFlightMode(flightMode, &base_mode, &custom_mode)) {
         SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
         if (!sharedLink) {
-            qDebug(VehicleLog) << "setFlightMode: primary link gone!";
+            qCDebug(VehicleLog) << "setFlightMode: primary link gone!";
             return;
         }
 
@@ -1971,7 +1971,7 @@ void Vehicle::setFlightMode(const QString& flightMode)
                                        custom_mode);
         sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     } else {
-        qWarning() << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
+        qCWarning(VehicleLog) << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
     }
 }
 
@@ -1990,7 +1990,7 @@ void Vehicle::requestDataStream(MAV_DATA_STREAM stream, uint16_t rate, bool send
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog) << "requestDataStream: primary link gone!";
+        qCDebug(VehicleLog) << "requestDataStream: primary link gone!";
         return;
     }
 
@@ -2126,7 +2126,7 @@ void Vehicle::_firstRallyPointLoadComplete()
 
 void Vehicle::_parametersReady(bool parametersReady)
 {
-    qDebug() << "_parametersReady" << parametersReady;
+    qCDebug(VehicleLog) << "_parametersReady" << parametersReady;
 
     // Try to set current unix time to the vehicle
     _sendQGCTimeToVehicle();
@@ -2143,7 +2143,7 @@ void Vehicle::_sendQGCTimeToVehicle()
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog) << "_sendQGCTimeToVehicle: primary link gone!";
+        qCDebug(VehicleLog) << "_sendQGCTimeToVehicle: primary link gone!";
         return;
     }
 
@@ -2589,7 +2589,7 @@ void Vehicle::setCurrentMissionSequence(int seq)
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog) << "setCurrentMissionSequence: primary link gone!";
+        qCDebug(VehicleLog) << "setCurrentMissionSequence: primary link gone!";
         return;
     }
 
@@ -3130,7 +3130,7 @@ void Vehicle::startCalibration(Vehicle::CalibrationType calType)
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog) << "startCalibration: primary link gone!";
+        qCDebug(VehicleLog) << "startCalibration: primary link gone!";
         return;
     }
 
@@ -3257,7 +3257,7 @@ void Vehicle::setOfflineEditingDefaultComponentId(int defaultComponentId)
     if (_offlineEditingVehicle) {
         _defaultComponentId = defaultComponentId;
     } else {
-        qWarning() << "Call to Vehicle::setOfflineEditingDefaultComponentId on vehicle which is not offline";
+        qCWarning(VehicleLog) << "Call to Vehicle::setOfflineEditingDefaultComponentId on vehicle which is not offline";
     }
 }
 
@@ -3286,7 +3286,7 @@ void Vehicle::_ackMavlinkLogData(uint16_t sequence)
 {
     SharedLinkInterfacePtr  sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog) << "_ackMavlinkLogData: primary link gone!";
+        qCDebug(VehicleLog) << "_ackMavlinkLogData: primary link gone!";
         return;
     }
 
@@ -3788,7 +3788,7 @@ void Vehicle::sendParamMapRC(const QString& paramName, double scale, double cent
 {
     SharedLinkInterfacePtr  sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog) << "sendParamMapRC: primary link gone!";
+        qCDebug(VehicleLog) << "sendParamMapRC: primary link gone!";
         return;
     }
 
@@ -3822,7 +3822,7 @@ void Vehicle::clearAllParamMapRC(void)
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog)<< "clearAllParamMapRC: primary link gone!";
+        qCDebug(VehicleLog)<< "clearAllParamMapRC: primary link gone!";
         return;
     }
 
@@ -3848,7 +3848,7 @@ void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, flo
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qDebug(VehicleLog)<< "sendJoystickDataThreadSafe: primary link gone!";
+        qCDebug(VehicleLog)<< "sendJoystickDataThreadSafe: primary link gone!";
         return;
     }
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -583,7 +583,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     unsigned mavlinkVersion = _mavlink->getCurrentVersion();
     if (_maxProtoVersion != mavlinkVersion && mavlinkVersion >= 200) {
         _maxProtoVersion = mavlinkVersion;
-        qCDebug(VehicleLog) << "Vehicle::_mavlinkMessageReceived Link already running Mavlink v2. Setting _maxProtoVersion" << _maxProtoVersion;
+        qCDebug(VehicleLog) << "_mavlinkMessageReceived Link already running Mavlink v2. Setting _maxProtoVersion" << _maxProtoVersion;
     }
 
     if (message.sysid != _id && message.sysid != 0) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1475,29 +1475,29 @@ void Vehicle::_updateArmed(bool armed)
 
 void Vehicle::_handlePing(LinkInterface* link, mavlink_message_t& message)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog) << "_handlePing: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    mavlink_ping_t      ping;
+    mavlink_message_t   msg;
 
-        mavlink_ping_t      ping;
-        mavlink_message_t   msg;
+    mavlink_msg_ping_decode(&message, &ping);
 
-        mavlink_msg_ping_decode(&message, &ping);
-
-        if ((ping.target_system == 0) && (ping.target_component == 0)) {
-            // Mavlink defines a ping request as a MSG_ID_PING which contains target_system = 0 and target_component = 0
-            // So only send a ping response when you receive a valid ping request
-            mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                                    sharedLink->mavlinkChannel(),
-                                    &msg,
-                                    ping.time_usec,
-                                    ping.seq,
-                                    message.sysid,
-                                    message.compid);
-            sendMessageOnLinkThreadSafe(link, msg);
-        }
+    if ((ping.target_system == 0) && (ping.target_component == 0)) {
+        // Mavlink defines a ping request as a MSG_ID_PING which contains target_system = 0 and target_component = 0
+        // So only send a ping response when you receive a valid ping request
+        mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                static_cast<uint8_t>(_mavlink->getComponentId()),
+                                sharedLink->mavlinkChannel(),
+                                &msg,
+                                ping.time_usec,
+                                ping.seq,
+                                message.sysid,
+                                message.compid);
+        sendMessageOnLinkThreadSafe(link, msg);
     }
 }
 
@@ -1948,26 +1948,27 @@ void Vehicle::setFlightMode(const QString& flightMode)
     uint32_t    custom_mode;
 
     if (_firmwarePlugin->setFlightMode(flightMode, &base_mode, &custom_mode)) {
-        WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-        if (!weakLink.expired()) {
-            uint8_t                 newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
-            SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-            // setFlightMode will only set MAV_MODE_FLAG_CUSTOM_MODE_ENABLED in base_mode, we need to move back in the existing
-            // states.
-            newBaseMode |= base_mode;
-
-            mavlink_message_t msg;
-            mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
-                                           _mavlink->getComponentId(),
-                                           sharedLink->mavlinkChannel(),
-                                           &msg,
-                                           id(),
-                                           newBaseMode,
-                                           custom_mode);
-            sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+        SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+        if (!sharedLink) {
+            qDebug(VehicleLog) << "setFlightMode: primary link gone!";
+            return;
         }
+
+        uint8_t newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
+
+        // setFlightMode will only set MAV_MODE_FLAG_CUSTOM_MODE_ENABLED in base_mode, we need to move back in the existing
+        // states.
+        newBaseMode |= base_mode;
+
+        mavlink_message_t msg;
+        mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
+                                       _mavlink->getComponentId(),
+                                       sharedLink->mavlinkChannel(),
+                                       &msg,
+                                       id(),
+                                       newBaseMode,
+                                       custom_mode);
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     } else {
         qWarning() << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
     }
@@ -1986,33 +1987,34 @@ QVariantList Vehicle::links() const {
 
 void Vehicle::requestDataStream(MAV_DATA_STREAM stream, uint16_t rate, bool sendMultiple)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog) << "requestDataStream: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        mavlink_message_t               msg;
-        mavlink_request_data_stream_t   dataStream;
-        SharedLinkInterfacePtr          sharedLink = weakLink.lock();
+    mavlink_message_t               msg;
+    mavlink_request_data_stream_t   dataStream;
 
-        memset(&dataStream, 0, sizeof(dataStream));
+    memset(&dataStream, 0, sizeof(dataStream));
 
-        dataStream.req_stream_id = stream;
-        dataStream.req_message_rate = rate;
-        dataStream.start_stop = 1;  // start
-        dataStream.target_system = id();
-        dataStream.target_component = _defaultComponentId;
+    dataStream.req_stream_id = stream;
+    dataStream.req_message_rate = rate;
+    dataStream.start_stop = 1;  // start
+    dataStream.target_system = id();
+    dataStream.target_component = _defaultComponentId;
 
-        mavlink_msg_request_data_stream_encode_chan(_mavlink->getSystemId(),
-                                                    _mavlink->getComponentId(),
-                                                    sharedLink->mavlinkChannel(),
-                                                    &msg,
-                                                    &dataStream);
+    mavlink_msg_request_data_stream_encode_chan(_mavlink->getSystemId(),
+                                                _mavlink->getComponentId(),
+                                                sharedLink->mavlinkChannel(),
+                                                &msg,
+                                                &dataStream);
 
-        if (sendMultiple) {
-            // We use sendMessageMultiple since we really want these to make it to the vehicle
-            sendMessageMultiple(msg);
-        } else {
-            sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
-        }
+    if (sendMultiple) {
+        // We use sendMessageMultiple since we really want these to make it to the vehicle
+        sendMessageMultiple(msg);
+    } else {
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
 }
 
@@ -2021,10 +2023,9 @@ void Vehicle::_sendMessageMultipleNext()
     if (_nextSendMessageMultipleIndex < _sendMessageMultipleList.count()) {
         qCDebug(VehicleLog) << "_sendMessageMultipleNext:" << _sendMessageMultipleList[_nextSendMessageMultipleIndex].message.msgid;
 
-        WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-        if (!weakLink.expired()) {
-            sendMessageOnLinkThreadSafe(weakLink.lock().get(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
+        SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+        if (sharedLink) {
+            sendMessageOnLinkThreadSafe(sharedLink.get(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
         }
 
         if (--_sendMessageMultipleList[_nextSendMessageMultipleIndex].retryCount <= 0) {
@@ -2139,25 +2140,26 @@ void Vehicle::_parametersReady(bool parametersReady)
 
 void Vehicle::_sendQGCTimeToVehicle()
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        mavlink_system_time_t   cmd;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        // Timestamp of the master clock in microseconds since UNIX epoch.
-        cmd.time_unix_usec = QDateTime::currentDateTime().currentMSecsSinceEpoch()*1000;
-        // Timestamp of the component clock since boot time in milliseconds (Not necessary).
-        cmd.time_boot_ms = 0;
-        mavlink_msg_system_time_encode_chan(_mavlink->getSystemId(),
-                                            _mavlink->getComponentId(),
-                                            sharedLink->mavlinkChannel(),
-                                            &msg,
-                                            &cmd);
-
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog) << "_sendQGCTimeToVehicle: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+    mavlink_system_time_t   cmd;
+
+    // Timestamp of the master clock in microseconds since UNIX epoch.
+    cmd.time_unix_usec = QDateTime::currentDateTime().currentMSecsSinceEpoch()*1000;
+    // Timestamp of the component clock since boot time in milliseconds (Not necessary).
+    cmd.time_boot_ms = 0;
+    mavlink_msg_system_time_encode_chan(_mavlink->getSystemId(),
+                                        _mavlink->getComponentId(),
+                                        sharedLink->mavlinkChannel(),
+                                        &msg,
+                                        &cmd);
+
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_imageReady(UASInterface*)
@@ -2584,25 +2586,26 @@ void Vehicle::emergencyStop()
 
 void Vehicle::setCurrentMissionSequence(int seq)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (!_firmwarePlugin->sendHomePositionToVehicle()) {
-            seq--;
-        }
-        mavlink_msg_mission_set_current_pack_chan(
-                    static_cast<uint8_t>(_mavlink->getSystemId()),
-                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                    sharedLink->mavlinkChannel(),
-                    &msg,
-                    static_cast<uint8_t>(id()),
-                    _compID,
-                    static_cast<uint16_t>(seq));
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog) << "setCurrentMissionSequence: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+
+    if (!_firmwarePlugin->sendHomePositionToVehicle()) {
+        seq--;
+    }
+    mavlink_msg_mission_set_current_pack_chan(
+                static_cast<uint8_t>(_mavlink->getSystemId()),
+                static_cast<uint8_t>(_mavlink->getComponentId()),
+                sharedLink->mavlinkChannel(),
+                &msg,
+                static_cast<uint8_t>(id()),
+                _compID,
+                static_cast<uint16_t>(seq));
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::sendMavCommand(int compId, MAV_CMD command, bool showError, float param1, float param2, float param3, float param4, float param5, float param6, float param7)
@@ -2787,56 +2790,57 @@ void Vehicle::_sendMavCommandFromList(int index)
 
     qCDebug(VehicleLog) << "_sendMavCommandFromList command:tryCount" << rawCommandName << commandEntry.tryCount;
 
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (commandEntry.useCommandInt) {
-            mavlink_command_int_t  cmd;
-
-            memset(&cmd, 0, sizeof(cmd));
-            cmd.target_system =     _id;
-            cmd.target_component =  commandEntry.targetCompId;
-            cmd.command =           commandEntry.command;
-            cmd.frame =             commandEntry.frame;
-            cmd.param1 =            commandEntry.rgParam[0];
-            cmd.param2 =            commandEntry.rgParam[1];
-            cmd.param3 =            commandEntry.rgParam[2];
-            cmd.param4 =            commandEntry.rgParam[3];
-            cmd.x =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[4] : commandEntry.rgParam[4] * 1e7;
-            cmd.y =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[5] : commandEntry.rgParam[5] * 1e7;
-            cmd.z =                 commandEntry.rgParam[6];
-            mavlink_msg_command_int_encode_chan(_mavlink->getSystemId(),
-                                                _mavlink->getComponentId(),
-                                                sharedLink->mavlinkChannel(),
-                                                &msg,
-                                                &cmd);
-        } else {
-            mavlink_command_long_t  cmd;
-
-            memset(&cmd, 0, sizeof(cmd));
-            cmd.target_system =     _id;
-            cmd.target_component =  commandEntry.targetCompId;
-            cmd.command =           commandEntry.command;
-            cmd.confirmation =      0;
-            cmd.param1 =            commandEntry.rgParam[0];
-            cmd.param2 =            commandEntry.rgParam[1];
-            cmd.param3 =            commandEntry.rgParam[2];
-            cmd.param4 =            commandEntry.rgParam[3];
-            cmd.param5 =            commandEntry.rgParam[4];
-            cmd.param6 =            commandEntry.rgParam[5];
-            cmd.param7 =            commandEntry.rgParam[6];
-            mavlink_msg_command_long_encode_chan(_mavlink->getSystemId(),
-                                                 _mavlink->getComponentId(),
-                                                 sharedLink->mavlinkChannel(),
-                                                 &msg,
-                                                 &cmd);
-        }
-
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_sendMavCommandFromList: primary link gone!";
+        return;
     }
+
+    mavlink_message_t  msg;
+
+    if (commandEntry.useCommandInt) {
+        mavlink_command_int_t  cmd;
+
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.target_system =     _id;
+        cmd.target_component =  commandEntry.targetCompId;
+        cmd.command =           commandEntry.command;
+        cmd.frame =             commandEntry.frame;
+        cmd.param1 =            commandEntry.rgParam[0];
+        cmd.param2 =            commandEntry.rgParam[1];
+        cmd.param3 =            commandEntry.rgParam[2];
+        cmd.param4 =            commandEntry.rgParam[3];
+        cmd.x =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[4] : commandEntry.rgParam[4] * 1e7;
+        cmd.y =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[5] : commandEntry.rgParam[5] * 1e7;
+        cmd.z =                 commandEntry.rgParam[6];
+        mavlink_msg_command_int_encode_chan(_mavlink->getSystemId(),
+                                            _mavlink->getComponentId(),
+                                            sharedLink->mavlinkChannel(),
+                                            &msg,
+                                            &cmd);
+    } else {
+        mavlink_command_long_t  cmd;
+
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.target_system =     _id;
+        cmd.target_component =  commandEntry.targetCompId;
+        cmd.command =           commandEntry.command;
+        cmd.confirmation =      0;
+        cmd.param1 =            commandEntry.rgParam[0];
+        cmd.param2 =            commandEntry.rgParam[1];
+        cmd.param3 =            commandEntry.rgParam[2];
+        cmd.param4 =            commandEntry.rgParam[3];
+        cmd.param5 =            commandEntry.rgParam[4];
+        cmd.param6 =            commandEntry.rgParam[5];
+        cmd.param7 =            commandEntry.rgParam[6];
+        mavlink_msg_command_long_encode_chan(_mavlink->getSystemId(),
+                                             _mavlink->getComponentId(),
+                                             sharedLink->mavlinkChannel(),
+                                             &msg,
+                                             &cmd);
+    }
+
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_sendMavCommandResponseTimeoutCheck(void)
@@ -3118,75 +3122,75 @@ void Vehicle::rebootVehicle()
 
 void Vehicle::startCalibration(Vehicle::CalibrationType calType)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
-        float param1 = 0;
-        float param2 = 0;
-        float param3 = 0;
-        float param4 = 0;
-        float param5 = 0;
-        float param6 = 0;
-        float param7 = 0;
-
-        switch (calType) {
-        case CalibrationGyro:
-            param1 = 1;
-            break;
-        case CalibrationMag:
-            param2 = 1;
-            break;
-        case CalibrationRadio:
-            param4 = 1;
-            break;
-        case CalibrationCopyTrims:
-            param4 = 2;
-            break;
-        case CalibrationAccel:
-            param5 = 1;
-            break;
-        case CalibrationLevel:
-            param5 = 2;
-            break;
-        case CalibrationEsc:
-            param7 = 1;
-            break;
-        case CalibrationPX4Airspeed:
-            param6 = 1;
-            break;
-        case CalibrationPX4Pressure:
-            param3 = 1;
-            break;
-        case CalibrationAPMCompassMot:
-            param6 = 1;
-            break;
-        case CalibrationAPMPressureAirspeed:
-            param3 = 1;
-            break;
-        case CalibrationAPMPreFlight:
-            param3 = 1; // GroundPressure/Airspeed
-            if (multiRotor() || rover()) {
-                // Gyro cal for ArduCopter only
-                param1 = 1;
-            }
-        }
-
-        // We can't use sendMavCommand here since we have no idea how long it will be before the command returns a result. This in turn
-        // causes the retry logic to break down.
-        mavlink_message_t msg;
-        mavlink_msg_command_long_pack_chan(_mavlink->getSystemId(),
-                                           _mavlink->getComponentId(),
-                                           sharedLink->mavlinkChannel(),
-                                           &msg,
-                                           id(),
-                                           defaultComponentId(),            // target component
-                                           MAV_CMD_PREFLIGHT_CALIBRATION,    // command id
-                                           0,                                // 0=first transmission of command
-                                           param1, param2, param3, param4, param5, param6, param7);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog) << "startCalibration: primary link gone!";
+        return;
     }
+
+    float param1 = 0;
+    float param2 = 0;
+    float param3 = 0;
+    float param4 = 0;
+    float param5 = 0;
+    float param6 = 0;
+    float param7 = 0;
+
+    switch (calType) {
+    case CalibrationGyro:
+        param1 = 1;
+        break;
+    case CalibrationMag:
+        param2 = 1;
+        break;
+    case CalibrationRadio:
+        param4 = 1;
+        break;
+    case CalibrationCopyTrims:
+        param4 = 2;
+        break;
+    case CalibrationAccel:
+        param5 = 1;
+        break;
+    case CalibrationLevel:
+        param5 = 2;
+        break;
+    case CalibrationEsc:
+        param7 = 1;
+        break;
+    case CalibrationPX4Airspeed:
+        param6 = 1;
+        break;
+    case CalibrationPX4Pressure:
+        param3 = 1;
+        break;
+    case CalibrationAPMCompassMot:
+        param6 = 1;
+        break;
+    case CalibrationAPMPressureAirspeed:
+        param3 = 1;
+        break;
+    case CalibrationAPMPreFlight:
+        param3 = 1; // GroundPressure/Airspeed
+        if (multiRotor() || rover()) {
+            // Gyro cal for ArduCopter only
+            param1 = 1;
+        }
+    }
+
+    // We can't use sendMavCommand here since we have no idea how long it will be before the command returns a result. This in turn
+    // causes the retry logic to break down.
+    mavlink_message_t msg;
+    mavlink_msg_command_long_pack_chan(_mavlink->getSystemId(),
+                                       _mavlink->getComponentId(),
+                                       sharedLink->mavlinkChannel(),
+                                       &msg,
+                                       id(),
+                                       defaultComponentId(),            // target component
+                                       MAV_CMD_PREFLIGHT_CALIBRATION,    // command id
+                                       0,                                // 0=first transmission of command
+                                       param1, param2, param3, param4, param5, param6, param7);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::stopCalibration(void)
@@ -3274,25 +3278,26 @@ void Vehicle::stopMavlinkLog()
 
 void Vehicle::_ackMavlinkLogData(uint16_t sequence)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        mavlink_message_t       msg;
-        mavlink_logging_ack_t   ack;
-
-        memset(&ack, 0, sizeof(ack));
-        ack.sequence = sequence;
-        ack.target_component = _defaultComponentId;
-        ack.target_system = id();
-        mavlink_msg_logging_ack_encode_chan(
-                    _mavlink->getSystemId(),
-                    _mavlink->getComponentId(),
-                    sharedLink->mavlinkChannel(),
-                    &msg,
-                    &ack);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr  sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog) << "_ackMavlinkLogData: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+    mavlink_logging_ack_t   ack;
+
+    memset(&ack, 0, sizeof(ack));
+    ack.sequence = sequence;
+    ack.target_component = _defaultComponentId;
+    ack.target_system = id();
+    mavlink_msg_logging_ack_encode_chan(
+                _mavlink->getSystemId(),
+                _mavlink->getComponentId(),
+                sharedLink->mavlinkChannel(),
+                &msg,
+                &ack);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_handleMavlinkLoggingData(mavlink_message_t& message)
@@ -3775,20 +3780,50 @@ void Vehicle::updateFlightDistance(double distance)
 
 void Vehicle::sendParamMapRC(const QString& paramName, double scale, double centerValue, int tuningID, double minValue, double maxValue)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr  sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog) << "sendParamMapRC: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        mavlink_message_t       message;
+    mavlink_message_t       message;
 
-        char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
-        // Copy string into buffer, ensuring not to exceed the buffer size
-        for (unsigned int i = 0; i < sizeof(param_id_cstr); i++) {
-            if ((int)i < paramName.length()) {
-                param_id_cstr[i] = paramName.toLatin1()[i];
-            }
+    char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
+    // Copy string into buffer, ensuring not to exceed the buffer size
+    for (unsigned int i = 0; i < sizeof(param_id_cstr); i++) {
+        if ((int)i < paramName.length()) {
+            param_id_cstr[i] = paramName.toLatin1()[i];
         }
+    }
 
+    mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                       static_cast<uint8_t>(_mavlink->getComponentId()),
+                                       sharedLink->mavlinkChannel(),
+                                       &message,
+                                       _id,
+                                       MAV_COMP_ID_AUTOPILOT1,
+                                       param_id_cstr,
+                                       -1,                                                  // parameter name specified as string in previous argument
+                                       static_cast<uint8_t>(tuningID),
+                                       static_cast<float>(scale),
+                                       static_cast<float>(centerValue),
+                                       static_cast<float>(minValue),
+                                       static_cast<float>(maxValue));
+    sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+}
+
+void Vehicle::clearAllParamMapRC(void)
+{
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog)<< "clearAllParamMapRC: primary link gone!";
+        return;
+    }
+
+    char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
+
+    for (int i = 0; i < 3; i++) {
+        mavlink_message_t message;
         mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
                                            static_cast<uint8_t>(_mavlink->getComponentId()),
                                            sharedLink->mavlinkChannel(),
@@ -3796,74 +3831,46 @@ void Vehicle::sendParamMapRC(const QString& paramName, double scale, double cent
                                            _id,
                                            MAV_COMP_ID_AUTOPILOT1,
                                            param_id_cstr,
-                                           -1,                                                  // parameter name specified as string in previous argument
-                                           static_cast<uint8_t>(tuningID),
-                                           static_cast<float>(scale),
-                                           static_cast<float>(centerValue),
-                                           static_cast<float>(minValue),
-                                           static_cast<float>(maxValue));
+                                           -2,                                                  // Disable map for specified tuning id
+                                           i,                                                   // tuning id
+                                           0, 0, 0, 0);                                         // unused
         sendMessageOnLinkThreadSafe(sharedLink.get(), message);
-    }
-}
-
-void Vehicle::clearAllParamMapRC(void)
-{
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
-
-        for (int i = 0; i < 3; i++) {
-            mavlink_message_t message;
-            mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                                               static_cast<uint8_t>(_mavlink->getComponentId()),
-                                               sharedLink->mavlinkChannel(),
-                                               &message,
-                                               _id,
-                                               MAV_COMP_ID_AUTOPILOT1,
-                                               param_id_cstr,
-                                               -2,                                                  // Disable map for specified tuning id
-                                               i,                                                   // tuning id
-                                               0, 0, 0, 0);                                         // unused
-            sendMessageOnLinkThreadSafe(sharedLink.get(), message);
-        }
     }
 }
 
 void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, float thrust, quint16 buttons)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (sharedLink->linkConfiguration()->isHighLatency()) {
-            return;
-        }
-
-        mavlink_message_t message;
-
-        // Incoming values are in the range -1:1
-        float axesScaling =         1.0 * 1000.0;
-        float newRollCommand =      roll * axesScaling;
-        float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
-        float newYawCommand    =    yaw * axesScaling;
-        float newThrustCommand =    thrust * axesScaling;
-
-        mavlink_msg_manual_control_pack_chan(
-                    static_cast<uint8_t>(_mavlink->getSystemId()),
-                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                    sharedLink->mavlinkChannel(),
-                    &message,
-                    static_cast<uint8_t>(_id),
-                    static_cast<int16_t>(newPitchCommand),
-                    static_cast<int16_t>(newRollCommand),
-                    static_cast<int16_t>(newThrustCommand),
-                    static_cast<int16_t>(newYawCommand),
-                    buttons);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qDebug(VehicleLog)<< "sendJoystickDataThreadSafe: primary link gone!";
+        return;
     }
+
+    if (sharedLink->linkConfiguration()->isHighLatency()) {
+        return;
+    }
+
+    mavlink_message_t message;
+
+    // Incoming values are in the range -1:1
+    float axesScaling =         1.0 * 1000.0;
+    float newRollCommand =      roll * axesScaling;
+    float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
+    float newYawCommand    =    yaw * axesScaling;
+    float newThrustCommand =    thrust * axesScaling;
+
+    mavlink_msg_manual_control_pack_chan(
+                static_cast<uint8_t>(_mavlink->getSystemId()),
+                static_cast<uint8_t>(_mavlink->getComponentId()),
+                sharedLink->mavlinkChannel(),
+                &message,
+                static_cast<uint8_t>(_id),
+                static_cast<int16_t>(newPitchCommand),
+                static_cast<int16_t>(newRollCommand),
+                static_cast<int16_t>(newThrustCommand),
+                static_cast<int16_t>(newYawCommand),
+                buttons);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), message);
 }
 
 void Vehicle::triggerSimpleCamera()

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1657,7 +1657,7 @@ void Vehicle::_handleRCChannels(mavlink_message_t& message)
 bool Vehicle::sendMessageOnLinkThreadSafe(LinkInterface* link, mavlink_message_t message)
 {
     if (!link->isConnected()) {
-        qCDebug(VehicleLog) << "sendMessageOnLinkThreadSafe" << QThread::currentThread() << this << link << "not connected!";
+        qCDebug(VehicleLog) << "sendMessageOnLinkThreadSafe" << link << "not connected!";
         return false;
     }
 
@@ -2735,31 +2735,29 @@ void Vehicle::_sendMavCommandWorker(bool commandInt, bool requestMessage, bool s
         return;
     }
 
-    if (sharedLink) {
-        MavCommandListEntry_t   entry;
+    MavCommandListEntry_t   entry;
 
-        entry.useCommandInt     = commandInt;
-        entry.targetCompId      = targetCompId;
-        entry.command           = command;
-        entry.frame             = frame;
-        entry.showError         = showError;
-        entry.requestMessage    = requestMessage;
-        entry.resultHandler     = resultHandler;
-        entry.resultHandlerData = resultHandlerData;
-        entry.rgParam[0]        = param1;
-        entry.rgParam[1]        = param2;
-        entry.rgParam[2]        = param3;
-        entry.rgParam[3]        = param4;
-        entry.rgParam[4]        = param5;
-        entry.rgParam[5]        = param6;
-        entry.rgParam[6]        = param7;
-        entry.maxTries          = _sendMavCommandShouldRetry(command) ? _mavCommandMaxRetryCount : 1;
-        entry.ackTimeoutMSecs   = sharedLink->linkConfiguration()->isHighLatency() ? _mavCommandAckTimeoutMSecsHighLatency : _mavCommandAckTimeoutMSecs;
-        entry.elapsedTimer.start();
+    entry.useCommandInt     = commandInt;
+    entry.targetCompId      = targetCompId;
+    entry.command           = command;
+    entry.frame             = frame;
+    entry.showError         = showError;
+    entry.requestMessage    = requestMessage;
+    entry.resultHandler     = resultHandler;
+    entry.resultHandlerData = resultHandlerData;
+    entry.rgParam[0]        = param1;
+    entry.rgParam[1]        = param2;
+    entry.rgParam[2]        = param3;
+    entry.rgParam[3]        = param4;
+    entry.rgParam[4]        = param5;
+    entry.rgParam[5]        = param6;
+    entry.rgParam[6]        = param7;
+    entry.maxTries          = _sendMavCommandShouldRetry(command) ? _mavCommandMaxRetryCount : 1;
+    entry.ackTimeoutMSecs   = sharedLink->linkConfiguration()->isHighLatency() ? _mavCommandAckTimeoutMSecsHighLatency : _mavCommandAckTimeoutMSecs;
+    entry.elapsedTimer.start();
 
-        _mavCommandList.append(entry);
-        _sendMavCommandFromList(_mavCommandList.count() - 1);
-    }
+    _mavCommandList.append(entry);
+    _sendMavCommandFromList(_mavCommandList.count() - 1);
 }
 
 void Vehicle::_sendMavCommandFromList(int index)
@@ -2978,7 +2976,6 @@ void Vehicle::_waitForMavlinkMessageClear(void)
 
 void Vehicle::_waitForMavlinkMessageMessageReceived(const mavlink_message_t& message)
 {
-    qCDebug(VehicleLog) << "_waitForMavlinkMessageMessageReceived" << message.msgid << "vs" << _waitForMavlinkMessageId;
     if (_waitForMavlinkMessageId != 0) {
         if (_waitForMavlinkMessageId == message.msgid) {
             WaitForMavlinkMessageResultHandler  resultHandler       = _waitForMavlinkMessageResultHandler;

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -167,12 +167,17 @@ void VehicleLinkManager::_addLink(LinkInterface* link)
         qCWarning(VehicleLinkManagerLog) << "_addLink call with link which is already in the list";
         return;
     } else {
+        SharedLinkInterfacePtr sharedLink = _linkMgr->sharedLinkInterfacePointerForLink(link);
+        if (!sharedLink) {
+            qCDebug(VehicleLinkManagerLog) << "_addLink stale link" << (void*)link;
+            return;
+        }
         qCDebug(VehicleLinkManagerLog) << "_addLink:" << link->linkConfiguration()->name() << QString("%1").arg((qulonglong)link, 0, 16);
 
         link->addVehicleReference();
 
         LinkInfo_t linkInfo;
-        linkInfo.link = _linkMgr->sharedLinkInterfacePointerForLink(link);
+        linkInfo.link = sharedLink;
         if (!link->linkConfiguration()->isHighLatency()) {
             linkInfo.heartbeatElapsedTimer.start();
         }
@@ -231,7 +236,7 @@ void VehicleLinkManager::_linkDisconnected(void)
     }
 }
 
-WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
+SharedLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
 {
 #ifndef NO_SERIAL_LINK
     // Best choice is a USB connection
@@ -264,9 +269,10 @@ WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
     }
 
     // Last possible choice is a high latency link
-    if (!_primaryLink.expired() && _primaryLink.lock().get()->linkConfiguration()->isHighLatency()) {
+    SharedLinkInterfacePtr link = _primaryLink.lock();
+    if (link && link->linkConfiguration()->isHighLatency()) {
         // Best choice continues to be the current high latency link
-        return _primaryLink;
+        return link;
     } else {
         // Pick any high latency link if one exists
         for (const LinkInfo_t& linkInfo: _rgLinkInfo) {
@@ -280,25 +286,26 @@ WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
         }
     }
 
-    return WeakLinkInterfacePtr();
+    return {};
 }
 
 bool VehicleLinkManager::_updatePrimaryLink(void)
 {
-    int linkIndex = _containsLinkIndex(_primaryLink.lock().get());
-    if (linkIndex != -1 && !_rgLinkInfo[linkIndex].commLost && !_rgLinkInfo[linkIndex].link->linkConfiguration()->isHighLatency()) {
+    SharedLinkInterfacePtr primaryLink = _primaryLink.lock();
+    int linkIndex = _containsLinkIndex(primaryLink.get());
+    if (linkIndex != -1 && !_rgLinkInfo[linkIndex].commLost && !primaryLink->linkConfiguration()->isHighLatency()) {
         // Current priority link is still valid
         return false;
     }
 
-    WeakLinkInterfacePtr bestActivePrimaryLink = _bestActivePrimaryLink();
+    SharedLinkInterfacePtr bestActivePrimaryLink = _bestActivePrimaryLink();
 
-    if (linkIndex != -1 && bestActivePrimaryLink.expired()) {
+    if (linkIndex != -1 && !bestActivePrimaryLink) {
         // Nothing better available, leave things set to current primary link
         return false;
     } else {
-        if (bestActivePrimaryLink.lock().get() != _primaryLink.lock().get()) {
-            if (!_primaryLink.expired() && _primaryLink.lock()->linkConfiguration()->isHighLatency()) {
+        if (bestActivePrimaryLink != primaryLink) {
+            if (primaryLink && primaryLink->linkConfiguration()->isHighLatency()) {
                 _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
                                MAV_CMD_CONTROL_HIGH_LATENCY,
                                true,
@@ -308,7 +315,7 @@ bool VehicleLinkManager::_updatePrimaryLink(void)
             _primaryLink = bestActivePrimaryLink;
             emit primaryLinkChanged();
 
-            if (!bestActivePrimaryLink.expired() && bestActivePrimaryLink.lock()->linkConfiguration()->isHighLatency()) {
+            if (bestActivePrimaryLink && bestActivePrimaryLink->linkConfiguration()->isHighLatency()) {
                 _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
                                MAV_CMD_CONTROL_HIGH_LATENCY,
                                true,
@@ -390,11 +397,10 @@ QStringList VehicleLinkManager::linkStatuses(void) const
 
 bool VehicleLinkManager::primaryLinkIsPX4Flow(void) const
 {
-    WeakLinkInterfacePtr nullWeak;
-
-    if (_primaryLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = _primaryLink.lock();
+    if (!sharedLink) {
         return false;
     } else {
-        return _primaryLink.lock()->isPX4Flow();
+        return sharedLink->isPX4Flow();
     }
 }

--- a/src/Vehicle/VehicleLinkManager.h
+++ b/src/Vehicle/VehicleLinkManager.h
@@ -73,7 +73,7 @@ private:
     void                    _removeLink             (LinkInterface* link);
     void                    _linkDisconnected       (void);
     bool                    _updatePrimaryLink      (void);
-    WeakLinkInterfacePtr    _bestActivePrimaryLink  (void);
+    SharedLinkInterfacePtr  _bestActivePrimaryLink  (void);
     void                    _commRegainedOnLink     (LinkInterface*  link);
 
     typedef struct LinkInfo {

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -51,7 +51,7 @@ void LinkInterface::_setMavlinkChannel(uint8_t channel)
     if (_mavlinkChannelSet) {
         qWarning() << "Mavlink channel set multiple times";
     }
-    qCDebug(LinkInterfaceLog) << QThread::currentThread() << this << "setMavlinkChannel" << channel;
+    qCDebug(LinkInterfaceLog) << "setMavlinkChannel" << channel;
     _mavlinkChannelSet = true;
     _mavlinkChannel = channel;
 }
@@ -61,7 +61,7 @@ void LinkInterface::_setMavlinkAuxChannel(uint8_t channel)
     if (_mavlinkAuxChannelSet) {
         qWarning() << "Mavlink channel set multiple times";
     }
-    qCDebug(LinkInterfaceLog) << QThread::currentThread() << this << "setMavlinkChannel" << channel;
+    qCDebug(LinkInterfaceLog) << "setMavlinkChannel" << channel;
     _mavlinkAuxChannelSet = true;
     _mavlinkAuxChannel = channel;
 }

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -37,7 +37,7 @@ LinkInterface::~LinkInterface()
 uint8_t LinkInterface::mavlinkChannel(void) const
 {
     if (!mavlinkChannelIsSet()) {
-        qCWarning(LinkInterfaceLog) << "Call to MAVLinkChannel::id with isSet() == false";
+        qCWarning(LinkInterfaceLog) << "mavlinkChannel isSet() == false";
     }
     return _mavlinkChannel;
 }

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -38,6 +38,14 @@ uint8_t LinkInterface::mavlinkChannel(void) const
     return _mavlinkChannel;
 }
 
+uint8_t LinkInterface::mavlinkAuxChannel(void) const
+{
+    if (!_mavlinkAuxChannelSet) {
+        qWarning(LinkInterfaceLog) << "Call to LinkInterface::mavlinkAuxChannel with _mavlinkAuxChannelSet == false";
+    }
+    return _mavlinkAuxChannel;
+}
+
 void LinkInterface::_setMavlinkChannel(uint8_t channel)
 {
     if (_mavlinkChannelSet) {
@@ -46,6 +54,16 @@ void LinkInterface::_setMavlinkChannel(uint8_t channel)
     qCDebug(LinkInterfaceLog) << QThread::currentThread() << this << "setMavlinkChannel" << channel;
     _mavlinkChannelSet = true;
     _mavlinkChannel = channel;
+}
+
+void LinkInterface::_setMavlinkAuxChannel(uint8_t channel)
+{
+    if (_mavlinkAuxChannelSet) {
+        qWarning() << "Mavlink channel set multiple times";
+    }
+    qCDebug(LinkInterfaceLog) << QThread::currentThread() << this << "setMavlinkChannel" << channel;
+    _mavlinkAuxChannelSet = true;
+    _mavlinkAuxChannel = channel;
 }
 
 void LinkInterface::writeBytesThreadSafe(const char *bytes, int length)

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -10,6 +10,8 @@
 #include "LinkInterface.h"
 #include "QGCApplication.h"
 
+QGC_LOGGING_CATEGORY(LinkInterfaceLog, "LinkInterfaceLog")
+
 LinkInterface::LinkInterface(SharedLinkConfigurationPtr& config, bool isPX4Flow)
     : QThread   (0)
     , _config   (config)
@@ -23,7 +25,7 @@ LinkInterface::LinkInterface(SharedLinkConfigurationPtr& config, bool isPX4Flow)
 LinkInterface::~LinkInterface()
 {
     if (_vehicleReferenceCount != 0) {
-        qWarning() << "~LinkInterface still have vehicle references:" << _vehicleReferenceCount;
+        qWarning(LinkInterfaceLog) << "~LinkInterface still have vehicle references:" << _vehicleReferenceCount;
     }
     _config.reset();
 }
@@ -31,7 +33,7 @@ LinkInterface::~LinkInterface()
 uint8_t LinkInterface::mavlinkChannel(void) const
 {
     if (!_mavlinkChannelSet) {
-        qWarning() << "Call to LinkInterface::mavlinkChannel with _mavlinkChannelSet == false";
+        qWarning(LinkInterfaceLog) << "Call to LinkInterface::mavlinkChannel with _mavlinkChannelSet == false";
     }
     return _mavlinkChannel;
 }
@@ -41,6 +43,7 @@ void LinkInterface::_setMavlinkChannel(uint8_t channel)
     if (_mavlinkChannelSet) {
         qWarning() << "Mavlink channel set multiple times";
     }
+    qCDebug(LinkInterfaceLog) << QThread::currentThread() << this << "setMavlinkChannel" << channel;
     _mavlinkChannelSet = true;
     _mavlinkChannel = channel;
 }
@@ -66,7 +69,7 @@ void LinkInterface::removeVehicleReference(void)
             disconnect();
         }
     } else {
-        qWarning() << "LinkInterface::removeVehicleReference called with no vehicle references";
+        qWarning(LinkInterfaceLog) << "LinkInterface::removeVehicleReference called with no vehicle references";
     }
 }
 

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -99,7 +99,7 @@ void LinkInterface::removeVehicleReference(void)
             disconnect();
         }
     } else {
-        qCWarning(LinkInterfaceLog) << "LinkInterface::removeVehicleReference called with no vehicle references";
+        qCWarning(LinkInterfaceLog) << "removeVehicleReference called with no vehicle references";
     }
 }
 

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -11,6 +11,7 @@
 
 #include <QThread>
 #include <QDateTime>
+#include <QLoggingCategory>
 #include <QMutex>
 #include <QMutexLocker>
 #include <QMetaType>
@@ -25,6 +26,8 @@
 #include "MavlinkMessagesTimer.h"
 
 class LinkManager;
+
+Q_DECLARE_LOGGING_CATEGORY(LinkInterfaceLog)
 
 /**
 * @brief The link interface defines the interface for all links used to communicate

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -61,6 +61,7 @@ public:
     virtual bool isLogReplay    (void) { return false; }
 
     uint8_t mavlinkChannel              (void) const;
+    uint8_t mavlinkAuxChannel           (void) const;
     bool    decodedFirstMavlinkPacket   (void) const { return _decodedFirstMavlinkPacket; }
     bool    setDecodedFirstMavlinkPacket(bool decodedFirstMavlinkPacket) { return _decodedFirstMavlinkPacket = decodedFirstMavlinkPacket; }
     void    writeBytesThreadSafe        (const char *bytes, int length);
@@ -86,12 +87,19 @@ private:
     // connect is private since all links should be created through LinkManager::createConnectedLink calls
     virtual bool _connect(void) = 0;
 
+    // Most links only need a single channel to use mavlink to process data.
+    // However, some Links (eg, MockLink) will use an additional channel.
+    virtual bool _needAuxChannel(void) { return false; }
+
     virtual void _writeBytes(const QByteArray) = 0; // Not thread safe, only writeBytesThreadSafe is thread safe
 
     void _setMavlinkChannel(uint8_t channel);
+    void _setMavlinkAuxChannel(uint8_t channel);
 
     bool    _mavlinkChannelSet          = false;
-    uint8_t _mavlinkChannel;
+    uint8_t _mavlinkChannel             = 0;
+    bool    _mavlinkAuxChannelSet       = false;
+    uint8_t _mavlinkAuxChannel          = 0;
     bool    _decodedFirstMavlinkPacket  = false;
     bool    _isPX4Flow                  = false;
     int     _vehicleReferenceCount      = 0;

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -24,7 +24,6 @@
 #include "QGCMAVLink.h"
 #include "LinkConfiguration.h"
 #include "MavlinkMessagesTimer.h"
-#include "MAVLinkChannel.h"
 
 class LinkManager;
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -137,7 +137,7 @@ bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr& config, bool i
     }
 
     if (link) {
-        if (false == link->_reserveMavlinkChannel(*this) ) {
+        if (false == link->_allocateMavlinkChannel() ) {
             qCWarning(LinkManagerLog) << "Link failed to setup mavlink channels";
             return false;
         }
@@ -198,7 +198,7 @@ void LinkManager::_linkDisconnected(void)
     disconnect(link, &LinkInterface::bytesSent,           _mavlinkProtocol,    &MAVLinkProtocol::logSentBytes);
     disconnect(link, &LinkInterface::disconnected,        this,                &LinkManager::_linkDisconnected);
 
-    link->_freeMavlinkChannel(*this);
+    link->_freeMavlinkChannel();
     for (int i=0; i<_rgLinks.count(); i++) {
         if (_rgLinks[i].get() == link) {
             qCDebug(LinkManagerLog) << "LinkManager::_linkDisconnected" << _rgLinks[i]->linkConfiguration()->name() << _rgLinks[i].use_count();
@@ -836,27 +836,30 @@ void LinkManager::startAutoConnectedLinks(void)
     }
 }
 
-uint8_t LinkManager::reserveMavlinkChannel(void)
+uint8_t LinkManager::allocateMavlinkChannel(void)
 {
-    // Find a mavlink channel to use for this link, Channel 0 is reserved for internal use.
-    for (uint8_t mavlinkChannel = 1; mavlinkChannel < MAVLINK_COMM_NUM_BUFFERS; mavlinkChannel++) {
+    // Find a mavlink channel to use for this link
+    for (uint8_t mavlinkChannel = 0; mavlinkChannel < MAVLINK_COMM_NUM_BUFFERS; mavlinkChannel++) {
         if (!(_mavlinkChannelsUsedBitMask & 1 << mavlinkChannel)) {
             mavlink_reset_channel_status(mavlinkChannel);
             // Start the channel on Mav 1 protocol
             mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(mavlinkChannel);
             mavlinkStatus->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
             _mavlinkChannelsUsedBitMask |= 1 << mavlinkChannel;
-            qCDebug(LinkManagerLog) << "reserveMavlinkChannel" << mavlinkChannel;
+            qCDebug(LinkManagerLog) << "allocateMavlinkChannel" << mavlinkChannel;
             return mavlinkChannel;
         }
     }
-    qWarning(LinkManagerLog) << "reserveMavlinkChannel: all channels reserved!";
-    return 0;   // All channels reserved
+    qWarning(LinkManagerLog) << "allocateMavlinkChannel: all channels reserved!";
+    return invalidMavlinkChannel();   // All channels reserved
 }
 
-void LinkManager::freeMavlinkChannel(int channel)
+void LinkManager::freeMavlinkChannel(uint8_t channel)
 {
-    qCDebug(LinkManagerLog) << "freeMavlinkChannel" << 0;
+    qCDebug(LinkManagerLog) << "freeMavlinkChannel" << channel;
+    if (invalidMavlinkChannel() == channel) {
+        return;
+    }
     _mavlinkChannelsUsedBitMask &= ~(1 << channel);
 }
 

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -13,6 +13,8 @@
 #include <QMultiMap>
 #include <QMutex>
 
+#include <limits>
+
 #include "LinkConfiguration.h"
 #include "LinkInterface.h"
 #include "QGCLoggingCategory.h"
@@ -112,8 +114,12 @@ public:
     // Override from QGCTool
     virtual void setToolbox(QGCToolbox *toolbox);
 
-    /// @return This mavlink channel is never assigned to a vehicle.
-    static uint8_t reservedMavlinkChannel(void) { return 0; }
+    static constexpr uint8_t invalidMavlinkChannel(void) { return std::numeric_limits<uint8_t>::max(); }
+
+    /// Allocates a mavlink channel for use
+    /// @return Mavlink channel index, invalidMavlinkChannel() for no channels available
+    uint8_t allocateMavlinkChannel(void);
+    void freeMavlinkChannel(uint8_t channel);
 
     /// If you are going to hold a reference to a LinkInterface* in your object you must reference count it
     /// by using this method to get access to the shared pointer.
@@ -124,11 +130,6 @@ public:
     SharedLinkConfigurationPtr addConfiguration(LinkConfiguration* config);
 
     void startAutoConnectedLinks(void);
-
-    /// Reserves a mavlink channel for use
-    /// @return Mavlink channel index, 0 for no channels available
-    uint8_t reserveMavlinkChannel(void);
-    void freeMavlinkChannel(int channel);
 
     static const char*  settingsGroup;
 

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -113,7 +113,7 @@ public:
     virtual void setToolbox(QGCToolbox *toolbox);
 
     /// @return This mavlink channel is never assigned to a vehicle.
-    uint8_t reservedMavlinkChannel(void) { return 0; }
+    static uint8_t reservedMavlinkChannel(void) { return 0; }
 
     /// If you are going to hold a reference to a LinkInterface* in your object you must reference count it
     /// by using this method to get access to the shared pointer.
@@ -127,7 +127,8 @@ public:
 
     /// Reserves a mavlink channel for use
     /// @return Mavlink channel index, 0 for no channels available
-    int _reserveMavlinkChannel(void);
+    uint8_t reserveMavlinkChannel(void);
+    void freeMavlinkChannel(int channel);
 
     static const char*  settingsGroup;
 
@@ -147,7 +148,6 @@ private:
     void                _removeConfiguration        (LinkConfiguration* config);
     void                _addUDPAutoConnectLink      (void);
     void                _addMAVLinkForwardingLink   (void);
-    void                _freeMavlinkChannel         (int channel);
     bool                _isSerialPortConnected      (void);
 
 #ifndef NO_SERIAL_LINK

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -205,6 +205,8 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
 
     uint8_t mavlinkChannel = link->mavlinkChannel();
 
+    qDebug(MAVLinkProtocolLog) << QThread::currentThread() << this << "receiveBytes" << b.size() << mavlinkChannel;
+
     for (int position = 0; position < b.size(); position++) {
         if (mavlink_parse_char(mavlinkChannel, static_cast<uint8_t>(b[position]), &_message, &_status)) {
             // Got a valid message

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -197,8 +197,9 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
     // Since receiveBytes signals cross threads we can end up with signals in the queue
     // that come through after the link is disconnected. For these we just drop the data
     // since the link is closed.
-    WeakLinkInterfacePtr linkPtr = _linkMgr->sharedLinkInterfacePointerForLink(link, true);
-    if (linkPtr.expired()) {
+    SharedLinkInterfacePtr linkPtr = _linkMgr->sharedLinkInterfacePointerForLink(link, true);
+    if (!linkPtr) {
+        qDebug(MAVLinkProtocolLog) << "receiveBytes: link gone!" << b.size() << " bytes arrived too late";
         return;
     }
 
@@ -363,7 +364,7 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
 
             // Anyone handling the message could close the connection, which deletes the link,
             // so we check if it's expired
-            if (linkPtr.expired()) {
+            if (1 == linkPtr.use_count()) {
                 break;
             }
 

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -199,13 +199,11 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
     // since the link is closed.
     SharedLinkInterfacePtr linkPtr = _linkMgr->sharedLinkInterfacePointerForLink(link, true);
     if (!linkPtr) {
-        qDebug(MAVLinkProtocolLog) << "receiveBytes: link gone!" << b.size() << " bytes arrived too late";
+        qCDebug(MAVLinkProtocolLog) << "receiveBytes: link gone!" << b.size() << " bytes arrived too late";
         return;
     }
 
     uint8_t mavlinkChannel = link->mavlinkChannel();
-
-    qDebug(MAVLinkProtocolLog) << QThread::currentThread() << this << "receiveBytes" << b.size() << mavlinkChannel;
 
     for (int position = 0; position < b.size(); position++) {
         if (mavlink_parse_char(mavlinkChannel, static_cast<uint8_t>(b[position]), &_message, &_status)) {
@@ -214,7 +212,7 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, QByteArray b)
                 link->setDecodedFirstMavlinkPacket(true);
                 mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(mavlinkChannel);
                 if (!(mavlinkStatus->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) && (mavlinkStatus->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)) {
-                    qDebug() << "Switching outbound to mavlink 2.0 due to incoming mavlink 2.0 packet:" << mavlinkStatus << mavlinkChannel << mavlinkStatus->flags;
+                    qCDebug(MAVLinkProtocolLog) << "Switching outbound to mavlink 2.0 due to incoming mavlink 2.0 packet:" << mavlinkStatus << mavlinkChannel << mavlinkStatus->flags;
                     mavlinkStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
                     // Set all links to v2
                     setVersion(200);
@@ -463,7 +461,7 @@ void MAVLinkProtocol::_startLogging(void)
                 return;
             }
 
-            qDebug() << "Temp log" << _tempLogFile.fileName();
+            qCDebug(MAVLinkProtocolLog) << "Temp log" << _tempLogFile.fileName();
             emit checkTelemetrySavePath();
 
             _logSuspendError = false;

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -60,7 +60,6 @@ MockLink::MockLink(SharedLinkConfigurationPtr& config)
     , _missionItemHandler                   (this, qgcApp()->toolbox()->mavlinkProtocol())
     , _name                                 ("MockLink")
     , _connected                            (false)
-    , _mavlinkChannel                       (0)
     , _vehicleComponentId                   (MAV_COMP_ID_AUTOPILOT1)
     , _inNSH                                (false)
     , _mavlinkStarted                       (true)
@@ -123,7 +122,7 @@ bool MockLink::_connect(void)
     if (!_connected) {
         _connected = true;
         // MockLinks use Mavlink 2.0
-        mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(_mavlinkChannel);
+        mavlink_status_t* mavlinkStatus = mavlink_get_channel_status(mavlinkChannel());
         mavlinkStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
         start();
         emit connected();
@@ -309,7 +308,7 @@ void MockLink::_sendHeartBeat(void)
 
     mavlink_msg_heartbeat_pack_chan(_vehicleSystemId,
                                     _vehicleComponentId,
-                                    _mavlinkChannel,
+                                    mavlinkChannel(),
                                     &msg,
                                     _vehicleType,        // MAV_TYPE
                                     _firmwareType,      // MAV_AUTOPILOT
@@ -330,7 +329,7 @@ void MockLink::_sendHighLatency2(void)
     qDebug() << "Sending" << _mavCustomMode;
     mavlink_msg_high_latency2_pack_chan(_vehicleSystemId,
                                         _vehicleComponentId,
-                                        _mavlinkChannel,
+                                        mavlinkChannel(),
                                         &msg,
                                         0,                          // timestamp
                                         _vehicleType,               // MAV_TYPE
@@ -366,7 +365,7 @@ void MockLink::_sendSysStatus(void)
     mavlink_msg_sys_status_pack_chan(
                 _vehicleSystemId,
                 _vehicleComponentId,
-                static_cast<uint8_t>(_mavlinkChannel),
+                static_cast<uint8_t>(mavlinkChannel()),
                 &msg,
                 0,          // onboard_control_sensors_present
                 0,          // onboard_control_sensors_enabled
@@ -423,7 +422,7 @@ void MockLink::_sendBatteryStatus(void)
     mavlink_msg_battery_status_pack_chan(
                 _vehicleSystemId,
                 _vehicleComponentId,
-                static_cast<uint8_t>(_mavlinkChannel),
+                static_cast<uint8_t>(mavlinkChannel()),
                 &msg,
                 1,                          // battery id
                 MAV_BATTERY_FUNCTION_ALL,
@@ -444,7 +443,7 @@ void MockLink::_sendBatteryStatus(void)
     mavlink_msg_battery_status_pack_chan(
                 _vehicleSystemId,
                 _vehicleComponentId,
-                static_cast<uint8_t>(_mavlinkChannel),
+                static_cast<uint8_t>(mavlinkChannel()),
                 &msg,
                 2,                          // battery id
                 MAV_BATTERY_FUNCTION_ALL,
@@ -470,7 +469,7 @@ void MockLink::_sendVibration(void)
 
     mavlink_msg_vibration_pack_chan(_vehicleSystemId,
                                     _vehicleComponentId,
-                                    _mavlinkChannel,
+                                    mavlinkChannel(),
                                     &msg,
                                     0,       // time_usec
                                     50.5,    // vibration_x,
@@ -547,7 +546,7 @@ void MockLink::_handleIncomingMavlinkBytes(const uint8_t* bytes, int cBytes)
 
     for (qint64 i=0; i<cBytes; i++)
     {
-        if (!mavlink_parse_char(_mavlinkChannel, bytes[i], &msg, &comm)) {
+        if (!mavlink_parse_char(mavlinkChannel(), bytes[i], &msg, &comm)) {
             continue;
         }
 
@@ -815,7 +814,7 @@ void MockLink::_paramRequestListWorker(void)
 
         mavlink_msg_param_value_pack_chan(_vehicleSystemId,
                                           componentId,                                   // component id
-                                          _mavlinkChannel,
+                                          mavlinkChannel(),
                                           &responseMsg,                                  // Outgoing message
                                           paramId,                                       // Parameter name
                                           _floatUnionForParam(componentId, paramName),   // Parameter value
@@ -864,7 +863,7 @@ void MockLink::_handleParamSet(const mavlink_message_t& msg)
     mavlink_message_t responseMsg;
     mavlink_msg_param_value_pack_chan(_vehicleSystemId,
                                       componentId,                                               // component id
-                                      _mavlinkChannel,
+                                      mavlinkChannel(),
                                       &responseMsg,                                              // Outgoing message
                                       paramId,                                                   // Parameter name
                                       request.param_value,                                       // Send same value back
@@ -891,7 +890,7 @@ void MockLink::_handleParamRequestRead(const mavlink_message_t& msg)
         // Special case of magic hash check value
         mavlink_msg_param_value_pack_chan(_vehicleSystemId,
                                           componentId,
-                                          _mavlinkChannel,
+                                          mavlinkChannel(),
                                           &responseMsg,
                                           request.param_id,
                                           valueUnion.param_float,
@@ -933,7 +932,7 @@ void MockLink::_handleParamRequestRead(const mavlink_message_t& msg)
 
     mavlink_msg_param_value_pack_chan(_vehicleSystemId,
                                       componentId,                                               // component id
-                                      _mavlinkChannel,
+                                      mavlinkChannel(),
                                       &responseMsg,                                              // Outgoing message
                                       paramId,                                                   // Parameter name
                                       _floatUnionForParam(componentId, paramId),                 // Parameter value
@@ -955,7 +954,7 @@ void MockLink::emitRemoteControlChannelRawChanged(int channel, uint16_t raw)
     mavlink_message_t responseMsg;
     mavlink_msg_rc_channels_pack_chan(_vehicleSystemId,
                                       _vehicleComponentId,
-                                      _mavlinkChannel,
+                                      mavlinkChannel(),
                                       &responseMsg,          // Outgoing message
                                       0,                     // time since boot, ignored
                                       18,                    // channel count
@@ -1073,7 +1072,7 @@ void MockLink::_handleCommandLong(const mavlink_message_t& msg)
     mavlink_message_t commandAck;
     mavlink_msg_command_ack_pack_chan(_vehicleSystemId,
                                       _vehicleComponentId,
-                                      _mavlinkChannel,
+                                      mavlinkChannel(),
                                       &commandAck,
                                       request.command,
                                       commandResult,
@@ -1089,7 +1088,7 @@ void MockLink::sendUnexpectedCommandAck(MAV_CMD command, MAV_RESULT ackResult)
     mavlink_message_t commandAck;
     mavlink_msg_command_ack_pack_chan(_vehicleSystemId,
                                       _vehicleComponentId,
-                                      _mavlinkChannel,
+                                      mavlinkChannel(),
                                       &commandAck,
                                       command,
                                       ackResult,
@@ -1134,7 +1133,7 @@ void MockLink::_respondWithAutopilotVersion(void)
 
     mavlink_msg_autopilot_version_pack_chan(_vehicleSystemId,
                                             _vehicleComponentId,
-                                            _mavlinkChannel,
+                                            mavlinkChannel(),
                                             &msg,
                                             capabilities,
                                             flightVersion,                   // flight_sw_version,
@@ -1168,7 +1167,7 @@ void MockLink::_sendHomePosition(void)
 
     mavlink_msg_home_position_pack_chan(_vehicleSystemId,
                                         _vehicleComponentId,
-                                        _mavlinkChannel,
+                                        mavlinkChannel(),
                                         &msg,
                                         (int32_t)(_vehicleLatitude * 1E7),
                                         (int32_t)(_vehicleLongitude * 1E7),
@@ -1187,7 +1186,7 @@ void MockLink::_sendGpsRawInt(void)
 
     mavlink_msg_gps_raw_int_pack_chan(_vehicleSystemId,
                                       _vehicleComponentId,
-                                      _mavlinkChannel,
+                                      mavlinkChannel(),
                                       &msg,
                                       timeTick++,                           // time since boot
                                       3,                                    // 3D fix
@@ -1235,7 +1234,7 @@ void MockLink::_sendChunkedStatusText(uint16_t chunkId, bool missingChunks)
 
         mavlink_msg_statustext_pack_chan(_vehicleSystemId,
                                          _vehicleComponentId,
-                                         _mavlinkChannel,
+                                         mavlinkChannel(),
                                          &msg,
                                          MAV_SEVERITY_INFO,
                                          msgBuf,
@@ -1272,7 +1271,7 @@ void MockLink::_sendStatusTextMessages(void)
 
         mavlink_msg_statustext_pack_chan(_vehicleSystemId,
                                          _vehicleComponentId,
-                                         _mavlinkChannel,
+                                         mavlinkChannel(),
                                          &msg,
                                          status->severity,
                                          status->msg,
@@ -1410,7 +1409,7 @@ void MockLink::_sendRCChannels(void)
 
     mavlink_msg_rc_channels_pack_chan(_vehicleSystemId,
                                       _vehicleComponentId,
-                                      _mavlinkChannel,
+                                      mavlinkChannel(),
                                       &msg,
                                       0,                     // time_boot_ms
                                       16,                    // chancount
@@ -1446,7 +1445,7 @@ void MockLink::_handlePreFlightCalibration(const mavlink_command_long_t& request
     mavlink_message_t msg;
     mavlink_msg_statustext_pack_chan(_vehicleSystemId,
                                      _vehicleComponentId,
-                                     _mavlinkChannel,
+                                     mavlinkChannel(),
                                      &msg,
                                      MAV_SEVERITY_INFO,
                                      pCalMessage,
@@ -1468,7 +1467,7 @@ void MockLink::_handleLogRequestList(const mavlink_message_t& msg)
     mavlink_message_t responseMsg;
     mavlink_msg_log_entry_pack_chan(_vehicleSystemId,
                                     _vehicleComponentId,
-                                    _mavlinkChannel,
+                                    mavlinkChannel(),
                                     &responseMsg,
                                     _logDownloadLogId,       // log id
                                     1,                       // num_logs
@@ -1524,7 +1523,7 @@ void MockLink::_logDownloadWorker(void)
             mavlink_message_t responseMsg;
             mavlink_msg_log_data_pack_chan(_vehicleSystemId,
                                            _vehicleComponentId,
-                                           _mavlinkChannel,
+                                           mavlinkChannel(),
                                            &responseMsg,
                                            _logDownloadLogId,
                                            _logDownloadCurrentOffset,
@@ -1551,7 +1550,7 @@ void MockLink::_sendADSBVehicles(void)
     mavlink_message_t responseMsg;
     mavlink_msg_adsb_vehicle_pack_chan(_vehicleSystemId,
                                        _vehicleComponentId,
-                                       _mavlinkChannel,
+                                       mavlinkChannel(),
                                        &responseMsg,
                                        12345,                                       // ICAO address
                                        _adsbVehicleCoordinate.latitude() * 1e7,
@@ -1598,7 +1597,7 @@ bool MockLink::_handleRequestMessage(const mavlink_command_long_t& request, bool
         mavlink_message_t   responseMsg;
         mavlink_msg_debug_pack_chan(_vehicleSystemId,
                                     _vehicleComponentId,
-                                    _mavlinkChannel,
+                                    mavlinkChannel(),
                                     &responseMsg,
                                     0, 0, 0);
         respondWithMavlinkMessage(responseMsg);
@@ -1621,7 +1620,7 @@ void MockLink::_sendGeneralMetaData(void)
 
     mavlink_msg_component_information_pack_chan(_vehicleSystemId,
                                                 _vehicleComponentId,
-                                                _mavlinkChannel,
+                                                mavlinkChannel(),
                                                 &responseMsg,
                                                 0,                          // time_boot_ms
                                                 100,                        // general_metadata_file_crc

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -134,9 +134,27 @@ bool MockLink::_connect(void)
     return true;
 }
 
-bool MockLink::_needAuxChannel(void)
+bool MockLink::_reserveMavlinkChannel(LinkManager& mgr)
 {
+    if (!LinkInterface::_reserveMavlinkChannel(mgr)) {
+        return false;
+    }
+    if (!_mavlinkAuxChannel.reserve(mgr)) {
+        LinkInterface::_freeMavlinkChannel(mgr);
+        return false;
+    }
     return true;
+}
+
+void MockLink::_freeMavlinkChannel(LinkManager& mgr)
+{
+    _mavlinkAuxChannel.free(mgr);
+    LinkInterface::_freeMavlinkChannel(mgr);
+}
+
+uint8_t MockLink::mavlinkAuxChannel(void) const
+{
+    return _mavlinkAuxChannel.id();
 }
 
 void MockLink::disconnect(void)

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -553,7 +553,6 @@ void MockLink::_handleIncomingMavlinkBytes(const uint8_t* bytes, int cBytes)
     mavlink_message_t msg;
     mavlink_status_t comm;
     memset(&comm, 0, sizeof(comm));
-    auto raw = mavlink_get_channel_status(mavlinkAuxChannel());
     int parsed = 0;
 
     for (qint64 i=0; i<cBytes; i++)
@@ -562,62 +561,55 @@ void MockLink::_handleIncomingMavlinkBytes(const uint8_t* bytes, int cBytes)
         if (!parsed) {
             continue;
         }
-        qCDebug(MockLinkLog) << QThread::currentThread() << this << "_handleIncomingMavlinkBytes parsed " << cBytes << mavlinkAuxChannel() << comm.parse_error << raw->parse_error;
         lock.unlock();
         _handleIncomingMavlinkMsg(msg);
         lock.relock();
     }
-    if (!parsed) {
-        qCDebug(MockLinkLog) << QThread::currentThread() << this << "_handleIncomingMavlinkBytes unparsed!" << cBytes << mavlinkAuxChannel() << comm.parse_error << raw->parse_error;
-    }
 }
 
-bool MockLink::_handleIncomingMavlinkMsg(const mavlink_message_t &msg)
+void MockLink::_handleIncomingMavlinkMsg(const mavlink_message_t &msg)
 {
     if (_missionItemHandler.handleMessage(msg)) {
-        qCDebug(MockLinkLog) << "_handleIncomingMavlinkMsg missionItemHandler handled " << msg.msgid;
-        return true;
+        return;
     }
 
     switch (msg.msgid) {
     case MAVLINK_MSG_ID_HEARTBEAT:
         _handleHeartBeat(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_PARAM_REQUEST_LIST:
         _handleParamRequestList(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_SET_MODE:
         _handleSetMode(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_PARAM_SET:
         _handleParamSet(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_PARAM_REQUEST_READ:
         _handleParamRequestRead(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL:
         _handleFTP(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_COMMAND_LONG:
         _handleCommandLong(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_MANUAL_CONTROL:
         _handleManualControl(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_LOG_REQUEST_LIST:
         _handleLogRequestList(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_LOG_REQUEST_DATA:
         _handleLogRequestData(msg);
-        return true;
+        break;
     case MAVLINK_MSG_ID_PARAM_MAP_RC:
         _handleParamMapRC(msg);
-        return true;
+        break;
     default:
         break;
     }
-    qCDebug(MockLinkLog) << "_handleIncomingMavlinkMsg missionItemHandler unhandled " << msg.msgid;
-    return false;
 }
 
 void MockLink::_handleHeartBeat(const mavlink_message_t& msg)

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -83,7 +83,7 @@ MockLink::MockLink(SharedLinkConfigurationPtr& config)
     , _logDownloadBytesRemaining            (0)
     , _adsbAngle                            (0)
 {
-    qDebug() << "MockLink" << this;
+    qCDebug(MockLinkLog) << "MockLink" << this;
 
     MockConfiguration* mockConfig = qobject_cast<MockConfiguration*>(_config.get());
     _firmwareType       = mockConfig->firmwareType();
@@ -118,7 +118,7 @@ MockLink::~MockLink(void)
     if (!_logDownloadFilename.isEmpty()) {
         QFile::remove(_logDownloadFilename);
     }
-    qDebug() << "~MockLink" << this;
+    qCDebug(MockLinkLog) << "~MockLink" << this;
 }
 
 bool MockLink::_connect(void)
@@ -377,7 +377,7 @@ void MockLink::_sendHighLatency2(void)
     union px4_custom_mode   px4_cm;
     px4_cm.data = _mavCustomMode;
 
-    qDebug() << "Sending" << _mavCustomMode;
+    qCDebug(MockLinkLog) << "Sending" << _mavCustomMode;
     mavlink_msg_high_latency2_pack_chan(_vehicleSystemId,
                                         _vehicleComponentId,
                                         mavlinkChannel(),
@@ -577,7 +577,7 @@ void MockLink::_handleIncomingNSHBytes(const char* bytes, int cBytes)
     }
 
     if (cBytes > 0) {
-        qDebug() << "NSH:" << (const char*)bytes;
+        qCDebug(MockLinkLog) << "NSH:" << (const char*)bytes;
 
 #if 0
         // MockLink not quite ready to handle this correctly yet
@@ -669,11 +669,11 @@ void MockLink::_handleParamMapRC(const mavlink_message_t& msg)
     const QString paramName(QString::fromLocal8Bit(paramMapRC.param_id, static_cast<int>(strnlen(paramMapRC.param_id, MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN))));
 
     if (paramMapRC.param_index == -1) {
-        qDebug() << QStringLiteral("MockLink - PARAM_MAP_RC: param(%1) tuningID(%2) centerValue(%3) scale(%4) min(%5) max(%6)").arg(paramName).arg(paramMapRC.parameter_rc_channel_index).arg(paramMapRC.param_value0).arg(paramMapRC.scale).arg(paramMapRC.param_value_min).arg(paramMapRC.param_value_max);
+        qCDebug(MockLinkLog) << QStringLiteral("MockLink - PARAM_MAP_RC: param(%1) tuningID(%2) centerValue(%3) scale(%4) min(%5) max(%6)").arg(paramName).arg(paramMapRC.parameter_rc_channel_index).arg(paramMapRC.param_value0).arg(paramMapRC.scale).arg(paramMapRC.param_value_min).arg(paramMapRC.param_value_max);
     } else if (paramMapRC.param_index == -2) {
-        qDebug() << QStringLiteral("MockLink - PARAM_MAP_RC: Clear tuningID(%1)").arg(paramMapRC.parameter_rc_channel_index);
+        qCDebug(MockLinkLog) << QStringLiteral("MockLink - PARAM_MAP_RC: Clear tuningID(%1)").arg(paramMapRC.parameter_rc_channel_index);
     } else {
-        qWarning() << QStringLiteral("MockLink - PARAM_MAP_RC: Unsupported param_index(%1)").arg(paramMapRC.param_index);
+        qCWarning(MockLinkLog) << QStringLiteral("MockLink - PARAM_MAP_RC: Unsupported param_index(%1)").arg(paramMapRC.param_index);
     }
 }
 
@@ -1369,7 +1369,7 @@ void MockConfiguration::copyFrom(LinkConfiguration *source)
     auto* usource = qobject_cast<MockConfiguration*>(source);
 
     if (!usource) {
-        qWarning() << "dynamic_cast failed" << source << usource;
+        qCWarning(MockLinkLog) << "dynamic_cast failed" << source << usource;
         return;
     }
 
@@ -1521,7 +1521,7 @@ void MockLink::_handleLogRequestList(const mavlink_message_t& msg)
     mavlink_msg_log_request_list_decode(&msg, &request);
 
     if (request.start != 0 && request.end != 0xffff) {
-        qWarning() << "MockLink::_handleLogRequestList cannot handle partial requests";
+        qCWarning(MockLinkLog) << "_handleLogRequestList cannot handle partial requests";
         return;
     }
 
@@ -1551,12 +1551,12 @@ void MockLink::_handleLogRequestData(const mavlink_message_t& msg)
     }
 
     if (request.id != 0) {
-        qWarning() << "MockLink::_handleLogRequestData id must be 0";
+        qCWarning(MockLinkLog) << "_handleLogRequestData id must be 0";
         return;
     }
 
     if (request.ofs > _logDownloadFileSize - 1) {
-        qWarning() << "MockLink::_handleLogRequestData offset past end of file request.ofs:size" << request.ofs << _logDownloadFileSize;
+        qCWarning(MockLinkLog) << "_handleLogRequestData offset past end of file request.ofs:size" << request.ofs << _logDownloadFileSize;
         return;
     }
 
@@ -1579,7 +1579,7 @@ void MockLink::_logDownloadWorker(void)
             Q_ASSERT(file.seek(_logDownloadCurrentOffset));
             Q_ASSERT(file.read((char *)buffer, bytesToRead) == bytesToRead);
 
-            qDebug() << "MockLink::_logDownloadWorker" << _logDownloadCurrentOffset << _logDownloadBytesRemaining;
+            qCDebug(MockLinkLog) << "_logDownloadWorker" << _logDownloadCurrentOffset << _logDownloadBytesRemaining;
 
             mavlink_message_t responseMsg;
             mavlink_msg_log_data_pack_chan(_vehicleSystemId,
@@ -1597,7 +1597,7 @@ void MockLink::_logDownloadWorker(void)
 
             file.close();
         } else {
-            qWarning() << "MockLink::_logDownloadWorker open failed" << file.errorString();
+            qCWarning(MockLinkLog) << "_logDownloadWorker open failed" << file.errorString();
         }
     }
 }

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -236,7 +236,6 @@ private:
 
     QString                     _name;
     bool                        _connected;
-    int                         _mavlinkChannel;
 
     uint8_t                     _vehicleSystemId;
     uint8_t                     _vehicleComponentId             = MAV_COMP_ID_AUTOPILOT1;

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -189,8 +189,10 @@ private slots:
 
 private:
     // LinkInterface overrides
-    bool _connect(void) override;
-    bool _needAuxChannel(void) override;
+    bool _connect                       (void) override;
+    bool _reserveMavlinkChannel         (LinkManager& mgr) override;
+    void _freeMavlinkChannel            (LinkManager& mgr) override;
+    uint8_t mavlinkAuxChannel           (void) const;
 
     // QThread override
     void run(void) final;
@@ -235,6 +237,7 @@ private:
     static MockLink* _startMockLinkWorker(QString configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, MockConfiguration::FailureMode_t failureMode);
     static MockLink* _startMockLink(MockConfiguration* mockConfig);
 
+    Channel                     _mavlinkAuxChannel;
     QMutex                      _mavlinkAuxMutex;
 
     MockLinkMissionItemHandler  _missionItemHandler;

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -10,9 +10,10 @@
 #pragma once
 
 #include <QElapsedTimer>
-#include <QMap>
-#include <QLoggingCategory>
 #include <QGeoCoordinate>
+#include <QLoggingCategory>
+#include <QMap>
+#include <QMutex>
 
 #include "MockLinkMissionItemHandler.h"
 #include "MockLinkFTP.h"
@@ -189,6 +190,7 @@ private slots:
 private:
     // LinkInterface overrides
     bool _connect(void) override;
+    bool _needAuxChannel(void) override;
 
     // QThread override
     void run(void) final;
@@ -198,6 +200,7 @@ private:
     void _sendHighLatency2              (void);
     void _handleIncomingNSHBytes        (const char* bytes, int cBytes);
     void _handleIncomingMavlinkBytes    (const uint8_t* bytes, int cBytes);
+    bool _handleIncomingMavlinkMsg      (const mavlink_message_t& msg);
     void _loadParams                    (void);
     void _handleHeartBeat               (const mavlink_message_t& msg);
     void _handleSetMode                 (const mavlink_message_t& msg);
@@ -231,6 +234,8 @@ private:
 
     static MockLink* _startMockLinkWorker(QString configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, MockConfiguration::FailureMode_t failureMode);
     static MockLink* _startMockLink(MockConfiguration* mockConfig);
+
+    QMutex                      _mavlinkAuxMutex;
 
     MockLinkMissionItemHandler  _missionItemHandler;
 

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -200,7 +200,7 @@ private:
     void _sendHighLatency2              (void);
     void _handleIncomingNSHBytes        (const char* bytes, int cBytes);
     void _handleIncomingMavlinkBytes    (const uint8_t* bytes, int cBytes);
-    bool _handleIncomingMavlinkMsg      (const mavlink_message_t& msg);
+    void _handleIncomingMavlinkMsg      (const mavlink_message_t& msg);
     void _loadParams                    (void);
     void _handleHeartBeat               (const mavlink_message_t& msg);
     void _handleSetMode                 (const mavlink_message_t& msg);

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -190,9 +190,10 @@ private slots:
 private:
     // LinkInterface overrides
     bool _connect                       (void) override;
-    bool _reserveMavlinkChannel         (LinkManager& mgr) override;
-    void _freeMavlinkChannel            (LinkManager& mgr) override;
+    bool _allocateMavlinkChannel        () override;
+    void _freeMavlinkChannel            () override;
     uint8_t mavlinkAuxChannel           (void) const;
+    bool mavlinkAuxChannelIsSet         (void) const;
 
     // QThread override
     void run(void) final;
@@ -237,7 +238,7 @@ private:
     static MockLink* _startMockLinkWorker(QString configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, MockConfiguration::FailureMode_t failureMode);
     static MockLink* _startMockLink(MockConfiguration* mockConfig);
 
-    Channel                     _mavlinkAuxChannel;
+    uint8_t                     _mavlinkAuxChannel              = std::numeric_limits<uint8_t>::max();
     QMutex                      _mavlinkAuxMutex;
 
     MockLinkMissionItemHandler  _missionItemHandler;


### PR DESCRIPTION
This PR aims to fix [#9346](https://github.com/mavlink/qgroundcontrol/issues/9346). For AirMap, the JIRA ticket [BOSS-616].

Several issues identified and fixed.

* Many racey uses of [`if (weak_ptr::expired()) {... weak_ptr::lock() ... }`](https://en.cppreference.com/w/cpp/memory/weak_ptr/expired)
  ![racey weak_ptr expired lock](https://user-images.githubusercontent.com/72767521/114969668-7ac7af80-9e3e-11eb-86c3-9aab36181cf1.png)

* `MockLink` had its own `_mavlinkChannel` shadowing the inherited `LinkInterface::_mavlinkChannel`. So `MockLink` always used channel 0 for lots of work which caused `VehicleLinkManagerTest::_multiLinkSingleVehicleTest` to fail very frequently when its two links would use the same mavlink buffer to parse a reply to the vehicle. Its failure would poison subsequent tests. 
  ![MockLink _handleIncomingMavlinkBytes racey](https://user-images.githubusercontent.com/72767521/115046193-cf9a1300-9e9c-11eb-8cf9-0898f92d9d07.png)
  That diagram is huge and hard to follow because it reflects how deep the two call stacks are with signals. This table might be easier to understand (top is most-recent call):
  | Thread 1 | Thread 2 |
  | :- | -: |
  | [mavlink_parse_char](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L550) (racey->) | (<-racey) (same) |
  | [MockLink::_handleIncomingMavlinkBytes](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L543) | (same) |
  | [MockLink::_writeBytesQueued](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L514) ([signal handler](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L94)) | (same) |
  | [MockLink::writeBytesQueuedSignal](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L501) (signal) | (same) |
  | [MockLink::_writeBytes](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/LinkInterface.cc#L52) | (same) |
  | [LinkInterface::writeBytesThreadSafe](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/Vehicle.cc#L1670) | [LinkInterface::writeBytesThreadSafe](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/MultiVehicleManager.cc#L388) |
  | [Vehicle::sendMessageOnLinkThreadSafe](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/Vehicle.cc#L2838) | [MultiVehicleManager::_sendGCSHeartbeat](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/MultiVehicleManager.cc#L132) |
  | [Vehicle::_sendMavCommandFromList](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/Vehicle.cc#L2753) | ([signal handler](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/MultiVehicleManager.cc#L60)) [MultiVehicleManager::_vehicleHeartbeatInfo](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/MultiVehicleManager.cc#L70) |
  | [Vehicle::_sendMavCommandWorker](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/Vehicle.cc#L2637) | (signal) [MAVLinkProtocol::vehicleHeartbeatInfo](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MAVLinkProtocol.cc#L315) |
  | [Vehicle::sendMavCommandWithHandler](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/InitialConnectStateMachine.cc#L112) | ([signal handler](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/LinkManager.cc#L153)) [MAVLinkProtocol::receiveBytes](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MAVLinkProtocol.cc#L195) |
  | [InitialConnectStateMachine::_stateRequestCapabilities](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/Vehicle.cc#L239) ([initial state function](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/Vehicle/InitialConnectStateMachine.cc#L22)) | (signal) [MockLink::bytesReceived](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L493) |
  | | [MockLink::respondWithMavlinkMessage](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L320) |
  | | [MockLink::_sendHeartBeat](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L208) |
  | | (thread start & timer) [MockLink::_run10HzTasks](https://github.com/mavlink/qgroundcontrol/blob/2e093b834983f2956fec507938f142fd61915f92/src/comm/MockLink.cc#L145-L171) |

* `MAVLinkProtocol::receiveBytes` didn't lock the link's shared_ptr which meant undefined behavior was possible (dereferencing a raw pointer) if the connection closed before `MAVLinkProtocol` wasn't done. For example, when the mavlink channel 0 buffer was corrupted, it can stall the initial connection state machine. Then `_multiLinkSingleVehicleTest` gives up waiting for the initial connection complete signal then test teardown occurs. But if there's a heartbeat signal pending to be processed in the second thread then the link may be destroyed by the time the MAVLinkProtocol wants to access it. This undefined behavior often manifested in subsequent test failures.

* `_multiLinkSingleVehicleTest` also didn't understand that two links starting at the same time could have _either_ one of them set as the primary link (basically depends on which one starts sending heartbeats first).

The solutions aimed to fix the above issues are as follows:
* added the ability for a `LinkInterface` to desire an additional auxiliary mavlink channel and currently the `MockLink` makes use of the auxiliary channel for its reverse-direction message processing.
* added a mutex around the `MockLink`'s use of the auxiliary channel and ensured that the `MockLink` no longer shadows the `LinkInterface::_mavlinkChannel`.
* fixed a bunch of racey uses of `weak_ptr`
* ensured that `MAVLinkProtocol` holds a lock on the link's `shared_ptr` while it's processing data with that link. It continues to check, at the end of the message processing loop, to see if the link might have been orphaned suggesting a disconnect.
* `_multiLinkSingleVehicleTest` checks link1 and link2 to see who won the race for the primary link

I ran this test in a loop for about 12 hours last night and it was successful for every iteration.
`while xvfb-run --auto-servernum ./qgroundcontrol-start.sh --unittest:VehicleLinkManagerTest --logging:MAVLinkProtocolLog,VehicleLog,MockLinkLog,InitialConnectStateMachineLog,LinkInterfaceLog,"$(date -Is)" > log.txt; do sleep 1; done`
