### PR TITLE
Add New Holybro ProductID to QGC USBBoardInfo.Json.

### DIFF
--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -23,6 +23,7 @@
         { "vendorID": 8137, "productID": 28,        "boardClass": "Pixhawk",    "name": "PX4 FMUK66 v3.x" },
         { "vendorID": 1155, "productID": 41775,     "boardClass": "Pixhawk",    "name": "PX4 FMU ModalAI FCv1" },
         { "vendorID":12642, "productID": 75,        "boardClass": "Pixhawk",    "name": "PX4 DurandalV1" },
+        { "vendorID":12642, "productID": 80,        "boardClass": "Pixhawk",    "name": "Holybro Kakute Flight Controller" },
         { "vendorID": 4104, "productID": 1,         "boardClass": "Pixhawk",    "name": "PX4 FMU UVify Core" },
         { "vendorID": 12643, "productID": 76,       "boardClass": "Pixhawk",    "name": "CUAV Flight Controller" },
         { "vendorID": 1155, "productID": 55,        "boardClass": "Pixhawk",    "name": "PX4 FMU SmartAP AIRLink" },

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -16,6 +16,7 @@
         { "vendorID": 12677, "productID": 51,       "boardClass": "Pixhawk",    "name": "PX4 FMU V5X" },
         { "vendorID": 7052, "productID": 54,        "boardClass": "Pixhawk",    "name": "PX4 FMU V6U" },
         { "vendorID": 12677, "productID": 53,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6X" },
+        { "vendorID": 12642, "productID": 56,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6C" },
         { "vendorID": 9900, "productID": 64,        "boardClass": "Pixhawk",    "name": "TAP V1" },
         { "vendorID": 9900, "productID": 65,        "boardClass": "Pixhawk",    "name": "ASC V1" },
         { "vendorID": 9900, "productID": 22,        "boardClass": "Pixhawk",    "name": "Crazyflie 2" },


### PR DESCRIPTION
Add FMUv6C ProductID to QGC USBBoardInfo.Json, so QGC can recognize the board and Holybro can load FW onto QGC offline.

FMUv6C ProductID was created here.
https://github.com/PX4/PX4-Autopilot/blob/b406c86a9caa3f35a0becf245ee6fc4ba673760e/boards/px4/fmu-v6c/nuttx-config/bootloader/defconfig#L33