### PR TITLE
add release tag to metainfo file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,8 +224,13 @@ install(
     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps/
     RENAME org.mavlink.qgroundcontrol.png
 )
+configure_file(
+    ${CMAKE_SOURCE_DIR}/deploy/org.mavlink.qgroundcontrol.metainfo.xml.in
+    ${CMAKE_BINARY_DIR}/metainfo/org.mavlink.qgroundcontrol.metainfo.xml
+    @ONLY
+)
 install(
-    FILES ${CMAKE_SOURCE_DIR}/deploy/org.mavlink.qgroundcontrol.metainfo.xml
+    FILES ${CMAKE_BINARY_DIR}/metainfo/org.mavlink.qgroundcontrol.metainfo.xml
     DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo/
 )
 

--- a/cmake/Git.cmake
+++ b/cmake/Git.cmake
@@ -23,3 +23,13 @@ execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --tags
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 OUTPUT_VARIABLE APP_VERSION_STR
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+execute_process(COMMAND ${GIT_EXECUTABLE} describe --abbrev=0
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                OUTPUT_VARIABLE REL_VERSION
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+execute_process(COMMAND ${GIT_EXECUTABLE} log -1 --format=%aI ${REL_VERSION}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                OUTPUT_VARIABLE REL_DATE
+                OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/deploy/org.mavlink.qgroundcontrol.metainfo.xml.in
+++ b/deploy/org.mavlink.qgroundcontrol.metainfo.xml.in
@@ -24,6 +24,10 @@
 
   <content_rating type="oars-1.1" />
 
+  <releases>
+    <release date="@REL_DATE@" version="@REL_VERSION@"/>
+  </releases>
+
   <launchable type="desktop-id">org.mavlink.qgroundcontrol.desktop</launchable>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
This adds a `release` tag to the `.metainfo.xml`.

According to the [documentation](https://freedesktop.org/software/appstream/docs/chap-Quickstart.html#qsr-app-contents-suggestions), this is only suggested. But it is required for Flathub and would allow using the upstream metainfo file without modifications.