### PR TITLE
Add FMUv6C to FirmwareUpgradeController.cc

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -60,6 +60,7 @@ static QMap<int, QString> px4_board_name_map {
     {52, "px4_fmu-v6_default"},
     {53, "px4_fmu-v6x_default"},
     {54, "px4_fmu-v6u_default"},
+    {56, "px4_fmu-v6c_default"},
     {55, "sky-drones_smartap-airlink_default"},
     {88, "airmind_mindpx-v2_default"},
     {12, "bitcraze_crazyflie_default"},


### PR DESCRIPTION
Add FMUv6C to FirmwareUpgradeController.cc so user can flash FW using QGC.

FMUv6C ProductID = 0x0038 (Decimal is 56) shown [here.](https://github.com/PX4/PX4-Autopilot/blob/63155b5b0189619276dedea9686d6011d6e05fd5/boards/px4/fmu-v6c/nuttx-config/nsh/defconfig#L50)

v6C was added to PX4 Jenkinsfile-compile [here.](https://github.com/PX4/PX4-Autopilot/blob/9d0e57230a032a537123866f6eb71a1827649921/.ci/Jenkinsfile-compile#L108)