### PR TITLE
Added missing libraries for Linux

### DIFF
--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -89,6 +89,8 @@ LinuxBuild {
         libQt5PositioningQuick.so.5 \
         libQt5PrintSupport.so.5 \
         libQt5Qml.so.5 \
+        libQt5QmlModels.so.5 \
+        libQt5QmlWorkerScript.so.5 \
         libQt5Quick.so.5 \
         libQt5QuickControls2.so.5 \
         libQt5QuickShapes.so.5 \


### PR DESCRIPTION
Pretty self explanatory. If you try to launch QGC using `qgroundcontrol-start.sh` it will fail due to these two missing libraries. It will actually launch without `libQt5QmlWorkerScript.so.5` but you will get no UI.