### PR TITLE
Github actions: Remove android-33-ext5 from build image

### DIFF
--- a/.github/workflows/android_32_release.yml
+++ b/.github/workflows/android_32_release.yml
@@ -54,6 +54,11 @@ jobs:
           ndk-version: r21e
           add-to-path: false
 
+      - name: Remove Android SDK android-33-ext
+        run: |
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext5"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext4"
+
       - name: Install ccache
         run:  sudo apt-get install ccache
 

--- a/.github/workflows/android_64_release.yml
+++ b/.github/workflows/android_64_release.yml
@@ -54,6 +54,11 @@ jobs:
           ndk-version: r21e
           add-to-path: false
 
+      - name: Remove Android SDK android-33-ext
+        run: |
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext5"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext4"
+
       - name: Install ccache
         run:  sudo apt-get install ccache
 


### PR DESCRIPTION
Github workflow image ubuntu-20.04 version 20230313.1 have added Android SDK Platform android-33-ext5. Something, possible the gradle version bundled with qt does not parse this correctly, and sets androidCompileSdkVersion in android-build/gradle.properties to "ext5" instead of expected "33". This commit is a quick fix to the problem, so the build will revert to android-33 which was used before 20230109.1.

This fix was previously added for android-33-ext4 in image 20230109.1 in commit 6f636e7891fb9e204e4c6983eb2724e4d39c4aff.


