### PR TITLE
Center Version on Select Tool popup

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -342,8 +342,9 @@ ApplicationWindow {
                     }
 
                     ColumnLayout {
-                        width:      innerLayout.width
-                        spacing:    0
+                        width:                  innerLayout.width
+                        spacing:                0
+                        Layout.alignment:       Qt.AlignHCenter
 
                         QGCLabel {
                             id:                     versionLabel


### PR DESCRIPTION
Centers the version text on the Select Tool popup which looks much cleaner