### PR TITLE
fix: comm link bugs

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -160,6 +160,9 @@ bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr& config, bool i
         _mavlinkProtocol->setVersion(_mavlinkProtocol->getCurrentVersion());
 
         if (!link->_connect()) {
+            link->_freeMavlinkChannel();
+            _rgLinks.removeAt(_rgLinks.indexOf(link));
+            config->setLink(nullptr);
             return false;
         }
 

--- a/src/ui/preferences/LinkSettings.qml
+++ b/src/ui/preferences/LinkSettings.qml
@@ -130,7 +130,10 @@ Rectangle {
         QGCButton {
             text:       qsTr("Disconnect")
             enabled:    _currentSelection && _currentSelection.link
-            onClicked:  _currentSelection.link.disconnect()
+            onClicked:  {
+                _currentSelection.link.disconnect()
+                _currentSelection.linkChanged()
+            }
         }
         QGCButton {
             text:       qsTr("MockLink Options")


### PR DESCRIPTION
- Fix UI update when a link is disconnected
- Clean up properly if a link fails to connect

We should probably get rid of all of the std::shared_ptr and use QSharedPointer instead. ~A PR for another day.~ I pushed a commit that replace them, let me know if I should revert it. Seems like using Qt smart pointers is probably better for a Qt project. I can go through and change it everywhere in the code base if we want to do that.