### PR TITLE
Send radio cal start to Vehicle in all cases

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -442,7 +442,7 @@ void APMSensorsComponentController::cancelCalibration(void)
         emit waitingForCancelChanged();
         // The firmware doesn't always allow us to cancel calibration. The best we can do is wait
         // for it to timeout.
-        _vehicle->stopCalibration();
+        _vehicle->stopCalibration(true /* showError */);
     }
 
 }

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -797,9 +797,7 @@ void RadioComponentController::_startCalibration(void)
     _resetInternalCalibrationValues();
 
     // Let the mav known we are starting calibration. This should turn off motors and so forth.
-    if (_px4Vehicle()) {
-        _vehicle->startCalibration(Vehicle::CalibrationRadio);
-    }
+    _vehicle->startCalibration(Vehicle::CalibrationRadio);
 
     _nextButton->setProperty("text", tr("Next"));
     _cancelButton->setEnabled(true);
@@ -814,9 +812,9 @@ void RadioComponentController::_stopCalibration(void)
     _currentStep = -1;
 
     if (_uas) {
-        if (_px4Vehicle()) {
-            _vehicle->stopCalibration();
-        }
+        // Only PX4 is known to support this command in all versions. For other firmware which may or may not
+        // support this we don't show errors on failure.
+        _vehicle->stopCalibration(_px4Vehicle() ? true : false /* showError */);
         _setInternalCalibrationValuesFromParameters();
     } else {
         _resetInternalCalibrationValues();

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -493,7 +493,7 @@ void SensorsComponentController::cancelCalibration(void)
     _waitingForCancel = true;
     emit waitingForCancelChanged();
     _cancelButton->setEnabled(false);
-    _vehicle->stopCalibration();
+    _vehicle->stopCalibration(true /* showError */);
 }
 
 void SensorsComponentController::_handleParametersReset(bool success)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3305,11 +3305,11 @@ void Vehicle::startCalibration(Vehicle::CalibrationType calType)
     sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
-void Vehicle::stopCalibration(void)
+void Vehicle::stopCalibration(bool showError)
 {
     sendMavCommand(defaultComponentId(),    // target component
                    MAV_CMD_PREFLIGHT_CALIBRATION,     // command id
-                   true,                              // showError
+                   showError,
                    0,                                 // gyro cal
                    0,                                 // mag cal
                    0,                                 // ground pressure

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -613,7 +613,7 @@ public:
     };
 
     void startCalibration   (CalibrationType calType);
-    void stopCalibration    (void);
+    void stopCalibration    (bool showError);
 
     void startUAVCANBusConfig(void);
     void stopUAVCANBusConfig(void);


### PR DESCRIPTION
* This sends to radio calibration message to the vehicle for all firmwares
* For the stop calibration case it only shows errors for PX4 Firmwares. For other firmwares they may or may not have support so we can't pop an error.
* Related to https://github.com/ArduPilot/ardupilot/issues/8735