### PR TITLE
Support terrain frame in Survey/Corridor Scan as well as simple items

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -180,6 +180,7 @@
         <file alias="QGroundControl/Controls/TakeoffItemMapVisual.qml">src/PlanView/TakeoffItemMapVisual.qml</file>
         <file alias="QGroundControl/Controls/ToolStrip.qml">src/QmlControls/ToolStrip.qml</file>
        	<file alias="QGroundControl/Controls/ToolStripHoverButton.qml">src/QmlControls/ToolStripHoverButton.qml</file>
+        <file alias="QGroundControl/Controls/TransectStyleComplexItemEditor.qml">src/PlanView/TransectStyleComplexItemEditor.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemStats.qml">src/PlanView/TransectStyleComplexItemStats.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemTabBar.qml">src/PlanView/TransectStyleComplexItemTabBar.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemTerrainFollow.qml">src/PlanView/TransectStyleComplexItemTerrainFollow.qml</file>

--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -15,20 +15,22 @@
 
 #include <QQmlEngine>
 
-const char* CameraCalc::cameraNameName =                    "CameraName";
-const char* CameraCalc::valueSetIsDistanceName =            "ValueSetIsDistance";
-const char* CameraCalc::distanceToSurfaceName =             "DistanceToSurface";
-const char* CameraCalc::distanceToSurfaceRelativeName =     "DistanceToSurfaceRelative";
-const char* CameraCalc::imageDensityName =                  "ImageDensity";
-const char* CameraCalc::frontalOverlapName =                "FrontalOverlap";
-const char* CameraCalc::sideOverlapName =                   "SideOverlap";
-const char* CameraCalc::adjustedFootprintFrontalName =      "AdjustedFootprintFrontal";
-const char* CameraCalc::adjustedFootprintSideName =         "AdjustedFootprintSide";
+const char* CameraCalc::cameraNameName                  = "CameraName";
+const char* CameraCalc::valueSetIsDistanceName          = "ValueSetIsDistance";
+const char* CameraCalc::distanceToSurfaceName           = "DistanceToSurface";
+const char* CameraCalc::distanceModeName                = "DistanceMode";
+const char* CameraCalc::imageDensityName                = "ImageDensity";
+const char* CameraCalc::frontalOverlapName              = "FrontalOverlap";
+const char* CameraCalc::sideOverlapName                 = "SideOverlap";
+const char* CameraCalc::adjustedFootprintFrontalName    = "AdjustedFootprintFrontal";
+const char* CameraCalc::adjustedFootprintSideName       = "AdjustedFootprintSide";
 
-const char* CameraCalc::_jsonCameraSpecTypeKey =            "CameraSpecType";
+const char* CameraCalc::_jsonCameraSpecTypeKeyDeprecated            = "CameraSpecType";
+const char* CameraCalc::_jsonDistanceToSurfaceRelativeKeyDeprecated = "DistanceToSurfaceRelative";
 
 CameraCalc::CameraCalc(PlanMasterController* masterController, const QString& settingsGroup, QObject* parent)
     : CameraSpec                    (settingsGroup, parent)
+    , _distanceMode                 (masterController->missionController()->globalAltitudeModeDefault())
     , _knownCameraList              (masterController->controllerVehicle()->staticCameraList())
     , _metaDataMap                  (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/CameraCalc.FactMetaData.json"), this))
     , _cameraNameFact               (settingsGroup, _metaDataMap[cameraNameName])
@@ -42,19 +44,19 @@ CameraCalc::CameraCalc(PlanMasterController* masterController, const QString& se
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 
-    connect(&_valueSetIsDistanceFact,       &Fact::valueChanged,                            this, &CameraCalc::_setDirty);
-    connect(&_distanceToSurfaceFact,        &Fact::valueChanged,                            this, &CameraCalc::_setDirty);
-    connect(&_imageDensityFact,             &Fact::valueChanged,                            this, &CameraCalc::_setDirty);
-    connect(&_frontalOverlapFact,           &Fact::valueChanged,                            this, &CameraCalc::_setDirty);
-    connect(&_sideOverlapFact,              &Fact::valueChanged,                            this, &CameraCalc::_setDirty);
-    connect(&_adjustedFootprintSideFact,    &Fact::valueChanged,                            this, &CameraCalc::_setDirty);
-    connect(&_adjustedFootprintFrontalFact, &Fact::valueChanged,                            this, &CameraCalc::_setDirty);
-    connect(&_cameraNameFact,               &Fact::valueChanged,                            this, &CameraCalc::_setDirty);
-    connect(this,                           &CameraCalc::distanceToSurfaceRelativeChanged,  this, &CameraCalc::_setDirty);
+    connect(&_valueSetIsDistanceFact,       &Fact::valueChanged,                this, &CameraCalc::_setDirty);
+    connect(&_distanceToSurfaceFact,        &Fact::valueChanged,                this, &CameraCalc::_setDirty);
+    connect(&_imageDensityFact,             &Fact::valueChanged,                this, &CameraCalc::_setDirty);
+    connect(&_frontalOverlapFact,           &Fact::valueChanged,                this, &CameraCalc::_setDirty);
+    connect(&_sideOverlapFact,              &Fact::valueChanged,                this, &CameraCalc::_setDirty);
+    connect(&_adjustedFootprintSideFact,    &Fact::valueChanged,                this, &CameraCalc::_setDirty);
+    connect(&_adjustedFootprintFrontalFact, &Fact::valueChanged,                this, &CameraCalc::_setDirty);
+    connect(&_cameraNameFact,               &Fact::valueChanged,                this, &CameraCalc::_setDirty);
+    connect(this,                           &CameraCalc::distanceModeChanged,   this, &CameraCalc::_setDirty);
 
-    connect(&_cameraNameFact,               &Fact::valueChanged,                            this, &CameraCalc::_cameraNameChanged);
-    connect(&_cameraNameFact,               &Fact::valueChanged,                            this, &CameraCalc::isManualCameraChanged);
-    connect(&_cameraNameFact,               &Fact::valueChanged,                            this, &CameraCalc::isCustomCameraChanged);
+    connect(&_cameraNameFact, &Fact::valueChanged, this, &CameraCalc::_cameraNameChanged);
+    connect(&_cameraNameFact, &Fact::valueChanged, this, &CameraCalc::isManualCameraChanged);
+    connect(&_cameraNameFact, &Fact::valueChanged, this, &CameraCalc::isCustomCameraChanged);
 
     connect(&_distanceToSurfaceFact,    &Fact::rawValueChanged, this, &CameraCalc::_recalcTriggerDistance);
     connect(&_imageDensityFact,         &Fact::rawValueChanged, this, &CameraCalc::_recalcTriggerDistance);
@@ -81,14 +83,6 @@ CameraCalc::CameraCalc(PlanMasterController* masterController, const QString& se
     _setBrandModelFromCanonicalName(_cameraNameFact.rawValue().toString());
 
     setDirty(false);
-}
-
-void CameraCalc::setDirty(bool dirty)
-{
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(_dirty);
-    }
 }
 
 void CameraCalc::_cameraNameChanged(void)
@@ -138,7 +132,10 @@ void CameraCalc::_cameraNameChanged(void)
     }
 
     _recalcTriggerDistance();
-    _adjustDistanceToSurfaceRelative();
+    if (!isManualCamera() && distanceMode() == QGroundControlQmlGlobal::AltitudeModeAbsolute) {
+        // Manual grids support absolute alts whereas nothing else does. Make sure we are not left in absolute
+        setDistanceMode(QGroundControlQmlGlobal::AltitudeModeRelative);
+    }
 }
 
 void CameraCalc::_recalcTriggerDistance(void)
@@ -186,12 +183,12 @@ void CameraCalc::_recalcTriggerDistance(void)
 
 void CameraCalc::save(QJsonObject& json) const
 {
-    json[JsonHelper::jsonVersionKey] =      1;
-    json[adjustedFootprintSideName] =       _adjustedFootprintSideFact.rawValue().toDouble();
-    json[adjustedFootprintFrontalName] =    _adjustedFootprintFrontalFact.rawValue().toDouble();
-    json[distanceToSurfaceName] =           _distanceToSurfaceFact.rawValue().toDouble();
-    json[distanceToSurfaceRelativeName] =   _distanceToSurfaceRelative;
-    json[cameraNameName] =                  _cameraNameFact.rawValue().toString();
+    json[JsonHelper::jsonVersionKey]    = 2;
+    json[adjustedFootprintSideName]     = _adjustedFootprintSideFact.rawValue().toDouble();
+    json[adjustedFootprintFrontalName]  = _adjustedFootprintFrontalFact.rawValue().toDouble();
+    json[distanceToSurfaceName]         = _distanceToSurfaceFact.rawValue().toDouble();
+    json[distanceModeName]              = _distanceMode;
+    json[cameraNameName]                = _cameraNameFact.rawValue().toString();
 
     if (!isManualCamera()) {
         CameraSpec::save(json);
@@ -202,27 +199,42 @@ void CameraCalc::save(QJsonObject& json) const
     }
 }
 
