### PR TITLE
MAVFtp: Allow proper compId as default

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1970,7 +1970,7 @@ QGCCameraControl::_handleDefinitionFile(const QString &url)
             ver,
             ext.toStdString().c_str());
         connect(_vehicle->ftpManager(), &FTPManager::downloadComplete, this, &QGCCameraControl::_ftpDownloadComplete);
-        _vehicle->ftpManager()->download(url,
+        _vehicle->ftpManager()->download(_compID, url,
             qgcApp()->toolbox()->settingsManager()->appSettings()->parameterSavePath().toStdString().c_str(),
             fileName);
         return;

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -531,7 +531,7 @@ void ParameterManager::refreshAllParameters(uint8_t componentId)
         FTPManager* ftpManager = _vehicle->ftpManager();
         connect(ftpManager, &FTPManager::downloadComplete, this, &ParameterManager::_ftpDownloadComplete);
         _waitingParamTimeoutTimer.stop();
-        if (ftpManager->download("@PARAM/param.pck",
+        if (ftpManager->download(MAV_COMP_ID_AUTOPILOT1, "@PARAM/param.pck",
                                  QStandardPaths::writableLocation(QStandardPaths::TempLocation),
                                  "", false /* No filesize check */)) {
             connect(ftpManager, &FTPManager::commandProgress, this, &ParameterManager::_ftpDownloadProgress);

--- a/src/Vehicle/ComponentInformationManager.cc
+++ b/src/Vehicle/ComponentInformationManager.cc
@@ -420,7 +420,7 @@ void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, 
             qCDebug(ComponentInformationManagerLog) << "Downloading json" << uri;
             if (_uriIsMAVLinkFTP(uri)) {
                 connect(ftpManager, &FTPManager::downloadComplete, this, &RequestMetaDataTypeStateMachine::_ftpDownloadComplete);
-                if (ftpManager->download(uri, QStandardPaths::writableLocation(QStandardPaths::TempLocation))) {
+                if (ftpManager->download(MAV_COMP_ID_AUTOPILOT1, uri, QStandardPaths::writableLocation(QStandardPaths::TempLocation))) {
                     _downloadStartTime.start();
                     connect(ftpManager, &FTPManager::commandProgress, this, &RequestMetaDataTypeStateMachine::_ftpDownloadProgress);
                 } else {

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -630,7 +630,7 @@ void FTPManager::_sendRequestExpectAck(MavlinkFTP::Request* request)
 bool FTPManager::_parseURI(uint8_t fromCompId, const QString& uri, QString& parsedURI, uint8_t& compId)
 {
     parsedURI   = uri;
-    compId      = (fromCompId == MAV_COMP_ID_ALL) ? MAV_COMP_ID_AUTOPILOT1 : fromCompId;
+    compId      = (fromCompId == MAV_COMP_ID_ALL) ? (uint8_t)MAV_COMP_ID_AUTOPILOT1 : fromCompId;
 
     // Pull scheme off the front if there
     QString ftpPrefix(QStringLiteral("%1://").arg(mavlinkFTPScheme));

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -34,9 +34,9 @@ FTPManager::FTPManager(Vehicle* vehicle)
     Q_ASSERT(sizeof(MavlinkFTP::RequestHeader) == 12);
 }
 
-bool FTPManager::download(const QString& fromURI, const QString& toDir, const QString& fileName, bool checksize)
+bool FTPManager::download(uint8_t fromCompId, const QString& fromURI, const QString& toDir, const QString& fileName, bool checksize)
 {
-    qCDebug(FTPManagerLog) << "download fromURI:" << fromURI << "to:" << toDir;
+    qCDebug(FTPManagerLog) << "download fromURI:" << fromURI << "to:" << toDir << "fromCompId:" << fromCompId;
 
     if (!_rgStateMachine.isEmpty()) {
         qCDebug(FTPManagerLog) << "Cannot download. Already in another operation";
@@ -58,7 +58,7 @@ bool FTPManager::download(const QString& fromURI, const QString& toDir, const QS
     _downloadState.toDir.setPath(toDir);
     _downloadState.checksize = checksize;
 
-    if (!_parseURI(fromURI, _downloadState.fullPathOnVehicle, _ftpCompId)) {
+    if (!_parseURI(fromCompId, fromURI, _downloadState.fullPathOnVehicle, _ftpCompId)) {
         qCWarning(FTPManagerLog) << "_parseURI failed";
         return false;
     }
@@ -171,7 +171,8 @@ void FTPManager::_downloadComplete(const QString& errorMsg)
 
 void FTPManager::_mavlinkMessageReceived(const mavlink_message_t& message)
 {
-    if (message.msgid != MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL || message.compid != _ftpCompId) {
+    if (message.msgid != MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL ||
+            message.sysid != _vehicle->id() || message.compid != _ftpCompId) {
         return;
     }
 
@@ -626,10 +627,10 @@ void FTPManager::_sendRequestExpectAck(MavlinkFTP::Request* request)
     }
 }
 
-bool FTPManager::_parseURI(const QString& uri, QString& parsedURI, uint8_t& compId)
+bool FTPManager::_parseURI(uint8_t fromCompId, const QString& uri, QString& parsedURI, uint8_t& compId)
 {
     parsedURI   = uri;
-    compId      = MAV_COMP_ID_AUTOPILOT1;
+    compId      = (fromCompId == MAV_COMP_ID_ALL) ? MAV_COMP_ID_AUTOPILOT1 : fromCompId;
 
     // Pull scheme off the front if there
     QString ftpPrefix(QStringLiteral("%1://").arg(mavlinkFTPScheme));

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -43,7 +43,7 @@ public:
     ///                     a dynamic file creation on the vehicle.
     /// @return true: download has started, false: error, no download
     /// Signals downloadComplete, commandError, commandProgress
-    bool download(const QString& fromURI, const QString& toDir, const QString& fileName="", bool checksize = true);
+    bool download(uint8_t fromCompId, const QString& fromURI, const QString& toDir, const QString& fileName="", bool checksize = true);
 
     /// Cancel the current operation
     /// This will emit downloadComplete() when done, and if there's currently a download in progress
@@ -136,7 +136,7 @@ private:
     void    _fillRequestDataWithString(MavlinkFTP::Request* request, const QString& str);
     void    _fillMissingBlocksWorker    (bool firstRequest);
     void    _burstReadFileWorker        (bool firstRequest);
-    bool    _parseURI                   (const QString& uri, QString& parsedURI, uint8_t& compId);
+    bool    _parseURI                   (uint8_t fromCompId, const QString& uri, QString& parsedURI, uint8_t& compId);
 
     void    _terminateSessionBegin      (void);
     void    _terminateSessionAckOrNak   (const MavlinkFTP::Request* ackOrNak);

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -32,15 +32,16 @@ public:
     FTPManager(Vehicle* vehicle);
 
 	/// Downloads the specified file.
-    ///     @param fromURI  File to download from vehicle, fully qualified path. May be in the format "mftp://[;comp=<id>]..." where the component id is specified.
-    ///                     If component id is not specified MAV_COMP_ID_AUTOPILOT1 is used.
-    ///     @param toDir    Local directory to download file to
-    ///     @param filename (optional)
-    ///     @param checksize (optional, default true) If true compare the filesize indicated in the open
-    ///                     response with the transmitted filesize. If false the transmission is tftp style
-    ///                     and the indicated filesize from MAVFTP fileopen response is ignored.
-    ///                     This is used for the APM parameterdownload where the filesize is wrong due to
-    ///                     a dynamic file creation on the vehicle.
+    ///     @param fromCompId Component id of the component to download from. If fromCompId is MAV_COMP_ID_ALL, then MAV_COMP_ID_AUTOPILOT1 is used.
+    ///     @param fromURI    File to download from component, fully qualified path. May be in the format "mftp://[;comp=<id>]..." where the component id
+    ///                       is specified. If component id is not specified, then the id set via fromCompId is used.
+    ///     @param toDir      Local directory to download file to
+    ///     @param filename   (optional)
+    ///     @param checksize  (optional, default true) If true compare the filesize indicated in the open
+    ///                       response with the transmitted filesize. If false the transmission is tftp style
+    ///                       and the indicated filesize from MAVFTP fileopen response is ignored.
+    ///                       This is used for the APM parameter download where the filesize is wrong due to
+    ///                       a dynamic file creation on the vehicle.
     /// @return true: download has started, false: error, no download
     /// Signals downloadComplete, commandError, commandProgress
     bool download(uint8_t fromCompId, const QString& fromURI, const QString& toDir, const QString& fileName="", bool checksize = true);

--- a/src/Vehicle/FTPManagerTest.cc
+++ b/src/Vehicle/FTPManagerTest.cc
@@ -33,7 +33,7 @@ void FTPManagerTest::_testCaseWorker(const TestCase_t& testCase)
     QSignalSpy spyDownloadComplete(ftpManager, &FTPManager::downloadComplete);
 
     // void downloadComplete   (const QString& file, const QString& errorMsg);
-    ftpManager->download(testCase.file, QStandardPaths::writableLocation(QStandardPaths::TempLocation));
+    ftpManager->download(MAV_COMP_ID_AUTOPILOT1, testCase.file, QStandardPaths::writableLocation(QStandardPaths::TempLocation));
 
     QCOMPARE(spyDownloadComplete.wait(10000), true);
     QCOMPARE(spyDownloadComplete.count(), 1);
@@ -53,7 +53,7 @@ void FTPManagerTest::_sizeTestCaseWorker(int fileSize)
 
     QSignalSpy spyDownloadComplete(ftpManager, &FTPManager::downloadComplete);
 
-    ftpManager->download(filename, QStandardPaths::writableLocation(QStandardPaths::TempLocation));
+    ftpManager->download(MAV_COMP_ID_AUTOPILOT1, filename, QStandardPaths::writableLocation(QStandardPaths::TempLocation));
 
     QCOMPARE(spyDownloadComplete.wait(10000), true);
     QCOMPARE(spyDownloadComplete.count(), 1);
@@ -106,7 +106,7 @@ void FTPManagerTest::_testLostPackets(void)
     QSignalSpy spyDownloadComplete(ftpManager, &FTPManager::downloadComplete);
 
     _mockLink->mockLinkFTP()->enableRandromDrops(true);
-    ftpManager->download(filename, QStandardPaths::writableLocation(QStandardPaths::TempLocation));
+    ftpManager->download(MAV_COMP_ID_AUTOPILOT1, filename, QStandardPaths::writableLocation(QStandardPaths::TempLocation));
 
     QCOMPARE(spyDownloadComplete.wait(10000), true);
     QCOMPARE(spyDownloadComplete.count(), 1);


### PR DESCRIPTION
this PR allows to specify a default compId in MAVFtp downloads, which can be different from MAV_COMP_ID_AUTOPILOT1. 

As before, if the uri includes a [;comp=xxx], the compId used in the ftp is ovberrited to be that specified in the uri. However, if the uri does not contain a compId specifier, it is in general not approriate to assume MAV_COMP_ID_AUTOPILOT1. For instance, if it is a camera.

The PR corrects the behavior for the camera's. It leaves the behaviour unchanged for the ftp downloads in the ParameterManager and componentInformationManager.

The PR has a tiny second change, namely lines https://github.com/mavlink/qgroundcontrol/pull/10488/files#diff-3c77d06c121d54cdd5191ae158a04af0095c441da288069469a948a48abdfaaeR174-R175.  The additional check for sysid should make sense.

Tested with a STorM32 controller which provides a mavlink gimbal and a mavlink camera, which is connected to a ArduPilot flight controller.

The attached screenshots, which show the log in sequence, show that the camera ftp is corretly adressed at CompId 105, even though the uri doesn't have a comp specifier, and the that autopilot param ftp is correctly adressed at CompId 1.

![qgc-ftpcompid-1](https://user-images.githubusercontent.com/6089567/202014596-f537d466-42ee-4ed9-ba9a-e58b941d42af.jpg)

![qgc-ftpcompid-2](https://user-images.githubusercontent.com/6089567/202014610-a12b2b65-bac8-40c2-af1e-ee260c7fe867.jpg)
