### PR TITLE
Mavlink camera bug and increase request for camera information

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -130,7 +130,7 @@ QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
             } else {
                 //-- Try again. Maybe.
                 if(pInfo->lastHeartbeat.elapsed() > 2000) {
-                    if(pInfo->tryCount > 3) {
+                    if(pInfo->tryCount > 10) {
                         if(!pInfo->gaveUp) {
                             pInfo->gaveUp = true;
                             qWarning() << "Giving up requesting camera info from" << _vehicle->id() << message.compid;

--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -101,7 +101,7 @@ Rectangle {
 
     function toggleShooting() {
         console.log("toggleShooting", _anyVideoStreamAvailable)
-        if (_mavlinkCamera && _mavlinkCamera.capturesVideo) {
+        if (_mavlinkCamera && _mavlinkCamera.capturesVideo || _mavlinkCamera.capturesPhotos ) {
             if(_mavlinkCameraInVideoMode) {
                 _mavlinkCamera.toggleVideo()
             } else {


### PR DESCRIPTION
There was a bug in photovideocontrol.qml, on the trigger picture widget. It was only checking for video capabilities of the camera. So, if a camera responded with only picture capabilities, but not video recording capabilities, the widget would not allow to trigger simple pictures. 

This fix was confirmed to be working for Phaseone payloads, which are exactly this scenario, photo triggering but not video recording.

The other commit is to increase the amount of camera info requests ( used to be 3 ) to 10. Apparently this is very prone to fail in low bandwidth connections, because it is usually requested at the same time as parameter download, and it fails a lot. I think it would be nice to increase the request attempts to 10, but if you guys consider this is non optimal I can remove that commit from this PR and talk about it further.

Thanks!