### PR TITLE
libs: CMakeLists: Include qmdnsengine as static

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_subdirectory(libevents)
-add_subdirectory(qmdnsengine)
 add_subdirectory(qtandroidserialport)
 add_subdirectory(shapelib)
 if (WIN32)
@@ -9,3 +8,6 @@ endif (WIN32)
 if (GST_FOUND)
     add_subdirectory(qmlglsink)
 endif()
+
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Force qmdnsengine to build as static" FORCE)
+add_subdirectory(qmdnsengine)


### PR DESCRIPTION
libs is included as static, and as consequence only static can be included here

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


