### PR TITLE
APMPowerComponent.qml: add new entry for BR PM on Navigator

### DIFF
--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -350,6 +350,15 @@ SetupPage {
                 }
 
                 ListElement {
+                    text:       qsTr("Navigator w/ Blue Robotics Power Sense Module")
+                    voltPin:    5
+                    currPin:    4
+                    voltMult:   11.000
+                    ampPerVolt: 37.8788
+                    ampOffset:  0.330
+                }
+
+                ListElement {
                     text:       qsTr("Other")
                 }
             }


### PR DESCRIPTION
This is required because it uses different pins for reading the voltage
and current. This code probably needs a refactor to deal with different boards


![image](https://user-images.githubusercontent.com/4013804/170535810-774653bc-a381-49f8-9fae-6df6902b1133.png)
