### PR TITLE
Fix parsering of hygrometer message

### DIFF
--- a/src/Vehicle/VehicleHygrometerFactGroup.cc
+++ b/src/Vehicle/VehicleHygrometerFactGroup.cc
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2023 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
@@ -46,7 +46,7 @@ void VehicleHygrometerFactGroup::_handleHygrometerSensor(mavlink_message_t& mess
     mavlink_hygrometer_sensor_t hygrometer;
     mavlink_msg_hygrometer_sensor_decode(&message, &hygrometer);
 
-    _hygroTempFact.setRawValue(hygrometer.temperature);
+    _hygroTempFact.setRawValue(hygrometer.temperature/100.f);
     _hygroHumiFact.setRawValue(hygrometer.humidity);
     _hygroIDFact.setRawValue(hygrometer.id);
 }


### PR DESCRIPTION
Hi, 

[Hygrometer](https://mavlink.io/en/messages/common.html#HYGROMETER_SENSOR) mavlink message uses (is defined) centi-Celsius-degrees units (C*100). But in QGC, the message is currently parasersed as if they were the basic grades of Celsius. 

This PR converts the value from the message to basic unit DegresCelsius. 

![image](https://user-images.githubusercontent.com/5196729/236276679-75839dc6-7889-441e-abbd-cab9aae422eb.png)

![image](https://user-images.githubusercontent.com/5196729/236276734-d5f8f52e-8cf7-4d93-8858-92b874c00cc8.png)

![image](https://user-images.githubusercontent.com/5196729/236276845-edcfd387-d7cf-4721-b506-86afdf79849c.png)
