### PR TITLE
Rework altitude mode internals/ui

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -112,8 +112,9 @@ SOURCES += \
 	libs/libevents/libevents/libs/cpp/protocol/receive.cpp \
 	libs/libevents/libevents/libs/cpp/parse/parser.cpp \
 	libs/libevents/definitions.cpp
-INCLUDEPATH += libs/libevents
-
+INCLUDEPATH += \
+        libs/libevents \
+        libs/libevents/libs/cpp/parse
 #
 # [REQUIRED] shapelib library
 INCLUDEPATH += libs/shapelib

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -76,6 +76,7 @@
         <file alias="QGCInstrumentWidgetAlternate.qml">src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml</file>
         <file alias="QGroundControl/Controls/AnalyzePage.qml">src/AnalyzeView/AnalyzePage.qml</file>
         <file alias="QGroundControl/Controls/AppMessages.qml">src/QmlControls/AppMessages.qml</file>
+        <file alias="QGroundControl/Controls/AltModeDialog.qml">src/QmlControls/AltModeDialog.qml</file>
         <file alias="QGroundControl/Controls/AxisMonitor.qml">src/QmlControls/AxisMonitor.qml</file>
         <file alias="QGroundControl/Controls/CameraCalcCamera.qml">src/PlanView/CameraCalcCamera.qml</file>
         <file alias="QGroundControl/Controls/CameraCalcGrid.qml">src/PlanView/CameraCalcGrid.qml</file>

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -325,7 +325,7 @@ VisualMissionItem* MissionController::_insertSimpleMissionItemWorker(QGeoCoordin
 
             if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltitudeMode)) {
                 newItem->altitude()->setRawValue(prevAltitude);
-                if (globalAltitudeMode() == QGroundControlQmlGlobal::AltitudeModeNone) {
+                if (globalAltitudeMode() == QGroundControlQmlGlobal::AltitudeModeMixed) {
                     // We are in mixed altitude modes, so copy from previous. Otherwise alt mode will be set from global setting.
                     newItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltitudeMode>(prevAltitudeMode));
                 }
@@ -618,7 +618,7 @@ bool MissionController::_loadJsonMissionFileV1(const QJsonObject& json, QmlObjec
         return false;
     }
 
-    setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeModeNone);   // Mixed mode
+    setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeModeMixed);
 
     // Read complex items
     QList<SurveyComplexItem*> surveyItems;
@@ -723,7 +723,7 @@ bool MissionController::_loadJsonMissionFileV2(const QJsonObject& json, QmlObjec
         return false;
     }
 
-    setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeModeNone);   // Mixed mode
+    setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeModeMixed);
 
     qCDebug(MissionControllerLog) << "MissionController::_loadJsonMissionFileV2 itemCount:" << json[_jsonItemsKey].toArray().count();
 
@@ -1057,7 +1057,7 @@ bool MissionController::loadTextFile(QFile& file, QString& errorString)
     QByteArray  bytes = file.readAll();
     QTextStream stream(bytes);
 
