### PR TITLE
Add Reboot button to the Main Toolbar for easy access

### DIFF
--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -107,9 +107,26 @@ Rectangle {
         }
     }
 
+    //-- Reboot Button
+    RowLayout {
+        anchors.right:          brandingLogo.left
+        anchors.top:            parent.top
+        anchors.bottom:         parent.bottom
+        QGCButton {
+            id:             rebootButton
+            text:           qsTr("Reboot Vehicle")
+            onClicked:    mainWindow.showMessageDialog(qsTr("Reboot Vehicle"),
+                                                            qsTr("Select Ok to reboot vehicle."),
+                                                            StandardButton.Cancel | StandardButton.Ok,
+                                                            function() { _activeVehicle.rebootVehicle() })
+            visible:            _activeVehicle
+        }
+    }
+
     //-------------------------------------------------------------------------
     //-- Branding Logo
     Image {
+        id:                     brandingLogo
         anchors.right:          parent.right
         anchors.top:            parent.top
         anchors.bottom:         parent.bottom


### PR DESCRIPTION
## Problem Statement
Previously, to reboot a vehicle user had to:
1. Click Q icon
2. Click 'Vehicle Setup'
3. Click 'Parameters' all the way down in the left side of the panel
4. Click 'Tools' tab on the right-up side of the screen
5. Click 'Reboot Vehicle' button

This PR exposes that button to the Main Screen so that user has to:
1. Click 'Reboot vehicle' Button.

## Benefits
It is really useful to be able to reboot the vehicle efficiently and quickly. So this PR will help a lot of people in my opinion!

![RebootButton_Screenshot from 2022-04-01 18-19-22](https://user-images.githubusercontent.com/23277211/161303425-a988ca3c-542b-4895-bafb-7248316a0fc2.png)
