### PR TITLE
add missing source files to CMakeLists.txt

### DIFF
--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -82,7 +82,6 @@ add_custom_target(QmlControlsQml
 		PreFlightCheckList.qml
 		PreFlightCheckModel.qml
 		QGCButton.qml
-		AutotuneUI.qml
 		QGCCheckBox.qml
 		QGCColoredImage.qml
 		QGCComboBox.qml

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -16,6 +16,8 @@ if(BUILD_TESTING)
 endif()
 
 add_library(Vehicle
+	Autotune.cpp
+	Autotune.h
 	CompInfo.cc
 	CompInfo.h
 	CompInfoEvents.cc


### PR DESCRIPTION
files added in #9904
  - AutotuneUI.qml was added twice to src/QmlControls/CMakeLists.txt
  - Autotune.cpp was not added to src/Vehicle/CMakeLists.txt


