### PR TITLE
Update QGCMapUrlEngine for wrong new() constructor

### DIFF
--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -42,7 +42,7 @@ UrlFactory::UrlFactory() : _timeout(5 * 1000) {
     _providersTable["Google Satellite"]  = new GoogleSatelliteMapProvider(this);
     _providersTable["Google Terrain"]    = new GoogleTerrainMapProvider(this);
     _providersTable["Google Hybrid"]    = new GoogleHybridMapProvider(this);
-    _providersTable["Google Labels"]     = new GoogleTerrainMapProvider(this);
+    _providersTable["Google Labels"]     = new GoogleLabelsMapProvider(this);
 #endif
 
     _providersTable["Bing Road"]      = new BingRoadMapProvider(this);


### PR DESCRIPTION
The `_providersTable["Google Labels"]` has been constructed with `GoogleTerrainMapProvider` class as wrongly. It have to construct with `GoogleLabelsMapProvider` class.


