### PR TITLE
translation: Fix translation of Item #%1

### DIFF
--- a/translations/qgc_source_zh_CN.ts
+++ b/translations/qgc_source_zh_CN.ts
@@ -10170,7 +10170,7 @@ Click Ok to start the auto-tuning process.
     <message>
       <location filename="../src/PlanView/MissionItemEditor.qml" line="251"/>
       <source>Item #%1</source>
-      <translation>项目 1</translation>
+      <translation>项目 #%1</translation>
     </message>
     <message>
       <location filename="../src/PlanView/MissionItemEditor.qml" line="155"/>


### PR DESCRIPTION
Fixes translation issue reported in:

https://github.com/mavlink/qgroundcontrol/issues/10329

Is this the right place to fix this? I only have a rough idea of the translation workflow.
