### PR TITLE
Add Payload Delivery Gripper Mission item support

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -283,6 +283,7 @@ QList<MAV_CMD> PX4FirmwarePlugin::supportedMissionCommands(QGCMAVLink::VehicleCl
         MAV_CMD_NAV_DELAY,
         MAV_CMD_CONDITION_YAW,
         MAV_CMD_NAV_LOITER_TO_ALT,
+        MAV_CMD_DO_GRIPPER
     };
 
     QList<MAV_CMD> vtolCommands = {

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -65,6 +65,8 @@ const char* Joystick::_buttonActionGimbalLeft =         QT_TR_NOOP("Gimbal Left"
 const char* Joystick::_buttonActionGimbalRight =        QT_TR_NOOP("Gimbal Right");
 const char* Joystick::_buttonActionGimbalCenter =       QT_TR_NOOP("Gimbal Center");
 const char* Joystick::_buttonActionEmergencyStop =      QT_TR_NOOP("Emergency Stop");
+const char* Joystick::_buttonActionGripperGrab =        QT_TR_NOOP("Gripper Close");
+const char* Joystick::_buttonActionGripperRelease =     QT_TR_NOOP("Gripper Open");
 
 const char* Joystick::_rgFunctionSettingsKey[Joystick::maxFunction] = {
     "RollAxis",
@@ -106,6 +108,8 @@ Joystick::Joystick(const QString& name, int axisCount, int buttonCount, int hatC
     , _totalButtonCount(_buttonCount+_hatButtonCount)
     , _multiVehicleManager(multiVehicleManager)
 {
+    qRegisterMetaType<GRIPPER_ACTIONS>();
+
     _rgAxisValues   = new int[static_cast<size_t>(_axisCount)];
     _rgCalibration  = new Calibration_t[static_cast<size_t>(_axisCount)];
     _rgButtonValues = new uint8_t[static_cast<size_t>(_totalButtonCount)];
@@ -697,6 +701,7 @@ void Joystick::startPolling(Vehicle* vehicle)
             disconnect(this, &Joystick::centerGimbal,       _activeVehicle, &Vehicle::centerGimbal);
             disconnect(this, &Joystick::gimbalControlValue, _activeVehicle, &Vehicle::gimbalControlValue);
             disconnect(this, &Joystick::emergencyStop,      _activeVehicle, &Vehicle::emergencyStop);
+            disconnect(this, &Joystick::gripperAction,      _activeVehicle, &Vehicle::setGripperAction);
         }
         // Always set up the new vehicle
         _activeVehicle = vehicle;
@@ -719,6 +724,7 @@ void Joystick::startPolling(Vehicle* vehicle)
             connect(this, &Joystick::centerGimbal,       _activeVehicle, &Vehicle::centerGimbal);
             connect(this, &Joystick::gimbalControlValue, _activeVehicle, &Vehicle::gimbalControlValue);
             connect(this, &Joystick::emergencyStop,      _activeVehicle, &Vehicle::emergencyStop);
+            connect(this, &Joystick::gripperAction,      _activeVehicle, &Vehicle::setGripperAction);
         }
     }
     if (!isRunning()) {
@@ -738,6 +744,7 @@ void Joystick::stopPolling(void)
             disconnect(this, &Joystick::gimbalYawStep,      _activeVehicle, &Vehicle::gimbalYawStep);
             disconnect(this, &Joystick::centerGimbal,       _activeVehicle, &Vehicle::centerGimbal);
             disconnect(this, &Joystick::gimbalControlValue, _activeVehicle, &Vehicle::gimbalControlValue);
+            disconnect(this, &Joystick::gripperAction,      _activeVehicle, &Vehicle::setGripperAction);
         }
         _exitThread = true;
     }
@@ -1027,6 +1034,14 @@ void Joystick::_executeButtonAction(const QString& action, bool buttonDown)
         }
     } else if(action == _buttonActionEmergencyStop) {
       if(buttonDown) emit emergencyStop();
+    } else if(action == _buttonActionGripperGrab) {
+        if(buttonDown) {
+            emit gripperAction(GRIPPER_ACTION_GRAB);
+        }
+    } else if(action == _buttonActionGripperRelease) {
+        if(buttonDown) {
+            emit gripperAction(GRIPPER_ACTION_RELEASE);
+        }
     } else {
         if (buttonDown && _activeVehicle) {
             for (auto& item : _customMavCommands) {
@@ -1036,7 +1051,6 @@ void Joystick::_executeButtonAction(const QString& action, bool buttonDown)
                 }
             }
         }
