### PR TITLE
fix MavlinkConsoleController: avoid buffer out-of-bound access

### DIFF
--- a/src/AnalyzeView/MavlinkConsoleController.cc
+++ b/src/AnalyzeView/MavlinkConsoleController.cc
@@ -143,6 +143,8 @@ MavlinkConsoleController::_sendSerialData(QByteArray data, bool close)
     // Send maximum sized chunks until the complete buffer is transmitted
     while(data.size()) {
         QByteArray chunk{data.left(MAVLINK_MSG_SERIAL_CONTROL_FIELD_DATA_LEN)};
+        // Ensure the buffer is large enough, as the MAVLink parser expects MAVLINK_MSG_SERIAL_CONTROL_FIELD_DATA_LEN bytes
+        chunk.append(MAVLINK_MSG_SERIAL_CONTROL_FIELD_DATA_LEN - chunk.size(), '\0');
         uint8_t flags = SERIAL_CONTROL_FLAG_EXCLUSIVE |  SERIAL_CONTROL_FLAG_RESPOND | SERIAL_CONTROL_FLAG_MULTI;
         if (close) flags = 0;
         auto protocol = qgcApp()->toolbox()->mavlinkProtocol();


### PR DESCRIPTION
mavlink_msg_serial_control_pack_chan expects MAVLINK_MSG_SERIAL_CONTROL_FIELD_DATA_LEN bytes for 'data', but 'chuck' might be smaller than that.

Fixes https://github.com/mavlink/qgroundcontrol/issues/10059

