### PR TITLE
QGCDeploy: Fix mac deployment

### DIFF
--- a/cmake/QGCDeploy.cmake
+++ b/cmake/QGCDeploy.cmake
@@ -15,14 +15,34 @@ elseif(APPLE)
 	get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
 	find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
 
-	add_custom_command(TARGET QGroundControl
-		POST_BUILD
+	add_custom_target(dmg)
+
+	if(GST_FOUND)
+		add_custom_command(TARGET dmg
+			OUTPUT
+			COMMAND
+				${CMAKE_SOURCE_DIR}/tools/prepare_gstreamer_framework.sh ${CMAKE_BINARY_DIR}/gstwork/ QGroundControl.app QGroundControl
+		)
+	endif()
+
+	add_custom_command(TARGET dmg
+		OUTPUT
 		COMMAND
 			${MACDEPLOYQT_EXECUTABLE} $<TARGET_FILE_DIR:QGroundControl>/../.. -appstore-compliant -qmldir=${CMAKE_SOURCE_DIR}/src
 		COMMAND
 			rsync -a ${CMAKE_SOURCE_DIR}/libs/Frameworks $<TARGET_FILE_DIR:QGroundControl>/../../Contents/
 		COMMAND
 			${CMAKE_INSTALL_NAME_TOOL} -change "@rpath/SDL2.framework/Versions/A/SDL2" "@executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2" $<TARGET_FILE:QGroundControl>
+		COMMAND
+			mkdir -p ${CMAKE_BINARY_DIR}/package
+		COMMAND
+			mkdir -p ${CMAKE_BINARY_DIR}/staging
+		COMMAND
+			rsync -a --delete ${CMAKE_BINARY_DIR}/QGroundControl.app ${CMAKE_BINARY_DIR}/staging
+		COMMAND
+			hdiutil create /tmp/tmp.dmg -ov -volname "QGroundControl-$${GIT_VERSION}" -fs HFS+ -srcfolder "staging"
+		COMMAND
+			hdiutil convert /tmp/tmp.dmg -format UDBZ -o ${CMAKE_BINARY_DIR}/package/QGroundControl.dmg
 	)
 
 	set_target_properties(QGroundControl PROPERTIES MACOSX_BUNDLE YES)


### PR DESCRIPTION
- Do not deploy when compiling QGC
- Deploy with the custom command dmg
- Fix mac deployment 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


