### PR TITLE
Add FMUV6X

### DIFF
--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -14,6 +14,7 @@
         { "vendorID": 9900, "productID": 48,        "boardClass": "Pixhawk",    "name": "MindPX FMU V2" },
         { "vendorID": 9900, "productID": 50,        "boardClass": "Pixhawk",    "name": "PX4 FMU V5" },
         { "vendorID": 7052, "productID": 54,        "boardClass": "Pixhawk",    "name": "PX4 FMU V6U" },
+        { "vendorID": 12677, "productID": 53,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6X" },
         { "vendorID": 9900, "productID": 64,        "boardClass": "Pixhawk",    "name": "TAP V1" },
         { "vendorID": 9900, "productID": 65,        "boardClass": "Pixhawk",    "name": "ASC V1" },
         { "vendorID": 9900, "productID": 22,        "boardClass": "Pixhawk",    "name": "Crazyflie 2" },
@@ -51,6 +52,8 @@
     "boardDescriptionFallback": [
         { "regExp": "^PX4 FMU v6U.x$",      "boardClass": "Pixhawk" },
         { "regExp": "^PX4 BL FMU v6U.x$",   "boardClass": "Pixhawk" },
+        { "regExp": "^PX4 FMU v6X.x$",      "boardClass": "Pixhawk" },
+        { "regExp": "^PX4 BL FMU v6X.x$",   "boardClass": "Pixhawk" },
         { "regExp": "^PX4 FMU v5.x$",       "boardClass": "Pixhawk" },
         { "regExp": "^PX4 BL FMU v5.x$",    "boardClass": "Pixhawk" },
         { "regExp": "^PX4 FMU v4.x PRO$",   "boardClass": "Pixhawk" },


### PR DESCRIPTION
This PR adds the FMUV6X to the USB manifest. Solves https://github.com/mavlink/qgroundcontrol/issues/9738