### PR TITLE
MessageIndicator: Enable copy/paste of messages

### DIFF
--- a/src/ui/toolbar/MessageIndicator.qml
+++ b/src/ui/toolbar/MessageIndicator.qml
@@ -147,10 +147,13 @@ Item {
                 pixelAligned:       true
 
                 TextEdit {
-                    id:             messageText
-                    readOnly:       true
-                    textFormat:     TextEdit.RichText
-                    color:          qgcPal.text
+                    id:                 messageText
+                    readOnly:           true
+                    textFormat:         TextEdit.RichText
+                    selectByMouse:      true
+                    color:              qgcPal.text
+                    selectionColor:     qgcPal.text
+                    selectedTextColor:  qgcPal.window
                 }
             }
         }


### PR DESCRIPTION
Requested by user here:

https://github.com/mavlink/qgroundcontrol/issues/4503

I'm not sure about the `SelectionColor` and `SelectedTextColor` values.


