### PR TITLE
Publish horizontal PositionManager::gcsPositionHorizontalAccuracy

### DIFF
--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -81,9 +81,12 @@ void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
     if (update.isValid() && update.hasAttribute(QGeoPositionInfo::HorizontalAccuracy)) {
         // Note that gcsPosition filters out possible crap values
         if (qAbs(update.coordinate().latitude()) > 0.001 &&
-            qAbs(update.coordinate().longitude()) > 0.001 &&
-            update.attribute(QGeoPositionInfo::HorizontalAccuracy) <= MinHorizonalAccuracyMeters) {
-            newGCSPosition = update.coordinate();
+            qAbs(update.coordinate().longitude()) > 0.001 ) {
+            _gcsPositionHorizontalAccuracy = update.attribute(QGeoPositionInfo::HorizontalAccuracy);
+            if (_gcsPositionHorizontalAccuracy <= MinHorizonalAccuracyMeters) {
+                newGCSPosition = update.coordinate();
+            }
+            emit gcsPositionHorizontalAccuracyChanged();
         }
     }
     if (newGCSPosition != _gcsPosition) {

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -27,6 +27,8 @@ public:
 
     Q_PROPERTY(QGeoCoordinate gcsPosition  READ gcsPosition  NOTIFY gcsPositionChanged)
     Q_PROPERTY(qreal          gcsHeading   READ gcsHeading   NOTIFY gcsHeadingChanged)
+    Q_PROPERTY(qreal          gcsPositionHorizontalAccuracy  READ gcsPositionHorizontalAccuracy
+                                                             NOTIFY gcsPositionHorizontalAccuracyChanged)
 
     enum QGCPositionSource {
         Simulated,
@@ -37,6 +39,7 @@ public:
 
     QGeoCoordinate      gcsPosition         (void) { return _gcsPosition; }
     qreal               gcsHeading          (void) const{ return _gcsHeading; }
+    qreal               gcsPositionHorizontalAccuracy(void) const { return _gcsPositionHorizontalAccuracy; }
     QGeoPositionInfo    geoPositionInfo     (void) const { return _geoPositionInfo; }
     void                setPositionSource   (QGCPositionSource source);
     int                 updateInterval      (void) const;
@@ -54,12 +57,14 @@ signals:
     void gcsPositionChanged(QGeoCoordinate gcsPosition);
     void gcsHeadingChanged(qreal gcsHeading);
     void positionInfoUpdated(QGeoPositionInfo update);
+    void gcsPositionHorizontalAccuracyChanged();
 
 private:
     int                 _updateInterval =   0;
     QGeoPositionInfo    _geoPositionInfo;
     QGeoCoordinate      _gcsPosition;
     qreal               _gcsHeading =       qQNaN();
+    qreal               _gcsPositionHorizontalAccuracy = std::numeric_limits<qreal>::infinity();
 
     QGeoPositionInfoSource*     _currentSource =        nullptr;
     QGeoPositionInfoSource*     _defaultSource =        nullptr;


### PR DESCRIPTION
We would like to implement "Return to Groundstation" feature - i.e.: mid-flight, the pilot presses a button, the mission is aborted and much like returning home, the vehicle returns to hover above the ground control station.

We see there is some "prior art", namely:
- `rtgsFlightMode` in [here](https://github.com/mavlink/qgroundcontrol/blob/master/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc#L51), but, for some reason it's [not user-settable](https://github.com/mavlink/qgroundcontrol/blob/master/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc#L88).
- a seemingly stale feature request [here](https://github.com/PX4/PX4-Autopilot/issues/9343) - [a comment](https://github.com/PX4/PX4-Autopilot/issues/9343#issuecomment-382905192) in that feature request makes us suspect `rtgsFlightMode` is not settable, because it's only foreseen a flymode the vehicle can put itself into in some RC-loss situations.

But we otherwise see no functionality in QGC or PX4 that can achieve what we need.
We don't want to distract @DonLakeFlyer with a massive change **unless he asks for it**, so we will work on the feature on our fork. The minimum we need upstream however, is to know how well does the GCS know where it is. Only if that accuracy is decent (~10m sounds scary already), we can send the drone to hover above the GCS. Hence this small PR.
