### PR TITLE
QTime deprecated on Qt5.15, migrate to to QElapsedTimer; it's a one-liner.

### DIFF
--- a/src/Vehicle/ComponentInformationManager.h
+++ b/src/Vehicle/ComponentInformationManager.h
@@ -14,7 +14,7 @@
 #include "StateMachine.h"
 #include "ComponentInformationCache.h"
 
-#include <QTime>
+#include <QElapsedTimer>
 
 Q_DECLARE_LOGGING_CATEGORY(ComponentInformationManagerLog)
 
@@ -67,7 +67,7 @@ private:
     QString                         _currentCacheFileTag;
     bool                            _currentFileValidCrc        = false;
 
-    QTime                           _downloadStartTime;
+    QElapsedTimer                   _downloadStartTime;
 
     static StateFn  _rgStates[];
     static int      _cStates;


### PR DESCRIPTION
When building QGC for (Android and) Qt.5.15(.2) this appears:
```
/usr/local/Qt-5.15.2/include/QtCore/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
#    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                      ^
/src/AirBoss/src/Vehicle/ComponentInformationManager.cc:337:40: error: 'start' is deprecated: Use QElapsedTimer instead [-Werror,-Wdeprecated-declarations]
                    _downloadStartTime.start();
```

The [documentation for `QElapsedTimer`](https://doc.qt.io/qt-5/qelapsedtimer.html) encourages easy migration:

> The QElapsedTimer class is usually used to quickly calculate how much time has elapsed between two events. Its API is 
> similar to that of QTime, so code that was using that can be ported quickly to the new class.
> 
> However, unlike QTime, QElapsedTimer tries to use monotonic clocks if possible. This means it's not possible to convert 
> QElapsedTimer objects to a human-readable time.
> 
> The typical use-case for the class is to determine how much time was spent in a slow operation.
