### PR TITLE
Remove RC Throttle trim calibration value getting hard-set to Minimum value

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -462,13 +462,6 @@ void RadioComponentController::_inputStickMin(enum rcCalFunctions function, int 
 
             qCDebug(RadioComponentControllerLog) << "_inputStickMin Settle complete";
 
-            // Check if this is throttle and set trim accordingly
-            if (function == rcCalFunctionThrottle) {
-                _rgChannelInfo[channel].rcTrim = value;
-            }
-            // XXX to support configs which can reverse they need to check a reverse
-            // flag here and not do this.
-
             _advanceState();
         }
     }


### PR DESCRIPTION
## Descrption
A hotfix commit from 7 years ago was forcing RC transmitters to always have a trim value set to 'Min', effectively only allowing the [0, 1] range of the `manual_control_setpoint.throttle`.

This was the commit: https://github.com/mavlink/qgroundcontrol/commit/0577af2e944a0f53919aeb1367d580f744004b2c

## Changes
Removed this hotfix, and allows setting the trim values automatically in the state machine (need to check logic once again)

## Context
The discussion that discovered this flaw is here: https://github.com/PX4/PX4-Autopilot/pull/15949#issuecomment-1318728541

## TODOs
- [ ] I am still unclear how the rcTrim value would then get set for throttle, need to check the state machine logic to be sure.
