### PR TITLE
APMSafetyComponentSummarySub: Do not warn if BATT_FS_LOW_ACT and BATT_LOW_* are not available

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
@@ -15,7 +15,7 @@ Item {
     FactPanelController { id: controller; }
 
     // Enable/Action parameters
-    property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT")
+    property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT", false)
     property Fact _failsafeEKFEnable:         controller.getParameterFact(-1, "FS_EKF_ACTION")
     property Fact _failsafeGCSEnable:         controller.getParameterFact(-1, "FS_GCS_ENABLE")
     property Fact _failsafeLeakEnable:        controller.getParameterFact(-1, "FS_LEAK_ENABLE")
@@ -30,8 +30,8 @@ Item {
     property Fact _failsafeLeakPin:              controller.getParameterFact(-1, "LEAK1_PIN")
     property Fact _failsafeLeakLogic:            controller.getParameterFact(-1, "LEAK1_LOGIC")
     property Fact _failsafeEKFThreshold:         controller.getParameterFact(-1, "FS_EKF_THRESH")
-    property Fact _failsafeBatteryVoltage:       controller.getParameterFact(-1, "r.BATT_LOW_VOLT")
-    property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "r.BATT_LOW_MAH")
+    property Fact _failsafeBatteryVoltage:       controller.getParameterFact(-1, "r.BATT_LOW_VOLT", false)
+    property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "r.BATT_LOW_MAH", false)
 
     property Fact _armingCheck: controller.getParameterFact(-1, "ARMING_CHECK")
 


### PR DESCRIPTION

The parameters will exist if the battery monitor is enabled

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


