### PR TITLE
install-qt-linux.sh: Remove use of soon to be deprecated aqt install

### DIFF
--- a/deploy/docker/install-qt-linux.sh
+++ b/deploy/docker/install-qt-linux.sh
@@ -13,6 +13,6 @@ set -e
 apt-get update
 apt-get install python3 python3-pip -y
 pip3 install aqtinstall
-aqt install --outputdir ${QT_PATH} ${QT_VERSION} ${QT_HOST} ${QT_TARGET} -m ${QT_MODULES}
+aqt install-qt ${QT_HOST} ${QT_TARGET} ${QT_VERSION} -O ${QT_PATH} -m ${QT_MODULES}
 echo "Remember to export the following to your PATH: ${QT_PATH}/${QT_VERSION}/*/bin"
 echo "export PATH=$(readlink -e ${QT_PATH}/${QT_VERSION}/*/bin/):PATH"


### PR DESCRIPTION
The command "aqt install" is deprecated and marked for removal. It has been replaced with "aqt install-qt". 