### PR TITLE
Consolidate vehicle char array declarations and definitions

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -77,7 +77,7 @@ AutoPilotPlugin* APMFirmwarePlugin::autopilotPlugin(Vehicle* vehicle)
 
 bool APMFirmwarePlugin::isCapable(const Vehicle* vehicle, FirmwareCapabilities capabilities)
 {
-    uint32_t available = SetFlightModeCapability | PauseVehicleCapability | GuidedModeCapability;
+    uint32_t available = SetFlightModeCapability | PauseVehicleCapability | GuidedModeCapability | ChangeHeadingCapability;
     if (vehicle->multiRotor()) {
         available |= TakeoffVehicleCapability;
     } else if (vehicle->vtol()) {

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -52,6 +52,7 @@ public:
         OrbitModeCapability =               1 << 3, ///< Vehicle supports orbit mode
         TakeoffVehicleCapability =          1 << 4, ///< Vehicle supports guided takeoff
         ROIModeCapability =                 1 << 5, ///< Vehicle supports ROI (both in Fly guided mode and from Plan creation)
+        ChangeHeadingCapability =           1 << 6, ///< Vehicle supports changing heading at current location
     } FirmwareCapabilities;
 
     /// Maps from on parameter name to another

--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -489,6 +489,46 @@ FlightMap {
         }
     }
 
