### PR TITLE
Joystick: fix visualization

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -676,6 +676,8 @@ void Joystick::_handleAxis()
                     buttonPressedBits |= buttonBit;
                 }
             }
+            emit axisValues(roll, pitch, yaw, throttle);
+
             uint16_t shortButtons = static_cast<uint16_t>(buttonPressedBits & 0xFFFF);
             _activeVehicle->sendJoystickDataThreadSafe(roll, pitch, yaw, throttle, shortButtons);
         }


### PR DESCRIPTION
It turns out this signal was not called anywhere.

Fixes #10043.
