### PR TITLE
QGCCameraControl: allow to read camera information xml via ftp

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -2052,6 +2052,7 @@ void QGCCameraControl::_ftpDownloadComplete(const QString& fileName, const QStri
         return;
     }
 
+    _cached = true;
     QByteArray bytes = xmlFile.readAll();
     emit dataReady(bytes);
 }

--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -2038,7 +2038,7 @@ QGCCameraControl::_downloadFinished()
 
 void QGCCameraControl::_ftpDownloadComplete(const QString& fileName, const QString& errorMsg)
 {
-    qCDebug(CameraControlLog) << "QGCCameraControl::_ftpDownloadComplete fileName:errorMsg" << fileName << errorMsg;
+    qCDebug(CameraControlLog) << "FTP Download completed: " << fileName << ", " << errorMsg;
 
     disconnect(_vehicle->ftpManager(), &FTPManager::downloadComplete, this, &QGCCameraControl::_ftpDownloadComplete);
     QFile xmlFile(fileName);

--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -372,6 +372,7 @@ private:
     void    _updateRanges                   (Fact* pFact);
     void    _httpRequest                    (const QString& url);
     void    _handleDefinitionFile           (const QString& url);
+    void    _ftpDownloadComplete            (const QString& fileName, const QString& errorMsg);
 
     QStringList     _loadExclusions         (QDomNode option);
     QStringList     _loadUpdates            (QDomNode option);

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -112,7 +112,6 @@ QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
     //-- First time hearing from this one?
-    qCDebug(CameraManagerLog) << "Another Hearbeat from " << message.compid;
     QString sCompID = QString::number(message.compid);
     if(!_cameraInfoRequest.contains(sCompID)) {
         qCDebug(CameraManagerLog) << "Hearbeat from " << message.compid;

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -112,6 +112,7 @@ QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
     mavlink_heartbeat_t heartbeat;
     mavlink_msg_heartbeat_decode(&message, &heartbeat);
     //-- First time hearing from this one?
+    qCDebug(CameraManagerLog) << "Another Hearbeat from " << message.compid;
     QString sCompID = QString::number(message.compid);
     if(!_cameraInfoRequest.contains(sCompID)) {
         qCDebug(CameraManagerLog) << "Hearbeat from " << message.compid;

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -72,7 +72,7 @@ bool FTPManager::download(const QString& fromURI, const QString& toDir, const QS
     }
     lastDirSlashIndex++; // move past slash
 
-    if (fileName.size() == 0) {
+    if (fileName.isEmpty()) {
         _downloadState.fileName = _downloadState.fullPathOnVehicle.right(_downloadState.fullPathOnVehicle.size() - lastDirSlashIndex);
     } else {
         _downloadState.fileName = fileName;
@@ -645,9 +645,9 @@ bool FTPManager::_parseURI(const QString& uri, QString& parsedURI, uint8_t& comp
         if (!ok) {
             qCWarning(FTPManagerLog) << "Incorrect format for component id" << uri;
             return false;
-        } else {
-            qCDebug(FTPManagerLog) << "Found compId:" << (int)compId;
         }
+
+        qCDebug(FTPManagerLog) << "Found compId in MAVLink FTP URI: " << compId;
         parsedURI.replace(QRegularExpression("\\[\\;comp\\=\\d+\\]"), "");
     }
 

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -34,7 +34,7 @@ FTPManager::FTPManager(Vehicle* vehicle)
     Q_ASSERT(sizeof(MavlinkFTP::RequestHeader) == 12);
 }
 
-bool FTPManager::download(const QString& fromURI, const QString& toDir)
+bool FTPManager::download(const QString& fromURI, const QString& toDir, const QString& fileName)
 {
     qCDebug(FTPManagerLog) << "download fromURI:" << fromURI << "to:" << toDir;
 
@@ -72,7 +72,11 @@ bool FTPManager::download(const QString& fromURI, const QString& toDir)
     }
     lastDirSlashIndex++; // move past slash
 
-    _downloadState.fileName = _downloadState.fullPathOnVehicle.right(_downloadState.fullPathOnVehicle.size() - lastDirSlashIndex);
+    if (fileName.size() == 0) {
+        _downloadState.fileName = _downloadState.fullPathOnVehicle.right(_downloadState.fullPathOnVehicle.size() - lastDirSlashIndex);
+    } else {
+        _downloadState.fileName = fileName;
+    }
 
     qCDebug(FTPManagerLog) << "_downloadState.fullPathOnVehicle:_downloadState.fileName" << _downloadState.fullPathOnVehicle << _downloadState.fileName;
 
@@ -641,6 +645,8 @@ bool FTPManager::_parseURI(const QString& uri, QString& parsedURI, uint8_t& comp
         if (!ok) {
             qCWarning(FTPManagerLog) << "Incorrect format for component id" << uri;
             return false;
+        } else {
+            qCDebug(FTPManagerLog) << "Found compId:" << (int)compId;
         }
         parsedURI.replace(QRegularExpression("\\[\\;comp\\=\\d+\\]"), "");
     }

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -37,7 +37,7 @@ public:
     ///     @param toDir    Local directory to download file to
     /// @return true: download has started, false: error, no download
     /// Signals downloadComplete, commandError, commandProgress
-    bool download(const QString& fromURI, const QString& toDir);
+    bool download(const QString& fromURI, const QString& toDir, const QString& fileName="");
 
     /// Cancel the current operation
     /// This will emit downloadComplete() when done, and if there's currently a download in progress


### PR DESCRIPTION
This PR heavily reuses the MAVLink FTP capabilities already present in QGroundControl and allows to specify camera definition URLs in `CAMERA_INFORMATION` with the mftp prefix, like `mftp://[;comp=100]infos/camera_info.xml`.

Tested it against the MAVSDK camera manager example PR: https://github.com/mavlink/MAVSDK/pull/1655

TODO:

- re-use component ID from CAMERA_INFORMATION as default for the ftp communication, as this would allow URLs like `mftp://infos/camera_info.xml`
- test / handle communication aborts properly