### PR TITLE
LogDownloadPage.qml: fix TableView text color

### DIFF
--- a/src/AnalyzeView/LogDownloadPage.qml
+++ b/src/AnalyzeView/LogDownloadPage.qml
@@ -60,6 +60,7 @@ AnalyzePage {
                     width: ScreenTools.defaultFontPixelWidth * 6
                     horizontalAlignment: Text.AlignHCenter
                     delegate : Text  {
+                        color: styleData.textColor
                         horizontalAlignment: Text.AlignHCenter
                         text: {
                             var o = logController.model.get(styleData.row)
@@ -73,6 +74,7 @@ AnalyzePage {
                     width: ScreenTools.defaultFontPixelWidth * 34
                     horizontalAlignment: Text.AlignHCenter
                     delegate: Text  {
+                        color: styleData.textColor
                         text: {
                             var o = logController.model.get(styleData.row)
                             if (o) {
@@ -95,6 +97,7 @@ AnalyzePage {
                     width: ScreenTools.defaultFontPixelWidth * 18
                     horizontalAlignment: Text.AlignHCenter
                     delegate : Text  {
+                        color: styleData.textColor
                         horizontalAlignment: Text.AlignRight
                         text: {
                             var o = logController.model.get(styleData.row)
@@ -108,6 +111,7 @@ AnalyzePage {
                     width: ScreenTools.defaultFontPixelWidth * 22
                     horizontalAlignment: Text.AlignHCenter
                     delegate : Text  {
+                        color: styleData.textColor
                         horizontalAlignment: Text.AlignHCenter
                         text: {
                             var o = logController.model.get(styleData.row)


### PR DESCRIPTION
This passes the styleData.textColor property from the TableView to the Text items used to populate the rows to ensure the proper color of the text to match the alternating background colors of each row.

This fixes not being able to read the text on macOS where half of the rows were black text on almost black background.

Fixes: #10449


