### PR TITLE
Settings for the Workswell Wiris Security

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -849,7 +849,37 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle*)
                     this);              // parent
         _cameraList.append(QVariant::fromValue(metaData));
 
+        metaData = new CameraMetaData(
+                    "Workswell Wiris Security Thermal Camera",
+                    tr("Workswell"),
+                    tr("Wiris Security"),
+                    13.6,                // sensorWidth
+                    10.2,                // sensorHeight
+                    800,               // imageWidth
+                    600,               // imageHeight
+                    35,                // focalLength
+                    true,               // true: landscape orientation
+                    false,              // true: camera is fixed orientation
+                    1.0,                  // minimum trigger interval
+                    "",   // SHOULD BE BLANK FOR NEWLY ADDED CAMERAS. Deprecated translation from older builds.
+                    this);              // parent
+        _cameraList.append(QVariant::fromValue(metaData));
 
+        metaData = new CameraMetaData(
+                    "Workswell Wiris Security Visual Camera",
+                    tr("Workswell"),
+                    tr("Wiris Security"),
+                    4.826,                // sensorWidth
+                    3.556,                // sensorHeight
+                    1920,               // imageWidth
+                    1080,               // imageHeight
+                    4.3,                // focalLength
+                    true,               // true: landscape orientation
+                    false,              // true: camera is fixed orientation
+                    1.0,                  // minimum trigger interval
+                    "",   // SHOULD BE BLANK FOR NEWLY ADDED CAMERAS. Deprecated translation from older builds.
+                    this);              // parent
+        _cameraList.append(QVariant::fromValue(metaData));
     }
 
     return _cameraList;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -860,7 +860,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle*)
                     35,                // focalLength
                     true,               // true: landscape orientation
                     false,              // true: camera is fixed orientation
-                    1.0,                  // minimum trigger interval
+                    1.8,                  // minimum trigger interval
                     "",   // SHOULD BE BLANK FOR NEWLY ADDED CAMERAS. Deprecated translation from older builds.
                     this);              // parent
         _cameraList.append(QVariant::fromValue(metaData));
@@ -876,7 +876,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle*)
                     4.3,                // focalLength
                     true,               // true: landscape orientation
                     false,              // true: camera is fixed orientation
-                    1.0,                  // minimum trigger interval
+                    1.8,                  // minimum trigger interval
                     "",   // SHOULD BE BLANK FOR NEWLY ADDED CAMERAS. Deprecated translation from older builds.
                     this);              // parent
         _cameraList.append(QVariant::fromValue(metaData));


### PR DESCRIPTION
I added the Workswell Wiris Security as an option for surveys (https://workswell-thermal-camera.com/drone-security-thermal-imaging-camera-night-vision-uav/)
This is the datasheet I got the values for the image dimensions and focal length 
[wws-datasheet-en-210126.pdf](https://github.com/mavlink/qgroundcontrol/files/6939979/wws-datasheet-en-210126.pdf)
The sensor height and width information came from Workswell customer support.

