### PR TITLE
Rework flight mode menu for toolbar

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -108,6 +108,7 @@
         <file alias="QGroundControl/Controls/KMLOrSHPFileDialog.qml">src/QmlControls/KMLOrSHPFileDialog.qml</file>
         <file alias="QGroundControl/Controls/LogReplayStatusBar.qml">src/QmlControls/LogReplayStatusBar.qml</file>
         <file alias="QGroundControl/Controls/MainStatusIndicator.qml">src/ui/toolbar/MainStatusIndicator.qml</file>
+        <file alias="QGroundControl/Controls/FlightModeMenuIndicator.qml">src/ui/toolbar/FlightModeMenuIndicator.qml</file>
         <file alias="QGroundControl/Controls/MainToolBar.qml">src/ui/toolbar/MainToolBar.qml</file>
         <file alias="QGroundControl/Controls/MainWindowSavedState.qml">src/QmlControls/MainWindowSavedState.qml</file>
         <file alias="QGroundControl/Controls/MAVLinkChart.qml">src/QmlControls/MAVLinkChart.qml</file>

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -33,6 +33,7 @@ JoystickThumbPad                        1.0 JoystickThumbPad.qml
 KMLOrSHPFileDialog                      1.0 KMLOrSHPFileDialog.qml
 LogReplayStatusBar                      1.0 LogReplayStatusBar.qml
 MainStatusIndicator                     1.0 MainStatusIndicator.qml
+FlightModeMenuIndicator                 1.0 FlightModeMenuIndicator.qml
 MainToolBar                             1.0 MainToolBar.qml
 MainWindowSavedState                    1.0 MainWindowSavedState.qml
 MAVLinkMessageButton                    1.0 MAVLinkMessageButton.qml

--- a/src/ui/toolbar/CMakeLists.txt
+++ b/src/ui/toolbar/CMakeLists.txt
@@ -2,6 +2,7 @@ add_custom_target(UiToolbarQml
 	SOURCES
 		ArmedIndicator.qml
 		BatteryIndicator.qml
+		FlightModeMenuIndicator.qml
 		GPSIndicator.qml
 		GPSRTKIndicator.qml
 		JoystickIndicator.qml

--- a/src/ui/toolbar/FlightModeMenuIndicator.qml
+++ b/src/ui/toolbar/FlightModeMenuIndicator.qml
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick 2.11
+import QtQuick.Layouts 1.11
+
+import QGroundControl 1.0
+import QGroundControl.Controls 1.0
+import QGroundControl.MultiVehicleManager 1.0
+import QGroundControl.ScreenTools 1.0
+import QGroundControl.Palette 1.0
+
+RowLayout {
+    id: _root
+    spacing: 0
+
+    property real fontPointSize: ScreenTools.largeFontPointSize
+    property var activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+    Component {
+        id: flightModeMenu
+
+        Rectangle {
+            width: flickable.width + (ScreenTools.defaultFontPixelWidth * 2)
+            height: flickable.height + (ScreenTools.defaultFontPixelWidth * 2)
+            radius: ScreenTools.defaultFontPixelHeight * 0.5
+            color: qgcPal.window
+            border.color: qgcPal.text
+
+            QGCFlickable {
+                id: flickable
+                anchors.margins: ScreenTools.defaultFontPixelWidth
+                anchors.top: parent.top
+                anchors.left: parent.left
+                width: mainLayout.width
+                height: _fullWindowHeight <= mainLayout.height ? _fullWindowHeight : mainLayout.height
+                flickableDirection: Flickable.VerticalFlick
+                contentHeight: mainLayout.height
+                contentWidth: mainLayout.width
+
+                property real _fullWindowHeight: mainWindow.contentItem.height - (indicatorPopup.padding * 2) - (ScreenTools.defaultFontPixelWidth * 2)
+
+                ColumnLayout {
+                    id: mainLayout
+                    spacing: ScreenTools.defaultFontPixelWidth / 2
+
+                    Repeater {
+                        model: activeVehicle ? activeVehicle.flightModes : []
+
+                        QGCButton {
+                            text: modelData
+                            Layout.fillWidth: true
+                            onClicked: {
+                                activeVehicle.flightMode = text
+                                mainWindow.hideIndicatorPopup()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    RowLayout {
+        Layout.fillWidth: true
+
+        QGCLabel {
+            text: activeVehicle ? activeVehicle.flightMode : qsTr("N/A", "No data to display")
+            font.pointSize: fontPointSize
+            Layout.alignment: Qt.AlignCenter
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    mainWindow.showIndicatorPopup(_root, flightModeMenu)
+                }
+            }
+        }
+    }
+}

--- a/src/ui/toolbar/MainStatusIndicator.qml
+++ b/src/ui/toolbar/MainStatusIndicator.qml
@@ -114,12 +114,10 @@ RowLayout {
         visible:                flightModeMenu.visible
     }
 
-    FlightModeMenu {
+    FlightModeMenuIndicator {
         id:                     flightModeMenu
         Layout.preferredHeight: _root.height
-        verticalAlignment:      Text.AlignVCenter
-        font.pointSize:         _vehicleInAir ?  ScreenTools.largeFontPointSize : ScreenTools.defaultFontPointSize
-        mouseAreaLeftMargin:    -(flightModeMenu.x - flightModeIcon.x)
+        fontPointSize:          _vehicleInAir ?  ScreenTools.largeFontPointSize : ScreenTools.defaultFontPointSize
         visible:                _activeVehicle
     }
 


### PR DESCRIPTION
Add a flight mode menu indicator that matches the QGC style

Old menu style:
![Screenshot from 2022-08-11 16-15-58](https://user-images.githubusercontent.com/2522054/184142023-298b945e-0885-41ac-a4e7-d6961346926c.png)


New menu style:
![Screenshot from 2022-08-11 16-05-09](https://user-images.githubusercontent.com/2522054/184141125-0bd31ba3-0276-4c0c-b10a-d471ce47376a.png)
