### PR TITLE
Stable: Backport external GPS fix

### DIFF
--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -101,6 +101,8 @@ void QGCPositionManager::setNmeaSourceDevice(QIODevice* device)
     }
     _nmeaSource = new QNmeaPositionInfoSource(QNmeaPositionInfoSource::RealTimeMode, this);
     _nmeaSource->setDevice(device);
+    // set equivalent range error to enable position accuracy reporting
+    _nmeaSource->setUserEquivalentRangeError(5.1);
     setPositionSource(QGCPositionManager::NmeaGPS);
 }
 


### PR DESCRIPTION
Backporting https://github.com/mavlink/qgroundcontrol/pull/10374 to fix external gps support in 4.2