### PR TITLE
Video: increase timeout for RTSP video streaming (#9440)

### DIFF
--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -106,7 +106,7 @@
     "type":             "uint32",
     "min":              1,
     "units":            "s",
-    "default":     2
+    "default":     8
 },
 {
     "name":             "streamEnabled",

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -781,7 +781,11 @@ void
 VideoManager::_startReceiver(unsigned id)
 {
 #if defined(QGC_GST_STREAMING)
-    const unsigned timeout = _videoSettings->rtspTimeout()->rawValue().toUInt();
+    const QString source = _videoSettings->videoSource()->rawValue().toString();
+    const unsigned rtsptimeout = _videoSettings->rtspTimeout()->rawValue().toUInt();
+    /* The gstreamer rtsp source will switch to tcp if udp is not available after 5 seconds.
+       So we should allow for some negotiation time for rtsp */
+    const unsigned timeout = (source == VideoSettings::videoSourceRTSP ? rtsptimeout : 2 );
 
     if (id > 1) {
         qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;


### PR DESCRIPTION
In #9440 the video streaming failed for some cameras and the bunny example RTSP streaming movie. This worked in 4.0.6 and it did not work anymore in 4.1.0. The same unstable behaviour is observed in #10396.

The gstreamer rtsp source will switch to tcp when no data is received via udp after 5 seconds. The default timeout for the gstreamer video receiver is 2 seconds resulting in a permanent teardown and restart until eventually some data is received. As far as I understood the code 4.0.6 did not have a timeout which is in 4.1.0. I change the timeout for RTSP to 8 seconds and leave it at 2 seconds for the other streams. With 8 seconds timeout I can receive the bunny example without problems.

Closes: #9440

I tested this on MacOS with the changes from #10396 included and on Android.