### PR TITLE
Lower scroll speed

### DIFF
--- a/src/QmlControls/QGCFlickable.qml
+++ b/src/QmlControls/QGCFlickable.qml
@@ -1,12 +1,14 @@
 import QtQuick 2.3
 
-import QGroundControl.Palette 1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
 
 /// QGC version of Flickable control that shows horizontal/vertial scroll indicators
 Flickable {
-    id:             root
-    boundsBehavior: Flickable.StopAtBounds
-    clip:           true
+    id:                     root
+    boundsBehavior:         Flickable.StopAtBounds
+    clip:                   true
+    maximumFlickVelocity:   (ScreenTools.realPixelDensity * 25.4) * 8   // About two inches per second
 
     property color indicatorColor: qgcPal.text
 


### PR DESCRIPTION
* Fix for #10574
* This will affect everywhere which uses the QGCFlickable base control. This is the majority of everywhere but may be mission in some places. If fast scrolling is seen in specific spot it needs to changes to use QGCFlickable instead of Flickable.