### PR TITLE
PX4 Actuator & Geometry Configuration and Testing UI

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -697,6 +697,7 @@ HEADERS += \
     src/Vehicle/Actuators/Mixer.h \
     src/Vehicle/Actuators/MotorAssignment.h \
     src/Vehicle/CompInfo.h \
+    src/Vehicle/CompInfoActuators.h \
     src/Vehicle/CompInfoEvents.h \
     src/Vehicle/CompInfoParam.h \
     src/Vehicle/CompInfoGeneral.h \
@@ -946,6 +947,7 @@ SOURCES += \
     src/Vehicle/Actuators/Mixer.cc \
     src/Vehicle/Actuators/MotorAssignment.cc \
     src/Vehicle/CompInfo.cc \
+    src/Vehicle/CompInfoActuators.cc \
     src/Vehicle/CompInfoEvents.cc \
     src/Vehicle/CompInfoParam.cc \
     src/Vehicle/CompInfoGeneral.cc \

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -688,6 +688,14 @@ HEADERS += \
     src/SHPFileHelper.h \
     src/Terrain/TerrainQuery.h \
     src/TerrainTile.h \
+    src/Vehicle/Actuators/ActuatorActions.h \
+    src/Vehicle/Actuators/Actuators.h \
+    src/Vehicle/Actuators/ActuatorOutputs.h \
+    src/Vehicle/Actuators/ActuatorTesting.h \
+    src/Vehicle/Actuators/Common.h \
+    src/Vehicle/Actuators/GeometryImage.h \
+    src/Vehicle/Actuators/Mixer.h \
+    src/Vehicle/Actuators/MotorAssignment.h \
     src/Vehicle/CompInfo.h \
     src/Vehicle/CompInfoEvents.h \
     src/Vehicle/CompInfoParam.h \
@@ -929,6 +937,14 @@ SOURCES += \
     src/SHPFileHelper.cc \
     src/Terrain/TerrainQuery.cc \
     src/TerrainTile.cc\
+    src/Vehicle/Actuators/ActuatorActions.cc \
+    src/Vehicle/Actuators/Actuators.cc \
+    src/Vehicle/Actuators/ActuatorOutputs.cc \
+    src/Vehicle/Actuators/ActuatorTesting.cc \
+    src/Vehicle/Actuators/Common.cc \
+    src/Vehicle/Actuators/GeometryImage.cc \
+    src/Vehicle/Actuators/Mixer.cc \
+    src/Vehicle/Actuators/MotorAssignment.cc \
     src/Vehicle/CompInfo.cc \
     src/Vehicle/CompInfoEvents.cc \
     src/Vehicle/CompInfoParam.cc \
