### PR TITLE
Refactor and fix Video manager issues #10348

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewUVC.qml
+++ b/src/FlightDisplay/FlightDisplayViewUVC.qml
@@ -19,6 +19,7 @@ Rectangle {
     color:              Qt.rgba(0,0,0,0.75)
     clip:               true
     anchors.centerIn:   parent
+    visible:        QGroundControl.videoManager.isUvc
 
     function adjustAspectRatio()
     {
@@ -32,7 +33,7 @@ Rectangle {
 
     Camera {
         id:             camera
-        deviceId:       QGroundControl.videoManager.videoSourceID
+        deviceId:       QGroundControl.videoManager.uvcVideoSourceID
         captureMode:    Camera.CaptureViewfinder
         onDeviceIdChanged: {
             adjustAspectRatio()
@@ -47,12 +48,16 @@ Rectangle {
         source:         camera
         anchors.fill:   parent
         fillMode:       VideoOutput.PreserveAspectCrop
-        visible:        !QGroundControl.videoManager.isGStreamer
-    }
-    onVisibleChanged: {
-        if(visible)
-            camera.start()
-        else
-            camera.stop()
+        visible:        QGroundControl.videoManager.isUvc
+
+        onVisibleChanged: {
+            console.log('UVC Video output visible: ', visible);
+            if (visible) {
+                camera.start()
+                }
+            else {
+                camera.stop()
+                }
+        }
     }
 }

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -110,7 +110,6 @@ VideoManager::setToolbox(QGCToolbox *toolbox)
 #ifndef QGC_DISABLE_UVC
    // If we are using a UVC camera setup the device name
    _updateUVC();
-   emit isUvcChanged();
 #endif
 
     emit isGStreamerChanged();

--- a/src/VideoManager/VideoManager.h
+++ b/src/VideoManager/VideoManager.h
@@ -38,8 +38,9 @@ public:
 
     Q_PROPERTY(bool             hasVideo                READ    hasVideo                                    NOTIFY hasVideoChanged)
     Q_PROPERTY(bool             isGStreamer             READ    isGStreamer                                 NOTIFY isGStreamerChanged)
+    Q_PROPERTY(bool             isUvc                   READ    isUvc                                       NOTIFY isUvcChanged)
     Q_PROPERTY(bool             isTaisync               READ    isTaisync       WRITE   setIsTaisync        NOTIFY isTaisyncChanged)
-    Q_PROPERTY(QString          videoSourceID           READ    videoSourceID                               NOTIFY videoSourceIDChanged)
+    Q_PROPERTY(QString          uvcVideoSourceID        READ    uvcVideoSourceID                            NOTIFY uvcVideoSourceIDChanged)
     Q_PROPERTY(bool             uvcEnabled              READ    uvcEnabled                                  CONSTANT)
     Q_PROPERTY(bool             fullScreen              READ    fullScreen      WRITE   setfullScreen       NOTIFY fullScreenChanged)
     Q_PROPERTY(VideoReceiver*   videoReceiver           READ    videoReceiver                               CONSTANT)
@@ -58,9 +59,10 @@ public:
 
     virtual bool        hasVideo            ();
     virtual bool        isGStreamer         ();
+    virtual bool        isUvc               ();
     virtual bool        isTaisync           () { return _isTaisync; }
     virtual bool        fullScreen          () { return _fullScreen; }
-    virtual QString     videoSourceID       () { return _videoSourceID; }
+    virtual QString     uvcVideoSourceID    () { return _uvcVideoSourceID; }
     virtual double      aspectRatio         ();
     virtual double      thermalAspectRatio  ();
     virtual double      hfov                ();
@@ -114,7 +116,8 @@ public:
 signals:
     void hasVideoChanged            ();
     void isGStreamerChanged         ();
-    void videoSourceIDChanged       ();
+    void isUvcChanged               ();
+    void uvcVideoSourceIDChanged    ();
     void fullScreenChanged          ();
     void isAutoStreamChanged        ();
     void isTaisyncChanged           ();
@@ -170,7 +173,7 @@ protected:
     QAtomicInteger<bool>    _recording              = false;
     QAtomicInteger<quint32> _videoSize              = 0;
     VideoSettings*          _videoSettings          = nullptr;
-    QString                 _videoSourceID;
+    QString                 _uvcVideoSourceID;
     bool                    _fullScreen             = false;
     Vehicle*                _activeVehicle          = nullptr;
 };

--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -1297,6 +1297,7 @@ GstVideoReceiver::_onBusMessage(GstBus* bus, GstMessage* msg, gpointer data)
             gst_message_parse_error(msg, &error, &debug);
 
             if (debug != nullptr) {
+                qCDebug(VideoReceiverLog) << "GStreamer debug: " << debug;
                 g_free(debug);
                 debug = nullptr;
             }

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -300,7 +300,7 @@ Rectangle {
 
                                 QGCLabel {
                                     id:         videoFileFormatLabel
-                                    text:       qsTr("File Format")
+                                    text:       qsTr("Record File Format")
                                     visible:    _showSaveVideoSettings && _videoSettings.recordingFormat.visible
                                 }
                                 FactComboBox {


### PR DESCRIPTION
This fixes issues covered in Bug report #10348

That is 
* playing video even though source is switched to `Video stream disabled`
* displaying video preview window even though source is switched to `Video stream disabled`
* utilizing UVC and GStreamer even though source is switched to `Video stream disabled`