### PR TITLE
ArduPilot: fix Tuning page

### DIFF
--- a/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
@@ -17,6 +17,7 @@ import QGroundControl.FactControls  1.0
 import QGroundControl.Palette       1.0
 import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
 
 SetupPage {
     id:             tuningPage
@@ -27,6 +28,7 @@ SetupPage {
 
         Column {
             width: availableWidth
+            height: availableHeight
 
             FactPanelController { id: controller; }
 
@@ -459,19 +461,128 @@ SetupPage {
                 PIDTuning {
                     anchors.left:   parent.left
                     anchors.right:  parent.right
-                    tuneList:            [ qsTr("Roll"), qsTr("Pitch"), qsTr("Yaw") ]
-                    params:              [
-                        [ controller.getParameterFact(-1, "ATC_ANG_RLL_P"),
-                         controller.getParameterFact(-1, "ATC_RAT_RLL_P"),
-                         controller.getParameterFact(-1, "ATC_RAT_RLL_I"),
-                         controller.getParameterFact(-1, "ATC_RAT_RLL_D") ],
-                        [ controller.getParameterFact(-1, "ATC_ANG_PIT_P"),
-                         controller.getParameterFact(-1, "ATC_RAT_PIT_P"),
-                         controller.getParameterFact(-1, "ATC_RAT_PIT_I"),
-                         controller.getParameterFact(-1, "ATC_RAT_PIT_D") ],
-                        [ controller.getParameterFact(-1, "ATC_ANG_YAW_P"),
-                         controller.getParameterFact(-1, "ATC_RAT_YAW_P"),
-                         controller.getParameterFact(-1, "ATC_RAT_YAW_I") ] ]
+                    height: availableHeight
+
+                    property var roll: QtObject {
+                        property string name: qsTr("Roll")
+                        property var plot: [
+                            { name: "Response", value: globals.activeVehicle.rollRate.value },
+                            { name: "Setpoint", value: globals.activeVehicle.setpoint.rollRate.value }
+                        ]
+                        property var params: ListModel {
+                            ListElement {
+                                title:          qsTr("Roll axis angle controller P gain")
+                                param:          "ATC_ANG_RLL_P"
+                                description:    ""
+                                min:            3
+                                max:            12
+                                step:           1
+                            }
+                            ListElement {
+                                title:          qsTr("Roll axis rate controller P gain")
+                                param:          "ATC_RAT_RLL_P"
+                                description:    ""
+                                min:            0.001
+                                max:            0.5
+                                step:           0.025
+                            }
+                            ListElement {
+                                title:          qsTr("Roll axis rate controller I gain")
+                                param:          "ATC_RAT_RLL_I"
+                                description:    ""
+                                min:            0.01
+                                max:            2
+                                step:           0.05
+                            }
+                            ListElement {
+                                title:          qsTr("Roll axis rate controller D gain")
+                                param:          "ATC_RAT_RLL_D"
+                                description:    ""
+                                min:            0.0
+                                max:            0.05
+                                step:           0.001
+                            }
+                        }
+                    }
+                    property var pitch: QtObject {
+                        property string name: qsTr("Pitch")
+                        property var plot: [
+                            { name: "Response", value: globals.activeVehicle.pitchRate.value },
+                            { name: "Setpoint", value: globals.activeVehicle.setpoint.pitchRate.value }
+                        ]
+                        property var params: ListModel {
+                            ListElement {
+                                title:          qsTr("Pitch axis angle controller P gain")
+                                param:          "ATC_ANG_PIT_P"
+                                description:    ""
+                                min:            3
+                                max:            12
+                                step:           1
+                            }
+                            ListElement {
+                                title:          qsTr("Pitch axis rate controller P gain")
+                                param:          "ATC_RAT_PIT_P"
+                                description:    ""
+                                min:            0.001
+                                max:            0.5
+                                step:           0.025
+                            }
+                            ListElement {
+                                title:          qsTr("Pitch axis rate controller I gain")
+                                param:          "ATC_RAT_PIT_I"
+                                description:    ""
+                                min:            0.01
+                                max:            2
+                                step:           0.05
+                            }
+                            ListElement {
+                                title:          qsTr("Pitch axis rate controller D gain")
+                                param:          "ATC_RAT_PIT_D"
+                                description:    ""
+                                min:            0.0
+                                max:            0.05
+                                step:           0.001
+                            }
+                        }
+                    }
+                    property var yaw: QtObject {
+                        property string name: qsTr("Yaw")
+                        property var plot: [
+                            { name: "Response", value: globals.activeVehicle.yawRate.value },
+                            { name: "Setpoint", value: globals.activeVehicle.setpoint.yawRate.value }
+                        ]
+                        property var params: ListModel {
+                            ListElement {
+                                title:          qsTr("Yaw axis angle controller P gain")
+                                param:          "ATC_ANG_YAW_P"
+                                description:    ""
+                                min:            3
+                                max:            12
+                                step:           1
+                            }
+                            ListElement {
+                                title:          qsTr("Yaw axis rate controller P gain")
+                                param:          "ATC_RAT_YAW_P"
+                                description:    ""
+                                min:            0.1
+                                max:            2.5
+                                step:           0.05
+                            }
+                            ListElement {
+                                title:          qsTr("Yaw axis rate controller I gain")
+                                param:          "ATC_RAT_YAW_I"
+                                description:    ""
+                                min:            0.01
+                                max:            1
+                                step:           0.05
+                            }
+                        }
+                    }
+                    title: "Rate"
+                    tuningMode: Vehicle.ModeDisabled
+                    unit: "deg/s"
+                    axis: [ roll, pitch, yaw ]
+                    chartDisplaySec: 3
                 }
             } // Component - Advanced Page
         } // Column

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
@@ -17,7 +17,8 @@ import QGroundControl.FactSystem    1.0
 import QGroundControl.ScreenTools   1.0
 
 Item {
-    width: availableWidth
+    width:                            availableWidth
+    property bool _autotuningEnabled: true // used to restore setting when switching between tabs
 
     FactPanelController {
         id:         controller
@@ -39,6 +40,11 @@ Item {
         QGCTabButton {
             text:       qsTr("Position Controller")
         }
+        onCurrentIndexChanged: {
+            if (typeof loader.item.autotuningEnabled !== "undefined") {
+                _autotuningEnabled = loader.item.autotuningEnabled;
+            }
+        }
     }
 
     property var pages:  [
@@ -49,10 +55,16 @@ Item {
     ]
 
     Loader {
+        id:                loader
         source:            pages[bar.currentIndex]
         width:             parent.width
         anchors.top:       bar.bottom
         anchors.topMargin: ScreenTools.defaultFontPixelWidth
         anchors.bottom:    parent.bottom
+        onLoaded: {
+            if (typeof loader.item.autotuningEnabled !== "undefined") {
+                loader.item.autotuningEnabled = _autotuningEnabled;
+            }
+        }
     }
 }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
@@ -21,9 +21,11 @@ import QGroundControl.Vehicle       1.0
 ColumnLayout {
     width: availableWidth
     anchors.fill: parent
+    property alias autotuningEnabled: pidTuning.autotuningEnabled
 
     PIDTuning {
         width: availableWidth
+        id:    pidTuning
 
         property var roll: QtObject {
             property string name: qsTr("Roll")
@@ -81,6 +83,7 @@ ColumnLayout {
         unit: "deg"
         axis: [ roll, pitch, yaw ]
         showAutoModeChange: true
+        showAutoTuning:     true
     }
 }
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
@@ -23,6 +23,7 @@ ColumnLayout {
     anchors.fill: parent
     property Fact _airmode:           controller.getParameterFact(-1, "MC_AIRMODE", false)
     property Fact _thrustModelFactor: controller.getParameterFact(-1, "THR_MDL_FAC", false)
+    property alias autotuningEnabled: pidTuning.autotuningEnabled
 
     GridLayout {
         columns: 2
@@ -52,6 +53,7 @@ ColumnLayout {
     }
     PIDTuning {
         width: availableWidth
+        id:    pidTuning
 
         property var roll: QtObject {
             property string name: qsTr("Roll")
@@ -150,6 +152,7 @@ ColumnLayout {
         axis: [ roll, pitch, yaw ]
         chartDisplaySec: 3
         showAutoModeChange: true
+        showAutoTuning:     true
     }
 }
 

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -28,6 +28,8 @@ RowLayout {
     property var    tuningMode
     property double chartDisplaySec:     8 // number of seconds to display
     property bool   showAutoModeChange:  false
+    property bool   showAutoTuning:      false
+    property alias  autotuningEnabled:   autotuningEnabled.checked
 
     property real   _margins:           ScreenTools.defaultFontPixelHeight / 2
     property int    _currentAxis:       0
@@ -188,7 +190,7 @@ RowLayout {
             Row {
                 id:        _autotuneSelectRow
                 spacing:   _margins
-                visible:   tuningMode === Vehicle.ModeRateAndAttitude
+                visible:   showAutoTuning
 
                 Switch {
                     id:        autotuningEnabled


### PR DESCRIPTION

Tested against APM SITL:
![image](https://user-images.githubusercontent.com/281593/145860516-f16508e4-0269-4771-af21-006280467b54.png)


Fixes https://github.com/mavlink/qgroundcontrol/issues/10069

And for PX4: save & restore autotuning checkbox when switching between tabs