### PR TITLE
Ardupilotmega flag added for Mavlink Dialect

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -58,6 +58,11 @@ isEmpty(MAVLINK_CONF) {
     }
 }
 
+equals (MAVLINK_CONF, ardupilotmega) {
+    MAVLINK_CONF_ARDUPILOTMEGA = 1
+    DEFINES += MAVLINK_CONF_ARDUPILOTMEGA=$$MAVLINK_CONF_ARDUPILOTMEGA
+}
+
 # If defined, all APM specific MAVLink messages are disabled
 contains (CONFIG, QGC_DISABLE_APM_MAVLINK) {
     message("Disable APM MAVLink support")

--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -58,11 +58,6 @@ isEmpty(MAVLINK_CONF) {
     }
 }
 
-equals (MAVLINK_CONF, ardupilotmega) {
-    MAVLINK_CONF_ARDUPILOTMEGA = 1
-    DEFINES += MAVLINK_CONF_ARDUPILOTMEGA=$$MAVLINK_CONF_ARDUPILOTMEGA
-}
-
 # If defined, all APM specific MAVLink messages are disabled
 contains (CONFIG, QGC_DISABLE_APM_MAVLINK) {
     message("Disable APM MAVLink support")

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -728,9 +728,11 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_VFR_HUD:
         _handleVfrHud(message);
         break;
+#ifdef MAVLINK_CONF_ARDUPILOTMEGA
     case MAVLINK_MSG_ID_RANGEFINDER:
         _handleRangefinder(message);
         break;
+#endif
     case MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT:
         _handleNavControllerOutput(message);
         break;
@@ -1015,9 +1017,11 @@ void Vehicle::_handleVfrHud(mavlink_message_t& message)
 
 void Vehicle::_handleRangefinder(mavlink_message_t& message)
 {
+#ifdef MAVLINK_CONF_ARDUPILOTMEGA
     mavlink_rangefinder_t rangefinder;
     mavlink_msg_rangefinder_decode(&message, &rangefinder);
     _rangeFinderDistFact.setRawValue(qIsNaN(rangefinder.distance) ? 0 : rangefinder.distance);
+#endif
 }
 
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -728,11 +728,6 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_VFR_HUD:
         _handleVfrHud(message);
         break;
-#ifdef MAVLINK_CONF_ARDUPILOTMEGA
-    case MAVLINK_MSG_ID_RANGEFINDER:
-        _handleRangefinder(message);
-        break;
-#endif
     case MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT:
         _handleNavControllerOutput(message);
         break;
@@ -794,6 +789,9 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_CAMERA_FEEDBACK:
         _handleCameraFeedback(message);
         break;
+    case MAVLINK_MSG_ID_RANGEFINDER:
+        _handleRangefinder(message);
+        break;
 #endif
     }
 
@@ -814,6 +812,14 @@ void Vehicle::_handleCameraFeedback(const mavlink_message_t& message)
     QGeoCoordinate imageCoordinate((double)feedback.lat / qPow(10.0, 7.0), (double)feedback.lng / qPow(10.0, 7.0), feedback.alt_msl);
     qCDebug(VehicleLog) << "_handleCameraFeedback coord:index" << imageCoordinate << feedback.img_idx;
     _cameraTriggerPoints.append(new QGCQGeoCoordinate(imageCoordinate, this));
+}
+
+void Vehicle::_handleRangefinder(mavlink_message_t& message)
+{
+
+    mavlink_rangefinder_t rangefinder;
+    mavlink_msg_rangefinder_decode(&message, &rangefinder);
+    _rangeFinderDistFact.setRawValue(qIsNaN(rangefinder.distance) ? 0 : rangefinder.distance);
 }
 #endif
 
@@ -1014,16 +1020,6 @@ void Vehicle::_handleVfrHud(mavlink_message_t& message)
     }
     _altitudeTuningFact.setRawValue(vfrHud.alt - _altitudeTuningOffset);
 }
-
-void Vehicle::_handleRangefinder(mavlink_message_t& message)
-{
-#ifdef MAVLINK_CONF_ARDUPILOTMEGA
-    mavlink_rangefinder_t rangefinder;
-    mavlink_msg_rangefinder_decode(&message, &rangefinder);
-    _rangeFinderDistFact.setRawValue(qIsNaN(rangefinder.distance) ? 0 : rangefinder.distance);
-#endif
-}
-
 
 void Vehicle::_handleNavControllerOutput(mavlink_message_t& message)
 {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1033,7 +1033,6 @@ private:
     void _handleGlobalPositionInt       (mavlink_message_t& message);
     void _handleAltitude                (mavlink_message_t& message);
     void _handleVfrHud                  (mavlink_message_t& message);
-    void _handleRangefinder             (mavlink_message_t& message);
     void _handleNavControllerOutput     (mavlink_message_t& message);
     void _handleHighLatency             (mavlink_message_t& message);
     void _handleHighLatency2            (mavlink_message_t& message);
@@ -1048,6 +1047,7 @@ private:
     // ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)
     void _handleCameraFeedback          (const mavlink_message_t& message);
+    void _handleRangefinder             (mavlink_message_t& message);
 #endif
     void _handleCameraImageCaptured     (const mavlink_message_t& message);
     void _handleADSBVehicle             (const mavlink_message_t& message);


### PR DESCRIPTION
While building for Mavlink common dialect `common`, `mavlink_rangefinder_t` and all supporting functions are undefined as it is defined for only `ardupilotmega` dialect.

Have added flags to check the same. This I faced when I tried building for the custom QGC build with default dialect as `common`