### PR TITLE
OfflineMapButton: fix text overlapping on long tileset descriptions

### DIFF
--- a/src/QmlControls/OfflineMapButton.qml
+++ b/src/QmlControls/OfflineMapButton.qml
@@ -47,6 +47,8 @@ Button {
             text:   mapButton.text
             width:  mapButton.width * 0.4
             color:  _showHighlight ? qgcPal.buttonHighlightText : qgcPal.buttonText
+            wrapMode: Text.Wrap
+            maximumLineCount: 2
             anchors.verticalCenter: parent.verticalCenter
         }
         QGCLabel {


### PR DESCRIPTION
This addresses #10593

text wrap was added, and also the possibility to occupy 2 lines in case the tileset title is too long.

This is how it looked before the PR:

![Screenshot from 2023-02-22 22-57-29](https://user-images.githubusercontent.com/18221398/220768987-1af11ff5-84fa-4a6f-8d31-4675b3ad4d2f.png)

and this is how it looks after the PR:

![Screenshot from 2023-02-22 22-57-56](https://user-images.githubusercontent.com/18221398/220769063-b4c3f55c-0678-40a4-ac8b-7c8666e6e197.png)

