### PR TITLE
Replace deprecated functions

### DIFF
--- a/src/Airmap/AirMapWeatherInfoManager.cc
+++ b/src/Airmap/AirMapWeatherInfoManager.cc
@@ -30,12 +30,12 @@ AirMapWeatherInfoManager::setROI(const QGCGeoBoundingCube& roi, bool reset)
     if(reset || (!_lastRoiCenter.isValid() || _lastRoiCenter.distanceTo(roi.center()) > WEATHER_UPDATE_DISTANCE)) {
         _lastRoiCenter = roi.center();
         _requestWeatherUpdate(_lastRoiCenter);
-        _weatherTime.start();
+        _weatherTime = QTime::currentTime();
     } else {
         //-- Check weather once every WEATHER_UPDATE_TIME
-        if(_weatherTime.elapsed() > WEATHER_UPDATE_TIME) {
+        if(_weatherTime.msec() > WEATHER_UPDATE_TIME) {
             _requestWeatherUpdate(roi.center());
-            _weatherTime.start();
+            _weatherTime = QTime::currentTime();
         }
     }
 }

--- a/src/Airmap/QJsonWebToken/src/qjsonwebtoken.cpp
+++ b/src/Airmap/QJsonWebToken/src/qjsonwebtoken.cpp
@@ -186,9 +186,9 @@ bool QJsonWebToken::setAlgorithmStr(QString strAlgorithm)
 	// set algorithm
 	m_strAlgorithm = strAlgorithm;
 	// modify header
-	m_jdocHeader = QJsonDocument::fromJson(QObject::trUtf8("{\"typ\": \"JWT\", \"alg\" : \"").toUtf8()
+	m_jdocHeader = QJsonDocument::fromJson(QObject::tr("{\"typ\": \"JWT\", \"alg\" : \"").toUtf8()
 		                                 + m_strAlgorithm.toUtf8()
-		                                 + QObject::trUtf8("\"}").toUtf8());
+		                                 + QObject::tr("\"}").toUtf8());
 
 	return true;
 }

--- a/src/Vehicle/ComponentInformationManager.cc
+++ b/src/Vehicle/ComponentInformationManager.cc
@@ -290,7 +290,7 @@ void RequestMetaDataTypeStateMachine::_ftpDownloadComplete(const QString& fileNa
 
 void RequestMetaDataTypeStateMachine::_ftpDownloadProgress(float progress)
 {
-    int elapsedSec = _downloadStartTime.elapsed() / 1000;
+    int elapsedSec = _downloadStartTime.msec() / 1000;
     float totalDownloadTime = elapsedSec / progress;
     // abort download if it's too slow (e.g. over telemetry link) and use the fallback.
     // (we could also check if there's a http fallback)
@@ -334,7 +334,7 @@ void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, 
             if (_uriIsMAVLinkFTP(uri)) {
                 connect(ftpManager, &FTPManager::downloadComplete, this, &RequestMetaDataTypeStateMachine::_ftpDownloadComplete);
                 if (ftpManager->download(uri, QStandardPaths::writableLocation(QStandardPaths::TempLocation))) {
-                    _downloadStartTime.start();
+                    _downloadStartTime = QTime::currentTime();
                     connect(ftpManager, &FTPManager::commandProgress, this, &RequestMetaDataTypeStateMachine::_ftpDownloadProgress);
                 } else {
                     qCWarning(ComponentInformationManagerLog) << "RequestMetaDataTypeStateMachine::_requestFile FTPManager::download returned failure";
@@ -345,7 +345,7 @@ void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, 
                 QGCFileDownload* download = new QGCFileDownload(this);
                 connect(download, &QGCFileDownload::downloadComplete, this, &RequestMetaDataTypeStateMachine::_httpDownloadComplete);
                 if (download->download(uri)) {
-                    _downloadStartTime.start();
+                    _downloadStartTime = QTime::currentTime();
                 } else {
                     qCWarning(ComponentInformationManagerLog) << "RequestMetaDataTypeStateMachine::_requestFile QGCFileDownload::download returned failure";
                     disconnect(download, &QGCFileDownload::downloadComplete, this, &RequestMetaDataTypeStateMachine::_httpDownloadComplete);


### PR DESCRIPTION
Replaces deprecated functions with the not deprecated counterparts.

Without these fixes I can't build QGC on archlinux with `qmake ... && make`.