### PR TITLE
RTK GPS feature enabled for Android builds.

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/UsbIoManager.java
+++ b/android/src/org/mavlink/qgroundcontrol/UsbIoManager.java
@@ -44,7 +44,7 @@ public class UsbIoManager implements Runnable {
     private final ByteBuffer mReadBuffer = ByteBuffer.allocate(BUFSIZ);
     private final ByteBuffer mWriteBuffer = ByteBuffer.allocate(BUFSIZ);
 
-    private enum State
+    public enum State
     {
         STOPPED,
         RUNNING,
@@ -118,7 +118,14 @@ public class UsbIoManager implements Runnable {
         }
     }
 
-
+    public void start()
+    {
+        if(mState != State.STOPPED)
+        {
+            throw new IllegalStateException("already started");
+        }
+        new Thread(this, this.getClass().getSimpleName()).start();
+    }
 
     public synchronized void stop()
     {
@@ -131,7 +138,7 @@ public class UsbIoManager implements Runnable {
 
 
 
-    private synchronized State getState()
+    public synchronized State getState()
     {
         return mState;
     }
@@ -147,7 +154,7 @@ public class UsbIoManager implements Runnable {
     {
         synchronized (this)
         {
-            if (mState != State.STOPPED)
+            if (getState() != State.STOPPED)
                 throw new IllegalStateException("Already running.");
 
             mState = State.RUNNING;
@@ -196,7 +203,7 @@ public class UsbIoManager implements Runnable {
             }
             mReadBuffer.clear();
         }
-/*
+
         // Handle outgoing data.
         byte[] outBuff = null;
         synchronized (mWriteBuffer)
@@ -212,7 +219,6 @@ public class UsbIoManager implements Runnable {
         }
         if (outBuff != null)
             mDriver.write(outBuff, READ_WAIT_MILLIS);
-*/
     }
 }
 

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -794,6 +794,7 @@ HEADERS += \
     src/comm/SerialLink.h \
 }
 
+!iOSBuild {
 HEADERS += \
     src/GPS/Drivers/src/gps_helper.h \
     src/GPS/Drivers/src/rtcm.h \
@@ -807,7 +808,7 @@ HEADERS += \
     src/GPS/definitions.h \
     src/GPS/satellite_info.h \
     src/GPS/vehicle_gps_position.h \
-
+}
 
 !MobileBuild {
 HEADERS += \
@@ -1036,6 +1037,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
     }
 }
 
+!iOSBuild {
 SOURCES += \
     src/GPS/Drivers/src/gps_helper.cpp \
     src/GPS/Drivers/src/rtcm.cpp \
@@ -1045,6 +1047,7 @@ SOURCES += \
     src/GPS/GPSManager.cc \
     src/GPS/GPSProvider.cc \
     src/GPS/RTCM/RTCMMavlink.cc \
+}
 
 !MobileBuild {
 SOURCES += \

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -794,7 +794,6 @@ HEADERS += \
     src/comm/SerialLink.h \
 }
 
-!MobileBuild {
 HEADERS += \
     src/GPS/Drivers/src/gps_helper.h \
     src/GPS/Drivers/src/rtcm.h \
@@ -808,6 +807,10 @@ HEADERS += \
     src/GPS/definitions.h \
     src/GPS/satellite_info.h \
     src/GPS/vehicle_gps_position.h \
+
+
+!MobileBuild {
+HEADERS += \
     src/Joystick/JoystickSDL.h \
     src/RunGuard.h \
 }
@@ -1033,7 +1036,6 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
     }
 }
 
