### PR TITLE
RemoteIDManager: Fix GPS bad not being detected:

### DIFF
--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -337,15 +337,15 @@ void RemoteIDManager::_sendSystem()
                                                     _id_or_mac_unknown,
                                                     _settings->locationType()->rawValue().toUInt(),
                                                     _settings->classificationType()->rawValue().toUInt(),
-                                                    geoPositionInfo.isValid() ? ( gcsPosition.latitude()  * 1.0e7 ) : 0, // If position not valid, send a 0
-                                                    geoPositionInfo.isValid() ? ( gcsPosition.longitude() * 1.0e7 ) : 0, // If position not valid, send a 0
+                                                    _gcsGPSGood ? ( gcsPosition.latitude()  * 1.0e7 ) : 0, // If position not valid, send a 0
+                                                    _gcsGPSGood ? ( gcsPosition.longitude() * 1.0e7 ) : 0, // If position not valid, send a 0
                                                     AREA_COUNT,
                                                     AREA_RADIUS,
                                                     -1000.0f,
                                                     -1000.0f,
                                                     _settings->categoryEU()->rawValue().toUInt(),
                                                     _settings->classEU()->rawValue().toUInt(),
-                                                    geoPositionInfo.isValid() ? gcsPosition.altitude() : 0, // If position not valid, send a 0
+                                                    _gcsGPSGood ? gcsPosition.altitude() : 0, // If position not valid, send a 0
                                                     _timestamp2019()), // Time stamp needs to be since 00:00:00 1/1/2019
         _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }


### PR DESCRIPTION
we were using the geopositioninfo.isValid() in order to discard GPS and send lat/long/alt 0, but this function returns true even if latest GPS refresh was long time ago, so now instead we are using _gcsGPSGood, which takes into account the 5 seconds timeout as well.

This fixes the issue where unplugging GPS would still show "gps good" because QGC backend would take just the latest good GPS position, so as long as we had good GPS position at some point this was always true. Now after the 5 seconds timeout, if we don't have further "fresher" GPS updates, this flag will evaluate to false, and thus it will work correctly.

