### PR TITLE
Do not load Read-only parameters from files, load read-only metadata from ardupilot xmls

### DIFF
--- a/src/FirmwarePlugin/APM/APMParameterMetaData.cc
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.cc
@@ -378,6 +378,12 @@ bool APMParameterMetaData::parseParameterAttributes(QXmlStreamReader& xml, APMFa
                 QString units = xml.readElementText();
                 qCDebug(APMParameterMetaDataVerboseLog) << "read Units: " << units;
                 rawMetaData->units = units;
+            } else if (attributeName == "ReadOnly") {
+                QString strValue = xml.readElementText().trimmed();
+                if (strValue.compare("true", Qt::CaseInsensitive) == 0) {
+                    rawMetaData->readOnly = true;
+                }
+                qCDebug(APMParameterMetaDataVerboseLog) << "read ReadOnly: " << rawMetaData->readOnly;
             } else if (attributeName == "Bitmask") {
                 bool    parseError = false;
 
@@ -461,6 +467,7 @@ FactMetaData* APMParameterMetaData::getMetaDataForFact(const QString& name, MAV_
     }
     metaData->setGroup(rawMetaData->group);
     metaData->setVehicleRebootRequired(rawMetaData->rebootRequired);
+    metaData->setReadOnly(rawMetaData->readOnly);
 
     if (!rawMetaData->shortDescription.isEmpty()) {
         metaData->setShortDescription(rawMetaData->shortDescription);

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.h
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.h
@@ -42,6 +42,7 @@ public:
     QString incrementSize;
     QString units;
     bool    rebootRequired;
+    bool    readOnly;
     QList<QPair<QString, QString> > values;
     QList<QPair<QString, QString> > bitmask;
 };

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -278,6 +278,7 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 QString     units;
                 QVariant    fileValueVar    = fileValueStr;
                 bool        noVehicleValue   = false;
+                bool        readOnly         = false;
 
                 if (_vehicle->id() != vehicleId) {
                     _diffOtherVehicle = true;
@@ -299,6 +300,7 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                     fileFact->setMetaData(vehicleFact->metaData());
                     fileFact->setRawValue(fileValueStr);
                     vehicleFactMetaData->setVehicleRebootRequired(vehicleRebootRequired);
+                    readOnly = vehicleFact->readOnly();
 
                     if (vehicleFact->rawValue() == fileFact->rawValue()) {
                         continue;
@@ -311,18 +313,20 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                     noVehicleValue = true;
                 }
 
-                ParameterEditorDiff* paramDiff = new ParameterEditorDiff(this);
+                if (!readOnly) {
+                    ParameterEditorDiff* paramDiff = new ParameterEditorDiff(this);
 
-                paramDiff->componentId      = componentId;
-                paramDiff->name             = paramName;
-                paramDiff->valueType        = ParameterManager::mavTypeToFactType(static_cast<MAV_PARAM_TYPE>(mavParamType));
-                paramDiff->fileValue        = fileValueStr;
-                paramDiff->fileValueVar     = fileValueVar;
-                paramDiff->vehicleValue     = vehicleValueStr;
-                paramDiff->noVehicleValue   = noVehicleValue;
-                paramDiff->units            = units;
+                    paramDiff->componentId      = componentId;
+                    paramDiff->name             = paramName;
+                    paramDiff->valueType        = ParameterManager::mavTypeToFactType(static_cast<MAV_PARAM_TYPE>(mavParamType));
+                    paramDiff->fileValue        = fileValueStr;
+                    paramDiff->fileValueVar     = fileValueVar;
+                    paramDiff->vehicleValue     = vehicleValueStr;
+                    paramDiff->noVehicleValue   = noVehicleValue;
+                    paramDiff->units            = units;
 
-                _diffList.append(paramDiff);
+                    _diffList.append(paramDiff);
+                }
             }
         }
     }


### PR DESCRIPTION
The ReadOnly field is already in FactMetaData.h. This populates this field from ardupilot metadata and additionally ignores these parameters when loading a parameter file. 