### PR TITLE
Add custom actions to Fly View

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -431,6 +431,8 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 #
 
 HEADERS += \
+    src/QmlControls/CustomAction.h \
+    src/QmlControls/CustomActionManager.h \
     src/QmlControls/QmlUnitsConversion.h \
     src/Vehicle/VehicleEscStatusFactGroup.h \
     src/api/QGCCorePlugin.h \
@@ -445,6 +447,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 }
 
 SOURCES += \
+    src/QmlControls/CustomActionManager.cc \
     src/Vehicle/VehicleEscStatusFactGroup.cc \
     src/api/QGCCorePlugin.cc \
     src/api/QGCOptions.cc \

--- a/src/FlightDisplay/GuidedActionList.qml
+++ b/src/FlightDisplay/GuidedActionList.qml
@@ -14,6 +14,7 @@ import QtQuick.Layouts  1.2
 import QGroundControl               1.0
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Controls      1.0
+import QGroundControl.Controllers   1.0
 import QGroundControl.FlightDisplay 1.0
 import QGroundControl.Palette       1.0
 
@@ -71,6 +72,11 @@ Rectangle {
         }
     ]
 
+    property var _customManager: CustomActionManager {
+        id: customManager
+    }
+    readonly property bool hasCustomActions: QGroundControl.settingsManager.flyViewSettings.enableCustomActions.rawValue && customManager.hasActions
+
     QGCPalette { id: qgcPal }
 
     DeadMouseArea {
@@ -102,6 +108,7 @@ Rectangle {
                 id:         actionRow
                 spacing:    _actionHorizSpacing
 
+                // These are the pre-defined Actions
                 Repeater {
                     id:     actionRepeater
                     model:  _model
@@ -119,8 +126,6 @@ Rectangle {
                             Layout.minimumWidth:    _actionWidth
                             Layout.maximumWidth:    _actionWidth
                             Layout.fillHeight:      true
-
-                            property real _width: ScreenTools.defaultFontPixelWidth * 25
                         }
 
                         QGCButton {
@@ -133,8 +138,41 @@ Rectangle {
                                 guidedController.confirmAction(modelData.action)
                             }
                         }
-                    }
-                }
+                    } // ColumnLayout
+                } // Repeater
+
+                // These are the user-defined Custom Actions
+                Repeater {
+                    id:     customRepeater
+                    model:  customManager.actions
+
+                    ColumnLayout {
+                        spacing:            ScreenTools.defaultFontPixelHeight / 2
+                        visible:            _root.hasCustomActions
+                        Layout.fillHeight:  true
+
+                        QGCLabel {
+                            id:                     customMessage
+                            text:                   "Custom Action #" + (index + 1)
+                            horizontalAlignment:    Text.AlignHCenter
+                            wrapMode:               Text.WordWrap
+                            Layout.minimumWidth:    _actionWidth
+                            Layout.maximumWidth:    _actionWidth
+                            Layout.fillHeight:      true
+                        }
+
+                        QGCButton {
+                            id:                 customButton
+                            text:               object.label
+                            Layout.alignment:   Qt.AlignCenter
+
+                            onClicked: {
+                                var vehicle = QGroundControl.multiVehicleManager.activeVehicle
+                                object.sendTo(vehicle)
+                            }
+                        }
+                    } // ColumnLayout
+                } // Repeater
             }
         }
     }

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -130,7 +130,7 @@ Item {
     property bool showROI:              _guidedActionsEnabled && _vehicleFlying && __roiSupported && !_missionActive
     property bool showLandAbort:        _guidedActionsEnabled && _vehicleFlying && _fixedWingOnApproach
     property bool showGotoLocation:     _guidedActionsEnabled && _vehicleFlying
-    property bool showActionList:       _guidedActionsEnabled && (showStartMission || showResumeMission || showChangeAlt || showLandAbort)
+    property bool showActionList:       _guidedActionsEnabled && (showStartMission || showResumeMission || showChangeAlt || showLandAbort || actionList.hasCustomActions)
     property string changeSpeedTitle:   _fixedWing ? changeAirspeedTitle : changeCruiseSpeedTitle
     property string changeSpeedMessage: _fixedWing ? changeAirspeedMessage : changeCruiseSpeedMessage
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -102,6 +102,8 @@
 #include "QGCMAVLink.h"
 #include "VehicleLinkManager.h"
 #include "Autotune.h"
+#include "CustomAction.h"
+#include "CustomActionManager.h"
 
 #if defined(QGC_ENABLE_PAIRING)
 #include "PairingManager.h"
@@ -511,6 +513,8 @@ void QGCApplication::_initCommon()
     qmlRegisterType<SyslinkComponentController>     (kQGCControllers,                       1, 0, "SyslinkComponentController");
     qmlRegisterType<EditPositionDialogController>   (kQGCControllers,                       1, 0, "EditPositionDialogController");
     qmlRegisterType<RCToParamDialogController>      (kQGCControllers,                       1, 0, "RCToParamDialogController");
+    qmlRegisterType<CustomAction>                   (kQGCControllers,                       1, 0, "CustomAction");
+    qmlRegisterType<CustomActionManager>            (kQGCControllers,                       1, 0, "CustomActionManager");
 
     qmlRegisterType<TerrainProfile>                 ("QGroundControl.Controls",             1, 0, "TerrainProfile");
     qmlRegisterType<ToolStripAction>                ("QGroundControl.Controls",             1, 0, "ToolStripAction");

--- a/src/QmlControls/CustomAction.h
+++ b/src/QmlControls/CustomAction.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ * (c) 2009-2023 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include <QObject>
+
+#include "MAVLinkProtocol.h"
+#include "Vehicle.h"
+
+class CustomAction: public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString label   READ label   CONSTANT)
+
+
+public:
+    CustomAction() { CustomAction("", MAV_CMD(0)); } // this is required for QML reflection
+    CustomAction(
+            QString label,
+            MAV_CMD mavCmd,
+            MAV_COMPONENT compId = MAV_COMP_ID_AUTOPILOT1,
+            float param1 = 0.0f,
+            float param2 = 0.0f,
+            float param3 = 0.0f,
+            float param4 = 0.0f,
+            float param5 = 0.0f,
+            float param6 = 0.0f,
+            float param7 = 0.0f
+    ):
+        _label(label),
+        _mavCmd(mavCmd),
+        _compId(compId),
+        _params{ param1, param2, param3, param4, param5, param6, param7 }
+    {};
+
+    Q_INVOKABLE void sendTo(Vehicle* vehicle) {
+        if (vehicle) {
+            const bool showError = true;
+            vehicle->sendMavCommand(_compId, _mavCmd, showError, _params[0], _params[1], _params[2], _params[3], _params[4], _params[5], _params[6]);
+        }
+    };
+
+
+private:
+    QString  label() const  { return _label; }
+
+    QString _label;
+    MAV_CMD _mavCmd;
+    MAV_COMPONENT _compId;
+    float _params[7];
+
+};

