### PR TITLE
Stability Fixes - Vehicle Link Manager Test (cherry-pick & squash for Stable_V4.1)

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -26,6 +26,7 @@
 #include "ArduCopterFirmwarePlugin.h"
 #include "ArduRoverFirmwarePlugin.h"
 #include "ArduSubFirmwarePlugin.h"
+#include "LinkManager.h"
 
 #include <QTcpSocket>
 
@@ -185,11 +186,16 @@ void APMFirmwarePlugin::_handleIncomingParamValue(Vehicle* vehicle, mavlink_mess
     paramValue.param_value = paramUnion.param_float;
 
     // Re-Encoding is always done using mavlink 1.0
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(0);
+    uint8_t channel = _reencodeMavlinkChannel();
+    QMutexLocker reencode_lock{&_reencodeMavlinkChannelMutex()};
+
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
+
+    Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
     mavlink_msg_param_value_encode_chan(message->sysid,
                                         message->compid,
-                                        0,                  // Re-encoding uses reserved channel 0
+                                        channel,
                                         message,
                                         &paramValue);
 }
@@ -240,7 +246,11 @@ void APMFirmwarePlugin::_handleOutgoingParamSetThreadSafe(Vehicle* /*vehicle*/, 
     }
 
     _adjustOutgoingMavlinkMutex.lock();
-    mavlink_msg_param_set_encode_chan(message->sysid, message->compid, outgoingLink->mavlinkChannel(), message, &paramSet);
+    mavlink_msg_param_set_encode_chan(message->sysid,
+                                      message->compid,
+                                      outgoingLink->mavlinkChannel(),
+                                      message,
+                                      &paramSet);
     _adjustOutgoingMavlinkMutex.unlock();
 }
 
@@ -349,16 +359,20 @@ QString APMFirmwarePlugin::_getMessageText(mavlink_message_t* message) const
 void APMFirmwarePlugin::_setInfoSeverity(mavlink_message_t* message) const
 {
     // Re-Encoding is always done using mavlink 1.0
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(0);
+    uint8_t channel = _reencodeMavlinkChannel();
+    QMutexLocker reencode_lock{&_reencodeMavlinkChannelMutex()};
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
 
     mavlink_statustext_t statusText;
     mavlink_msg_statustext_decode(message, &statusText);
 
     statusText.severity = MAV_SEVERITY_INFO;
+
+    Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
     mavlink_msg_statustext_encode_chan(message->sysid,
                                        message->compid,
-                                       0,                  // Re-encoding uses reserved channel 0
+                                       channel,
                                        message,
                                        &statusText);
 }
@@ -367,11 +381,21 @@ void APMFirmwarePlugin::_adjustCalibrationMessageSeverity(mavlink_message_t* mes
 {
     mavlink_statustext_t statusText;
     mavlink_msg_statustext_decode(message, &statusText);
+
     // Re-Encoding is always done using mavlink 1.0
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(0);
+    uint8_t channel = _reencodeMavlinkChannel();
+    QMutexLocker reencode_lock{&_reencodeMavlinkChannelMutex()};
+
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
     statusText.severity = MAV_SEVERITY_INFO;
-    mavlink_msg_statustext_encode_chan(message->sysid, message->compid, 0, message, &statusText);
+
+    Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
+    mavlink_msg_statustext_encode_chan(message->sysid,
+                                       message->compid,
+                                       channel,
+                                       message,
+                                       &statusText);
 }
 
 void APMFirmwarePlugin::initializeStreamRates(Vehicle* vehicle)
@@ -711,12 +735,10 @@ void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
 
     setGuidedMode(vehicle, true);
 
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t                       msg;
         mavlink_set_position_target_local_ned_t cmd;
-        SharedLinkInterfacePtr                  sharedLink = weakLink.lock();
-
 
         memset(&cmd, 0, sizeof(cmd));
 
@@ -856,10 +878,9 @@ QString APMFirmwarePlugin::_versionRegex() {
 
 void APMFirmwarePlugin::_handleRCChannels(Vehicle* vehicle, mavlink_message_t* message)
 {
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_rc_channels_t   channels;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
         mavlink_msg_rc_channels_decode(message, &channels);
         //-- Ardupilot uses 0-255 to indicate 0-100% where QGC expects 0-100
@@ -878,10 +899,9 @@ void APMFirmwarePlugin::_handleRCChannels(Vehicle* vehicle, mavlink_message_t* m
 
 void APMFirmwarePlugin::_handleRCChannelsRaw(Vehicle* vehicle, mavlink_message_t *message)
 {
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_rc_channels_raw_t   channels;
-        SharedLinkInterfacePtr      sharedLink = weakLink.lock();
 
         mavlink_msg_rc_channels_raw_decode(message, &channels);
         //-- Ardupilot uses 0-255 to indicate 0-100% where QGC expects 0-100
@@ -919,11 +939,10 @@ void APMFirmwarePlugin::_sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMoti
         return;
     }
 
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         MAVLinkProtocol*                mavlinkProtocol = qgcApp()->toolbox()->mavlinkProtocol();
         mavlink_global_position_int_t   globalPositionInt;
-        SharedLinkInterfacePtr          sharedLink = weakLink.lock();
 
         memset(&globalPositionInt, 0, sizeof(globalPositionInt));
 
@@ -946,4 +965,28 @@ void APMFirmwarePlugin::_sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMoti
                                                     &globalPositionInt);
         vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), message);
     }
+}
+
+uint8_t APMFirmwarePlugin::_reencodeMavlinkChannel()
+{
+    // This mutex is only to guard against a race on allocating the channel id
+    // if two firmware plugins are created simultaneously from different threads
+    //
+    // Use of the allocated channel should be guarded by the mutex returned from
+    // _reencodeMavlinkChannelMutex()
+    //
+    static QMutex _channelMutex{};
+    _channelMutex.lock();
+    static uint8_t channel{LinkManager::invalidMavlinkChannel()};
+    if (LinkManager::invalidMavlinkChannel() == channel) {
+        channel = qgcApp()->toolbox()->linkManager()->allocateMavlinkChannel();
+    }
+    _channelMutex.unlock();
+    return channel;
+}
+
+QMutex& APMFirmwarePlugin::_reencodeMavlinkChannelMutex()
+{
+    static QMutex _mutex{};
+    return _mutex;
 }

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -119,6 +119,9 @@ private:
 
     static const char*      _artooIP;
     static const int        _artooVideoHandshakePort;
