### PR TITLE
TransectStyleComplexItem.cc: Fix bug generating empty surveys when no terrain data

### DIFF
--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -422,12 +422,14 @@ void TransectStyleComplexItem::_rebuildTransects(void)
         return;
     case QGroundControlQmlGlobal::AltitudeModeRelative:
     case QGroundControlQmlGlobal::AltitudeModeAbsolute:
-        // Not following terrain so we can build the flight path now
+    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
+        // Terrain height not needed to calculate path, as TerrainFrame specifies a fixed altitude over terrain, doesn't need to know the actual terrain height
+        // so vehicle is responsible for having or not this altitude calculation, so we can build the flight path right away.
         _buildFlightPathCoordInfoFromTransects();
         break;
     case QGroundControlQmlGlobal::AltitudeModeCalcAboveTerrain:
-    case QGroundControlQmlGlobal::AltitudeModeTerrainFrame:
-        // Query the terrain data. Once available flight path will be calculated
+        // Query the terrain data. Once available flight path will be calculated, as on this mode QGC actually calculates the individual altitude for each waypoint
+        // having into account terrain data.
         _queryTransectsPathHeightInfo();
         break;
     }


### PR DESCRIPTION
Selecting terrain data on surverys was generating an empty survey if the polygon was on an area where QGC doesn't have terrain height info about.

This is because QGC was waiting on terrain info to build the path on such surveys, which is not needed at all, because terrain frame just specifies an altitude above terrain, and relies on the vehicle for being able to calculate that height, by terrain database or by altitude sensors, having terrain height information is not needed at all to generate this kind of surveys.

I think this is heritage of a few time ago where QGC didn't support terrain frame for missions, and it was supporting only what we call now AltitudeModeCalcAboveTerrain, so this comprobation was needed.

I double checked what happens on this situation selecting AltitudeModeCalcAboveTerrain instead, and it works correctly, instead of uploading an empty survey it throws an error: 

"Plan is waiting on terrain data from server for correct altitude values."

So I think everything should be working correctly now. In any case, I would appreciate if @DonLakeFlyer and @booo can double check this makes sense.

Thank you very much @AndKe for reporting this issue #10557. Please let me know if this fixes the issue for you.