### PR TITLE
Fix polluted CI caused by leaking certain specific `VisualMissionItem`s

### DIFF
--- a/src/MissionManager/CameraSectionTest.cc
+++ b/src/MissionManager/CameraSectionTest.cc
@@ -367,12 +367,10 @@ void CameraSectionTest::_checkAvailable(void)
                             70.1234567,
                             true,           // autoContinue
                             false);         // isCurrentItem
-    SimpleMissionItem* item = new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this);
+    QScopedPointer<SimpleMissionItem> item(new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this));
     QVERIFY(item->cameraSection());
     QCOMPARE(item->cameraSection()->available(), false);
-    qCDebug(VisualMissionItemLog) << item << "(checkAvailable)";
 }
-
 
 void CameraSectionTest::_testItemCount(void)
 {

--- a/src/MissionManager/CameraSectionTest.cc
+++ b/src/MissionManager/CameraSectionTest.cc
@@ -370,6 +370,7 @@ void CameraSectionTest::_checkAvailable(void)
     SimpleMissionItem* item = new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this);
     QVERIFY(item->cameraSection());
     QCOMPARE(item->cameraSection()->available(), false);
+    qCDebug(VisualMissionItemLog) << item << "(checkAvailable)";
 }
 
 

--- a/src/MissionManager/LandingComplexItemTest.cc
+++ b/src/MissionManager/LandingComplexItemTest.cc
@@ -26,7 +26,7 @@ void LandingComplexItemTest::init(void)
 {
     VisualMissionItemTest::init();
 
-    _item = new SimpleLandingComplexItem(_masterController, false /* flyView */, this);
+    _item.reset(new SimpleLandingComplexItem(_masterController, false /* flyView */, this));
 
     // Start in a clean state
     QVERIFY(!_item->dirty());
@@ -34,7 +34,7 @@ void LandingComplexItemTest::init(void)
     _item->setDirty(false);
     QVERIFY(!_item->dirty());
 
-    VisualMissionItemTest::_createSpy(_item, &_viMultiSpy);
+    VisualMissionItemTest::_createSpy(_item.get(), &_viMultiSpy);
 
     rgSignals[finalApproachCoordinateChangedIndex]  = SIGNAL(finalApproachCoordinateChanged(QGeoCoordinate));
     rgSignals[loiterTangentCoordinateChangedIndex]  = SIGNAL(loiterTangentCoordinateChanged(QGeoCoordinate));
@@ -44,7 +44,7 @@ void LandingComplexItemTest::init(void)
     rgSignals[_updateFlightPathSegmentsSignalIndex] = SIGNAL(_updateFlightPathSegmentsSignal());
 
     _multiSpy = new MultiSignalSpy();
-    QCOMPARE(_multiSpy->init(_item, rgSignals, cSignals), true);
+    QCOMPARE(_multiSpy->init(_item.get(), rgSignals, cSignals), true);
 
     _validStopVideoItem     = CameraSectionTest::createValidStopTimeItem(_masterController, this);
     _validStopDistanceItem  = CameraSectionTest::createValidStopTimeItem(_masterController, this);
@@ -57,6 +57,7 @@ void LandingComplexItemTest::cleanup(void)
     delete _validStopVideoItem;
     delete _validStopDistanceItem;
     delete _validStopTimeItem;
+    _item.reset();
     VisualMissionItemTest::cleanup();
 }
 
@@ -99,7 +100,7 @@ void LandingComplexItemTest::_testDirty(void)
         qDebug() << boolName;
         QVERIFY(!_item->dirty());
         QMetaProperty boolProp = metaObject->property(metaObject->indexOfProperty(boolName));
-        QVERIFY(boolProp.write(_item, !boolProp.read(_item).toBool()));
+        QVERIFY(boolProp.write(_item.get(), !boolProp.read(_item.get()).toBool()));
         QVERIFY(_viMultiSpy->checkSignalByMask(dirtyChangedMask));
         QVERIFY(_viMultiSpy->pullBoolFromSignalIndex(dirtyChangedIndex));
         _item->setDirty(false);
