### PR TITLE
Added exceptions for features not supported by APM 4.1 earlier

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml
@@ -87,7 +87,7 @@ Item {
 
         VehicleSummaryRow {
             labelText: qsTr("Barometer(s):")
-            valueText: ""
+            valueText: sensorParams.baroIdAvailable ? "" : qsTr("Not Supported(Over APM 4.1)")
         }
 
         Repeater {

--- a/src/FirmwarePlugin/APM/APMSensorParams.qml
+++ b/src/FirmwarePlugin/APM/APMSensorParams.qml
@@ -100,9 +100,11 @@ Item {
     property Fact ins3Id:                           factPanelController.getParameterFact(-1, "INS_ACC3_ID")
     property var  rgInsId:                          [ ins1Id, ins2Id, ins3Id ]
 
-    property Fact baro1Id:                           factPanelController.getParameterFact(-1, "BARO1_DEVID")
-    property Fact baro2Id:                           factPanelController.getParameterFact(-1, "BARO2_DEVID")
-    property Fact baro3Id:                           factPanelController.getParameterFact(-1, "BARO3_DEVID")
-    property var  rgBaroId:                          [ baro1Id, baro2Id, baro3Id ]
+    property bool baroIdAvailable:                  factPanelController.parameterExists(-1, "BARO1_DEVID")
+
+    property Fact baro1Id:                          baroIdAvailable ? factPanelController.getParameterFact(-1, "BARO1_DEVID") : _noFact
+    property Fact baro2Id:                          baroIdAvailable ? factPanelController.getParameterFact(-1, "BARO2_DEVID") : _noFact
+    property Fact baro3Id:                          baroIdAvailable ? factPanelController.getParameterFact(-1, "BARO3_DEVID") : _noFact
+    property var  rgBaroId:                         [ baro1Id, baro2Id, baro3Id ]
 
 }


### PR DESCRIPTION
The BARO1_DEVID parameter seems to have been added in "APM 4.1.0". In earlier versions of APM firmware, it causes a Missing Parameter error. This PR fixes this.

Please review.