### PR TITLE
android: don't require "android.hardware.usb.accessory"

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -98,7 +98,7 @@
     <uses-feature android:name="android.hardware.location.gps" android:required="false"/>
     <uses-feature android:name="android.hardware.location.network" android:required="false"/>
     <uses-feature android:name="android.hardware.location" android:required="false"/>
-    <uses-feature android:name="android.hardware.usb.accessory"/>
+    <uses-feature android:name="android.hardware.usb.accessory" android:required="false"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE"/>


### PR DESCRIPTION
"android.hardware.usb.accessory" is listed in [1] and therefore should have `android:required="false"`.

[1]: https://chromeos.dev/en/android/manifest#unsupported-hardware-features


