### PR TITLE
Adsb: remove pointer to deleted object

### DIFF
--- a/src/ADSB/ADSBVehicle.h
+++ b/src/ADSB/ADSBVehicle.h
@@ -47,7 +47,7 @@ public:
     Q_PROPERTY(double           heading     READ heading        NOTIFY headingChanged)      // NaN for not available
     Q_PROPERTY(bool             alert       READ alert          NOTIFY alertChanged)        // Collision path
 
-    int             icaoAddress (void) const { return static_cast<int>(_icaoAddress); }
+    uint32_t        icaoAddress (void) const { return static_cast<uint32_t>(_icaoAddress); }
     QString         callsign    (void) const { return _callsign; }
     QGeoCoordinate  coordinate  (void) const { return _coordinate; }
     double          altitude    (void) const { return _altitude; }

--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -43,6 +43,10 @@ void ADSBVehicleManager::_cleanupStaleVehicles()
         if (adsbVehicle->expired()) {
             qCDebug(ADSBVehicleManagerLog) << "Expired " << QStringLiteral("%1").arg(adsbVehicle->icaoAddress(), 0, 16);
             _adsbVehicles.removeAt(i);
+
+            uint32_t key = adsbVehicle->icaoAddress();
+            _adsbICAOMap.remove(key);
+
             _adsbICAOMap.remove(adsbVehicle->icaoAddress());
             adsbVehicle->deleteLater();
         }


### PR DESCRIPTION
There is an illegal pointer access in QGC related to ADSB.

From the QGC code:
- `ADSBVehicleManager` contains a list of all `ADSBVehicle` objects that were allocated
- `ADSBVehicleManager` furthermore holds a key:value map with pointers to the `ADSBVehicle` objects

Once a second `ADSBVehicleManager` checks whether any stored vehicle information is expired. This happens after no information was received for 120 seconds. The `ADSBVehicle` object is then marked for deletion with Qt's `deleteLater()` function. 

However, the map containing the pointer to this object was not groomed. If the airplane now re-enters the area, QGC will access the pointer of an object that was possibly deleted:

This can lead to a segfault