### PR TITLE
APM: APMPowerComponent: Fix Blue Robotics power module name

### DIFF
--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -341,7 +341,7 @@ SetupPage {
                 }
 
                 ListElement {
-                    text:       qsTr("Blue Robotics Power Sense Module R2")
+                    text:       qsTr("Blue Robotics Power Sense Module")
                     voltPin:    2
                     currPin:    3
                     voltMult:   11.000


### PR DESCRIPTION
Revision is not necessary, it does not change the parameters

- Fix https://github.com/mavlink/qgroundcontrol/issues/10027

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


