### PR TITLE
Update Sentera Double 4K minTriggerInterval

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -501,7 +501,7 @@ const QVariantList& FirmwarePlugin::cameraList(const Vehicle*)
                     5.4,                // focalLength
                     true,               // landscape
                     false,              // fixedOrientation
-                    0.5,                // minTriggerInterval
+                    0.8,                // minTriggerInterval
                     tr("Sentera Double 4K Sensor"),// SHOULD BE BLANK FOR NEWLY ADDED CAMERAS. Deprecated translation from older builds.
                     this);
         _cameraList.append(QVariant::fromValue(metaData));


### PR DESCRIPTION
Update to the Sentera Double 4K Sensor's `minTriggerInterval`, increasing the value from 0.5s to 0.8s.