### PR TITLE
add content_rating to metainfo and fix metadata_license

### DIFF
--- a/deploy/org.mavlink.qgroundcontrol.metainfo.xml
+++ b/deploy/org.mavlink.qgroundcontrol.metainfo.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>org.mavlink.qgroundcontrol</id>
-  
+
   <name>QGroundControl</name>
   <summary>UAS ground control station</summary>
   <developer_name>Dronecode Project, Inc.</developer_name>
-  
+
   <metadata_license>GPL-3.0 AND Apache-2.0</metadata_license>
   <project_license>GPL-3.0 AND Apache-2.0</project_license>
-  
+
   <recommends>
     <control>pointing</control>
     <control>keyboard</control>
     <control>touch</control>
     <control>gamepad</control>
   </recommends>
-  
+
   <description>
     <p>
       Intuitive and Powerful Ground Control Station for the MAVLink protocol.
     </p>
   </description>
-  
+
   <launchable type="desktop-id">org.mavlink.qgroundcontrol.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://docs.qgroundcontrol.com/assets/quickstart/ConnectedVehicle.jpg</image>
     </screenshot>
   </screenshots>
-  
+
   <url type="homepage">http://qgroundcontrol.com/</url>
   <url type="help">https://docs.qgroundcontrol.com/master/en/index.html</url>
   <url type="bugtracker">https://github.com/mavlink/qgroundcontrol/issues</url>
@@ -37,7 +37,7 @@
     <category>Utility</category>
     <category>Maps</category>
   </categories>
-  
+
   <provides>
     <binary>QGroundControl</binary>
   </provides>

--- a/deploy/org.mavlink.qgroundcontrol.metainfo.xml
+++ b/deploy/org.mavlink.qgroundcontrol.metainfo.xml
@@ -6,7 +6,7 @@
   <summary>UAS ground control station</summary>
   <developer_name>Dronecode Project, Inc.</developer_name>
 
-  <metadata_license>GPL-3.0 AND Apache-2.0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0 AND Apache-2.0</project_license>
 
   <recommends>

--- a/deploy/org.mavlink.qgroundcontrol.metainfo.xml
+++ b/deploy/org.mavlink.qgroundcontrol.metainfo.xml
@@ -22,6 +22,8 @@
     </p>
   </description>
 
+  <content_rating type="oars-1.1" />
+
   <launchable type="desktop-id">org.mavlink.qgroundcontrol.desktop</launchable>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
This adds the tag `content_rating` to the `metainfo.xml` using the interactive form at https://odrs.gnome.org/oars.

The `metadata_license` states `GPL-3.0 AND Apache-2.0`. I assume this only applies to the project and not the metadata, i.e. this `metainfo.xml` itself. Usually, these metadata files use one of the "Creative Commons" licences. I propose to use the "CC0-1.0".