### PR TITLE
libs: OpenSSL update to 1.1.1l_1.0.2u

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/mavlink/c_library_v2.git
 [submodule "libs/OpenSSL/android_openssl"]
 	path = libs/OpenSSL/android_openssl
-	url = https://github.com/Auterion/android_openssl
+	url = https://github.com/KDAB/android_openssl
 [submodule "libs/qmlglsink/gst-plugins-good"]
 	path = libs/qmlglsink/gst-plugins-good
 	url = https://github.com/mavlink/gst-plugins-good.git


### PR DESCRIPTION
OpenSSL for android wasn't updated for 3 years. Fetching elevation data in Android wasn't working, it reported a TLS error. Updating to latest openSSL solves the problem.

By the way, openssl for android submodule is pointing to a branch in Auterion repo. That Auterion repo doesn't have any modification at all in this front. Would it make sense to make it point to the original openssl repo Auterion repo is pointing to?

Thank you very much to Arace UAS for reporting this issue!