-    setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeModeNone);   // Mixed mode
+    setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeModeMixed);
 
     QmlObjectListModel* loadedVisualItems = new QmlObjectListModel(this);
     if (!_loadTextMissionFile(stream, loadedVisualItems, errorStr)) {
@@ -2647,7 +2647,7 @@ QGroundControlQmlGlobal::AltitudeMode MissionController::globalAltitudeMode(void
 
 QGroundControlQmlGlobal::AltitudeMode MissionController::globalAltitudeModeDefault(void)
 {
-    if (_globalAltMode == QGroundControlQmlGlobal::AltitudeModeNone) {
+    if (_globalAltMode == QGroundControlQmlGlobal::AltitudeModeMixed) {
         return QGroundControlQmlGlobal::AltitudeModeRelative;
     } else {
         return _globalAltMode;

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -109,7 +109,7 @@ public:
     Q_PROPERTY(double               minAMSLAltitude                 MEMBER _minAMSLAltitude             NOTIFY minAMSLAltitudeChanged)          ///< Minimum altitude associated with this mission. Used to calculate percentages for terrain status.
     Q_PROPERTY(double               maxAMSLAltitude                 MEMBER _maxAMSLAltitude             NOTIFY maxAMSLAltitudeChanged)          ///< Maximum altitude associated with this mission. Used to calculate percentages for terrain status.
 
-    Q_PROPERTY(QGroundControlQmlGlobal::AltitudeMode globalAltitudeMode         READ globalAltitudeMode         WRITE setGlobalAltitudeMode NOTIFY globalAltitudeModeChanged)   ///< AltitudeModeNone indicates the plan can used mixed modes
+    Q_PROPERTY(QGroundControlQmlGlobal::AltitudeMode globalAltitudeMode         READ globalAltitudeMode         WRITE setGlobalAltitudeMode NOTIFY globalAltitudeModeChanged)
     Q_PROPERTY(QGroundControlQmlGlobal::AltitudeMode globalAltitudeModeDefault  READ globalAltitudeModeDefault  NOTIFY globalAltitudeModeChanged)                               ///< Default to use for newly created items
 
     Q_INVOKABLE void removeVisualItem(int viIndex);

--- a/src/MissionManager/MissionControllerTest.cc
+++ b/src/MissionManager/MissionControllerTest.cc
@@ -264,10 +264,10 @@ void MissionControllerTest::_testGlobalAltMode(void)
         QGroundControlQmlGlobal::AltitudeMode   altMode;
         MAV_FRAME                               expectedMavFrame;
     } altModeTestCases[] = {
-        { QGroundControlQmlGlobal::AltitudeModeRelative,        MAV_FRAME_GLOBAL_RELATIVE_ALT },
-        { QGroundControlQmlGlobal::AltitudeModeAbsolute,        MAV_FRAME_GLOBAL },
-        { QGroundControlQmlGlobal::AltitudeModeAboveTerrain,    MAV_FRAME_GLOBAL },
-        { QGroundControlQmlGlobal::AltitudeModeTerrainFrame,    MAV_FRAME_GLOBAL_TERRAIN_ALT },
+        { QGroundControlQmlGlobal::AltitudeModeRelative,            MAV_FRAME_GLOBAL_RELATIVE_ALT },
+        { QGroundControlQmlGlobal::AltitudeModeAbsolute,            MAV_FRAME_GLOBAL },
+        { QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain,    MAV_FRAME_GLOBAL },
+        { QGroundControlQmlGlobal::AltitudeModeTerrainFrame,        MAV_FRAME_GLOBAL_TERRAIN_ALT },
     };
 
     for (const _globalAltMode_s& testCase: altModeTestCases) {

--- a/src/PlanView/CorridorScanEditor.qml
+++ b/src/PlanView/CorridorScanEditor.qml
@@ -121,7 +121,7 @@ Rectangle {
                     vehicleFlightIsFrontal:         true
                     distanceToSurfaceLabel:         qsTr("Altitude")
                     distanceToSurfaceAltitudeMode:  missionItem.followTerrain ?
-                                                        QGroundControl.AltitudeModeAboveTerrain :
+                                                        QGroundControl.AltitudeModeCalcAboveTerrain :
                                                         (missionItem.cameraCalc.distanceToSurfaceRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute)
                     frontalDistanceLabel:           qsTr("Trigger Dist")
                     sideDistanceLabel:              qsTr("Spacing")

--- a/src/PlanView/GeoFenceEditor.qml
+++ b/src/PlanView/GeoFenceEditor.qml
@@ -342,9 +342,8 @@ QGCFlickable {
                             text: qsTr("Altitude")
                         }
 
-                        AltitudeFactTextField {
-                            fact:           myGeoFenceController.breachReturnAltitude
-                            altitudeMode:   QGroundControl.AltitudeModeRelative
+                        FactTextField {
+                            fact: myGeoFenceController.breachReturnAltitude
                         }
                     }
 

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -45,6 +45,16 @@ Rectangle {
 
     QGCPalette { id: qgcPal }
     QGCFileDialogController { id: fileController }
+    Component { id: altModeDialogComponent; AltModeDialog { } }
+
+    Connections {
+        target: _controllerVehicle
+        onSupportsTerrainFrameChanged: {
+            if (!_controllerVehicle.supportsTerrainFrame && _missionController.globalAltitudeMode === QGroundControl.AltitudeModeTerrainFrame) {
+                _missionController.globalAltitudeMode = QGroundControl.AltitudeModeCalcAboveTerrain
+            }
+        }
+    }
 
     ColumnLayout {
         id:                 valuesColumn
@@ -58,75 +68,43 @@ Rectangle {
             text:           qsTr("All Altitudes")
             font.pointSize: ScreenTools.smallFontPointSize
         }
-        QGCComboBox {
-            id:                     altModeCombo
-            model:                  enumStrings
-            Layout.fillWidth:       true
+        MouseArea {
+            Layout.preferredWidth:  childrenRect.width
+            Layout.preferredHeight: childrenRect.height
             enabled:                _noMissionItemsAdded
-            onActivated:            _missionController.globalAltitudeMode = enumValues[index]
-            Component.onCompleted:  buildEnumStrings()
 
-            readonly property var enumStringsBase:   [ QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeRelative),
-                QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeAbsolute),
-                QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeAboveTerrain),
-                QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeTerrainFrame),
-                qsTr("Mixed Modes") ]
-            readonly property var enumValuesBase:    [QGroundControl.AltitudeModeRelative, QGroundControl.AltitudeModeAbsolute, QGroundControl.AltitudeModeAboveTerrain, QGroundControl.AltitudeModeTerrainFrame, QGroundControl.AltitudeModeNone  ]
-
-            property var enumStrings:   [ ]
-            property var enumValues:    [ ]
-
-            function buildEnumStrings() {
-                var newEnumStrings = enumStringsBase.slice(0)
-                var newEnumValues = enumValuesBase.slice(0)
+            onClicked: {
+                var removeModes = []
+                var updateFunction = function(altMode){ _missionController.globalAltitudeMode = altMode }
                 if (!_controllerVehicle.supportsTerrainFrame) {
-                    // We need to find and pull out the QGroundControl.AltitudeModeTerrainFrame values
-                    var deleteIndex = newEnumValues.lastIndexOf(QGroundControl.AltitudeModeTerrainFrame)
-                    newEnumStrings.splice(deleteIndex, 1)
-                    newEnumValues.splice(deleteIndex, 1)
-                    if (_missionController.globalAltitudeMode == QGroundControl.AltitudeModeTerrainFrame) {
-                        _missionController.globalAltitudeMode = QGroundControl.AltitudeModeAboveTerrain
-                    }
+                    removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
                 }
-                enumStrings = newEnumStrings
-                enumValues = newEnumValues
-                currentIndex = enumValues.lastIndexOf(_missionController.globalAltitudeMode)
+                mainWindow.showPopupDialogFromComponent(altModeDialogComponent, { rgRemoveModes: removeModes, updateAltModeFn: updateFunction })
             }
 
-            Connections {
-                target:                         _controllerVehicle
-                onSupportsTerrainFrameChanged:  altModeCombo.buildEnumStrings()
+            RowLayout {
+                spacing: ScreenTools.defaultFontPixelWidth
+                enabled: _noMissionItemsAdded
+
+                QGCLabel {
+                    id:     altModeLabel
+                    text:   QGroundControl.altitudeModeShortDescription(_missionController.globalAltitudeMode)
+                }
+                QGCColoredImage {
+                    height:     ScreenTools.defaultFontPixelHeight / 2
+                    width:      height
+                    source:     "/res/DropArrow.svg"
+                    color:      altModeLabel.color
+                }
             }
-        }
-        QGCLabel {
-            Layout.fillWidth:       true
-            wrapMode:               Text.WordWrap
-            horizontalAlignment:    Text.AlignHCenter
-            font.pointSize:         ScreenTools.smallFontPointSize
-            text:                   switch(_missionController.globalAltitudeMode) {
-                                    case QGroundControl.AltitudeModeAboveTerrain:
-                                        qsTr("Specified altitudes are distance above terrain. Actual altitudes sent to vehicle are calculated from terrain data and sent in AMSL")
-                                        break
-                                    case QGroundControl.AltitudeModeTerrainFrame:
-                                        qsTr("Specified altitudes are distance above terrain. The actual altitude flown is controlled by the vehicle either from terrain height maps being sent to vehicle or a distance sensor.")
-                                        break
-                                    case QGroundControl.AltitudeModeNone:
-                                        qsTr("The altitude mode can differ for each individual item.")
-                                        break
-                                    default:
-                                        ""
-                                        break
-                                    }
-            visible:                _missionController.globalAltitudeMode == QGroundControl.AltitudeModeAboveTerrain || _missionController.globalAltitudeMode == QGroundControl.AltitudeModeTerrainFrame || _missionController.globalAltitudeMode == QGroundControl.AltitudeModeNone
         }
 
         QGCLabel {
             text:           qsTr("Initial Waypoint Alt")
             font.pointSize: ScreenTools.smallFontPointSize
         }
-        AltitudeFactTextField {
+        FactTextField {
             fact:               QGroundControl.settingsManager.appSettings.defaultMissionItemAltitude
-            altitudeMode:       _missionController.globalAltitudeModeDefault
             Layout.fillWidth:   true
         }
 

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -19,33 +19,24 @@ Rectangle {
 
     property bool _specifiesAltitude:       missionItem.specifiesAltitude
     property real _margin:                  ScreenTools.defaultFontPixelHeight / 2
+    property real _altRectMargin:           ScreenTools.defaultFontPixelWidth / 2
     property var  _controllerVehicle:       missionItem.masterController.controllerVehicle
     property bool _supportsTerrainFrame:    _controllerVehicle.supportsTerrainFrame
     property int  _globalAltMode:           missionItem.masterController.missionController.globalAltitudeMode
-    property bool _globalAltModeIsMixed:    _globalAltMode == QGroundControl.AltitudeModeNone
+    property bool _globalAltModeIsMixed:    _globalAltMode == QGroundControl.AltitudeModeMixed
     property real _radius:                  ScreenTools.defaultFontPixelWidth / 2
-
-    property string _altModeRelativeHelpText:       qsTr("Altitude relative to launch altitude")
-    property string _altModeAbsoluteHelpText:       qsTr("Altitude above mean sea level")
-    property string _altModeAboveTerrainHelpText:   qsTr("Altitude above terrain\nActual AMSL altitude: %1 %2").arg(missionItem.amslAltAboveTerrain.valueString).arg(missionItem.amslAltAboveTerrain.units)
-    property string _altModeTerrainFrameHelpText:   qsTr("Using terrain reference frame")
 
     function updateAltitudeModeText() {
         if (missionItem.altitudeMode === QGroundControl.AltitudeModeRelative) {
             altModeLabel.text = QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeRelative)
-            altModeHelp.text = _altModeRelativeHelpText
         } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeAbsolute) {
             altModeLabel.text = QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeAbsolute)
-            altModeHelp.text = _altModeAbsoluteHelpText
-        } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeAboveTerrain) {
-            altModeLabel.text = QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeAboveTerrain)
-            altModeHelp.text = Qt.binding(function() { return _altModeAboveTerrainHelpText })
+        } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeCalcAboveTerrain) {
+            altModeLabel.text = QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeCalcAboveTerrain)
         } else if (missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame) {
             altModeLabel.text = QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeTerrainFrame)
-            altModeHelp.text = _altModeTerrainFrameHelpText
         } else {
             altModeLabel.text = qsTr("Internal Error")
-            altModeHelp.text = ""
         }
     }
 
@@ -57,6 +48,7 @@ Rectangle {
     }
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+    Component { id: altModeDialogComponent; AltModeDialog { } }
 
     Column {
         id:                 editorColumn
@@ -83,10 +75,10 @@ Rectangle {
 
             QGCLabel {
                 text:               qsTr("Move '%1' %2 to the %3 location. %4")
-                                        .arg(_controllerVehicle.vtol ? qsTr("T") : qsTr("T"))
-                                        .arg(_controllerVehicle.vtol ? qsTr("Transition Direction") : qsTr("Takeoff"))
-                                        .arg(_controllerVehicle.vtol ? qsTr("desired") : qsTr("climbout"))
-                                        .arg(_controllerVehicle.vtol ? (qsTr("Ensure distance from launch to transition direction is far enough to complete transition.")) : "")
+                .arg(_controllerVehicle.vtol ? qsTr("T") : qsTr("T"))
+                .arg(_controllerVehicle.vtol ? qsTr("Transition Direction") : qsTr("Takeoff"))
+                .arg(_controllerVehicle.vtol ? qsTr("desired") : qsTr("climbout"))
+                .arg(_controllerVehicle.vtol ? (qsTr("Ensure distance from launch to transition direction is far enough to complete transition.")) : "")
                 Layout.fillWidth:   true
                 wrapMode:           Text.WordWrap
                 visible:            !initialClickLabel.visible
@@ -122,113 +114,78 @@ Rectangle {
         Column {
             anchors.left:       parent.left
             anchors.right:      parent.right
-            spacing:            _margin
+            spacing:            _altRectMargin
             visible:            !missionItem.wizardMode
 
-            // This control needs to morph between a simple altitude entry field to a more complex alt mode picker based on the global plan alt mode
-            Rectangle {
+            ColumnLayout {
                 anchors.left:   parent.left
                 anchors.right:  parent.right
-                height:         altColumn.y + altColumn.height + _margin
-                color:          _globalAltModeIsMixed ? qgcPal.windowShadeLight : qgcPal.windowShadeDark
+                spacing:        0
                 visible:        _specifiesAltitude
 
-                ColumnLayout {
-                    id:                 altColumn
-                    anchors.margins:    _globalAltModeIsMixed ? _margin : 0
-                    anchors.top:        parent.top
-                    anchors.left:       parent.left
-                    anchors.right:      parent.right
-                    spacing:            _globalAltModeIsMixed ? _margin : 0
+                QGCLabel {
+                    Layout.fillWidth:   true
+                    wrapMode:           Text.WordWrap
+                    font.pointSize:     ScreenTools.smallFontPointSize
+                    text:               qsTr("Altitude below specifies the approximate altitude of the ground. Normally 0 for landing back at original launch location.")
+                    visible:            missionItem.isLandCommand
+                }
 
-                    QGCLabel {
-                        Layout.fillWidth:   true
-                        wrapMode:           Text.WordWrap
-                        font.pointSize:     ScreenTools.smallFontPointSize
-                        text:               qsTr("Altitude below specifies the approximate altitude of the ground. Normally 0 for landing back at original launch location.")
-                        visible:            missionItem.isLandCommand
+                MouseArea {
+                    Layout.preferredWidth:  childrenRect.width
+                    Layout.preferredHeight: childrenRect.height
+
+                    onClicked: {
+                        if (_globalAltModeIsMixed) {
+                            var removeModes = []
+                            var updateFunction = function(altMode){ missionItem.altitudeMode = altMode }
+                            if (!_controllerVehicle.supportsTerrainFrame) {
+                                removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
+                            }
+                            if (!QGroundControl.corePlugin.options.showMissionAbsoluteAltitude && missionItem.altitudeMode !== QGroundControl.AltitudeModeAbsolute) {
+                                removeModes.push(QGroundControl.AltitudeModeAbsolute)
+                            }
+                            if (!_supportsTerrainFrame) {
+                                removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
+                            }
+                            removeModes.push(QGroundControl.AltitudeModeMixed)
+                            mainWindow.showPopupDialogFromComponent(altModeDialogComponent, { rgRemoveModes: removeModes, updateAltModeFn: updateFunction })
+                        }
                     }
 
-                    Item {
-                        Layout.preferredWidth:  altModeDropArrow.x + altModeDropArrow.width
-                        Layout.preferredHeight: altModeLabel.height
-                        visible:                _globalAltModeIsMixed
+                    RowLayout {
+                        spacing: _altRectMargin
 
-                        QGCLabel { id: altModeLabel }
-
+                        QGCLabel {
+                            Layout.alignment:   Qt.AlignBaseline
+                            text:               qsTr("Altitude")
+                            font.pointSize:     ScreenTools.smallFontPointSize
+                        }
+                        QGCLabel {
+                            id:                 altModeLabel
+                            Layout.alignment:   Qt.AlignBaseline
+                            visible:            _globalAltMode !== QGroundControl.AltitudeModeRelative
+                        }
                         QGCColoredImage {
-                            id:                     altModeDropArrow
-                            anchors.leftMargin:     ScreenTools.defaultFontPixelWidth / 4
-                            anchors.left:           altModeLabel.right
-                            anchors.verticalCenter: altModeLabel.verticalCenter
-                            width:                  ScreenTools.defaultFontPixelHeight / 2
-                            height:                 width
-                            sourceSize.height:      height
-                            source:                 "/res/DropArrow.svg"
-                            color:                  qgcPal.text
-                        }
-
-                        QGCMouseArea {
-                            anchors.fill:   parent
-                            onClicked:      altModeMenu.popup()
-                        }
-
-                        QGCMenu {
-                            id: altModeMenu
-
-                            QGCMenuItem {
-                                text:           QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeRelative)
-                                checkable:      true
-                                checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeRelative
-                                onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeRelative
-                            }
-
-                            QGCMenuItem {
-                                text:           QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeAbsolute)
-                                checkable:      true
-                                checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeAbsolute
-                                visible:        QGroundControl.corePlugin.options.showMissionAbsoluteAltitude
-                                onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeAbsolute
-                            }
-
-                            QGCMenuItem {
-                                text:           QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeAboveTerrain)
-                                checkable:      true
-                                checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeAboveTerrain
-                                onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeAboveTerrain
-                                visible:        missionItem.specifiesCoordinate
-                            }
-
-                            QGCMenuItem {
-                                text:           QGroundControl.altitudeModeShortDescription(QGroundControl.AltitudeModeTerrainFrame)
-                                checkable:      true
-                                checked:        missionItem.altitudeMode === QGroundControl.AltitudeModeTerrainFrame
-                                visible:        _supportsTerrainFrame && (missionItem.specifiesCoordinate || missionItem.specifiesAltitudeOnly)
-                                onTriggered:    missionItem.altitudeMode = QGroundControl.AltitudeModeTerrainFrame
-                            }
+                            height:     ScreenTools.defaultFontPixelHeight / 2
+                            width:      height
+                            source:     "/res/DropArrow.svg"
+                            color:      qgcPal.text
+                            visible:    _globalAltModeIsMixed
                         }
                     }
+                }
 
-                    QGCLabel {
-                        text:           qsTr("Altitude")
-                        font.pointSize: ScreenTools.smallFontPointSize
-                        visible:        !_globalAltModeIsMixed
-                    }
+                FactTextField {
+                    id:                 altField
+                    Layout.fillWidth:   true
+                    fact:               missionItem.altitude
+                }
 
-                    AltitudeFactTextField {
-                        id:                 altField
-                        Layout.fillWidth:   true
-                        fact:               missionItem.altitude
-                        altitudeMode:       missionItem.altitudeMode
-                    }
-
-                    QGCLabel {
-                        id:                 altModeHelp
-                        Layout.fillWidth:   true
-                        wrapMode:           Text.WordWrap
-                        font.pointSize:     ScreenTools.smallFontPointSize
-                        visible:            _globalAltModeIsMixed
-                    }
+                QGCLabel {
+                    font.pointSize:     ScreenTools.smallFontPointSize
+                    text:               qsTr("Actual AMSL alt sent: %1 %2").arg(missionItem.amslAltAboveTerrain.valueString).arg(missionItem.amslAltAboveTerrain.units)
+                    visible:            missionItem.altitudeMode === QGroundControl.AltitudeModeCalcAboveTerrain
                 }
             }
 

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -113,7 +113,7 @@ Rectangle {
                     vehicleFlightIsFrontal:         true
                     distanceToSurfaceLabel:         qsTr("Altitude")
                     distanceToSurfaceAltitudeMode:  _missionItem.followTerrain ?
-                                                        QGroundControl.AltitudeModeAboveTerrain :
+                                                        QGroundControl.AltitudeModeCalcAboveTerrain :
                                                         (_missionItem.cameraCalc.distanceToSurfaceRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute)
                     frontalDistanceLabel:           qsTr("Trigger Dist")
                     sideDistanceLabel:              qsTr("Spacing")

--- a/src/QmlControls/AltModeDialog.qml
+++ b/src/QmlControls/AltModeDialog.qml
@@ -1,0 +1,113 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 2.12
+import QtQuick.Dialogs  1.3
+import QtQuick.Layouts  1.12
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+
+QGCPopupDialog {
+    title:   qsTr("Select Altitude Mode")
+    buttons: StandardButton.Close
+
+    Component.onCompleted: {
+        // Check for custom build override on AMSL usage
+        if (!QGroundControl.corePlugin.options.showMissionAbsoluteAltitude && dialogProperties.currentAltMode != QGroundControl.AltitudeModeAbsolute) {
+            dialogProperties.rgRemoveModes.push(QGroundControl.AltitudeModeAbsolute)
+        }
+
+        // Remove modes specified by consumer
+        for (var i=0; i<dialogProperties.rgRemoveModes.length; i++) {
+            for (var j=0; j<buttonModel.count; j++) {
+                if (buttonModel.get(j).modeValue == dialogProperties.rgRemoveModes[i]) {
+                    buttonModel.remove(j)
+                    break
+                }
+            }
+        }
+
+
+        buttonRepeater.model = buttonModel
+    }
+
+    ListModel {
+        id: buttonModel
+
+        ListElement {
+            modeName:   qsTr("Relative To Launch")
+            help:       qsTr("Specified altitudes are relative to launch position height.")
+            modeValue:  QGroundControl.AltitudeModeRelative
+        }
+        ListElement {
+            modeName:   qsTr("AMSL")
+            help:       qsTr("Specified altitudes are Above Mean Sea Level.")
+            modeValue:  QGroundControl.AltitudeModeAbsolute
+        }
+        ListElement {
+            modeName:   qsTr("Calculated Above Terrain")
+            help:       qsTr("Specified altitudes are distance above terrain. Actual altitudes sent to vehicle are calculated from terrain data and sent as AMSL values.")
+            modeValue:  QGroundControl.AltitudeModeCalcAboveTerrain
+        }
+        ListElement {
+            modeName:   qsTr("Terrain Frame")
+            help:       qsTr("Specified altitudes are distance above terrain. The actual altitude flown is controlled by the vehicle either from terrain height maps being sent to vehicle or a distance sensor.")
+            modeValue:  QGroundControl.AltitudeModeTerrainFrame
+        }
+        ListElement {
+            modeName:   qsTr("Mixed Modes")
+            help:       qsTr("The altitude mode can differ for each individual item.")
+            modeValue:  QGroundControl.AltitudeModeMixed
+        }
+    }
+
+    Column {
+        spacing: ScreenTools.defaultFontPixelWidth
+
+        Repeater {
+            id: buttonRepeater
+
+            Button {
+                hoverEnabled:   true
+                checked:        modeValue == dialogProperties.currentAltMode
+
+                background: Rectangle {
+                    radius: ScreenTools.defaultFontPixelHeight / 2
+                    color:  pressed | hovered | checked ? QGroundControl.globalPalette.buttonHighlight: QGroundControl.globalPalette.button
+                }
+
+                contentItem: Column {
+                    spacing: 0
+
+                    QGCLabel {
+                        id:     modeNameLabel
+                        text:   modeName
+                        color:  pressed | hovered | checked ? QGroundControl.globalPalette.buttonHighlightText: QGroundControl.globalPalette.buttonText
+                    }
+
+                    QGCLabel {
+                        width:              ScreenTools.defaultFontPixelWidth * 40
+                        text:               help
+                        wrapMode:           Label.WordWrap
+                        font.pointSize:     ScreenTools.smallFontPointSize
+                        color:              modeNameLabel.color
+                    }
+                }
+
+                onClicked: {
+                    dialogProperties.updateAltModeFn(modeValue)
+                    hideDialog()
+                }
+            }
+        }
+    }
+}

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -2,6 +2,7 @@ Module QGroundControl.Controls
 
 AnalyzePage                             1.0 AnalyzePage.qml
 AppMessages                             1.0 AppMessages.qml
+AltModeDialog                           1.0 AltModeDialog.qml
 AxisMonitor                             1.0 AxisMonitor.qml
 CameraCalcCamera                        1.0 CameraCalcCamera.qml
 CameraCalcGrid                          1.0 CameraCalcGrid.qml

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -271,10 +271,13 @@ QString QGroundControlQmlGlobal::altitudeModeExtraUnits(AltitudeMode altMode)
         return QString();
     case AltitudeModeAbsolute:
         return tr("(AMSL)");
-    case AltitudeModeAboveTerrain:
-        return tr("(Abv Terr)");
+    case AltitudeModeCalcAboveTerrain:
+        return tr("(CalcT)");
     case AltitudeModeTerrainFrame:
         return tr("(TerrF)");
+    case AltitudeModeMixed:
+        qWarning() << "Internal Error: QGroundControlQmlGlobal::altitudeModeExtraUnits called with altMode == AltitudeModeMixed";
+        return QString();
     }
 
     // Should never get here but makes some compilers happy
@@ -289,11 +292,13 @@ QString QGroundControlQmlGlobal::altitudeModeShortDescription(AltitudeMode altMo
     case AltitudeModeRelative:
         return tr("Relative To Launch");
     case AltitudeModeAbsolute:
-        return tr("Above Mean Sea Level");
-    case AltitudeModeAboveTerrain:
-        return tr("Above Terrain");
+        return tr("AMSL");
+    case AltitudeModeCalcAboveTerrain:
+        return tr("Calc Above Terrain");
     case AltitudeModeTerrainFrame:
         return tr("Terrain Frame");
+    case AltitudeModeMixed:
+        return tr("Mixed Modes");
     }
 
     // Should never get here but makes some compilers happy

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -49,11 +49,12 @@ public:
     ~QGroundControlQmlGlobal();
 
     enum AltitudeMode {
-        AltitudeModeNone,           // Being used as distance value unrelated to ground (for example distance to structure)
-        AltitudeModeRelative,       // MAV_FRAME_GLOBAL_RELATIVE_ALT
-        AltitudeModeAbsolute,       // MAV_FRAME_GLOBAL
-        AltitudeModeAboveTerrain,   // Absolute altitude above terrain calculated from terrain data
-        AltitudeModeTerrainFrame    // MAV_FRAME_GLOBAL_TERRAIN_ALT
+        AltitudeModeMixed,              // Used by global altitude mode for mission planning
+        AltitudeModeRelative,           // MAV_FRAME_GLOBAL_RELATIVE_ALT
+        AltitudeModeAbsolute,           // MAV_FRAME_GLOBAL
+        AltitudeModeCalcAboveTerrain,   // Absolute altitude above terrain calculated from terrain data
+        AltitudeModeTerrainFrame,       // MAV_FRAME_GLOBAL_TERRAIN_ALT
+        AltitudeModeNone,               // Being used as distance value unrelated to ground (for example distance to structure)
     };
     Q_ENUM(AltitudeMode)
 


### PR DESCRIPTION
* I'm working my towards support Terrain Frame (MAV_FRAME_GLOBAL_TERRAIN_ALT) in Surveys
* First step was taking another cleanup pass through the "Altitude Mode" concept
* Changed naming of "Above Terrain" to "Calculated Above Terrain" to be more specified
* Change Alt Mode selection from Combo dropdown to full dialog to provide better information on each possibility
* If you always use Relatative Alts and don't know anything about what I'm talking about then the UI for you will look exactly like it did before

Mission Start
* New Alt Mode picker dialog
* You also get this dialog when picking Alt Mode from a simple item if you are using Mixed Modes
![Screen Shot 2021-05-26 at 2 05 06 PM](https://user-images.githubusercontent.com/5876851/119732605-3fe96c00-be2d-11eb-8186-050725df4218.png)

Simple Item Editor
* New ui for altitude value display. Showing non-relative example. Relative Alts ui is still as before.
![Screen Shot 2021-05-26 at 2 03 22 PM](https://user-images.githubusercontent.com/5876851/119732690-5db6d100-be2d-11eb-80f6-5788d87768a3.png)