### PR TITLE
Missionitem: Set condition_yaw default to absolute heading

### DIFF
--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -457,7 +457,7 @@
                 "label":            "Offset",
                 "enumStrings":      "Relative,Absolute",
                 "enumValues":       "1,0",
-                "default":          1
+                "default":          0
             }
         },
         { "id": 176, "rawName": "MAV_CMD_DO_SET_MODE", "friendlyName": "Set mode" },


### PR DESCRIPTION
I find myself changing this every time. In almost all scenarios I've been flying, I prefer to change heading to absolute direction, rather than relative (because relative will accumulate any heading error, especially if the command is executed while turning.)
The absolute heading is the most used/typical way of using this mission item.