+    // Change Heading visuals
+    MapQuickItem {
+        id:             changeHeadingItem
+        visible:        false
+        z:              QGroundControl.zOrderMapItems
+        anchorPoint.x:  sourceItem.anchorPointX
+        anchorPoint.y:  sourceItem.anchorPointY
+        sourceItem: MissionItemIndexLabel {
+            checked:    true
+            index:      -1
+            label:      qsTr("Yaw towards here", "Turn towards location waypoint")
+        }
+
+        Connections {
+            target: QGroundControl.multiVehicleManager
+            function onActiveVehicleChanged(activeVehicle) {
+                if (!activeVehicle) {
+                    changeHeadingItem.visible = false
+                }
+            }
+        }
+
+        function show(coord) {
+            changeHeadingItem.coordinate = coord
+            changeHeadingItem.visible = true
+        }
+
+        function hide() {
+            changeHeadingItem.visible = false
+        }
+
+        function actionConfirmed() {
+            hide()
+        }
+
+        function actionCancelled() {
+            hide()
+        }
+    }
+
     // Orbit telemetry visuals
     QGCMapCircleVisuals {
         id:             orbitTelemetryCircle
@@ -543,6 +583,15 @@ FlightMap {
                 onTriggered: {
                     roiLocationItem.show(clickMenu.coord)
                     globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionROI, clickMenu.coord, roiLocationItem)
+                }
+            }
+            QGCMenuItem {
+                text:           qsTr("Yaw towards location")
+                visible:        globals.guidedControllerFlyView.showChangeHeading
+
+                onTriggered: {
+                    changeHeadingItem.show(clickMenu.coord)
+                    globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionChangeHeading, clickMenu.coord, changeHeadingItem)
                 }
             }
         }

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -47,6 +47,7 @@ Item {
     readonly property string pauseTitle:                    qsTr("Pause")
     readonly property string mvPauseTitle:                  qsTr("Pause (MV)")
     readonly property string changeAltTitle:                qsTr("Change Altitude")
+    readonly property string changeHeadingTitle:            qsTr("Change Heading")
     readonly property string orbitTitle:                    qsTr("Orbit")
     readonly property string landAbortTitle:                qsTr("Land Abort")
     readonly property string setWaypointTitle:              qsTr("Set Waypoint")
@@ -66,6 +67,7 @@ Item {
     readonly property string landMessage:                       qsTr("Land the vehicle at the current position.")
     readonly property string rtlMessage:                        qsTr("Return to the launch position of the vehicle.")
     readonly property string changeAltMessage:                  qsTr("Change the altitude of the vehicle up or down.")
+    readonly property string changeHeadingMessage:              qsTr("Change the heading of the vehicle toward the specified location.")
     readonly property string gotoMessage:                       qsTr("Move the vehicle to the specified location.")
              property string setWaypointMessage:                qsTr("Adjust current waypoint to %1.").arg(_actionData)
     readonly property string orbitMessage:                      qsTr("Orbit the vehicle around the specified location.")
@@ -100,6 +102,7 @@ Item {
     readonly property int actionROI:                        22
     readonly property int actionActionList:                 23
     readonly property int actionForceArm:                   24
+    readonly property int actionChangeHeading:              25
 
     property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
     property bool   _useChecklist:              QGroundControl.settingsManager.appSettings.useChecklist.rawValue && QGroundControl.corePlugin.options.preFlightChecklistUrl.toString().length
@@ -117,6 +120,7 @@ Item {
     property bool showContinueMission:  _guidedActionsEnabled && _missionAvailable && !_missionActive && _vehicleArmed && _vehicleFlying && (_currentMissionIndex < _missionItemCount - 1)
     property bool showPause:            _guidedActionsEnabled && _vehicleArmed && _activeVehicle.pauseVehicleSupported && _vehicleFlying && !_vehiclePaused && !_fixedWingOnApproach
     property bool showChangeAlt:        _guidedActionsEnabled && _vehicleFlying && _activeVehicle.guidedModeSupported && _vehicleArmed && !_missionActive
+    property bool showChangeHeading:    _guidedActionsEnabled && _activeVehicle.changeHeadingSupported && _vehicleFlying && _activeVehicle.guidedModeSupported && _vehicleArmed && !_missionActive
     property bool showOrbit:            _guidedActionsEnabled && _vehicleFlying && __orbitSupported && !_missionActive
     property bool showROI:              _guidedActionsEnabled && _vehicleFlying && __roiSupported && !_missionActive
     property bool showLandAbort:        _guidedActionsEnabled && _vehicleFlying && _fixedWingOnApproach
@@ -221,6 +225,12 @@ Item {
     onShowChangeAltChanged: {
         if (_corePlugin.guidedActionsControllerLogging()) {
             console.log("showChangeAlt", showChangeAlt)
+        }
+        _outputState()
+    }
+    onShowChangeHeadingChanged: {
+        if (_corePlugin.guidedActionsControllerLogging()) {
+            console.log("showChangeHeading", showChangeHeading)
         }
         _outputState()
     }
@@ -401,6 +411,11 @@ Item {
             altitudeSlider.reset()
             altitudeSlider.visible = true
             break;
+        case actionChangeHeading:
+            confirmDialog.title = changeHeadingTitle
+            confirmDialog.message = changeHeadingMessage
+            confirmDialog.hideTrigger = Qt.binding(function() { return !showChangeHeading })
+            break;
         case actionGoto:
             confirmDialog.title = gotoTitle
             confirmDialog.message = gotoMessage
@@ -501,6 +516,9 @@ Item {
             break
         case actionChangeAlt:
             _activeVehicle.guidedModeChangeAltitude(actionAltitudeChange, false /* pauseVehicle */)
+            break
+        case actionChangeHeading:
+            _activeVehicle.guidedModeChangeHeading(actionData)
             break
         case actionGoto:
             _activeVehicle.guidedModeGotoLocation(actionData)

--- a/src/Vehicle/CompInfoGeneral.cc
+++ b/src/Vehicle/CompInfoGeneral.cc
@@ -21,8 +21,6 @@
 
 QGC_LOGGING_CATEGORY(CompInfoGeneralLog, "CompInfoGeneralLog")
 
-const char* CompInfoGeneral::_jsonMetadataTypesKey = "metadataTypes";
-
 CompInfoGeneral::CompInfoGeneral(uint8_t compId, Vehicle* vehicle, QObject* parent)
     : CompInfo(COMP_METADATA_TYPE_GENERAL, compId, vehicle, parent)
 {

--- a/src/Vehicle/CompInfoGeneral.h
+++ b/src/Vehicle/CompInfoGeneral.h
@@ -40,5 +40,5 @@ public:
 private:
     QMap<COMP_METADATA_TYPE, Uris>   _supportedTypes;
 
-    static const char*          _jsonMetadataTypesKey;
+    static constexpr const char* _jsonMetadataTypesKey = "metadataTypes";
 };

--- a/src/Vehicle/CompInfoParam.cc
+++ b/src/Vehicle/CompInfoParam.cc
@@ -20,10 +20,6 @@
 
 QGC_LOGGING_CATEGORY(CompInfoParamLog, "CompInfoParamLog")
 
-const char* CompInfoParam::_jsonParametersKey           = "parameters";
-const char* CompInfoParam::_cachedMetaDataFilePrefix    = "ParameterFactMetaData";
-const char* CompInfoParam::_indexedNameTag              = "{n}";
-
 CompInfoParam::CompInfoParam(uint8_t compId, Vehicle* vehicle, QObject* parent)
     : CompInfo(COMP_METADATA_TYPE_PARAMETER, compId, vehicle, parent)
 {

--- a/src/Vehicle/CompInfoParam.h
+++ b/src/Vehicle/CompInfoParam.h
@@ -49,7 +49,7 @@ private:
     QList<RegexFactMetaDataPair_t>      _indexedNameMetaDataList;
     QObject*                            _opaqueParameterMetaData    = nullptr;
 
-    static const char* _cachedMetaDataFilePrefix;
-    static const char* _jsonParametersKey;
-    static const char* _indexedNameTag;
+    static constexpr const char* _jsonParametersKey           = "parameters";
+    static constexpr const char* _cachedMetaDataFilePrefix    = "ParameterFactMetaData";
+    static constexpr const char* _indexedNameTag              = "{n}";
 };

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -19,8 +19,6 @@
 
 QGC_LOGGING_CATEGORY(FTPManagerLog, "FTPManagerLog")
 
-const char* FTPManager::mavlinkFTPScheme = "mftp";
-
 FTPManager::FTPManager(Vehicle* vehicle)
     : QObject   (vehicle)
     , _vehicle  (vehicle)

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -43,7 +43,7 @@ public:
     /// This will emit downloadComplete() when done, and if there's currently a download in progress
     void cancel();
 
-    static const char* mavlinkFTPScheme;
+    static constexpr const char* mavlinkFTPScheme = "mftp";
 
 signals:
     void downloadComplete(const QString& file, const QString& errorMsg);

--- a/src/Vehicle/GPSRTKFactGroup.cc
+++ b/src/Vehicle/GPSRTKFactGroup.cc
@@ -9,16 +9,6 @@
 
 #include "GPSRTKFactGroup.h"
 
-const char* GPSRTKFactGroup::_connectedFactName =                "connected";
-const char* GPSRTKFactGroup::_currentAccuracyFactName =          "currentAccuracy";
-const char* GPSRTKFactGroup::_currentDurationFactName =          "currentDuration";
-const char* GPSRTKFactGroup::_currentLatitudeFactName =          "currentLatitude";
-const char* GPSRTKFactGroup::_currentLongitudeFactName =         "currentLongitude";
-const char* GPSRTKFactGroup::_currentAltitudeFactName =          "currentAltitude";
-const char* GPSRTKFactGroup::_validFactName =                    "valid";
-const char* GPSRTKFactGroup::_activeFactName =                   "active";
-const char* GPSRTKFactGroup::_numSatellitesFactName =            "numSatellites";
-
 GPSRTKFactGroup::GPSRTKFactGroup(QObject* parent)
     : FactGroup             (1000, ":/json/Vehicle/GPSRTKFact.json", parent)
     , _connected            (0, _connectedFactName,         FactMetaData::valueTypeBool)

--- a/src/Vehicle/GPSRTKFactGroup.h
+++ b/src/Vehicle/GPSRTKFactGroup.h
@@ -39,15 +39,15 @@ public:
     Fact* active            (void) { return &_active; }
     Fact* numSatellites     (void) { return &_numSatellites; }
 
-    static const char* _connectedFactName;
-    static const char* _currentDurationFactName;
-    static const char* _currentAccuracyFactName;
-    static const char* _currentLatitudeFactName;
-    static const char* _currentLongitudeFactName;
-    static const char* _currentAltitudeFactName;
-    static const char* _validFactName;
-    static const char* _activeFactName;
-    static const char* _numSatellitesFactName;
+    static constexpr const char* _connectedFactName         = "connected";
+    static constexpr const char* _currentAccuracyFactName   = "currentAccuracy";
+    static constexpr const char* _currentDurationFactName   = "currentDuration";
+    static constexpr const char* _currentLatitudeFactName   = "currentLatitude";
+    static constexpr const char* _currentLongitudeFactName  = "currentLongitude";
+    static constexpr const char* _currentAltitudeFactName   = "currentAltitude";
+    static constexpr const char* _validFactName             = "valid";
+    static constexpr const char* _activeFactName            = "active";
+    static constexpr const char* _numSatellitesFactName     = "numSatellites";
 
 private:
     Fact _connected;        ///< is an RTK gps connected?

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -27,8 +27,6 @@
 
 QGC_LOGGING_CATEGORY(MultiVehicleManagerLog, "MultiVehicleManagerLog")
 
-const char* MultiVehicleManager::_gcsHeartbeatEnabledKey = "gcsHeartbeatEnabled";
-
 MultiVehicleManager::MultiVehicleManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
     , _activeVehicleAvailable(false)

--- a/src/Vehicle/MultiVehicleManager.h
+++ b/src/Vehicle/MultiVehicleManager.h
@@ -118,7 +118,7 @@ private:
     QTimer              _gcsHeartbeatTimer;             ///< Timer to emit heartbeats
     bool                _gcsHeartbeatEnabled;           ///< Enabled/disable heartbeat emission
     static const int    _gcsHeartbeatRateMSecs = 1000;  ///< Heartbeat rate
-    static const char*  _gcsHeartbeatEnabledKey;
+    static constexpr const char* _gcsHeartbeatEnabledKey = "gcsHeartbeatEnabled";
 };
 
 #endif

--- a/src/Vehicle/TerrainFactGroup.cc
+++ b/src/Vehicle/TerrainFactGroup.cc
@@ -9,9 +9,6 @@
 
 #include "TerrainFactGroup.h"
 
-const char* TerrainFactGroup::_blocksPendingFactName =  "blocksPending";
-const char* TerrainFactGroup::_blocksLoadedFactName =   "blocksLoaded";
-
 TerrainFactGroup::TerrainFactGroup(QObject* parent)
     : FactGroup         (1000, ":/json/Vehicle/TerrainFactGroup.json", parent)
     , _blocksPendingFact(0, _blocksPendingFactName, FactMetaData::valueTypeDouble)

--- a/src/Vehicle/TerrainFactGroup.h
+++ b/src/Vehicle/TerrainFactGroup.h
@@ -26,8 +26,8 @@ public:
     Fact* blocksPending () { return &_blocksPendingFact; }
     Fact* blocksLoaded  () { return &_blocksLoadedFact; }
 
-    static const char* _blocksPendingFactName;
-    static const char* _blocksLoadedFactName;
+    static constexpr const char* _blocksPendingFactName = "blocksPending";
+    static constexpr const char* _blocksLoadedFactName  = "blocksLoaded";
 
 private:
     Fact _blocksPendingFact;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2450,6 +2450,11 @@ bool Vehicle::takeoffVehicleSupported() const
     return _firmwarePlugin->isCapable(this, FirmwarePlugin::TakeoffVehicleCapability);
 }
 
+bool Vehicle::changeHeadingSupported() const
+{
+    return _firmwarePlugin->isCapable(this, FirmwarePlugin::ChangeHeadingCapability);
+}
+
 QString Vehicle::gotoFlightMode() const
 {
     return _firmwarePlugin->gotoFlightMode();
@@ -2516,6 +2521,50 @@ void Vehicle::guidedModeChangeAltitude(double altitudeChange, bool pauseVehicle)
         return;
     }
     _firmwarePlugin->guidedModeChangeAltitude(this, altitudeChange, pauseVehicle);
+}
+
+void Vehicle::guidedModeChangeHeading(const QGeoCoordinate& headingCoord)
+{
+    if (!changeHeadingSupported()) {
+        qgcApp()->showAppMessage(QStringLiteral("Changing heading not supported by Vehicle."));
+        return;
+    }
+    if (!guidedModeSupported()) {
+        qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
+        return;
+    }
+    if (!coordinate().isValid()) {
+        return;
+    }
+    if (qIsNaN(heading()->rawValue().toDouble())) {
+        qgcApp()->showAppMessage(QStringLiteral("Unable to yaw to location, vehicle heading not known."));
+        return;
+    }
+
+    bool ok;
+    double delta = (int)(coordinate().azimuthTo(headingCoord) - heading()->rawValue().toDouble(&ok) + 540.0) % 360 - 180.0;
+    if (!ok) {
+        qgcApp()->showAppMessage(QString("Current heading is invalid"));
+        return;
+    }
+    double direction = 1.0f ? delta > 0: -1.0f;
+    
+    double maxYawRate = 0;
+    QString maxYawRateParam(QStringLiteral("ATC_RATE_Y_MAX"));
+    if (parameterManager()->parameterExists(defaultComponentId(), maxYawRateParam)) {
+        maxYawRate = parameterManager()->getParameter(defaultComponentId(), maxYawRateParam)->rawValue().toDouble();
+    }
+    if (maxYawRate == 0) {
+        maxYawRate = 60; // Value meaning "Slow" for APM
+    }
+    
+    sendMavCommand(defaultComponentId(),
+                            MAV_CMD_CONDITION_YAW,
+                            true, // show error
+                            static_cast<float>(coordinate().azimuthTo(headingCoord)),
+                            maxYawRate,
+                            static_cast<float>(direction),
+                            0.0f);
 }
 
 void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, double amslAltitude)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -67,48 +67,6 @@ QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
 
 const QString guided_mode_not_supported_by_vehicle = QObject::tr("Guided mode not supported by Vehicle.");
 
-const char* Vehicle::_settingsGroup =               "Vehicle%1";        // %1 replaced with mavlink system id
-const char* Vehicle::_joystickEnabledSettingsKey =  "JoystickEnabled";
-
-const char* Vehicle::_rollFactName =                "roll";
-const char* Vehicle::_pitchFactName =               "pitch";
-const char* Vehicle::_headingFactName =             "heading";
-const char* Vehicle::_rollRateFactName =             "rollRate";
-const char* Vehicle::_pitchRateFactName =           "pitchRate";
-const char* Vehicle::_yawRateFactName =             "yawRate";
-const char* Vehicle::_airSpeedFactName =            "airSpeed";
-const char* Vehicle::_airSpeedSetpointFactName =    "airSpeedSetpoint";
-const char* Vehicle::_xTrackErrorFactName =         "xTrackError";
-const char* Vehicle::_groundSpeedFactName =         "groundSpeed";
-const char* Vehicle::_climbRateFactName =           "climbRate";
-const char* Vehicle::_altitudeRelativeFactName =    "altitudeRelative";
-const char* Vehicle::_altitudeAMSLFactName =        "altitudeAMSL";
-const char* Vehicle::_altitudeTuningFactName =      "altitudeTuning";
-const char* Vehicle::_altitudeTuningSetpointFactName = "altitudeTuningSetpoint";
-const char* Vehicle::_flightDistanceFactName =      "flightDistance";
-const char* Vehicle::_flightTimeFactName =          "flightTime";
-const char* Vehicle::_distanceToHomeFactName =      "distanceToHome";
-const char* Vehicle::_missionItemIndexFactName =    "missionItemIndex";
-const char* Vehicle::_headingToNextWPFactName =     "headingToNextWP";
-const char* Vehicle::_headingToHomeFactName =       "headingToHome";
-const char* Vehicle::_distanceToGCSFactName =       "distanceToGCS";
-const char* Vehicle::_hobbsFactName =               "hobbs";
-const char* Vehicle::_throttlePctFactName =         "throttlePct";
-
-const char* Vehicle::_gpsFactGroupName =                "gps";
-const char* Vehicle::_gps2FactGroupName =               "gps2";
-const char* Vehicle::_windFactGroupName =               "wind";
-const char* Vehicle::_vibrationFactGroupName =          "vibration";
-const char* Vehicle::_temperatureFactGroupName =        "temperature";
-const char* Vehicle::_clockFactGroupName =              "clock";
-const char* Vehicle::_setpointFactGroupName =           "setpoint";
-const char* Vehicle::_distanceSensorFactGroupName =     "distanceSensor";
-const char* Vehicle::_localPositionFactGroupName =      "localPosition";
-const char* Vehicle::_localPositionSetpointFactGroupName ="localPositionSetpoint";
-const char* Vehicle::_escStatusFactGroupName =          "escStatus";
-const char* Vehicle::_estimatorStatusFactGroupName =    "estimatorStatus";
-const char* Vehicle::_terrainFactGroupName =            "terrain";
-
 // Standard connected vehicle
 Vehicle::Vehicle(LinkInterface*             link,
                  int                        vehicleId,

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1321,50 +1321,50 @@ private:
     ImageProtocolManager*           _imageProtocolManager       = nullptr;
     InitialConnectStateMachine*     _initialConnectStateMachine = nullptr;
 
-    static const char* _rollFactName;
-    static const char* _pitchFactName;
-    static const char* _headingFactName;
-    static const char* _rollRateFactName;
-    static const char* _pitchRateFactName;
-    static const char* _yawRateFactName;
-    static const char* _groundSpeedFactName;
-    static const char* _airSpeedFactName;
-    static const char* _airSpeedSetpointFactName;
-    static const char* _climbRateFactName;
-    static const char* _altitudeRelativeFactName;
-    static const char* _altitudeAMSLFactName;
-    static const char* _altitudeTuningFactName;
-    static const char* _altitudeTuningSetpointFactName;
-    static const char* _xTrackErrorFactName;
-    static const char* _flightDistanceFactName;
-    static const char* _flightTimeFactName;
-    static const char* _distanceToHomeFactName;
-    static const char* _missionItemIndexFactName;
-    static const char* _headingToNextWPFactName;
-    static const char* _headingToHomeFactName;
-    static const char* _distanceToGCSFactName;
-    static const char* _hobbsFactName;
-    static const char* _throttlePctFactName;
+    static constexpr const char* _rollFactName                       = "roll";
+    static constexpr const char* _pitchFactName                      = "pitch";
+    static constexpr const char* _headingFactName                    = "heading";
+    static constexpr const char* _rollRateFactName                   = "rollRate";
+    static constexpr const char* _pitchRateFactName                  = "pitchRate";
+    static constexpr const char* _yawRateFactName                    = "yawRate";
+    static constexpr const char* _airSpeedFactName                   = "airSpeed";
+    static constexpr const char* _airSpeedSetpointFactName           = "airSpeedSetpoint";
+    static constexpr const char* _xTrackErrorFactName                = "xTrackError";
+    static constexpr const char* _groundSpeedFactName                = "groundSpeed";
+    static constexpr const char* _climbRateFactName                  = "climbRate";
+    static constexpr const char* _altitudeRelativeFactName           = "altitudeRelative";
+    static constexpr const char* _altitudeAMSLFactName               = "altitudeAMSL";
+    static constexpr const char* _altitudeTuningFactName             = "altitudeTuning";
+    static constexpr const char* _altitudeTuningSetpointFactName     = "altitudeTuningSetpoint";
+    static constexpr const char* _flightDistanceFactName             = "flightDistance";
+    static constexpr const char* _flightTimeFactName                 = "flightTime";
+    static constexpr const char* _distanceToHomeFactName             = "distanceToHome";
+    static constexpr const char* _missionItemIndexFactName           = "missionItemIndex";
+    static constexpr const char* _headingToNextWPFactName            = "headingToNextWP";
+    static constexpr const char* _headingToHomeFactName              = "headingToHome";
+    static constexpr const char* _distanceToGCSFactName              = "distanceToGCS";
+    static constexpr const char* _hobbsFactName                      = "hobbs";
+    static constexpr const char* _throttlePctFactName                = "throttlePct";
 
-    static const char* _gpsFactGroupName;
-    static const char* _gps2FactGroupName;
-    static const char* _windFactGroupName;
-    static const char* _vibrationFactGroupName;
-    static const char* _temperatureFactGroupName;
-    static const char* _clockFactGroupName;
-    static const char* _setpointFactGroupName;
-    static const char* _distanceSensorFactGroupName;
-    static const char* _localPositionFactGroupName;
-    static const char* _localPositionSetpointFactGroupName;
-    static const char* _escStatusFactGroupName;
-    static const char* _estimatorStatusFactGroupName;
-    static const char* _terrainFactGroupName;
+    static constexpr const char* _gpsFactGroupName                   = "gps";
+    static constexpr const char* _gps2FactGroupName                  = "gps2";
+    static constexpr const char* _windFactGroupName                  = "wind";
+    static constexpr const char* _vibrationFactGroupName             = "vibration";
+    static constexpr const char* _temperatureFactGroupName           = "temperature";
+    static constexpr const char* _clockFactGroupName                 = "clock";
+    static constexpr const char* _setpointFactGroupName              = "setpoint";
+    static constexpr const char* _distanceSensorFactGroupName        = "distanceSensor";
+    static constexpr const char* _localPositionFactGroupName         = "localPosition";
+    static constexpr const char* _localPositionSetpointFactGroupName = "localPositionSetpoint";
+    static constexpr const char* _escStatusFactGroupName             = "escStatus";
+    static constexpr const char* _estimatorStatusFactGroupName       = "estimatorStatus";
+    static constexpr const char* _terrainFactGroupName               = "terrain";
 
     static const int _vehicleUIUpdateRateMSecs      = 100;
 
     // Settings keys
-    static const char* _settingsGroup;
-    static const char* _joystickEnabledSettingsKey;
+    static constexpr const char* _settingsGroup              = "Vehicle%1"; // %1 replaced with mavlink system id
+    static constexpr const char* _joystickEnabledSettingsKey = "JoystickEnabled";
 };
 
 Q_DECLARE_METATYPE(Vehicle::MavCmdResultFailureCode_t)

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -268,6 +268,7 @@ public:
     Q_PROPERTY(bool     orbitModeSupported      READ orbitModeSupported                             CONSTANT)                   ///< Orbit mode is supported by this vehicle
     Q_PROPERTY(bool     roiModeSupported        READ roiModeSupported                               CONSTANT)                   ///< Orbit mode is supported by this vehicle
     Q_PROPERTY(bool     takeoffVehicleSupported READ takeoffVehicleSupported                        CONSTANT)                   ///< Guided takeoff supported
+    Q_PROPERTY(bool     changeHeadingSupported  READ changeHeadingSupported                         CONSTANT)                   ///< Guided change yaw supported
     Q_PROPERTY(QString  gotoFlightMode          READ gotoFlightMode                                 CONSTANT)                   ///< Flight mode vehicle is in while performing goto
 
     Q_PROPERTY(ParameterManager*        parameterManager    READ parameterManager   CONSTANT)
@@ -356,6 +357,9 @@ public:
     ///     @param pauseVehicle true: pause vehicle prior to altitude change
     Q_INVOKABLE void guidedModeChangeAltitude(double altitudeChange, bool pauseVehicle);
 
+    /// Command vehicle to change heading 
+    Q_INVOKABLE void guidedModeChangeHeading(const QGeoCoordinate& headingCoord);
+
     /// Command vehicle to orbit given center point
     ///     @param centerCoord Orit around this point
     ///     @param radius Distance from vehicle to centerCoord
@@ -439,6 +443,7 @@ public:
     bool    orbitModeSupported      () const;
     bool    roiModeSupported        () const;
     bool    takeoffVehicleSupported () const;
+    bool    changeHeadingSupported  () const;
     QString gotoFlightMode          () const;
 
     // Property accessors

--- a/src/Vehicle/VehicleBatteryFactGroup.cc
+++ b/src/Vehicle/VehicleBatteryFactGroup.cc
@@ -11,23 +11,6 @@
 #include "QmlObjectListModel.h"
 #include "Vehicle.h"
 
-const char* VehicleBatteryFactGroup::_batteryFactGroupNamePrefix    = "battery";
-
-const char* VehicleBatteryFactGroup::_batteryIdFactName             = "id";
-const char* VehicleBatteryFactGroup::_batteryFunctionFactName       = "batteryFunction";
-const char* VehicleBatteryFactGroup::_batteryTypeFactName           = "batteryType";
-const char* VehicleBatteryFactGroup::_voltageFactName               = "voltage";
-const char* VehicleBatteryFactGroup::_percentRemainingFactName      = "percentRemaining";
-const char* VehicleBatteryFactGroup::_mahConsumedFactName           = "mahConsumed";
-const char* VehicleBatteryFactGroup::_currentFactName               = "current";
-const char* VehicleBatteryFactGroup::_temperatureFactName           = "temperature";
-const char* VehicleBatteryFactGroup::_instantPowerFactName          = "instantPower";
-const char* VehicleBatteryFactGroup::_timeRemainingFactName         = "timeRemaining";
-const char* VehicleBatteryFactGroup::_timeRemainingStrFactName      = "timeRemainingStr";
-const char* VehicleBatteryFactGroup::_chargeStateFactName           = "chargeState";
-
-const char* VehicleBatteryFactGroup::_settingsGroup =                       "Vehicle.battery";
-
 VehicleBatteryFactGroup::VehicleBatteryFactGroup(uint8_t batteryId, QObject* parent)
     : FactGroup             (1000, ":/json/Vehicle/BatteryFact.json", parent)
     , _batteryIdFact        (0, _batteryIdFactName,                 FactMetaData::valueTypeUint8)

--- a/src/Vehicle/VehicleBatteryFactGroup.h
+++ b/src/Vehicle/VehicleBatteryFactGroup.h
@@ -47,20 +47,20 @@ public:
     Fact* timeRemainingStr          () { return &_timeRemainingStrFact; }
     Fact* chargeState               () { return &_chargeStateFact; }
 
-    static const char* _batteryIdFactName;
-    static const char* _batteryFunctionFactName;
-    static const char* _batteryTypeFactName;
-    static const char* _temperatureFactName;
-    static const char* _voltageFactName;
-    static const char* _currentFactName;
-    static const char* _mahConsumedFactName;
-    static const char* _percentRemainingFactName;
-    static const char* _timeRemainingFactName;
-    static const char* _timeRemainingStrFactName;
-    static const char* _chargeStateFactName;
-    static const char* _instantPowerFactName;
+    static constexpr const char* _batteryIdFactName             = "id";
+    static constexpr const char* _batteryFunctionFactName       = "batteryFunction";
+    static constexpr const char* _batteryTypeFactName           = "batteryType";
+    static constexpr const char* _voltageFactName               = "voltage";
+    static constexpr const char* _percentRemainingFactName      = "percentRemaining";
+    static constexpr const char* _mahConsumedFactName           = "mahConsumed";
+    static constexpr const char* _currentFactName               = "current";
+    static constexpr const char* _temperatureFactName           = "temperature";
+    static constexpr const char* _instantPowerFactName          = "instantPower";
+    static constexpr const char* _timeRemainingFactName         = "timeRemaining";
+    static constexpr const char* _timeRemainingStrFactName      = "timeRemainingStr";
+    static constexpr const char* _chargeStateFactName           = "chargeState";
 
-    static const char* _settingsGroup;
+    static constexpr const char* _settingsGroup                 = "Vehicle.battery";
 
     /// Creates a new fact group for the battery id as needed and updates the Vehicle with it
     static void handleMessageForFactGroupCreation(Vehicle* vehicle, mavlink_message_t& message);
@@ -90,5 +90,5 @@ private:
     Fact            _chargeStateFact;
     Fact            _instantPowerFact;
 
-    static const char* _batteryFactGroupNamePrefix;
+    static constexpr const char* _batteryFactGroupNamePrefix = "battery";
 };

--- a/src/Vehicle/VehicleClockFactGroup.cc
+++ b/src/Vehicle/VehicleClockFactGroup.cc
@@ -10,9 +10,6 @@
 #include "VehicleClockFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleClockFactGroup::_currentTimeFactName = "currentTime";
-const char* VehicleClockFactGroup::_currentDateFactName = "currentDate";
-
 VehicleClockFactGroup::VehicleClockFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/ClockFact.json", parent)
     , _currentTimeFact  (0, _currentTimeFactName,    FactMetaData::valueTypeString)

--- a/src/Vehicle/VehicleClockFactGroup.h
+++ b/src/Vehicle/VehicleClockFactGroup.h
@@ -27,8 +27,8 @@ public:
     Fact* currentTime () { return &_currentTimeFact; }
     Fact* currentDate () { return &_currentDateFact; }
 
-    static const char* _currentTimeFactName;
-    static const char* _currentDateFactName;
+    static constexpr const char* _currentTimeFactName = "currentTime";
+    static constexpr const char* _currentDateFactName = "currentDate";
 
     static const char* _settingsGroup;
 

--- a/src/Vehicle/VehicleDistanceSensorFactGroup.cc
+++ b/src/Vehicle/VehicleDistanceSensorFactGroup.cc
@@ -10,19 +10,6 @@
 #include "VehicleDistanceSensorFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleDistanceSensorFactGroup::_rotationNoneFactName =     "rotationNone";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw45FactName =    "rotationYaw45";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw90FactName =    "rotationYaw90";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw135FactName =   "rotationYaw135";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw180FactName =   "rotationYaw180";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw225FactName =   "rotationYaw225";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw270FactName =   "rotationYaw270";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw315FactName =   "rotationYaw315";
-const char* VehicleDistanceSensorFactGroup::_rotationPitch90FactName =  "rotationPitch90";
-const char* VehicleDistanceSensorFactGroup::_rotationPitch270FactName = "rotationPitch270";
-const char* VehicleDistanceSensorFactGroup::_minDistanceFactName =      "minDistance";
-const char* VehicleDistanceSensorFactGroup::_maxDistanceFactName =      "maxDistance";
-
 VehicleDistanceSensorFactGroup::VehicleDistanceSensorFactGroup(QObject* parent)
     : FactGroup             (1000, ":/json/Vehicle/DistanceSensorFact.json", parent)
     , _rotationNoneFact     (0, _rotationNoneFactName,      FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleDistanceSensorFactGroup.h
+++ b/src/Vehicle/VehicleDistanceSensorFactGroup.h
@@ -50,18 +50,18 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _rotationNoneFactName;
-    static const char* _rotationYaw45FactName;
-    static const char* _rotationYaw90FactName;
-    static const char* _rotationYaw135FactName;
-    static const char* _rotationYaw180FactName;
-    static const char* _rotationYaw225FactName;
-    static const char* _rotationYaw270FactName;
-    static const char* _rotationYaw315FactName;
-    static const char* _rotationPitch90FactName;
-    static const char* _rotationPitch270FactName;
-    static const char* _minDistanceFactName;
-    static const char* _maxDistanceFactName;
+    static constexpr const char* _rotationNoneFactName      = "rotationNone";
+    static constexpr const char* _rotationYaw45FactName     = "rotationYaw45";
+    static constexpr const char* _rotationYaw90FactName     = "rotationYaw90";
+    static constexpr const char* _rotationYaw135FactName    = "rotationYaw135";
+    static constexpr const char* _rotationYaw180FactName    = "rotationYaw180";
+    static constexpr const char* _rotationYaw225FactName    = "rotationYaw225";
+    static constexpr const char* _rotationYaw270FactName    = "rotationYaw270";
+    static constexpr const char* _rotationYaw315FactName    = "rotationYaw315";
+    static constexpr const char* _rotationPitch90FactName   = "rotationPitch90";
+    static constexpr const char* _rotationPitch270FactName  = "rotationPitch270";
+    static constexpr const char* _minDistanceFactName       = "minDistance";
+    static constexpr const char* _maxDistanceFactName       = "maxDistance";
 
 private:
     Fact _rotationNoneFact;

--- a/src/Vehicle/VehicleEscStatusFactGroup.cc
+++ b/src/Vehicle/VehicleEscStatusFactGroup.cc
@@ -10,23 +10,6 @@
 #include "VehicleEscStatusFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleEscStatusFactGroup::_indexFactName =                             "index";
-
-const char* VehicleEscStatusFactGroup::_rpmFirstFactName =                          "rpm1";
-const char* VehicleEscStatusFactGroup::_rpmSecondFactName =                         "rpm2";
-const char* VehicleEscStatusFactGroup::_rpmThirdFactName =                          "rpm3";
-const char* VehicleEscStatusFactGroup::_rpmFourthFactName =                         "rpm4";
-
-const char* VehicleEscStatusFactGroup::_currentFirstFactName =                      "current1";
-const char* VehicleEscStatusFactGroup::_currentSecondFactName =                     "current2";
-const char* VehicleEscStatusFactGroup::_currentThirdFactName =                      "current3";
-const char* VehicleEscStatusFactGroup::_currentFourthFactName =                     "current4";
-
-const char* VehicleEscStatusFactGroup::_voltageFirstFactName =                      "voltage1";
-const char* VehicleEscStatusFactGroup::_voltageSecondFactName =                     "voltage2";
-const char* VehicleEscStatusFactGroup::_voltageThirdFactName =                      "voltage3";
-const char* VehicleEscStatusFactGroup::_voltageFourthFactName =                     "voltage4";
-
 VehicleEscStatusFactGroup::VehicleEscStatusFactGroup(QObject* parent)
     : FactGroup                         (1000, ":/json/Vehicle/EscStatusFactGroup.json", parent)
     , _indexFact                        (0, _indexFactName,                         FactMetaData::valueTypeUint8)

--- a/src/Vehicle/VehicleEscStatusFactGroup.h
+++ b/src/Vehicle/VehicleEscStatusFactGroup.h
@@ -58,22 +58,23 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _indexFactName;
+    static constexpr const char* _indexFactName = "index";
 
-    static const char* _rpmFirstFactName;
-    static const char* _rpmSecondFactName;
-    static const char* _rpmThirdFactName;
-    static const char* _rpmFourthFactName;
+    static constexpr const char* _rpmFirstFactName  = "rpm1";
+    static constexpr const char* _rpmSecondFactName = "rpm2";
+    static constexpr const char* _rpmThirdFactName  = "rpm3";
+    static constexpr const char* _rpmFourthFactName = "rpm4";
 
-    static const char* _currentFirstFactName;
-    static const char* _currentSecondFactName;
-    static const char* _currentThirdFactName;
-    static const char* _currentFourthFactName;
+    static constexpr const char* _currentFirstFactName  = "current1";
+    static constexpr const char* _currentSecondFactName = "current2";
+    static constexpr const char* _currentThirdFactName  = "current3";
+    static constexpr const char* _currentFourthFactName = "current4";
 
-    static const char* _voltageFirstFactName;
-    static const char* _voltageSecondFactName;
-    static const char* _voltageThirdFactName;
-    static const char* _voltageFourthFactName;
+    static constexpr const char* _voltageFirstFactName  = "voltage1";
+    static constexpr const char* _voltageSecondFactName = "voltage2";
+    static constexpr const char* _voltageThirdFactName  = "voltage3";
+    static constexpr const char* _voltageFourthFactName = "voltage4";
+    
 private:
     Fact _indexFact;
 

--- a/src/Vehicle/VehicleEstimatorStatusFactGroup.cc
+++ b/src/Vehicle/VehicleEstimatorStatusFactGroup.cc
@@ -10,27 +10,6 @@
 #include "VehicleEstimatorStatusFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleEstimatorStatusFactGroup::_goodAttitudeEstimateFactName =        "goodAttitudeEsimate";
-const char* VehicleEstimatorStatusFactGroup::_goodHorizVelEstimateFactName =        "goodHorizVelEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodVertVelEstimateFactName =         "goodVertVelEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodHorizPosRelEstimateFactName =     "goodHorizPosRelEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodHorizPosAbsEstimateFactName =     "goodHorizPosAbsEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodVertPosAbsEstimateFactName =      "goodVertPosAbsEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodVertPosAGLEstimateFactName =      "goodVertPosAGLEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodConstPosModeEstimateFactName =    "goodConstPosModeEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodPredHorizPosRelEstimateFactName = "goodPredHorizPosRelEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodPredHorizPosAbsEstimateFactName = "goodPredHorizPosAbsEstimate";
-const char* VehicleEstimatorStatusFactGroup::_gpsGlitchFactName =                   "gpsGlitch";
-const char* VehicleEstimatorStatusFactGroup::_accelErrorFactName =                  "accelError";
-const char* VehicleEstimatorStatusFactGroup::_velRatioFactName =                    "velRatio";
-const char* VehicleEstimatorStatusFactGroup::_horizPosRatioFactName =               "horizPosRatio";
-const char* VehicleEstimatorStatusFactGroup::_vertPosRatioFactName =                "vertPosRatio";
-const char* VehicleEstimatorStatusFactGroup::_magRatioFactName =                    "magRatio";
-const char* VehicleEstimatorStatusFactGroup::_haglRatioFactName =                   "haglRatio";
-const char* VehicleEstimatorStatusFactGroup::_tasRatioFactName =                    "tasRatio";
-const char* VehicleEstimatorStatusFactGroup::_horizPosAccuracyFactName =            "horizPosAccuracy";
-const char* VehicleEstimatorStatusFactGroup::_vertPosAccuracyFactName =             "vertPosAccuracy";
-
 VehicleEstimatorStatusFactGroup::VehicleEstimatorStatusFactGroup(QObject* parent)
     : FactGroup                         (500, ":/json/Vehicle/EstimatorStatusFactGroup.json", parent)
     , _goodAttitudeEstimateFact         (0, _goodAttitudeEstimateFactName,          FactMetaData::valueTypeBool)

--- a/src/Vehicle/VehicleEstimatorStatusFactGroup.h
+++ b/src/Vehicle/VehicleEstimatorStatusFactGroup.h
@@ -66,26 +66,26 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _goodAttitudeEstimateFactName;
-    static const char* _goodHorizVelEstimateFactName;
-    static const char* _goodVertVelEstimateFactName;
-    static const char* _goodHorizPosRelEstimateFactName;
-    static const char* _goodHorizPosAbsEstimateFactName;
-    static const char* _goodVertPosAbsEstimateFactName;
-    static const char* _goodVertPosAGLEstimateFactName;
-    static const char* _goodConstPosModeEstimateFactName;
-    static const char* _goodPredHorizPosRelEstimateFactName;
-    static const char* _goodPredHorizPosAbsEstimateFactName;
-    static const char* _gpsGlitchFactName;
-    static const char* _accelErrorFactName;
-    static const char* _velRatioFactName;
-    static const char* _horizPosRatioFactName;
-    static const char* _vertPosRatioFactName;
-    static const char* _magRatioFactName;
-    static const char* _haglRatioFactName;
-    static const char* _tasRatioFactName;
-    static const char* _horizPosAccuracyFactName;
-    static const char* _vertPosAccuracyFactName;
+    static constexpr const char* _goodAttitudeEstimateFactName          = "goodAttitudeEsimate";
+    static constexpr const char* _goodHorizVelEstimateFactName          = "goodHorizVelEstimate";
+    static constexpr const char* _goodVertVelEstimateFactName           = "goodVertVelEstimate";
+    static constexpr const char* _goodHorizPosRelEstimateFactName       = "goodHorizPosRelEstimate";
+    static constexpr const char* _goodHorizPosAbsEstimateFactName       = "goodHorizPosAbsEstimate";
+    static constexpr const char* _goodVertPosAbsEstimateFactName        = "goodVertPosAbsEstimate";
+    static constexpr const char* _goodVertPosAGLEstimateFactName        = "goodVertPosAGLEstimate";
+    static constexpr const char* _goodConstPosModeEstimateFactName      = "goodConstPosModeEstimate";
+    static constexpr const char* _goodPredHorizPosRelEstimateFactName   = "goodPredHorizPosRelEstimate";
+    static constexpr const char* _goodPredHorizPosAbsEstimateFactName   = "goodPredHorizPosAbsEstimate";
+    static constexpr const char* _gpsGlitchFactName                     = "gpsGlitch";
+    static constexpr const char* _accelErrorFactName                    = "accelError";
+    static constexpr const char* _velRatioFactName                      = "velRatio";
+    static constexpr const char* _horizPosRatioFactName                 = "horizPosRatio";
+    static constexpr const char* _vertPosRatioFactName                  = "vertPosRatio";
+    static constexpr const char* _magRatioFactName                      = "magRatio";
+    static constexpr const char* _haglRatioFactName                     = "haglRatio";
+    static constexpr const char* _tasRatioFactName                      = "tasRatio";
+    static constexpr const char* _horizPosAccuracyFactName              = "horizPosAccuracy";
+    static constexpr const char* _vertPosAccuracyFactName               = "vertPosAccuracy";
 
 private:
     Fact _goodAttitudeEstimateFact;

--- a/src/Vehicle/VehicleGPSFactGroup.cc
+++ b/src/Vehicle/VehicleGPSFactGroup.cc
@@ -11,15 +11,6 @@
 #include "Vehicle.h"
 #include "QGCGeo.h"
 
-const char* VehicleGPSFactGroup::_latFactName =                 "lat";
-const char* VehicleGPSFactGroup::_lonFactName =                 "lon";
-const char* VehicleGPSFactGroup::_mgrsFactName =                "mgrs";
-const char* VehicleGPSFactGroup::_hdopFactName =                "hdop";
-const char* VehicleGPSFactGroup::_vdopFactName =                "vdop";
-const char* VehicleGPSFactGroup::_courseOverGroundFactName =    "courseOverGround";
-const char* VehicleGPSFactGroup::_countFactName =               "count";
-const char* VehicleGPSFactGroup::_lockFactName =                "lock";
-
 VehicleGPSFactGroup::VehicleGPSFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/GPSFact.json", parent)
     , _latFact              (0, _latFactName,               FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleGPSFactGroup.h
+++ b/src/Vehicle/VehicleGPSFactGroup.h
@@ -40,14 +40,14 @@ public:
     // Overrides from FactGroup
     virtual void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _latFactName;
-    static const char* _lonFactName;
-    static const char* _mgrsFactName;
-    static const char* _hdopFactName;
-    static const char* _vdopFactName;
-    static const char* _courseOverGroundFactName;
-    static const char* _countFactName;
-    static const char* _lockFactName;
+    static constexpr const char* _latFactName                 = "lat";
+    static constexpr const char* _lonFactName                 = "lon";
+    static constexpr const char* _mgrsFactName                = "mgrs";
+    static constexpr const char* _hdopFactName                = "hdop";
+    static constexpr const char* _vdopFactName                = "vdop";
+    static constexpr const char* _courseOverGroundFactName    = "courseOverGround";
+    static constexpr const char* _countFactName               = "count";
+    static constexpr const char* _lockFactName                = "lock";
 
 protected:
     void _handleGpsRawInt   (mavlink_message_t& message);

--- a/src/Vehicle/VehicleLinkManagerTest.cc
+++ b/src/Vehicle/VehicleLinkManagerTest.cc
@@ -14,13 +14,6 @@
 #include "QGCApplication.h"
 #include "MultiSignalSpyV2.h"
 
-const char* VehicleLinkManagerTest::_primaryLinkChangedSignalName               = "primaryLinkChanged";
-const char* VehicleLinkManagerTest::_allLinksRemovedSignalName                  = "allLinksRemoved";
-const char* VehicleLinkManagerTest::_communicationLostChangedSignalName         = "communicationLostChanged";
-const char* VehicleLinkManagerTest::_communicationLostEnabledChangedSignalName  = "communicationLostEnabledChanged";
-const char* VehicleLinkManagerTest::_linkNamesChangedSignalName                 = "linkNamesChanged";
-const char* VehicleLinkManagerTest::_linkStatusesChangedSignalName              = "linkStatusesChanged";
-
 VehicleLinkManagerTest::VehicleLinkManagerTest(void)
 {
 

--- a/src/Vehicle/VehicleLinkManagerTest.h
+++ b/src/Vehicle/VehicleLinkManagerTest.h
@@ -45,10 +45,10 @@ private:
     //void _highLatencyLinkTest       (void);
     MultiVehicleManager*    _multiVehicleMgr = nullptr;
 
-    static const char* _primaryLinkChangedSignalName;
-    static const char* _allLinksRemovedSignalName;
-    static const char* _communicationLostChangedSignalName;
-    static const char* _communicationLostEnabledChangedSignalName;
-    static const char* _linkNamesChangedSignalName;
-    static const char* _linkStatusesChangedSignalName;
+    static constexpr const char* _primaryLinkChangedSignalName               = "primaryLinkChanged";
+    static constexpr const char* _allLinksRemovedSignalName                  = "allLinksRemoved";
+    static constexpr const char* _communicationLostChangedSignalName         = "communicationLostChanged";
+    static constexpr const char* _communicationLostEnabledChangedSignalName  = "communicationLostEnabledChanged";
+    static constexpr const char* _linkNamesChangedSignalName                 = "linkNamesChanged";
+    static constexpr const char* _linkStatusesChangedSignalName              = "linkStatusesChanged";
 };

--- a/src/Vehicle/VehicleLocalPositionFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionFactGroup.cc
@@ -12,13 +12,6 @@
 
 #include <QtMath>
 
-const char* VehicleLocalPositionFactGroup::_xFactName =     "x";
-const char* VehicleLocalPositionFactGroup::_yFactName =     "y";
-const char* VehicleLocalPositionFactGroup::_zFactName =     "z";
-const char* VehicleLocalPositionFactGroup::_vxFactName =    "vx";
-const char* VehicleLocalPositionFactGroup::_vyFactName =    "vy";
-const char* VehicleLocalPositionFactGroup::_vzFactName =    "vz";
-
 VehicleLocalPositionFactGroup::VehicleLocalPositionFactGroup(QObject* parent)
     : FactGroup     (1000, ":/json/Vehicle/LocalPositionFact.json", parent)
     , _xFact    (0, _xFactName,     FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleLocalPositionFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionFactGroup.h
@@ -36,12 +36,12 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _xFactName;
-    static const char* _yFactName;
-    static const char* _zFactName;
-    static const char* _vxFactName;
-    static const char* _vyFactName;
-    static const char* _vzFactName;
+    static constexpr const char* _xFactName     = "x";
+    static constexpr const char* _yFactName     = "y";
+    static constexpr const char* _zFactName     = "z";
+    static constexpr const char* _vxFactName    = "vx";
+    static constexpr const char* _vyFactName    = "vy";
+    static constexpr const char* _vzFactName    = "vz";
 
 private:
     Fact _xFact;

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
@@ -12,13 +12,6 @@
 
 #include <QtMath>
 
-const char* VehicleLocalPositionSetpointFactGroup::_xFactName =     "x";
-const char* VehicleLocalPositionSetpointFactGroup::_yFactName =     "y";
-const char* VehicleLocalPositionSetpointFactGroup::_zFactName =     "z";
-const char* VehicleLocalPositionSetpointFactGroup::_vxFactName =    "vx";
-const char* VehicleLocalPositionSetpointFactGroup::_vyFactName =    "vy";
-const char* VehicleLocalPositionSetpointFactGroup::_vzFactName =    "vz";
-
 VehicleLocalPositionSetpointFactGroup::VehicleLocalPositionSetpointFactGroup(QObject* parent)
     : FactGroup     (1000, ":/json/Vehicle/LocalPositionSetpointFact.json", parent)
     , _xFact    (0, _xFactName,     FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
@@ -36,12 +36,12 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _xFactName;
-    static const char* _yFactName;
-    static const char* _zFactName;
-    static const char* _vxFactName;
-    static const char* _vyFactName;
-    static const char* _vzFactName;
+    static constexpr const char* _xFactName     = "x";
+    static constexpr const char* _yFactName     = "y";
+    static constexpr const char* _zFactName     = "z";
+    static constexpr const char* _vxFactName    = "vx";
+    static constexpr const char* _vyFactName    = "vy";
+    static constexpr const char* _vzFactName    = "vz";
 
 private:
     Fact _xFact;

--- a/src/Vehicle/VehicleSetpointFactGroup.cc
+++ b/src/Vehicle/VehicleSetpointFactGroup.cc
@@ -12,13 +12,6 @@
 
 #include <QtMath>
 
-const char* VehicleSetpointFactGroup::_rollFactName =       "roll";
-const char* VehicleSetpointFactGroup::_pitchFactName =      "pitch";
-const char* VehicleSetpointFactGroup::_yawFactName =        "yaw";
-const char* VehicleSetpointFactGroup::_rollRateFactName =   "rollRate";
-const char* VehicleSetpointFactGroup::_pitchRateFactName =  "pitchRate";
-const char* VehicleSetpointFactGroup::_yawRateFactName =    "yawRate";
-
 VehicleSetpointFactGroup::VehicleSetpointFactGroup(QObject* parent)
     : FactGroup     (1000, ":/json/Vehicle/SetpointFact.json", parent)
     , _rollFact     (0, _rollFactName,      FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleSetpointFactGroup.h
+++ b/src/Vehicle/VehicleSetpointFactGroup.h
@@ -36,12 +36,12 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _rollFactName;
-    static const char* _pitchFactName;
-    static const char* _yawFactName;
-    static const char* _rollRateFactName;
-    static const char* _pitchRateFactName;
-    static const char* _yawRateFactName;
+    static constexpr const char* _rollFactName        = "roll";
+    static constexpr const char* _pitchFactName       = "pitch";
+    static constexpr const char* _yawFactName         = "yaw";
+    static constexpr const char* _rollRateFactName    = "rollRate";
+    static constexpr const char* _pitchRateFactName   = "pitchRate";
+    static constexpr const char* _yawRateFactName     = "yawRate";
 
 private:
     Fact _rollFact;

--- a/src/Vehicle/VehicleTemperatureFactGroup.cc
+++ b/src/Vehicle/VehicleTemperatureFactGroup.cc
@@ -10,10 +10,6 @@
 #include "VehicleSetpointFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleTemperatureFactGroup::_temperature1FactName =      "temperature1";
-const char* VehicleTemperatureFactGroup::_temperature2FactName =      "temperature2";
-const char* VehicleTemperatureFactGroup::_temperature3FactName =      "temperature3";
-
 VehicleTemperatureFactGroup::VehicleTemperatureFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/TemperatureFact.json", parent)
     , _temperature1Fact    (0, _temperature1FactName,     FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleTemperatureFactGroup.h
+++ b/src/Vehicle/VehicleTemperatureFactGroup.h
@@ -30,9 +30,9 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _temperature1FactName;
-    static const char* _temperature2FactName;
-    static const char* _temperature3FactName;
+    static constexpr const char* _temperature1FactName    = "temperature1";
+    static constexpr const char* _temperature2FactName    = "temperature2";
+    static constexpr const char* _temperature3FactName    = "temperature3";
 
     static const char* _settingsGroup;
 

--- a/src/Vehicle/VehicleVibrationFactGroup.cc
+++ b/src/Vehicle/VehicleVibrationFactGroup.cc
@@ -10,13 +10,6 @@
 #include "VehicleVibrationFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleVibrationFactGroup::_xAxisFactName =      "xAxis";
-const char* VehicleVibrationFactGroup::_yAxisFactName =      "yAxis";
-const char* VehicleVibrationFactGroup::_zAxisFactName =      "zAxis";
-const char* VehicleVibrationFactGroup::_clipCount1FactName = "clipCount1";
-const char* VehicleVibrationFactGroup::_clipCount2FactName = "clipCount2";
-const char* VehicleVibrationFactGroup::_clipCount3FactName = "clipCount3";
-
 VehicleVibrationFactGroup::VehicleVibrationFactGroup(QObject* parent)
     : FactGroup         (1000, ":/json/Vehicle/VibrationFact.json", parent)
     , _xAxisFact        (0, _xAxisFactName,         FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleVibrationFactGroup.h
+++ b/src/Vehicle/VehicleVibrationFactGroup.h
@@ -36,12 +36,12 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _xAxisFactName;
-    static const char* _yAxisFactName;
-    static const char* _zAxisFactName;
-    static const char* _clipCount1FactName;
-    static const char* _clipCount2FactName;
-    static const char* _clipCount3FactName;
+    static constexpr const char* _xAxisFactName      = "xAxis";
+    static constexpr const char* _yAxisFactName      = "yAxis";
+    static constexpr const char* _zAxisFactName      = "zAxis";
+    static constexpr const char* _clipCount1FactName = "clipCount1";
+    static constexpr const char* _clipCount2FactName = "clipCount2";
+    static constexpr const char* _clipCount3FactName = "clipCount3";
 
 private:
     Fact        _xAxisFact;

--- a/src/Vehicle/VehicleWindFactGroup.cc
+++ b/src/Vehicle/VehicleWindFactGroup.cc
@@ -12,10 +12,6 @@
 
 #include <QtMath>
 
-const char* VehicleWindFactGroup::_directionFactName =      "direction";
-const char* VehicleWindFactGroup::_speedFactName =          "speed";
-const char* VehicleWindFactGroup::_verticalSpeedFactName =  "verticalSpeed";
-
 VehicleWindFactGroup::VehicleWindFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/WindFact.json", parent)
     , _directionFact    (0, _directionFactName,     FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleWindFactGroup.h
+++ b/src/Vehicle/VehicleWindFactGroup.h
@@ -30,9 +30,9 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _directionFactName;
-    static const char* _speedFactName;
-    static const char* _verticalSpeedFactName;
+    static constexpr const char* _directionFactName     = "direction";
+    static constexpr const char* _speedFactName         = "speed";
+    static constexpr const char* _verticalSpeedFactName = "verticalSpeed";
 
 private:
     void _handleHighLatency (mavlink_message_t& message);


### PR DESCRIPTION
Use constexpr to reduce redundant code in the vehicle folder by defining and declaring char arrays in the header file