### PR TITLE
Vehicle: SubmarineFact: Fix RangeFinder unit

### DIFF
--- a/src/Vehicle/SubmarineFact.json
+++ b/src/Vehicle/SubmarineFact.json
@@ -44,7 +44,7 @@
     "shortDesc": "Rangefinder",
     "type":             "float",
     "decimalPlaces":    2,
-    "units":            "meters"
+    "units":            "m"
 },
 {   "name":             "rollPitchToggle",
     "shortDesc": "Roll/Pitch Toggle",


### PR DESCRIPTION
Use 'm' over 'meters'

Older version:
![image](https://user-images.githubusercontent.com/1215497/126692131-f3f343e1-a84b-4d65-8400-9d733222e741.png)
New version:
![image](https://user-images.githubusercontent.com/1215497/126692172-3a5cb406-67e3-4eff-afbe-7baf84b9c7fa.png)


Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


