### PR TITLE
Qt version change cleanup

### DIFF
--- a/src/QGCLoggingCategory.cc
+++ b/src/QGCLoggingCategory.cc
@@ -115,6 +115,8 @@ void QGCLoggingCategoryRegister::setFilterRulesFromSettings(const QString& comma
     // Logging from GStreamer library itself controlled by gstreamer debug levels is always turned on
     filterRules += filterRuleFormat.arg("GStreamerAPILog");
 
+    filterRules += "qt.qml.connections=false";
+
     qDebug() << "Filter rules" << filterRules;
     QLoggingCategory::setFilterRules(filterRules);
 }

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -71,7 +71,6 @@ Button {
             text:                   control.text
             font.pointSize:         pointSize
             font.family:            ScreenTools.normalFontFamily
-            width:                  parent.width
             color:                  _showHighlight ?
                                         qgcPal.buttonHighlightText :
                                         (primary ? qgcPal.primaryButtonText : qgcPal.buttonText)

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -444,7 +444,7 @@ void LinkManager::_addZeroConfAutoConnectLink(void)
     };
 
     connect(browser.get(), &QMdnsEngine::Browser::serviceAdded, this, [checkIfConnectionLinkExist, this](const QMdnsEngine::Service &service) {
-        qCDebug(LinkManagerLog) << "Found Zero-Conf:" << service.type() << service.name() << service.hostname() << service.port() << service.attributes();
+        qCDebug(LinkManagerVerboseLog) << "Found Zero-Conf:" << service.type() << service.name() << service.hostname() << service.port() << service.attributes();
 
         if(!service.type().startsWith("_mavlink")) {
             return;


### PR DESCRIPTION
* Fix button text centering
* Disable logging for deprecated onFoo silliness. We'll deal with all of these when we are forced to.
* Move zero-conf logging to verbose since it was spewing tones of output