### PR TITLE
fix: check VIDEO_STREAM_STATUS messages whether stream is running

### DIFF
--- a/src/Camera/QGCCameraControl.cc
+++ b/src/Camera/QGCCameraControl.cc
@@ -1624,8 +1624,9 @@ QGCCameraControl::handleVideoStatus(const mavlink_video_stream_status_t* vs)
 void
 QGCCameraControl::setCurrentStream(int stream)
 {
-    if (stream != _currentStream && 0 <= stream && stream < _streamLabels.count()) {
-        if(QGCVideoStreamInfo* pInfo = currentStreamInstance()) {
+    if (stream != _currentStream && (stream == -1 || (0 <= stream && stream < _streamLabels.count()))) {
+        // stop the old stream if possible
+        if (QGCVideoStreamInfo* pInfo = currentStreamInstance()) {
             qCDebug(CameraControlLog) << "Stopping stream: " << modelName() << " uri=" << pInfo->uri();
             //-- Stop current stream
             _vehicle->sendMavCommand(
@@ -1634,8 +1635,10 @@ QGCCameraControl::setCurrentStream(int stream)
                 false,                                  // ShowError
                 pInfo->streamID());                     // Stream ID
         }
+
+        // start the new stream, unless it's -1, in which case currentStreamInstance() is null
         _currentStream = stream;
-        if(QGCVideoStreamInfo* pInfo = currentStreamInstance()) {
+        if (QGCVideoStreamInfo* pInfo = currentStreamInstance()) {
             qCDebug(CameraControlLog) << "Starting stream: " << modelName() << " uri=" << pInfo->uri();
             //-- Start new stream
             _vehicle->sendMavCommand(

--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -45,6 +45,7 @@ public:
     int     type            () const{ return _streamInfo.type; }
     int     streamID        () const{ return _streamInfo.stream_id; }
     bool    isThermal       () const{ return _streamInfo.flags & VIDEO_STREAM_STATUS_FLAGS_THERMAL; }
+    bool    isRunning       () const{ return _streamInfo.flags & VIDEO_STREAM_STATUS_FLAGS_RUNNING; }
 
     bool    update          (const mavlink_video_stream_status_t* vs);
 
@@ -420,7 +421,7 @@ protected:
     QStringList                         _updatesToRequest;
     //-- Video Streams
     int                                 _requestCount       = 0;
-    int                                 _currentStream      = 0;
+    int                                 _currentStream      = -1;
     int                                 _expectedCount      = 1;
     QTimer                              _streamInfoTimer;
     QTimer                              _streamStatusTimer;

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -43,6 +43,10 @@ void
 QGCCameraManager::setCurrentCamera(int sel)
 {
     if(sel != _currentCamera && sel >= 0 && sel < _cameras.count()) {
+        // stop the old camera stream
+        if (QGCCameraControl* pOldCamera = currentCameraInstance()) {
+            pOldCamera->setCurrentStream(-1);
+        }
         _currentCamera = sel;
         emit currentCameraChanged();
         if (QGCCameraControl* pCamera = currentCameraInstance()) {

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -45,7 +45,11 @@ QGCCameraManager::setCurrentCamera(int sel)
     if(sel != _currentCamera && sel >= 0 && sel < _cameras.count()) {
         _currentCamera = sel;
         emit currentCameraChanged();
-        emit streamChanged();
+        if (QGCCameraControl* pCamera = currentCameraInstance()) {
+            // automatically enable stream 0 to update the stream status
+            // this will trigger the streamChanged() event
+            pCamera->setCurrentStream(0);
+        }
     }
 }
 


### PR DESCRIPTION
I discovered this bug when trying to add integration support for a multi-camera mavlink device with multiple streams.

The current code assumed that each Camera would always be streaming, but this is not always the case, and not guaranteed by MAVLink camera protocol. Especially with 3+ cameras, due to data rate limitations only 1 out 3 might be active.

QGC would be stuck assuming that the streams are running, but the camera system could be expecting for a VIDEO_START_STREAMING command for those particular streams.

The VIDEO_STREAM_STATUS `flags` field describes whether the Stream is actually running, and updating the `_currentStream` value according to those flags re-enables video stream switching.

I also slightly improved the camera debug logging to make it easier to debug multi-camera system issues.
