### PR TITLE
fix survey center position editing

### DIFF
--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -27,9 +27,10 @@ public:
     /// @param kmlOrShpFile Polygon comes from this file, empty for default polygon
     SurveyComplexItem(PlanMasterController* masterController, bool flyView, const QString& kmlOrShpFile);
 
-    Q_PROPERTY(Fact* gridAngle              READ gridAngle              CONSTANT)
-    Q_PROPERTY(Fact* flyAlternateTransects  READ flyAlternateTransects  CONSTANT)
-    Q_PROPERTY(Fact* splitConcavePolygons   READ splitConcavePolygons   CONSTANT)
+    Q_PROPERTY(Fact*            gridAngle              READ gridAngle              CONSTANT)
+    Q_PROPERTY(Fact*            flyAlternateTransects  READ flyAlternateTransects  CONSTANT)
+    Q_PROPERTY(Fact*            splitConcavePolygons   READ splitConcavePolygons   CONSTANT)
+    Q_PROPERTY(QGeoCoordinate   centerCoordinate       READ centerCoordinate       WRITE setCenterCoordinate)
 
     Fact* gridAngle             (void) { return &_gridAngleFact; }
     Fact* flyAlternateTransects (void) { return &_flyAlternateTransectsFact; }
@@ -38,12 +39,15 @@ public:
     Q_INVOKABLE void rotateEntryPoint(void);
 
     // Overrides from ComplexMissionItem
-    QString patternName         (void) const final { return name; }
-    bool    load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
-    QString mapVisualQML        (void) const final { return QStringLiteral("SurveyMapVisual.qml"); }
-    QString presetsSettingsGroup(void) { return settingsGroup; }
-    void    savePreset          (const QString& name);
-    void    loadPreset          (const QString& name);
+    QString         patternName         (void) const final { return name; }
+    bool            load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
+    QString         mapVisualQML        (void) const final { return QStringLiteral("SurveyMapVisual.qml"); }
+    QString         presetsSettingsGroup(void) { return settingsGroup; }
+    void            savePreset          (const QString& name);
+    void            loadPreset          (const QString& name);
+    bool            isSurveyItem        (void) const final { return true; }
+    QGeoCoordinate  centerCoordinate    (void) const { return _surveyAreaPolygon.center(); }
+    void            setCenterCoordinate (const QGeoCoordinate& coordinate) { _surveyAreaPolygon.setCenter(coordinate); }
 
     // Overrides from TransectStyleComplexItem
     void    save                (QJsonArray&  planItems) final;

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -71,6 +71,7 @@ public:
     Q_PROPERTY(bool             isSimpleItem                        READ isSimpleItem                                                       NOTIFY isSimpleItemChanged)                         ///< Simple or Complex MissionItem
     Q_PROPERTY(bool             isTakeoffItem                       READ isTakeoffItem                                                      NOTIFY isTakeoffItemChanged)                        ///< true: Takeoff item special case
     Q_PROPERTY(bool             isLandCommand                       READ isLandCommand                                                      NOTIFY isLandCommandChanged)
+    Q_PROPERTY(bool             isSurveyItem                        READ isSurveyItem                                                       )                                                   ///< true: Survey item special case for editing center position through mission item list menue
     Q_PROPERTY(QString          editorQml                           MEMBER _editorQml                                                       CONSTANT)                                           ///< Qml code for editing this item
     Q_PROPERTY(QString          mapVisualQML                        READ mapVisualQML                                                       CONSTANT)                                           ///< QMl code for map visuals
     Q_PROPERTY(double           specifiedFlightSpeed                READ specifiedFlightSpeed                                               NOTIFY specifiedFlightSpeedChanged)                 ///< NaN for not specified
@@ -143,6 +144,7 @@ public:
     virtual bool            isSimpleItem            (void) const = 0;
     virtual bool            isTakeoffItem           (void) const { return false; }
     virtual bool            isLandCommand           (void) const { return false; }
+    virtual bool            isSurveyItem            (void) const { return false; }
     virtual bool            isStandaloneCoordinate  (void) const = 0;
     virtual bool            specifiesCoordinate     (void) const = 0;
     virtual bool            specifiesAltitudeOnly   (void) const = 0;

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -71,8 +71,8 @@ Rectangle {
         id: editPositionDialog
 
         EditPositionDialog {
-            coordinate: missionItem.coordinate
-            onCoordinateChanged: missionItem.coordinate = coordinate
+            coordinate: missionItem.isSurveyItem ?  missionItem.centerCoordinate : missionItem.coordinate
+            onCoordinateChanged: missionItem.isSurveyItem ?  missionItem.centerCoordinate = coordinate : missionItem.coordinate = coordinate
         }
     }
 


### PR DESCRIPTION
This fixes the not working editing of the center position of a survey pattern.

With this fix, the user can edit the center position of the survey pattern through the mission item list "Edit position..." mechanism.

This was tested on the stable_v4.1 branch. I cant build on the current master branch due to error #9864 .

**EDIT**: was able to build and test my patch on the master branch (== julled:fixSurveyPosEditMaster) so therefore its tested on current master. 