### PR TITLE
Ground Vehicle PID Tuning Page

### DIFF
--- a/src/AutoPilotPlugins/PX4/CMakeLists.txt
+++ b/src/AutoPilotPlugins/PX4/CMakeLists.txt
@@ -14,6 +14,7 @@ add_custom_target(PX4AutoPilotPluginQml
 		PX4TuningComponentCopter.qml
 		PX4TuningComponentPlane.qml
 		PX4TuningComponentVTOL.qml
+		PX4TuningComponentGroundVehicle.qml
 		SafetyComponent.qml
 		SafetyComponentSummary.qml
 		SensorsComponent.qml

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
@@ -53,9 +53,18 @@ QUrl PX4TuningComponent::setupSource(void) const
     QString qmlFile;
 
     switch (_vehicle->vehicleType()) {
+        // Ground Vehicle
+        case MAV_TYPE_GROUND_ROVER:
+        case MAV_TYPE_SURFACE_BOAT:
+            qmlFile = "qrc:/qml/PX4TuningComponentGroundVehicle.qml";
+            break;
+
+        // Flying Wing
         case MAV_TYPE_FIXED_WING:
             qmlFile = "qrc:/qml/PX4TuningComponentPlane.qml";
             break;
+
+        // Multirotor
         case MAV_TYPE_QUADROTOR:
         case MAV_TYPE_COAXIAL:
         case MAV_TYPE_HELICOPTER:
@@ -64,6 +73,8 @@ QUrl PX4TuningComponent::setupSource(void) const
         case MAV_TYPE_TRICOPTER:
             qmlFile = "qrc:/qml/PX4TuningComponentCopter.qml";
             break;
+
+        // VTOL
         case MAV_TYPE_VTOL_TAILSITTER_DUOROTOR:
         case MAV_TYPE_VTOL_TAILSITTER_QUADROTOR:
         case MAV_TYPE_VTOL_TILTROTOR:
@@ -73,6 +84,8 @@ QUrl PX4TuningComponent::setupSource(void) const
         case MAV_TYPE_VTOL_RESERVED5:
             qmlFile = "qrc:/qml/PX4TuningComponentVTOL.qml";
             break;
+        
+        // Invalid
         default:
             break;
     }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicle.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicle.qml
@@ -1,0 +1,28 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+
+SetupPage {
+    id:             tuningPage
+    pageComponent:  pageComponent
+
+    Component {
+        id: pageComponent
+
+        PX4TuningComponentGroundVehicleAll {
+            height: availableHeight
+        }
+    } // Component - pageComponent
+} // SetupPage

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAll.qml
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.ScreenTools   1.0
+
+Item {
+    width: availableWidth
+
+    FactPanelController {
+        id:         controller
+    }
+
+    QGCTabBar {
+        id:             bar
+        width:          parent.width
+        anchors.top:    parent.top
+        
+        QGCTabButton {
+            text:       qsTr("Rate Controller")
+        }
+        QGCTabButton {
+            text:       qsTr("Attitude Controller")
+        }
+        QGCTabButton {
+            text:       qsTr("Velocity Controller")
+        }
+        QGCTabButton {
+            text:       qsTr("Position Controller")
+        }
+    }
+
+    property var pages:  [
+        "PX4TuningComponentGroundVehicleRate.qml",
+        "PX4TuningComponentGroundVehicleAttitude.qml",
+        "PX4TuningComponentGroundVehicleVelocity.qml",
+        "PX4TuningComponentGroundVehiclePosition.qml"
+    ]
+
+    Loader {
+        source:            pages[bar.currentIndex]
+        width:             parent.width
+        anchors.top:       bar.bottom
+        anchors.topMargin: ScreenTools.defaultFontPixelWidth
+        anchors.bottom:    parent.bottom
+    }
+}

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAttitude.qml
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+ColumnLayout {
+    width: availableWidth
+    anchors.fill: parent
+    property alias autotuningEnabled: pidTuning.autotuningEnabled
+
+    PIDTuning {
+        width: availableWidth
+        id:    pidTuning
+
+        title: "Attitude"
+        tuningMode: Vehicle.ModeRateAndAttitude
+        unit: "deg"
+        axis: [ yaw ]
+        showAutoModeChange: true
+        showAutoTuning:     true
+
+        property var yaw: QtObject {
+            property string name: qsTr("Yaw")
+            
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.yaw.value },
+                { name: "Setpoint", value: globals.activeVehicle.setpoint.yaw.value }
+            ]
+
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Attitude P-gain (GND_ATT_P)")
+                    description:    qsTr("P-gain for setting rate setpoint based on attitude error")
+                    param:          "GND_ATT_P"
+                    min:            0.0
+                    max:            1.0
+                    step:           0.05
+                }
+            }
+        }
+        
+    }
+}

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAttitude.qml
@@ -21,7 +21,6 @@ import QGroundControl.Vehicle       1.0
 ColumnLayout {
     width: availableWidth
     anchors.fill: parent
-    property alias autotuningEnabled: pidTuning.autotuningEnabled
 
     PIDTuning {
         width: availableWidth
@@ -31,25 +30,34 @@ ColumnLayout {
         tuningMode: Vehicle.ModeRateAndAttitude
         unit: "deg"
         axis: [ yaw ]
-        showAutoModeChange: true
-        showAutoTuning:     true
 
         property var yaw: QtObject {
             property string name: qsTr("Yaw")
             
             property var plot: [
-                { name: "Response", value: globals.activeVehicle.yaw.value },
+                { name: "Response", value: globals.activeVehicle.heading.value },
                 { name: "Setpoint", value: globals.activeVehicle.setpoint.yaw.value }
             ]
 
             property var params: ListModel {
+//                Note: Having this `GND_ATT_P` parameter's unit as 'rad' in PX4 messed up the QGC's Fact system, and the sliders were
+//                considered as `deg` (by default, not sure why that's happening). So the P-gain getting
+//                written was multiplied by PI / 180. This is likely a QGC Bug.
                 ListElement {
                     title:          qsTr("Attitude P-gain (GND_ATT_P)")
                     description:    qsTr("P-gain for setting rate setpoint based on attitude error")
                     param:          "GND_ATT_P"
                     min:            0.0
-                    max:            1.0
+                    max:            5.0
                     step:           0.05
+                }
+                ListElement {
+                    title:          qsTr("Maximum Manual Attitude Control Yaw rate (GND_MAN_Y_MAX) [deg/s]")
+                    description:    qsTr("In Attitude mode, maximum roll stick deflection will command yaw rate of `GND_MAN_Y_MAX`")
+                    param:          "GND_MAN_Y_MAX"
+                    min:            0.0
+                    max:            400.0
+                    step:           5.0
                 }
             }
         }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehiclePosition.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehiclePosition.qml
@@ -22,8 +22,6 @@ ColumnLayout {
     width: availableWidth
     anchors.fill: parent
 
-    
-
     PIDTuning {
         width: availableWidth
         id:    pidTuning
@@ -51,7 +49,7 @@ ColumnLayout {
                     min:            1.0
                     max:            50.0
                     step:           0.1
-                },
+                }
                 ListElement {
                     title:          qsTr("L1 guidance distance (GND_L1_PERIOD)")
                     description:    qsTr("L1 distance definining the tracking point ahead of the ground vehicle it's following")
@@ -59,7 +57,7 @@ ColumnLayout {
                     min:            0.5
                     max:            50.0
                     step:           0.1
-                },
+                }
                 ListElement {
                     title:          qsTr("Cruise throttle (GND_THR_CRUISE)")
                     description:    qsTr("Throttle setting required for achieving desired cruise speed (shouldn't this be automatically be estimated?)")
@@ -67,7 +65,7 @@ ColumnLayout {
                     min:            0.0
                     max:            1.0
                     step:           0.01
-                },
+                }
                 ListElement {
                     title:          qsTr("Minimum throttle (GND_THR_MIN)")
                     description:    qsTr("Minimum throttle outputted by the controller")
@@ -75,7 +73,7 @@ ColumnLayout {
                     min:            0.0
                     max:            1.0
                     step:           0.01
-                },
+                }
                 ListElement {
                     title:          qsTr("Maximum throttle (GND_THR_MAX)")
                     description:    qsTr("Maximum throttle outputted by the controller")

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehiclePosition.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehiclePosition.qml
@@ -1,0 +1,94 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+ColumnLayout {
+    width: availableWidth
+    anchors.fill: parent
+
+    
+
+    PIDTuning {
+        width: availableWidth
+        id:    pidTuning
+
+        title: "Position"
+        tuningMode: Vehicle.ModeVelocityAndPosition
+        unit: ""
+        axis: [ all ]
+
+        property var all: QtObject {
+            property string name: qsTr("Position")
+
+            property var plot: [
+                { name: "Pos X Response", value: globals.activeVehicle.localPosition.x.value },
+                { name: "Pos X Setpoint", value: globals.activeVehicle.localPositionSetpoint.x.value },
+                { name: "Pos Y Response", value: globals.activeVehicle.localPosition.y.value },
+                { name: "Pos Y Setpoint", value: globals.activeVehicle.localPositionSetpoint.y.value }
+            ]
+
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("L1 Waypoint activation distance (GND_L1_DIST)")
+                    description:    qsTr("Distance at which the next waypoint is activated")
+                    param:          "GND_L1_DIST"
+                    min:            1.0
+                    max:            50.0
+                    step:           0.1
+                },
+                ListElement {
+                    title:          qsTr("L1 guidance distance (GND_L1_PERIOD)")
+                    description:    qsTr("L1 distance definining the tracking point ahead of the ground vehicle it's following")
+                    param:          "GND_L1_PERIOD"
+                    min:            0.5
+                    max:            50.0
+                    step:           0.1
+                },
+                ListElement {
+                    title:          qsTr("Cruise throttle (GND_THR_CRUISE)")
+                    description:    qsTr("Throttle setting required for achieving desired cruise speed (shouldn't this be automatically be estimated?)")
+                    param:          "GND_THR_CRUISE"
+                    min:            0.0
+                    max:            1.0
+                    step:           0.01
+                },
+                ListElement {
+                    title:          qsTr("Minimum throttle (GND_THR_MIN)")
+                    description:    qsTr("Minimum throttle outputted by the controller")
+                    param:          "GND_THR_MIN"
+                    min:            0.0
+                    max:            1.0
+                    step:           0.01
+                },
+                ListElement {
+                    title:          qsTr("Maximum throttle (GND_THR_MAX)")
+                    description:    qsTr("Maximum throttle outputted by the controller")
+                    param:          "GND_THR_MAX"
+                    min:            0.0
+                    max:            1.0
+                    step:           0.01
+                }
+            }
+        }
+        
+    }
+}
+
+
+

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleRate.qml
@@ -23,21 +23,15 @@ ColumnLayout {
     anchors.fill: parent
     property alias autotuningEnabled: pidTuning.autotuningEnabled
 
-    GridLayout {
-        columns: 2
-    }
-
     PIDTuning {
         width: availableWidth
-        id:    PIDTuning
+        id:    pidTuning
 
         title: "Rate"
         tuningMode: Vehicle.ModeRateAndAttitude
         unit: "deg/s"
         axis: [ yaw ]
         chartDisplaySec: 3
-        showAutoModeChange: true
-        showAutoTuning:     true
 
         // Yaw tuning parameters
         property var yaw: QtObject {
@@ -49,6 +43,15 @@ ColumnLayout {
             ]
 
             property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Maximum Yaw rate (GND_RATE_MAX) [rad/s]")
+                    description:    qsTr("Maximum Yaw rate reachable by the vehicle's actuator & body. If in Manual mode, edit `GND_MAN_Y_MAX`")
+                    param:          "GND_RATE_MAX"
+                    min:            0.0
+                    max:            5.0
+                    step:           0.05
+                    // SITL Boat can reach upto ~17 deg/s == 0.25 rad/s | Real Racing Boat can reach upto 6.00 rad/s
+                }
                 ListElement {
                     title:          qsTr("Feedforward Gain (GND_RATE_FF)")
                     description:    qsTr("Feedforward used to compensate for gronds damping. Cruicial for Boats")
@@ -62,7 +65,7 @@ ColumnLayout {
                     description:    qsTr("Porportional Gain.")
                     param:          "GND_RATE_P"
                     min:            0.0
-                    max:            1
+                    max:            5.0
                     step:           0.005
                 }
                 ListElement {
@@ -74,20 +77,20 @@ ColumnLayout {
                     step:           0.005
                 }
                 ListElement {
+                    title:          qsTr("Derivative Gain (GND_RATE_D)")
+                    description:    qsTr("Derivative Gain")
+                    param:          "GND_RATE_D"
+                    min:            0.0
+                    max:            1.0
+                    step:           0.005
+                }
+                ListElement {
                     title:          qsTr("Integral max (GND_RATE_IMAX)")
                     description:    qsTr("Sanity limit to prevent integrator from running away.")
-                    param:          "GND_RATE_D"
+                    param:          "GND_RATE_IMAX"
                     min:            0.0
                     max:            50.0
                     step:           0.5
-                }
-                ListElement {
-                    title:          qsTr("Maximum Yaw rate (GND_RATE_MAX) [rad/s]")
-                    description:    qsTr("Maximum Yaw rate reachable by the vehicle's actuator & body. If in Manual mode, edit `GND_MAN_Y_MAX`")
-                    param:          "GND_RATE_MAX"
-                    min:            0.0
-                    max:            5.0
-                    step:           0.01
                 }
             }
         }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleRate.qml
@@ -1,0 +1,96 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+ColumnLayout {
+    width: availableWidth
+    anchors.fill: parent
+    property alias autotuningEnabled: pidTuning.autotuningEnabled
+
+    GridLayout {
+        columns: 2
+    }
+
+    PIDTuning {
+        width: availableWidth
+        id:    PIDTuning
+
+        title: "Rate"
+        tuningMode: Vehicle.ModeRateAndAttitude
+        unit: "deg/s"
+        axis: [ yaw ]
+        chartDisplaySec: 3
+        showAutoModeChange: true
+        showAutoTuning:     true
+
+        // Yaw tuning parameters
+        property var yaw: QtObject {
+            property string name: qsTr("Yaw")
+
+            property var plot: [
+                { name: "Response", value: globals.activeVehicle.yawRate.value },
+                { name: "Setpoint", value: globals.activeVehicle.setpoint.yawRate.value }
+            ]
+
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Feedforward Gain (GND_RATE_FF)")
+                    description:    qsTr("Feedforward used to compensate for gronds damping. Cruicial for Boats")
+                    param:          "GND_RATE_FF"
+                    min:            0.0
+                    max:            10.0
+                    step:           0.05
+                }
+                ListElement {
+                    title:          qsTr("Porportional Gain (GND_RATE_P)")
+                    description:    qsTr("Porportional Gain.")
+                    param:          "GND_RATE_P"
+                    min:            0.0
+                    max:            1
+                    step:           0.005
+                }
+                ListElement {
+                    title:          qsTr("Integral Gain (GND_RATE_I)")
+                    description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                    param:          "GND_RATE_I"
+                    min:            0.0
+                    max:            1.0
+                    step:           0.005
+                }
+                ListElement {
+                    title:          qsTr("Integral max (GND_RATE_IMAX)")
+                    description:    qsTr("Sanity limit to prevent integrator from running away.")
+                    param:          "GND_RATE_D"
+                    min:            0.0
+                    max:            50.0
+                    step:           0.5
+                }
+                ListElement {
+                    title:          qsTr("Maximum Yaw rate (GND_RATE_MAX) [rad/s]")
+                    description:    qsTr("Maximum Yaw rate reachable by the vehicle's actuator & body. If in Manual mode, edit `GND_MAN_Y_MAX`")
+                    param:          "GND_RATE_MAX"
+                    min:            0.0
+                    max:            5.0
+                    step:           0.01
+                }
+            }
+        }
+    }
+}
+

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleVelocity.qml
@@ -48,51 +48,37 @@ ColumnLayout {
         title: "Velocity"
         tuningMode: Vehicle.ModeVelocityAndPosition
         unit: "m/s"
-        axis: [ all ]
+        axis: [ velocity ]
 
-        property var all: QtObject {
-            property string name: qsTr("Velocity")
+        property var velocity: QtObject {
+            property string name: qsTr("velocity")
             
             property var plot: [
-                { name: "Vel X Response", value: globals.activeVehicle.localPosition.vx.value },
-                { name: "Vel X Setpoint", value: globals.activeVehicle.localPositionSetpoint.vx.value },
-                { name: "Vel Y Response", value: globals.activeVehicle.localPosition.vy.value },
-                { name: "Vel Y Setpoint", value: globals.activeVehicle.localPositionSetpoint.vy.value }
+                { name: "Vel XY Response", value: globals.activeVehicle.localPosition.vxy },
+                { name: "Vel XY Setpoint", value: globals.activeVehicle.localPositionSetpoint.vxy },
+//                { name: "Vel X Response", value: globals.activeVehicle.localPosition.vx.value },
+//                { name: "Vel X Setpoint", value: globals.activeVehicle.localPositionSetpoint.vx.value }
+//                { name: "Vel Y Response", value: globals.activeVehicle.localPosition.vy.value },
+//                { name: "Vel Y Setpoint", value: globals.activeVehicle.localPositionSetpoint.vy.value }
             ]
 
             property var params: ListModel {
                 ListElement {
                     title:          qsTr("Trim ground speed (GND_SPEED_TRIM)")
-                    description:    qsTr("Trim speed that will be the target speed for missions")
+                    description:    qsTr("Target speed in mission mode (autonomous)")
                     param:          "GND_SPEED_TRIM"
                     min:            0.0
                     max:            20.0
                     step:           0.1
-                },
+                }
                 ListElement {
                     title:          qsTr("Minimum ground speed (GND_SPEED_MIN)")
-                    description:    qsTr("Minimum ground speed")
+                    description:    qsTr("Minimum ground speed, used for velocity saturation in waypoint navigation")
                     param:          "GND_SPEED_MIN"
                     min:            0.0
                     max:            20.0
                     step:           0.1
-                },
-                ListElement {
-                    title:          qsTr("Maximum ground speed (GND_SPEED_MAX)")
-                    description:    qsTr("")
-                    param:          "GND_SPEED_MAX"
-                    min:            0.0
-                    max:            20.0
-                    step:           0.1
-                },
-                ListElement {
-                    title:          qsTr("Speed to throttle scalar (GND_SPEED_THR_SC)")
-                    description:    qsTr("This is a gain to map the speed control output to the throttle linearly.")
-                    param:          "GND_SPEED_THR_SC"
-                    min:            0.0
-                    max:            5.0
-                    step:           0.1
-                },
+                }
                 ListElement {
                     title:          qsTr("Porportional Gain (GND_SPEED_P)")
                     description:    qsTr("Porportional Gain.")
@@ -100,7 +86,7 @@ ColumnLayout {
                     min:            0.0
                     max:            10.0
                     step:           0.01
-                },
+                }
                 ListElement {
                     title:          qsTr("Integral Gain (GND_SPEED_I)")
                     description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
@@ -108,7 +94,7 @@ ColumnLayout {
                     min:            0.0
                     max:            10.0
                     step:           0.01
-                },
+                }
                 ListElement {
                     title:          qsTr("Derivative Gain (GND_SPEED_D)")
                     description:    qsTr("Derivative gain for velocity controller")
@@ -116,7 +102,7 @@ ColumnLayout {
                     min:            0.0
                     max:            10.0
                     step:           0.01
-                },
+                }
                 ListElement {
                     title:          qsTr("Speed Integral maximum value (GND_SPEED_IMAX)")
                     description:    qsTr("Maximum value integral can reach to prevent wind-up")
@@ -125,8 +111,52 @@ ColumnLayout {
                     max:            1.0
                     step:           0.01
                 }
+                ListElement {
+                    title:          qsTr("Maximum output of velocity PID controller (GND_SPEED_PID_MX)")
+                    description:    qsTr("Maximum output from the velocity PID controller")
+                    param:          "GND_SPEED_PID_MX"
+                    min:            0.0
+                    max:            40.0
+                    step:           0.1
+                }
+                ListElement {
+                    title:          qsTr("Speed to throttle scalar (GND_SPEED_THR_SC)")
+                    description:    qsTr("This is a gain to map the speed control output to the throttle linearly.")
+                    param:          "GND_SPEED_THR_SC"
+                    min:            0.0
+                    max:            2.0
+                    step:           0.01
+                }
             }
         }
-        
+
+//        property var throttle: QtObject {
+//            property string name: qsTr("throttle")
+
+//            property var plot: [
+////                { name: "Vel XY Response", value: globals.activeVehicle.localPosition.vxy },
+////                { name: "Vel XY Setpoint", value: globals.activeVehicle.localPositionSetpoint.vxy },
+//                { name: "Throttle output", value: globals.activeVehicle.localPositionSetpoint.throttle }
+//            ]
+
+//            property var params: ListModel {
+//                ListElement {
+//                    title:          qsTr("Maximum output of velocity PID controller (GND_SPEED_PID_MX)")
+//                    description:    qsTr("Maximum output from the velocity PID controller")
+//                    param:          "GND_SPEED_PID_MX"
+//                    min:            0.0
+//                    max:            40.0
+//                    step:           0.1
+//                }
+//                ListElement {
+//                    title:          qsTr("Speed to throttle scalar (GND_SPEED_THR_SC)")
+//                    description:    qsTr("This is a gain to map the speed control output to the throttle linearly.")
+//                    param:          "GND_SPEED_THR_SC"
+//                    min:            0.0
+//                    max:            2.0
+//                    step:           0.01
+//                }
+//            }
+//        }
     }
 }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleVelocity.qml
@@ -1,0 +1,132 @@
+/****************************************************************************
+ *
+ * (c) 2021 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.3
+import QtQuick.Controls 1.2
+import QtQuick.Layouts  1.2
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.Vehicle       1.0
+
+ColumnLayout {
+    width: availableWidth
+    anchors.fill: parent
+    property alias autotuningEnabled: pidTuning.autotuningEnabled
+
+    // If set to 1, use closed-loop PID control using GPS velocity. If 0, fix throttle at cruise throttle of mission settings.
+    property Fact _gndVehicleSpeedControlMode: controller.getParameterFact(-1, "GND_SP_CTRL_MODE", false)
+
+    // Reminder for setting the velocity control mode to closed-loop PID control
+    GridLayout {
+        columns: 2
+
+        QGCLabel {
+            text:               qsTr("Velocity control mode (set this to 'Close the loop' for PID tuning):")
+            visible:            !_gndVehicleSpeedControlMode
+        }
+
+        FactComboBox {
+            fact:               _gndVehicleSpeedControlMode
+            indexModel:         false
+        }
+    }
+
+    PIDTuning {
+        width: availableWidth
+        id:    pidTuning
+
+        title: "Velocity"
+        tuningMode: Vehicle.ModeVelocityAndPosition
+        unit: "m/s"
+        axis: [ all ]
+
+        property var all: QtObject {
+            property string name: qsTr("Velocity")
+            
+            property var plot: [
+                { name: "Vel X Response", value: globals.activeVehicle.localPosition.vx.value },
+                { name: "Vel X Setpoint", value: globals.activeVehicle.localPositionSetpoint.vx.value },
+                { name: "Vel Y Response", value: globals.activeVehicle.localPosition.vy.value },
+                { name: "Vel Y Setpoint", value: globals.activeVehicle.localPositionSetpoint.vy.value }
+            ]
+
+            property var params: ListModel {
+                ListElement {
+                    title:          qsTr("Trim ground speed (GND_SPEED_TRIM)")
+                    description:    qsTr("Trim speed that will be the target speed for missions")
+                    param:          "GND_SPEED_TRIM"
+                    min:            0.0
+                    max:            20.0
+                    step:           0.1
+                },
+                ListElement {
+                    title:          qsTr("Minimum ground speed (GND_SPEED_MIN)")
+                    description:    qsTr("Minimum ground speed")
+                    param:          "GND_SPEED_MIN"
+                    min:            0.0
+                    max:            20.0
+                    step:           0.1
+                },
+                ListElement {
+                    title:          qsTr("Maximum ground speed (GND_SPEED_MAX)")
+                    description:    qsTr("")
+                    param:          "GND_SPEED_MAX"
+                    min:            0.0
+                    max:            20.0
+                    step:           0.1
+                },
+                ListElement {
+                    title:          qsTr("Speed to throttle scalar (GND_SPEED_THR_SC)")
+                    description:    qsTr("This is a gain to map the speed control output to the throttle linearly.")
+                    param:          "GND_SPEED_THR_SC"
+                    min:            0.0
+                    max:            5.0
+                    step:           0.1
+                },
+                ListElement {
+                    title:          qsTr("Porportional Gain (GND_SPEED_P)")
+                    description:    qsTr("Porportional Gain.")
+                    param:          "GND_SPEED_P"
+                    min:            0.0
+                    max:            10.0
+                    step:           0.01
+                },
+                ListElement {
+                    title:          qsTr("Integral Gain (GND_SPEED_I)")
+                    description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                    param:          "GND_SPEED_I"
+                    min:            0.0
+                    max:            10.0
+                    step:           0.01
+                },
+                ListElement {
+                    title:          qsTr("Derivative Gain (GND_SPEED_D)")
+                    description:    qsTr("Derivative gain for velocity controller")
+                    param:          "GND_SPEED_D"
+                    min:            0.0
+                    max:            10.0
+                    step:           0.01
+                },
+                ListElement {
+                    title:          qsTr("Speed Integral maximum value (GND_SPEED_IMAX)")
+                    description:    qsTr("Maximum value integral can reach to prevent wind-up")
+                    param:          "GND_SPEED_IMAX"
+                    min:            0.0
+                    max:            1.0
+                    step:           0.01
+                }
+            }
+        }
+        
+    }
+}

--- a/src/FirmwarePlugin/PX4/PX4Resources.qrc
+++ b/src/FirmwarePlugin/PX4/PX4Resources.qrc
@@ -47,4 +47,12 @@
         <file alias="PX4ParameterFactMetaData.xml">PX4ParameterFactMetaData.xml</file>
         <file alias="PX4.OfflineEditing.params">V1.4.OfflineEditing.params</file>
     </qresource>
+    <qresource prefix="/">
+        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicle.qml</file>
+        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAll.qml</file>
+        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAttitude.qml</file>
+        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehiclePosition.qml</file>
+        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleRate.qml</file>
+        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleVelocity.qml</file>
+    </qresource>
 </RCC>

--- a/src/FirmwarePlugin/PX4/PX4Resources.qrc
+++ b/src/FirmwarePlugin/PX4/PX4Resources.qrc
@@ -24,6 +24,12 @@
         <file alias="PX4TuningComponentPlaneTECS.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml</file>
         <file alias="PX4TuningComponentVTOL.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml</file>
         <file alias="SafetyComponent.qml">../../AutoPilotPlugins/PX4/SafetyComponent.qml</file>
+        <file alias="PX4TuningComponentGroundVehicle.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicle.qml</file>
+        <file alias="PX4TuningComponentGroundVehicleAll.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAll.qml</file>
+        <file alias="PX4TuningComponentGroundVehicleRate.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleRate.qml</file>
+        <file alias="PX4TuningComponentGroundVehicleAttitude.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAttitude.qml</file>
+        <file alias="PX4TuningComponentGroundVehicleVelocity.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleVelocity.qml</file>
+        <file alias="PX4TuningComponentGroundVehiclePosition.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehiclePosition.qml</file>
         <file alias="SafetyComponentSummary.qml">../../AutoPilotPlugins/PX4/SafetyComponentSummary.qml</file>
         <file alias="SensorsComponent.qml">../../AutoPilotPlugins/PX4/SensorsComponent.qml</file>
         <file alias="SensorsComponentSummary.qml">../../AutoPilotPlugins/PX4/SensorsComponentSummary.qml</file>
@@ -46,13 +52,5 @@
     <qresource prefix="/FirmwarePlugin/PX4">
         <file alias="PX4ParameterFactMetaData.xml">PX4ParameterFactMetaData.xml</file>
         <file alias="PX4.OfflineEditing.params">V1.4.OfflineEditing.params</file>
-    </qresource>
-    <qresource prefix="/">
-        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicle.qml</file>
-        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAll.qml</file>
-        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleAttitude.qml</file>
-        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehiclePosition.qml</file>
-        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleRate.qml</file>
-        <file>../../AutoPilotPlugins/PX4/PX4TuningComponentGroundVehicleVelocity.qml</file>
     </qresource>
 </RCC>

--- a/src/Vehicle/VehicleLocalPositionFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionFactGroup.cc
@@ -42,6 +42,8 @@ VehicleLocalPositionFactGroup::VehicleLocalPositionFactGroup(QObject* parent)
     _vxFact.setRawValue(qQNaN());
     _vyFact.setRawValue(qQNaN());
     _vzFact.setRawValue(qQNaN());
+
+    _vxy = qQNaN();
 }
 
 void VehicleLocalPositionFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
@@ -60,6 +62,8 @@ void VehicleLocalPositionFactGroup::handleMessage(Vehicle* /* vehicle */, mavlin
     vx()->setRawValue(localPosition.vx);
     vy()->setRawValue(localPosition.vy);
     vz()->setRawValue(localPosition.vz);
+
+    _vxy = qSqrt(localPosition.vx * localPosition.vx + localPosition.vy * localPosition.vy);
 
     _setTelemetryAvailable(true);
 }

--- a/src/Vehicle/VehicleLocalPositionFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionFactGroup.h
@@ -26,12 +26,17 @@ public:
     Q_PROPERTY(Fact* vy    READ vy   CONSTANT)
     Q_PROPERTY(Fact* vz    READ vz   CONSTANT)
 
+    // XY plane velocity, calculated from vx and vy
+    Q_PROPERTY(double vxy  READ vxy CONSTANT)
+
     Fact* x    () { return &_xFact; }
     Fact* y    () { return &_yFact; }
     Fact* z    () { return &_zFact; }
     Fact* vx   () { return &_vxFact; }
     Fact* vy   () { return &_vyFact; }
     Fact* vz   () { return &_vzFact; }
+
+    double vxy () { return _vxy; }
 
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
@@ -50,4 +55,6 @@ private:
     Fact _vxFact;
     Fact _vyFact;
     Fact _vzFact;
+
+    double _vxy;
 };

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
@@ -44,6 +44,7 @@ VehicleLocalPositionSetpointFactGroup::VehicleLocalPositionSetpointFactGroup(QOb
     _vzFact.setRawValue(qQNaN());
 
     _vxy = qQNaN();
+    _throttle = qQNaN();
 }
 
 void VehicleLocalPositionSetpointFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
