### PR TITLE
Fix joystick set*Frequency boundary checks. #10175

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -944,8 +944,8 @@ void Joystick::setCircleCorrection(bool circleCorrection)
 void Joystick::setAxisFrequency(float val)
 {
     //-- Arbitrary limits
-    val = qMin(_minAxisFrequencyHz, val);
-    val = qMax(_maxAxisFrequencyHz, val);
+    val = qMax(_minAxisFrequencyHz, val);
+    val = qMin(_maxAxisFrequencyHz, val);
     _axisFrequencyHz = val;
     _saveSettings();
     emit axisFrequencyHzChanged();
@@ -954,8 +954,8 @@ void Joystick::setAxisFrequency(float val)
 void Joystick::setButtonFrequency(float val)
 {
     //-- Arbitrary limits
-    val = qMin(_minButtonFrequencyHz, val);
-    val = qMax(_maxButtonFrequencyHz, val);
+    val = qMax(_minButtonFrequencyHz, val);
+    val = qMin(_maxButtonFrequencyHz, val);
     _buttonFrequencyHz = val;
     _saveSettings();
     emit buttonFrequencyHzChanged();


### PR DESCRIPTION
Joystick::setAxisFrequency and Joystick::setButtonFrequency has wrong boundary checks. Instead of boundary check value will set to maximum allowed value.
This was referenced in issues #10175