### PR TITLE
APMFirmwarePlugin, RCRSSIIncidator: solve bug where no valid rssi would show indicator:

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -954,9 +954,10 @@ void APMFirmwarePlugin::_handleRCChannels(Vehicle* vehicle, mavlink_message_t* m
         mavlink_rc_channels_t   channels;
 
         mavlink_msg_rc_channels_decode(message, &channels);
-        //-- Ardupilot uses 0-255 to indicate 0-100% where QGC expects 0-100
-        if(channels.rssi) {
-            channels.rssi = static_cast<uint8_t>(static_cast<double>(channels.rssi) / 255.0 * 100.0);
+        //-- Ardupilot uses 0-254 to indicate 0-100% where QGC expects 0-100
+        // As per mavlink specs, 255 means invalid, we must leave it like that for indicators to hide if no rssi data
+        if(channels.rssi && channels.rssi != 255) {
+            channels.rssi = static_cast<uint8_t>(static_cast<double>(channels.rssi) / 254.0 * 100.0);
         }
         MAVLinkProtocol* mavlink = qgcApp()->toolbox()->mavlinkProtocol();
         mavlink_msg_rc_channels_encode_chan(

--- a/src/ui/toolbar/RCRSSIIndicator.qml
+++ b/src/ui/toolbar/RCRSSIIndicator.qml
@@ -24,7 +24,7 @@ Item {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
 
-    property bool showIndicator: _activeVehicle.supportsRadio
+    property bool showIndicator: _activeVehicle.supportsRadio && _rcRSSIAvailable
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property bool   _rcRSSIAvailable:   _activeVehicle ? _activeVehicle.rcRSSI > 0 && _activeVehicle.rcRSSI <= 100 : false


### PR DESCRIPTION
There was a bug scaling rc rssi from rc_channels mavlink message where it was scaled to 0-100 from 0-255, and this was wrong because 255 is meant to be invalid, and AP uses 0-254 anyway. We must leave 255 as it is so the frontend can understand if we don't have data.

Also, in RCRSSIIndicator, we don't show the indicator anymore if data is not valid, there is no point in showing it when rssi is 255 ( not valid ).

This was causing the rc rssi icon to show on systems where no rc was available at all, which is confusing ( it was showing 100% ) and takes up space in the top toolbar with no reason.

This was only affecting Ardupilot as far as I know.
