### PR TITLE
Fix PlanView warnings

### DIFF
--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -795,7 +795,7 @@ Item {
                         map:            editorMap
                         masterController:  _planMasterController
                         missionItem:    object
-                        width:          parent.width
+                        width:          missionItemEditorListView.width
                         readOnly:       false
                         onClicked:      _missionController.setCurrentPlanViewSeqNum(object.sequenceNumber, false)
                         onRemove: {

--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -220,9 +220,9 @@ void QmlObjectListModel::insert(int i, QList<QObject*> objects)
                 QObject::connect(object, SIGNAL(dirtyChanged(bool)), this, SLOT(_childDirtyChanged(bool)));
             }
         }
-        j++;
 
         _objectList.insert(j, object);
+        j++;
     }
 
     insertRows(i, objects.count());


### PR DESCRIPTION
This fixes a warning about property width of null not existing when all mission items are removed and fixes the QList insert method that produced an invalid index warning from being one index too high each insertion (#10122).