### PR TITLE
Add setting to force enable "ROI at Location" in FlyView

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -434,6 +434,7 @@ HEADERS += \
     src/QmlControls/CustomAction.h \
     src/QmlControls/CustomActionManager.h \
     src/QmlControls/QmlUnitsConversion.h \
+    src/Settings/FirmwareCapabilitiesSettings.h \
     src/Vehicle/VehicleEscStatusFactGroup.h \
     src/api/QGCCorePlugin.h \
     src/api/QGCOptions.h \
@@ -448,6 +449,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 
 SOURCES += \
     src/QmlControls/CustomActionManager.cc \
+    src/Settings/FirmwareCapabilitiesSettings.cc \
     src/Vehicle/VehicleEscStatusFactGroup.cc \
     src/api/QGCCorePlugin.cc \
     src/api/QGCOptions.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -302,6 +302,7 @@
         <file alias="CorridorScan.SettingsGroup.json">src/MissionManager/CorridorScan.SettingsGroup.json</file>
         <file alias="RemoteID.SettingsGroup.json">src/Settings/RemoteID.SettingsGroup.json</file>
         <file alias="EditPositionDialog.FactMetaData.json">src/QmlControls/EditPositionDialog.FactMetaData.json</file>
+        <file alias="FirmwareCapabilities.SettingsGroup.json">src/Settings/FirmwareCapabilities.SettingsGroup.json</file>
         <file alias="FirmwareUpgrade.SettingsGroup.json">src/Settings/FirmwareUpgrade.SettingsGroup.json</file>
         <file alias="FlightMap.SettingsGroup.json">src/Settings/FlightMap.SettingsGroup.json</file>
         <file alias="FlyView.SettingsGroup.json">src/Settings/FlyView.SettingsGroup.json</file>

--- a/src/Settings/FirmwareCapabilities.SettingsGroup.json
+++ b/src/Settings/FirmwareCapabilities.SettingsGroup.json
@@ -1,0 +1,13 @@
+{
+    "version":      1,
+    "fileType":  "FactMetaData",
+    "QGC.MetaData.Facts":
+[
+{
+    "name":      "enableROI",
+    "shortDesc": "Force enable the ROI features in Fly and Plan Views",
+    "type":      "bool",
+    "default":   false
+}
+]
+}

--- a/src/Settings/FirmwareCapabilitiesSettings.cc
+++ b/src/Settings/FirmwareCapabilitiesSettings.cc
@@ -1,0 +1,21 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "FirmwareCapabilitiesSettings.h"
+
+#include <QQmlEngine>
+#include <QtQml>
+
+DECLARE_SETTINGGROUP(FirmwareCapabilities, "FirmwareCapabilities")
+{
+    qmlRegisterUncreatableType<FirmwareCapabilitiesSettings>("QGroundControl.SettingsManager", 1, 0, "FirmwareCapabilitiesSettings", "Reference only"); \
+}
+
+DECLARE_SETTINGSFACT(FirmwareCapabilitiesSettings, enableROI)
+

--- a/src/Settings/FirmwareCapabilitiesSettings.h
+++ b/src/Settings/FirmwareCapabilitiesSettings.h
@@ -1,0 +1,23 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "SettingsGroup.h"
+
+class FirmwareCapabilitiesSettings : public SettingsGroup
+{
+    Q_OBJECT
+public:
+    FirmwareCapabilitiesSettings(QObject* parent = nullptr);
+
+    DEFINE_SETTING_NAME_GROUP()
+
+    DEFINE_SETTINGFACT(enableROI)
+};

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -24,6 +24,7 @@ SettingsManager::SettingsManager(QGCApplication* app, QGCToolbox* toolbox)
     , _flightMapSettings            (nullptr)
     , _rtkSettings                  (nullptr)
     , _flyViewSettings              (nullptr)
+    , _firmwareCapabilitiesSettings (nullptr)
     , _planViewSettings             (nullptr)
     , _brandImageSettings           (nullptr)
     , _offlineMapsSettings          (nullptr)
@@ -50,6 +51,7 @@ void SettingsManager::setToolbox(QGCToolbox *toolbox)
     _flightMapSettings =            new FlightMapSettings           (this);
     _rtkSettings =                  new RTKSettings                 (this);
     _flyViewSettings =              new FlyViewSettings             (this);
+    _firmwareCapabilitiesSettings = new FirmwareCapabilitiesSettings(this);
     _planViewSettings =             new PlanViewSettings            (this);
     _brandImageSettings =           new BrandImageSettings          (this);
     _offlineMapsSettings =          new OfflineMapsSettings         (this);

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -21,6 +21,7 @@
 #include "FlightMapSettings.h"
 #include "RTKSettings.h"
 #include "FlyViewSettings.h"
+#include "FirmwareCapabilitiesSettings.h"
 #include "PlanViewSettings.h"
 #include "BrandImageSettings.h"
 #include "OfflineMapsSettings.h"
@@ -51,6 +52,7 @@ public:
     Q_PROPERTY(QObject* flightMapSettings               READ flightMapSettings              CONSTANT)
     Q_PROPERTY(QObject* rtkSettings                     READ rtkSettings                    CONSTANT)
     Q_PROPERTY(QObject* flyViewSettings                 READ flyViewSettings                CONSTANT)
