### PR TITLE
deploy: fix UI not starting

### DIFF
--- a/deploy/qgroundcontrol-start.sh
+++ b/deploy/qgroundcontrol-start.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 HERE="$(dirname "$(readlink -f "${0}")")"
-export LD_LIBRARY_PATH="${HERE}/usr/lib/x86_64-linux-gnu":"${HERE}/Qt/libs":$LD_LIBRARY_PATH
-export QML2_IMPORT_PATH="${HERE}/Qt/qml"
-export QT_PLUGIN_PATH="${HERE}/Qt/plugins"
+export LD_LIBRARY_PATH="${HERE}/Qt/libs":$LD_LIBRARY_PATH
 
 # hack until icon issue with AppImage is resolved
 mkdir -p ~/.icons && cp ${HERE}/qgroundcontrol.png ~/.icons


### PR DESCRIPTION
This fixes the problem I had on Arch Linux when building and starting with:

```
mkdir build && cd build
~/Qt/5.15.2/gcc_64/bin/qmake -r ../qgroundcontrol.pro
make -j8
build/staging/qgroundcontrol-start.sh
```

Where I got the error:
```
QQmlApplicationEngine failed to load component
qrc:/qml/MainRootWindow.qml:25:1: Type ApplicationWindow unavailable
file:///home/julianoes/Qt/5.15.2/gcc_64/qml/QtQuick/Controls.2/qmldir: plugin cannot be loaded for module "QtQuick.Controls": Cannot install type 'VerticalHeaderView' into protected module 'QtQuick.Controls' version '2'
<Unknown File>: Cannot install type 'HorizontalHeaderView' into protected module 'QtQuick.Controls' version '2'
<Unknown File>: Cannot install element 'SplitHandle' into protected module 'QtQuick.Controls' version '2'
<Unknown File>: Cannot install type 'SplitView' into protected module 'QtQuick.Controls' version '2'
...
```

From what I can tell, the only thing that needs to happen in qgroundcontrol-start.sh is that libairmap-cpp.so.2.0.0 is found.
Maybe I'm missing something but this patch works for me.


