### PR TITLE
WIP: Remove mavlink fork of gst-plugins-good

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -14,7 +14,7 @@ defaults:
 
 env:
   SOURCE_DIR:   ${{ github.workspace }}
-  QT_VERSION:   5.12.6
+  QT_VERSION:   5.15.2
 
 jobs:
   build:

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -14,7 +14,7 @@ defaults:
 
 env:
   SOURCE_DIR:   ${{ github.workspace }}
-  QT_VERSION:   5.12.6
+  QT_VERSION:   5.15.2
   ARTIFACT:     QGroundControl.AppImage
 
 jobs:

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -14,7 +14,7 @@ defaults:
 
 env:
   SOURCE_DIR:   ${{ github.workspace }}
-  QT_VERSION:   5.12.6
+  QT_VERSION:   5.15.2
   ARTIFACT:     QGroundControl.dmg
 
 jobs:

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -14,7 +14,7 @@ defaults:
 
 env:
   SOURCE_DIR:   ${{ github.workspace }}
-  QT_VERSION:   5.12.6
+  QT_VERSION:   5.15.2
   ARTIFACT:     QGroundControl-installer.exe
 
 jobs:

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/Auterion/android_openssl
 [submodule "libs/qmlglsink/gst-plugins-good"]
 	path = libs/qmlglsink/gst-plugins-good
-	url = https://github.com/mavlink/gst-plugins-good.git
+	url = git://anongit.freedesktop.org/gstreamer/gst-plugins-good
 [submodule "libs/xz-embedded"]
 	path = libs/xz-embedded
 	url = https://github.com/Auterion/xz-embedded.git

--- a/libs/qmlglsink/CMakeLists.txt
+++ b/libs/qmlglsink/CMakeLists.txt
@@ -18,6 +18,12 @@ add_library(qmlglsink
     gst-plugins-good/ext/qt/gstqtsrc.h
     gst-plugins-good/ext/qt/qtwindow.h
     gst-plugins-good/ext/qt/qtitem.h
+
+    gst-plugins-good/ext/qt/gstqtoverlay.cc
+    gst-plugins-good/ext/qt/gstqtoverlay.h
+
+    gst-plugins-good/ext/qt/qtglrenderer.cc
+    gst-plugins-good/ext/qt/qtglrenderer.h
 )
 
 if(LINUX)
@@ -52,6 +58,7 @@ endif()
 target_link_libraries(qmlglsink
 	PUBLIC
 		Qt5::Core
+		Qt5::Quick
 		Qt5::OpenGL
 		Qt5::GuiPrivate
 		${GST_LINK_LIBRARIES}

--- a/qmlglsink.pri
+++ b/qmlglsink.pri
@@ -18,7 +18,9 @@ SOURCES += \
     libs/qmlglsink/gst-plugins-good/ext/qt/gstqtsink.cc \
     libs/qmlglsink/gst-plugins-good/ext/qt/gstqtsrc.cc \
     libs/qmlglsink/gst-plugins-good/ext/qt/qtwindow.cc \
-    libs/qmlglsink/gst-plugins-good/ext/qt/qtitem.cc
+    libs/qmlglsink/gst-plugins-good/ext/qt/qtitem.cc \
+    libs/qmlglsink/gst-plugins-good/ext/qt/gstqtoverlay.cc \
+    libs/qmlglsink/gst-plugins-good/ext/qt/qtglrenderer.cc \
 
 HEADERS += \
     libs/qmlglsink/gst-plugins-good/ext/qt/gstqsgtexture.h \
@@ -27,4 +29,6 @@ HEADERS += \
     libs/qmlglsink/gst-plugins-good/ext/qt/gstqtsink.h \
     libs/qmlglsink/gst-plugins-good/ext/qt/gstqtsrc.h \
     libs/qmlglsink/gst-plugins-good/ext/qt/qtwindow.h \
-    libs/qmlglsink/gst-plugins-good/ext/qt/qtitem.h
+    libs/qmlglsink/gst-plugins-good/ext/qt/qtitem.h \
+    libs/qmlglsink/gst-plugins-good/ext/qt/gstqtoverlay.h \
+    libs/qmlglsink/gst-plugins-good/ext/qt/qtglrenderer.h \


### PR DESCRIPTION
Uses original repository of gst-plugins-good.
Tested under android and linux. 