--- a/src/QmlControls/CustomActionManager.cc
+++ b/src/QmlControls/CustomActionManager.cc
@@ -1,0 +1,96 @@
+/****************************************************************************
+ *
+ * (c) 2009-2023 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include <QQmlEngine>
+
+#include "CustomActionManager.h"
+#include "CustomAction.h"
+#include "JsonHelper.h"
+#include "QGCApplication.h"
+#include "SettingsManager.h"
+
+CustomActionManager::CustomActionManager(void) {
+    auto flyViewSettings = qgcApp()->toolbox()->settingsManager()->flyViewSettings();
+    Fact* customActionsFact = flyViewSettings->customActionDefinitions();
+
+    connect(customActionsFact, &Fact::valueChanged, this, &CustomActionManager::_loadFromJson);
+    _loadFromJson(customActionsFact->rawValue());
+}
+
+void CustomActionManager::_loadFromJson(QVariant fact) {
+    QString path = fact.toString();
+
+    const char* kQgcFileType = "CustomActions";
+    const char* kActionListKey = "actions";
+
+    _actions.clearAndDeleteContents();
+
+    QString errorString;
+    int version;
+    QJsonObject jsonObject = JsonHelper::openInternalQGCJsonFile(path, kQgcFileType, 1, 1, version, errorString);
+    if (!errorString.isEmpty()) {
+        qWarning() << "Custom Actions Internal Error: " << errorString;
+        emit actionsChanged();
+        return;
+    }
+
+    QList<JsonHelper::KeyValidateInfo> keyInfoList = {
+        { kActionListKey, QJsonValue::Array, /* required= */ true },
+    };
+    if (!JsonHelper::validateKeys(jsonObject, keyInfoList, errorString)) {
+        qWarning() << "Custom Actions JSON document incorrect format:" << errorString;
+        emit actionsChanged();
+        return;
+    }
+
+    QJsonArray actionList = jsonObject[kActionListKey].toArray();
+    for (auto actionJson: actionList) {
+        if (!actionJson.isObject()) {
+            qWarning() << "Custom Actions JsonValue not an object: " << actionJson;
+            continue;
+        }
+
+        auto actionObj = actionJson.toObject();
+
+        QList<JsonHelper::KeyValidateInfo> actionKeyInfoList = {
+            { "label",  QJsonValue::String, /* required= */ true },
+            { "mavCmd", QJsonValue::Double, /* required= */ true },
+
+            { "compId", QJsonValue::Double, /* required= */ false },
+            { "param1", QJsonValue::Double, /* required= */ false },
+            { "param2", QJsonValue::Double, /* required= */ false },
+            { "param3", QJsonValue::Double, /* required= */ false },
+            { "param4", QJsonValue::Double, /* required= */ false },
+            { "param5", QJsonValue::Double, /* required= */ false },
+            { "param6", QJsonValue::Double, /* required= */ false },
+            { "param7", QJsonValue::Double, /* required= */ false },
+        };
+        if (!JsonHelper::validateKeys(actionObj, actionKeyInfoList, errorString)) {
+            qWarning() << "Custom Actions JSON document incorrect format:" << errorString;
+            continue;
+        }
+
+        auto label = actionObj["label"].toString();
+        auto mavCmd = (MAV_CMD)actionObj["mavCmd"].toInt();
+        auto compId = (MAV_COMPONENT)actionObj["compId"].toInt(MAV_COMP_ID_AUTOPILOT1);
+        auto param1 = actionObj["param1"].toDouble(0.0);
+        auto param2 = actionObj["param2"].toDouble(0.0);
+        auto param3 = actionObj["param3"].toDouble(0.0);
+        auto param4 = actionObj["param4"].toDouble(0.0);
+        auto param5 = actionObj["param5"].toDouble(0.0);
+        auto param6 = actionObj["param6"].toDouble(0.0);
+        auto param7 = actionObj["param7"].toDouble(0.0);
+
+        CustomAction* action = new CustomAction(label, mavCmd, compId, param1, param2, param3, param4, param5, param6, param7);
+        QQmlEngine::setObjectOwnership(action, QQmlEngine::CppOwnership);
+        _actions.append(action);
+    }
+
+    emit actionsChanged();
+}

