### PR TITLE
Fix #10143: ADSB SBS-1 messages parsing and displaying

### DIFF
--- a/src/ADSB/ADSBVehicle.cc
+++ b/src/ADSB/ADSBVehicle.cc
@@ -14,9 +14,10 @@
 #include <QDebug>
 #include <QtMath>
 
-ADSBVehicle::ADSBVehicle(const VehicleInfo_t& vehicleInfo, QObject* parent)
+ADSBVehicle::ADSBVehicle(const ADSBVehicleInfo_t & vehicleInfo, QObject* parent)
     : QObject       (parent)
     , _icaoAddress  (vehicleInfo.icaoAddress)
+    , _coordinate   (QGeoCoordinate(qQNaN(),qQNaN()))
     , _altitude     (qQNaN())
     , _heading      (qQNaN())
     , _alert        (false)
@@ -24,12 +25,14 @@ ADSBVehicle::ADSBVehicle(const VehicleInfo_t& vehicleInfo, QObject* parent)
     update(vehicleInfo);
 }
 
-void ADSBVehicle::update(const VehicleInfo_t& vehicleInfo)
+void ADSBVehicle::update(const ADSBVehicleInfo_t & vehicleInfo)
 {
     if (_icaoAddress != vehicleInfo.icaoAddress) {
         qCWarning(ADSBVehicleManagerLog) << "ICAO address mismatch expected:actual" << _icaoAddress << vehicleInfo.icaoAddress;
         return;
     }
+    qCDebug(ADSBVehicleManagerLog) << "Updating" << QStringLiteral("%1 Flags: %2").arg(vehicleInfo.icaoAddress, 0, 16).arg(vehicleInfo.availableFlags, 0, 2);
+
     if (vehicleInfo.availableFlags & CallsignAvailable) {
         if (vehicleInfo.callsign != _callsign) {
             _callsign = vehicleInfo.callsign;

--- a/src/ADSB/ADSBVehicle.h
+++ b/src/ADSB/ADSBVehicle.h
@@ -36,9 +36,9 @@ public:
         double          heading;
         bool            alert;
         uint32_t        availableFlags;
-    } VehicleInfo_t;
+    } ADSBVehicleInfo_t;
 
-    ADSBVehicle(const VehicleInfo_t& vehicleInfo, QObject* parent);
+    ADSBVehicle(const ADSBVehicleInfo_t & vehicleInfo, QObject* parent);
 
     Q_PROPERTY(int              icaoAddress READ icaoAddress    CONSTANT)
     Q_PROPERTY(QString          callsign    READ callsign       NOTIFY callsignChanged)
@@ -54,7 +54,7 @@ public:
     double          heading     (void) const { return _heading; }
     bool            alert       (void) const { return _alert; }
 
-    void update(const VehicleInfo_t& vehicleInfo);
+    void update(const ADSBVehicleInfo_t & vehicleInfo);
 
     /// check if the vehicle is expired and should be removed
     bool expired();
@@ -80,5 +80,5 @@ private:
                                                             ///< AirMap sends updates for each vehicle every second.
 };
 
-Q_DECLARE_METATYPE(ADSBVehicle::VehicleInfo_t)
+Q_DECLARE_METATYPE(ADSBVehicle::ADSBVehicleInfo_t)
 

--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -23,7 +23,6 @@ ADSBVehicleManager::ADSBVehicleManager(QGCApplication* app, QGCToolbox* toolbox)
 void ADSBVehicleManager::setToolbox(QGCToolbox* toolbox)
 {
     QGCTool::setToolbox(toolbox);
-
     connect(&_adsbVehicleCleanupTimer, &QTimer::timeout, this, &ADSBVehicleManager::_cleanupStaleVehicles);
     _adsbVehicleCleanupTimer.setSingleShot(false);
     _adsbVehicleCleanupTimer.start(1000);
@@ -42,7 +41,7 @@ void ADSBVehicleManager::_cleanupStaleVehicles()
     for (int i=_adsbVehicles.count()-1; i>=0; i--) {
         ADSBVehicle* adsbVehicle = _adsbVehicles.value<ADSBVehicle*>(i);
         if (adsbVehicle->expired()) {
-            qCDebug(ADSBVehicleManagerLog) << "Expired" << QStringLiteral("%1").arg(adsbVehicle->icaoAddress(), 0, 16);
+            qCDebug(ADSBVehicleManagerLog) << "Expired " << QStringLiteral("%1").arg(adsbVehicle->icaoAddress(), 0, 16);
             _adsbVehicles.removeAt(i);
             _adsbICAOMap.remove(adsbVehicle->icaoAddress());
             adsbVehicle->deleteLater();
@@ -50,7 +49,7 @@ void ADSBVehicleManager::_cleanupStaleVehicles()
     }
 }
 
-void ADSBVehicleManager::adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehicleInfo)
+void ADSBVehicleManager::adsbVehicleUpdate(const ADSBVehicle::ADSBVehicleInfo_t vehicleInfo)
 {
     uint32_t icaoAddress = vehicleInfo.icaoAddress;
 
@@ -61,6 +60,7 @@ void ADSBVehicleManager::adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehi
             ADSBVehicle* adsbVehicle = new ADSBVehicle(vehicleInfo, this);
             _adsbICAOMap[icaoAddress] = adsbVehicle;
             _adsbVehicles.append(adsbVehicle);
+            qCDebug(ADSBVehicleManagerLog) << "Added " << QStringLiteral("%1").arg(adsbVehicle->icaoAddress(), 0, 16);
         }
     }
 }
