### PR TITLE
Fix cmake build after add libevents_health_and_arming_checks

### DIFF
--- a/libs/libevents/CMakeLists.txt
+++ b/libs/libevents/CMakeLists.txt
@@ -11,3 +11,7 @@ add_library(libevents_parser
 target_include_directories(libevents_parser PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(libevents_parser PUBLIC Qt5::Core)
 target_link_libraries(libevents_parser PUBLIC comm)
+
+add_library(libevents_health_and_arming_checks
+    libevents/libs/cpp/parse/health_and_arming_checks.cpp)
+target_link_libraries(libevents_health_and_arming_checks PRIVATE comm)

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -107,6 +107,7 @@ target_link_libraries(Vehicle
 		compression
 		libevents_generated
 		libevents_parser
+		libevents_health_and_arming_checks
 	PUBLIC
 		qgc
 )


### PR DESCRIPTION
This PR fix linking libevents_health_and_arming_checks issue for Vehicle library 