### PR TITLE
JoyStickButtonAssignment: Fix warning text

### DIFF
--- a/src/VehicleSetup/JoystickConfigButtons.qml
+++ b/src/VehicleSetup/JoystickConfigButtons.qml
@@ -23,6 +23,8 @@ import QGroundControl.FactControls  1.0
 ColumnLayout {
     width:                  availableWidth
     height:                 (globals.activeVehicle.supportsJSButton ? buttonCol.height : flowColumn.height) + (ScreenTools.defaultFontPixelHeight * 2)
+    spacing:                ScreenTools.defaultFontPixelHeight
+    
     Connections {
         target: _activeJoystick
         onRawButtonPressedChanged: {
@@ -34,16 +36,20 @@ ColumnLayout {
             }
         }
     }
+
     ColumnLayout {
         id:         flowColumn
-        y:          ScreenTools.defaultFontPixelHeight / 2
         width:      parent.width
-        spacing:    ScreenTools.defaultFontPixelHeight / 2
+        anchors.centerIn:   parent
+        spacing:    ScreenTools.defaultFontPixelHeight
+
+        // Note for reminding the use of multiple buttons for the same action
         QGCLabel {
             Layout.preferredWidth:  parent.width
             wrapMode:               Text.WordWrap
-            text:                   qsTr("Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.")
+            text:                   qsTr(" Multiple buttons that have the same action must be pressed simultaneously to invoke the action.")
         }
+        
         Flow {
             id:                     buttonFlow
             Layout.preferredWidth:  parent.width

--- a/translations/qgc.ts
+++ b/translations/qgc.ts
@@ -8447,7 +8447,7 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
         <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-        <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
+        <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/qgc_source_az_AZ.ts
+++ b/translations/qgc_source_az_AZ.ts
@@ -8472,7 +8472,7 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
       <translation>Eyni hərəkəti bir neçə düyməyə təyin etmək, hərəkət üçün bütün bu düymələrin basılmasını tələb edir. Bu, Xodlama və ya Təcili Yardım kimi kritik hərəkətlər üçün təsadüfi düymələrin basılmasının qarşısını almaq üçün faydalıdır.</translation>
     </message>
     <message>

--- a/translations/qgc_source_bg_BG.ts
+++ b/translations/qgc_source_bg_BG.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_de_DE.ts
+++ b/translations/qgc_source_de_DE.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_el_GR.ts
+++ b/translations/qgc_source_el_GR.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_es_ES.ts
+++ b/translations/qgc_source_es_ES.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_fi_FI.ts
+++ b/translations/qgc_source_fi_FI.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_fr_FR.ts
+++ b/translations/qgc_source_fr_FR.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_he_IL.ts
+++ b/translations/qgc_source_he_IL.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_it_IT.ts
+++ b/translations/qgc_source_it_IT.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_ja_JP.ts
+++ b/translations/qgc_source_ja_JP.ts
@@ -8463,7 +8463,7 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
       <translation>複数のボタンに同じアクションを割り当てる場合、アクションを実行するためには、それらのボタンすべてを押す必要があります。これはアームや緊急停止などの重大なアクションの際に、誤ってボタンを押してしまうことを防止するために有効です。</translation>
     </message>
     <message>

--- a/translations/qgc_source_ko_KR.ts
+++ b/translations/qgc_source_ko_KR.ts
@@ -8476,8 +8476,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_nl_NL.ts
+++ b/translations/qgc_source_nl_NL.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_no_NO.ts
+++ b/translations/qgc_source_no_NO.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_pl_PL.ts
+++ b/translations/qgc_source_pl_PL.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_pt_PT.ts
+++ b/translations/qgc_source_pt_PT.ts
@@ -8469,7 +8469,7 @@ Clique em Ok para inciar o processo de auto-ajuste.</translation>
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
       <translation>A atribuição da mesma ação para vários botões requer que todos esses botões sejam pressionados para a ação ser tomada. Isso é útil para prevenir acidentes com ações críticas como Armar ou Parada de Emergência.</translation>
     </message>
     <message>

--- a/translations/qgc_source_ru_RU.ts
+++ b/translations/qgc_source_ru_RU.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_sv_SE.ts
+++ b/translations/qgc_source_sv_SE.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_tr_TR.ts
+++ b/translations/qgc_source_tr_TR.ts
@@ -8470,8 +8470,8 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
-      <translation type="unfinished">Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</translation>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
+      <translation type="unfinished"> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</translation>
     </message>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="94"/>

--- a/translations/qgc_source_zh_CN.ts
+++ b/translations/qgc_source_zh_CN.ts
@@ -8472,7 +8472,7 @@ Click Ok to start the auto-tuning process.
     <name>JoystickConfigButtons</name>
     <message>
       <location filename="../src/VehicleSetup/JoystickConfigButtons.qml" line="45"/>
-      <source>Assigning the same action to multiple buttons requires the press of all those buttons for the action to be taken. This is useful to prevent accidental button presses for critical actions like Arm or Emergency Stop.</source>
+      <source> Multiple buttons that have the same action must be pressed simultaneously to invoke the action.</source>
       <translation>将相同动作分配给多个按钮需要按下所有这些按钮才能进行操作。 这有助于防止对诸如解锁或紧急站等关键行动的意外按键按下。</translation>
     </message>
     <message>


### PR DESCRIPTION
## Description
This improves readability of the Joystick multi-button assignment warning!

Resolves https://github.com/PX4/PX4-user_guide/pull/2072#issuecomment-1308198119

## Note
I had to apply an anchor, as the text was too squashed to the top, and was visually not great (not enough spacing between column items)

## TODO
- [ ] Make warning only visible when 2+ buttons are actually assigned to the same action (not visible by default)