### PR TITLE
Fix PlanMapItems typo error

### DIFF
--- a/src/FlightMap/MapItems/PlanMapItems.qml
+++ b/src/FlightMap/MapItems/PlanMapItems.qml
@@ -27,9 +27,9 @@ Item {
 
     property var    _map:                       map
     property var    _vehicle:                   vehicle
-    property var    _missionController:         masterController.missionController
-    property var    _geoFenceController:        masterController.geoFenceController
-    property var    _rallyPointController:      masterController.rallyPointController
+    property var    _missionController:         planMasterController.missionController
+    property var    _geoFenceController:        planMasterController.geoFenceController
+    property var    _rallyPointController:      planMasterController.rallyPointController
     property var    _guidedController:          globals.guidedControllerFlyView
     property var    _missionLineViewComponent
 


### PR DESCRIPTION
When I connected multiple vehicles, I found that the vehicle mission displayed on the screen was not updated properly. I don't know if it's related to this, but I found out that the bug was fixed after applying it. Please review my PR.