### PR TITLE
Fixed ModalAi Flight Core V2 Firmware Update Not Working On QGC

### DIFF
--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -23,6 +23,7 @@
         { "vendorID": 9900, "productID": 1,         "boardClass": "Pixhawk",    "name": "Omnibus F4 SD" },
         { "vendorID": 8137, "productID": 28,        "boardClass": "Pixhawk",    "name": "PX4 FMUK66 v3.x" },
         { "vendorID": 1155, "productID": 41775,     "boardClass": "Pixhawk",    "name": "PX4 FMU ModalAI FCv1" },
+        { "vendorID": 1155, "productID": 41776,     "boardClass": "Pixhawk",    "name": "PX4 FMU ModalAI FCv2" },
         { "vendorID":12642, "productID": 75,        "boardClass": "Pixhawk",    "name": "PX4 DurandalV1" },
         { "vendorID":12642, "productID": 80,        "boardClass": "Pixhawk",    "name": "Holybro Kakute Flight Controller" },
         { "vendorID": 4104, "productID": 1,         "boardClass": "Pixhawk",    "name": "PX4 FMU UVify Core" },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/84941452/232159477-54d5a8f7-c151-4655-ac1c-1ccd5cedd144.png)

Updating the firmware on the FlightCore V2 would not work on QGC due to the board not being included on USBBoardInfo.json. After I put the board on USBBoardInfo.json, I could update the firmware like normal. Without its inclusion, commands to the board would time out during update.