### PR TITLE
Fix a few issues with NMEA GPS for GCS position

### DIFF
--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -153,6 +153,17 @@ void QGCPositionManager::setPositionSource(QGCPositionManager::QGCPositionSource
     if (_currentSource != nullptr) {
         _currentSource->stopUpdates();
         disconnect(_currentSource);
+
+        // Reset all values so we dont get stuck on old values
+        _geoPositionInfo = QGeoPositionInfo();
+        _gcsPosition = QGeoCoordinate();
+        _gcsHeading =       qQNaN();
+        _gcsPositionHorizontalAccuracy = std::numeric_limits<qreal>::infinity();
+
+        emit gcsPositionChanged(_gcsPosition);
+        emit gcsHeadingChanged(_gcsHeading);
+        emit positionInfoUpdated(_geoPositionInfo);
+        emit gcsPositionHorizontalAccuracyChanged();
     }
 
     if (qgcApp()->runningUnitTests()) {

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -713,8 +713,8 @@ void LinkManager::_updateSerialPorts()
     _commPortList.clear();
     _commPortDisplayList.clear();
 #ifndef NO_SERIAL_LINK
-    QList<QSerialPortInfo> portList = QSerialPortInfo::availablePorts();
-    for (const QSerialPortInfo &info: portList)
+    QList<QGCSerialPortInfo> portList = QGCSerialPortInfo::availablePorts();
+    for (const QGCSerialPortInfo &info: portList)
     {
         QString port = info.systemLocation().trimmed();
         _commPortList += port;

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -305,8 +305,12 @@ QList<QGCSerialPortInfo> QGCSerialPortInfo::availablePorts(void)
                 VidPidPair_t vidPid(portInfo.vendorIdentifier(), portInfo.productIdentifier());
                 if (seenSerialNumbers.contains(vidPid) && seenSerialNumbers[vidPid].contains(portInfo.serialNumber())) {
                     // Some boards are a composite USB device, with the first port being mavlink and the second something else. We only expose to first mavlink port.
-                    qCDebug(QGCSerialPortInfoLog) << "Skipping secondary port on same device" << portInfo.portName() << portInfo.vendorIdentifier() << portInfo.productIdentifier() << portInfo.serialNumber();
-                    continue;
+                    // However internal NMEA devices can present like this, so dont skip anything with NMEA in description
+                    if(!portInfo.description().contains("NMEA"))
+                    {
+                        qCDebug(QGCSerialPortInfoLog) << "Skipping secondary port on same device" << portInfo.portName() << portInfo.vendorIdentifier() << portInfo.productIdentifier() << portInfo.serialNumber();
+                        continue;
+                    }
                 }
                 seenSerialNumbers[vidPid].append(portInfo.serialNumber());
             }


### PR DESCRIPTION
While working on getting Remote ID working with Master QGC I encountered a few small problems in using an NMEA GPS.
I am using a Toughbook FZ-G2 running windows 10, which has an internal GPS module which presents as a NMEA stream on a COM port (COM5 in my case).

# First problem - Serial port list mismatch:
While I was able to select COM5 in the drop down, and I got a lat lon to show up in the Remote ID Page, it would never show altitude. In digging into the issue, I discovered what was happening.
The dropdown menu in the UI was pulling from LinkManager::serialPorts(), which was pulling from QSerialPortInfo::availablePorts(). However, in the LinkManager::_updateAutoConnectLinks(), where the NMEA port is passed to the position manager, it would iterate through a smaller list provided by QGCSerialPortInfo::availablePorts(), which is a override which provides a filtered version of the availablePorts list.
**This drills down to two problems:**
a) the list of serial ports in the UI is not the same as the list which are actually possible to use
b) the override for availablePorts is filtering out my internal NMEA GPS port.

**My Solutions**
for a) This is a simple fix to make the data passed to the UI call the same override, so that the two lists match.
for b) I'm not sure the best solution, I added a check that doesn't skip any links which have the word NMEA in the description.

# Second Problem - latched values on changing position source:
Once I fixed the above so I could select and use the NMEA GPS, I found the following issue:
If I booted up QGC when the GPS didn't have a fix, it would show a fixed GPS position, even though the NMEA source had no fix.
**The cause:**
When QGC Starts, it first selects the default/internal position source. On my device, that provides a position update with the last position the GPS had. Then after a few seconds, the _updateAutoConnectLinks() passes the real NMEA port to PositionManager, which switches to the NMEA GPS. However, since the NMEA GPS has an invalid fix, the values in the UI are latched at the values provided by the internal GPS source. This is really confusing, and makes it look like the GPS has a fix when it doesnt.
**The solution:**
I fixed this by resetting all the stored position values when setPositionSource is called.