### PR TITLE
Joystick: Enable button up signal for hat buttons

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -520,6 +520,8 @@ void Joystick::_handleButtons()
             int rgButtonValueIndex = hatIndex*numHatButtons + hatButtonIndex + _buttonCount;
             // Get hat value from joystick
             bool newButtonValue = _getHat(hatIndex, hatButtonIndex);
+            if(rgButtonValueIndex < 256)
+                lastBbuttonValues[rgButtonValueIndex] = _rgButtonValues[rgButtonValueIndex];
             if (newButtonValue && _rgButtonValues[rgButtonValueIndex] == BUTTON_UP) {
                 _rgButtonValues[rgButtonValueIndex] = BUTTON_DOWN;
                 emit rawButtonPressedChanged(rgButtonValueIndex, newButtonValue);


### PR DESCRIPTION
Releasing a hat button did not lead to _executeButtonAction being called with BUTTON_UP. This adds the hat buttons to lastBbuttonValues, such that the button up transitions for hat buttons are recorded. 