### PR TITLE
Fixed GStreamer support in Android build for Qt 5.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,9 @@ install:
 
   # android dependencies: qt, gstreamer, android-ndk
   - if [ "${SPEC}" = "android-clang" ]; then
-        wget --quiet https://qgroundcontrol.s3-us-west-2.amazonaws.com/dependencies/gstreamer-1.0-android-universal-1.18.1.tar.xz &&
-        mkdir gstreamer-1.0-android-universal-1.18.1 &&
-        tar xf gstreamer-1.0-android-universal-1.18.1.tar.xz -C gstreamer-1.0-android-universal-1.18.1 &&
+        wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz &&
+        mkdir gstreamer-1.0-android-universal-1.18.5 &&
+        tar xf gstreamer-1.0-android-universal-1.18.5.tar.xz -C gstreamer-1.0-android-universal-1.18.5 &&
         wget --quiet https://dl.google.com/android/repository/android-ndk-r20-linux-x86_64.zip &&
         unzip android-ndk-r20-linux-x86_64.zip > /dev/null &&
         export ANDROID_NDK_ROOT=`pwd`/android-ndk-r20 &&

--- a/src/VideoReceiver/README.md
+++ b/src/VideoReceiver/README.md
@@ -89,12 +89,12 @@ The installer places them under ~/Library/Developer/GStreamer/iPhone.sdk/GStream
 
 ### Android
 
-Download the gstreamer from here: [gstreamer-1.0-android-universal-1.18.1.tar.xz](https://gstreamer.freedesktop.org/data/pkg/android/1.18.1/gstreamer-1.0-android-universal-1.18.1.tar.xz)
+Download the gstreamer from here: [gstreamer-1.0-android-universal-1.18.5.tar.xz](https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz)
 
-Create a directory named "gstreamer-1.0-android-universal-1.18.1" under the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). Extract the downloaded archive under this directory. That's where the build system will look for it. Make sure your archive tool doesn't create any additional top level directories. The structure after extracting the archive should look like this:
+Create a directory named "gstreamer-1.0-android-universal-1.18.5" under the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). Extract the downloaded archive under this directory. That's where the build system will look for it. Make sure your archive tool doesn't create any additional top level directories. The structure after extracting the archive should look like this:
 ```
 qgroundcontrol
-├── gstreamer-1.0-android-universal-1.18.1
+├── gstreamer-1.0-android-universal-1.18.5
 │   │
 │   ├──armv7
 │   │   ├── bin

--- a/src/VideoReceiver/VideoReceiver.pri
+++ b/src/VideoReceiver/VideoReceiver.pri
@@ -62,13 +62,16 @@ LinuxBuild {
         QMAKE_POST_LINK += $$escape_expand(\\n) xcopy \"$$GST_ROOT_WIN\\lib\\gstreamer-1.0\\*.dll\" \"$$DESTDIR_WIN\\gstreamer-plugins\\\" /Y $$escape_expand(\\n)
     }
 } else:AndroidBuild {
-    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-1.18.1/***
-    contains(QT_ARCH, arm) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.1/armv7
-    } else:contains(QT_ARCH, arm64) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.1/arm64
+    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-1.18.5/***
+    contains(ANDROID_TARGET_ARCH, armeabi-v7a) {
+        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/armv7
+    } else:contains(ANDROID_TARGET_ARCH, arm64-v8a) {
+        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/arm64
+    } else:contains(ANDROID_TARGET_ARCH, x86_64) {
+        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/x86_64
     } else {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.1/x86
+        message(Unknown ANDROID_TARGET_ARCH $$ANDROID_TARGET_ARCH)
+        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/x86
     }
     exists($$GST_ROOT) {
         QMAKE_CXXFLAGS  += -pthread


### PR DESCRIPTION
Resolves https://github.com/mavlink/qgroundcontrol/issues/9917 issue specifically for new Qt 5.15 Multi-Abi build. GStreamer version updated to [`gstreamer-1.0-android-universal-1.18.5`](https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz) to fix [the crash](https://github.com/mavlink/qgroundcontrol/issues/9917#issuecomment-942703344).

See more info about gstreamer latest stable version: https://gstreamer.freedesktop.org/download/