### PR TITLE
Use recommended mapReady signal

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -103,9 +103,11 @@ Map {
 
     on_ActiveVehicleCoordinateChanged: _possiblyCenterToVehiclePosition()
 
-    Component.onCompleted: {
-        updateActiveMapType()
-        _possiblyCenterToVehiclePosition()
+    onMapReadyChanged: {
+        if (_map.mapReady) {
+            updateActiveMapType()
+            _possiblyCenterToVehiclePosition()
+        }
     }
 
     Connections {


### PR DESCRIPTION
Due to the architecture of the [Map](https://doc.qt.io/qt-5/qml-qtlocation-map.html), it's advised to use the signal emitted for this [property](https://doc.qt.io/qt-5/qml-qtlocation-map.html#mapReady-prop) in place of [Component.onCompleted](https://doc.qt.io/qt-5/qml-qtqml-component.html#completed-signal), to make sure that everything behaves as expected.