### PR TITLE
Github actions: Fix deprecation warning for node12

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -89,7 +89,5 @@ jobs:
               export QT_FATAL_WARNINGS=1
 
       - name: Run unit tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          working-directory:  ${{ runner.temp }}/shadow_build_dir  
-          run:                ./staging/qgroundcontrol-start.sh --unittest
+        working-directory:  ${{ runner.temp }}/shadow_build_dir  
+        run:                xvfb-run -a ./staging/qgroundcontrol-start.sh --unittest


### PR DESCRIPTION
"Node.js 12 actions are deprecated. For more information see:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Please update the following actions to use Node.js 16:

GabrielBB/xvfb-action@v1"

Replaces the obsolete action as suggested by @alisonatwork in

https://github.com/GabrielBB/xvfb-action/issues/30#issuecomment-1335389183


