### PR TITLE
Fix Analyze Page popup ownership

### DIFF
--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -127,43 +127,8 @@ Rectangle {
         property string title
 
         Connections {
-            target: panelLoader.item
-            onPopout: {
-                var windowedPage = windowedAnalyzePage.createObject(mainWindow)
-                windowedPage.title = panelLoader.title
-                windowedPage.source = panelLoader.source
-                _root.popout()
-            }
+            target:     panelLoader.item
+            onPopout:   mainWindow.createrWindowedAnalyzePage(panelLoader.title, panelLoader.source)
         }
-
-    }
-
-    Component {
-        id: windowedAnalyzePage
-
-        Window {
-            width:      ScreenTools.defaultFontPixelWidth  * 100
-            height:     ScreenTools.defaultFontPixelHeight * 40
-            visible:    true
-
-            property alias source: loader.source
-
-            Rectangle {
-                color:          QGroundControl.globalPalette.window
-                anchors.fill:   parent
-
-                Loader {
-                    id:             loader
-                    anchors.fill:   parent
-                    onLoaded:       item.popped = true
-                }
-            }
-
-            onClosing: {
-                visible = false
-                source = ""
-            }
-        }
-
     }
 }

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -666,4 +666,42 @@ ApplicationWindow {
             indicatorPopup.currentIndicator = null
         }
     }
+
+    // We have to create the popup windows for the Analyze pages here so that the creation context is rooted
+    // to mainWindow. Otherwise if they are rooted to the AnalyzeView itself they will die when the analyze viewSwitch
+    // closes.
+
+    function createrWindowedAnalyzePage(title, source) {
+        var windowedPage = windowedAnalyzePage.createObject(mainWindow)
+        windowedPage.title = title
+        windowedPage.source = source
+    }
+
+    Component {
+        id: windowedAnalyzePage
+
+        Window {
+            width:      ScreenTools.defaultFontPixelWidth  * 100
+            height:     ScreenTools.defaultFontPixelHeight * 40
+            visible:    true
+
+            property alias source: loader.source
+
+            Rectangle {
+                color:          QGroundControl.globalPalette.window
+                anchors.fill:   parent
+
+                Loader {
+                    id:             loader
+                    anchors.fill:   parent
+                    onLoaded:       item.popped = true
+                }
+            }
+
+            onClosing: {
+                visible = false
+                source = ""
+            }
+        }
+    }
 }


### PR DESCRIPTION
Do this:
* Analyze View
* Mavlink Inspector
* Pop it out to a window
* Back from Analyze View
* Open Vehicle Setup
* You'll see that that mavlink inspector stops showing values

This was caused by the fact that the popout window was created in the context of the Analyze VIew. When that view went away all it's child objects are killed as well. Changed to create analyze popouts in the context of the main ui window.