### PR TITLE
Stable v4.1 - create an "autoconfig" function for RTSP video streaming (IP setting)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,8 @@ install:
       Write-Host "Installed" -ForegroundColor Green
 
 build_script:
-  - mkdir %SHADOW_BUILD_DIR% && cd %SHADOW_BUILD_DIR% && %QT_QMAKE_DIR%\qmake -r CONFIG+=%CONFIG% %APPVEYOR_BUILD_FOLDER%\qgroundcontrol.pro
+  - if %APPVEYOR_REPO_TAG% EQU "true" ( set STABLE_OR_DAILY=StableBuild ) else ( set STABLE_OR_DAILY=DailyBuild )
+  - mkdir %SHADOW_BUILD_DIR% && cd %SHADOW_BUILD_DIR% && %QT_QMAKE_DIR%\qmake -r CONFIG+=%CONFIG% CONFIG+=%STABLE_OR_DAILY% %APPVEYOR_BUILD_FOLDER%\qgroundcontrol.pro
   - cd %SHADOW_BUILD_DIR% && %QT_JOM_DIR%\jom
   - if "%CONFIG%" EQU "installer" ( copy %SHADOW_BUILD_DIR%\staging\QGroundControl-installer.exe %APPVEYOR_BUILD_FOLDER%\QGroundControl-installer.exe )
 # Generate the source server information to embed in the PDB

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@ install:
       Write-Host "Installed" -ForegroundColor Green
 
 build_script:
-  - if %APPVEYOR_REPO_TAG% EQU "true" ( set STABLE_OR_DAILY=StableBuild ) else ( set STABLE_OR_DAILY=DailyBuild )
+  - ps: $env:STABLE_OR_DAILY = if ($env:APPVEYOR_REPO_TAG -eq $True) { "StableBuild" } else { "DailyBuild" }
   - mkdir %SHADOW_BUILD_DIR% && cd %SHADOW_BUILD_DIR% && %QT_QMAKE_DIR%\qmake -r CONFIG+=%CONFIG% CONFIG+=%STABLE_OR_DAILY% %APPVEYOR_BUILD_FOLDER%\qgroundcontrol.pro
   - cd %SHADOW_BUILD_DIR% && %QT_JOM_DIR%\jom
   - if "%CONFIG%" EQU "installer" ( copy %SHADOW_BUILD_DIR%\staging\QGroundControl-installer.exe %APPVEYOR_BUILD_FOLDER%\QGroundControl-installer.exe )

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,9 +85,9 @@ addons:
 
 before_install:
   # fetch entire git repo to properly determine the version
-  - if [ "${CONFIG}" = "installer" ]; then
-        cd ${TRAVIS_BUILD_DIR} && git fetch --unshallow && git fetch --all --tags;
-    fi
+  - cd ${TRAVIS_BUILD_DIR}
+  - git fetch --unshallow
+  - git fetch --all --tags
 
   # compile threads
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@ Note: This file only contains high level features or important fixes.
 
 ## 4.1
 
+### 4.1.2 - Not yet released
+* Bug: Radio setup - Fix double send of `MAV_CMD_PREFLIGHT_CALIBRATION` causing "Unable to send command" error.
+
 ### 4.1.1 - Stable
 * Fix TCP link comms
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 Note: This file only contains high level features or important fixes.
 
+## 4.1.1 Not yet released
+* Fix TCPLink comms
+
 ## 4.1 - Daily build
 
 * Support simple cameras which only support DIGICAM_CONTROL in the Photo/Video control on Fly View.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,12 @@
 
 Note: This file only contains high level features or important fixes.
 
-## 4.1.1 Not yet released
-* Fix TCPLink comms
+## 4.1
 
-## 4.1 - Daily build
+### 4.1.1 - Stable
+* Fix TCP link comms
+
+### 4.1.0
 
 * Support simple cameras which only support DIGICAM_CONTROL in the Photo/Video control on Fly View.
 * Load Parameters From File: Support loading parameters which don't currently existing on the vehicle.
@@ -25,30 +27,30 @@ Note: This file only contains high level features or important fixes.
 
 ## 4.0
 
-## 4.0.9 - Not yet released
+### 4.0.9
 
 * Don't auto-connect to second Cube Orange/Yellow composite port
 * Plan: Fix bugs associated with mission commands which specify and altitude but no lat/lon
 * Fix bug which could prevent view switching from working after altitude mode warning dialog would pop up
 
-## 4.0.8 - Stable
+### 4.0.8
 
 * iOS: Modify QGC file storage location to support new Files app
 * Mobile: Fix Log Replay status bar file selection
 
-## 4.0.7 - Stable
+### 4.0.7
 
 * Fix video page sizing
 * Virtual Joystick: Fix right stick centering. Fix/add support for rover/sub reverse throttle support.
 * Fix display of multiple ADSB vehicles
 
-### 4.0.6 - Stable
+### 4.0.6
 
 * Analyze/Log Download - Fix download on mobile versions of QGC
 * Fly: Fix problems where Continue Mission and Change Altitude were not available after a Mission Pause.
 * PX4 Flow: Fix video display problem
 
-### 4.0.5 - Stable
+### 4.0.5
 
 * Solo: Fix mission upload failures
 * Plan: Fix crash when using Create Plan - Survey for fixed wing vehicle

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,8 @@ Note: This file only contains high level features or important fixes.
 ## 4.1
 
 ### 4.1.2 - Not yet released
-* Bug: Radio setup - Fix double send of `MAV_CMD_PREFLIGHT_CALIBRATION` causing "Unable to send command" error.
+* Bug: Radio setup - Fix double send of `MAV_CMD_PREFLIGHT_CALIBRATION` causing "Unable to send command" error. [GitHub Issue](https://github.com/mavlink/qgroundcontrol/issues/9381)
+* Bug: Fly View - Pause - Fix "Unable to send command" error. [GitHub Issue](https://github.com/mavlink/qgroundcontrol/issues/9397)
 
 ### 4.1.1 - Stable
 * Fix TCP link comms

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <manifest package="org.mavlink.qgroundcontrol" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="3.0.0-243-gd759437" android:versionCode="300243" android:installLocation="auto">
-    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="-- %%INSERT_APP_NAME%% --" android:icon="@drawable/icon">
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="-- %%INSERT_APP_NAME%% --" android:icon="@drawable/icon" android:requestLegacyExternalStorage="true">
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.mavlink.qgroundcontrol.QGCActivity" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="sensorLandscape" android:launchMode="singleTask" android:keepScreenOn="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/custom-example/qgcresources.exclusion
+++ b/custom-example/qgcresources.exclusion
@@ -1,3 +1,2 @@
         <file alias="PaperPlane.svg">src/ui/toolbar/Images/PaperPlane.svg</file>
-        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlightDisplay/FlyViewCustomLayer.qml</file>
 

--- a/custom-example/qgroundcontrol.exclusion
+++ b/custom-example/qgroundcontrol.exclusion
@@ -1,0 +1,2 @@
+        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlightDisplay/FlyViewCustomLayer.qml</file>
+

--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -200,7 +200,6 @@
 		<file alias="QGroundControl/FlightDisplay/FlightDisplayViewWidgets.qml">../src/FlightDisplay/FlightDisplayViewWidgets.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewAirspaceIndicator.qml">../src/FlightDisplay/FlyViewAirspaceIndicator.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyView.qml">../src/FlightDisplay/FlyView.qml</file>
-		<file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">../src/FlightDisplay/FlyViewCustomLayer.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewInstrumentPanel.qml">../src/FlightDisplay/FlyViewInstrumentPanel.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewMap.qml">../src/FlightDisplay/FlyViewMap.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewMissionCompleteDialog.qml">../src/FlightDisplay/FlyViewMissionCompleteDialog.qml</file>

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
@@ -189,6 +189,20 @@ SetupPage {
             }
 
             Flow {
+                function getParametersFile(frame) {
+                    const filename = frame === "heavy" ? "Sub/bluerov2-heavy" : "Sub/bluerov2"
+                    if (globals.activeVehicle.versionCompare(4 ,0 ,0) >= 0) {
+                        return filename + "-4_0_0.params"
+                    }
+                    if (globals.activeVehicle.versionCompare(3 ,5 ,4) >= 0) {
+                        return filename + "-3_5_4.params"
+                    }
+                    if (globals.activeVehicle.versionCompare(3 ,5 ,2) >= 0) {
+                        return filename + "-3_5_2.params"
+                    }
+                    return filename + "-3_5.params"
+                }
+
                 anchors.margins:    _margins
                 anchors.top:        applyParamsText.bottom
                 anchors.left:       parent.left
@@ -200,10 +214,9 @@ SetupPage {
                 QGCButton {
                     width:  parent.width
                     text:   "Blue Robotics BlueROV2"
-                    property var file:   _oldFW ? "Sub/bluerov2-3_5.params" : "Sub/bluerov2-3_5_2.params"
 
                     onClicked : {
-                        controller.loadParameters(file)
+                        controller.loadParameters(parent.getParametersFile())
                         hideDialog()
                     }
                 }
@@ -211,10 +224,9 @@ SetupPage {
                 QGCButton {
                     width:  parent.width
                     text:   "Blue Robotics BlueROV2 Heavy"
-                    property var file:  "Sub/bluerov2-heavy-3_5_2.params"
 
                     onClicked : {
-                        controller.loadParameters(file)
+                        controller.loadParameters(parent.getParametersFile("heavy"))
                         hideDialog()
                     }
                 }

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -700,10 +700,6 @@ void RadioComponentController::_writeCalibration(void)
 {
     if (!_uas) return;
 
-    if (_px4Vehicle()) {
-        _vehicle->stopCalibration();
-    }
-
     if (!_px4Vehicle() && (_vehicle->vehicleType() == MAV_TYPE_HELICOPTER || _vehicle->multiRotor()) &&  _rgChannelInfo[_rgFunctionChannelMapping[rcCalFunctionThrottle]].reversed) {
         // A reversed throttle could lead to dangerous power up issues if the firmware doesn't handle it absolutely correctly in all places.
         // So in this case fail the calibration for anything other than PX4 which is known to be able to handle this correctly.

--- a/src/FactSystem/FactControls/FactCheckBox.qml
+++ b/src/FactSystem/FactControls/FactCheckBox.qml
@@ -7,8 +7,6 @@ import QGroundControl.Palette 1.0
 import QGroundControl.Controls 1.0
 
 QGCCheckBox {
-    checkedState: isFactChecked()
-
     property Fact fact: Fact { }
 
     property variant checkedValue:   1

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -26,6 +26,7 @@
 #include "ArduCopterFirmwarePlugin.h"
 #include "ArduRoverFirmwarePlugin.h"
 #include "ArduSubFirmwarePlugin.h"
+#include "LinkManager.h"
 
 #include <QTcpSocket>
 
@@ -185,11 +186,16 @@ void APMFirmwarePlugin::_handleIncomingParamValue(Vehicle* vehicle, mavlink_mess
     paramValue.param_value = paramUnion.param_float;
 
     // Re-Encoding is always done using mavlink 1.0
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(0);
+    uint8_t channel = _reencodeMavlinkChannel();
+    QMutexLocker reencode_lock{&_reencodeMavlinkChannelMutex()};
+
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
+
+    Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
     mavlink_msg_param_value_encode_chan(message->sysid,
                                         message->compid,
-                                        0,                  // Re-encoding uses reserved channel 0
+                                        channel,
                                         message,
                                         &paramValue);
 }
@@ -240,7 +246,11 @@ void APMFirmwarePlugin::_handleOutgoingParamSetThreadSafe(Vehicle* /*vehicle*/, 
     }
 
     _adjustOutgoingMavlinkMutex.lock();
-    mavlink_msg_param_set_encode_chan(message->sysid, message->compid, outgoingLink->mavlinkChannel(), message, &paramSet);
+    mavlink_msg_param_set_encode_chan(message->sysid,
+                                      message->compid,
+                                      outgoingLink->mavlinkChannel(),
+                                      message,
+                                      &paramSet);
     _adjustOutgoingMavlinkMutex.unlock();
 }
 
@@ -349,16 +359,20 @@ QString APMFirmwarePlugin::_getMessageText(mavlink_message_t* message) const
 void APMFirmwarePlugin::_setInfoSeverity(mavlink_message_t* message) const
 {
     // Re-Encoding is always done using mavlink 1.0
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(0);
+    uint8_t channel = _reencodeMavlinkChannel();
+    QMutexLocker reencode_lock{&_reencodeMavlinkChannelMutex()};
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
 
     mavlink_statustext_t statusText;
     mavlink_msg_statustext_decode(message, &statusText);
 
     statusText.severity = MAV_SEVERITY_INFO;
+
+    Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
     mavlink_msg_statustext_encode_chan(message->sysid,
                                        message->compid,
-                                       0,                  // Re-encoding uses reserved channel 0
+                                       channel,
                                        message,
                                        &statusText);
 }
@@ -367,11 +381,21 @@ void APMFirmwarePlugin::_adjustCalibrationMessageSeverity(mavlink_message_t* mes
 {
     mavlink_statustext_t statusText;
     mavlink_msg_statustext_decode(message, &statusText);
+
     // Re-Encoding is always done using mavlink 1.0
-    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(0);
+    uint8_t channel = _reencodeMavlinkChannel();
+    QMutexLocker reencode_lock{&_reencodeMavlinkChannelMutex()};
+
+    mavlink_status_t* mavlinkStatusReEncode = mavlink_get_channel_status(channel);
     mavlinkStatusReEncode->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
     statusText.severity = MAV_SEVERITY_INFO;
-    mavlink_msg_statustext_encode_chan(message->sysid, message->compid, 0, message, &statusText);
+
+    Q_ASSERT(qgcApp()->thread() == QThread::currentThread());
+    mavlink_msg_statustext_encode_chan(message->sysid,
+                                       message->compid,
+                                       channel,
+                                       message,
+                                       &statusText);
 }
 
 void APMFirmwarePlugin::initializeStreamRates(Vehicle* vehicle)
@@ -711,12 +735,10 @@ void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
 
     setGuidedMode(vehicle, true);
 
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t                       msg;
         mavlink_set_position_target_local_ned_t cmd;
-        SharedLinkInterfacePtr                  sharedLink = weakLink.lock();
-
 
         memset(&cmd, 0, sizeof(cmd));
 
@@ -856,10 +878,9 @@ QString APMFirmwarePlugin::_versionRegex() {
 
 void APMFirmwarePlugin::_handleRCChannels(Vehicle* vehicle, mavlink_message_t* message)
 {
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_rc_channels_t   channels;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
         mavlink_msg_rc_channels_decode(message, &channels);
         //-- Ardupilot uses 0-255 to indicate 0-100% where QGC expects 0-100
@@ -878,10 +899,9 @@ void APMFirmwarePlugin::_handleRCChannels(Vehicle* vehicle, mavlink_message_t* m
 
 void APMFirmwarePlugin::_handleRCChannelsRaw(Vehicle* vehicle, mavlink_message_t *message)
 {
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_rc_channels_raw_t   channels;
-        SharedLinkInterfacePtr      sharedLink = weakLink.lock();
 
         mavlink_msg_rc_channels_raw_decode(message, &channels);
         //-- Ardupilot uses 0-255 to indicate 0-100% where QGC expects 0-100
@@ -919,11 +939,10 @@ void APMFirmwarePlugin::_sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMoti
         return;
     }
 
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         MAVLinkProtocol*                mavlinkProtocol = qgcApp()->toolbox()->mavlinkProtocol();
         mavlink_global_position_int_t   globalPositionInt;
-        SharedLinkInterfacePtr          sharedLink = weakLink.lock();
 
         memset(&globalPositionInt, 0, sizeof(globalPositionInt));
 
@@ -946,4 +965,28 @@ void APMFirmwarePlugin::_sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMoti
                                                     &globalPositionInt);
         vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), message);
     }
+}
+
+uint8_t APMFirmwarePlugin::_reencodeMavlinkChannel()
+{
+    // This mutex is only to guard against a race on allocating the channel id
+    // if two firmware plugins are created simultaneously from different threads
+    //
+    // Use of the allocated channel should be guarded by the mutex returned from
+    // _reencodeMavlinkChannelMutex()
+    //
+    static QMutex _channelMutex{};
+    _channelMutex.lock();
+    static uint8_t channel{LinkManager::invalidMavlinkChannel()};
+    if (LinkManager::invalidMavlinkChannel() == channel) {
+        channel = qgcApp()->toolbox()->linkManager()->allocateMavlinkChannel();
+    }
+    _channelMutex.unlock();
+    return channel;
+}
+
+QMutex& APMFirmwarePlugin::_reencodeMavlinkChannelMutex()
+{
+    static QMutex _mutex{};
+    return _mutex;
 }

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -699,10 +699,15 @@ void APMFirmwarePlugin::guidedModeRTL(Vehicle* vehicle, bool smartRTL)
     _setFlightModeAndValidate(vehicle, smartRTL ? smartRTLFlightMode() : rtlFlightMode());
 }
 
-void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange)
+void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange, bool pauseVehicle)
 {
     if (qIsNaN(vehicle->altitudeRelative()->rawValue().toDouble())) {
         qgcApp()->showAppMessage(tr("Unable to change altitude, vehicle altitude not known."));
+        return;
+    }
+
+    if (pauseVehicle && !_setFlightModeAndValidate(vehicle, pauseFlightMode())) {
+        qgcApp()->showAppMessage(tr("Unable to pause vehicle."));
         return;
     }
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -481,13 +481,6 @@ FactMetaData* APMFirmwarePlugin::_getMetaDataForFact(QObject* parameterMetaData,
 
 QList<MAV_CMD> APMFirmwarePlugin::supportedMissionCommands(QGCMAVLink::VehicleClass_t vehicleClass)
 {
-    return {
-#if 0
-    // Waiting for module update
-        MAV_CMD_DO_SET_REVERSE,
-#endif
-    };
-
     QList<MAV_CMD> supportedCommands = {
         MAV_CMD_NAV_WAYPOINT,
         MAV_CMD_NAV_LOITER_UNLIM, MAV_CMD_NAV_LOITER_TURNS, MAV_CMD_NAV_LOITER_TIME,

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -119,6 +119,9 @@ private:
 
     static const char*      _artooIP;
     static const int        _artooVideoHandshakePort;
+
+    static uint8_t          _reencodeMavlinkChannel();
+    static QMutex&          _reencodeMavlinkChannelMutex();
 };
 
 #endif

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -68,7 +68,7 @@ public:
     QString             missionFlightMode               (void) const override { return QString("Auto"); }
     void                pauseVehicle                    (Vehicle* vehicle) override;
     void                guidedModeRTL                   (Vehicle* vehicle, bool smartRTL) override;
-    void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeChange) override;
+    void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeChange, bool pauseVehicle) override;
     bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) override;
     void                adjustOutgoingMavlinkMessageThreadSafe(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message) override;
     virtual void        initializeStreamRates           (Vehicle* vehicle);

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -71,11 +71,8 @@ int ArduRoverFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVer
     return majorVersionNumber == 3 ? 5 : Vehicle::versionNotSetValue;
 }
 
-void ArduRoverFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange)
+void ArduRoverFirmwarePlugin::guidedModeChangeAltitude(Vehicle* /*vehicle*/, double /*altitudeChange*/, bool /*pauseVehicle*/)
 {
-    Q_UNUSED(vehicle);
-    Q_UNUSED(altitudeChange);
-
     qgcApp()->showAppMessage(QStringLiteral("Change altitude not supported."));
 }
 

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -50,7 +50,7 @@ public:
     // Overrides from FirmwarePlugin
     QString pauseFlightMode                         (void) const override { return QStringLiteral("Hold"); }
     QString followFlightMode                        (void) const override { return QStringLiteral("Follow"); }
-    void    guidedModeChangeAltitude                (Vehicle* vehicle, double altitudeChange) final;
+    void    guidedModeChangeAltitude                (Vehicle* vehicle, double altitudeChange, bool pauseVehicle) final;
     int     remapParamNameHigestMinorVersionNumber  (int majorVersionNumber) const final;
     const   FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     bool    supportsNegativeThrust                  (Vehicle *) final;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -260,7 +260,7 @@ void FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordina
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
 }
 
-void FirmwarePlugin::guidedModeChangeAltitude(Vehicle*, double)
+void FirmwarePlugin::guidedModeChangeAltitude(Vehicle*, double, bool pauseVehicle)
 {
     // Not supported by generic vehicle
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -155,7 +155,8 @@ public:
 
     /// Command vehicle to change altitude
     ///     @param altitudeChange If > 0, go up by amount specified, if < 0, go down by amount specified
-    virtual void guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange);
+    ///     @param pauseVehicle true: pause vehicle prior to altitude change
+    virtual void guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange, bool pauseVehicle);
 
     /// Default tx mode to apply to joystick axes
     /// TX modes are as outlined here: http://www.rc-airplane-world.com/rc-transmitter-modes.html

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -7,12 +7,7 @@
  *
  ****************************************************************************/
 
-
-/// @file
-///     @author Don Gagne <don@thegagnes.com>
-
-#ifndef PX4FirmwarePlugin_H
-#define PX4FirmwarePlugin_H
+#pragma once
 
 #include "FirmwarePlugin.h"
 #include "ParameterManager.h"
@@ -25,6 +20,9 @@ class PX4FirmwarePlugin : public FirmwarePlugin
 public:
     PX4FirmwarePlugin   ();
     ~PX4FirmwarePlugin  () override;
+
+    // Called internally only
+    void _changeAltAfterPause(void* resultHandlerData, bool pauseSucceeded);
 
     // Overrides from FirmwarePlugin
 
@@ -49,7 +47,7 @@ public:
     void                guidedModeLand                  (Vehicle* vehicle) override;
     void                guidedModeTakeoff               (Vehicle* vehicle, double takeoffAltRel) override;
     void                guidedModeGotoLocation          (Vehicle* vehicle, const QGeoCoordinate& gotoCoord) override;
