### PR TITLE
FlightDisplay: put zoom buttons on the left of the scale

### DIFF
--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -586,7 +586,7 @@ FlightMap {
         anchors.left:       parent.left
         anchors.top:        parent.top
         mapControl:         _root
-        buttonsOnLeft:      false
+        buttonsOnLeft:      true
         visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && mapControl.pipState.state === mapControl.pipState.windowState
 
         property real centerInset: visible ? parent.height - y : 0

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -267,7 +267,7 @@ Item {
         anchors.left:       toolStrip.right
         anchors.top:        parent.top
         mapControl:         _mapControl
-        buttonsOnLeft:      false
+        buttonsOnLeft:      true
         visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && mapControl.pipState.state === mapControl.pipState.fullState
 
         property real centerInset: visible ? parent.height - y : 0


### PR DESCRIPTION
The map scale width changes when the zoom up/down buttons are clicked.
When buttons are on the right, and when the user quickly clicks a zoom
up/down button several times, the first click change the scale, which
changes the buttons position. Subsequent clicks are most of the time not
where the user wanted to put them.

Putting buttons on the left of the scale will keep them at a fixed
position, fixing this unfortunate behavior.

Signed-off-by: Julien Olivain <ju.o@free.fr>