+    Q_PROPERTY(QObject* firmwareCapabilitiesSettings    READ firmwareCapabilitiesSettings   CONSTANT)
     Q_PROPERTY(QObject* planViewSettings                READ planViewSettings               CONSTANT)
     Q_PROPERTY(QObject* brandImageSettings              READ brandImageSettings             CONSTANT)
     Q_PROPERTY(QObject* offlineMapsSettings             READ offlineMapsSettings            CONSTANT)
@@ -73,6 +75,7 @@ public:
     FlightMapSettings*              flightMapSettings           (void) { return _flightMapSettings; }
     RTKSettings*                    rtkSettings                 (void) { return _rtkSettings; }
     FlyViewSettings*                flyViewSettings             (void) { return _flyViewSettings; }
+    FirmwareCapabilitiesSettings*   firmwareCapabilitiesSettings(void) { return _firmwareCapabilitiesSettings; }
     PlanViewSettings*               planViewSettings            (void) { return _planViewSettings; }
     BrandImageSettings*             brandImageSettings          (void) { return _brandImageSettings; }
     OfflineMapsSettings*            offlineMapsSettings         (void) { return _offlineMapsSettings; }
@@ -93,6 +96,7 @@ private:
     FlightMapSettings*              _flightMapSettings;
     RTKSettings*                    _rtkSettings;
     FlyViewSettings*                _flyViewSettings;
+    FirmwareCapabilitiesSettings*   _firmwareCapabilitiesSettings;
     PlanViewSettings*               _planViewSettings;
     BrandImageSettings*             _brandImageSettings;
     OfflineMapsSettings*            _offlineMapsSettings;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -191,6 +191,8 @@ Vehicle::Vehicle(LinkInterface*             link,
 
     connect(_toolbox->multiVehicleManager(), &MultiVehicleManager::parameterReadyVehicleAvailableChanged, this, &Vehicle::_vehicleParamLoaded);
 
+    connect(_settingsManager->firmwareCapabilitiesSettings()->enableROI(), &Fact::rawValueChanged, this, &Vehicle::capabilitiesChanged);
+
     _uas = new UAS(_mavlink, this, _firmwarePluginManager);
     _uas->setParent(this);
 
@@ -2596,7 +2598,10 @@ bool Vehicle::orbitModeSupported() const
 
 bool Vehicle::roiModeSupported() const
 {
-    return _firmwarePlugin->isCapable(this, FirmwarePlugin::ROIModeCapability);
+    Fact* capabilityFact  = _settingsManager->firmwareCapabilitiesSettings()->enableROI();
+    bool userEnabled = capabilityFact && capabilityFact->rawValue().toBool();
+    bool firmwareEnabled = _firmwarePlugin->isCapable(this, FirmwarePlugin::ROIModeCapability);
+    return userEnabled || firmwareEnabled;
 }
 
 bool Vehicle::takeoffVehicleSupported() const

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -270,7 +270,7 @@ public:
     Q_PROPERTY(bool     guidedModeSupported     READ guidedModeSupported                            CONSTANT)                   ///< Guided mode commands are supported by this vehicle
     Q_PROPERTY(bool     pauseVehicleSupported   READ pauseVehicleSupported                          CONSTANT)                   ///< Pause vehicle command is supported
     Q_PROPERTY(bool     orbitModeSupported      READ orbitModeSupported                             CONSTANT)                   ///< Orbit mode is supported by this vehicle
-    Q_PROPERTY(bool     roiModeSupported        READ roiModeSupported                               CONSTANT)                   ///< Orbit mode is supported by this vehicle
+    Q_PROPERTY(bool     roiModeSupported        READ roiModeSupported                               NOTIFY capabilitiesChanged) ///< ROI mode is supported by this vehicle
     Q_PROPERTY(bool     takeoffVehicleSupported READ takeoffVehicleSupported                        CONSTANT)                   ///< Guided takeoff supported
     Q_PROPERTY(QString  gotoFlightMode          READ gotoFlightMode                                 CONSTANT)                   ///< Flight mode vehicle is in while performing goto
     Q_PROPERTY(bool     haveMRSpeedLimits       READ haveMRSpeedLimits                              NOTIFY haveMRSpeedLimChanged)
@@ -887,6 +887,7 @@ signals:
     void flyingChanged                  (bool flying);
     void landingChanged                 (bool landing);
     void guidedModeChanged              (bool guidedMode);
+    void capabilitiesChanged            ();
     void vtolInFwdFlightChanged         (bool vtolInFwdFlight);
     void prearmErrorChanged             (const QString& prearmError);
     void soloFirmwareChanged            (bool soloFirmware);

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -189,6 +189,14 @@ Rectangle {
                             }
 
                             FactCheckBox {
+                                text:       qsTr("Force enable \"ROI at Location\"")
+                                visible:    _enableROI.visible
+                                fact:       _enableROI
+
+                                property Fact _enableROI: QGroundControl.settingsManager.firmwareCapabilitiesSettings.enableROI
+                            }
+
+                            FactCheckBox {
                                 text:       qsTr("Enable Custom Actions")
                                 visible:    _enableCustomActions.visible
                                 fact:       _enableCustomActions


### PR DESCRIPTION
Addresses #10640 by adding a User Setting to force enable the "ROI at Location" in FlyView.

This is the simplest way to allow setting ROIs on ArduPilot vehicles fitted with a Gimbal.