### PR TITLE
Fix gpsrtkindicator warning

### DIFF
--- a/src/ui/toolbar/GPSRTKIndicator.qml
+++ b/src/ui/toolbar/GPSRTKIndicator.qml
@@ -23,7 +23,7 @@ Item {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
 
-    property bool showIndicator: QGroundControl.gpsRtk.connected.value
+    property bool showIndicator: QGroundControl.gpsRtk ? QGroundControl.gpsRtk.connected.value : false
 
     Component {
         id: gpsInfo


### PR DESCRIPTION
check if QGroundControl.gpsRtk exists before checking if it is connected