### PR TITLE
[DRAFT] Include support for Ardupilot terrain servers as elevation data source

### DIFF
--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -588,11 +588,23 @@ FlightMap {
                         globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionROI, clickMenu.coord, roiLocationItem)
                     }
                 }
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    text: "Set home here"
+                    visible: globals.guidedControllerFlyView.showSetHome
+                    onClicked: {
+                        if (clickMenu.opened) {
+                            clickMenu.close()
+                        }
+                        globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionSetHome, clickMenu.coord)
+                    }
+                }
             }
         }
 
         onClicked: {
-            if (!globals.guidedControllerFlyView.guidedUIVisible && (globals.guidedControllerFlyView.showGotoLocation || globals.guidedControllerFlyView.showOrbit || globals.guidedControllerFlyView.showROI)) {
+            if (!globals.guidedControllerFlyView.guidedUIVisible && (globals.guidedControllerFlyView.showGotoLocation || globals.guidedControllerFlyView.showOrbit || globals.guidedControllerFlyView.showROI || globals.guidedControllerFlyView.showSetHome)) {
                 orbitMapCircle.hide()
                 gotoLocationItem.hide()
                 var clickCoord = _root.toCoordinate(Qt.point(mouse.x, mouse.y), false /* clipToViewPort */)

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -55,6 +55,7 @@ Item {
     readonly property string gotoTitle:                     qsTr("Go To Location")
     readonly property string vtolTransitionTitle:           qsTr("VTOL Transition")
     readonly property string roiTitle:                      qsTr("ROI")
+    readonly property string setHomeTitle:                  qsTr("Set Home")
     readonly property string actionListTitle:               qsTr("Action")
 
     readonly property string armMessage:                        qsTr("Arm the vehicle.")
@@ -79,6 +80,7 @@ Item {
     readonly property string vtolTransitionFwdMessage:          qsTr("Transition VTOL to fixed wing flight.")
     readonly property string vtolTransitionMRMessage:           qsTr("Transition VTOL to multi-rotor flight.")
     readonly property string roiMessage:                        qsTr("Make the specified location a Region Of Interest.")
+    readonly property string setHomeMessage:                    qsTr("Set vehicle home as the specified location. This will affect Return to Home position")
 
     readonly property int actionRTL:                        1
     readonly property int actionLand:                       2
@@ -105,6 +107,7 @@ Item {
     readonly property int actionActionList:                 23
     readonly property int actionForceArm:                   24
     readonly property int actionChangeSpeed:                25
+    readonly property int actionSetHome:                    26
 
     property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
     property bool   _useChecklist:              QGroundControl.settingsManager.appSettings.useChecklist.rawValue && QGroundControl.corePlugin.options.preFlightChecklistUrl.toString().length
@@ -130,6 +133,7 @@ Item {
     property bool showROI:              _guidedActionsEnabled && _vehicleFlying && __roiSupported && !_missionActive
     property bool showLandAbort:        _guidedActionsEnabled && _vehicleFlying && _fixedWingOnApproach
     property bool showGotoLocation:     _guidedActionsEnabled && _vehicleFlying
+    property bool showSetHome:          _guidedActionsEnabled
     property bool showActionList:       _guidedActionsEnabled && (showStartMission || showResumeMission || showChangeAlt || showLandAbort || actionList.hasCustomActions)
     property string changeSpeedTitle:   _fixedWing ? changeAirspeedTitle : changeCruiseSpeedTitle
     property string changeSpeedMessage: _fixedWing ? changeAirspeedMessage : changeCruiseSpeedMessage
@@ -496,6 +500,11 @@ Item {
             confirmDialog.message = changeSpeedMessage
             guidedValueSlider.visible = true
             break
+        case actionSetHome:
+            confirmDialog.title = setHomeTitle
+            confirmDialog.message = setHomeMessage
+            confirmDialog.hideTrigger = Qt.binding(function() { return !showSetHome })
+            break
         default:
             console.warn("Unknown actionCode", actionCode)
             return
@@ -584,6 +593,9 @@ Item {
                     _activeVehicle.guidedModeChangeGroundSpeed(sliderOutputValue)
                 }
             }
+            break
+        case actionSetHome:
+            _activeVehicle.doSetHome(actionData)
             break
         default:
             console.warn(qsTr("Internal error: unknown actionCode"), actionCode)

--- a/src/QtLocationPlugin/ElevationMapProvider.cpp
+++ b/src/QtLocationPlugin/ElevationMapProvider.cpp
@@ -88,6 +88,8 @@ QString ApStr1ElevationProvider::_getURL(const int x, const int y, const int zoo
          .arg(QString(formattedStringYLat))
          .arg(QString(formattedStringXLong))
          ;
+
+    qDebug() << "Ardupilot string: " << urlString;
     
     return urlString;
 }
@@ -110,4 +112,9 @@ QGCTileSet ApStr1ElevationProvider::getTileCount(const int zoom, const double to
     set.tileSize = getAverageSize() * set.tileCount;
 
     return set;
+}
+
+QByteArray ApStr1ElevationProvider::unzipTile(QByteArray response) {
+    
+    return response;
 }

--- a/src/QtLocationPlugin/ElevationMapProvider.cpp
+++ b/src/QtLocationPlugin/ElevationMapProvider.cpp
@@ -115,6 +115,18 @@ QGCTileSet ApStr1ElevationProvider::getTileCount(const int zoom, const double to
 }
 
 QByteArray ApStr1ElevationProvider::unzipTile(QByteArray response) {
+
+    // This is not working, we need to use a proper zip library like zlib
+    
+    int decompressedSize = 25000000; // Uncompressed AP terrain files STR1 are aprox 25 Mb. 
+    response.prepend((unsigned char)((decompressedSize >> 24) & 0xFF));
+    response.prepend((unsigned char)((decompressedSize >> 16) & 0xFF));
+    response.prepend((unsigned char)((decompressedSize >> 8) & 0xFF));
+    response.prepend((unsigned char)((decompressedSize >> 0) & 0xFF));
+
+    qDebug() << "response before: " << response.size();
+    response = qUncompress(response);
+    qDebug() << "response aftery: " << response.size();
     
     return response;
 }

--- a/src/QtLocationPlugin/ElevationMapProvider.cpp
+++ b/src/QtLocationPlugin/ElevationMapProvider.cpp
@@ -6,8 +6,8 @@
 #include "QGCMapEngine.h"
 #include "TerrainTile.h"
 
-ElevationProvider::ElevationProvider(const QString& imageFormat, quint32 averageSize, QGeoMapType::MapStyle mapType, QObject* parent)
-    : MapProvider(QStringLiteral("https://api.airmap.com/"), imageFormat, averageSize, mapType, parent) {}
+ElevationProvider::ElevationProvider(const QString& imageFormat, quint32 averageSize, QGeoMapType::MapStyle mapType, const QString &referrer, QObject* parent)
+    : MapProvider(referrer, imageFormat, averageSize, mapType, parent) {}
 
 //-----------------------------------------------------------------------------
 int AirmapElevationProvider::long2tileX(const double lon, const int z) const {

--- a/src/QtLocationPlugin/ElevationMapProvider.cpp
+++ b/src/QtLocationPlugin/ElevationMapProvider.cpp
@@ -49,3 +49,7 @@ QGCTileSet AirmapElevationProvider::getTileCount(const int zoom, const double to
 
     return set;
 }
+
+QByteArray AirmapElevationProvider::serializeTile(QByteArray image) {
+    return TerrainTile::serializeFromAirMapJson(image);
+}

--- a/src/QtLocationPlugin/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/ElevationMapProvider.h
@@ -16,7 +16,8 @@ class ElevationProvider : public MapProvider {
     Q_OBJECT
   public:
     ElevationProvider(const QString& imageFormat, quint32 averageSize,
-                      QGeoMapType::MapStyle mapType, QObject* parent = nullptr);
+                      QGeoMapType::MapStyle mapType, const QString &referrer, 
+                      QObject* parent = nullptr);
 
     virtual bool _isElevationProvider() const override { return true; }
 };
@@ -29,7 +30,7 @@ class AirmapElevationProvider : public ElevationProvider {
   public:
     AirmapElevationProvider(QObject* parent = nullptr)
         : ElevationProvider(QStringLiteral("bin"), AVERAGE_AIRMAP_ELEV_SIZE,
-                            QGeoMapType::StreetMap, parent) {}
+                            QGeoMapType::StreetMap, QStringLiteral("https://api.airmap.com/"), parent) {}
 
     int long2tileX(const double lon, const int z) const override;
 

--- a/src/QtLocationPlugin/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/ElevationMapProvider.h
@@ -11,6 +11,7 @@
 #include <QString>
 
 static const quint32 AVERAGE_AIRMAP_ELEV_SIZE = 2786;
+static const quint32 AVERAGE_APSTR3_ELEV_SIZE = 100000; // Around 1 MB?
 
 class ElevationProvider : public MapProvider {
     Q_OBJECT
@@ -49,3 +50,25 @@ class AirmapElevationProvider : public ElevationProvider {
     QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
 };
 
+// -----------------------------------------------------------
+// Ardupilot Terrain Server Elevation SRTM1
+// https://terrain.ardupilot.org/SRTM1/
+
+class ApStr1ElevationProvider : public ElevationProvider {
+    Q_OBJECT
+  public:
+    ApStr1ElevationProvider(QObject* parent = nullptr)
+        : ElevationProvider(QStringLiteral("bin"), AVERAGE_APSTR3_ELEV_SIZE,
+                            QGeoMapType::StreetMap, QStringLiteral("https://terrain.ardupilot.org/SRTM1/"), parent) {}
+
+    int long2tileX(const double lon, const int z) const override;
+
+    int lat2tileY(const double lat, const int z) const override;
+
+    QGCTileSet getTileCount(const int zoom, const double topleftLon,
+                            const double topleftLat, const double bottomRightLon,
+                            const double bottomRightLat) const override;
+
+  protected:
+    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+};

--- a/src/QtLocationPlugin/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/ElevationMapProvider.h
@@ -58,7 +58,7 @@ class ApStr1ElevationProvider : public ElevationProvider {
     Q_OBJECT
   public:
     ApStr1ElevationProvider(QObject* parent = nullptr)
-        : ElevationProvider(QStringLiteral("bin"), AVERAGE_APSTR3_ELEV_SIZE,
+        : ElevationProvider(QStringLiteral("hgt"), AVERAGE_APSTR3_ELEV_SIZE,
                             QGeoMapType::StreetMap, QStringLiteral("https://terrain.ardupilot.org/SRTM1/"), parent) {}
 
     int long2tileX(const double lon, const int z) const override;

--- a/src/QtLocationPlugin/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/ElevationMapProvider.h
@@ -40,6 +40,11 @@ class AirmapElevationProvider : public ElevationProvider {
                             const double topleftLat, const double bottomRightLon,
                             const double bottomRightLat) const override;
 
+    // Airmap needs to serialize the tiles, because they are received in json format. This way we can work with
+    // them in the map tiles database
+    bool serializeTilesNeeded() override { return true; }
+    QByteArray serializeTile(QByteArray image) override;
+
   protected:
     QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
 };

--- a/src/QtLocationPlugin/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/ElevationMapProvider.h
@@ -69,6 +69,9 @@ class ApStr1ElevationProvider : public ElevationProvider {
                             const double topleftLat, const double bottomRightLon,
                             const double bottomRightLat) const override;
 
+    bool unzippingTilesNeeded() override { return true; }
+    QByteArray unzipTile(QByteArray response) override;
+
   protected:
     QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
 };

--- a/src/QtLocationPlugin/MapProvider.h
+++ b/src/QtLocationPlugin/MapProvider.h
@@ -52,6 +52,9 @@ public:
                                      const double topleftLat, const double bottomRightLon,
                                      const double bottomRightLat) const;
 
+    virtual bool serializeTilesNeeded() { return false; }
+    virtual QByteArray serializeTile(QByteArray image) { return image; }
+
 protected:
     QString _tileXYToQuadKey(const int tileX, const int tileY, const int levelOfDetail) const;
     int _getServerNum(const int x, const int y, const int max) const;

--- a/src/QtLocationPlugin/MapProvider.h
+++ b/src/QtLocationPlugin/MapProvider.h
@@ -54,6 +54,8 @@ public:
 
     virtual bool serializeTilesNeeded() { return false; }
     virtual QByteArray serializeTile(QByteArray image) { return image; }
+    virtual bool unzippingTilesNeeded() { return false; }
+    virtual QByteArray unzipTile(QByteArray response) { return response; }
 
 protected:
     QString _tileXYToQuadKey(const int tileX, const int tileY, const int levelOfDetail) const;

--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -287,8 +287,9 @@ QGCCachedTileSet::_networkReplyFinished()
             qCDebug(QGCCachedTileSetLog) << "Tile fetched" << hash;
             QByteArray image = reply->readAll();
             QString type = getQGCMapEngine()->hashToType(hash);
-            if (type == "Airmap Elevation" ) {
-                image = TerrainTile::serializeFromAirMapJson(image);
+            // Some providers need the images to be serialized because the response is not directly a image based tile
+            if (getQGCMapEngine()->urlFactory()->needsSerializingTiles(type)) {
+                image = getQGCMapEngine()->urlFactory()->serializeTileForId(image, type);
             }
             QString format = getQGCMapEngine()->urlFactory()->getImageFormat(type, image);
             if(!format.isEmpty()) {

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -76,6 +76,7 @@ UrlFactory::UrlFactory() : _timeout(5 * 1000) {
     _providersTable["VWorld Satellite Map"] = new VWorldSatMapProvider(this);
 
     _providersTable["Airmap Elevation"] = new AirmapElevationProvider(this);
+    _providersTable["Ardupilot-SRTM1 Elevation"] = new ApStr1ElevationProvider(this);
 
     _providersTable["Japan-GSI Contour"] = new JapanStdMapProvider(this);
     _providersTable["Japan-GSI Seamless"] = new JapanSeamlessMapProvider(this);

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -220,3 +220,11 @@ bool UrlFactory::needsSerializingTiles(QString mapType){
 QByteArray UrlFactory::serializeTileForId(QByteArray image, QString mapType){
     return _providersTable[mapType]->serializeTile(image);
 }
+
+bool UrlFactory::needsUnzippingTiles(QString mapType){
+    return _providersTable[mapType]->unzippingTilesNeeded();
+}
+
+QByteArray UrlFactory::unzipTileForType(QByteArray response, QString mapType) {
+    return _providersTable[mapType]->unzipTile(response);
+}

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -207,3 +207,15 @@ UrlFactory::getTileCount(int zoom, double topleftLon, double topleftLat, double 
 bool UrlFactory::isElevation(int mapId){
     return _providersTable[getTypeFromId(mapId)]->_isElevationProvider();
 }
+
+bool UrlFactory::isElevation(QString mapType){
+    return _providersTable[mapType]->_isElevationProvider();
+}
+
+bool UrlFactory::needsSerializingTiles(QString mapType){
+    return _providersTable[mapType]->serializeTilesNeeded();
+}
+
+QByteArray UrlFactory::serializeTileForId(QByteArray image, QString mapType){
+    return _providersTable[mapType]->serializeTile(image);
+}

--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -58,6 +58,8 @@ public:
     bool isElevation(int mapId);
     bool needsSerializingTiles(QString mapType);
     QByteArray serializeTileForId(QByteArray image, QString mapType);
+    bool needsUnzippingTiles(QString mapType);
+    QByteArray unzipTileForType(QByteArray response, QString mapType);
 
   private:
     int             _timeout;

--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -54,7 +54,10 @@ public:
                             double bottomRightLon, double bottomRightLat,
                             QString mapType);
 
+    bool isElevation(QString mapType);
     bool isElevation(int mapId);
+    bool needsSerializingTiles(QString mapType);
+    QByteArray serializeTileForId(QByteArray image, QString mapType);
 
   private:
     int             _timeout;

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -226,6 +226,21 @@ QGCMapEngineManager::mapProviderList()
     mapList.removeDuplicates();
     return mapList;
 }
+//-----------------------------------------------------------------------------
+QStringList
+QGCMapEngineManager::elevationProviderList()
+{
+    QStringList mapList = getQGCMapEngine()->getMapNameList();
+    QStringList elevationMapList;
+
+    for (const QString& providerString : mapList) {
+        int mapid = getQGCMapEngine()->urlFactory()->getIdFromType(providerString);
+        if (getQGCMapEngine()->urlFactory()->isElevation(mapid)) {
+            elevationMapList.append(providerString);
+        }
+    }
+    return elevationMapList;
+}
 
 //-----------------------------------------------------------------------------
 QStringList

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -37,26 +37,27 @@ public:
     };
     Q_ENUM(ImportAction)
 
-    Q_PROPERTY(quint64              tileCount       READ    tileCount       NOTIFY tileCountChanged)
-    Q_PROPERTY(QString              tileCountStr    READ    tileCountStr    NOTIFY tileCountChanged)
-    Q_PROPERTY(quint64              tileSize        READ    tileSize        NOTIFY tileSizeChanged)
-    Q_PROPERTY(QString              tileSizeStr     READ    tileSizeStr     NOTIFY tileSizeChanged)
-    Q_PROPERTY(QmlObjectListModel*  tileSets        READ    tileSets        NOTIFY tileSetsChanged)
-    Q_PROPERTY(QStringList          mapList         READ    mapList         CONSTANT)
-    Q_PROPERTY(QStringList          mapProviderList READ    mapProviderList CONSTANT)
-    Q_PROPERTY(quint32              maxMemCache     READ    maxMemCache     WRITE   setMaxMemCache  NOTIFY  maxMemCacheChanged)
-    Q_PROPERTY(quint32              maxDiskCache    READ    maxDiskCache    WRITE   setMaxDiskCache NOTIFY  maxDiskCacheChanged)
-    Q_PROPERTY(QString              errorMessage    READ    errorMessage    NOTIFY  errorMessageChanged)
-    Q_PROPERTY(bool                 fetchElevation  READ    fetchElevation  WRITE   setFetchElevation   NOTIFY  fetchElevationChanged)
+    Q_PROPERTY(quint64              tileCount             READ    tileCount             NOTIFY tileCountChanged)
+    Q_PROPERTY(QString              tileCountStr          READ    tileCountStr          NOTIFY tileCountChanged)
+    Q_PROPERTY(quint64              tileSize              READ    tileSize              NOTIFY tileSizeChanged)
+    Q_PROPERTY(QString              tileSizeStr           READ    tileSizeStr           NOTIFY tileSizeChanged)
+    Q_PROPERTY(QmlObjectListModel*  tileSets              READ    tileSets              NOTIFY tileSetsChanged)
+    Q_PROPERTY(QStringList          mapList               READ    mapList               CONSTANT)
+    Q_PROPERTY(QStringList          mapProviderList       READ    mapProviderList       CONSTANT)
+    Q_PROPERTY(QStringList          elevationProviderList READ    elevationProviderList CONSTANT)
+    Q_PROPERTY(quint32              maxMemCache           READ    maxMemCache           WRITE   setMaxMemCache      NOTIFY  maxMemCacheChanged)
+    Q_PROPERTY(quint32              maxDiskCache          READ    maxDiskCache          WRITE   setMaxDiskCache     NOTIFY  maxDiskCacheChanged)
+    Q_PROPERTY(QString              errorMessage          READ    errorMessage          NOTIFY  errorMessageChanged)
+    Q_PROPERTY(bool                 fetchElevation        READ    fetchElevation        WRITE   setFetchElevation   NOTIFY  fetchElevationChanged)
     //-- Disk Space in MB
-    Q_PROPERTY(quint32              freeDiskSpace   READ    freeDiskSpace   NOTIFY  freeDiskSpaceChanged)
-    Q_PROPERTY(quint32              diskSpace       READ    diskSpace       CONSTANT)
+    Q_PROPERTY(quint32              freeDiskSpace         READ    freeDiskSpace         NOTIFY  freeDiskSpaceChanged)
+    Q_PROPERTY(quint32              diskSpace             READ    diskSpace             CONSTANT)
     //-- Tile set export
-    Q_PROPERTY(int                  selectedCount   READ    selectedCount   NOTIFY selectedCountChanged)
-    Q_PROPERTY(int                  actionProgress  READ    actionProgress  NOTIFY actionProgressChanged)
-    Q_PROPERTY(ImportAction         importAction    READ    importAction    WRITE  setImportAction   NOTIFY importActionChanged)
+    Q_PROPERTY(int                  selectedCount         READ    selectedCount         NOTIFY selectedCountChanged)
+    Q_PROPERTY(int                  actionProgress        READ    actionProgress        NOTIFY actionProgressChanged)
+    Q_PROPERTY(ImportAction         importAction          READ    importAction          WRITE  setImportAction      NOTIFY importActionChanged)
 
-    Q_PROPERTY(bool                 importReplace   READ    importReplace   WRITE   setImportReplace   NOTIFY importReplaceChanged)
+    Q_PROPERTY(bool                 importReplace         READ    importReplace         WRITE   setImportReplace    NOTIFY importReplaceChanged)
 
     Q_INVOKABLE void                loadTileSets            ();
     Q_INVOKABLE void                updateForCurrentView    (double lon0, double lat0, double lon1, double lat1, int minZoom, int maxZoom, const QString& mapName);
@@ -79,6 +80,7 @@ public:
     QString                         tileSizeStr             () const;
     QStringList                     mapList                 ();
     QStringList                     mapProviderList         ();
+    QStringList                     elevationProviderList   ();
     Q_INVOKABLE QStringList         mapTypeList             (QString provider);
     QmlObjectListModel*             tileSets                () { return &_tileSets; }
     quint32                         maxMemCache             ();

--- a/src/Settings/FlightMap.SettingsGroup.json
+++ b/src/Settings/FlightMap.SettingsGroup.json
@@ -14,6 +14,12 @@
     "shortDesc": "Currently selected map type for flight maps",
     "type":             "string",
     "default":     "Hybrid"
+},
+{
+    "name":             "elevationMapProvider",
+    "shortDesc": "Currently selected elevation map provider",
+    "type":             "string",
+    "default":     "Airmap Elevation"
 }
 ]
 }

--- a/src/Settings/FlightMap.SettingsGroup.json
+++ b/src/Settings/FlightMap.SettingsGroup.json
@@ -19,7 +19,8 @@
     "name":             "elevationMapProvider",
     "shortDesc": "Currently selected elevation map provider",
     "type":             "string",
-    "default":     "Airmap Elevation"
+    "default":     "Airmap Elevation",
+    "qgcRebootRequired": true
 }
 ]
 }

--- a/src/Settings/FlightMapSettings.cc
+++ b/src/Settings/FlightMapSettings.cc
@@ -23,3 +23,4 @@ DECLARE_SETTINGGROUP(FlightMap, "FlightMap")
 
 DECLARE_SETTINGSFACT(FlightMapSettings, mapProvider)
 DECLARE_SETTINGSFACT(FlightMapSettings, mapType)
+DECLARE_SETTINGSFACT(FlightMapSettings, elevationMapProvider)

--- a/src/Settings/FlightMapSettings.h
+++ b/src/Settings/FlightMapSettings.h
@@ -22,5 +22,6 @@ public:
     DEFINE_SETTING_NAME_GROUP()
     DEFINE_SETTINGFACT(mapProvider)
     DEFINE_SETTINGFACT(mapType)
+    DEFINE_SETTINGFACT(elevationMapProvider)
 
 };

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -500,6 +500,43 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
         reply->deleteLater();
         return;
     }
+
+    // This is Mattew's code
+
+    // QString providerName = getQGCMapEngine()->urlFactory()->getTypeFromId(spec.mapId());
+    // // Some providers like Ardupilot SRTM servers send files zipped. check if it is needed
+    // if (getQGCMapEngine()->urlFactory()->needsUnzippingTiles(providerName)) {
+    //     // responseBytes = getQGCMapEngine()->urlFactory()->unzipTileForType(responseBytes, providerName);
+        
+    //     // Split out filename from path
+    //     QString remoteFileName = QFileInfo(reply->url().toString()).fileName();
+    //     if (remoteFileName.isEmpty()) {
+    //         qWarning() << "Unabled to parse filename from remote url" << reply->url().toString();
+    //         remoteFileName = "DownloadedFile";
+    //     }
+
+    //     // Strip out http parameters from remote filename
+    //     int parameterIndex = remoteFileName.indexOf("?");
+    //     if (parameterIndex != -1) {
+    //         remoteFileName  = remoteFileName.left(parameterIndex);
+    //     }
+    //     QFileInfo fi(remoteFileName);
+    //     QString ext = fi.completeSuffix();
+    //     //need to save ardupilot terrain data zip for extraction
+    //     if (ext == "hgt.zip"){
+    //         // Determine location to download file to
+    //         QString downloadFilename = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    //         downloadFilename += "/"  + remoteFileName;
+    //         if (!downloadFilename.isEmpty()) {
+    //             // Store downloaded file in download location
+    //             QFile file(downloadFilename);
+    //             if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    //                 file.write(image);
+    //                 file.close();
+    //             }
+    //         }
+    //     }
+    // }
     if (responseBytes.isEmpty()) {
         qCWarning(TerrainQueryLog) << "Error in fetching elevation tile. Empty response.";
         _tileFailed();
@@ -508,7 +545,8 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
     }
 
     qCDebug(TerrainQueryLog) << "Received some bytes of terrain data: " << responseBytes.size();
-
+    qDebug() << "Received some bytes of terrain data: " << responseBytes.size();
+    return;
     TerrainTile* terrainTile = new TerrainTile(responseBytes);
     if (terrainTile->isValid()) {
         _tilesMutex.lock();

--- a/src/TerrainTile.cc
+++ b/src/TerrainTile.cc
@@ -92,6 +92,7 @@ TerrainTile::TerrainTile(QByteArray byteArray)
     }
 
     _data = new int16_t*[_gridSizeLat];
+    // Here we have trouble crashing, obviously, we need to manage this whole terrain tile thing for other providers
     for (int k = 0; k < _gridSizeLat; k++) {
         _data[k] = new int16_t[_gridSizeLon];
     }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -47,6 +47,7 @@
 #include "FTPManager.h"
 #include "ImageProtocolManager.h"
 #include "HealthAndArmingCheckReport.h"
+#include "TerrainQuery.h"
 
 class Actuators;
 class EventHandler;
@@ -462,6 +463,8 @@ public:
 #if !defined(NO_ARDUPILOT_DIALECT)
     Q_INVOKABLE void flashBootloader();
 #endif
+    /// Set home from flight map coordinate
+    Q_INVOKABLE void doSetHome(const QGeoCoordinate& coord);
 
     bool    isInitialConnectComplete() const;
     bool    guidedModeSupported     () const;
@@ -1083,6 +1086,9 @@ private:
 
     static void _rebootCommandResultHandler(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress, MavCmdResultFailureCode_t failureCode);
 
+    // This is called after we get terrain data triggered from a doSetHome()
+    void _doSetHomeTerrainReceived      (bool success, QList<double> heights);
+
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
     bool    _offlineEditingVehicle = false; ///< true: This Vehicle is a "disconnected" vehicle for ui use while offline editing
@@ -1445,6 +1451,11 @@ private:
     // Settings keys
     static const char* _settingsGroup;
     static const char* _joystickEnabledSettingsKey;
+
+    // Terrain query members, used to get terrain altitude for doSetHome()
+    QTimer                      _updateDoSetHomeTerrainTimer;
+    TerrainAtCoordinateQuery*   _currentDoSetHomeTerrainAtCoordinateQuery = nullptr;
+    QGeoCoordinate              _doSetHomeCoordinate;
 };
 
 Q_DECLARE_METATYPE(Vehicle::MavCmdResultFailureCode_t)

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -42,6 +42,7 @@ Rectangle {
     property real   _valueFieldWidth:           ScreenTools.defaultFontPixelWidth * 10
     property string _mapProvider:               QGroundControl.settingsManager.flightMapSettings.mapProvider.value
     property string _mapType:                   QGroundControl.settingsManager.flightMapSettings.mapType.value
+    property string _elevationMapProvider:      QGroundControl.settingsManager.flightMapSettings.elevationMapProvider.value
     property Fact   _followTarget:              QGroundControl.settingsManager.appSettings.followTarget
     property real   _panelWidth:                _root.width * _internalWidthRatio
     property real   _margins:                   ScreenTools.defaultFontPixelWidth
@@ -593,6 +594,25 @@ Rectangle {
                                         var index = mapTypeCombo.find(_mapType)
                                         if(index < 0) index = 0
                                         mapTypeCombo.currentIndex = index
+                                    }
+                                }
+
+                                QGCLabel {
+                                    text:       qsTr("Elevation Map Provider")
+                                    width:      _labelWidth
+                                }
+                                QGCComboBox {
+                                    id:             elevationMapProviderCombo
+                                    model:          QGroundControl.mapEngineManager.elevationProviderList
+                                    Layout.preferredWidth:  _comboFieldWidth
+                                    onActivated: {
+                                        _elevationMapProvider = textAt(index)
+                                        QGroundControl.settingsManager.flightMapSettings.elevationMapProvider.value=textAt(index)
+                                    }
+                                    Component.onCompleted: {
+                                        var index = elevationMapProviderCombo.find(_elevationMapProvider)
+                                        if(index < 0) index = 0
+                                        elevationMapProviderCombo.currentIndex = index
                                     }
                                 }
 


### PR DESCRIPTION
I thought it would be good to start making public the current work done over a separate branch, so we can start testing builds when it is functional.

**current state of it:**
De coupling of Airmap in elevation architecture is mostly done, and database management should be fine for this new provider ( not tested yet ).

**latest commit is a work in progress, it doesn't build with it**

If the above indeed is good, we would need to sort out:
- getting url properly and be sure the file gets to be handled nicely by cache engine
- adapt whatever is neccesary in TerrainQuery and TerrainTile when it works with other sources than Airmap. Make sure here it is really provider agnostic, and ideally move the relevant methods to ElevationMapProvider.cpp/h 

Thanks @mwrightE38 for joining! 