### PR TITLE
Images: Fix battery icon xml

### DIFF
--- a/src/ui/toolbar/Images/Battery.svg
+++ b/src/ui/toolbar/Images/Battery.svg
@@ -1,19 +1,13 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 72 72" style="enable-background:new 0 0 72 72;" xml:space="preserve">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg enable-background="new 0 0 72 72" version="1.1" viewBox="0 0 72 72" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
 <style type="text/css">
 	.st0{fill:none;}
 	.st1{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:6;stroke-miterlimit:10;}
 	.st2{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:2;}
 </style>
-<path id="rect4360" inkscape:connector-curvature="0" class="st0" d="M14.4,65.5v-55c0-1.6,1.9-2.9,4.2-2.9h34.7
-	c2.4,0,4.2,1.3,4.2,2.9v55c0,1.6-1.9,2.9-4.2,2.9H18.7C16.3,68.4,14.4,67.1,14.4,65.5z"/>
-<g id="g4222" transform="translate(-127.22081,216.20249)">
-	<path id="path4224" inkscape:connector-curvature="0" class="st1" d="M171.9-208c0,0.2-0.2,0.4-0.4,0.4H155c-0.2,0-0.4-0.2-0.4-0.4
-		v-4.2c0-0.2,0.2-0.4,0.4-0.4h16.5c0.2,0,0.4,0.2,0.4,0.4V-208L171.9-208L171.9-208z"/>
+<path class="st0" d="m14.4 65.5v-55c0-1.6 1.9-2.9 4.2-2.9h34.7c2.4 0 4.2 1.3 4.2 2.9v55c0 1.6-1.9 2.9-4.2 2.9h-34.6c-2.4 0-4.3-1.3-4.3-2.9z"/>
+<g transform="translate(-127.22 216.2)">
+	<path class="st1" d="m171.9-208c0 0.2-0.2 0.4-0.4 0.4h-16.5c-0.2 0-0.4-0.2-0.4-0.4v-4.2c0-0.2 0.2-0.4 0.4-0.4h16.5c0.2 0 0.4 0.2 0.4 0.4v4.2z"/>
 </g>
-<path class="st2" d="M51.6,9.4H19.6c-2.2,0-3.9,1.3-3.9,2.8v52.9c0,1.6,1.7,2.8,3.9,2.8h31.9c2.2,0,3.9-1.3,3.9-2.8V12.2
-	C55.5,10.6,53.7,9.4,51.6,9.4z M20.6,24h30.1v8.2H20.6V24z M50.6,63.8H20.6v-8.2h30.1V63.8z M50.6,53.3H20.6v-8.2h30.1V53.3z
-	 M50.6,42.8H20.6v-8.2h30.1V42.8z M50.6,21.7H20.6v-8.2h30.1V21.7z"/>
+<path class="st2" d="m51.6 9.4h-32c-2.2 0-3.9 1.3-3.9 2.8v52.9c0 1.6 1.7 2.8 3.9 2.8h31.9c2.2 0 3.9-1.3 3.9-2.8v-52.9c0.1-1.6-1.7-2.8-3.8-2.8zm-31 14.6h30.1v8.2h-30.1v-8.2zm30 39.8h-30v-8.2h30.1v8.2zm0-10.5h-30v-8.2h30.1v8.2zm0-10.5h-30v-8.2h30.1v8.2zm0-21.1h-30v-8.2h30.1v8.2z"/>
 </svg>


### PR DESCRIPTION
Fix error Qt xml error: "Namespace prefix inkscape for connector-curvature on path is not defined"

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


