### PR TITLE
Actuators: some smaller updates

### DIFF
--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -31,10 +31,23 @@ SetupPage {
                 implicitWidth:              _leftColumnWidth
 
                 // mixer ui
-                QGCLabel {
-                    text:                   qsTr("Geometry")
-                    font.pointSize:         ScreenTools.mediumFontPointSize
-                    visible:                actuators.mixer.groups.count > 0
+                RowLayout {
+                    width:                      _leftColumnWidth
+                    visible:                    actuators.mixer.groups.count > 0
+                    QGCLabel {
+                        text:                   qsTr("Geometry") + (actuators.mixer.title ? ": " + actuators.mixer.title : "")
+                        font.pointSize:         ScreenTools.mediumFontPointSize
+                        Layout.fillWidth:       true
+                    }
+                    QGCLabel {
+                        text:                   "<a href='"+actuators.mixer.helpUrl+"'>?</a>"
+                        font.pointSize:         ScreenTools.mediumFontPointSize
+                        visible:                actuators.mixer.helpUrl
+                        textFormat:             Text.RichText
+                        onLinkActivated: {
+                            Qt.openUrlExternally(link);
+                        }
+                    }
                 }
 
                 Rectangle {

--- a/src/Vehicle/Actuators/Actuators.cc
+++ b/src/Vehicle/Actuators/Actuators.cc
@@ -594,6 +594,8 @@ bool Actuators::parseJson(const QJsonDocument &json)
         Mixer::MixerOption option{};
         option.option = mixerConfig["option"].toString();
         option.type = mixerConfig["type"].toString();
+        option.title = mixerConfig["title"].toString();
+        option.helpUrl = mixerConfig["help-url"].toString();
         QJsonArray actuatorsJson = mixerConfig["actuators"].toArray();
         for (const auto& actuatorJson : actuatorsJson) {
             QJsonValue actuatorJsonVal = actuatorJson.toObject();

--- a/src/Vehicle/Actuators/Mixer.cc
+++ b/src/Vehicle/Actuators/Mixer.cc
@@ -414,6 +414,21 @@ QString Mixers::configuredType() const
     return _mixerOptions[_selectedMixer].type;
 }
 
+QString Mixers::title() const
+{
+    if (_selectedMixer == -1) {
+        return "";
+    }
+    return _mixerOptions[_selectedMixer].title;
+}
+QString Mixers::helpUrl() const
+{
+    if (_selectedMixer == -1) {
+        return "";
+    }
+    return _mixerOptions[_selectedMixer].helpUrl;
+}
+
 Fact* Mixers::getFact(const QString& paramName)
 {
     if (!_parameterManager->parameterExists(FactSystem::defaultComponentId, paramName)) {

--- a/src/Vehicle/Actuators/Mixer.h
+++ b/src/Vehicle/Actuators/Mixer.h
@@ -78,6 +78,8 @@ struct MixerOption
     };
     QString option{};
     QString type{}; ///< Mixer type, e.g. multirotor
+    QString title{};
+    QString helpUrl{};
     QList<ActuatorGroup> actuators{};
 };
 
@@ -306,8 +308,13 @@ public:
             const QMap<int, OutputFunction>& functions, const Rules& rules);
 
     Q_PROPERTY(QmlObjectListModel* groups         READ groups        NOTIFY groupsChanged)
+    Q_PROPERTY(QString title                      READ title         NOTIFY groupsChanged)
+    Q_PROPERTY(QString helpUrl                    READ helpUrl       NOTIFY groupsChanged)
 
     QmlObjectListModel* groups() { return _groups; }
+
+    QString title() const;
+    QString helpUrl() const;
 
     const ActuatorTypes& actuatorTypes() const { return _actuatorTypes; }
 


### PR DESCRIPTION
- display geometry title if set
- show help url if set
- simplify axis configuration by adding a virtual dropdown if all 3 axis are set, which then sets the individual axis accordingly. Axes can still be configured individually by using Custom:

![qgc_actuators_standard_vtol](https://user-images.githubusercontent.com/281593/154077813-e5104761-eb91-4fbc-ada3-7f14806ba727.png)

![qgc_actuators_standard_vtol_custom](https://user-images.githubusercontent.com/281593/154077820-0406840c-a249-4a1e-8394-e29e68b98271.png)

