### PR TITLE
update tri airframe images

### DIFF
--- a/src/AutoPilotPlugins/Common/Images/YMinus.svg
+++ b/src/AutoPilotPlugins/Common/Images/YMinus.svg
@@ -1,35 +1,126 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 19.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="draw" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 343.449 305.834" enable-background="new 0 0 343.449 305.834" xml:space="preserve">
-<title>YMinus</title>
-<rect x="168.017" y="120.306" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="6.777" height="133.572"/>
-<rect x="162.955" y="83.772" transform="matrix(0.8697 -0.4936 0.4936 0.8697 -13.0842 124.7602)" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="133.572" height="6.777"/>
-<rect x="110.334" y="20.064" transform="matrix(0.4969 -0.8678 0.8678 0.4969 -18.2066 142.4161)" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="6.777" height="133.692"/>
-<path fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" d="M214.838,127.079l-36.195,36.195
-	c-3.869,3.869-10.141,3.869-14.009,0l-36.195-36.195c-3.869-3.869-3.869-10.141,0-14.009l36.195-36.195
-	c3.869-3.869,10.141-3.869,14.009,0l36.195,36.195C218.706,116.938,218.706,123.21,214.838,127.079z"/>
-<polygon fill="#FF442B" stroke="#000000" stroke-miterlimit="10" points="153.46,142.074 171.637,91.074 189.815,142.074 "/>
-<g opacity="0.8">
-	
-		<ellipse transform="matrix(0.7091 -0.7051 0.7051 0.7091 48.7212 221.2241)" fill="#159E1F" cx="292.453" cy="51.569" rx="50.993" ry="51.004"/>
-</g>
-<path fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" d="M300.324,42.677c-4.374-4.384-11.473-4.393-15.858-0.019
-	c-4.384,4.374-4.393,11.473-0.019,15.858c4.365,4.375,11.447,4.394,15.835,0.042c4.397-4.335,4.446-11.414,0.111-15.811
-	C300.37,42.723,300.347,42.7,300.324,42.677z"/>
-<g opacity="0.8">
-	
-		<ellipse transform="matrix(0.7051 -0.7091 0.7091 0.7051 -21.1165 51.1916)" fill="#159E1F" cx="50.994" cy="50.986" rx="50.993" ry="51.004"/>
-</g>
-<path fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" d="M58.914,43.059c4.384,4.374,4.393,11.473,0.02,15.858
-	c-4.374,4.384-11.473,4.393-15.857,0.02c-4.376-4.365-4.395-11.447-0.042-15.835c4.335-4.397,11.414-4.446,15.811-0.111
-	C58.868,43.013,58.891,43.036,58.914,43.059z"/>
-<g opacity="0.8">
-	
-		<ellipse transform="matrix(0.7091 -0.7051 0.7051 0.7091 -129.8555 194.9725)" fill="#159E1F" cx="171.352" cy="254.853" rx="50.993" ry="51.004"/>
-</g>
-<path fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" d="M179.224,245.961c-4.374-4.384-11.473-4.393-15.858-0.019
-	c-4.384,4.374-4.393,11.473-0.019,15.858c4.365,4.375,11.447,4.394,15.835,0.042c4.397-4.335,4.446-11.414,0.111-15.811
-	C179.27,246.007,179.247,245.984,179.224,245.961z"/>
-</svg>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="draw"
+   x="0px"
+   y="0px"
+   viewBox="0 0 343.449 305.834"
+   enable-background="new 0 0 343.449 305.834"
+   xml:space="preserve"
+   sodipodi:docname="YMinus.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:export-filename="\\nask.man.ac.uk\home$\Desktop\YMinus2.png"
+   inkscape:export-xdpi="60.013401"
+   inkscape:export-ydpi="60.013401"><metadata
+     id="metadata40613"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title>YMinus</dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs40611" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     id="namedview40609"
+     showgrid="false"
+     inkscape:zoom="1.5433208"
+     inkscape:cx="134.19374"
+     inkscape:cy="125.45233"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="draw" /><title
+     id="title40578">YMinus</title><g
+     transform="translate(242.45506,0.63253)"
+     style="opacity:0.8"
+     id="g41456"><ellipse
+       style="fill:#4ec3e8"
+       transform="matrix(0.7051,-0.7091,0.7091,0.7051,-21.1175,51.1935)"
+       cx="50.995998"
+       cy="50.987999"
+       rx="50.993"
+       ry="51.004002"
+       id="ellipse41454" /></g><rect
+     x="168.017"
+     y="120.306"
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     width="6.777"
+     height="133.572"
+     id="rect40580" /><rect
+     x="162.955"
+     y="83.772"
+     transform="matrix(0.8697 -0.4936 0.4936 0.8697 -13.0842 124.7602)"
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     width="133.572"
+     height="6.777"
+     id="rect40582" /><rect
+     x="110.334"
+     y="20.064"
+     transform="matrix(0.4969 -0.8678 0.8678 0.4969 -18.2066 142.4161)"
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     width="6.777"
+     height="133.692"
+     id="rect40584" /><path
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     d="M214.838,127.079l-36.195,36.195  c-3.869,3.869-10.141,3.869-14.009,0l-36.195-36.195c-3.869-3.869-3.869-10.141,0-14.009l36.195-36.195  c3.869-3.869,10.141-3.869,14.009,0l36.195,36.195C218.706,116.938,218.706,123.21,214.838,127.079z"
+     id="path40586" /><polygon
+     fill="#FF442B"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     points="153.46,142.074 171.637,91.074 189.815,142.074 "
+     id="polygon40588" /><path
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     d="M300.324,42.677c-4.374-4.384-11.473-4.393-15.858-0.019  c-4.384,4.374-4.393,11.473-0.019,15.858c4.365,4.375,11.447,4.394,15.835,0.042c4.397-4.335,4.446-11.414,0.111-15.811  C300.37,42.723,300.347,42.7,300.324,42.677z"
+     id="path40594" /><g
+     opacity="0.8"
+     id="g40598"><ellipse
+       transform="matrix(0.7051 -0.7091 0.7091 0.7051 -21.1165 51.1916)"
+       fill="#159E1F"
+       cx="50.994"
+       cy="50.986"
+       rx="50.993"
+       ry="51.004"
+       id="ellipse40596" /></g><path
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     d="M58.914,43.059c4.384,4.374,4.393,11.473,0.02,15.858  c-4.374,4.384-11.473,4.393-15.857,0.02c-4.376-4.365-4.395-11.447-0.042-15.835c4.335-4.397,11.414-4.446,15.811-0.111  C58.868,43.013,58.891,43.036,58.914,43.059z"
+     id="path40600" /><g
+     opacity="0.8"
+     id="g40604"><ellipse
+       transform="matrix(0.7091 -0.7051 0.7051 0.7091 -129.8555 194.9725)"
+       fill="#159E1F"
+       cx="171.352"
+       cy="254.853"
+       rx="50.993"
+       ry="51.004"
+       id="ellipse40602" /></g><path
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     d="M179.224,245.961c-4.374-4.384-11.473-4.393-15.858-0.019  c-4.384,4.374-4.393,11.473-0.019,15.858c4.365,4.375,11.447,4.394,15.835,0.042c4.397-4.335,4.446-11.414,0.111-15.811  C179.27,246.007,179.247,245.984,179.224,245.961z"
+     id="path40606" /></svg>

