### PR TITLE
PhotoVideoControl.qml: fix Slider setting some facts to minimum:

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -467,8 +467,19 @@ Rectangle {
                                 stepSize:                   parent._fact.increment
                                 visible:                    parent._isSlider
                                 updateValueWhileDragging:   false
-                                onValueChanged:             parent._fact.value = value
-                                Component.onCompleted:      value = parent._fact.value
+                                property bool initialized:  false
+
+                                onValueChanged: {
+                                    if (!initialized) {
+                                        return
+                                    }
+                                    parent._fact.value = value
+                                }
+
+                                Component.onCompleted: {
+                                    value = parent._fact.value
+                                    initialized = true
+                                }
                             }
                             QGCSwitch {
                                 checked:        parent._fact ? parent._fact.value : false


### PR DESCRIPTION
for some reason the QGCSlider that is assigned to the activesettings of _mavlinkcamera was setting the facts to its minimum value when that menu was instantiated. 

I realized this testing the camera protocol with a Workswell WirisPro  camera. This only seemed to affect some facts instantiated by a facttextfield. The fact that was being reset had the following .xml description:

parameter name="PIP_OPACITY" type="uint8" default="50" min="10" max="100"

but for instance there was another pretty similar that behaved correctly:

parameter name="PALETTE" type="uint8" default="0"

I have not dug deeper than this into all the fact generation from the .xml, maybe the bug is coming from there, but this commit fixes the behaviour.


