### PR TITLE
PX4: allow flight mode setup without sensors calibrated

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -156,8 +156,6 @@ QString PX4AutoPilotPlugin::prerequisiteSetup(VehicleComponent* component) const
                 return _airframeComponent->name();
             } else if (_radioComponent && !_radioComponent->setupComplete()) {
                 return _radioComponent->name();
-            } else if (_sensorsComponent && !_sensorsComponent->setupComplete()) {
-                return _sensorsComponent->name();
             }
         }
     } else if (qobject_cast<const PX4RadioComponent*>(component)) {


### PR DESCRIPTION
Before this change it is not allowed to set up the flight modes unless all sensor calibrations are completed.

I don't think that makes sense because it is possible to calibrate RC without having the sensors calibrated, and it's the logical next step right after that.

It is also a problem if HITL (hardware-in-the-loop) is used where the sensors are not marked as calibrated but you still need to be able to configure the flight modes. This is what prompted me to suggest this change.


