### PR TITLE
`UnitTest::cleanup()` shall drain any remaining signals or events.

### DIFF
--- a/src/qgcunittest/UnitTest.cc
+++ b/src/qgcunittest/UnitTest.cc
@@ -32,7 +32,7 @@ enum UnitTest::FileDialogType UnitTest::_fileDialogExpectedType = getOpenFileNam
 int UnitTest::_missedFileDialogCount = 0;
 
 UnitTest::UnitTest(void)
-{    
+{
 
 }
 
@@ -50,7 +50,7 @@ void UnitTest::_addTest(UnitTest* test)
     QList<UnitTest*>& tests = _testList();
 
     Q_ASSERT(!tests.contains(test));
-    
+
     tests.append(test);
 }
 
@@ -63,13 +63,13 @@ void UnitTest::_unitTestCalled(void)
 QList<UnitTest*>& UnitTest::_testList(void)
 {
     static QList<UnitTest*> tests;
-	return tests;
+    return tests;
 }
 
 int UnitTest::run(QString& singleTest)
 {
     int ret = 0;
-    
+
     for (UnitTest* test: _testList()) {
         if (singleTest.isEmpty() || singleTest == test->objectName()) {
             if (test->standalone() && singleTest.isEmpty()) {
@@ -80,7 +80,7 @@ int UnitTest::run(QString& singleTest)
             ret += QTest::qExec(test, args);
         }
     }
-    
+
     return ret;
 }
 
@@ -100,12 +100,12 @@ void UnitTest::init(void)
     AppSettings* appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
     appSettings->offlineEditingFirmwareClass()->setRawValue(appSettings->offlineEditingFirmwareClass()->rawDefaultValue());
     appSettings->offlineEditingVehicleClass()->setRawValue(appSettings->offlineEditingVehicleClass()->rawDefaultValue());
-    
+
     _messageBoxRespondedTo = false;
     _missedMessageBoxCount = 0;
     _badResponseButton = false;
     _messageBoxResponseButton = QMessageBox::NoButton;
-    
+
     _fileDialogRespondedTo = false;
     _missedFileDialogCount = 0;
     _fileDialogResponseSet = false;
@@ -113,7 +113,7 @@ void UnitTest::init(void)
 
     _expectMissedFileDialog = false;
     _expectMissedMessageBox = false;
-    
+
     MAVLinkProtocol::deleteTempLogFiles();
 }
 
@@ -134,6 +134,12 @@ void UnitTest::cleanup(void)
         QEXPECT_FAIL("", "Expecting failure due internal testing", Continue);
     }
     QCOMPARE(_missedFileDialogCount, 0);
+
+    // Don't let any lingering signals or events cross to the next unit test.
+    // If you have a failure whose stack trace points to this then
+    // your test is leaking signals or events. It could cause use-after-free or
+    // segmentation faults from wild pointers.
+    qgcApp()->processEvents();
 }
 
 void UnitTest::setExpectedMessageBox(QMessageBox::StandardButton response)
