### PR TITLE
Don't resolve tcp host when adding a config

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -479,8 +479,7 @@ void LinkManager::_addZeroConfAutoConnectLink(void)
             }
 
             auto link = new TCPConfiguration(tcpName);
-            QHostAddress address(hostname);
-            link->setAddress(address);
+            link->setHost(hostname);
             link->setPort(service.port());
             link->setAutoConnect(true);
             link->setDynamic(true);

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -43,10 +43,8 @@ public:
     TCPConfiguration(TCPConfiguration* source);
 
     quint16             port        (void) const                         { return _port; }
-    const QHostAddress& address     (void)                          { return _address; }
-    const QString       host        (void)                          { return _address.toString(); }
+    QString             host        (void) const                         { return _host; }
     void                setPort     (quint16 port);
-    void                setAddress  (const QHostAddress& address);
     void                setHost     (const QString host);
 
     //LinkConfiguration overrides
@@ -62,7 +60,7 @@ signals:
     void hostChanged(void);
 
 private:
-    QHostAddress    _address;
+    QString         _host;
     quint16         _port;
 };
 


### PR DESCRIPTION
Currently when adding a hostname in string form for tcp connection,
resolving to IP is done immediately, and in case of an error
the host is not stored and used default one instead.

Also the ip might be not known when adding the config, but hostname is known,
which also might be not resolvable at time when the config is being created.

Since hostName in QAbstractSocket::connectToHost
may be an IP address in string form (e.g., "43.195.83.32"),
or it may be a host name (e.g., "example.com").
QAbstractSocket will do a lookup only if required.

So suggesting to totally remove resolving of ip from TCPLink.
Resolving will be performed in QTcpSocket::connectToHost() when actual connection is requested.


