### PR TITLE
PlanManager: drop spurious items for unexpected mission types

### DIFF
--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -389,9 +389,9 @@ void PlanManager::_handleMissionItem(const mavlink_message_t& message)
     mavlink_mission_item_int_t missionItem;
     mavlink_msg_mission_item_int_decode(&message, &missionItem);
 
-    command =       (MAV_CMD)missionItem.command,
-            frame =         (MAV_FRAME)missionItem.frame,
-            param1 =        missionItem.param1;
+    command =       (MAV_CMD)missionItem.command;
+    frame =         (MAV_FRAME)missionItem.frame;
+    param1 =        missionItem.param1;
     param2 =        missionItem.param2;
     param3 =        missionItem.param3;
     param4 =        missionItem.param4;

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -373,24 +373,26 @@ void PlanManager::_requestNextMissionItem(void)
 
 void PlanManager::_handleMissionItem(const mavlink_message_t& message)
 {
-    MAV_CMD     command;
-    MAV_FRAME   frame;
-    double      param1;
-    double      param2;
-    double      param3;
-    double      param4;
-    double      param5;
-    double      param6;
-    double      param7;
-    bool        autoContinue;
-    bool        isCurrentItem;
-    int         seq;
+    MAV_CMD          command;
+    MAV_FRAME        frame;
+    MAV_MISSION_TYPE missionType;
+    double           param1;
+    double           param2;
+    double           param3;
+    double           param4;
+    double           param5;
+    double           param6;
+    double           param7;
+    bool             autoContinue;
+    bool             isCurrentItem;
+    int              seq;
 
     mavlink_mission_item_int_t missionItem;
     mavlink_msg_mission_item_int_decode(&message, &missionItem);
 
     command =       (MAV_CMD)missionItem.command;
     frame =         (MAV_FRAME)missionItem.frame;
+    missionType =   (MAV_MISSION_TYPE)missionItem.mission_type;
     param1 =        missionItem.param1;
     param2 =        missionItem.param2;
     param3 =        missionItem.param3;
@@ -401,6 +403,13 @@ void PlanManager::_handleMissionItem(const mavlink_message_t& message)
     autoContinue =  missionItem.autocontinue;
     isCurrentItem = missionItem.current;
     seq =           missionItem.seq;
+
+    // Check the mission_type field. It can happen that we receive a late duplicate message for a
+    // different mission_type request.
+    if (missionType != _planType) {
+       qCDebug(PlanManagerLog) << QStringLiteral("_handleMissionItem %1 dropping spurious item seq:command:missionType").arg(_planTypeString()) << seq << command << missionType;
+       return;
+    }
 
     // We don't support editing ALT_INT frames so change on the way in.
     if (frame == MAV_FRAME_GLOBAL_INT) {


### PR DESCRIPTION
With the short timeout on requesting mission items, some items are requested multiple times. That's usually no problem as spurious items are ignored. However if we moved on to requesting items for a different mission type, say fences, then a spurious duplicate would confuse the manager who would just accept it, and later complain that the command is invalid for this mission type.

The root cause is that the mission type of incoming mission items is not checked, which is an easy fix.