### PR TITLE
Add ARKV6X

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -61,6 +61,7 @@ static QMap<int, QString> px4_board_name_map {
     {53, "px4_fmu-v6x_default"},
     {54, "px4_fmu-v6u_default"},
     {56, "px4_fmu-v6c_default"},
+    {57, "ark_fmu-v6x_default"},
     {55, "sky-drones_smartap-airlink_default"},
     {88, "airmind_mindpx-v2_default"},
     {12, "bitcraze_crazyflie_default"},

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -28,6 +28,7 @@
         { "vendorID": 4104, "productID": 1,         "boardClass": "Pixhawk",    "name": "PX4 FMU UVify Core" },
         { "vendorID": 12643, "productID": 76,       "boardClass": "Pixhawk",    "name": "CUAV Flight Controller" },
         { "vendorID": 1155, "productID": 55,        "boardClass": "Pixhawk",    "name": "PX4 FMU SmartAP AIRLink" },
+        { "vendorID": 12677, "productID": 57,       "boardClass": "Pixhawk",    "name": "ARK FMU V6X" },
 
         { "vendorID": 1155, "productID": 22336,     "boardClass": "Pixhawk",    "name": "ArduPilot ChibiOS" },
         { "vendorID": 4617, "productID": 22336,     "boardClass": "Pixhawk",    "name": "ArduPilot ChibiOS" },
@@ -82,6 +83,8 @@
         { "regExp": "^PX4 OmnibusF4SD",     "boardClass": "Pixhawk" },
         { "regExp": "^fmuv[2345]$",         "boardClass": "Pixhawk" },
         { "regExp": "^mRoControlZeroF7",    "boardClass": "Pixhawk" },
+        { "regExp": "^ARK FMU v6X.x$",      "boardClass": "Pixhawk" },
+        { "regExp": "^ARK BL FMU v6X.x$",   "boardClass": "Pixhawk" },
         { "regExp": "PX4.*Flow",            "boardClass": "PX4 Flow" },
         { "regExp": "^FT231X USB UART$",    "boardClass": "SiK Radio" },
         { "regExp": "USB UART$",            "boardClass": "SiK Radio",  "androidOnly": true, "comment": "Very broad fallback, too dangerous for non-android" }


### PR DESCRIPTION
This PR adds the ARKV6X PAB form factor flight controller. Starting it as a WIP PR to get CI to build a working version of QGC to test with.

I am currently using Auterions VID, which isn't ideal. Ideally we get a common Pixhawk VID.

https://arkelectron.com/product/arkv6x/

![Xp9i8CtCTjakj7GU5trL_IMG_3800](https://user-images.githubusercontent.com/2019539/189507702-bd679fa1-d81b-4743-9fa7-8bf676c96d8c.jpg)
![rU27nbgvQLGVOuwWshKy_IMG_3799](https://user-images.githubusercontent.com/2019539/189507704-10df2609-e6db-4cad-849e-7bdb60a837cf.jpg)