@@ -178,20 +184,20 @@ void UnitTest::checkExpectedMessageBox(int expectFailFlags)
 {
     // Previous call to setExpectedMessageBox should have already checked this
     Q_ASSERT(_missedMessageBoxCount == 0);
-    
+
     // Check for a valid response
-    
+
     if (expectFailFlags & expectFailBadResponseButton) {
         QEXPECT_FAIL("", "Expecting failure due to bad button response", Continue);
     }
     QCOMPARE(_badResponseButton, false);
-    
+
     if (expectFailFlags & expectFailNoDialog) {
         QEXPECT_FAIL("", "Expecting failure due to no message box", Continue);
     }
-    
+
     // Clear this flag before QCOMPARE since anything after QCOMPARE will be skipped on failure
-    
+
     //-- TODO
     // bool messageBoxRespondedTo = _messageBoxRespondedTo;
     // QCOMPARE(messageBoxRespondedTo, true);
@@ -208,7 +214,7 @@ void UnitTest::checkMultipleExpectedMessageBox(int messageCount)
 void UnitTest::checkExpectedFileDialog(int expectFailFlags)
 {
     // Internal testing
-    
+
     if (expectFailFlags & expectFailNoDialog) {
         QEXPECT_FAIL("", "Expecting failure due to no file dialog", Continue);
     }
@@ -218,18 +224,18 @@ void UnitTest::checkExpectedFileDialog(int expectFailFlags)
         // Previous call to setExpectedFileDialog should have already checked this
         Q_ASSERT(_missedFileDialogCount == 0);
     }
-    
+
     // Clear this flag before QCOMPARE since anything after QCOMPARE will be skipped on failure
     bool fileDialogRespondedTo = _fileDialogRespondedTo;
     _fileDialogRespondedTo = false;
-    
+
     QCOMPARE(fileDialogRespondedTo, true);
 }
 
 QMessageBox::StandardButton UnitTest::_messageBox(QMessageBox::Icon icon, const QString& title, const QString& text, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton)
 {
     QMessageBox::StandardButton retButton;
-    
+
     Q_UNUSED(icon);
     Q_UNUSED(title);
     Q_UNUSED(text);
@@ -249,10 +255,10 @@ QMessageBox::StandardButton UnitTest::_messageBox(QMessageBox::Icon icon, const 
         }
         _messageBoxRespondedTo = true;
     }
-    
+
     // Clear response for next message box
     _messageBoxResponseButton = QMessageBox::NoButton;
-    
+
     return retButton;
 }
 
@@ -260,7 +266,7 @@ QMessageBox::StandardButton UnitTest::_messageBox(QMessageBox::Icon icon, const 
 QString UnitTest::_fileDialogResponseSingle(enum FileDialogType type)
 {
     QString retFile;
-    
+
     if (!_fileDialogResponseSet || _fileDialogExpectedType != type) {
         // If no response is set or the type does not match what we expected it means we were not expecting this file dialog.
         // Respond with no selection.
@@ -272,11 +278,11 @@ QString UnitTest::_fileDialogResponseSingle(enum FileDialogType type)
         }
         _fileDialogRespondedTo = true;
     }
-    
+
     // Clear response for next message box
     _fileDialogResponse.clear();
     _fileDialogResponseSet = false;
-    
+
     return retFile;
 }
 
@@ -306,7 +312,7 @@ QString UnitTest::_getOpenFileName(
     Q_UNUSED(dir);
     Q_UNUSED(filter);
     Q_UNUSED(options);
-    
+
     return _fileDialogResponseSingle(getOpenFileName);
 }
 
