### PR TITLE
Allow app data to save to sd card on android

### DIFF
--- a/android.pri
+++ b/android.pri
@@ -53,3 +53,12 @@ DISTFILES += \
     $$PWD/android/build.gradle \
     $$PWD/android/gradle/wrapper/gradle-wrapper.properties \
     $$PWD/android/gradlew.bat
+
+SOURCES += \
+    $$PWD/android/src/AndroidInterface.cc
+
+HEADERS += \
+    $$PWD/android/src/AndroidInterface.h
+
+INCLUDEPATH += \
+    $$PWD/android/src

--- a/android/src/AndroidInterface.cc
+++ b/android/src/AndroidInterface.cc
@@ -1,0 +1,21 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2018 Pinecone Inc. All rights reserved.
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include <QtAndroidExtras/QtAndroidExtras>
+#include <QtAndroidExtras/QAndroidJniObject>
+#include "QGCApplication.h"
+#include "AndroidInterface.h"
+#include <QAndroidJniObject>
+
+QString AndroidInterface::getSDCardPath()
+{
+    QAndroidJniObject value = QAndroidJniObject::callStaticObjectMethod("org/mavlink/qgroundcontrol/QGCActivity", "getSDCardPath",
+                            "()Ljava/lang/String;");
+    return value.toString();
+}

--- a/android/src/AndroidInterface.h
+++ b/android/src/AndroidInterface.h
@@ -1,0 +1,21 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2018 Pinecone Inc. All rights reserved.
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <jni.h>
+#include <QtCore/private/qjni_p.h>
+#include <QtCore/private/qjnihelpers_p.h>
+
+class AndroidInterface
+{
+public:
+    static QString getSDCardPath();
+};

--- a/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Executors;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 import android.app.Activity;
 import android.app.PendingIntent;
@@ -58,6 +59,8 @@ import android.app.PendingIntent;
 import android.view.WindowManager;
 import android.os.Bundle;
 import android.bluetooth.BluetoothDevice;
+import android.os.storage.StorageManager;
+import android.os.storage.StorageVolume;
 
 import com.hoho.android.usbserial.driver.*;
 import org.qtproject.qt5.android.bindings.QtActivity;
@@ -761,6 +764,35 @@ public class QGCActivity extends QtActivity
                 }
             }
         }).start();
+    }
+
+    public static String getSDCardPath() {
+        StorageManager storageManager = (StorageManager)_instance.getSystemService(Activity.STORAGE_SERVICE);
+        List<StorageVolume> volumes = storageManager.getStorageVolumes();
+        Method mMethodGetPath;
+        String path = "";
+        for (StorageVolume vol : volumes) {
+            try {
+                mMethodGetPath = vol.getClass().getMethod("getPath");
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+                continue;
+            }
+            try {
+                path = (String) mMethodGetPath.invoke(vol);
+            } catch (Exception e) {
+                e.printStackTrace();
+                continue;
+            }
+
+            if (vol.isRemovable() == true) {
+                Log.i(TAG, "removable sd card mounted " + path);
+                return path;
+            } else {
+                Log.i(TAG, "storage mounted " + path);
+            }
+        }
+        return "";
     }
 }
 

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -174,9 +174,17 @@
 {
     "name":             "savePath",
     "shortDesc": "Application save directory",
-    "longDesc":  "Directory to which all data files  are saved/loaded from",
+    "longDesc":  "Directory to which all data files are saved/loaded from",
     "type":             "string",
     "default":     ""
+},
+{
+    "name":                 "androidSaveToSDCard",
+    "shortDesc":            "Save to SD card",
+    "longDesc":             "Application data is saved to the sd card",
+    "type":                 "bool",
+    "default":              false,
+    "qgcRebootRequired":    true
 },
 {
     "name":             "userBrandImageIndoor",

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -44,6 +44,7 @@ public:
     DEFINE_SETTINGFACT(indoorPalette)
     DEFINE_SETTINGFACT(showLargeCompass)
     DEFINE_SETTINGFACT(savePath)
+    DEFINE_SETTINGFACT(androidSaveToSDCard)
     DEFINE_SETTINGFACT(useChecklist)
     DEFINE_SETTINGFACT(enforceChecklist)
     DEFINE_SETTINGFACT(mapboxToken)

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -248,6 +248,13 @@ bool QGCCorePlugin::adjustSettingMetaData(const QString& settingsGroup, FactMeta
             return true;
         }
 #endif
+
+#ifndef __android__
+        if (metaData.name() == AppSettings::androidSaveToSDCardName) {
+            // This only shows on android builds
+            return false;
+        }
+#endif
     }
 
     return true; // Show setting in ui

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -686,6 +686,13 @@ Rectangle {
                                 }
 
                                 FactCheckBox {
+                                    text:       qsTr("Save application data to SD Card")
+                                    fact:       _androidSaveToSDCard
+                                    visible:    _androidSaveToSDCard.visible
+                                    property Fact _androidSaveToSDCard: QGroundControl.settingsManager.appSettings.androidSaveToSDCard
+                                }
+
+                                FactCheckBox {
                                     text:       qsTr("Check for Internet connection")
                                     fact:       _checkInternet
                                     visible:    _checkInternet && _checkInternet.visible
@@ -727,8 +734,6 @@ Rectangle {
                             }
                         }
 
-                        //-----------------------------------------------------------------
-                        //-- Save path
                         RowLayout {
                             id:                 pathRow
                             anchors.margins:    _margins


### PR DESCRIPTION
* Add setting to General/Misc in the UI to save all application data to the SD card for android builds.
* If option is enabled and no SD card available or write protected user is notified about the problem and that internal storage instead will be used.

This was added to move forward the Herelink version. The current Herelink variant saves video to the SD card. Nice feature, but in reality it makes sense to allow for all data to be on the SD Card which is much easier to work with than the internal storage. Adding this upstream change then allows me to carry it over to the new Herelink version.