### PR TITLE
Bug fix. Flightmap not properly displayed after video disable if video screen is main.

### DIFF
--- a/src/QmlControls/QGCPipOverlay.qml
+++ b/src/QmlControls/QGCPipOverlay.qml
@@ -70,6 +70,7 @@ Item {
             item1.pipState.state = item1.pipState.fullState
             _fullItem = item1
             _pipOrWindowItem = null
+            item1.visible = true
         }
         _setPipIsExpanded(QGroundControl.loadBoolGlobalSetting(_pipExpandedSettingsKey, true))
     }


### PR DESCRIPTION
This PR solves a bug encountered while toggling from video enabled to disabled.

There is a bug when having the video enabled in fullState while the map is in pip state. If the video is disabled the map is being set to fullState but not to visible. Therefore the map was not being displayed properly, either by showing nothing or by showing the UVC video display if available in the device.

Steps to reproduce the bug:

1- Turn on any video source in "General Settings".
2- In the Fly View, click on the pipable to make the video big (fullState) and the map small (pipState).
3- Turn off video by selecting "video disable" in "General Settings".
4- Go back to "Fly view" to encounter a bug of the map not showing/UVC video being shown.



