### PR TITLE
Vehicle.cc: fix strncpy overflow compiler warning

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -947,7 +947,7 @@ void Vehicle::_handleStatusText(mavlink_message_t& message)
     uint8_t compId = message.compid;
 
     b.resize(MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1);
-    strncpy(b.data(), statustext.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
+    strncpy(b.data(), statustext.text, qMin((int)sizeof(statustext.text), MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN));
     b[b.length()-1] = '\0';
     messageText = QString(b);
     bool includesNullTerminator = messageText.length() < MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN;


### PR DESCRIPTION
Addresses #10595

Please @AndKe report back if this fix the issue for you. I tested with Ardupilot SITL on a super long string and it is processed and displayed correctly.

I don't get the compiler warning @AndKe is getting, but I wasn't getting it before the PR neither. I am building with Qt 5.15.2 on ubuntu 20.04.