### PR TITLE
Vehicle: fix odd warning in _handleStatusText

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -944,7 +944,6 @@ void Vehicle::_chunkedStatusTextCompleted(uint8_t compId)
 
 void Vehicle::_handleStatusText(mavlink_message_t& message)
 {
-    QByteArray  b;
     QString     messageText;
 
     mavlink_statustext_t statustext;
@@ -952,9 +951,9 @@ void Vehicle::_handleStatusText(mavlink_message_t& message)
 
     uint8_t compId = message.compid;
 
-    b.resize(MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1);
-    strncpy(b.data(), statustext.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
-    b[b.length()-1] = '\0';
+    char b[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1];
+    strncpy(b, statustext.text, MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN);
+    b[sizeof(b)-1] = '\0';
     messageText = QString(b);
     bool includesNullTerminator = messageText.length() < MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN;
 


### PR DESCRIPTION
This fixes the warning that I get with GCC 11.3:

```
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:34:

warning: ‘__builtin_strncpy’ writing 50 bytes into a region of size 24 overflows the destination [-Wstringop-overflow=]

   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |                                  ^
/usr/include/x86_64-linux-gnu/bits/string_fortified.h: In member function ‘_handleStatusText’:
../Qt/5.15.2/gcc_64/include/QtCore/qarraydata.h:129:8: note: destination object ‘<anonymous>’ of size 24
  129 | struct QTypedArrayData
      |        ^
```

