### PR TITLE
Correct S3 upload URL with subfolder builds/

### DIFF
--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -97,4 +97,4 @@ jobs:
         run: |
               aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
               aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-              aws s3 cp ${ARTIFACT} s3://qgroundcontrol/master/${ARTIFACT} --region us-west-2 --acl public-read
+              aws s3 cp ${ARTIFACT} s3://qgroundcontrol/builds/master/${ARTIFACT} --region us-west-2 --acl public-read

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -92,5 +92,4 @@ jobs:
         run: |
               aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
               aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-              aws s3 cp ${ARTIFACT} s3://qgroundcontrol/master/${ARTIFACT} --region us-west-2 --acl public-read
-              
+              aws s3 cp ${ARTIFACT} s3://qgroundcontrol/builds/master/${ARTIFACT} --region us-west-2 --acl public-read

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -98,4 +98,4 @@ jobs:
         run: |
               aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
               aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-              aws s3 cp ${{ env.ARTIFACT }} s3://qgroundcontrol/master/${{ env.ARTIFACT }} --region us-west-2 --acl public-read
+              aws s3 cp ${{ env.ARTIFACT }} s3://qgroundcontrol/builds/master/${{ env.ARTIFACT }} --region us-west-2 --acl public-read


### PR DESCRIPTION
fixes https://github.com/mavlink/qgroundcontrol/issues/10021

As also discussed in https://github.com/mavlink/qgroundcontrol/issues/9946#issuecomment-969176516 CI doesn't drop the artifacts of the latest daily build to the original locations which are linked in the documentation here: https://docs.qgroundcontrol.com/master/en/releases/daily_builds.html

The new presumably erroneous URL is
`https://s3-us-west-2.amazonaws.com/qgroundcontrol/master/*`
while it used to be
`https://s3-us-west-2.amazonaws.com/qgroundcontrol/builds/master/*`