### PR TITLE
solve the crash caused by map

### DIFF
--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -243,8 +243,5 @@ QGeoTiledMapReplyQGC::cacheReply(QGCCacheTile* tile)
 void
 QGeoTiledMapReplyQGC::timeout()
 {
-    if(_reply) {
-        _reply->abort();
-    }
     emit aborted();
 }


### PR DESCRIPTION
when I tested qgc in windwos and android , I found a crash. The repeated step is that my copter link qgc by  tcp, then I enter the offlinemap setting , I zoom in and out frequently, qgc quickly crash. I use windbg check the bug, I find the error is "Qt5Network!QNetworkAccessManager", then I find that the code of "_reply->abort()" leaded the crash. I  think we can delete the row.


