### PR TITLE
VideoManager: support receiving the stream URI

### DIFF
--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -640,7 +640,11 @@ VideoManager::_updateSettings(unsigned id)
                         }
                         break;
                     case VIDEO_STREAM_TYPE_RTPUDP:
-                        if ((settingsChanged |= _updateVideoUri(id, QStringLiteral("udp://0.0.0.0:%1").arg(pInfo->uri())))) {
+                        if ((settingsChanged |= _updateVideoUri(
+                                        id,
+                                        pInfo->uri().contains("udp://")
+                                            ? pInfo->uri() // Specced case
+                                            : QStringLiteral("udp://0.0.0.0:%1").arg(pInfo->uri())))) {
                             _toolbox->settingsManager()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceUDPH264);
                         }
                         break;


### PR DESCRIPTION
With this change we support receiving the full URI for a UDP video stream such as udp://127.0.0.1:5600. The previous case where only the port number is sent as "URI" is still handled.

Related to https://github.com/mavlink/qgroundcontrol/issues/9870.