### PR TITLE
CI: Use Ubuntu 20.04 as build platform

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on:  ubuntu-18.04
+    runs-on:  ubuntu-20.04
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build:
-    runs-on:  ubuntu-18.04
+    runs-on:  ubuntu-20.04
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
"The ubuntu-18.04 environment is deprecated, consider switching to
ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details
see https://github.com/actions/virtual-environments/issues/6002"


