### PR TITLE
CorridorScanComplexItem: Fixed camera triggering during return leg

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -346,7 +346,15 @@ void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
                 QList<TransectStyleComplexItem::CoordInfo_t> reversedVertices;
                 for (int j=transectVertices.count()-1; j>=0; j--) {
                     reversedVertices.append(transectVertices[j]);
+
+                    // as we are flying the transect reversed, we also need to swap entry and exit coordinate types
+                    if (reversedVertices.last().coordType == CoordTypeSurveyEntry) {
+                        reversedVertices.last().coordType = CoordTypeSurveyExit;
+                    } else if (reversedVertices.last().coordType == CoordTypeSurveyExit) {
+                        reversedVertices.last().coordType = CoordTypeSurveyEntry;
+                    }
                 }
+
                 transectVertices = reversedVertices;
             } else {
                 reverseVertices = true;


### PR DESCRIPTION
**Problem solved by this PR:**
During the return path of a corridor scan no pictures were taken if the survey was configured NOT to take pictures during turnarounds (I believe this is not the default and likely the reason why this bug did not surface).

The reason for this is that when vertices are reversed in a transect, the entry and exit coordinate types were not swapped.
This meant that a leg would start with an exit type and end with an entry type. Since these types basically define camera triggering start and stop points, obviously this could not work.

This is how a corridor scan looked like prior to this fix. Notice that waypoint 12 which is at the exit starts camera triggering.
![qgc_corridor_bad](https://user-images.githubusercontent.com/7610489/153995061-70ebd22f-e894-46db-a394-4f028074afaa.png)

This is how a corridor scan looks like with this PR. Notice that waypoint 10 starts camera triggering for the return leg of the corridor scan.

![qgc_corridor_fixed](https://user-images.githubusercontent.com/7610489/153995151-f1c848ad-3649-4c7e-baca-37c2792fba72.png)

