### PR TITLE
Correct typos in korean translation

### DIFF
--- a/translations/qgc_source_ko_KR.ts
+++ b/translations/qgc_source_ko_KR.ts
@@ -10173,7 +10173,7 @@ Click Ok to start the auto-tuning process.
     <message>
       <location filename="../src/PlanView/MissionItemEditor.qml" line="251"/>
       <source>Item #%1</source>
-      <translation>항목 1</translation>
+      <translation>항목 #%1</translation>
     </message>
     <message>
       <location filename="../src/PlanView/MissionItemEditor.qml" line="155"/>


### PR DESCRIPTION
Correct typos in korean translation.

fixed QString::arg: Argument missing: "항목 1" , 0 error.

