### PR TITLE
Rework fly view map guided mode menu

### DIFF
--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -12,6 +12,7 @@ import QtQuick.Controls             2.4
 import QtLocation                   5.3
 import QtPositioning                5.3
 import QtQuick.Dialogs              1.2
+import QtQuick.Layouts              1.11
 
 import QGroundControl               1.0
 import QGroundControl.Airspace      1.0
@@ -511,38 +512,81 @@ FlightMap {
         }
     }
 
+
     // Handle guided mode clicks
     MouseArea {
         anchors.fill: parent
 
-        QGCMenu {
+        Popup {
             id: clickMenu
+            modal: true
+
             property var coord
-            QGCMenuItem {
-                text:           qsTr("Go to location")
-                visible:        globals.guidedControllerFlyView.showGotoLocation
 
-                onTriggered: {
-                    gotoLocationItem.show(clickMenu.coord)
-                    globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionGoto, clickMenu.coord, gotoLocationItem)
+            function setCoordinates(mouseX, mouseY) {
+                var newX = mouseX
+                var newY = mouseY
+
+                // Filtering coordinates
+                if (newX + clickMenu.width > _root.width) {
+                    newX = _root.width - clickMenu.width
                 }
-            }
-            QGCMenuItem {
-                text:           qsTr("Orbit at location")
-                visible:        globals.guidedControllerFlyView.showOrbit
-
-                onTriggered: {
-                    orbitMapCircle.show(clickMenu.coord)
-                    globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionOrbit, clickMenu.coord, orbitMapCircle)
+                if (newY + clickMenu.height > _root.height) {
+                    newY = _root.height - clickMenu.height
                 }
-            }
-            QGCMenuItem {
-                text:           qsTr("ROI at location")
-                visible:        globals.guidedControllerFlyView.showROI
 
-                onTriggered: {
-                    roiLocationItem.show(clickMenu.coord)
-                    globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionROI, clickMenu.coord, roiLocationItem)
+                // Set coordiantes
+                x = newX
+                y = newY
+            }
+
+            background: Rectangle {
+                radius: ScreenTools.defaultFontPixelHeight * 0.5
+                color: qgcPal.window
+                border.color: qgcPal.text
+            }
+
+            ColumnLayout {
+                id: mainLayout
+                spacing: ScreenTools.defaultFontPixelWidth / 2
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    text: "Go to location"
+                    visible: globals.guidedControllerFlyView.showGotoLocation
+                    onClicked: {
+                        if (clickMenu.opened) {
+                            clickMenu.close()
+                        }
+                        gotoLocationItem.show(clickMenu.coord)
+                        globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionGoto, clickMenu.coord, gotoLocationItem)
+                    }
+                }
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    text: "Orbit at location"
+                    visible: globals.guidedControllerFlyView.showOrbit
+                    onClicked: {
+                        if (clickMenu.opened) {
+                            clickMenu.close()
+                        }
+                        orbitMapCircle.show(clickMenu.coord)
+                        globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionOrbit, clickMenu.coord, orbitMapCircle)
+                    }
+                }
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    text: "ROI at location"
+                    visible: globals.guidedControllerFlyView.showROI
+                    onClicked: {
+                        if (clickMenu.opened) {
+                            clickMenu.close()
+                        }
+                        roiLocationItem.show(clickMenu.coord)
+                        globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionROI, clickMenu.coord, roiLocationItem)
+                    }
                 }
             }
         }
@@ -553,7 +597,8 @@ FlightMap {
                 gotoLocationItem.hide()
                 var clickCoord = _root.toCoordinate(Qt.point(mouse.x, mouse.y), false /* clipToViewPort */)
                 clickMenu.coord = clickCoord
-                clickMenu.popup()
+                clickMenu.setCoordinates(mouse.x, mouse.y)
+                clickMenu.open()
             }
         }
     }


### PR DESCRIPTION
This PR is designed to make the guided mode menu a little more beautiful and unified in style with QGC

Old style menu (Go to location and Orbit at location):
![Screenshot from 2022-08-09 16-47-51](https://user-images.githubusercontent.com/2522054/183666846-b2f65be1-a48d-4137-a1e8-193da71979e9.png)

New style menu:
![Screenshot from 2022-08-09 16-42-53](https://user-images.githubusercontent.com/2522054/183667259-2a207374-78a2-4dd8-a95f-fb53458e5fd7.png)

