### PR TITLE
joystick range multiplier

### DIFF
--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -109,6 +109,7 @@ public:
     Q_PROPERTY(float    maxButtonFrequencyHz    MEMBER _maxButtonFrequencyHz                            CONSTANT)
     Q_PROPERTY(bool     negativeThrust          READ negativeThrust         WRITE setNegativeThrust     NOTIFY negativeThrustChanged)
     Q_PROPERTY(float    exponential             READ exponential            WRITE setExponential        NOTIFY exponentialChanged)
+    Q_PROPERTY(float    joystick_multi             READ joystick_multi            WRITE setjoystick_multi        NOTIFY joystick_multiChanged)
     Q_PROPERTY(bool     accumulator             READ accumulator            WRITE setAccumulator        NOTIFY accumulatorChanged)
     Q_PROPERTY(bool     circleCorrection        READ circleCorrection       WRITE setCircleCorrection   NOTIFY circleCorrectionChanged)
 
@@ -157,6 +158,9 @@ public:
     float exponential       () const;
     void  setExponential    (float expo);
 
+    float joystick_multi       () const;
+    void  setjoystick_multi    (float multi);
+
     bool  accumulator       () const;
     void  setAccumulator    (bool accu);
 
@@ -192,6 +196,7 @@ signals:
     void throttleModeChanged        (int mode);
     void negativeThrustChanged      (bool allowNegative);
     void exponentialChanged         (float exponential);
+    void joystick_multiChanged         (float joystick_multi);
     void accumulatorChanged         (bool accumulator);
     void enabledChanged             (bool enabled);
     void circleCorrectionChanged    (bool circleCorrection);
@@ -272,6 +277,7 @@ protected:
     ThrottleMode_t _throttleMode    = ThrottleModeDownZero;
     bool    _negativeThrust         = false;
     float   _exponential            = 0;
+    float   _joystick_multi         = 0;
     bool    _accumulator            = false;
     bool    _deadband               = false;
     bool    _circleCorrection       = true;
@@ -312,6 +318,7 @@ private:
     static const char* _buttonActionRepeatKey;
     static const char* _throttleModeSettingsKey;
     static const char* _exponentialSettingsKey;
+    static const char* _joystick_multiSettingsKey;
     static const char* _accumulatorSettingsKey;
     static const char* _deadbandSettingsKey;
     static const char* _circleCorrectionSettingsKey;

--- a/src/VehicleSetup/JoystickConfigAdvanced.qml
+++ b/src/VehicleSetup/JoystickConfigAdvanced.qml
@@ -87,6 +87,25 @@ Item {
                 text:   expoSlider.value.toFixed(2)
             }
         }
+        //---------------------------------------------------------------------
+        QGCLabel {
+            text:               qsTr("multiplication:")
+        }
+        Row {
+            spacing:            ScreenTools.defaultFontPixelWidth
+            QGCSlider {
+                id:             multiSlider
+                width:          ScreenTools.defaultFontPixelWidth * 20
+                minimumValue:   0.25
+                maximumValue:   2.5
+                Component.onCompleted: value = -_activeJoystick.joystick_multi
+                onValueChanged: _activeJoystick.joystick_multi = -value
+             }
+            QGCLabel {
+                id:     multiSliderIndicator
+                text:   multiSlider.value.toFixed(2)
+            }
+        }
         //-----------------------------------------------------------------
         //-- Enable Advanced Mode
         QGCLabel {
@@ -184,5 +203,3 @@ Item {
         }
     }
 }
-
-


### PR DESCRIPTION
I have the problem that my controller only covers a range from 1300 to 1700.
the servos then do not move far enough.
I therefore simply have completely parallel to the _exponential
the _joystick_multi built in.
That would help me incredibly if it was simply included in the next release and I can't imagine that I'm the only one who has the problem.

**possible mistakes:**
I don't know if the numbers can get too big.

and I know that I have installed everything correctly and have not forgotten anything.

**Thank you so much!
great software!**