### PR TITLE
QTimer deprecated API build error fix

### DIFF
--- a/src/Vehicle/ComponentInformationManager.h
+++ b/src/Vehicle/ComponentInformationManager.h
@@ -14,7 +14,7 @@
 #include "StateMachine.h"
 #include "ComponentInformationCache.h"
 
-#include <QTime>
+#include <QElapsedTimer>
 
 Q_DECLARE_LOGGING_CATEGORY(ComponentInformationManagerLog)
 
@@ -67,7 +67,7 @@ private:
     QString                         _currentCacheFileTag;
     bool                            _currentFileValidCrc        = false;
 
-    QTime                           _downloadStartTime;
+    QElapsedTimer                   _downloadStartTime;
 
     static StateFn  _rgStates[];
     static int      _cStates;


### PR DESCRIPTION
Small fix for deprecated API build error (especially necessary for Qt 5.15). Build error fixed is:

```

.../src/Vehicle/ComponentInformationManager.cc:348:40: error: 'start' is deprecated: 
Use QElapsedTimer instead [-Werror,-Wdeprecated-declarations]
                    _downloadStartTime.start();

note: expanded from macro 'QT_DEPRECATED_X'
#  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
```