### PR TITLE
[Draft] Make the Log Viewer sortable by date

### DIFF
--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -765,6 +765,22 @@ QGCLogModel::clear(void)
 }
 
 //-----------------------------------------------------------------------------
+void
+QGCLogModel::sort_by_time(void)
+{
+    if(!_logEntries.isEmpty()) {
+        beginRemoveRows(QModelIndex(), 0, _logEntries.count());
+        while (_logEntries.count()) {
+            QGCLogEntry* entry = _logEntries.last();
+            if(entry) entry->deleteLater();
+            _logEntries.removeLast();
+        }
+        endRemoveRows();
+        emit countChanged();
+    }
+}
+
+//-----------------------------------------------------------------------------
 QGCLogEntry*
 QGCLogModel::operator[](int index)
 {

--- a/src/AnalyzeView/LogDownloadPage.qml
+++ b/src/AnalyzeView/LogDownloadPage.qml
@@ -72,6 +72,9 @@ AnalyzePage {
                     title: qsTr("Date")
                     width: ScreenTools.defaultFontPixelWidth * 34
                     horizontalAlignment: Text.AlignHCenter
+                    onClicked() {
+                        
+                    }
                     delegate: Text  {
                         text: {
                             var o = logController.model.get(styleData.row)


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/23277211/155994379-c94ef1fd-4331-4041-88f9-e789fc946575.png)
Currently, QGC's Log Viewer page doesn't have sort by date option. While doing a SITL tests, I discovered that the logs created don't have the id in order of the time. Which is annoying since it's hard to spot and download the 'latest' log.

I had this idea for a week, and after around 30 minutes of scanning, I couldn't figure out a concrete way to implement this (since QTableView doesn't support sorting via clicking the header by default). So any help / comment would be appreciated!