### PR TITLE
gstreamer: increase buffersize for udpsrc on android

### DIFF
--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -718,8 +718,12 @@ GstVideoReceiver::_makeSource(const QString& uri)
             }
         } else if(isUdp264 || isUdp265 || isUdpMPEGTS || isTaisync) {
             if ((source = gst_element_factory_make("udpsrc", "source")) != nullptr) {
-                g_object_set(static_cast<gpointer>(source), "uri", QString("udp://%1:%2").arg(qPrintable(url.host()), QString::number(url.port())).toUtf8().data(), nullptr);
-
+                g_object_set(static_cast<gpointer>(source), "uri", QString("udp://%1:%2").arg(qPrintable(url.host()), QString::number(url.port())).toUtf8().data(),
+#ifdef Q_OS_ANDROID
+                    // Typical android devices have too small default receive buffer size, causing packet loss.
+                    "buffer-size", 524288,
+#endif
+                    nullptr);
                 GstCaps* caps = nullptr;
 
                 if(isUdp264) {


### PR DESCRIPTION
This PR fixes #10377.

I choose 524288, as this also seems to be the default buffer size of a udp socket when used via gstreamers [rtspsrc](https://gstreamer.freedesktop.org/documentation/rtsp/rtspsrc.html?gi-language=c#rtspsrc:udp-buffer-size) (for udpsrc it is the default value of the os).
I experienced good results with this value on different devices.