### PR TITLE
FactMetaData: Fix default for decimal places

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -1337,7 +1337,7 @@ FactMetaData* FactMetaData::createFromJsonObject(const QJsonObject& json, QMap<Q
         }
     }
 
-    metaData->setDecimalPlaces(json[_decimalPlacesJsonKey].toInt(0));
+    metaData->setDecimalPlaces(json[_decimalPlacesJsonKey].toInt(kUnknownDecimalPlaces));
     metaData->setShortDescription(json[_shortDescriptionJsonKey].toString());
     metaData->setLongDescription(json[_longDescriptionJsonKey].toString());
 

--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -36,7 +36,7 @@
 
         { "vendorID": 12642, "productID": 0,        "boardClass": "Pixhawk",    "name": "Holybro" },
 
-        { "vendorID": 11694, "productID": 0,        "boardClass": "Pixhawk",    "name": "Hex/ProfiCNC" },
+        { "vendorID": 11694, "productID": 0,        "boardClass": "Pixhawk",    "name": "CubePilot" },
 
         { "vendorID": 13735, "productID": 1,        "boardClass": "Pixhawk",    "name": "ThePeach FCC-K1" },
         { "vendorID": 13735, "productID": 2,        "boardClass": "Pixhawk",    "name": "ThePeach FCC-R1" },


### PR DESCRIPTION
Fix #9781

When fact metadata was loaded from json if decimalPlaces was not specified it was defaulting to 0 instead of unknown. Unknown in turn defaults to 3 decimal places.