### PR TITLE
fix cmake issues on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.idea/
+.vscode/
+cmake-build-*/
+out/
 libs/lib/Frameworks/GStreamer.framework
 *_qmlcache.qrc
 *.swp

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_subdirectory(qtandroidserialport)
 add_subdirectory(shapelib)
+if (WIN32)
+    add_subdirectory(zlib)
+endif (WIN32)
 if (GST_FOUND)
     add_subdirectory(qmlglsink)
 endif()

--- a/libs/shapelib/CMakeLists.txt
+++ b/libs/shapelib/CMakeLists.txt
@@ -33,11 +33,13 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
 cmake_policy(SET CMP0026 OLD) # Disallow use of the LOCATION property for build targets
 
-add_compile_options(
-	-Wno-missing-braces
-	-Wno-sign-compare
-	-Wno-return-type
-)
+if(NOT MSVC)
+  add_compile_options(
+  	-Wno-missing-braces
+  	-Wno-sign-compare
+  	-Wno-return-type
+  )
+endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/libs/zlib/CMakeLists.txt
+++ b/libs/zlib/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(z STATIC)
+target_link_libraries(z PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/windows/lib/zlibstat.lib)
+target_include_directories(z PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/windows/include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -168,14 +168,13 @@ add_subdirectory(VideoReceiver)
 target_link_libraries(qgc
 	PRIVATE
 		shp
-                Qt5::QuickControls2
-                z # zlib
+		Qt5::QuickControls2
 
 	PUBLIC
 		Qt5::QuickWidgets
 		Qt5::Widgets
 
-                ADSB
+		ADSB
 		Airmap
 		AnalyzeView
 		api
@@ -201,6 +200,7 @@ target_link_libraries(qgc
 		Vehicle
 		VehicleSetup
 		VideoManager
+		z # zlib
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
ignore typical IDE folders (CLion, VSCode)
exclude none windows compiler flags, make zlib include/linker files available
- cl : Command line error D8021 : invalid numeric argument '/Wno-missing-braces'
- ..\src\VehicleSetup\FirmwareUpgradeController.cc(29): fatal error C1083: Cannot open include file: 'zlib.h': No such file or directory