### PR TITLE
fix implicitly defined properties in Connections

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -79,7 +79,7 @@ Item {
 
                 Connections {
                     target: QGroundControl.videoManager
-                    onImageFileChanged: {
+                    function onImageFileChanged() {
                         videoContent.grabToImage(function(result) {
                             if (!result.saveToFile(QGroundControl.videoManager.imageFile)) {
                                 console.error('Error capturing video frame');

--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -108,10 +108,10 @@ FlightMap {
     Connections {
         target: gesture
 
-        onPanStarted:       _disableVehicleTracking = true
-        onFlickStarted:     _disableVehicleTracking = true
-        onPanFinished:      panRecenterTimer.restart()
-        onFlickFinished:    panRecenterTimer.restart()
+        function onPanStarted() {       _disableVehicleTracking = true }
+        function onFlickStarted() {     _disableVehicleTracking = true }
+        function onPanFinished() {      panRecenterTimer.restart() }
+        function onFlickFinished() {    panRecenterTimer.restart() }
     }
 
     function pointInRect(point, rect) {
@@ -207,7 +207,7 @@ FlightMap {
     Connections {
         target:                 _missionController
         ignoreUnknownSignals:   true
-        onNewItemsFromVehicle: {
+        function onNewItemsFromVehicle() {
             var visualItems = _missionController.visualItems
             if (visualItems && visualItems.count !== 1) {
                 mapFitFunctions.fitMapViewportToMissionItems()
@@ -238,7 +238,9 @@ FlightMap {
 
         Connections {
             target:                 QGroundControl.multiVehicleManager
-            onActiveVehicleChanged: trajectoryPolyline.path = _activeVehicle ? _activeVehicle.trajectoryPoints.list() : []
+            function onActiveVehicleChanged() {
+                trajectoryPolyline.path = _activeVehicle ? _activeVehicle.trajectoryPoints.list() : []
+            }
         }
 
         Connections {
@@ -380,7 +382,7 @@ FlightMap {
 
         Connections {
             target: QGroundControl.multiVehicleManager
-            onActiveVehicleChanged: {
+            function onActiveVehicleChanged() {
                 if (!activeVehicle) {
                     gotoLocationItem.visible = false
                 }
@@ -418,7 +420,7 @@ FlightMap {
 
         Connections {
             target: QGroundControl.multiVehicleManager
-            onActiveVehicleChanged: {
+            function onActiveVehicleChanged() {
                 if (!activeVehicle) {
                     orbitMapCircle.visible = false
                 }

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -268,16 +268,16 @@ Item {
 
     Connections {
         target:                     missionController
-        onResumeMissionUploadFail:  confirmAction(actionResumeMissionUploadFail)
+        function onResumeMissionUploadFail() { confirmAction(actionResumeMissionUploadFail) }
     }
 
     Connections {
         target:                             mainWindow
-        onArmVehicleRequest:                armVehicleRequest()
-        onForceArmVehicleRequest:           forceArmVehicleRequest()
-        onDisarmVehicleRequest:             disarmVehicleRequest()
-        onVtolTransitionToFwdFlightRequest: vtolTransitionToFwdFlightRequest()
-        onVtolTransitionToMRFlightRequest:  vtolTransitionToMRFlightRequest()
+        function onArmVehicleRequest() { armVehicleRequest() }
+        function onForceArmVehicleRequest() { forceArmVehicleRequest() }
+        function onDisarmVehicleRequest() { disarmVehicleRequest() }
+        function onVtolTransitionToFwdFlightRequest() { vtolTransitionToFwdFlightRequest() }
+        function onVtolTransitionToMRFlightRequest() { vtolTransitionToMRFlightRequest() }
     }
 
     function armVehicleRequest() {

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -109,12 +109,12 @@ Map {
 
     Connections {
         target:             QGroundControl.settingsManager.flightMapSettings.mapType
-        onRawValueChanged:  updateActiveMapType()
+        function onRawValueChanged() { updateActiveMapType() }
     }
 
     Connections {
         target:             QGroundControl.settingsManager.flightMapSettings.mapProvider
-        onRawValueChanged:  updateActiveMapType()
+        function onRawValueChanged() { updateActiveMapType() }
     }
 
     /// Ground Station location

--- a/src/FlightMap/MapScale.qml
+++ b/src/FlightMap/MapScale.qml
@@ -131,9 +131,9 @@ Item {
 
     Connections {
         target:             mapControl
-        onWidthChanged:     scaleTimer.restart()
-        onHeightChanged:    scaleTimer.restart()
-        onZoomLevelChanged: scaleTimer.restart()
+        function onWidthChanged() {     scaleTimer.restart() }
+        function onHeightChanged() {    scaleTimer.restart() }
+        function onZoomLevelChanged() { scaleTimer.restart() }
     }
 
     Timer {

--- a/src/MissionManager/QGCMapCircleVisuals.qml
+++ b/src/MissionManager/QGCMapCircleVisuals.qml
@@ -122,7 +122,7 @@ Item {
 
             Connections {
                 target:             mapCircle
-                onCenterChanged:    updateCoordinate()
+                function onCenterChanged()    { updateCoordinate() }
             }
 
             sourceItem: Shape {

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -49,7 +49,7 @@ Rectangle {
 
     Connections {
         target: _controllerVehicle
-        onSupportsTerrainFrameChanged: {
+        function onSupportsTerrainFrameChanged() {
             if (!_controllerVehicle.supportsTerrainFrame && _missionController.globalAltitudeMode === QGroundControl.AltitudeModeTerrainFrame) {
                 _missionController.globalAltitudeMode = QGroundControl.AltitudeModeCalcAboveTerrain
             }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -116,7 +116,7 @@ Item {
 
     Connections {
         target: _appSettings ? _appSettings.defaultMissionItemAltitude : null
-        onRawValueChanged: {
+        function onRawValueChanged() {
             if (_visualItems.count > 1) {
                 mainWindow.showComponentDialog(applyNewAltitude, qsTr("Apply new altitude"), mainWindow.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
             }
@@ -198,7 +198,7 @@ Item {
 
     Connections {
         target: QGroundControl.airspaceManager
-        onAirspaceVisibleChanged: {
+        function onAirspaceVisibleChanged() {
             planControlColapsed = QGroundControl.airspaceManager.airspaceVisible
         }
     }
@@ -303,7 +303,7 @@ Item {
     Connections {
         target: _missionController
 
-        onNewItemsFromVehicle: {
+        function onNewItemsFromVehicle() {
             if (_visualItems && _visualItems.count !== 1) {
                 mapFitFunctions.fitMapViewportToMissionItems()
             }
@@ -545,13 +545,13 @@ Item {
 
                 Connections {
                     target:                 _missionController
-                    onSplitSegmentChanged:  splitSegmentItem._updateSplitCoord()
+                    function onSplitSegmentChanged()  { splitSegmentItem._updateSplitCoord() }
                 }
 
                 Connections {
                     target:                 _missionController.splitSegment
-                    onCoordinate1Changed:   splitSegmentItem._updateSplitCoord()
-                    onCoordinate2Changed:   splitSegmentItem._updateSplitCoord()
+                    function onCoordinate1Changed()   { splitSegmentItem._updateSplitCoord() }
+                    function onCoordinate2Changed()   { splitSegmentItem._updateSplitCoord() }
                 }
             }
 

--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -89,8 +89,8 @@ Item {
     Connections {
         target: _missionItem
 
-        onIsCurrentItemChanged:         updateDragArea()
-        onSpecifiesCoordinateChanged:   updateDragArea()
+        function onIsCurrentItemChanged() {         updateDragArea() }
+        function onSpecifiesCoordinateChanged() {   updateDragArea() }
     }
 
     Connections {
@@ -172,7 +172,9 @@ Item {
 
                 Connections {
                     target:            _mapCircle.radius
-                    onRawValueChanged: if(!blockSignals) loiterMapCircleVisuals.updateMissionItem()
+                    function onRawValueChanged() {
+                        if(!blockSignals) loiterMapCircleVisuals.updateMissionItem()
+                    }
                 }
             }
         }

--- a/src/QmlControls/FlightModeMenu.qml
+++ b/src/QmlControls/FlightModeMenu.qml
@@ -58,7 +58,7 @@ QGCLabel {
 
     Connections {
         target:                 QGroundControl.multiVehicleManager
-        onActiveVehicleChanged: _root.updateFlightModesMenu()
+        function onActiveVehicleChanged() { _root.updateFlightModesMenu() }
     }
 
     MouseArea {

--- a/src/QmlControls/InstrumentValueLabel.qml
+++ b/src/QmlControls/InstrumentValueLabel.qml
@@ -59,9 +59,9 @@ ColumnLayout {
 
         Connections {
             target:                 instrumentValueData
-            onRangeTypeChanged:     valueIcon.updateIcon()
-            onCurrentIconChanged:   valueIcon.updateIcon()
-            onIconChanged:          valueIcon.updateIcon()
+            function onRangeTypeChanged() { valueIcon.updateIcon() }
+            function onCurrentIconChanged() { valueIcon.updateIcon() }
+            function onIconChanged() { valueIcon.updateIcon() }
         }
         Component.onCompleted:      updateIcon();
 

--- a/src/QmlControls/MainWindowSavedState.qml
+++ b/src/QmlControls/MainWindowSavedState.qml
@@ -42,12 +42,12 @@ Item {
     }
 
     Connections {
-        target:                 window
-        onXChanged:             if(_enabled) saveSettingsTimer.restart()
-        onYChanged:             if(_enabled) saveSettingsTimer.restart()
-        onWidthChanged:         if(_enabled) saveSettingsTimer.restart()
-        onHeightChanged:        if(_enabled) saveSettingsTimer.restart()
-        onVisibilityChanged:    if(_enabled) saveSettingsTimer.restart()
+        target:                         window
+        function onXChanged()           { if(_enabled) saveSettingsTimer.restart() }
+        function onYChanged()           { if(_enabled) saveSettingsTimer.restart() }
+        function onWidthChanged()       { if(_enabled) saveSettingsTimer.restart() }
+        function onHeightChanged()      { if(_enabled) saveSettingsTimer.restart() }
+        function onVisibilityChanged()  { if(_enabled) saveSettingsTimer.restart() }
     }
 
     Timer {

--- a/src/QmlControls/QGCFlickableHorizontalIndicator.qml
+++ b/src/QmlControls/QGCFlickableHorizontalIndicator.qml
@@ -22,9 +22,9 @@ Rectangle {
 
     Connections {
         target:                    horizontalIndicator.parent
-        onMovementStarted:         horizontalIndicator.opacity = 1.0
-        onMovementEnded:           animateOpacity.restart()
-        onContentHeightChanged:    animateOpacity.restart()
+        function onMovementStarted()         { horizontalIndicator.opacity = 1.0 }
+        function onMovementEnded()           { animateOpacity.restart() }
+        function onContentHeightChanged()  { animateOpacity.restart() }
     }
 
     NumberAnimation {

--- a/src/QmlControls/QGCFlickableVerticalIndicator.qml
+++ b/src/QmlControls/QGCFlickableVerticalIndicator.qml
@@ -22,9 +22,9 @@ Rectangle {
 
     Connections {
         target:                    verticalIndicator.parent
-        onMovementStarted:         verticalIndicator.opacity = 1.0
-        onMovementEnded:           animateOpacity.restart()
-        onContentHeightChanged:    animateOpacity.restart()
+        function onMovementStarted()        { verticalIndicator.opacity = 1.0 }
+        function onMovementEnded()          { animateOpacity.restart() }
+        function onContentHeightChanged()   {  animateOpacity.restart() }
     }
 
     NumberAnimation {

--- a/src/QmlControls/QGCPipOverlay.qml
+++ b/src/QmlControls/QGCPipOverlay.qml
@@ -174,7 +174,7 @@ Item {
     Connections {
         target: _root.parent
 
-        onWidthChanged: {
+        function onWidthChanged() {
             if (!_componentComplete) {
                 // Wait until first time setup is done
                 return

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -112,7 +112,7 @@ Item {
     */
     Connections {
         target: QGroundControl.settingsManager.appSettings.appFontPointSize
-        onValueChanged: {
+        function onValueChanged() {
             _setBasePointSize(QGroundControl.settingsManager.appSettings.appFontPointSize.value)
         }
     }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -186,7 +186,7 @@ Rectangle {
 
         Connections {
             target:                 QGroundControl.multiVehicleManager
-            onActiveVehicleChanged: largeProgressBar._userHide = false
+            function onActiveVehicleChanged() { largeProgressBar._userHide = false }
         }
 
         Rectangle {


### PR DESCRIPTION
Implicitly defined properties are deprecated in newer Qt versions.
This changes the syntax of the property functions to the new style.


