### PR TITLE
VideoSettings: allow forcing software video decoder on android

### DIFF
--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -82,6 +82,12 @@ DECLARE_SETTINGGROUP(Video, "Video")
         VideoDecoderOptions::ForceVideoDecoderDirectX3D,
         VideoDecoderOptions::ForceVideoDecoderVAAPI,
 #endif
+#ifdef Q_OS_ANDROID
+        VideoDecoderOptions::ForceVideoDecoderDirectX3D,
+        VideoDecoderOptions::ForceVideoDecoderVideoToolbox,
+        VideoDecoderOptions::ForceVideoDecoderVAAPI,
+        VideoDecoderOptions::ForceVideoDecoderNVIDIA,
+#endif
     };
 
     for(const auto& value : removeForceVideoDecodeList) {
@@ -139,11 +145,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, forceVideoDecoder)
 #ifdef Q_OS_IOS
             false
 #else
-#ifdef Q_OS_ANDROID
-            false
-#else
             true
-#endif
 #endif
         );
 


### PR DESCRIPTION
This PR activates the dropdown menu to select the video decoder priority for android and enables the "Force Software Decoder" option.

Usecase: On powerful devices (and/or low bitrates streams) this can improve latency.
I don't know the details, but avdec_h264 somehow can handles things different (does not need to wait for a whole frame!?) than a hardware decoder and so has less latency...