@@ -65,6 +66,9 @@ void VehicleLocalPositionSetpointFactGroup::handleMessage(Vehicle* /* vehicle */
 
     // Calculate horizontal velocity
     _vxy = qSqrt(localPosition.vx * localPosition.vx + localPosition.vy * localPosition.vy);
+
+    // Hack: Use Acceleration X field for relaying the throttle setpoint information for now (Boat tuning debug)
+    _throttle = localPosition.afx;
 
     _setTelemetryAvailable(true);
 }

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
@@ -42,6 +42,8 @@ VehicleLocalPositionSetpointFactGroup::VehicleLocalPositionSetpointFactGroup(QOb
     _vxFact.setRawValue(qQNaN());
     _vyFact.setRawValue(qQNaN());
     _vzFact.setRawValue(qQNaN());
+
+    _vxy = qQNaN();
 }
 
 void VehicleLocalPositionSetpointFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
@@ -60,6 +62,9 @@ void VehicleLocalPositionSetpointFactGroup::handleMessage(Vehicle* /* vehicle */
     vx()->setRawValue(localPosition.vx);
     vy()->setRawValue(localPosition.vy);
     vz()->setRawValue(localPosition.vz);
+
+    // Calculate horizontal velocity
+    _vxy = qSqrt(localPosition.vx * localPosition.vx + localPosition.vy * localPosition.vy);
 
     _setTelemetryAvailable(true);
 }

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
@@ -26,12 +26,17 @@ public:
     Q_PROPERTY(Fact* vy    READ vy   CONSTANT)
     Q_PROPERTY(Fact* vz    READ vz   CONSTANT)
 