@@ -245,7 +246,7 @@ void LandingComplexItemTest::_testScanForItems(void)
         QCOMPARE(visualItems->count(), 1);
         SimpleLandingComplexItem* scannedItem = visualItems->value<SimpleLandingComplexItem*>(0);
         QVERIFY(scannedItem);
-        _validateItem(scannedItem, _item);
+        _validateItem(scannedItem, _item.get());
 
         visualItems->deleteLater();
         rgMissionItems.clear();
@@ -270,7 +271,7 @@ void LandingComplexItemTest::_testSaveLoad(void)
     }
     QVERIFY(loadSuccess);
     QVERIFY(errorString.isEmpty());
-    _validateItem(newItem, _item);
+    _validateItem(newItem, _item.get());
     newItem->deleteLater();
 
     // Test useDeprecatedRelAltKeys = true
@@ -285,7 +286,7 @@ void LandingComplexItemTest::_testSaveLoad(void)
     }
     QVERIFY(loadSuccess);
     QVERIFY(errorString.isEmpty());
-    _validateItem(newItem, _item);
+    _validateItem(newItem, _item.get());
     newItem->deleteLater();
 
     // Test for _jsonDeprecatedLoiterCoordinateKey support
@@ -302,7 +303,7 @@ void LandingComplexItemTest::_testSaveLoad(void)
     }
     QVERIFY(loadSuccess);
     QVERIFY(errorString.isEmpty());
-    _validateItem(newItem, _item);
+    _validateItem(newItem, _item.get());
     newItem->deleteLater();
 }
 

--- a/src/MissionManager/LandingComplexItemTest.h
+++ b/src/MissionManager/LandingComplexItemTest.h
@@ -56,7 +56,7 @@ private:
     static const size_t cSignals = maxSignalIndex;
     const char*         rgSignals[cSignals];
 
-    LandingComplexItem* _item                   = nullptr;
+    QScopedPointer<LandingComplexItem> _item;
     MultiSignalSpy*     _multiSpy               = nullptr;
     MultiSignalSpy*     _viMultiSpy             = nullptr;
     SimpleMissionItem*  _validStopVideoItem     = nullptr;
@@ -78,7 +78,7 @@ public:
     QString mapVisualQML(void) const final { return QStringLiteral("FWLandingPatternMapVisual.qml"); }
 
     // Overrides from VisualMissionItem
-    void    save        (QJsonArray&  /*missionItems*/) override { };
+    void    save        (QJsonArray&  /*missionItems*/) override { }
 
     static const QString name;
 
@@ -103,7 +103,7 @@ private:
     const Fact*     _useLoiterToAlt         (void) const final { return &_useLoiterToAltFact; }
     const Fact*     _stopTakingPhotos       (void) const final { return &_stopTakingPhotosFact; }
     const Fact*     _stopTakingVideo        (void) const final { return &_stopTakingVideoFact; }
-    void            _calcGlideSlope         (void) final { };
+    void            _calcGlideSlope         (void) final { }
     MissionItem*    _createLandItem         (int seqNum, bool altRel, double lat, double lon, double alt, QObject* parent) final;
 
     QMap<QString, FactMetaData*> _metaDataMap;

--- a/src/MissionManager/SectionTest.cc
+++ b/src/MissionManager/SectionTest.cc
@@ -11,7 +11,7 @@
 #include "SurveyComplexItem.h"
 
 SectionTest::SectionTest(void)
-    : _simpleItem(nullptr)
+    : _simpleItem{}
 {
     
 }
@@ -37,13 +37,12 @@ void SectionTest::init(void)
                             70.1234567,
                             true,           // autoContinue
                             false);         // isCurrentItem
-    _simpleItem = new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this);
-    qCDebug(VisualMissionItemLog) << _simpleItem << "(SectionTest::_simpleItem)";
+    _simpleItem.reset(new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this));
 }
 
 void SectionTest::cleanup(void)
 {
-    _simpleItem->deleteLater();
+    _simpleItem.reset();
     VisualMissionItemTest::cleanup();
 }
 

