### PR TITLE
RESUBMIT #8108 - Only accept ATTITUDE messages from the vehicle

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1027,6 +1027,11 @@ void Vehicle::_handleAttitudeWorker(double rollRadians, double pitchRadians, dou
 
 void Vehicle::_handleAttitude(mavlink_message_t& message)
 {
+    // only accept the attitude message from the vehicle's flight controller
+    if (message.sysid != _id || message.compid != _compID) {
+        return;
+    }
+
     if (_receivingAttitudeQuaternion) {
         return;
     }
@@ -1039,6 +1044,11 @@ void Vehicle::_handleAttitude(mavlink_message_t& message)
 
 void Vehicle::_handleAttitudeQuaternion(mavlink_message_t& message)
 {
+    // only accept the attitude message from the vehicle's flight controller
+    if (message.sysid != _id || message.compid != _compID) {
+        return;
+    }
+
     _receivingAttitudeQuaternion = true;
 
     mavlink_attitude_quaternion_t attitudeQuaternion;


### PR DESCRIPTION
This is an effort to bring in PR #8108 since that branch got stale, and CI wasn't reporting accurately anymore. As soon as CI does its thing, we should be good to go.

@LorenzMeier previously approved this PR on https://github.com/mavlink/qgroundcontrol/pull/8108#issuecomment-757521904

FYI @olliw42 @dagar @DonLakeFlyer @patrickelectric 

As discussed on https://discuss.px4.io/t/qgc-dev-call-june-11-2021/22545