+
+    static uint8_t          _reencodeMavlinkChannel();
+    static QMutex&          _reencodeMavlinkChannelMutex();
 };
 
 #endif

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -56,14 +56,12 @@ void InitialConnectStateMachine::_stateRequestCapabilities(StateMachine* stateMa
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestCapabilities Skipping capability request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "Skipping capability request due to link type";
             connectMachine->advance();
@@ -168,14 +166,12 @@ void InitialConnectStateMachine::_stateRequestProtocolVersion(StateMachine* stat
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestProtocolVersion Skipping protocol version request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestProtocolVersion Skipping protocol version request due to link type";
             connectMachine->advance();
@@ -271,14 +267,12 @@ void InitialConnectStateMachine::_stateRequestMission(StateMachine* stateMachine
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestMission: Skipping first mission load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestMission: Skipping first mission load request due to link type";
             vehicle->_firstMissionLoadComplete();
@@ -293,14 +287,12 @@ void InitialConnectStateMachine::_stateRequestGeoFence(StateMachine* stateMachin
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestGeoFence: Skipping first geofence load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestGeoFence: Skipping first geofence load request due to link type";
             vehicle->_firstGeoFenceLoadComplete();
@@ -320,14 +312,12 @@ void InitialConnectStateMachine::_stateRequestRallyPoints(StateMachine* stateMac
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestRallyPoints: Skipping first rally point load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestRallyPoints: Skipping first rally point load request due to link type";
             vehicle->_firstRallyPointLoadComplete();

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -555,7 +555,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     unsigned mavlinkVersion = _mavlink->getCurrentVersion();
     if (_maxProtoVersion != mavlinkVersion && mavlinkVersion >= 200) {
         _maxProtoVersion = mavlinkVersion;
-        qCDebug(VehicleLog) << "Vehicle::_mavlinkMessageReceived Link already running Mavlink v2. Setting _maxProtoVersion" << _maxProtoVersion;
+        qCDebug(VehicleLog) << "_mavlinkMessageReceived Link already running Mavlink v2. Setting _maxProtoVersion" << _maxProtoVersion;
     }
 
     if (message.sysid != _id && message.sysid != 0) {
@@ -1433,29 +1433,29 @@ void Vehicle::_updateArmed(bool armed)
 
 void Vehicle::_handlePing(LinkInterface* link, mavlink_message_t& message)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_handlePing: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    mavlink_ping_t      ping;
+    mavlink_message_t   msg;
 
-        mavlink_ping_t      ping;
-        mavlink_message_t   msg;
+    mavlink_msg_ping_decode(&message, &ping);
 
-        mavlink_msg_ping_decode(&message, &ping);
-
-        if ((ping.target_system == 0) && (ping.target_component == 0)) {
-            // Mavlink defines a ping request as a MSG_ID_PING which contains target_system = 0 and target_component = 0
-            // So only send a ping response when you receive a valid ping request
-            mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                                    sharedLink->mavlinkChannel(),
-                                    &msg,
-                                    ping.time_usec,
-                                    ping.seq,
-                                    message.sysid,
-                                    message.compid);
-            sendMessageOnLinkThreadSafe(link, msg);
-        }
+    if ((ping.target_system == 0) && (ping.target_component == 0)) {
+        // Mavlink defines a ping request as a MSG_ID_PING which contains target_system = 0 and target_component = 0
+        // So only send a ping response when you receive a valid ping request
+        mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                static_cast<uint8_t>(_mavlink->getComponentId()),
+                                sharedLink->mavlinkChannel(),
+                                &msg,
+                                ping.time_usec,
+                                ping.seq,
+                                message.sysid,
+                                message.compid);
+        sendMessageOnLinkThreadSafe(link, msg);
     }
 }
 
@@ -1615,6 +1615,7 @@ void Vehicle::_handleRCChannels(mavlink_message_t& message)
 bool Vehicle::sendMessageOnLinkThreadSafe(LinkInterface* link, mavlink_message_t message)
 {
     if (!link->isConnected()) {
+        qCDebug(VehicleLog) << "sendMessageOnLinkThreadSafe" << link << "not connected!";
         return false;
     }
 
@@ -1906,28 +1907,29 @@ void Vehicle::setFlightMode(const QString& flightMode)
     uint32_t    custom_mode;
 
     if (_firmwarePlugin->setFlightMode(flightMode, &base_mode, &custom_mode)) {
-        WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-        if (!weakLink.expired()) {
-            uint8_t                 newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
-            SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-            // setFlightMode will only set MAV_MODE_FLAG_CUSTOM_MODE_ENABLED in base_mode, we need to move back in the existing
-            // states.
-            newBaseMode |= base_mode;
-
-            mavlink_message_t msg;
-            mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
-                                           _mavlink->getComponentId(),
-                                           sharedLink->mavlinkChannel(),
-                                           &msg,
-                                           id(),
-                                           newBaseMode,
-                                           custom_mode);
-            sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+        SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+        if (!sharedLink) {
+            qCDebug(VehicleLog) << "setFlightMode: primary link gone!";
+            return;
         }
+
+        uint8_t newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
+
+        // setFlightMode will only set MAV_MODE_FLAG_CUSTOM_MODE_ENABLED in base_mode, we need to move back in the existing
+        // states.
+        newBaseMode |= base_mode;
+
+        mavlink_message_t msg;
+        mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
+                                       _mavlink->getComponentId(),
+                                       sharedLink->mavlinkChannel(),
+                                       &msg,
+                                       id(),
+                                       newBaseMode,
+                                       custom_mode);
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     } else {
-        qWarning() << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
+        qCWarning(VehicleLog) << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
     }
 }
 
@@ -1944,33 +1946,34 @@ QVariantList Vehicle::links() const {
 
 void Vehicle::requestDataStream(MAV_DATA_STREAM stream, uint16_t rate, bool sendMultiple)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "requestDataStream: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        mavlink_message_t               msg;
-        mavlink_request_data_stream_t   dataStream;
-        SharedLinkInterfacePtr          sharedLink = weakLink.lock();
+    mavlink_message_t               msg;
+    mavlink_request_data_stream_t   dataStream;
 
-        memset(&dataStream, 0, sizeof(dataStream));
+    memset(&dataStream, 0, sizeof(dataStream));
 
-        dataStream.req_stream_id = stream;
-        dataStream.req_message_rate = rate;
-        dataStream.start_stop = 1;  // start
-        dataStream.target_system = id();
-        dataStream.target_component = _defaultComponentId;
+    dataStream.req_stream_id = stream;
+    dataStream.req_message_rate = rate;
+    dataStream.start_stop = 1;  // start
+    dataStream.target_system = id();
+    dataStream.target_component = _defaultComponentId;
 
-        mavlink_msg_request_data_stream_encode_chan(_mavlink->getSystemId(),
-                                                    _mavlink->getComponentId(),
-                                                    sharedLink->mavlinkChannel(),
-                                                    &msg,
-                                                    &dataStream);
+    mavlink_msg_request_data_stream_encode_chan(_mavlink->getSystemId(),
+                                                _mavlink->getComponentId(),
+                                                sharedLink->mavlinkChannel(),
+                                                &msg,
+                                                &dataStream);
 
-        if (sendMultiple) {
-            // We use sendMessageMultiple since we really want these to make it to the vehicle
-            sendMessageMultiple(msg);
-        } else {
-            sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
-        }
+    if (sendMultiple) {
+        // We use sendMessageMultiple since we really want these to make it to the vehicle
+        sendMessageMultiple(msg);
+    } else {
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
 }
 
@@ -1979,10 +1982,9 @@ void Vehicle::_sendMessageMultipleNext()
     if (_nextSendMessageMultipleIndex < _sendMessageMultipleList.count()) {
         qCDebug(VehicleLog) << "_sendMessageMultipleNext:" << _sendMessageMultipleList[_nextSendMessageMultipleIndex].message.msgid;
 
-        WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-        if (!weakLink.expired()) {
-            sendMessageOnLinkThreadSafe(weakLink.lock().get(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
+        SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+        if (sharedLink) {
+            sendMessageOnLinkThreadSafe(sharedLink.get(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
         }
 
         if (--_sendMessageMultipleList[_nextSendMessageMultipleIndex].retryCount <= 0) {
@@ -2070,7 +2072,7 @@ void Vehicle::_firstRallyPointLoadComplete()
 
 void Vehicle::_parametersReady(bool parametersReady)
 {
-    qDebug() << "_parametersReady" << parametersReady;
+    qCDebug(VehicleLog) << "_parametersReady" << parametersReady;
 
     // Try to set current unix time to the vehicle
     _sendQGCTimeToVehicle();
@@ -2085,25 +2087,26 @@ void Vehicle::_parametersReady(bool parametersReady)
 
 void Vehicle::_sendQGCTimeToVehicle()
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        mavlink_system_time_t   cmd;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        // Timestamp of the master clock in microseconds since UNIX epoch.
-        cmd.time_unix_usec = QDateTime::currentDateTime().currentMSecsSinceEpoch()*1000;
-        // Timestamp of the component clock since boot time in milliseconds (Not necessary).
-        cmd.time_boot_ms = 0;
-        mavlink_msg_system_time_encode_chan(_mavlink->getSystemId(),
-                                            _mavlink->getComponentId(),
-                                            sharedLink->mavlinkChannel(),
-                                            &msg,
-                                            &cmd);
-
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_sendQGCTimeToVehicle: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+    mavlink_system_time_t   cmd;
+
+    // Timestamp of the master clock in microseconds since UNIX epoch.
+    cmd.time_unix_usec = QDateTime::currentDateTime().currentMSecsSinceEpoch()*1000;
+    // Timestamp of the component clock since boot time in milliseconds (Not necessary).
+    cmd.time_boot_ms = 0;
+    mavlink_msg_system_time_encode_chan(_mavlink->getSystemId(),
+                                        _mavlink->getComponentId(),
+                                        sharedLink->mavlinkChannel(),
+                                        &msg,
+                                        &cmd);
+
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_imageReady(UASInterface*)
@@ -2530,25 +2533,26 @@ void Vehicle::emergencyStop()
 
 void Vehicle::setCurrentMissionSequence(int seq)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (!_firmwarePlugin->sendHomePositionToVehicle()) {
-            seq--;
-        }
-        mavlink_msg_mission_set_current_pack_chan(
-                    static_cast<uint8_t>(_mavlink->getSystemId()),
-                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                    sharedLink->mavlinkChannel(),
-                    &msg,
-                    static_cast<uint8_t>(id()),
-                    _compID,
-                    static_cast<uint16_t>(seq));
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "setCurrentMissionSequence: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+
+    if (!_firmwarePlugin->sendHomePositionToVehicle()) {
+        seq--;
+    }
+    mavlink_msg_mission_set_current_pack_chan(
+                static_cast<uint8_t>(_mavlink->getSystemId()),
+                static_cast<uint8_t>(_mavlink->getComponentId()),
+                sharedLink->mavlinkChannel(),
+                &msg,
+                static_cast<uint8_t>(id()),
+                _compID,
+                static_cast<uint16_t>(seq));
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::sendMavCommand(int compId, MAV_CMD command, bool showError, float param1, float param2, float param3, float param4, float param5, float param6, float param7)
@@ -2672,32 +2676,34 @@ void Vehicle::_sendMavCommandWorker(bool commandInt, bool requestMessage, bool s
     }
 
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
-
-    if (sharedLink) {
-        MavCommandListEntry_t   entry;
-
-        entry.useCommandInt     = commandInt;
-        entry.targetCompId      = targetCompId;
-        entry.command           = command;
-        entry.frame             = frame;
-        entry.showError         = showError;
-        entry.requestMessage    = requestMessage;
-        entry.resultHandler     = resultHandler;
-        entry.resultHandlerData = resultHandlerData;
-        entry.rgParam[0]        = param1;
-        entry.rgParam[1]        = param2;
-        entry.rgParam[2]        = param3;
-        entry.rgParam[3]        = param4;
-        entry.rgParam[4]        = param5;
-        entry.rgParam[5]        = param6;
-        entry.rgParam[6]        = param7;
-        entry.maxTries          = _sendMavCommandShouldRetry(command) ? _mavCommandMaxRetryCount : 1;
-        entry.ackTimeoutMSecs   = sharedLink->linkConfiguration()->isHighLatency() ? _mavCommandAckTimeoutMSecsHighLatency : _mavCommandAckTimeoutMSecs;
-        entry.elapsedTimer.start();
-
-        _mavCommandList.append(entry);
-        _sendMavCommandFromList(_mavCommandList.count() - 1);
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_sendMavCommandWorker: primary link gone!";
+        return;
     }
+
+    MavCommandListEntry_t   entry;
+
+    entry.useCommandInt     = commandInt;
+    entry.targetCompId      = targetCompId;
+    entry.command           = command;
+    entry.frame             = frame;
+    entry.showError         = showError;
+    entry.requestMessage    = requestMessage;
+    entry.resultHandler     = resultHandler;
+    entry.resultHandlerData = resultHandlerData;
+    entry.rgParam[0]        = param1;
+    entry.rgParam[1]        = param2;
+    entry.rgParam[2]        = param3;
+    entry.rgParam[3]        = param4;
+    entry.rgParam[4]        = param5;
+    entry.rgParam[5]        = param6;
+    entry.rgParam[6]        = param7;
+    entry.maxTries          = _sendMavCommandShouldRetry(command) ? _mavCommandMaxRetryCount : 1;
+    entry.ackTimeoutMSecs   = sharedLink->linkConfiguration()->isHighLatency() ? _mavCommandAckTimeoutMSecsHighLatency : _mavCommandAckTimeoutMSecs;
+    entry.elapsedTimer.start();
+
+    _mavCommandList.append(entry);
+    _sendMavCommandFromList(_mavCommandList.count() - 1);
 }
 
 void Vehicle::_sendMavCommandFromList(int index)
@@ -2733,56 +2739,57 @@ void Vehicle::_sendMavCommandFromList(int index)
 
     qCDebug(VehicleLog) << "_sendMavCommandFromList command:tryCount" << rawCommandName << commandEntry.tryCount;
 
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (commandEntry.useCommandInt) {
-            mavlink_command_int_t  cmd;
-
-            memset(&cmd, 0, sizeof(cmd));
-            cmd.target_system =     _id;
-            cmd.target_component =  commandEntry.targetCompId;
-            cmd.command =           commandEntry.command;
-            cmd.frame =             commandEntry.frame;
-            cmd.param1 =            commandEntry.rgParam[0];
-            cmd.param2 =            commandEntry.rgParam[1];
-            cmd.param3 =            commandEntry.rgParam[2];
-            cmd.param4 =            commandEntry.rgParam[3];
-            cmd.x =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[4] : commandEntry.rgParam[4] * 1e7;
-            cmd.y =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[5] : commandEntry.rgParam[5] * 1e7;
-            cmd.z =                 commandEntry.rgParam[6];
-            mavlink_msg_command_int_encode_chan(_mavlink->getSystemId(),
-                                                _mavlink->getComponentId(),
-                                                sharedLink->mavlinkChannel(),
-                                                &msg,
-                                                &cmd);
-        } else {
-            mavlink_command_long_t  cmd;
-
-            memset(&cmd, 0, sizeof(cmd));
-            cmd.target_system =     _id;
-            cmd.target_component =  commandEntry.targetCompId;
-            cmd.command =           commandEntry.command;
-            cmd.confirmation =      0;
-            cmd.param1 =            commandEntry.rgParam[0];
-            cmd.param2 =            commandEntry.rgParam[1];
-            cmd.param3 =            commandEntry.rgParam[2];
-            cmd.param4 =            commandEntry.rgParam[3];
-            cmd.param5 =            commandEntry.rgParam[4];
-            cmd.param6 =            commandEntry.rgParam[5];
-            cmd.param7 =            commandEntry.rgParam[6];
-            mavlink_msg_command_long_encode_chan(_mavlink->getSystemId(),
-                                                 _mavlink->getComponentId(),
-                                                 sharedLink->mavlinkChannel(),
-                                                 &msg,
-                                                 &cmd);
-        }
-
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_sendMavCommandFromList: primary link gone!";
+        return;
     }
+
+    mavlink_message_t  msg;
+
+    if (commandEntry.useCommandInt) {
+        mavlink_command_int_t  cmd;
+
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.target_system =     _id;
+        cmd.target_component =  commandEntry.targetCompId;
+        cmd.command =           commandEntry.command;
+        cmd.frame =             commandEntry.frame;
+        cmd.param1 =            commandEntry.rgParam[0];
+        cmd.param2 =            commandEntry.rgParam[1];
+        cmd.param3 =            commandEntry.rgParam[2];
+        cmd.param4 =            commandEntry.rgParam[3];
+        cmd.x =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[4] : commandEntry.rgParam[4] * 1e7;
+        cmd.y =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[5] : commandEntry.rgParam[5] * 1e7;
+        cmd.z =                 commandEntry.rgParam[6];
+        mavlink_msg_command_int_encode_chan(_mavlink->getSystemId(),
+                                            _mavlink->getComponentId(),
+                                            sharedLink->mavlinkChannel(),
+                                            &msg,
+                                            &cmd);
+    } else {
+        mavlink_command_long_t  cmd;
+
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.target_system =     _id;
+        cmd.target_component =  commandEntry.targetCompId;
+        cmd.command =           commandEntry.command;
+        cmd.confirmation =      0;
+        cmd.param1 =            commandEntry.rgParam[0];
+        cmd.param2 =            commandEntry.rgParam[1];
+        cmd.param3 =            commandEntry.rgParam[2];
+        cmd.param4 =            commandEntry.rgParam[3];
+        cmd.param5 =            commandEntry.rgParam[4];
+        cmd.param6 =            commandEntry.rgParam[5];
+        cmd.param7 =            commandEntry.rgParam[6];
+        mavlink_msg_command_long_encode_chan(_mavlink->getSystemId(),
+                                             _mavlink->getComponentId(),
+                                             sharedLink->mavlinkChannel(),
+                                             &msg,
+                                             &cmd);
+    }
+
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_sendMavCommandResponseTimeoutCheck(void)
@@ -2903,6 +2910,9 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
 void Vehicle::_waitForMavlinkMessage(WaitForMavlinkMessageResultHandler resultHandler, void* resultHandlerData, int messageId, int timeoutMsecs)
 {
     qCDebug(VehicleLog) << "_waitForMavlinkMessage msg:timeout" << messageId << timeoutMsecs;
+    if (_waitForMavlinkMessageResultHandler) {
+        qCCritical(VehicleLog) << "_waitForMavlinkMessage: collision";
+    }
     _waitForMavlinkMessageResultHandler     = resultHandler;
     _waitForMavlinkMessageResultHandlerData = resultHandlerData;
     _waitForMavlinkMessageId                = messageId;
@@ -3072,75 +3082,75 @@ void Vehicle::rebootVehicle()
 
 void Vehicle::startCalibration(Vehicle::CalibrationType calType)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
-        float param1 = 0;
-        float param2 = 0;
-        float param3 = 0;
-        float param4 = 0;
-        float param5 = 0;
-        float param6 = 0;
-        float param7 = 0;
-
-        switch (calType) {
-        case CalibrationGyro:
-            param1 = 1;
-            break;
-        case CalibrationMag:
-            param2 = 1;
-            break;
-        case CalibrationRadio:
-            param4 = 1;
-            break;
-        case CalibrationCopyTrims:
-            param4 = 2;
-            break;
-        case CalibrationAccel:
-            param5 = 1;
-            break;
-        case CalibrationLevel:
-            param5 = 2;
-            break;
-        case CalibrationEsc:
-            param7 = 1;
-            break;
-        case CalibrationPX4Airspeed:
-            param6 = 1;
-            break;
-        case CalibrationPX4Pressure:
-            param3 = 1;
-            break;
-        case CalibrationAPMCompassMot:
-            param6 = 1;
-            break;
-        case CalibrationAPMPressureAirspeed:
-            param3 = 1;
-            break;
-        case CalibrationAPMPreFlight:
-            param3 = 1; // GroundPressure/Airspeed
-            if (multiRotor() || rover()) {
-                // Gyro cal for ArduCopter only
-                param1 = 1;
-            }
-        }
-
-        // We can't use sendMavCommand here since we have no idea how long it will be before the command returns a result. This in turn
-        // causes the retry logic to break down.
-        mavlink_message_t msg;
-        mavlink_msg_command_long_pack_chan(_mavlink->getSystemId(),
-                                           _mavlink->getComponentId(),
-                                           sharedLink->mavlinkChannel(),
-                                           &msg,
-                                           id(),
-                                           defaultComponentId(),            // target component
-                                           MAV_CMD_PREFLIGHT_CALIBRATION,    // command id
-                                           0,                                // 0=first transmission of command
-                                           param1, param2, param3, param4, param5, param6, param7);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "startCalibration: primary link gone!";
+        return;
     }
+
+    float param1 = 0;
+    float param2 = 0;
+    float param3 = 0;
+    float param4 = 0;
+    float param5 = 0;
+    float param6 = 0;
+    float param7 = 0;
+
+    switch (calType) {
+    case CalibrationGyro:
+        param1 = 1;
+        break;
+    case CalibrationMag:
+        param2 = 1;
+        break;
+    case CalibrationRadio:
+        param4 = 1;
+        break;
+    case CalibrationCopyTrims:
+        param4 = 2;
+        break;
+    case CalibrationAccel:
+        param5 = 1;
+        break;
+    case CalibrationLevel:
+        param5 = 2;
+        break;
+    case CalibrationEsc:
+        param7 = 1;
+        break;
+    case CalibrationPX4Airspeed:
+        param6 = 1;
+        break;
+    case CalibrationPX4Pressure:
+        param3 = 1;
+        break;
+    case CalibrationAPMCompassMot:
+        param6 = 1;
+        break;
+    case CalibrationAPMPressureAirspeed:
+        param3 = 1;
+        break;
+    case CalibrationAPMPreFlight:
+        param3 = 1; // GroundPressure/Airspeed
+        if (multiRotor() || rover()) {
+            // Gyro cal for ArduCopter only
+            param1 = 1;
+        }
+    }
+
+    // We can't use sendMavCommand here since we have no idea how long it will be before the command returns a result. This in turn
+    // causes the retry logic to break down.
+    mavlink_message_t msg;
+    mavlink_msg_command_long_pack_chan(_mavlink->getSystemId(),
+                                       _mavlink->getComponentId(),
+                                       sharedLink->mavlinkChannel(),
+                                       &msg,
+                                       id(),
+                                       defaultComponentId(),            // target component
+                                       MAV_CMD_PREFLIGHT_CALIBRATION,    // command id
+                                       0,                                // 0=first transmission of command
+                                       param1, param2, param3, param4, param5, param6, param7);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::stopCalibration(void)
@@ -3201,7 +3211,7 @@ void Vehicle::setOfflineEditingDefaultComponentId(int defaultComponentId)
     if (_offlineEditingVehicle) {
         _defaultComponentId = defaultComponentId;
     } else {
-        qWarning() << "Call to Vehicle::setOfflineEditingDefaultComponentId on vehicle which is not offline";
+        qCWarning(VehicleLog) << "Call to Vehicle::setOfflineEditingDefaultComponentId on vehicle which is not offline";
     }
 }
 
@@ -3228,25 +3238,26 @@ void Vehicle::stopMavlinkLog()
 
 void Vehicle::_ackMavlinkLogData(uint16_t sequence)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        mavlink_message_t       msg;
-        mavlink_logging_ack_t   ack;
-
-        memset(&ack, 0, sizeof(ack));
-        ack.sequence = sequence;
-        ack.target_component = _defaultComponentId;
-        ack.target_system = id();
-        mavlink_msg_logging_ack_encode_chan(
-                    _mavlink->getSystemId(),
-                    _mavlink->getComponentId(),
-                    sharedLink->mavlinkChannel(),
-                    &msg,
-                    &ack);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr  sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_ackMavlinkLogData: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+    mavlink_logging_ack_t   ack;
+
+    memset(&ack, 0, sizeof(ack));
+    ack.sequence = sequence;
+    ack.target_component = _defaultComponentId;
+    ack.target_system = id();
+    mavlink_msg_logging_ack_encode_chan(
+                _mavlink->getSystemId(),
+                _mavlink->getComponentId(),
+                sharedLink->mavlinkChannel(),
+                &msg,
+                &ack);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_handleMavlinkLoggingData(mavlink_message_t& message)
@@ -3774,20 +3785,50 @@ void Vehicle::updateFlightDistance(double distance)
 
 void Vehicle::sendParamMapRC(const QString& paramName, double scale, double centerValue, int tuningID, double minValue, double maxValue)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr  sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "sendParamMapRC: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        mavlink_message_t       message;
+    mavlink_message_t       message;
 
-        char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
-        // Copy string into buffer, ensuring not to exceed the buffer size
-        for (unsigned int i = 0; i < sizeof(param_id_cstr); i++) {
-            if ((int)i < paramName.length()) {
-                param_id_cstr[i] = paramName.toLatin1()[i];
-            }
+    char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
+    // Copy string into buffer, ensuring not to exceed the buffer size
+    for (unsigned int i = 0; i < sizeof(param_id_cstr); i++) {
+        if ((int)i < paramName.length()) {
+            param_id_cstr[i] = paramName.toLatin1()[i];
         }
+    }
 
+    mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                       static_cast<uint8_t>(_mavlink->getComponentId()),
+                                       sharedLink->mavlinkChannel(),
+                                       &message,
+                                       _id,
+                                       MAV_COMP_ID_AUTOPILOT1,
+                                       param_id_cstr,
+                                       -1,                                                  // parameter name specified as string in previous argument
+                                       static_cast<uint8_t>(tuningID),
+                                       static_cast<float>(scale),
+                                       static_cast<float>(centerValue),
+                                       static_cast<float>(minValue),
+                                       static_cast<float>(maxValue));
+    sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+}
+
+void Vehicle::clearAllParamMapRC(void)
+{
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog)<< "clearAllParamMapRC: primary link gone!";
+        return;
+    }
+
+    char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
+
+    for (int i = 0; i < 3; i++) {
+        mavlink_message_t message;
         mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
                                            static_cast<uint8_t>(_mavlink->getComponentId()),
                                            sharedLink->mavlinkChannel(),
@@ -3795,74 +3836,46 @@ void Vehicle::sendParamMapRC(const QString& paramName, double scale, double cent
                                            _id,
                                            MAV_COMP_ID_AUTOPILOT1,
                                            param_id_cstr,
-                                           -1,                                                  // parameter name specified as string in previous argument
-                                           static_cast<uint8_t>(tuningID),
-                                           static_cast<float>(scale),
-                                           static_cast<float>(centerValue),
-                                           static_cast<float>(minValue),
-                                           static_cast<float>(maxValue));
+                                           -2,                                                  // Disable map for specified tuning id
+                                           i,                                                   // tuning id
+                                           0, 0, 0, 0);                                         // unused
         sendMessageOnLinkThreadSafe(sharedLink.get(), message);
-    }
-}
-
-void Vehicle::clearAllParamMapRC(void)
-{
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
-
-        for (int i = 0; i < 3; i++) {
-            mavlink_message_t message;
-            mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                                               static_cast<uint8_t>(_mavlink->getComponentId()),
-                                               sharedLink->mavlinkChannel(),
-                                               &message,
-                                               _id,
-                                               MAV_COMP_ID_AUTOPILOT1,
-                                               param_id_cstr,
-                                               -2,                                                  // Disable map for specified tuning id
-                                               i,                                                   // tuning id
-                                               0, 0, 0, 0);                                         // unused
-            sendMessageOnLinkThreadSafe(sharedLink.get(), message);
-        }
     }
 }
 
 void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, float thrust, quint16 buttons)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (sharedLink->linkConfiguration()->isHighLatency()) {
-            return;
-        }
-
-        mavlink_message_t message;
-
-        // Incoming values are in the range -1:1
-        float axesScaling =         1.0 * 1000.0;
-        float newRollCommand =      roll * axesScaling;
-        float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
-        float newYawCommand    =    yaw * axesScaling;
-        float newThrustCommand =    thrust * axesScaling;
-
-        mavlink_msg_manual_control_pack_chan(
-                    static_cast<uint8_t>(_mavlink->getSystemId()),
-                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                    sharedLink->mavlinkChannel(),
-                    &message,
-                    static_cast<uint8_t>(_id),
-                    static_cast<int16_t>(newPitchCommand),
-                    static_cast<int16_t>(newRollCommand),
-                    static_cast<int16_t>(newThrustCommand),
-                    static_cast<int16_t>(newYawCommand),
-                    buttons);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog)<< "sendJoystickDataThreadSafe: primary link gone!";
+        return;
     }
