### PR TITLE
uas: Converts a plain text string to an HTML string replaced by HTML entities

### DIFF
--- a/src/uas/UASMessageHandler.cc
+++ b/src/uas/UASMessageHandler.cc
@@ -187,7 +187,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     if (_multiComp) {
         compString = QString(" COMP:%1").arg(compId);
     }
-    message->_setFormatedText(QString("<font style=\"%1\">[%2%3]%4 %5</font><br/>").arg(style).arg(dateString).arg(compString).arg(severityText).arg(text));
+    message->_setFormatedText(QString("<font style=\"%1\">[%2%3]%4 %5</font><br/>").arg(style).arg(dateString).arg(compString).arg(severityText).arg(text.toHtmlEscaped()));
 
     if (message->severityIsError()) {
         _latestError = severityText + " " + text;
@@ -202,7 +202,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     emit textMessageCountChanged(count);
 
     if (_showErrorsInToolbar && message->severityIsError()) {
-        _app->showCriticalVehicleMessage(message->getText());
+        _app->showCriticalVehicleMessage(message->getText().toHtmlEscaped());
     }
 }
 


### PR DESCRIPTION
Messages are displayed in HTML format.
ArduPilot uses "<" for IMU heater temperature notification.
The ArduPilot does not display anything below this symbol.
Converts a plain text string to an HTML string with HTML metacharacters <, >, &, and " replaced by HTML entities.

AFTER
![スクリーンショット_2023-01-07_00-43-59](https://user-images.githubusercontent.com/646194/211054596-ac936247-8dd1-4da6-b64b-201b3242532f.png)
![スクリーンショット_2023-01-07_00-43-41](https://user-images.githubusercontent.com/646194/211054602-7f517874-b2e4-4291-877e-ec94406185c4.png)

BEFORE
![スクリーンショット_2023-01-07_00-14-32](https://user-images.githubusercontent.com/646194/211054522-77da2104-f2bb-4d0d-ac39-88d8be24d842.png)
![スクリーンショット_2023-01-07_00-14-06](https://user-images.githubusercontent.com/646194/211054529-59402ac0-ca35-46be-af9b-1369b5c7c35b.png)