-!MobileBuild {
 SOURCES += \
     src/GPS/Drivers/src/gps_helper.cpp \
     src/GPS/Drivers/src/rtcm.cpp \
@@ -1043,6 +1045,9 @@ SOURCES += \
     src/GPS/GPSManager.cc \
     src/GPS/GPSProvider.cc \
     src/GPS/RTCM/RTCMMavlink.cc \
+
+!MobileBuild {
+SOURCES += \
     src/Joystick/JoystickSDL.cc \
     src/RunGuard.cc \
 }

--- a/src/GPS/GPSProvider.cc
+++ b/src/GPS/GPSProvider.cc
@@ -59,7 +59,7 @@ void GPSProvider::run()
             }
         }
         if (_serial->error() != QSerialPort::NoError) {
-            qWarning() << "GPS: Failed to open Serial Device" << _device << _serial->errorString();
+            qCDebug(RTKGPSLog) << "GPS: Failed to open Serial Device" << _device << _serial->errorString();
             return;
         }
     }
@@ -203,7 +203,9 @@ int GPSProvider::callback(GPSCallbackType type, void *data1, int data2)
         }
         case GPSCallbackType::writeDeviceData:
             if (_serial->write((char*) data1, data2) >= 0) {
+#ifndef __android__
                 if (_serial->waitForBytesWritten(-1))
+#endif
                     return data2;
             }
             return -1;

--- a/src/GPS/GPSProvider.h
+++ b/src/GPS/GPSProvider.h
@@ -13,7 +13,12 @@
 #include <QString>
 #include <QThread>
 #include <QByteArray>
+
+#ifdef __android__
+#include "qserialport.h"
+#else
 #include <QSerialPort>
+#endif
 
 #include <atomic>
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -115,7 +115,9 @@
 #include "SerialLink.h"
 #endif
 
+#ifndef __ios__
 #include "GPS/GPSManager.h"
+#endif
 
 #ifdef QGC_RTLAB_ENABLED
 #include "OpalLink.h"
@@ -351,6 +353,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     _toolbox = new QGCToolbox(this);
     _toolbox->setChildToolboxes();
 
+#ifndef __ios__
     _gpsRtkFactGroup = new GPSRTKFactGroup(this);
    GPSManager *gpsManager = _toolbox->gpsManager();
    if (gpsManager) {
@@ -359,6 +362,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
        connect(gpsManager, &GPSManager::surveyInStatus,     this, &QGCApplication::_gpsSurveyInStatus);
        connect(gpsManager, &GPSManager::satelliteUpdate,    this, &QGCApplication::_gpsNumSatellites);
    }
+#endif
 
     _checkForNewVersion();
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -115,9 +115,7 @@
 #include "SerialLink.h"
 #endif
 
-#ifndef __mobile__
 #include "GPS/GPSManager.h"
-#endif
 
 #ifdef QGC_RTLAB_ENABLED
 #include "OpalLink.h"
@@ -353,7 +351,6 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     _toolbox = new QGCToolbox(this);
     _toolbox->setChildToolboxes();
 
-#ifndef __mobile__
     _gpsRtkFactGroup = new GPSRTKFactGroup(this);
    GPSManager *gpsManager = _toolbox->gpsManager();
    if (gpsManager) {
@@ -362,7 +359,6 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
        connect(gpsManager, &GPSManager::surveyInStatus,     this, &QGCApplication::_gpsSurveyInStatus);
        connect(gpsManager, &GPSManager::satelliteUpdate,    this, &QGCApplication::_gpsNumSatellites);
    }
-#endif /* __mobile__ */
 
     _checkForNewVersion();
 }

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -11,7 +11,9 @@
 #include "FactSystem.h"
 #include "FirmwarePluginManager.h"
 #include "AudioOutput.h"
+#ifndef __ios__
 #include "GPSManager.h"
+#endif
 #include "JoystickManager.h"
 #include "LinkManager.h"
 #include "MAVLinkProtocol.h"
@@ -57,7 +59,9 @@ QGCToolbox::QGCToolbox(QGCApplication* app)
     _audioOutput            = new AudioOutput               (app, this);
     _factSystem             = new FactSystem                (app, this);
     _firmwarePluginManager  = new FirmwarePluginManager     (app, this);
+#ifndef __ios__
     _gpsManager             = new GPSManager                (app, this);