@@ -324,7 +330,7 @@ QStringList UnitTest::_getOpenFileNames(
     Q_UNUSED(options);
 
     QStringList retFiles;
-    
+
     if (!_fileDialogResponseSet || _fileDialogExpectedType != getOpenFileNames) {
         // If no response is set or the type does not match what we expected it means we were not expecting this file dialog.
         // Respond with no selection.
@@ -334,11 +340,11 @@ QStringList UnitTest::_getOpenFileNames(
         retFiles = _fileDialogResponse;
         _fileDialogRespondedTo = true;
     }
-    
+
     // Clear response for next message box
     _fileDialogResponse.clear();
     _fileDialogResponseSet = false;
-    
+
     return retFiles;
 }
 


### PR DESCRIPTION
For AirMap, this is PR related to BOSS-741.

Some signals, events, or objects are outliving the unit test which emits it. Any signals or events which do (including deleting objects marked with `deleteLater()`) may cause segmentation faults or use-after-free errors.

## Expected Behavior
Each unit test shall be isolated and should not pollute later unit tests with incorrect, incomplete, invalid, data nor with signals or events pointed to objects that have already been destroyed. Every unit test should have consistent 

This isn't directly a problem with unit tests (per se) but rather with the design of some of the objects being tested.

## Current Behavior
Some unit tests leak objects with (wild) pointers pointing to stack- or heap-based objects whose lifetimes exist exclusively within the unit test. The leaked objects make attempts to access the stack- or heap after the objects have expired and cause problems including spurious failures and segmentation faults during later unit tests.

## Steps to Reproduce:
Please provide an unambiguous set of steps to reproduce the current behavior
1. Checkout or merge this branch
2. Build and run unit tests in Debug mode, or with Address Sanitizer.
- a. In Debug mode, you may observe "random" crashes or some tests may unexpectedly fail.
- b. In Address Sanitizer mode, Address Sanitizer will almost undoubtedly discover at least one heap-use-after-free error, and possibly some additional errors.

## System Information
irrelevant

## Detailed Description
Provide further details about your issue/bug.
Unit tests are correct to exercise code. Some of the exercises are incomplete in that the unit test does not ensure that the code is well-isolated. A test which isn't well isolated may cause problems that make you think are due to other, unrelated, tests.

This PR _does not actually fix anything_. Instead, it exposes the problems so that they can be identified (eg, via Address Sanitizer (see [previous](https://github.com/mavlink/qgroundcontrol/pull/9595#issuecomment-824974766) [mentions](https://github.com/mavlink/qgroundcontrol/issues/9626)). Because it doesn't relate to any one single fix I have therefore opted to keep the change in this PR separate from any distinct fixes.

## Log Files and Screenshots
- Note that there will be a follow-up PR which addresses the screenshot and log below
- ![Screenshot from 2021-06-22 10-57-56](https://user-images.githubusercontent.com/72767521/123001871-d77fa300-d376-11eb-97b8-eda468123931.png)
```PASS   : SpeedSectionTest::_testDirty()
QWARN  : SpeedSectionTest::_testSettingsAvailable() PX4ParameterMetaDataLog: Invalid max value, name: "TRIG_PINS_EX"  type: 5  max: "4294967040"  error: "Value must be within 0 and 2147483647"
=================================================================
==499986==ERROR: AddressSanitizer: heap-use-after-free on address 0x619000b310f8 at pc 0x555555d64f7c bp 0x7fffffffa270 sp 0x7fffffffa260
READ of size 8 at 0x619000b310f8 thread T0
    #0 0x555555d64f7b in MissionController::plannedHomePosition() const /home/kbennett/src/public/qgroundcontrol/src/MissionManager/MissionController.cc:2262
    #1 0x555555e01c18 in SimpleMissionItem::amslEntryAlt() const /home/kbennett/src/public/qgroundcontrol/src/MissionManager/SimpleMissionItem.cc:1079
    #2 0x555555e654bb in VisualMissionItem::_amslEntryAltChanged() /home/kbennett/src/public/qgroundcontrol/src/MissionManager/VisualMissionItem.cc:240
    #3 0x555555ce07b3 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (VisualMissionItem::*)()>::call(void (VisualMissionItem::*)(), VisualMissionItem*, void**) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:152
    #4 0x555555ce04fa in void QtPrivate::FunctionPointer<void (VisualMissionItem::*)()>::call<QtPrivate::List<>, void>(void (VisualMissionItem::*)(), VisualMissionItem*, void**) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:185
    #5 0x555555cdfde0 in QtPrivate::QSlotObject<void (VisualMissionItem::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:414
    #6 0x7ffff1cf0305 in QtPrivate::QSlotObjectBase::call(QObject*, void**) ../../include/QtCore/../../src/corelib/kernel/qobjectdefs_impl.h:394
    #7 0x7ffff1cf0305 in QMetaObject::activate(QObject*, int, int, void**) kernel/qobject.cpp:3784
    #8 0x5555566c36fa in VisualMissionItem::terrainAltitudeChanged(double) /home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/moc_VisualMissionItem.cpp:1132
    #9 0x555555e652c8 in VisualMissionItem::_terrainDataReceived(bool, QList<double>) /home/kbennett/src/public/qgroundcontrol/src/MissionManager/VisualMissionItem.cc:210
    #10 0x555555e66a47 in QtPrivate::FunctorCall<QtPrivate::IndexesList<0, 1>, QtPrivate::List<bool, QList<double> >, void, void (VisualMissionItem::*)(bool, QList<double>)>::call(void (VisualMissionItem::*)(bool, QList<double>), VisualMissionItem*, void**) (/home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/staging/QGroundControl+0x912a47)
    #11 0x555555e66521 in void QtPrivate::FunctionPointer<void (VisualMissionItem::*)(bool, QList<double>)>::call<QtPrivate::List<bool, QList<double> >, void>(void (VisualMissionItem::*)(bool, QList<double>), VisualMissionItem*, void**) (/home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/staging/QGroundControl+0x912521)
    #12 0x555555e660a0 in QtPrivate::QSlotObject<void (VisualMissionItem::*)(bool, QList<double>), QtPrivate::List<bool, QList<double> >, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (/home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/staging/QGroundControl+0x9120a0)
    #13 0x7ffff1cf0305 in QtPrivate::QSlotObjectBase::call(QObject*, void**) ../../include/QtCore/../../src/corelib/kernel/qobjectdefs_impl.h:394
    #14 0x7ffff1cf0305 in QMetaObject::activate(QObject*, int, int, void**) kernel/qobject.cpp:3784
    #15 0x5555567418c8 in TerrainAtCoordinateQuery::terrainDataReceived(bool, QList<double>) /home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/moc_TerrainQuery.cpp:754
    #16 0x555555fda603 in TerrainAtCoordinateQuery::_signalTerrainData(bool, QList<double>&) /home/kbennett/src/public/qgroundcontrol/src/Terrain/TerrainQuery.cc:728
    #17 0x555555fd8820 in TerrainAtCoordinateBatchManager::_batchFailed() /home/kbennett/src/public/qgroundcontrol/src/Terrain/TerrainQuery.cc:635
    #18 0x555555fd9c8b in TerrainAtCoordinateBatchManager::_coordinateHeights(bool, QList<double>) /home/kbennett/src/public/qgroundcontrol/src/Terrain/TerrainQuery.cc:686
    #19 0x555555feace3 in QtPrivate::FunctorCall<QtPrivate::IndexesList<0, 1>, QtPrivate::List<bool, QList<double> >, void, void (TerrainAtCoordinateBatchManager::*)(bool, QList<double>)>::call(void (TerrainAtCoordinateBatchManager::*)(bool, QList<double>), TerrainAtCoordinateBatchManager*, void**) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:152
    #20 0x555555fe976c in void QtPrivate::FunctionPointer<void (TerrainAtCoordinateBatchManager::*)(bool, QList<double>)>::call<QtPrivate::List<bool, QList<double> >, void>(void (TerrainAtCoordinateBatchManager::*)(bool, QList<double>), TerrainAtCoordinateBatchManager*, void**) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:185
    #21 0x555555fe85d2 in QtPrivate::QSlotObject<void (TerrainAtCoordinateBatchManager::*)(bool, QList<double>), QtPrivate::List<bool, QList<double> >, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:414
    #22 0x7ffff1cf0305 in QtPrivate::QSlotObjectBase::call(QObject*, void**) ../../include/QtCore/../../src/corelib/kernel/qobjectdefs_impl.h:394
    #23 0x7ffff1cf0305 in QMetaObject::activate(QObject*, int, int, void**) kernel/qobject.cpp:3784
    #24 0x55555673f7ac in TerrainQueryInterface::coordinateHeightsReceived(bool, QList<double>) /home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/moc_TerrainQuery.cpp:192
    #25 0x555555fdbdeb in UnitTestTerrainQuery::requestCoordinateHeights(QList<QGeoCoordinate> const&) /home/kbennett/src/public/qgroundcontrol/src/Terrain/TerrainQuery.cc:848
    #26 0x555555fd07b2 in TerrainOfflineAirMapQuery::requestCoordinateHeights(QList<QGeoCoordinate> const&) /home/kbennett/src/public/qgroundcontrol/src/Terrain/TerrainQuery.cc:286
    #27 0x555555fd8321 in TerrainAtCoordinateBatchManager::_sendNextBatch() /home/kbennett/src/public/qgroundcontrol/src/Terrain/TerrainQuery.cc:625
    #28 0x555555fea9a9 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (TerrainAtCoordinateBatchManager::*)()>::call(void (TerrainAtCoordinateBatchManager::*)(), TerrainAtCoordinateBatchManager*, void**) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:152
    #29 0x555555fe9723 in void QtPrivate::FunctionPointer<void (TerrainAtCoordinateBatchManager::*)()>::call<QtPrivate::List<>, void>(void (TerrainAtCoordinateBatchManager::*)(), TerrainAtCoordinateBatchManager*, void**) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:185
    #30 0x555555fe83ea in QtPrivate::QSlotObject<void (TerrainAtCoordinateBatchManager::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /home/kbennett/storage/Qt/5.12.10/gcc_64/include/QtCore/qobjectdefs_impl.h:414
    #31 0x7ffff1cf0305 in QtPrivate::QSlotObjectBase::call(QObject*, void**) ../../include/QtCore/../../src/corelib/kernel/qobjectdefs_impl.h:394
    #32 0x7ffff1cf0305 in QMetaObject::activate(QObject*, int, int, void**) kernel/qobject.cpp:3784
    #33 0x7ffff1cfcc66 in QTimer::timeout(QTimer::QPrivateSignal) .moc/moc_qtimer.cpp:204
    #34 0x7ffff1cfcf37 in QTimer::timerEvent(QTimerEvent*) kernel/qtimer.cpp:255
    #35 0x7ffff1cf0eba in QObject::event(QEvent*) kernel/qobject.cpp:1283
    #36 0x7ffff48858fb in QApplicationPrivate::notify_helper(QObject*, QEvent*) kernel/qapplication.cpp:3650
    #37 0x7ffff488ca1f in QApplication::notify(QObject*, QEvent*) kernel/qapplication.cpp:3396
    #38 0x7ffff1cc44e7 in QCoreApplication::notifyInternal2(QObject*, QEvent*) kernel/qcoreapplication.cpp:1088
    #39 0x7ffff1d1adb8 in QTimerInfoList::activateTimers() kernel/qtimerinfo_unix.cpp:643
    #40 0x7ffff1d1b590 in timerSourceDispatch kernel/qeventdispatcher_glib.cpp:182
    #41 0x7ffff608317c in g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5217c)
    #42 0x7ffff60833ff  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x523ff)
    #43 0x7ffff60834a2 in g_main_context_iteration (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x524a2)
    #44 0x7ffff1d1b8fe in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) kernel/qeventdispatcher_glib.cpp:422
    #45 0x555555b805bd in UnitTest::cleanup() /home/kbennett/src/public/qgroundcontrol/src/qgcunittest/UnitTest.cc:138
    #46 0x555555b45fef in VisualMissionItemTest::cleanup() /home/kbennett/src/public/qgroundcontrol/src/MissionManager/VisualMissionItemTest.cc:54
    #47 0x555555af1013 in SectionTest::cleanup() /home/kbennett/src/public/qgroundcontrol/src/MissionManager/SectionTest.cc:46
    #48 0x555555b068ad in SpeedSectionTest::cleanup() /home/kbennett/src/public/qgroundcontrol/src/MissionManager/SpeedSectionTest.cc:38
    #49 0x55555663723e in UnitTest::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) /home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/moc_UnitTest.cpp:81
    #50 0x7ffff1cd0738 in QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const kernel/qmetaobject.cpp:2308
    #51 0x7ffff22014b2 in QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const ../../include/QtCore/../../src/corelib/kernel/qmetaobject.h:123
    #52 0x7ffff22014b2 in QTest::TestMethods::invokeTestOnData(int) const /home/qt/work/qt/qtbase/src/testlib/qtestcase.cpp:943
    #53 0x7ffff2201c52 in QTest::TestMethods::invokeTest(int, char const*, QTest::WatchDog*) const /home/qt/work/qt/qtbase/src/testlib/qtestcase.cpp:1133
    #54 0x7ffff2202211 in QTest::TestMethods::invokeTests(QObject*) const /home/qt/work/qt/qtbase/src/testlib/qtestcase.cpp:1475
    #55 0x7ffff22025d2 in QTest::qRun() /home/qt/work/qt/qtbase/src/testlib/qtestcase.cpp:1915
    #56 0x7ffff220288a in QTest::qExec(QObject*, int, char**) /home/qt/work/qt/qtbase/src/testlib/qtestcase.cpp:1802
    #57 0x7ffff2202b69 in QTest::qExec(QObject*, QStringList const&) /home/qt/work/qt/qtbase/src/testlib/qtestcase.cpp:1990
    #58 0x555555b7fbfb in UnitTest::run(QString&) /home/kbennett/src/public/qgroundcontrol/src/qgcunittest/UnitTest.cc:80
    #59 0x5555561894eb in main /home/kbennett/src/public/qgroundcontrol/src/main.cc:381
    #60 0x7ffff15370b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #61 0x555555889fdd in _start (/home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/staging/QGroundControl+0x335fdd)

0x619000b310f8 is located 120 bytes inside of 960-byte region [0x619000b31080,0x619000b31440)
freed by thread T0 here:
    #0 0x7ffff76808df in operator delete(void*) (/lib/x86_64-linux-gnu/libasan.so.5+0x1108df)
    #1 0x555555db2db1 in PlanMasterController::~PlanMasterController() /home/kbennett/src/public/qgroundcontrol/src/MissionManager/PlanMasterController.cc:87
    #2 0x7ffff1cf0f37 in QObject::event(QEvent*) kernel/qobject.cpp:1252
    #3 0x7ffff48858fb in QApplicationPrivate::notify_helper(QObject*, QEvent*) kernel/qapplication.cpp:3650

previously allocated by thread T0 here:
    #0 0x7ffff767f947 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0x10f947)
    #1 0x555555b459aa in VisualMissionItemTest::init() /home/kbennett/src/public/qgroundcontrol/src/MissionManager/VisualMissionItemTest.cc:24
    #2 0x555555af0cd4 in SectionTest::init() /home/kbennett/src/public/qgroundcontrol/src/MissionManager/SectionTest.cc:21
    #3 0x555555a19a75 in CameraSectionTest::init() /home/kbennett/src/public/qgroundcontrol/src/MissionManager/CameraSectionTest.cc:34
    #4 0x5555566371e1 in UnitTest::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) /home/kbennett/src/public/qgroundcontrol/build/build-qgroundcontrol-Desktop_Qt_5_12_10_GCC_64bit-ASan/moc_UnitTest.cpp:80
    #5 0x7ffff1cd0738 in QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericReturnArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const kernel/qmetaobject.cpp:2308
    #6 0x7ffff2200ec3 in QMetaMethod::invoke(QObject*, Qt::ConnectionType, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument, QGenericArgument) const ../../include/QtCore/../../src/corelib/kernel/qmetaobject.h:123
    #7 0x7ffff2200ec3 in QTest::TestMethods::invokeTestOnData(int) const /home/qt/work/qt/qtbase/src/testlib/qtestcase.cpp:922
    #8 0x7ffff2201c52 in QTest::TestMethods::invokeTest(int, char const*, QTest::WatchDog*) const /home/qt/work/qt/qtbase/src/testlib/qtestcase.cpp:1133

SUMMARY: AddressSanitizer: heap-use-after-free /home/kbennett/src/public/qgroundcontrol/src/MissionManager/MissionController.cc:2262 in MissionController::plannedHomePosition() const
Shadow bytes around the buggy address:
  0x0c328015e1c0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c328015e1d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c328015e1e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c328015e1f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c328015e200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x0c328015e210: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]
  0x0c328015e220: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c328015e230: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c328015e240: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c328015e250: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c328015e260: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==499986==ABORTING
```