--- a/src/MissionManager/SectionTest.cc
+++ b/src/MissionManager/SectionTest.cc
@@ -38,6 +38,7 @@ void SectionTest::init(void)
                             true,           // autoContinue
                             false);         // isCurrentItem
     _simpleItem = new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this);
+    qCDebug(VisualMissionItemLog) << _simpleItem << "(SectionTest::_simpleItem)";
 }
 
 void SectionTest::cleanup(void)

--- a/src/MissionManager/SectionTest.h
+++ b/src/MissionManager/SectionTest.h
@@ -45,5 +45,5 @@ protected:
     static const size_t cSectionSignals = maxSignalIndex;
     const char*         rgSectionSignals[cSectionSignals];
 
-    SimpleMissionItem*  _simpleItem;
+    QScopedPointer<SimpleMissionItem>  _simpleItem;
 };

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -134,6 +134,7 @@ SimpleMissionItem::SimpleMissionItem(PlanMasterController* masterController, boo
     emit coordinateChanged(coordinate());
 
     setDirty(false);
+    qCDebug(VisualMissionItemLog) << this << "ctor";
 }
 
 void SimpleMissionItem::_connectSignals(void)
@@ -269,7 +270,8 @@ void SimpleMissionItem::_setupMetaData(void)
 }
 
 SimpleMissionItem::~SimpleMissionItem()
-{    
+{
+    qCDebug(VisualMissionItemLog) << this << "dtor";
 }
 
 void SimpleMissionItem::save(QJsonArray&  missionItems)

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -134,7 +134,6 @@ SimpleMissionItem::SimpleMissionItem(PlanMasterController* masterController, boo
     emit coordinateChanged(coordinate());
 
     setDirty(false);
-    qCDebug(VisualMissionItemLog) << this << "ctor";
 }
 
 void SimpleMissionItem::_connectSignals(void)
@@ -271,7 +270,6 @@ void SimpleMissionItem::_setupMetaData(void)
 
 SimpleMissionItem::~SimpleMissionItem()
 {
-    qCDebug(VisualMissionItemLog) << this << "dtor";
 }
 
 void SimpleMissionItem::save(QJsonArray&  missionItems)

--- a/src/MissionManager/SimpleMissionItemTest.cc
+++ b/src/MissionManager/SimpleMissionItemTest.cc
@@ -97,20 +97,20 @@ void SimpleMissionItemTest::init(void)
                             70.1234567,
                             true,           // autoContinue
                             false);         // isCurrentItem
-    _simpleItem = new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this);
+    _simpleItem.reset(new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this));
 
     // It's important top check that the right signals are emitted at the right time since that drives ui change.
     // It's also important to check that things are not being over-signalled when they should not be, since that can lead
     // to incorrect ui or perf impact of uneeded signals propogating ui change.
 
     _spySimpleItem = new MultiSignalSpy();
-    QCOMPARE(_spySimpleItem->init(_simpleItem, rgSimpleItemSignals, cSimpleItemSignals), true);
-    VisualMissionItemTest::_createSpy(_simpleItem, &_spyVisualItem);
+    QCOMPARE(_spySimpleItem->init(_simpleItem.get(), rgSimpleItemSignals, cSimpleItemSignals), true);
+    VisualMissionItemTest::_createSpy(_simpleItem.get(), &_spyVisualItem);
 }
 
 void SimpleMissionItemTest::cleanup(void)
 {
-    delete _simpleItem;
+    _simpleItem.reset();
     VisualMissionItemTest::cleanup();
 }
 

--- a/src/MissionManager/SimpleMissionItemTest.h
+++ b/src/MissionManager/SimpleMissionItemTest.h
@@ -81,7 +81,7 @@ private:
     void _testEditorFactsWorker (QGCMAVLink::VehicleClass_t vehicleClass, QGCMAVLink::VehicleClass_t vtolMode, const ItemExpected_t* rgExpected);
     bool _classMatch            (QGCMAVLink::VehicleClass_t vehicleClass, QGCMAVLink::VehicleClass_t testClass);
 