+#endif
     _imageProvider          = new QGCImageProvider          (app, this);
     _joystickManager        = new JoystickManager           (app, this);
     _linkManager            = new LinkManager               (app, this);
@@ -99,7 +103,9 @@ void QGCToolbox::setChildToolboxes(void)
     _audioOutput->setToolbox(this);
     _factSystem->setToolbox(this);
     _firmwarePluginManager->setToolbox(this);
+#ifndef __ios__
     _gpsManager->setToolbox(this);
+#endif
     _imageProvider->setToolbox(this);
     _joystickManager->setToolbox(this);
     _linkManager->setToolbox(this);

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -11,9 +11,7 @@
 #include "FactSystem.h"
 #include "FirmwarePluginManager.h"
 #include "AudioOutput.h"
-#ifndef __mobile__
 #include "GPSManager.h"
-#endif
 #include "JoystickManager.h"
 #include "LinkManager.h"
 #include "MAVLinkProtocol.h"
@@ -59,9 +57,7 @@ QGCToolbox::QGCToolbox(QGCApplication* app)
     _audioOutput            = new AudioOutput               (app, this);
     _factSystem             = new FactSystem                (app, this);
     _firmwarePluginManager  = new FirmwarePluginManager     (app, this);
-#ifndef __mobile__
     _gpsManager             = new GPSManager                (app, this);
-#endif
     _imageProvider          = new QGCImageProvider          (app, this);
     _joystickManager        = new JoystickManager           (app, this);
     _linkManager            = new LinkManager               (app, this);
@@ -103,9 +99,7 @@ void QGCToolbox::setChildToolboxes(void)
     _audioOutput->setToolbox(this);
     _factSystem->setToolbox(this);
     _firmwarePluginManager->setToolbox(this);
-#ifndef __mobile__
     _gpsManager->setToolbox(this);
-#endif
     _imageProvider->setToolbox(this);
     _joystickManager->setToolbox(this);
     _linkManager->setToolbox(this);

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -72,9 +72,7 @@ public:
 #if defined(QGC_ENABLE_PAIRING)
     PairingManager*             pairingManager          () { return _pairingManager; }
 #endif
-#ifndef __mobile__
     GPSManager*                 gpsManager              () { return _gpsManager; }
-#endif
 #if defined(QGC_GST_TAISYNC_ENABLED)
     TaisyncManager*             taisyncManager          () { return _taisyncManager; }
 #endif
@@ -90,9 +88,7 @@ private:
     AudioOutput*                _audioOutput            = nullptr;
     FactSystem*                 _factSystem             = nullptr;
     FirmwarePluginManager*      _firmwarePluginManager  = nullptr;
-#ifndef __mobile__
     GPSManager*                 _gpsManager             = nullptr;
-#endif
     QGCImageProvider*           _imageProvider          = nullptr;
     JoystickManager*            _joystickManager        = nullptr;
     LinkManager*                _linkManager            = nullptr;

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -72,7 +72,9 @@ public:
 #if defined(QGC_ENABLE_PAIRING)
     PairingManager*             pairingManager          () { return _pairingManager; }
 #endif
+#ifndef __ios__
     GPSManager*                 gpsManager              () { return _gpsManager; }
+#endif
 #if defined(QGC_GST_TAISYNC_ENABLED)
     TaisyncManager*             taisyncManager          () { return _taisyncManager; }
 #endif
@@ -88,7 +90,9 @@ private:
     AudioOutput*                _audioOutput            = nullptr;
     FactSystem*                 _factSystem             = nullptr;
     FirmwarePluginManager*      _firmwarePluginManager  = nullptr;
+#ifndef __ios__
     GPSManager*                 _gpsManager             = nullptr;
+#endif
     QGCImageProvider*           _imageProvider          = nullptr;
     JoystickManager*            _joystickManager        = nullptr;
     LinkManager*                _linkManager            = nullptr;

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -179,14 +179,14 @@ private:
 #endif
 
     // NMEA GPS device for GCS position
