### PR TITLE
deploy/docker: use apt-get instead of apt

### DIFF
--- a/deploy/docker/Dockerfile-build-linux
+++ b/deploy/docker/Dockerfile-build-linux
@@ -18,7 +18,7 @@ ENV QT_DESKTOP $QT_PATH/${QT_VERSION}/gcc_64
 
 ENV PATH /usr/lib/ccache:$QT_DESKTOP/bin:$PATH
 
-RUN apt update && apt -y --quiet --no-install-recommends install \
+RUN apt-get update && apt-get -y --quiet --no-install-recommends install \
 		apt-utils \
 		binutils \
 		build-essential \

--- a/deploy/docker/install-qt-linux.sh
+++ b/deploy/docker/install-qt-linux.sh
@@ -10,8 +10,8 @@ QT_MODULES="${QT_MODULES:-qtcharts}"
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-apt update
-apt install python3 python3-pip -y
+apt-get update
+apt-get install python3 python3-pip -y
 pip3 install aqtinstall
 aqt install --outputdir ${QT_PATH} ${QT_VERSION} ${QT_HOST} ${QT_TARGET} -m ${QT_MODULES}
 echo "Remember to export the following to your PATH: ${QT_PATH}/${QT_VERSION}/*/bin"


### PR DESCRIPTION
`apt` complains loudly:

    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

We can use `apt-get` instead to avoid this warning.