+
+    if (sharedLink->linkConfiguration()->isHighLatency()) {
+        return;
+    }
+
+    mavlink_message_t message;
+
+    // Incoming values are in the range -1:1
+    float axesScaling =         1.0 * 1000.0;
+    float newRollCommand =      roll * axesScaling;
+    float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
+    float newYawCommand    =    yaw * axesScaling;
+    float newThrustCommand =    thrust * axesScaling;
+
+    mavlink_msg_manual_control_pack_chan(
+                static_cast<uint8_t>(_mavlink->getSystemId()),
+                static_cast<uint8_t>(_mavlink->getComponentId()),
+                sharedLink->mavlinkChannel(),
+                &message,
+                static_cast<uint8_t>(_id),
+                static_cast<int16_t>(newPitchCommand),
+                static_cast<int16_t>(newRollCommand),
+                static_cast<int16_t>(newThrustCommand),
+                static_cast<int16_t>(newYawCommand),
+                buttons);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), message);
 }
 
 void Vehicle::triggerSimpleCamera()

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -167,12 +167,17 @@ void VehicleLinkManager::_addLink(LinkInterface* link)
         qCWarning(VehicleLinkManagerLog) << "_addLink call with link which is already in the list";
         return;
     } else {
+        SharedLinkInterfacePtr sharedLink = _linkMgr->sharedLinkInterfacePointerForLink(link);
+        if (!sharedLink) {
+            qCDebug(VehicleLinkManagerLog) << "_addLink stale link" << (void*)link;
+            return;
+        }
         qCDebug(VehicleLinkManagerLog) << "_addLink:" << link->linkConfiguration()->name() << QString("%1").arg((qulonglong)link, 0, 16);
 
         link->addVehicleReference();
 
         LinkInfo_t linkInfo;
-        linkInfo.link = _linkMgr->sharedLinkInterfacePointerForLink(link);
+        linkInfo.link = sharedLink;
         if (!link->linkConfiguration()->isHighLatency()) {
             linkInfo.heartbeatElapsedTimer.start();
         }
@@ -231,7 +236,7 @@ void VehicleLinkManager::_linkDisconnected(void)
     }
 }
 
-WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
+SharedLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
 {
 #ifndef NO_SERIAL_LINK
     // Best choice is a USB connection
@@ -264,9 +269,10 @@ WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
     }
 
     // Last possible choice is a high latency link
-    if (!_primaryLink.expired() && _primaryLink.lock().get()->linkConfiguration()->isHighLatency()) {
+    SharedLinkInterfacePtr link = _primaryLink.lock();
+    if (link && link->linkConfiguration()->isHighLatency()) {
         // Best choice continues to be the current high latency link
-        return _primaryLink;
+        return link;
     } else {
         // Pick any high latency link if one exists
         for (const LinkInfo_t& linkInfo: _rgLinkInfo) {
@@ -280,25 +286,26 @@ WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
         }
     }
 
-    return WeakLinkInterfacePtr();
+    return {};
 }
 
 bool VehicleLinkManager::_updatePrimaryLink(void)
 {
-    int linkIndex = _containsLinkIndex(_primaryLink.lock().get());
-    if (linkIndex != -1 && !_rgLinkInfo[linkIndex].commLost && !_rgLinkInfo[linkIndex].link->linkConfiguration()->isHighLatency()) {
+    SharedLinkInterfacePtr primaryLink = _primaryLink.lock();
+    int linkIndex = _containsLinkIndex(primaryLink.get());
+    if (linkIndex != -1 && !_rgLinkInfo[linkIndex].commLost && !primaryLink->linkConfiguration()->isHighLatency()) {
         // Current priority link is still valid
         return false;
     }
 
-    WeakLinkInterfacePtr bestActivePrimaryLink = _bestActivePrimaryLink();
+    SharedLinkInterfacePtr bestActivePrimaryLink = _bestActivePrimaryLink();
 
-    if (linkIndex != -1 && bestActivePrimaryLink.expired()) {
+    if (linkIndex != -1 && !bestActivePrimaryLink) {
         // Nothing better available, leave things set to current primary link
         return false;
     } else {
-        if (bestActivePrimaryLink.lock().get() != _primaryLink.lock().get()) {
-            if (!_primaryLink.expired() && _primaryLink.lock()->linkConfiguration()->isHighLatency()) {
+        if (bestActivePrimaryLink != primaryLink) {
+            if (primaryLink && primaryLink->linkConfiguration()->isHighLatency()) {
                 _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
                                MAV_CMD_CONTROL_HIGH_LATENCY,
                                true,
@@ -308,7 +315,7 @@ bool VehicleLinkManager::_updatePrimaryLink(void)
             _primaryLink = bestActivePrimaryLink;
             emit primaryLinkChanged();
 
-            if (!bestActivePrimaryLink.expired() && bestActivePrimaryLink.lock()->linkConfiguration()->isHighLatency()) {
+            if (bestActivePrimaryLink && bestActivePrimaryLink->linkConfiguration()->isHighLatency()) {
                 _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
                                MAV_CMD_CONTROL_HIGH_LATENCY,
                                true,
@@ -390,11 +397,10 @@ QStringList VehicleLinkManager::linkStatuses(void) const
 
 bool VehicleLinkManager::primaryLinkIsPX4Flow(void) const
 {
-    WeakLinkInterfacePtr nullWeak;
-
-    if (_primaryLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = _primaryLink.lock();
+    if (!sharedLink) {
         return false;
     } else {
-        return _primaryLink.lock()->isPX4Flow();
+        return sharedLink->isPX4Flow();
     }
 }

--- a/src/Vehicle/VehicleLinkManager.h
+++ b/src/Vehicle/VehicleLinkManager.h
@@ -73,7 +73,7 @@ private:
     void                    _removeLink             (LinkInterface* link);
     void                    _linkDisconnected       (void);
     bool                    _updatePrimaryLink      (void);
-    WeakLinkInterfacePtr    _bestActivePrimaryLink  (void);
+    SharedLinkInterfacePtr  _bestActivePrimaryLink  (void);
     void                    _commRegainedOnLink     (LinkInterface*  link);
 
     typedef struct LinkInfo {

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -8,7 +8,13 @@
  ****************************************************************************/
 
 #include "LinkInterface.h"
+#include "LinkManager.h"
 #include "QGCApplication.h"
+
+QGC_LOGGING_CATEGORY(LinkInterfaceLog, "LinkInterfaceLog")
+
+// The LinkManager is only forward declared in the header, so the static_assert is here instead.
+static_assert(LinkManager::invalidMavlinkChannel() == std::numeric_limits<uint8_t>::max(), "update LinkInterface::_mavlinkChannel");
 
 LinkInterface::LinkInterface(SharedLinkConfigurationPtr& config, bool isPX4Flow)
     : QThread   (0)
@@ -23,26 +29,53 @@ LinkInterface::LinkInterface(SharedLinkConfigurationPtr& config, bool isPX4Flow)
 LinkInterface::~LinkInterface()
 {
     if (_vehicleReferenceCount != 0) {
-        qWarning() << "~LinkInterface still have vehicle references:" << _vehicleReferenceCount;
+        qCWarning(LinkInterfaceLog) << "~LinkInterface still have vehicle references:" << _vehicleReferenceCount;
     }
     _config.reset();
 }
 
 uint8_t LinkInterface::mavlinkChannel(void) const
 {
-    if (!_mavlinkChannelSet) {
-        qWarning() << "Call to LinkInterface::mavlinkChannel with _mavlinkChannelSet == false";
+    if (!mavlinkChannelIsSet()) {
+        qCWarning(LinkInterfaceLog) << "mavlinkChannel isSet() == false";
     }
     return _mavlinkChannel;
 }
 
-void LinkInterface::_setMavlinkChannel(uint8_t channel)
+bool LinkInterface::mavlinkChannelIsSet(void) const
 {
-    if (_mavlinkChannelSet) {
-        qWarning() << "Mavlink channel set multiple times";
+    return (LinkManager::invalidMavlinkChannel() != _mavlinkChannel);
+}
+
+bool LinkInterface::_allocateMavlinkChannel()
+{
+    // should only be called by the LinkManager during setup
+    Q_ASSERT(!mavlinkChannelIsSet());
+    if (mavlinkChannelIsSet()) {
+        qCWarning(LinkInterfaceLog) << "_allocateMavlinkChannel already have " << _mavlinkChannel;
+        return true;
     }
-    _mavlinkChannelSet = true;
-    _mavlinkChannel = channel;
+
+    auto mgr = qgcApp()->toolbox()->linkManager();
+    _mavlinkChannel = mgr->allocateMavlinkChannel();
+    if (!mavlinkChannelIsSet()) {
+        qCWarning(LinkInterfaceLog) << "_allocateMavlinkChannel failed";
+        return false;
+    }
+    qCDebug(LinkInterfaceLog) << "_allocateMavlinkChannel" << _mavlinkChannel;
+    return true;
+}
+
+void LinkInterface::_freeMavlinkChannel()
+{
+    qCDebug(LinkInterfaceLog) << "_freeMavlinkChannel" << _mavlinkChannel;
+    if (LinkManager::invalidMavlinkChannel() == _mavlinkChannel) {
+        return;
+    }
+
+    auto mgr = qgcApp()->toolbox()->linkManager();
+    mgr->freeMavlinkChannel(_mavlinkChannel);
+    _mavlinkChannel = LinkManager::invalidMavlinkChannel();
 }
 
 void LinkInterface::writeBytesThreadSafe(const char *bytes, int length)
@@ -66,7 +99,7 @@ void LinkInterface::removeVehicleReference(void)
             disconnect();
         }
     } else {
-        qWarning() << "LinkInterface::removeVehicleReference called with no vehicle references";
+        qCWarning(LinkInterfaceLog) << "removeVehicleReference called with no vehicle references";
     }
 }
 

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -11,6 +11,7 @@
 
 #include <QThread>
 #include <QDateTime>
+#include <QLoggingCategory>
 #include <QMutex>
 #include <QMutexLocker>
 #include <QMetaType>
@@ -26,6 +27,8 @@
 
 class LinkManager;
 
+Q_DECLARE_LOGGING_CATEGORY(LinkInterfaceLog)
+
 /**
 * @brief The link interface defines the interface for all links used to communicate
 * with the ground station application.
@@ -36,7 +39,8 @@ class LinkInterface : public QThread
 
     friend class LinkManager;
 
-public:    
+public:
+
     virtual ~LinkInterface();
 
     Q_PROPERTY(bool isPX4Flow   READ isPX4Flow  CONSTANT)
@@ -58,6 +62,8 @@ public:
     virtual bool isLogReplay    (void) { return false; }
 
     uint8_t mavlinkChannel              (void) const;
+    bool    mavlinkChannelIsSet         (void) const;
+
     bool    decodedFirstMavlinkPacket   (void) const { return _decodedFirstMavlinkPacket; }
     bool    setDecodedFirstMavlinkPacket(bool decodedFirstMavlinkPacket) { return _decodedFirstMavlinkPacket = decodedFirstMavlinkPacket; }
     void    writeBytesThreadSafe        (const char *bytes, int length);
@@ -79,16 +85,24 @@ protected:
 
     SharedLinkConfigurationPtr _config;
 
+    ///
+    /// \brief _allocateMavlinkChannel
+    ///     Called by the LinkManager during LinkInterface construction
+    /// instructing the link to setup channels.
+    ///
+    /// Default implementation allocates a single channel. But some link types
+    /// (such as MockLink) need more than one.
+    ///
+    virtual bool _allocateMavlinkChannel();
+    virtual void _freeMavlinkChannel    ();
+
 private:
     // connect is private since all links should be created through LinkManager::createConnectedLink calls
     virtual bool _connect(void) = 0;
 
     virtual void _writeBytes(const QByteArray) = 0; // Not thread safe, only writeBytesThreadSafe is thread safe
 
-    void _setMavlinkChannel(uint8_t channel);
-
-    bool    _mavlinkChannelSet          = false;
-    uint8_t _mavlinkChannel;
+    uint8_t _mavlinkChannel             = std::numeric_limits<uint8_t>::max();
     bool    _decodedFirstMavlinkPacket  = false;
     bool    _isPX4Flow                  = false;
     int     _vehicleReferenceCount      = 0;

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -13,6 +13,8 @@
 #include <QMultiMap>
 #include <QMutex>
 
+#include <limits>
+
 #include "LinkConfiguration.h"
 #include "LinkInterface.h"
 #include "QGCLoggingCategory.h"
@@ -112,8 +114,12 @@ public:
     // Override from QGCTool
     virtual void setToolbox(QGCToolbox *toolbox);
 
-    /// @return This mavlink channel is never assigned to a vehicle.
-    uint8_t reservedMavlinkChannel(void) { return 0; }
+    static constexpr uint8_t invalidMavlinkChannel(void) { return std::numeric_limits<uint8_t>::max(); }
+
+    /// Allocates a mavlink channel for use
+    /// @return Mavlink channel index, invalidMavlinkChannel() for no channels available
+    uint8_t allocateMavlinkChannel(void);
+    void freeMavlinkChannel(uint8_t channel);
 
     /// If you are going to hold a reference to a LinkInterface* in your object you must reference count it
     /// by using this method to get access to the shared pointer.
@@ -124,10 +130,6 @@ public:
     SharedLinkConfigurationPtr addConfiguration(LinkConfiguration* config);
 
     void startAutoConnectedLinks(void);
-
-    /// Reserves a mavlink channel for use
-    /// @return Mavlink channel index, 0 for no channels available
-    int _reserveMavlinkChannel(void);
 
     static const char*  settingsGroup;
 
@@ -147,7 +149,6 @@ private:
     void                _removeConfiguration        (LinkConfiguration* config);
     void                _addUDPAutoConnectLink      (void);
     void                _addMAVLinkForwardingLink   (void);
-    void                _freeMavlinkChannel         (int channel);
     bool                _isSerialPortConnected      (void);
 
 #ifndef NO_SERIAL_LINK

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -10,9 +10,10 @@
 #pragma once
 
 #include <QElapsedTimer>
-#include <QMap>
-#include <QLoggingCategory>
 #include <QGeoCoordinate>
+#include <QLoggingCategory>
+#include <QMap>
+#include <QMutex>
 
 #include "MockLinkMissionItemHandler.h"
 #include "MockLinkFTP.h"
@@ -188,7 +189,11 @@ private slots:
 
 private:
     // LinkInterface overrides
-    bool _connect(void) override;
+    bool _connect                       (void) override;
+    bool _allocateMavlinkChannel        () override;
+    void _freeMavlinkChannel            () override;
+    uint8_t mavlinkAuxChannel           (void) const;
+    bool mavlinkAuxChannelIsSet         (void) const;
 
     // QThread override
     void run(void) final;
@@ -198,6 +203,7 @@ private:
     void _sendHighLatency2              (void);
     void _handleIncomingNSHBytes        (const char* bytes, int cBytes);
     void _handleIncomingMavlinkBytes    (const uint8_t* bytes, int cBytes);
+    void _handleIncomingMavlinkMsg      (const mavlink_message_t& msg);
     void _loadParams                    (void);
     void _handleHeartBeat               (const mavlink_message_t& msg);
     void _handleSetMode                 (const mavlink_message_t& msg);
@@ -233,11 +239,13 @@ private:
     static MockLink* _startMockLinkWorker(QString configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, MockConfiguration::FailureMode_t failureMode);
     static MockLink* _startMockLink(MockConfiguration* mockConfig);
 
+    uint8_t                     _mavlinkAuxChannel              = std::numeric_limits<uint8_t>::max();
+    QMutex                      _mavlinkAuxMutex;
+
     MockLinkMissionItemHandler  _missionItemHandler;
 
     QString                     _name;
     bool                        _connected;
-    int                         _mavlinkChannel;
 
     uint8_t                     _vehicleSystemId;
     uint8_t                     _vehicleComponentId             = MAV_COMP_ID_AUTOPILOT1;


### PR DESCRIPTION
Squashed commit of the following:

```
commit 8797ce4767ffa4b257a6f4477db30fef85eb6dc5
Author: Keith Bennett <keith@airmap.com>
Date:   Sun Apr 25 15:37:42 2021 -0500

    Fix from rebase

commit ea0d6b9f4401fc7453a8a5be54bbe288334c749e
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 22 22:39:59 2021 -0500

    * Fix spurious failure in `_multiLinkSingleVehicleTest`

    * Fix more racey instances of `if (!weakPtr.expired()){...weakPtr.lock()...}`
    * Fix `_multiLinkSingleVehicleTest` thinking that link 1 will always be the primary link

commit ce2c43fd245443dc6588b41b3a9e8a85a6f07aaf
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 22 18:16:34 2021 -0500

    Remove references to the MAVLinkChannel.{h,cpp} files that I still have locally

commit d7d44e3acc1a7a7b3c521786855537bac31adf48
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 22 18:07:54 2021 -0500

    Normalize to qCDebug and qCWarning on their respective log channels

commit 850cc7d193046626c2d2e6b8fbcd90cb6548ae52
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 22 17:58:25 2021 -0500

    Per feedback, use qCDebug and qCWarning

commit 4ebae9ac345a4bc86c038e5d0e39d4f049dac54d
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 22 14:43:16 2021 -0500

    Updates from review

    * Remove the `LinkInterface::Channel` object
    * Remove the reserved channel 0 and make channel 0 reservable
    * Ensure that any user of the `reserveMavlinkChannel()` function will get a compiler error to note that a return of 0 no longer means error
    * Make the `APMFirmwarePlugin` use a static channel member mutexed also by a static member

commit 80a3bd225cbbc71ff6dbdcaec01bc4c46e95f975
Author: Keith Bennett <keith@airmap.com>
Date:   Wed Apr 21 00:44:12 2021 -0500

    Use a temporary-allocated channel instead of the reserved channel 0

commit cd8efddcf548ead8fb584b9f5585295b1d0276b9
Author: Keith Bennett <keith@airmap.com>
Date:   Tue Apr 20 22:06:50 2021 -0500

    fix racey `if (!weakLink.expired()) {...weakLink.lock()...}`

commit 2c68a63e863ddd0ea076f217d2d0d8361071abd7
Author: Keith Bennett <keith@airmap.com>
Date:   Tue Apr 20 22:06:17 2021 -0500

    Specify a channel parameter instead of hardcode to 0

commit 92e9c38aae31e791cc4cf74bd7548811f9b0f78f
Author: Keith Bennett <keith@airmap.com>
Date:   Tue Apr 20 20:37:31 2021 -0500

    Refactor the mavlink channel

    * `LinkInterface::Channel` now represents the channel id association with `LinkManager`

commit d30d9a22a7412b4aae5d244d390080357bceffb2
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 15 22:43:57 2021 -0500

    Clean up debug logs

commit e0d52d6bdf9472523a157f69b7185e76944a3659
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 15 22:01:15 2021 -0500

    fix racey `if (weak_ptr.expired()) {...weak_ptr.lock()...}`

commit b6f70efb8796e59accc130583cd4b1988ffee42c
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 15 21:26:38 2021 -0500

    Fix `MockLink` channel collision and racey processing of reverse-direction messages

    * `_handleIncomingMavlinkBytes` needs to use a different channel because it processes messages parallel to `MAVLinkProtocol::receiveBytes`

    * `_handleIncomingMavlinkBytes`'s auxiliary channel needs its own mutex guard

commit f9265aad4566503f706ab2ea955d4f0220460cca
Author: Keith Bennett <keith@airmap.com>
Date:   Thu Apr 15 07:50:07 2021 -0500

    Debug messages (revert me later)

commit 8d5bfec35bb0aef9f41fe94349dcc8c10cfe12bf
Author: Keith Bennett <keith@airmap.com>
Date:   Wed Apr 14 21:59:24 2021 -0500

    fix `MockLink::_mavlinkChannel` hiding `LinkInterface::_mavlinkChannel`

    * causes all calls out to mavlink library from `MockLink` to use channel 0,
      which causes problems with at least `VehicleLinkManagerTest::_multiLinkSingleVehicleTest()`
      and possibly other tests

commit 6b4e8e9af4b813045c79a870641f9f3a396569d4
Author: Keith Bennett <keith@airmap.com>
Date:   Wed Apr 14 17:23:24 2021 -0500

    ensure `MAVLinkProtocol::receiveBytes` locks the link's shared_ptr while it's in use

commit 9d352c818a054694f2c95ca0238a39f0e31f1145
Author: Keith Bennett <keith@airmap.com>
Date:   Wed Apr 14 16:41:04 2021 -0500

    fix racey `if (weak_ptr.expired()) {...weak_ptr.lock()...}`

commit 9e4a7248874bc5a5ddb6ef3932901d604767c14a
Author: Keith Bennett <keith@airmap.com>
Date:   Sun Apr 11 23:50:46 2021 -0500

    fix racey check of weak_ptr expiration

```
