### PR TITLE
Moved Guided Confirm slider to top of window

### DIFF
--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -106,6 +106,16 @@ Item {
         visible:            !multiVehiclePanelSelector.showSingleVehiclePanel
     }
 
+
+    GuidedActionConfirm {
+        anchors.margins:            _toolsMargin
+        anchors.top:                parent.top
+        anchors.horizontalCenter:   parent.horizontalCenter
+        z:                          QGroundControl.zOrderTopMost
+        guidedController:           _guidedController
+        guidedValueSlider:          _guidedValueSlider
+    }
+
     FlyViewInstrumentPanel {
         id:                         instrumentPanel
         anchors.margins:            _toolsMargin

--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -17,12 +17,12 @@ import QGroundControl.Controls      1.0
 import QGroundControl.Palette       1.0
 
 Rectangle {
-    id:                     _root
-    Layout.minimumWidth:    mainLayout.width + (_margins * 2)
-    Layout.preferredHeight: mainLayout.height + (_margins * 2)
-    radius:                 ScreenTools.defaultFontPixelWidth / 2
-    color:                  qgcPal.windowShadeLight
-    visible:                false
+    id:         _root
+    width:      ScreenTools.defaultFontPixelWidth * 45
+    height:     mainLayout.height + (_margins * 2)
+    radius:     ScreenTools.defaultFontPixelWidth / 2
+    color:      qgcPal.window
+    visible:    false
 
     property var    guidedController
     property var    guidedValueSlider
@@ -77,15 +77,18 @@ Rectangle {
     QGCPalette { id: qgcPal }
 
     ColumnLayout {
-        id:                         mainLayout
-        anchors.horizontalCenter:   parent.horizontalCenter
-        spacing:                    _margins
+        id:                 mainLayout
+        anchors.margins:    _margins
+        anchors.left:       parent.left
+        anchors.right:      parent.right
+        spacing:            _margins
 
         QGCLabel {
             id:                     messageText
             Layout.fillWidth:       true
             horizontalAlignment:    Text.AlignHCenter
             wrapMode:               Text.WordWrap
+            font.pointSize:         ScreenTools.mediumFontPointSize
         }
 
         QGCCheckBox {
@@ -96,13 +99,13 @@ Rectangle {
         }
 
         RowLayout {
-            Layout.alignment:       Qt.AlignHCenter
-            spacing:                ScreenTools.defaultFontPixelWidth
+            Layout.fillWidth:   true
+            spacing:            ScreenTools.defaultFontPixelWidth
 
             SliderSwitch {
-                id:                     slider
-                confirmText:            qsTr("Slide to confirm")
-                Layout.minimumWidth:    Math.max(implicitWidth, ScreenTools.defaultFontPixelWidth * 30)
+                id:                 slider
+                confirmText:        qsTr("Slide to confirm")
+                Layout.fillWidth:   true
 
                 onAccept: {
                     _root.visible = false

--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -101,11 +101,5 @@ Rectangle {
             userSettingsGroup:      telemetryBarUserSettingsGroup
             defaultSettingsGroup:   telemetryBarDefaultSettingsGroup
         }
-
-        GuidedActionConfirm {
-            Layout.fillWidth:   true
-            guidedController:   _guidedController
-            guidedValueSlider:     _guidedValueSlider
-        }
     }
 }


### PR DESCRIPTION
Here is what the current Guided Confirmation slider looks like using Outdoor colors:
![Screen Shot 2022-10-28 at 10 07 14 AM](https://user-images.githubusercontent.com/5876851/198693800-cecfe345-007e-4f99-a9b1-2e97cec53b8a.png)

There are a number of problems with this:
* Since it is part of the Telemetry Bar when you move the mouse over it to slide the slider the telemetry bar edit tools show up
* When it shows up it causes the telemetry bar to move position
* On a small screen like a 10" tablet, stacking telemetry and slider begin to invade the center of the map which is tried to keep clear as much as possible
* The coloring of the slider in the outdoor colors makes it very hard to see in the sun outdoors
* The text explaining what the slider is about is pretty small once again making it hard to read outdoors which is kind of important for these sliders since they are critical functionality

Here is the new version:
![Screen Shot 2022-10-28 at 10 04 35 AM](https://user-images.githubusercontent.com/5876851/198694379-161dcfb5-547d-4712-8336-3aba84a75f1b.png)

This is better because:
* It keeps the center of the map clearer
* The telemetry bar no longer moves around on you
* The coloring and text size make it is easier to read outdoors
