### PR TITLE
MavlinkConsoleController: add target sysid/compid

### DIFF
--- a/src/AnalyzeView/MavlinkConsoleController.cc
+++ b/src/AnalyzeView/MavlinkConsoleController.cc
@@ -158,7 +158,8 @@ MavlinkConsoleController::_sendSerialData(QByteArray data, bool close)
                     0,
                     0,
                     chunk.size(),
-                    reinterpret_cast<uint8_t*>(chunk.data()));
+                    reinterpret_cast<uint8_t*>(chunk.data()),
+                    _vehicle->id(), _vehicle->defaultComponentId());
         _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
         data.remove(0, chunk.size());
     }


### PR DESCRIPTION
The SERIAL_CONSOLE message now includes a target_system and target_component which prevents serial messages being sent to the wrong vehicle in case there are multiple vehicles connected.

More background:
https://github.com/mavlink/mavlink/pull/1725


