### PR TITLE
src: FlyViewVideo: Remove Double-click text after 10 seconds

### DIFF
--- a/src/FlightDisplay/FlyViewVideo.qml
+++ b/src/FlightDisplay/FlyViewVideo.qml
@@ -69,6 +69,20 @@ Item {
         font.pointSize: ScreenTools.largeFontPointSize
         visible: QGroundControl.videoManager.fullScreen && flyViewVideoMouseArea.containsMouse
         anchors.centerIn: parent
+
+        onVisibleChanged: {
+            if (visible) {
+                labelAnimation.start()
+            }
+        }
+
+        PropertyAnimation on opacity {
+            id: labelAnimation
+            duration: 10000
+            from: 1.0
+            to: 0.0
+            easing.type: Easing.InExpo
+        }
     }
 
     MouseArea {


### PR DESCRIPTION
People wants to usue fullscreen without some text on the mididle of the screen,
10 seconds is enough to get the message.

Fix #10334 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>


