### PR TITLE
docker image for android build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!deploy/docker/*

--- a/android_environment.sh
+++ b/android_environment.sh
@@ -1,21 +1,15 @@
 #!/bin/bash
 #----------------------------------------------------------
 # You will need:
-# - Qt 5.5.x android_armv7 kit
+# - Qt 5.15.2 android kit
 # - Android SDK
 # - Androig NDK
-# - Current Java
-# - ant
+# - jdk 11
 #----------------------------------------------------------
 # Update with correct location for these
 export ANDROID_HOME=~/Library/Android/sdk
 export ANDROID_SDK_ROOT=~/Library/Android/sdk
 export ANDROID_NDK_ROOT=~/Library/Android/sdk/ndk-bundle
-export ANDROID_NDK_HOST=darwin-x86_64
-export ANDROID_NDK_PLATFORM=/android-9
-export ANDROID_NDK_TOOLCHAIN_PREFIX=arm-linux-androideabi
-export ANDROID_NDK_TOOLCHAIN_VERSION=4.9
-export ANDROID_NDK_TOOLS_PREFIX=arm-linux-androideabi
 #----------------------------------------------------------
 # To build it, run (replacing the path with where you have Qt installed)
 #
@@ -23,7 +17,6 @@ export ANDROID_NDK_TOOLS_PREFIX=arm-linux-androideabi
 # cd ../
 # mkdir android_build
 # cd android_build
-# >~/local/Qt/5.4/android_armv7/bin/qmake -r -spec android-g++ CONFIG+=debug ../qgroundcontrol/qgroundcontrol.pro
-# >make -j24 install INSTALL_ROOT=./android-build/
-# >~/local/Qt/5.4/android_armv7/bin/androiddeployqt --input ./android-libQGroundControl.so-deployment-settings.json --output ./android-build --deployment bundled --android-platform android-22 --jdk /System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/Home --verbose --ant /usr/local/bin/ant
+# >~/local/Qt/5.15.2/android/bin/qmake -r -spec android-clang CONFIG+=debug ANDROID_ABIS=armeabi-v7a ../qgroundcontrol/qgroundcontrol.pro
+# >make -j24 apk
 #

--- a/deploy/docker/Dockerfile-build-android
+++ b/deploy/docker/Dockerfile-build-android
@@ -1,0 +1,92 @@
+#
+# QGroundControl android build environment
+#
+
+FROM ubuntu:20.04
+LABEL authors="Tobias Herzog <pasdVn3@gmx.de>"
+
+ARG QT_VERSION=5.15.2
+ARG ANDROID_NDK_VERSION=21.4.7075529
+ARG ANDROID_API_LEVEL=30
+# build tool version is determined by gradle-template file of Qt
+ARG ANDROID_BUILD_TOOLS=28.0.3
+ARG GSTREAMER_VERSION=1.18.5
+
+ENV ANDROID_ABIS armeabi-v7a
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV DISPLAY :99
+
+ENV QMAKESPEC android-clang
+
+ENV QT_PATH /opt/Qt
+ENV QT_DESKTOP $QT_PATH/${QT_VERSION}/android
+ENV QT_TARGET android
+
+ENV ANDROID_HOME /opt/android_sdk
+ENV ANDROID_SDK_ROOT ${ANDROID_HOME}
+ENV ANDROID_NDK_ROOT /opt/android_sdk/ndk/${ANDROID_NDK_VERSION}
+ENV GSTREAMER_HOME /opt/gstreamer-1.0-android-universal-${GSTREAMER_VERSION}
+
+
+ENV PATH /usr/lib/ccache:$QT_DESKTOP/bin:$PATH
+
+RUN apt update && apt -y --quiet --no-install-recommends install \
+		apt-utils \
+		ca-certificates \
+		ccache \
+		git \
+		locales \
+		make \
+		openssl \
+		openjdk-11-jdk-headless \
+		wget \
+		unzip \
+		xz-utils \
+		zlib1g-dev \
+	&& apt-get -y autoremove \
+	&& apt-get clean autoclean \
+	&& rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# Install Qt
+COPY deploy/docker/install-qt-linux.sh /tmp/qt/
+RUN /tmp/qt/install-qt-linux.sh && \
+    rm -rf ~/.cache/pip && \
+    rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# install android sdk and ndk
+RUN cd /opt && \
+    mkdir -p $ANDROID_HOME/cmdline-tools && cd $ANDROID_HOME/cmdline-tools && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip && \
+    unzip -q commandlinetools-linux-8512546_latest.zip && \
+    rm *.zip && \
+    mv cmdline-tools latest
+RUN yes Y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install \
+        "build-tools;${ANDROID_BUILD_TOOLS}" \
+        "platforms;android-${ANDROID_API_LEVEL}" \
+        "ndk;${ANDROID_NDK_VERSION}" && \
+    yes Y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
+
+# dowload gstreamer
+RUN cd /opt && \
+    wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/${GSTREAMER_VERSION}/gstreamer-1.0-android-universal-${GSTREAMER_VERSION}.tar.xz && \
+    mkdir gstreamer-1.0-android-universal-${GSTREAMER_VERSION}
+RUN cd /opt && tar xf gstreamer-1.0-android-universal-${GSTREAMER_VERSION}.tar.xz -C gstreamer-1.0-android-universal-${GSTREAMER_VERSION} && \
+    rm gstreamer-1.0-android-universal-${GSTREAMER_VERSION}.tar.xz
+
+# Reconfigure locale
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+
+# create user with id 1000 to not run commands/generate files as root
+RUN useradd user --create-home --home-dir /home/user --shell /bin/bash --uid 1000
+USER user
+
+# pre download gradle and prepare ccache cache dir for mounting volume
+RUN ${QT_DESKTOP}/src/3rdparty/gradle/gradlew --version && \
+    find /home/user/.gradle/ -name "*.zip" -type f -delete && \
+    mkdir /home/user/.ccache
+
+WORKDIR /project/build
+CMD qmake /project/source ANDROID_ABIS="${ANDROID_ABIS}" && make -j$(nproc) apk
+

--- a/deploy/docker/Dockerfile-build-linux
+++ b/deploy/docker/Dockerfile-build-linux
@@ -70,5 +70,8 @@ RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
 RUN useradd user --create-home --home-dir /home/user --shell /bin/bash --uid 1000
 USER user
 
+# prepare ccache cache dir for mounting volume
+RUN mkdir /home/user/.ccache
+
 WORKDIR /project/build
 CMD qmake /project/source && make -j$(nproc)

--- a/deploy/docker/install-qt-linux.sh
+++ b/deploy/docker/install-qt-linux.sh
@@ -11,8 +11,9 @@ QT_MODULES="${QT_MODULES:-qtcharts}"
 set -e
 
 apt update
-apt install python3 python3-pip -y
+apt install python3 python3-pip -y --no-install-recommends
 pip3 install aqtinstall
 aqt install --outputdir ${QT_PATH} ${QT_VERSION} ${QT_HOST} ${QT_TARGET} -m ${QT_MODULES}
 echo "Remember to export the following to your PATH: ${QT_PATH}/${QT_VERSION}/*/bin"
 echo "export PATH=$(readlink -e ${QT_PATH}/${QT_VERSION}/*/bin/):PATH"
