### PR TITLE
Github actions: update actions-download-file version

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -48,7 +48,7 @@ jobs:
           setup-python: false
 
       - name: Download JOM
-        uses: suisei-cn/actions-download-file@v1
+        uses: suisei-cn/actions-download-file@v1.3.0
         with:
           url:    http://download.qt.io/official_releases/jom/jom.zip
           target: ${{ runner.temp }}\
@@ -59,13 +59,13 @@ jobs:
               7z x jom.zip -ojom
 
       - name: Download Gstreamer
-        uses: suisei-cn/actions-download-file@v1
+        uses: suisei-cn/actions-download-file@v1.3.0
         with:
           url:    https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/gstreamer-1.0-msvc-x86_64-1.18.1.msi
           target: ${{ runner.temp }}\
 
       - name: Download Gstreamer dev
-        uses: suisei-cn/actions-download-file@v1
+        uses: suisei-cn/actions-download-file@v1.3.0
         with:
           url:    https://s3-us-west-2.amazonaws.com/qgroundcontrol/dependencies/gstreamer-1.0-devel-msvc-x86_64-1.18.1.msi
           target: ${{ runner.temp }}\


### PR DESCRIPTION
Used to download files in windows workflow. Update from v1 to v1.3.0 to remove warnings about deprecated set-output command.