-bool CameraCalc::load(const QJsonObject& json, QString& errorString)
+bool CameraCalc::load(const QJsonObject& originalJson, bool deprecatedFollowTerrain, QString& errorString, bool forPresets)
 {
-    QJsonObject v1Json = json;
+    QJsonObject json = originalJson;
 
-    if (!json.contains(JsonHelper::jsonVersionKey)) {
-        // Version 0 file. Differences from Version 1 for conversion:
-        //  JsonHelper::jsonVersionKey not stored
-        //  _jsonCameraSpecTypeKey stores CameraSpecType
-        //  _jsonCameraNameKey only set if CameraSpecKnown
-        int cameraSpec = v1Json[_jsonCameraSpecTypeKey].toInt(CameraSpecNone);
-        if (cameraSpec == CameraSpecCustom) {
-            v1Json[cameraNameName] = canonicalCustomCameraName();
-        } else if (cameraSpec == CameraSpecNone) {
-            v1Json[cameraNameName] = canonicalManualCameraName();
-        }
-        v1Json.remove(_jsonCameraSpecTypeKey);
-        v1Json[JsonHelper::jsonVersionKey] = 1;
+    int version = 0;
+    if (json.contains(JsonHelper::jsonVersionKey)) {
+        version = json[JsonHelper::jsonVersionKey].toInt();
     }
 
-    int version = v1Json[JsonHelper::jsonVersionKey].toInt();
-    if (version != 1) {
+    if (version == 0) {
+        // Version 0->1 differences:
+        //  - JsonHelper::jsonVersionKey not stored
+        //  - _jsonCameraSpecTypeKeyDeprecated is only in v0 files and stores CameraSpecType. V2 files store same info in cameraNameName.
+        //  - _jsonCameraNameKey only set if CameraSpecKnown
+        int cameraSpec = json[_jsonCameraSpecTypeKeyDeprecated].toInt(CameraSpecNone);
+        if (cameraSpec == CameraSpecCustom) {
+            json[cameraNameName] = canonicalCustomCameraName();
+        } else if (cameraSpec == CameraSpecNone) {
+            json[cameraNameName] = canonicalManualCameraName();
+        }
+        json.remove(_jsonCameraSpecTypeKeyDeprecated);
+        version = 1;
+    }
+    if (version == 1) {
+        // Version 1->2 differences:
+        //  - _jsonDistanceToSurfaceRelativeKeyDeprecated changed to distanceMode
+        //  - deprecatedFollowTerrain value was loaded from upper level callers and represents AltitudeModeCalcAboveTerrain. AtitudeModeTerrainFrame was not supported yet.
+        if (deprecatedFollowTerrain) {
+            json[distanceModeName] = QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain;
+        } else {
+            json[distanceModeName] = json[_jsonDistanceToSurfaceRelativeKeyDeprecated].toBool() ? QGroundControlQmlGlobal::AltitudeModeRelative : QGroundControlQmlGlobal::AltitudeModeAbsolute;
+        }
+        json.remove(_jsonDistanceToSurfaceRelativeKeyDeprecated);
+        version = 2;
+    }
+    if (version != 2) {
         errorString = tr("CameraCalc section version %1 not supported").arg(version);
         return false;
     }
@@ -232,24 +244,24 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
         { adjustedFootprintSideName,        QJsonValue::Double, true },
         { adjustedFootprintFrontalName,     QJsonValue::Double, true },
         { distanceToSurfaceName,            QJsonValue::Double, true },
-        { distanceToSurfaceRelativeName,    QJsonValue::Bool,   true },
+        { distanceModeName,                 QJsonValue::Double, true },
     };
-    if (!JsonHelper::validateKeys(v1Json, keyInfoList1, errorString)) {
+    if (!JsonHelper::validateKeys(json, keyInfoList1, errorString)) {
         return false;
     }
 
-    _disableRecalc = true;
-
-    _distanceToSurfaceRelative = v1Json[distanceToSurfaceRelativeName].toBool();
-
-    _adjustedFootprintSideFact.setRawValue      (v1Json[adjustedFootprintSideName].toDouble());
-    _adjustedFootprintFrontalFact.setRawValue   (v1Json[adjustedFootprintFrontalName].toDouble());
-    _distanceToSurfaceFact.setRawValue          (v1Json[distanceToSurfaceName].toDouble());
+    _disableRecalc = !forPresets;
 
     // We have to clean up camera names. Older builds incorrectly used translated the camera names in the persisted plan file.
     // Newer builds use a canonical english camera name in plan files.
-    QString canonicalCameraName = _validCanonicalCameraName(v1Json[cameraNameName].toString());
+    QString canonicalCameraName = _validCanonicalCameraName(json[cameraNameName].toString());
     _cameraNameFact.setRawValue(canonicalCameraName);
+
+    setDistanceMode(static_cast<QGroundControlQmlGlobal::AltMode>(json[distanceModeName].toInt()));
+
+    _adjustedFootprintSideFact.setRawValue      (json[adjustedFootprintSideName].toDouble());
+    _adjustedFootprintFrontalFact.setRawValue   (json[adjustedFootprintFrontalName].toDouble());
+    _distanceToSurfaceFact.setRawValue          (json[distanceToSurfaceName].toDouble());
 
     if (!isManualCamera()) {
         QList<JsonHelper::KeyValidateInfo> keyInfoList2 = {
@@ -258,17 +270,17 @@ bool CameraCalc::load(const QJsonObject& json, QString& errorString)
             { frontalOverlapName,       QJsonValue::Double, true },
             { sideOverlapName,          QJsonValue::Double, true },
         };
-        if (!JsonHelper::validateKeys(v1Json, keyInfoList2, errorString)) {
+        if (!JsonHelper::validateKeys(json, keyInfoList2, errorString)) {
             _disableRecalc = false;
             return false;
         }
 
-        _valueSetIsDistanceFact.setRawValue (v1Json[valueSetIsDistanceName].toBool());
-        _frontalOverlapFact.setRawValue     (v1Json[frontalOverlapName].toDouble());
-        _sideOverlapFact.setRawValue        (v1Json[sideOverlapName].toDouble());
-        _imageDensityFact.setRawValue       (v1Json[imageDensityName].toDouble());
+        _valueSetIsDistanceFact.setRawValue (json[valueSetIsDistanceName].toBool());
+        _frontalOverlapFact.setRawValue     (json[frontalOverlapName].toDouble());
+        _sideOverlapFact.setRawValue        (json[sideOverlapName].toDouble());
+        _imageDensityFact.setRawValue       (json[imageDensityName].toDouble());
 
-        if (!CameraSpec::load(v1Json, errorString)) {
+        if (!CameraSpec::load(json, errorString)) {
             _disableRecalc = false;
             return false;
         }
@@ -303,18 +315,11 @@ QString CameraCalc::xlatManualCameraName(void)
     return tr("Manual (no camera specs)");
 }
 
-void CameraCalc::_adjustDistanceToSurfaceRelative(void)
+void CameraCalc::setDistanceMode(QGroundControlQmlGlobal::AltMode altMode)
 {
-    if (!isManualCamera()) {
-        setDistanceToSurfaceRelative(true);
-    }
-}
-
-void CameraCalc::setDistanceToSurfaceRelative(bool distanceToSurfaceRelative)
-{
-    if (distanceToSurfaceRelative != _distanceToSurfaceRelative) {
-        _distanceToSurfaceRelative = distanceToSurfaceRelative;
-        emit distanceToSurfaceRelativeChanged(distanceToSurfaceRelative);
+    if (altMode != _distanceMode) {
+        _distanceMode = altMode;
+        emit distanceModeChanged(_distanceMode);
     }
 }
 

--- a/src/MissionManager/CameraCalcTest.cc
+++ b/src/MissionManager/CameraCalcTest.cc
@@ -26,13 +26,8 @@ void CameraCalcTest::init(void)
     _cameraCalc->setCameraBrand(CameraCalc::canonicalCustomCameraName());
     _cameraCalc->setDirty(false);
 
-    _rgSignals[dirtyChangedIndex] =                     SIGNAL(dirtyChanged(bool));
-    _rgSignals[imageFootprintSideChangedIndex] =        SIGNAL(imageFootprintSideChanged(double));
-    _rgSignals[imageFootprintFrontalChangedIndex] =     SIGNAL(imageFootprintFrontalChanged(double));
-    _rgSignals[distanceToSurfaceRelativeChangedIndex] = SIGNAL(distanceToSurfaceRelativeChanged(bool));
-
-    _multiSpy = new MultiSignalSpy();
-    QCOMPARE(_multiSpy->init(_cameraCalc, _rgSignals, _cSignals), true);
+    _multiSpy = new MultiSignalSpyV2();
+    QVERIFY(_multiSpy->init(_cameraCalc));
 }
 
 void CameraCalcTest::cleanup(void)
@@ -43,6 +38,9 @@ void CameraCalcTest::cleanup(void)
 
 void CameraCalcTest::_testDirty(void)
 {
+    const char* dirtyChangedSignal  = "dirtyChanged";
+    auto        dirtyChangedMask    = _multiSpy->signalNameToMask(dirtyChangedSignal);
+
     QVERIFY(!_cameraCalc->dirty());
     _cameraCalc->setDirty(false);
     QVERIFY(!_cameraCalc->dirty());
@@ -51,7 +49,7 @@ void CameraCalcTest::_testDirty(void)
     _cameraCalc->setDirty(true);
     QVERIFY(_cameraCalc->dirty());
     QVERIFY(_multiSpy->checkOnlySignalByMask(dirtyChangedMask));
-    QVERIFY(_multiSpy->pullBoolFromSignalIndex(dirtyChangedIndex));
+    QVERIFY(_multiSpy->pullBoolFromSignal(dirtyChangedSignal));
     _multiSpy->clearAllSignals();
 
     _cameraCalc->setDirty(false);
@@ -83,7 +81,7 @@ void CameraCalcTest::_testDirty(void)
     rgFacts.clear();
 
 
-    _cameraCalc->setDistanceToSurfaceRelative(!_cameraCalc->distanceToSurfaceRelative());
+    _cameraCalc->setDistanceMode(_cameraCalc->distanceMode() == QGroundControlQmlGlobal::AltitudeModeRelative ? QGroundControlQmlGlobal::AltitudeModeAbsolute : QGroundControlQmlGlobal::AltitudeModeRelative);
     QVERIFY(_cameraCalc->dirty());
     _multiSpy->clearAllSignals();
 

--- a/src/MissionManager/CameraCalcTest.h
+++ b/src/MissionManager/CameraCalcTest.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "UnitTest.h"
-#include "MultiSignalSpy.h"
+#include "MultiSignalSpyV2.h"
 #include "CameraCalc.h"
 #include "PlanMasterController.h"
 
@@ -33,26 +33,8 @@ private slots:
     void _testAltDensityRecalc  (void);
 
 private:
-    enum {
-        dirtyChangedIndex = 0,
-        imageFootprintSideChangedIndex,
-        imageFootprintFrontalChangedIndex,
-        distanceToSurfaceRelativeChangedIndex,
-        maxSignalIndex
-    };
-
-    enum {
-        dirtyChangedMask =                      1 << dirtyChangedIndex,
-        imageFootprintSideChangedMask =         1 << imageFootprintSideChangedIndex,
-        imageFootprintFrontalChangedMask =      1 << imageFootprintFrontalChangedIndex,
-        distanceToSurfaceRelativeChangedMask =  1 << distanceToSurfaceRelativeChangedIndex,
-    };
-
-    static const size_t _cSignals = maxSignalIndex;
-    const char*         _rgSignals[_cSignals];
-
-    PlanMasterController*   _masterController =     nullptr;
-    Vehicle*                _controllerVehicle =    nullptr;
-    MultiSignalSpy*         _multiSpy =             nullptr;
-    CameraCalc*             _cameraCalc =           nullptr;
+    PlanMasterController*   _masterController   = nullptr;
+    Vehicle*                _controllerVehicle  = nullptr;
+    MultiSignalSpyV2*       _multiSpy           = nullptr;
+    CameraCalc*             _cameraCalc         = nullptr;
 };

--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -65,6 +65,20 @@ void CorridorScanComplexItem::save(QJsonArray&  planItems)
 {
     QJsonObject saveObject;
 
+    _saveCommon(saveObject);
+    planItems.append(saveObject);
+}
+
+void CorridorScanComplexItem::savePreset(const QString& name)
+{
+    QJsonObject saveObject;
+
+    _saveCommon(saveObject);
+    _savePresetJson(name, saveObject);
+}
+
+void CorridorScanComplexItem::_saveCommon(QJsonObject& saveObject)
+{
     TransectStyleComplexItem::_save(saveObject);
 
     saveObject[JsonHelper::jsonVersionKey] =                    2;
@@ -74,14 +88,22 @@ void CorridorScanComplexItem::save(QJsonArray&  planItems)
     saveObject[_jsonEntryPointKey] =                            _entryPoint;
 
     _corridorPolyline.saveToJson(saveObject);
-
-    planItems.append(saveObject);
 }
 
-bool CorridorScanComplexItem::load(const QJsonObject& complexObject, int sequenceNumber, QString& errorString)
+void CorridorScanComplexItem::loadPreset(const QString& name)
 {
-    // We don't recalc while loading since all the information we need is specified in the file
-    _ignoreRecalc = true;
+    QString errorString;
+
+    QJsonObject presetObject = _loadPresetJson(name);
+    if (!_loadWorker(presetObject, 0, errorString, true /* forPresets */)) {
+        qgcApp()->showAppMessage(QStringLiteral("Internal Error: Preset load failed. Name: %1 Error: %2").arg(name).arg(errorString));
+    }
+    _rebuildTransects();
+}
+
+bool CorridorScanComplexItem::_loadWorker(const QJsonObject& complexObject, int sequenceNumber, QString& errorString, bool forPresets)
+{
+    _ignoreRecalc = !forPresets;
 
     QList<JsonHelper::KeyValidateInfo> keyInfoList = {
         { JsonHelper::jsonVersionKey,                   QJsonValue::Double, true },
@@ -92,11 +114,6 @@ bool CorridorScanComplexItem::load(const QJsonObject& complexObject, int sequenc
         { QGCMapPolyline::jsonPolylineKey,              QJsonValue::Array,  true },
     };
     if (!JsonHelper::validateKeys(complexObject, keyInfoList, errorString)) {
-        _ignoreRecalc = false;
-        return false;
-    }
-
-    if (!_corridorPolyline.loadFromJson(complexObject, true, errorString)) {
         _ignoreRecalc = false;
         return false;
     }
@@ -116,14 +133,21 @@ bool CorridorScanComplexItem::load(const QJsonObject& complexObject, int sequenc
         return false;
     }
 
+    if (!forPresets) {
+        if (!_corridorPolyline.loadFromJson(complexObject, true, errorString)) {
+            _ignoreRecalc = false;
+            return false;
+        }
+    }
+
     setSequenceNumber(sequenceNumber);
 
-    if (!_load(complexObject, false /* forPresets */, errorString)) {
+    if (!_load(complexObject, forPresets, errorString)) {
         _ignoreRecalc = false;
         return false;
     }
 
-    _corridorWidthFact.setRawValue      (complexObject[corridorWidthName].toDouble());
+    _corridorWidthFact.setRawValue(complexObject[corridorWidthName].toDouble());
 
     _entryPoint = complexObject[_jsonEntryPointKey].toInt();
 
@@ -136,6 +160,11 @@ bool CorridorScanComplexItem::load(const QJsonObject& complexObject, int sequenc
     }
 
     return true;
+}
+
+bool CorridorScanComplexItem::load(const QJsonObject& complexObject, int sequenceNumber, QString& errorString)
+{
+    return _loadWorker(complexObject, sequenceNumber, errorString, false /* forPresets */);
 }
 
 bool CorridorScanComplexItem::specifiesCoordinate(void) const
@@ -237,20 +266,20 @@ void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
 
             // Extend the transect ends for turnaround
             if (_hasTurnaround()) {
-                 QGeoCoordinate turnaroundCoord;
-                 double turnAroundDistance = _turnAroundDistanceFact.rawValue().toDouble();
+                QGeoCoordinate turnaroundCoord;
+                double turnAroundDistance = _turnAroundDistanceFact.rawValue().toDouble();
 
-                 double azimuth = transectCoords[0].azimuthTo(transectCoords[1]);
-                 turnaroundCoord = transectCoords[0].atDistanceAndAzimuth(-turnAroundDistance, azimuth);
-                 turnaroundCoord.setAltitude(qQNaN());
-                 TransectStyleComplexItem::CoordInfo_t coordInfo = { turnaroundCoord, CoordTypeTurnaround };
-                 transect.prepend(coordInfo);
+                double azimuth = transectCoords[0].azimuthTo(transectCoords[1]);
+                turnaroundCoord = transectCoords[0].atDistanceAndAzimuth(-turnAroundDistance, azimuth);
+                turnaroundCoord.setAltitude(qQNaN());
+                TransectStyleComplexItem::CoordInfo_t coordInfo = { turnaroundCoord, CoordTypeTurnaround };
+                transect.prepend(coordInfo);
 
-                 azimuth = transectCoords.last().azimuthTo(transectCoords[transectCoords.count() - 2]);
-                 turnaroundCoord = transectCoords.last().atDistanceAndAzimuth(-turnAroundDistance, azimuth);
-                 turnaroundCoord.setAltitude(qQNaN());
-                 coordInfo = { turnaroundCoord, CoordTypeTurnaround };
-                 transect.append(coordInfo);
+                azimuth = transectCoords.last().azimuthTo(transectCoords[transectCoords.count() - 2]);
+                turnaroundCoord = transectCoords.last().atDistanceAndAzimuth(-turnAroundDistance, azimuth);
+                turnaroundCoord.setAltitude(qQNaN());
+                coordInfo = { turnaroundCoord, CoordTypeTurnaround };
+                transect.append(coordInfo);
             }
 
 #if 0

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -44,6 +44,9 @@ public:
     // Overrides from ComplexMissionItem
     bool    load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
     QString mapVisualQML        (void) const final { return QStringLiteral("CorridorScanMapVisual.qml"); }
+    QString presetsSettingsGroup(void) { return settingsGroup; }
+    void    savePreset          (const QString& name);
+    void    loadPreset          (const QString& name);
 
     // Overrides from VisualMissionionItem
     QString             commandDescription  (void) const final { return tr("Corridor Scan"); }
@@ -71,6 +74,8 @@ private slots:
 private:
     double  _calcTransectSpacing    (void) const;
     int     _calcTransectCount      (void) const;
+    void    _saveCommon             (QJsonObject& complexObject);
+    bool    _loadWorker              (const QJsonObject& complexObject, int sequenceNumber, QString& errorString, bool forPresets);
 
     QGCMapPolyline                  _corridorPolyline;
     QList<QList<QGeoCoordinate>>    _transectSegments;      ///< Internal transect segments including grid exit, turnaround and internal camera points

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -320,14 +320,14 @@ VisualMissionItem* MissionController::_insertSimpleMissionItemWorker(QGeoCoordin
 
     if (newItem->specifiesAltitude()) {
         if (!qgcApp()->toolbox()->missionCommandTree()->isLandCommand(command)) {
-            double  prevAltitude;
-            int     prevAltitudeMode;
+            double                              prevAltitude;
+            QGroundControlQmlGlobal::AltMode    prevAltMode;
 
-            if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltitudeMode)) {
+            if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltMode)) {
                 newItem->altitude()->setRawValue(prevAltitude);
                 if (globalAltitudeMode() == QGroundControlQmlGlobal::AltitudeModeMixed) {
                     // We are in mixed altitude modes, so copy from previous. Otherwise alt mode will be set from global setting.
-                    newItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltitudeMode>(prevAltitudeMode));
+                    newItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltMode>(prevAltMode));
                 }
             }
         }
@@ -364,12 +364,12 @@ VisualMissionItem* MissionController::insertTakeoffItem(QGeoCoordinate /*coordin
     _initVisualItem(_takeoffMissionItem);
 
     if (_takeoffMissionItem->specifiesAltitude()) {
-        double  prevAltitude;
-        int     prevAltitudeMode;
+        double                              prevAltitude;
+        QGroundControlQmlGlobal::AltMode    prevAltMode;
 
-        if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltitudeMode)) {
+        if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltMode)) {
             _takeoffMissionItem->altitude()->setRawValue(prevAltitude);
-            _takeoffMissionItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltitudeMode>(prevAltitudeMode));
+            _takeoffMissionItem->setAltitudeMode(static_cast<QGroundControlQmlGlobal::AltMode>(prevAltMode));
         }
     }
     if (visualItemIndex == -1) {
@@ -433,6 +433,15 @@ VisualMissionItem* MissionController::insertComplexMissionItem(QString itemName,
     if (itemName == SurveyComplexItem::name) {
         newItem = new SurveyComplexItem(_masterController, _flyView, QString() /* kmlFile */, _visualItems /* parent */);
         newItem->setCoordinate(mapCenterCoordinate);
+
+        double                              prevAltitude;
+        QGroundControlQmlGlobal::AltMode    prevAltMode;
+        if (globalAltitudeMode() == QGroundControlQmlGlobal::AltitudeModeMixed) {
+            // We are in mixed altitude modes, so copy from previous. Otherwise alt mode will be set from global setting in constructor.
+            if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltMode)) {
+                qobject_cast<SurveyComplexItem*>(newItem)->cameraCalc()->setDistanceMode(prevAltMode);
+            }
+        }
     } else if (itemName == FixedWingLandingComplexItem::name) {
         newItem = new FixedWingLandingComplexItem(_masterController, _flyView, _visualItems /* parent */);
     } else if (itemName == VTOLLandingComplexItem::name) {
@@ -756,7 +765,7 @@ bool MissionController::_loadJsonMissionFileV2(const QJsonObject& json, QmlObjec
         appSettings->offlineEditingHoverSpeed()->setRawValue(json[_jsonHoverSpeedKey].toDouble());
     }
     if (json.contains(_jsonGlobalPlanAltitudeModeKey)) {
-        setGlobalAltitudeMode(json[_jsonGlobalPlanAltitudeModeKey].toVariant().value<QGroundControlQmlGlobal::AltitudeMode>());
+        setGlobalAltitudeMode(json[_jsonGlobalPlanAltitudeModeKey].toVariant().value<QGroundControlQmlGlobal::AltMode>());
     }
 
     QGeoCoordinate homeCoordinate;
@@ -1152,7 +1161,7 @@ double MissionController::_calcDistanceToHome(VisualMissionItem* currentItem, Vi
     return distanceOk ? homeCoord.distanceTo(currentCoord) : 0.0;
 }
 
-FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemPair& pair)
+FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemPair& pair, bool mavlinkTerrainFrame)
 {
     // The takeoff goes straight up from ground to alt and then over to specified position at same alt. Which means
     // that coord 1 altitude is the same as coord altitude.
@@ -1163,7 +1172,7 @@ FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemP
     double              coord2AMSLAlt       = pair.second->amslEntryAlt();
     double              coord1AMSLAlt       = takeoffStraightUp ? coord2AMSLAlt : pair.first->amslExitAlt();
 
-    FlightPathSegment::SegmentType segmentType = FlightPathSegment::SegmentTypeGeneric;
+    FlightPathSegment::SegmentType segmentType = mavlinkTerrainFrame ? FlightPathSegment::SegmentTypeTerrainFrame : FlightPathSegment::SegmentTypeGeneric;
     if (pair.second->isTakeoffItem()) {
         segmentType = FlightPathSegment::SegmentTypeTakeoff;
     } else if (pair.second->isLandCommand()) {
@@ -1192,15 +1201,15 @@ FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemP
     return segment;
 }
 
-FlightPathSegment* MissionController::_addFlightPathSegment(FlightPathSegmentHashTable& prevItemPairHashTable, VisualItemPair& pair)
+FlightPathSegment* MissionController::_addFlightPathSegment(FlightPathSegmentHashTable& prevItemPairHashTable, VisualItemPair& pair, bool mavlinkTerrainFrame)
 {
     FlightPathSegment* segment = nullptr;
 
-    if (prevItemPairHashTable.contains(pair)) {
+    if (prevItemPairHashTable.contains(pair) && (prevItemPairHashTable[pair]->segmentType() == FlightPathSegment::SegmentTypeTerrainFrame) != mavlinkTerrainFrame) {
         // Pair already exists and connected, just re-use
         _flightPathSegmentHashTable[pair] = segment = prevItemPairHashTable.take(pair);
     } else {
-        segment = _createFlightPathSegmentWorker(pair);
+        segment = _createFlightPathSegmentWorker(pair, mavlinkTerrainFrame);
         _flightPathSegmentHashTable[pair] = segment;
     }
 
@@ -1355,7 +1364,9 @@ void MissionController::_recalcFlightPathSegments(void)
 
                     lastSegmentVisualItemPair =  VisualItemPair(lastFlyThroughVI, visualItem);
                     if (!_flyView || addDirectionArrow) {
-                        FlightPathSegment* segment = _addFlightPathSegment(oldSegmentTable, lastSegmentVisualItemPair);
+                        SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(lastFlyThroughVI);
+                        bool mavlinkTerrainFrame = simpleItem ? simpleItem->missionItem().frame() == MAV_FRAME_GLOBAL_TERRAIN_ALT : false;
+                        FlightPathSegment* segment = _addFlightPathSegment(oldSegmentTable, lastSegmentVisualItemPair, mavlinkTerrainFrame);
                         segment->setSpecialVisual(roiActive);
                         if (addDirectionArrow) {
                             _directionArrows.append(segment);
@@ -1379,7 +1390,7 @@ void MissionController::_recalcFlightPathSegments(void)
         if (_flyView) {
             _waypointPath.append(QVariant::fromValue(_settingsItem->coordinate()));
         }
-        FlightPathSegment* segment = _addFlightPathSegment(oldSegmentTable, lastSegmentVisualItemPair);
+        FlightPathSegment* segment = _addFlightPathSegment(oldSegmentTable, lastSegmentVisualItemPair, false /* mavlinkTerrainFrame */);
         segment->setSpecialVisual(roiActive);
         lastFlyThroughVI->setSimpleFlighPathSegment(segment);
     }
@@ -2005,11 +2016,11 @@ void MissionController::_inProgressChanged(bool inProgress)
     emit syncInProgressChanged(inProgress);
 }
 
-bool MissionController::_findPreviousAltitude(int newIndex, double* prevAltitude, int* prevAltitudeMode)
+bool MissionController::_findPreviousAltitude(int newIndex, double* prevAltitude, QGroundControlQmlGlobal::AltMode* prevAltitudeMode)
 {
-    bool        found = false;
-    double      foundAltitude = 0;
-    int         foundAltitudeMode = QGroundControlQmlGlobal::AltitudeModeNone;
+    bool                                found = false;
+    double                              foundAltitude = 0;
+    QGroundControlQmlGlobal::AltMode    foundAltMode = QGroundControlQmlGlobal::AltitudeModeNone;
 
     if (newIndex > _visualItems->count()) {
         return false;
@@ -2023,9 +2034,9 @@ bool MissionController::_findPreviousAltitude(int newIndex, double* prevAltitude
             if (visualItem->isSimpleItem()) {
                 SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(visualItem);
                 if (simpleItem->specifiesAltitude()) {
-                    foundAltitude = simpleItem->altitude()->rawValue().toDouble();
-                    foundAltitudeMode = simpleItem->altitudeMode();
-                    found = true;
+                    foundAltitude   = simpleItem->altitude()->rawValue().toDouble();
+                    foundAltMode    = simpleItem->altitudeMode();
+                    found           = true;
                     break;
                 }
             }
@@ -2033,8 +2044,8 @@ bool MissionController::_findPreviousAltitude(int newIndex, double* prevAltitude
     }
 
     if (found) {
-        *prevAltitude = foundAltitude;
-        *prevAltitudeMode = foundAltitudeMode;
+        *prevAltitude       = foundAltitude;
+        *prevAltitudeMode   = foundAltMode;
     }
 
     return found;
@@ -2640,12 +2651,12 @@ MissionController::SendToVehiclePreCheckState MissionController::sendToVehiclePr
     return SendToVehiclePreCheckStateOk;
 }
 
-QGroundControlQmlGlobal::AltitudeMode MissionController::globalAltitudeMode(void)
+QGroundControlQmlGlobal::AltMode MissionController::globalAltitudeMode(void)
 {
     return _globalAltMode;
 }
 
-QGroundControlQmlGlobal::AltitudeMode MissionController::globalAltitudeModeDefault(void)
+QGroundControlQmlGlobal::AltMode MissionController::globalAltitudeModeDefault(void)
 {
     if (_globalAltMode == QGroundControlQmlGlobal::AltitudeModeMixed) {
         return QGroundControlQmlGlobal::AltitudeModeRelative;
@@ -2654,7 +2665,7 @@ QGroundControlQmlGlobal::AltitudeMode MissionController::globalAltitudeModeDefau
     }
 }
 
-void MissionController::setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeMode altMode)
+void MissionController::setGlobalAltitudeMode(QGroundControlQmlGlobal::AltMode altMode)
 {
     if (_globalAltMode != altMode) {
         _globalAltMode = altMode;

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -109,8 +109,8 @@ public:
     Q_PROPERTY(double               minAMSLAltitude                 MEMBER _minAMSLAltitude             NOTIFY minAMSLAltitudeChanged)          ///< Minimum altitude associated with this mission. Used to calculate percentages for terrain status.
     Q_PROPERTY(double               maxAMSLAltitude                 MEMBER _maxAMSLAltitude             NOTIFY maxAMSLAltitudeChanged)          ///< Maximum altitude associated with this mission. Used to calculate percentages for terrain status.
 
-    Q_PROPERTY(QGroundControlQmlGlobal::AltitudeMode globalAltitudeMode         READ globalAltitudeMode         WRITE setGlobalAltitudeMode NOTIFY globalAltitudeModeChanged)
-    Q_PROPERTY(QGroundControlQmlGlobal::AltitudeMode globalAltitudeModeDefault  READ globalAltitudeModeDefault  NOTIFY globalAltitudeModeChanged)                               ///< Default to use for newly created items
+    Q_PROPERTY(QGroundControlQmlGlobal::AltMode globalAltitudeMode         READ globalAltitudeMode         WRITE setGlobalAltitudeMode NOTIFY globalAltitudeModeChanged)
+    Q_PROPERTY(QGroundControlQmlGlobal::AltMode globalAltitudeModeDefault  READ globalAltitudeModeDefault  NOTIFY globalAltitudeModeChanged)                               ///< Default to use for newly created items
 
     Q_INVOKABLE void removeVisualItem(int viIndex);
 
@@ -254,9 +254,9 @@ public:
 
     bool isEmpty                    (void) const;
 
-    QGroundControlQmlGlobal::AltitudeMode globalAltitudeMode(void);
-    QGroundControlQmlGlobal::AltitudeMode globalAltitudeModeDefault(void);
-    void setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeMode altMode);
+    QGroundControlQmlGlobal::AltMode globalAltitudeMode(void);
+    QGroundControlQmlGlobal::AltMode globalAltitudeModeDefault(void);
+    void setGlobalAltitudeMode(QGroundControlQmlGlobal::AltMode altMode);
 
 signals:
     void visualItemsChanged                 (void);
@@ -329,7 +329,7 @@ private:
     void                    _deinitVisualItem                   (VisualMissionItem* item);
     void                    _setupActiveVehicle                 (Vehicle* activeVehicle, bool forceLoadFromVehicle);
     void                    _calcPrevWaypointValues             (VisualMissionItem* currentItem, VisualMissionItem* prevItem, double* azimuth, double* distance, double* altDifference);
-    bool                    _findPreviousAltitude               (int newIndex, double* prevAltitude, int* prevAltitudeMode);
+    bool                    _findPreviousAltitude               (int newIndex, double* prevAltitude, QGroundControlQmlGlobal::AltMode* prevAltMode);
     MissionSettingsItem*    _addMissionSettings                 (QmlObjectListModel* visualItems);
     void                    _centerHomePositionOnMissionItems   (QmlObjectListModel* visualItems);
     bool                    _loadJsonMissionFile                (const QByteArray& bytes, QmlObjectListModel* visualItems, QString& errorString);
@@ -345,13 +345,13 @@ private:
     void                    _updateBatteryInfo                  (int waypointIndex);
     bool                    _loadItemsFromJson                  (const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString);
     void                    _initLoadedVisualItems              (QmlObjectListModel* loadedVisualItems);
-    FlightPathSegment*      _addFlightPathSegment               (FlightPathSegmentHashTable& prevItemPairHashTable, VisualItemPair& pair);
+    FlightPathSegment*      _addFlightPathSegment               (FlightPathSegmentHashTable& prevItemPairHashTable, VisualItemPair& pair, bool mavlinkTerrainFrame);
     void                    _addTimeDistance                    (bool vtolInHover, double hoverTime, double cruiseTime, double extraTime, double distance, int seqNum);
     VisualMissionItem*      _insertSimpleMissionItemWorker      (QGeoCoordinate coordinate, MAV_CMD command, int visualItemIndex, bool makeCurrentItem);
     void                    _insertComplexMissionItemWorker     (const QGeoCoordinate& mapCenterCoordinate, ComplexMissionItem* complexItem, int visualItemIndex, bool makeCurrentItem);
     bool                    _isROIBeginItem                     (SimpleMissionItem* simpleItem);
     bool                    _isROICancelItem                    (SimpleMissionItem* simpleItem);
-    FlightPathSegment*      _createFlightPathSegmentWorker      (VisualItemPair& pair);
+    FlightPathSegment*      _createFlightPathSegmentWorker      (VisualItemPair& pair, bool mavlinkTerrainFrame);
     void                    _allItemsRemoved                    (void);
     void                    _firstItemAdded                     (void);
 
@@ -398,7 +398,7 @@ private:
     double                      _maxAMSLAltitude =              0;
     bool                        _missionContainsVTOLTakeoff =   false;
 
-    QGroundControlQmlGlobal::AltitudeMode _globalAltMode = QGroundControlQmlGlobal::AltitudeModeRelative;
+    QGroundControlQmlGlobal::AltMode _globalAltMode = QGroundControlQmlGlobal::AltitudeModeRelative;
 
     static const char*  _settingsGroup;
 

--- a/src/MissionManager/MissionControllerTest.cc
+++ b/src/MissionManager/MissionControllerTest.cc
@@ -261,7 +261,7 @@ void MissionControllerTest::_testGlobalAltMode(void)
     _initForFirmwareType(MAV_AUTOPILOT_PX4);
 
     struct  _globalAltMode_s {
-        QGroundControlQmlGlobal::AltitudeMode   altMode;
+        QGroundControlQmlGlobal::AltMode   altMode;
         MAV_FRAME                               expectedMavFrame;
     } altModeTestCases[] = {
         { QGroundControlQmlGlobal::AltitudeModeRelative,            MAV_FRAME_GLOBAL_RELATIVE_ALT },

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -99,7 +99,7 @@ SimpleMissionItem::SimpleMissionItem(PlanMasterController* masterController, boo
 
     struct MavFrame2AltMode_s {
         MAV_FRAME                               mavFrame;
-        QGroundControlQmlGlobal::AltitudeMode   altMode;
+        QGroundControlQmlGlobal::AltMode   altMode;
     };
 
     const struct MavFrame2AltMode_s rgMavFrame2AltMode[] = {
@@ -330,7 +330,7 @@ bool SimpleMissionItem::load(const QJsonObject& json, int sequenceNumber, QStrin
                 return false;
             }
 
-            _altitudeMode = (QGroundControlQmlGlobal::AltitudeMode)(int)json[_jsonAltitudeModeKey].toDouble();
+            _altitudeMode = (QGroundControlQmlGlobal::AltMode)(int)json[_jsonAltitudeModeKey].toDouble();
             _altitudeFact.setRawValue(JsonHelper::possibleNaNJsonValue(json[_jsonAltitudeKey]));
             _amslAltAboveTerrainFact.setRawValue(JsonHelper::possibleNaNJsonValue(json[_jsonAltitudeKey]));
         } else {
@@ -728,16 +728,20 @@ void SimpleMissionItem::_terrainAltChanged(void)
         return;
     }
 
-    if (_altitudeMode == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
+    if (_altitudeMode == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain || _altitudeMode == QGroundControlQmlGlobal::AltitudeModeTerrainFrame) {
         if (qIsNaN(terrainAltitude())) {
             // Set NaNs to signal we are waiting on terrain data
-            _missionItem._param7Fact.setRawValue(qQNaN());
+            if (_altitudeMode == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
+                _missionItem._param7Fact.setRawValue(qQNaN());
+            }
             _amslAltAboveTerrainFact.setRawValue(qQNaN());
         } else {
             double newAboveTerrain = terrainAltitude() + _altitudeFact.rawValue().toDouble();
             double oldAboveTerrain = _amslAltAboveTerrainFact.rawValue().toDouble();
             if (!QGC::fuzzyCompare(newAboveTerrain, oldAboveTerrain)) {
-                _missionItem._param7Fact.setRawValue(newAboveTerrain);
+                if (_altitudeMode == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
+                    _missionItem._param7Fact.setRawValue(newAboveTerrain);
+                }
                 _amslAltAboveTerrainFact.setRawValue(newAboveTerrain);
             }
         }
@@ -1016,7 +1020,7 @@ void SimpleMissionItem::setMissionFlightStatus(MissionController::MissionFlightS
     }
 }
 
-void SimpleMissionItem::setAltitudeMode(QGroundControlQmlGlobal::AltitudeMode altitudeMode)
+void SimpleMissionItem::setAltitudeMode(QGroundControlQmlGlobal::AltMode altitudeMode)
 {
     if (altitudeMode != _altitudeMode) {
         _altitudeMode = altitudeMode;

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -34,7 +34,7 @@ public:
     Q_PROPERTY(bool             rawEdit                 READ rawEdit                WRITE setRawEdit            NOTIFY rawEditChanged)              ///< true: raw item editing with all params
     Q_PROPERTY(bool             specifiesAltitude       READ specifiesAltitude                                  NOTIFY commandChanged)
     Q_PROPERTY(Fact*            altitude                READ altitude                                           CONSTANT)                           ///< Altitude as specified by altitudeMode. Not necessarily true mission item altitude
-    Q_PROPERTY(QGroundControlQmlGlobal::AltitudeMode altitudeMode READ altitudeMode WRITE setAltitudeMode       NOTIFY altitudeModeChanged)
+    Q_PROPERTY(QGroundControlQmlGlobal::AltMode altitudeMode READ altitudeMode WRITE setAltitudeMode       NOTIFY altitudeModeChanged)
     Q_PROPERTY(Fact*            amslAltAboveTerrain     READ amslAltAboveTerrain                                CONSTANT)                           ///< Actual AMSL altitude for item if altitudeMode == AltitudeAboveTerrain
     Q_PROPERTY(int              command                 READ command                WRITE setCommand            NOTIFY commandChanged)
     Q_PROPERTY(bool             isLoiterItem            READ isLoiterItem                                       NOTIFY isLoiterItemChanged)
@@ -70,7 +70,7 @@ public:
     bool            friendlyEditAllowed (void) const;
     bool            rawEdit             (void) const;
     bool            specifiesAltitude   (void) const;
-    QGroundControlQmlGlobal::AltitudeMode altitudeMode(void) const { return _altitudeMode; }
+    QGroundControlQmlGlobal::AltMode altitudeMode(void) const { return _altitudeMode; }
     Fact*           altitude            (void) { return &_altitudeFact; }
     Fact*           amslAltAboveTerrain (void) { return &_amslAltAboveTerrainFact; }
     bool            isLoiterItem        (void) const;
@@ -85,7 +85,7 @@ public:
     QmlObjectListModel* comboboxFacts   (void) { return &_comboboxFacts; }
 
     void setRawEdit(bool rawEdit);
-    void setAltitudeMode(QGroundControlQmlGlobal::AltitudeMode altitudeMode);
+    void setAltitudeMode(QGroundControlQmlGlobal::AltMode altitudeMode);
     
     void setCommandByIndex(int index);
 
@@ -186,9 +186,9 @@ private:
 
     Fact                _supportedCommandFact;
 
-    QGroundControlQmlGlobal::AltitudeMode   _altitudeMode = QGroundControlQmlGlobal::AltitudeModeRelative;
-    Fact                                    _altitudeFact;
-    Fact                                    _amslAltAboveTerrainFact;
+    QGroundControlQmlGlobal::AltMode    _altitudeMode = QGroundControlQmlGlobal::AltitudeModeRelative;
+    Fact                                _altitudeFact;
+    Fact                                _amslAltAboveTerrainFact;
 
     QmlObjectListModel  _textFieldFacts;
     QmlObjectListModel  _nanFacts;

--- a/src/MissionManager/SimpleMissionItemTest.h
+++ b/src/MissionManager/SimpleMissionItemTest.h
@@ -30,7 +30,7 @@ typedef struct {
     size_t                          cFactValues;
     const FactValue_t*              rgFactValues;
     double                          altValue;
-    QGroundControlQmlGlobal::AltitudeMode altMode;
+    QGroundControlQmlGlobal::AltMode altMode;
 } ItemExpected_t;
 
 class SimpleMissionItemTest : public VisualMissionItemTest

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -245,7 +245,7 @@ bool StructureScanComplexItem::load(const QJsonObject& complexObject, int sequen
     setSequenceNumber(sequenceNumber);
 
     // Load CameraCalc first since it will trigger camera name change which will trounce gimbal angles
-    if (!_cameraCalc.load(complexObject[_jsonCameraCalcKey].toObject(), errorString)) {
+    if (!_cameraCalc.load(complexObject[_jsonCameraCalcKey].toObject(), false /* v1FollowTerrain */, errorString, false /* forPresets */)) {
         return false;
     }
 

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -115,7 +115,7 @@ void SurveyComplexItem::save(QJsonArray&  planItems)
 {
     QJsonObject saveObject;
 
-    _saveWorker(saveObject);
+    _saveCommon(saveObject);
     planItems.append(saveObject);
 }
 
@@ -123,11 +123,11 @@ void SurveyComplexItem::savePreset(const QString& name)
 {
     QJsonObject saveObject;
 
-    _saveWorker(saveObject);
+    _saveCommon(saveObject);
     _savePresetJson(name, saveObject);
 }
 
-void SurveyComplexItem::_saveWorker(QJsonObject& saveObject)
+void SurveyComplexItem::_saveCommon(QJsonObject& saveObject)
 {
     TransectStyleComplexItem::_save(saveObject);
 
@@ -292,7 +292,7 @@ bool SurveyComplexItem::_loadV3(const QJsonObject& complexObject, int sequenceNu
     _cameraTriggerInTurnAroundFact.setRawValue  (complexObject[_jsonV3CameraTriggerInTurnaroundKey].toBool(true));
 
     _cameraCalc.valueSetIsDistance()->setRawValue   (complexObject[_jsonV3FixedValueIsAltitudeKey].toBool(true));
-    _cameraCalc.setDistanceToSurfaceRelative        (complexObject[_jsonV3GridAltitudeRelativeKey].toBool(true));
+    _cameraCalc.setDistanceMode(complexObject[_jsonV3GridAltitudeRelativeKey].toBool(true) ? QGroundControlQmlGlobal::AltitudeModeRelative : QGroundControlQmlGlobal::AltitudeModeAbsolute);
 
     bool manualGrid = complexObject[_jsonV3ManualGridKey].toBool(true);
 
@@ -301,7 +301,7 @@ bool SurveyComplexItem::_loadV3(const QJsonObject& complexObject, int sequenceNu
         { _jsonV3GridAltitudeRelativeKey,   QJsonValue::Bool,   true },
         { _jsonV3GridAngleKey,              QJsonValue::Double, true },
         { _jsonV3GridSpacingKey,            QJsonValue::Double, true },
-        { _jsonEntryPointKey,      QJsonValue::Double, false },
+        { _jsonEntryPointKey,               QJsonValue::Double, false },
         { _jsonV3TurnaroundDistKey,         QJsonValue::Double, true },
     };
     QJsonObject gridObject = complexObject[_jsonV3GridObjectKey].toObject();

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -118,7 +118,7 @@ private:
     bool _hoverAndCaptureEnabled(void) const;
     bool _loadV3(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     bool _loadV4V5(const QJsonObject& complexObject, int sequenceNumber, QString& errorString, int version, bool forPresets);
-    void _saveWorker(QJsonObject& complexObject);
+    void _saveCommon(QJsonObject& complexObject);
     void _rebuildTransectsPhase1Worker(bool refly);
     void _rebuildTransectsPhase1WorkerSinglePolygon(bool refly);
     void _rebuildTransectsPhase1WorkerSplitPolygons(bool refly);

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -25,22 +25,23 @@
 
 QGC_LOGGING_CATEGORY(TransectStyleComplexItemLog, "TransectStyleComplexItemLog")
 
-const char* TransectStyleComplexItem::turnAroundDistanceName =              "TurnAroundDistance";
-const char* TransectStyleComplexItem::turnAroundDistanceMultiRotorName =    "TurnAroundDistanceMultiRotor";
-const char* TransectStyleComplexItem::cameraTriggerInTurnAroundName =       "CameraTriggerInTurnAround";
-const char* TransectStyleComplexItem::hoverAndCaptureName =                 "HoverAndCapture";
-const char* TransectStyleComplexItem::refly90DegreesName =                  "Refly90Degrees";
-const char* TransectStyleComplexItem::terrainAdjustToleranceName =          "TerrainAdjustTolerance";
-const char* TransectStyleComplexItem::terrainAdjustMaxClimbRateName =       "TerrainAdjustMaxClimbRate";
-const char* TransectStyleComplexItem::terrainAdjustMaxDescentRateName =     "TerrainAdjustMaxDescentRate";
+const char* TransectStyleComplexItem::turnAroundDistanceName                = "TurnAroundDistance";
+const char* TransectStyleComplexItem::turnAroundDistanceMultiRotorName      = "TurnAroundDistanceMultiRotor";
+const char* TransectStyleComplexItem::cameraTriggerInTurnAroundName         = "CameraTriggerInTurnAround";
+const char* TransectStyleComplexItem::hoverAndCaptureName                   = "HoverAndCapture";
+const char* TransectStyleComplexItem::refly90DegreesName                    = "Refly90Degrees";
+const char* TransectStyleComplexItem::terrainAdjustToleranceName            = "TerrainAdjustTolerance";
+const char* TransectStyleComplexItem::terrainAdjustMaxClimbRateName         = "TerrainAdjustMaxClimbRate";
+const char* TransectStyleComplexItem::terrainAdjustMaxDescentRateName       = "TerrainAdjustMaxDescentRate";
 
-const char* TransectStyleComplexItem::_jsonTransectStyleComplexItemKey =    "TransectStyleComplexItem";
-const char* TransectStyleComplexItem::_jsonCameraCalcKey =                  "CameraCalc";
-const char* TransectStyleComplexItem::_jsonVisualTransectPointsKey =        "VisualTransectPoints";
-const char* TransectStyleComplexItem::_jsonItemsKey =                       "Items";
-const char* TransectStyleComplexItem::_jsonTerrainFollowKey =               "FollowTerrain";
-const char* TransectStyleComplexItem::_jsonTerrainFlightSpeed =             "TerrainFlightSpeed";
-const char* TransectStyleComplexItem::_jsonCameraShotsKey =                 "CameraShots";
+const char* TransectStyleComplexItem::_jsonTransectStyleComplexItemKey      = "TransectStyleComplexItem";
+const char* TransectStyleComplexItem::_jsonCameraCalcKey                    = "CameraCalc";
+const char* TransectStyleComplexItem::_jsonVisualTransectPointsKey          = "VisualTransectPoints";
+const char* TransectStyleComplexItem::_jsonItemsKey                         = "Items";
+const char* TransectStyleComplexItem::_jsonTerrainFlightSpeed               = "TerrainFlightSpeed";
+const char* TransectStyleComplexItem::_jsonCameraShotsKey                   = "CameraShots";
+
+const char* TransectStyleComplexItem::_jsonTerrainFollowKeyDeprecated       = "FollowTerrain";
 
 TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterController, bool flyView, QString settingsGroup, QObject* parent)
     : ComplexMissionItem                (masterController, flyView, parent)
@@ -62,18 +63,18 @@ TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterC
     connect(this, &TransectStyleComplexItem::_updateFlightPathSegmentsSignal, this, &TransectStyleComplexItem::_updateFlightPathSegmentsDontCallDirectly,   Qt::QueuedConnection);
     qgcApp()->addCompressedSignal(QMetaMethod::fromSignal(&TransectStyleComplexItem::_updateFlightPathSegmentsSignal));
 
-    connect(&_turnAroundDistanceFact,                   &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(&_hoverAndCaptureFact,                      &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(&_refly90DegreesFact,                       &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(this,                      &TransectStyleComplexItem::followTerrainChanged, this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(&_terrainAdjustMaxClimbRateFact,            &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(&_terrainAdjustMaxDescentRateFact,          &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(&_terrainAdjustToleranceFact,               &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(&_surveyAreaPolygon,                        &QGCMapPolygon::pathChanged,    this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(&_cameraTriggerInTurnAroundFact,            &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(_cameraCalc.adjustedFootprintSide(),        &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(_cameraCalc.adjustedFootprintFrontal(),     &Fact::valueChanged,            this, &TransectStyleComplexItem::_rebuildTransects);
-    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,         this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_turnAroundDistanceFact,                   &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_hoverAndCaptureFact,                      &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_refly90DegreesFact,                       &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_terrainAdjustMaxClimbRateFact,            &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_terrainAdjustMaxDescentRateFact,          &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_terrainAdjustToleranceFact,               &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_surveyAreaPolygon,                        &QGCMapPolygon::pathChanged,        this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_cameraTriggerInTurnAroundFact,            &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(_cameraCalc.adjustedFootprintSide(),        &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(_cameraCalc.adjustedFootprintFrontal(),     &Fact::valueChanged,                this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,             this, &TransectStyleComplexItem::_rebuildTransects);
+    connect(&_cameraCalc,                               &CameraCalc::distanceModeChanged,   this, &TransectStyleComplexItem::_rebuildTransects);
 
     connect(&_turnAroundDistanceFact,                   &Fact::valueChanged,            this, &TransectStyleComplexItem::complexDistanceChanged);
     connect(&_hoverAndCaptureFact,                      &Fact::valueChanged,            this, &TransectStyleComplexItem::complexDistanceChanged);
@@ -89,7 +90,6 @@ TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterC
     connect(&_cameraTriggerInTurnAroundFact,            &Fact::valueChanged,            this, &TransectStyleComplexItem::_setDirty);
     connect(&_hoverAndCaptureFact,                      &Fact::valueChanged,            this, &TransectStyleComplexItem::_setDirty);
     connect(&_refly90DegreesFact,                       &Fact::valueChanged,            this, &TransectStyleComplexItem::_setDirty);
-    connect(this,                      &TransectStyleComplexItem::followTerrainChanged, this, &TransectStyleComplexItem::_setDirty);
     connect(&_terrainAdjustMaxClimbRateFact,            &Fact::valueChanged,            this, &TransectStyleComplexItem::_setDirty);
     connect(&_terrainAdjustMaxDescentRateFact,          &Fact::valueChanged,            this, &TransectStyleComplexItem::_setDirty);
     connect(&_terrainAdjustToleranceFact,               &Fact::valueChanged,            this, &TransectStyleComplexItem::_setDirty);
@@ -100,25 +100,24 @@ TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterC
 
     connect(&_surveyAreaPolygon,                        &QGCMapPolygon::pathChanged,    this, &TransectStyleComplexItem::coveredAreaChanged);
 
-    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,                         this, &TransectStyleComplexItem::_amslEntryAltChanged);
-    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,                         this, &TransectStyleComplexItem::_amslExitAltChanged);
-    connect(&_cameraCalc,                               &CameraCalc::distanceToSurfaceRelativeChanged,  this, &TransectStyleComplexItem::_amslEntryAltChanged);
-    connect(&_cameraCalc,                               &CameraCalc::distanceToSurfaceRelativeChanged,  this, &TransectStyleComplexItem::_amslExitAltChanged);
-    connect(&_cameraCalc,                               &CameraCalc::distanceToSurfaceRelativeChanged,  this, &TransectStyleComplexItem::_updateFlightPathSegmentsSignal);
-
-    connect(&_cameraCalc,                               &CameraCalc::distanceToSurfaceRelativeChanged,  _missionController, &MissionController::recalcTerrainProfile);
+    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,             this, &TransectStyleComplexItem::_amslEntryAltChanged);
+    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,             this, &TransectStyleComplexItem::_amslExitAltChanged);
+    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,             this, &TransectStyleComplexItem::minAMSLAltitudeChanged);
+    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,             this, &TransectStyleComplexItem::maxAMSLAltitudeChanged);
+    connect(&_cameraCalc,                               &CameraCalc::distanceModeChanged,   this, &TransectStyleComplexItem::_amslEntryAltChanged);
+    connect(&_cameraCalc,                               &CameraCalc::distanceModeChanged,   this, &TransectStyleComplexItem::_amslExitAltChanged);
+    connect(&_cameraCalc,                               &CameraCalc::distanceModeChanged,   this, &TransectStyleComplexItem::minAMSLAltitudeChanged);
+    connect(&_cameraCalc,                               &CameraCalc::distanceModeChanged,   this, &TransectStyleComplexItem::maxAMSLAltitudeChanged);
+    connect(&_cameraCalc,                               &CameraCalc::distanceModeChanged,   this, &TransectStyleComplexItem::_updateFlightPathSegmentsSignal);
+    connect(&_cameraCalc,                               &CameraCalc::distanceModeChanged,   this, &TransectStyleComplexItem::_distanceModeChanged);
+    connect(&_cameraCalc,                               &CameraCalc::distanceModeChanged,  _missionController, &MissionController::recalcTerrainProfile);
 
     connect(&_hoverAndCaptureFact,                      &Fact::rawValueChanged,         this, &TransectStyleComplexItem::_handleHoverAndCaptureEnabled);
 
     connect(this,                                       &TransectStyleComplexItem::visualTransectPointsChanged, this, &TransectStyleComplexItem::complexDistanceChanged);
     connect(this,                                       &TransectStyleComplexItem::visualTransectPointsChanged, this, &TransectStyleComplexItem::greatestDistanceToChanged);
-    connect(this,                                       &TransectStyleComplexItem::followTerrainChanged,        this, &TransectStyleComplexItem::_followTerrainChanged);
     connect(this,                                       &TransectStyleComplexItem::wizardModeChanged,           this, &TransectStyleComplexItem::readyForSaveStateChanged);
 
-    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,                                 this, &TransectStyleComplexItem::minAMSLAltitudeChanged);
-    connect(_cameraCalc.distanceToSurface(),            &Fact::rawValueChanged,                                 this, &TransectStyleComplexItem::maxAMSLAltitudeChanged);
-    connect(&_cameraCalc,                               &CameraCalc::distanceToSurfaceRelativeChanged,          this, &TransectStyleComplexItem::minAMSLAltitudeChanged);
-    connect(&_cameraCalc,                               &CameraCalc::distanceToSurfaceRelativeChanged,          this, &TransectStyleComplexItem::maxAMSLAltitudeChanged);
 
     connect(&_surveyAreaPolygon,                        &QGCMapPolygon::isValidChanged, this, &TransectStyleComplexItem::readyForSaveStateChanged);
 
@@ -149,15 +148,14 @@ void TransectStyleComplexItem::_save(QJsonObject& complexObject)
 {
     QJsonObject innerObject;
 
-    innerObject[JsonHelper::jsonVersionKey] =       1;
+    innerObject[JsonHelper::jsonVersionKey] =       2;
     innerObject[turnAroundDistanceName] =           _turnAroundDistanceFact.rawValue().toDouble();
     innerObject[cameraTriggerInTurnAroundName] =    _cameraTriggerInTurnAroundFact.rawValue().toBool();
     innerObject[hoverAndCaptureName] =              _hoverAndCaptureFact.rawValue().toBool();
     innerObject[refly90DegreesName] =               _refly90DegreesFact.rawValue().toBool();
-    innerObject[_jsonTerrainFollowKey] =            _followTerrain;
     innerObject[_jsonCameraShotsKey] =              _cameraShots;
 
-    if (_followTerrain) {
+    if (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
         innerObject[terrainAdjustToleranceName]         = _terrainAdjustToleranceFact.rawValue().toDouble();
         innerObject[terrainAdjustMaxClimbRateName]      = _terrainAdjustMaxClimbRateFact.rawValue().toDouble();
         innerObject[terrainAdjustMaxDescentRateName]    = _terrainAdjustMaxDescentRateFact.rawValue().toDouble();
@@ -211,12 +209,29 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, bool forP
     // The TransectStyleComplexItem is a sub-object of the main complex item object
     QJsonObject innerObject = complexObject[_jsonTransectStyleComplexItemKey].toObject();
 
+    int version = 0;
+    bool v1FollowTerrain = false;
     if (innerObject.contains(JsonHelper::jsonVersionKey)) {
-        int version = innerObject[JsonHelper::jsonVersionKey].toInt();
-        if (version != 1) {
-            errorString = tr("TransectStyleComplexItem version %2 not supported").arg(version);
-            return false;
+        version = innerObject[JsonHelper::jsonVersionKey].toInt();
+    }
+    if (version == 0) {
+        // There are really old versions without version stamp
+        version = 1;
+    }
+    if (version == 1) {
+        // Version 1->2 differences
+        //  - _jsonCameraShotsKey was optional in V1 since is was added later
+        //  - _jsonTerrainFollowKeyDeprecated replaced by CameraCalc::distanceMode
+        if (!innerObject.contains(_jsonCameraShotsKey)) {
+            innerObject[_jsonCameraShotsKey] = 0;
         }
+        v1FollowTerrain = innerObject[_jsonTerrainFollowKeyDeprecated].toBool();
+        innerObject.remove(_jsonTerrainFollowKeyDeprecated);
+        version = 2;
+    }
+    if (version != 2) {
+        errorString = tr("TransectStyleComplexItem version %2 not supported").arg(version);
+        return false;
     }
 
     QList<JsonHelper::KeyValidateInfo> innerKeyInfoList = {
@@ -228,8 +243,7 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, bool forP
         { _jsonCameraCalcKey,               QJsonValue::Object, true },
         { _jsonVisualTransectPointsKey,     QJsonValue::Array,  !forPresets },
         { _jsonItemsKey,                    QJsonValue::Array,  !forPresets },
-        { _jsonTerrainFollowKey,            QJsonValue::Bool,   true },
-        { _jsonCameraShotsKey,              QJsonValue::Double, false },        // Not required since it was missing from initial implementation
+        { _jsonCameraShotsKey,              QJsonValue::Double, true },
     };
     if (!JsonHelper::validateKeys(innerObject, innerKeyInfoList, errorString)) {
         return false;
@@ -259,7 +273,7 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, bool forP
     }
 
     // Load CameraCalc data
-    if (!_cameraCalc.load(innerObject[_jsonCameraCalcKey].toObject(), errorString)) {
+    if (!_cameraCalc.load(innerObject[_jsonCameraCalcKey].toObject(), v1FollowTerrain, errorString, forPresets)) {
         return false;
     }
 
@@ -268,7 +282,6 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, bool forP
     _cameraTriggerInTurnAroundFact.setRawValue  (innerObject[cameraTriggerInTurnAroundName].toBool());
     _hoverAndCaptureFact.setRawValue            (innerObject[hoverAndCaptureName].toBool());
     _refly90DegreesFact.setRawValue             (innerObject[refly90DegreesName].toBool());
-    _followTerrain = innerObject[_jsonTerrainFollowKey].toBool();
 
     // These two keys where not included in initial implementation so they are optional. Without them the values will be
     // incorrect when loaded though.
@@ -276,7 +289,7 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, bool forP
         _cameraShots = innerObject[_jsonCameraShotsKey].toInt();
     }
 
-    if (_followTerrain) {
+    if (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
         QList<JsonHelper::KeyValidateInfo> followTerrainKeyInfoList = {
             { terrainAdjustToleranceName,       QJsonValue::Double, true },
             { terrainAdjustMaxClimbRateName,    QJsonValue::Double, true },
@@ -309,10 +322,7 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, bool forP
         }
     }
 
-    if (forPresets) {
-        // Most signalling will happen after the transects are rebuilt so we don't over signal here
-        emit followTerrainChanged(_followTerrain);
-    } else {
+    if (!forPresets) {
         emit minAMSLAltitudeChanged();
         emit maxAMSLAltitudeChanged();
         _amslEntryAltChanged();
@@ -400,12 +410,21 @@ void TransectStyleComplexItem::_rebuildTransects(void)
 
     _minAMSLAltitude = _maxAMSLAltitude = qQNaN();
 
-    if (_followTerrain) {
-        // Query the terrain data. Once available terrain heights will be calculated
-        _queryTransectsPathHeightInfo();
-    } else {
+    switch (_cameraCalc.distanceMode()) {
+    case QGroundControlQmlGlobal::AltitudeModeMixed:
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qCWarning(TransectStyleComplexItemLog) << "Internal Error: _rebuildTransects - invalid _cameraCalc.distanceMode()" << _cameraCalc.distanceMode();
+        return;
+    case QGroundControlQmlGlobal::AltitudeModeRelative:
+    case QGroundControlQmlGlobal::AltitudeModeAbsolute:
         // Not following terrain so we can build the flight path now
         _buildRawFlightPath();
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain:
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
+        // Query the terrain data. Once available flight path will be calculated
+        _queryTransectsPathHeightInfo();
+        break;
     }
 
     // Calc bounding cube
@@ -479,38 +498,16 @@ void TransectStyleComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
     _flightPathSegments.beginReset();
     _flightPathSegments.clearAndDeleteContents();
 
-    if (_followTerrain) {
-        if (_loadedMissionItems.count()) {
-            // We are working from loaded mission items from a plan. We have to grovel through the mission items
-            // building up segments from waypoints.
-            QGeoCoordinate prevCoord = QGeoCoordinate();
-            double prevAlt = 0;
-            for (const MissionItem* missionItem: _loadedMissionItems) {
-                if (missionItem->command() == MAV_CMD_NAV_WAYPOINT || missionItem->command() == MAV_CMD_CONDITION_GATE) {
-                    if (prevCoord.isValid()) {
-                        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, prevCoord, prevAlt, missionItem->coordinate(), missionItem->param7());
-                    }
-                    prevCoord = missionItem->coordinate();
-                    prevAlt = missionItem->param7();
-                }
-            }
-        } else {
-            // We are working from live transect data. We don't show flight path segments until terrain data is back and recalced
-            if (_rgFlightPathCoordInfo.count()) {
-                // The altitudes of the flight path segment coordinates for follow terrain can all occur at different altitudes. Because of that we
-                // need to to add FlightPathSegment's for all points in order to get good terrain collision data and flight path profile.
-                for (int i=0; i<_rgFlightPathCoordInfo.count() - 1; i++) {
-                    const QGeoCoordinate& fromCoord = _rgFlightPathCoordInfo[i].coord;
-                    const QGeoCoordinate& toCoord   = _rgFlightPathCoordInfo[i+1].coord;
-                    //qDebug() << _rgFlightPathCoordInfo.count() << fromCoord << _rgFlightPathCoordInfo[i].coordType << toCoord << _rgFlightPathCoordInfo[i+1].coordType;
-                    _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, fromCoord, fromCoord.altitude(), toCoord, toCoord.altitude());
-                }
-            }
-        }
-    } else {
+    switch (_cameraCalc.distanceMode()) {
+    case QGroundControlQmlGlobal::AltitudeModeMixed:
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qCWarning(TransectStyleComplexItemLog) << "Internal Error: _updateFlightPathSegmentsDontCallDirectly - invalid _cameraCalc.distanceMode()" << _cameraCalc.distanceMode();
+        return;
+    case QGroundControlQmlGlobal::AltitudeModeRelative:
+    case QGroundControlQmlGlobal::AltitudeModeAbsolute:
+    {
         // Since we aren't following terrain all the transects are at the same height. We can use _visualTransectPoints to build the
-        // flight path segments. The benefit of _visualTransectPoints is that it is also available when a Plan is loaded from a file
-        // and we are working from  stored mission items. In that case we don't have _transects set up for use.
+        // flight path segments.
         QGeoCoordinate prevCoord;
         double surveyAlt = amslEntryAlt();
         for (const QVariant& varCoord: _visualTransectPoints) {
@@ -520,6 +517,38 @@ void TransectStyleComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
             }
             prevCoord = thisCoord;
         }
+    }
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain:
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
+        if (_loadedMissionItems.count()) {
+            // FIXME: Missing support for AltitudeModeTerrainFrame
+            if (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
+                // building up segments from waypoints.
+                QGeoCoordinate prevCoord = QGeoCoordinate();
+                double prevAlt = 0;
+                for (const MissionItem* missionItem: _loadedMissionItems) {
+                    if (missionItem->command() == MAV_CMD_NAV_WAYPOINT || missionItem->command() == MAV_CMD_CONDITION_GATE) {
+                        if (prevCoord.isValid()) {
+                            _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, prevCoord, prevAlt, missionItem->coordinate(), missionItem->param7());
+                        }
+                        prevCoord = missionItem->coordinate();
+                        prevAlt = missionItem->param7();
+                    }
+                }
+            }
+        } else {
+            // We are working from live transect data. We don't show flight path segments until terrain data is back and _rgFlightPathCoordInfo is set up
+            if (_rgFlightPathCoordInfo.count()) {
+                FlightPathSegment::SegmentType segmentType = _cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain ? FlightPathSegment::SegmentTypeGeneric : FlightPathSegment::SegmentTypeTerrainFrame;
+                for (int i=0; i<_rgFlightPathCoordInfo.count() - 1; i++) {
+                    const QGeoCoordinate& fromCoord = _rgFlightPathCoordInfo[i].coord;
+                    const QGeoCoordinate& toCoord   = _rgFlightPathCoordInfo[i+1].coord;
+                    _appendFlightPathSegment(segmentType, fromCoord, fromCoord.altitude(), toCoord, toCoord.altitude());
+                }
+            }
+        }
+        break;
     }
 
     _flightPathSegments.endReset();
@@ -546,6 +575,8 @@ void TransectStyleComplexItem::_queryTransectsPathHeightInfo(void)
 
 void TransectStyleComplexItem::_reallyQueryTransectsPathHeightInfo(void)
 {
+    qCDebug(TransectStyleComplexItemLog) << "_reallyQueryTransectsPathHeightInfo";
+
     // Clear any previous query
     if (_currentTerrainFollowQuery) {
         // We are already waiting on another query. We don't care about those results any more.
@@ -570,6 +601,8 @@ void TransectStyleComplexItem::_reallyQueryTransectsPathHeightInfo(void)
 
 void TransectStyleComplexItem::_polyPathTerrainData(bool success, const QList<TerrainPathQuery::PathHeightInfo_t>& rgPathHeightInfo)
 {
+    qCDebug(TransectStyleComplexItemLog) << "_polyPathTerrainData" << success;
+
     _rgPathHeightInfo.clear();
     emit readyForSaveStateChanged();
 
@@ -591,7 +624,7 @@ void TransectStyleComplexItem::_polyPathTerrainData(bool success, const QList<Te
 TransectStyleComplexItem::ReadyForSaveState TransectStyleComplexItem::readyForSaveState(void) const
 {
     bool terrainReady = false;
-    if (_followTerrain) {
+    if (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
         if (_loadedMissionItems.count()) {
             // We have loaded mission items. Everything is ready to go.
             terrainReady = true;
@@ -611,32 +644,43 @@ TransectStyleComplexItem::ReadyForSaveState TransectStyleComplexItem::readyForSa
 
 void TransectStyleComplexItem::_adjustTransectsForTerrain(void)
 {
-    if (_followTerrain) {
-        if (_rgPathHeightInfo.count() == 0) {
-            qCWarning(TransectStyleComplexItemLog) << "_adjustTransectPointsForTerrain called when terrain data not ready";
-            qgcApp()->showAppMessage(tr("INTERNAL ERROR: TransectStyleComplexItem::_adjustTransectPointsForTerrain called when terrain data not ready. Plan will be incorrect."));
-            return;
-        }
+    if (_rgPathHeightInfo.count() == 0) {
+        qCWarning(TransectStyleComplexItemLog) << "_adjustTransectPointsForTerrain called when terrain data not ready";
+        qgcApp()->showAppMessage(tr("INTERNAL ERROR: TransectStyleComplexItem::_adjustTransectPointsForTerrain called when terrain data not ready. Plan will be incorrect."));
+        return;
+    }
 
+    switch (_cameraCalc.distanceMode()) {
+    case QGroundControlQmlGlobal::AltitudeModeMixed:
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qCWarning(TransectStyleComplexItemLog) << "Internal Error: _adjustTransectsForTerrain - invalid _cameraCalc.distanceMode()" << _cameraCalc.distanceMode();
+        return;
+    case QGroundControlQmlGlobal::AltitudeModeRelative:
+    case QGroundControlQmlGlobal::AltitudeModeAbsolute:
+        // No additional work needed
+        return;
+    case QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain:
         _buildRawFlightPath();
         _adjustForMaxRates();
         _adjustForTolerance();
-
-        emit lastSequenceNumberChanged(lastSequenceNumber());
-        emit _updateFlightPathSegmentsSignal();
-
-        _amslEntryAltChanged();
-        _amslExitAltChanged();
-
         _minAMSLAltitude = qQNaN();
         _maxAMSLAltitude = qQNaN();
         for (const CoordInfo_t& coordInfo: _rgFlightPathCoordInfo) {
             _minAMSLAltitude = std::fmin(_minAMSLAltitude, coordInfo.coord.altitude());
             _maxAMSLAltitude = std::fmax(_maxAMSLAltitude, coordInfo.coord.altitude());
         }
-        emit minAMSLAltitudeChanged();
-        emit maxAMSLAltitudeChanged();
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
+        _buildRawFlightPath();
+        break;
     }
+
+    _amslEntryAltChanged();
+    _amslExitAltChanged();
+    emit lastSequenceNumberChanged(lastSequenceNumber());
+    emit _updateFlightPathSegmentsSignal();
+    emit minAMSLAltitudeChanged();
+    emit maxAMSLAltitudeChanged();
 }
 
 /// Returns the altitude in between the two points on a line.
@@ -774,27 +818,47 @@ void TransectStyleComplexItem::_adjustForTolerance(void)
 /// Build flight path prior to any post-processing adjustment.
 bool TransectStyleComplexItem::_buildRawFlightPath(void)
 {
-    if (_followTerrain && _rgPathHeightInfo.count() == 0) {
-        qCWarning(TransectStyleComplexItemLog) << "TransectStyleComplexItem::_buildRawFlightPath _followTerrain with _rgPathHeightInfo.count() == 0";
+    _minAMSLAltitude = _maxAMSLAltitude = qQNaN();
+
+    switch (_cameraCalc.distanceMode()) {
+    case QGroundControlQmlGlobal::AltitudeModeMixed:
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qCWarning(TransectStyleComplexItemLog) << "Internal Error: _buildRawFlightPath - invalid _cameraCalc.distanceMode()" << _cameraCalc.distanceMode();
         return false;
+    case QGroundControlQmlGlobal::AltitudeModeRelative:
+    case QGroundControlQmlGlobal::AltitudeModeAbsolute:
+        // Processing handled below
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain:
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
+        if (_rgPathHeightInfo.count() == 0) {
+            qCWarning(TransectStyleComplexItemLog) << "TransectStyleComplexItem::_buildRawFlightPath terrain height needed but _rgPathHeightInfo.count() == 0";
+            return false;
+        }
+        // Processing handled below
+        break;
     }
 
-    double distanceToSurface = _cameraCalc.distanceToSurface()->rawValue().toDouble();
+    bool    calcAboveTerrain                    = _cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain;
+    bool    terrainFrame                        = _cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeTerrainFrame;
+    bool    adjustCoordAltitudesAboveTerrain    = calcAboveTerrain || terrainFrame;
+    double  distanceToSurface                   = _cameraCalc.distanceToSurface()->rawValue().toDouble();
 
     _rgFlightPathCoordInfo.clear();
     int pathHeightIndex = 0;
     for (int transectIndex=0; transectIndex<_transects.count(); transectIndex++) {
         const QList<CoordInfo_t>& transect = _transects[transectIndex];
 
+        // Build flight path for transect
         for (int transectCoordIndex=0; transectCoordIndex<transect.count() - 1; transectCoordIndex++) {
             CoordInfo_t fromCoordInfo   = transect[transectCoordIndex];
             CoordInfo_t toCoordInfo     = transect[transectCoordIndex+1];
 
-            const auto* prgPathHeightInfo = _followTerrain ? &_rgPathHeightInfo[pathHeightIndex++] : nullptr;
+            const auto* prgPathHeightInfo = adjustCoordAltitudesAboveTerrain ? &_rgPathHeightInfo[pathHeightIndex++] : nullptr;
 
             fromCoordInfo.coord.setAltitude(distanceToSurface);
             toCoordInfo.coord.setAltitude(distanceToSurface);
-            if (_followTerrain) {
+            if (adjustCoordAltitudesAboveTerrain) {
                 fromCoordInfo.coord.setAltitude(fromCoordInfo.coord.altitude() + prgPathHeightInfo->heights.first());
                 toCoordInfo.coord.setAltitude(toCoordInfo.coord.altitude() + prgPathHeightInfo->heights.last());
             }
@@ -804,7 +868,7 @@ bool TransectStyleComplexItem::_buildRawFlightPath(void)
             }
 
             // For follow terrain we add interstitial points at max resolution of our terrain data
-            if (_followTerrain) {
+            if (calcAboveTerrain) {
                 int cHeights = prgPathHeightInfo->heights.count();
 
                 double azimuth  = fromCoordInfo.coord.azimuthTo(toCoordInfo.coord);
@@ -826,8 +890,9 @@ bool TransectStyleComplexItem::_buildRawFlightPath(void)
             _rgFlightPathCoordInfo.append(toCoordInfo);
         }
 
+        // Build flight path for turnaround
         // Add terrain interstitial points to the turn segment if not the last transect
-        if (_followTerrain && transectIndex != _transects.count() - 1) {
+        if (calcAboveTerrain && transectIndex != _transects.count() - 1) {
             const TerrainPathQuery::PathHeightInfo_t& pathHeightInfo = _rgPathHeightInfo[pathHeightIndex++];
 
             int cHeights = pathHeightInfo.heights.count();
@@ -849,18 +914,13 @@ bool TransectStyleComplexItem::_buildRawFlightPath(void)
 
                 _rgFlightPathCoordInfo.append(interstitialCoordInfo);
             }
+        } else {
+            // Even though we don't use it we still have path heights for the turnaround segment
+            pathHeightIndex++;
         }
     }
 
     return true;
-}
-
-void TransectStyleComplexItem::setFollowTerrain(bool followTerrain)
-{
-    if (followTerrain != _followTerrain) {
-        _followTerrain = followTerrain;
-        emit followTerrainChanged(followTerrain);
-    }
 }
 
 int TransectStyleComplexItem::lastSequenceNumber(void) const
@@ -937,10 +997,9 @@ int TransectStyleComplexItem::lastSequenceNumber(void) const
     }
 }
 
-void TransectStyleComplexItem::_followTerrainChanged(bool followTerrain)
+void TransectStyleComplexItem::_distanceModeChanged(int distanceMode)
 {
-    _cameraCalc.setDistanceToSurfaceRelative(!followTerrain);
-    if (followTerrain) {
+    if (static_cast<QGroundControlQmlGlobal::AltMode>(distanceMode) == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
         _refly90DegreesFact.setRawValue(false);
         _hoverAndCaptureFact.setRawValue(false);
     }
@@ -1057,9 +1116,27 @@ void TransectStyleComplexItem::_buildAndAppendMissionItems(QList<MissionItem*>& 
 {
     int                         seqNum      = _sequenceNumber;
     BuildMissionItemsState_t    buildState  = _buildMissionItemsState();
-    MAV_FRAME                   mavFrame    = followTerrain() || !_cameraCalc.distanceToSurfaceRelative() ? MAV_FRAME_GLOBAL : MAV_FRAME_GLOBAL_RELATIVE_ALT;
+    MAV_FRAME                   mavFrame;
 
     qCDebug(TransectStyleComplexItemLog) << "_buildAndAppendMissionItems";
+
+    switch (_cameraCalc.distanceMode()) {
+    case QGroundControlQmlGlobal::AltitudeModeRelative:
+        mavFrame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeAbsolute:
+    case QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain:
+        mavFrame = MAV_FRAME_GLOBAL;
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
+        mavFrame = MAV_FRAME_GLOBAL_TERRAIN_ALT;
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeMixed:
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qCWarning(TransectStyleComplexItemLog) << "Internal Error: _buildAndAppendMissionItems incorrect _cameraCalc.distanceMode" << _cameraCalc.distanceMode();
+        mavFrame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+        break;
+    }
 
     // Note: The code below is written to be understable as oppose to being compact and/or remove all duplicate code
     for (int coordIndex=0; coordIndex<_rgFlightPathCoordInfo.count(); coordIndex++) {
@@ -1155,9 +1232,18 @@ void TransectStyleComplexItem::_recalcComplexDistance(void)
 
 double TransectStyleComplexItem::amslEntryAlt(void) const
 {
-    double alt = qQNaN();
+    double alt                  = qQNaN();
+    double distanceToSurface    = _cameraCalc.distanceToSurface()->rawValue().toDouble();
 
-    if (_followTerrain) {
+    switch (_cameraCalc.distanceMode()) {
+    case QGroundControlQmlGlobal::AltitudeModeRelative:
+        alt = distanceToSurface + _missionController->plannedHomePosition().altitude();
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeAbsolute:
+        alt = distanceToSurface;
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain:
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
         if (_loadedMissionItems.count()) {
             // The first item might not be a waypoint we have to find it.
             MissionCommandTree* commandTree = qgcApp()->toolbox()->missionCommandTree();
@@ -1165,7 +1251,15 @@ double TransectStyleComplexItem::amslEntryAlt(void) const
                 MissionItem* item = _loadedMissionItems[i];
                 const MissionCommandUIInfo* uiInfo = commandTree->getUIInfo(_controllerVehicle, QGCMAVLink::VehicleClassGeneric, item->command());
                 if (uiInfo && uiInfo->specifiesCoordinate() && !uiInfo->isStandaloneCoordinate()) {
-                    alt = item->param7();
+                    if (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
+                        // AltitudeModeCalcAboveTerrain has AMSL alt in param 7
+                        alt = item->param7();
+                    } else {
+                        // AltitudeModeTerrainFrame has terrain frame relative alt in param 7. So we need terrain heights to calc AMSL.
+                        if (_rgPathHeightInfo.count()) {
+                            alt = item->param7() + _rgPathHeightInfo.first().heights.first();
+                        }
+                    }
                     break;
                 }
             }
@@ -1174,8 +1268,11 @@ double TransectStyleComplexItem::amslEntryAlt(void) const
                 alt = _rgFlightPathCoordInfo.first().coord.altitude();
             }
         }
-    } else {
-        alt = _cameraCalc.distanceToSurface()->rawValue().toDouble() + (_cameraCalc.distanceToSurfaceRelative() ? _missionController->plannedHomePosition().altitude() : 0) ;
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeMixed:
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qCWarning(TransectStyleComplexItemLog) << "Internal Error: amslEntryAlt incorrect _cameraCalc.distanceMode" << _cameraCalc.distanceMode();
+        break;
     }
 
     return alt;
@@ -1183,9 +1280,15 @@ double TransectStyleComplexItem::amslEntryAlt(void) const
 
 double TransectStyleComplexItem::amslExitAlt(void) const
 {
-    double alt = qQNaN();
+    double alt                  = qQNaN();
 
-    if (_followTerrain) {
+    switch (_cameraCalc.distanceMode()) {
+    case QGroundControlQmlGlobal::AltitudeModeRelative:
+    case QGroundControlQmlGlobal::AltitudeModeAbsolute:
+        alt = amslEntryAlt();
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain:
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
         if (_loadedMissionItems.count()) {
             // The last item might not be a waypoint we have to find it.
             MissionCommandTree* commandTree = qgcApp()->toolbox()->missionCommandTree();
@@ -1193,7 +1296,15 @@ double TransectStyleComplexItem::amslExitAlt(void) const
                 MissionItem* item = _loadedMissionItems[i];
                 const MissionCommandUIInfo* uiInfo = commandTree->getUIInfo(_controllerVehicle, QGCMAVLink::VehicleClassGeneric, item->command());
                 if (uiInfo && uiInfo->specifiesCoordinate() && !uiInfo->isStandaloneCoordinate()) {
-                    alt = item->param7();
+                    if (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
+                        // AltitudeModeCalcAboveTerrain has AMSL alt in param 7
+                        alt = item->param7();
+                    } else {
+                        // AltitudeModeTerrainFrame has terrain frame relative alt in param 7. So we need terrain heights to calc AMSL.
+                        if (_rgPathHeightInfo.count()) {
+                            alt = item->param7() + _rgPathHeightInfo.last().heights.last();
+                        }
+                    }
                     break;
                 }
             }
@@ -1202,8 +1313,11 @@ double TransectStyleComplexItem::amslExitAlt(void) const
                 alt = _rgFlightPathCoordInfo.last().coord.altitude();
             }
         }
-    } else {
-        alt = _cameraCalc.distanceToSurface()->rawValue().toDouble() + (_cameraCalc.distanceToSurfaceRelative() ? _missionController->plannedHomePosition().altitude() : 0) ;
+        break;
+    case QGroundControlQmlGlobal::AltitudeModeMixed:
+    case QGroundControlQmlGlobal::AltitudeModeNone:
+        qCWarning(TransectStyleComplexItemLog) << "Internal Error: amslExitAlt incorrect _cameraCalc.distanceMode" << _cameraCalc.distanceMode();
+        break;
     }
 
     return alt;
@@ -1213,23 +1327,26 @@ void TransectStyleComplexItem::applyNewAltitude(double newAltitude)
 {
     _cameraCalc.valueSetIsDistance()->setRawValue(true);
     _cameraCalc.distanceToSurface()->setRawValue(newAltitude);
-    _cameraCalc.setDistanceToSurfaceRelative(true);
 }
 
 double TransectStyleComplexItem::minAMSLAltitude(void) const
 {
-    if (_followTerrain) {
+    // FIXME: What about terrain frame
+
+    if (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
         return _minAMSLAltitude;
     } else {
-        return _cameraCalc.distanceToSurface()->rawValue().toDouble() + (_cameraCalc.distanceToSurfaceRelative() ? _missionController->plannedHomePosition().altitude() : 0);
+        return _cameraCalc.distanceToSurface()->rawValue().toDouble() + (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeRelative ? _missionController->plannedHomePosition().altitude() : 0);
     }
 }
 
 double TransectStyleComplexItem::maxAMSLAltitude(void) const
 {
-    if (_followTerrain) {
+    // FIXME: What about terrain frame
+
+    if (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain) {
         return _maxAMSLAltitude;
     } else {
-        return _cameraCalc.distanceToSurface()->rawValue().toDouble() + (_cameraCalc.distanceToSurfaceRelative() ? _missionController->plannedHomePosition().altitude() : 0);
+        return _cameraCalc.distanceToSurface()->rawValue().toDouble() + (_cameraCalc.distanceMode() == QGroundControlQmlGlobal::AltitudeModeRelative ? _missionController->plannedHomePosition().altitude() : 0);
     }
 }

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -42,7 +42,6 @@ public:
     Q_PROPERTY(bool             hoverAndCaptureAllowed      READ hoverAndCaptureAllowed                             CONSTANT)
     Q_PROPERTY(QVariantList     visualTransectPoints        READ visualTransectPoints                               NOTIFY visualTransectPointsChanged)
 
-    Q_PROPERTY(bool             followTerrain               READ followTerrain              WRITE setFollowTerrain  NOTIFY followTerrainChanged)
     Q_PROPERTY(Fact*            terrainAdjustTolerance      READ terrainAdjustTolerance                             CONSTANT)
     Q_PROPERTY(Fact*            terrainAdjustMaxDescentRate READ terrainAdjustMaxDescentRate                        CONSTANT)
     Q_PROPERTY(Fact*            terrainAdjustMaxClimbRate   READ terrainAdjustMaxClimbRate                          CONSTANT)
@@ -64,11 +63,8 @@ public:
     int             cameraShots             (void) const { return _cameraShots; }
     double          coveredArea             (void) const;
     bool            hoverAndCaptureAllowed  (void) const;
-    bool            followTerrain           (void) const { return _followTerrain; }
 
     virtual double  timeBetweenShots        (void) { return 0; } // Most be overridden. Implementation here is needed for unit testing.
-
-    void setFollowTerrain(bool followTerrain);
 
     double  triggerDistance         (void) const { return _cameraCalc.adjustedFootprintFrontal()->rawValue().toDouble(); }
     bool    hoverAndCaptureEnabled  (void) const { return hoverAndCapture()->rawValue().toBool(); }
@@ -128,7 +124,6 @@ signals:
     void timeBetweenShotsChanged        (void);
     void visualTransectPointsChanged    (void);
     void coveredAreaChanged             (void);
-    void followTerrainChanged           (bool followTerrain);
     void _updateFlightPathSegmentsSignal(void);
 
 protected slots:
@@ -188,7 +183,6 @@ protected:
     double          _timeBetweenShots = 0;
     double          _vehicleSpeed =     5;
     CameraCalc      _cameraCalc;
-    bool            _followTerrain =    false;
     double          _minAMSLAltitude =  qQNaN();
     double          _maxAMSLAltitude =  qQNaN();
 
@@ -209,7 +203,6 @@ protected:
     static const char* _jsonTransectStyleComplexItemKey;
     static const char* _jsonVisualTransectPointsKey;
     static const char* _jsonItemsKey;
-    static const char* _jsonTerrainFollowKey;
     static const char* _jsonTerrainFlightSpeed;
     static const char* _jsonCameraShotsKey;
 
@@ -218,10 +211,10 @@ protected:
 
 private slots:
     void _reallyQueryTransectsPathHeightInfo        (void);
-    void _followTerrainChanged                      (bool followTerrain);
     void _handleHoverAndCaptureEnabled              (QVariant enabled);
     void _updateFlightPathSegmentsDontCallDirectly  (void);
     void _segmentTerrainCollisionChanged            (bool terrainCollision) final;
+    void _distanceModeChanged                       (int distanceMode);
 
 private:
     typedef struct {
@@ -242,4 +235,7 @@ private:
 
     TerrainPolyPathQuery*       _currentTerrainFollowQuery =            nullptr;
     QTimer                      _terrainQueryTimer;
+
+    // Deprecated json keys
+    static const char* _jsonTerrainFollowKeyDeprecated;
 };

--- a/src/MissionManager/TransectStyleComplexItemTest.cc
+++ b/src/MissionManager/TransectStyleComplexItemTest.cc
@@ -9,6 +9,7 @@
 
 #include "TransectStyleComplexItemTest.h"
 #include "QGCApplication.h"
+#include "QGroundControlQmlGlobal.h"
 
 TransectStyleComplexItemTest::TransectStyleComplexItemTest(void)
 {
@@ -89,6 +90,8 @@ void TransectStyleComplexItemTest::_testRebuildTransects(void)
 {
     auto coveredAreaChangedMask         = _multiSpy->signalNameToMask(SIGNAL(coveredAreaChanged));
     auto lastSequenceNumberChangedMask  = _multiSpy->signalNameToMask(SIGNAL(lastSequenceNumberChanged));
+
+    _transectStyleItem->cameraCalc()->setCameraBrand(CameraCalc::xlatCustomCameraName());
 
     // Changing the survey polygon should trigger:
     //  _rebuildTransects calls
@@ -181,32 +184,6 @@ void TransectStyleComplexItemTest::_testDistanceSignalling(void)
     rgFacts.clear();
 }
 
-
-
-void TransectStyleComplexItemTest::_testAltMode(void)
-{
-    // Default should be relative
-    QVERIFY(_transectStyleItem->cameraCalc()->distanceToSurfaceRelative());
-
-    // Manual camera allows non-relative altitudes, validate that changing back to known
-    // camera switches back to relative
-    _transectStyleItem->cameraCalc()->setCameraBrand(CameraCalc::canonicalManualCameraName());
-    _transectStyleItem->cameraCalc()->setDistanceToSurfaceRelative(false);
-    _transectStyleItem->cameraCalc()->setCameraBrand(CameraCalc::canonicalCustomCameraName());
-    QVERIFY(_transectStyleItem->cameraCalc()->distanceToSurfaceRelative());
-
-    // When you turn off terrain following mode make sure that the altitude mode changed back to relative altitudes
-    _transectStyleItem->cameraCalc()->setDistanceToSurfaceRelative(false);
-    _transectStyleItem->setFollowTerrain(true);
-
-    QVERIFY(!_transectStyleItem->cameraCalc()->distanceToSurfaceRelative());
-    QVERIFY(_transectStyleItem->followTerrain());
-
-    _transectStyleItem->setFollowTerrain(false);
-    QVERIFY(_transectStyleItem->cameraCalc()->distanceToSurfaceRelative());
-    QVERIFY(!_transectStyleItem->followTerrain());
-}
-
 void TransectStyleComplexItemTest::_testAltitudes(void)
 {
     _transectStyleItem->cameraCalc()->distanceToSurface()->setRawValue(50);
@@ -229,7 +206,7 @@ void TransectStyleComplexItemTest::_testFollowTerrain(void)
 {
     _transectStyleItem->cameraCalc()->distanceToSurface()->setRawValue(50);
     _transectStyleItem->cameraCalc()->adjustedFootprintFrontal()->setRawValue(0);
-    _transectStyleItem->setFollowTerrain(true);
+    _transectStyleItem->cameraCalc()->setDistanceMode(QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain);
 
     QVERIFY(QTest::qWaitFor([&]() { return _transectStyleItem->readyForSaveState() == TransectStyleComplexItem::ReadyForSave; }, 2000));
 

--- a/src/MissionManager/TransectStyleComplexItemTest.h
+++ b/src/MissionManager/TransectStyleComplexItemTest.h
@@ -30,20 +30,13 @@ protected:
     void cleanup(void) final;
 
 private slots:
-    //void _testDirty             (void);
-    //void _testRebuildTransects  (void);
-    //void _testDistanceSignalling(void);
-    //void _testAltMode           (void);
-    void _testAltitudes         (void);
-    //void _testFollowTerrain     (void);
-
-private:
     void _testDirty             (void);
     void _testRebuildTransects  (void);
     void _testDistanceSignalling(void);
-    void _testAltMode           (void);
-    //void _testAltitudes         (void);
+    void _testAltitudes         (void);
     void _testFollowTerrain     (void);
+
+private:
     MultiSignalSpyV2*       _multiSpy =             nullptr;
     TestTransectStyleItem*  _transectStyleItem =    nullptr;
 };

--- a/src/PlanView/CameraCalcCamera.qml
+++ b/src/PlanView/CameraCalcCamera.qml
@@ -9,10 +9,8 @@ import QGroundControl.FactControls      1.0
 import QGroundControl.Palette           1.0
 
 // Camera calculator "Camera" section for mission item editors
-Column {
-    anchors.left:   parent.left
-    anchors.right:  parent.right
-    spacing:        _margin
+ColumnLayout {
+    spacing: _margin
 
     property var    cameraCalc
 
@@ -21,25 +19,23 @@ Column {
     property var    _vehicle:           QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
     property var    _vehicleCameraList: _vehicle ? _vehicle.staticCameraList : []
 
-    Component.onCompleted:{
+    Component.onCompleted: {
         cameraBrandCombo.selectCurrentBrand()
         cameraModelCombo.selectCurrentModel()
     }
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
-    Column {
-        anchors.left:   parent.left
-        anchors.right:  parent.right
-        spacing:        _margin
+    ColumnLayout {
+        Layout.fillWidth:   true
+        spacing:            _margin
 
         QGCComboBox {
-            id:             cameraBrandCombo
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            model:          cameraCalc.cameraBrandList
-            onModelChanged: selectCurrentBrand()
-            onActivated:    cameraCalc.cameraBrand = currentText
+            id:                 cameraBrandCombo
+            Layout.fillWidth:   true
+            model:              cameraCalc.cameraBrandList
+            onModelChanged:     selectCurrentBrand()
+            onActivated:        cameraCalc.cameraBrand = currentText
 
             Connections {
                 target:                 cameraCalc
@@ -52,13 +48,12 @@ Column {
         }
 
         QGCComboBox {
-            id:             cameraModelCombo
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            model:          cameraCalc.cameraModelList
-            visible:        !cameraCalc.isManualCamera && !cameraCalc.isCustomCamera
-            onModelChanged: selectCurrentModel()
-            onActivated:    cameraCalc.cameraModel = currentText
+            id:                 cameraModelCombo
+            Layout.fillWidth:   true
+            model:              cameraCalc.cameraModelList
+            visible:            !cameraCalc.isManualCamera && !cameraCalc.isCustomCamera
+            onModelChanged:     selectCurrentModel()
+            onActivated:        cameraCalc.cameraModel = currentText
 
             Connections {
                 target:                 cameraCalc
@@ -71,16 +66,15 @@ Column {
         }
 
         // Camera based grid ui
-        Column {
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            spacing:        _margin
-            visible:        !cameraCalc.isManualCamera
+        ColumnLayout {
+            Layout.fillWidth:   true
+            spacing:            _margin
+            visible:            !cameraCalc.isManualCamera
 
-            Row {
-                spacing:                    _margin
-                anchors.horizontalCenter:   parent.horizontalCenter
-                visible:                    !cameraCalc.fixedOrientation.value
+            RowLayout {
+                Layout.alignment:   Qt.AlignHCenter
+                spacing:            _margin
+                visible:            !cameraCalc.fixedOrientation.value
 
                 QGCRadioButton {
                     width:          _editFieldWidth
@@ -98,17 +92,16 @@ Column {
             }
 
             // Custom camera specs
-            Column {
-                id:             custCameraCol
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                spacing:        _margin
-                enabled:        cameraCalc.isCustomCamera
+            ColumnLayout {
+                id:                 custCameraCol
+                Layout.fillWidth:   true
+                spacing:            _margin
+                enabled:            cameraCalc.isCustomCamera
 
                 RowLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    spacing:        _margin
+                    Layout.fillWidth:   true
+                    spacing:            _margin
+
                     Item { Layout.fillWidth: true }
                     QGCLabel {
                         Layout.preferredWidth:  _root._fieldWidth
@@ -121,9 +114,9 @@ Column {
                 }
 
                 RowLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    spacing:        _margin
+                    Layout.fillWidth:   true
+                    spacing:            _margin
+
                     QGCLabel { text: qsTr("Sensor"); Layout.fillWidth: true }
                     FactTextField {
                         Layout.preferredWidth:  _root._fieldWidth
@@ -136,9 +129,9 @@ Column {
                 }
 
                 RowLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    spacing:        _margin
+                    Layout.fillWidth:   true
+                    spacing:            _margin
+
                     QGCLabel { text: qsTr("Image"); Layout.fillWidth: true }
                     FactTextField {
                         Layout.preferredWidth:  _root._fieldWidth
@@ -151,9 +144,8 @@ Column {
                 }
 
                 RowLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    spacing:        _margin
+                    Layout.fillWidth:   true
+                    spacing:            _margin
                     QGCLabel {
                         text:                   qsTr("Focal length")
                         Layout.fillWidth:       true
@@ -163,7 +155,7 @@ Column {
                         fact:                   cameraCalc.focalLength
                     }
                 }
-            } // Column - custom camera specs
-        } // Column - Camera spec based ui
-    } // Column - Camera Section
-} // Column
+            }
+        }
+    }
+}

--- a/src/PlanView/CameraCalcGrid.qml
+++ b/src/PlanView/CameraCalcGrid.qml
@@ -10,19 +10,15 @@ import QGroundControl.Palette           1.0
 
 // Camera calculator "Grid" section for mission item editors
 Column {
-    anchors.left:   parent.left
-    anchors.right:  parent.right
-    spacing:        _margin
+    spacing: _margin
 
     property var    cameraCalc
     property bool   vehicleFlightIsFrontal:         true
     property string distanceToSurfaceLabel
-    property int    distanceToSurfaceAltitudeMode:  QGroundControl.AltitudeModeNone
     property string frontalDistanceLabel
     property string sideDistanceLabel
 
     property real   _margin:            ScreenTools.defaultFontPixelWidth / 2
-    property string _cameraName:        cameraCalc.cameraName.value
     property real   _fieldWidth:        ScreenTools.defaultFontPixelWidth * 10.5
     property var    _cameraList:        [ ]
     property var    _vehicle:           QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
@@ -95,7 +91,7 @@ Column {
 
             AltitudeFactTextField {
                 fact:                       cameraCalc.distanceToSurface
-                altitudeMode:               distanceToSurfaceAltitudeMode
+                altitudeMode:               cameraCalc.distanceMode
                 enabled:                    fixedDistanceRadio.checked
                 Layout.fillWidth:           true
             }
@@ -128,7 +124,7 @@ Column {
         QGCLabel { text: distanceToSurfaceLabel }
         AltitudeFactTextField {
             fact:                       cameraCalc.distanceToSurface
-            altitudeMode:               distanceToSurfaceAltitudeMode
+            altitudeMode:               cameraCalc.distanceMode
             Layout.fillWidth:           true
         }
 

--- a/src/PlanView/CorridorScanEditor.qml
+++ b/src/PlanView/CorridorScanEditor.qml
@@ -13,247 +13,50 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.FlightMap     1.0
 
-Rectangle {
-    id:         _root
-    height:     visible ? (editorColumn.height + (_margin * 2)) : 0
-    width:      availableWidth
-    color:      qgcPal.windowShadeDark
-    radius:     _radius
+TransectStyleComplexItemEditor {
+    transectAreaDefinitionComplete: _missionItem.corridorPolyline.isValid
+    transectAreaDefinitionHelp:     qsTr("Use the Polyline Tools to create the polyline which defines the corridor.")
+    transectValuesHeaderName:       qsTr("Corridor")
+    transectValuesComponent:        _transectValuesComponent
+    presetsTransectValuesComponent: _transectValuesComponent
 
     // The following properties must be available up the hierarchy chain
-    //property real   availableWidth    ///< Width for control
-    //property var    missionItem       ///< Mission Item for editor
+    //  property real   availableWidth    ///< Width for control
+    //  property var    missionItem       ///< Mission Item for editor
 
-    property real   _margin:                    ScreenTools.defaultFontPixelWidth / 2
-    property real   _fieldWidth:                ScreenTools.defaultFontPixelWidth * 10.5
-    property var    _vehicle:                   QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
-    property real   _cameraMinTriggerInterval:  missionItem.cameraCalc.minTriggerInterval.rawValue
+    property real   _margin:        ScreenTools.defaultFontPixelWidth / 2
+    property var    _missionItem:   missionItem
 
-    function polygonCaptureStarted() {
-        missionItem.clearPolygon()
-    }
+    Component {
+        id: _transectValuesComponent
 
-    function polygonCaptureFinished(coordinates) {
-        for (var i=0; i<coordinates.length; i++) {
-            missionItem.addPolygonCoordinate(coordinates[i])
-        }
-    }
+        GridLayout {
+            columnSpacing:  _margin
+            rowSpacing:     _margin
+            columns:        2
 
-    function polygonAdjustVertex(vertexIndex, vertexCoordinate) {
-        missionItem.adjustPolygonCoordinate(vertexIndex, vertexCoordinate)
-    }
-
-    function polygonAdjustStarted() { }
-    function polygonAdjustFinished() { }
-
-    QGCPalette { id: qgcPal; colorGroupEnabled: true }
-
-    Column {
-        id:                 editorColumn
-        anchors.margins:    _margin
-        anchors.top:        parent.top
-        anchors.left:       parent.left
-        anchors.right:      parent.right
-
-        ColumnLayout {
-            id:             wizardModeColumn
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            spacing:        _margin
-            visible:        !missionItem.corridorPolyline.isValid || missionItem.wizardMode
+            QGCLabel { text: qsTr("Width") }
+            FactTextField {
+                fact:               _missionItem.corridorWidth
+                Layout.fillWidth:   true
+            }
 
             QGCLabel {
+                text:       qsTr("Turnaround dist")
+                visible:    !forPresets
+            }
+            FactTextField {
+                fact:               _missionItem.turnAroundDistance
                 Layout.fillWidth:   true
-                wrapMode:           Text.WordWrap
-                text:               qsTr("Use the Polyline Tools to create the polyline which defines the corridor.")
+                visible:            !forPresets
             }
 
-            /*
-              Trial of new "done" model so leaving for now in case it comes back
-            QGCButton {
-                text:               qsTr("Done With Polyline")
-                Layout.fillWidth:   true
-                enabled:            missionItem.corridorPolyline.isValid && !missionItem.corridorPolyline.traceMode
-                onClicked: {
-                    missionItem.wizardMode = false
-                    // Trial of no auto select next item
-                    //editorRoot.selectNextNotReadyItem()
-                }
-            }
-            */
-        }
-
-        Column {
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            spacing:        _margin
-            visible:        !wizardModeColumn.visible
-
-            QGCTabBar {
-                id:             tabBar
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-
-                Component.onCompleted: currentIndex = 0
-
-                QGCTabButton { text: qsTr("Grid") }
-                QGCTabButton { text: qsTr("Camera") }
-            }
-
-            Column {
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                spacing:            _margin
-                visible:            tabBar.currentIndex == 0
-
-                QGCLabel {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    text:           qsTr("WARNING: Photo interval is below minimum interval (%1 secs) supported by camera.").arg(_cameraMinTriggerInterval.toFixed(1))
-                    wrapMode:       Text.WordWrap
-                    color:          qgcPal.warningText
-                    visible:        missionItem.cameraShots > 0 && _cameraMinTriggerInterval !== 0 && _cameraMinTriggerInterval > missionItem.timeBetweenShots
-                }
-
-
-                CameraCalcGrid {
-                    cameraCalc:                     missionItem.cameraCalc
-                    vehicleFlightIsFrontal:         true
-                    distanceToSurfaceLabel:         qsTr("Altitude")
-                    distanceToSurfaceAltitudeMode:  missionItem.followTerrain ?
-                                                        QGroundControl.AltitudeModeCalcAboveTerrain :
-                                                        (missionItem.cameraCalc.distanceToSurfaceRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute)
-                    frontalDistanceLabel:           qsTr("Trigger Dist")
-                    sideDistanceLabel:              qsTr("Spacing")
-                }
-
-                SectionHeader {
-                    id:             corridorHeader
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    text:           qsTr("Corridor")
-                }
-
-                GridLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    columnSpacing:  _margin
-                    rowSpacing:     _margin
-                    columns:        2
-                    visible:        corridorHeader.checked
-
-                    QGCLabel { text: qsTr("Width") }
-                    FactTextField {
-                        fact:                   missionItem.corridorWidth
-                        Layout.fillWidth:       true
-                    }
-
-                    QGCLabel { text: qsTr("Turnaround dist") }
-                    FactTextField {
-                        fact:                   missionItem.turnAroundDistance
-                        Layout.fillWidth:       true
-                    }
-
-                    QGCOptionsComboBox {
-                        Layout.columnSpan:  2
-                        Layout.fillWidth:   true
-
-                        model: [
-                            {
-                                text:       qsTr("Images in turnarounds"),
-                                fact:       missionItem.cameraTriggerInTurnAround,
-                                enabled:    missionItem.hoverAndCaptureAllowed ? !missionItem.hoverAndCapture.rawValue : true,
-                                visible:    true
-                            },
-                            {
-                                text:       qsTr("Relative altitude"),
-                                enabled:    missionItem.cameraCalc.isManualCamera && !missionItem.followTerrain,
-                                visible:    QGroundControl.corePlugin.options.showMissionAbsoluteAltitude || (!missionItem.cameraCalc.distanceToSurfaceRelative && !missionItem.followTerrain),
-                                checked:    missionItem.cameraCalc.distanceToSurfaceRelative
-                            }
-                        ]
-
-                        onItemClicked: {
-                            if (index == 1) {
-                                missionItem.cameraCalc.distanceToSurfaceRelative = !missionItem.cameraCalc.distanceToSurfaceRelative
-                                console.log(missionItem.cameraCalc.distanceToSurfaceRelative)
-                            }
-                        }
-                    }
-                }
-
-                QGCButton {
-                    text:       qsTr("Rotate Entry Point")
-                    onClicked:  missionItem.rotateEntryPoint()
-                }
-
-                SectionHeader {
-                    id:             terrainHeader
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    text:           qsTr("Terrain")
-                    checked:        missionItem.followTerrain
-                }
-
-                ColumnLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    spacing:        _margin
-                    visible:        terrainHeader.checked
-
-                    QGCCheckBox {
-                        id:         followsTerrainCheckBox
-                        text:       qsTr("Vehicle follows terrain")
-                        checked:    missionItem.followTerrain
-                        onClicked:  missionItem.followTerrain = checked
-                    }
-
-                    GridLayout {
-                        Layout.fillWidth:   true
-                        columnSpacing:      _margin
-                        rowSpacing:         _margin
-                        columns:            2
-                        visible:            followsTerrainCheckBox.checked
-
-                        QGCLabel { text: qsTr("Tolerance") }
-                        FactTextField {
-                            fact:               missionItem.terrainAdjustTolerance
-                            Layout.fillWidth:   true
-                        }
-
-                        QGCLabel { text: qsTr("Max Climb Rate") }
-                        FactTextField {
-                            fact:               missionItem.terrainAdjustMaxClimbRate
-                            Layout.fillWidth:   true
-                        }
-
-                        QGCLabel { text: qsTr("Max Descent Rate") }
-                        FactTextField {
-                            fact:               missionItem.terrainAdjustMaxDescentRate
-                            Layout.fillWidth:   true
-                        }
-                    }
-                }
-
-                SectionHeader {
-                    id:             statsHeader
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    text:           qsTr("Statistics")
-                }
-
-                TransectStyleComplexItemStats { }
-            } // Grid Column
-
-            Column {
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                spacing:            _margin
-                visible:            tabBar.currentIndex == 1
-
-                CameraCalcCamera {
-                    cameraCalc: missionItem.cameraCalc
-                }
+            FactCheckBox {
+                Layout.columnSpan:  2
+                text:               qsTr("Images in turnarounds")
+                fact:               _missionItem.cameraTriggerInTurnAround
+                enabled:            _missionItem.hoverAndCaptureAllowed ? !_missionItem.hoverAndCapture.rawValue : true
+                visible:            !forPresets
             }
         }
     }

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -21,7 +21,6 @@ Rectangle {
     property real _margin:                  ScreenTools.defaultFontPixelHeight / 2
     property real _altRectMargin:           ScreenTools.defaultFontPixelWidth / 2
     property var  _controllerVehicle:       missionItem.masterController.controllerVehicle
-    property bool _supportsTerrainFrame:    _controllerVehicle.supportsTerrainFrame
     property int  _globalAltMode:           missionItem.masterController.missionController.globalAltitudeMode
     property bool _globalAltModeIsMixed:    _globalAltMode == QGroundControl.AltitudeModeMixed
     property real _radius:                  ScreenTools.defaultFontPixelWidth / 2
@@ -144,9 +143,6 @@ Rectangle {
                             }
                             if (!QGroundControl.corePlugin.options.showMissionAbsoluteAltitude && missionItem.altitudeMode !== QGroundControl.AltitudeModeAbsolute) {
                                 removeModes.push(QGroundControl.AltitudeModeAbsolute)
-                            }
-                            if (!_supportsTerrainFrame) {
-                                removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
                             }
                             removeModes.push(QGroundControl.AltitudeModeMixed)
                             mainWindow.showPopupDialogFromComponent(altModeDialogComponent, { rgRemoveModes: removeModes, updateAltModeFn: updateFunction })

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -128,7 +128,6 @@ Rectangle {
                     cameraCalc:                     missionItem.cameraCalc
                     vehicleFlightIsFrontal:         false
                     distanceToSurfaceLabel:         qsTr("Scan Distance")
-                    distanceToSurfaceAltitudeMode:  QGroundControl.AltitudeModeNone
                     frontalDistanceLabel:           qsTr("Layer Height")
                     sideDistanceLabel:              qsTr("Trigger Distance")
                 }

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -13,392 +13,91 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.FlightMap     1.0
 
-Rectangle {
-    id:         _root
-    height:     visible ? (editorColumn.height + (_margin * 2)) : 0
-    width:      availableWidth
-    color:      qgcPal.windowShadeDark
-    radius:     _radius
+TransectStyleComplexItemEditor {
+    transectAreaDefinitionComplete: missionItem.surveyAreaPolygon.isValid
+    transectAreaDefinitionHelp:     qsTr("Use the Polygon Tools to create the polygon which outlines your survey area.")
+    transectValuesHeaderName:       qsTr("Transects")
+    transectValuesComponent:        _transectValuesComponent
+    presetsTransectValuesComponent: _transectValuesComponent
 
     // The following properties must be available up the hierarchy chain
-    //property real   availableWidth    ///< Width for control
-    //property var    missionItem       ///< Mission Item for editor
+    //  property real   availableWidth    ///< Width for control
+    //  property var    missionItem       ///< Mission Item for editor
 
-    property real   _margin:                    ScreenTools.defaultFontPixelWidth / 2
-    property real   _fieldWidth:                ScreenTools.defaultFontPixelWidth * 10.5
-    property var    _vehicle:                   QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
-    property real   _cameraMinTriggerInterval:  _missionItem.cameraCalc.minTriggerInterval.rawValue
-    property bool   _polygonDone:               false
-    property string _doneAdjusting:             qsTr("Done")
-    property var    _missionItem:               missionItem
-    property bool   _presetsAvailable:          _missionItem.presetNames.length !== 0
+    property real   _margin:        ScreenTools.defaultFontPixelWidth / 2
+    property var    _missionItem:   missionItem
 
-    function polygonCaptureStarted() {
-        _missionItem.clearPolygon()
-    }
+    Component {
+        id: _transectValuesComponent
 
-    function polygonCaptureFinished(coordinates) {
-        for (var i=0; i<coordinates.length; i++) {
-            _missionItem.addPolygonCoordinate(coordinates[i])
-        }
-    }
+        GridLayout {
+            Layout.fillWidth:   true
+            columnSpacing:      _margin
+            rowSpacing:         _margin
+            columns:            2
 
-    function polygonAdjustVertex(vertexIndex, vertexCoordinate) {
-        _missionItem.adjustPolygonCoordinate(vertexIndex, vertexCoordinate)
-    }
+            QGCLabel { text: qsTr("Angle") }
+            FactTextField {
+                fact:                   missionItem.gridAngle
+                Layout.fillWidth:       true
+                onUpdated:              angleSlider.value = missionItem.gridAngle.value
+            }
 
-    function polygonAdjustStarted() { }
-    function polygonAdjustFinished() { }
+            QGCSlider {
+                id:                     angleSlider
+                minimumValue:           0
+                maximumValue:           359
+                stepSize:               1
+                tickmarksEnabled:       false
+                Layout.fillWidth:       true
+                Layout.columnSpan:      2
+                Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.5
+                onValueChanged:         missionItem.gridAngle.value = value
+                Component.onCompleted:  value = missionItem.gridAngle.value
+                updateValueWhileDragging: true
+            }
 
-    QGCPalette { id: qgcPal; colorGroupEnabled: true }
-
-    Column {
-        id:                 editorColumn
-        anchors.margins:    _margin
-        anchors.top:        parent.top
-        anchors.left:       parent.left
-        anchors.right:      parent.right
-
-        ColumnLayout {
-            id:             wizardColumn
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            spacing:        _margin
-            visible:        !_missionItem.surveyAreaPolygon.isValid || _missionItem.wizardMode
-
-            ColumnLayout {
+            QGCLabel {
+                text:       qsTr("Turnaround dist")
+                visible:    !forPresets
+            }
+            FactTextField {
                 Layout.fillWidth:   true
-                spacing:             _margin
-                visible:            !_polygonDone
-
-                QGCLabel {
-                    Layout.fillWidth:       true
-                    wrapMode:               Text.WordWrap
-                    horizontalAlignment:    Text.AlignHCenter
-                    text:                   qsTr("Use the Polygon Tools to create the polygon which outlines your survey area.")
-                }
-            }
-        }
-
-        Column {
-            anchors.left:   parent.left
-            anchors.right:  parent.right
-            spacing:        _margin
-            visible:        !wizardColumn.visible
-
-            TransectStyleComplexItemTabBar {
-                id:             tabBar
-                anchors.left:   parent.left
-                anchors.right:  parent.right
+                fact:               missionItem.turnAroundDistance
+                visible:            !forPresets
             }
 
-            // Grid tab
-            Column {
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                spacing:            _margin
-                visible:            tabBar.currentIndex === 0
+            QGCOptionsComboBox {
+                Layout.columnSpan:  2
+                Layout.fillWidth:   true
+                visible:            !forPresets
 
-                QGCLabel {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    text:           qsTr("WARNING: Photo interval is below minimum interval (%1 secs) supported by camera.").arg(_cameraMinTriggerInterval.toFixed(1))
-                    wrapMode:       Text.WordWrap
-                    color:          qgcPal.warningText
-                    visible:        _missionItem.cameraShots > 0 && _cameraMinTriggerInterval !== 0 && _cameraMinTriggerInterval > _missionItem.timeBetweenShots
-                }
-
-                CameraCalcGrid {
-                    cameraCalc:                     _missionItem.cameraCalc
-                    vehicleFlightIsFrontal:         true
-                    distanceToSurfaceLabel:         qsTr("Altitude")
-                    distanceToSurfaceAltitudeMode:  _missionItem.followTerrain ?
-                                                        QGroundControl.AltitudeModeCalcAboveTerrain :
-                                                        (_missionItem.cameraCalc.distanceToSurfaceRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute)
-                    frontalDistanceLabel:           qsTr("Trigger Dist")
-                    sideDistanceLabel:              qsTr("Spacing")
-                }
-
-                SectionHeader {
-                    id:             transectsHeader
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    text:           qsTr("Transects")
-                }
-
-                GridLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    columnSpacing:  _margin
-                    rowSpacing:     _margin
-                    columns:        2
-                    visible:        transectsHeader.checked
-
-                    QGCLabel { text: qsTr("Angle") }
-                    FactTextField {
-                        fact:                   _missionItem.gridAngle
-                        Layout.fillWidth:       true
-                        onUpdated:              angleSlider.value = _missionItem.gridAngle.value
+                model: [
+                    {
+                        text:       qsTr("Hover and capture image"),
+                        fact:       missionItem.hoverAndCapture,
+                        enabled:    missionItem.cameraCalc.distanceMode === QGroundControl.AltitudeModeRelative || missionItem.cameraCalc.distanceMode === QGroundControl.AltitudeModeAbsolute,
+                        visible:    missionItem.hoverAndCaptureAllowed
+                    },
+                    {
+                        text:       qsTr("Refly at 90 deg offset"),
+                        fact:       missionItem.refly90Degrees,
+                        enabled:    missionItem.cameraCalc.distanceMode !== QGroundControl.AltitudeModeCalcAboveTerrain,
+                        visible:    true
+                    },
+                    {
+                        text:       qsTr("Images in turnarounds"),
+                        fact:       missionItem.cameraTriggerInTurnAround,
+                        enabled:    missionItem.hoverAndCaptureAllowed ? !missionItem.hoverAndCapture.rawValue : true,
+                        visible:    true
+                    },
+                    {
+                        text:       qsTr("Fly alternate transects"),
+                        fact:       missionItem.flyAlternateTransects,
+                        enabled:    true,
+                        visible:    _vehicle ? (_vehicle.fixedWing || _vehicle.vtol) : false
                     }
-
-                    QGCSlider {
-                        id:                     angleSlider
-                        minimumValue:           0
-                        maximumValue:           359
-                        stepSize:               1
-                        tickmarksEnabled:       false
-                        Layout.fillWidth:       true
-                        Layout.columnSpan:      2
-                        Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.5
-                        onValueChanged:         _missionItem.gridAngle.value = value
-                        Component.onCompleted:  value = _missionItem.gridAngle.value
-                        updateValueWhileDragging: true
-                    }
-
-                    QGCLabel {
-                        text:       qsTr("Turnaround dist")
-                    }
-                    FactTextField {
-                        fact:               _missionItem.turnAroundDistance
-                        Layout.fillWidth:   true
-                    }
-                }
-
-                QGCButton {
-                    text:               qsTr("Rotate Entry Point")
-                    onClicked:          _missionItem.rotateEntryPoint();
-                }
-
-                ColumnLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    spacing:        _margin
-                    visible:        transectsHeader.checked
-
-                    QGCOptionsComboBox {
-                        Layout.fillWidth: true
-
-                        model: [
-                            {
-                                text:       qsTr("Hover and capture image"),
-                                fact:       _missionItem.hoverAndCapture,
-                                enabled:    !_missionItem.followTerrain,
-                                visible:    _missionItem.hoverAndCaptureAllowed
-                            },
-                            {
-                                text:       qsTr("Refly at 90 deg offset"),
-                                fact:       _missionItem.refly90Degrees,
-                                enabled:    !_missionItem.followTerrain,
-                                visible:    true
-                            },
-                            {
-                                text:       qsTr("Images in turnarounds"),
-                                fact:       _missionItem.cameraTriggerInTurnAround,
-                                enabled:    _missionItem.hoverAndCaptureAllowed ? !_missionItem.hoverAndCapture.rawValue : true,
-                                visible:    true
-                            },
-                            {
-                                text:       qsTr("Fly alternate transects"),
-                                fact:       _missionItem.flyAlternateTransects,
-                                enabled:    true,
-                                visible:    _vehicle ? (_vehicle.fixedWing || _vehicle.vtol) : false
-                            },
-                            {
-                                text:       qsTr("Relative altitude"),
-                                enabled:    _missionItem.cameraCalc.isManualCamera && !_missionItem.followTerrain,
-                                visible:    QGroundControl.corePlugin.options.showMissionAbsoluteAltitude || (!_missionItem.cameraCalc.distanceToSurfaceRelative && !_missionItem.followTerrain),
-                                checked:    _missionItem.cameraCalc.distanceToSurfaceRelative
-                            }
-                        ]
-
-                        onItemClicked: {
-                            if (index == 4) {
-                                _missionItem.cameraCalc.distanceToSurfaceRelative = !_missionItem.cameraCalc.distanceToSurfaceRelative
-                                console.log(_missionItem.cameraCalc.distanceToSurfaceRelative)
-                            }
-                        }
-                    }
-                }
-
-                SectionHeader {
-                    id:             statsHeader
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    text:           qsTr("Statistics")
-                }
-
-                TransectStyleComplexItemStats {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    visible:        statsHeader.checked
-                }
-            } // Grid Column
-
-            // Camera Tab
-            Column {
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                spacing:            _margin
-                visible:            tabBar.currentIndex === 1
-
-                CameraCalcCamera {
-                    cameraCalc: _missionItem.cameraCalc
-                }
-            } // Camera Column
-
-            // Terrain Tab
-            TransectStyleComplexItemTerrainFollow {
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                spacing:        _margin
-                visible:        tabBar.currentIndex === 2
-                missionItem:    _missionItem
-            }
-
-            // Presets Tab
-            ColumnLayout {
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                spacing:            _margin
-                visible:            tabBar.currentIndex === 3
-
-                QGCLabel {
-                    Layout.fillWidth:   true
-                    text:               qsTr("Presets")
-                    wrapMode:           Text.WordWrap
-                }
-
-                QGCComboBox {
-                    id:                 presetCombo
-                    Layout.fillWidth:   true
-                    model:              _missionItem.presetNames
-                }
-
-                RowLayout {
-                    Layout.fillWidth:   true
-
-                    QGCButton {
-                        Layout.fillWidth:   true
-                        text:               qsTr("Apply Preset")
-                        enabled:            _missionItem.presetNames.length != 0
-                        onClicked:          _missionItem.loadPreset(presetCombo.textAt(presetCombo.currentIndex))
-                    }
-
-                    QGCButton {
-                        Layout.fillWidth:   true
-                        text:               qsTr("Delete Preset")
-                        enabled:            _missionItem.presetNames.length != 0
-                        onClicked:          mainWindow.showComponentDialog(deletePresetMessage, qsTr("Delete Preset"), mainWindow.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
-
-                        Component {
-                            id: deletePresetMessage
-                            QGCViewMessage {
-                                message: qsTr("Are you sure you want to delete '%1' preset?").arg(presetName)
-                                property string presetName: presetCombo.textAt(presetCombo.currentIndex)
-                                function accept() {
-                                    _missionItem.deletePreset(presetName)
-                                    hideDialog()
-                                }
-                            }
-                        }
-                    }
-                }
-
-                Item { height: ScreenTools.defaultFontPixelHeight; width: 1 }
-
-                QGCButton {
-                    Layout.alignment:   Qt.AlignCenter
-                    Layout.fillWidth:   true
-                    text:               qsTr("Save Settings As New Preset")
-                    onClicked:          mainWindow.showComponentDialog(savePresetDialog, qsTr("Save Preset"), mainWindow.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel)
-                }
-
-                SectionHeader {
-                    id:                 presectsTransectsHeader
-                    Layout.fillWidth:   true
-                    text:               qsTr("Transects")
-                }
-
-                GridLayout {
-                    Layout.fillWidth:   true
-                    columnSpacing:      _margin
-                    rowSpacing:         _margin
-                    columns:            2
-                    visible:            presectsTransectsHeader.checked
-
-                    QGCLabel { text: qsTr("Angle") }
-                    FactTextField {
-                        fact:                   _missionItem.gridAngle
-                        Layout.fillWidth:       true
-                        onUpdated:              presetsAngleSlider.value = _missionItem.gridAngle.value
-                    }
-
-                    QGCSlider {
-                        id:                     presetsAngleSlider
-                        minimumValue:           0
-                        maximumValue:           359
-                        stepSize:               1
-                        tickmarksEnabled:       false
-                        Layout.fillWidth:       true
-                        Layout.columnSpan:      2
-                        Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.5
-                        onValueChanged:         _missionItem.gridAngle.value = value
-                        Component.onCompleted:  value = _missionItem.gridAngle.value
-                        updateValueWhileDragging: true
-                    }
-
-                    QGCButton {
-                        Layout.columnSpan:  2
-                        Layout.fillWidth:   true
-                        text:               qsTr("Rotate Entry Point")
-                        onClicked:          _missionItem.rotateEntryPoint();
-                    }
-                }
-
-                SectionHeader {
-                    id:                 presetsStatsHeader
-                    Layout.fillWidth:   true
-                    text:               qsTr("Statistics")
-                }
-
-                TransectStyleComplexItemStats {
-                    Layout.fillWidth:   true
-                    visible:            presetsStatsHeader.checked
-                }
-            } // Main editing column
-        } // Top level  Column
-
-        Component {
-            id: savePresetDialog
-
-            QGCViewDialog {
-                function accept() {
-                    if (presetNameField.text != "") {
-                        _missionItem.savePreset(presetNameField.text)
-                        hideDialog()
-                    }
-                }
-
-                ColumnLayout {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
-                    spacing:        ScreenTools.defaultFontPixelHeight
-
-                    QGCLabel {
-                        Layout.fillWidth:   true
-                        text:               qsTr("Save the current settings as a named preset.")
-                        wrapMode:           Text.WordWrap
-                    }
-
-                    QGCLabel {
-                        text: qsTr("Preset Name")
-                    }
-
-                    QGCTextField {
-                        id:                 presetNameField
-                        Layout.fillWidth:   true
-                    }
-                }
+                ]
             }
         }
     }
@@ -409,10 +108,10 @@ Rectangle {
         selectExisting: true
 
         onAcceptedForLoad: {
-            _missionItem.surveyAreaPolygon.loadKMLOrSHPFile(file)
-            _missionItem.resetState = false
-            //editorMap.mapFitFunctions.fitMapViewportTo_missionItems()
+            missionItem.surveyAreaPolygon.loadKMLOrSHPFile(file)
+            missionItem.resetState = false
+            //editorMap.mapFitFunctions.fitMapViewportTomissionItems()
             close()
         }
     }
-} // Rectangle
+}

--- a/src/PlanView/TransectStyleComplexItemEditor.qml
+++ b/src/PlanView/TransectStyleComplexItemEditor.qml
@@ -1,0 +1,274 @@
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Dialogs  1.2
+import QtQuick.Extras   1.4
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.FlightMap     1.0
+
+Rectangle {
+    id:         _root
+    height:     childrenRect.y + childrenRect.height + _margin
+    width:      availableWidth
+    color:      qgcPal.windowShadeDark
+    radius:     _radius
+
+    property bool   transectAreaDefinitionComplete: true
+    property string transectAreaDefinitionHelp:     _internalError
+    property string transectValuesHeaderName:       _internalError
+    property var    transectValuesComponent:        undefined
+    property var    presetsTransectValuesComponent: undefined
+
+    readonly property string _internalError: "Internal Error"
+
+    property var    _missionItem:               missionItem
+    property real   _margin:                    ScreenTools.defaultFontPixelWidth / 2
+    property real   _fieldWidth:                ScreenTools.defaultFontPixelWidth * 10.5
+    property var    _vehicle:                   QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
+    property real   _cameraMinTriggerInterval:  _missionItem.cameraCalc.minTriggerInterval.rawValue
+    property string _doneAdjusting:             qsTr("Done")
+    property bool   _presetsAvailable:          _missionItem.presetNames.length !== 0
+
+    function polygonCaptureStarted() {
+        _missionItem.clearPolygon()
+    }
+
+    function polygonCaptureFinished(coordinates) {
+        for (var i=0; i<coordinates.length; i++) {
+            _missionItem.addPolygonCoordinate(coordinates[i])
+        }
+    }
+
+    function polygonAdjustVertex(vertexIndex, vertexCoordinate) {
+        _missionItem.adjustPolygonCoordinate(vertexIndex, vertexCoordinate)
+    }
+
+    function polygonAdjustStarted() { }
+    function polygonAdjustFinished() { }
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    ColumnLayout {
+        id:                 editorColumn
+        anchors.margins:    _margin
+        anchors.top:        parent.top
+        anchors.left:       parent.left
+        anchors.right:      parent.right
+
+        QGCLabel {
+            id:                     transectAreaDefinitionCompleteLabel
+            Layout.fillWidth:       true
+            wrapMode:               Text.WordWrap
+            horizontalAlignment:    Text.AlignHCenter
+            text:                   transectAreaDefinitionHelp
+            visible:                !transectAreaDefinitionComplete || _missionItem.wizardMode
+        }
+
+        ColumnLayout {
+            Layout.fillWidth:   true
+            spacing:            _margin
+            visible:            transectAreaDefinitionComplete && !_missionItem.wizardMode
+
+            TransectStyleComplexItemTabBar {
+                id:                 tabBar
+                Layout.fillWidth:   true
+            }
+
+            // Grid tab
+            ColumnLayout {
+                Layout.fillWidth:   true
+                spacing:            _margin
+                visible:            tabBar.currentIndex === 0
+
+                QGCLabel {
+                    Layout.fillWidth:   true
+                    text:               qsTr("WARNING: Photo interval is below minimum interval (%1 secs) supported by camera.").arg(_cameraMinTriggerInterval.toFixed(1))
+                    wrapMode:           Text.WordWrap
+                    color:              qgcPal.warningText
+                    visible:            _missionItem.cameraShots > 0 && _cameraMinTriggerInterval !== 0 && _cameraMinTriggerInterval > _missionItem.timeBetweenShots
+                }
+
+                CameraCalcGrid {
+                    Layout.fillWidth:               true
+                    cameraCalc:                     _missionItem.cameraCalc
+                    vehicleFlightIsFrontal:         true
+                    distanceToSurfaceLabel:         qsTr("Altitude")
+                    frontalDistanceLabel:           qsTr("Trigger Dist")
+                    sideDistanceLabel:              qsTr("Spacing")
+                }
+
+                SectionHeader {
+                    id:                 transectValuesHeader
+                    Layout.fillWidth:   true
+                    text:               transectValuesHeaderName
+                }
+
+                Loader {
+                    Layout.fillWidth:   true
+                    visible:            transectValuesHeader.checked
+                    sourceComponent:    transectValuesComponent
+
+                    property bool forPresets: false
+                }
+
+                QGCButton {
+                    Layout.alignment:   Qt.AlignHCenter
+                    text:               qsTr("Rotate Entry Point")
+                    onClicked:          _missionItem.rotateEntryPoint()
+                    visible:            transectValuesHeader.checked
+                }
+
+                SectionHeader {
+                    id:                 statsHeader
+                    Layout.fillWidth:   true
+                    text:               qsTr("Statistics")
+                }
+
+                TransectStyleComplexItemStats {
+                    Layout.fillWidth:   true
+                    visible:            statsHeader.checked
+                }
+            } // Grid Column
+
+            // Camera Tab
+            CameraCalcCamera {
+                Layout.fillWidth:   true
+                visible:            tabBar.currentIndex === 1
+                cameraCalc:         _missionItem.cameraCalc
+            }
+
+            // Terrain Tab
+            TransectStyleComplexItemTerrainFollow {
+                Layout.fillWidth:   true
+                spacing:            _margin
+                visible:            tabBar.currentIndex === 2
+                missionItem:        _missionItem
+            }
+
+            // Presets Tab
+            ColumnLayout {
+                Layout.fillWidth:   true
+                spacing:            _margin
+                visible:            tabBar.currentIndex === 3
+
+                QGCLabel {
+                    Layout.fillWidth:   true
+                    text:               qsTr("Presets")
+                    wrapMode:           Text.WordWrap
+                }
+
+                QGCComboBox {
+                    id:                 presetCombo
+                    Layout.fillWidth:   true
+                    model:              _missionItem.presetNames
+                }
+
+                RowLayout {
+                    Layout.fillWidth:   true
+
+                    QGCButton {
+                        Layout.fillWidth:   true
+                        text:               qsTr("Apply Preset")
+                        enabled:            _missionItem.presetNames.length != 0
+                        onClicked:          _missionItem.loadPreset(presetCombo.textAt(presetCombo.currentIndex))
+                    }
+
+                    QGCButton {
+                        Layout.fillWidth:   true
+                        text:               qsTr("Delete Preset")
+                        enabled:            _missionItem.presetNames.length != 0
+                        onClicked:          mainWindow.showComponentDialog(deletePresetMessage, qsTr("Delete Preset"), mainWindow.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
+
+                        Component {
+                            id: deletePresetMessage
+                            QGCViewMessage {
+                                message: qsTr("Are you sure you want to delete '%1' preset?").arg(presetName)
+                                property string presetName: presetCombo.textAt(presetCombo.currentIndex)
+                                function accept() {
+                                    _missionItem.deletePreset(presetName)
+                                    hideDialog()
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Item { height: ScreenTools.defaultFontPixelHeight; width: 1 }
+
+                QGCButton {
+                    Layout.alignment:   Qt.AlignCenter
+                    Layout.fillWidth:   true
+                    text:               qsTr("Save Settings As New Preset")
+                    onClicked:          mainWindow.showComponentDialog(savePresetDialog, qsTr("Save Preset"), mainWindow.showDialogDefaultWidth, StandardButton.Save | StandardButton.Cancel)
+                }
+
+                SectionHeader {
+                    id:                 presectsTransectValuesHeader
+                    Layout.fillWidth:   true
+                    text:               transectValuesHeaderName
+                    visible:            !!presetsTransectValuesComponent
+                }
+
+                Loader {
+                    Layout.fillWidth:   true
+                    visible:            presectsTransectValuesHeader.checked && !!presetsTransectValuesComponent
+                    sourceComponent:    presetsTransectValuesComponent
+
+                    property bool forPresets: true
+                }
+
+                SectionHeader {
+                    id:                 presetsStatsHeader
+                    Layout.fillWidth:   true
+                    text:               qsTr("Statistics")
+                }
+
+                TransectStyleComplexItemStats {
+                    Layout.fillWidth:   true
+                    visible:            presetsStatsHeader.checked
+                }
+            } // Main editing column
+        } // Top level  Column
+
+        Component {
+            id: savePresetDialog
+
+            QGCViewDialog {
+                function accept() {
+                    if (presetNameField.text != "") {
+                        _missionItem.savePreset(presetNameField.text)
+                        hideDialog()
+                    }
+                }
+
+                ColumnLayout {
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    spacing:        ScreenTools.defaultFontPixelHeight
+
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        text:               qsTr("Save the current settings as a named preset.")
+                        wrapMode:           Text.WordWrap
+                    }
+
+                    QGCLabel {
+                        text: qsTr("Preset Name")
+                    }
+
+                    QGCTextField {
+                        id:                 presetNameField
+                        Layout.fillWidth:   true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/PlanView/TransectStyleComplexItemTabBar.qml
+++ b/src/PlanView/TransectStyleComplexItemTabBar.qml
@@ -5,9 +5,7 @@ import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0
 
 QGCTabBar {
-    id:             tabBar
-    anchors.left:   parent.left
-    anchors.right:  parent.right
+    id: tabBar
 
     Component.onCompleted: currentIndex = QGroundControl.settingsManager.planViewSettings.displayPresetsTabFirst.rawValue ? 2 : 0
 

--- a/src/QmlControls/FlightPathSegment.cc
+++ b/src/QmlControls/FlightPathSegment.cc
@@ -143,31 +143,34 @@ void FlightPathSegment::_updateTotalDistance(void)
 
 void FlightPathSegment::_updateTerrainCollision(void)
 {
-    double slope =      (_coord2AMSLAlt - _coord1AMSLAlt) / _totalDistance;
-    double yIntercept = _coord1AMSLAlt;
-
     bool newTerrainCollision = false;
-    double x = 0;
-    for (int i=0; i<_amslTerrainHeights.count(); i++) {
-        bool ignoreCollision = false;
-        if (_segmentType == SegmentTypeTakeoff && x < _collisionIgnoreMeters) {
-            ignoreCollision = true;
-        } else if (_segmentType == SegmentTypeLand && x > _totalDistance - _collisionIgnoreMeters) {
-            ignoreCollision = true;
-        }
 
-        if (!ignoreCollision) {
-            double y = _amslTerrainHeights[i].value<double>();
-            if (y > (slope * x) + yIntercept) {
-                newTerrainCollision = true;
-                break;
+    if (_segmentType != SegmentTypeTerrainFrame) {
+        double slope =      (_coord2AMSLAlt - _coord1AMSLAlt) / _totalDistance;
+        double yIntercept = _coord1AMSLAlt;
+
+        double x = 0;
+        for (int i=0; i<_amslTerrainHeights.count(); i++) {
+            bool ignoreCollision = false;
+            if (_segmentType == SegmentTypeTakeoff && x < _collisionIgnoreMeters) {
+                ignoreCollision = true;
+            } else if (_segmentType == SegmentTypeLand && x > _totalDistance - _collisionIgnoreMeters) {
+                ignoreCollision = true;
             }
-        }
 
-        if (i == _amslTerrainHeights.count() - 2) {
-            x += _finalDistanceBetween;
-        } else {
-            x += _distanceBetween;
+            if (!ignoreCollision) {
+                double y = _amslTerrainHeights[i].value<double>();
+                if (y > (slope * x) + yIntercept) {
+                    newTerrainCollision = true;
+                    break;
+                }
+            }
+
+            if (i == _amslTerrainHeights.count() - 2) {
+                x += _finalDistanceBetween;
+            } else {
+                x += _distanceBetween;
+            }
         }
     }
 

--- a/src/QmlControls/FlightPathSegment.h
+++ b/src/QmlControls/FlightPathSegment.h
@@ -25,9 +25,10 @@ class FlightPathSegment : public QObject
     
 public:
     enum SegmentType {
-        SegmentTypeTakeoff, // Takeoff segments ignore the first part of the segment for terrain collisions
-        SegmentTypeGeneric, // Generic segments take into account the entire segment for terrain collisions
-        SegmentTypeLand     // Land segments ignore the last part of the segment for terrain collisions
+        SegmentTypeTakeoff,         // Takeoff segments ignore the first part of the segment for terrain collisions
+        SegmentTypeGeneric,         // Generic segments take into account the entire segment for terrain collisions
+        SegmentTypeLand,            // Land segments ignore the last part of the segment for terrain collisions
+        SegmentTypeTerrainFrame,    // Flight path in between the two coords follows terrain
     };
     Q_ENUM(SegmentType)
 

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -102,6 +102,7 @@ SliderSwitch                            1.0 SliderSwitch.qml
 SubMenuButton                           1.0 SubMenuButton.qml
 SurveyMapVisuals                        1.0 SurveyMapVisuals.qml
 TerrainStatus                           1.0 TerrainStatus.qml
+TransectStyleComplexItemEditor          1.0 TransectStyleComplexItemEditor.qml
 TransectStyleComplexItemStats           1.0 TransectStyleComplexItemStats.qml
 TransectStyleComplexItemTabBar          1.0 TransectStyleComplexItemTabBar.qml
 TransectStyleComplexItemTerrainFollow   1.0 TransectStyleComplexItemTerrainFollow.qml

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -29,6 +29,7 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox
 {
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
     setParent(nullptr);
+
     // Load last coordinates and zoom from config file
     QSettings settings;
     settings.beginGroup(_flightMapPositionSettingsGroup);
@@ -261,7 +262,7 @@ QString QGroundControlQmlGlobal::qgcVersion(void) const
     return versionStr;
 }
 
-QString QGroundControlQmlGlobal::altitudeModeExtraUnits(AltitudeMode altMode)
+QString QGroundControlQmlGlobal::altitudeModeExtraUnits(AltMode altMode)
 {
     switch (altMode) {
     case AltitudeModeNone:
@@ -284,7 +285,7 @@ QString QGroundControlQmlGlobal::altitudeModeExtraUnits(AltitudeMode altMode)
     return QString();
 }
 
-QString QGroundControlQmlGlobal::altitudeModeShortDescription(AltitudeMode altMode)
+QString QGroundControlQmlGlobal::altitudeModeShortDescription(AltMode altMode)
 {
     switch (altMode) {
     case AltitudeModeNone:

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -48,7 +48,7 @@ public:
     QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox* toolbox);
     ~QGroundControlQmlGlobal();
 
-    enum AltitudeMode {
+    enum AltMode {
         AltitudeModeMixed,              // Used by global altitude mode for mission planning
         AltitudeModeRelative,           // MAV_FRAME_GLOBAL_RELATIVE_ALT
         AltitudeModeAbsolute,           // MAV_FRAME_GLOBAL
@@ -56,7 +56,7 @@ public:
         AltitudeModeTerrainFrame,       // MAV_FRAME_GLOBAL_TERRAIN_ALT
         AltitudeModeNone,               // Being used as distance value unrelated to ground (for example distance to structure)
     };
-    Q_ENUM(AltitudeMode)
+    Q_ENUM(AltMode)
 
     Q_PROPERTY(QString              appName                 READ    appName                 CONSTANT)
     Q_PROPERTY(LinkManager*         linkManager             READ    linkManager             CONSTANT)
@@ -143,8 +143,8 @@ public:
 
     Q_INVOKABLE bool linesIntersect(QPointF xLine1, QPointF yLine1, QPointF xLine2, QPointF yLine2);
 
-    Q_INVOKABLE QString altitudeModeExtraUnits(AltitudeMode altMode);       ///< String shown in the FactTextField.extraUnits ui
-    Q_INVOKABLE QString altitudeModeShortDescription(AltitudeMode altMode); ///< String shown when a user needs to select an altitude mode
+    Q_INVOKABLE QString altitudeModeExtraUnits(AltMode altMode);        ///< String shown in the FactTextField.extraUnits ui
+    Q_INVOKABLE QString altitudeModeShortDescription(AltMode altMode);  ///< String shown when a user needs to select an altitude mode
 
     // Property accesors
 

--- a/src/qgcunittest/MultiSignalSpyV2.cc
+++ b/src/qgcunittest/MultiSignalSpyV2.cc
@@ -34,7 +34,7 @@ bool MultiSignalSpyV2::init(QObject* signalEmitter)
     bool error = false;
 
     if (!signalEmitter) {
-        qDebug() << "No signalEmitter specified";
+        qWarning() << "No signalEmitter specified";
         return false;
     }
     
@@ -46,12 +46,21 @@ bool MultiSignalSpyV2::init(QObject* signalEmitter)
         if (method.methodType() == QMetaMethod::Signal) {
             QString signalName = method.name();
 
+#if 0
+            // FIXME: CompexMissionItem has duplicate signals which still need to be fixed
+            if (signalName != "destroyed" && _rgSignalNames.contains(signalName)) {
+                qWarning() << "Duplicate signal name" << signalName;
+                error = true;
+                break;
+            }
+#endif
             _rgSignalNames.append(signalName);
+
             QSignalSpy* spy = new QSignalSpy(_signalEmitter, QStringLiteral("2%1").arg(method.methodSignature().data()).toLocal8Bit().data());
             if (spy->isValid()) {
                 _rgSpys.append(spy);
             } else {
-                qDebug() << "Invalid signal:" << signalName;
+                qWarning() << "Invalid signal:" << signalName;
                 error = true;
                 break;
             }
@@ -78,7 +87,7 @@ bool MultiSignalSpyV2::_checkSignalByMaskWorker(quint64 mask, bool multipleSigna
             Q_ASSERT(spy != nullptr);
             
             if ((multipleSignalsAllowed && spy->count() ==  0) || (!multipleSignalsAllowed && spy->count() != 1)) {
-                qDebug() << "Failed index:" << i;
+                qWarning() << "Failed index:" << i;
                 _printSignalState(mask);
                 return false;
             }
@@ -266,7 +275,6 @@ QGeoCoordinate MultiSignalSpyV2::pullQGeoCoordinateFromSignal(const char* signal
 quint64 MultiSignalSpyV2::signalNameToMask(const char* signalName)
 {
     for (int i=0; i<_rgSignalNames.count(); i++) {
-        qDebug() << "signalNameToMask" << signalName << _rgSignalNames[i];
         if (_rgSignalNames[i] == signalName) {
             return 1ll << i;
         }


### PR DESCRIPTION
This is a pretty massive set of changes to make all of this work:
* Survey/Corridor Scan now support terrain frame natively for usage with mavlink terrain tile protocol or lidar height sensing
* Terrain Profile display shows correct flight profiles when using terrain frame in either simple waypoint missions or patterns
* Fix for #9546

There is still some things not working which I will fix in subsequent pulls:
* When loading a pattern which using terrain frame from a file the terrain profile display does not update. Upload to vehicle will be fine. The plan file itself and data within is correct.
* min/max AMSL alt statistics when loading terrain frame back from a file will be incorrect
* Likely other bugs due to large scale change. Take care in testing this out with real vehicles. Best to round trip through the vehicle to double check the pattern generation.

Simple example using Terrain Frame on waypoints:
![Screen Shot 2021-06-11 at 11 10 14 AM](https://user-images.githubusercontent.com/5876851/121736988-2131d900-caad-11eb-9aa9-948ba3f94e00.png)

Survey example using Terrain Frame:
![Screen Shot 2021-06-11 at 11 10 56 AM](https://user-images.githubusercontent.com/5876851/121737002-25f68d00-caad-11eb-93d8-aaa88dd9793b.png)