+    // [m/s] Magnitude of the horizontal (XY) velocity calculated from vx and vy
+    // Note: this field doesn't exist in the Local position message, but is calculated from vx and vy
+    Q_PROPERTY(double vxy READ vxy   CONSTANT)
+
     Fact* x    () { return &_xFact; }
     Fact* y    () { return &_yFact; }
     Fact* z    () { return &_zFact; }
     Fact* vx   () { return &_vxFact; }
     Fact* vy   () { return &_vyFact; }
     Fact* vz   () { return &_vzFact; }
+    double vxy  () { return _vxy; }
 
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
@@ -50,4 +55,5 @@ private:
     Fact _vxFact;
     Fact _vyFact;
     Fact _vzFact;
+    double _vxy;
 };

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
@@ -28,7 +28,13 @@ public:
 
     // [m/s] Magnitude of the horizontal (XY) velocity calculated from vx and vy
     // Note: this field doesn't exist in the Local position message, but is calculated from vx and vy
-    Q_PROPERTY(double vxy READ vxy   CONSTANT)
+    Q_PROPERTY(double vxy  READ vxy  CONSTANT)
+
+    // Magnitude of the throttle command in XY plane, normalized (max thrust == 1.0)
+    // Note: this field doesn't exist in the Local position message
+    // Now I am hack-fully utilizing Acceleration-X field for sending this value,
+    // since vehicle_thrust_setpoint uORB message isn't translated into MAVLink yet.
+    Q_PROPERTY(double throttle  READ throttle  CONSTANT)
 
     Fact* x    () { return &_xFact; }
     Fact* y    () { return &_yFact; }
@@ -36,7 +42,9 @@ public:
     Fact* vx   () { return &_vxFact; }
     Fact* vy   () { return &_vyFact; }
     Fact* vz   () { return &_vzFact; }
+
     double vxy  () { return _vxy; }
+    double throttle  () { return _throttle; }
 
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
@@ -55,5 +63,7 @@ private:
     Fact _vxFact;
     Fact _vyFact;
     Fact _vzFact;
+
     double _vxy;
+    double _throttle;
 };


### PR DESCRIPTION
## Description
This adds PID tuning page for Ground Vehicle

## Pre-requisites
This UI involves parameters defined in the upcoming PR to fully support Ground Vehicle's Mission mode through rate controller support: https://github.com/PX4/PX4-Autopilot/pull/20082

## Additional notes
This will resolve https://github.com/mavlink/qgroundcontrol/issues/10429