### PR TITLE
APM: Mission Flight Speed

### DIFF
--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -36,7 +36,7 @@ Rectangle {
     property bool   _waypointsOnlyMode:             QGroundControl.corePlugin.options.missionWaypointsOnly
     property bool   _showCameraSection:             (_waypointsOnlyMode || QGroundControl.corePlugin.showAdvancedUI) && !_controllerVehicle.apmFirmware
     property bool   _simpleMissionStart:            QGroundControl.corePlugin.options.showSimpleMissionStart
-    property bool   _showFlightSpeed:               !_controllerVehicle.vtol && !_simpleMissionStart && !_controllerVehicle.apmFirmware
+    property bool   _showFlightSpeed:               !_controllerVehicle.vtol && !_simpleMissionStart
     property bool   _allowFWVehicleTypeSelection:   _noMissionItemsAdded && !globals.activeVehicle
 
     readonly property string _firmwareLabel:    qsTr("Firmware")


### PR DESCRIPTION
APM firmware does indeed support the MAV_CMD_DO_CHANGE_SPEED command for changing the speed for a mission. I tested this in sim against Copter-4.0.7 and QGC master as of today.