-#ifndef __mobile__
 #ifndef NO_SERIAL_LINK
     QString                             _nmeaDeviceName;
     QSerialPort*                        _nmeaPort;
     uint32_t                            _nmeaBaud;
+#ifndef __mobile__
     UdpIODevice                         _nmeaSocket;
 #endif
-#endif
+#endif //NO_SERIAL_LINK
 
     static const char*  _defaultUDPLinkName;
     static const char*  _mavlinkForwardingLinkName;

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -179,6 +179,7 @@ private:
 #endif
 
     // NMEA GPS device for GCS position
+#ifndef __ios__
 #ifndef NO_SERIAL_LINK
     QString                             _nmeaDeviceName;
     QSerialPort*                        _nmeaPort;
@@ -187,6 +188,7 @@ private:
     UdpIODevice                         _nmeaSocket;
 #endif
 #endif //NO_SERIAL_LINK
+#endif //__ios__
 
     static const char*  _defaultUDPLinkName;
     static const char*  _mavlinkForwardingLinkName;

--- a/src/main.cc
+++ b/src/main.cc
@@ -24,13 +24,18 @@
 
 #ifndef NO_SERIAL_LINK
     #include "SerialLink.h"
-    #include "QGCSerialPortInfo.h"
-#ifndef __mobile__
-    #include <QSerialPort>
-#else
-    #include <qserialport.h>
 #endif
-#endif //NO_SERIAL_LINK
+
+#ifndef __ios__
+    #include "QGCSerialPortInfo.h"
+ #ifndef NO_SERIAL_LINK
+  #ifdef __android__
+    #include <qserialport.h>
+  #else
+    #include <QSerialPort>
+  #endif
+ #endif // NO_SERIAL_LINK
+#endif //__ios__
 
 #ifndef __mobile__
     #include "RunGuard.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -24,14 +24,16 @@
 
 #ifndef NO_SERIAL_LINK
     #include "SerialLink.h"
+    #include "QGCSerialPortInfo.h"
+#ifndef __mobile__
+    #include <QSerialPort>
+#else
+    #include <qserialport.h>
 #endif
+#endif //NO_SERIAL_LINK
 
 #ifndef __mobile__
-    #include "QGCSerialPortInfo.h"
     #include "RunGuard.h"
-#ifndef NO_SERIAL_LINK
-    #include <QSerialPort>
-#endif
 #endif
 
 #ifdef UNITTEST_BUILD


### PR DESCRIPTION
Hello!
I have got RTK working on Android devices. Radio-link and RTK device connected to phone via tiny USB switch. It works correctly and QGC sends RTK messages to the vehicle.
The only problem I could not solve:
Case 1 (fail):
Steps to reproduce: Both radio-link and RTK devices are connected. Disconnect RTK device.
Result (problem): Radio-link disconnects. Re-plugging radio-link does not help, it is not visible in the list of connected devices anymore. Only re-plugging USB-switch allows to connect USB devices again.

Case 2 (pass):
Steps to reproduce: Both radio-link and RTK devices are connected. Re-plug radio-link.
Result: Radio-link connected successfully.

Tested on Samsung A32 only.

Conclusion: I suspect CdcAcmSerialDriver closes USB connection in a wrong way (may be it closes not dedicated USB RTK-device, but USB-switch connection). I'm a newbie at Android programming, hope community can help.

Changes performed:
1) Multiple USB devices connected info. _QGCActivity::availableDevicesInfo()_
2) Every _UsbIoManager_ instance for every particular connected device now runs in a separate thread. _UsbIoManager::start()_ added.
3) _QGCActivity::write()_ moved to async mode.
4) _GPSProvider::callback::writeDeviceData_ . Disable _serial->waitForBytesWritten_ because it is not supported currently for Android.

Please review my changes and send me your questions, objections, comments.

Thank you,
Michael Naumov.