### PR TITLE
Hardware: Add support for Holybro Kakute H7

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -87,6 +87,7 @@ static QMap<int, QString> px4_board_name_map {
     {1017, "mro_pixracerpro_default"},
     {1023, "mro_ctrl-zero-h7_default"},
     {1024, "mro_ctrl-zero-h7-oem_default"},
+    {1048, "holybro_kakuteh7_default"},
 };
 
 uint qHash(const FirmwareUpgradeController::FirmwareIdentifier& firmwareId)


### PR DESCRIPTION
adds the kakute h7 board id 

This should make sure QGC detects the board correctly and installs the proper firmware

cc @vincentpoont2

fixes https://github.com/PX4/PX4-Autopilot/issues/19432