-    SimpleMissionItem*  _simpleItem;
-    MultiSignalSpy*     _spySimpleItem;
-    MultiSignalSpy*     _spyVisualItem;
+    QScopedPointer<SimpleMissionItem> _simpleItem;
+    MultiSignalSpy*                   _spySimpleItem;
+    MultiSignalSpy*                   _spyVisualItem;
 };

--- a/src/MissionManager/SpeedSectionTest.cc
+++ b/src/MissionManager/SpeedSectionTest.cc
@@ -135,7 +135,7 @@ void SpeedSectionTest::_checkAvailable(void)
                             70.1234567,
                             true,           // autoContinue
                             false);         // isCurrentItem
-    SimpleMissionItem* item = new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this);
+    QScopedPointer<SimpleMissionItem> item(new SimpleMissionItem(_masterController, false /* flyView */, missionItem, this));    QVERIFY(item->speedSection());
     QVERIFY(item->speedSection());
     QCOMPARE(item->speedSection()->available(), false);
 }

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -19,6 +19,8 @@
 #include "PlanMasterController.h"
 #include "QGC.h"
 
+QGC_LOGGING_CATEGORY(VisualMissionItemLog, "VisualMissionItemLog")
+
 const char* VisualMissionItem::jsonTypeKey =                "type";
 const char* VisualMissionItem::jsonTypeSimpleItemValue =    "SimpleItem";
 const char* VisualMissionItem::jsonTypeComplexItemValue =   "ComplexItem";