--- a/src/AutoPilotPlugins/Common/Images/YPlus.svg
+++ b/src/AutoPilotPlugins/Common/Images/YPlus.svg
@@ -1,35 +1,126 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Generator: Adobe Illustrator 19.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="draw" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 343.449 305.834" enable-background="new 0 0 343.449 305.834" xml:space="preserve">
-<title>YPlus</title>
-<rect x="168.017" y="120.306" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="6.777" height="133.572"/>
-<rect x="162.951" y="83.772" transform="matrix(0.8697 -0.4936 0.4936 0.8697 -13.085 124.7584)" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="133.572" height="6.777"/>
-<rect x="110.335" y="20.065" transform="matrix(0.4969 -0.8678 0.8678 0.4969 -18.2066 142.4172)" fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" width="6.777" height="133.692"/>
-<path fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" d="M214.837,127.079l-36.195,36.195
-	c-3.869,3.869-10.141,3.869-14.009,0l-36.195-36.195c-3.869-3.869-3.869-10.141,0-14.009l36.195-36.195
-	c3.869-3.869,10.141-3.869,14.009,0l36.195,36.195C218.705,116.938,218.705,123.21,214.837,127.079z"/>
-<polygon fill="#FF442B" stroke="#000000" stroke-miterlimit="10" points="153.46,142.074 171.637,91.074 189.815,142.074 "/>
-<g opacity="0.8">
-	
-		<ellipse transform="matrix(0.7091 -0.7051 0.7051 0.7091 48.7216 221.2214)" fill="#4EC3E8" cx="292.45" cy="51.567" rx="50.993" ry="51.004"/>
-</g>
-<path fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" d="M300.322,42.677c-4.374-4.384-11.473-4.393-15.858-0.019
-	c-4.384,4.374-4.393,11.473-0.019,15.858c4.365,4.375,11.447,4.394,15.835,0.042c4.397-4.335,4.446-11.414,0.111-15.811
-	C300.368,42.723,300.345,42.7,300.322,42.677z"/>
-<g opacity="0.8">
-	
-		<ellipse transform="matrix(0.7051 -0.7091 0.7091 0.7051 -21.1175 51.1935)" fill="#4EC3E8" cx="50.996" cy="50.988" rx="50.993" ry="51.004"/>
-</g>
-<path fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" d="M58.914,43.059c4.384,4.374,4.393,11.473,0.019,15.858
-	c-4.374,4.384-11.473,4.393-15.858,0.019c-4.375-4.365-4.394-11.447-0.042-15.835c4.335-4.397,11.414-4.446,15.811-0.111
-	C58.868,43.013,58.891,43.036,58.914,43.059z"/>
-<g opacity="0.8">
-	
-		<ellipse transform="matrix(0.7091 -0.7051 0.7051 0.7091 -129.8543 194.9702)" fill="#4EC3E8" cx="171.349" cy="254.85" rx="50.993" ry="51.004"/>
-</g>
-<path fill="#FFFFFF" stroke="#000000" stroke-miterlimit="10" d="M179.221,245.961c-4.374-4.384-11.473-4.393-15.858-0.019
-	c-4.384,4.374-4.393,11.473-0.019,15.858c4.365,4.375,11.447,4.394,15.835,0.042c4.397-4.335,4.446-11.414,0.111-15.811
-	C179.267,246.007,179.244,245.984,179.221,245.961z"/>
-</svg>
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="draw"
+   x="0px"
+   y="0px"
+   viewBox="0 0 343.449 305.834"
+   enable-background="new 0 0 343.449 305.834"
+   xml:space="preserve"
+   sodipodi:docname="YPlus.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   inkscape:export-filename="\\nask.man.ac.uk\home$\Desktop\YPlus2.png"
+   inkscape:export-xdpi="60.013401"
+   inkscape:export-ydpi="60.013401"><metadata
+     id="metadata41471"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title>YPlus</dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs41469" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     id="namedview41467"
+     showgrid="false"
+     inkscape:zoom="2.1825852"
+     inkscape:cx="210.05676"
+     inkscape:cy="157.88035"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="draw" /><title
+     id="title41436">YPlus</title><rect
+     x="168.017"
+     y="120.306"
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     width="6.777"
+     height="133.572"
+     id="rect41438" /><rect
+     x="162.951"
+     y="83.772"
+     transform="matrix(0.8697 -0.4936 0.4936 0.8697 -13.085 124.7584)"
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     width="133.572"
+     height="6.777"
+     id="rect41440" /><rect
+     x="110.335"
+     y="20.065"
+     transform="matrix(0.4969 -0.8678 0.8678 0.4969 -18.2066 142.4172)"
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     width="6.777"
+     height="133.692"
+     id="rect41442" /><path
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     d="M214.837,127.079l-36.195,36.195  c-3.869,3.869-10.141,3.869-14.009,0l-36.195-36.195c-3.869-3.869-3.869-10.141,0-14.009l36.195-36.195  c3.869-3.869,10.141-3.869,14.009,0l36.195,36.195C218.705,116.938,218.705,123.21,214.837,127.079z"
+     id="path41444" /><polygon
+     fill="#FF442B"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     points="153.46,142.074 171.637,91.074 189.815,142.074 "
+     id="polygon41446" /><g
+     opacity="0.8"
+     id="g41456"><ellipse
+       transform="matrix(0.7051 -0.7091 0.7091 0.7051 -21.1175 51.1935)"
+       fill="#4EC3E8"
+       cx="50.996"
+       cy="50.988"
+       rx="50.993"
+       ry="51.004"
+       id="ellipse41454" /></g><path
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     d="M58.914,43.059c4.384,4.374,4.393,11.473,0.019,15.858  c-4.374,4.384-11.473,4.393-15.858,0.019c-4.375-4.365-4.394-11.447-0.042-15.835c4.335-4.397,11.414-4.446,15.811-0.111  C58.868,43.013,58.891,43.036,58.914,43.059z"
+     id="path41458" /><g
+     opacity="0.8"
+     id="g41462"><ellipse
+       transform="matrix(0.7091 -0.7051 0.7051 0.7091 -129.8543 194.9702)"
+       fill="#4EC3E8"
+       cx="171.349"
+       cy="254.85"
+       rx="50.993"
+       ry="51.004"
+       id="ellipse41460" /></g><path
+     fill="#FFFFFF"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     d="M179.221,245.961c-4.374-4.384-11.473-4.393-15.858-0.019  c-4.384,4.374-4.393,11.473-0.019,15.858c4.365,4.375,11.447,4.394,15.835,0.042c4.397-4.335,4.446-11.414,0.111-15.811  C179.267,246.007,179.244,245.984,179.221,245.961z"
+     id="path41464" /><g
+     transform="translate(241.37185,0.28067)"
+     style="opacity:0.8"
+     id="g40598"><ellipse
+       style="fill:#159e1f"
+       transform="matrix(0.7051,-0.7091,0.7091,0.7051,-21.1165,51.1916)"
+       cx="50.993999"
+       cy="50.986"
+       rx="50.993"
+       ry="51.004002"
+       id="ellipse40596" /></g><path
+     stroke-miterlimit="10"
+     d="m 300.322,42.677 c -4.374,-4.384 -11.473,-4.393 -15.858,-0.019 -4.384,4.374 -4.393,11.473 -0.019,15.858 4.365,4.375 11.447,4.394 15.835,0.042 4.397,-4.335 4.446,-11.414 0.111,-15.811 -0.023,-0.024 -0.046,-0.047 -0.069,-0.07 z"
+     id="path41452"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke:#000000;stroke-miterlimit:10" /></svg>


### PR DESCRIPTION
### Why?
Tri airframe config. have been updated in px4 user guide to say that direction of propellers is not taken into account in px4 software. The recommended airframe setup images have been updated too. See https://github.com/PX4/PX4-user_guide/issues/725

This PR updates the images in QGC to correspond with those in px4 user guide.