### PR TITLE
[Hold for Flatpak] QMake: Don't override AIRMAP_PLATFORM_SDK_PATH

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -285,7 +285,9 @@ contains (DEFINES, DISABLE_AIRMAP) {
 } else:exists(user_config.pri):infile(user_config.pri, DEFINES, DISABLE_AIRMAP) {
     message("Skipping support for AirMap (manual override from user_config.pri)")
 } else {
-    AIRMAP_PLATFORM_SDK_PATH    = $${OUT_PWD}/libs/airmap-platform-sdk
+    !defined(AIRMAP_PLATFORM_SDK_PATH, var) {
+        AIRMAP_PLATFORM_SDK_PATH    = $${OUT_PWD}/libs/airmap-platform-sdk
+    }
     AIRMAP_QT_PATH              = Qt.$${QT_MAJOR_VERSION}.$${QT_MINOR_VERSION}
     message("Including support for AirMap")
     MacBuild {


### PR DESCRIPTION
In case you want to use a different SDK installation from a custom path, you can set AIRMAP_PLATFORM_SDK_PATH to whatever you want.
However, there is no check whether it is already defined and therefore it will get overwritten in any case.

Let's avoid it!


