### PR TITLE
PositionManager: set UERE to enable position accuracy reporting

### DIFF
--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -101,6 +101,8 @@ void QGCPositionManager::setNmeaSourceDevice(QIODevice* device)
     }
     _nmeaSource = new QNmeaPositionInfoSource(QNmeaPositionInfoSource::RealTimeMode, this);
     _nmeaSource->setDevice(device);
+    // set equivalent range error to enable position accuracy reporting
+    _nmeaSource->setUserEquivalentRangeError(5.1);
     setPositionSource(QGCPositionManager::NmeaGPS);
 }
 

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -170,7 +170,7 @@ void QGCPositionManager::setPositionSource(QGCPositionManager::QGCPositionSource
         _currentSource = _nmeaSource;
         break;
     case QGCPositionManager::InternalGPS:
-    default:        
+    default:
         _currentSource = _defaultSource;
         break;
     }


### PR DESCRIPTION
"QNmeaPositionInfoSource supports reporting the accuracy of the
horizontal and vertical position. To enable position accuracy reporting
an estimate of the User Equivalent Range Error associated with the NMEA
source must be set with setUserEquivalentRangeError."

Source: https://doc.qt.io/qt-6/qnmeapositioninfosource.html#details

Commit 2a9ecabad86f37ccfcf8de9d0d5853238678ab4c introduced new behaviour
that broke use of external GPS. This change fixes the problem reported
in https://github.com/mavlink/qgroundcontrol/issues/10271.


