### PR TITLE
MainRootWindow: fix bug toolbar dissapearing:

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -264,7 +264,7 @@ ApplicationWindow {
     header: MainToolBar {
         id:         toolbar
         height:     ScreenTools.toolbarHeight
-        visible:    !QGroundControl.videoManager.fullScreen
+        visible:    !(QGroundControl.videoManager.fullScreen && flightView.visible)
     }
 
     footer: LogReplayStatusBar {


### PR DESCRIPTION
In the edge scenario where we set video view in full screen and for some reason QGC brings us to setup view ( if the vehicle has calibration/setup pending ) the toolbar would dissapear, thus not being able to get out of that state.