@@ -31,6 +33,7 @@ VisualMissionItem::VisualMissionItem(PlanMasterController* masterController, boo
     , _controllerVehicle(masterController->controllerVehicle())
 {
     _commonInit();
+    qCDebug(VisualMissionItemLog) << this << "ctor";
 }
 
 VisualMissionItem::VisualMissionItem(const VisualMissionItem& other, bool flyView, QObject* parent)
@@ -40,6 +43,7 @@ VisualMissionItem::VisualMissionItem(const VisualMissionItem& other, bool flyVie
     *this = other;
 
     _commonInit();
+    qCDebug(VisualMissionItemLog) << this << "ctor";
 }
 
 void VisualMissionItem::_commonInit(void)
@@ -75,7 +79,13 @@ const VisualMissionItem& VisualMissionItem::operator=(const VisualMissionItem& o
 }
 
 VisualMissionItem::~VisualMissionItem()
-{    
+{
+    if (_currentTerrainAtCoordinateQuery) {
+        disconnect(_currentTerrainAtCoordinateQuery, &TerrainAtCoordinateQuery::terrainDataReceived,
+                this, &VisualMissionItem::_terrainDataReceived);
+        _currentTerrainAtCoordinateQuery = nullptr;
+    }
+    qCDebug(VisualMissionItemLog) << this << "dtor";
 }
 
 void VisualMissionItem::setIsCurrentItem(bool isCurrentItem)
@@ -206,6 +216,7 @@ void VisualMissionItem::_reallyUpdateTerrainAltitude(void)
 
 void VisualMissionItem::_terrainDataReceived(bool success, QList<double> heights)
 {
+    qCDebug(VisualMissionItemLog) << this << "_terrainDataReceived";
     _terrainAltitude = success ? heights[0] : qQNaN();
     emit terrainAltitudeChanged(_terrainAltitude);
     _currentTerrainAtCoordinateQuery = nullptr;

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -19,8 +19,6 @@
 #include "PlanMasterController.h"
 #include "QGC.h"
 
-QGC_LOGGING_CATEGORY(VisualMissionItemLog, "VisualMissionItemLog")
-
 const char* VisualMissionItem::jsonTypeKey =                "type";
 const char* VisualMissionItem::jsonTypeSimpleItemValue =    "SimpleItem";
 const char* VisualMissionItem::jsonTypeComplexItemValue =   "ComplexItem";
@@ -33,7 +31,6 @@ VisualMissionItem::VisualMissionItem(PlanMasterController* masterController, boo
     , _controllerVehicle(masterController->controllerVehicle())
 {
     _commonInit();
-    qCDebug(VisualMissionItemLog) << this << "ctor";
 }
 
 VisualMissionItem::VisualMissionItem(const VisualMissionItem& other, bool flyView, QObject* parent)
@@ -43,7 +40,6 @@ VisualMissionItem::VisualMissionItem(const VisualMissionItem& other, bool flyVie
     *this = other;
 
     _commonInit();
-    qCDebug(VisualMissionItemLog) << this << "ctor";
 }
 
 void VisualMissionItem::_commonInit(void)
@@ -85,7 +81,6 @@ VisualMissionItem::~VisualMissionItem()
                 this, &VisualMissionItem::_terrainDataReceived);
         _currentTerrainAtCoordinateQuery = nullptr;
     }
-    qCDebug(VisualMissionItemLog) << this << "dtor";
 }
 
 void VisualMissionItem::setIsCurrentItem(bool isCurrentItem)
@@ -216,7 +211,6 @@ void VisualMissionItem::_reallyUpdateTerrainAltitude(void)
 
 void VisualMissionItem::_terrainDataReceived(bool success, QList<double> heights)
 {
-    qCDebug(VisualMissionItemLog) << this << "_terrainDataReceived";
     _terrainAltitude = success ? heights[0] : qQNaN();
     emit terrainAltitudeChanged(_terrainAltitude);
     _currentTerrainAtCoordinateQuery = nullptr;

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -30,8 +30,6 @@ class PlanMasterController;
 class MissionController;
 class TerrainAtCoordinateQuery;
 
-Q_DECLARE_LOGGING_CATEGORY(VisualMissionItemLog)
-
 // Abstract base class for all Simple and Complex visual mission objects.
 class VisualMissionItem : public QObject
 {

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -30,6 +30,8 @@ class PlanMasterController;
 class MissionController;
 class TerrainAtCoordinateQuery;
 
+Q_DECLARE_LOGGING_CATEGORY(VisualMissionItemLog)
+
 // Abstract base class for all Simple and Complex visual mission objects.
 class VisualMissionItem : public QObject
 {


### PR DESCRIPTION
Related to #9718; this PR addresses AirMap's BOSS-741.

The problem is that some of the `VisualMissionItem`s lifetimes are exceeding the `MissionController` object that they're attached to and leaking beyond the scope of the unit test in which they were created.

By leaking beyond the scope of the unit test, the `TerrainQuery` classes will return an answer after the unit test has finished... and after another (or several) other unit tests have started. By exceeding the lifetime of its associated MissionController, its internal `_missionController` pointer is now wild. Accessing that pointer causes `heap-use-after-free` or segmentation fault.

The problem lies in the design of the TerrainQuery (it's far too easy to misuse), the design of `VisualMissionItem` (if its lifetime needs to be tied to the `MissionController` then the `MissionController` should create it), and `QmlObjectListModel` (for many reasons, not least of which is that it doesn't actually _own_ the objects in it, and you have to _actively_ tell it to delete its pointers... and doing so will only call `deleteLater()` on the objects instead of deleting them immediately). All of these combine to make the lifetimes of each of these objects far too complicated and easy to get wrong.

This table might be easier to understand (top is most-recent call):

| Thread 1 (during `UnitTest::cleanup()` |
| - |
| [:fire:](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/MissionController.cc#L2262) Address Sanitizer detects heap-use-after-free of MissionController object |
| [MissionController::plannedHomePosition()`](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/SimpleMissionItem.cc#L1079) |
| [SimpleMissionItem::amslEntryAlt()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.cc#L240) |
| [VisualMissionItem::_amslEntryAltChanged()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/SimpleMissionItem.cc#L164) (slot) |
| [VisualMissionItem::terrainAltitudeChanged()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.cc#L210) (signal) |
| [VisualMissionItem::_terrainDataReceived()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.cc#L200) (slot) |
| [TerrainAtCoordinateQuery::terrainDataReceived()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L728) (signal) |
| [TerrainAtCoordinateQuery::_signalTerrainData()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L635) |
| [TerrainAtCoordinateQuery::_batchFailed()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L686) |
| [TerrainAtCoordinateBatchManager::_coordinateHeights()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L577) (slot) |
| [TerrainQueryInterface::coordinateHeightsReceived()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L848) (signal) |
| [UnitTestTerrainQuery::requestCoordinateHeights()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L286) |
| [TerrainOfflineAirMapQuery::requestCoordinateHeights()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L625) |
| [TerrainAtCoordinateBatchManager::_sendNextBatch](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L576) (slot) |
| [QTimer::timeout()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L576) (signal) |
| QApplication::processEvents() |
| UnitTest::cleanup() |

So: that call stack which demonstrates that the timer's callback has outlived the unit test. But where does the timer's callback get started? See below.

To be clear, we're looking at [`TerrainAtCoordinateBatchManager::_batchTimer`](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.h#L198).

Ultimately, the problem is caused by a violation of [this comment](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.h#L202-L209). The comment is in a random place and there is no strict guarantee that the object will live its necessary lifetime. So this is ultimately a very big design problem that needs to be resolved.

| Thread 1 (_possibly_ during unit test run, or also possibly during `UnitTest::cleanup()`) |
| - |
| [_batchTimer.start()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L587) |
| [_TerrainAtCoordinateBatchManager->addQuery()](https://github.com/mavlink/qgroundcontrol/blob/master/src/Terrain/TerrainQuery.cc#L718) |
| [_currentTerrainAtCoordinateQuery->requestData()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.cc#L203) |
| [VisualMissionItem::_reallyUpdateTerrainAltitude(https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.cc#L52)]() (slot) |
| [QTimer::timeout()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.cc#L52) (signal) |

Why yes, that _is_ another timer. But, how does that one get started? Consider the following call stack:

| Thread 1 (during unit test run) |
| - |
| [_updateTerrainTimer.start()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.cc#L185) |
| [VisualMissionItem::_updateTerrainAltitude()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.cc#L173) (slot) |
| [VisualMissionItem::coordinateChanged()](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/VisualMissionItem.h#L54) (signal) |

Okay, so `VisualMissionItem` (such as a SimpleMissionItem) gets called from _just about anywhere_ -- any time the visual mission item's coordinate is written to. Any unit test which creates a VisualMissionItem and assigns it a coordinate "could" trigger this problem if it doesn't take care to ensure that the timers are stopped or expired! Some surveys could create hundreds or thousands of timers. Indeed, some surveys might create and destroy many VisualMissionItems.

This PR does _not_ aim to fix the poor design of the `TerrainQuery`. It is aimed to triage the heap-use-after-free and help fix some of the polluted unit tests.

You should take note that the `VisualMissionItem` seems to also outlive the unit test. That's because of yet another very big design flaw: the `QmlObjectListModel`, and _nearly every single use of `QObject::deleteLater`_.

Address Sanitizer is pretty great. One of the pretty cool things it does, in addition to telling us exactly _what_ was used after it was freed, is to also tell us where that object was first allocated and finally freed.

The initial log output, [including changes from the branch which drains the application event queue between each test](https://github.com/airmap/qgroundcontrol/tree/keith/BOSS-741/fix-tests), is [here](https://github.com/mavlink/qgroundcontrol/files/6697575/A.txt). It simply demonstrates that there is (at least one) heap-use-after-free in the base branch.

[This log output](https://github.com/mavlink/qgroundcontrol/files/6697617/F.txt) roughly corresponds to commit `8ecee67f43c68641a8a7a34adadb49b1b7a16c32` wherein I'm logging the lifetime of each `SimpleMissionItem` to eliminate each leak.