+

--- a/src/VideoReceiver/VideoReceiver.pri
+++ b/src/VideoReceiver/VideoReceiver.pri
@@ -62,16 +62,22 @@ LinuxBuild {
         QMAKE_POST_LINK += $$escape_expand(\\n) xcopy \"$$GST_ROOT_WIN\\lib\\gstreamer-1.0\\*.dll\" \"$$DESTDIR_WIN\\gstreamer-plugins\\\" /Y $$escape_expand(\\n)
     }
 } else:AndroidBuild {
-    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-1.18.5/***
+    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-1.18.5/***, but may be overriden
+    # by setting GSTREAMER_HOME environment variable
+    GST_BASE = $$(GSTREAMER_HOME)
+    isEmpty(GST_BASE) {
+        GST_BASE = $$PWD/../../gstreamer-1.0-android-universal-1.18.5
+    }
+    
     contains(ANDROID_TARGET_ARCH, armeabi-v7a) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/armv7
+        GST_ROOT = $$GST_BASE/armv7
     } else:contains(ANDROID_TARGET_ARCH, arm64-v8a) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/arm64
+        GST_ROOT = $$GST_BASE/arm64
     } else:contains(ANDROID_TARGET_ARCH, x86_64) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/x86_64
+        GST_ROOT = $$GST_BASE/x86_64
     } else {
         message(Unknown ANDROID_TARGET_ARCH $$ANDROID_TARGET_ARCH)
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/x86
+        GST_ROOT = $$GST_BASE/x86
     }
     exists($$GST_ROOT) {
         QMAKE_CXXFLAGS  += -pthread


### PR DESCRIPTION
As the setup of the build environment for android is quite hard it makes sense to provide a docker container for the local build (or maybe even for CI usage in the future) with all external dependencies prepared.

The container usage is the same as with the already existing linux build container:

First build the image by running 
`docker build --file ./deploy/docker/Dockerfile-build-android -t qgc-android-docker .` 

Then you may run the container by
`docker run --rm -v ${PWD}:/project/source -v ${PWD}/build:/project/build qgc-android-docker`

This will build the apk for `armeabi-v7a`. If you want to build for `arm64-v8a` you can override environment variable `ANDROID_ABIS` accordingly (defaults to `armeabi-v7a`) 
`docker run --rm -v ${PWD}:/project/source -v ${PWD}/build:/project/build -e ANDROID_ABIS=arm64-v8a qgc-android-docker`

The image is also prepared to use a persistent ccache. To use it have to mount a volume to the ccache directory like this:
`docker run --rm -v ${PWD}:/project/source -v ${PWD}/build_android_docker:/project/build -v qgc_build_cache:/home/user/.ccache qgc-android-docker`

I could also prepare a PR for the documentation, if this PR is accepted.