### PR TITLE
HorizontalFactValueGrid: Fix the valuerepeater index

### DIFF
--- a/src/QmlControls/HorizontalFactValueGrid.qml
+++ b/src/QmlControls/HorizontalFactValueGrid.qml
@@ -80,7 +80,7 @@ T.HorizontalFactValueGrid {
                             function recalcWidth() {
                                 var newMaxWidth = 0
                                 for (var i=0; i<valueRepeater.count; i++) {
-                                    newMaxWidth = Math.max(newMaxWidth, valueRepeater.itemAt(0).contentWidth)
+                                    newMaxWidth = Math.max(newMaxWidth, valueRepeater.itemAt(i).contentWidth)
                                 }
                                 maxWidth = Math.min(maxWidth, newMaxWidth)
                             }


### PR DESCRIPTION
The newMaxWidth is now the max between all values for a same column in the grid. The index was set to 0 instead of i, hence not checking for every content width of the column. 