-        qCDebug(JoystickLog) << "_buttonAction unknown action:" << action;
     }
 }
 
@@ -1124,8 +1138,12 @@ void Joystick::_buildActionList(Vehicle* activeVehicle)
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionGimbalRight,   true));
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionGimbalCenter));
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionEmergencyStop));
-    for (auto& item : _customMavCommands)
+    _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionGripperGrab));
+    _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionGripperRelease));
+
+    for (auto& item : _customMavCommands) {
         _assignableButtonActions.append(new AssignableButtonAction(this, item.name()));
+    }
 
     for(int i = 0; i < _assignableButtonActions.count(); i++) {
         AssignableButtonAction* p = qobject_cast<AssignableButtonAction*>(_assignableButtonActions[i]);

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -14,15 +14,16 @@
 
 #include <QObject>
 #include <QThread>
+#include <atomic>
 
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
 #include "MultiVehicleManager.h"
 #include "JoystickMavCommand.h"
-#include <atomic>
 
 Q_DECLARE_LOGGING_CATEGORY(JoystickLog)
 Q_DECLARE_LOGGING_CATEGORY(JoystickValuesLog)
+Q_DECLARE_METATYPE(GRIPPER_ACTIONS)
 
 /// Action assigned to button
 class AssignedButtonAction : public QObject {
@@ -217,6 +218,12 @@ signals:
     void setVtolInFwdFlight         (bool set);
     void setFlightMode              (const QString& flightMode);
     void emergencyStop              ();
+    /**
+     * @brief Send MAV_CMD_DO_GRIPPER command to the vehicle
+     * 
+     * @param gripperAction (Open / Close) Gripper action to command
+     */
+    void gripperAction              (GRIPPER_ACTIONS gripperAction);
 
 protected:
     void    _setDefaultCalibration  ();
@@ -352,6 +359,9 @@ private:
     static const char* _buttonActionGimbalRight;
     static const char* _buttonActionGimbalCenter;
     static const char* _buttonActionEmergencyStop;
+    static const char* _buttonActionGripperGrab;
+    static const char* _buttonActionGripperRelease;
+
 
 private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -988,8 +988,8 @@
         {
             "id":                   211,
             "rawName":              "MAV_CMD_DO_GRIPPER",
-            "friendlyName":         "Gripper",
-            "description":          "Operate EPM gripper.",
+            "friendlyName":         "Gripper Mechanism",
+            "description":          "Control a gripper mechanism.",
             "specifiesCoordinate":  false,
             "friendlyEdit":         true,
             "category":             "Advanced",

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -4177,3 +4177,14 @@ void Vehicle::triggerSimpleCamera()
                    0.0, 0.0, 0.0, 0.0,          // param 1-4 unused
                    1.0);                        // trigger camera
 }
+
+void Vehicle::setGripperAction(GRIPPER_ACTIONS gripperAction)
+{
+    sendMavCommand(
+            _defaultComponentId,
+            MAV_CMD_DO_GRIPPER,
+            false,                               // Don't show errors
+            0,                                   // Param1: Gripper ID (Always set to 0)
+            gripperAction,                       // Param2: Gripper Action
+            0, 0, 0, 0, 0);                      // Param 3 ~ 7 : unused
+}

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -517,6 +517,14 @@ public:
     void setFlightMode                      (const QString& flightMode);
 
     bool airship() const;
+
+    /**
+     * @brief Send MAV_CMD_DO_GRIPPER command to trigger specified action in the vehicle
+     * 
+     * @param gripperAction Gripper action to trigger
+     */
+    void setGripperAction(GRIPPER_ACTIONS gripperAction);
+
     bool fixedWing() const;
     bool multiRotor() const;
     bool vtol() const;


### PR DESCRIPTION
## Added
- Exposed the Gripper Mission item to the mission planning GUI
- Added Gripper Open/Close command to the Joysticks GUI

## Information
This is a QGC support for PX4's new package delivery feature: https://github.com/PX4/PX4-Autopilot/pull/19963