### PR TITLE
Update Pixhawk FMUv6C vendor id

### DIFF
--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -16,7 +16,7 @@
         { "vendorID": 12677, "productID": 51,       "boardClass": "Pixhawk",    "name": "PX4 FMU V5X" },
         { "vendorID": 7052, "productID": 54,        "boardClass": "Pixhawk",    "name": "PX4 FMU V6U" },
         { "vendorID": 12677, "productID": 53,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6X" },
-        { "vendorID": 12642, "productID": 56,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6C" },
+        { "vendorID": 12677, "productID": 56,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6C" },
         { "vendorID": 9900, "productID": 64,        "boardClass": "Pixhawk",    "name": "TAP V1" },
         { "vendorID": 9900, "productID": 65,        "boardClass": "Pixhawk",    "name": "ASC V1" },
         { "vendorID": 9900, "productID": 22,        "boardClass": "Pixhawk",    "name": "Crazyflie 2" },


### PR DESCRIPTION
We use the generic vendor id available on the bootloader, which is set to Auterion. We plan to change that to either Dronecode or Pixhawk, we realize it's not ideal, but it will have to do for now until we get a USB Vendor ID approved

cc @vincentpoont2 @davids5 

