### PR TITLE
cmake: fix missing define APP_VERSION_STR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_definitions(
 	)
 
 include(Git)
-message(STATUS "QGroundControl version: ${GIT_VERSION}")
+message(STATUS "QGroundControl version: ${APP_VERSION_STR}")
 
 #=============================================================================
 # ccache

--- a/VideoReceiverApp/CMakeLists.txt
+++ b/VideoReceiverApp/CMakeLists.txt
@@ -39,7 +39,7 @@ set(COPYRIGHT "Copyright (c) 2020 VideoReceiverApp. All rights reserved.")
 set(IDENTIFIER "labs.auterion.VideoReceiverApp")
 
 include(Git)
-message(STATUS "VideoReceiverApp version: ${GIT_VERSION}")
+message(STATUS "VideoReceiverApp version: ${APP_VERSION_STR}")
 
 #=============================================================================
 # ccache

--- a/cmake/Git.cmake
+++ b/cmake/Git.cmake
@@ -21,5 +21,5 @@ endif()
 # Fetch the necessary git variables
 execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --tags
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                OUTPUT_VARIABLE GIT_VERSION
+                OUTPUT_VARIABLE APP_VERSION_STR
                 OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/cmake/QGCDeploy.cmake
+++ b/cmake/QGCDeploy.cmake
@@ -40,7 +40,7 @@ elseif(APPLE)
 		COMMAND
 			rsync -a --delete ${CMAKE_BINARY_DIR}/QGroundControl.app ${CMAKE_BINARY_DIR}/staging
 		COMMAND
-			hdiutil create /tmp/tmp.dmg -ov -volname "QGroundControl-$${GIT_VERSION}" -fs HFS+ -srcfolder "staging"
+			hdiutil create /tmp/tmp.dmg -ov -volname "QGroundControl-$${APP_VERSION_STR}" -fs HFS+ -srcfolder "staging"
 		COMMAND
 			hdiutil convert /tmp/tmp.dmg -format UDBZ -o ${CMAKE_BINARY_DIR}/package/QGroundControl.dmg
 	)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -112,7 +112,7 @@ add_library(qgc
 	TerrainTile.h
 )
 
-set_source_files_properties(QGCApplication.cc PROPERTIES COMPILE_DEFINITIONS GIT_VERSION="${GIT_VERSION}")
+set_source_files_properties(QGCApplication.cc PROPERTIES COMPILE_DEFINITIONS APP_VERSION_STR="${APP_VERSION_STR}")
 
 add_subdirectory(ui)
 


### PR DESCRIPTION
a renaming of `GIT_VERSION` to `APP_VERSION_STR` happened in cf9588a12ce9ace68cc6c2a6578caedabafcfad6

The code expects `APP_VERSION_STR` to be defined. Follow the QtCreator naming.