### PR TITLE
Fix failing android workflow by removing android-33-ext4 from build image

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -63,6 +63,9 @@ jobs:
           ndk-version: r21e
           add-to-path: false
 
+      - name: Remove Android SDK android-33-ext4
+        run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext4"
+
       - name: Install ccache
         run:  sudo apt-get install ccache
 


### PR DESCRIPTION
Github workflow image ubuntu-20.04 version 20230109.1 have added Android SDK Platform android-33-ext4. Something, possible the gradle version bundled with qt does not parse this correctly, and sets androidCompileSdkVersion in android-build/gradle.properties to "ext4" instead of expected "33". This commit is a quick fix to the problem, so the build will revert to android-33 wich was used before 20230109.1.

The documentation for the added package in the image version can be found here:
https://github.com/actions/runner-images/pull/6895

