### PR TITLE
Update PX4FirmwarePlugin.cc

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -643,7 +643,7 @@ QString PX4FirmwarePlugin::_versionRegex() {
 
 bool PX4FirmwarePlugin::supportsNegativeThrust(Vehicle* vehicle)
 {
-    return vehicle->vehicleType() == MAV_TYPE_GROUND_ROVER;
+    return ((vehicle->vehicleType() == MAV_TYPE_GROUND_ROVER) || (vehicle->vehicleType() == MAV_TYPE_SUBMARINE));
 }
 
 QString PX4FirmwarePlugin::getHobbsMeter(Vehicle* vehicle) 


### PR DESCRIPTION
This allows UUV-vehicle types the ability to have negative thrust in PX4. I have successfully built QGC with these changes and my uuv supports negative thrust now. 