### PR TITLE
Actuators: update output function parameter metadata

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -278,6 +278,7 @@ void Fact::setEnumInfo(const QStringList& strings, const QVariantList& values)
 {
     if (_metaData) {
         _metaData->setEnumInfo(strings, values);
+        emit enumsChanged();
     } else {
         qWarning() << kMissingMetadata << name();
     }

--- a/src/FactSystem/FactControls/FactComboBox.qml
+++ b/src/FactSystem/FactControls/FactComboBox.qml
@@ -14,6 +14,17 @@ QGCComboBox {
 
     currentIndex: fact ? (indexModel ? fact.value : fact.enumIndex) : 0
 
+    onModelChanged: {
+        // When the model changes, the index gets reset to 0, so make sure to
+        // restore it correctly.
+        // Since enumIndex could trigger a model change, we use callLater() to
+        // avoid an event binding loop (the 2. call will for certain not trigger
+        // another model change)
+        Qt.callLater(function() {
+            currentIndex = fact ? (indexModel ? fact.value : fact.enumIndex) : 0
+        })
+    }
+
     onActivated: {
         if (indexModel) {
             fact.value = index

--- a/src/Vehicle/Actuators/Actuators.h
+++ b/src/Vehicle/Actuators/Actuators.h
@@ -106,6 +106,8 @@ private:
 
     void highlightActuators(bool highlight);
 
+    void updateFunctionMetadata();
+
     QSet<Fact*> _subscribedFacts{};
     QJsonDocument _jsonMetadata;
     bool _init{false};
@@ -120,5 +122,6 @@ private:
     bool _imageRefreshFlag{false}; ///< indicator to QML to reload the image
     int _selectedActuatorOutput{0};
     Vehicle* _vehicle{nullptr};
+    QMap<int, QString> _usedMixerLabels;
 };
 

--- a/src/Vehicle/Actuators/Mixer.h
+++ b/src/Vehicle/Actuators/Mixer.h
@@ -321,9 +321,9 @@ public:
     QString getSpecificLabelForFunction(int function) const;
 
     /**
-     * Get the set of all required actuator functions
+     * Get the set of all (required) actuator functions
      */
-    QSet<int> requiredFunctions() const;
+    QSet<int> getFunctions(bool requiredOnly) const;
 
     QString configuredType() const;
 


### PR DESCRIPTION
- remove the mixer functions that are unused with the current configration
  (e.g. if 4 motors -> remove motors 5-N)
- use the specific labels

### Before
![qgc_actuators_metadata_before](https://user-images.githubusercontent.com/281593/149749919-2713d634-159b-427f-b728-c42f7f495822.png)
![qgc_actuators_metadata_before_popup](https://user-images.githubusercontent.com/281593/149750286-8e36a64b-8ecd-4b8a-8a4c-dda7da16b098.png)

### After
![qgc_actuators_metadata_after](https://user-images.githubusercontent.com/281593/149749945-98b3c558-3d3f-458d-a87a-6939df7c5ca6.png)
![qgc_actuators_metadata_after_popup](https://user-images.githubusercontent.com/281593/149750300-41c4d855-2822-4695-a5c6-5544760af757.png)

@hamishwillee @MaEtUgR  fyi