### PR TITLE
fixes #9754

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ if (GST_FOUND)
 
     option(QGC_GST_MICROHARD_ENABLED "Enable microhard" OFF)
     option(QGC_GST_TAISYNC_ENABLED "Enable taisyng" OFF)
+else()
+	if (QGC_GST_MICROHARD_ENABLED OR QGC_GST_TAISYNC_ENABLED)
+		message(FATAL_ERROR "You tried to enable Microhard or Taisync but gstreamer is not found. Make sure to set PKG_CONFIG_EXECUTABLE and/or PKG_CONFIG_PATH properly.")
+	endif()
 endif()
 
 add_definitions(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,8 +193,14 @@ target_link_libraries(qgc
 )
 
 if(GST_FOUND)
-	target_link_libraries(qgc PUBLIC Microhard)
-	target_link_libraries(qgc PUBLIC Taisync)
+	if (${QGC_GST_MICROHARD_ENABLED})
+		target_compile_definitions(qgc PUBLIC QGC_GST_MICROHARD_ENABLED)
+		target_link_libraries(qgc PUBLIC Microhard)
+	endif()
+	if (${QGC_GST_TAISYNC_ENABLED})
+		target_compile_definitions(qgc PUBLIC QGC_GST_TAISYNC_ENABLED)
+		target_link_libraries(qgc PUBLIC Taisync)
+	endif()
 endif()
 
 if(BUILD_TESTING)


### PR DESCRIPTION
- if gstreamer is not found but Microhard or Taisync is enabled
  issue an error message and cancel CMake generation
- exclude the target_link_libraries call if Microhard or Taisync
  is not enabled
- if Microhard or Taisync is enabled add compile definitions to
  enable #defines in the source code, else there are build errors
