### PR TITLE
PlanToolBarIndicators: Use more descriptive label for distance to WP

### DIFF
--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -158,7 +158,7 @@ Item {
 
             Item { width: 1; height: 1 }
 
-            QGCLabel { text: qsTr("Distance:"); font.pointSize: _dataFontSize; }
+            QGCLabel { text: qsTr("Dist prev WP:"); font.pointSize: _dataFontSize; }
             QGCLabel {
                 text:                   _distanceText
                 font.pointSize:         _dataFontSize


### PR DESCRIPTION
The current implementation displays two different distances by the same name. One of the distances is actually the distance to the privous waypoint. For the user it is "hard" to tell which one is which. I try to resolve this with a more descriptive label for the distance to the privous waypoint.

An alternative is maybe to rename the other distance to total distance or total mission distance.


