### PR TITLE
[Wait for gst] Video: Fix MPEG-TS UDP streaming / Fix Android Recording - fix crashes (#9830, #9838)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = https://github.com/Auterion/android_openssl
 [submodule "libs/qmlglsink/gst-plugins-good"]
 	path = libs/qmlglsink/gst-plugins-good
-	url = https://github.com/mavlink/gst-plugins-good.git
+	url = https://github.com/fredowski/gst-plugins-good.git
 [submodule "libs/xz-embedded"]
 	path = libs/xz-embedded
 	url = https://github.com/Auterion/xz-embedded.git

--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -759,6 +759,8 @@ GstVideoReceiver::_makeSource(const QString& uri)
             break;
         }
 
+        g_signal_connect(parser, "autoplug-query", G_CALLBACK(_filterParserCaps), nullptr);
+
         gst_bin_add_many(GST_BIN(bin), source, parser, nullptr);
 
         // FIXME: AV: Android does not determine MPEG2-TS via parsebin - have to explicitly state which demux to use
@@ -847,13 +849,13 @@ GstElement*
 GstVideoReceiver::_makeDecoder(GstCaps* caps, GstElement* videoSink)
 {
     Q_UNUSED(caps)
-    Q_UNUSED(videoSink)
     GstElement* decoder = nullptr;
 
     do {
-        if ((decoder = gst_element_factory_make("decodebin3", nullptr)) == nullptr) {
-            qCCritical(VideoReceiverLog) << "gst_element_factory_make('decodebin3') failed";
+        if ((decoder = gst_element_factory_make("decodebin", nullptr)) == nullptr) {
+            qCCritical(VideoReceiverLog) << "gst_element_factory_make('decodebin') failed";
             break;
+            g_signal_connect(decoder, "autoplug-query", G_CALLBACK(_autoplugQuery), videoSink);
         }
     } while(0);
 
@@ -1016,7 +1018,7 @@ GstVideoReceiver::_addDecoder(GstElement* src)
     gst_object_unref(srcpad);
     srcpad = nullptr;
 
-    if ((_decoder = _makeDecoder()) == nullptr) {
+    if ((_decoder = _makeDecoder(caps, _videoSink)) == nullptr) {
         qCCritical(VideoReceiverLog) << "_makeDecoder() failed";
         gst_caps_unref(caps);
         caps = nullptr;
@@ -1444,6 +1446,138 @@ GstVideoReceiver::_padProbe(GstElement* element, GstPad* pad, gpointer user_data
 
     return TRUE;
 }
+
+gboolean
+GstVideoReceiver::_filterParserCaps(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data)
+{
+    Q_UNUSED(bin)
+    Q_UNUSED(pad)
+    Q_UNUSED(element)
+    Q_UNUSED(data)
+
+    if (GST_QUERY_TYPE(query) != GST_QUERY_CAPS) {
+        return FALSE;
+    }
+
+    GstCaps* srcCaps;
+
+    gst_query_parse_caps(query, &srcCaps);
+
+    if (srcCaps == nullptr || gst_caps_is_any(srcCaps)) {
+        return FALSE;
+    }
+
+    GstCaps* sinkCaps = nullptr;
+
+    GstCaps* filter;
+
+    if (sinkCaps == nullptr && (filter = gst_caps_from_string("video/x-h264")) != nullptr) {
+        if (gst_caps_can_intersect(srcCaps, filter)) {
+            sinkCaps = gst_caps_from_string("video/x-h264,stream-format=avc");
+        }
+
+        gst_caps_unref(filter);
+        filter = nullptr;
+    } else if (sinkCaps == nullptr && (filter = gst_caps_from_string("video/x-h265")) != nullptr) {
+        if (gst_caps_can_intersect(srcCaps, filter)) {
+            sinkCaps = gst_caps_from_string("video/x-h265,stream-format=hvc1");
+        }
+
+        gst_caps_unref(filter);
+        filter = nullptr;
+    }
+
+    if (sinkCaps == nullptr) {
+        return FALSE;
+    }
+
+    gst_query_set_caps_result(query, sinkCaps);
+
+    gst_caps_unref(sinkCaps);
+    sinkCaps = nullptr;
+
+    return TRUE;
+}
+
+gboolean
+GstVideoReceiver::_autoplugQueryCaps(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data)
+{
+    Q_UNUSED(bin)
+    Q_UNUSED(pad)
+    Q_UNUSED(element)
+
+    GstElement* glupload = (GstElement* )data;
+
+    GstPad* sinkpad;
+
+    if ((sinkpad = gst_element_get_static_pad(glupload, "sink")) == nullptr) {
+        qCCritical(VideoReceiverLog) << "No sink pad found";
+        return FALSE;
+    }
+
+    GstCaps* filter;
+
+    gst_query_parse_caps(query, &filter);
+
+    GstCaps* sinkcaps = gst_pad_query_caps(sinkpad, filter);
+
+    gst_query_set_caps_result(query, sinkcaps);
+
+    const gboolean ret = !gst_caps_is_empty(sinkcaps);
+
+    gst_caps_unref(sinkcaps);
+    sinkcaps = nullptr;
+
+    gst_object_unref(sinkpad);
+    sinkpad = nullptr;
+
+    return ret;
+}
+
+gboolean
+GstVideoReceiver::_autoplugQueryContext(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data)
+{
+    Q_UNUSED(bin)
+    Q_UNUSED(pad)
+    Q_UNUSED(element)
+
+    GstElement* glsink = (GstElement* )data;
+
+    GstPad* sinkpad;
+
+    if ((sinkpad = gst_element_get_static_pad(glsink, "sink")) == nullptr){
+        qCCritical(VideoReceiverLog) << "No sink pad found";
+        return FALSE;
+    }
+
+    const gboolean ret = gst_pad_query(sinkpad, query);
+
+    gst_object_unref(sinkpad);
+    sinkpad = nullptr;
+
+    return ret;
+}
+
+gboolean
+GstVideoReceiver::_autoplugQuery(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data)
+{
+    gboolean ret;
+
+    switch (GST_QUERY_TYPE(query)) {
+    case GST_QUERY_CAPS:
+        ret = _autoplugQueryCaps(bin, pad, element, query, data);
+        break;
+    case GST_QUERY_CONTEXT:
+        ret = _autoplugQueryContext(bin, pad, element, query, data);
+        break;
+    default:
+        ret = FALSE;
+        break;
+    }
+
+    return ret;
+}
+
 
 GstPadProbeReturn
 GstVideoReceiver::_teeProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data)

--- a/src/VideoReceiver/GstVideoReceiver.h
+++ b/src/VideoReceiver/GstVideoReceiver.h
@@ -109,7 +109,7 @@ protected:
     virtual void _onNewSourcePad(GstPad* pad);
     virtual void _onNewDecoderPad(GstPad* pad);
     virtual bool _addDecoder(GstElement* src);
-    virtual bool _addVideoSink(GstPad* pad);
+    virtual bool _linkVideoSink(GstPad* pad);
     virtual void _noteTeeFrame(void);
     virtual void _noteVideoSinkFrame(void);
     virtual void _noteEndOfStream(void);

--- a/src/VideoReceiver/GstVideoReceiver.h
+++ b/src/VideoReceiver/GstVideoReceiver.h
@@ -125,6 +125,10 @@ protected:
     static void _wrapWithGhostPad(GstElement* element, GstPad* pad, gpointer data);
     static void _linkPad(GstElement* element, GstPad* pad, gpointer data);
     static gboolean _padProbe(GstElement* element, GstPad* pad, gpointer user_data);
+    static gboolean _filterParserCaps(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data);
+    static gboolean _autoplugQueryCaps(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data);
+    static gboolean _autoplugQueryContext(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data);
+    static gboolean _autoplugQuery(GstElement* bin, GstPad* pad, GstElement* element, GstQuery* query, gpointer data);
     static GstPadProbeReturn _teeProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     static GstPadProbeReturn _videoSinkProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     static GstPadProbeReturn _eosProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);

--- a/src/VideoReceiver/GstVideoReceiver.h
+++ b/src/VideoReceiver/GstVideoReceiver.h
@@ -133,6 +133,7 @@ protected:
     static GstPadProbeReturn _videoSinkProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     static GstPadProbeReturn _eosProbe(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
     static GstPadProbeReturn _keyframeWatch(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
+    static GstPadProbeReturn _linkValve(GstPad* pad, GstPadProbeInfo* info, gpointer user_data);
 
     bool                _streaming;
     bool                _decoding;


### PR DESCRIPTION
### Problem
Decodebin3 breaks the MPEG-TS/UDP streaming. Decodebin3 is still named "experimental" on the gstreamer site. So this PR fixes the following problems:

Closes: MPEG-TS not streaming on Android #9830, #10200 
Closes: Recording not working on Android #9838

### What is done

This patch reverts to decodebin.  I reverted including the previously working recording fix for android. Reverting to decodebin makes threading problems transparent which were not visible in decodebin3 and which were introduced by the new videoreceiver design. The root problem is the addition of gstreamer elements in the callbacks of gstreamer. The callbacks run on threads of the existing gstreamer elements. This becomes apparent as "flickering" problems on Android and MacOS. This can be fixed by moving the gstreamer element addition back to the main gstreamer thread. This closes the problems described  #10396 and #10380.

The new videoreceiver design relies on dynamic pipeline modifications also for the video display part. I think the concept of first starting the pipeline with "start" and then adding the decoder part with "startdecoding" on an already running pipeline made threading problems visible. Depending on the platform, different numbers of threads are active. There is the main loop, then the "gstreamer main thread = VideoReceiver", then the "Rendering thread" on Android and then the threads which are introduced by gstreamer itself depending on the pipeline.  After starting and stopping a stream three times, the whole qgc application freezes on Android. I could fix that by backporting bugfixes from the qt gstreamer-plugins release 1.18.6 to qgroundcontrol gstreamer-plugins. I only backported bugfixes and not the additional overlay function which requires a complete switch to 1.18.6. Maybe it would be safer to step back and configure the video streaming pipeline including the decoding branch at start. Then only the recording branch would be added dynamically to the pipeline. But that is not part of this PR.

**This PR has to wait on https://github.com/mavlink/gst-plugins-good/pull/2 and https://github.com/mavlink/qgroundcontrol/pull/10396**

and then this PR has to be updated to use the gstreamer plugins from the mavlink repository.

### Tests

I tested this PR on MacOS, Android and Windows 11 and I could not find problems. On MacOS I tested this on top of PR #10396.

 I tested if the video is displayed. For a subset of resolutions I tested if the recording works.

**UDP H.264 results**

`gst-launch-1.0 videotestsrc ! 'video/x-raw, width=720, height=576' ! x264enc ! 'video/x-h264, profile=main' ! rtph264pay ! udpsink host=192.168.1.165 port=5600` 

I tested the following other resolutions

* 1920 x 1080 => worked, recording tested and works
* 720 x 576 => worked
* 640 x 480 => worked
* 320 x 240 => worked

**MPEG-TS (h.264) results**

I streamed a video from VLC Player on a Mac via MPEG-TS. I disabled the audio channel. This worked. This is a screenshot: 

![Screenshots 9_16_2022 4_04_24 PM](https://user-images.githubusercontent.com/112891091/190659278-22718dcc-61de-42cf-829d-7a6c2082c984.png)

I generated testdata on a Mac and streamed it to the windows computer. The testdata was generated with gstreamer 1.18.6. This is the script I used:

`gst-launch-1.0 videotestsrc ! 'video/x-raw, width=720, height=576' ! x264enc ! 'video/x-h264, profile=main' ! mpegtsmux ! queue ! udpsink host=192.168.1.165 port=5600` => worked

I tested the following resolutions

* 1920 x 1080 => worked, recording tested and works
* 720 x 576 => worked
* 640 x 480 => worked
* 320 x 240 => worked


@andrewvoznytsa: Can you maybe review this PR? 
