### PR TITLE
Joystick input should switch to the active vehicle when the active vehicle changes

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -178,7 +178,8 @@ Vehicle::Vehicle(LinkInterface*             link,
     _linkManager = _toolbox->linkManager();
 
     connect(_joystickManager, &JoystickManager::activeJoystickChanged, this, &Vehicle::_loadSettings);
-    connect(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::activeVehicleAvailableChanged, this, &Vehicle::_loadSettings);
+    connect(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::activeVehicleAvailableChanged, this, &Vehicle::_activeVehicleAvailableChanged);
+    connect(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::activeVehicleChanged, this, &Vehicle::_activeVehicleChanged);
 
     _mavlink = _toolbox->mavlinkProtocol();
     qCDebug(VehicleLog) << "Link started with Mavlink " << (_mavlink->getCurrentVersion() >= 200 ? "V2" : "V1");
@@ -2081,6 +2082,22 @@ void Vehicle::_loadSettings()
     if (_toolbox->joystickManager()->joysticks().count()) {
         setJoystickEnabled(settings.value(_joystickEnabledSettingsKey, false).toBool());
         _startJoystick(true);
+    }
+}
+
+void Vehicle::_activeVehicleAvailableChanged(bool isActiveVehicleAvailable)
+{
+    // if there is no longer an active vehicle, disconnect the joystick
+    if(!isActiveVehicleAvailable) {
+        setJoystickEnabled(false);
+    }
+}
+
+void Vehicle::_activeVehicleChanged(Vehicle *newActiveVehicle)
+{
+    if(newActiveVehicle == this) {
+        // this vehicle is the newly active vehicle
+        setJoystickEnabled(true);
     }
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1018,6 +1018,8 @@ private slots:
 
 private:
     void _loadSettings                  ();
+    void _activeVehicleAvailableChanged (bool isActiveVehicleAvailable);
+    void _activeVehicleChanged          (Vehicle* newActiveVehicle);
     void _saveSettings                  ();
     void _startJoystick                 (bool start);
     void _handlePing                    (LinkInterface* link, mavlink_message_t& message);


### PR DESCRIPTION
This addresses issue #10544. 

When there are multiple vehicles, and you select a vehicle, the joystick should switch over to the newly active vehicle, and _only_ the active vehicle (so that joystick inputs are not sent to a vehicle you do not intend to control). 

In this PR, we achieve this by handling the `MultiVehicleManager::activeVehicleAvailableChanged` and `MultiVehicleManager::activeVehicleChanged` signals and invoking `setJoystickEnabled()` appropriately. 