### PR TITLE
Fix unit test running

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install QGC source dependencies
         run:  sudo apt-get install -y libsdl2-dev
 
+      - name: Install source dependencies required to run unit tests in workflow container
+        run:  sudo apt-get install -y libxkbcommon-x11-0
+
       - name: Install Gstreamer dev packages
         run:  sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev
 


### PR DESCRIPTION
All Git Hub Workflow Action Linux Debug unit test runs suddenly started failing. This pull fixes that.

@bpmooch @booo FYI: Here are some details on how I figured this out. Which will hopefully help you with maintenance.

* So only Linux Debug was failing which you can see here: https://github.com/mavlink/qgroundcontrol/actions/workflows/linux_debug.yml
* If you scroll down through that display you see the it start failing between two runs of the same pull! And the pull is a one liner change that has no affect on unit tests at all. All of which is odd.
* It fails with this error:
```
Run xvfb-run -a ./staging/qgroundcontrol-start.sh --unittest
[18](https://github.com/mavlink/qgroundcontrol/actions/runs/4217407205/jobs/7321343057#step:15:19)
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
[19](https://github.com/mavlink/qgroundcontrol/actions/runs/4217407205/jobs/7321343057#step:15:20)
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
[20](https://github.com/mavlink/qgroundcontrol/actions/runs/4217407205/jobs/7321343057#step:15:21)

[21](https://github.com/mavlink/qgroundcontrol/actions/runs/4217407205/jobs/7321343057#step:15:22)
Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, xcb.
[22](https://github.com/mavlink/qgroundcontrol/actions/runs/4217407205/jobs/7321343057#step:15:23)

[23](https://github.com/mavlink/qgroundcontrol/actions/runs/4217407205/jobs/7321343057#step:15:24)
Aborted (core dumped)
[24](https://github.com/mavlink/qgroundcontrol/actions/runs/4217407205/jobs/7321343057#step:15:25)
Error: Process completed with exit code 134.
```
* I've seen this numerous time and it's always a mystery as to how to fix. It tends to indicate something in the container environment that the unit tests run in has changed.
* First step was Google the error which leads to advice on setting QT_DEBUG_PLUGINS=1 in the environment to debug the plugin loading.
* I put up a test pull with that and it spit out all sorts and unhelpful crap that didn't lead me anywhere.
* So then I kept thinking about the fact that something changed in the container environment. Which made me look at the run logs for the workflow. 
* I tried to visually compare the run for the one that worked to the one that didn't. It was too hard to compare visually.
* So then I downloaded the full log file info from github and use a diff tool to compare them. At that point I noticed the fact that the commit for the github action which installs Qt had moved. So although we were using the same version of that action the commit under had changed out from under us.
* I then diffed the detailed Qt installer action log and saw that the one that worked installed `libxkbcommon-x11-0` and the one that failed didn't.
* And the plugin error definitely had something to do with X.
* So I changed my testing pull to try installing than and the unit tests now ran but at the end they crashed with some strange error about QT_GLOBAL_STATIC.
* I tried running with QT_DEBUG_PLUGINS on my own local build and I just booted and exited and saw the same error about that there. So I realized it was just some problem with QT_DEBUG_PLUGINS.
* So then I removed QT_DEBUG_PLUGINS and left the lib install. And everything worked correctly.

And now you all no why I lost my mind after doing QGC mainteance for 6 years straight...