### PR TITLE
QGCTileCacheWorker: Use explicit type in lambda function

### DIFF
--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -1197,7 +1197,7 @@ QGCCacheWorker::_lookupReady(QHostInfo info)
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
         connect(socket, QOverload<QAbstractSocket::SocketError>::of(&QAbstractSocket::error), this, [this, socket](QAbstractSocket::SocketError error) {
 #else
-        connect(socket, &QAbstractSocket::errorOccurred, this, [this, socket](auto error) {
+        connect(socket, &QAbstractSocket::errorOccurred, this, [this, socket](QAbstractSocket::SocketError error) {
 #endif
             qCDebug(QGCTileCacheLog) << "No internet connection, reason:" << error;
             emit internetStatus(false);


### PR DESCRIPTION
This fixes a broken build on my setup. Otherwise I see the following
error:

/home/borgers/projects/qgroundcontrol/src/QtLocationPlugin/QGCTileCacheWorker.cpp:1200:79: error: use of ‘auto’ in lambda parameter declaration only available with ‘-std=c++14’ or ‘-std=gnu++14’
 1200 |         connect(socket, &QAbstractSocket::errorOccurred, this, [this, socket](auto error) {
      |

As mentioned in https://github.com/mavlink/qgroundcontrol/pull/9591


