### PR TITLE
Android: Serial port fix possible crash

### DIFF
--- a/libs/qtandroidserialport/src/qserialportinfo_android.cpp
+++ b/libs/qtandroidserialport/src/qserialportinfo_android.cpp
@@ -86,6 +86,7 @@ QList<QSerialPortInfo> availablePortsByFiltersOfDevices(bool &ok)
         //__android_log_print(ANDROID_LOG_INFO, V_TAG, "Adding device: %s", rawStringL);
         QStringList strListL = QString::fromUtf8(rawStringL).split(QStringLiteral(":"));
         envL->ReleaseStringUTFChars(stringL, rawStringL);
+        envL->DeleteLocalRef(stringL);
 
         priv.portName               = strListL[0];
         priv.device                 = strListL[0];


### PR DESCRIPTION
Delete the local JNI reference after use to fix possible crashes after some time periodically scanning ports on several android devices:
JNI ERROR (app bug): local reference table overflow (max=512)

https://stackoverflow.com/questions/26685491/jni-error-app-bug-local-reference-table-overflow-max-512


