### PR TITLE
CMakeLists: Add missing compression on QGC link

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -169,6 +169,7 @@ target_link_libraries(qgc
 		AutoPilotPlugins
 		Camera
 		comm
+		compression
 		FactSystem
 		FirmwarePlugin
 		FlightMap


### PR DESCRIPTION
Fix cmake build