### PR TITLE
VehicleClockFactGroup: Add option to display UTC time in flight data …

### DIFF
--- a/src/Vehicle/ClockFact.json
+++ b/src/Vehicle/ClockFact.json
@@ -9,6 +9,11 @@
     "type":             "string"
 },
 {
+    "name":             "currentUTCTime",
+    "shortDesc": "UTC Time",
+    "type":             "string"
+},
+{
     "name":             "currentDate",
     "shortDesc": "Date",
     "type":             "string"

--- a/src/Vehicle/VehicleClockFactGroup.cc
+++ b/src/Vehicle/VehicleClockFactGroup.cc
@@ -11,24 +11,29 @@
 #include "Vehicle.h"
 
 const char* VehicleClockFactGroup::_currentTimeFactName = "currentTime";
+const char* VehicleClockFactGroup::_currentUTCTimeFactName = "currentUTCTime";
 const char* VehicleClockFactGroup::_currentDateFactName = "currentDate";
 
 VehicleClockFactGroup::VehicleClockFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/ClockFact.json", parent)
     , _currentTimeFact  (0, _currentTimeFactName,    FactMetaData::valueTypeString)
+    , _currentUTCTimeFact  (0, _currentUTCTimeFactName,    FactMetaData::valueTypeString)
     , _currentDateFact  (0, _currentDateFactName,    FactMetaData::valueTypeString)
 {
     _addFact(&_currentTimeFact, _currentTimeFactName);
+    _addFact(&_currentUTCTimeFact, _currentUTCTimeFactName);
     _addFact(&_currentDateFact, _currentDateFactName);
 
     // Start out as not available "--.--"
     _currentTimeFact.setRawValue(std::numeric_limits<float>::quiet_NaN());
+    _currentUTCTimeFact.setRawValue(std::numeric_limits<float>::quiet_NaN());
     _currentDateFact.setRawValue(std::numeric_limits<float>::quiet_NaN());
 }
 
 void VehicleClockFactGroup::_updateAllValues()
 {
     _currentTimeFact.setRawValue(QTime::currentTime().toString());
+    _currentUTCTimeFact.setRawValue(QDateTime::currentDateTimeUtc().time().toString());
     _currentDateFact.setRawValue(QDateTime::currentDateTime().toString(QLocale::system().dateFormat(QLocale::ShortFormat)));
     _setTelemetryAvailable(true);
 

--- a/src/Vehicle/VehicleClockFactGroup.h
+++ b/src/Vehicle/VehicleClockFactGroup.h
@@ -22,12 +22,15 @@ public:
     VehicleClockFactGroup(QObject* parent = nullptr);
 
     Q_PROPERTY(Fact* currentTime READ currentTime CONSTANT)
+    Q_PROPERTY(Fact* currentUTCTime READ currentUTCTime CONSTANT)
     Q_PROPERTY(Fact* currentDate READ currentDate CONSTANT)
 
     Fact* currentTime () { return &_currentTimeFact; }
+    Fact* currentUTCTime () { return &_currentUTCTimeFact; }
     Fact* currentDate () { return &_currentDateFact; }
 
     static const char* _currentTimeFactName;
+    static const char* _currentUTCTimeFactName;
     static const char* _currentDateFactName;
 
     static const char* _settingsGroup;
@@ -37,5 +40,6 @@ private slots:
 
 private:
     Fact            _currentTimeFact;
+    Fact            _currentUTCTimeFact;
     Fact            _currentDateFact;
 };


### PR DESCRIPTION
…panel

Add a UTC time fact to the VehicleClockFactGroup group that allows us to display time in UTC.

Feature requested in:

https://github.com/mavlink/qgroundcontrol/issues/5182

Looks like this:

![screenshot_20221023_160808](https://user-images.githubusercontent.com/424513/197396888-c7419e22-11f7-4ad2-a06e-e7fc4538fe52.png)


