### PR TITLE
Migrate from deprecated enums (Qt5.15)

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1994,7 +1994,7 @@ QGCCameraControl::_httpRequest(const QString &url)
     tempProxy.setType(QNetworkProxy::DefaultProxy);
     _netManager->setProxy(tempProxy);
     QNetworkRequest request(url);
-    request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, true);
     QSslConfiguration conf = request.sslConfiguration();
     conf.setPeerVerifyMode(QSslSocket::VerifyNone);
     request.setSslConfiguration(conf);

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -423,7 +423,7 @@ void QGCApplication::setLanguage()
             _locale = QLocale(QLocale::Korean);
             break;
         case 13:
-            _locale = QLocale(QLocale::Norwegian);
+            _locale = QLocale(QLocale::NorwegianBokmal);
             break;
         case 14:
             _locale = QLocale(QLocale::Polish);

--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -743,7 +743,7 @@ MAVLinkLogManager::_sendLog(const QString& logFile)
     file->setParent(multiPart);
     QNetworkRequest request(_uploadURL);
 #if QT_VERSION > 0x050600
-    request.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, true);
 #endif
     QNetworkReply* reply = _nam->post(request, multiPart);
     connect(reply, &QNetworkReply::finished,  this, &MAVLinkLogManager::_uploadFinished);

--- a/src/VideoManager/SubtitleWriter.cc
+++ b/src/VideoManager/SubtitleWriter.cc
@@ -166,7 +166,7 @@ void SubtitleWriter::_captureTelemetry()
     stringColumns << QStringLiteral("Dialogue: 0,%1,%2,Default,,0,0,0,,{\\pos(10,35)}%3\n")
         .arg(start.toString("H:mm:ss.zzz").chopped(2))
         .arg(end.toString("H:mm:ss.zzz").chopped(2))
-        .arg(QDateTime::currentDateTime().toString(Qt::SystemLocaleShortDate));
+        .arg(QDateTime::currentDateTime().toString(QLocale::system().dateFormat(QLocale::ShortFormat)));
     // Write new data
     QTextStream stream(&_file);
     for (const auto& i : stringColumns) {


### PR DESCRIPTION
It appears [this](https://github.com/mavlink/qgroundcontrol/commit/ce1551ca1a73b886844a708424dd9aa676082ab8) change had made the build process sensitive to enums deprecated going from Qt 5.12->5.15

It's a bit hard to prove, but there are some hints that only starting from C++14 one can deprecate enums:
- [deprecated attribute](https://en.cppreference.com/w/cpp/language/attributes/deprecated)
- deprecated enums are a ["new" thing in C++ (gcc 6+)](https://gcc.gnu.org/gcc-6/changes.html) - i know we way past it, but perhaps they are enabled C++14+ while dormant for when we use the C++11 dialect.
- removing the `CONFIG += c++17` directive **hides** the problem.
