### PR TITLE
ToolStrip.qml: Fix Flickable height, it was bigger than panel

### DIFF
--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -52,7 +52,7 @@ Rectangle {
         anchors.top:        parent.top
         anchors.left:       parent.left
         anchors.right:      parent.right
-        height:             parent.height
+        height:             parent.height - anchors.margins * 2
         contentHeight:      toolStripColumn.height
         flickableDirection: Flickable.VerticalFlick
         clip:               true


### PR DESCRIPTION
When the toolbar height is smaller than the content height, the elements would protrude a bit, the margins of the flickable were not taken into account for its height ( note the left toolstrip ):
![before](https://github.com/mavlink/qgroundcontrol/assets/18221398/56a1f531-5313-474f-872a-e0ee5e3ec549)
After this commit:
![after](https://github.com/mavlink/qgroundcontrol/assets/18221398/e4356931-2d8a-4b07-8716-9af901f177f2)
