### PR TITLE
Simple factory calibration button implemented in QGC.

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -61,6 +61,8 @@ SensorsComponentController::SensorsComponentController(void)
     , _unknownFirmwareVersion                   (false)
     , _waitingForCancel                         (false)
 {
+    connect(_vehicle, &Vehicle::sensorsParametersResetAck, this, &SensorsComponentController::_handleParametersReset);
+
 }
 
 bool SensorsComponentController::usingUDPLink(void)
@@ -492,4 +494,29 @@ void SensorsComponentController::cancelCalibration(void)
     emit waitingForCancelChanged();
     _cancelButton->setEnabled(false);
     _vehicle->stopCalibration();
+}
+
+void SensorsComponentController::_handleParametersReset(bool success)
+{
+    if (success) {
+        qgcApp()->showAppMessage(tr("Reset successful"));
+
+        QTimer::singleShot(1000, this, [this]() {
+            _refreshParams();
+        });
+    }
+    else {
+        qgcApp()->showAppMessage(tr("Reset failed"));
+    }
+}
+
+void SensorsComponentController::resetFactoryParameters()
+{
+    auto compId = _vehicle->defaultComponentId();
+
+    _vehicle->sendMavCommand(compId,
+                             MAV_CMD_PREFLIGHT_STORAGE,
+                             true,  // showError
+                             3,     // Reset factory parameters
+                             -1);   // Don't do anything with mission storage
 }

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -82,6 +82,7 @@ public:
     Q_INVOKABLE void calibrateAirspeed(void);
     Q_INVOKABLE void cancelCalibration(void);
     Q_INVOKABLE bool usingUDPLink(void);
+    Q_INVOKABLE void resetFactoryParameters();
     
 signals:
     void showGyroCalAreaChanged(void);
@@ -96,6 +97,7 @@ signals:
 
 private slots:
     void _handleUASTextMessage(int uasId, int compId, int severity, QString text);
+    void _handleParametersReset(bool success);
     
 private:
     void _startLogCalibration(void);

--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -623,6 +623,21 @@ Item {
                     }
                 }
             }
+
+            QGCButton {
+                text:  qsTr("Factory reset")
+                width: _buttonWidth
+
+                anchors {
+                    right:       orientationCalArea.left
+                    rightMargin: ScreenTools.defaultFontPixelWidth/2
+                    bottom:      orientationCalArea.bottom
+                }
+
+                onClicked: {
+                    controller.resetFactoryParameters()
+                }
+            }
         }
     }
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2984,6 +2984,11 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
         }
     }
 
+    if (ack.command == MAV_CMD_PREFLIGHT_STORAGE) {
+        auto result = (ack.result == MAV_RESULT_ACCEPTED);
+        emit sensorsParametersResetAck(result);
+    }
+
 #if !defined(NO_ARDUPILOT_DIALECT)
     if (ack.command == MAV_CMD_FLASH_BOOTLOADER && ack.result == MAV_RESULT_ACCEPTED) {
         qgcApp()->showAppMessage(tr("Bootloader flash succeeded"));

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -930,6 +930,8 @@ signals:
     void isROIEnabledChanged            ();
     void initialConnectComplete         ();
 
+    void sensorsParametersResetAck      (bool success);
+
 private slots:
     void _mavlinkMessageReceived            (LinkInterface* link, mavlink_message_t message);
     void _sendMessageMultipleNext           ();


### PR DESCRIPTION
1. In-field calibration should be made visible by default on the calibration window if calibration parameters are already loaded.
2. Otherwise, factory calibration option should be provided.
3. A smaller button for factory calibration reset should be provided on the calibration window to allow the user to reset to factory calibration parameters. (since this is HW specific, a check for the loaded FW should be done, in order to tell the user if this action is possible or not - only FMU-V5X compatible atm)

Changes in the UI:
![FactoryReset](https://user-images.githubusercontent.com/1894862/136008189-1edd9b71-0437-416e-86d3-6d6eeb7076d8.jpg)
