### PR TITLE
Fix build problems with docker

### DIFF
--- a/deploy/docker/Dockerfile-build-linux
+++ b/deploy/docker/Dockerfile-build-linux
@@ -64,8 +64,9 @@ RUN /tmp/qt/install-qt-linux.sh
 # Reconfigure locale
 RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
 
-# create user with id 1001 (jenkins docker workflow default)
-RUN useradd --shell /bin/bash -u 1001 -c "" -m user && usermod -a -G dialout user
+# create user with id 1000 to not run commands/generate files as root
+RUN useradd user --create-home --home-dir /home/user --shell /bin/bash --uid 1000
+USER user
 
 WORKDIR /project/build
 CMD git --git-dir=/project/source/.git submodule update --init --recursive \

--- a/deploy/docker/Dockerfile-build-linux
+++ b/deploy/docker/Dockerfile-build-linux
@@ -69,5 +69,4 @@ RUN useradd user --create-home --home-dir /home/user --shell /bin/bash --uid 100
 USER user
 
 WORKDIR /project/build
-CMD git --git-dir=/project/source/.git submodule update --init --recursive \
-	&& qmake /project/source && make -j$(nproc)
+CMD qmake /project/source && make -j$(nproc)


### PR DESCRIPTION
Fixes two problems:
  - Fix and use default user to avoid the creation/modification of files as root
  - Remove git commands since it breaks git internals when running inside docker