### PR TITLE
Fix compile errors for MacOS Build

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -107,6 +107,7 @@ linux {
         QMAKE_CXXFLAGS += -fvisibility=hidden
         QMAKE_CXXFLAGS_WARN_ON += -Werror \
             -Wno-unused-parameter \         # gst-plugins-good
+            -Wno-unused-but-set-variable \ # eigen & QGCTileCacheWorker.cpp
             -Wno-deprecated-declarations    # eigen
     } else {
         error("Unsupported Mac toolchain, only 64-bit LLVM+clang is supported")


### PR DESCRIPTION
Building master QGC (or latest stable 4.2.6) on MacOS qmake or qtcreator was failing due to "unused but set variable" errors in QGCTileCacheWorker.cpp and the Eigen library.

My environment is:
- macOS Ventura 13.4.1
- x86_64
- using SDK 13.3 from Xcode 14

Adding -Wno-unused-but-set-variable suppresses the errors and the build succeeds fine.
These errors could be directly resolved in QGCTileCacheWorker.cpp but they would still be in the Eigen lib so I figured suppressing them was the better option but I could be wrong.

Another couple of notes about building QGC on MacOS Ventura which might be helpful for others
- the qt online installer is criminally slow, can use this line to open the online installer using a faster mirror and it will take 20 minutes rather than 20 hours `open qt-unified-macOS-x64-4.6.0-online.app --args --mirror https://mirrors.ocf.berkeley.edu/qt/`
- running qmake will warn you that Qt 5.15.2 is only supported for SDK 10.15. and that you may encounter build issues.
- By default MacOS doesn't support installing old SDK versions on newer operating systems, however, you can find the SDK archive [here](https://github.com/phracker/MacOSX-SDKs), insert it into your Xcode.app file, edit the minimum sdk version in a plist file, and then add `QMAKE_MAC_SDK = macosx10.15` into your QGCCommon.pri file, which will cause QGC to be built with SDK 10.15, and the warnings to go away.
- I didn't see any build or runtime issues with SDK 13.3 except for the ones that this pull request resolves, and switching to 10.15 doesn't resolve that error without changing the file as I have done in this pull request.