@@ -101,9 +101,7 @@ void ADSBTCPLink::run(void)
 void ADSBTCPLink::_hardwareConnect()
 {
     _socket = new QTcpSocket();
-
     QObject::connect(_socket, &QTcpSocket::readyRead, this, &ADSBTCPLink::_readBytes);
-
     _socket->connectToHost(_hostAddress, static_cast<quint16>(_port));
 
     // Give the socket a second to connect to the other side otherwise error out
@@ -121,72 +119,110 @@ void ADSBTCPLink::_hardwareConnect()
 void ADSBTCPLink::_readBytes(void)
 {
     if (_socket) {
-        QByteArray bytes = _socket->readLine();
-        _parseLine(QString::fromLocal8Bit(bytes));
+        while(_socket->canReadLine()) {
+            QByteArray bytes = _socket->readLine();
+            _parseLine(QString::fromLocal8Bit(bytes));
+        }
     }
 }
 
-void ADSBTCPLink::_parseLine(const QString& line)
+void ADSBTCPLink::_parseLine(const QString &line)
 {
     if (line.startsWith(QStringLiteral("MSG"))) {
-        qCDebug(ADSBVehicleManagerLog) << "ADSB SBS-1" << line;
+        bool icaoOk;
+        int msgType = line.at(4).digitValue();
+        if (msgType == -1) {
+            qCDebug(ADSBVehicleManagerLog) << "ADSB Invalid message type " << line.at(4);
+            return;
+        }
+        // Skip unsupported mesg types to avoid parsing
+        if (msgType == 2 || msgType > 6) {
+            return;
+        }
+        qCDebug(ADSBVehicleManagerLog) << " ADSB SBS-1 " << line;
+        QStringList values = line.split(QChar(','));
+        uint32_t icaoAddress = values[4].toUInt(&icaoOk, 16);
 
-        QStringList values = line.split(QStringLiteral(","));
+        if (!icaoOk) {
+            return;
+        }
 
-        if (values[1] == QStringLiteral("3")) {
-            bool icaoOk, altOk, latOk, lonOk;
+        ADSBVehicle::ADSBVehicleInfo_t adsbInfo;
+        adsbInfo.icaoAddress = icaoAddress;
 
-            uint32_t    icaoAddress =   values[4].toUInt(&icaoOk, 16);
-            int         modeCAltitude = values[11].toInt(&altOk);
-            double      lat =           values[14].toDouble(&latOk);
-            double      lon =           values[15].toDouble(&lonOk);
-            QString     callsign =      values[10];
-
-            if (!icaoOk || !altOk || !latOk || !lonOk) {
-                return;
-            }
-            if (lat == 0 && lon == 0) {
-                return;
-            }
-
-            double altitude = modeCAltitude / 3.048;
-            QGeoCoordinate location(lat, lon);
-
-            ADSBVehicle::VehicleInfo_t adsbInfo;
-            adsbInfo.icaoAddress = icaoAddress;
-            adsbInfo.callsign = callsign;
-            adsbInfo.location = location;
-            adsbInfo.altitude = altitude;
-            adsbInfo.availableFlags = ADSBVehicle::CallsignAvailable | ADSBVehicle::LocationAvailable | ADSBVehicle::AltitudeAvailable;
-            emit adsbVehicleUpdate(adsbInfo);
-        } else if (values[1] == QStringLiteral("4")) {
-            bool icaoOk, headingOk;
-
-            uint32_t    icaoAddress =   values[4].toUInt(&icaoOk, 16);
-            double      heading =       values[13].toDouble(&headingOk);
-
-            if (!icaoOk || !headingOk) {
-                return;
-            }
-
-            ADSBVehicle::VehicleInfo_t adsbInfo;
-            adsbInfo.icaoAddress = icaoAddress;
-            adsbInfo.heading = heading;
-            adsbInfo.availableFlags = ADSBVehicle::HeadingAvailable;
-            emit adsbVehicleUpdate(adsbInfo);
-        } else if (values[1] == QStringLiteral("1")) {
-            bool icaoOk;
-
-            uint32_t icaoAddress = values[4].toUInt(&icaoOk, 16);
-            if (!icaoOk) {
-                return;
-            }
-
-            ADSBVehicle::VehicleInfo_t adsbInfo;
-            adsbInfo.icaoAddress = icaoAddress;
-            adsbInfo.callsign = values[10];
-            adsbInfo.availableFlags = ADSBVehicle::CallsignAvailable;
-            emit adsbVehicleUpdate(adsbInfo);
+        switch (msgType) {
+        case 1:
+        case 5:
+        case 6:
+            _parseAndEmitCallsign(adsbInfo, values);
+            break;
+        case 3:
+            _parseAndEmitLocation(adsbInfo, values);
+            break;
+        case 4:
+            _parseAndEmitHeading(adsbInfo, values);
+            break;
         }
     }
+}
+
+void ADSBTCPLink::_parseAndEmitCallsign(ADSBVehicle::ADSBVehicleInfo_t &adsbInfo, QStringList values)
+{
+    QString callsign = values[10].trimmed();
+    if (callsign.isEmpty()) {
+        return;
+    }
+
+    adsbInfo.callsign = callsign;
+    adsbInfo.availableFlags = ADSBVehicle::CallsignAvailable;
+    emit adsbVehicleUpdate(adsbInfo);
+}
+
+void ADSBTCPLink::_parseAndEmitLocation(ADSBVehicle::ADSBVehicleInfo_t &adsbInfo, QStringList values)
+{
+    bool altOk, latOk, lonOk;
+    int modeCAltitude;
+
+    QString altitudeStr = values[11];
+    // Altitude is either Barometric - based on pressure, in ft
+    // or HAE - as reported by GPS - based on WGS84 Ellipsoid, in ft
+    // If altitude ends with H, we have HAE
+    // There's a slight difference between Barometric alt and HAE, but it would require
+    // knowledge about Geoid shape in particular Lat, Lon. It's not worth complicating the code
+    if (altitudeStr.endsWith('H')) {
+        altitudeStr.chop(1);
+    }
+    modeCAltitude = altitudeStr.toInt(&altOk);
+
+    double lat = values[14].toDouble(&latOk);
+    double lon = values[15].toDouble(&lonOk);
+    int alert = values[19].toInt();
+
+    if (!altOk || !latOk || !lonOk) {
+        return;
+    }
+    if (lat == 0 && lon == 0) {
+        return;
+    }
+
+    double altitude = modeCAltitude * 0.3048;
+    QGeoCoordinate location(lat, lon);
+    adsbInfo.location = location;
+    adsbInfo.altitude = altitude;
+    adsbInfo.alert = alert == 1;
+    adsbInfo.availableFlags = ADSBVehicle::LocationAvailable | ADSBVehicle::AltitudeAvailable | ADSBVehicle::AlertAvailable;
+    emit adsbVehicleUpdate(adsbInfo);
+}
+
+void ADSBTCPLink::_parseAndEmitHeading(ADSBVehicle::ADSBVehicleInfo_t &adsbInfo, QStringList values)
+{
+    bool headingOk;
+    double heading = values[13].toDouble(&headingOk);
+    if (!headingOk) {
+        return;
+    }
+
+    adsbInfo.heading = heading;
+    adsbInfo.availableFlags = ADSBVehicle::HeadingAvailable;
+    emit adsbVehicleUpdate(adsbInfo);
 }

--- a/src/ADSB/ADSBVehicleManager.h
+++ b/src/ADSB/ADSBVehicleManager.h
@@ -29,7 +29,7 @@ public:
     ~ADSBTCPLink();
 
 signals:
-    void adsbVehicleUpdate(const ADSBVehicle::VehicleInfo_t vehicleInfo);
+    void adsbVehicleUpdate(const ADSBVehicle::ADSBVehicleInfo_t vehicleInfo);
     void error(const QString errorMsg);
 
 protected:
@@ -45,6 +45,9 @@ private:
     QString         _hostAddress;
     int             _port;
     QTcpSocket*     _socket =   nullptr;
+    void _parseAndEmitCallsign(ADSBVehicle::ADSBVehicleInfo_t &adsbInfo, QStringList values);
+    void _parseAndEmitLocation(ADSBVehicle::ADSBVehicleInfo_t &adsbInfo, QStringList values);
+    void _parseAndEmitHeading(ADSBVehicle::ADSBVehicleInfo_t &adsbInfo, QStringList values);
 };
 
 class ADSBVehicleManager : public QGCTool {
@@ -61,7 +64,7 @@ public:
     void setToolbox(QGCToolbox* toolbox) final;
 
 public slots:
-    void adsbVehicleUpdate  (const ADSBVehicle::VehicleInfo_t vehicleInfo);
+    void adsbVehicleUpdate  (const ADSBVehicle::ADSBVehicleInfo_t vehicleInfo);
     void _tcpError          (const QString errorMsg);
 
 private slots:

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3584,7 +3584,7 @@ void Vehicle::_handleADSBVehicle(const mavlink_message_t& message)
 
     mavlink_msg_adsb_vehicle_decode(&message, &adsbVehicleMsg);
     if ((adsbVehicleMsg.flags & ADSB_FLAGS_VALID_COORDS) && adsbVehicleMsg.tslc <= maxTimeSinceLastSeen) {
-        ADSBVehicle::VehicleInfo_t vehicleInfo;
+        ADSBVehicle::ADSBVehicleInfo_t vehicleInfo;
 
         vehicleInfo.availableFlags = 0;
         vehicleInfo.icaoAddress = adsbVehicleMsg.ICAO_address;

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -1023,7 +1023,7 @@ Rectangle {
                             FactTextField {
                                 fact:                   adsbGrid.adsbSettings.adsbServerHostAddress
                                 visible:                adsbGrid.adsbSettings.adsbServerHostAddress.visible
-                                Layout.preferredWidth:  _valueFieldWidth
+                                Layout.fillWidth:       true
                             }
 
                             QGCLabel {


### PR DESCRIPTION
Hi.
I'm very thrilled that I can push my first PR to QGroundControl. I've spend whole weekend playing with the code. Now I've tidy it up and here it is :)

# Fixes and improvements

## Choice of MSG types
I have analysed lots of ADSB SBS-1 messages from various sources and despite that protocol description states that Callsign should be present only in MSG type 1, it's also often present in MSG types 5 and 6. So I've included those types as well to increase chances to obtain Callsign ASAP.

## Decreasing timeout/cleanup time
I've decreased cleanup (expiry) time do 60s. Previous was 120s. The reasoning behind that is that maybe except for helicopters all aircrafts with ADSB are in constant move with speed expected to be more than 100km/h (small low flying planes). At this speed after 2 mins aircraft should to be further than 4km away (if it's a jet it will be over 30km away!). It makes no sense to keep it frozen on the map. A heli is an exception but it's more likely that we have a plane above our heads and 2min timeout is simply too much IMO. To be discussed.

## Fix in altitude calculation
First of all there was an error in the formula. To convert altitude in `ft` to `m` it should be multiplied by `0.3048`. If you're into dividing then `ft` should be divided by `3.28` **not** by `3.048`. 

Also @timtuxworth is using SBS-1 data source that sends altitude in HAE (GPS altitude) instead of Barometric alt. Those are the values with H at the end.  I've spent about 3 hours to understand what this might be as SBS-1 is documented good on only one web page if found:
[http://woodair.net/sbs/article/barebones42_socket_data.htm](http://woodair.net/sbs/article/barebones42_socket_data.htm)
with no info about H altitude. It mentioned HAE but as an internal feature of SBS BaseStation there. So I deduced it might be HAE as an altitude with H.

The main problem with **NOT** displaying most of @timtuxworth data was that the `ASDBVehicleManager` code exits if it fails converting altitude string (here an int with H character) and thus not showing planes. This was the main reason that Tim opened a bug ticket :)

## Fix of reading data from Socket
I've discovered a major problem with reading of incoming data! As I was experimenting with ADSB messages I discovered that after about 30 minutes all messages were delayed about 15-20 seconds. A message was sent by an ADSB server but it was parsed and used by QGC with a such delay.   The reason was that at every TCP `readyRead` event only one line was read. And if messages flooded QGC a queue of "lines" was rising. I've fixed that and now messages are parsed immediately.

## Other fixes
I've fixed width of ADSB server address in the Settings as it was to narrow to hold the address.
And I've changed a bit storing of `ADSBVehicles` so a Vehicle is also created when a callsign comes in first without knowing a position. This makes it more usable because callsign rarely come, and it's good to store it as soon as it comes. The Vehicle is not shown if it misses Lat and Lon, so it was required to fix a bit UI but without storing callsign it would not show either before Lat, Lon was received.

While looking for display delay (see tcp problem above) I've applied some minor speedups that I think are worth keeping. For example skipping splitting/parsing messages of non-supported types. Why bother CPU with data that will be discarded :)

**I can explain or defend every line in this PR so please ask :)**

# How to test

Connect to own ASDB SBS-1 server OR use my ADSB Fake replay server :)
I've created for this occasion an ADSB SBS-1 replay server that emits messages from csv file with a respect for message record times.

[adsb tools](https://github.com/zdanek/adsb-tools)

Using flags you can enable displaying most important messages and looping. More features to come. It's very useful. Stars would be appreciated :star2: 