--- a/src/QmlControls/CustomActionManager.h
+++ b/src/QmlControls/CustomActionManager.h
@@ -1,0 +1,37 @@
+/****************************************************************************
+ *
+ * (c) 2009-2023 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include <QObject>
+#include <QmlObjectListModel.h>
+
+
+class CustomActionManager : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QmlObjectListModel*  actions     READ  actions     NOTIFY  actionsChanged)
+    Q_PROPERTY(bool                 hasActions  READ  hasActions  NOTIFY  actionsChanged)
+
+public:
+    CustomActionManager(void);
+
+    QmlObjectListModel* actions(void) { return &_actions; }
+    bool hasActions(void) { return  _actions.count() > 0; }
+
+signals:
+    void actionsChanged();
+
+private slots:
+    void _loadFromJson(QVariant path);
+
+private:
+    QmlObjectListModel  _actions;
+    bool _hasActions;
+
+};

--- a/src/QmlControls/CustomActions.json
+++ b/src/QmlControls/CustomActions.json
@@ -1,0 +1,22 @@
+{
+    "version":  1,
+    "fileType": "CustomActions",
+    "actions": [
+        {
+            "label":  "Image Start Capture",
+            "mavCmd": 2000,
+            "compId": 1,
+            "param1": 0,
+            "param2": 0,
+            "param3": 0,
+            "param4": 0,
+            "param5": 0,
+            "param6": 0,
+            "param7": 0
+        },
+        {
+            "label":  "Image Stop Capture",
+            "mavCmd": 2001
+        }
+    ]
+}

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -34,6 +34,7 @@ const char* AppSettings::logDirectory =             QT_TRANSLATE_NOOP("AppSettin
 const char* AppSettings::videoDirectory =           QT_TRANSLATE_NOOP("AppSettings", "Video");
 const char* AppSettings::photoDirectory =           QT_TRANSLATE_NOOP("AppSettings", "Photo");
 const char* AppSettings::crashDirectory =           QT_TRANSLATE_NOOP("AppSettings", "CrashLogs");
+const char* AppSettings::customActionsDirectory =   QT_TRANSLATE_NOOP("AppSettings", "CustomActions");
 
 // Release languages are 90%+ complete
 QList<int> AppSettings::_rgReleaseLanguages = {
@@ -217,6 +218,7 @@ void AppSettings::_checkSavePathDirectories(void)
         savePathDir.mkdir(videoDirectory);
         savePathDir.mkdir(photoDirectory);
         savePathDir.mkdir(crashDirectory);
+        savePathDir.mkdir(customActionsDirectory);
     }
 }
 
@@ -291,6 +293,16 @@ QString AppSettings::crashSavePath(void)
     if (!path.isEmpty() && QDir(path).exists()) {
         QDir dir(path);
         return dir.filePath(crashDirectory);
+    }
+    return QString();
+}
+
+QString AppSettings::customActionsSavePath(void)
+{
+    QString path = savePath()->rawValue().toString();
+    if (!path.isEmpty() && QDir(path).exists()) {
+        QDir dir(path);
+        return dir.filePath(customActionsDirectory);
     }
     return QString();
 }

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -70,13 +70,14 @@ public:
     // Although this is a global setting it only affects ArduPilot vehicle since PX4 automatically starts the stream from the vehicle side
     DEFINE_SETTINGFACT(apmStartMavlinkStreams)
 
-    Q_PROPERTY(QString missionSavePath      READ missionSavePath    NOTIFY savePathsChanged)
-    Q_PROPERTY(QString parameterSavePath    READ parameterSavePath  NOTIFY savePathsChanged)
-    Q_PROPERTY(QString telemetrySavePath    READ telemetrySavePath  NOTIFY savePathsChanged)
-    Q_PROPERTY(QString logSavePath          READ logSavePath        NOTIFY savePathsChanged)
-    Q_PROPERTY(QString videoSavePath        READ videoSavePath      NOTIFY savePathsChanged)
-    Q_PROPERTY(QString photoSavePath        READ photoSavePath      NOTIFY savePathsChanged)
-    Q_PROPERTY(QString crashSavePath        READ crashSavePath      NOTIFY savePathsChanged)
+    Q_PROPERTY(QString missionSavePath          READ missionSavePath            NOTIFY savePathsChanged)
+    Q_PROPERTY(QString parameterSavePath        READ parameterSavePath          NOTIFY savePathsChanged)
+    Q_PROPERTY(QString telemetrySavePath        READ telemetrySavePath          NOTIFY savePathsChanged)
+    Q_PROPERTY(QString logSavePath              READ logSavePath                NOTIFY savePathsChanged)
+    Q_PROPERTY(QString videoSavePath            READ videoSavePath              NOTIFY savePathsChanged)
+    Q_PROPERTY(QString photoSavePath            READ photoSavePath              NOTIFY savePathsChanged)
+    Q_PROPERTY(QString crashSavePath            READ crashSavePath              NOTIFY savePathsChanged)
+    Q_PROPERTY(QString customActionsSavePath    READ customActionsSavePath      NOTIFY savePathsChanged)
 
     Q_PROPERTY(QString planFileExtension        MEMBER planFileExtension        CONSTANT)
     Q_PROPERTY(QString missionFileExtension     MEMBER missionFileExtension     CONSTANT)
@@ -87,13 +88,14 @@ public:
     Q_PROPERTY(QString shpFileExtension         MEMBER shpFileExtension         CONSTANT)
     Q_PROPERTY(QString logFileExtension         MEMBER logFileExtension         CONSTANT)
 
-    QString missionSavePath     ();
-    QString parameterSavePath   ();
-    QString telemetrySavePath   ();
-    QString logSavePath         ();
-    QString videoSavePath       ();
-    QString photoSavePath       ();
-    QString crashSavePath       ();
+    QString missionSavePath       ();
+    QString parameterSavePath     ();
+    QString telemetrySavePath     ();
+    QString logSavePath           ();
+    QString videoSavePath         ();
+    QString photoSavePath         ();
+    QString crashSavePath         ();
+    QString customActionsSavePath ();
 
     // Helper methods for working with firstRunPromptIds QVariant settings string list
     static QList<int> firstRunPromptsIdsVariantToList   (const QVariant& firstRunPromptIds);
@@ -120,6 +122,7 @@ public:
     static const char* videoDirectory;
     static const char* photoDirectory;
     static const char* crashDirectory;
+    static const char* customActionsDirectory;
 
     // Returns the current qLocaleLanguage setting bypassing the standard SettingsGroup path. This should only be used
     // by QGCApplication::setLanguage to query the language setting as early in the boot process as possible.

--- a/src/Settings/FlyView.SettingsGroup.json
+++ b/src/Settings/FlyView.SettingsGroup.json
@@ -72,6 +72,19 @@
     "shortDesc": "Send updated GCS' home position to autopilot in case of change of the home position",
     "type":                 "bool",
     "default":              false
+},
+{
+    "name":      "enableCustomActions",
+    "shortDesc": "Enable Custom Actions",
+    "type":      "bool",
+    "default":   false
+},
+{
+    "name":      "customActionDefinitions",
+    "shortDesc": "Custom Action Definitions",
+    "longDesc":  "File that defines custom actions to send connected vehicle",
+    "type":      "string",
+    "default":   ""
 }
 ]
 }

--- a/src/Settings/FlyViewSettings.cc
+++ b/src/Settings/FlyViewSettings.cc
@@ -28,4 +28,6 @@ DECLARE_SETTINGSFACT(FlyViewSettings, keepMapCenteredOnVehicle)
 DECLARE_SETTINGSFACT(FlyViewSettings, showSimpleCameraControl)
 DECLARE_SETTINGSFACT(FlyViewSettings, showObstacleDistanceOverlay)
 DECLARE_SETTINGSFACT(FlyViewSettings, updateHomePosition)
+DECLARE_SETTINGSFACT(FlyViewSettings, enableCustomActions)
+DECLARE_SETTINGSFACT(FlyViewSettings, customActionDefinitions)
 

--- a/src/Settings/FlyViewSettings.h
+++ b/src/Settings/FlyViewSettings.h
@@ -30,4 +30,6 @@ public:
     DEFINE_SETTINGFACT(showSimpleCameraControl)
     DEFINE_SETTINGFACT(showObstacleDistanceOverlay)
     DEFINE_SETTINGFACT(updateHomePosition)
+    DEFINE_SETTINGFACT(enableCustomActions)
+    DEFINE_SETTINGFACT(customActionDefinitions)
 };

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -188,6 +188,70 @@ Rectangle {
                                 property Fact _updateHomePosition: QGroundControl.settingsManager.flyViewSettings.updateHomePosition
                             }
 
+                            FactCheckBox {
+                                text:       qsTr("Enable Custom Actions")
+                                visible:    _enableCustomActions.visible
+                                fact:       _enableCustomActions
+
+                                property Fact _enableCustomActions: QGroundControl.settingsManager.flyViewSettings.enableCustomActions
+                            }
+
+                            //-----------------------------------------------------------------
+                            //-- CustomAction definition path
+                            GridLayout {
+                                id: customActions
+
+                                columns:  2
+                                visible:  QGroundControl.settingsManager.flyViewSettings.enableCustomActions.rawValue
+
+                                onVisibleChanged: {
+                                    if (jsonFile.rawValue === "" && ScreenTools.isMobile) {
+                                        jsonFile.rawValue = _defaultFile
+                                    }
+                                }
+
+                                property Fact   jsonFile:     QGroundControl.settingsManager.flyViewSettings.customActionDefinitions
+                                property string _defaultDir:  QGroundControl.settingsManager.appSettings.customActionsSavePath
+                                property string _defaultFile: _defaultDir + "/CustomActions.json"
+
+                                QGCLabel {
+                                    text: qsTr("Custom Action Definitions")
+
+                                    Layout.columnSpan:  2
+                                    Layout.alignment:   Qt.AlignHCenter
+                                }
+
+                                QGCTextField {
+                                    Layout.fillWidth:   true
+                                    readOnly:           true
+                                    text:               customActions.jsonFile.rawValue === "" ? qsTr("<not set>") : customActions.jsonFile.rawValue
+                                }
+                                QGCButton {
+                                    visible:    !ScreenTools.isMobile
+                                    text:       qsTr("Browse")
+                                    onClicked:  customActionPathBrowseDialog.openForLoad()
+                                    QGCFileDialog {
+                                        id:             customActionPathBrowseDialog
+                                        title:          qsTr("Choose the Custom Action Definitions file")
+                                        folder:         customActions.jsonFile.rawValue
+                                        selectExisting: true
+                                        selectFolder:   false
+                                        onAcceptedForLoad: customActions.jsonFile.rawValue = file
+                                        nameFilters: ["JSON files (*.json)"]
+                                    }
+                                }
+                                // The file loader on Android doesn't work, so we hard code the path to the
+                                // JSON file. However, we need a button to force a refresh if the JSON file
+                                // is changed.
+                                QGCButton {
+                                    visible:    ScreenTools.isMobile
+                                    text:       qsTr("Reload")
+                                    onClicked:  {
+                                        customActions.jsonFile.valueChanged(customActions.jsonFile.rawValue)
+                                    }
+                                }
+                            }
+
                             GridLayout {
                                 columns: 2
 


### PR DESCRIPTION
# Summary

This PR adds user-customisable action buttons to the Fly View. The buttons are configurable via a user-selected JSON file, and when clicked, will send a MAVLink command to the active vehicle.

The use case for this is when operating a vehicle with capabilities that do not have built-in controls in QGC, such as vehicles with landing gear.

# Details

There are two new Fly View settings added:
1. a setting to enable the Custom Actions; and
2. a setting to provide the JSON file used to define the Custom Actions.
![Custom Actions - settings](https://user-images.githubusercontent.com/48079543/217442710-d63ff05f-aadd-4a70-9601-e7e5f64d9258.png)

When enabled in the Settings, and with an active vehicle connected, the Custom Actions look like the following:
![Custom Actions - visible](https://user-images.githubusercontent.com/48079543/217441033-75a4916d-0150-40f8-8ab4-04306fac1511.png)

The Custom Actions button will be visible but will be disabled if either:
1. the JSON file is invalid (i.e. is malformed or doesn't contain any action definitions); or
3. there is no active vehicle connected;

as shown in the following:
![Custom Actions - disabled](https://user-images.githubusercontent.com/48079543/217441029-e9573980-c332-4dae-8b28-b50d4e9a4d82.png)

Due to issues with the file loader on Android, this PR currently hard codes the path for the Custom Actions definition JSON file on mobile devices.
