### PR TITLE
travis: Only run build for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 
 language: cpp
 
+# We only build tags since we have a limited number of credits for travis
+if: tag IS present
+
 env:
   global:
     - JOBS=4


### PR DESCRIPTION
There is a limited number of credits that can be used in Travis

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


