### PR TITLE
APMSafetyComponentSub: deal with missing params in case of improper power module setup

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
@@ -38,7 +38,7 @@ SetupPage {
             property bool _firmware34:       globals.activeVehicle.versionCompare(3, 5, 0) < 0
 
             // Enable/Action parameters
-            property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT")
+            property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT", false)
             property Fact _failsafeEKFEnable:         controller.getParameterFact(-1, "FS_EKF_ACTION")
             property Fact _failsafeGCSEnable:         controller.getParameterFact(-1, "FS_GCS_ENABLE")
             property Fact _failsafeLeakEnable:        controller.getParameterFact(-1, "FS_LEAK_ENABLE")
@@ -53,8 +53,9 @@ SetupPage {
             property Fact _failsafeLeakPin:              controller.getParameterFact(-1, "LEAK1_PIN")
             property Fact _failsafeLeakLogic:            controller.getParameterFact(-1, "LEAK1_LOGIC")
             property Fact _failsafeEKFThreshold:         controller.getParameterFact(-1, "FS_EKF_THRESH")
-            property Fact _failsafeBatteryVoltage:       controller.getParameterFact(-1, "r.BATT_LOW_VOLT")
-            property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "r.BATT_LOW_MAH")
+            property Fact _failsafeBatteryVoltage:       controller.getParameterFact(-1, "r.BATT_LOW_VOLT", false)
+            property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "r.BATT_LOW_MAH", false)
+            property bool _batteryDetected:              controller.parameterExists(-1, "r.BATT_LOW_MAH")
 
             property Fact _armingCheck: controller.getParameterFact(-1, "ARMING_CHECK")
 
@@ -167,9 +168,18 @@ SetupPage {
 
                             FactComboBox {
                                 id:                 batteryEnableCombo
+                                enabled:            _batteryDetected
                                 width:              failsafeSettings._editWidth
                                 fact:               _failsafeBatteryEnable
                                 indexModel:         false
+                            }
+
+                            QGCLabel {
+                                text:                   qsTr("Power module not set up")
+                                width:                  failsafeSettings._labelWidth
+                                color:                  ggcPal.warningText
+                                anchors.verticalCenter: batteryEnableCombo.verticalCenter
+                                visible:                !_batteryDetected
                             }
 
                             QGCLabel {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4013804/171929578-a7a03fd0-36f8-4f1d-9f15-419f74a87d7f.png)
