### PR TITLE
MacOS: update GStreamer 1.18.1 to 1.18.6 and fix CI (#10393 / #10408) 

### DIFF
--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -87,7 +87,6 @@ jobs:
         working-directory: ${{ runner.temp }}/shadow_build_dir
         run:  |
               export JOBS=$((`sysctl -n hw.ncpu`+1))
-              export LIBRARY_PATH=/Library/Frameworks/GStreamer.framework/Versions/1.0/lib/
               qmake -r ${SOURCE_DIR}/qgroundcontrol.pro CONFIG+=installer CONFIG+=${BUILD_TYPE}
               make -j$JOBS
 

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Install Gstreamer
         run: |
-            wget https://gstreamer.freedesktop.org/data/pkg/osx/1.18.1/gstreamer-1.0-devel-1.18.1-x86_64.pkg
-            wget https://gstreamer.freedesktop.org/data/pkg/osx/1.18.1/gstreamer-1.0-1.18.1-x86_64.pkg
+            wget https://gstreamer.freedesktop.org/data/pkg/osx/1.18.6/gstreamer-1.0-devel-1.18.6-x86_64.pkg
+            wget https://gstreamer.freedesktop.org/data/pkg/osx/1.18.6/gstreamer-1.0-1.18.6-x86_64.pkg
             for package in *.pkg ;
               do sudo installer -verbose -pkg "$package" -target /
             done

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -47,9 +47,12 @@ jobs:
           setup-python: false
 
       - name: Install Gstreamer
-        run:  |
-            wget --quiet https://qgroundcontrol.s3-us-west-2.amazonaws.com/dependencies/gstreamer-osx-1.18.1.tar.bz2 &&
-            sudo tar zxf gstreamer-osx-1.18.1.tar.bz2 -C /Library/Frameworks
+        run: |
+            wget https://gstreamer.freedesktop.org/data/pkg/osx/1.18.1/gstreamer-1.0-devel-1.18.1-x86_64.pkg
+            wget https://gstreamer.freedesktop.org/data/pkg/osx/1.18.1/gstreamer-1.0-1.18.1-x86_64.pkg
+            for package in *.pkg ;
+              do sudo installer -verbose -pkg "$package" -target /
+            done
 
       - name: Install ccache
         run:  brew install ccache
@@ -83,8 +86,10 @@ jobs:
       - name: Build
         working-directory: ${{ runner.temp }}/shadow_build_dir
         run:  |
+              export JOBS=$((`sysctl -n hw.ncpu`+1))
+              export LIBRARY_PATH=/Library/Frameworks/GStreamer.framework/Versions/1.0/lib/
               qmake -r ${SOURCE_DIR}/qgroundcontrol.pro CONFIG+=installer CONFIG+=${BUILD_TYPE}
-              make -j3
+              make -j$JOBS
 
       - name: ccache post-run
         run:  ccache -s

--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -25,7 +25,7 @@ MacBuild {
     # with the differences between post list command running in a shell script (XCode) versus a makefile (Qt Creator)
     macx-xcode {
         # SDL2 Framework
-        QMAKE_POST_LINK += && rsync -a --delete $$SOURCE_DIR/libs/Frameworks/SDL2.Framework $BUILT_PRODUCTS_DIR/$${TARGET}.app/Contents/Frameworks
+        QMAKE_POST_LINK += && rsync -a --delete $$SOURCE_DIR/libs/Frameworks/SDL2.framework $BUILT_PRODUCTS_DIR/$${TARGET}.app/Contents/Frameworks
         QMAKE_POST_LINK += && install_name_tool -change "@rpath/SDL2.framework/Versions/A/SDL2" "@executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2" $BUILT_PRODUCTS_DIR/$${TARGET}.app/Contents/MacOS/$${TARGET}
         # AirMap
         contains (DEFINES, QGC_AIRMAP_ENABLED) {
@@ -34,7 +34,7 @@ MacBuild {
         }
     } else {
         # SDL2 Framework
-        QMAKE_POST_LINK += && rsync -a --delete $$SOURCE_DIR/libs/Frameworks/SDL2.Framework $${TARGET}.app/Contents/Frameworks
+        QMAKE_POST_LINK += && rsync -a --delete $$SOURCE_DIR/libs/Frameworks/SDL2.framework $${TARGET}.app/Contents/Frameworks
         QMAKE_POST_LINK += && install_name_tool -change "@rpath/SDL2.framework/Versions/A/SDL2" "@executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2" $${TARGET}.app/Contents/MacOS/$${TARGET}
         # AirMap
         contains (DEFINES, QGC_AIRMAP_ENABLED) {

--- a/QGCPostLinkInstaller.pri
+++ b/QGCPostLinkInstaller.pri
@@ -16,7 +16,7 @@ installer {
         QMAKE_POST_LINK += && $$dirname(QMAKE_QMAKE)/macdeployqt $${TARGET}.app -appstore-compliant -verbose=1 -qmldir=$${SOURCE_DIR}/src
 
         # macdeployqt is missing some relocations once in a while. "Fix" it:
-        QMAKE_POST_LINK += && cp -R /Library/Frameworks/GStreamer.framework $${TARGET}.app/Contents/Frameworks
+        QMAKE_POST_LINK += && rsync -a --delete /Library/Frameworks/GStreamer.framework $${TARGET}.app/Contents/Frameworks
         QMAKE_POST_LINK += && echo libexec
         QMAKE_POST_LINK += && ln -sf $${TARGET}.app/Contents/Frameworks $${TARGET}.app/Contents/Frameworks/GStreamer.framework/Versions/1.0/libexec/Frameworks
         QMAKE_POST_LINK += && install_name_tool -change /Library/Frameworks/GStreamer.framework/Versions/1.0/lib/GStreamer @executable_path/../Frameworks/GStreamer.framework/Versions/1.0/lib/GStreamer $${TARGET}.app/Contents/MacOS/QGroundControl
@@ -34,6 +34,8 @@ installer {
         QMAKE_POST_LINK += && mkdir -p package
         QMAKE_POST_LINK += && mkdir -p staging
         QMAKE_POST_LINK += && rsync -a --delete $${TARGET}.app staging
+        QMAKE_POST_LINK += && rm -rf /tmp/tmp.dmg
+        QMAKE_POST_LINK += && rm -rf package/$${TARGET}.dmg
         QMAKE_POST_LINK += && hdiutil create /tmp/tmp.dmg -ov -volname "$${TARGET}-$${MAC_VERSION}" -fs HFS+ -srcfolder "staging"
         QMAKE_POST_LINK += && hdiutil convert /tmp/tmp.dmg -format UDBZ -o package/$${TARGET}.dmg
         QMAKE_POST_LINK += && rm /tmp/tmp.dmg

--- a/src/VideoReceiver/README.md
+++ b/src/VideoReceiver/README.md
@@ -68,11 +68,11 @@ The build system is setup to use pkgconfig and it will find the necessary header
 
 ### Mac OS
 
-Download the gstreamer framework from here: http://gstreamer.freedesktop.org/data/pkg/osx. Supported version is 1.18.1. QGC may work with newer version, but it is untested.
+Download the gstreamer framework from here: http://gstreamer.freedesktop.org/data/pkg/osx. Supported version is 1.18.6. QGC may work with newer version, but it is untested.
 
 You need two packages:
-- [gstreamer-1.0-devel-1.18.1-x86_64.pkg](https://gstreamer.freedesktop.org/data/pkg/osx/1.18.1/gstreamer-1.0-devel-1.18.1-x86_64.pkg)
-- [gstreamer-1.0-1.18.1-x86_64.pkg](https://gstreamer.freedesktop.org/data/pkg/osx/1.18.1/gstreamer-1.0-1.18.1-x86_64.pkg)
+- [gstreamer-1.0-devel-1.18.6-x86_64.pkg](https://gstreamer.freedesktop.org/data/pkg/osx/1.18.6/gstreamer-1.0-devel-1.18.6-x86_64.pkg)
+- [gstreamer-1.0-1.18.6-x86_64.pkg](https://gstreamer.freedesktop.org/data/pkg/osx/1.18.6/gstreamer-1.0-1.18.6-x86_64.pkg)
 
 The installer places them under /Library/Frameworks/GStreamer.framework, which is where the QGC build system will look for it. That's all that is needed. When you build QGC and it finds the gstreamer framework, it automatically builds video streaming support.
 

--- a/src/VideoReceiver/VideoReceiver.pri
+++ b/src/VideoReceiver/VideoReceiver.pri
@@ -25,6 +25,7 @@ LinuxBuild {
         CONFIG      += VideoEnabled
         INCLUDEPATH += $$GST_ROOT/Headers
         LIBS        += -F/Library/Frameworks -framework GStreamer
+        QMAKE_LIBDIR += $$GST_ROOT/Versions/1.0/lib/
     }
 } else:iOSBuild {
     #- gstreamer framework installed by the gstreamer iOS SDK installer (default to home directory)


### PR DESCRIPTION
The CI builds on master for MacOS do not work. This PR updates the CI for MacOS and 

  * MacOS CI: Use official gstreamer package by picking patches from @patrickelectric from stable
  * MacOS CI: Update gstreamer from 1.18.1 to 1.18.6 for MacOS

With GStreamer 1.18.6 the application does not crash anymore from the videofeed

`gst-launch-1.0 videotestsrc ! x264enc ! rtph264pay ! udpsink host=127.0.0.1 port=5600`

Closes: #10393 
Closes: #10408
Closes: #10435 