### PR TITLE
Fix vibration page bar and count display

### DIFF
--- a/src/AnalyzeView/VibrationPage.qml
+++ b/src/AnalyzeView/VibrationPage.qml
@@ -21,7 +21,7 @@ import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controllers   1.0
 
 AnalyzePage {
-    id:                 geoTagPage
+    id:                 vibrationPage
     pageComponent:      pageComponent
     pageDescription:    qsTr("Analyze vibration associated with your vehicle.")
     allowPopout:        true

--- a/src/AnalyzeView/VibrationPage.qml
+++ b/src/AnalyzeView/VibrationPage.qml
@@ -21,7 +21,7 @@ import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controllers   1.0
 
 AnalyzePage {
-    id:                 vibrationPage
+    id:                 geoTagPage
     pageComponent:      pageComponent
     pageDescription:    qsTr("Analyze vibration associated with your vehicle.")
     allowPopout:        true
@@ -29,7 +29,7 @@ AnalyzePage {
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
     property bool   _available:     !isNaN(_activeVehicle.vibration.xAxis.rawValue)
     property real   _margins:       ScreenTools.defaultFontPixelWidth / 2
-    property real   _barWidth:      ScreenTools.defaultFontPixelWidth * 3
+    property real   _barWidth:      ScreenTools.defaultFontPixelWidth * 7
     property real   _barHeight:     ScreenTools.defaultFontPixelHeight * 10
     property real   _xValue:        _activeVehicle.vibration.xAxis.rawValue
     property real   _yValue:        _activeVehicle.vibration.yAxis.rawValue
@@ -38,6 +38,7 @@ AnalyzePage {
     readonly property real _barMinimum:     0.0
     readonly property real _barMaximum:     90.0
     readonly property real _barBadValue:    60.0
+    readonly property real _barMidValue:    30.0
 
     QGCPalette { id:qgcPal; colorGroupEnabled: true }
 
@@ -50,7 +51,7 @@ AnalyzePage {
 
             RowLayout {
                 id:         barRow
-                spacing:    ScreenTools.defaultFontPixelWidth * 4
+                spacing:    ScreenTools.defaultFontPixelWidth * 2
 
                 ColumnLayout {
                     Rectangle {
@@ -58,6 +59,7 @@ AnalyzePage {
                         height:             _barHeight
                         width:              _barWidth
                         Layout.alignment:   Qt.AlignHCenter
+                        color:              "transparent"
                         border.width:       1
                         border.color:       qgcPal.text
 
@@ -67,19 +69,42 @@ AnalyzePage {
                             height:         parent.height * (Math.min(_barMaximum, _xValue) / (_barMaximum - _barMinimum))
                             color:          qgcPal.text
                         }
+
+                        // Max vibe indication line at 60
+                        Rectangle {
+                            anchors.topMargin:      parent.height * (1.0 - ((_barBadValue - _barMinimum) / (_barMaximum - _barMinimum)))
+                            anchors.top:            parent.top
+                            anchors.left:           parent.left
+                            anchors.right:          parent.right
+                            width:                  parent.width
+                            height:                 1
+                            color:                  "red"
+                        }
+
+                        // Mid vibe indication line at 30
+                        Rectangle {
+                            anchors.topMargin:      parent.height * (1.0 - ((_barMidValue - _barMinimum) / (_barMaximum - _barMinimum)))
+                            anchors.top:            parent.top
+                            anchors.left:           parent.left
+                            anchors.right:          parent.right
+                            width:                  parent.width
+                            height:                 1
+                            color:                  "red"
+                        }
                     }
 
                     QGCLabel {
                         Layout.alignment:   Qt.AlignHCenter
-                        text:               qsTr("X")
+                        text:               qsTr("X (%1)").arg(_xValue.toFixed(0))
                     }
                 }
 
-                Column {
+                ColumnLayout {
                     Rectangle {
                         height:             _barHeight
                         width:              _barWidth
                         Layout.alignment:   Qt.AlignHCenter
+                        color:              "transparent"
                         border.width:       1
                         border.color:       qgcPal.text
 
@@ -89,19 +114,42 @@ AnalyzePage {
                             height:         parent.height * (Math.min(_barMaximum, _yValue) / (_barMaximum - _barMinimum))
                             color:          qgcPal.text
                         }
+
+                        // Max vibe indication line at 60
+                        Rectangle {
+                            anchors.topMargin:      parent.height * (1.0 - ((_barBadValue - _barMinimum) / (_barMaximum - _barMinimum)))
+                            anchors.top:            parent.top
+                            anchors.left:           parent.left
+                            anchors.right:          parent.right
+                            width:                  parent.width
+                            height:                 1
+                            color:                  "red"
+                        }
+
+                        // Mid vibe indication line at 30
+                        Rectangle {
+                            anchors.topMargin:      parent.height * (1.0 - ((_barMidValue - _barMinimum) / (_barMaximum - _barMinimum)))
+                            anchors.top:            parent.top
+                            anchors.left:           parent.left
+                            anchors.right:          parent.right
+                            width:                  parent.width
+                            height:                 1
+                            color:                  "red"
+                        }
                     }
 
                     QGCLabel {
                         Layout.alignment:   Qt.AlignHCenter
-                        text:               qsTr("Y")
+                        text:               qsTr("Y (%1)").arg(_yValue.toFixed(0))
                     }
                 }
 
-                Column {
+                ColumnLayout {
                     Rectangle {
                         height:             _barHeight
                         width:              _barWidth
                         Layout.alignment:   Qt.AlignHCenter
+                        color:              "transparent"
                         border.width:       1
                         border.color:       qgcPal.text
 
@@ -111,24 +159,35 @@ AnalyzePage {
                             height:         parent.height * (Math.min(_barMaximum, _zValue) / (_barMaximum - _barMinimum))
                             color:          qgcPal.text
                         }
+
+                        // Max vibe indication line at 60
+                        Rectangle {
+                            anchors.topMargin:      parent.height * (1.0 - ((_barBadValue - _barMinimum) / (_barMaximum - _barMinimum)))
+                            anchors.top:            parent.top
+                            anchors.left:           parent.left
+                            anchors.right:          parent.right
+                            width:                  parent.width
+                            height:                 1
+                            color:                  "red"
+                        }
+
+                        // Mid vibe indication line at 30
+                        Rectangle {
+                            anchors.topMargin:      parent.height * (1.0 - ((_barMidValue - _barMinimum) / (_barMaximum - _barMinimum)))
+                            anchors.top:            parent.top
+                            anchors.left:           parent.left
+                            anchors.right:          parent.right
+                            width:                  parent.width
+                            height:                 1
+                            color:                  "red"
+                        }
                     }
 
                     QGCLabel {
                         Layout.alignment:   Qt.AlignHCenter
-                        text:               qsTr("Z")
+                        text:               qsTr("Z (%1)").arg(_zValue.toFixed(0))
                     }
                 }
-            }
-
-            // Max vibe indication line at 60
-            Rectangle {
-                anchors.topMargin:      xBar.height * (1.0 - ((_barBadValue - _barMinimum) / (_barMaximum - _barMinimum)))
-                anchors.top:            barRow.top
-                anchors.left:           barRow.left
-                anchors.right:          barRow.right
-                width:                  barRow.width
-                height:                 1
-                color:                  "red"
             }
 
             Column {
@@ -140,15 +199,15 @@ AnalyzePage {
                 }
 
                 QGCLabel {
-                    text: qsTr("Accel 1: ") + (_activeVehicle.vibration.clipCount1.rawValueString)
+                    text: qsTr("Accel 1: %1").arg(_activeVehicle.vibration.clipCount1.rawValue)
                 }
 
                 QGCLabel {
-                    text: qsTr("Accel 2: ") + (_activeVehicle.vibration.clipCount2.rawValueString)
+                    text: qsTr("Accel 2: %1").arg(_activeVehicle.vibration.clipCount2.rawValue)
                 }
 
                 QGCLabel {
-                    text: qsTr("Accel 3: ") + (_activeVehicle.vibration.clipCount3.rawValueString)
+                    text: qsTr("Accel 3: %1").arg(_activeVehicle.vibration.clipCount3.rawValue)
                 }
             }
 


### PR DESCRIPTION
- Vibration page bars were drawn white on background white, which is why they never shown any value
- Fixed the clip count display
- Added bar current value display
- Move indication line into the bar instead of crossing all bars
- Added additional indication line at value 30, similar to MissionPlanner view - https://ardupilot.org/copter/_images/vibration-realtime-mp.png