### PR TITLE
Better user model / ui for critical vehicle messages

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2050,7 +2050,7 @@ void Vehicle::_handleTextMessage(int newCount)
     }
 }
 
-void Vehicle::resetMessages()
+void Vehicle::resetAllMessages()
 {
     // Reset Counts
     int count = _currentMessageCount;
@@ -2064,6 +2064,31 @@ void Vehicle::resetMessages()
         emit newMessageCountChanged();
     }
     if(type != _currentMessageType) {
+        emit messageTypeChanged();
+    }
+}
+
+// Reset warning counts only
+void Vehicle::resetErrorLevelMessages()
+{
+    int prevMessageCount = _currentMessageCount;
+    MessageType_t prevMessagetype = _currentMessageType;
+
+    _currentMessageCount -= _currentErrorCount;
+    _currentErrorCount   = 0;
+
+    if (_currentWarningCount > 0) {
+        _currentMessageType = MessageWarning;
+    } else if (_currentNormalCount > 0) {
+        _currentMessageType = MessageNormal;
+    } else {
+        _currentMessageType = MessageNone;
+    }
+
+    if (prevMessageCount != _currentMessageCount) {
+        emit newMessageCountChanged();
+    }
+    if (prevMessagetype != _currentMessageType) {
         emit messageTypeChanged();
     }
 }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -341,7 +341,8 @@ public:
     Q_INVOKABLE void resetCounters  ();
 
     // Called when the message drop-down is invoked to clear current count
-    Q_INVOKABLE void resetMessages();
+    Q_INVOKABLE void resetAllMessages();
+    Q_INVOKABLE void resetErrorLevelMessages();
 
     Q_INVOKABLE void virtualTabletJoystickValue(double roll, double pitch, double yaw, double thrust);
 

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -199,14 +199,22 @@ void MockLink::run(void)
     QTimer  timer1HzTasks;
     QTimer  timer10HzTasks;
     QTimer  timer500HzTasks;
+    QTimer  timerStatusText;
 
-    QObject::connect(&timer1HzTasks,  &QTimer::timeout, this, &MockLink::_run1HzTasks);
-    QObject::connect(&timer10HzTasks, &QTimer::timeout, this, &MockLink::_run10HzTasks);
+    QObject::connect(&timer1HzTasks,   &QTimer::timeout, this, &MockLink::_run1HzTasks);
+    QObject::connect(&timer10HzTasks,  &QTimer::timeout, this, &MockLink::_run10HzTasks);
     QObject::connect(&timer500HzTasks, &QTimer::timeout, this, &MockLink::_run500HzTasks);
+    QObject::connect(&timerStatusText, &QTimer::timeout, this, &MockLink::_sendStatusTextMessages);
 
     timer1HzTasks.start(1000);
     timer10HzTasks.start(100);
     timer500HzTasks.start(2);
+
+    // Wait a little bit for the ui to finish loading up before sending out status text messages
+    if (_sendStatusText) {
+        timerStatusText.setSingleShot(true);
+        timerStatusText.start(10000);
+    }
 
     // Send first set right away
     _run1HzTasks();
@@ -241,10 +249,6 @@ void MockLink::_run1HzTasks(void)
                 _sendHomePositionDelayCount--;
             } else {
                 _sendHomePosition();
-            }
-            if (_sendStatusText) {
-                _sendStatusText = false;
-                _sendStatusTextMessages();
             }
         }
     }

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -189,10 +189,11 @@ private slots:
     // LinkInterface overrides
     void _writeBytes(const QByteArray bytes) final;
 
-    void _writeBytesQueued(const QByteArray bytes);
-    void _run1HzTasks(void);
-    void _run10HzTasks(void);
-    void _run500HzTasks(void);
+    void _writeBytesQueued      (const QByteArray bytes);
+    void _run1HzTasks           (void);
+    void _run10HzTasks          (void);
+    void _run500HzTasks         (void);
+    void _sendStatusTextMessages(void);
 
 private:
     // LinkInterface overrides
@@ -232,7 +233,6 @@ private:
     void _sendVibration                 (void);
     void _sendSysStatus                 (void);
     void _sendBatteryStatus             (void);
