### PR TITLE
fix Android CI for 32bit and 64bit builds (#10360)

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -47,7 +47,7 @@ jobs:
           git fetch --all --tags -f
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2
+        uses: jurplel/install-qt-action@v3
         with:
           version:      ${{ env.QT_VERSION }}
           host:         linux
@@ -55,6 +55,13 @@ jobs:
           dir:          ${{ runner.temp }}
           modules:      qtcharts
           setup-python: true
+
+      - name: Install Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r21e
+          add-to-path: false
 
       - name: Install ccache
         run:  sudo apt-get install ccache
@@ -107,6 +114,10 @@ jobs:
         working-directory: ${{ runner.temp }}/shadow_build_dir
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_LATEST_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
         run:  |
             qmake -r ${SOURCE_DIR}/qgroundcontrol.pro -spec android-clang CONFIG+=${BUILD_TYPE} CONFIG+=installer ANDROID_ABIS="${{ matrix.eabi }}"
             make -j2 apk


### PR DESCRIPTION
  * install and use NDK r21e
  * update QT install action from v2 to v3

Starting with NDK Version r24 llvm will not accept one-dash
long options anymore. This is bug QTBUG-104580

https://bugreports.qt.io/browse/QTBUG-104580

The r23c NDK version did not work due to issues with
stripping symbols. So I install and use r21e. QT 5.15.2 uses
gradle version 5.6.4 with the default android gradle plugin 3.6.0.
With gradle 6.9.2 and android gradle plugin 4.2.2 the 32bits
build worked. NDK r22b is not compatible with gstreamer 1.18 and
results in a failing 64bit build. Therefore r21e is required for
gstreamer support.

Closes: https://github.com/mavlink/qgroundcontrol/issues/10360