### PR TITLE
Allow selection of first item in ardupilot firmware list

### DIFF
--- a/src/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/VehicleSetup/FirmwareUpgrade.qml
@@ -208,7 +208,7 @@ SetupPage {
                                             firmwareSelectDialog.preventClose = true
                                             return
                                         }
-                                        if (ardupilotFirmwareSelectionCombo.currentIndex == 0) {
+                                        if (ardupilotFirmwareSelectionCombo.currentIndex == -1) {
                                             mainWindow.showMessageDialog(firmwareSelectDialog.title, qsTr("You must choose a board type."))
                                             firmwareSelectDialog.preventClose = true
                                             return


### PR DESCRIPTION
Ardupilot firmware flash was broken. You couldn't pick the first item in the firmware list. Especially problematic if there was only one firmware option!