### PR TITLE
implement use of apm circle geofence from parameters

### DIFF
--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -35,8 +35,8 @@ public:
     Q_PROPERTY(QGeoCoordinate       breachReturnPoint       READ breachReturnPoint      WRITE setBreachReturnPoint  NOTIFY breachReturnPointChanged)
     Q_PROPERTY(Fact*                breachReturnAltitude    READ breachReturnAltitude                               CONSTANT)
 
-    // Hack to expose PX4 circular fence controlled by GF_MAX_HOR_DIST
-    Q_PROPERTY(double               paramCircularFence  READ paramCircularFence                             NOTIFY paramCircularFenceChanged)
+    // Radius of the "paramCircularFence" which is called the "Geofence Failsafe" in PX4 and the "Circular Geofence" on ArduPilot
+    Q_PROPERTY(double               paramCircularFence      READ paramCircularFence                                 NOTIFY paramCircularFenceChanged)
 
     /// Add a new inclusion polygon to the fence
     ///     @param topLeft: Top left coordinate or map viewport
@@ -114,11 +114,18 @@ private:
     Fact                _breachReturnAltitudeFact;
     double              _breachReturnDefaultAltitude =  qQNaN();
     bool                _itemsRequested =               false;
-    Fact*               _px4ParamCircularFenceFact =    nullptr;
+
+    Fact*               _px4ParamCircularFenceFact =        nullptr;
+    Fact*               _apmParamCircularFenceRadiusFact =  nullptr;
+    Fact*               _apmParamCircularFenceEnabledFact = nullptr;
+    Fact*               _apmParamCircularFenceTypeFact =    nullptr;
 
     static QMap<QString, FactMetaData*> _metaDataMap;
 
     static const char* _px4ParamCircularFence;
+    static const char* _apmParamCircularFenceRadius;
+    static const char* _apmParamCircularFenceEnabled;
+    static const char* _apmParamCircularFenceType;
 
     static const int _jsonCurrentVersion = 2;
 


### PR DESCRIPTION
On PX4 the circular geofence around the home point is displayed by checking the parameter GF_MAX_HOR_DIST.
This PR adds equivalent functionality for APM by using the parameters "FENCE_RADIUS" "FENCE_ENABLE" and "FENCE_TYPE".

Tested with arducopter 4.3, arduplane, and px4 1.13, all seem to work fine.

I've been using a version of this in my own custom build for a while, but thought it would be useful for enough people to warrant a PR. Happy to rework it if anyone has any suggestions.