### PR TITLE
main: allow quitting using Ctrl+C on Linux

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -211,6 +211,18 @@ bool checkAndroidWritePermission() {
 }
 #endif
 
+// To shut down QGC on Ctrl+C on Linux
+#ifdef Q_OS_LINUX
+#include <csignal>
+
+void sigHandler(int s)
+{
+    std::signal(s, SIG_DFL);
+    QApplication::instance()->quit();
+}
+
+#endif /* Q_OS_LINUX */
+
 //-----------------------------------------------------------------------------
 /**
  * @brief Starts the application
@@ -277,6 +289,11 @@ int main(int argc, char *argv[])
         }
     }
 #endif
+
+#ifdef Q_OS_LINUX
+    std::signal(SIGINT, sigHandler);
+    std::signal(SIGTERM, sigHandler);
+#endif /* Q_OS_LINUX */
 
     // The following calls to qRegisterMetaType are done to silence debug output which warns
     // that we use these types in signals, and without calling qRegisterMetaType we can't queue


### PR DESCRIPTION
This catches the signals SIGINT and SIGTERM to shut down QGC.

I find this quite convenient as a user and developer. Any objections?
