### PR TITLE
APMSafetyComponentSummarySub: Add 'Disabled' text when battery monitor is not enabled

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
@@ -53,7 +53,17 @@ Item {
         VehicleSummaryRow {
             visible: !_firmware34
             labelText: qsTr("Battery failsafe:")
-            valueText: _firmware34 ? "" : _failsafeBatteryEnable.enumOrValueString
+            valueText: {
+                if(_firmware34) {
+                    return "Firmware not supported"
+                }
+
+                if (!_failsafeBatteryEnable) {
+                    return "Disabled"
+                }
+
+                return _failsafeBatteryEnable.enumOrValueString
+            }
         }
         VehicleSummaryRow {
             visible: !_firmware34


### PR DESCRIPTION

Parameter only exists if the battery monitor was configured (not None)

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


