### PR TITLE
QGCMapPolygonVisuals: Visualize edge lengths of polygon

### DIFF
--- a/src/MissionManager/QGCMapPolygonVisuals.qml
+++ b/src/MissionManager/QGCMapPolygonVisuals.qml
@@ -62,7 +62,7 @@ Item {
 
     function addEditingVisuals() {
         if (_objMgrEditingVisuals.empty) {
-            _objMgrEditingVisuals.createObjects([ dragHandlesComponent, splitHandlesComponent, centerDragHandleComponent ], mapControl, false /* addToMap */)
+            _objMgrEditingVisuals.createObjects([ dragHandlesComponent, splitHandlesComponent, centerDragHandleComponent, edgeLengthHandlesComponent ], mapControl, false /* addToMap */)
         }
     }
 
@@ -307,6 +307,25 @@ Item {
     }
 
     Component {
+        id: edgeLengthHandleComponent
+
+        MapQuickItem {
+            id:             mapQuickItem
+            anchorPoint.x:  sourceItem.width / 2
+            anchorPoint.y:  sourceItem.height / 2
+            visible:        !_circleMode
+
+            property int vertexIndex
+            property real distance
+
+            sourceItem: Text {
+              text: distance.toFixed(2) + " m"
+              color: "white"
+            }
+        }
+    }
+
+    Component {
         id: splitHandlesComponent
 
         Repeater {
@@ -336,6 +355,43 @@ Item {
                 Component.onDestruction: {
                     if (_splitHandle) {
                         _splitHandle.destroy()
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: edgeLengthHandlesComponent
+
+        Repeater {
+            model: mapPolygon.path
+
+            delegate: Item {
+                property var _edgeLengthHandle
+                property var _vertices:     mapPolygon.path
+
+                function _setHandlePosition() {
+                    var nextIndex = index + 1
+                    if (nextIndex > _vertices.length - 1) {
+                        nextIndex = 0
+                    }
+                    var distance = _vertices[index].distanceTo(_vertices[nextIndex])
+                    var azimuth = _vertices[index].azimuthTo(_vertices[nextIndex])
+                    _edgeLengthHandle.coordinate =_vertices[index].atDistanceAndAzimuth(distance / 3, azimuth)
+                    _edgeLengthHandle.distance = distance
+                }
+
+                Component.onCompleted: {
+                    _edgeLengthHandle = edgeLengthHandleComponent.createObject(mapControl)
+                    _edgeLengthHandle.vertexIndex = index
+                    _setHandlePosition()
+                    mapControl.addMapItem(_edgeLengthHandle)
+                }
+
+                Component.onDestruction: {
+                    if (_edgeLengthHandle) {
+                        _edgeLengthHandle.destroy()
                     }
                 }
             }


### PR DESCRIPTION
This adds information about the edge lengths of the polygon to the map. With the current tools it is quite hard to plan e.g. a square of 1 km x 1 km on the open sea. One can orientate on the map scale but that yields imprecise results.

In trace mode it is not perfect until you have more than two points.


