### PR TITLE
More work on QGCPopupDialog, and QGCSimpleMessageDialog usage

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -164,7 +164,6 @@
         <file alias="QGroundControl/Controls/QGCToolInsets.qml">src/QmlControls/QGCToolInsets.qml</file>
         <file alias="QGroundControl/Controls/QGCViewDialog.qml">src/QmlControls/QGCViewDialog.qml</file>
         <file alias="QGroundControl/Controls/QGCViewDialogContainer.qml">src/QmlControls/QGCViewDialogContainer.qml</file>
-        <file alias="QGroundControl/Controls/QGCViewMessage.qml">src/QmlControls/QGCViewMessage.qml</file>
         <file alias="QGroundControl/Controls/qmldir">src/QmlControls/QGroundControl/Controls/qmldir</file>
         <file alias="QGroundControl/Controls/RallyPointEditorHeader.qml">src/PlanView/RallyPointEditorHeader.qml</file>
         <file alias="QGroundControl/Controls/RallyPointItemEditor.qml">src/PlanView/RallyPointItemEditor.qml</file>

--- a/src/AnalyzeView/LogDownloadPage.qml
+++ b/src/AnalyzeView/LogDownloadPage.qml
@@ -169,21 +169,10 @@ AnalyzePage {
                     enabled:    !logController.requestingList && !logController.downloadingLogs && logController.model.count > 0
                     text:       qsTr("Erase All")
                     width:      _butttonWidth
-                    onClicked:  mainWindow.showComponentDialog(
-                        eraseAllMessage,
-                        qsTr("Delete All Log Files"),
-                        mainWindow.showDialogDefaultWidth,
-                        StandardButton.Yes | StandardButton.No)
-                    Component {
-                        id: eraseAllMessage
-                        QGCViewMessage {
-                            message:    qsTr("All log files will be erased permanently. Is this really what you want?")
-                            function accept() {
-                                logController.eraseAll()
-                                hideDialog()
-                            }
-                        }
-                    }
+                    onClicked:  mainWindow.showMessageDialog(qsTr("Delete All Log Files"),
+                                                             qsTr("All log files will be erased permanently. Is this really what you want?"),
+                                                             StandardButton.Yes | StandardButton.No,
+                                                             function() { logController.eraseAll() })
                 }
                 QGCButton {
                     text:       qsTr("Cancel")

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -464,13 +464,7 @@ SetupPage {
                 QGCButton {
                     text:       qsTr("Calculate")
                     visible:    _showAdvanced
-
-                    onClicked: {
-                        _calcVoltageDlgVehicleVoltage = vehicleVoltage
-                        _calcVoltageDlgBattVoltMultParam = battVoltMult
-                        mainWindow.showComponentDialog(calcVoltageMultiplierDlgComponent, qsTr("Calculate Voltage Multiplier"), mainWindow.showDialogDefaultWidth, StandardButton.Close)
-                    }
-
+                    onClicked:  calcVoltageMultiplierDlgComponent.createObject(mainWindow, { vehicleVoltageFact: vehicleVoltage, battVoltMultFact: battVoltMult }).open()
                 }
 
                 QGCLabel {
@@ -496,12 +490,7 @@ SetupPage {
                 QGCButton {
                     text:       qsTr("Calculate")
                     visible:    _showAdvanced
-
-                    onClicked: {
-                        _calcAmpsPerVoltDlgVehicleCurrent = vehicleCurrent
-                        _calcAmpsPerVoltDlgBattAmpPerVoltParam = battAmpPerVolt
-                        mainWindow.showComponentDialog(calcAmpsPerVoltDlgComponent, qsTr("Calculate Amps per Volt"), mainWindow.showDialogDefaultWidth, StandardButton.Close)
-                    }
+                    onClicked:  calcAmpsPerVoltDlgComponent.createObject(mainWindow, { vehicleCurrentFact: vehicleCurrent, battAmpPerVoltFact: battAmpPerVolt }).open()
                 }
 
                 QGCLabel {
@@ -537,127 +526,109 @@ SetupPage {
         } // Column
     } // Component - powerSetupComponent
 
-    // Must be set prior to use of calcVoltageMultiplierDlgComponent
-    property Fact _calcVoltageDlgVehicleVoltage
-    property Fact _calcVoltageDlgBattVoltMultParam
-
     Component {
         id: calcVoltageMultiplierDlgComponent
 
-        QGCViewDialog {
-            id: calcVoltageMultiplierDlg
+        QGCPopupDialog {
+            title:      qsTr("Calculate Voltage Multiplier")
+            buttons:    StandardButton.Close
 
-            QGCFlickable {
-                anchors.fill:   parent
-                contentHeight:  column.height
-                contentWidth:   column.width
+            property Fact vehicleVoltageFact
+            property Fact battVoltMultFact
 
-                Column {
-                    id:         column
-                    width:      calcVoltageMultiplierDlg.width
-                    spacing:    ScreenTools.defaultFontPixelHeight
+            ColumnLayout {
+                spacing: ScreenTools.defaultFontPixelHeight
+
+                QGCLabel {
+                    Layout.preferredWidth:  gridLayout.width
+                    wrapMode:               Text.WordWrap
+                    text:                   qsTr("Measure battery voltage using an external voltmeter and enter the value below. Click Calculate to set the new adjusted voltage multiplier.")
+                }
+
+                GridLayout {
+                    id:         gridLayout
+                    columns:    2
 
                     QGCLabel {
-                        width:      parent.width
-                        wrapMode:   Text.WordWrap
-                        text:       qsTr("Measure battery voltage using an external voltmeter and enter the value below. Click Calculate to set the new adjusted voltage multiplier.")
+                        text: qsTr("Measured voltage:")
                     }
+                    QGCTextField { id: measuredVoltage }
 
-                    Grid {
-                        columns: 2
-                        spacing: ScreenTools.defaultFontPixelHeight / 2
-                        verticalItemAlignment: Grid.AlignVCenter
+                    QGCLabel { text: qsTr("Vehicle voltage:") }
+                    FactLabel { fact: vehicleVoltageFact }
 
-                        QGCLabel {
-                            text: qsTr("Measured voltage:")
+                    QGCLabel { text: qsTr("Voltage multiplier:") }
+                    FactLabel { fact: battVoltMultFact }
+                }
+
+                QGCButton {
+                    text: qsTr("Calculate And Set")
+
+                    onClicked:  {
+                        var measuredVoltageValue = parseFloat(measuredVoltage.text)
+                        if (measuredVoltageValue == 0 || isNaN(measuredVoltageValue)) {
+                            return
                         }
-                        QGCTextField { id: measuredVoltage }
-
-                        QGCLabel { text: qsTr("Vehicle voltage:") }
-                        FactLabel { fact: _calcVoltageDlgVehicleVoltage }
-
-                        QGCLabel { text: qsTr("Voltage multiplier:") }
-                        FactLabel { fact: _calcVoltageDlgBattVoltMultParam }
-                    }
-
-                    QGCButton {
-                        text: qsTr("Calculate And Set")
-
-                        onClicked:  {
-                            var measuredVoltageValue = parseFloat(measuredVoltage.text)
-                            if (measuredVoltageValue == 0 || isNaN(measuredVoltageValue)) {
-                                return
-                            }
-                            var newVoltageMultiplier = (measuredVoltageValue * _calcVoltageDlgBattVoltMultParam.value) / _calcVoltageDlgVehicleVoltage.value
-                            if (newVoltageMultiplier > 0) {
-                                _calcVoltageDlgBattVoltMultParam.value = newVoltageMultiplier
-                            }
+                        var newVoltageMultiplier = (measuredVoltageValue * battVoltMultFact.value) / vehicleVoltageFact.value
+                        if (newVoltageMultiplier > 0) {
+                            battVoltMultFact.value = newVoltageMultiplier
                         }
                     }
-                } // Column
-            } // QGCFlickable
-        } // QGCViewDialog
-    } // Component - calcVoltageMultiplierDlgComponent
-
-    // Must be set prior to use of calcAmpsPerVoltDlgComponent
-    property Fact _calcAmpsPerVoltDlgVehicleCurrent
-    property Fact _calcAmpsPerVoltDlgBattAmpPerVoltParam
+                }
+            }
+        }
+    }
 
     Component {
         id: calcAmpsPerVoltDlgComponent
 
-        QGCViewDialog {
-            id: calcAmpsPerVoltDlg
+        QGCPopupDialog {
+            title:      qsTr("Calculate Amps per Volt")
+            buttons:    StandardButton.Close
 
-            QGCFlickable {
-                anchors.fill:   parent
-                contentHeight:  column.height
-                contentWidth:   column.width
+            property Fact vehicleCurrentFact
+            property Fact battAmpPerVoltFact
 
-                Column {
-                    id:         column
-                    width:      calcAmpsPerVoltDlg.width
-                    spacing:    ScreenTools.defaultFontPixelHeight
+            ColumnLayout {
+                spacing: ScreenTools.defaultFontPixelHeight
+
+                QGCLabel {
+                    Layout.preferredWidth:  gridLayout.width
+                    wrapMode:               Text.WordWrap
+                    text:                   qsTr("Measure current draw using an external current meter and enter the value below. Click Calculate to set the new amps per volt value.")
+                }
+
+                GridLayout {
+                    id:         gridLayout
+                    columns:    2
 
                     QGCLabel {
-                        width:      parent.width
-                        wrapMode:   Text.WordWrap
-                        text:       qsTr("Measure current draw using an external current meter and enter the value below. Click Calculate to set the new amps per volt value.")
+                        text: qsTr("Measured current:")
                     }
+                    QGCTextField { id: measuredCurrent }
 
-                    Grid {
-                        columns: 2
-                        spacing: ScreenTools.defaultFontPixelHeight / 2
-                        verticalItemAlignment: Grid.AlignVCenter
+                    QGCLabel { text: qsTr("Vehicle current:") }
+                    FactLabel { fact: vehicleCurrentFact }
 
-                        QGCLabel {
-                            text: qsTr("Measured current:")
+                    QGCLabel { text: qsTr("Amps per volt:") }
+                    FactLabel { fact: battAmpPerVoltFact }
+                }
+
+                QGCButton {
+                    text: qsTr("Calculate And Set")
+
+                    onClicked:  {
+                        var measuredCurrentValue = parseFloat(measuredCurrent.text)
+                        if (measuredCurrentValue == 0) {
+                            return
                         }
-                        QGCTextField { id: measuredCurrent }
-
-                        QGCLabel { text: qsTr("Vehicle current:") }
-                        FactLabel { fact: _calcAmpsPerVoltDlgVehicleCurrent }
-
-                        QGCLabel { text: qsTr("Amps per volt:") }
-                        FactLabel { fact: _calcAmpsPerVoltDlgBattAmpPerVoltParam }
-                    }
-
-                    QGCButton {
-                        text: qsTr("Calculate And Set")
-
-                        onClicked:  {
-                            var measuredCurrentValue = parseFloat(measuredCurrent.text)
-                            if (measuredCurrentValue == 0) {
-                                return
-                            }
-                            var newAmpsPerVolt = (measuredCurrentValue * _calcAmpsPerVoltDlgBattAmpPerVoltParam.value) / _calcAmpsPerVoltDlgVehicleCurrent.value
-                            if (newAmpsPerVolt != 0) {
-                                _calcAmpsPerVoltDlgBattAmpPerVoltParam.value = newAmpsPerVolt
-                            }
+                        var newAmpsPerVolt = (measuredCurrentValue * battAmpPerVoltFact.value) / vehicleCurrentFact.value
+                        if (newAmpsPerVolt != 0) {
+                            battAmpPerVoltFact.value = newAmpsPerVolt
                         }
                     }
-                } // Column
-            } // QGCFlickable
-        } // QGCViewDialog
-    } // Component - calcAmpsPerVoltDlgComponent
+                }
+            }
+        }
+    }
 } // SetupPage

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -152,7 +152,7 @@ SetupPage {
 
                 onWaitingForCancelChanged: {
                     if (controller.waitingForCancel) {
-                        mainWindow.showComponentDialog(waitForCancelDialogComponent, qsTr("Calibration Cancel"), mainWindow.showDialogDefaultWidth, 0)
+                        waitForCancelDialogComponent.createObject(mainWindow).open()
                     }
                 }
 
@@ -181,15 +181,17 @@ SetupPage {
             Component {
                 id: waitForCancelDialogComponent
 
-                QGCViewMessage {
-                    message: qsTr("Waiting for Vehicle to response to Cancel. This may take a few seconds.")
+                QGCSimpleMessageDialog {
+                    title:      qsTr("Calibration Cancel")
+                    text:       qsTr("Waiting for Vehicle to response to Cancel. This may take a few seconds.")
+                    buttons:    0
 
                     Connections {
                         target: controller
 
                         onWaitingForCancelChanged: {
                             if (!controller.waitingForCancel) {
-                                hideDialog()
+                                close()
                             }
                         }
                     }

--- a/src/AutoPilotPlugins/Common/RadioComponent.qml
+++ b/src/AutoPilotPlugins/Common/RadioComponent.qml
@@ -54,50 +54,13 @@ SetupPage {
             }
 
             Component {
-                id: copyTrimsDialogComponent
-
-                QGCSimpleMessageDialog {
-                    title:          qsTr("Copy Trims")
-                    text:           qsTr("Center your sticks and move throttle all the way down, then press Ok to copy trims. After pressing Ok, reset the trims on your radio back to zero.")
-                    destroyOnClose: true
-                    onAccepted:     controller.copyTrims()
-                }
-            }
-
-            Component {
-                id: zeroTrimsDialogComponent
-
-                QGCSimpleMessageDialog {
-                    title:          qsTr("Zero Trims")
-                    text:           qsTr("Before calibrating you should zero all your trims and subtrims. Click Ok to start Calibration.\n\n%1").arg(
-                                        (QGroundControl.multiVehicleManager.activeVehicle.px4Firmware ? "" : qsTr("Please ensure all motor power is disconnected AND all props are removed from the vehicle.")))
-                    destroyOnClose: true
-                    onAccepted:     controller.nextButtonClicked()
-                }
-            }
-
-            Component {
-                id: channelCountDialogComponent
-
-                QGCSimpleMessageDialog {
-                    title:          qsTr("Radio Not Ready")
-                    text:           controller.channelCount == 0 ? qsTr("Please turn on transmitter.") :
-                                                                   (controller.channelCount < controller.minChannelCount ?
-                                                                        qsTr("%1 channels or more are needed to fly.").arg(controller.minChannelCount) :
-                                                                        qsTr("Ready to calibrate."))
-                    destroyOnClose: true
-                }
-            }
-
-            Component {
                 id: spektrumBindDialogComponent
 
                 QGCPopupDialog {
-                    title:          qsTr("Spektrum Bind")
-                    buttons:        StandardButton.Ok | StandardButton.Cancel
-                    destroyOnClose: true
+                    title:      qsTr("Spektrum Bind")
+                    buttons:    StandardButton.Ok | StandardButton.Cancel
 
-                    onAccepted: controller.spektrumBindMode(radioGroup.checkedButton.bindMode)
+                    onAccepted: { controller.spektrumBindMode(radioGroup.checkedButton.bindMode) }
 
                     ButtonGroup { id: radioGroup }
 
@@ -351,9 +314,17 @@ SetupPage {
                         onClicked: {
                             if (text === qsTr("Calibrate")) {
                                 if (controller.channelCount < controller.minChannelCount) {
-                                    channelCountDialogComponent.createObject(mainWindow).open()
+                                    mainWindow.showMessageDialog(qsTr("Radio Not Ready"),
+                                                                 controller.channelCount == 0 ? qsTr("Please turn on transmitter.") :
+                                                                                                (controller.channelCount < controller.minChannelCount ?
+                                                                                                     qsTr("%1 channels or more are needed to fly.").arg(controller.minChannelCount) :
+                                                                                                     qsTr("Ready to calibrate.")))
                                 } else {
-                                    zeroTrimsDialogComponent.createObject(mainWindow).open()
+                                    mainWindow.showMessageDialog(qsTr("Zero Trims"),
+                                                                 qsTr("Before calibrating you should zero all your trims and subtrims. Click Ok to start Calibration.\n\n%1").arg(
+                                                                     (QGroundControl.multiVehicleManager.activeVehicle.px4Firmware ? "" : qsTr("Please ensure all motor power is disconnected AND all props are removed from the vehicle."))),
+                                                                 StandardButton.Ok,
+                                                                 function() { controller.nextButtonClicked() })
                                 }
                             } else {
                                 controller.nextButtonClicked()
@@ -419,7 +390,10 @@ SetupPage {
 
                     QGCButton {
                         text:       qsTr("Copy Trims")
-                        onClicked:  copyTrimsDialogComponent.createObject(mainWindow).open()
+                        onClicked:  mainWindow.showMessageDialog(qsTr("Copy Trims"),
+                                                                 qsTr("Center your sticks and move throttle all the way down, then press Ok to copy trims. After pressing Ok, reset the trims on your radio back to zero."),
+                                                                 StandardButton.Ok | StandardButton.Cancel,
+                                                                 function() { controller.copyTrims() })
                     }
                 }
             } // Column - Left Column

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.qml
@@ -97,20 +97,6 @@ SetupPage {
                 }
             }
 
-            Component {
-                id: applyRestartDialogComponent
-
-                QGCSimpleMessageDialog {
-                    buttons:        StandardButton.Apply | StandardButton.Cancel
-                    title:          qsTr("Apply and Restart")
-                    text:           qsTr("Clicking 'Apply' will save the changes you have made to your airframe configuration.<br><br>\
-All vehicle parameters other than Radio Calibration will be reset.<br><br>\
-Your vehicle will also be restarted in order to complete the process.")
-                    destroyOnClose: true
-                    onAccepted:     controller.changeAutostart()
-                }
-            }
-
             Item {
                 id:             helpApplyRow
                 anchors.left:   parent.left
@@ -132,8 +118,13 @@ Your vehicle will also be restarted in order to complete the process.")
                     id:             applyButton
                     anchors.right:  parent.right
                     text:           qsTr("Apply and Restart")
+                    onClicked:      mainWindow.showMessageDialog(qsTr("Apply and Restart"),
+                                                                 qsTr("Clicking 'Apply' will save the changes you have made to your airframe configuration.<br><br>\
+                                                                        All vehicle parameters other than Radio Calibration will be reset.<br><br>\
+                                                                        Your vehicle will also be restarted in order to complete the process."),
+                                                                 StandardButton.Apply | StandardButton.Cancel,
+                                                                 function() { controller.changeAutostart() })
 
-                    onClicked:      applyRestartDialogComponent.createObject(mainWindow).open()
                 }
             }
 

--- a/src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml
+++ b/src/AutoPilotPlugins/PX4/PX4AdvancedFlightModes.qml
@@ -152,14 +152,6 @@ Item {
         scrollItem.height = nextY
     }
 
-    Component {
-        id: joystickEnabledDialogComponent
-
-        QGCViewMessage {
-            message: qsTr("Flight Mode Config is disabled since you have a Joystick enabled.")
-        }
-    }
-
     ScrollView {
         id:                         scroll
         anchors.fill:               parent

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -412,9 +412,8 @@ SetupPage {
                 id: calcVoltageDividerDlgComponent
 
                 QGCPopupDialog {
-                    title:          qsTr("Calculate Voltage Divider")
-                    buttons:        StandardButton.Close
-                    destroyOnClose: true
+                    title:      qsTr("Calculate Voltage Divider")
+                    buttons:    StandardButton.Close
 
                     property alias batteryIndex: batParams.batteryIndex
 
@@ -471,9 +470,8 @@ SetupPage {
                 id: calcAmpsPerVoltDlgComponent
 
                 QGCPopupDialog {
-                    title:          qsTr("Calculate Amps per Volt")
-                    buttons:        StandardButton.Close
-                    destroyOnClose: true
+                    title:      qsTr("Calculate Amps per Volt")
+                    buttons:    StandardButton.Close
 
                     property alias batteryIndex: batParams.batteryIndex
 
@@ -534,7 +532,6 @@ SetupPage {
                     title:                  qsTr("ESC Calibration")
                     buttons:                StandardButton.Ok
                     acceptButtonEnabled:    false
-                    destroyOnClose:         true
 
                     Connections {
                         target: controller

--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -47,7 +47,6 @@ QGCTextField {
             validate:       true
             validateValue:  _validateString
             fact:           _textField.fact
-            destroyOnClose: true
         }
     }
 
@@ -57,7 +56,6 @@ QGCTextField {
         ParameterEditorDialog {
             title:          qsTr("Value Details")
             fact:           _textField.fact
-            destroyOnClose: true
         }
     }
 }

--- a/src/FirstRunPromptDialogs/FirstRunPrompt.qml
+++ b/src/FirstRunPromptDialogs/FirstRunPrompt.qml
@@ -15,7 +15,7 @@ import QGroundControl.Controls  1.0
 
 // Base class for all first run prompt dialogs
 QGCPopupDialog {
-    buttons:    StandardButton.Ok
+    buttons: StandardButton.Ok
 
     property int  promptId
     property bool markAsShownOnClose: true

--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -313,9 +313,8 @@ Rectangle {
         id: settingsDialogComponent
 
         QGCPopupDialog {
-            title:          qsTr("Settings")
-            buttons:        StandardButton.Close
-            destroyOnClose: true
+            title:      qsTr("Settings")
+            buttons:    StandardButton.Close
 
             ColumnLayout {
                 spacing: _margins

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -45,7 +45,7 @@ Rectangle {
 
     QGCPalette { id: qgcPal }
     QGCFileDialogController { id: fileController }
-    Component { id: altModeDialogComponent; AltModeDialog { destroyOnClose: true } }
+    Component { id: altModeDialogComponent; AltModeDialog { } }
 
     Connections {
         target: _controllerVehicle

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -47,7 +47,7 @@ Rectangle {
     }
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
-    Component { id: altModeDialogComponent; AltModeDialog { destroyOnClose: true } }
+    Component { id: altModeDialogComponent; AltModeDialog { } }
 
     Column {
         id:                 editorColumn

--- a/src/PlanView/TransectStyleComplexItemEditor.qml
+++ b/src/PlanView/TransectStyleComplexItemEditor.qml
@@ -189,16 +189,14 @@ Rectangle {
                         Component {
                             id: deletePresetDialog
 
-                            QGCPopupDialog {
-                                title:          qsTr("Delete Preset")
-                                buttons:        StandardButton.Yes | StandardButton.No
-                                destroyOnClose: true
+                            QGCSimpleMessageDialog {
+                                title:      qsTr("Delete Preset")
+                                text:       qsTr("Are you sure you want to delete '%1' preset?").arg(presetName)
+                                buttons:    StandardButton.Yes | StandardButton.No
 
                                 property string presetName
 
-                                onAccepted: _missionItem.deletePreset(presetName)
-
-                                QGCLabel { text: qsTr("Are you sure you want to delete '%1' preset?").arg(presetName) }
+                                onAccepted: { _missionItem.deletePreset(presetName) }
                             }
                         }
                     }
@@ -245,10 +243,9 @@ Rectangle {
             id: savePresetDialog
 
             QGCPopupDialog {
-                id:             popupDialog
-                title:          qsTr("Save Preset")
-                buttons:        StandardButton.Save | StandardButton.Cancel
-                destroyOnClose: true
+                id:         popupDialog
+                title:      qsTr("Save Preset")
+                buttons:    StandardButton.Save | StandardButton.Cancel
 
                 onAccepted: {
                     if (presetNameField.text != "") {

--- a/src/PlanView/TransectStyleComplexItemTerrainFollow.qml
+++ b/src/PlanView/TransectStyleComplexItemTerrainFollow.qml
@@ -31,7 +31,7 @@ ColumnLayout {
             altModeDialogComponent.createObject(mainWindow, { rgRemoveModes: removeModes, updateAltModeFn: updateFunction }).open()
         }
 
-        //Component { id: altModeDialogComponent; AltModeDialog { destroyOnClose: true } }
+        //Component { id: altModeDialogComponent; AltModeDialog { } }
 
         RowLayout {
             spacing: ScreenTools.defaultFontPixelWidth / 2

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -749,7 +749,7 @@ void QGCApplication::showAppMessage(const QString& message, const QString& title
     if (rootQmlObject) {
         QVariant varReturn;
         QVariant varMessage = QVariant::fromValue(message);
-        QMetaObject::invokeMethod(_rootQmlObject(), "showMessageDialog", Q_RETURN_ARG(QVariant, varReturn), Q_ARG(QVariant, dialogTitle), Q_ARG(QVariant, varMessage));
+        QMetaObject::invokeMethod(_rootQmlObject(), "_showMessageDialog", Q_RETURN_ARG(QVariant, varReturn), Q_ARG(QVariant, dialogTitle), Q_ARG(QVariant, varMessage));
     } else if (runningUnitTests()) {
         // Unit tests can run without UI
         qDebug() << "QGCApplication::showAppMessage unittest title:message" << dialogTitle << message;

--- a/src/QmlControls/AppMessages.qml
+++ b/src/QmlControls/AppMessages.qml
@@ -156,9 +156,8 @@ Item {
         id: filtersDialogComponent
 
         QGCPopupDialog {
-            title:          qsTr("Logging categories")
-            buttons:        StandardButton.Close
-            destroyOnClose: true
+            title:      qsTr("Logging categories")
+            buttons:    StandardButton.Close
 
             ColumnLayout {
                 RowLayout {

--- a/src/QmlControls/AutotuneUI.qml
+++ b/src/QmlControls/AutotuneUI.qml
@@ -31,24 +31,6 @@ Item {
         colorGroupEnabled: enabled
     }
 
-    Component {
-        id: autotuneConfirmationDialogComponent
-        QGCViewMessage {
-            message: qsTr("WARNING!\
-\n\nThe auto-tuning procedure should be executed with caution and requires the vehicle to fly stable enough before \
-attempting the procedure!\n\nBefore starting the auto-tuning process, make sure that: \
-\n1. You have read the auto-tuning guide and have followed the preliminary steps \
-\n2. The current control gains are good enough to stabilize the drone in presence of medium disturbances \
-\n3. You are ready to abort the auto-tuning sequence by moving the RC sticks, if anything unexpected happens. \
-\n\nClick Ok to start the auto-tuning process.\n")
-
-            function accept() {
-                hideDialog()
-                _autotune.autotuneRequest()
-            }
-        }
-    }
-
     Rectangle {
         width:   _root.width
         height:  statusColumn.height + (2 * _margins)
@@ -66,12 +48,16 @@ attempting the procedure!\n\nBefore starting the auto-tuning process, make sure 
                 verticalCenter:   parent.verticalCenter
             }
 
-            onClicked: {
-                mainWindow.showComponentDialog(autotuneConfirmationDialogComponent,
-                                               dialogTitle,
-                                               mainWindow.showDialogDefaultWidth,
-                                               StandardButton.Ok | StandardButton.Cancel)
-            }
+            onClicked: mainWindow.showMessageDialog(dialogTitle,
+                                                    qsTr("WARNING!\
+            \n\nThe auto-tuning procedure should be executed with caution and requires the vehicle to fly stable enough before attempting the procedure! \
+            \n\nBefore starting the auto-tuning process, make sure that: \
+            \n1. You have read the auto-tuning guide and have followed the preliminary steps \
+            \n2. The current control gains are good enough to stabilize the drone in presence of medium disturbances \
+            \n3. You are ready to abort the auto-tuning sequence by moving the RC sticks, if anything unexpected happens. \
+            \n\nClick Ok to start the auto-tuning process.\n"),
+                                                    StandardButton.Ok | StandardButton.Cancel,
+                                                    function() { _autotune.autotuneRequest() })
         }
 
         Column {

--- a/src/QmlControls/HorizontalFactValueGrid.qml
+++ b/src/QmlControls/HorizontalFactValueGrid.qml
@@ -189,6 +189,6 @@ T.HorizontalFactValueGrid {
     Component {
         id: valueEditDialog
 
-        InstrumentValueEditDialog { destroyOnClose: true }
+        InstrumentValueEditDialog { }
     }
 }

--- a/src/QmlControls/InstrumentValueEditDialog.qml
+++ b/src/QmlControls/InstrumentValueEditDialog.qml
@@ -513,9 +513,8 @@ QGCPopupDialog {
         id: iconPickerDialog
 
         QGCPopupDialog {
-            title:          qsTr("Select Icon")
-            buttons:        StandardButton.Close
-            destroyOnClose: true
+            title:      qsTr("Select Icon")
+            buttons:    StandardButton.Close
 
             property var     iconNames
             property string  icon

--- a/src/QmlControls/ParameterDiffDialog.qml
+++ b/src/QmlControls/ParameterDiffDialog.qml
@@ -25,10 +25,7 @@ QGCPopupDialog {
 
     property var paramController
 
-    function accept() {
-        paramController.sendDiff()
-        close()
-    }
+    onAccepted: paramController.sendDiff()
 
     Component.onDestruction: paramController.clearDiff();
 

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -107,12 +107,18 @@ Item {
         }
         QGCMenuItem {
             text:           qsTr("Reset all to firmware's defaults")
-            onTriggered:    mainWindow.showComponentDialog(resetToDefaultConfirmComponent, qsTr("Reset All"), mainWindow.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Reset)
+            onTriggered:    mainWindow.showMessageDialog(qsTr("Reset All"),
+                                                         qsTr("Select Reset to reset all parameters to their defaults.\n\nNote that this will also completely reset everything, including UAVCAN nodes, all vehicle settings, setup and calibrations."),
+                                                         StandardButton.Cancel | StandardButton.Reset,
+                                                         function() { controller.resetAllToDefaults() })
         }
         QGCMenuItem {
             text:           qsTr("Reset to vehicle's configuration defaults")
             visible:        !_activeVehicle.apmFirmware
-            onTriggered:    mainWindow.showComponentDialog(resetToVehicleConfigurationConfirmComponent, qsTr("Reset All"), mainWindow.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Reset)
+            onTriggered:    mainWindow.showMessageDialog(qsTr("Reset All"),
+                                                         qsTr("Select Reset to reset all parameters to the vehicle's configuration defaults."),
+                                                         StandardButton.Cancel | StandardButton.Reset,
+                                                         function() { controller.resetAllToVehicleConfiguration() })
         }
         QGCMenuSeparator { }
         QGCMenuItem {
@@ -140,7 +146,10 @@ Item {
         QGCMenuSeparator { }
         QGCMenuItem {
             text:           qsTr("Reboot Vehicle")
-            onTriggered:    mainWindow.showComponentDialog(rebootVehicleConfirmComponent, qsTr("Reboot Vehicle"), mainWindow.showDialogDefaultWidth, StandardButton.Cancel | StandardButton.Ok)
+            onTriggered:    mainWindow.showMessageDialog(qsTr("Reboot Vehicle"),
+                                                         qsTr("Select Ok to reboot vehicle."),
+                                                         StandardButton.Cancel | StandardButton.Ok,
+                                                         function() { _activeVehicle.rebootVehicle() })
         }
     }
 
@@ -312,54 +321,6 @@ Item {
         ParameterEditorDialog {
             fact:           _editorDialogFact
             showRCToParam:  _showRCToParam
-            destroyOnClose: true
-        }
-    }
-
-    Component {
-        id: resetToDefaultConfirmComponent
-        QGCViewDialog {
-            function accept() {
-                controller.resetAllToDefaults()
-                hideDialog()
-            }
-            QGCLabel {
-                width:              parent.width
-                wrapMode:           Text.WordWrap
-                text:               qsTr("Select Reset to reset all parameters to their defaults.\n\nNote that this will also completely reset everything, including UAVCAN nodes, all vehicle settings, setup and calibrations.")
-            }
-        }
-    }
-
-    Component {
-        id: resetToVehicleConfigurationConfirmComponent
-        QGCViewDialog {
-            function accept() {
-                controller.resetAllToVehicleConfiguration()
-                hideDialog()
-            }
-            QGCLabel {
-                width:              parent.width
-                wrapMode:           Text.WordWrap
-                text:               qsTr("Select Reset to reset all parameters to the vehicle's configuration defaults.")
-            }
-        }
-    }
-
-    Component {
-        id: rebootVehicleConfirmComponent
-
-        QGCViewDialog {
-            function accept() {
-                hideDialog()
-                _activeVehicle.rebootVehicle()
-            }
-
-            QGCLabel {
-                width:              parent.width
-                wrapMode:           Text.WordWrap
-                text:               qsTr("Select Ok to reboot vehicle.")
-            }
         }
     }
 
@@ -367,8 +328,7 @@ Item {
         id: parameterDiffDialog
 
         ParameterDiffDialog {
-            paramController:    _controller
-            destroyOnClose:     true
+            paramController: _controller
         }
     }
 }

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -62,7 +62,7 @@ QGCPopupDialog {
                 if (_allowForceSave) {
                     forceSave.visible = true
                 }
-                root.preventClose = true
+                preventClose = true
             }
         }
     }
@@ -268,8 +268,7 @@ QGCPopupDialog {
         id: rcToParamDialog
 
         RCToParamDialog {
-            tuningFact:     fact
-            destroyOnClose: true
+            tuningFact: fact
         }
     }
 }

--- a/src/QmlControls/QGCSimpleMessageDialog.qml
+++ b/src/QmlControls/QGCSimpleMessageDialog.qml
@@ -14,7 +14,14 @@ import QGroundControl.Controls      1.0
 import QGroundControl.ScreenTools   1.0
 
 QGCPopupDialog {
-    property alias text: label.text
+    property alias  text:           label.text
+    property var    acceptFunction: null        // Mainly used by MainRootWindow.showMessage to specify accept function in call
+
+    onAccepted: {
+        if (acceptFunction) {
+            acceptFunction()
+        }
+    }
 
     ColumnLayout {
         QGCLabel {

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -89,7 +89,6 @@ QGCToolBarButton                        1.0 QGCToolBarButton.qml
 QGCToolInsets                           1.0 QGCToolInsets.qml
 QGCViewDialog                           1.0 QGCViewDialog.qml
 QGCViewDialogContainer                  1.0 QGCViewDialogContainer.qml
-QGCViewMessage                          1.0 QGCViewMessage.qml
 RallyPointEditorHeader                  1.0 RallyPointEditorHeader.qml
 RallyPointItemEditor                    1.0 RallyPointItemEditor.qml
 RallyPointMapVisuals                    1.0 RallyPointMapVisuals.qml

--- a/src/QtLocationPlugin/QMLControl/OfflineMap.qml
+++ b/src/QtLocationPlugin/QMLControl/OfflineMap.qml
@@ -411,19 +411,17 @@ Item {
 
     Component {
         id: deleteConfirmationDialogComponent
-        QGCViewMessage {
-            id:  deleteConfirmationDialog
-            message: {
-                if(offlineMapView._currentSelection.defaultSet)
-                    return qsTr("This will delete all tiles INCLUDING the tile sets you have created yourself.\n\nIs this really what you want?");
-                else
-                    return qsTr("Delete %1 and all its tiles.\n\nIs this really what you want?").arg(offlineMapView._currentSelection.name);
-            }
-            function accept() {
+        QGCSimpleMessageDialog {
+            title:      qsTr("Confirm Delete")
+            text:       offlineMapView._currentSelection.defaultSet ?
+                            qsTr("This will delete all tiles INCLUDING the tile sets you have created yourself.\n\nIs this really what you want?") :
+                            qsTr("Delete %1 and all its tiles.\n\nIs this really what you want?").arg(offlineMapView._currentSelection.name)
+            buttons:    StandardButton.Yes | StandardButton.No
+
+            onAccepted: {
                 QGroundControl.mapEngineManager.deleteTileSet(offlineMapView._currentSelection)
                 deleteConfirmationDialog.hideDialog()
                 leaveInfoView()
-                showList()
             }
         }
     }
@@ -606,7 +604,7 @@ Item {
                         QGCButton {
                             text:       qsTr("Delete")
                             width:      ScreenTools.defaultFontPixelWidth * (infoView._extraButton ? 6 : 10)
-                            onClicked:  mainWindow.showComponentDialog(deleteConfirmationDialogComponent, qsTr("Confirm Delete"), mainWindow.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
+                            onClicked:  deleteConfirmationDialogComponent.createObject(mainWindow).open()
                         }
                         QGCButton {
                             text:       qsTr("Ok")

--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -66,12 +66,6 @@ SetupPage {
 
             property bool _singleFirmwareMode:          QGroundControl.corePlugin.options.firmwareUpgradeSingleURL.length != 0   ///< true: running in special single firmware download mode
 
-            function cancelFlash() {
-                statusTextArea.append(highlightPrefix + qsTr("Upgrade cancelled") + highlightSuffix)
-                statusTextArea.append("------------------------------------------")
-                controller.cancel()
-            }
-
             function setupPageCompleted() {
                 controller.startBoardSearch()
                 _defaultFirmwareIsPX4 = _defaultFirmwareFact.rawValue === _defaultFimwareTypePX4 // we don't want this to be bound and change as radios are selected
@@ -136,15 +130,17 @@ SetupPage {
                     }
                 }
 
-                onShowFirmwareSelectDlg:    mainWindow.showComponentDialog(firmwareSelectDialogComponent, title, mainWindow.showDialogDefaultWidth, StandardButton.Ok | StandardButton.Cancel)
+                onShowFirmwareSelectDlg:    firmwareSelectDialogComponent.createObject(mainWindow).open()
                 onError:                    statusTextArea.append(flashFailText)
             }
 
             Component {
                 id: firmwareSelectDialogComponent
 
-                QGCViewDialog {
-                    id: pixhawkFirmwareSelectDialog
+                QGCPopupDialog {
+                    id:         firmwareSelectDialog
+                    title:      qsTr("Firmware Setup")
+                    buttons:    StandardButton.Ok | StandardButton.Cancel
 
                     property bool showFirmwareTypeSelection:    _advanced.checked
                     property bool px4Flow:                      controller.px4FlowBoard
@@ -189,7 +185,7 @@ SetupPage {
                         onError:    reject()
                     }
 
-                    function accept() {
+                    onAccepted: {
                         if (_singleFirmwareMode) {
                             controller.flashSingleFirmwareMode(controller.selectedFirmwareBuildType)
                         } else {
@@ -208,14 +204,23 @@ SetupPage {
                                     } else {
                                         if (controller.apmFirmwareNames.length === 0) {
                                             // Not ready yet, or no firmware available
+                                            mainWindow.showMessageDialog(firmwareSelectDialog.title, qsTr("Either firmware list is still downloading, or no firmware is available for current selection."))
+                                            firmwareSelectDialog.preventClose = true
                                             return
                                         }
+                                        if (ardupilotFirmwareSelectionCombo.currentIndex == 0) {
+                                            mainWindow.showMessageDialog(firmwareSelectDialog.title, qsTr("You must choose a board type."))
+                                            firmwareSelectDialog.preventClose = true
+                                            return
+                                        }
+
                                         var firmwareUrl = controller.apmFirmwareUrls[ardupilotFirmwareSelectionCombo.currentIndex]
                                         if (firmwareUrl == "") {
+                                            mainWindow.showMessageDialog(firmwareSelectDialog.title, qsTr("No firmware was found for the current selection."))
+                                            firmwareSelectDialog.preventClose = true
                                             return
                                         }
                                         controller.flashFirmwareUrl(controller.apmFirmwareUrls[ardupilotFirmwareSelectionCombo.currentIndex])
-                                        hideDialog()
                                         return
                                     }
                                 }
@@ -226,13 +231,14 @@ SetupPage {
                             } else {
                                 controller.flash(stack, firmwareBuildType, vehicleType)
                             }
-                            hideDialog()
                         }
                     }
 
                     function reject() {
-                        hideDialog()
-                        cancelFlash()
+                        statusTextArea.append(highlightPrefix + qsTr("Upgrade cancelled") + highlightSuffix)
+                        statusTextArea.append("------------------------------------------")
+                        controller.cancel()
+                        close()
                     }
 
                     ListModel {
@@ -295,211 +301,165 @@ SetupPage {
                         }
                     }
 
-                    QGCFlickable {
-                        anchors.fill:   parent
-                        contentHeight:  mainColumn.height
+                    ColumnLayout {
+                        width:      Math.max(ScreenTools.defaultFontPixelWidth * 40, firmwareRadiosColumn.width)
+                        spacing:    globals.defaultTextHeight / 2
+
+                        QGCLabel {
+                            Layout.fillWidth:   true
+                            wrapMode:           Text.WordWrap
+                            text:               (_singleFirmwareMode || !QGroundControl.apmFirmwareSupported) ? _singleFirmwareLabel : (px4Flow ? _px4FlowLabel : _pixhawkLabel)
+
+                            readonly property string _px4FlowLabel:          qsTr("Detected PX4 Flow board. The firmware you use on the PX4 Flow must match the AutoPilot firmware type you are using on the vehicle:")
+                            readonly property string _pixhawkLabel:          qsTr("Detected Pixhawk board. You can select from the following flight stacks:")
+                            readonly property string _singleFirmwareLabel:   qsTr("Press Ok to upgrade your vehicle.")
+                        }
 
                         Column {
-                            id:             mainColumn
-                            anchors.left:   parent.left
-                            anchors.right:  parent.right
-                            spacing:        globals.defaultTextHeight
+                            id:         firmwareRadiosColumn
+                            spacing:    0
 
-                            QGCLabel {
-                                width:      parent.width
-                                wrapMode:   Text.WordWrap
-                                text:       (_singleFirmwareMode || !QGroundControl.apmFirmwareSupported) ? _singleFirmwareLabel : (px4Flow ? _px4FlowLabel : _pixhawkLabel)
+                            visible: !_singleFirmwareMode && !px4Flow && QGroundControl.apmFirmwareSupported
 
-                                readonly property string _px4FlowLabel:          qsTr("Detected PX4 Flow board. The firmware you use on the PX4 Flow must match the AutoPilot firmware type you are using on the vehicle:")
-                                readonly property string _pixhawkLabel:          qsTr("Detected Pixhawk board. You can select from the following flight stacks:")
-                                readonly property string _singleFirmwareLabel:   qsTr("Press Ok to upgrade your vehicle.")
-                            }
-
-                            QGCLabel { text: qsTr("Flight Stack"); visible: QGroundControl.apmFirmwareSupported }
-
-                            Column {
-
-                                Component.onCompleted: {
-                                    if(!QGroundControl.apmFirmwareSupported) {
-                                        _defaultFirmwareFact.rawValue = _defaultFimwareTypePX4
-                                        firmwareVersionChanged(firmwareBuildTypeList)
-                                    }
-                                }
-
-                                QGCRadioButton {
-                                    id:             px4FlightStackRadio
-                                    text:           qsTr("PX4 Pro ")
-                                    font.bold:      _defaultFirmwareIsPX4
-                                    checked:        _defaultFirmwareIsPX4
-                                    visible:        !_singleFirmwareMode && !px4Flow && QGroundControl.apmFirmwareSupported
-
-                                    onClicked: {
-                                        _defaultFirmwareFact.rawValue = _defaultFimwareTypePX4
-                                        firmwareVersionChanged(firmwareBuildTypeList)
-                                    }
-                                }
-
-                                QGCRadioButton {
-                                    id:             apmFlightStack
-                                    text:           qsTr("ArduPilot")
-                                    font.bold:      !_defaultFirmwareIsPX4
-                                    checked:        !_defaultFirmwareIsPX4
-                                    visible:        !_singleFirmwareMode && !px4Flow && QGroundControl.apmFirmwareSupported
-
-                                    onClicked: {
-                                        _defaultFirmwareFact.rawValue = _defaultFimwareTypeAPM
-                                        firmwareVersionChanged(firmwareBuildTypeList)
-                                    }
+                            Component.onCompleted: {
+                                if(!QGroundControl.apmFirmwareSupported) {
+                                    _defaultFirmwareFact.rawValue = _defaultFimwareTypePX4
+                                    firmwareVersionChanged(firmwareBuildTypeList)
                                 }
                             }
 
-                            FactComboBox {
-                                anchors.left:   parent.left
-                                anchors.right:  parent.right
-                                visible:        !px4Flow && apmFlightStack.checked
-                                fact:           _firmwareUpgradeSettings.apmChibiOS
-                                indexModel:     false
-                            }
+                            QGCRadioButton {
+                                id:             px4FlightStackRadio
+                                text:           qsTr("PX4 Pro ")
+                                font.bold:      _defaultFirmwareIsPX4
+                                checked:        _defaultFirmwareIsPX4
 
-                            FactComboBox {
-                                id:             apmVehicleTypeCombo
-                                anchors.left:   parent.left
-                                anchors.right:  parent.right
-                                visible:        !px4Flow && apmFlightStack.checked
-                                fact:           _firmwareUpgradeSettings.apmVehicleType
-                                indexModel:     false
-                            }
-
-                            QGCComboBox {
-                                id:             ardupilotFirmwareSelectionCombo
-                                anchors.left:   parent.left
-                                anchors.right:  parent.right
-                                visible:        !px4Flow && apmFlightStack.checked && !controller.downloadingFirmwareList && controller.apmFirmwareNames.length !== 0
-                                model:          controller.apmFirmwareNames
-                                onModelChanged: currentIndex = controller.apmFirmwareNamesBestIndex
-                            }
-
-                            QGCLabel {
-                                anchors.left:   parent.left
-                                anchors.right:  parent.right
-                                wrapMode:       Text.WordWrap
-                                text:           qsTr("Downloading list of available firmwares...")
-                                visible:        controller.downloadingFirmwareList
-                            }
-
-                            QGCLabel {
-                                anchors.left:   parent.left
-                                anchors.right:  parent.right
-                                wrapMode:       Text.WordWrap
-                                text:           qsTr("No Firmware Available")
-                                visible:        !controller.downloadingFirmwareList && (QGroundControl.apmFirmwareSupported && controller.apmFirmwareNames.length === 0)
-                            }
-
-                            QGCComboBox {
-                                id:             px4FlowTypeSelectionCombo
-                                anchors.left:   parent.left
-                                anchors.right:  parent.right
-                                visible:        px4Flow
-                                model:          px4FlowFirmwareList
-                                textRole:       "text"
-                                currentIndex:   _defaultFirmwareIsPX4 ? 0 : 1
-                            }
-
-                            Row {
-                                width:      parent.width
-                                spacing:    ScreenTools.defaultFontPixelWidth / 2
-                                visible:    !px4Flow
-
-                                Rectangle {
-                                    height:     1
-                                    width:      ScreenTools.defaultFontPixelWidth * 5
-                                    color:      qgcPal.text
-                                    anchors.verticalCenter: _advanced.verticalCenter
-                                }
-
-                                QGCCheckBox {
-                                    id:         _advanced
-                                    text:       qsTr("Advanced settings")
-                                    checked:    px4Flow ? true : false
-
-                                    onClicked: {
-                                        firmwareBuildTypeCombo.currentIndex = 0
-                                        firmwareWarningMessageVisible = false
-                                        updatePX4VersionDisplay()
-                                    }
-                                }
-
-                                Rectangle {
-                                    height:     1
-                                    width:      ScreenTools.defaultFontPixelWidth * 5
-                                    color:      qgcPal.text
-                                    anchors.verticalCenter: _advanced.verticalCenter
+                                onClicked: {
+                                    _defaultFirmwareFact.rawValue = _defaultFimwareTypePX4
+                                    firmwareVersionChanged(firmwareBuildTypeList)
                                 }
                             }
 
-                            QGCLabel {
-                                width:      parent.width
-                                wrapMode:   Text.WordWrap
-                                visible:    showFirmwareTypeSelection
-                                text:       _singleFirmwareMode ?  qsTr("Select the standard version or one from the file system (previously downloaded):") :
-                                                                  (px4Flow ? qsTr("Select which version of the firmware you would like to install:") :
-                                                                             qsTr("Select which version of the above flight stack you would like to install:"))
-                            }
+                            QGCRadioButton {
+                                id:             apmFlightStack
+                                text:           qsTr("ArduPilot")
+                                font.bold:      !_defaultFirmwareIsPX4
+                                checked:        !_defaultFirmwareIsPX4
 
-                            QGCComboBox {
-                                id:             firmwareBuildTypeCombo
-                                anchors.left:   parent.left
-                                anchors.right:  parent.right
-                                visible:        showFirmwareTypeSelection
-                                textRole:       "text"
-                                model:          _singleFirmwareMode ? singleFirmwareModeTypeList : (px4Flow ? px4FlowTypeList : firmwareBuildTypeList)
-
-                                onActivated: {
-                                    controller.selectedFirmwareBuildType = model.get(index).firmwareType
-                                    if (model.get(index).firmwareType === FirmwareUpgradeController.BetaFirmware) {
-                                        firmwareWarningMessageVisible = true
-                                        firmwareVersionWarningLabel.text = qsTr("WARNING: BETA FIRMWARE. ") +
-                                                qsTr("This firmware version is ONLY intended for beta testers. ") +
-                                                qsTr("Although it has received FLIGHT TESTING, it represents actively changed code. ") +
-                                                qsTr("Do NOT use for normal operation.")
-                                    } else if (model.get(index).firmwareType === FirmwareUpgradeController.DeveloperFirmware) {
-                                        firmwareWarningMessageVisible = true
-                                        firmwareVersionWarningLabel.text = qsTr("WARNING: CONTINUOUS BUILD FIRMWARE. ") +
-                                                qsTr("This firmware has NOT BEEN FLIGHT TESTED. ") +
-                                                qsTr("It is only intended for DEVELOPERS. ") +
-                                                qsTr("Run bench tests without props first. ") +
-                                                qsTr("Do NOT fly this without additional safety precautions. ") +
-                                                qsTr("Follow the forums actively when using it.")
-                                    } else {
-                                        firmwareWarningMessageVisible = false
-                                    }
-                                    updatePX4VersionDisplay()
+                                onClicked: {
+                                    _defaultFirmwareFact.rawValue = _defaultFimwareTypeAPM
+                                    firmwareVersionChanged(firmwareBuildTypeList)
                                 }
                             }
+                        }
 
-                            QGCLabel {
-                                id:         firmwareVersionWarningLabel
-                                width:      parent.width
-                                wrapMode:   Text.WordWrap
-                                visible:    firmwareWarningMessageVisible
+                        FactComboBox {
+                            Layout.fillWidth:   true
+                            visible:            !px4Flow && apmFlightStack.checked
+                            fact:               _firmwareUpgradeSettings.apmChibiOS
+                            indexModel:         false
+                        }
+
+                        FactComboBox {
+                            id:                 apmVehicleTypeCombo
+                            Layout.fillWidth:   true
+                            visible:            !px4Flow && apmFlightStack.checked
+                            fact:               _firmwareUpgradeSettings.apmVehicleType
+                            indexModel:         false
+                        }
+
+                        QGCComboBox {
+                            id:                 ardupilotFirmwareSelectionCombo
+                            Layout.fillWidth:   true
+                            visible:            !px4Flow && apmFlightStack.checked && !controller.downloadingFirmwareList && controller.apmFirmwareNames.length !== 0
+                            model:              controller.apmFirmwareNames
+                            onModelChanged:     currentIndex = controller.apmFirmwareNamesBestIndex
+                        }
+
+                        QGCLabel {
+                            Layout.fillWidth:   true
+                            wrapMode:           Text.WordWrap
+                            text:               qsTr("Downloading list of available firmwares...")
+                            visible:            controller.downloadingFirmwareList
+                        }
+
+                        QGCLabel {
+                            Layout.fillWidth:   true
+                            wrapMode:           Text.WordWrap
+                            text:               qsTr("No Firmware Available")
+                            visible:            !controller.downloadingFirmwareList && (QGroundControl.apmFirmwareSupported && controller.apmFirmwareNames.length === 0)
+                        }
+
+                        QGCComboBox {
+                            id:                 px4FlowTypeSelectionCombo
+                            Layout.fillWidth:   true
+                            visible:            px4Flow
+                            model:              px4FlowFirmwareList
+                            textRole:           "text"
+                            currentIndex:       _defaultFirmwareIsPX4 ? 0 : 1
+                        }
+
+                        QGCCheckBox {
+                            id:         _advanced
+                            text:       qsTr("Advanced settings")
+                            checked:    px4Flow ? true : false
+                            visible:    !px4Flow
+
+                            onClicked: {
+                                firmwareBuildTypeCombo.currentIndex = 0
+                                firmwareWarningMessageVisible = false
+                                updatePX4VersionDisplay()
                             }
-                        } // Column
-                    } // QGCFLickable
-                } // QGCViewDialog
+                        }
+
+                        QGCLabel {
+                            Layout.fillWidth:   true
+                            wrapMode:           Text.WordWrap
+                            visible:            showFirmwareTypeSelection
+                            text:               _singleFirmwareMode ?  qsTr("Select the standard version or one from the file system (previously downloaded):") :
+                                                                      (px4Flow ? qsTr("Select which version of the firmware you would like to install:") :
+                                                                                 qsTr("Select which version of the above flight stack you would like to install:"))
+                        }
+
+                        QGCComboBox {
+                            id:                 firmwareBuildTypeCombo
+                            Layout.fillWidth:   true
+                            visible:            showFirmwareTypeSelection
+                            textRole:           "text"
+                            model:              _singleFirmwareMode ? singleFirmwareModeTypeList : (px4Flow ? px4FlowTypeList : firmwareBuildTypeList)
+
+                            onActivated: {
+                                controller.selectedFirmwareBuildType = model.get(index).firmwareType
+                                if (model.get(index).firmwareType === FirmwareUpgradeController.BetaFirmware) {
+                                    firmwareWarningMessageVisible = true
+                                    firmwareVersionWarningLabel.text = qsTr("WARNING: BETA FIRMWARE. ") +
+                                            qsTr("This firmware version is ONLY intended for beta testers. ") +
+                                            qsTr("Although it has received FLIGHT TESTING, it represents actively changed code. ") +
+                                            qsTr("Do NOT use for normal operation.")
+                                } else if (model.get(index).firmwareType === FirmwareUpgradeController.DeveloperFirmware) {
+                                    firmwareWarningMessageVisible = true
+                                    firmwareVersionWarningLabel.text = qsTr("WARNING: CONTINUOUS BUILD FIRMWARE. ") +
+                                            qsTr("This firmware has NOT BEEN FLIGHT TESTED. ") +
+                                            qsTr("It is only intended for DEVELOPERS. ") +
+                                            qsTr("Run bench tests without props first. ") +
+                                            qsTr("Do NOT fly this without additional safety precautions. ") +
+                                            qsTr("Follow the forums actively when using it.")
+                                } else {
+                                    firmwareWarningMessageVisible = false
+                                }
+                                updatePX4VersionDisplay()
+                            }
+                        }
+
+                        QGCLabel {
+                            id:                 firmwareVersionWarningLabel
+                            Layout.fillWidth:   true
+                            wrapMode:           Text.WordWrap
+                            visible:            firmwareWarningMessageVisible
+                        }
+                    } // ColumnLayout
+                } // QGCPopupDialog
             } // Component - firmwareSelectDialogComponent
-
-            Component {
-                id: firmwareWarningDialog
-
-                QGCViewMessage {
-                    message: firmwareWarningMessage
-
-                    function accept() {
-                        hideDialog()
-                        controller.doFirmwareUpgrade();
-                    }
-                }
-            }
 
             ProgressBar {
                 id:                     progressBar


### PR DESCRIPTION
* This is the second phase of the work happening in this area
* Even more work done to make QGCPopupDialog instead of "sort of" work like a standard Qml Dialog it works exactly like it now
* Converted all usage of QGCViewMessage to either `mainWindow.showMessage` or direct `QGCSimpleMessageDialog` usage
* Converted a few more QGCViewDialog usages to the new QGCPopupDialog
* Added new support to `mainWindow.showMessage` to make it way easier to write code which needs to do something based on a simple yes/no style questions. It now has two additional optional parameters to specify buttons and accept function all within the showMessage function call. Example:
```
mainWindow.showMessage(
    "title", 
    "text", 
    StandardButton.Yes | StandardButton.No,
    function() { doAcceptStuff here } )
```

Remaining work:
* Convert remaining usage of QGCViewDialog to QGCPopupDialog