### PR TITLE
Vehicle: create '_commandCanBeDuplicated()', use for MOTOR_TEST

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1296,6 +1296,7 @@ private:
     void _sendMavCommandFromList(int index);
     int  _findMavCommandListEntryIndex(int targetCompId, MAV_CMD command);
     bool _sendMavCommandShouldRetry(MAV_CMD command);
+    bool _commandCanBeDuplicated(MAV_CMD command);
 
     QMap<uint8_t /* batteryId */, uint8_t /* MAV_BATTERY_CHARGE_STATE_OK */> _lowestBatteryChargeStateAnnouncedMap;
 


### PR DESCRIPTION
For some commands we don't care about response as much as we care about sending them regularly.
This test avoids commands not being sent due to an ACK not being received yet.
CMD_DO_MOTOR_TEST in ardusub is a case where we need a constant stream of commands so it don't time out.