### PR TITLE
APM: Change the ZIGZAG in the flight mode list to one

### DIFF
--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -77,7 +77,6 @@ ArduCopterFirmwarePlugin::ArduCopterFirmwarePlugin(void)
         APMCopterMode(APMCopterMode::FLOWHOLD,      true),
         APMCopterMode(APMCopterMode::FOLLOW,        true),
         APMCopterMode(APMCopterMode::ZIGZAG,        true),
-        APMCopterMode(APMCopterMode::ZIGZAG,        true),
         APMCopterMode(APMCopterMode::SYSTEMID,      true),
         APMCopterMode(APMCopterMode::AUTOROTATE,    true),
         APMCopterMode(APMCopterMode::AUTO_RTL,      true),


### PR DESCRIPTION
Two ZIGZAGs showed up in the flight mode list.
I set it to one.