### PR TITLE
FactMetadata: fix bitset metadata parsing from json

### DIFF
--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -238,7 +238,7 @@ private:
 
     static bool _parseEnum          (const QJsonObject& jsonObject, DefineMap_t defineMap, QStringList& rgDescriptions, QStringList& rgValues, QString& errorString);
     static bool _parseValuesArray   (const QJsonObject& jsonObject, QStringList& rgDescriptions, QList<double>& rgValues, QString& errorString);
-    static bool _parseBitmaskArray  (const QJsonObject& jsonObject, QStringList& rgDescriptions, QList<double>& rgValues, QString& errorString);
+    static bool _parseBitmaskArray  (const QJsonObject& jsonObject, QStringList& rgDescriptions, QList<int>& rgValues, QString& errorString);
 
     // Built in translators
     static QVariant _defaultTranslator(const QVariant& from) { return from; }

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -169,7 +169,7 @@ QGCViewDialog {
             Column {
                 id:         bitmaskColumn
                 spacing:    ScreenTools.defaultFontPixelHeight / 2
-                visible:    fact.bitmaskStrings.length > 0 ? true : false;
+                visible:    fact.bitmaskStrings.length > 0
 
                 Repeater {
                     id:     bitmaskRepeater


### PR DESCRIPTION
- use int's instead of double's
- use bitshift to match the logic in the xml

@DonLakeFlyer I did not see any internal uses of the bitmask in any json config file, so this should not affect anything else, but maybe you're aware of something?

Fixes #9854

