### PR TITLE
Add The Peach K1/R1 USB Board info

### DIFF
--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -37,6 +37,9 @@
 
         { "vendorID": 11694, "productID": 0,        "boardClass": "Pixhawk",    "name": "Hex/ProfiCNC" },
 
+        { "vendorID": 13735, "productID": 1,        "boardClass": "Pixhawk",    "name": "ThePeach FCC-K1" },
+        { "vendorID": 13735, "productID": 2,        "boardClass": "Pixhawk",    "name": "ThePeach FCC-R1" },
+
         { "vendorID": 9900, "productID": 21,        "boardClass": "PX4 Flow",   "name": "PX4 Flow" },
 
         { "vendorID": 1027, "productID": 24597,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "3DR Radio" },


### PR DESCRIPTION
Hi,

We developed a Flight Controller.
I would like to add USB Board info of our K1/R1 Flight Controller to the QGroundControl.

please check theses PR !
- PX4-user-guide: https://github.com/PX4/PX4-user_guide/pull/2034#event-7336074804
- PX4-Autopilot: https://github.com/PX4/PX4-Autopilot/pull/20176
- PX4-Bootloader: https://github.com/PX4/PX4-Bootloader/pull/219

Thanks