### PR TITLE
Add keyboard support to SliderSwitch

### DIFF
--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -40,6 +40,12 @@ Rectangle {
 
     Component.onCompleted: guidedController.confirmDialog = this
 
+    onVisibleChanged: {
+        if (visible) {
+            slider.focus = true
+        }
+    }
+
     onHideTriggerChanged: {
         if (hideTrigger) {
             confirmCancelled()
@@ -104,7 +110,7 @@ Rectangle {
 
             SliderSwitch {
                 id:                 slider
-                confirmText:        qsTr("Slide to confirm")
+                confirmText:        qsTr("Slide or hold spacebar")
                 Layout.fillWidth:   true
 
                 onAccept: {

--- a/src/QmlControls/SliderSwitch.qml
+++ b/src/QmlControls/SliderSwitch.qml
@@ -1,11 +1,11 @@
-import QtQuick                  2.3
-import QtQuick.Controls         1.2
+import QtQuick                  2.15
+import QtQuick.Controls         2.15
 
 import QGroundControl.ScreenTools   1.0
 import QGroundControl.Palette       1.0
 
 /// The SliderSwitch control implements a sliding switch control similar to the power off
-/// control on an iPhone.
+/// control on an iPhone. It supports holding the space bar to slide the switch.
 Rectangle {
     id:             _root
     implicitWidth:  label.contentWidth + (_diameter * 2.5) + (_border * 4)
@@ -18,15 +18,46 @@ Rectangle {
     property string confirmText                         ///< Text for slider
     property alias  fontPointSize: label.font.pointSize ///< Point size for text
 
-    property real _border: 4
-    property real _diameter: height - (_border * 2)
+    property real _border:                      4   
+    property real _diameter:                    height - (_border * 2)
+    property real _dragStartX:                  _border
+    property real _dragStopX:                   _root.width - (_diameter + _border)
+    property bool _waitingForLastAutoRepeat:    false
+
+    Keys.onSpacePressed: {
+        if (visible && event.modifiers === Qt.NoModifier && event.isAutoRepeat && !sliderDragArea.drag.active) {
+            event.accepted = true
+            if (_waitingForLastAutoRepeat) {
+                resetSpaceBarSliding()
+                accept()
+            } else {
+                sliderAnimation.start()
+                spaceBarTimout.restart()
+            }
+        }
+    }
+
+    function resetSpaceBarSliding() {
+        _waitingForLastAutoRepeat = false
+        spaceBarTimout.stop()
+        slider.reset()
+    }
+
+    Timer {
+        id:             spaceBarTimout
+        interval:       200
+        repeat:         false
+        onTriggered:    _root.resetSpaceBarSliding()
+    }
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     QGCLabel {
         id:                         label
-        anchors.horizontalCenter:   parent.horizontalCenter
+        x:                          _diameter + _border
+        width:                      parent.width - x
         anchors.verticalCenter:     parent.verticalCenter
+        horizontalAlignment:        Text.AlignHCenter
         text:                       confirmText
         color:                      qgcPal.buttonText
     }
@@ -53,6 +84,19 @@ Rectangle {
             source:                 "/res/ArrowRight.svg"
         }
 
+        PropertyAnimation on x {
+            id:         sliderAnimation
+            duration:   1500
+            from:       _dragStartX
+            to:         _dragStopX
+            running:    false
+            onFinished: _waitingForLastAutoRepeat = true
+        }
+
+        function reset() {
+            slider.x = _border
+            sliderAnimation.stop()
+        }
     }
 
     QGCMouseArea {
@@ -61,20 +105,18 @@ Rectangle {
         fillItem:           slider
         drag.target:        slider
         drag.axis:          Drag.XAxis
-        drag.minimumX:      _border
-        drag.maximumX:      _maxXDrag
+        drag.minimumX:      _dragStartX
+        drag.maximumX:      _dragStopX
         preventStealing:    true
 
-        property real _maxXDrag:    _root.width - (_diameter + _border)
-        property bool dragActive:   drag.active
-        property real _dragOffset:  1
+        property bool dragActive: drag.active
 
         onDragActiveChanged: {
             if (!sliderDragArea.drag.active) {
-                if (slider.x > _maxXDrag - _border) {
+                if (slider.x > _dragStopX - _border) {
                     _root.accept()
                 }
-                slider.x = _border
+                slider.reset()
             }
         }
     }


### PR DESCRIPTION
![Screen Shot 2023-03-24 at 11 30 00](https://user-images.githubusercontent.com/5876851/227610367-be54dda0-67fd-406a-aaf3-53fbceca7ade.png)

SliderSwitch is used by the Guided Action confirmation ui. With touch it's easy to slide the slider with your finger. But if you are running QGC on a laptop with a trackpad, sliding that thing over with your fingers is a royal PITA.

Updates the SliderSwitch control:
* Support holding down the spacebar for confirmation. 
* The length of time you have to hold the spacebar is fairly long at 1.5 seconds. The reason for this is you want to give the user enough time to bail out if this isn't really what they wanted. Otherwise the slider swishes across the screen too fast to give you time to release to need to release the space bar.
* I also updated and centered the slider prompt text