### PR TITLE
Plan view bug fixes

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1756,7 +1756,7 @@ void MissionController::_recalcMissionFlightStatus()
     }
 
     emit missionMaxTelemetryChanged     (_missionFlightStatus.maxTelemetryDistance);
-    //emit missionDistanceChanged         (_missionFlightStatus.totalDistance);
+    emit missionDistanceChanged         (_missionFlightStatus.totalDistance);
     emit missionHoverDistanceChanged    (_missionFlightStatus.hoverDistance);
     emit missionCruiseDistanceChanged   (_missionFlightStatus.cruiseDistance);
     emit missionTimeChanged             ();

--- a/src/PlanView/TransectStyleComplexItemTerrainFollow.qml
+++ b/src/PlanView/TransectStyleComplexItemTerrainFollow.qml
@@ -31,7 +31,7 @@ ColumnLayout {
             altModeDialogComponent.createObject(mainWindow, { rgRemoveModes: removeModes, updateAltModeFn: updateFunction }).open()
         }
 
-        //Component { id: altModeDialogComponent; AltModeDialog { } }
+        Component { id: altModeDialogComponent; AltModeDialog { } }
 
         RowLayout {
             spacing: ScreenTools.defaultFontPixelWidth / 2


### PR DESCRIPTION
This PR attempts to solve two bugs encountered:

1- The total mission distance in the Plan Toolbar Indicators was not being updated while planning the mission. A signal emission had been commented out in MissionController.cc preventing this value to be updated.

2- Terrain following selector was not opening any options. Again a component was commented out from TransectStyleComplexItemTerrainFollow.qml preventing the correct dialog to open.