### PR TITLE
ArduCopter: Hack to set vehicle type when FRAME_CLASS is not set.

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
@@ -72,7 +72,7 @@ SetupPage {
                                          qsTr("Currently set to frame class '%1'").arg(_frameClass.enumStringValue) +
                                          (_frameTypeAvailable ?  qsTr(" and frame type '%2'").arg(_frameType.enumStringValue) : "") +
                                          qsTr(".", "period for end of sentence")) +
-                                    qsTr(" To change this configuration, select the desired frame class below.")
+                                    qsTr(" To change this configuration, select the desired frame class below and then reboot the vehicle.")
                 font.family:        ScreenTools.demiboldFontFamily
                 wrapMode:           Text.WordWrap
             }

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -91,6 +91,15 @@ void MultiVehicleManager::_vehicleHeartbeatInfo(LinkInterface* link, int vehicle
         }
     }
 
+#if !defined(NO_ARDUPILOT_DIALECT)
+    // When you flash a new ArduCopter it does not set a FRAME_CLASS for some reason. This is the only ArduPilot variant which
+    // works this way. Because of this the vehicle type is not known at first connection. In order to make QGC work reasonably
+    // we assume ArduCopter for this case.
+    if (vehicleType == 0 && vehicleFirmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+        vehicleType = MAV_TYPE_QUADROTOR;
+    }
+#endif
+
     if (_vehicles.count() > 0 && !qgcApp()->toolbox()->corePlugin()->options()->multiVehicleEnabled()) {
         return;
     }


### PR DESCRIPTION
If you flash an ArduCopter firmware over a non-previously setup ArduCopter board FRAME_CLASS will be initialized to 0 which in turn causes HEARTBEAT.type=0 which means that QGC does not know this is a copter class vehicle. This is a hack to work around that. Without it QGC doesn't show vehicle ui in this case which leads to a somewhat useless user experience.

Fix for : https://github.com/ArduPilot/ardupilot/issues/19446