### PR TITLE
Update language selection

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -383,71 +383,9 @@ void QGCApplication::setLanguage()
     _locale = QLocale::system();
     qDebug() << "System reported locale:" << _locale << "; Name" << _locale.name() << "; Preffered (used in maps): " << (QLocale::system().uiLanguages().length() > 0 ? QLocale::system().uiLanguages()[0] : "None");
 
-    int langID = AppSettings::_languageID();
-    //-- See App.SettinsGroup.json for index
-    if(langID) {
-        switch(langID) {
-        case 1:
-            _locale = QLocale(QLocale::Bulgarian);
-            break;
-        case 2:
-            _locale = QLocale(QLocale::Chinese);
-            break;
-        case 3:
-            _locale = QLocale(QLocale::Dutch);
-            break;
-        case 4:
-            _locale = QLocale(QLocale::English);
-            break;
-        case 5:
-            _locale = QLocale(QLocale::Finnish);
-            break;
-        case 6:
-            _locale = QLocale(QLocale::French);
-            break;
-        case 7:
-            _locale = QLocale(QLocale::German);
-            break;
-        case 8:
-            _locale = QLocale(QLocale::Greek);
-            break;
-        case 9:
-            _locale = QLocale(QLocale::Hebrew);
-            break;
-        case 10:
-            _locale = QLocale(QLocale::Italian);
-            break;
-        case 11:
-            _locale = QLocale(QLocale::Japanese);
-            break;
-        case 12:
-            _locale = QLocale(QLocale::Korean);
-            break;
-        case 13:
-            _locale = QLocale(QLocale::NorwegianBokmal);
-            break;
-        case 14:
-            _locale = QLocale(QLocale::Polish);
-            break;
-        case 15:
-            _locale = QLocale(QLocale::Portuguese);
-            break;
-        case 16:
-            _locale = QLocale(QLocale::Russian);
-            break;
-        case 17:
-            _locale = QLocale(QLocale::Spanish);
-            break;
-        case 18:
-            _locale = QLocale(QLocale::Swedish);
-            break;
-        case 19:
-            _locale = QLocale(QLocale::Turkish);
-            break;
-        case 20:
-            _locale = QLocale(QLocale::Azerbaijani);
-            break;
-        }
+    QLocale::Language possibleLocale = AppSettings::_qLocaleLanguageID();
+    if (possibleLocale != QLocale::AnyLanguage) {
+        _locale = QLocale(possibleLocale);
     }
     //-- We have specific fonts for Korean
     if(_locale == QLocale::Korean) {

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -55,8 +55,8 @@ QString
 ScreenToolsController::normalFontFamily() const
 {
     //-- See App.SettinsGroup.json for index
-    int langID = qgcApp()->toolbox()->settingsManager()->appSettings()->language()->rawValue().toInt();
-    if(langID == 6 /*Korean*/) {
+    int langID = qgcApp()->toolbox()->settingsManager()->appSettings()->qLocaleLanguage()->rawValue().toInt();
+    if(langID == QLocale::Korean) {
         return QString("NanumGothic");
     } else {
         return QString("Open Sans");
@@ -67,8 +67,8 @@ QString
 ScreenToolsController::boldFontFamily() const
 {
     //-- See App.SettinsGroup.json for index
-    int langID = qgcApp()->toolbox()->settingsManager()->appSettings()->language()->rawValue().toInt();
-    if(langID == 6 /*Korean*/) {
+    int langID = qgcApp()->toolbox()->settingsManager()->appSettings()->qLocaleLanguage()->rawValue().toInt();
+    if(langID == QLocale::Korean) {
         return QString("NanumGothic");
     } else {
         return QString("Open Sans Semibold");

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -277,12 +277,13 @@
     "default":     false
 },
 {
-    "name":             "language",
-    "shortDesc": "Language",
-    "type":             "uint32",
-    "enumStrings":      "System,български (Bulgarian),中文 (Chinese),Nederlands (Dutch),English,Suomi (Finnish),Français (French),Deutsche (German),Ελληνικά (Greek), עברית (Hebrew),Italiano (Italian),日本人 (Japanese),한국어 (Korean),Norsk (Norwegian),Polskie (Polish),Português (Portuguese),Pусский (Russian),Español (Spanish),Svenska (Swedish),Türk (Turkish),Azerbaijani (Azerbaijani)",
-    "enumValues":       "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20",
-    "default":     0
+    "name":         "qLocaleLanguage",
+    "shortDesc":    "Language",
+    "type":         "uint32",
+    "enumStrings":  "System,Azerbaijani (Azerbaijani),български (Bulgarian),中文 (Chinese),Nederlands (Dutch),English,Suomi (Finnish),Français (French),Deutsche (German),Ελληνικά (Greek), עברית (Hebrew),Italiano (Italian),日本人 (Japanese),한국어 (Korean),Norsk (Norwegian),Polskie (Polish),Português (Portuguese),Pусский (Russian),Español (Spanish),Svenska (Swedish),Türk (Turkish)",
+    "enumValues":   "0,12,20,25,30,31,36,37,42,43,48,58,59,66,85,90,91,96,111,114,125",
+    "comment":      "enumValues uses Qt QLocale::Language values",
+    "default":      0
 },
 {
     "name":             "disableAllPersistence",

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -58,7 +58,7 @@ public:
     DEFINE_SETTINGFACT(enableTaisync)
     DEFINE_SETTINGFACT(enableTaisyncVideo)
     DEFINE_SETTINGFACT(enableMicrohard)
-    DEFINE_SETTINGFACT(language)
+    DEFINE_SETTINGFACT(qLocaleLanguage)
     DEFINE_SETTINGFACT(disableAllPersistence)
     DEFINE_SETTINGFACT(usePairing)
     DEFINE_SETTINGFACT(saveCsvTelemetry)
@@ -121,11 +121,11 @@ public:
     static const char* photoDirectory;
     static const char* crashDirectory;
 
-    // Returns the current language setting bypassing the standard SettingsGroup path. This should only be used
+    // Returns the current qLocaleLanguage setting bypassing the standard SettingsGroup path. This should only be used
     // by QGCApplication::setLanguage to query the language setting as early in the boot process as possible.
     // Specfically prior to any JSON files being loaded such that JSON file can be translated. Also since this
     // is a one-off mechanism custom build overrides for language are not currently supported.
-    static int _languageID(void);
+    static QLocale::Language _qLocaleLanguageID(void);
 
 signals:
     void savePathsChanged();
@@ -133,5 +133,9 @@ signals:
 private slots:
     void _indoorPaletteChanged();
     void _checkSavePathDirectories();
-    void _languageChanged();
+    void _qLocaleLanguageChanged();
+
+private:
+    static QList<int> _rgReleaseLanguages;
+    static QList<int> _rgPartialLanguages;
 };

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -466,13 +466,13 @@ Rectangle {
 
                                 QGCLabel {
                                     text:           qsTr("Language")
-                                    visible: QGroundControl.settingsManager.appSettings.language.visible
+                                    visible: QGroundControl.settingsManager.appSettings.qLocaleLanguage.visible
                                 }
                                 FactComboBox {
                                     Layout.preferredWidth:  _comboFieldWidth
-                                    fact:                   QGroundControl.settingsManager.appSettings.language
+                                    fact:                   QGroundControl.settingsManager.appSettings.qLocaleLanguage
                                     indexModel:             false
-                                    visible:                QGroundControl.settingsManager.appSettings.language.visible
+                                    visible:                QGroundControl.settingsManager.appSettings.qLocaleLanguage.visible
                                 }
 
                                 QGCLabel {


### PR DESCRIPTION
Current problem:
* QGC displays all possible language from CrowdIn as selectable in all releases
* This confuses people into thinking all of those languages have translations available which is in fact not the case. We get Issues all the time about various languages not working when in fact there are no translations for that language.

How it works now:
* There are the categories of language translation state
   * Released: Over 90% translated
   * Partial: Over 40%
   * Test only:  Less then 40% translated
* Daily builds will show all languages as available for selection with special tagging on Partial and Test Only languages. This allows for translators to use daily builds to work on seeing their translations in the product.
* Stable build will ONLY show Release and Partial languages as selectable. This prevents users from mistakenly selecting a language for which there is no/minimal translation available.

Note: I am working my way through cleaning up CrowdIn state. So for now the categorization of the languages will be in flux till I figure out where everything stands.