### PR TITLE
PhotoVideoControl.qml: check if camera captures video before telling it to do so

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -101,7 +101,7 @@ Rectangle {
 
     function toggleShooting() {
         console.log("toggleShooting", _anyVideoStreamAvailable)
-        if (_mavlinkCamera) {
+        if (_mavlinkCamera && _mavlinkCamera.capturesVideo) {
             if(_mavlinkCameraInVideoMode) {
                 _mavlinkCamera.toggleVideo()
             } else {


### PR DESCRIPTION
This allows recording video locally in QGC when the camera doesn't advertise it is able to record the video by itself.


