### PR TITLE
FirmwareUpgrade: add CubeOrange+

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -82,6 +82,7 @@ static QMap<int, QString> px4_board_name_map {
     {136, "mro_x21-777_default"},
     {139, "holybro_durandal-v1_default"},
     {140, "cubepilot_cubeorange_default"},
+    {1063, "cubepilot_cubeorangeplus_default"},
     {141, "mro_ctrl-zero-f7_default"},
     {142, "mro_ctrl-zero-f7-oem_default"},
     {1009, "cuav_nora_default"},

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -36,7 +36,7 @@
 
         { "vendorID": 12642, "productID": 0,        "boardClass": "Pixhawk",    "name": "Holybro" },
 
-        { "vendorID": 11694, "productID": 0,        "boardClass": "Pixhawk",    "name": "Hex/ProfiCNC" },
+        { "vendorID": 11694, "productID": 0,        "boardClass": "Pixhawk",    "name": "CubePilot" },
 
         { "vendorID": 13735, "productID": 1,        "boardClass": "Pixhawk",    "name": "ThePeach FCC-K1" },
         { "vendorID": 13735, "productID": 2,        "boardClass": "Pixhawk",    "name": "ThePeach FCC-R1" },


### PR DESCRIPTION
This is according to https://github.com/PX4/PX4-Bootloader/blob/main/board_types.txt

FYI @bugobliterator