### PR TITLE
use strcpy instead of strncpy

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -922,7 +922,6 @@ void Vehicle::_chunkedStatusTextCompleted(uint8_t compId)
 
 void Vehicle::_handleStatusText(mavlink_message_t& message)
 {
-    QByteArray  b;
     QString     messageText;
 
     mavlink_statustext_t statustext;
@@ -930,8 +929,7 @@ void Vehicle::_handleStatusText(mavlink_message_t& message)
 
     uint8_t compId = message.compid;
 
-    b.resize(MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1);
-    strncpy(b.data(), statustext.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
+    QByteArray  b(statustext.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1);
     b[b.length()-1] = '\0';
     messageText = QString(b);
     bool includesNullTerminator = messageText.length() < MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN;


### PR DESCRIPTION
resolves stringop-overflow warning as at compile time b (QByteArray) is always 24, whereas the source is 50. 

~This means strncpy is not really useful in terms of checking length, (infact it is hurtful as it omits the null terminator~

fixes #10141 