-    void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeRel) override;
+    void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeRel, bool pauseVehicle) override;
     double              minimumTakeoffAltitude          (Vehicle* vehicle) override;
     void                startMission                    (Vehicle* vehicle) override;
     bool                isGuidedMode                    (const Vehicle* vehicle) const override;
@@ -107,9 +105,10 @@ private slots:
     void _mavCommandResult(int vehicleId, int component, int command, int result, bool noReponseFromVehicle);
 
 private:
-    void _handleAutopilotVersion(Vehicle* vehicle, mavlink_message_t* message);
-    QString _getLatestVersionFileUrl(Vehicle* vehicle) override;
-    QString _versionRegex() override;
+    void    _handleAutopilotVersion         (Vehicle* vehicle, mavlink_message_t* message);
+
+    QString _getLatestVersionFileUrl        (Vehicle* vehicle) override;
+    QString _versionRegex                   () override;
 
     // Any instance data here must be global to all vehicles
     // Vehicle specific data should go into PX4FirmwarePluginInstanceData
@@ -124,5 +123,3 @@ public:
 
     bool versionNotified;  ///< true: user notified over version issue
 };
-
-#endif

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -120,10 +120,31 @@ Item {
     }
 
     PhotoVideoControl {
+        id:                     photoVideoControl
         anchors.margins:        _toolsMargin
-        anchors.verticalCenter: parent.verticalCenter
         anchors.right:          parent.right
         width:                  _rightPanelWidth
+        state:                  _verticalCenter ? "verticalCenter" : "topAnchor"
+        states: [
+            State {
+                name: "verticalCenter"
+                AnchorChanges {
+                    target:                 photoVideoControl
+                    anchors.top:            undefined
+                    anchors.verticalCenter: _root.verticalCenter
+                }
+            },
+            State {
+                name: "topAnchor"
+                AnchorChanges {
+                    target:                 photoVideoControl
+                    anchors.verticalCenter: undefined
+                    anchors.top:            instrumentPanel.bottom
+                }
+            }
+        ]
+
+        property bool _verticalCenter: !QGroundControl.settingsManager.flyViewSettings.alternateInstrumentPanel.rawValue
     }
 
     TelemetryValuesBar {

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -500,7 +500,7 @@ Item {
             _activeVehicle.emergencyStop()
             break
         case actionChangeAlt:
-            _activeVehicle.guidedModeChangeAltitude(actionAltitudeChange)
+            _activeVehicle.guidedModeChangeAltitude(actionAltitudeChange, false /* pauseVehicle */)
             break
         case actionGoto:
             _activeVehicle.guidedModeGotoLocation(actionData)
@@ -515,8 +515,7 @@ Item {
             _activeVehicle.abortLanding(50)     // hardcoded value for climbOutAltitude that is currently ignored
             break
         case actionPause:
-            _activeVehicle.pauseVehicle()
-            _activeVehicle.guidedModeChangeAltitude(actionAltitudeChange)
+            _activeVehicle.guidedModeChangeAltitude(actionAltitudeChange, true /* pauseVehicle */)
             break
         case actionMVPause:
             rgVehicle = QGroundControl.multiVehicleManager.vehicles

--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -20,10 +20,8 @@ Rectangle {
     id:                 telemetryPanel
     height:             telemetryLayout.height + (_toolsMargin * 2)
     width:              telemetryLayout.width + (_toolsMargin * 2)
-    color:              Qt.hsla(_baseBGColor.hslHue, _baseBGColor.hslSaturation, _baseBGColor.hslLightness, 0.5)
+    color:              qgcPal.window
     radius:             ScreenTools.defaultFontPixelWidth / 2
-
-    property color _baseBGColor: qgcPal.window
 
     DeadMouseArea { anchors.fill: parent }
 

--- a/src/FlightMap/MapItems/CameraTriggerIndicator.qml
+++ b/src/FlightMap/MapItems/CameraTriggerIndicator.qml
@@ -29,13 +29,39 @@ MapQuickItem {
 
         readonly property real _radius: ScreenTools.defaultFontPixelHeight * 0.6
 
-        QGCColoredImage {
-            anchors.margins:    3
-            anchors.fill:       parent
-            color:              "white"
-            mipmap:             true
-            fillMode:           Image.PreserveAspectFit
-            source:             "/qmlimages/camera.svg"
+        // Bigger rectangle of camera icon
+        Rectangle {
+            id:                       cameraIconFrameRectangle
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter:   parent.verticalCenter
+            height:                   width * 0.6
+            width:                    parent.width * 0.6
+            color:                    qgcPal.window
+            radius:                   4
+
+            // Little rectangle on top indicating viewfinder
+            Rectangle {
+                id:                       cameraIconViewFinderRectangle
+                anchors.horizontalCenter: cameraIconFrameRectangle.horizontalCenter
+                anchors.bottom:           cameraIconFrameRectangle.top
+                width:                    cameraIconFrameRectangle.width * 0.5
+                height:                   cameraIconFrameRectangle.height * 0.3
+                color:                    qgcPal.window
+                radius:                   2
+            }
+        }
+
+        // Circunference indicating the lens
+        Rectangle {
+            id:                      cameraIconLens
+            anchors.centerIn:        cameraIconFrameRectangle
+            height:                  width
+            width:                   cameraIconFrameRectangle.height * 0.9
+            color:                   "transparent"
+            border.color:            "black"
+            opacity:                 0.9
+            border.width:            2
+            radius:                  width * 0.5
         }
     }
 }

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -31,6 +31,7 @@ MapQuickItem {
     anchorPoint.y:  vehicleItem.height / 2
     visible:        coordinate.isValid
 
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property bool   _adsbVehicle:   vehicle ? false : true
     property real   _uavSize:       ScreenTools.defaultFontPixelHeight * 5
     property real   _adsbSize:      ScreenTools.defaultFontPixelHeight * 2.5
@@ -41,7 +42,7 @@ MapQuickItem {
         id:         vehicleItem
         width:      vehicleIcon.width
         height:     vehicleIcon.height
-        opacity:    vehicle ? (vehicle.active ? 1.0 : 0.5) : 1.0
+        opacity:    (vehicle && _activeVehicle) ? ((vehicle === _activeVehicle) ? 1.0 : 0.5) : 1.0
 
         Rectangle {
             id:                 vehicleShadow

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -42,7 +42,7 @@ MapQuickItem {
         id:         vehicleItem
         width:      vehicleIcon.width
         height:     vehicleIcon.height
-        opacity:    (vehicle && _activeVehicle) ? ((vehicle === _activeVehicle) ? 1.0 : 0.5) : 1.0
+        opacity:    _adsbVehicle || vehicle === _activeVehicle ? 1.0 : 0.5
 
         Rectangle {
             id:                 vehicleShadow

--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -27,7 +27,7 @@ Rectangle {
     height:     mainLayout.height + (_margins * 2)
     color:      "#80000000"
     radius:     _margins
-    visible:    !QGroundControl.settingsManager.flyViewSettings.alternateInstrumentPanel.rawValue && (_mavlinkCamera || _videoStreamAvailable || _simpleCameraAvailable) && multiVehiclePanelSelector.showSingleVehiclePanel
+    visible:    (_mavlinkCamera || _videoStreamAvailable || _simpleCameraAvailable) && multiVehiclePanelSelector.showSingleVehiclePanel
 
     property real   _margins:                                   ScreenTools.defaultFontPixelHeight / 2
     property var    _activeVehicle:                             QGroundControl.multiVehicleManager.activeVehicle

--- a/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
+++ b/src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml
@@ -7,7 +7,6 @@
  *
  ****************************************************************************/
 
-
 import QtQuick 2.3
 
 import QGroundControl               1.0
@@ -18,30 +17,23 @@ import QGroundControl.FlightMap     1.0
 import QGroundControl.Palette       1.0
 
 Rectangle {
-    id:             root
-    height:         _outerRadius * 4 + _valuesWidget.height
-    radius:         _outerRadius
-    color:          qgcPal.window
+    height: _outerRadius * 4
+    radius: _outerRadius
+    color:  QGroundControl.globalPalette.window
 
-    // These properties are expected to be in the Loader
-    //  property real maxHeight
-    //  property bool showValues - true: show value pages
-
-    property real   _innerRadius:   (width - (_topBottomMargin * 2)) / 2
-    property real   _outerRadius:   _innerRadius + _topBottomMargin * 2
-    property real   _margins:       (width * 0.05) / 2
+    property real _outerMargin: (width * 0.05) / 2
+    property real _outerRadius: width / 2
+    property real _innerRadius: _outerRadius - _outerMargin
 
     // Prevent all clicks from going through to lower layers
     DeadMouseArea {
         anchors.fill: parent
     }
 
-    QGCPalette { id: qgcPal }
-
     QGCAttitudeWidget {
         id:                         attitude
         anchors.horizontalCenter:   parent.horizontalCenter
-        anchors.margins :           _margins
+        anchors.topMargin:          _outerMargin
         anchors.top:                parent.top
         size:                       _innerRadius * 2
         vehicle:                    globals.activeVehicle
@@ -50,7 +42,7 @@ Rectangle {
     QGCCompassWidget {
         id:                         compass
         anchors.horizontalCenter:   parent.horizontalCenter
-        anchors.margins:            _margins
+        anchors.topMargin:          _outerMargin * 2
         anchors.top:                attitude.bottom
         size:                       _innerRadius * 2
         vehicle:                    globals.activeVehicle

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -121,10 +121,17 @@ Joystick::Joystick(const QString& name, int axisCount, int buttonCount, int hatC
     connect(_multiVehicleManager, &MultiVehicleManager::activeVehicleChanged, this, &Joystick::_activeVehicleChanged);
 }
 
-Joystick::~Joystick()
+void Joystick::stop()
 {
     _exitThread = true;
     wait();
+}
+
+Joystick::~Joystick()
+{
+    if (!_exitThread) {
+        qWarning() << "Joystick thread still running!";
+    }
     delete[] _rgAxisValues;
     delete[] _rgCalibration;
     delete[] _rgButtonValues;

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -18,6 +18,7 @@
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
 #include "MultiVehicleManager.h"
+#include <atomic>
 
 Q_DECLARE_LOGGING_CATEGORY(JoystickLog)
 Q_DECLARE_LOGGING_CATEGORY(JoystickValuesLog)
@@ -53,7 +54,7 @@ class Joystick : public QThread
 public:
     Joystick(const QString& name, int axisCount, int buttonCount, int hatCount, MultiVehicleManager* multiVehicleManager);
 
-    ~Joystick();
+    virtual ~Joystick();
 
     typedef struct Calibration_t {
         int     min;
@@ -137,6 +138,7 @@ public:
     void setFunctionAxis(AxisFunction_t function, int axis);
     int getFunctionAxis(AxisFunction_t function);
 
+    void stop();
 
 /*
     // Joystick index used by sdl library
@@ -263,7 +265,7 @@ protected:
 
     uint8_t*_rgButtonValues         = nullptr;
 
-    bool    _exitThread             = false;    ///< true: signal thread to exit
+    std::atomic<bool> _exitThread{false};    ///< true: signal thread to exit
     bool    _calibrationMode        = false;
     int*    _rgAxisValues           = nullptr;
     Calibration_t* _rgCalibration   = nullptr;

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -38,6 +38,7 @@ JoystickManager::~JoystickManager() {
     QMap<QString, Joystick*>::iterator i;
     for (i = _name2JoystickMap.begin(); i != _name2JoystickMap.end(); ++i) {
         qCDebug(JoystickManagerLog) << "Releasing joystick:" << i.key();
+        i.value()->stop();
         delete i.value();
     }
     qDebug() << "Done";

--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -79,7 +79,11 @@ void ComplexMissionItem::_savePresetJson(const QString& name, QJsonObject& prese
     QSettings settings;
     settings.beginGroup(presetsSettingsGroup());
     settings.beginGroup(_presetSettingsKey);
-    settings.setValue(name, QCborMap::fromJsonObject(presetObject).toCborValue().toByteArray());
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    settings.setValue(name, QJsonDocument(presetObject).toBinaryData());
+#else
+    settings.setValue(name, QCborMap::fromJsonObject(presetObject).toCborValue().toVariant());
+#endif
 
     // Use this to save a survey preset as a JSON file to be included in the build
     // as a built-in survey preset that cannot be deleted.
@@ -108,7 +112,11 @@ QJsonObject ComplexMissionItem::_loadPresetJson(const QString& name)
     QSettings settings;
     settings.beginGroup(presetsSettingsGroup());
     settings.beginGroup(_presetSettingsKey);
-    return QCborValue(settings.value(name).toByteArray()).toMap().toJsonObject();
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+    return QJsonDocument::fromBinaryData(settings.value(name).toByteArray()).object();
+#else
+    return QCborValue::fromVariant(settings.value(name)).toMap().toJsonObject();
+#endif
 }
 
 void ComplexMissionItem::addKMLVisuals(KMLPlanDomDocument& /* domDocument */)

--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -27,7 +27,10 @@ ComplexMissionItem::ComplexMissionItem(PlanMasterController* masterController, b
     , _toolbox          (qgcApp()->toolbox())
     , _settingsManager  (_toolbox->settingsManager())
 {
-
+    connect(_missionController, &MissionController::plannedHomePositionChanged,         this, &ComplexMissionItem::_amslEntryAltChanged);
+    connect(_missionController, &MissionController::plannedHomePositionChanged,         this, &ComplexMissionItem::_amslExitAltChanged);
+    connect(_missionController, &MissionController::plannedHomePositionChanged,         this, &ComplexMissionItem::minAMSLAltitudeChanged);
+    connect(_missionController, &MissionController::plannedHomePositionChanged,         this, &ComplexMissionItem::maxAMSLAltitudeChanged);
 }
 
 const ComplexMissionItem& ComplexMissionItem::operator=(const ComplexMissionItem& other)

--- a/src/MissionManager/ComplexMissionItem.cc
+++ b/src/MissionManager/ComplexMissionItem.cc
@@ -124,9 +124,9 @@ void ComplexMissionItem::addKMLVisuals(KMLPlanDomDocument& /* domDocument */)
     // Default implementation has no visuals
 }
 
-void ComplexMissionItem::_appendFlightPathSegment(const QGeoCoordinate& coord1, double coord1AMSLAlt, const QGeoCoordinate& coord2, double coord2AMSLAlt)
+void ComplexMissionItem::_appendFlightPathSegment(FlightPathSegment::SegmentType segmentType, const QGeoCoordinate& coord1, double coord1AMSLAlt, const QGeoCoordinate& coord2, double coord2AMSLAlt)
 {
-    FlightPathSegment* segment = new FlightPathSegment(coord1, coord1AMSLAlt, coord2, coord2AMSLAlt, true /* queryTerrainData */, this /* parent */);
+    FlightPathSegment* segment = new FlightPathSegment(segmentType, coord1, coord1AMSLAlt, coord2, coord2AMSLAlt, true /* queryTerrainData */, this /* parent */);
 
     connect(segment, &FlightPathSegment::terrainCollisionChanged,       this,               &ComplexMissionItem::_segmentTerrainCollisionChanged);
     connect(segment, &FlightPathSegment::terrainCollisionChanged,       _missionController, &MissionController::recalcTerrainProfile, Qt::QueuedConnection);

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -15,6 +15,7 @@
 #include "SettingsManager.h"
 #include "KMLPlanDomDocument.h"
 #include "QmlObjectListModel.h"
+#include "FlightPathSegment.h"
 
 #include <QSettings>
 
@@ -117,7 +118,7 @@ protected slots:
 protected:
     void        _savePresetJson         (const QString& name, QJsonObject& presetObject);
     QJsonObject _loadPresetJson         (const QString& name);
-    void        _appendFlightPathSegment(const QGeoCoordinate& coord1, double coord1AMSLAlt, const QGeoCoordinate& coord2, double coord2AMSLAlt);
+    void        _appendFlightPathSegment(FlightPathSegment::SegmentType segmentType, const QGeoCoordinate& coord1, double coord1AMSLAlt, const QGeoCoordinate& coord2, double coord2AMSLAlt);
 
     bool                _isIncomplete =                 true;
     int                 _cTerrainCollisionSegments =    0;

--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -170,10 +170,10 @@ void FixedWingLandingComplexItem::_updateFlightPathSegmentsDontCallDirectly(void
     _flightPathSegments.beginReset();
     _flightPathSegments.clearAndDeleteContents();
     if (useLoiterToAlt()->rawValue().toBool()) {
-        _appendFlightPathSegment(finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
-        _appendFlightPathSegment(loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
     } else {
-        _appendFlightPathSegment(finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
     }
     _flightPathSegments.endReset();
 

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -96,8 +96,6 @@ void LandingComplexItem::_init(void)
 
     connect(this,                       &LandingComplexItem::altitudesAreRelativeChanged,   this, &LandingComplexItem::_amslEntryAltChanged);
     connect(this,                       &LandingComplexItem::altitudesAreRelativeChanged,   this, &LandingComplexItem::_amslExitAltChanged);
-    connect(_missionController,         &MissionController::plannedHomePositionChanged,     this, &LandingComplexItem::_amslEntryAltChanged);
-    connect(_missionController,         &MissionController::plannedHomePositionChanged,     this, &LandingComplexItem::_amslExitAltChanged);
     connect(finalApproachAltitude(),    &Fact::valueChanged,                                this, &LandingComplexItem::_amslEntryAltChanged);
     connect(landingAltitude(),          &Fact::valueChanged,                                this, &LandingComplexItem::_amslExitAltChanged);
     connect(this,                       &LandingComplexItem::amslEntryAltChanged,           this, &LandingComplexItem::maxAMSLAltitudeChanged);

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -72,11 +72,11 @@ void LandingComplexItem::_init(void)
     connect(landingHeading(),           &Fact::valueChanged,                                this, &LandingComplexItem::_recalcFromHeadingAndDistanceChange);
 
     connect(loiterRadius(),             &Fact::valueChanged,                                this, &LandingComplexItem::_recalcFromRadiusChange);
-    connect(this,                       &LandingComplexItem::loiterClockwiseChanged,        this, &LandingComplexItem::_recalcFromRadiusChange);
+    connect(loiterClockwise(),          &Fact::rawValueChanged,                             this, &LandingComplexItem::_recalcFromRadiusChange);
 
     connect(this,                       &LandingComplexItem::finalApproachCoordinateChanged,this, &LandingComplexItem::_recalcFromCoordinateChange);
     connect(this,                       &LandingComplexItem::landingCoordinateChanged,      this, &LandingComplexItem::_recalcFromCoordinateChange);
-    connect(this,                       &LandingComplexItem::useLoiterToAltChanged,         this, &LandingComplexItem::_recalcFromCoordinateChange);
+    connect(useLoiterToAlt(),           &Fact::rawValueChanged,                             this, &LandingComplexItem::_recalcFromCoordinateChange);
 
     connect(finalApproachAltitude(),    &Fact::valueChanged,                                this, &LandingComplexItem::_setDirty);
     connect(landingAltitude(),          &Fact::valueChanged,                                this, &LandingComplexItem::_setDirty);
@@ -89,9 +89,7 @@ void LandingComplexItem::_init(void)
     connect(stopTakingVideo(),          &Fact::valueChanged,                                this, &LandingComplexItem::_setDirty);
     connect(this,                       &LandingComplexItem::finalApproachCoordinateChanged,this, &LandingComplexItem::_setDirty);
     connect(this,                       &LandingComplexItem::landingCoordinateChanged,      this, &LandingComplexItem::_setDirty);
-    connect(this,                       &LandingComplexItem::loiterClockwiseChanged,        this, &LandingComplexItem::_setDirty);
     connect(this,                       &LandingComplexItem::altitudesAreRelativeChanged,   this, &LandingComplexItem::_setDirty);
-    connect(this,                       &LandingComplexItem::useLoiterToAltChanged,         this, &LandingComplexItem::_setDirty);
 
     connect(stopTakingPhotos(),         &Fact::valueChanged,                                this, &LandingComplexItem::_signalLastSequenceNumberChanged);
     connect(stopTakingVideo(),          &Fact::valueChanged,                                this, &LandingComplexItem::_signalLastSequenceNumberChanged);

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -195,7 +195,7 @@ void LandingComplexItem::_recalcFromHeadingAndDistanceChange(void)
         _loiterTangentCoordinate = _landingCoordinate.atDistanceAndAzimuth(landToTangentDistance, heading + 180);
 
         // Loiter coord is 90 degrees counter clockwise from tangent coord
-        _finalApproachCoordinate = _loiterTangentCoordinate.atDistanceAndAzimuth(radius, heading - 180 - 90);
+        _finalApproachCoordinate = _loiterTangentCoordinate.atDistanceAndAzimuth(radius, heading - 180 + (_loiterClockwise()->rawValue().toBool() ? -90 : 90));
         _finalApproachCoordinate.setAltitude(finalApproachAltitude()->rawValue().toDouble());
 
         _ignoreRecalcSignals = true;

--- a/src/MissionManager/LandingComplexItem.h
+++ b/src/MissionManager/LandingComplexItem.h
@@ -122,8 +122,6 @@ signals:
     void loiterTangentCoordinateChanged (QGeoCoordinate coordinate);
     void landingCoordinateChanged       (QGeoCoordinate coordinate);
     void landingCoordSetChanged         (bool landingCoordSet);
-    void loiterClockwiseChanged         (bool loiterClockwise);
-    void useLoiterToAltChanged          (bool useLoiterToAlt);
     void altitudesAreRelativeChanged    (bool altitudesAreRelative);
     void _updateFlightPathSegmentsSignal(void);
 

--- a/src/MissionManager/LandingComplexItemTest.cc
+++ b/src/MissionManager/LandingComplexItemTest.cc
@@ -40,8 +40,6 @@ void LandingComplexItemTest::init(void)
     rgSignals[loiterTangentCoordinateChangedIndex]  = SIGNAL(loiterTangentCoordinateChanged(QGeoCoordinate));
     rgSignals[landingCoordinateChangedIndex]        = SIGNAL(landingCoordinateChanged(QGeoCoordinate));
     rgSignals[landingCoordSetChangedIndex]          = SIGNAL(landingCoordSetChanged(bool));
-    rgSignals[loiterClockwiseChangedIndex]          = SIGNAL(loiterClockwiseChanged(bool));
-    rgSignals[useLoiterToAltChangedIndex]           = SIGNAL(useLoiterToAltChanged(bool));
     rgSignals[altitudesAreRelativeChangedIndex]     = SIGNAL(altitudesAreRelativeChanged(bool));
     rgSignals[_updateFlightPathSegmentsSignalIndex] = SIGNAL(_updateFlightPathSegmentsSignal());
 

--- a/src/MissionManager/LandingComplexItemTest.cc
+++ b/src/MissionManager/LandingComplexItemTest.cc
@@ -386,10 +386,10 @@ void SimpleLandingComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
     _flightPathSegments.beginReset();
     _flightPathSegments.clearAndDeleteContents();
     if (useLoiterToAlt()->rawValue().toBool()) {
-        _appendFlightPathSegment(finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
-        _appendFlightPathSegment(loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
     } else {
-        _appendFlightPathSegment(finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
     }
     _flightPathSegments.endReset();
 

--- a/src/MissionManager/LandingComplexItemTest.h
+++ b/src/MissionManager/LandingComplexItemTest.h
@@ -39,8 +39,6 @@ private:
         loiterTangentCoordinateChangedIndex,
         landingCoordinateChangedIndex,
         landingCoordSetChangedIndex,
-        loiterClockwiseChangedIndex,
-        useLoiterToAltChangedIndex,
         altitudesAreRelativeChangedIndex,
         _updateFlightPathSegmentsSignalIndex,
         maxSignalIndex,
@@ -51,8 +49,6 @@ private:
         loiterTangentCoordinateChangedMask      = 1 << loiterTangentCoordinateChangedIndex,
         landingCoordinateChangedMask            = 1 << landingCoordinateChangedIndex,
         landingCoordSetChangedMask              = 1 << landingCoordSetChangedIndex,
-        loiterClockwiseChangedMask              = 1 << loiterClockwiseChangedIndex,
-        useLoiterToAltChangedMask               = 1 << useLoiterToAltChangedIndex,
         altitudesAreRelativeChangedMask         = 1 << altitudesAreRelativeChangedIndex,
         _updateFlightPathSegmentsSignalMask     = 1 << _updateFlightPathSegmentsSignalIndex,
     };

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -196,20 +196,7 @@
             "specifiesCoordinate":  true,
             "isTakeoffCommand":     true,
             "friendlyEdit":         true,
-            "category":             "Basic",
-            "param1": {
-                "label":            "Pitch",
-                "units":            "deg",
-                "default":          15,
-                "decimalPlaces":    2
-            },
-            "param4": {
-                "label":            "Yaw",
-                "units":            "deg",
-                "nanUnchanged":     true,
-                "default":          null,
-                "decimalPlaces":    2
-            }
+            "category":             "Basic"
         },
         { "id": 23, "rawName": "MAV_CMD_NAV_LAND_LOCAL", "friendlyName": "Land local" },
         { "id": 24, "rawName": "MAV_CMD_NAV_TAKEOFF_LOCAL", "friendlyName": "Takeoff local" },

--- a/src/MissionManager/MavCmdInfoFixedWing.json
+++ b/src/MissionManager/MavCmdInfoFixedWing.json
@@ -22,7 +22,12 @@
         {
             "id":           22,
             "comment":      "MAV_CMD_NAV_TAKEOFF",
-            "paramRemove":  "4"
+            "param1": {
+                "label":            "Pitch",
+                "units":            "deg",
+                "default":          15,
+                "decimalPlaces":    2
+            }
         }
     ]
 }

--- a/src/MissionManager/MavCmdInfoMultiRotor.json
+++ b/src/MissionManager/MavCmdInfoMultiRotor.json
@@ -22,7 +22,13 @@
         {
             "id":           22,
             "comment":      "MAV_CMD_NAV_TAKEOFF",
-            "paramRemove":  "1"
+            "param4": {
+                "label":            "Yaw",
+                "units":            "deg",
+                "nanUnchanged":     true,
+                "default":          null,
+                "decimalPlaces":    2
+            }
         },
         {
             "id":           31,

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1163,7 +1163,14 @@ FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemP
     double              coord2AMSLAlt       = pair.second->amslEntryAlt();
     double              coord1AMSLAlt       = takeoffStraightUp ? coord2AMSLAlt : pair.first->amslExitAlt();
 
-    FlightPathSegment* segment = new FlightPathSegment(coord1, coord1AMSLAlt, coord2, coord2AMSLAlt, !_flyView /* queryTerrainData */,  this);
+    FlightPathSegment::SegmentType segmentType = FlightPathSegment::SegmentTypeGeneric;
+    if (pair.second->isTakeoffItem()) {
+        segmentType = FlightPathSegment::SegmentTypeTakeoff;
+    } else if (pair.second->isLandCommand()) {
+        segmentType = FlightPathSegment::SegmentTypeLand;
+    }
+
+    FlightPathSegment* segment = new FlightPathSegment(segmentType, coord1, coord1AMSLAlt, coord2, coord2AMSLAlt, !_flyView /* queryTerrainData */,  this);
 
     if (takeoffStraightUp) {
         connect(pair.second, &VisualMissionItem::amslEntryAltChanged, segment, &FlightPathSegment::setCoord1AMSLAlt);
@@ -1391,13 +1398,15 @@ void MissionController::_recalcFlightPathSegments(void)
             // Pair already exists in old table, pull from old to new and reuse
             _flightPathSegmentHashTable[lastSegmentVisualItemPair] = coordVector = oldSegmentTable.take(lastSegmentVisualItemPair);
         } else {
-            // Create a new segment. Since this is the fly view there is no need to wire change signals.
-            coordVector = new FlightPathSegment(lastSegmentVisualItemPair.first->isSimpleItem() ? lastSegmentVisualItemPair.first->coordinate() : lastSegmentVisualItemPair.first->exitCoordinate(),
-                                                lastSegmentVisualItemPair.first->isSimpleItem() ? lastSegmentVisualItemPair.first->amslEntryAlt() : lastSegmentVisualItemPair.first->amslExitAlt(),
-                                                lastSegmentVisualItemPair.second->coordinate(),
-                                                lastSegmentVisualItemPair.second->amslEntryAlt(),
-                                                !_flyView /* queryTerrainData */,
-                                                this);
+            // Create a new segment. Since this is the fly view there is no need to wire change signals or worry about correct SegmentType
+            coordVector = new FlightPathSegment(
+                        FlightPathSegment::SegmentTypeGeneric,
+                        lastSegmentVisualItemPair.first->isSimpleItem() ? lastSegmentVisualItemPair.first->coordinate() : lastSegmentVisualItemPair.first->exitCoordinate(),
+                        lastSegmentVisualItemPair.first->isSimpleItem() ? lastSegmentVisualItemPair.first->amslEntryAlt() : lastSegmentVisualItemPair.first->amslExitAlt(),
+                        lastSegmentVisualItemPair.second->coordinate(),
+                        lastSegmentVisualItemPair.second->amslEntryAlt(),
+                        !_flyView /* queryTerrainData */,
+                        this);
             _flightPathSegmentHashTable[lastSegmentVisualItemPair] = coordVector;
         }
 

--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -98,11 +98,11 @@ void MissionManager::generateResumeMission(int resumeIndex)
     resumeIndex = qMax(0, qMin(resumeIndex, _missionItems.count() - 1));
 
     // Adjust resume index to be a location based command
-    const MissionCommandUIInfo* uiInfo = qgcApp()->toolbox()->missionCommandTree()->getUIInfo(_vehicle, QGCMAVLink::VehicleClassGeneric, _missionItems[resumeIndex]->command());
+    const MissionCommandUIInfo* uiInfo = qgcApp()->toolbox()->missionCommandTree()->getUIInfo(_vehicle, _vehicle->vehicleClass(), _missionItems[resumeIndex]->command());
     if (!uiInfo || uiInfo->isStandaloneCoordinate() || !uiInfo->specifiesCoordinate()) {
         // We have to back up to the last command which the vehicle flies through
         while (--resumeIndex > 0) {
-            uiInfo = qgcApp()->toolbox()->missionCommandTree()->getUIInfo(_vehicle, QGCMAVLink::VehicleClassGeneric, _missionItems[resumeIndex]->command());
+            uiInfo = qgcApp()->toolbox()->missionCommandTree()->getUIInfo(_vehicle, _vehicle->vehicleClass(), _missionItems[resumeIndex]->command());
             if (uiInfo && (uiInfo->specifiesCoordinate() && !uiInfo->isStandaloneCoordinate())) {
                 // Found it
                 break;
@@ -130,15 +130,15 @@ void MissionManager::generateResumeMission(int resumeIndex)
                            << MAV_CMD_VIDEO_START_CAPTURE
                            << MAV_CMD_VIDEO_STOP_CAPTURE
                            << MAV_CMD_DO_CHANGE_SPEED
-                           << MAV_CMD_SET_CAMERA_MODE
-                           << MAV_CMD_NAV_TAKEOFF;
+                           << MAV_CMD_SET_CAMERA_MODE;
 
     bool addHomePosition = _vehicle->firmwarePlugin()->sendHomePositionToVehicle();
 
     int prefixCommandCount = 0;
     for (int i=0; i<_missionItems.count(); i++) {
         MissionItem* oldItem = _missionItems[i];
-        if ((i == 0 && addHomePosition) || i >= resumeIndex || includedResumeCommands.contains(oldItem->command())) {
+        const MissionCommandUIInfo* uiInfo = qgcApp()->toolbox()->missionCommandTree()->getUIInfo(_vehicle, _vehicle->vehicleClass(), oldItem->command());
+        if ((i == 0 && addHomePosition) || i >= resumeIndex || includedResumeCommands.contains(oldItem->command()) || (uiInfo && uiInfo->isTakeoffCommand())) {
             if (i < resumeIndex) {
                 prefixCommandCount++;
             }

--- a/src/MissionManager/MissionManager.h
+++ b/src/MissionManager/MissionManager.h
@@ -40,7 +40,10 @@ private slots:
     void _mavlinkMessageReceived(const mavlink_message_t& message);
 
 private:
+    void _handleHighLatency(const mavlink_message_t& message);
+    void _handleHighLatency2(const mavlink_message_t& message);
     void _handleMissionCurrent(const mavlink_message_t& message);
+    void _updateMissionIndex(int index);
     void _handleHeartbeat(const mavlink_message_t& message);
 
     int _cachedLastCurrentIndex;

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -673,7 +673,9 @@ void SimpleMissionItem::_altitudeChanged(void)
     if (_altitudeMode == QGroundControlQmlGlobal::AltitudeModeAboveTerrain || _altitudeMode == QGroundControlQmlGlobal::AltitudeModeTerrainFrame) {
         _amslAltAboveTerrainFact.setRawValue(qQNaN());
         _terrainAltChanged();
-    } else {
+    }
+
+    if (_altitudeMode != QGroundControlQmlGlobal::AltitudeModeAboveTerrain) {
         _missionItem._param7Fact.setRawValue(_altitudeFact.rawValue());
     }
 }

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -206,6 +206,9 @@ void SimpleMissionItem::_connectSignals(void)
     // Propogate signals from MissionItem up to SimpleMissionItem
     connect(&_missionItem,                      &MissionItem::sequenceNumberChanged,        this, &SimpleMissionItem::sequenceNumberChanged);
     connect(&_missionItem,                      &MissionItem::specifiedFlightSpeedChanged,  this, &SimpleMissionItem::specifiedFlightSpeedChanged);
+
+    connect(_missionController,                 &MissionController::plannedHomePositionChanged, this, &SimpleMissionItem::_amslEntryAltChanged);
+    connect(_missionController,                 &MissionController::plannedHomePositionChanged, this, &SimpleMissionItem::_amslExitAltChanged);
 }
 
 void SimpleMissionItem::_setupMetaData(void)

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -712,23 +712,23 @@ void StructureScanComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
 
         // Entrance to first layer entrance
         double entranceAlt = _entranceAltFact.rawValue().toDouble() + _missionController->plannedHomePosition().altitude();
-        _appendFlightPathSegment(layerEntranceCoord, entranceAlt, layerEntranceCoord, layerAltitude);
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, layerEntranceCoord, entranceAlt, layerEntranceCoord, layerAltitude);
 
         // Segments for each layer
         for (int layerIndex=0; layerIndex<_layersFact.rawValue().toInt(); layerIndex++) {
             // Move from one layer to the next
             if (layerIndex != 0) {
-                _appendFlightPathSegment(layerEntranceCoord, prevLayerAltitude, layerEntranceCoord, layerAltitude);
+                _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, layerEntranceCoord, prevLayerAltitude, layerEntranceCoord, layerAltitude);
             }
 
             QGeoCoordinate prevCoord = QGeoCoordinate();
             for (const QGeoCoordinate& coord: _flightPolygon.coordinateList()) {
                 if (prevCoord.isValid()) {
-                    _appendFlightPathSegment(prevCoord, layerAltitude, coord, layerAltitude);
+                    _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, prevCoord, layerAltitude, coord, layerAltitude);
                 }
                 prevCoord = coord;
             }
-            _appendFlightPathSegment(_flightPolygon.coordinateList().last(), layerAltitude, _flightPolygon.coordinateList().first(), layerAltitude);
+            _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, _flightPolygon.coordinateList().last(), layerAltitude, _flightPolygon.coordinateList().first(), layerAltitude);
 
             // Move to next layer altitude
             prevLayerAltitude = layerAltitude;
@@ -740,7 +740,7 @@ void StructureScanComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
         }
 
         // Last layer exit back to entrance
-        _appendFlightPathSegment(layerEntranceCoord, prevLayerAltitude, layerEntranceCoord, entranceAlt);
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, layerEntranceCoord, prevLayerAltitude, layerEntranceCoord, entranceAlt);
     }
 
     _flightPathSegments.endReset();

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -95,12 +95,9 @@ StructureScanComplexItem::StructureScanComplexItem(PlanMasterController* masterC
 
     connect(this, &StructureScanComplexItem::wizardModeChanged, this, &StructureScanComplexItem::readyForSaveStateChanged);
 
-    connect(_missionController, &MissionController::plannedHomePositionChanged,     this, &StructureScanComplexItem::_amslEntryAltChanged);
     connect(&_entranceAltFact,  &Fact::valueChanged,                                this, &StructureScanComplexItem::_amslEntryAltChanged);
     connect(this,               &StructureScanComplexItem::amslEntryAltChanged,     this, &StructureScanComplexItem::amslExitAltChanged);
 
-    connect(_missionController, &MissionController::plannedHomePositionChanged,     this, &StructureScanComplexItem::minAMSLAltitudeChanged);
-    connect(_missionController, &MissionController::plannedHomePositionChanged,     this, &StructureScanComplexItem::maxAMSLAltitudeChanged);
     connect(this,               &StructureScanComplexItem::topFlightAltChanged,     this, &StructureScanComplexItem::minAMSLAltitudeChanged);
     connect(this,               &StructureScanComplexItem::topFlightAltChanged,     this, &StructureScanComplexItem::maxAMSLAltitudeChanged);
     connect(this,               &StructureScanComplexItem::bottomFlightAltChanged,  this, &StructureScanComplexItem::minAMSLAltitudeChanged);

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -729,8 +729,8 @@ void TransectStyleComplexItem::_adjustForMaxRates(void)
             //qDebug() << "descent rate pass";
             descentRateAdjusted = false;
             for (int i=0; i<_rgFlightPathCoordInfo.count() - 1; i++) {
-                QGeoCoordinate& fromCoord   = _rgFlightPathCoordInfo[i-1].coord;
-                QGeoCoordinate& toCoord     = _rgFlightPathCoordInfo[i].coord;
+                QGeoCoordinate& fromCoord   = _rgFlightPathCoordInfo[i].coord;
+                QGeoCoordinate& toCoord     = _rgFlightPathCoordInfo[i+1].coord;
 
                 double altDifference    = toCoord.altitude() - fromCoord.altitude();
                 double distance         = fromCoord.distanceTo(toCoord);

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -115,11 +115,6 @@ TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterC
     connect(this,                                       &TransectStyleComplexItem::followTerrainChanged,        this, &TransectStyleComplexItem::_followTerrainChanged);
     connect(this,                                       &TransectStyleComplexItem::wizardModeChanged,           this, &TransectStyleComplexItem::readyForSaveStateChanged);
 
-    connect(_missionController,                         &MissionController::plannedHomePositionChanged,         this, &TransectStyleComplexItem::_amslEntryAltChanged);
-    connect(_missionController,                         &MissionController::plannedHomePositionChanged,         this, &TransectStyleComplexItem::_amslExitAltChanged);
-
-    connect(_missionController,                         &MissionController::plannedHomePositionChanged,         this, &TransectStyleComplexItem::minAMSLAltitudeChanged);
-    connect(_missionController,                         &MissionController::plannedHomePositionChanged,         this, &TransectStyleComplexItem::maxAMSLAltitudeChanged);
     connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,                                 this, &TransectStyleComplexItem::minAMSLAltitudeChanged);
     connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,                                 this, &TransectStyleComplexItem::maxAMSLAltitudeChanged);
     connect(&_cameraCalc,                               &CameraCalc::distanceToSurfaceRelativeChanged,          this, &TransectStyleComplexItem::minAMSLAltitudeChanged);

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -309,7 +309,10 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, bool forP
         }
     }
 
-    if (!forPresets) {
+    if (forPresets) {
+        // Most signalling will happen after the transects are rebuilt so we don't over signal here
+        emit followTerrainChanged(_followTerrain);
+    } else {
         emit minAMSLAltitudeChanged();
         emit maxAMSLAltitudeChanged();
         _amslEntryAltChanged();

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -490,7 +490,7 @@ void TransectStyleComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
             for (const MissionItem* missionItem: _loadedMissionItems) {
                 if (missionItem->command() == MAV_CMD_NAV_WAYPOINT || missionItem->command() == MAV_CMD_CONDITION_GATE) {
                     if (prevCoord.isValid()) {
-                        _appendFlightPathSegment(prevCoord, prevAlt, missionItem->coordinate(), missionItem->param7());
+                        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, prevCoord, prevAlt, missionItem->coordinate(), missionItem->param7());
                     }
                     prevCoord = missionItem->coordinate();
                     prevAlt = missionItem->param7();
@@ -505,7 +505,7 @@ void TransectStyleComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
                     const QGeoCoordinate& fromCoord = _rgFlightPathCoordInfo[i].coord;
                     const QGeoCoordinate& toCoord   = _rgFlightPathCoordInfo[i+1].coord;
                     //qDebug() << _rgFlightPathCoordInfo.count() << fromCoord << _rgFlightPathCoordInfo[i].coordType << toCoord << _rgFlightPathCoordInfo[i+1].coordType;
-                    _appendFlightPathSegment(fromCoord, fromCoord.altitude(), toCoord, toCoord.altitude());
+                    _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, fromCoord, fromCoord.altitude(), toCoord, toCoord.altitude());
                 }
             }
         }
@@ -518,7 +518,7 @@ void TransectStyleComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
         for (const QVariant& varCoord: _visualTransectPoints) {
             QGeoCoordinate thisCoord = varCoord.value<QGeoCoordinate>();
             if (prevCoord.isValid()) {
-                _appendFlightPathSegment(prevCoord,  surveyAlt, thisCoord,  surveyAlt);
+                _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, prevCoord,  surveyAlt, thisCoord,  surveyAlt);
             }
             prevCoord = thisCoord;
         }

--- a/src/MissionManager/VTOLLandingComplexItem.cc
+++ b/src/MissionManager/VTOLLandingComplexItem.cc
@@ -133,12 +133,12 @@ void VTOLLandingComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
     _flightPathSegments.beginReset();
     _flightPathSegments.clearAndDeleteContents();
     if (useLoiterToAlt()->rawValue().toBool()) {
-        _appendFlightPathSegment(finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
-        _appendFlightPathSegment(loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslEntryAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslEntryAlt());
     } else {
-        _appendFlightPathSegment(finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslEntryAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslEntryAlt());
     }
-    _appendFlightPathSegment(landingCoordinate(), amslEntryAlt(), landingCoordinate(), amslExitAlt());
+    _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, landingCoordinate(), amslEntryAlt(), landingCoordinate(), amslExitAlt());
     _flightPathSegments.endReset();
 
     if (_cTerrainCollisionSegments != 0) {

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -18,7 +18,7 @@ Item {
 
     property var    missionItems:               _controllerValid ? _planMasterController.missionController.visualItems : undefined
     property real   missionDistance:            _controllerValid ? _planMasterController.missionController.missionDistance : NaN
-    property real   missionTime:                _controllerValid ? _planMasterController.missionController.missionTime : NaN
+    property real   missionTime:                _controllerValid ? _planMasterController.missionController.missionTime : 0
     property real   missionMaxTelemetry:        _controllerValid ? _planMasterController.missionController.missionMaxTelemetry : NaN
     property bool   missionDirty:               _controllerValid ? _planMasterController.missionController.dirty : false
 
@@ -69,10 +69,12 @@ Item {
     readonly property real _margins: ScreenTools.defaultFontPixelWidth
 
     function getMissionTime() {
-        if(_missionTime == 0) {
+        if (_missionTime == 0) {
             return "00:00:00"
         }
-        var t = new Date(0, 0, 0, 0, 0, Number(_missionTime))
+        // On some versions of jscript, passing in year=0 returns bad time formatting, on some it doesnt. Setting year to a specific
+        // year makes it always work correctly.
+        var t = new Date(2021, 0, 0, 0, 0, Number(_missionTime))
         return Qt.formatTime(t, 'hh:mm:ss')
     }
 

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -150,9 +150,9 @@ Rectangle {
                     }
 
                     Item {
-                        width:      altModeDropArrow.x + altModeDropArrow.width
-                        height:     altModeLabel.height
-                        visible:    _globalAltModeIsMixed
+                        Layout.preferredWidth:  altModeDropArrow.x + altModeDropArrow.width
+                        Layout.preferredHeight: altModeLabel.height
+                        visible:                _globalAltModeIsMixed
 
                         QGCLabel { id: altModeLabel }
 

--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -57,17 +57,23 @@ Item {
     }
 
     function showDragArea() {
-        if (!_dragAreaShowing && _missionItem.specifiesCoordinate) {
+        if (!_dragAreaShowing) {
             _dragArea = dragAreaComponent.createObject(map)
             _dragAreaShowing = true
         }
     }
 
+    function updateDragArea() {
+        if (_missionItem.isCurrentItem && map.planView && _missionItem.specifiesCoordinate) {
+            showDragArea()
+        } else {
+            hideDragArea()
+        }
+    }
+
     Component.onCompleted: {
         showItemVisuals()
-        if (_missionItem.isCurrentItem && map.planView) {
-            showDragArea()
-        }
+        updateDragArea()
     }
 
     Component.onDestruction: {
@@ -79,13 +85,8 @@ Item {
     Connections {
         target: _missionItem
 
-        onIsCurrentItemChanged: {
-            if (_missionItem.isCurrentItem && map.planView) {
-                showDragArea()
-            } else {
-                hideDragArea()
-            }
-        }
+        onIsCurrentItemChanged:         updateDragArea()
+        onSpecifiesCoordinateChanged:   updateDragArea()
     }
 
     // Control which is used to drag items

--- a/src/PlanView/TransectStyleComplexItemTerrainFollow.qml
+++ b/src/PlanView/TransectStyleComplexItemTerrainFollow.qml
@@ -21,6 +21,10 @@ ColumnLayout {
         text:       qsTr("Vehicle follows terrain")
         checked:    missionItem.followTerrain
         onClicked:  missionItem.followTerrain = checked
+
+        Binding on checkedState {
+            value: missionItem.followTerrain ? Qt.Checked : Qt.Unchecked
+        }
     }
 
     GridLayout {

--- a/src/QmlControls/FactValueGrid.cc
+++ b/src/QmlControls/FactValueGrid.cc
@@ -136,13 +136,8 @@ void FactValueGrid::_saveValueData(QSettings& settings, InstrumentValueData* val
         break;
     }
 
-    if (value->fact()) {
-        settings.setValue(_factGroupNameKey,    value->factGroupName());
-        settings.setValue(_factNameKey,         value->factName());
-    } else {
-        settings.setValue(_factGroupNameKey,    "");
-        settings.setValue(_factNameKey,         "");
-    }
+    settings.setValue(_factGroupNameKey,    value->factGroupName());
+    settings.setValue(_factNameKey,         value->factName());
 }
 
 void FactValueGrid::_loadValueData(QSettings& settings, InstrumentValueData* value)

--- a/src/QmlControls/FlightModeMenu.qml
+++ b/src/QmlControls/FlightModeMenu.qml
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-import QtQuick                      2.11
-import QtQuick.Controls             2.4
+import QtQuick                      2.12
+import QtQuick.Controls             2.12
 
 import QGroundControl               1.0
 import QGroundControl.Controls      1.0
@@ -16,20 +16,21 @@ import QGroundControl.ScreenTools   1.0
 
 // Label control whichs pop up a flight mode change menu when clicked
 QGCLabel {
-    id:     flightModeMenuLabel
+    id:     _root
     text:   currentVehicle ? currentVehicle.flightMode : qsTr("N/A", "No data to display")
 
     property var    currentVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property real   mouseAreaLeftMargin:    0
 
-    QGCMenu {
+    Menu {
         id: flightModesMenu
     }
 
     Component {
         id: flightModeMenuItemComponent
 
-        QGCMenuItem {
+        MenuItem {
+            enabled: true
             onTriggered: currentVehicle.flightMode = text
         }
     }
@@ -53,11 +54,11 @@ QGCLabel {
         }
     }
 
-    Component.onCompleted: flightModeMenuLabel.updateFlightModesMenu()
+    Component.onCompleted: _root.updateFlightModesMenu()
 
     Connections {
         target:                 QGroundControl.multiVehicleManager
-        onActiveVehicleChanged: flightModeMenuLabel.updateFlightModesMenu()
+        onActiveVehicleChanged: _root.updateFlightModesMenu()
     }
 
     MouseArea {
@@ -65,6 +66,6 @@ QGCLabel {
         visible:            currentVehicle && currentVehicle.flightModeSetAvailable
         anchors.leftMargin: mouseAreaLeftMargin
         anchors.fill:       parent
-        onClicked:          flightModesMenu.popup()
+        onClicked:          flightModesMenu.popup((_root.width - flightModesMenu.width) / 2, _root.height)
     }
 }

--- a/src/QmlControls/FlightPathSegment.h
+++ b/src/QmlControls/FlightPathSegment.h
@@ -24,7 +24,14 @@ class FlightPathSegment : public QObject
     Q_OBJECT
     
 public:
-    FlightPathSegment(const QGeoCoordinate& coord1, double coord1AMSLAlt, const QGeoCoordinate& coord2, double coord2AMSLAlt, bool queryTerrainData, QObject* parent);
+    enum SegmentType {
+        SegmentTypeTakeoff, // Takeoff segments ignore the first part of the segment for terrain collisions
+        SegmentTypeGeneric, // Generic segments take into account the entire segment for terrain collisions
+        SegmentTypeLand     // Land segments ignore the last part of the segment for terrain collisions
+    };
+    Q_ENUM(SegmentType)
+
+    FlightPathSegment(SegmentType segmentType, const QGeoCoordinate& coord1, double coord1AMSLAlt, const QGeoCoordinate& coord2, double coord2AMSLAlt, bool queryTerrainData, QObject* parent);
 
     Q_PROPERTY(QGeoCoordinate   coordinate1             MEMBER _coord1                                          NOTIFY coordinate1Changed)
     Q_PROPERTY(QGeoCoordinate   coordinate2             MEMBER _coord2                                          NOTIFY coordinate2Changed)
@@ -35,7 +42,8 @@ public:
     Q_PROPERTY(double           distanceBetween         MEMBER _distanceBetween                                 NOTIFY distanceBetweenChanged)
     Q_PROPERTY(double           finalDistanceBetween    MEMBER _finalDistanceBetween                            NOTIFY finalDistanceBetweenChanged)
     Q_PROPERTY(double           totalDistance           MEMBER _totalDistance                                   NOTIFY totalDistanceChanged)
-    Q_PROPERTY(bool             terrainCollision        MEMBER _terrainCollision                                NOTIFY terrainCollisionChanged);
+    Q_PROPERTY(bool             terrainCollision        MEMBER _terrainCollision                                NOTIFY terrainCollisionChanged)
+    Q_PROPERTY(SegmentType      segmentType             MEMBER _segmentType                                     CONSTANT)
 
     QGeoCoordinate      coordinate1         (void) const { return _coord1; }
     QGeoCoordinate      coordinate2         (void) const { return _coord2; }
@@ -47,6 +55,7 @@ public:
     double              totalDistance       (void) const { return _totalDistance; }
     bool                specialVisual       (void) const { return _specialVisual; }
     bool                terrainCollision    (void) const { return _terrainCollision; }
+    SegmentType         segmentType         (void) const { return _segmentType; }
 
     void setSpecialVisual(bool specialVisual);
 
@@ -88,4 +97,7 @@ private:
     double              _distanceBetween =              0;
     double              _finalDistanceBetween =         0;
     double              _totalDistance =                0;
+    SegmentType         _segmentType =                  SegmentTypeGeneric;
+
+    static constexpr double _collisionIgnoreMeters =    10; // Distance to ignore for takeoff/land segments
 };

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -29,8 +29,12 @@ Rectangle {
     property var _dropPanel: dropPanel
 
     function simulateClick(buttonIndex) {
-        buttonIndex = buttonIndex + 1 // skip over title
-        toolStripColumn.children[buttonIndex].clicked()
+        buttonIndex = buttonIndex + 1 // skip over title label
+        var button = toolStripColumn.children[buttonIndex]
+        if (button.checkable) {
+            button.checked = !button.checked
+        }
+        button.clicked()
     }
 
     // Ensure we don't get narrower than content

--- a/src/QtLocationPlugin/MapboxMapProvider.cpp
+++ b/src/QtLocationPlugin/MapboxMapProvider.cpp
@@ -3,7 +3,7 @@
 #include "QGCMapEngine.h"
 #include "SettingsManager.h"
 
-static const QString MapBoxUrl = QStringLiteral("https://api.mapbox.com/v4/%1/%2/%3/%4.jpg80?access_token=%5");
+static const QString MapBoxUrl = QStringLiteral("https://api.mapbox.com/styles/v1/mapbox/%1/tiles/%2/%3/%4?access_token=%5");
 static const QString MapBoxUrlCustom = QStringLiteral("https://api.mapbox.com/styles/v1/%1/%2/tiles/256/%3/%4/%5?access_token=%6");
 
 MapboxMapProvider::MapboxMapProvider(const QString &mapName, const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject* parent)

--- a/src/QtLocationPlugin/MapboxMapProvider.h
+++ b/src/QtLocationPlugin/MapboxMapProvider.h
@@ -31,7 +31,7 @@ class MapboxStreetMapProvider : public MapboxMapProvider {
 
 public:
     MapboxStreetMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.streets"), AVERAGE_MAPBOX_STREET_MAP,
+        : MapboxMapProvider(QStringLiteral("streets-v10"), AVERAGE_MAPBOX_STREET_MAP,
                             QGeoMapType::StreetMap, parent) {}
 };
 
@@ -40,7 +40,7 @@ class MapboxLightMapProvider : public MapboxMapProvider {
 
 public:
     MapboxLightMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.light"), AVERAGE_TILE_SIZE,
+        : MapboxMapProvider(QStringLiteral("light-v9"), AVERAGE_TILE_SIZE,
                             QGeoMapType::CustomMap, parent) {}
 };
 
@@ -49,7 +49,7 @@ class MapboxDarkMapProvider : public MapboxMapProvider {
 
 public:
     MapboxDarkMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.dark"), AVERAGE_TILE_SIZE,
+        : MapboxMapProvider(QStringLiteral("dark-v9"), AVERAGE_TILE_SIZE,
                             QGeoMapType::CustomMap, parent) {}
 };
 
@@ -58,7 +58,7 @@ class MapboxSatelliteMapProvider : public MapboxMapProvider {
 
 public:
     MapboxSatelliteMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.satellite"), AVERAGE_MAPBOX_SAT_MAP,
+        : MapboxMapProvider(QStringLiteral("satellite-v9"), AVERAGE_MAPBOX_SAT_MAP,
                             QGeoMapType::SatelliteMapDay, parent) {}
 };
 
@@ -67,16 +67,16 @@ class MapboxHybridMapProvider : public MapboxMapProvider {
 
 public:
     MapboxHybridMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.streets-satellite"), AVERAGE_MAPBOX_SAT_MAP,
+        : MapboxMapProvider(QStringLiteral("satellite-streets-v10"), AVERAGE_MAPBOX_SAT_MAP,
                             QGeoMapType::HybridMap, parent) {}
 };
 
-class MapboxWheatPasteMapProvider : public MapboxMapProvider {
+class MapboxBrightMapProvider : public MapboxMapProvider {
     Q_OBJECT
 
 public:
-    MapboxWheatPasteMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.wheatpaste"), AVERAGE_TILE_SIZE,
+    MapboxBrightMapProvider(QObject* parent = nullptr)
+        : MapboxMapProvider(QStringLiteral("bright-v9"), AVERAGE_TILE_SIZE,
                             QGeoMapType::CustomMap, parent) {}
 };
 
@@ -85,17 +85,8 @@ class MapboxStreetsBasicMapProvider : public MapboxMapProvider {
 
 public:
     MapboxStreetsBasicMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.streets-basic"), AVERAGE_TILE_SIZE,
+        : MapboxMapProvider(QStringLiteral("basic-v9"), AVERAGE_TILE_SIZE,
                             QGeoMapType::StreetMap, parent) {}
-};
-
-class MapboxComicMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxComicMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.comic"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
 };
 
 class MapboxOutdoorsMapProvider : public MapboxMapProvider {
@@ -103,52 +94,7 @@ class MapboxOutdoorsMapProvider : public MapboxMapProvider {
 
 public:
     MapboxOutdoorsMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.outdoors"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
-};
-
-class MapboxRunBikeHikeMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxRunBikeHikeMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.run-bike-hike"), AVERAGE_MAPBOX_STREET_MAP,
-                            QGeoMapType::CycleMap, parent) {}
-};
-
-class MapboxPencilMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxPencilMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.pencil"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
-};
-
-class MapboxPiratesMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxPiratesMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.pirates"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
-};
-
-class MapboxEmeraldMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxEmeraldMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.emerald"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
-};
-
-class MapboxHighContrastMapProvider : public MapboxMapProvider {
-    Q_OBJECT
-
-public:
-    MapboxHighContrastMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.high-contrast"), AVERAGE_TILE_SIZE,
+        : MapboxMapProvider(QStringLiteral("outdoors-v10"), AVERAGE_TILE_SIZE,
                             QGeoMapType::CustomMap, parent) {}
 };
 

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -65,8 +65,7 @@ UrlFactory::UrlFactory() : _timeout(5 * 1000) {
     _providersTable["Mapbox Hybrid"]       = new MapboxHybridMapProvider(this);
     _providersTable["Mapbox StreetsBasic"] = new MapboxStreetsBasicMapProvider(this);
     _providersTable["Mapbox Outdoors"]     = new MapboxOutdoorsMapProvider(this);
-    _providersTable["Mapbox RunBikeHike"]  = new MapboxRunBikeHikeMapProvider(this);
-    _providersTable["Mapbox HighContrast"] = new MapboxHighContrastMapProvider(this);
+    _providersTable["Mapbox Bright"]       = new MapboxBrightMapProvider(this);
     _providersTable["Mapbox Custom"]       = new MapboxCustomMapProvider(this);
 
     //_providersTable["MapQuest Map"] = new MapQuestMapMapProvider(this);

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -76,12 +76,12 @@ QGCCacheWorker::quit()
     if(_hostLookupID) {
         QHostInfo::abortHostLookup(_hostLookupID);
     }
-    _mutex.lock();
+    QMutexLocker lock(&_taskQueueMutex);
     while(_taskQueue.count()) {
         QGCMapTask* task = _taskQueue.dequeue();
         delete task;
     }
-    _mutex.unlock();
+    lock.unlock(); // don't need the lock any more
     if(this->isRunning()) {
         _waitc.wakeAll();
     }
@@ -97,9 +97,9 @@ QGCCacheWorker::enqueueTask(QGCMapTask* task)
         task->deleteLater();
         return false;
     }
-    _mutex.lock();
+    QMutexLocker lock(&_taskQueueMutex);
     _taskQueue.enqueue(task);
-    _mutex.unlock();
+    lock.unlock(); // don't need to hold the mutex any more
     if(this->isRunning()) {
         _waitc.wakeAll();
     } else {
@@ -116,61 +116,19 @@ QGCCacheWorker::run()
         _init();
     }
     if(_valid) {
-        _db = new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kSession));
-        _db->setDatabaseName(_databasePath);
-        _db->setConnectOptions("QSQLITE_ENABLE_SHARED_CACHE");
-        _valid = _db->open();
+        _connectDB();
     }
     _deleteBingNoTileTiles();
+    QMutexLocker lock(&_taskQueueMutex);
     while(true) {
         QGCMapTask* task;
         if(_taskQueue.count()) {
-            _mutex.lock();
             task = _taskQueue.dequeue();
-            _mutex.unlock();
-            switch(task->type()) {
-                case QGCMapTask::taskInit:
-                    break;
-                case QGCMapTask::taskCacheTile:
-                    _saveTile(task);
-                    break;
-                case QGCMapTask::taskFetchTile:
-                    _getTile(task);
-                    break;
-                case QGCMapTask::taskFetchTileSets:
-                    _getTileSets(task);
-                    break;
-                case QGCMapTask::taskCreateTileSet:
-                    _createTileSet(task);
-                    break;
-                case QGCMapTask::taskGetTileDownloadList:
-                    _getTileDownloadList(task);
-                    break;
-                case QGCMapTask::taskUpdateTileDownloadState:
-                    _updateTileDownloadState(task);
-                    break;
-                case QGCMapTask::taskDeleteTileSet:
-                    _deleteTileSet(task);
-                    break;
-                case QGCMapTask::taskRenameTileSet:
-                    _renameTileSet(task);
-                    break;
-                case QGCMapTask::taskPruneCache:
-                    _pruneCache(task);
-                    break;
-                case QGCMapTask::taskReset:
-                    _resetCacheDatabase(task);
-                    break;
-                case QGCMapTask::taskExport:
-                    _exportSets(task);
-                    break;
-                case QGCMapTask::taskImport:
-                    _importSets(task);
-                    break;
-                case QGCMapTask::taskTestInternet:
-                    _testInternet();
-                    break;
-            }
+
+            // Don't need the lock while running the task.
+            lock.unlock();
+            _runTask(task);
+            lock.relock();
             task->deleteLater();
             //-- Check for update timeout
             size_t count = static_cast<size_t>(_taskQueue.count());
@@ -181,29 +139,75 @@ QGCCacheWorker::run()
             }
             if(!count || (time(nullptr) - _lastUpdate > _updateTimeout)) {
                 if(_valid) {
+                    // _updateTotals() will emit a signal. Don't keep the lock
+                    // while any slots process the signal.
+                    lock.unlock();
                     _updateTotals();
+                    lock.relock();
                 }
             }
         } else {
             //-- Wait a bit before shutting things down
-            _waitmutex.lock();
-            unsigned long timeout = 5000;
-            _waitc.wait(&_waitmutex, timeout);
-            _waitmutex.unlock();
-            _mutex.lock();
+            unsigned long timeoutMilliseconds = 5000;
+            _waitc.wait(lock.mutex(), timeoutMilliseconds);
             //-- If nothing to do, close db and leave thread
             if(!_taskQueue.count()) {
-                _mutex.unlock();
                 break;
             }
-            _mutex.unlock();
         }
     }
-    if(_db) {
-        delete _db;
-        _db = nullptr;
-        QSqlDatabase::removeDatabase(kSession);
+    lock.unlock();
+    _disconnectDB();
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCCacheWorker::_runTask(QGCMapTask *task)
+{
+    switch(task->type()) {
+        case QGCMapTask::taskInit:
+            return;
+        case QGCMapTask::taskCacheTile:
+            _saveTile(task);
+            return;
+        case QGCMapTask::taskFetchTile:
+            _getTile(task);
+            return;
+        case QGCMapTask::taskFetchTileSets:
+            _getTileSets(task);
+            return;
+        case QGCMapTask::taskCreateTileSet:
+            _createTileSet(task);
+            return;
+        case QGCMapTask::taskGetTileDownloadList:
+            _getTileDownloadList(task);
+            return;
+        case QGCMapTask::taskUpdateTileDownloadState:
+            _updateTileDownloadState(task);
+            return;
+        case QGCMapTask::taskDeleteTileSet:
+            _deleteTileSet(task);
+            return;
+        case QGCMapTask::taskRenameTileSet:
+            _renameTileSet(task);
+            return;
+        case QGCMapTask::taskPruneCache:
+            _pruneCache(task);
+            return;
+        case QGCMapTask::taskReset:
+            _resetCacheDatabase(task);
+            return;
+        case QGCMapTask::taskExport:
+            _exportSets(task);
+            return;
+        case QGCMapTask::taskImport:
+            _importSets(task);
+            return;
+        case QGCMapTask::taskTestInternet:
+            _testInternet();
+            return;
     }
+    qCWarning(QGCTileCacheLog) << "_runTask given unhandled task type" << task->type();
 }
 
 //-----------------------------------------------------------------------------
@@ -703,7 +707,7 @@ QGCCacheWorker::_resetCacheDatabase(QGCMapTask* mtask)
     query.exec(s);
     s = QString("DROP TABLE TilesDownload");
     query.exec(s);
-    _valid = _createDB(_db);
+    _valid = _createDB(*_db);
     task->setResetCompleted();
 }
 
@@ -718,11 +722,7 @@ QGCCacheWorker::_importSets(QGCMapTask* mtask)
     //-- If replacing, simply copy over it
     if(task->replace()) {
         //-- Close and delete old database
-        if(_db) {
-            delete _db;
-            _db = nullptr;
-            QSqlDatabase::removeDatabase(kSession);
-        }
+        _disconnectDB();
         QFile file(_databasePath);
         file.remove();
         //-- Copy given database
@@ -731,10 +731,7 @@ QGCCacheWorker::_importSets(QGCMapTask* mtask)
         _init();
         if(_valid) {
             task->setProgress(50);
-            _db = new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kSession));
-            _db->setDatabaseName(_databasePath);
-            _db->setConnectOptions("QSQLITE_ENABLE_SHARED_CACHE");
-            _valid = _db->open();
+            _connectDB();
         }
         task->setProgress(100);
     } else {
@@ -905,11 +902,11 @@ QGCCacheWorker::_exportSets(QGCMapTask* mtask)
     QFile file(task->path());
     file.remove();
     //-- Create exported database
-    QSqlDatabase *dbExport = new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kExportSession));
+    QScopedPointer<QSqlDatabase> dbExport(new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kExportSession)));
     dbExport->setDatabaseName(task->path());
     dbExport->setConnectOptions("QSQLITE_ENABLE_SHARED_CACHE");
     if (dbExport->open()) {
-        if(_createDB(dbExport, false)) {
+        if(_createDB(*dbExport, false)) {
             //-- Prepare progress report
             quint64 tileCount = 0;
             quint64 currentCount = 0;
@@ -997,7 +994,7 @@ QGCCacheWorker::_exportSets(QGCMapTask* mtask)
         qCritical() << "Map Cache SQL error (create export database):" << dbExport->lastError();
         task->setError("Error opening export database");
     }
-    delete dbExport;
+    dbExport.reset();
     QSqlDatabase::removeDatabase(kExportSession);
     task->setExportCompleted();
 }
@@ -1020,11 +1017,8 @@ QGCCacheWorker::_init()
     if(!_databasePath.isEmpty()) {
         qCDebug(QGCTileCacheLog) << "Mapping cache directory:" << _databasePath;
         //-- Initialize Database
-        _db = new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kSession));
-        _db->setDatabaseName(_databasePath);
-        _db->setConnectOptions("QSQLITE_ENABLE_SHARED_CACHE");
-        if (_db->open()) {
-            _valid = _createDB(_db);
+        if (_connectDB()) {
+            _valid = _createDB(*_db);
             if(!_valid) {
                 _failed = true;
             }
@@ -1032,9 +1026,7 @@ QGCCacheWorker::_init()
             qCritical() << "Map Cache SQL error (init() open db):" << _db->lastError();
             _failed = true;
         }
-        delete _db;
-        _db = nullptr;
-        QSqlDatabase::removeDatabase(kSession);
+        _disconnectDB();
     } else {
         qCritical() << "Could not find suitable cache directory.";
         _failed = true;
@@ -1045,10 +1037,21 @@ QGCCacheWorker::_init()
 
 //-----------------------------------------------------------------------------
 bool
-QGCCacheWorker::_createDB(QSqlDatabase* db, bool createDefault)
+QGCCacheWorker::_connectDB()
+{
+    _db.reset(new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kSession)));
+    _db->setDatabaseName(_databasePath);
+    _db->setConnectOptions("QSQLITE_ENABLE_SHARED_CACHE");
+    _valid = _db->open();
+    return _valid;
+}
+
+//-----------------------------------------------------------------------------
+bool
+QGCCacheWorker::_createDB(QSqlDatabase& db, bool createDefault)
 {
     bool res = false;
-    QSqlQuery query(*db);
+    QSqlQuery query(db);
     if(!query.exec(
         "CREATE TABLE IF NOT EXISTS Tiles ("
         "tileID INTEGER PRIMARY KEY NOT NULL, "
@@ -1116,12 +1119,12 @@ QGCCacheWorker::_createDB(QSqlDatabase* db, bool createDefault)
                 query.addBindValue(1);
                 query.addBindValue(QDateTime::currentDateTime().toTime_t());
                 if(!query.exec()) {
-                    qWarning() << "Map Cache SQL error (Creating default tile set):" << db->lastError();
+                    qWarning() << "Map Cache SQL error (Creating default tile set):" << db.lastError();
                     res = false;
                 }
             }
         } else {
-            qWarning() << "Map Cache SQL error (Looking for default tile set):" << db->lastError();
+            qWarning() << "Map Cache SQL error (Looking for default tile set):" << db.lastError();
         }
     }
     if(!res) {
@@ -1129,6 +1132,16 @@ QGCCacheWorker::_createDB(QSqlDatabase* db, bool createDefault)
         file.remove();
     }
     return res;
+}
+
+//-----------------------------------------------------------------------------
+void
+QGCCacheWorker::_disconnectDB()
+{
+    if (_db) {
+        _db.reset();
+        QSqlDatabase::removeDatabase(kSession);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -54,6 +54,8 @@ private slots:
     void        _lookupReady            (QHostInfo info);
 
 private:
+    void        _runTask                (QGCMapTask* task);
+
     void        _saveTile               (QGCMapTask* mtask);
     void        _getTile                (QGCMapTask* mtask);
     void        _getTileSets            (QGCMapTask* mtask);
@@ -74,7 +76,9 @@ private:
     bool        _findTileSetID          (const QString name, quint64& setID);
     void        _updateSetTotals        (QGCCachedTileSet* set);
     bool        _init                   ();
-    bool        _createDB               (QSqlDatabase *db, bool createDefault = true);
+    bool        _connectDB              ();
+    bool        _createDB               (QSqlDatabase& db, bool createDefault = true);
+    void        _disconnectDB           ();
     quint64     _getDefaultTileSet      ();
     void        _updateTotals           ();
     void        _deleteTileSet          (qulonglong id);
@@ -84,22 +88,21 @@ signals:
     void        internetStatus          (bool active);
 
 private:
-    QQueue<QGCMapTask*>     _taskQueue;
-    QMutex                  _mutex;
-    QMutex                  _waitmutex;
-    QWaitCondition          _waitc;
-    QString                 _databasePath;
-    QSqlDatabase*           _db;
-    bool                    _valid;
-    bool                    _failed;
-    quint64                 _defaultSet;
-    quint64                 _totalSize;
-    quint32                 _totalCount;
-    quint64                 _defaultSize;
-    quint32                 _defaultCount;
-    time_t                  _lastUpdate;
-    int                     _updateTimeout;
-    int                     _hostLookupID;
+    QQueue<QGCMapTask*>             _taskQueue;
+    QMutex                          _taskQueueMutex;
+    QWaitCondition                  _waitc;
+    QString                         _databasePath;
+    QScopedPointer<QSqlDatabase>    _db;
+    std::atomic_bool                _valid;
+    bool                            _failed;
+    quint64                         _defaultSet;
+    quint64                         _totalSize;
+    quint32                         _totalCount;
+    quint64                         _defaultSize;
+    quint32                         _defaultCount;
+    time_t                          _lastUpdate;
+    int                             _updateTimeout;
+    int                             _hostLookupID;
 };
 
 #endif // QGC_TILE_CACHE_WORKER_H

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -193,9 +193,10 @@ void InitialConnectStateMachine::_stateRequestProtocolVersion(StateMachine* stat
 
 void InitialConnectStateMachine::_protocolVersionCmdResultHandler(void* resultHandlerData, int /*compId*/, MAV_RESULT result, Vehicle::MavCmdResultFailureCode_t failureCode)
 {
+    InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(resultHandlerData);
+
     if (result != MAV_RESULT_ACCEPTED) {
-        InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(resultHandlerData);
-        Vehicle*                    vehicle         = connectMachine->_vehicle;
+        Vehicle* vehicle = connectMachine->_vehicle;
 
         switch (failureCode) {
         case Vehicle::MavCmdResultCommandResultOnly:
@@ -213,8 +214,8 @@ void InitialConnectStateMachine::_protocolVersionCmdResultHandler(void* resultHa
         vehicle->_mavlinkProtocolRequestComplete = true;
         vehicle->_setMaxProtoVersionFromBothSources();
         vehicle->_waitForMavlinkMessageClear();
-        connectMachine->advance();
     }
+    connectMachine->advance();
 }
 
 void InitialConnectStateMachine::_waitForProtocolVersionResultHandler(void* resultHandlerData, bool noResponsefromVehicle, const mavlink_message_t& message)

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -56,14 +56,12 @@ void InitialConnectStateMachine::_stateRequestCapabilities(StateMachine* stateMa
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestCapabilities Skipping capability request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "Skipping capability request due to link type";
             connectMachine->advance();
@@ -168,14 +166,12 @@ void InitialConnectStateMachine::_stateRequestProtocolVersion(StateMachine* stat
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestProtocolVersion Skipping protocol version request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestProtocolVersion Skipping protocol version request due to link type";
             connectMachine->advance();
@@ -272,14 +268,12 @@ void InitialConnectStateMachine::_stateRequestMission(StateMachine* stateMachine
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestMission: Skipping first mission load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestMission: Skipping first mission load request due to link type";
             vehicle->_firstMissionLoadComplete();
@@ -294,14 +288,12 @@ void InitialConnectStateMachine::_stateRequestGeoFence(StateMachine* stateMachin
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestGeoFence: Skipping first geofence load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestGeoFence: Skipping first geofence load request due to link type";
             vehicle->_firstGeoFenceLoadComplete();
@@ -321,14 +313,12 @@ void InitialConnectStateMachine::_stateRequestRallyPoints(StateMachine* stateMac
 {
     InitialConnectStateMachine* connectMachine  = static_cast<InitialConnectStateMachine*>(stateMachine);
     Vehicle*                    vehicle         = connectMachine->_vehicle;
-    WeakLinkInterfacePtr        weakLink        = vehicle->vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr      sharedLink      = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-    if (weakLink.expired()) {
+    if (!sharedLink) {
         qCDebug(InitialConnectStateMachineLog) << "_stateRequestRallyPoints: Skipping first rally point load request due to no primary link";
         connectMachine->advance();
     } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "_stateRequestRallyPoints: Skipping first rally point load request due to link type";
             vehicle->_firstRallyPointLoadComplete();

--- a/src/Vehicle/RequestMessageTest.cc
+++ b/src/Vehicle/RequestMessageTest.cc
@@ -13,7 +13,7 @@
 #include "MockLink.h"
 
 RequestMessageTest::TestCase_t RequestMessageTest::_rgTestCases[] = {
-//    {  MockLink::FailRequestMessageNone,                                MAV_RESULT_ACCEPTED,    Vehicle::RequestMessageNoFailure,                   1,                                  false },
+    {  MockLink::FailRequestMessageNone,                                MAV_RESULT_ACCEPTED,    Vehicle::RequestMessageNoFailure,                   1,                                  false },
     {  MockLink::FailRequestMessageCommandAcceptedMsgNotSent,           MAV_RESULT_FAILED,      Vehicle::RequestMessageFailureMessageNotReceived,   1,                                  false },
     {  MockLink::FailRequestMessageCommandUnsupported,                  MAV_RESULT_UNSUPPORTED, Vehicle::RequestMessageFailureCommandError,         1,                                  false },
     {  MockLink::FailRequestMessageCommandNoResponse,                   MAV_RESULT_FAILED,      Vehicle::RequestMessageFailureCommandNotAcked,      Vehicle::_mavCommandMaxRetryCount,  false },

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1438,15 +1438,20 @@ void Vehicle::_handlePing(LinkInterface* link, mavlink_message_t& message)
         mavlink_message_t   msg;
 
         mavlink_msg_ping_decode(&message, &ping);
-        mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                                   static_cast<uint8_t>(_mavlink->getComponentId()),
-                                   sharedLink->mavlinkChannel(),
-                                   &msg,
-                                   ping.time_usec,
-                                   ping.seq,
-                                   message.sysid,
-                                   message.compid);
-        sendMessageOnLinkThreadSafe(link, msg);
+
+        if ((ping.target_system == 0) && (ping.target_component == 0)) {
+            // Mavlink defines a ping request as a MSG_ID_PING which contains target_system = 0 and target_component = 0
+            // So only send a ping response when you receive a valid ping request
+            mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                    static_cast<uint8_t>(_mavlink->getComponentId()),
+                                    sharedLink->mavlinkChannel(),
+                                    &msg,
+                                    ping.time_usec,
+                                    ping.seq,
+                                    message.sysid,
+                                    message.compid);
+            sendMessageOnLinkThreadSafe(link, msg);
+        }
     }
 }
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -455,6 +455,10 @@ Vehicle::~Vehicle()
     delete _mav;
     _mav = nullptr;
 
+    if (_joystickManager) {
+        _startJoystick(false);
+    }
+
 #if defined(QGC_AIRMAP_ENABLED)
     if (_airspaceVehicleManager) {
         delete _airspaceVehicleManager;
@@ -1848,6 +1852,7 @@ void Vehicle::_startJoystick(bool start)
             joystick->startPolling(this);
         } else {
             joystick->stopPolling();
+            joystick->wait(500);
         }
     }
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -555,7 +555,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     unsigned mavlinkVersion = _mavlink->getCurrentVersion();
     if (_maxProtoVersion != mavlinkVersion && mavlinkVersion >= 200) {
         _maxProtoVersion = mavlinkVersion;
-        qCDebug(VehicleLog) << "Vehicle::_mavlinkMessageReceived Link already running Mavlink v2. Setting _maxProtoVersion" << _maxProtoVersion;
+        qCDebug(VehicleLog) << "_mavlinkMessageReceived Link already running Mavlink v2. Setting _maxProtoVersion" << _maxProtoVersion;
     }
 
     if (message.sysid != _id && message.sysid != 0) {
@@ -1433,29 +1433,29 @@ void Vehicle::_updateArmed(bool armed)
 
 void Vehicle::_handlePing(LinkInterface* link, mavlink_message_t& message)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_handlePing: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    mavlink_ping_t      ping;
+    mavlink_message_t   msg;
 
-        mavlink_ping_t      ping;
-        mavlink_message_t   msg;
+    mavlink_msg_ping_decode(&message, &ping);
 
-        mavlink_msg_ping_decode(&message, &ping);
-
-        if ((ping.target_system == 0) && (ping.target_component == 0)) {
-            // Mavlink defines a ping request as a MSG_ID_PING which contains target_system = 0 and target_component = 0
-            // So only send a ping response when you receive a valid ping request
-            mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                                    sharedLink->mavlinkChannel(),
-                                    &msg,
-                                    ping.time_usec,
-                                    ping.seq,
-                                    message.sysid,
-                                    message.compid);
-            sendMessageOnLinkThreadSafe(link, msg);
-        }
+    if ((ping.target_system == 0) && (ping.target_component == 0)) {
+        // Mavlink defines a ping request as a MSG_ID_PING which contains target_system = 0 and target_component = 0
+        // So only send a ping response when you receive a valid ping request
+        mavlink_msg_ping_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                static_cast<uint8_t>(_mavlink->getComponentId()),
+                                sharedLink->mavlinkChannel(),
+                                &msg,
+                                ping.time_usec,
+                                ping.seq,
+                                message.sysid,
+                                message.compid);
+        sendMessageOnLinkThreadSafe(link, msg);
     }
 }
 
@@ -1615,6 +1615,7 @@ void Vehicle::_handleRCChannels(mavlink_message_t& message)
 bool Vehicle::sendMessageOnLinkThreadSafe(LinkInterface* link, mavlink_message_t message)
 {
     if (!link->isConnected()) {
+        qCDebug(VehicleLog) << "sendMessageOnLinkThreadSafe" << link << "not connected!";
         return false;
     }
 
@@ -1906,28 +1907,29 @@ void Vehicle::setFlightMode(const QString& flightMode)
     uint32_t    custom_mode;
 
     if (_firmwarePlugin->setFlightMode(flightMode, &base_mode, &custom_mode)) {
-        WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-        if (!weakLink.expired()) {
-            uint8_t                 newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
-            SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-            // setFlightMode will only set MAV_MODE_FLAG_CUSTOM_MODE_ENABLED in base_mode, we need to move back in the existing
-            // states.
-            newBaseMode |= base_mode;
-
-            mavlink_message_t msg;
-            mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
-                                           _mavlink->getComponentId(),
-                                           sharedLink->mavlinkChannel(),
-                                           &msg,
-                                           id(),
-                                           newBaseMode,
-                                           custom_mode);
-            sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+        SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+        if (!sharedLink) {
+            qCDebug(VehicleLog) << "setFlightMode: primary link gone!";
+            return;
         }
+
+        uint8_t newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
+
+        // setFlightMode will only set MAV_MODE_FLAG_CUSTOM_MODE_ENABLED in base_mode, we need to move back in the existing
+        // states.
+        newBaseMode |= base_mode;
+
+        mavlink_message_t msg;
+        mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
+                                       _mavlink->getComponentId(),
+                                       sharedLink->mavlinkChannel(),
+                                       &msg,
+                                       id(),
+                                       newBaseMode,
+                                       custom_mode);
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     } else {
-        qWarning() << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
+        qCWarning(VehicleLog) << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
     }
 }
 
@@ -1944,33 +1946,34 @@ QVariantList Vehicle::links() const {
 
 void Vehicle::requestDataStream(MAV_DATA_STREAM stream, uint16_t rate, bool sendMultiple)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "requestDataStream: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        mavlink_message_t               msg;
-        mavlink_request_data_stream_t   dataStream;
-        SharedLinkInterfacePtr          sharedLink = weakLink.lock();
+    mavlink_message_t               msg;
+    mavlink_request_data_stream_t   dataStream;
 
-        memset(&dataStream, 0, sizeof(dataStream));
+    memset(&dataStream, 0, sizeof(dataStream));
 
-        dataStream.req_stream_id = stream;
-        dataStream.req_message_rate = rate;
-        dataStream.start_stop = 1;  // start
-        dataStream.target_system = id();
-        dataStream.target_component = _defaultComponentId;
+    dataStream.req_stream_id = stream;
+    dataStream.req_message_rate = rate;
+    dataStream.start_stop = 1;  // start
+    dataStream.target_system = id();
+    dataStream.target_component = _defaultComponentId;
 
-        mavlink_msg_request_data_stream_encode_chan(_mavlink->getSystemId(),
-                                                    _mavlink->getComponentId(),
-                                                    sharedLink->mavlinkChannel(),
-                                                    &msg,
-                                                    &dataStream);
+    mavlink_msg_request_data_stream_encode_chan(_mavlink->getSystemId(),
+                                                _mavlink->getComponentId(),
+                                                sharedLink->mavlinkChannel(),
+                                                &msg,
+                                                &dataStream);
 
-        if (sendMultiple) {
-            // We use sendMessageMultiple since we really want these to make it to the vehicle
-            sendMessageMultiple(msg);
-        } else {
-            sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
-        }
+    if (sendMultiple) {
+        // We use sendMessageMultiple since we really want these to make it to the vehicle
+        sendMessageMultiple(msg);
+    } else {
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
 }
 
@@ -1979,10 +1982,9 @@ void Vehicle::_sendMessageMultipleNext()
     if (_nextSendMessageMultipleIndex < _sendMessageMultipleList.count()) {
         qCDebug(VehicleLog) << "_sendMessageMultipleNext:" << _sendMessageMultipleList[_nextSendMessageMultipleIndex].message.msgid;
 
-        WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-        if (!weakLink.expired()) {
-            sendMessageOnLinkThreadSafe(weakLink.lock().get(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
+        SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+        if (sharedLink) {
+            sendMessageOnLinkThreadSafe(sharedLink.get(), _sendMessageMultipleList[_nextSendMessageMultipleIndex].message);
         }
 
         if (--_sendMessageMultipleList[_nextSendMessageMultipleIndex].retryCount <= 0) {
@@ -2070,7 +2072,7 @@ void Vehicle::_firstRallyPointLoadComplete()
 
 void Vehicle::_parametersReady(bool parametersReady)
 {
-    qDebug() << "_parametersReady" << parametersReady;
+    qCDebug(VehicleLog) << "_parametersReady" << parametersReady;
 
     // Try to set current unix time to the vehicle
     _sendQGCTimeToVehicle();
@@ -2085,25 +2087,26 @@ void Vehicle::_parametersReady(bool parametersReady)
 
 void Vehicle::_sendQGCTimeToVehicle()
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        mavlink_system_time_t   cmd;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        // Timestamp of the master clock in microseconds since UNIX epoch.
-        cmd.time_unix_usec = QDateTime::currentDateTime().currentMSecsSinceEpoch()*1000;
-        // Timestamp of the component clock since boot time in milliseconds (Not necessary).
-        cmd.time_boot_ms = 0;
-        mavlink_msg_system_time_encode_chan(_mavlink->getSystemId(),
-                                            _mavlink->getComponentId(),
-                                            sharedLink->mavlinkChannel(),
-                                            &msg,
-                                            &cmd);
-
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_sendQGCTimeToVehicle: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+    mavlink_system_time_t   cmd;
+
+    // Timestamp of the master clock in microseconds since UNIX epoch.
+    cmd.time_unix_usec = QDateTime::currentDateTime().currentMSecsSinceEpoch()*1000;
+    // Timestamp of the component clock since boot time in milliseconds (Not necessary).
+    cmd.time_boot_ms = 0;
+    mavlink_msg_system_time_encode_chan(_mavlink->getSystemId(),
+                                        _mavlink->getComponentId(),
+                                        sharedLink->mavlinkChannel(),
+                                        &msg,
+                                        &cmd);
+
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_imageReady(UASInterface*)
@@ -2530,25 +2533,26 @@ void Vehicle::emergencyStop()
 
 void Vehicle::setCurrentMissionSequence(int seq)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (!_firmwarePlugin->sendHomePositionToVehicle()) {
-            seq--;
-        }
-        mavlink_msg_mission_set_current_pack_chan(
-                    static_cast<uint8_t>(_mavlink->getSystemId()),
-                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                    sharedLink->mavlinkChannel(),
-                    &msg,
-                    static_cast<uint8_t>(id()),
-                    _compID,
-                    static_cast<uint16_t>(seq));
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "setCurrentMissionSequence: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+
+    if (!_firmwarePlugin->sendHomePositionToVehicle()) {
+        seq--;
+    }
+    mavlink_msg_mission_set_current_pack_chan(
+                static_cast<uint8_t>(_mavlink->getSystemId()),
+                static_cast<uint8_t>(_mavlink->getComponentId()),
+                sharedLink->mavlinkChannel(),
+                &msg,
+                static_cast<uint8_t>(id()),
+                _compID,
+                static_cast<uint16_t>(seq));
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::sendMavCommand(int compId, MAV_CMD command, bool showError, float param1, float param2, float param3, float param4, float param5, float param6, float param7)
@@ -2672,32 +2676,34 @@ void Vehicle::_sendMavCommandWorker(bool commandInt, bool requestMessage, bool s
     }
 
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
-
-    if (sharedLink) {
-        MavCommandListEntry_t   entry;
-
-        entry.useCommandInt     = commandInt;
-        entry.targetCompId      = targetCompId;
-        entry.command           = command;
-        entry.frame             = frame;
-        entry.showError         = showError;
-        entry.requestMessage    = requestMessage;
-        entry.resultHandler     = resultHandler;
-        entry.resultHandlerData = resultHandlerData;
-        entry.rgParam[0]        = param1;
-        entry.rgParam[1]        = param2;
-        entry.rgParam[2]        = param3;
-        entry.rgParam[3]        = param4;
-        entry.rgParam[4]        = param5;
-        entry.rgParam[5]        = param6;
-        entry.rgParam[6]        = param7;
-        entry.maxTries          = _sendMavCommandShouldRetry(command) ? _mavCommandMaxRetryCount : 1;
-        entry.ackTimeoutMSecs   = sharedLink->linkConfiguration()->isHighLatency() ? _mavCommandAckTimeoutMSecsHighLatency : _mavCommandAckTimeoutMSecs;
-        entry.elapsedTimer.start();
-
-        _mavCommandList.append(entry);
-        _sendMavCommandFromList(_mavCommandList.count() - 1);
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_sendMavCommandWorker: primary link gone!";
+        return;
     }
+
+    MavCommandListEntry_t   entry;
+
+    entry.useCommandInt     = commandInt;
+    entry.targetCompId      = targetCompId;
+    entry.command           = command;
+    entry.frame             = frame;
+    entry.showError         = showError;
+    entry.requestMessage    = requestMessage;
+    entry.resultHandler     = resultHandler;
+    entry.resultHandlerData = resultHandlerData;
+    entry.rgParam[0]        = param1;
+    entry.rgParam[1]        = param2;
+    entry.rgParam[2]        = param3;
+    entry.rgParam[3]        = param4;
+    entry.rgParam[4]        = param5;
+    entry.rgParam[5]        = param6;
+    entry.rgParam[6]        = param7;
+    entry.maxTries          = _sendMavCommandShouldRetry(command) ? _mavCommandMaxRetryCount : 1;
+    entry.ackTimeoutMSecs   = sharedLink->linkConfiguration()->isHighLatency() ? _mavCommandAckTimeoutMSecsHighLatency : _mavCommandAckTimeoutMSecs;
+    entry.elapsedTimer.start();
+
+    _mavCommandList.append(entry);
+    _sendMavCommandFromList(_mavCommandList.count() - 1);
 }
 
 void Vehicle::_sendMavCommandFromList(int index)
@@ -2733,56 +2739,57 @@ void Vehicle::_sendMavCommandFromList(int index)
 
     qCDebug(VehicleLog) << "_sendMavCommandFromList command:tryCount" << rawCommandName << commandEntry.tryCount;
 
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        mavlink_message_t       msg;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (commandEntry.useCommandInt) {
-            mavlink_command_int_t  cmd;
-
-            memset(&cmd, 0, sizeof(cmd));
-            cmd.target_system =     _id;
-            cmd.target_component =  commandEntry.targetCompId;
-            cmd.command =           commandEntry.command;
-            cmd.frame =             commandEntry.frame;
-            cmd.param1 =            commandEntry.rgParam[0];
-            cmd.param2 =            commandEntry.rgParam[1];
-            cmd.param3 =            commandEntry.rgParam[2];
-            cmd.param4 =            commandEntry.rgParam[3];
-            cmd.x =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[4] : commandEntry.rgParam[4] * 1e7;
-            cmd.y =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[5] : commandEntry.rgParam[5] * 1e7;
-            cmd.z =                 commandEntry.rgParam[6];
-            mavlink_msg_command_int_encode_chan(_mavlink->getSystemId(),
-                                                _mavlink->getComponentId(),
-                                                sharedLink->mavlinkChannel(),
-                                                &msg,
-                                                &cmd);
-        } else {
-            mavlink_command_long_t  cmd;
-
-            memset(&cmd, 0, sizeof(cmd));
-            cmd.target_system =     _id;
-            cmd.target_component =  commandEntry.targetCompId;
-            cmd.command =           commandEntry.command;
-            cmd.confirmation =      0;
-            cmd.param1 =            commandEntry.rgParam[0];
-            cmd.param2 =            commandEntry.rgParam[1];
-            cmd.param3 =            commandEntry.rgParam[2];
-            cmd.param4 =            commandEntry.rgParam[3];
-            cmd.param5 =            commandEntry.rgParam[4];
-            cmd.param6 =            commandEntry.rgParam[5];
-            cmd.param7 =            commandEntry.rgParam[6];
-            mavlink_msg_command_long_encode_chan(_mavlink->getSystemId(),
-                                                 _mavlink->getComponentId(),
-                                                 sharedLink->mavlinkChannel(),
-                                                 &msg,
-                                                 &cmd);
-        }
-
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_sendMavCommandFromList: primary link gone!";
+        return;
     }
+
+    mavlink_message_t  msg;
+
+    if (commandEntry.useCommandInt) {
+        mavlink_command_int_t  cmd;
+
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.target_system =     _id;
+        cmd.target_component =  commandEntry.targetCompId;
+        cmd.command =           commandEntry.command;
+        cmd.frame =             commandEntry.frame;
+        cmd.param1 =            commandEntry.rgParam[0];
+        cmd.param2 =            commandEntry.rgParam[1];
+        cmd.param3 =            commandEntry.rgParam[2];
+        cmd.param4 =            commandEntry.rgParam[3];
+        cmd.x =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[4] : commandEntry.rgParam[4] * 1e7;
+        cmd.y =                 commandEntry.frame == MAV_FRAME_MISSION ? commandEntry.rgParam[5] : commandEntry.rgParam[5] * 1e7;
+        cmd.z =                 commandEntry.rgParam[6];
+        mavlink_msg_command_int_encode_chan(_mavlink->getSystemId(),
+                                            _mavlink->getComponentId(),
+                                            sharedLink->mavlinkChannel(),
+                                            &msg,
+                                            &cmd);
+    } else {
+        mavlink_command_long_t  cmd;
+
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.target_system =     _id;
+        cmd.target_component =  commandEntry.targetCompId;
+        cmd.command =           commandEntry.command;
+        cmd.confirmation =      0;
+        cmd.param1 =            commandEntry.rgParam[0];
+        cmd.param2 =            commandEntry.rgParam[1];
+        cmd.param3 =            commandEntry.rgParam[2];
+        cmd.param4 =            commandEntry.rgParam[3];
+        cmd.param5 =            commandEntry.rgParam[4];
+        cmd.param6 =            commandEntry.rgParam[5];
+        cmd.param7 =            commandEntry.rgParam[6];
+        mavlink_msg_command_long_encode_chan(_mavlink->getSystemId(),
+                                             _mavlink->getComponentId(),
+                                             sharedLink->mavlinkChannel(),
+                                             &msg,
+                                             &cmd);
+    }
+
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_sendMavCommandResponseTimeoutCheck(void)
@@ -2903,6 +2910,9 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
 void Vehicle::_waitForMavlinkMessage(WaitForMavlinkMessageResultHandler resultHandler, void* resultHandlerData, int messageId, int timeoutMsecs)
 {
     qCDebug(VehicleLog) << "_waitForMavlinkMessage msg:timeout" << messageId << timeoutMsecs;
+    if (_waitForMavlinkMessageResultHandler) {
+        qCCritical(VehicleLog) << "_waitForMavlinkMessage: collision";
+    }
     _waitForMavlinkMessageResultHandler     = resultHandler;
     _waitForMavlinkMessageResultHandlerData = resultHandlerData;
     _waitForMavlinkMessageId                = messageId;
@@ -3072,75 +3082,75 @@ void Vehicle::rebootVehicle()
 
 void Vehicle::startCalibration(Vehicle::CalibrationType calType)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
-        float param1 = 0;
-        float param2 = 0;
-        float param3 = 0;
-        float param4 = 0;
-        float param5 = 0;
-        float param6 = 0;
-        float param7 = 0;
-
-        switch (calType) {
-        case CalibrationGyro:
-            param1 = 1;
-            break;
-        case CalibrationMag:
-            param2 = 1;
-            break;
-        case CalibrationRadio:
-            param4 = 1;
-            break;
-        case CalibrationCopyTrims:
-            param4 = 2;
-            break;
-        case CalibrationAccel:
-            param5 = 1;
-            break;
-        case CalibrationLevel:
-            param5 = 2;
-            break;
-        case CalibrationEsc:
-            param7 = 1;
-            break;
-        case CalibrationPX4Airspeed:
-            param6 = 1;
-            break;
-        case CalibrationPX4Pressure:
-            param3 = 1;
-            break;
-        case CalibrationAPMCompassMot:
-            param6 = 1;
-            break;
-        case CalibrationAPMPressureAirspeed:
-            param3 = 1;
-            break;
-        case CalibrationAPMPreFlight:
-            param3 = 1; // GroundPressure/Airspeed
-            if (multiRotor() || rover()) {
-                // Gyro cal for ArduCopter only
-                param1 = 1;
-            }
-        }
-
-        // We can't use sendMavCommand here since we have no idea how long it will be before the command returns a result. This in turn
-        // causes the retry logic to break down.
-        mavlink_message_t msg;
-        mavlink_msg_command_long_pack_chan(_mavlink->getSystemId(),
-                                           _mavlink->getComponentId(),
-                                           sharedLink->mavlinkChannel(),
-                                           &msg,
-                                           id(),
-                                           defaultComponentId(),            // target component
-                                           MAV_CMD_PREFLIGHT_CALIBRATION,    // command id
-                                           0,                                // 0=first transmission of command
-                                           param1, param2, param3, param4, param5, param6, param7);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "startCalibration: primary link gone!";
+        return;
     }
+
+    float param1 = 0;
+    float param2 = 0;
+    float param3 = 0;
+    float param4 = 0;
+    float param5 = 0;
+    float param6 = 0;
+    float param7 = 0;
+
+    switch (calType) {
+    case CalibrationGyro:
+        param1 = 1;
+        break;
+    case CalibrationMag:
+        param2 = 1;
+        break;
+    case CalibrationRadio:
+        param4 = 1;
+        break;
+    case CalibrationCopyTrims:
+        param4 = 2;
+        break;
+    case CalibrationAccel:
+        param5 = 1;
+        break;
+    case CalibrationLevel:
+        param5 = 2;
+        break;
+    case CalibrationEsc:
+        param7 = 1;
+        break;
+    case CalibrationPX4Airspeed:
+        param6 = 1;
+        break;
+    case CalibrationPX4Pressure:
+        param3 = 1;
+        break;
+    case CalibrationAPMCompassMot:
+        param6 = 1;
+        break;
+    case CalibrationAPMPressureAirspeed:
+        param3 = 1;
+        break;
+    case CalibrationAPMPreFlight:
+        param3 = 1; // GroundPressure/Airspeed
+        if (multiRotor() || rover()) {
+            // Gyro cal for ArduCopter only
+            param1 = 1;
+        }
+    }
+
+    // We can't use sendMavCommand here since we have no idea how long it will be before the command returns a result. This in turn
+    // causes the retry logic to break down.
+    mavlink_message_t msg;
+    mavlink_msg_command_long_pack_chan(_mavlink->getSystemId(),
+                                       _mavlink->getComponentId(),
+                                       sharedLink->mavlinkChannel(),
+                                       &msg,
+                                       id(),
+                                       defaultComponentId(),            // target component
+                                       MAV_CMD_PREFLIGHT_CALIBRATION,    // command id
+                                       0,                                // 0=first transmission of command
+                                       param1, param2, param3, param4, param5, param6, param7);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::stopCalibration(void)
@@ -3201,7 +3211,7 @@ void Vehicle::setOfflineEditingDefaultComponentId(int defaultComponentId)
     if (_offlineEditingVehicle) {
         _defaultComponentId = defaultComponentId;
     } else {
-        qWarning() << "Call to Vehicle::setOfflineEditingDefaultComponentId on vehicle which is not offline";
+        qCWarning(VehicleLog) << "Call to Vehicle::setOfflineEditingDefaultComponentId on vehicle which is not offline";
     }
 }
 
@@ -3228,25 +3238,26 @@ void Vehicle::stopMavlinkLog()
 
 void Vehicle::_ackMavlinkLogData(uint16_t sequence)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        mavlink_message_t       msg;
-        mavlink_logging_ack_t   ack;
-
-        memset(&ack, 0, sizeof(ack));
-        ack.sequence = sequence;
-        ack.target_component = _defaultComponentId;
-        ack.target_system = id();
-        mavlink_msg_logging_ack_encode_chan(
-                    _mavlink->getSystemId(),
-                    _mavlink->getComponentId(),
-                    sharedLink->mavlinkChannel(),
-                    &msg,
-                    &ack);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
+    SharedLinkInterfacePtr  sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "_ackMavlinkLogData: primary link gone!";
+        return;
     }
+
+    mavlink_message_t       msg;
+    mavlink_logging_ack_t   ack;
+
+    memset(&ack, 0, sizeof(ack));
+    ack.sequence = sequence;
+    ack.target_component = _defaultComponentId;
+    ack.target_system = id();
+    mavlink_msg_logging_ack_encode_chan(
+                _mavlink->getSystemId(),
+                _mavlink->getComponentId(),
+                sharedLink->mavlinkChannel(),
+                &msg,
+                &ack);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
 void Vehicle::_handleMavlinkLoggingData(mavlink_message_t& message)
@@ -3774,20 +3785,50 @@ void Vehicle::updateFlightDistance(double distance)
 
 void Vehicle::sendParamMapRC(const QString& paramName, double scale, double centerValue, int tuningID, double minValue, double maxValue)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
+    SharedLinkInterfacePtr  sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog) << "sendParamMapRC: primary link gone!";
+        return;
+    }
 
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        mavlink_message_t       message;
+    mavlink_message_t       message;
 
-        char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
-        // Copy string into buffer, ensuring not to exceed the buffer size
-        for (unsigned int i = 0; i < sizeof(param_id_cstr); i++) {
-            if ((int)i < paramName.length()) {
-                param_id_cstr[i] = paramName.toLatin1()[i];
-            }
+    char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
+    // Copy string into buffer, ensuring not to exceed the buffer size
+    for (unsigned int i = 0; i < sizeof(param_id_cstr); i++) {
+        if ((int)i < paramName.length()) {
+            param_id_cstr[i] = paramName.toLatin1()[i];
         }
+    }
 
+    mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
+                                       static_cast<uint8_t>(_mavlink->getComponentId()),
+                                       sharedLink->mavlinkChannel(),
+                                       &message,
+                                       _id,
+                                       MAV_COMP_ID_AUTOPILOT1,
+                                       param_id_cstr,
+                                       -1,                                                  // parameter name specified as string in previous argument
+                                       static_cast<uint8_t>(tuningID),
+                                       static_cast<float>(scale),
+                                       static_cast<float>(centerValue),
+                                       static_cast<float>(minValue),
+                                       static_cast<float>(maxValue));
+    sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+}
+
+void Vehicle::clearAllParamMapRC(void)
+{
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog)<< "clearAllParamMapRC: primary link gone!";
+        return;
+    }
+
+    char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
+
+    for (int i = 0; i < 3; i++) {
+        mavlink_message_t message;
         mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
                                            static_cast<uint8_t>(_mavlink->getComponentId()),
                                            sharedLink->mavlinkChannel(),
@@ -3795,74 +3836,46 @@ void Vehicle::sendParamMapRC(const QString& paramName, double scale, double cent
                                            _id,
                                            MAV_COMP_ID_AUTOPILOT1,
                                            param_id_cstr,
-                                           -1,                                                  // parameter name specified as string in previous argument
-                                           static_cast<uint8_t>(tuningID),
-                                           static_cast<float>(scale),
-                                           static_cast<float>(centerValue),
-                                           static_cast<float>(minValue),
-                                           static_cast<float>(maxValue));
+                                           -2,                                                  // Disable map for specified tuning id
+                                           i,                                                   // tuning id
+                                           0, 0, 0, 0);                                         // unused
         sendMessageOnLinkThreadSafe(sharedLink.get(), message);
-    }
-}
-
-void Vehicle::clearAllParamMapRC(void)
-{
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-        char param_id_cstr[MAVLINK_MSG_PARAM_MAP_RC_FIELD_PARAM_ID_LEN] = {};
-
-        for (int i = 0; i < 3; i++) {
-            mavlink_message_t message;
-            mavlink_msg_param_map_rc_pack_chan(static_cast<uint8_t>(_mavlink->getSystemId()),
-                                               static_cast<uint8_t>(_mavlink->getComponentId()),
-                                               sharedLink->mavlinkChannel(),
-                                               &message,
-                                               _id,
-                                               MAV_COMP_ID_AUTOPILOT1,
-                                               param_id_cstr,
-                                               -2,                                                  // Disable map for specified tuning id
-                                               i,                                                   // tuning id
-                                               0, 0, 0, 0);                                         // unused
-            sendMessageOnLinkThreadSafe(sharedLink.get(), message);
-        }
     }
 }
 
 void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, float thrust, quint16 buttons)
 {
-    WeakLinkInterfacePtr weakLink = vehicleLinkManager()->primaryLink();
-
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
-        if (sharedLink->linkConfiguration()->isHighLatency()) {
-            return;
-        }
-
-        mavlink_message_t message;
-
-        // Incoming values are in the range -1:1
-        float axesScaling =         1.0 * 1000.0;
-        float newRollCommand =      roll * axesScaling;
-        float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
-        float newYawCommand    =    yaw * axesScaling;
-        float newThrustCommand =    thrust * axesScaling;
-
-        mavlink_msg_manual_control_pack_chan(
-                    static_cast<uint8_t>(_mavlink->getSystemId()),
-                    static_cast<uint8_t>(_mavlink->getComponentId()),
-                    sharedLink->mavlinkChannel(),
-                    &message,
-                    static_cast<uint8_t>(_id),
-                    static_cast<int16_t>(newPitchCommand),
-                    static_cast<int16_t>(newRollCommand),
-                    static_cast<int16_t>(newThrustCommand),
-                    static_cast<int16_t>(newYawCommand),
-                    buttons);
-        sendMessageOnLinkThreadSafe(sharedLink.get(), message);
+    SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCDebug(VehicleLog)<< "sendJoystickDataThreadSafe: primary link gone!";
+        return;
     }
+
+    if (sharedLink->linkConfiguration()->isHighLatency()) {
+        return;
+    }
+
+    mavlink_message_t message;
+
+    // Incoming values are in the range -1:1
+    float axesScaling =         1.0 * 1000.0;
+    float newRollCommand =      roll * axesScaling;
+    float newPitchCommand  =    pitch * axesScaling;    // Joystick data is reverse of mavlink values
+    float newYawCommand    =    yaw * axesScaling;
+    float newThrustCommand =    thrust * axesScaling;
+
+    mavlink_msg_manual_control_pack_chan(
+                static_cast<uint8_t>(_mavlink->getSystemId()),
+                static_cast<uint8_t>(_mavlink->getComponentId()),
+                sharedLink->mavlinkChannel(),
+                &message,
+                static_cast<uint8_t>(_id),
+                static_cast<int16_t>(newPitchCommand),
+                static_cast<int16_t>(newRollCommand),
+                static_cast<int16_t>(newThrustCommand),
+                static_cast<int16_t>(newYawCommand),
+                buttons);
+    sendMessageOnLinkThreadSafe(sharedLink.get(), message);
 }
 
 void Vehicle::triggerSimpleCamera()

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2376,13 +2376,13 @@ void Vehicle::guidedModeGotoLocation(const QGeoCoordinate& gotoCoord)
     _firmwarePlugin->guidedModeGotoLocation(this, gotoCoord);
 }
 
-void Vehicle::guidedModeChangeAltitude(double altitudeChange)
+void Vehicle::guidedModeChangeAltitude(double altitudeChange, bool pauseVehicle)
 {
     if (!guidedModeSupported()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
-    _firmwarePlugin->guidedModeChangeAltitude(this, altitudeChange);
+    _firmwarePlugin->guidedModeChangeAltitude(this, altitudeChange, pauseVehicle);
 }
 
 void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, double amslAltitude)
@@ -2691,16 +2691,19 @@ void Vehicle::_sendMavCommandWorker(bool commandInt, bool requestMessage, bool s
         entry.elapsedTimer.start();
 
         _mavCommandList.append(entry);
-        _sendMavCommandFromList(_mavCommandList.last());
+        _sendMavCommandFromList(_mavCommandList.count() - 1);
     }
 }
 
-void Vehicle::_sendMavCommandFromList(MavCommandListEntry_t& commandEntry)
+void Vehicle::_sendMavCommandFromList(int index)
 {
+    MavCommandListEntry_t commandEntry = _mavCommandList[index];
+
     QString rawCommandName  = _toolbox->missionCommandTree()->rawName(commandEntry.command);
 
-    if (++commandEntry.tryCount > commandEntry.maxTries) {
+    if (++_mavCommandList[index].tryCount > commandEntry.maxTries) {
         qCDebug(VehicleLog) << "_sendMavCommandFromList giving up after max retries" << rawCommandName;
+        _mavCommandList.removeAt(index);
         if (commandEntry.resultHandler) {
             (*commandEntry.resultHandler)(commandEntry.resultHandlerData, commandEntry.targetCompId, MAV_RESULT_FAILED, MavCmdResultFailureNoResponseToCommand);
         } else {
@@ -2709,7 +2712,6 @@ void Vehicle::_sendMavCommandFromList(MavCommandListEntry_t& commandEntry)
         if (commandEntry.showError) {
             qgcApp()->showAppMessage(tr("Vehicle did not respond to command: %1").arg(rawCommandName));
         }
-        _mavCommandList.removeAt(_findMavCommandListEntryIndex(commandEntry.targetCompId, commandEntry.command));
         return;
     }
 
@@ -2789,7 +2791,7 @@ void Vehicle::_sendMavCommandResponseTimeoutCheck(void)
         MavCommandListEntry_t& commandEntry = _mavCommandList[i];
         if (commandEntry.elapsedTimer.elapsed() > commandEntry.ackTimeoutMSecs) {
             // Try sending command again
-            _sendMavCommandFromList(commandEntry);
+            _sendMavCommandFromList(i);
         }
     }
 }
@@ -2825,7 +2827,7 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
     int entryIndex = _findMavCommandListEntryIndex(message.compid, static_cast<MAV_CMD>(ack.command));
     bool commandInList = false;
     if (entryIndex != -1) {
-        const MavCommandListEntry_t& commandEntry = _mavCommandList[entryIndex];
+        MavCommandListEntry_t commandEntry = _mavCommandList.takeAt(entryIndex);
         if (commandEntry.command == ack.command) {
             if (commandEntry.requestMessage) {
                 RequestMessageInfo_t* pInfo = static_cast<RequestMessageInfo_t*>(commandEntry.resultHandlerData);
@@ -2871,8 +2873,6 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
                     emit mavCommandResult(_id, message.compid, ack.command, ack.result, MavCmdResultCommandResultOnly);
                 }
             }
-
-            _mavCommandList.removeAt(entryIndex);
             commandInList = true;
         }
     }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -422,6 +422,7 @@ public:
     int id() { return _id; }
     MAV_AUTOPILOT firmwareType() const { return _firmwareType; }
     MAV_TYPE vehicleType() const { return _vehicleType; }
+    QGCMAVLink::VehicleClass_t vehicleClass(void) const { return QGCMAVLink::vehicleClass(_vehicleType); }
     Q_INVOKABLE QString vehicleTypeName() const;
 
     /// Sends a message to the specified link

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -328,7 +328,8 @@ public:
 
     /// Command vehicle to change altitude
     ///     @param altitudeChange If > 0, go up by amount specified, if < 0, go down by amount specified
-    Q_INVOKABLE void guidedModeChangeAltitude(double altitudeChange);
+    ///     @param pauseVehicle true: pause vehicle prior to altitude change
+    Q_INVOKABLE void guidedModeChangeAltitude(double altitudeChange, bool pauseVehicle);
 
     /// Command vehicle to orbit given center point
     ///     @param centerCoord Orit around this point
@@ -1176,7 +1177,7 @@ private:
     static const int                _mavCommandAckTimeoutMSecsHighLatency   = 120000;
 
     void _sendMavCommandWorker  (bool commandInt, bool requestMessage, bool showError, MavCmdResultHandler resultHandler, void* resultHandlerData, int compId, MAV_CMD command, MAV_FRAME frame, float param1, float param2, float param3, float param4, float param5, float param6, float param7);
-    void _sendMavCommandFromList(MavCommandListEntry_t& commandEntry);
+    void _sendMavCommandFromList(int index);
     int  _findMavCommandListEntryIndex(int targetCompId, MAV_CMD command);
     bool _sendMavCommandShouldRetry(MAV_CMD command);
 

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -74,10 +74,7 @@ void VehicleLinkManager::_commRegainedOnLink(LinkInterface* link)
     }
     if (!primarySwitchMessage.isEmpty()) {
         _vehicle->_say(primarySwitchMessage);
-    }
-    if (!commRegainedMessage.isEmpty() || !primarySwitchMessage.isEmpty()) {
-        bool showBothMessages = !commRegainedMessage.isEmpty() && !primarySwitchMessage.isEmpty();
-        qgcApp()->showAppMessage(QStringLiteral("%1%2%3").arg(commRegainedMessage).arg(showBothMessages ? " " : "").arg(primarySwitchMessage));
+        qgcApp()->showAppMessage(primarySwitchMessage);
     }
 
     emit linkStatusesChanged();
@@ -117,7 +114,6 @@ void VehicleLinkManager::_commLostCheck(void)
             if (_rgLinkInfo.count() > 1) {
                 QString msg = tr("%1Communication lost on %2 link.").arg(_vehicle->_vehicleIdSpeech()).arg(isPrimaryLink ? tr("primary") : tr("secondary"));
                 _vehicle->_say(msg);
-                qgcApp()->showAppMessage(msg);
             }
         }
     }

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -167,12 +167,17 @@ void VehicleLinkManager::_addLink(LinkInterface* link)
         qCWarning(VehicleLinkManagerLog) << "_addLink call with link which is already in the list";
         return;
     } else {
+        SharedLinkInterfacePtr sharedLink = _linkMgr->sharedLinkInterfacePointerForLink(link);
+        if (!sharedLink) {
+            qCDebug(VehicleLinkManagerLog) << "_addLink stale link" << (void*)link;
+            return;
+        }
         qCDebug(VehicleLinkManagerLog) << "_addLink:" << link->linkConfiguration()->name() << QString("%1").arg((qulonglong)link, 0, 16);
 
         link->addVehicleReference();
 
         LinkInfo_t linkInfo;
-        linkInfo.link = _linkMgr->sharedLinkInterfacePointerForLink(link);
+        linkInfo.link = sharedLink;
         if (!link->linkConfiguration()->isHighLatency()) {
             linkInfo.heartbeatElapsedTimer.start();
         }
@@ -231,7 +236,7 @@ void VehicleLinkManager::_linkDisconnected(void)
     }
 }
 
-WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
+SharedLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
 {
 #ifndef NO_SERIAL_LINK
     // Best choice is a USB connection
@@ -264,9 +269,10 @@ WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
     }
 
     // Last possible choice is a high latency link
-    if (!_primaryLink.expired() && _primaryLink.lock().get()->linkConfiguration()->isHighLatency()) {
+    SharedLinkInterfacePtr link = _primaryLink.lock();
+    if (link && link->linkConfiguration()->isHighLatency()) {
         // Best choice continues to be the current high latency link
-        return _primaryLink;
+        return link;
     } else {
         // Pick any high latency link if one exists
         for (const LinkInfo_t& linkInfo: _rgLinkInfo) {
@@ -280,25 +286,26 @@ WeakLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
         }
     }
 
-    return WeakLinkInterfacePtr();
+    return {};
 }
 
 bool VehicleLinkManager::_updatePrimaryLink(void)
 {
-    int linkIndex = _containsLinkIndex(_primaryLink.lock().get());
-    if (linkIndex != -1 && !_rgLinkInfo[linkIndex].commLost && !_rgLinkInfo[linkIndex].link->linkConfiguration()->isHighLatency()) {
+    SharedLinkInterfacePtr primaryLink = _primaryLink.lock();
+    int linkIndex = _containsLinkIndex(primaryLink.get());
+    if (linkIndex != -1 && !_rgLinkInfo[linkIndex].commLost && !primaryLink->linkConfiguration()->isHighLatency()) {
         // Current priority link is still valid
         return false;
     }
 
-    WeakLinkInterfacePtr bestActivePrimaryLink = _bestActivePrimaryLink();
+    SharedLinkInterfacePtr bestActivePrimaryLink = _bestActivePrimaryLink();
 
-    if (linkIndex != -1 && bestActivePrimaryLink.expired()) {
+    if (linkIndex != -1 && !bestActivePrimaryLink) {
         // Nothing better available, leave things set to current primary link
         return false;
     } else {
-        if (bestActivePrimaryLink.lock().get() != _primaryLink.lock().get()) {
-            if (!_primaryLink.expired() && _primaryLink.lock()->linkConfiguration()->isHighLatency()) {
+        if (bestActivePrimaryLink != primaryLink) {
+            if (primaryLink && primaryLink->linkConfiguration()->isHighLatency()) {
                 _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
                                MAV_CMD_CONTROL_HIGH_LATENCY,
                                true,
@@ -308,7 +315,7 @@ bool VehicleLinkManager::_updatePrimaryLink(void)
             _primaryLink = bestActivePrimaryLink;
             emit primaryLinkChanged();
 
-            if (!bestActivePrimaryLink.expired() && bestActivePrimaryLink.lock()->linkConfiguration()->isHighLatency()) {
+            if (bestActivePrimaryLink && bestActivePrimaryLink->linkConfiguration()->isHighLatency()) {
                 _vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
                                MAV_CMD_CONTROL_HIGH_LATENCY,
                                true,
@@ -390,11 +397,10 @@ QStringList VehicleLinkManager::linkStatuses(void) const
 
 bool VehicleLinkManager::primaryLinkIsPX4Flow(void) const
 {
-    WeakLinkInterfacePtr nullWeak;
-
-    if (_primaryLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = _primaryLink.lock();
+    if (!sharedLink) {
         return false;
     } else {
-        return _primaryLink.lock()->isPX4Flow();
+        return sharedLink->isPX4Flow();
     }
 }

--- a/src/Vehicle/VehicleLinkManager.h
+++ b/src/Vehicle/VehicleLinkManager.h
@@ -73,7 +73,7 @@ private:
     void                    _removeLink             (LinkInterface* link);
     void                    _linkDisconnected       (void);
     bool                    _updatePrimaryLink      (void);
-    WeakLinkInterfacePtr    _bestActivePrimaryLink  (void);
+    SharedLinkInterfacePtr  _bestActivePrimaryLink  (void);
     void                    _commRegainedOnLink     (LinkInterface*  link);
 
     typedef struct LinkInfo {

--- a/src/VideoManager/SubtitleWriter.cc
+++ b/src/VideoManager/SubtitleWriter.cc
@@ -39,7 +39,8 @@ void SubtitleWriter::startCapturingTelemetry(const QString& videoFile)
     _values = settings.value("large").toStringList().replaceInStrings(QStringLiteral("Vehicle."), QString());
     _values += settings.value("small").toStringList().replaceInStrings(QStringLiteral("Vehicle."), QString());
 
-    _startTime = QDateTime::currentDateTime();
+    // One subtitle always starts where the previous ended
+    _lastEndTime = QTime(0, 0);
 
     QFileInfo videoFileInfo(videoFile);
     QString subtitleFilePath = QStringLiteral("%1/%2.ass").arg(videoFileInfo.path(), videoFileInfo.completeBaseName());
@@ -108,10 +109,11 @@ void SubtitleWriter::_captureTelemetry()
     }
 
     // The time to start displaying this subtitle text
-    QTime start = QTime(0, 0).addMSecs(_startTime.time().msecsTo(QDateTime::currentDateTime().time()));
+    QTime start = _lastEndTime;
 
     // The time to stop displaying this subtitle text
     QTime end = start.addMSecs(1000/_sampleRate);
+    _lastEndTime = end;
 
     // This splits the screen in N parts and uses the N-1 internal parts to align the subtitles to.
     // Should we try to get the resolution from the pipeline? This seems to work fine with other resolutions too.

--- a/src/VideoManager/SubtitleWriter.h
+++ b/src/VideoManager/SubtitleWriter.h
@@ -43,7 +43,7 @@ private slots:
 private:
     QTimer _timer;
     QStringList _values;
-    QDateTime _startTime;
+    QTime _lastEndTime;
     QFile _file;
 
     static const int _sampleRate;

--- a/src/VideoManager/SubtitleWriter.h
+++ b/src/VideoManager/SubtitleWriter.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "QGCLoggingCategory.h"
+#include "Fact.h"
 #include <QObject>
 #include <QTimer>
 #include <QDateTime>
@@ -42,9 +43,9 @@ private slots:
 
 private:
     QTimer _timer;
-    QStringList _values;
+    QList<Fact*> _facts;
     QTime _lastEndTime;
     QFile _file;
 
-    static const int _sampleRate;
+    static const int _sampleRate; // Sample rate in Hz for getting telemetry data, most players do weird stuff when > 1Hz
 };

--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -1401,6 +1401,30 @@ GstVideoReceiver::_wrapWithGhostPad(GstElement* element, GstPad* pad, gpointer d
 void
 GstVideoReceiver::_linkPad(GstElement* element, GstPad* pad, gpointer data)
 {
+    bool is_video = true;
+
+    GstCaps* filter = gst_caps_from_string("application/x-rtp, media=(string)video");
+
+    if (filter != nullptr) {
+        GstCaps* caps = gst_pad_query_caps(pad, nullptr);
+
+        if (caps != nullptr) {
+            if (!gst_caps_is_any(caps) && !gst_caps_can_intersect(caps, filter)) {
+                is_video = false;
+            }
+
+            gst_caps_unref(caps);
+            caps = nullptr;
+        }
+
+        gst_caps_unref(filter);
+        filter = nullptr;
+    }
+
+    if (!is_video) {
+        return;
+    }
+
     gchar* name;
 
     if ((name = gst_pad_get_name(pad)) != nullptr) {

--- a/src/comm/LinkInterface.cc
+++ b/src/comm/LinkInterface.cc
@@ -8,7 +8,13 @@
  ****************************************************************************/
 
 #include "LinkInterface.h"
+#include "LinkManager.h"
 #include "QGCApplication.h"
+
+QGC_LOGGING_CATEGORY(LinkInterfaceLog, "LinkInterfaceLog")
+
+// The LinkManager is only forward declared in the header, so the static_assert is here instead.
+static_assert(LinkManager::invalidMavlinkChannel() == std::numeric_limits<uint8_t>::max(), "update LinkInterface::_mavlinkChannel");
 
 LinkInterface::LinkInterface(SharedLinkConfigurationPtr& config, bool isPX4Flow)
     : QThread   (0)
@@ -23,26 +29,53 @@ LinkInterface::LinkInterface(SharedLinkConfigurationPtr& config, bool isPX4Flow)
 LinkInterface::~LinkInterface()
 {
     if (_vehicleReferenceCount != 0) {
-        qWarning() << "~LinkInterface still have vehicle references:" << _vehicleReferenceCount;
+        qCWarning(LinkInterfaceLog) << "~LinkInterface still have vehicle references:" << _vehicleReferenceCount;
     }
     _config.reset();
 }
 
 uint8_t LinkInterface::mavlinkChannel(void) const
 {
-    if (!_mavlinkChannelSet) {
-        qWarning() << "Call to LinkInterface::mavlinkChannel with _mavlinkChannelSet == false";
+    if (!mavlinkChannelIsSet()) {
+        qCWarning(LinkInterfaceLog) << "mavlinkChannel isSet() == false";
     }
     return _mavlinkChannel;
 }
 
-void LinkInterface::_setMavlinkChannel(uint8_t channel)
+bool LinkInterface::mavlinkChannelIsSet(void) const
 {
-    if (_mavlinkChannelSet) {
-        qWarning() << "Mavlink channel set multiple times";
+    return (LinkManager::invalidMavlinkChannel() != _mavlinkChannel);
+}
+
+bool LinkInterface::_allocateMavlinkChannel()
+{
+    // should only be called by the LinkManager during setup
+    Q_ASSERT(!mavlinkChannelIsSet());
+    if (mavlinkChannelIsSet()) {
+        qCWarning(LinkInterfaceLog) << "_allocateMavlinkChannel already have " << _mavlinkChannel;
+        return true;
     }
-    _mavlinkChannelSet = true;
-    _mavlinkChannel = channel;
+
+    auto mgr = qgcApp()->toolbox()->linkManager();
+    _mavlinkChannel = mgr->allocateMavlinkChannel();
+    if (!mavlinkChannelIsSet()) {
+        qCWarning(LinkInterfaceLog) << "_allocateMavlinkChannel failed";
+        return false;
+    }
+    qCDebug(LinkInterfaceLog) << "_allocateMavlinkChannel" << _mavlinkChannel;
+    return true;
+}
+
+void LinkInterface::_freeMavlinkChannel()
+{
+    qCDebug(LinkInterfaceLog) << "_freeMavlinkChannel" << _mavlinkChannel;
+    if (LinkManager::invalidMavlinkChannel() == _mavlinkChannel) {
+        return;
+    }
+
+    auto mgr = qgcApp()->toolbox()->linkManager();
+    mgr->freeMavlinkChannel(_mavlinkChannel);
+    _mavlinkChannel = LinkManager::invalidMavlinkChannel();
 }
 
 void LinkInterface::writeBytesThreadSafe(const char *bytes, int length)
@@ -66,7 +99,7 @@ void LinkInterface::removeVehicleReference(void)
             disconnect();
         }
     } else {
-        qWarning() << "LinkInterface::removeVehicleReference called with no vehicle references";
+        qCWarning(LinkInterfaceLog) << "removeVehicleReference called with no vehicle references";
     }
 }
 

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -11,6 +11,7 @@
 
 #include <QThread>
 #include <QDateTime>
+#include <QLoggingCategory>
 #include <QMutex>
 #include <QMutexLocker>
 #include <QMetaType>
@@ -26,6 +27,8 @@
 
 class LinkManager;
 
+Q_DECLARE_LOGGING_CATEGORY(LinkInterfaceLog)
+
 /**
 * @brief The link interface defines the interface for all links used to communicate
 * with the ground station application.
@@ -36,7 +39,8 @@ class LinkInterface : public QThread
 
     friend class LinkManager;
 
-public:    
+public:
+
     virtual ~LinkInterface();
 
     Q_PROPERTY(bool isPX4Flow   READ isPX4Flow  CONSTANT)
@@ -58,6 +62,8 @@ public:
     virtual bool isLogReplay    (void) { return false; }
 
     uint8_t mavlinkChannel              (void) const;
+    bool    mavlinkChannelIsSet         (void) const;
+
     bool    decodedFirstMavlinkPacket   (void) const { return _decodedFirstMavlinkPacket; }
     bool    setDecodedFirstMavlinkPacket(bool decodedFirstMavlinkPacket) { return _decodedFirstMavlinkPacket = decodedFirstMavlinkPacket; }
     void    writeBytesThreadSafe        (const char *bytes, int length);
@@ -79,16 +85,24 @@ protected:
 
     SharedLinkConfigurationPtr _config;
 
+    ///
+    /// \brief _allocateMavlinkChannel
+    ///     Called by the LinkManager during LinkInterface construction
+    /// instructing the link to setup channels.
+    ///
+    /// Default implementation allocates a single channel. But some link types
+    /// (such as MockLink) need more than one.
+    ///
+    virtual bool _allocateMavlinkChannel();
+    virtual void _freeMavlinkChannel    ();
+
 private:
     // connect is private since all links should be created through LinkManager::createConnectedLink calls
     virtual bool _connect(void) = 0;
 
     virtual void _writeBytes(const QByteArray) = 0; // Not thread safe, only writeBytesThreadSafe is thread safe
 
-    void _setMavlinkChannel(uint8_t channel);
-
-    bool    _mavlinkChannelSet          = false;
-    uint8_t _mavlinkChannel;
+    uint8_t _mavlinkChannel             = std::numeric_limits<uint8_t>::max();
     bool    _decodedFirstMavlinkPacket  = false;
     bool    _isPX4Flow                  = false;
     int     _vehicleReferenceCount      = 0;

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -13,6 +13,8 @@
 #include <QMultiMap>
 #include <QMutex>
 
+#include <limits>
+
 #include "LinkConfiguration.h"
 #include "LinkInterface.h"
 #include "QGCLoggingCategory.h"
@@ -112,8 +114,12 @@ public:
     // Override from QGCTool
     virtual void setToolbox(QGCToolbox *toolbox);
 
-    /// @return This mavlink channel is never assigned to a vehicle.
-    uint8_t reservedMavlinkChannel(void) { return 0; }
+    static constexpr uint8_t invalidMavlinkChannel(void) { return std::numeric_limits<uint8_t>::max(); }
+
+    /// Allocates a mavlink channel for use
+    /// @return Mavlink channel index, invalidMavlinkChannel() for no channels available
+    uint8_t allocateMavlinkChannel(void);
+    void freeMavlinkChannel(uint8_t channel);
 
     /// If you are going to hold a reference to a LinkInterface* in your object you must reference count it
     /// by using this method to get access to the shared pointer.
@@ -124,10 +130,6 @@ public:
     SharedLinkConfigurationPtr addConfiguration(LinkConfiguration* config);
 
     void startAutoConnectedLinks(void);
-
-    /// Reserves a mavlink channel for use
-    /// @return Mavlink channel index, 0 for no channels available
-    int _reserveMavlinkChannel(void);
 
     static const char*  settingsGroup;
 
@@ -147,7 +149,6 @@ private:
     void                _removeConfiguration        (LinkConfiguration* config);
     void                _addUDPAutoConnectLink      (void);
     void                _addMAVLinkForwardingLink   (void);
-    void                _freeMavlinkChannel         (int channel);
     bool                _isSerialPortConnected      (void);
 
 #ifndef NO_SERIAL_LINK

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -10,9 +10,10 @@
 #pragma once
 
 #include <QElapsedTimer>
-#include <QMap>
-#include <QLoggingCategory>
 #include <QGeoCoordinate>
+#include <QLoggingCategory>
+#include <QMap>
+#include <QMutex>
 
 #include "MockLinkMissionItemHandler.h"
 #include "MockLinkFTP.h"
@@ -188,7 +189,11 @@ private slots:
 
 private:
     // LinkInterface overrides
-    bool _connect(void) override;
+    bool _connect                       (void) override;
+    bool _allocateMavlinkChannel        () override;
+    void _freeMavlinkChannel            () override;
+    uint8_t mavlinkAuxChannel           (void) const;
+    bool mavlinkAuxChannelIsSet         (void) const;
 
     // QThread override
     void run(void) final;
@@ -198,6 +203,7 @@ private:
     void _sendHighLatency2              (void);
     void _handleIncomingNSHBytes        (const char* bytes, int cBytes);
     void _handleIncomingMavlinkBytes    (const uint8_t* bytes, int cBytes);
+    void _handleIncomingMavlinkMsg      (const mavlink_message_t& msg);
     void _loadParams                    (void);
     void _handleHeartBeat               (const mavlink_message_t& msg);
     void _handleSetMode                 (const mavlink_message_t& msg);
@@ -233,11 +239,13 @@ private:
     static MockLink* _startMockLinkWorker(QString configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, MockConfiguration::FailureMode_t failureMode);
     static MockLink* _startMockLink(MockConfiguration* mockConfig);
 
+    uint8_t                     _mavlinkAuxChannel              = std::numeric_limits<uint8_t>::max();
+    QMutex                      _mavlinkAuxMutex;
+
     MockLinkMissionItemHandler  _missionItemHandler;
 
     QString                     _name;
     bool                        _connected;
-    int                         _mavlinkChannel;
 
     uint8_t                     _vehicleSystemId;
     uint8_t                     _vehicleComponentId             = MAV_COMP_ID_AUTOPILOT1;

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -81,24 +81,14 @@ public:
     bool isConnected(void) const override;
     void disconnect (void) override;
 
-public slots:
-    void waitForBytesWritten(int msecs);
-    void waitForReadyRead   (int msecs);
-
-protected slots:
-    void _socketError   (QAbstractSocket::SocketError socketError);
-    void readBytes      (void);
-
-protected:
-    // QThread overrides
-    void run(void) override;
-
 private slots:
+    void _socketError   (QAbstractSocket::SocketError socketError);
+    void _readBytes     (void);
+
     // LinkInterface overrides
     void _writeBytes(const QByteArray data) override;
 
 private:
-
     // LinkInterface overrides
     bool _connect(void) override;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -223,7 +223,14 @@ bool checkAndroidWritePermission() {
 int main(int argc, char *argv[])
 {
 #ifndef __mobile__
-    RunGuard guard("QGroundControlRunGuardKey");
+    // We make the runguard key different for custom and non custom
+    // builds, so they can be executed together in the same device.
+    // Stable and Daily have same QGC_APPLICATION_NAME so they would
+    // not be able to run at the same time
+    QString runguardString(QGC_APPLICATION_NAME);
+    runguardString.append("RunGuardKey");
+
+    RunGuard guard(runguardString);
     if (!guard.tryToRun()) {
         // QApplication is necessary to use QMessageBox
         QApplication errorApp(argc, argv);

--- a/src/qgcunittest/MultiSignalSpyV2.cc
+++ b/src/qgcunittest/MultiSignalSpyV2.cc
@@ -268,7 +268,7 @@ quint64 MultiSignalSpyV2::signalNameToMask(const char* signalName)
     for (int i=0; i<_rgSignalNames.count(); i++) {
         qDebug() << "signalNameToMask" << signalName << _rgSignalNames[i];
         if (_rgSignalNames[i] == signalName) {
-            return 1 << i;
+            return 1ll << i;
         }
     }
 

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -329,55 +329,50 @@ ApplicationWindow {
         visible: QGroundControl.settingsManager.flyViewSettings.showLogReplayStatusBar.rawValue
     }
 
-    Drawer {
-        id:             toolSelectDrawer
-        height:         mainWindow.height
-        edge:           Qt.LeftEdge
-        interactive:    true
-        dragMargin:     0
-        visible:        false
+    function showToolSelectDialog() {
+        if (!mainWindow.preventViewSwitch()) {
+            showPopupDialogFromComponent(toolSelectDialogComponent)
+        }
+    }
 
-        property var    _mainWindow:       mainWindow
-        property real   _toolButtonHeight: ScreenTools.defaultFontPixelHeight * 3
+    Component {
+        id: toolSelectDialogComponent
 
-        Rectangle {
-            width:  mainLayout.width + (mainLayout.anchors.margins * 2)
-            height: parent.height
-            color:  qgcPal.window
+        QGCPopupDialog {
+            id:         toolSelectDialog
+            title:      qsTr("Select Tool")
+            buttons:    StandardButton.Close
 
-            QGCFlickable {
-                anchors.top:        parent.top
-                anchors.bottom:     qgcVersionLayout.top
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                contentHeight:      mainLayout.height + (mainLayout.anchors.margins * 2)
-                flickableDirection: QGCFlickable.VerticalFlick
+            property real _toolButtonHeight:    ScreenTools.defaultFontPixelHeight * 3
+            property real _margins:             ScreenTools.defaultFontPixelWidth
+
+            ColumnLayout {
+                width:  innerLayout.width + (_margins * 2)
+                height: innerLayout.height + (_margins * 2)
 
                 ColumnLayout {
-                    id:                 mainLayout
-                    anchors.margins:    ScreenTools.defaultFontPixelWidth
-                    anchors.left:       parent.left
-                    anchors.top:        parent.top
-                    spacing:            ScreenTools.defaultFontPixelWidth
+                    id:             innerLayout
+                    Layout.margins: _margins
+                    spacing:        ScreenTools.defaultFontPixelWidth
 
                     SubMenuButton {
                         id:                 setupButton
-                        height:             toolSelectDrawer._toolButtonHeight
+                        height:             _toolButtonHeight
                         Layout.fillWidth:   true
                         text:               qsTr("Vehicle Setup")
                         imageColor:         qgcPal.text
                         imageResource:      "/qmlimages/Gears.svg"
                         onClicked: {
                             if (!mainWindow.preventViewSwitch()) {
+                                toolSelectDialog.hideDialog()
                                 mainWindow.showSetupTool()
-                                toolSelectDrawer.visible = false
                             }
                         }
                     }
 
                     SubMenuButton {
                         id:                 analyzeButton
-                        height:             toolSelectDrawer._toolButtonHeight
+                        height:             _toolButtonHeight
                         Layout.fillWidth:   true
                         text:               qsTr("Analyze Tools")
                         imageResource:      "/qmlimages/Analyze.svg"
@@ -385,15 +380,15 @@ ApplicationWindow {
                         visible:            QGroundControl.corePlugin.showAdvancedUI
                         onClicked: {
                             if (!mainWindow.preventViewSwitch()) {
+                                toolSelectDialog.hideDialog()
                                 mainWindow.showAnalyzeTool()
-                                toolSelectDrawer.visible = false
                             }
                         }
                     }
 
                     SubMenuButton {
                         id:                 settingsButton
-                        height:             toolSelectDrawer._toolButtonHeight
+                        height:             _toolButtonHeight
                         Layout.fillWidth:   true
                         text:               qsTr("Application Settings")
                         imageResource:      "/res/QGCLogoFull"
@@ -401,65 +396,61 @@ ApplicationWindow {
                         visible:            !QGroundControl.corePlugin.options.combineSettingsAndSetup
                         onClicked: {
                             if (!mainWindow.preventViewSwitch()) {
+                                toolSelectDialog.hideDialog()
                                 mainWindow.showSettingsTool()
-                                toolSelectDrawer.visible = false
                             }
                         }
                     }
-                }
-            }
 
-            ColumnLayout {
-                id:             qgcVersionLayout
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                anchors.bottom: parent.bottom
-                spacing:        0
+                    ColumnLayout {
+                        width:      innerLayout.width
+                        spacing:    0
 
-                QGCLabel {
-                    text:                   qsTr("%1 Version").arg(QGroundControl.appName)
-                    font.pointSize:         ScreenTools.smallFontPointSize
-                    wrapMode:               QGCLabel.WordWrap
-                    Layout.maximumWidth:    parent.width
-                    Layout.alignment:       Qt.AlignHCenter
-                }
-                QGCLabel {
-                    text:                   QGroundControl.qgcVersion
-                    font.pointSize:         ScreenTools.smallFontPointSize
-                    wrapMode:               QGCLabel.WrapAnywhere
-                    Layout.maximumWidth:    parent.width
-                    Layout.alignment:       Qt.AlignHCenter
-                }
-            }
-
-            DeadMouseArea {
-                anchors.fill: easterEggMouseArea
-            }
-
-            QGCMouseArea {
-                id:             easterEggMouseArea
-                anchors.fill:   qgcVersionLayout
-
-                onClicked: {
-                    if (mouse.modifiers & Qt.ControlModifier) {
-                        QGroundControl.corePlugin.showTouchAreas = !QGroundControl.corePlugin.showTouchAreas
-                    } else if (mouse.modifiers & Qt.ShiftModifier) {
-                        if(!QGroundControl.corePlugin.showAdvancedUI) {
-                            advancedModeConfirmation.open()
-                        } else {
-                            QGroundControl.corePlugin.showAdvancedUI = false
+                        QGCLabel {
+                            id:                     versionLabel
+                            text:                   qsTr("%1 Version").arg(QGroundControl.appName)
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                            wrapMode:               QGCLabel.WordWrap
+                            Layout.maximumWidth:    parent.width
+                            Layout.alignment:       Qt.AlignHCenter
                         }
-                    }
-                }
 
-                MessageDialog {
-                    id:                 advancedModeConfirmation
-                    title:              qsTr("Advanced Mode")
-                    text:               QGroundControl.corePlugin.showAdvancedUIMessage
-                    standardButtons:    StandardButton.Yes | StandardButton.No
-                    onYes: {
-                        QGroundControl.corePlugin.showAdvancedUI = true
-                        advancedModeConfirmation.close()
+                        QGCLabel {
+                            text:                   QGroundControl.qgcVersion
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                            wrapMode:               QGCLabel.WrapAnywhere
+                            Layout.maximumWidth:    parent.width
+                            Layout.alignment:       Qt.AlignHCenter
+
+                            QGCMouseArea {
+                                id:                 easterEggMouseArea
+                                anchors.topMargin:  -versionLabel.height
+                                anchors.fill:       parent
+
+                                onClicked: {
+                                    if (mouse.modifiers & Qt.ControlModifier) {
+                                        QGroundControl.corePlugin.showTouchAreas = !QGroundControl.corePlugin.showTouchAreas
+                                    } else if (mouse.modifiers & Qt.ShiftModifier) {
+                                        if(!QGroundControl.corePlugin.showAdvancedUI) {
+                                            advancedModeConfirmation.open()
+                                        } else {
+                                            QGroundControl.corePlugin.showAdvancedUI = false
+                                        }
+                                    }
+                                }
+
+                                MessageDialog {
+                                    id:                 advancedModeConfirmation
+                                    title:              qsTr("Advanced Mode")
+                                    text:               QGroundControl.corePlugin.showAdvancedUIMessage
+                                    standardButtons:    StandardButton.Yes | StandardButton.No
+                                    onYes: {
+                                        QGroundControl.corePlugin.showAdvancedUI = true
+                                        advancedModeConfirmation.close()
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/ui/toolbar/MainStatusIndicator.qml
+++ b/src/ui/toolbar/MainStatusIndicator.qml
@@ -147,67 +147,76 @@ RowLayout {
         id: sensorStatusInfoComponent
 
         Rectangle {
-            width:          mainLayout.width   + (_margins * 2)
-            height:         mainLayout.height  + (_margins * 2)
+            width:          flickable.width + (_margins * 2)
+            height:         flickable.height + (_margins * 2)
             radius:         ScreenTools.defaultFontPixelHeight * 0.5
             color:          qgcPal.window
             border.color:   qgcPal.text
 
-            ColumnLayout {
-                id:                 mainLayout
+            QGCFlickable {
+                id:                 flickable
                 anchors.margins:    _margins
                 anchors.top:        parent.top
                 anchors.left:       parent.left
-                spacing:            _spacing
+                width:              mainLayout.width
+                height:             mainWindow.contentItem.height - (indicatorPopup.padding * 2) - (_margins * 2)
+                flickableDirection: Flickable.VerticalFlick
+                contentHeight:      mainLayout.height
+                contentWidth:       mainLayout.width
 
-                QGCLabel {
-                    Layout.alignment:   Qt.AlignHCenter
-                    text:               qsTr("Sensor Status")
-                }
+                ColumnLayout {
+                    id:         mainLayout
+                    spacing:    _spacing
 
-                GridLayout {
-                    rowSpacing:     _spacing
-                    columnSpacing:  _spacing
-                    rows:           _activeVehicle.sysStatusSensorInfo.sensorNames.length
-                    flow:           GridLayout.TopToBottom
+                    QGCButton {
+                        Layout.alignment:   Qt.AlignHCenter
+                        text:               _armed ?  qsTr("Disarm") : (forceArm ? qsTr("Force Arm") : qsTr("Arm"))
 
-                    Repeater {
-                        model: _activeVehicle.sysStatusSensorInfo.sensorNames
+                        property bool forceArm: false
 
-                        QGCLabel {
-                            text: modelData
-                        }
-                    }
+                        onPressAndHold: forceArm = true
 
-                    Repeater {
-                        model: _activeVehicle.sysStatusSensorInfo.sensorStatus
-
-                        QGCLabel {
-                            text: modelData
-                        }
-                    }
-                }
-
-                QGCButton {
-                    Layout.alignment:   Qt.AlignHCenter
-                    text:               _armed ?  qsTr("Disarm") : (forceArm ? qsTr("Force Arm") : qsTr("Arm"))
-
-                    property bool forceArm: false
-
-                    onPressAndHold: forceArm = true
-
-                    onClicked: {
-                        if (_armed) {
-                            mainWindow.disarmVehicleRequest()
-                        } else {
-                            if (forceArm) {
-                                mainWindow.forceArmVehicleRequest()
+                        onClicked: {
+                            if (_armed) {
+                                mainWindow.disarmVehicleRequest()
                             } else {
-                                mainWindow.armVehicleRequest()
+                                if (forceArm) {
+                                    mainWindow.forceArmVehicleRequest()
+                                } else {
+                                    mainWindow.armVehicleRequest()
+                                }
+                            }
+                            forceArm = false
+                            mainWindow.hideIndicatorPopup()
+                        }
+                    }
+
+                    QGCLabel {
+                        Layout.alignment:   Qt.AlignHCenter
+                        text:               qsTr("Sensor Status")
+                    }
+
+                    GridLayout {
+                        rowSpacing:     _spacing
+                        columnSpacing:  _spacing
+                        rows:           _activeVehicle.sysStatusSensorInfo.sensorNames.length
+                        flow:           GridLayout.TopToBottom
+
+                        Repeater {
+                            model: _activeVehicle.sysStatusSensorInfo.sensorNames
+
+                            QGCLabel {
+                                text: modelData
                             }
                         }
-                        forceArm = false
-                        mainWindow.hideIndicatorPopup()
+
+                        Repeater {
+                            model: _activeVehicle.sysStatusSensorInfo.sensorStatus
+
+                            QGCLabel {
+                                text: modelData
+                            }
+                        }
                     }
                 }
             }

--- a/src/ui/toolbar/MainStatusIndicator.qml
+++ b/src/ui/toolbar/MainStatusIndicator.qml
@@ -93,23 +93,23 @@ RowLayout {
     }
 
     Item {
-        width:  ScreenTools.defaultFontPixelWidth
-        height: 1
+        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * ScreenTools.largeFontPointRatio * 1.5
+        height:                 1
     }
 
     QGCColoredImage {
         id:         flightModeIcon
-        width:      height
+        width:      ScreenTools.defaultFontPixelWidth * 2
         height:     ScreenTools.defaultFontPixelHeight * 0.75
         fillMode:   Image.PreserveAspectFit
         mipmap:     true
         color:      qgcPal.text
         source:     "/qmlimages/FlightModesComponentIcon.png"
-        visible:    _activeVehicle
+        visible:    flightModeMenu.visible
     }
 
     Item {
-        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * (_vehicleInAir ?  ScreenTools.largeFontPointRatio : 1) / 3
+        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth / 2
         height:                 1
         visible:                flightModeMenu.visible
     }
@@ -124,7 +124,7 @@ RowLayout {
     }
 
     Item {
-        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * ScreenTools.largeFontPointRatio
+        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * ScreenTools.largeFontPointRatio * 1.5
         height:                 1
         visible:                vtolModeLabel.visible
     }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -87,7 +87,7 @@ Rectangle {
 
     QGCFlickable {
         id:                     toolsFlickable
-        anchors.leftMargin:     ScreenTools.defaultFontPixelHeight / 2
+        anchors.leftMargin:     ScreenTools.defaultFontPixelWidth * ScreenTools.largeFontPointRatio * 1.5
         anchors.left:           viewButtonRow.right
         anchors.bottomMargin:   1
         anchors.top:            parent.top
@@ -98,8 +98,7 @@ Rectangle {
 
         Loader {
             id:                 indicatorLoader
-            anchors.leftMargin: currentToolbar !== planViewToolbar ? ScreenTools.defaultFontPixelHeight / 2 : 0
-            anchors.left:       parent.left//currentToolbar !== planViewToolbar ? valueArea.right : parent.left
+            anchors.left:       parent.left
             anchors.top:        parent.top
             anchors.bottom:     parent.bottom
             source:             currentToolbar === flyViewToolbar ?

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -69,7 +69,7 @@ Rectangle {
             Layout.preferredHeight: viewButtonRow.height
             icon.source:            "/res/QGCLogoFull"
             logo:                   true
-            onClicked:              toolSelectDrawer.visible = true
+            onClicked:              mainWindow.showToolSelectDialog()
         }
 
         MainStatusIndicator {

--- a/tools/update_android_version.sh
+++ b/tools/update_android_version.sh
@@ -1,45 +1,74 @@
 #!/usr/bin/env bash
 
-VERSIONNAME=`git describe --always --tags | sed -e 's/^v//'`
+# git tag is in the form vX.Y.Z for builds from tagged commit 
+# git tag is in the form vX.Y.Z-1234-gSHA for builds from non-tagged commit 
 
-# Android versionCode from git tag vX.Y.Z-123-gSHA
+# Strip the 'v' from the beginning of the tag
+VERSIONNAME=`git describe --always --tags | sed -e 's/^v//'`
+echo "tag $VERSIONNAME"
+
+# Change all occurences of '-' in tag to '.' and separate into parts
 IFS=. read major minor patch dev sha <<<"${VERSIONNAME//-/.}"
-VERSIONCODE=$(($major*100000))
-VERSIONCODE=$(($(($minor*10000)) + $VERSIONCODE))
+echo "major:$major minor:$minor patch:$patch dev:$dev sha:$sha"
+
+# Max Android version code is 2100000000. Version codes must increase with each release and the 
+# version codes for multiple apks for the same release must be unique and not collide as well. 
+# All of this makes it next to impossible to create a rational system of building a version code
+# from a semantic version without imposing some strict restrictions.
+if [ $major -gt 9 ]; then
+    echo "Error: Major version larger than 1 digit: $major"
+    exit 1
+fi
+if [ $minor -gt 9 ]; then
+    echo "Error: Minor version larger than 1 digit: $minor"
+    exit 1
+fi
+if [ $patch -gt 99 ]; then
+    echo "Error: Patch version larger than 2 digits: $patch"
+    exit 1
+fi
+if [ $dev -gt 999 ]; then
+    echo "Error: Dev version larger than 3 digits: $dev"
+    exit 1
+fi
+
+# Version code format: BBMIPPDDD (B=Bitness, I=Minor)
+VERSIONCODE=$(($major*1000000))
+VERSIONCODE=$(($(($minor*100000)) + $VERSIONCODE))
 VERSIONCODE=$(($(($patch*1000)) + $VERSIONCODE))
 VERSIONCODE=$(($(($dev)) + $VERSIONCODE))
 
-# The 32 bit and 64 bit APKs each need there own version code.
+# The 32 bit and 64 bit APKs each need there own version code unique version code
 if [ "$1" = "32" ]; then
-    VERSIONCODE=330$VERSIONCODE
+    VERSIONCODE=34$VERSIONCODE
 else
-    VERSIONCODE=650$VERSIONCODE
+    VERSIONCODE=66$VERSIONCODE
 fi
 
 MANIFEST_FILE=android/AndroidManifest.xml
 
 # manifest package
 if [ "$2" = "master" ]; then
+	echo "Adjusting package name for daily build"
 	QGC_PKG_NAME="org.mavlink.qgroundcontrolbeta"
 	sed -i -e 's/package *= *"[^"]*"/package="'$QGC_PKG_NAME'"/' $MANIFEST_FILE
-	echo "Android package name: $QGC_PKG_NAME"
 fi
 
 # android:versionCode
 if [ -n "$VERSIONCODE" ]; then
+	echo "Android versionCode: ${VERSIONCODE}"
 	sed -i -e "s/android:versionCode=\"[0-9][0-9]*\"/android:versionCode=\"$VERSIONCODE\"/" $MANIFEST_FILE
-	echo "Android version: ${VERSIONCODE}"
 else
-	echo "Error versionCode empty"
-	exit 0 # don't cause the build to fail
+	echo "Error: versionCode empty"
+	exit 1
 fi
 
 # android:versionName
 if [ -n "$VERSIONNAME" ]; then
+	echo "Android versionName: ${VERSIONNAME}"
 	sed -i -e 's/versionName *= *"[^"]*"/versionName="'$VERSIONNAME'"/' $MANIFEST_FILE
-	echo "Android name: ${VERSIONNAME}"
 else
-	echo "Error versionName empty"
-	exit 0 # don't cause the build to fail
+	echo "Error: versionName empty"
+	exit 1
 fi
 


### PR DESCRIPTION
It would be a good idea if there's an auto detect mechanism for the RTSP string (at least for IP address).
One option would be:
- take the ip from comm link (detect which one is the active connection - Q it's already doing it)
- then take that IP and put it into RTSP string. 

This would work when using a secondary tablet connected with herelink, so if it changes IP or you change from a wifi network to hotspot mode, you would not need to change your config.

Another method would be to make a list of RTSP urls, like it's in comm links' IP host list, so Q would scan them when opening. User could fill that list with some "preset" urls, so no need to change everytime you open app
