### PR TITLE
Fix GInstanceInitFunc for register GtypeIfo

### DIFF
--- a/src/VideoReceiver/gstqgcvideosinkbin.c
+++ b/src/VideoReceiver/gstqgcvideosinkbin.c
@@ -114,10 +114,10 @@ _vsb_sink_pad_query(GstPad* pad, GstObject* parent, GstQuery* query)
 static void
 _vsb_init(GTypeInstance *instanceData, void *vsbVoid)
 {
-    Q_UNUSED(instanceData);
+    Q_UNUSED(vsbVoid);
 
     GstQgcVideoSinkBin *vsb;
-    vsb = (GstQgcVideoSinkBin *)vsbVoid;
+    vsb = (GstQgcVideoSinkBin *)instanceData;
 
     gboolean initialized        = FALSE;
     GstElement* glcolorconvert  = NULL;


### PR DESCRIPTION
I found out that video streaming stopped working after this commit 3f479fc8410d3422dc4e27208b17eebcdb0bd617.
The resulting errors are below:

(QGroundControl:238965): GLib-GObject-WARNING **: 15:02:27.061: invalid uninstantiatable type '<unknown>' in cast to 'GstBin'

(QGroundControl:238965): GStreamer-CRITICAL **: 15:02:27.061: gst_bin_add_many: assertion 'GST_IS_BIN (bin)' failed

(QGroundControl:238965): GLib-GObject-WARNING **: 15:02:27.064: invalid uninstantiatable type '<unknown>' in cast to 'GstElement'

(QGroundControl:238965): GStreamer-CRITICAL **: 15:02:27.064: gst_element_add_pad: assertion 'GST_IS_ELEMENT (element)' failed

(QGroundControl:238965): GLib-GObject-CRITICAL **: 15:02:27.064: g_object_set: assertion 'G_IS_OBJECT (object)' failed
VideoReceiverLog: Unable to find sink pad of video sink "udp://0.0.0.0:4545"

(QGroundControl:238965): GLib-GObject-WARNING **: 15:02:27.065: invalid uninstantiatable type 'void' in cast to 'GstBin'

(QGroundControl:238965): GStreamer-CRITICAL **: 15:02:27.065: gst_bin_add_many: assertion 'GST_IS_BIN (bin)' failed

(QGroundControl:238965): GLib-GObject-WARNING **: 15:02:27.068: invalid uninstantiatable type 'void' in cast to 'GstElement'

(QGroundControl:238965): GStreamer-CRITICAL **: 15:02:27.068: gst_element_add_pad: assertion 'GST_IS_ELEMENT (element)' failed

(QGroundControl:238965): GLib-GObject-CRITICAL **: 15:02:27.068: g_object_set: assertion 'G_IS_OBJECT (object)' failed

Apparently, during refactoring, variables were mixed up in places. 
This PR fixes the problem.
@bkueng Please review this changes since the previous changes were merged into the master branch by you. 