### PR TITLE
Parameters Tab improvements

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -95,7 +95,6 @@ Item {
         anchors.bottom: header.bottom
         anchors.right:  parent.right
         text:           qsTr("Tools")
-        visible:        !_searchFilter
         onClicked:      toolsMenu.popup()
     }
 


### PR DESCRIPTION
## Objective
There are couple of things that can be improved in the Parameters tab:
- [x] Don't hide the 'Tools' button (that contains all the useful functions) when user is using the search function
- [ ] Organize / Group the Parameter groups so that similar items are organized together (e.g. Dshot & PWM out, as the 'output' group)
- [ ] Parameter Edit Pop-up is quite small (width wise), would be nicer to make it larger

## Questions
1. How can the param edit pop-up's width be changed? I tried editing the '_editFieldWidth' value but it doesn't seem to change the width :( https://github.com/mavlink/qgroundcontrol/blob/12d286fb75189f8343851b1bfd603535c9a489cb/src/QmlControls/ParameterEditorDialog.qml#L36

## Context
Continuation of  #10277 as it was closed due to the repository begin deleted & re-created in my side!