### PR TITLE
Small ui tweaks

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -25,7 +25,7 @@ import QGroundControl.FactControls      1.0
 
 Rectangle {
     height:     mainLayout.height + (_margins * 2)
-    color:      "#80000000"
+    color:      Qt.rgba(qgcPal.window.r, qgcPal.window.g, qgcPal.window.b, 0.5)
     radius:     _margins
     visible:    (_mavlinkCamera || _videoStreamAvailable || _simpleCameraAvailable) && multiVehiclePanelSelector.showSingleVehiclePanel
 

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -27,6 +27,7 @@ T.ComboBox {
                              contentItem.implicitWidth + leftPadding + rightPadding + padding)
     implicitHeight: Math.max(background ? background.implicitHeight : 0,
                              Math.max(contentItem.implicitHeight, indicator ? indicator.implicitHeight : 0) + topPadding + bottomPadding)
+    baselineOffset: contentItem.y + text.baselineOffset
     leftPadding:    padding + (!control.mirrored || !indicator || !indicator.visible ? 0 : indicator.width + spacing)
     rightPadding:   padding + (control.mirrored || !indicator || !indicator.visible ? 0 : indicator.width)
 

--- a/src/ui/preferences/MavlinkSettings.qml
+++ b/src/ui/preferences/MavlinkSettings.qml
@@ -624,8 +624,8 @@ Rectangle {
                             text:               QGroundControl.mavlinkLogManager.feedback
                             enabled:            !_disableDataPersistence
                             style: TextAreaStyle {
-                                textColor:          qgcPal.windowShade
-                                backgroundColor:    qgcPal.text
+                                textColor:          qgcPal.textFieldText
+                                backgroundColor:    qgcPal.textField
                             }
                         }
                     }


### PR DESCRIPTION
This PR fixes a couple things that don't look right.

1. PhotoVideoControl.qml
Outdoor mode before change
![beforeLight](https://user-images.githubusercontent.com/46759700/150882763-5fec9ec7-0db9-4070-9d9f-743ceea03f9e.png)
Outdoor mode after the change
![afterLight](https://user-images.githubusercontent.com/46759700/150882773-e2ac53c7-617d-41de-9f90-9b6962604864.png)

2. QGCComboBox.qml.qml
Alignment before change
![beforeMavDark](https://user-images.githubusercontent.com/46759700/150882814-e49c7ffe-e826-4753-a998-9a7307800b1b.png)
Alignment after change
![afterMavDark](https://user-images.githubusercontent.com/46759700/150882836-c8ea2c1c-439a-4375-b7f4-1fdcf1e4d24b.png)

3. MavlinkSettings.qml
Indoor mode before change
![beforeMavLight](https://user-images.githubusercontent.com/46759700/150882927-90f7f5bc-5f79-4122-ba13-00895a4958e4.png)
Indoor mode after the change
![afterMavLight](https://user-images.githubusercontent.com/46759700/150882941-19d96f69-59ac-4e41-b967-3e79567d8f3c.png)