-    void _sendStatusTextMessages        (void);
     void _sendChunkedStatusText         (uint16_t chunkId, bool missingChunks);
     void _respondWithAutopilotVersion   (void);
     void _sendRCChannels                (void);

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -503,15 +503,15 @@ ApplicationWindow {
     //-------------------------------------------------------------------------
     //-- Critical Vehicle Message Popup
 
-    property var    _vehicleMessageQueue:      []
-    property string _vehicleMessage:     ""
-
     function showCriticalVehicleMessage(message) {
         indicatorPopup.close()
         if (criticalVehicleMessagePopup.visible || QGroundControl.videoManager.fullScreen) {
-            _vehicleMessageQueue.push(message)
+            // We received additional wanring message while an older warning message was still displayed.
+            // When the user close the older one drop the message indicator tool so they can see the rest of them.
+            criticalVehicleMessagePopup.dropMessageIndicatorOnClose = true
         } else {
-            _vehicleMessage = message
+            criticalVehicleMessagePopup.criticalVehicleMessage      = message
+            criticalVehicleMessagePopup.dropMessageIndicatorOnClose = false
             criticalVehicleMessagePopup.open()
         }
     }
@@ -521,10 +521,13 @@ ApplicationWindow {
         y:                  ScreenTools.defaultFontPixelHeight
         x:                  Math.round((mainWindow.width - width) * 0.5)
         width:              mainWindow.width  * 0.55
-        height:             ScreenTools.defaultFontPixelHeight * 6
+        height:             criticalVehicleMessageText.contentHeight + ScreenTools.defaultFontPixelHeight * 2
         modal:              false
         focus:              true
         closePolicy:        Popup.CloseOnEscape
+
+        property alias  criticalVehicleMessage:        criticalVehicleMessageText.text
+        property bool   dropMessageIndicatorOnClose:   false
 
         background: Rectangle {
             anchors.fill:   parent
@@ -532,89 +535,71 @@ ApplicationWindow {
             radius:         ScreenTools.defaultFontPixelHeight * 0.5
             border.color:   qgcPal.alertBorder
             border.width:   2
-        }
 
-        onOpened: {
-            criticalVehicleMessageText.text = mainWindow._vehicleMessage
-        }
+            Rectangle {
+                anchors.horizontalCenter:   parent.horizontalCenter
+                anchors.top:                parent.top
+                anchors.topMargin:          -(height / 2)
+                color:                      qgcPal.alertBackground
+                radius:                     ScreenTools.defaultFontPixelHeight * 0.25
+                border.color:               qgcPal.alertBorder
+                border.width:               1
+                width:                      vehicleWarningLabel.contentWidth + _margins
+                height:                     vehicleWarningLabel.contentHeight + _margins
 
-        onClosed: {
-            //-- Are there messages in the waiting queue?
-            if(mainWindow._vehicleMessageQueue.length) {
-                mainWindow._vehicleMessage = ""
-                //-- Show all messages in queue
-                for (var i = 0; i < mainWindow._vehicleMessageQueue.length; i++) {
-                    var text = mainWindow._vehicleMessageQueue[i]
-                    if(i) mainWindow._vehicleMessage += "<br>"
-                    mainWindow._vehicleMessage += text
+                property real _margins: ScreenTools.defaultFontPixelHeight * 0.25
+
+                QGCLabel {
+                    id:                 vehicleWarningLabel
+                    anchors.centerIn:   parent
+                    text:               qsTr("Vehicle Error")
+                    font.pointSize:     ScreenTools.smallFontPointSize
+                    color:              qgcPal.alertText
                 }
-                //-- Clear it
-                mainWindow._vehicleMessageQueue = []
-                criticalVehicleMessagePopup.open()
-            } else {
-                mainWindow._vehicleMessage = ""
             }
-        }
 
-        Flickable {
-            id:                 criticalVehicleMessageFlick
-            anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.5
-            anchors.fill:       parent
-            contentHeight:      criticalVehicleMessageText.height
-            contentWidth:       criticalVehicleMessageText.width
-            boundsBehavior:     Flickable.StopAtBounds
-            pixelAligned:       true
-            clip:               true
-            TextEdit {
-                id:             criticalVehicleMessageText
-                width:          criticalVehicleMessagePopup.width - criticalVehicleMessageClose.width - (ScreenTools.defaultFontPixelHeight * 2)
-                anchors.centerIn: parent
-                readOnly:       true
-                textFormat:     TextEdit.RichText
-                font.pointSize: ScreenTools.defaultFontPointSize
-                font.family:    ScreenTools.demiboldFontFamily
-                wrapMode:       TextEdit.WordWrap
-                color:          qgcPal.alertText
-            }
-        }
+            Rectangle {
+                id:                         additionalErrorsIndicator
+                anchors.horizontalCenter:   parent.horizontalCenter
+                anchors.bottom:             parent.bottom
+                anchors.bottomMargin:       -(height / 2)
+                color:                      qgcPal.alertBackground
+                radius:                     ScreenTools.defaultFontPixelHeight * 0.25
+                border.color:               qgcPal.alertBorder
+                border.width:               1
+                width:                      additionalErrorsLabel.contentWidth + _margins
+                height:                     additionalErrorsLabel.contentHeight + _margins
+                visible:                    criticalVehicleMessagePopup.dropMessageIndicatorOnClose
 
-        //-- Dismiss Vehicle Message
-        QGCColoredImage {
-            id:                 criticalVehicleMessageClose
-            anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.5
-            anchors.top:        parent.top
-            anchors.right:      parent.right
-            width:              ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
-            height:             width
-            sourceSize.height:  width
-            source:             "/res/XDelete.svg"
-            fillMode:           Image.PreserveAspectFit
-            color:              qgcPal.alertText
-            MouseArea {
-                anchors.fill:       parent
-                anchors.margins:    -ScreenTools.defaultFontPixelHeight
-                onClicked: {
-                    criticalVehicleMessagePopup.close()
+                property real _margins: ScreenTools.defaultFontPixelHeight * 0.25
+
+                QGCLabel {
+                    id:                 additionalErrorsLabel
+                    anchors.centerIn:   parent
+                    text:               qsTr("Additional errors received")
+                    font.pointSize:     ScreenTools.smallFontPointSize
+                    color:              qgcPal.alertText
                 }
             }
         }
 
-        //-- More text below indicator
-        QGCColoredImage {
-            anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.5
-            anchors.bottom:     parent.bottom
-            anchors.right:      parent.right
-            width:              ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
-            height:             width
-            sourceSize.height:  width
-            source:             "/res/ArrowDown.svg"
-            fillMode:           Image.PreserveAspectFit
-            visible:            criticalVehicleMessageText.lineCount > 5
+        QGCLabel {
+            id:                 criticalVehicleMessageText
+            width:              criticalVehicleMessagePopup.width - ScreenTools.defaultFontPixelHeight
+            anchors.centerIn:   parent
+            wrapMode:           Text.WordWrap
             color:              qgcPal.alertText
-            MouseArea {
-                anchors.fill:   parent
-                onClicked: {
-                    criticalVehicleMessageFlick.flick(0,-500)
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                criticalVehicleMessagePopup.close()
+                console.log("Clicked", criticalVehicleMessagePopup.dropMessageIndicatorOnClose);
+                if (criticalVehicleMessagePopup.dropMessageIndicatorOnClose) {
+                    criticalVehicleMessagePopup.dropMessageIndicatorOnClose = false;
+                    QGroundControl.multiVehicleManager.activeVehicle.resetErrorLevelMessages();
+                    toolbar.dropMessageIndicatorTool();
                 }
             }
         }

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -33,6 +33,12 @@ Rectangle {
     property bool   _communicationLost: _activeVehicle ? _activeVehicle.vehicleLinkManager.communicationLost : false
     property color  _mainStatusBGColor: qgcPal.brandingPurple
 
+    function dropMessageIndicatorTool() {
+        if (currentToolbar === flyViewToolbar) {
+            indicatorLoader.item.dropMessageIndicatorTool();
+        }
+    }
+
     QGCPalette { id: qgcPal }
 
     /// Bottom single pixel divider

--- a/src/ui/toolbar/MainToolBarIndicators.qml
+++ b/src/ui/toolbar/MainToolBarIndicators.qml
@@ -24,6 +24,10 @@ Row {
     property var  _activeVehicle:           QGroundControl.multiVehicleManager.activeVehicle
     property real _toolIndicatorMargins:    ScreenTools.defaultFontPixelHeight * 0.66
 
+    function dropMessageIndicatorTool() {
+        toolIndicatorsRepeater.dropMessageIndicatorTool();
+    }
+
     Repeater {
         id:     appRepeater
         model:  QGroundControl.corePlugin.toolBarIndicators
@@ -36,7 +40,18 @@ Row {
     }
 
     Repeater {
-        model: _activeVehicle ? _activeVehicle.toolIndicators : []
+        id:     toolIndicatorsRepeater
+        model:  _activeVehicle ? _activeVehicle.toolIndicators : []
+
+        function dropMessageIndicatorTool() {
+            for (var i=0; i<count; i++) {
+                var thisTool = itemAt(i);
+                if (thisTool.item.dropMessageIndicator) {
+                    thisTool.item.dropMessageIndicator();
+                }
+            }
+        }
+
         Loader {
             anchors.top:        parent.top
             anchors.bottom:     parent.bottom

--- a/src/ui/toolbar/MessageIndicator.qml
+++ b/src/ui/toolbar/MessageIndicator.qml
@@ -31,6 +31,10 @@ Item {
     property var    _activeVehicle:         QGroundControl.multiVehicleManager.activeVehicle
     property bool   _isMessageImportant:    _activeVehicle ? !_activeVehicle.messageTypeNormal && !_activeVehicle.messageTypeNone : false
 
+    function dropMessageIndicator() {
+        mainWindow.showIndicatorPopup(_root, vehicleMessagesPopup);
+    }
+
     function getMessageColor() {
         if (_activeVehicle) {
             if (_activeVehicle.messageTypeNone)
@@ -70,7 +74,7 @@ Item {
 
     MouseArea {
         anchors.fill:   parent
-        onClicked:      mainWindow.showIndicatorPopup(_root, vehicleMessagesPopup)
+        onClicked:      dropMessageIndicator()
     }
 
     Component {
@@ -95,7 +99,7 @@ Item {
                 //-- Hack to scroll to last message
                 for (var i = 0; i < _activeVehicle.messageCount; i++)
                     messageFlick.flick(0,-5000)
-                _activeVehicle.resetMessages()
+                _activeVehicle.resetAllMessages()
             }
 
             Connections {


### PR DESCRIPTION
Problems with current implementation:
* Users don't understand that these messages come directly from the vehicle
* The popup is massive and the X to close is even more massive! Example:
![Screen Shot 2023-02-25 at 15 04 04](https://user-images.githubusercontent.com/5876851/221384205-b85bb912-0f07-415f-93d9-32e29655b5f8.png)
* Some time you may get multiples of these in a row. Close one, and you just get another. Depending on what the vehicle is sending.
* Current ui can show multiples at one time. Example:
![Screen Shot 2023-02-25 at 15 04 15](https://user-images.githubusercontent.com/5876851/221384208-85f0ce22-03bb-459b-9f4d-77150c566fff.png)
* There is also a case where you can get a little mystery down array in the popup which means you should scroll because there are more for you to see.
* And then to make things even worse. If you dismiss one of these popups clearing that fact that you saw all critical messages. The Message Indicator in the toolbar would continue to display the Red yield sign indicator meaning there is something bad there you should look at.

The new thing which I think is a bit better and slightly less annoying:
* The popup only ever shows a single critical message and is smaller:
![Screen Shot 2023-02-25 at 14 49 23](https://user-images.githubusercontent.com/5876851/221384313-15b4bad7-e766-41b5-9e6b-349913b32a3e.png)
* If while this popup is being displayed you get additional critical messages it tells you that:
![Screen Shot 2023-02-25 at 14 48 00](https://user-images.githubusercontent.com/5876851/221384326-75ec2b26-3631-46b0-82b7-9c9439ce83e2.png)
* And then if that is the case of additional messages you should look at, when you click to close the crticial popup the Message Indicator dropdown will drop showing you all the gory details of all the messages that just came in:
![Screen Shot 2023-02-25 at 15 32 50](https://user-images.githubusercontent.com/5876851/221384364-efc82d64-f3fe-489a-9a0a-ab7d1fd0dbbf.png)


Also includes in this pull are fixes to MockLink status text sending support which is support to allow you to test this sort of stuff with a MockLink but was broken.