### PR TITLE
Do not send PROTOCOL_VERSION request when using Ardupilot firmware

### DIFF
--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -216,6 +216,11 @@ void InitialConnectStateMachine::_stateRequestProtocolVersion(StateMachine* stat
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(InitialConnectStateMachineLog) << "Skipping REQUEST_MESSAGE:PROTOCOL_VERSION request due to link type";
             connectMachine->advance();
+        }
+
+        if (vehicle->apmFirmware()) {
+            qCDebug(InitialConnectStateMachineLog) << "Skipping REQUEST_MESSAGE:PROTOCOL_VERSION request due to Ardupilot firmware";
+            connectMachine->advance();
         } else {
             qCDebug(InitialConnectStateMachineLog) << "Sending REQUEST_MESSAGE:PROTOCOL_VERSION";
             vehicle->requestMessage(_protocolVersionRequestMessageHandler,


### PR DESCRIPTION
The Ardupilot firmware doesn't seem to handle PROTOCOL_VERSION requests. 

It seems to be using the capabilities field in the AUTOPILOT_VERSION message.

So, When connecting the Ardupilot firmware vehicle after #10436, QGC failed to upload rally points and geofences.

Please review this PR.
(I'm not good with English, so I used a translator.)