### PR TITLE
Remote id fronted: hide all indicators if RID comms is not healthy:

### DIFF
--- a/src/ui/preferences/RemoteIDSettings.qml
+++ b/src/ui/preferences/RemoteIDSettings.qml
@@ -42,6 +42,9 @@ Rectangle {
     // Flag to get active vehicle and active RID
     property var  _activeRID:           _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager : null
 
+    // Healthy connection with RID device
+    property bool commsGood:            _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.commsGood : false
+
     // General properties
     property var  _activeVehicle:       QGroundControl.multiVehicleManager.activeVehicle
     property int  _regionOperation:     QGroundControl.settingsManager.remoteIDSettings.region.value
@@ -151,6 +154,7 @@ Rectangle {
                         Layout.preferredWidth:  flagsWidth
                         color:                  _activeRID ? (_activeVehicle.remoteIDManager.armStatusGood ? qgcPal.colorGreen : qgcPal.colorRed) : qgcPal.colorGrey
                         radius:                 radiusFlags
+                        visible:                commsGood
 
                         QGCLabel {
                             anchors.fill:           parent
@@ -178,7 +182,7 @@ Rectangle {
 
                         QGCLabel {
                             anchors.fill:           parent
-                            text:                   qsTr("RID COMMS")
+                            text:                   _activeRID && _activeVehicle.remoteIDManager.commsGood ? qsTr("RID COMMS") : qsTr("NOT CONNECTED")
                             wrapMode:               Text.WordWrap
                             horizontalAlignment:    Text.AlignHCenter
                             verticalAlignment:      Text.AlignVCenter
@@ -192,6 +196,7 @@ Rectangle {
                         Layout.preferredWidth:  flagsWidth
                         color:                  _activeRID ? (_activeVehicle.remoteIDManager.gcsGPSGood ? qgcPal.colorGreen : qgcPal.colorRed) : qgcPal.colorGrey
                         radius:                 radiusFlags
+                        visible:                commsGood
 
                         QGCLabel {
                             anchors.fill:           parent
@@ -215,6 +220,7 @@ Rectangle {
                         Layout.preferredWidth:  flagsWidth
                         color:                  _activeRID ? (_activeVehicle.remoteIDManager.basicIDGood ? qgcPal.colorGreen : qgcPal.colorRed) : qgcPal.colorGrey
                         radius:                 radiusFlags
+                        visible:                commsGood
 
                         QGCLabel {
                             anchors.fill:           parent
@@ -238,7 +244,7 @@ Rectangle {
                         Layout.preferredWidth:  flagsWidth
                         color:                  _activeRID ? (_activeVehicle.remoteIDManager.operatorIDGood ? qgcPal.colorGreen : qgcPal.colorRed) : qgcPal.colorGrey
                         radius:                 radiusFlags
-                        visible:                _activeRID ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDSettings.RegionOperation.EU) : false
+                        visible:                commsGood && _activeRID ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDSettings.RegionOperation.EU) : false
 
                         QGCLabel {
                             anchors.fill:           parent

--- a/src/ui/toolbar/RemoteIDIndicator.qml
+++ b/src/ui/toolbar/RemoteIDIndicator.qml
@@ -142,6 +142,7 @@ Item {
                         source:             armFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
                         fillMode:           Image.PreserveAspectFit
                         sourceSize.height:  height
+                        visible:            commsFlag
 
                         QGCLabel {
                             anchors.fill:           parent
@@ -169,7 +170,7 @@ Item {
 
                         QGCLabel {
                             anchors.fill:           parent
-                            text:                   qsTr("RID COMMS")
+                            text:                   commsFlag ? qsTr("RID COMMS") : qsTr("NOT CONNECTED")
                             wrapMode:               Text.WordWrap
                             horizontalAlignment:    Text.AlignHCenter
                             verticalAlignment:      Text.AlignVCenter
@@ -190,6 +191,7 @@ Item {
                         source:             gpsFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
                         fillMode:           Image.PreserveAspectFit
                         sourceSize.height:  height
+                        visible:            commsFlag
 
                         QGCLabel {
                             anchors.fill:           parent
@@ -214,6 +216,7 @@ Item {
                         source:             basicIDFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
                         fillMode:           Image.PreserveAspectFit
                         sourceSize.height:  height
+                        visible:            commsFlag
 
                         QGCLabel {
                             anchors.fill:           parent
@@ -238,7 +241,7 @@ Item {
                         source:             operatorIDFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
                         fillMode:           Image.PreserveAspectFit
                         sourceSize.height:  height
-                        visible:            _activeVehicle ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDIndicator.RegionOperation.EU) : false
+                        visible:            commsFlag && _activeVehicle ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDIndicator.RegionOperation.EU) : false
 
                         QGCLabel {
                             anchors.fill:           parent


### PR DESCRIPTION
All this remote id feature depends on a device being detected so it makes sense to not show the rest of the flags until a healthy connection has been detected. Now it looks like this until we have healthy connection with RID device ( arm status message received ):

![rid settigns](https://github.com/mavlink/qgroundcontrol/assets/18221398/9e7eb1d2-d5dc-4764-96e3-ce081a205047)
![rid indicator](https://github.com/mavlink/qgroundcontrol/assets/18221398/f41b2581-6871-4b1e-9cfa-eeba2445782a)

It addresses the issues mentioned here #10654.