@@ -1168,6 +1184,7 @@ PX4FirmwarePlugin {
         src/FirmwarePlugin/PX4 \
 
     HEADERS+= \
+        src/AutoPilotPlugins/PX4/ActuatorComponent.h \
         src/AutoPilotPlugins/PX4/AirframeComponent.h \
         src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h \
         src/AutoPilotPlugins/PX4/AirframeComponentController.h \
@@ -1189,6 +1206,7 @@ PX4FirmwarePlugin {
         src/FirmwarePlugin/PX4/PX4ParameterMetaData.h \
 
     SOURCES += \
+        src/AutoPilotPlugins/PX4/ActuatorComponent.cc \
         src/AutoPilotPlugins/PX4/AirframeComponent.cc \
         src/AutoPilotPlugins/PX4/AirframeComponentAirframes.cc \
         src/AutoPilotPlugins/PX4/AirframeComponentController.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -66,6 +66,9 @@
         <file alias="MockLink.qml">src/ui/preferences/MockLink.qml</file>
         <file alias="MockLinkSettings.qml">src/ui/preferences/MockLinkSettings.qml</file>
         <file alias="MotorComponent.qml">src/AutoPilotPlugins/Common/MotorComponent.qml</file>
+        <file alias="ActuatorComponent.qml">src/AutoPilotPlugins/PX4/ActuatorComponent.qml</file>
+        <file alias="ActuatorFact.qml">src/AutoPilotPlugins/PX4/ActuatorFact.qml</file>
+        <file alias="ActuatorSlider.qml">src/AutoPilotPlugins/PX4/ActuatorSlider.qml</file>
         <file alias="OfflineMap.qml">src/QtLocationPlugin/QMLControl/OfflineMap.qml</file>
         <file alias="PlanToolBar.qml">src/PlanView/PlanToolBar.qml</file>
         <file alias="PlanToolBarIndicators.qml">src/PlanView/PlanToolBarIndicators.qml</file>

--- a/src/AutoPilotPlugins/CMakeLists.txt
+++ b/src/AutoPilotPlugins/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(AutoPilotPlugins
 
 	Generic/GenericAutoPilotPlugin.cc
 
+	PX4/ActuatorComponent.cc
+	PX4/ActuatorComponent.h
 	PX4/AirframeComponentAirframes.cc
 	PX4/AirframeComponentAirframes.h
 	PX4/AirframeComponent.cc

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.cc
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.cc
@@ -1,0 +1,66 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "ActuatorComponent.h"
+
+#include "QGCApplication.h"
+
+static bool imageProviderAdded{false};
+
+ActuatorComponent::ActuatorComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
+    VehicleComponent(vehicle, autopilot, parent),
+    _name(tr("Actuators")), _actuators(*vehicle->actuators())
+{
+    if (!imageProviderAdded) {
+        qgcApp()->qmlAppEngine()->addImageProvider(QLatin1String("actuators"), GeometryImage::VehicleGeometryImageProvider::instance());
+        imageProviderAdded = true;
+    }
+
+    connect(&_actuators, &Actuators::hasUnsetRequiredFunctionsChanged, this, [this]() { _triggerUpdated({}); });
+}
+
+QString ActuatorComponent::name(void) const
+{
+    return _name;
+}
+
+QString ActuatorComponent::description(void) const
+{
+    return "";
+}
+
+QString ActuatorComponent::iconResource(void) const
+{
+    return QStringLiteral("/qmlimages/MotorComponentIcon.svg");
+}
+
+bool ActuatorComponent::requiresSetup(void) const
+{
+    return true;
+}
+
+bool ActuatorComponent::setupComplete(void) const
+{
+    return !_actuators.hasUnsetRequiredFunctions();
+}
+
+QStringList ActuatorComponent::setupCompleteChangedTriggerList(void) const
+{
+    return QStringList();
+}
+
+QUrl ActuatorComponent::setupSource(void) const
+{
+    return QUrl::fromUserInput(QStringLiteral("qrc:/qml/ActuatorComponent.qml"));
+}
+
+QUrl ActuatorComponent::summaryQmlSource(void) const
+{
+    return QUrl();
+}

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.h
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+#pragma once
+
+#include "VehicleComponent.h"
+#include "Fact.h"
+
+#include "Actuators/Actuators.h"
+
+class ActuatorComponent : public VehicleComponent
+{
+    Q_OBJECT
+    
+public:
+    ActuatorComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = nullptr);
+
+    // Virtuals from VehicleComponent
+    QStringList setupCompleteChangedTriggerList(void) const final;
+    
+    // Virtuals from VehicleComponent
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    bool requiresSetup(void) const final;
+    bool setupComplete(void) const final;
+    virtual QUrl setupSource(void) const;
+    QUrl summaryQmlSource(void) const final;
+
+private:
+    const QString   _name;
+    Actuators& _actuators;
+};
+

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -1,0 +1,531 @@
+import QtQuick 2.12
+import QtQuick.Controls 1.2
+import QtQuick.Dialogs 1.2
+import QtQuick.Layouts 1.3
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.ScreenTools   1.0
+
+SetupPage {
+    id:             actuatorPage
+    pageComponent:  pageComponent
+    showAdvanced:   true
+
+    property var actuators:       globals.activeVehicle.actuators
+
+    property var _showAdvanced:              advanced
+    readonly property real _margins:         ScreenTools.defaultFontPixelHeight
+
+    Component {
+        id: pageComponent
+
+        Row {
+            spacing:                        ScreenTools.defaultFontPixelWidth * 4
+            property var _leftColumnWidth:  Math.max(actuatorTesting.implicitWidth, mixerUi.implicitWidth) + (_margins * 2)
+
+            ColumnLayout {
+                spacing:                    ScreenTools.defaultFontPixelHeight
+                implicitWidth:              _leftColumnWidth
+
+                // mixer ui
+                QGCLabel {
+                    text:                   qsTr("Geometry")
+                    font.pointSize:         ScreenTools.mediumFontPointSize
+                    visible:                actuators.mixer.groups.count > 0
+                }
+
+                Rectangle {
+                    implicitWidth:          _leftColumnWidth
+                    implicitHeight:         mixerUi.height + (_margins * 2)
+                    color:                  qgcPal.windowShade
+                    visible:                actuators.mixer.groups.count > 0
+
+                    Column {
+                        id:                 mixerUi
+                        spacing:            _margins
+                        anchors {
+                            left:           parent.left
+                            leftMargin:     _margins
+                            verticalCenter: parent.verticalCenter
+                        }
+                        enabled:            !safetySwitch.checked && !actuators.motorAssignmentActive
+                        Repeater {
+                            model:          actuators.mixer.groups
+                            ColumnLayout {
+                                property var mixerGroup: object
+
+                                RowLayout {
+                                    QGCLabel {
+                                        text:                    mixerGroup.label
+                                        font.bold:               true
+                                        rightPadding:            ScreenTools.defaultFontPixelWidth * 3
+                                    }
+                                    ActuatorFact {
+                                        property var countParam: mixerGroup.countParam
+                                        visible:                 countParam != null
+                                        fact:                    countParam ? countParam.fact : null
+                                    }
+                                }
+
+                                GridLayout {
+                                    rows:       1 + mixerGroup.channels.count
+                                    columns:    1 + mixerGroup.channelConfigs.count
+
+                                    QGCLabel {
+                                        text:   ""
+                                    }
+
+                                    // param config labels
+                                    Repeater {
+                                        model:              mixerGroup.channelConfigs
+                                        QGCLabel {
+                                            text:           object.label
+                                            visible:        object.visible && (_showAdvanced || !object.advanced)
+                                            Layout.row:     0
+                                            Layout.column:  1 + index
+                                        }
+                                    }
+                                    // param instances
+                                    Repeater {
+                                        model:              mixerGroup.channels
+                                        QGCLabel {
+                                            text:           object.label + ":"
+                                            Layout.row:     1 + index
+                                            Layout.column:  0
+                                        }
+                                    }
+                                    Repeater {
+                                        model:              mixerGroup.channels
+                                        Repeater {
+                                            property var channel: object
+                                            property var channelIndex: index
+
+                                            model: object.configInstances
+
+                                            ActuatorFact {
+                                                fact:           object.fact
+                                                Layout.row:     1 + channelIndex
+                                                Layout.column:  1 + index
+                                                visible:        object.config.visible && (_showAdvanced || !object.config.advanced)
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // extra group config params
+                                Repeater {
+                                    model: mixerGroup.configParams
+
+                                    RowLayout {
+                                        spacing:     ScreenTools.defaultFontPixelWidth
+                                        QGCLabel {
+                                            text:    object.label + ":"
+                                            visible: _showAdvanced || !object.advanced
+                                        }
+                                        ActuatorFact {
+                                            fact: object.fact
+                                            visible: _showAdvanced || !object.advanced
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // actuator image
+                Image {
+                    property var refreshFlag:         actuators.imageRefreshFlag
+                    readonly property real imageSize: 9 * ScreenTools.defaultFontPixelHeight
+
+                    id:                actuatorImage
+                    source:            "image://actuators/geometry"+refreshFlag
+                    sourceSize.width:  Math.max(parent.width, imageSize)
+                    sourceSize.height: imageSize
+                    visible:           actuators.isMultirotor
+                    cache:             false
+                    MouseArea {
+                        anchors.fill:  parent
+                        onClicked: {
+                            if (mouse.button == Qt.LeftButton) {
+                                actuators.imageClicked(mouse.x, mouse.y);
+                            }
+                        }
+                    }
+                }
+
+                // actuator testing
+                QGCLabel {
+                    text:               qsTr("Actuator Testing")
+                    font.pointSize:     ScreenTools.mediumFontPointSize
+                }
+
+                Rectangle {
+                    implicitWidth:            _leftColumnWidth
+                    implicitHeight:           actuatorTesting.height + (_margins * 2)
+                    color:                    qgcPal.windowShade
+
+                    Column {
+                        id:                   actuatorTesting
+                        spacing:              _margins
+                        anchors {
+                            left:             parent.left
+                            leftMargin:       _margins
+                            verticalCenter:   parent.verticalCenter
+                        }
+
+                        QGCLabel {
+                            text: qsTr("Configure some outputs in order to test them.")
+                            visible: actuators.actuatorTest.actuators.count == 0
+                        }
+
+                        Row {
+                            spacing: ScreenTools.defaultFontPixelWidth
+                            visible: actuators.actuatorTest.actuators.count > 0
+
+                            Switch {
+                                id:      safetySwitch
+                                enabled: !actuators.motorAssignmentActive &&  !actuators.actuatorTest.hadFailure
+                                Connections {
+                                    target: actuators.actuatorTest
+                                    onHadFailureChanged: {
+                                        if (actuators.actuatorTest.hadFailure) {
+                                            safetySwitch.checked = false;
+                                            safetySwitch.switchUpdated();
+                                        }
+                                    }
+                                }
+                                onClicked: {
+                                    switchUpdated();
+                                }
+                                function switchUpdated() {
+                                    if (!checked) {
+                                        for (var channelIdx=0; channelIdx<sliderRepeater.count; channelIdx++) {
+                                            sliderRepeater.itemAt(channelIdx).stop();
+                                        }
+                                        if (allMotorsLoader.item != null)
+                                            allMotorsLoader.item.stop();
+                                    }
+                                    actuators.actuatorTest.setActive(checked);
+                                }
+                            }
+
+                            QGCLabel {
+                                color:  qgcPal.warningText
+                                text: safetySwitch.checked ? qsTr("Careful: Actuator sliders are enabled") : qsTr("Propellers are removed - Enable sliders")
+                            }
+                        } // Row
+
+                        Row {
+                            spacing: ScreenTools.defaultFontPixelWidth * 2
+                            enabled: safetySwitch.checked
+
+                            // (optional) slider for all motors
+                            Loader {
+                                id:                allMotorsLoader
+                                sourceComponent:   actuators.actuatorTest.allMotorsActuator ?  allMotorsComponent : null
+                                Layout.alignment:  Qt.AlignTop
+                            }
+                            Component {
+                                id:                allMotorsComponent
+                                ActuatorSlider {
+                                    channel:       actuators.actuatorTest.allMotorsActuator
+                                    rightPadding:  ScreenTools.defaultFontPixelWidth * 3
+                                    onActuatorValueChanged: {
+                                        stopTimer();
+                                        for (var channelIdx=0; channelIdx<sliderRepeater.count; channelIdx++) {
+                                            var channelSlider = sliderRepeater.itemAt(channelIdx);
+                                            if (channelSlider.channel.isMotor) {
+                                                channelSlider.value = sliderValue;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // all channels
+                            Repeater {
+                                id:         sliderRepeater
+                                model:      actuators.actuatorTest.actuators
+
+                                ActuatorSlider {
+                                    channel: object
+                                    onActuatorValueChanged: {
+                                        if (isNaN(value)) {
+                                            actuators.actuatorTest.stopControl(index);
+                                            stop();
+                                        } else {
+                                            actuators.actuatorTest.setChannelTo(index, value);
+                                        }
+                                    }
+                                }
+                            } // Repeater
+                        } // Row
+
+                        // actuator actions
+                        Column {
+                            visible: actuators.actuatorActions.count > 0
+                            enabled: !safetySwitch.checked && !actuators.motorAssignmentActive
+                            Row {
+                                spacing: ScreenTools.defaultFontPixelWidth * 2
+                                Repeater {
+                                    model: actuators.actuatorActions
+
+                                    QGCButton {
+                                        property var actionGroup: object
+                                        text:          actionGroup.label
+                                        onClicked:     actionMenu.popup()
+                                        QGCMenu {
+                                            id:                 actionMenu
+
+                                            Instantiator {
+                                                model:              actionGroup.actions
+                                                QGCMenuItem {
+                                                    text:           object.label
+                                                    onTriggered:	object.trigger()
+                                                }
+                                                onObjectAdded:      actionMenu.insertItem(index, object)
+                                                onObjectRemoved:    actionMenu.removeItem(object)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                        } // Column
+
+                    } // Column
+                } // Rectangle
+            }
+
+            // Right column
+            Column {
+                QGCLabel {
+                    text:               qsTr("Actuator Outputs")
+                    font.pointSize:     ScreenTools.mediumFontPointSize
+                    bottomPadding:      ScreenTools.defaultFontPixelHeight
+                }
+                QGCLabel {
+                    text:          qsTr("One or more actuator still needs to be assigned to an output.")
+                    visible:       actuators.hasUnsetRequiredFunctions
+                    color:         qgcPal.warningText
+                    bottomPadding: ScreenTools.defaultFontPixelHeight
+                }
+
+
+                // actuator output selection tabs
+                QGCTabBar {
+                    Repeater {
+                        model: actuators.actuatorOutputs
+                        QGCTabButton {
+                            text:      '   ' + object.label + '   '
+                            width:     implicitWidth
+                        }
+                    }
+                    onCurrentIndexChanged: {
+                        actuators.selectActuatorOutput(currentIndex)
+                    }
+                }
+
+                // actuator outputs
+                Rectangle {
+                    id:                             selActuatorOutput
+                    implicitWidth:                  actuatorGroupColumn.width + (_margins * 2)
+                    implicitHeight:                 actuatorGroupColumn.height + (_margins * 2)
+                    color:                          qgcPal.windowShade
+
+                    property var actuatorOutput:    actuators.selectedActuatorOutput
+
+                    Column {
+                        id:               actuatorGroupColumn
+                        spacing:          _margins
+                        anchors.centerIn: parent
+
+                        // Motor assignment
+                        Row {
+                            visible:           actuators.isMultirotor
+                            enabled:           !safetySwitch.checked
+                            anchors.right:     parent.right
+                            spacing:           _margins
+                            QGCButton {
+                                text:          qsTr("Identify & Assign Motors")
+                                visible:       !actuators.motorAssignmentActive && selActuatorOutput.actuatorOutput.groupsVisible
+                                onClicked: {
+                                    var success = actuators.initMotorAssignment()
+                                    if (success) {
+                                        motorAssignmentConfirmDialog.open()
+                                    } else {
+                                        motorAssignmentFailureDialog.open()
+                                    }
+                                }
+                                MessageDialog {
+                                    id:         motorAssignmentConfirmDialog
+                                    visible:    false
+                                    icon:       StandardIcon.Warning
+                                    standardButtons: StandardButton.Yes | StandardButton.No
+                                    title:      qsTr("Motor Order Identification and Assignment")
+                                    text: actuators.motorAssignmentMessage
+                                    onYes: {
+                                        console.log(actuators.motorAssignmentActive)
+                                        actuators.startMotorAssignment()
+                                    }
+                                }
+                                MessageDialog {
+                                    id:         motorAssignmentFailureDialog
+                                    visible:    false
+                                    icon:       StandardIcon.Critical
+                                    standardButtons: StandardButton.Ok
+                                    title:      qsTr("Error")
+                                    text: actuators.motorAssignmentMessage
+                                }
+                            }
+                            QGCButton {
+                                text:          qsTr("Spin Motor Again")
+                                visible:       actuators.motorAssignmentActive
+                                onClicked: {
+                                    actuators.spinCurrentMotor()
+                                }
+                            }
+                            QGCButton {
+                                text:          qsTr("Abort")
+                                visible:       actuators.motorAssignmentActive
+                                onClicked: {
+                                    actuators.abortMotorAssignment()
+                                }
+                            }
+                        }
+
+                        Column {
+                            enabled:          !safetySwitch.checked && !actuators.motorAssignmentActive
+                            spacing:          _margins
+
+                            RowLayout {
+                                property var enableParam:     selActuatorOutput.actuatorOutput.enableParam
+                                QGCLabel {
+                                    visible:                  parent.enableParam != null
+                                    text:                     parent.enableParam ? parent.enableParam.label + ":" : ""
+                                }
+                                ActuatorFact {
+                                    visible:                  parent.enableParam != null
+                                    fact:                     parent.enableParam ?  parent.enableParam.fact : null
+                                }
+                            }
+
+
+                            Repeater {
+                                model: selActuatorOutput.actuatorOutput.subgroups
+
+                                ColumnLayout {
+                                    property var subgroup: object
+                                    visible:               selActuatorOutput.actuatorOutput.groupsVisible
+
+                                    RowLayout {
+                                        visible: subgroup.label != ""
+                                        QGCLabel {
+                                            text:                    subgroup.label
+                                            font.bold:               true
+                                            rightPadding:            ScreenTools.defaultFontPixelWidth * 3
+                                        }
+                                        ActuatorFact {
+                                            property var primaryParam: subgroup.primaryParam
+                                            visible:                   primaryParam != null
+                                            fact:                      primaryParam ? primaryParam.fact : null
+                                        }
+                                    }
+
+                                    GridLayout {
+                                        rows:      1 + subgroup.channels.count
+                                        columns:   1 + subgroup.channelConfigs.count
+
+                                        QGCLabel {
+                                            text: ""
+                                        }
+
+                                        // param config labels
+                                        Repeater {
+                                            model: subgroup.channelConfigs
+                                            QGCLabel {
+                                                text:           object.label
+                                                visible:        object.visible && (_showAdvanced || !object.advanced)
+                                                Layout.row:     0
+                                                Layout.column:  1 + index
+                                            }
+                                        }
+                                        // param instances
+                                        Repeater {
+                                            model: subgroup.channels
+                                            QGCLabel {
+                                                text:            object.label + ":"
+                                                Layout.row:      1 + index
+                                                Layout.column:   0
+                                            }
+                                        }
+                                        Repeater {
+                                            model: subgroup.channels
+                                            Repeater {
+                                                property var channel:      object
+                                                property var channelIndex: index
+                                                model:                     object.configInstances
+                                                ActuatorFact {
+                                                    fact:           object.fact
+                                                    Layout.row:     1 + channelIndex
+                                                    Layout.column:  1 + index
+                                                    visible:        object.config.visible && (_showAdvanced || !object.config.advanced)
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // extra subgroup config params
+                                    Repeater {
+                                        model: subgroup.configParams
+
+                                        RowLayout {
+                                            QGCLabel {
+                                                text: object.label + ":"
+                                            }
+                                            ActuatorFact {
+                                                fact: object.fact
+                                            }
+                                        }
+                                    }
+
+                                }
+                            } // subgroup Repeater
+
+                            // extra actuator config params
+                            Repeater {
+                                model: selActuatorOutput.actuatorOutput.configParams
+
+                                RowLayout {
+                                    QGCLabel {
+                                        text: object.label + ":"
+                                    }
+                                    ActuatorFact {
+                                        fact: object.fact
+                                    }
+                                }
+                            }
+
+                            // notes
+                            Repeater {
+                                model: selActuatorOutput.actuatorOutput.notes
+                                ColumnLayout {
+                                    spacing: ScreenTools.defaultFontPixelHeight
+                                    QGCLabel {
+                                        text:       modelData
+                                        color:      qgcPal.warningText
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } // Rectangle
+            } // Column
+        } // Row
+
+    }
+}

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -109,7 +109,8 @@ SetupPage {
                                                 fact:           object.fact
                                                 Layout.row:     1 + channelIndex
                                                 Layout.column:  1 + index
-                                                visible:        object.config.visible && (_showAdvanced || !object.config.advanced)
+                                                visible:        object.config.visible && (_showAdvanced || !object.config.advanced) && object.visible
+                                                enabled:        object.enabled
                                             }
                                         }
                                     }

--- a/src/AutoPilotPlugins/PX4/ActuatorFact.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorFact.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.12
+import QtQuick.Controls 1.2
+import QtQuick.Layouts 1.3
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+
+Loader {
+	property var fact
+	id:                     loader
+
+	Component {
+		id: factComboBox
+		FactComboBox {
+			fact:           loader.fact
+			indexModel:     false
+			sizeToContents: true
+		}
+	}
+	Component {
+		id: factCheckbox
+		FactCheckBox {
+			fact:           loader.fact
+		}
+	}
+
+	Component {
+		id: factTextField
+		FactTextField {
+			fact:           loader.fact
+			width:          ScreenTools.defaultFontPixelWidth * 8
+			showUnits:      false
+		}
+	}
+	Component {
+		id: factReadOnly
+		QGCLabel {
+			text:           loader.fact.valueString
+		}
+	}
+	Component {
+		id: notAvailable
+		QGCLabel {
+			text:           qsTr("(Param not available)")
+		}
+	}
+	sourceComponent: fact ? 
+		(fact.enumStrings.length > 0 ? factComboBox : 
+			(fact.readOnly ? factReadOnly : (fact.typeIsBool ? factCheckbox : factTextField))
+		) : notAvailable
+}
+

--- a/src/AutoPilotPlugins/PX4/ActuatorSlider.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorSlider.qml
@@ -43,7 +43,8 @@ Column {
         value:                      defaultVal
         updateValueWhileDragging:   true
         anchors.horizontalCenter:   parent.horizontalCenter
-		height:                     ScreenTools.defaultFontPixelHeight * _sliderHeight
+        height:                     ScreenTools.defaultFontPixelHeight * _sliderHeight
+        indicatorBarVisible:        sendTimer.running
 
         onValueChanged: {
             if (blockUpdates)

--- a/src/AutoPilotPlugins/PX4/ActuatorSlider.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorSlider.qml
@@ -1,0 +1,94 @@
+import QtQuick 2.12
+import QtQuick.Controls 1.2
+import QtQuick.Layouts 1.3
+
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+
+Column {
+    property var channel
+    property alias value:             channelSlider.value
+
+    // If the default value is NaN, we add a small range
+    // below, which snaps into place
+    property var snap:                isNaN(channel.defaultValue)
+    property var span:                channel.max - channel.min
+    property var snapRange:           span * 0.15
+    property var defaultVal:          snap ? channel.min - snapRange : channel.defaultValue
+    property var blockUpdates:        true // avoid slider changes on startup
+
+    id:                               root
+
+    Layout.alignment:                 Qt.AlignTop
+
+    readonly property int _sliderHeight: 6
+
+    function stopTimer() {
+        sendTimer.stop();
+    }
+
+    function stop() {
+        channelSlider.value = defaultVal;
+        stopTimer();
+    }
+
+    signal actuatorValueChanged(real value, real sliderValue)
+
+    QGCSlider {
+        id:                         channelSlider
+        orientation:                Qt.Vertical
+        minimumValue:               snap ? channel.min - snapRange : channel.min
+        maximumValue:               channel.max
+        stepSize:                   (channel.max-channel.min)/100
+        value:                      defaultVal
+        updateValueWhileDragging:   true
+        anchors.horizontalCenter:   parent.horizontalCenter
+		height:                     ScreenTools.defaultFontPixelHeight * _sliderHeight
+
+        onValueChanged: {
+            if (blockUpdates)
+                return;
+            if (snap) {
+                if (value < channel.min) {
+                    if (value < channel.min - snapRange/2) {
+                        value = channel.min - snapRange;
+                    } else {
+                        value = channel.min;
+                    }
+                }
+            }
+            sendTimer.start()
+        }
+
+        Timer {
+            id:               sendTimer
+            interval:         50
+            triggeredOnStart: true
+            repeat:           true
+            running:          false
+            onTriggered:      {
+                var sendValue = channelSlider.value;
+                if (sendValue < channel.min - snapRange/2) {
+                    sendValue = channel.defaultValue;
+                }
+                root.actuatorValueChanged(sendValue, channelSlider.value)
+            }
+        }
+
+        Component.onCompleted: {
+            blockUpdates = false;
+        }
+    }
+
+    QGCLabel {
+        id: channelLabel
+        anchors.horizontalCenter: parent.horizontalCenter
+        text:                     channel.label
+        width:                    contentHeight
+        height:                   contentWidth
+        transform: [
+            Rotation { origin.x: 0; origin.y: 0; angle: -90 },
+            Translate { y: channelLabel.height + 5 }
+            ]
+    }
+} // Column

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -36,8 +36,10 @@ PX4AutoPilotPlugin::PX4AutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     , _flightModesComponent(nullptr)
     , _sensorsComponent(nullptr)
     , _safetyComponent(nullptr)
+    , _cameraComponent(nullptr)
     , _powerComponent(nullptr)
     , _motorComponent(nullptr)
+    , _actuatorComponent(nullptr)
     , _tuningComponent(nullptr)
     , _flightBehavior(nullptr)
     , _syslinkComponent(nullptr)
@@ -85,9 +87,19 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
                 _powerComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_powerComponent)));
 
-                _motorComponent = new MotorComponent(_vehicle, this, this);
-                _motorComponent->setupTriggerSignals();
-                _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_motorComponent)));
+                if (_vehicle->actuators()) {
+                    _vehicle->actuators()->init(); // At this point params are loaded, so we can init the actuators
+                }
+                if (_vehicle->actuators() && _vehicle->actuators()->showUi()) {
+                    _actuatorComponent = new ActuatorComponent(_vehicle, this, this);
+                    _actuatorComponent->setupTriggerSignals();
+                    _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_actuatorComponent)));
+                } else {
+                    // show previous motor UI instead
+                    _motorComponent = new MotorComponent(_vehicle, this, this);
+                    _motorComponent->setupTriggerSignals();
+                    _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_motorComponent)));
+                }
 
                 _safetyComponent = new SafetyComponent(_vehicle, this, this);
                 _safetyComponent->setupTriggerSignals();

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
@@ -12,6 +12,7 @@
 #define PX4AUTOPILOT_H
 
 #include "AutoPilotPlugin.h"
+#include "ActuatorComponent.h"
 #include "PX4AirframeLoader.h"
 #include "AirframeComponent.h"
 #include "PX4RadioComponent.h"
@@ -58,6 +59,7 @@ protected:
     CameraComponent*        _cameraComponent;
     PowerComponent*         _powerComponent;
     MotorComponent*         _motorComponent;
+    ActuatorComponent*      _actuatorComponent;
     PX4TuningComponent*     _tuningComponent;
     PX4FlightBehavior*      _flightBehavior;
     SyslinkComponent*       _syslinkComponent;

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -165,6 +165,8 @@ public:
 
     bool    isErrorState() const { return _error; }
 
+    QQmlApplicationEngine* qmlAppEngine() { return _qmlAppEngine; }
+
 public:
     // Although public, these methods are internal and should only be called by UnitTest code
 

--- a/src/QmlControls/QGCSlider.qml
+++ b/src/QmlControls/QGCSlider.qml
@@ -22,6 +22,7 @@ Slider {
     // Value indicator starts display from zero instead of min value
     property bool zeroCentered: false
     property bool displayValue: false
+    property bool indicatorBarVisible: true
 
     style: SliderStyle {
         groove: Item {
@@ -40,6 +41,7 @@ Slider {
             Item {
                 id:     indicatorBar
                 clip:   true
+                visible: indicatorBarVisible
                 x:      _root.zeroCentered ? zeroCenteredIndicatorStart : 0
                 width:  _root.zeroCentered ? centerIndicatorWidth : styleData.handlePosition
                 height: parent.height

--- a/src/Vehicle/Actuators/ActuatorActions.cc
+++ b/src/Vehicle/Actuators/ActuatorActions.cc
@@ -1,0 +1,79 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "ActuatorActions.h"
+
+#include "QGCApplication.h"
+
+using namespace ActuatorActions;
+
+QString Config::typeToLabel() const
+{
+    switch (type) {
+        case Type::beep: return QCoreApplication::translate("ActuatorAction", "Beep");
+        case Type::set3DModeOn: return QCoreApplication::translate("ActuatorAction", "3D mode: On");
+        case Type::set3DModeOff: return QCoreApplication::translate("ActuatorAction", "3D mode: Off");
+        case Type::setSpinDirection1: return QCoreApplication::translate("ActuatorAction", "Set Spin Direction 1");
+        case Type::setSpinDirection2: return QCoreApplication::translate("ActuatorAction", "Set Spin Direction 2");
+    }
+    return "";
+}
+
+Action::Action(QObject *parent, const Config &action, const QString &label, int outputFunction,
+        Vehicle *vehicle)
+    : _label(label), _outputFunction(outputFunction), _type(action.type), _vehicle(vehicle)
+{
+}
+
+void Action::trigger()
+{
+    if (_commandInProgress) {
+        return;
+    }
+    sendMavlinkRequest();
+}
+
+void Action::ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
+        Vehicle::MavCmdResultFailureCode_t failureCode)
+{
+    Action* action = (Action*)resultHandlerData;
+    action->ackHandler(commandResult, failureCode);
+}
+
+void Action::ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode)
+{
+    _commandInProgress = false;
+    if (failureCode != Vehicle::MavCmdResultFailureNoResponseToCommand && commandResult != MAV_RESULT_ACCEPTED) {
+        qgcApp()->showAppMessage(tr("Actuator action command failed"));
+    }
+}
+
+void Action::sendMavlinkRequest()
+{
+    qCDebug(ActuatorsConfigLog) << "Sending actuator action, function:" << _outputFunction << "type:" << (int)_type;
+
+    _vehicle->sendMavCommandWithHandler(
+            ackHandlerEntry,                  // Ack callback
+            this,                             // Ack callback data
+            MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
+            MAV_CMD_CONFIGURE_ACTUATOR,       // the mavlink command
+            (int)_type,                       // action type
+            0,                                // unused parameter
+            0,                                // unused parameter
+            0,                                // unused parameter
+            1000+_outputFunction,             // function
+            0,                                // unused parameter
+            0);
+    _commandInProgress = true;
+}
+
+ActionGroup::ActionGroup(QObject *parent, const QString &label, Config::Type type)
+    : _label(label), _type(type)
+{
+}

--- a/src/Vehicle/Actuators/ActuatorActions.h
+++ b/src/Vehicle/Actuators/ActuatorActions.h
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include "Common.h"
+
+#include <QmlObjectListModel.h>
+
+namespace ActuatorActions {
+
+struct Config {
+    enum class Type {
+        beep = ACTUATOR_CONFIGURATION_BEEP,                            ///< beep actuator
+        set3DModeOn = ACTUATOR_CONFIGURATION_3D_MODE_ON,               ///< motors: enable 3D mode (reversible)
+        set3DModeOff = ACTUATOR_CONFIGURATION_3D_MODE_OFF,             ///< motors: disable 3D mode (reversible)
+        setSpinDirection1 = ACTUATOR_CONFIGURATION_SPIN_DIRECTION1,    ///< motors: set spin direction 1
+        setSpinDirection2 = ACTUATOR_CONFIGURATION_SPIN_DIRECTION2,    ///< motors: set spin direction 2
+    };
+
+    QString typeToLabel() const;
+
+    Type type;
+    Condition condition;
+    QSet<QString> actuatorTypes;
+};
+
+class Action : public QObject
+{
+    Q_OBJECT
+public:
+    Action(QObject* parent, const Config& action, const QString& label,
+            int outputFunction, Vehicle* vehicle);
+
+    Q_PROPERTY(QString label                     READ label              CONSTANT)
+
+    const QString& label() const { return _label; }
+
+    Q_INVOKABLE void trigger();
+
+private:
+    static void ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
+            Vehicle::MavCmdResultFailureCode_t failureCode);
+    void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
+    void sendMavlinkRequest();
+
+    const QString _label;
+    const int _outputFunction;
+    const Config::Type _type;
+    Vehicle* _vehicle{nullptr};
+
+    bool _commandInProgress{false};
+};
+
+class ActionGroup : public QObject
+{
+    Q_OBJECT
+public:
+    ActionGroup(QObject* parent, const QString& label, Config::Type type);
+
+    Q_PROPERTY(QString label                     READ label              CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* actions       READ actions            CONSTANT)
+
+    QmlObjectListModel* actions() { return _actions; }
+    const QString& label() const { return _label; }
+
+    void addAction(Action* action) { _actions->append(action); }
+
+    Config::Type type() const { return _type; }
+
+private:
+    const QString _label;
+    QmlObjectListModel* _actions = new QmlObjectListModel(this); ///< list of Action*
+    const Config::Type _type;
+};
+
+} // namespace ActuatorActions

--- a/src/Vehicle/Actuators/ActuatorOutputs.cc
+++ b/src/Vehicle/Actuators/ActuatorOutputs.cc
@@ -1,0 +1,126 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "ActuatorOutputs.h"
+
+#include <QDebug>
+
+using namespace ActuatorOutputs;
+
+void ChannelConfig::reevaluate()
+{
+    emit visibleChanged();
+}
+
+ActuatorOutputChannel::ActuatorOutputChannel(QObject *parent, const QString &label, int paramIndex,
+        QmlObjectListModel &channelConfigs, ParameterManager* parameterManager, std::function<void(Fact*)> factAddedCb) :
+        QObject(parent), _label(label), _paramIndex(paramIndex)
+{
+    for (int i = 0; i < channelConfigs.count(); ++i) {
+        auto channelConfig = channelConfigs.value<ChannelConfig*>(i);
+        QString param = channelConfig->parameter();
+        QString sparamIndex = QString::number(paramIndex + channelConfig->indexOffset());
+        param.replace("${i}", sparamIndex);
+
+        Fact* fact = nullptr;
+        if (parameterManager->parameterExists(FactSystem::defaultComponentId, param)) {
+            fact = parameterManager->getParameter(FactSystem::defaultComponentId, param);
+            if (channelConfig->displayOption() == Parameter::DisplayOption::Bitset) {
+                fact = new FactBitset(channelConfig, fact, paramIndex + channelConfig->indexOffset());
+            } else if (channelConfig->displayOption() == Parameter::DisplayOption::BoolTrueIfPositive) {
+                fact = new FactFloatAsBool(channelConfig, fact);
+            }
+            factAddedCb(fact);
+        } else {
+            qCDebug(ActuatorsConfigLog) << "ActuatorOutputChannel: Param does not exist:" << param;
+        }
+
+        ChannelConfigInstance *instance = new ChannelConfigInstance(this, fact, *channelConfig);
+        _configInstances->append(instance);
+    }
+}
+
+void ActuatorOutputSubgroup::addChannelConfig(ChannelConfig *channelConfig)
+{
+    _channelConfigs->append(channelConfig);
+    emit channelConfigsChanged();
+}
+
+void ActuatorOutputSubgroup::addChannel(ActuatorOutputChannel *channel)
+{
+    _channels->append(channel);
+    emit channelsChanged();
+}
+
+void ActuatorOutputSubgroup::addConfigParam(ConfigParameter *param)
+{
+    if (param->function() == ConfigParameter::Function::Primary) {
+        delete _primaryParam;
+        _primaryParam = param;
+    } else {
+        _params->append(param);
+    }
+}
+
+ActuatorOutput::ActuatorOutput(QObject* parent, const QString& label, const Condition& groupVisibilityCondition)
+        : QObject(parent), _label(label), _groupVisibilityCondition(groupVisibilityCondition)
+{
+    if (_groupVisibilityCondition.fact()) {
+        connect(_groupVisibilityCondition.fact(), &Fact::rawValueChanged, this, &ActuatorOutput::groupsVisibleChanged);
+    }
+}
+
+void ActuatorOutput::addSubgroup(ActuatorOutputSubgroup *subgroup)
+{
+    _subgroups->append(subgroup);
+    emit subgroupsChanged();
+}
+
+void ActuatorOutput::addConfigParam(ConfigParameter *param)
+{
+    if (param->function() == ConfigParameter::Function::Enable) {
+        delete _enableParam;
+        _enableParam = param;
+    } else {
+        _params->append(param);
+    }
+}
+
+void ActuatorOutput::getAllChannelFunctions(QList<Fact*> &allFunctions) const
+{
+    forEachOutputFunction([&allFunctions](ActuatorOutputSubgroup*, ChannelConfigInstance*, Fact* fact) {
+        allFunctions.append(fact);
+    });
+}
+
+bool ActuatorOutput::hasExistingOutputFunctionParams() const
+{
+    bool hasExistingOutputFunction = false;
+    forEachOutputFunction([&hasExistingOutputFunction](ActuatorOutputSubgroup*, ChannelConfigInstance*, Fact* fact) {
+        hasExistingOutputFunction = true;
+    });
+    return hasExistingOutputFunction;
+}
+
+void ActuatorOutput::forEachOutputFunction(std::function<void(ActuatorOutputSubgroup*, ChannelConfigInstance*, Fact*)> callback) const
+{
+    for (int subgroupIdx = 0; subgroupIdx < _subgroups->count(); subgroupIdx++) {
+        ActuatorOutputSubgroup *subgroup = qobject_cast<ActuatorOutputSubgroup*>(_subgroups->get(subgroupIdx));
+        for (int channelIdx = 0; channelIdx < subgroup->channels()->count(); channelIdx++) {
+            ActuatorOutputChannel *channel = qobject_cast<ActuatorOutputChannel*>(subgroup->channels()->get(channelIdx));
+            for (int configIdx = 0; configIdx < channel->configInstances()->count(); configIdx++) {
+                ChannelConfigInstance *configInstance = qobject_cast<ChannelConfigInstance*>(channel->configInstances()->get(configIdx));
+                Fact* fact = configInstance->fact();
+                if (configInstance->channelConfig()->function() == ChannelConfig::Function::OutputFunction && fact) {
+                    callback(subgroup, configInstance, fact);
+                }
+            }
+        }
+    }
+}

--- a/src/Vehicle/Actuators/ActuatorOutputs.h
+++ b/src/Vehicle/Actuators/ActuatorOutputs.h
@@ -1,0 +1,240 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include <functional>
+
+#include "Common.h"
+#include "ActuatorActions.h"
+
+#include <QmlObjectListModel.h>
+
+namespace ActuatorOutputs {
+
+/**
+ * Config parameters that apply to a subgroup of actuators
+ */
+class ConfigParameter : public QObject
+{
+    Q_OBJECT
+public:
+    enum class Function {
+        Unspecified = 0,
+        Enable,             ///< Parameter to enable/disable the outputs
+        Primary,            ///< Primary parameter to configure the group of outputs
+    };
+
+    ConfigParameter(QObject* parent, Fact* fact, const QString& label, Function function)
+        : QObject(parent), _fact(fact), _label(label), _function(function) {}
+
+    Q_PROPERTY(QString label          READ label       CONSTANT)
+    Q_PROPERTY(Fact* fact             READ fact        CONSTANT)
+
+    const QString& label() const { return _label; }
+    Fact* fact() { return _fact; }
+    Function function() const { return _function; }
+
+private:
+    Fact* _fact{nullptr};
+    const QString _label;
+    const Function _function;
+};
+
+/**
+ * Config parameters that apply to individual channels
+ */
+class ChannelConfig : public QObject
+{
+    Q_OBJECT
+public:
+
+    /// Describes the meaning of the parameter
+    enum class Function {
+        Unspecified = 0,
+        OutputFunction,
+        Disarmed,
+        Minimum,
+        Maximum,
+        Failsafe
+    };
+
+    ChannelConfig(QObject* parent, const Parameter& param, Function function,
+            const Condition& visibilityCondition)
+        : QObject(parent), _parameter(param), _function(function), _visibilityCondition(visibilityCondition) {}
+
+    Q_PROPERTY(QString label      READ label      CONSTANT)
+    Q_PROPERTY(bool advanced      READ advanced   CONSTANT)
+    Q_PROPERTY(bool visible       READ visible    NOTIFY visibleChanged)
+
+    const QString& label() const { return _parameter.label; }
+    const QString& parameter() const { return _parameter.name; }
+    Function function() const { return _function; }
+    const Condition& visibilityCondition() const { return _visibilityCondition; }
+    bool advanced() const { return _parameter.advanced; }
+    bool visible() const { return _visibilityCondition.evaluate(); }
+
+    Parameter::DisplayOption displayOption() const { return _parameter.displayOption; }
+    int indexOffset() const { return _parameter.indexOffset; }
+
+    void reevaluate();
+
+signals:
+    void visibleChanged();
+private:
+    const Parameter _parameter;
+    const Function _function;
+    const Condition _visibilityCondition;
+};
+
+/**
+ * Per-channel instance for a ChannelConfig
+ */
+class ChannelConfigInstance : public QObject
+{
+    Q_OBJECT
+public:
+    ChannelConfigInstance(QObject* parent, Fact* fact, ChannelConfig& config)
+        : QObject(parent), _fact(fact), _config(config) {}
+
+    Q_PROPERTY(ChannelConfig* config      READ channelConfig   CONSTANT)
+    Q_PROPERTY(Fact* fact                 READ fact            CONSTANT)
+
+    Fact* fact() { return _fact; }
+
+    ChannelConfig* channelConfig() const { return &_config; }
+
+private:
+
+    Fact* _fact{nullptr};
+    ChannelConfig& _config;
+};
+
+class ActuatorOutputChannel : public QObject
+{
+    Q_OBJECT
+public:
+    ActuatorOutputChannel(QObject* parent, const QString& label, int paramIndex, QmlObjectListModel& channelConfigs,
+            ParameterManager* parameterManager, std::function<void(Fact*)> factAddedCb);
+
+    Q_PROPERTY(QString label                            READ label               CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* configInstances      READ configInstances     NOTIFY configInstancesChanged)
+
+    const QString& label() const { return _label; }
+
+    QmlObjectListModel* configInstances() { return _configInstances; }
+
+signals:
+    void configInstancesChanged();
+
+private:
+    const QString _label;
+    const int _paramIndex{};
+
+    QmlObjectListModel* _configInstances = new QmlObjectListModel(this); ///< list of ChannelConfigInstance*
+};
+
+class ActuatorOutputSubgroup : public QObject
+{
+    Q_OBJECT
+public:
+    ActuatorOutputSubgroup(QObject* parent, const QString& label)
+        : QObject(parent), _label(label) {}
+
+    Q_PROPERTY(QString label                        READ label            CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* channels         READ channels         NOTIFY channelsChanged)
+    Q_PROPERTY(QmlObjectListModel* channelConfigs   READ channelConfigs   NOTIFY channelConfigsChanged)
+    Q_PROPERTY(ConfigParameter* primaryParam        READ primaryParam     CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* configParams     READ configParams     CONSTANT)
+
+    const QString& label() const { return _label; }
+
+    // per-channel-params
+    QmlObjectListModel* channelConfigs() { return _channelConfigs; }
+    void addChannelConfig(ChannelConfig* channelConfig);
+
+
+    QmlObjectListModel* channels() { return _channels; }
+    void addChannel(ActuatorOutputChannel* channel);
+
+    ConfigParameter* primaryParam() const { return _primaryParam; }
+    void addConfigParam(ConfigParameter* param);
+    QmlObjectListModel* configParams() { return _params; }
+
+    const QList<ActuatorActions::Config>& actions() const { return _actions; }
+    void addAction(const ActuatorActions::Config& action) { _actions.append(action); }
+
+signals:
+    void channelsChanged();
+    void channelConfigsChanged();
+private:
+
+    const QString _label;
+    QmlObjectListModel* _channels = new QmlObjectListModel(this); ///< list of ActuatorOutputChannel*
+    QmlObjectListModel* _channelConfigs = new QmlObjectListModel(this); ///< list of ChannelConfig*
+
+    ConfigParameter* _primaryParam{nullptr};
+    QmlObjectListModel* _params  = new QmlObjectListModel(this); ///< list of ConfigParameter*
+
+    QList<ActuatorActions::Config> _actions;
+};
+
+class ActuatorOutput : public QObject
+{
+    Q_OBJECT
+public:
+    ActuatorOutput(QObject* parent, const QString& label, const Condition& groupVisibilityCondition);
+
+    Q_PROPERTY(QString label                     READ label              CONSTANT)
+    Q_PROPERTY(bool groupsVisible                READ groupsVisible      NOTIFY groupsVisibleChanged)
+    Q_PROPERTY(QmlObjectListModel* subgroups     READ subgroups          NOTIFY subgroupsChanged)
+    Q_PROPERTY(ConfigParameter* enableParam      READ enableParam        CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* configParams  READ configParams       CONSTANT)
+    Q_PROPERTY(QStringList notes                 READ notes              NOTIFY notesChanged)
+
+    const QString& label() const { return _label; }
+
+    QmlObjectListModel* subgroups() { return _subgroups; }
+    bool groupsVisible() const { return _groupVisibilityCondition.evaluate(); }
+    ConfigParameter* enableParam() const { return _enableParam; }
+    QmlObjectListModel* configParams() { return _params; }
+
+    void addSubgroup(ActuatorOutputSubgroup* subgroup);
+
+    void addConfigParam(ConfigParameter* param);
+
+    void getAllChannelFunctions(QList<Fact*>& allFunctions) const;
+
+    bool hasExistingOutputFunctionParams() const;
+
+    void addNote(const QString& note) { _notes.append(note); emit notesChanged(); }
+    void clearNotes() { _notes.clear(); emit notesChanged(); }
+    const QStringList& notes() const { return _notes; }
+
+    void forEachOutputFunction(std::function<void(ActuatorOutputSubgroup*, ChannelConfigInstance*, Fact*)> callback) const;
+
+signals:
+    void subgroupsChanged();
+    void groupsVisibleChanged();
+    void notesChanged();
+
+private:
+    const QString _label;
+    const Condition _groupVisibilityCondition;
+    QmlObjectListModel* _subgroups = new QmlObjectListModel(this); ///< list of ActuatorOutputSubgroup*
+
+    ConfigParameter* _enableParam{nullptr};
+    QmlObjectListModel* _params  = new QmlObjectListModel(this); ///< list of ConfigParameter*
+    QStringList _notes;
+};
+
+} // namespace ActuatorOutputs

--- a/src/Vehicle/Actuators/ActuatorTesting.cc
+++ b/src/Vehicle/Actuators/ActuatorTesting.cc
@@ -1,0 +1,206 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "ActuatorTesting.h"
+#include "Common.h"
+
+#include "QGCApplication.h"
+
+#include <QDebug>
+
+#include <cmath>
+
+using namespace ActuatorTesting;
+
+ActuatorTest::ActuatorTest(Vehicle* vehicle)
+    : _vehicle(vehicle)
+{
+    _watchdogTimer.setInterval(100);
+    _watchdogTimer.setSingleShot(false);
+    connect(&_watchdogTimer, &QTimer::timeout, this, &ActuatorTest::watchdogTimeout);
+    _watchdogTimer.start();
+}
+
+ActuatorTest::~ActuatorTest()
+{
+    _actuators->clearAndDeleteContents();
+    delete _allMotorsActuator;
+}
+
+void ActuatorTest::updateFunctions(const QList<Actuator*> &actuators)
+{
+    _actuators->clearAndDeleteContents();
+    _allMotorsActuator->deleteLater();
+    _allMotorsActuator = nullptr;
+
+    Actuator* motorActuator{nullptr};
+    for (const auto& actuator : actuators) {
+        if (actuator->isMotor()) {
+            motorActuator = actuator;
+        }
+        _actuators->append(actuator);
+    }
+    if (motorActuator) {
+        _allMotorsActuator = new Actuator(this, tr("All Motors"), motorActuator->min(), motorActuator->max(), motorActuator->defaultValue(),
+                motorActuator->function(), true);
+    }
+    resetStates();
+
+    emit actuatorsChanged();
+}
+
+void ActuatorTest::resetStates()
+{
+    _states.clear();
+    _currentState = -1;
+    for (int i = 0; i < _actuators->count(); ++i) {
+        _states.append(ActuatorState{});
+    }
+}
+
+void ActuatorTest::watchdogTimeout()
+{
+    for (int i = 0; i < _states.size(); ++i) {
+        if (_states[i].state == ActuatorState::State::Active) {
+            if (_states[i].lastUpdated.elapsed() > 100) {
+                qCWarning(ActuatorsConfigLog) << "Stopping actuator due to timeout:" << i;
+                _states[i].state = ActuatorState::State::StopRequest;
+            }
+        }
+    }
+    sendNext();
+}
+
+void ActuatorTest::setChannelTo(int index, float value)
+{
+    if (!_active || index >= _states.size()) {
+        return;
+    }
+    qCDebug(ActuatorsConfigLog) << "setting actuator: index:" << index << "value:" << value;
+
+    _states[index].value = value;
+    _states[index].state = ActuatorState::State::Active;
+    _states[index].lastUpdated.start();
+    sendNext();
+}
+
+void ActuatorTest::stopControl(int index)
+{
+    if (index >= _states.size() || index < -1) {
+        return;
+    }
+    qCDebug(ActuatorsConfigLog) << "stop actuator control: index:" << index;
+
+    if (index == -1) {
+        for (int i = 0; i < _states.size(); ++i) {
+            if (_states[i].state == ActuatorState::State::Active) {
+                _states[i].state = ActuatorState::State::StopRequest;
+            }
+        }
+    } else {
+        if (_states[index].state == ActuatorState::State::Active) {
+            _states[index].state = ActuatorState::State::StopRequest;
+        }
+    }
+    sendNext();
+}
+
+void ActuatorTest::setActive(bool active)
+{
+    qCDebug(ActuatorsConfigLog) << "setting active: " << active;
+    if (!active) {
+        stopControl(-1);
+    }
+    _active = active;
+}
+
+void ActuatorTest::ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
+        Vehicle::MavCmdResultFailureCode_t failureCode)
+{
+    ActuatorTest* actuatorTest = (ActuatorTest*)resultHandlerData;
+    actuatorTest->ackHandler(commandResult, failureCode);
+}
+
+void ActuatorTest::ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode)
+{
+    // upon receiving an (n)ack, continuously cycle through the active actuators, one at a time
+    _commandInProgress = false;
+    if (failureCode == Vehicle::MavCmdResultFailureNoResponseToCommand) {
+        // on timeout, just try the next one
+        sendNext();
+    } else if (commandResult == MAV_RESULT_ACCEPTED) {
+        if (_currentState != -1 && _states[_currentState].state == ActuatorState::State::Stopping) {
+            _states[_currentState].state = ActuatorState::State::NotActive;
+        }
+        sendNext();
+    } else { // failure
+        if (_currentState != -1) {
+            _states[_currentState].state = ActuatorState::State::NotActive;
+        }
+
+        if (!_hadFailure) {
+            QString message;
+            if (commandResult == MAV_RESULT_TEMPORARILY_REJECTED) {
+                message = tr("Actuator test command temporarily rejected");
+            } else if (commandResult == MAV_RESULT_DENIED) {
+                message = tr("Actuator test command denied");
+            } else if (commandResult == MAV_RESULT_UNSUPPORTED) {
+                message = tr("Actuator test command not supported");
+            } else {
+                message = tr("Actuator test command failed");
+            }
+            qgcApp()->showAppMessage(message);
+            _hadFailure = true;
+            emit hadFailureChanged();
+        }
+        sendNext();
+    }
+}
+
+void ActuatorTest::sendNext()
+{
+    if (_commandInProgress) {
+        return;
+    }
+
+    // find the next actuator not in state NotActive
+    for (int i = 0; i < _states.size(); ++i) {
+        _currentState = (_currentState + 1) % _states.size();
+        Actuator* actuator = _actuators->value<Actuator*>(_currentState);
+        if (_states[_currentState].state == ActuatorState::State::Active) {
+            sendMavlinkRequest(actuator->function(), _states[_currentState].value, 1.f);
+            break;
+        } else if (_states[_currentState].state == ActuatorState::State::StopRequest) {
+            _states[_currentState].state = ActuatorState::State::Stopping;
+            sendMavlinkRequest(actuator->function(), NAN, 0.f);
+            break;
+        }
+    }
+}
+
+void ActuatorTest::sendMavlinkRequest(int function, float value, float timeout)
+{
+    qCDebug(ActuatorsConfigLog) << "Sending actuator test function:" << function << "value:" << value;
+
+    // TODO: consider using a lower command timeout
+
+    _vehicle->sendMavCommandWithHandler(
+            ackHandlerEntry,                  // Ack callback
+            this,                             // Ack callback data
+            MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
+            MAV_CMD_ACTUATOR_TEST,            // the mavlink command
+            value,                            // value
+            timeout,                          // timeout
+            0,                                // unused parameter
+            0,                                // unused parameter
+            1000+function,                    // function
+            0,                                // unused parameter
+            0);
+    _commandInProgress = true;
+}

--- a/src/Vehicle/Actuators/ActuatorTesting.h
+++ b/src/Vehicle/Actuators/ActuatorTesting.h
@@ -1,0 +1,133 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include <QmlObjectListModel.h>
+
+#include <QTimer>
+#include "Vehicle.h"
+#include "MAVLinkProtocol.h"
+
+namespace ActuatorTesting {
+
+class Actuator : public QObject
+{
+    Q_OBJECT
+public:
+    Actuator(QObject* parent, const QString& label, float min, float max, float defaultValue, int function, bool isMotor)
+        : QObject(parent), _label(label), _min(min), _max(max), _defaultValue(defaultValue), _function(function),
+          _isMotor(isMotor) {}
+
+    Q_PROPERTY(QString label              READ label                             CONSTANT)
+    Q_PROPERTY(float min                  READ min                               CONSTANT)
+    Q_PROPERTY(float max                  READ max                               CONSTANT)
+    Q_PROPERTY(float defaultValue         READ defaultValue                      CONSTANT)
+    Q_PROPERTY(int function               READ function                          CONSTANT)
+    Q_PROPERTY(bool isMotor               READ isMotor                           CONSTANT)
+
+    const QString& label() const { return _label; }
+    float min() const { return _min; }
+    float max() const { return _max; }
+    float defaultValue() const { return _defaultValue; }
+    int function() const { return _function; }
+    bool isMotor() const { return _isMotor; }
+
+private:
+    const QString _label;
+    const float _min;
+    const float _max;
+    const float _defaultValue;
+    const int _function;
+    const bool _isMotor;
+};
+
+class ActuatorTest : public QObject
+{
+    Q_OBJECT
+public:
+    ActuatorTest(Vehicle* vehicle);
+
+    ~ActuatorTest();
+
+    Q_PROPERTY(QmlObjectListModel* actuators         READ actuators                NOTIFY actuatorsChanged)
+    Q_PROPERTY(Actuator* allMotorsActuator           READ allMotorsActuator        NOTIFY actuatorsChanged)
+    Q_PROPERTY(bool hadFailure                       READ hadFailure               NOTIFY hadFailureChanged)
+
+    QmlObjectListModel* actuators() { return _actuators; }
+    Actuator* allMotorsActuator() { return _allMotorsActuator; }
+
+    void updateFunctions(const QList<Actuator*>& actuators);
+
+    /**
+     * (de-)activate actuator testing. No channels can be changed while deactivated
+     */
+    Q_INVOKABLE void setActive(bool active);
+
+    /**
+     * Control an actuator.
+     * This needs to be called at least every 100ms for each controlled channel, to refresh that channel,
+     * otherwise it will be stopped.
+     * @param index actuator index
+     * @param value control value in range defined by the actuator
+     */
+    Q_INVOKABLE void setChannelTo(int index, float value);
+
+    /**
+     * Stop controlling an actuator
+     * @param index actuator index (-1 for all)
+     */
+    Q_INVOKABLE void stopControl(int index);
+
+    bool hadFailure() const { return _hadFailure; }
+
+signals:
+    void actuatorsChanged();
+    void hadFailureChanged();
+
+private:
+
+    struct ActuatorState {
+        enum class State {
+            NotActive,
+            Active,
+            StopRequest,
+            Stopping
+        };
+        State state{State::NotActive};
+        float value{0.f};
+        QElapsedTimer lastUpdated;
+    };
+
+    void resetStates();
+
+    static void ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
+            Vehicle::MavCmdResultFailureCode_t failureCode);
+    void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
+    void sendMavlinkRequest(int function, float value, float timeout);
+
+    void sendNext();
+    void watchdogTimeout();
+
+    QmlObjectListModel* _actuators{new QmlObjectListModel(this)}; ///< list of Actuator*
+    Vehicle* _vehicle{nullptr};
+    Actuator* _allMotorsActuator{nullptr};
+    bool _active{false};
+    bool _commandInProgress{false};
+
+    QList<ActuatorState> _states;
+    int _currentState{-1};
+    QTimer _watchdogTimer;
+    bool _hadFailure{false};
+};
+
+} // namespace ActuatorTesting

--- a/src/Vehicle/Actuators/Actuators.cc
+++ b/src/Vehicle/Actuators/Actuators.cc
@@ -1,0 +1,664 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "Actuators.h"
+
+#include <QString>
+#include <QFile>
+#include <QtGlobal>
+#include <QJsonArray>
+#include <QJsonObject>
+
+#include <algorithm>
+
+using namespace ActuatorOutputs;
+
+Actuators::Actuators(QObject* parent, Vehicle* vehicle)
+    : QObject(parent), _actuatorTest(vehicle), _mixer(vehicle->parameterManager()),
+      _motorAssignment(nullptr, vehicle, _actuatorOutputs), _vehicle(vehicle)
+{
+    connect(&_mixer, &Mixer::Mixers::paramChanged, this, &Actuators::parametersChanged);
+    qRegisterMetaType<Actuators*>("Actuators*");
+    connect(&_motorAssignment, &MotorAssignment::activeChanged, this, &Actuators::motorAssignmentActiveChanged);
+    connect(&_motorAssignment, &MotorAssignment::messageChanged, this, &Actuators::motorAssignmentMessageChanged);
+    connect(&_motorAssignment, &MotorAssignment::onAbort, this, [this]() { highlightActuators(false); });
+}
+
+void Actuators::imageClicked(float x, float y)
+{
+    GeometryImage::VehicleGeometryImageProvider* provider = GeometryImage::VehicleGeometryImageProvider::instance();
+    int motorIndex = provider->getHighlightedMotorIndexAtPos(QPointF{ x, y });
+    qCDebug(ActuatorsConfigLog) << "Image clicked:" << x << "," << y << "motor index:" << motorIndex;
+
+    if (_motorAssignment.active()) {
+        QList<ActuatorGeometry>& actuators = provider->actuators();
+        bool found = false;
+        for (auto& actuator : actuators) {
+            if (actuator.type == ActuatorGeometry::Type::Motor && actuator.index == motorIndex) {
+                actuator.renderOptions.highlight = false;
+                found = true;
+            }
+        }
+        updateGeometryImage();
+
+        if (found) {
+            // call this outside of the loop as it might lead to an actuator refresh
+            _motorAssignment.selectMotor(motorIndex);
+        }
+    }
+}
+
+void Actuators::selectActuatorOutput(int index)
+{
+    if (index >= _actuatorOutputs->count() || index < 0) {
+        index = 0;
+    }
+    _selectedActuatorOutput = index;
+    emit selectedActuatorOutputChanged();
+}
+ActuatorOutput* Actuators::selectedActuatorOutput() const
+{
+    if (_actuatorOutputs->count() == 0) {
+        return nullptr;
+    }
+    return _actuatorOutputs->value<ActuatorOutputs::ActuatorOutput*>(_selectedActuatorOutput);
+}
+
+void Actuators::updateGeometryImage()
+{
+    GeometryImage::VehicleGeometryImageProvider* provider = GeometryImage::VehicleGeometryImageProvider::instance();
+
+    QList<ActuatorGeometry>& actuators = provider->actuators();
+    QList<ActuatorGeometry> previousActuators = actuators;
+
+    // collect the actuators
+    actuators.clear();
+    for (int mixerGroupIdx = 0; mixerGroupIdx < _mixer.groups()->count(); ++mixerGroupIdx) {
+        Mixer::MixerConfigGroup* mixerGroup = _mixer.groups()->value<Mixer::MixerConfigGroup*>(mixerGroupIdx);
+        for (int mixerChannelIdx = 0; mixerChannelIdx < mixerGroup->channels()->count(); ++mixerChannelIdx) {
+            const Mixer::MixerChannel* mixerChannel = mixerGroup->channels()->value<Mixer::MixerChannel*>(mixerChannelIdx);
+            ActuatorGeometry geometry{};
+            if (mixerChannel->getGeometry(_mixer.actuatorTypes(), mixerGroup->group(), geometry)) {
+                actuators.append(geometry);
+                qCDebug(ActuatorsConfigLog) << "Airframe actuator:" << geometry.index << "pos:" << geometry.position;
+            }
+        }
+    }
+
+    // restore render options if actuators did not change
+    if (previousActuators.size() == actuators.size()) {
+        for (int i = 0; i < actuators.size(); ++i) {
+            if (previousActuators[i].type == actuators[i].type && previousActuators[i].index == actuators[i].index) {
+                actuators[i].renderOptions = previousActuators[i].renderOptions;
+            }
+        }
+    }
+
+    _imageRefreshFlag = !_imageRefreshFlag;
+    emit imageRefreshFlagChanged();
+}
+
+bool Actuators::isMultirotor() const
+{
+    return _mixer.configuredType() == "multirotor";
+}
+
+void Actuators::load(const QString &json_file)
+{
+    QFile file;
+    file.setFileName(json_file);
+    file.open(QIODevice::ReadOnly | QIODevice::Text);
+    QString json_data = file.readAll();
+    file.close();
+
+    // store the metadata to be loaded later after all params are available
+    _jsonMetadata = QJsonDocument::fromJson(json_data.toUtf8());
+}
+
+void Actuators::init()
+{
+    if (_init) {
+        return;
+    }
+
+    if (!_vehicle->parameterManager()->parametersReady()) {
+        qWarning() << "Incorrect calling order, parameters not yet ready";
+    }
+
+    if (!parseJson(_jsonMetadata)) {
+        return;
+    }
+    _jsonMetadata = {};
+
+    // Remove groups that have no enable param and none of the function params is available
+    for (int groupIdx = 0; groupIdx < _actuatorOutputs->count(); groupIdx++) {
+        ActuatorOutput* group = qobject_cast<ActuatorOutput*>(_actuatorOutputs->get(groupIdx));
+        if (!group->enableParam() && !group->hasExistingOutputFunctionParams()) {
+            qCDebug(ActuatorsConfigLog) << "Removing actuator group w/o function parameters at" << groupIdx;
+            _actuatorOutputs->removeAt(groupIdx);
+            delete group;
+            --groupIdx;
+        }
+    }
+
+    emit actuatorOutputsChanged();
+    parametersChanged();
+}
+
+void Actuators::parametersChanged()
+{
+    qCDebug(ActuatorsConfigLog) << "Param update";
+
+    _mixer.update();
+
+    // gather all enabled functions
+    QList<int> allFunctions;
+    for (int groupIdx = 0; groupIdx < _actuatorOutputs->count(); groupIdx++) {
+        ActuatorOutput* group = qobject_cast<ActuatorOutput*>(_actuatorOutputs->get(groupIdx));
+        group->clearNotes();
+        QList<Fact*> groupFunctions;
+        group->getAllChannelFunctions(groupFunctions);
+        for (const auto& groupFunction : groupFunctions) {
+            int function = groupFunction->rawValue().toInt();
+            if (function != 0) { // disabled
+                allFunctions.append(function);
+            }
+
+            // update notes for configured functions
+            const auto iter = _mixer.functions().find(function);
+            if (iter != _mixer.functions().end() && iter->note != "") {
+                if (iter->noteCondition.evaluate()) {
+                    qCDebug(ActuatorsConfigLog) << "Showing Note:" << iter->note;
+                    group->addNote(iter->note);
+                }
+            }
+        }
+
+        // update channel visibility
+        for (int subbroupIdx = 0; subbroupIdx < group->subgroups()->count(); subbroupIdx++) {
+            ActuatorOutputSubgroup* subgroup = qobject_cast<ActuatorOutputSubgroup*>(group->subgroups()->get(subbroupIdx));
+            for (int channelIdx = 0; channelIdx < subgroup->channelConfigs()->count(); channelIdx++) {
+                ChannelConfig* channel = qobject_cast<ChannelConfig*>(subgroup->channelConfigs()->get(channelIdx));
+                channel->reevaluate();
+            }
+        }
+    }
+
+    std::sort(allFunctions.begin(), allFunctions.end());
+
+    // create list of actuators from configured functions
+    QList<ActuatorTesting::Actuator*> actuators;
+    QSet<int> uniqueConfiguredFunctions;
+    const Mixer::ActuatorTypes &actuatorTypes = _mixer.actuatorTypes();
+    for (int function : allFunctions) {
+        if (uniqueConfiguredFunctions.find(function) != uniqueConfiguredFunctions.end()) { // only add once
+            continue;
+        }
+        uniqueConfiguredFunctions.insert(function);
+        QString label = _mixer.getSpecificLabelForFunction(function);
+
+        // check if we should exclude the function from testing
+        bool excludeFromActuatorTesting = false;
+        const auto iter = _mixer.functions().find(function);
+        if (iter != _mixer.functions().end()) {
+            excludeFromActuatorTesting = iter->excludeFromActuatorTesting;
+        }
+
+        // find actuator
+        if (!excludeFromActuatorTesting) {
+            bool found = false;
+            for (const auto& actuatorTypeName : actuatorTypes.keys()) {
+                const Mixer::ActuatorType& actuatorType = actuatorTypes[actuatorTypeName];
+                if (function >= actuatorType.functionMin && function <= actuatorType.functionMax) {
+                    bool isMotor = ActuatorGeometry::typeFromStr(actuatorTypeName) == ActuatorGeometry::Type::Motor;
+                    actuators.append(
+                            new ActuatorTesting::Actuator(&_actuatorTest, label, actuatorType.values.min, actuatorType.values.max,
+                                    actuatorType.values.defaultVal, function, isMotor));
+                    found = true;
+                    break;
+                }
+            }
+            if (!found && actuatorTypes.find("DEFAULT") != actuatorTypes.end()) {
+                const Mixer::ActuatorType& actuatorType = actuatorTypes["DEFAULT"];
+                actuators.append(
+                        new ActuatorTesting::Actuator(&_actuatorTest, label, actuatorType.values.min, actuatorType.values.max,
+                                actuatorType.values.defaultVal, function, false));
+            }
+        }
+    }
+    _actuatorTest.updateFunctions(actuators);
+
+    // check if there are required functions, but not set on any output
+    QSet<int> requiredFunctions = _mixer.requiredFunctions();
+    _hasUnsetRequiredFunctions = false;
+    for (int requiredFunction : requiredFunctions) {
+        if (uniqueConfiguredFunctions.find(requiredFunction) == uniqueConfiguredFunctions.end()) {
+            _hasUnsetRequiredFunctions = true;
+        }
+    }
+    emit hasUnsetRequiredFunctionsChanged();
+
+    updateActuatorActions();
+
+    updateGeometryImage();
+}
+
+void Actuators::updateActuatorActions()
+{
+    _actuatorActions->clearAndDeleteContents();
+    QSet<int> addedFunctions;
+    for (int groupIdx = 0; groupIdx < _actuatorOutputs->count(); groupIdx++) {
+        ActuatorOutput* group = qobject_cast<ActuatorOutput*>(_actuatorOutputs->get(groupIdx));
+
+        group->forEachOutputFunction([&](ActuatorOutputSubgroup* subgroup, ChannelConfigInstance*, Fact* fact) {
+            int outputFunctionVal = fact->rawValue().toInt();
+            if (outputFunctionVal != 0 && !addedFunctions.contains(outputFunctionVal)) {
+                auto outputFunctionIter = _mixer.functions().find(outputFunctionVal);
+                if (outputFunctionIter != _mixer.functions().end()) {
+                    const Mixer::Mixers::OutputFunction& outputFunction = outputFunctionIter.value();
+                    for (const auto& action : subgroup->actions()) {
+                        if (!action.condition.evaluate()) {
+                            continue;
+                        }
+                        if (!action.actuatorTypes.empty() && action.actuatorTypes.find(outputFunction.actuatorType) == action.actuatorTypes.end()) {
+                            continue;
+                        }
+
+                        // add the action
+                        auto actuatorAction = new ActuatorActions::Action(this, action, outputFunction.label, outputFunctionVal, _vehicle);
+                        ActuatorActions::ActionGroup* actionGroup = nullptr;
+                        // try to find the group
+                        for (int groupIdx = 0; groupIdx < _actuatorActions->count(); groupIdx++) {
+                            ActuatorActions::ActionGroup* curActionGroup =
+                                    qobject_cast<ActuatorActions::ActionGroup*>(_actuatorActions->get(groupIdx));
+                            if (curActionGroup->type() == action.type) {
+                                actionGroup = curActionGroup;
+                                break;
+                            }
+                        }
+
+                        if (!actionGroup) {
+                            QString groupLabel = action.typeToLabel();
+                            actionGroup = new ActuatorActions::ActionGroup(this, groupLabel, action.type);
+                            _actuatorActions->append(actionGroup);
+                        }
+                        actionGroup->addAction(actuatorAction);
+                        addedFunctions.insert(outputFunctionVal);
+                    }
+                }
+            }
+        });
+    }
+
+    emit actuatorActionsChanged();
+}
+
+bool Actuators::parseJson(const QJsonDocument &json)
+{
+    _actuatorOutputs->clearAndDeleteContents();
+
+    QJsonObject obj = json.object();
+    QJsonValue outputsJson = obj.value("outputs_v1");
+    QJsonValue functionsJson = obj.value("functions_v1");
+    QJsonValue mixerJson = obj.value("mixer_v1");
+    if (outputsJson.isNull() || functionsJson.isNull() || mixerJson.isNull()) {
+        qCWarning(ActuatorsConfigLog) << "Missing json section:" << outputsJson << "\n" << functionsJson << "\n" << mixerJson;
+        return false;
+    }
+
+    // parse outputs
+    QJsonArray outputs = outputsJson.toArray();
+    for (const auto &outputJson : outputs) {
+        QJsonValue output = outputJson.toObject();
+        QString label = output["label"].toString();
+
+        qCDebug(ActuatorsConfigLog) << "Actuator group:" << label;
+
+        Condition groupVisibilityCondition(output["show-subgroups-if"].toString(""), _vehicle->parameterManager());
+        subscribeFact(groupVisibilityCondition.fact());
+
+        ActuatorOutput* currentActuatorOutput = new ActuatorOutput(this, label, groupVisibilityCondition);
+        _actuatorOutputs->append(currentActuatorOutput);
+
+        auto parseParam = [&currentActuatorOutput, this](const QJsonValue &parameter) {
+            Parameter param{};
+            param.parse(parameter);
+            QString functionStr = parameter["function"].toString("");
+            qCDebug(ActuatorsConfigLog) << "param:" << param.name << "label:" << param.label << "function:" << functionStr;
+            ConfigParameter::Function function = ConfigParameter::Function::Unspecified;
+            if (functionStr == "enable") {
+                function = ConfigParameter::Function::Enable;
+            } else if (functionStr == "primary") {
+                function = ConfigParameter::Function::Primary;
+            } else if (functionStr != "") {
+                qCWarning(ActuatorsConfigLog) << "Unknown function " << functionStr << "for param" << param.name;
+            }
+            return new ConfigParameter(currentActuatorOutput, getFact(param.name), param.label, function);
+        };
+
+        QJsonArray parameters = output["parameters"].toArray();
+        for (const auto& parameterJson : parameters) {
+            currentActuatorOutput->addConfigParam(parseParam(parameterJson.toObject()));
+        }
+
+        QJsonArray subgroups = output["subgroups"].toArray();
+        for (const auto& subgroupJson : subgroups) {
+            QJsonValue subgroup = subgroupJson.toObject();
+            QString subgroupLabel = subgroup["label"].toString();
+            ActuatorOutputSubgroup* actuatorSubgroup = new ActuatorOutputSubgroup(this, subgroupLabel);
+            currentActuatorOutput->addSubgroup(actuatorSubgroup);
+
+            QJsonValue supportedActions = subgroup["supported-actions"];
+            if (!supportedActions.isNull()) {
+                QJsonObject supportedActionsObj = supportedActions.toObject();
+                for (const auto& actionName : supportedActionsObj.keys()) {
+                    QJsonObject actionObj = supportedActionsObj.value(actionName).toObject();
+                    ActuatorActions::Config action{};
+                    bool knownAction = true;
+                    if (actionName == "beep") {
+                        action.type = ActuatorActions::Config::Type::beep;
+                    } else if (actionName == "3d-mode-on") {
+                        action.type = ActuatorActions::Config::Type::set3DModeOn;
+                    } else if (actionName == "3d-mode-off") {
+                        action.type = ActuatorActions::Config::Type::set3DModeOff;
+                    } else if (actionName == "set-spin-direction1") {
+                        action.type = ActuatorActions::Config::Type::setSpinDirection1;
+                    } else if (actionName == "set-spin-direction2") {
+                        action.type = ActuatorActions::Config::Type::setSpinDirection2;
+                    } else {
+                        knownAction = false;
+                        qCWarning(ActuatorsConfigLog) << "Unknown 'supported-actions':" << actionName;
+                    }
+                    if (knownAction) {
+                        QJsonArray actuatorTypesArr = actionObj["actuator-types"].toArray();
+                        for (const auto &type : actuatorTypesArr) {
+                            action.actuatorTypes.insert(type.toString());
+                        }
+                        action.condition = Condition(actionObj["supported-if"].toString(), _vehicle->parameterManager());
+                        subscribeFact(action.condition.fact());
+                        actuatorSubgroup->addAction(action);
+                    }
+                }
+            }
+
+            QJsonArray parameters = subgroup["parameters"].toArray();
+            for (const auto& parameterJson : parameters) {
+                actuatorSubgroup->addConfigParam(parseParam(parameterJson.toObject()));
+            }
+
+            QJsonArray channelParameters = subgroup["per-channel-parameters"].toArray();
+            for (const auto& channelParametersJson : channelParameters) {
+                QJsonValue channelParameter = channelParametersJson.toObject();
+                Parameter param;
+                param.parse(channelParameter);
+
+                ChannelConfig::Function function = ChannelConfig::Function::Unspecified;
+                QString functionStr = channelParameter["function"].toString("");
+                if (functionStr == "function") {
+                    function = ChannelConfig::Function::OutputFunction;
+                } else if (functionStr == "disarmed") {
+                    function = ChannelConfig::Function::Disarmed;
+                } else if (functionStr == "min") {
+                    function = ChannelConfig::Function::Minimum;
+                } else if (functionStr == "max") {
+                    function = ChannelConfig::Function::Maximum;
+                } else if (functionStr == "failsafe") {
+                    function = ChannelConfig::Function::Failsafe;
+                } else if (functionStr != "") {
+                    qCWarning(ActuatorsConfigLog) << "Unknown 'function':" << functionStr;
+                }
+
+                Condition visibilityCondition(channelParameter["show-if"].toString(""), _vehicle->parameterManager());
+                subscribeFact(visibilityCondition.fact());
+
+                qCDebug(ActuatorsConfigLog) << "per-channel-param:" << param.label << "param:" << param.name;
+                actuatorSubgroup->addChannelConfig(new ChannelConfig(this, param, function, visibilityCondition));
+            }
+
+            QJsonArray channels = subgroup["channels"].toArray();
+            for (const auto& channelJson : channels) {
+                QJsonValue channel = channelJson.toObject();
+                QString channelLabel = channel["label"].toString();
+                int paramIndex = channel["param-index"].toInt();
+                qCDebug(ActuatorsConfigLog) << "channel label:" << channelLabel << "param-index" << paramIndex;
+                actuatorSubgroup->addChannel(
+                        new ActuatorOutputChannel(this, channelLabel, paramIndex, *actuatorSubgroup->channelConfigs(),
+                                _vehicle->parameterManager(), [this](Fact* fact) { subscribeFact(fact); }));
+            }
+        }
+    }
+
+    _showUi = Condition(obj.value("show-ui-if").toString(""), _vehicle->parameterManager());
+
+    // parse functions
+    QMap<int, Mixer::Mixers::OutputFunction> outputFunctions;
+    QJsonObject functions = functionsJson.toObject();
+    for (const auto& functionKey : functions.keys()) {
+        bool ok;
+        int key = functionKey.toInt(&ok);
+        if (ok) {
+            QJsonObject functionObj = functions.value(functionKey).toObject();
+            QString label = functionObj["label"].toString();
+            if (label != "") {
+                QJsonObject noteObj = functionObj["note"].toObject();
+                QString note = noteObj["text"].toString();
+                QString condition = noteObj["condition"].toString();
+                QString noteCondition = functionObj["label"].toString();
+                bool exclude = functionObj["exclude-from-actuator-testing"].toBool(false);
+                Condition conditionObj{condition, _vehicle->parameterManager()};
+                subscribeFact(conditionObj.fact());
+                outputFunctions[key] = Mixer::Mixers::OutputFunction{label, conditionObj, note, exclude};
+            }
+        }
+    }
+    qCDebug(ActuatorsConfigLog) << "functions:" << outputFunctions;
+
+    Mixer::ActuatorTypes actuatorTypes;
+    // parse mixer
+    QJsonObject actuatorTypesJson = mixerJson.toObject().value("actuator-types").toObject();
+    for (const auto& actuatorTypeName : actuatorTypesJson.keys()) {
+        QJsonValue actuatorTypeVal = actuatorTypesJson.value(actuatorTypeName).toObject();
+        Mixer::ActuatorType actuatorType{};
+        actuatorType.functionMin = actuatorTypeVal["function-min"].toInt();
+        actuatorType.functionMax = actuatorTypeVal["function-max"].toInt();
+        actuatorType.labelIndexOffset = actuatorTypeVal["label-index-offset"].toInt(0);
+        QJsonValue values = actuatorTypeVal["values"].toObject();
+        actuatorType.values.min = values["min"].toDouble();
+        actuatorType.values.max = values["max"].toDouble();
+        actuatorType.values.defaultVal = values["default"].toDouble();
+        if (values["default-is-nan"].toBool()) {
+            actuatorType.values.defaultVal = NAN;
+        }
+        actuatorType.values.reversible = values["reversible"].toBool();
+
+        QJsonArray perItemParametersJson = actuatorTypeVal["per-item-parameters"].toArray();
+        for (const auto& perItemParameterJson : perItemParametersJson) {
+            QJsonValue perItemParameter = perItemParameterJson.toObject();
+            Parameter param{};
+            param.parse(perItemParameter);
+            actuatorType.perItemParams.append(param);
+        }
+        actuatorTypes[actuatorTypeName] = actuatorType;
+    }
+
+    // fill in the actuator types
+    auto actuatorTypeIter = actuatorTypes.constBegin();
+    while (actuatorTypeIter != actuatorTypes.constEnd()) {
+        if (actuatorTypeIter.key() != "DEFAULT") {
+            for (int function = actuatorTypeIter.value().functionMin; function <= actuatorTypeIter.value().functionMax; ++function) {
+                auto functionIter = outputFunctions.find(function);
+                if (functionIter != outputFunctions.end()) {
+                    functionIter->actuatorType = actuatorTypeIter.key();
+                }
+            }
+        }
+        ++actuatorTypeIter;
+    }
+
+    Mixer::MixerOptions mixerOptions{};
+    QJsonValue mixerConfigJson = mixerJson.toObject().value("config");
+    QJsonArray mixerConfigJsonArr = mixerConfigJson.toArray();
+    for (const auto& mixerConfigJson : mixerConfigJsonArr) {
+        QJsonValue mixerConfig = mixerConfigJson.toObject();
+        Mixer::MixerOption option{};
+        option.option = mixerConfig["option"].toString();
+        option.type = mixerConfig["type"].toString();
+        QJsonArray actuatorsJson = mixerConfig["actuators"].toArray();
+        for (const auto& actuatorJson : actuatorsJson) {
+            QJsonValue actuatorJsonVal = actuatorJson.toObject();
+            Mixer::MixerOption::ActuatorGroup actuator{};
+            actuator.groupLabel = actuatorJsonVal["group-label"].toString();
+            if (actuatorJsonVal["count"].isString()) {
+                actuator.count = actuatorJsonVal["count"].toString();
+            } else {
+                actuator.fixedCount = actuatorJsonVal["count"].toInt();
+            }
+            actuator.actuatorType = actuatorJsonVal["actuator-type"].toString();
+            actuator.required = actuatorJsonVal["required"].toBool(false);
+            QJsonArray parametersJson = actuatorJsonVal["parameters"].toArray();
+            for (const auto& parameterJson : parametersJson) {
+                QJsonValue parameter = parameterJson.toObject();
+                Parameter mixerParameter{};
+                mixerParameter.parse(parameter);
+                actuator.parameters.append(mixerParameter);
+            }
+
+            QJsonArray perItemParametersJson = actuatorJsonVal["per-item-parameters"].toArray();
+            for (const auto& parameterJson : perItemParametersJson) {
+                QJsonValue parameter = parameterJson.toObject();
+                Mixer::MixerParameter mixerParameter{};
+                mixerParameter.param.parse(parameter);
+                QString function = parameter["function"].toString();
+                if (function == "posx") {
+                    mixerParameter.function = Mixer::Function::PositionX;
+                } else if (function == "posy") {
+                    mixerParameter.function = Mixer::Function::PositionY;
+                } else if (function == "posz") {
+                    mixerParameter.function = Mixer::Function::PositionZ;
+                } else if (function == "spin-dir") {
+                    mixerParameter.function = Mixer::Function::SpinDirection;
+                } else if (function == "axisx") {
+                    mixerParameter.function = Mixer::Function::AxisX;
+                } else if (function == "axisy") {
+                    mixerParameter.function = Mixer::Function::AxisY;
+                } else if (function == "axisz") {
+                    mixerParameter.function = Mixer::Function::AxisZ;
+                } else if (function == "type") {
+                    mixerParameter.function = Mixer::Function::Type;
+                } else if (function != "") {
+                    qCWarning(ActuatorsConfigLog) << "Unknown param function:" << function;
+                }
+                // check if not configurable: in that case we expect a list of values
+                bool invalid = false;
+                if (mixerParameter.param.name == "") {
+                    QJsonArray valuesJson = parameter["value"].toArray();
+                    for (const auto& valueJson : valuesJson) {
+                        mixerParameter.values.append(valueJson.toDouble());
+                    }
+
+                    if (actuator.fixedCount != mixerParameter.values.size() && mixerParameter.values.size() != 1) {
+                        invalid = true;
+                        qCWarning(ActuatorsConfigLog) << "Invalid mixer param config:" << actuator.fixedCount << "," << mixerParameter.values.size();
+                    }
+                }
+                if (!invalid) {
+                    actuator.perItemParameters.append(mixerParameter);
+                }
+            }
+
+            if (actuatorJsonVal["item-label-prefix"].isString()) {
+                actuator.itemLabelPrefix.append(actuatorJsonVal["item-label-prefix"].toString());
+            } else {
+                QJsonArray itemLabelPrefixJson = actuatorJsonVal["item-label-prefix"].toArray();
+                for (const auto& itemLabelPrefix : itemLabelPrefixJson) {
+                    actuator.itemLabelPrefix.append(itemLabelPrefix.toString());
+                }
+                if (actuator.fixedCount != actuator.itemLabelPrefix.size() && actuator.itemLabelPrefix.size() > 1) {
+                    qCWarning(ActuatorsConfigLog) << "Invalid mixer config (item-label-prefix):" << actuator.fixedCount << ","
+                            << actuator.itemLabelPrefix.size();
+                }
+            }
+
+            option.actuators.append(actuator);
+        }
+        mixerOptions.append(option);
+    }
+
+    _mixer.reset(actuatorTypes, mixerOptions, outputFunctions);
+    _init = true;
+    return true;
+}
+
+Fact* Actuators::getFact(const QString& paramName)
+{
+    if (!_vehicle->parameterManager()->parameterExists(FactSystem::defaultComponentId, paramName)) {
+        qCDebug(ActuatorsConfigLog) << "Mixer: Param does not exist:" << paramName;
+        return nullptr;
+    }
+    Fact* fact = _vehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, paramName);
+	subscribeFact(fact);
+	return fact;
+}
+
+void Actuators::subscribeFact(Fact* fact)
+{
+    if (fact && !_subscribedFacts.contains(fact)) {
+        connect(fact, &Fact::rawValueChanged, this, &Actuators::parametersChanged);
+        _subscribedFacts.insert(fact);
+    }
+}
+
+bool Actuators::showUi() const
+{
+    return _init && _showUi.evaluate();
+}
+
+bool Actuators::initMotorAssignment()
+{
+    GeometryImage::VehicleGeometryImageProvider* provider = GeometryImage::VehicleGeometryImageProvider::instance();
+    int numMotors = 0;
+    QList<ActuatorGeometry>& actuators = provider->actuators();
+    for (const auto& actuator : actuators) {
+        if (actuator.type == ActuatorGeometry::Type::Motor) {
+            ++numMotors;
+        }
+    }
+
+    // get the minimum function for motors
+    bool ret = false;
+    auto iter = _mixer.actuatorTypes().find("motor");
+    if (iter == _mixer.actuatorTypes().end()) {
+        qWarning() << "Actuator type 'motor' not found";
+    } else {
+        ret = _motorAssignment.initAssignment(_selectedActuatorOutput, iter->functionMin, numMotors);
+    }
+    return ret;
+}
+
+void Actuators::highlightActuators(bool highlight)
+{
+    GeometryImage::VehicleGeometryImageProvider* provider = GeometryImage::VehicleGeometryImageProvider::instance();
+    QList<ActuatorGeometry>& actuators = provider->actuators();
+    for (auto& actuator : actuators) {
+        if (actuator.type == ActuatorGeometry::Type::Motor) {
+            actuator.renderOptions.highlight = highlight;
+        }
+    }
+    updateGeometryImage();
+}
+
+void Actuators::startMotorAssignment()
+{
+    highlightActuators(true);
+    _motorAssignment.start();
+}
+void Actuators::abortMotorAssignment()
+{
+    _motorAssignment.abort();
+}

--- a/src/Vehicle/Actuators/Actuators.h
+++ b/src/Vehicle/Actuators/Actuators.h
@@ -1,0 +1,120 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QJsonDocument>
+
+#include "ActuatorOutputs.h"
+#include "ActuatorTesting.h"
+#include "Mixer.h"
+#include "GeometryImage.h"
+#include "MotorAssignment.h"
+
+
+class Actuators : public QObject
+{
+    Q_OBJECT
+public:
+    Actuators(QObject* parent, Vehicle* vehicle);
+    ~Actuators() = default;
+
+    Q_PROPERTY(QmlObjectListModel* actuatorOutputs         READ actuatorOutputs           NOTIFY actuatorOutputsChanged)
+    Q_PROPERTY(QmlObjectListModel* actuatorActions         READ actuatorActions           NOTIFY actuatorActionsChanged)
+    Q_PROPERTY(bool isMultirotor                           READ isMultirotor              CONSTANT)
+    Q_PROPERTY(bool imageRefreshFlag                       READ imageRefreshFlag          NOTIFY imageRefreshFlagChanged)
+    Q_PROPERTY(bool hasUnsetRequiredFunctions              READ hasUnsetRequiredFunctions NOTIFY hasUnsetRequiredFunctionsChanged)
+    Q_PROPERTY(bool motorAssignmentActive                  READ motorAssignmentActive     NOTIFY motorAssignmentActiveChanged)
+    Q_PROPERTY(QString motorAssignmentMessage              READ motorAssignmentMessage    NOTIFY motorAssignmentMessageChanged)
+
+    Q_PROPERTY(ActuatorTesting::ActuatorTest* actuatorTest                      READ actuatorTest              CONSTANT)
+    Q_PROPERTY(Mixer::Mixers* mixer                                             READ mixer                     CONSTANT)
+    Q_PROPERTY(ActuatorOutputs::ActuatorOutput* selectedActuatorOutput          READ selectedActuatorOutput    NOTIFY selectedActuatorOutputChanged)
+
+    Q_INVOKABLE void imageClicked(float x, float y);
+
+    Q_INVOKABLE void selectActuatorOutput(int index);
+
+    /**
+     * load JSON metadata file
+     */
+    void load(const QString& json_file);
+
+    /**
+     * Initialize the loaded metadata. Call this after all vehicle parameters are loaded.
+     */
+    void init();
+
+    QmlObjectListModel* actuatorOutputs() { return _actuatorOutputs; }
+    ActuatorOutputs::ActuatorOutput* selectedActuatorOutput() const;
+
+    ActuatorTesting::ActuatorTest* actuatorTest() { return &_actuatorTest; }
+
+    bool isMultirotor() const;
+
+    bool imageRefreshFlag() const { return _imageRefreshFlag; }
+
+    Mixer::Mixers* mixer() { return &_mixer; }
+
+    bool hasUnsetRequiredFunctions() const { return _hasUnsetRequiredFunctions; }
+
+    bool showUi() const;
+
+    QmlObjectListModel* actuatorActions() { return _actuatorActions; }
+
+    Q_INVOKABLE bool initMotorAssignment();
+    Q_INVOKABLE void startMotorAssignment();
+    Q_INVOKABLE void spinCurrentMotor() { _motorAssignment.spinCurrentMotor(); }
+    Q_INVOKABLE void abortMotorAssignment();
+    bool motorAssignmentActive() const { return _motorAssignment.active(); }
+    const QString& motorAssignmentMessage() const { return _motorAssignment.message(); }
+
+public slots:
+    void parametersChanged();
+
+signals:
+    void actuatorOutputsChanged();
+    void selectedActuatorOutputChanged();
+    void imageRefreshFlagChanged();
+    void hasUnsetRequiredFunctionsChanged();
+    void motorAssignmentActiveChanged();
+    void motorAssignmentMessageChanged();
+    void actuatorActionsChanged();
+
+private slots:
+    void updateGeometryImage();
+
+private:
+    bool parseJson(const QJsonDocument& json);
+
+    void updateActuatorActions();
+
+    void subscribeFact(Fact* fact);
+
+    Fact* getFact(const QString& paramName);
+
+    void highlightActuators(bool highlight);
+
+    QSet<Fact*> _subscribedFacts{};
+    QJsonDocument _jsonMetadata;
+    bool _init{false};
+    Condition _showUi;
+    QmlObjectListModel* _actuatorOutputs = new QmlObjectListModel(this); ///< list of ActuatorOutputs::ActuatorOutput*
+    QmlObjectListModel* _actuatorActions = new QmlObjectListModel(this); ///< list of ActuatorActionGroup*
+    ActuatorTesting::ActuatorTest _actuatorTest;
+    Mixer::Mixers _mixer;
+    MotorAssignment _motorAssignment;
+    bool _hasUnsetRequiredFunctions{false};
+    bool _imageRefreshFlag{false}; ///< indicator to QML to reload the image
+    int _selectedActuatorOutput{0};
+    Vehicle* _vehicle{nullptr};
+};
+

--- a/src/Vehicle/Actuators/CMakeLists.txt
+++ b/src/Vehicle/Actuators/CMakeLists.txt
@@ -1,0 +1,20 @@
+
+add_library(Actuators
+	ActuatorActions.cc
+	ActuatorActions.h
+	ActuatorOutputs.cc
+	ActuatorOutputs.h
+	Actuators.cc
+	Actuators.h
+	ActuatorTesting.cc
+	ActuatorTesting.h
+	Common.cc
+	Common.h
+	GeometryImage.cc
+	GeometryImage.h
+	Mixer.cc
+	Mixer.h
+	MotorAssignment.cc
+	MotorAssignment.h
+)
+

--- a/src/Vehicle/Actuators/Common.cc
+++ b/src/Vehicle/Actuators/Common.cc
@@ -1,0 +1,189 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "Common.h"
+
+#include <QDebug>
+
+QGC_LOGGING_CATEGORY(ActuatorsConfigLog, "ActuatorsConfigLog")
+
+
+void Parameter::parse(const QJsonValue& jsonValue)
+{
+    label = jsonValue["label"].toString();
+    name = jsonValue["name"].toString();
+    indexOffset = jsonValue["index-offset"].toInt(0);
+    QString displayOptionStr = jsonValue["show-as"].toString();
+    if (displayOptionStr == "true-if-positive") {
+        displayOption = DisplayOption::BoolTrueIfPositive;
+    } else if (displayOptionStr == "bitset") {
+        displayOption = DisplayOption::Bitset;
+    } else if (displayOptionStr != "") {
+        qCDebug(ActuatorsConfigLog) << "Unknown param display option (show-as):" << displayOptionStr;
+    }
+    advanced = jsonValue["advanced"].toBool(false);
+}
+
+FactBitset::FactBitset(QObject* parent, Fact* integerFact, int offset)
+    : Fact("", new FactMetaData(FactMetaData::valueTypeBool, "", parent), parent),
+      _integerFact(integerFact), _offset(offset)
+{
+    forceSetRawValue(false); // need to force set an initial bool value so the type is correct
+    onIntegerFactChanged();
+    connect(this, &Fact::rawValueChanged, this, &FactBitset::onThisFactChanged);
+    connect(_integerFact, &Fact::rawValueChanged, this, &FactBitset::onIntegerFactChanged);
+}
+
+void FactBitset::onIntegerFactChanged()
+{
+    if (_ignoreChange) {
+        return;
+    }
+    _ignoreChange = true;
+    // sync to this
+    setRawValue((_integerFact->rawValue().toInt() & (1 << _offset)) != 0);
+    _ignoreChange = false;
+}
+
+void FactBitset::onThisFactChanged()
+{
+    if (_ignoreChange) {
+        return;
+    }
+    _ignoreChange = true;
+    // sync to integer fact
+    int value = _integerFact->rawValue().toInt();
+    if (rawValue().toBool()) {
+        _integerFact->forceSetRawValue(value | (1u << _offset));
+    } else {
+        _integerFact->forceSetRawValue(value & ~(1u << _offset));
+    }
+    _ignoreChange = false;
+}
+
+
+FactFloatAsBool::FactFloatAsBool(QObject* parent, Fact* floatFact)
+    : Fact("", new FactMetaData(FactMetaData::valueTypeBool, "", parent), parent),
+      _floatFact(floatFact)
+{
+    onFloatFactChanged();
+    connect(this, &Fact::rawValueChanged, this, &FactFloatAsBool::onThisFactChanged);
+    connect(_floatFact, &Fact::rawValueChanged, this, &FactFloatAsBool::onFloatFactChanged);
+}
+
+void FactFloatAsBool::onFloatFactChanged()
+{
+    if (_ignoreChange) {
+        return;
+    }
+    _ignoreChange = true;
+    // sync to this
+    forceSetRawValue(_floatFact->rawValue().toFloat() > 0.f);
+    _ignoreChange = false;
+}
+
+void FactFloatAsBool::onThisFactChanged()
+{
+    if (_ignoreChange) {
+        return;
+    }
+    _ignoreChange = true;
+    // sync to float fact
+    float value = _floatFact->rawValue().toFloat();
+    if (rawValue().toBool()) {
+        _floatFact->forceSetRawValue(std::abs(value));
+    } else {
+        _floatFact->forceSetRawValue(-std::abs(value));
+    }
+    _ignoreChange = false;
+}
+
+Condition::Condition(const QString &condition, ParameterManager* parameterManager)
+{
+    QRegularExpression re("^([0-9A-Za-z_-]+)([\\!=<>]+)(-?\\d+)$");
+    QRegularExpressionMatch match = re.match(condition);
+    if (condition == "true") {
+        _operation = Operation::AlwaysTrue;
+    } else if (condition == "false") {
+        _operation = Operation::AlwaysFalse;
+    } else if (match.hasMatch()) {
+        _parameter = match.captured(1);
+        QString operation = match.captured(2);
+        if (operation == ">") {
+            _operation = Operation::GreaterThan;
+        } else if (operation == ">=") {
+            _operation = Operation::GreaterEqual;
+        } else if (operation == "==") {
+            _operation = Operation::Equal;
+        } else if (operation == "!=") {
+            _operation = Operation::NotEqual;
+        } else if (operation == "<") {
+            _operation = Operation::LessThan;
+        } else if (operation == "<=") {
+            _operation = Operation::LessEqual;
+        } else {
+            qCWarning(ActuatorsConfigLog) << "Unknown condition operation: " << operation;
+        }
+        _value = match.captured(3).toInt();
+
+        qCDebug(ActuatorsConfigLog) << "Condition: Param:" << _parameter << "op:" << operation << "value:" << _value;
+
+        if (parameterManager->parameterExists(FactSystem::defaultComponentId, _parameter)) {
+            Fact* param = parameterManager->getParameter(FactSystem::defaultComponentId, _parameter);
+            if (param->type() == FactMetaData::ValueType_t::valueTypeBool ||
+                    param->type() == FactMetaData::ValueType_t::valueTypeInt32) {
+                _fact = param;
+            } else {
+                qCDebug(ActuatorsConfigLog) << "Condition: Unsupported param type:" << (int)param->type();
+            }
+        } else {
+            qCDebug(ActuatorsConfigLog) << "Condition: Param does not exist:" << _parameter;
+        }
+    }
+
+}
+
+bool Condition::evaluate() const
+{
+    if (_operation == Operation::AlwaysFalse) {
+        return false;
+    }
+
+    if (_operation == Operation::AlwaysTrue || _parameter.isEmpty()) {
+        return true;
+    }
+
+    if (!_fact) {
+        return false;
+    }
+
+    int32_t paramValue = _fact->rawValue().toInt();
+    switch (_operation) {
+        case Operation::AlwaysTrue: return true;
+        case Operation::AlwaysFalse: return false;
+        case Operation::GreaterThan: return paramValue > _value;
+        case Operation::GreaterEqual: return paramValue >= _value;
+        case Operation::Equal: return paramValue == _value;
+        case Operation::NotEqual: return paramValue != _value;
+        case Operation::LessThan: return paramValue < _value;
+        case Operation::LessEqual: return paramValue <= _value;
+    }
+    return false;
+}
+
+ActuatorGeometry::Type ActuatorGeometry::typeFromStr(const QString &type)
+{
+    if (type == "motor") {
+        return ActuatorGeometry::Type::Motor;
+    } else if (type == "servo") {
+        return ActuatorGeometry::Type::Servo;
+    }
+    return ActuatorGeometry::Type::Other;
+}
+

--- a/src/Vehicle/Actuators/Common.h
+++ b/src/Vehicle/Actuators/Common.h
@@ -1,0 +1,158 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+
+#include <QString>
+#include <QRegularExpressionMatch>
+#include <QVector3D>
+#include <QJsonValue>
+
+#include <stdint.h>
+
+#include "ParameterManager.h"
+
+Q_DECLARE_LOGGING_CATEGORY(ActuatorsConfigLog)
+
+
+/**
+ * Represents a per-channel or per-item vehicle configuration parameter
+ */
+struct Parameter {
+    enum class DisplayOption {
+        Default,
+        BoolTrueIfPositive, ///< Show checkbox for float/int value
+        Bitset,             ///< integer displayed as boolean (checkbox), where the index defines the bit
+    };
+
+    QString label{};
+    QString name{};                                       ///< vehicle parameter name, this may have an index in the form '${i}'
+    int indexOffset{};                                    ///< extra offset to the ${i} index, or bitset shift offset
+    DisplayOption displayOption{DisplayOption::Default};
+    bool advanced{false};                                 ///< whether this should only be shown as advanced option
+
+    void parse(const QJsonValue& jsonValue);
+};
+
+/**
+ * Fact to show a specific bit in a bitset (integer fact) as boolean option
+ */
+class FactBitset : public Fact
+{
+    Q_OBJECT
+public:
+    FactBitset(QObject* parent, Fact* integerFact, int offset);
+
+    virtual ~FactBitset() = default;
+
+private slots:
+    void onIntegerFactChanged();
+    void onThisFactChanged();
+private:
+    Fact* _integerFact{nullptr};
+    const int _offset;
+    bool _ignoreChange{false};
+};
+
+/**
+ * Fact to show a float fact as boolean, true if >0, false otherwise
+ */
+class FactFloatAsBool : public Fact
+{
+    Q_OBJECT
+public:
+    FactFloatAsBool(QObject* parent, Fact* floatFact);
+
+    virtual ~FactFloatAsBool() = default;
+
+private slots:
+    void onFloatFactChanged();
+    void onThisFactChanged();
+private:
+    Fact* _floatFact{nullptr};
+    bool _ignoreChange{false};
+};
+
+/**
+ * Evaluates a string expression containing a vehicle parameter name and comparison to a constant value
+ */
+class Condition
+{
+public:
+    enum class Operation {
+        AlwaysTrue,
+        AlwaysFalse,
+        GreaterThan,  // >
+        GreaterEqual, // >=
+        Equal,        // ==
+        NotEqual,     // !=
+        LessThan,     // <
+        LessEqual     // <=
+    };
+
+    Condition() = default;
+
+    /**
+     * Constructor
+     * @param condition generic form: true|false|<param_name><operation><signed integer>
+     *                  where: <operation>: [>,>=,==,!=,<,<=]
+     */
+    Condition(const QString& condition, ParameterManager* parameterManager);
+
+    bool evaluate() const;
+
+    bool hasCondition() const { return _operation != Operation::AlwaysTrue; }
+
+    Fact* fact() const { return _fact; }
+
+private:
+    QString _parameter{};
+    Operation _operation{Operation::AlwaysTrue};
+    int32_t _value{0};
+    Fact* _fact{nullptr};
+};
+
+
+/**
+ * Actuator used for rendering
+ */
+struct ActuatorGeometry
+{
+    enum class Type {
+        Motor,
+        Servo,
+        Other
+    };
+
+    enum class SpinDirection {
+        Unspecified,
+        ClockWise,
+        CounterClockWise,
+    };
+
+    static Type typeFromStr(const QString& type);
+
+    struct RenderOptions {
+        bool highlight{false};
+    };
+
+    ActuatorGeometry(Type type_=Type::Other, int index_=0, QVector3D position_={},
+            SpinDirection spinDirection_=SpinDirection::Unspecified)
+    : type(type_), index(index_), position(position_), spinDirection(spinDirection_) { }
+
+    Type type;
+    int index;
+    int labelIndexOffset{0};
+    QVector3D position;
+    SpinDirection spinDirection;
+
+    RenderOptions renderOptions{};
+};
+

--- a/src/Vehicle/Actuators/GeometryImage.cc
+++ b/src/Vehicle/Actuators/GeometryImage.cc
@@ -1,0 +1,417 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "GeometryImage.h"
+
+#include <QDir>
+
+#include <array>
+
+using namespace GeometryImage;
+
+
+static void generateTestGeometries(VehicleGeometryImageProvider& provider)
+{
+#if 0 // enable this to generate a set of test geometry images on startup in the current working directory
+    const QString imagePrefix = "test_geometry_";
+    static bool generatedOnce = false;
+    if (generatedOnce) {
+        return;
+    }
+    generatedOnce = true;
+
+    qWarning() << "Generating Test Geometry Images";
+
+    const QList<ActuatorGeometry> geometries[] = {
+        { // quad
+            {ActuatorGeometry::Type::Motor, 1, QVector3D{1, 1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 2, QVector3D{-1, -1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 3, QVector3D{1, -1, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 4, QVector3D{-1, 1, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+        },
+        { // off-center quad
+            {ActuatorGeometry::Type::Motor, 1, QVector3D{1, 1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 2, QVector3D{-0.5, -0.5, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 3, QVector3D{1, -0.5, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 4, QVector3D{-0.5, 1, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+        },
+        { // weird penta
+            {ActuatorGeometry::Type::Motor, 1, QVector3D{2, 1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 2, QVector3D{-0.5, -0.5, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 3, QVector3D{2, -0.5, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 4, QVector3D{-0.5, 1, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 5, QVector3D{0.5, 1.5, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+        },
+        { // octo
+            {ActuatorGeometry::Type::Motor, 1, QVector3D{1, 1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 2, QVector3D{-1, -1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 3, QVector3D{1, -1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 4, QVector3D{-1, 1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 5, QVector3D{1.4, 0, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 6, QVector3D{-1.4, 0, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 7, QVector3D{0, -1.4, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 8, QVector3D{0, 1.4, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+        },
+        { // octo coax
+            {ActuatorGeometry::Type::Motor, 1, QVector3D{1, 1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 2, QVector3D{-1, -1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 3, QVector3D{1, -1, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 4, QVector3D{-1, 1, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 5, QVector3D{1, 1, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 6, QVector3D{-1, -1, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 7, QVector3D{1, -1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 8, QVector3D{-1, 1, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+        },
+        { // hex
+            {ActuatorGeometry::Type::Motor, 1, QVector3D{1, 0.7, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 2, QVector3D{-1, -0.7, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 3, QVector3D{1, -0.7, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+            {ActuatorGeometry::Type::Motor, 4, QVector3D{-1, 0.7, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 5, QVector3D{0, -1.2, 0}, ActuatorGeometry::SpinDirection::CounterClockWise},
+            {ActuatorGeometry::Type::Motor, 6, QVector3D{0, 1.2, 0}, ActuatorGeometry::SpinDirection::ClockWise},
+        }
+    };
+
+    const QSize sizes[] = {
+            { 160, 160 },
+            { 120 * 2, 120 },
+            { 160 * 2, 160 }, // default size
+            { 250 * 2, 250 },
+    };
+
+    for (unsigned sizeIdx = 0; sizeIdx < sizeof(sizes) / sizeof(sizes[0]); ++sizeIdx) {
+        const QSize& size = sizes[sizeIdx];
+        for (unsigned geometryIdx = 0; geometryIdx < sizeof(geometries) / sizeof(geometries[0]); ++geometryIdx) {
+            provider.actuators() = geometries[geometryIdx];
+            QPixmap pixmap = provider.requestPixmap("", nullptr, size);
+
+            QString imageFileName = QDir(QDir::currentPath()).filePath(imagePrefix + QString::number(sizeIdx)+"_"
+                    +QString::number(geometryIdx)+".png");
+            qWarning() << "Generating image" << imageFileName;
+            QFile file(imageFileName);
+            file.open(QIODevice::WriteOnly);
+            pixmap.save(&file, "PNG");
+        }
+    }
+
+#endif
+}
+
+VehicleGeometryImageProvider::VehicleGeometryImageProvider()
+: QQuickImageProvider(QQuickImageProvider::Pixmap)
+{
+    generateTestGeometries(*this);
+}
+
+void VehicleGeometryImageProvider::drawAxisIndicator(QPainter& p, const QPointF& origin, float fontSize, const QColor& color)
+{
+    const float lineLength = fontSize * 2.f;
+    const float arrowWidth = 6.f;
+    const float arrowHeight = 8.f;
+
+    p.setPen(QPen{color, 1.5f});
+    p.setBrush(color);
+
+    QFont font = p.font();
+    font.setPixelSize(fontSize);
+    p.setFont(font);
+
+    auto drawArrow = [&](const QPointF& start, const QPointF& end) {
+        float lineLength = QLineF{start, end}.length();
+        p.save();
+        p.translate(end);
+        float angle = atan2f(end.y()-start.y(), end.x()-start.x());
+        p.rotate(angle * (180.f / M_PI) + 90.f);
+        p.drawLine(QPointF{0, arrowHeight/2}, QPointF{0, lineLength});
+        QPointF arrow[3] = {
+            QPointF{0.f - arrowWidth/2.f, arrowHeight},
+            QPointF{0.f, 0.f},
+            QPointF{0.f + arrowWidth/2.f, arrowHeight},
+        };
+        p.drawConvexPolygon(arrow, sizeof(arrow) / sizeof(arrow[0]));
+        p.restore();
+    };
+
+    // upwards
+    {
+        QPointF endPos{origin.x(), origin.y() - lineLength};
+        drawArrow(origin, endPos);
+
+        p.save();
+        p.translate(endPos);
+        QRectF textRect{-lineLength, -lineLength, lineLength * 2.f, lineLength};
+        p.drawText(textRect, Qt::AlignHCenter | Qt::AlignBottom, "x");
+        p.restore();
+    }
+
+    // rightwards
+    {
+        QPointF endPos{origin.x() + lineLength, origin.y()};
+        drawArrow(origin, endPos);
+
+        p.save();
+        p.translate(endPos);
+        QRectF textRect{0, -lineLength / 2, lineLength, lineLength};
+        p.drawText(textRect, Qt::AlignLeft | Qt::AlignBaseline, " y");
+        p.restore();
+    }
+}
+
+QPixmap VehicleGeometryImageProvider::requestPixmap(const QString& id, QSize* size, const QSize& requestedSize)
+{
+    int width = requestedSize.width();
+    int height = requestedSize.height();
+    if (size)
+        *size = QSize(width, height);
+
+    QPixmap pixmap(width, height);
+    pixmap.fill(Qt::transparent);
+
+    _actuatorImagePositions.clear();
+
+    // get the dimensions
+    QVector3D min{1e10f, 1e10f, 1e10f};
+    QVector3D max{-1e10f, -1e10f, -1e10f};
+    for (const auto& actuator : _actuators) {
+        for (int i = 0; i < 3; ++i) {
+            if (actuator.position[i] < min[i]) {
+                min[i] = actuator.position[i];
+            }
+            if (actuator.position[i] > max[i]) {
+                max[i] = actuator.position[i];
+            }
+        }
+    }
+
+    if (_actuators.size() <= 1 || max.x() - min.x() < 0.0001f || max.y() - min.y() < 0.0001f ) {
+        return pixmap;
+    }
+
+    // separate actuators, check for coax (on top of each other)
+    QList<ActuatorGeometry> actuators;
+    QList<ActuatorGeometry> coaxActuators;
+    for (const auto& actuator : _actuators) {
+        if (actuator.type == ActuatorGeometry::Type::Motor) {
+            bool isCoax = false;
+            for (const auto& actuatorBefore : _actuators) {
+                if (actuatorBefore.type == ActuatorGeometry::Type::Motor) {
+                    if (&actuatorBefore == &actuator) {
+                        break;
+                    }
+                    QVector2D diff = actuatorBefore.position.toVector2D() - actuator.position.toVector2D();
+                    if (diff.length() < 0.03f) {
+                        coaxActuators.append(actuator);
+                        isCoax = true;
+                        break;
+                    }
+                }
+            }
+            if (!isCoax) {
+                actuators.append(actuator);
+            }
+        }
+    }
+
+    QPainter p(&pixmap);
+    p.setRenderHint(QPainter::Antialiasing);
+    p.setRenderHint(QPainter::TextAntialiasing);
+
+    const float axisIndicatorSize = 15.f; // font size
+    const float margin = 5.f; // from image borders
+
+    // scaling & center offset
+    float usableWidth = width - 2.f * margin;
+    float usableHeight = height - 2.f * margin;
+    float extraOffsetX = 0.f;
+    // if there's not enough space on the left for the axis to ensure there's no overlap, reduce the usable size
+    if (width < height + axisIndicatorSize * 4.f) {
+        usableWidth -= axisIndicatorSize;
+        usableHeight -= axisIndicatorSize;
+        extraOffsetX = axisIndicatorSize;
+    }
+
+    const float rotorDiameter = std::min(usableWidth, usableHeight) * (_actuators.length() <= 6 ? 0.31f : 0.25f);
+    const float fontSize = rotorDiameter * 0.4f;
+    const float extraYMargin = coaxActuators.length() > 0 ? fontSize * 1.1f : 0.f;
+
+    const float scaleX = (usableWidth - rotorDiameter) / (max.y() - min.y());
+    const float scaleY = (usableHeight - extraYMargin - rotorDiameter) / (max.x() - min.x());
+    const float scale = std::min(scaleX, scaleY);
+    const float offsetX = margin + extraOffsetX + usableWidth / 2.f - (max.y() + min.y()) / 2.f * scale;
+    const float offsetY = margin + (usableHeight - extraYMargin) / 2.f + (max.x() + min.x()) / 2.f * scale;
+
+    // style
+    const QColor clockWiseColor{ 21, 158, 31, 200 };
+    const QColor counterClockWiseColor{ 78, 195, 232, 200 };
+    const QColor frameArrowColor{ 255, 68, 43, 200 };
+    const QColor frameColor{ 150, 150, 150 };
+    const float frameWidth{ 6.f };
+    const float rotorFontSize{ rotorDiameter * 0.4f };
+    const QColor rotorHighlightColor{ frameArrowColor };
+    const QColor fontColor{ _palette.text() };
+
+    auto iterateMotors = [scale, offsetX, offsetY](const QList<ActuatorGeometry> &actuators,
+            std::function<void(const ActuatorGeometry&, QPointF)> draw) {
+                for (const auto& actuator : actuators) {
+                    if (actuator.type == ActuatorGeometry::Type::Motor) {
+                        QPointF pos{
+                            offsetX + actuator.position.y()*scale,
+                            offsetY - actuator.position.x()*scale
+                        };
+                        draw(actuator, pos);
+                    }
+                }
+            };
+
+    // draw line from center to actuators first
+    iterateMotors(actuators, [&](const ActuatorGeometry& actuator, QPointF pos) {
+        p.setPen(QPen{frameColor, frameWidth});
+        p.drawLine(QPointF{offsetX, offsetY}, pos);
+    });
+
+    // frame body
+    p.setPen(frameColor);
+    p.setBrush(QBrush{frameColor});
+    float centerSize = rotorDiameter * 0.8f;
+    p.drawRoundedRect(QRectF{offsetX - centerSize / 2.f, offsetY - centerSize / 2.f, centerSize, centerSize}, frameWidth, frameWidth);
+    p.setPen(frameArrowColor);
+    p.setBrush(frameArrowColor);
+    float arrowWidth = rotorDiameter / 4.f;
+    float arrowHeight = rotorDiameter / 2.f;
+    QPointF arrow[3] = {
+            QPointF{offsetX - arrowWidth / 2.f, offsetY + arrowHeight / 2.f},
+            QPointF{offsetX,                    offsetY - arrowHeight / 2.f},
+            QPointF{offsetX + arrowWidth / 2.f, offsetY + arrowHeight / 2.f},
+    };
+    p.drawConvexPolygon(arrow, sizeof(arrow) / sizeof(arrow[0]));
+
+    drawAxisIndicator(p, QPointF{axisIndicatorSize / 2.f, height - axisIndicatorSize / 2.f}, axisIndicatorSize, fontColor);
+
+    auto drawMotor = [&](const ActuatorGeometry& actuator, QPointF pos, float yPosOffset, bool labelAtBottom) {
+        p.setPen(Qt::NoPen);
+        QColor arrowColor;
+        if (actuator.spinDirection == ActuatorGeometry::SpinDirection::ClockWise) {
+            p.setBrush(QBrush{clockWiseColor});
+            arrowColor = clockWiseColor;
+        } else {
+            p.setBrush(QBrush{counterClockWiseColor});
+            arrowColor = counterClockWiseColor;
+        }
+        arrowColor.setAlpha(255);
+        if (_palette.globalTheme() == QGCPalette::Light) {
+            arrowColor = arrowColor.darker(200);
+        } else {
+            arrowColor = arrowColor.lighter(130);
+        }
+
+        pos.setY(pos.y() + yPosOffset);
+
+        p.drawEllipse(pos, rotorDiameter/2, rotorDiameter/2);
+
+        QRectF textRect;
+        if (labelAtBottom) {
+            textRect = QRectF{pos.x()-rotorDiameter/2.f, pos.y()+rotorDiameter/2.f-yPosOffset, rotorDiameter, yPosOffset};
+        } else {
+            textRect = QRectF{pos.x()-rotorDiameter/2.f, pos.y()-rotorDiameter/2.f, rotorDiameter, rotorDiameter};
+        }
+        if (actuator.renderOptions.highlight) {
+            p.setPen(rotorHighlightColor);
+            p.setBrush(rotorHighlightColor);
+            float radius;
+            if (labelAtBottom) {
+                radius = rotorFontSize / 2.f;
+            } else {
+                radius = rotorDiameter / 2.f;
+            }
+            p.drawEllipse(textRect.center(), radius, radius);
+            _actuatorImagePositions.append(ImagePosition{actuator.type, actuator.index, textRect.center(), radius});
+        }
+        p.setPen(fontColor);
+        QFont font = p.font();
+        font.setPixelSize(rotorFontSize);
+        p.setFont(font);
+        p.drawText(textRect, Qt::AlignCenter, QString::number(actuator.index + actuator.labelIndexOffset));
+
+        // spin direction arrows
+        int angle = 50;// angle for the whole arc
+        float arrowWidth = frameWidth;
+        float arrowHeight = frameWidth * 1.25f;
+        float arrowPosition = rotorDiameter / 2.f;
+        p.setPen(QPen{arrowColor, 2.5f});
+        p.setBrush(arrowColor);
+        std::array<int, 2> angleOffsets;
+        if (labelAtBottom) {
+            angleOffsets = {30, 180-30}; // bottom right + left sides
+        } else {
+            angleOffsets = {0, 180}; // right + left sides
+        }
+        for (int angleOffset : angleOffsets) {
+            p.save();
+            p.translate(pos);
+            float ySign = 1.f;
+            if (actuator.spinDirection == ActuatorGeometry::SpinDirection::ClockWise) {
+                p.rotate(angle / 2.f + angleOffset);
+                ySign = -1.f;
+            } else {
+                p.rotate(-angle / 2.f + angleOffset);
+            }
+            QRectF arrowRect{-arrowPosition, -arrowPosition, arrowPosition * 2.f, arrowPosition * 2.f};
+            p.drawArc(arrowRect, 0, -ySign * 16 * angle);
+            QPointF arrow[3] = {
+                QPointF{arrowPosition - arrowWidth/2.f, ySign*arrowHeight/2.f},
+                QPointF{arrowPosition,                  -ySign*arrowHeight/2.f},
+                QPointF{arrowPosition + arrowWidth/2.f, ySign*arrowHeight/2.f},
+            };
+            p.drawConvexPolygon(arrow, sizeof(arrow) / sizeof(arrow[0]));
+            p.restore();
+        }
+    };
+
+    // draw coax motors
+    iterateMotors(coaxActuators, [&](const ActuatorGeometry& actuator, QPointF pos) {
+        drawMotor(actuator, pos, extraYMargin, true);
+    });
+
+    // draw the rest of the motors
+    iterateMotors(actuators, [&](const ActuatorGeometry& actuator, QPointF pos) {
+        drawMotor(actuator, pos, 0.f, false);
+    });
+
+    return pixmap;
+}
+
+VehicleGeometryImageProvider* VehicleGeometryImageProvider::instance()
+{
+    static VehicleGeometryImageProvider* instance = nullptr;
+    // The instance is managed & deleted by the QML engine
+    if (!instance)
+        instance = new VehicleGeometryImageProvider();
+    return instance;
+}
+
+int VehicleGeometryImageProvider::getHighlightedMotorIndexAtPos(const QPointF &position)
+{
+    int foundIdx = -1;
+    for (int i = 0; i < _actuatorImagePositions.size(); ++i) {
+        if (_actuatorImagePositions[i].type == ActuatorGeometry::Type::Motor) {
+            float radius = _actuatorImagePositions[i].radius;
+            if (QLineF{_actuatorImagePositions[i].position, position}.length() < radius) {
+                // in case of multiple matches (overlaps), be safe and do not return any match
+                if (foundIdx != -1) {
+                    return -1;
+                }
+                foundIdx = i;
+            }
+        }
+    }
+    if (foundIdx >= 0) {
+        return _actuatorImagePositions[foundIdx].index;
+    }
+    return -1;
+}

--- a/src/Vehicle/Actuators/GeometryImage.h
+++ b/src/Vehicle/Actuators/GeometryImage.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include <functional>
+#include <cmath>
+
+#include <QQuickImageProvider>
+#include <QVector2D>
+#include <QPainter>
+
+#include <QGCPalette.h>
+
+#include "Common.h"
+
+
+namespace GeometryImage {
+
+/**
+ * Renders an image of an airframe geometry (currently only multirotor)
+ */
+class VehicleGeometryImageProvider : public QQuickImageProvider
+{
+public:
+
+    struct ImagePosition {
+        ActuatorGeometry::Type type;
+        int index;
+        QPointF position;
+        float radius;
+    };
+
+    void drawAxisIndicator(QPainter& p, const QPointF& origin, float fontSize, const QColor& color);
+
+    QPixmap requestPixmap(const QString& id, QSize* size, const QSize& requestedSize) override;
+
+    static VehicleGeometryImageProvider* instance();
+
+    int getHighlightedMotorIndexAtPos(const QPointF& position);
+
+    QList<ActuatorGeometry>& actuators() { return _actuators; }
+
+private:
+    VehicleGeometryImageProvider();
+    ~VehicleGeometryImageProvider() = default;
+
+    QList<ActuatorGeometry> _actuators{};
+
+    QList<ImagePosition> _actuatorImagePositions{}; ///< highlighted actuators image positions
+    QGCPalette           _palette;
+};
+
+} // namespace GeometryImage
+

--- a/src/Vehicle/Actuators/Mixer.cc
+++ b/src/Vehicle/Actuators/Mixer.cc
@@ -1,0 +1,304 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "Mixer.h"
+
+#include <QDebug>
+
+#include <cmath>
+
+using namespace Mixer;
+
+MixerChannel::MixerChannel(QObject *parent, const QString &label, int actuatorFunction, int paramIndex, int actuatorTypeIndex,
+        QmlObjectListModel &channelConfigs, ParameterManager* parameterManager, std::function<void(Fact*)> factAddedCb) :
+        QObject(parent), _label(label), _actuatorFunction(actuatorFunction), _paramIndex(paramIndex), _actuatorTypeIndex(actuatorTypeIndex)
+{
+    for (int i = 0; i < channelConfigs.count(); ++i) {
+        auto channelConfig = channelConfigs.value<ChannelConfig*>(i);
+        QString param = channelConfig->parameter();
+        int usedParamIndex;
+        if (channelConfig->isActuatorTypeConfig()) {
+            usedParamIndex = actuatorTypeIndex + channelConfig->indexOffset();
+        } else {
+            usedParamIndex = paramIndex + channelConfig->indexOffset();
+        }
+        param.replace("${i}", QString::number(usedParamIndex));
+
+        Fact* fact = nullptr;
+        if (param == "" && !channelConfig->isActuatorTypeConfig()) { // constant value
+            float value = 0.f;
+            if (channelConfig->fixedValues().size() == 1) {
+                value = channelConfig->fixedValues()[0];
+            } else if (paramIndex < channelConfig->fixedValues().size()) {
+                value = channelConfig->fixedValues()[paramIndex];
+            }
+
+            FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeFloat, "", this);
+            metaData->setReadOnly(true);
+            metaData->setDecimalPlaces(4);
+            fact = new Fact("", metaData, this);
+            fact->setRawValue(value);
+
+        } else if (parameterManager->parameterExists(FactSystem::defaultComponentId, param)) {
+            fact = parameterManager->getParameter(FactSystem::defaultComponentId, param);
+            if (channelConfig->displayOption() == Parameter::DisplayOption::Bitset) {
+                fact = new FactBitset(channelConfig, fact, usedParamIndex);
+            } else if (channelConfig->displayOption() == Parameter::DisplayOption::BoolTrueIfPositive) {
+                fact = new FactFloatAsBool(channelConfig, fact);
+            }
+            factAddedCb(fact);
+        } else {
+            qCDebug(ActuatorsConfigLog) << "ActuatorOutputChannel: Param does not exist:" << param;
+        }
+
+        ChannelConfigInstance* instance = new ChannelConfigInstance(this, fact, *channelConfig);
+        _configInstances->append(instance);
+    }
+}
+
+bool MixerChannel::getGeometry(const ActuatorTypes& actuatorTypes, const MixerOption::ActuatorGroup& group,
+        ActuatorGeometry& geometry) const
+{
+    geometry.type = ActuatorGeometry::typeFromStr(group.actuatorType);
+    const auto iter = actuatorTypes.find(group.actuatorType);
+    if (iter == actuatorTypes.end()) {
+        return false;
+    }
+    geometry.index = _actuatorTypeIndex;
+    geometry.labelIndexOffset = iter->labelIndexOffset;
+    int numPositionAxis = 0;
+
+    for (int i = 0; i < _configInstances->count(); ++i) {
+        ChannelConfigInstance* configInstance = _configInstances->value<ChannelConfigInstance*>(i);
+        if (!configInstance->fact()) {
+            continue;
+        }
+        switch (configInstance->channelConfig()->function()) {
+            case Function::PositionX:
+                geometry.position.setX(configInstance->fact()->rawValue().toFloat());
+                ++numPositionAxis;
+                break;
+            case Function::PositionY:
+                geometry.position.setY(configInstance->fact()->rawValue().toFloat());
+                ++numPositionAxis;
+                break;
+            case Function::PositionZ:
+                geometry.position.setZ(configInstance->fact()->rawValue().toFloat());
+                ++numPositionAxis;
+                break;
+            case Function::SpinDirection:
+                geometry.spinDirection = configInstance->fact()->rawValue().toBool() ?
+					ActuatorGeometry::SpinDirection::CounterClockWise : ActuatorGeometry::SpinDirection::ClockWise;
+                break;
+            case Function::AxisX:
+            case Function::AxisY:
+            case Function::AxisZ:
+            case Function::Type:
+            case Function::Unspecified:
+                break;
+        }
+    }
+
+    return numPositionAxis == 3;
+}
+
+void MixerConfigGroup::addChannelConfig(ChannelConfig* channelConfig)
+{
+    _channelConfigs->append(channelConfig);
+    emit channelConfigsChanged();
+}
+
+void MixerConfigGroup::addChannel(MixerChannel* channel)
+{
+    _channels->append(channel);
+    emit channelsChanged();
+}
+
+void MixerConfigGroup::addConfigParam(ConfigParameter* param)
+{
+    _params->append(param);
+}
+
+void Mixers::reset(const ActuatorTypes& actuatorTypes, const MixerOptions& mixerOptions,
+        const QMap<int, OutputFunction>& functions)
+{
+    _groups->clearAndDeleteContents();
+    _actuatorTypes = actuatorTypes;
+    _mixerOptions = mixerOptions;
+    _functions = functions;
+    _functionsSpecificLabel.clear();
+    _mixerConditions.clear();
+    for (const auto& mixerOption : _mixerOptions) {
+        _mixerConditions.append(Condition(mixerOption.option, _parameterManager));
+    }
+    update();
+}
+
+void Mixers::update()
+{
+    // clear first
+    _groups->clearAndDeleteContents();
+    _functionsSpecificLabel.clear();
+
+    unsubscribeFacts();
+
+    // find configured mixer
+    _selectedMixer = -1;
+    for (int i = 0; i < _mixerConditions.size(); ++i) {
+        if (_mixerConditions[i].evaluate()) {
+            _selectedMixer = i;
+            break;
+        }
+    }
+
+
+    if (_selectedMixer != -1) {
+
+        subscribeFact(_mixerConditions[_selectedMixer].fact());
+
+        qCDebug(ActuatorsConfigLog) << "selected mixer index:" << _selectedMixer;
+
+        const auto& actuatorGroups = _mixerOptions[_selectedMixer].actuators;
+        QMap<QString, int> actuatorTypeCount;
+        for (const auto &actuatorGroup : actuatorGroups) {
+            int count = actuatorGroup.fixedCount;
+            if (actuatorGroup.count != "") {
+                Fact* countFact = getFact(actuatorGroup.count);
+                if (countFact) {
+                    count = countFact->rawValue().toInt();
+                }
+            }
+
+            int actuatorTypeIndex = actuatorTypeCount.value(actuatorGroup.actuatorType, 0);
+
+            MixerConfigGroup* currentMixerGroup = new MixerConfigGroup(this, actuatorGroup);
+
+            // params
+            const auto actuatorType = _actuatorTypes.find(actuatorGroup.actuatorType);
+            if (actuatorType != _actuatorTypes.end()) {
+                for (const auto& perItemParam : actuatorType->perItemParams) {
+                    MixerParameter param{};
+                    param.param = perItemParam;
+                    currentMixerGroup->addChannelConfig(new ChannelConfig(currentMixerGroup, param, true));
+                }
+            }
+            for (const auto& perItemParam : actuatorGroup.perItemParameters) {
+                currentMixerGroup->addChannelConfig(new ChannelConfig(currentMixerGroup, perItemParam, false));
+            }
+
+            // 'count' param
+            if (actuatorGroup.count != "") {
+                currentMixerGroup->setCountParam(new ConfigParameter(currentMixerGroup, getFact(actuatorGroup.count),
+                        "", false));
+            }
+
+            for (int actuatorIdx = 0; actuatorIdx < count; ++actuatorIdx) {
+                QString label = "";
+                int actuatorFunction = 0;
+                if (actuatorType != _actuatorTypes.end()) {
+                    actuatorFunction = actuatorType->functionMin + actuatorTypeIndex;
+                    label = _functions.value(actuatorFunction).label;
+                    if (label == "") {
+                        qCWarning(ActuatorsConfigLog) << "No label for output function" << actuatorFunction;
+                    }
+                    QString itemLabelPrefix{};
+                    if (actuatorGroup.itemLabelPrefix.size() == 1) {
+                        QString paramIndex = QString::number(actuatorIdx + 1);
+                        itemLabelPrefix = actuatorGroup.itemLabelPrefix[0];
+                        itemLabelPrefix.replace("${i}", paramIndex);
+                    } else if (actuatorIdx < actuatorGroup.itemLabelPrefix.size()) {
+                        itemLabelPrefix = actuatorGroup.itemLabelPrefix[actuatorIdx];
+                    }
+                    if (itemLabelPrefix != "") {
+                        label = itemLabelPrefix + " (" + label + ")";
+                        _functionsSpecificLabel[actuatorFunction] = label;
+                    }
+                }
+                MixerChannel* channel = new MixerChannel(currentMixerGroup, label, actuatorFunction, actuatorIdx, actuatorTypeIndex,
+                        *currentMixerGroup->channelConfigs(), _parameterManager, [this](Fact* fact) { subscribeFact(fact); });
+                currentMixerGroup->addChannel(channel);
+                ++actuatorTypeIndex;
+            }
+
+            // config params
+            for (const auto& parameter : actuatorGroup.parameters) {
+                currentMixerGroup->addConfigParam(new ConfigParameter(currentMixerGroup, getFact(parameter.name),
+                        parameter.label, parameter.advanced));
+            }
+
+            _groups->append(currentMixerGroup);
+            actuatorTypeCount[actuatorGroup.actuatorType] = actuatorTypeIndex;
+        }
+    }
+
+    emit groupsChanged();
+
+}
+
+QString Mixers::getSpecificLabelForFunction(int function) const
+{
+    const auto iter = _functionsSpecificLabel.find(function);
+    if (iter == _functionsSpecificLabel.end()) {
+        return _functions.value(function).label;
+    }
+    return *iter;
+}
+
+QSet<int> Mixers::requiredFunctions() const
+{
+    QSet<int> ret;
+    for (int mixerGroupIdx = 0; mixerGroupIdx < _groups->count(); ++mixerGroupIdx) {
+        Mixer::MixerConfigGroup* mixerGroup = _groups->value<Mixer::MixerConfigGroup*>(mixerGroupIdx);
+        if (mixerGroup->group().required) {
+            for (int mixerChannelIdx = 0; mixerChannelIdx < mixerGroup->channels()->count(); ++mixerChannelIdx) {
+                const Mixer::MixerChannel* mixerChannel = mixerGroup->channels()->value<Mixer::MixerChannel*>(mixerChannelIdx);
+                if (mixerChannel->actuatorFunction() != 0) {
+                    ret.insert(mixerChannel->actuatorFunction());
+                }
+            }
+        }
+    }
+
+    return ret;
+}
+
+QString Mixers::configuredType() const
+{
+    if (_selectedMixer == -1) {
+        return "";
+    }
+    return _mixerOptions[_selectedMixer].type;
+}
+
+Fact* Mixers::getFact(const QString& paramName)
+{
+    if (!_parameterManager->parameterExists(FactSystem::defaultComponentId, paramName)) {
+        qCDebug(ActuatorsConfigLog) << "Mixers: Param does not exist:" << paramName;
+        return nullptr;
+    }
+    Fact* fact = _parameterManager->getParameter(FactSystem::defaultComponentId, paramName);
+	subscribeFact(fact);
+	return fact;
+}
+
+void Mixers::subscribeFact(Fact* fact)
+{
+    if (fact && !_subscribedFacts.contains(fact)) {
+        connect(fact, &Fact::rawValueChanged, this, &Mixers::paramChanged);
+        _subscribedFacts.insert(fact);
+    }
+}
+
+void Mixers::unsubscribeFacts()
+{
+    for (Fact* fact : _subscribedFacts) {
+        disconnect(fact, &Fact::rawValueChanged, this, &Mixers::paramChanged);
+    }
+    _subscribedFacts.clear();
+}

--- a/src/Vehicle/Actuators/Mixer.h
+++ b/src/Vehicle/Actuators/Mixer.h
@@ -207,7 +207,7 @@ class MixerChannel : public QObject
 public:
     MixerChannel(QObject* parent, const QString& label, int actuatorFunction,
             int paramIndex, int actuatorTypeIndex, QmlObjectListModel& channelConfigs, ParameterManager* parameterManager,
-            const Rule* rule, std::function<void(Fact*)> factAddedCb);
+            const Rule* rule, std::function<void(Function, Fact*)> factAddedCb);
 
     Q_PROPERTY(QString label                            READ label               CONSTANT)
     Q_PROPERTY(QmlObjectListModel* configInstances      READ configInstances     NOTIFY configInstancesChanged)
@@ -219,6 +219,8 @@ public:
 
     bool getGeometry(const ActuatorTypes& actuatorTypes, const MixerOption::ActuatorGroup& group,
             ActuatorGeometry& geometry) const;
+
+    Fact* getFact(Function function) const;
 
 public slots:
     void applyRule(bool noConstraints = false);

--- a/src/Vehicle/Actuators/Mixer.h
+++ b/src/Vehicle/Actuators/Mixer.h
@@ -1,0 +1,313 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QList>
+#include <QSet>
+
+#include "Common.h"
+
+#include <QmlObjectListModel.h>
+
+namespace Mixer {
+
+enum class Function {
+    Unspecified=0,
+    PositionX,
+    PositionY,
+    PositionZ,
+    SpinDirection, ///< CCW = true or 1
+    AxisX,
+    AxisY,
+    AxisZ,
+    Type,
+};
+
+struct MixerParameter {
+    Parameter param;
+    Function function{Function::Unspecified};
+    QList<float> values{}; ///< fixed values if not configurable (param.name == "")
+};
+
+/**
+ * Actuator type configuration (directly corresponds to the json entries)
+ */
+struct ActuatorType
+{
+    struct Values {
+        float min{};
+        float max{};
+        float defaultVal{};
+        bool reversible{};
+    };
+
+    int functionMin{};
+    int functionMax{};
+    Values values{};
+    QList<Parameter> perItemParams{};
+    int labelIndexOffset{};
+};
+
+using ActuatorTypes = QMap<QString, ActuatorType>; ///< key is the group name, where 'DEFAULT' is the default group
+
+/**
+ * Mixer configuration option (directly corresponds to the json entries)
+ */
+struct MixerOption
+{
+    struct ActuatorGroup {
+        QString groupLabel{};
+        QString count{}; ///< param to configure the amount. If empty, fixedCount is non-zero
+        int fixedCount{};
+        QString actuatorType{};
+        bool required{}; ///< if true, actuator has to be configured for a valid setup
+        QList<Parameter> parameters{};
+        QList<MixerParameter> perItemParameters{};
+        QStringList itemLabelPrefix{}; ///< size = either fixedCount or 1 or 0 items
+    };
+    QString option{};
+    QString type{}; ///< Mixer type, e.g. multirotor
+    QList<ActuatorGroup> actuators{};
+};
+
+using MixerOptions = QList<MixerOption>;
+
+/**
+ * Config parameters that apply to a group of actuators
+ */
+class ConfigParameter : public QObject
+{
+    Q_OBJECT
+public:
+    ConfigParameter(QObject* parent, Fact* fact, const QString& label, bool advanced)
+        : QObject(parent), _fact(fact), _label(label), _advanced(advanced) {}
+
+    Q_PROPERTY(QString label          READ label       CONSTANT)
+    Q_PROPERTY(Fact* fact             READ fact        CONSTANT)
+    Q_PROPERTY(bool advanced          READ advanced    CONSTANT)
+
+    const QString& label() const { return _label; }
+    Fact* fact() { return _fact; }
+    bool advanced() const { return _advanced; }
+
+private:
+    Fact* _fact{nullptr};
+    const QString _label;
+    const bool _advanced;
+};
+
+/**
+ * Config parameters that apply to individual channels
+ */
+class ChannelConfig : public QObject
+{
+    Q_OBJECT
+public:
+
+    ChannelConfig(QObject* parent, const MixerParameter& parameter, bool isActuatorTypeConfig=false)
+        : QObject(parent), _parameter(parameter), _isActuatorTypeConfig(isActuatorTypeConfig) {}
+
+    Q_PROPERTY(QString label      READ label        CONSTANT)
+    Q_PROPERTY(bool visible       READ visible      CONSTANT)
+    Q_PROPERTY(bool advanced      READ advanced     CONSTANT)
+
+    const QString& label() const { return _parameter.param.label; }
+    const QString& parameter() const { return _parameter.param.name; }
+    Function function() const { return _parameter.function; }
+    bool advanced() const { return _parameter.param.advanced; }
+    bool isActuatorTypeConfig() const { return _isActuatorTypeConfig; }
+
+    bool visible() const { return true; }
+
+    const QList<float>& fixedValues() const { return _parameter.values; }
+
+    Parameter::DisplayOption displayOption() const { return _parameter.param.displayOption; }
+    int indexOffset() const { return _parameter.param.indexOffset; }
+
+private:
+    const MixerParameter _parameter;
+    const bool _isActuatorTypeConfig; ///< actuator type config instead of mixer channel config
+};
+
+/**
+ * Per-channel instance for a ChannelConfig
+ */
+class ChannelConfigInstance : public QObject
+{
+    Q_OBJECT
+public:
+    ChannelConfigInstance(QObject* parent, Fact* fact, ChannelConfig& config)
+        : QObject(parent), _fact(fact), _config(config) {}
+
+    Q_PROPERTY(ChannelConfig* config      READ channelConfig    CONSTANT)
+    Q_PROPERTY(Fact* fact                 READ fact            CONSTANT)
+
+    ChannelConfig* channelConfig() const { return &_config; }
+
+    Fact* fact() { return _fact; }
+
+private:
+
+    Fact* _fact{nullptr};
+    ChannelConfig& _config;
+};
+
+class MixerChannel : public QObject
+{
+    Q_OBJECT
+public:
+    MixerChannel(QObject* parent, const QString& label, int actuatorFunction,
+            int paramIndex, int actuatorTypeIndex, QmlObjectListModel& channelConfigs, ParameterManager* parameterManager,
+            std::function<void(Fact*)> factAddedCb);
+
+    Q_PROPERTY(QString label                            READ label               CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* configInstances      READ configInstances     NOTIFY configInstancesChanged)
+
+    const QString& label() const { return _label; }
+    int actuatorFunction() const { return _actuatorFunction; }
+
+    QmlObjectListModel* configInstances() { return _configInstances; }
+
+    bool getGeometry(const ActuatorTypes& actuatorTypes, const MixerOption::ActuatorGroup& group,
+            ActuatorGeometry& geometry) const;
+
+signals:
+    void configInstancesChanged();
+private:
+
+    const QString _label;
+    const int _actuatorFunction;
+    const int _paramIndex;
+    const int _actuatorTypeIndex;
+
+    QmlObjectListModel* _configInstances = new QmlObjectListModel(this); ///< list of ChannelConfigInstance*
+};
+
+class MixerConfigGroup : public QObject
+{
+    Q_OBJECT
+public:
+    MixerConfigGroup(QObject* parent, const MixerOption::ActuatorGroup& group)
+        : QObject(parent), _group(group) {}
+
+    Q_PROPERTY(QString label                        READ label              CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* channels         READ channels           NOTIFY channelsChanged)
+    Q_PROPERTY(QmlObjectListModel* channelConfigs   READ channelConfigs     NOTIFY channelConfigsChanged)
+    Q_PROPERTY(ConfigParameter* countParam          READ countParam         CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* configParams     READ configParams       CONSTANT)
+
+    const QString& label() const { return _group.groupLabel; }
+
+    // per-channel-params
+    QmlObjectListModel* channelConfigs() { return _channelConfigs; }
+    void addChannelConfig(ChannelConfig* channelConfig);
+
+    QmlObjectListModel* channels() { return _channels; }
+    void addChannel(MixerChannel* channel);
+
+    ConfigParameter* countParam() const { return _countParam; }
+    void addConfigParam(ConfigParameter* param);
+    QmlObjectListModel* configParams() { return _params; }
+
+    void setCountParam(ConfigParameter* param) { delete _countParam; _countParam = param; }
+
+    const MixerOption::ActuatorGroup& group() const { return _group; }
+
+signals:
+    void channelsChanged();
+    void channelConfigsChanged();
+
+private:
+    const MixerOption::ActuatorGroup& _group;
+    QmlObjectListModel* _channels = new QmlObjectListModel(this); ///< list of MixerChannel*
+    QmlObjectListModel* _channelConfigs = new QmlObjectListModel(this); ///< list of ChannelConfig*
+
+    ConfigParameter* _countParam{nullptr};
+    QmlObjectListModel* _params  = new QmlObjectListModel(this); ///< list of ConfigParameter*
+};
+
+class Mixers : public QObject
+{
+    Q_OBJECT
+public:
+    Mixers(ParameterManager* parameterManager)
+        : _parameterManager(parameterManager) {}
+
+    struct OutputFunction {
+        QString label;
+        Condition noteCondition;
+        QString note;
+        bool excludeFromActuatorTesting;
+        QString actuatorType{};
+
+        operator QString() const { return label; }
+    };
+
+    void reset(const ActuatorTypes& actuatorTypes, const MixerOptions& mixerOptions,
+            const QMap<int, OutputFunction>& functions);
+
+    Q_PROPERTY(QmlObjectListModel* groups         READ groups        NOTIFY groupsChanged)
+
+    QmlObjectListModel* groups() { return _groups; }
+
+    const ActuatorTypes& actuatorTypes() const { return _actuatorTypes; }
+
+    /**
+     * Get the mixer-specific label for a certain output function and the current configuration,
+     * combined with the generic label.
+     * E.g. 'Front Left Tilt (Servo 1)' for the 'Servo 1' function.
+     * @param function actuator output function
+     * @return empty string if there's no such function
+     */
+    QString getSpecificLabelForFunction(int function) const;
+
+    /**
+     * Get the set of all required actuator functions
+     */
+    QSet<int> requiredFunctions() const;
+
+    QString configuredType() const;
+
+    const QMap<int, OutputFunction>& functions() const { return _functions; }
+
+public slots:
+
+    /**
+     * Call this on param update(s)
+     */
+    void update();
+
+signals:
+    void groupsChanged();
+    void paramChanged();
+
+private:
+
+    Fact* getFact(const QString& paramName);
+    void subscribeFact(Fact* fact);
+    void unsubscribeFacts();
+
+    QSet<Fact*> _subscribedFacts{};
+
+    ActuatorTypes _actuatorTypes;
+    MixerOptions _mixerOptions;
+    QMap<int, OutputFunction> _functions;  ///< all possible output functions
+
+    QList<Condition> _mixerConditions;
+    int _selectedMixer{-1};
+    QmlObjectListModel* _groups = new QmlObjectListModel(this); ///< list of MixerConfigGroup*
+
+    QMap<int, QString> _functionsSpecificLabel; ///< function with specific label, e.g. 'Front Left Motor (Motor 1)'
+    ParameterManager* _parameterManager{nullptr};
+};
+
+} // namespace Mixer

--- a/src/Vehicle/Actuators/MotorAssignment.cc
+++ b/src/Vehicle/Actuators/MotorAssignment.cc
@@ -1,0 +1,231 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "MotorAssignment.h"
+#include "ActuatorOutputs.h"
+
+#include "QGCApplication.h"
+
+#include <vector>
+
+MotorAssignment::MotorAssignment(QObject* parent, Vehicle* vehicle, QmlObjectListModel* actuators)
+        : QObject(parent), _vehicle(vehicle), _actuators(actuators)
+{
+    _spinTimer.setInterval(1000);
+    _spinTimer.setSingleShot(true);
+    connect(&_spinTimer, &QTimer::timeout, this, &MotorAssignment::spinTimeout);
+}
+
+bool MotorAssignment::initAssignment(int selectedActuatorIdx, int firstMotorsFunction, int numMotors)
+{
+    if (_state != State::Idle) {
+        qCWarning(ActuatorsConfigLog) << "Already init/running";
+    }
+
+    // gather all the function facts
+    _functionFacts.clear();
+    for (int groupIdx = 0; groupIdx < _actuators->count(); groupIdx++) {
+        auto group = qobject_cast<ActuatorOutputs::ActuatorOutput*>(_actuators->get(groupIdx));
+        _functionFacts.append(QList<Fact*>{});
+        group->getAllChannelFunctions(_functionFacts.last());
+    }
+
+    // Check the current configuration for these cases:
+    // - no motors assigned: ask to assign to selected output
+    // - there are motors, but none assigned to the selected output: ask to remove and assign to selected output
+    // - partially assigned motors: abort with error
+    // - all assigned to current output: nothing further to do
+
+    int index = 0;
+    std::vector<bool> selectedAssignment(numMotors);
+    std::vector<bool> otherAssignment(numMotors);
+    for (auto& group : _functionFacts) {
+        bool selected = index == selectedActuatorIdx;
+        for (auto& fact : group) {
+            int currentFunction = fact->rawValue().toInt();
+            if (currentFunction >= firstMotorsFunction && currentFunction < firstMotorsFunction + numMotors) {
+                if (selected) {
+                    selectedAssignment[currentFunction - firstMotorsFunction] = true;
+                } else {
+                    otherAssignment[currentFunction - firstMotorsFunction] = true;
+                }
+            }
+        }
+        ++index;
+    }
+    int numAssigned = 0;
+    int numAssignedToSelected = 0;
+    for (int i = 0; i < numMotors; ++i) {
+        numAssigned += selectedAssignment[i] || otherAssignment[i];
+        numAssignedToSelected += selectedAssignment[i];
+    }
+
+    QString selectedActuatorOutputName = qobject_cast<ActuatorOutputs::ActuatorOutput*>(_actuators->get(selectedActuatorIdx))->label();
+
+    _assignMotors = false;
+    QString extraMessage;
+    if (numAssigned == 0 && _functionFacts[selectedActuatorIdx].size() >= numMotors) {
+        _assignMotors = true;
+        extraMessage = tr(
+R"(<br />No motors are assigned yet.
+By saying yes, all motors will be assigned to the first %1 channels of the selected output (%2)
+ (you can also first assign all motors, then start the identification).<br />)").arg(numMotors).arg(selectedActuatorOutputName);
+
+    } else if (numAssigned > 0 && numAssignedToSelected == 0 && _functionFacts[selectedActuatorIdx].size() >= numMotors) {
+        _assignMotors = true;
+        extraMessage = tr(
+R"(<br />Motors are currently assigned to a different output.
+By saying yes, all motors will be reassigned to the first %1 channels of the selected output (%2).<br />)")
+            .arg(numMotors).arg(selectedActuatorOutputName);
+
+    } else if (numAssigned < numMotors) {
+        _message = tr("Not all motors are assigned yet. Either clear all existing assignments or assign all motors to an output.");
+        emit messageChanged();
+        return false;
+    }
+
+    _message = tr(
+R"(This will automatically spin individual motors at 15% thrust.<br /><br />
+<b>Warning: Only proceed if you removed all propellers</b>.<br />
+%1
+<br />
+The procedure is as following:<br />
+- After confirming, the first motor starts to spin for 0.5 seconds.<br />
+- Then click on the motor that was spinning.<br />
+- The above steps are repeated for all motors.<br />
+- The motor output functions will automatically be reassigned by the selected order.<br />
+<br />
+Do you wish to proceed?)").arg(extraMessage);
+    emit messageChanged();
+
+    _selectedActuatorIdx = selectedActuatorIdx;
+    _firstMotorsFunction = firstMotorsFunction;
+    _numMotors = numMotors;
+    _selectedMotors.clear();
+    _state = State::Init;
+    emit activeChanged();
+    return true;
+}
+
+void MotorAssignment::start()
+{
+    if (_state != State::Init) {
+        qCWarning(ActuatorsConfigLog) << "Invalid state";
+        return;
+    }
+
+    if (_assignMotors) {
+        // clear all motors
+        for (auto& group : _functionFacts) {
+            for (auto& fact : group) {
+                int currentFunction = fact->rawValue().toInt();
+                if (currentFunction >= _firstMotorsFunction && currentFunction < _firstMotorsFunction + _numMotors) {
+                    fact->setRawValue(0);
+                }
+            }
+        }
+        // assign to selected output
+        int index = 0;
+        for (auto& fact : _functionFacts[_selectedActuatorIdx]) {
+            fact->setRawValue(_firstMotorsFunction + index);
+            if (++index >= _numMotors) {
+                break;
+            }
+        }
+    }
+    _state = State::Running;
+    emit activeChanged();
+    _spinTimer.start();
+}
+
+void MotorAssignment::selectMotor(int motorIndex)
+{
+    if (_state != State::Running) {
+        qCDebug(ActuatorsConfigLog) << "Not running";
+        return;
+    }
+
+    _selectedMotors.append(motorIndex);
+    if (_selectedMotors.size() == _numMotors) {
+
+        // finished, change functions
+        for (auto& group : _functionFacts) {
+            for (auto& fact : group) {
+                int currentFunction = fact->rawValue().toInt();
+                if (currentFunction >= _firstMotorsFunction && currentFunction < _firstMotorsFunction + _numMotors) {
+                    // this is set to a motor -> update
+                    fact->setRawValue(_firstMotorsFunction + _selectedMotors[currentFunction - _firstMotorsFunction]);
+                }
+            }
+        }
+
+        _state = State::Idle;
+        emit activeChanged();
+    } else {
+        // spin the next motor after some time
+        _spinTimer.start();
+    }
+}
+
+void MotorAssignment::spinCurrentMotor()
+{
+    if (!_commandInProgress) {
+        _spinTimer.stop();
+        int motorIndex = _selectedMotors.size();
+        sendMavlinkRequest(_firstMotorsFunction + motorIndex, 0.15f);
+    }
+}
+
+void MotorAssignment::abort()
+{
+    _spinTimer.stop();
+    _state = State::Idle;
+    emit activeChanged();
+    emit onAbort();
+}
+
+void MotorAssignment::spinTimeout()
+{
+    spinCurrentMotor();
+}
+
+void MotorAssignment::ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
+        Vehicle::MavCmdResultFailureCode_t failureCode)
+{
+    MotorAssignment* motorAssignment = (MotorAssignment*)resultHandlerData;
+    motorAssignment->ackHandler(commandResult, failureCode);
+}
+
+void MotorAssignment::ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode)
+{
+    _commandInProgress = false;
+    if (failureCode != Vehicle::MavCmdResultFailureNoResponseToCommand && commandResult != MAV_RESULT_ACCEPTED) {
+        abort();
+        qgcApp()->showAppMessage(tr("Actuator test command failed"));
+    }
+}
+
+void MotorAssignment::sendMavlinkRequest(int function, float value)
+{
+    qCDebug(ActuatorsConfigLog) << "Sending actuator test function:" << function << "value:" << value;
+
+    _vehicle->sendMavCommandWithHandler(
+            ackHandlerEntry,                  // Ack callback
+            this,                             // Ack callback data
+            MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
+            MAV_CMD_ACTUATOR_TEST,            // the mavlink command
+            value,                            // value
+            0.5f,                             // timeout
+            0,                                // unused parameter
+            0,                                // unused parameter
+            1000+function,                    // function
+            0,                                // unused parameter
+            0);
+    _commandInProgress = true;
+}

--- a/src/Vehicle/Actuators/MotorAssignment.h
+++ b/src/Vehicle/Actuators/MotorAssignment.h
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+#include "Common.h"
+
+#include "QmlControls/QmlObjectListModel.h"
+
+/**
+ * Handles automatic motor ordering assignment by spinning individual motors, and then having the user
+ * to select the corresponding motor.
+ */
+class MotorAssignment : public QObject
+{
+    Q_OBJECT
+public:
+    MotorAssignment(QObject* parent, Vehicle* vehicle, QmlObjectListModel* actuators);
+
+    virtual ~MotorAssignment() = default;
+
+    /**
+     * Initialize assignment, and set the UI confirmation message to be shown to the user.
+     * @return true on success, false on failure (message will contain the error message)
+     */
+    bool initAssignment(int selectedActuatorIdx, int firstMotorsFunction, int numMotors);
+
+    /**
+     * Start the assignment, called after confirming.
+     */
+    void start();
+
+    void selectMotor(int motorIndex);
+
+    void spinCurrentMotor();
+
+    void abort();
+
+    bool active() const { return _state == State::Running; }
+
+    const QString& message() const { return _message; }
+
+signals:
+    void activeChanged();
+    void messageChanged();
+    void onAbort();
+
+private slots:
+    void spinTimeout();
+
+private:
+    static void ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
+            Vehicle::MavCmdResultFailureCode_t failureCode);
+    void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
+    void sendMavlinkRequest(int function, float value);
+
+    enum class State {
+        Idle,
+        Init,
+        Running
+    };
+
+    Vehicle* _vehicle{nullptr};
+    QmlObjectListModel* _actuators{nullptr}; ///< list of ActuatorOutput*
+
+    int _selectedActuatorIdx{-1};
+    int _firstMotorsFunction{};
+    int _numMotors{};
+    QTimer _spinTimer;
+
+    State _state{State::Idle};
+    bool _assignMotors{false};
+    QList<int> _selectedMotors{};
+    bool _commandInProgress{false};
+    QList<QList<Fact*>> _functionFacts;
+    QString _message; ///< current message to show to the user after initializing
+};
+

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -1,4 +1,6 @@
 
+add_subdirectory(Actuators)
+
 set(EXTRA_SRC)
 if(BUILD_TESTING)
 	list(APPEND EXTRA_SRC
@@ -96,6 +98,7 @@ add_library(Vehicle
 
 target_link_libraries(Vehicle
 	PRIVATE
+		Actuators
 		ui
 		compression
 		libevents_generated

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(Vehicle
 	Autotune.h
 	CompInfo.cc
 	CompInfo.h
+	CompInfoActuators.cc
+	CompInfoActuators.h
 	CompInfoEvents.cc
 	CompInfoEvents.h
 	CompInfoParam.cc

--- a/src/Vehicle/CompInfoActuators.cc
+++ b/src/Vehicle/CompInfoActuators.cc
@@ -1,0 +1,25 @@
+/****************************************************************************
+ *
+ * (c) 2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "CompInfoActuators.h"
+#include "Vehicle.h"
+
+CompInfoActuators::CompInfoActuators(uint8_t compId, Vehicle* vehicle, QObject* parent)
+    : CompInfo(COMP_METADATA_TYPE_ACTUATORS, compId, vehicle, parent)
+{
+
+}
+
+void CompInfoActuators::setJson(const QString& metadataJsonFileName, const QString& translationJsonFileName)
+{
+    if (!metadataJsonFileName.isEmpty()) {
+        vehicle->setActuatorsMetadata(compId, metadataJsonFileName, translationJsonFileName);
+    }
+}
+

--- a/src/Vehicle/CompInfoActuators.h
+++ b/src/Vehicle/CompInfoActuators.h
@@ -1,0 +1,31 @@
+/****************************************************************************
+ *
+ * (c) 2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "CompInfo.h"
+
+#include <QObject>
+
+class FactMetaData;
+class Vehicle;
+class FirmwarePlugin;
+
+class CompInfoActuators : public CompInfo
+{
+    Q_OBJECT
+
+public:
+    CompInfoActuators(uint8_t compId, Vehicle* vehicle, QObject* parent = nullptr);
+
+    // Overrides from CompInfo
+    void setJson(const QString& metadataJsonFileName, const QString& translationJsonFileName) override;
+
+private:
+};

--- a/src/Vehicle/ComponentInformationManager.cc
+++ b/src/Vehicle/ComponentInformationManager.cc
@@ -15,6 +15,7 @@
 #include "CompInfoGeneral.h"
 #include "CompInfoParam.h"
 #include "CompInfoEvents.h"
+#include "CompInfoActuators.h"
 #include "QGCFileDownload.h"
 #include "QGCApplication.h"
 
@@ -29,6 +30,7 @@ const ComponentInformationManager::StateFn ComponentInformationManager::_rgState
     ComponentInformationManager::_stateRequestCompInfoGeneralComplete,
     ComponentInformationManager::_stateRequestCompInfoParam,
     ComponentInformationManager::_stateRequestCompInfoEvents,
+    ComponentInformationManager::_stateRequestCompInfoActuators,
     ComponentInformationManager::_stateRequestAllCompInfoComplete
 };
 
@@ -52,6 +54,7 @@ ComponentInformationManager::ComponentInformationManager(Vehicle* vehicle)
     _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_GENERAL]    = new CompInfoGeneral   (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
     _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_PARAMETER]  = new CompInfoParam     (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
     _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_EVENTS]     = new CompInfoEvents    (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
+    _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_ACTUATORS]  = new CompInfoActuators (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
 }
 
 int ComponentInformationManager::stateCount(void) const
@@ -136,6 +139,18 @@ void ComponentInformationManager::_stateRequestCompInfoEvents(StateMachine* stat
     }
 }
 
+void ComponentInformationManager::_stateRequestCompInfoActuators(StateMachine* stateMachine)
+{
+    ComponentInformationManager* compMgr = static_cast<ComponentInformationManager*>(stateMachine);
+
+    if (compMgr->_isCompTypeSupported(COMP_METADATA_TYPE_ACTUATORS)) {
+        compMgr->_requestTypeStateMachine.request(compMgr->_compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_ACTUATORS]);
+    } else {
+        qCDebug(ComponentInformationManagerLog) << "_stateRequestCompInfoActuators skipping, not supported";
+        compMgr->advance();
+    }
+}
+
 void ComponentInformationManager::_stateRequestAllCompInfoComplete(StateMachine* stateMachine)
 {
     ComponentInformationManager* compMgr = static_cast<ComponentInformationManager*>(stateMachine);
@@ -208,6 +223,7 @@ QString RequestMetaDataTypeStateMachine::typeToString(void)
         case COMP_METADATA_TYPE_COMMANDS: return "COMP_METADATA_TYPE_COMMANDS";
         case COMP_METADATA_TYPE_PERIPHERALS: return "COMP_METADATA_TYPE_PERIPHERALS";
         case COMP_METADATA_TYPE_EVENTS: return "COMP_METADATA_TYPE_EVENTS";
+        case COMP_METADATA_TYPE_ACTUATORS: return "COMP_METADATA_TYPE_ACTUATORS";
         default: break;
     }
     return "Unknown";

--- a/src/Vehicle/ComponentInformationManager.h
+++ b/src/Vehicle/ComponentInformationManager.h
@@ -111,6 +111,7 @@ private:
     static void _stateRequestCompInfoGeneralComplete(StateMachine* stateMachine);
     static void _stateRequestCompInfoParam          (StateMachine* stateMachine);
     static void _stateRequestCompInfoEvents         (StateMachine* stateMachine);
+    static void _stateRequestCompInfoActuators      (StateMachine* stateMachine);
     static void _stateRequestAllCompInfoComplete    (StateMachine* stateMachine);
 
     Vehicle*                        _vehicle                    = nullptr;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -50,6 +50,7 @@
 #include "InitialConnectStateMachine.h"
 #include "VehicleBatteryFactGroup.h"
 #include "EventHandler.h"
+#include "Actuators/Actuators.h"
 #ifdef QT_DEBUG
 #include "MockLink.h"
 #endif
@@ -1615,6 +1616,14 @@ EventHandler& Vehicle::_eventHandler(uint8_t compid)
 void Vehicle::setEventsMetadata(uint8_t compid, const QString& metadataJsonFileName, const QString& translationJsonFileName)
 {
     _eventHandler(compid).setMetadata(metadataJsonFileName, translationJsonFileName);
+}
+
+void Vehicle::setActuatorsMetadata(uint8_t compid, const QString& metadataJsonFileName, const QString& translationJsonFileName)
+{
+    if (!_actuators) {
+        _actuators = new Actuators(this, this);
+    }
+    _actuators->load(metadataJsonFileName);
 }
 
 void Vehicle::_handleHeartbeat(mavlink_message_t& message)

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -46,6 +46,7 @@
 #include "FTPManager.h"
 #include "ImageProtocolManager.h"
 
+class Actuators;
 class EventHandler;
 class UAS;
 class UASInterface;
@@ -315,6 +316,7 @@ public:
     Q_PROPERTY(FactGroup*           localPosition   READ localPositionFactGroup     CONSTANT)
     Q_PROPERTY(FactGroup*           localPositionSetpoint READ localPositionSetpointFactGroup CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  batteries       READ batteries                  CONSTANT)
+    Q_PROPERTY(Actuators*           actuators       READ actuators                  CONSTANT)
 
     Q_PROPERTY(int      firmwareMajorVersion        READ firmwareMajorVersion       NOTIFY firmwareVersionChanged)
     Q_PROPERTY(int      firmwareMinorVersion        READ firmwareMinorVersion       NOTIFY firmwareVersionChanged)
@@ -592,6 +594,7 @@ public:
     QObject*        sysStatusSensorInfo         () { return &_sysStatusSensorInfo; }
     bool            requiresGpsFix              () const { return static_cast<bool>(_onboardControlSensorsPresent & SysStatusSensorGPS); }
     bool            hilMode                     () const { return _base_mode & MAV_MODE_FLAG_HIL_ENABLED; }
+    Actuators*      actuators                   () const { return _actuators; }
 
     /// Get the maximum MAVLink protocol version supported
     /// @return the maximum version
@@ -823,6 +826,7 @@ public:
     double loadProgress                 () const { return _loadProgress; }
 
     void setEventsMetadata(uint8_t compid, const QString& metadataJsonFileName, const QString& translationJsonFileName);
+    void setActuatorsMetadata(uint8_t compid, const QString& metadataJsonFileName, const QString& translationJsonFileName);
 
 public slots:
     void setVtolInFwdFlight                 (bool vtolInFwdFlight);
@@ -1320,6 +1324,7 @@ private:
     FTPManager*                     _ftpManager                 = nullptr;
     ImageProtocolManager*           _imageProtocolManager       = nullptr;
     InitialConnectStateMachine*     _initialConnectStateMachine = nullptr;
+    Actuators*                      _actuators                  = nullptr;
 
     static const char* _rollFactName;
     static const char* _pitchFactName;


### PR DESCRIPTION
This brings a new configuration page that goes together with the PX4 control allocation work (replacing the mixer config files with a parameter-based implementation).

It's using metadata from the fmu to dynamically create a UI matching the vehicle's hardware capabilities and geometry/airframe configuration.
For example this is how it looks like for a multirotor:
![qgc_actuators_mc_aux](https://user-images.githubusercontent.com/281593/139041125-e2b74174-20b6-4507-baec-bdf9f89e7eba.png)

Or for a VTOL (tiltrotor) w/o configurable geometry:
![qgc_actuators_vtol_tiltrotor](https://user-images.githubusercontent.com/281593/139041205-4b2f5634-8be0-4a86-9305-1233cb3dbfa1.png)

Video going through the UI: https://youtu.be/oKru4EsF1aM

Notes:
- The geometry image is dynamically rendered based on the actuator position parameters, and only shown for multirotors. It's however possible to extend for different vehicle types later on
- Tested with light & dark themes
- A param change for any of the used params in the UI leads to a complete UI update. It's fast enough but could be made more fine granular.
- I don't really like the `setActuatorsController()` in Vehicle, maybe @DonLakeFlyer you have a better approach?
- The UI can be improved further, in particular I don't like the actuator actions buttons too much.

Some MC geometries:
![test_geometry_2_3](https://user-images.githubusercontent.com/281593/139041767-62de8586-60de-4f47-8938-0f4dd681eff5.png)
![test_geometry_2_4](https://user-images.githubusercontent.com/281593/139041783-06fe9de6-8b28-4009-83f0-3b8ee894c113.png)
![test_geometry_2_5](https://user-images.githubusercontent.com/281593/139041812-125af9ae-355b-44b4-8885-d441447ae937.png)

TODO:
- [x] COMPONENT_INFORMATION API integration
- [x] Mavlink messages
- [x] metadata generation on the PX4 side
- [ ] potentially add an example json to the mock link