### PR TITLE
Actuators: minor updates

### DIFF
--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -286,7 +286,7 @@ SetupPage {
                                                 model:              actionGroup.actions
                                                 QGCMenuItem {
                                                     text:           object.label
-                                                    onTriggered:	object.trigger()
+                                                    onTriggered:    object.trigger()
                                                 }
                                                 onObjectAdded:      actionMenu.insertItem(index, object)
                                                 onObjectRemoved:    actionMenu.removeItem(object)
@@ -354,6 +354,7 @@ SetupPage {
                             QGCButton {
                                 text:          qsTr("Identify & Assign Motors")
                                 visible:       !actuators.motorAssignmentActive && selActuatorOutput.actuatorOutput.groupsVisible
+                                enabled:       actuators.motorAssignmentEnabled
                                 onClicked: {
                                     var success = actuators.initMotorAssignment()
                                     if (success) {

--- a/src/Vehicle/Actuators/Actuators.cc
+++ b/src/Vehicle/Actuators/Actuators.cc
@@ -103,6 +103,9 @@ void Actuators::updateGeometryImage()
 
     _imageRefreshFlag = !_imageRefreshFlag;
     emit imageRefreshFlagChanged();
+
+    _motorAssignmentEnabled = provider->numMotors() > 0;
+    emit motorAssignmentEnabledChanged();
 }
 
 bool Actuators::isMultirotor() const
@@ -674,13 +677,7 @@ bool Actuators::showUi() const
 bool Actuators::initMotorAssignment()
 {
     GeometryImage::VehicleGeometryImageProvider* provider = GeometryImage::VehicleGeometryImageProvider::instance();
-    int numMotors = 0;
-    QList<ActuatorGeometry>& actuators = provider->actuators();
-    for (const auto& actuator : actuators) {
-        if (actuator.type == ActuatorGeometry::Type::Motor) {
-            ++numMotors;
-        }
-    }
+    int numMotors = provider->numMotors();
 
     // get the minimum function for motors
     bool ret = false;

--- a/src/Vehicle/Actuators/Actuators.h
+++ b/src/Vehicle/Actuators/Actuators.h
@@ -33,6 +33,7 @@ public:
     Q_PROPERTY(bool imageRefreshFlag                       READ imageRefreshFlag          NOTIFY imageRefreshFlagChanged)
     Q_PROPERTY(bool hasUnsetRequiredFunctions              READ hasUnsetRequiredFunctions NOTIFY hasUnsetRequiredFunctionsChanged)
     Q_PROPERTY(bool motorAssignmentActive                  READ motorAssignmentActive     NOTIFY motorAssignmentActiveChanged)
+    Q_PROPERTY(bool motorAssignmentEnabled                 READ motorAssignmentEnabled    NOTIFY motorAssignmentEnabledChanged)
     Q_PROPERTY(QString motorAssignmentMessage              READ motorAssignmentMessage    NOTIFY motorAssignmentMessageChanged)
 
     Q_PROPERTY(ActuatorTesting::ActuatorTest* actuatorTest                      READ actuatorTest              CONSTANT)
@@ -75,6 +76,7 @@ public:
     Q_INVOKABLE void spinCurrentMotor() { _motorAssignment.spinCurrentMotor(); }
     Q_INVOKABLE void abortMotorAssignment();
     bool motorAssignmentActive() const { return _motorAssignment.active(); }
+    bool motorAssignmentEnabled() const { return _motorAssignmentEnabled; }
     const QString& motorAssignmentMessage() const { return _motorAssignment.message(); }
 
 public slots:
@@ -86,6 +88,7 @@ signals:
     void imageRefreshFlagChanged();
     void hasUnsetRequiredFunctionsChanged();
     void motorAssignmentActiveChanged();
+    void motorAssignmentEnabledChanged();
     void motorAssignmentMessageChanged();
     void actuatorActionsChanged();
 
@@ -112,6 +115,7 @@ private:
     ActuatorTesting::ActuatorTest _actuatorTest;
     Mixer::Mixers _mixer;
     MotorAssignment _motorAssignment;
+    bool _motorAssignmentEnabled{false};
     bool _hasUnsetRequiredFunctions{false};
     bool _imageRefreshFlag{false}; ///< indicator to QML to reload the image
     int _selectedActuatorOutput{0};

--- a/src/Vehicle/Actuators/GeometryImage.cc
+++ b/src/Vehicle/Actuators/GeometryImage.cc
@@ -415,3 +415,14 @@ int VehicleGeometryImageProvider::getHighlightedMotorIndexAtPos(const QPointF &p
     }
     return -1;
 }
+
+int VehicleGeometryImageProvider::numMotors() const
+{
+    int numMotors = 0;
+    for (const auto& actuator : _actuators) {
+        if (actuator.type == ActuatorGeometry::Type::Motor) {
+            ++numMotors;
+        }
+    }
+    return numMotors;
+}

--- a/src/Vehicle/Actuators/GeometryImage.h
+++ b/src/Vehicle/Actuators/GeometryImage.h
@@ -50,6 +50,8 @@ public:
 
     QList<ActuatorGeometry>& actuators() { return _actuators; }
 
+    int numMotors() const;
+
 private:
     VehicleGeometryImageProvider();
     ~VehicleGeometryImageProvider() = default;

--- a/src/Vehicle/Actuators/MotorAssignment.cc
+++ b/src/Vehicle/Actuators/MotorAssignment.cc
@@ -17,7 +17,7 @@
 MotorAssignment::MotorAssignment(QObject* parent, Vehicle* vehicle, QmlObjectListModel* actuators)
         : QObject(parent), _vehicle(vehicle), _actuators(actuators)
 {
-    _spinTimer.setInterval(1000);
+    _spinTimer.setInterval(_spinTimeoutDefaultSec);
     _spinTimer.setSingleShot(true);
     connect(&_spinTimer, &QTimer::timeout, this, &MotorAssignment::spinTimeout);
 }
@@ -141,6 +141,7 @@ void MotorAssignment::start()
     }
     _state = State::Running;
     emit activeChanged();
+    _spinTimer.setInterval(_assignMotors ? _spinTimeoutHighSec : _spinTimeoutDefaultSec);
     _spinTimer.start();
 }
 
@@ -169,6 +170,7 @@ void MotorAssignment::selectMotor(int motorIndex)
         emit activeChanged();
     } else {
         // spin the next motor after some time
+        _spinTimer.setInterval(_spinTimeoutDefaultSec);
         _spinTimer.start();
     }
 }

--- a/src/Vehicle/Actuators/MotorAssignment.h
+++ b/src/Vehicle/Actuators/MotorAssignment.h
@@ -59,6 +59,9 @@ private slots:
     void spinTimeout();
 
 private:
+    static constexpr int _spinTimeoutDefaultSec = 1000;
+    static constexpr int _spinTimeoutHighSec = 3000; ///< wait a bit longer after assigning motors, so ESCs can initialize
+
     static void ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
             Vehicle::MavCmdResultFailureCode_t failureCode);
     void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);


### PR DESCRIPTION
- disable motor assignment button if geometry does not have motors
- increase motor spin timeout to 3s when assigning motors 
  So that ESC's can initialize. Note that some are faster than others and 1s is enough in some cases.

I can bring this to stable as well.