### PR TITLE
Added support for displaying RPM MAVLink message in the main QGroundControl values panel

### DIFF
--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -328,7 +328,8 @@
 		<file alias="Vehicle/VehicleFact.json">../src/Vehicle/VehicleFact.json</file>
 		<file alias="Vehicle/VibrationFact.json">../src/Vehicle/VibrationFact.json</file>
 		<file alias="Vehicle/WindFact.json">../src/Vehicle/WindFact.json</file>
-                <file alias="Vehicle/HygrometerFact.json">../src/Vehicle/HygrometerFact.json</file>
+        <file alias="Vehicle/HygrometerFact.json">../src/Vehicle/HygrometerFact.json</file>
+        <file alias="Vehicle/RpmFact.json">../src/Vehicle/RpmFact.json</file>
 		<file alias="Video.SettingsGroup.json">../src/Settings/Video.SettingsGroup.json</file>
 		<file alias="VTOLLandingPattern.FactMetaData.json">../src/MissionManager/VTOLLandingPattern.FactMetaData.json</file>
 	</qresource>

--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -328,8 +328,8 @@
 		<file alias="Vehicle/VehicleFact.json">../src/Vehicle/VehicleFact.json</file>
 		<file alias="Vehicle/VibrationFact.json">../src/Vehicle/VibrationFact.json</file>
 		<file alias="Vehicle/WindFact.json">../src/Vehicle/WindFact.json</file>
-        <file alias="Vehicle/HygrometerFact.json">../src/Vehicle/HygrometerFact.json</file>
-        <file alias="Vehicle/RpmFact.json">../src/Vehicle/RpmFact.json</file>
+		<file alias="Vehicle/HygrometerFact.json">../src/Vehicle/HygrometerFact.json</file>
+		<file alias="Vehicle/RpmFact.json">../src/Vehicle/RpmFact.json</file>
 		<file alias="Video.SettingsGroup.json">../src/Settings/Video.SettingsGroup.json</file>
 		<file alias="VTOLLandingPattern.FactMetaData.json">../src/MissionManager/VTOLLandingPattern.FactMetaData.json</file>
 	</qresource>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -745,6 +745,7 @@ HEADERS += \
     src/Vehicle/VehicleVibrationFactGroup.h \
     src/Vehicle/VehicleWindFactGroup.h \
     src/Vehicle/VehicleHygrometerFactGroup.h \
+    src/Vehicle/VehicleRpmFactGroup.h \
     src/VehicleSetup/JoystickConfigController.h \
     src/comm/LinkConfiguration.h \
     src/comm/LinkInterface.h \
@@ -1003,6 +1004,7 @@ SOURCES += \
     src/Vehicle/VehicleTemperatureFactGroup.cc \
     src/Vehicle/VehicleVibrationFactGroup.cc \
     src/Vehicle/VehicleHygrometerFactGroup.cc \
+    src/Vehicle/VehicleRpmFactGroup.cc \
     src/Vehicle/VehicleWindFactGroup.cc \
     src/VehicleSetup/JoystickConfigController.cc \
     src/comm/LinkConfiguration.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -345,6 +345,7 @@
         <file alias="Vehicle/VibrationFact.json">src/Vehicle/VibrationFact.json</file>
         <file alias="Vehicle/WindFact.json">src/Vehicle/WindFact.json</file>
         <file alias="Vehicle/HygrometerFact.json">src/Vehicle/HygrometerFact.json</file>
+        <file alias="Vehicle/RpmFact.json">src/Vehicle/RpmFact.json</file>
         <file alias="Video.SettingsGroup.json">src/Settings/Video.SettingsGroup.json</file>
         <file alias="VTOLLandingPattern.FactMetaData.json">src/MissionManager/VTOLLandingPattern.FactMetaData.json</file>
     </qresource>

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -116,7 +116,7 @@ FactGroup* FactGroup::getFactGroup(const QString& name)
         factGroup = _nameToFactGroupMap[camelCaseName];
         QQmlEngine::setObjectOwnership(factGroup, QQmlEngine::CppOwnership);
     } else {
-        qWarning() << "Unknown FactGroup (" << camelCaseName << ")";
+        qWarning() << "Unknown FactGroup (camelCaseName)" << camelCaseName;
         qWarning() << "Available FactGroups:" << _nameToFactGroupMap.keys();
     }
 

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -116,7 +116,8 @@ FactGroup* FactGroup::getFactGroup(const QString& name)
         factGroup = _nameToFactGroupMap[camelCaseName];
         QQmlEngine::setObjectOwnership(factGroup, QQmlEngine::CppOwnership);
     } else {
-        qWarning() << "Unknown FactGroup" << camelCaseName;
+        qWarning() << "Unknown FactGroup CC" << camelCaseName;
+        qWarning() << "Available FactGroups:" << _nameToFactGroupMap.keys();
     }
 
     return factGroup;

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -116,7 +116,7 @@ FactGroup* FactGroup::getFactGroup(const QString& name)
         factGroup = _nameToFactGroupMap[camelCaseName];
         QQmlEngine::setObjectOwnership(factGroup, QQmlEngine::CppOwnership);
     } else {
-        qWarning() << "Unknown FactGroup CC" << camelCaseName;
+        qWarning() << "Unknown FactGroup (" << camelCaseName << ")";
         qWarning() << "Available FactGroups:" << _nameToFactGroupMap.keys();
     }
 

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -96,8 +96,10 @@ add_library(Vehicle
 	VehicleVibrationFactGroup.h
 	VehicleWindFactGroup.cc
 	VehicleWindFactGroup.h
-        VehicleHygrometerFactGroup.cc
-        VehicleHygrometerFactGroup.h
+	VehicleHygrometerFactGroup.cc
+	VehicleHygrometerFactGroup.h
+	VehicleRpmFactGroup.cc
+	VehicleRpmFactGroup.h
 	RemoteIDManager.h
 	RemoteIDManager.cc
 

--- a/src/Vehicle/RpmFact.json
+++ b/src/Vehicle/RpmFact.json
@@ -1,0 +1,35 @@
+{
+    "version":      1,
+    "fileType":  "FactMetaData",
+    "QGC.MetaData.Facts":
+    [
+        {
+            "name":             "rpm1",
+            "shortDesc": "RPM 1",
+            "type":             "double",
+            "decimalPlaces":    2,
+            "units":            "RPM"
+        },
+        {
+            "name":             "rpm2",
+            "shortDesc": "RPM 2",
+            "type":             "double",
+            "decimalPlaces":    2,
+            "units":            "RPM"
+        },
+        {
+            "name":             "rpm3",
+            "shortDesc": "RPM 3",
+            "type":             "double",
+            "decimalPlaces":    2,
+            "units":            "RPM"
+        },
+        {
+            "name":             "rpm4",
+            "shortDesc": "RPM 4",
+            "type":             "double",
+            "decimalPlaces":    2,
+            "units":            "RPM"
+        }
+    ]
+}

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -97,6 +97,7 @@ const char* Vehicle::_distanceToGCSFactName =       "distanceToGCS";
 const char* Vehicle::_hobbsFactName =               "hobbs";
 const char* Vehicle::_throttlePctFactName =         "throttlePct";
 const char* Vehicle::_imuTempFactName =             "imuTemp";
+// const char* Vehicle::_rpmFactName =                 "rpm";
 
 const char* Vehicle::_gpsFactGroupName =                "gps";
 const char* Vehicle::_gps2FactGroupName =               "gps2";
@@ -112,6 +113,7 @@ const char* Vehicle::_escStatusFactGroupName =          "escStatus";
 const char* Vehicle::_estimatorStatusFactGroupName =    "estimatorStatus";
 const char* Vehicle::_terrainFactGroupName =            "terrain";
 const char* Vehicle::_hygrometerFactGroupName =         "hygrometer";
+const char* Vehicle::_rpmFactGroupName =                "rpm";
 
 // Standard connected vehicle
 Vehicle::Vehicle(LinkInterface*             link,
@@ -174,6 +176,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _escStatusFactGroup           (this)
     , _estimatorStatusFactGroup     (this)
     , _hygrometerFactGroup          (this)
+    , _rpmFactGroup                 (this)
     , _terrainFactGroup             (this)
     , _terrainProtocolHandler       (new TerrainProtocolHandler(this, &_terrainFactGroup, this))
 {
@@ -307,6 +310,7 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _hobbsFact                        (0, _hobbsFactName,             FactMetaData::valueTypeString)
     , _throttlePctFact                  (0, _throttlePctFactName,       FactMetaData::valueTypeUint16)
     , _imuTempFact                      (0, _imuTempFactName,           FactMetaData::valueTypeInt16)
+//    , _rpmFact                          (0, _rpmFactName,               FactMetaData::valueTypeInt16)
     , _gpsFactGroup                     (this)
     , _gps2FactGroup                    (this)
     , _windFactGroup                    (this)
@@ -435,6 +439,7 @@ void Vehicle::_commonInit()
     _addFact(&_distanceToGCSFact,       _distanceToGCSFactName);
     _addFact(&_throttlePctFact,         _throttlePctFactName);
     _addFact(&_imuTempFact,             _imuTempFactName);
+    //_addFact(&_rpmFact,                 _rpmFactName);
 
     _hobbsFact.setRawValue(QVariant(QString("0000:00:00")));
     _addFact(&_hobbsFact,               _hobbsFactName);
@@ -452,6 +457,7 @@ void Vehicle::_commonInit()
     _addFactGroup(&_escStatusFactGroup,         _escStatusFactGroupName);
     _addFactGroup(&_estimatorStatusFactGroup,   _estimatorStatusFactGroupName);
     _addFactGroup(&_hygrometerFactGroup,        _hygrometerFactGroupName);
+    _addFactGroup(&_rpmFactGroup,               _rpmFactGroupName);
     _addFactGroup(&_terrainFactGroup,           _terrainFactGroupName);
 
     // Add firmware-specific fact groups, if provided

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -97,7 +97,6 @@ const char* Vehicle::_distanceToGCSFactName =       "distanceToGCS";
 const char* Vehicle::_hobbsFactName =               "hobbs";
 const char* Vehicle::_throttlePctFactName =         "throttlePct";
 const char* Vehicle::_imuTempFactName =             "imuTemp";
-// const char* Vehicle::_rpmFactName =                 "rpm";
 
 const char* Vehicle::_gpsFactGroupName =                "gps";
 const char* Vehicle::_gps2FactGroupName =               "gps2";
@@ -310,7 +309,6 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _hobbsFact                        (0, _hobbsFactName,             FactMetaData::valueTypeString)
     , _throttlePctFact                  (0, _throttlePctFactName,       FactMetaData::valueTypeUint16)
     , _imuTempFact                      (0, _imuTempFactName,           FactMetaData::valueTypeInt16)
-//    , _rpmFact                          (0, _rpmFactName,               FactMetaData::valueTypeInt16)
     , _gpsFactGroup                     (this)
     , _gps2FactGroup                    (this)
     , _windFactGroup                    (this)
@@ -439,8 +437,6 @@ void Vehicle::_commonInit()
     _addFact(&_distanceToGCSFact,       _distanceToGCSFactName);
     _addFact(&_throttlePctFact,         _throttlePctFactName);
     _addFact(&_imuTempFact,             _imuTempFactName);
-    //_addFact(&_rpmFact,                 _rpmFactName);
-
     _hobbsFact.setRawValue(QVariant(QString("0000:00:00")));
     _addFact(&_hobbsFact,               _hobbsFactName);
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -40,6 +40,7 @@
 #include "VehicleEscStatusFactGroup.h"
 #include "VehicleEstimatorStatusFactGroup.h"
 #include "VehicleHygrometerFactGroup.h"
+#include "VehicleRpmFactGroup.h"
 #include "VehicleLinkManager.h"
 #include "MissionManager.h"
 #include "GeoFenceManager.h"
@@ -323,6 +324,7 @@ public:
     Q_PROPERTY(FactGroup*           localPosition   READ localPositionFactGroup     CONSTANT)
     Q_PROPERTY(FactGroup*           localPositionSetpoint READ localPositionSetpointFactGroup CONSTANT)
     Q_PROPERTY(FactGroup*           hygrometer      READ hygrometerFactGroup        CONSTANT)
+    Q_PROPERTY(FactGroup*           rpm             READ rpmFactGroup               CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  batteries       READ batteries                  CONSTANT)
     Q_PROPERTY(Actuators*           actuators       READ actuators                  CONSTANT)
     Q_PROPERTY(HealthAndArmingCheckReport* healthAndArmingCheckReport READ healthAndArmingCheckReport CONSTANT)
@@ -698,6 +700,7 @@ public:
     Fact* hobbs                             () { return &_hobbsFact; }
     Fact* throttlePct                       () { return &_throttlePctFact; }
     Fact* imuTemp                           () { return &_imuTempFact; }
+   // Fact* rpm                               () { return &_rpmFact; }
 
     FactGroup* gpsFactGroup                 () { return &_gpsFactGroup; }
     FactGroup* gps2FactGroup                () { return &_gps2FactGroup; }
@@ -713,6 +716,7 @@ public:
     FactGroup* estimatorStatusFactGroup     () { return &_estimatorStatusFactGroup; }
     FactGroup* terrainFactGroup             () { return &_terrainFactGroup; }
     FactGroup* hygrometerFactGroup          () { return &_hygrometerFactGroup; }
+    FactGroup* rpmFactGroup                 () { return &_rpmFactGroup; }
     QmlObjectListModel* batteries           () { return &_batteryFactGroupListModel; }
 
     MissionManager*                 missionManager      () { return _missionManager; }
@@ -1377,6 +1381,7 @@ private:
     Fact _hobbsFact;
     Fact _throttlePctFact;
     Fact _imuTempFact;
+    //Fact _rpmFact;
 
     VehicleGPSFactGroup             _gpsFactGroup;
     VehicleGPS2FactGroup            _gps2FactGroup;
@@ -1391,6 +1396,7 @@ private:
     VehicleEscStatusFactGroup       _escStatusFactGroup;
     VehicleEstimatorStatusFactGroup _estimatorStatusFactGroup;
     VehicleHygrometerFactGroup      _hygrometerFactGroup;
+    VehicleRpmFactGroup             _rpmFactGroup;
     TerrainFactGroup                _terrainFactGroup;
     QmlObjectListModel              _batteryFactGroupListModel;
 
@@ -1433,6 +1439,7 @@ private:
     static const char* _hobbsFactName;
     static const char* _throttlePctFactName;
     static const char* _imuTempFactName;
+ //   static const char* _rpmFactName;
 
     static const char* _gpsFactGroupName;
     static const char* _gps2FactGroupName;
@@ -1447,6 +1454,7 @@ private:
     static const char* _escStatusFactGroupName;
     static const char* _estimatorStatusFactGroupName;
     static const char* _hygrometerFactGroupName;
+    static const char* _rpmFactGroupName;
     static const char* _terrainFactGroupName;
 
     static const int _vehicleUIUpdateRateMSecs      = 100;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -700,7 +700,6 @@ public:
     Fact* hobbs                             () { return &_hobbsFact; }
     Fact* throttlePct                       () { return &_throttlePctFact; }
     Fact* imuTemp                           () { return &_imuTempFact; }
-   // Fact* rpm                               () { return &_rpmFact; }
 
     FactGroup* gpsFactGroup                 () { return &_gpsFactGroup; }
     FactGroup* gps2FactGroup                () { return &_gps2FactGroup; }
@@ -1381,7 +1380,6 @@ private:
     Fact _hobbsFact;
     Fact _throttlePctFact;
     Fact _imuTempFact;
-    //Fact _rpmFact;
 
     VehicleGPSFactGroup             _gpsFactGroup;
     VehicleGPS2FactGroup            _gps2FactGroup;
@@ -1439,8 +1437,6 @@ private:
     static const char* _hobbsFactName;
     static const char* _throttlePctFactName;
     static const char* _imuTempFactName;
- //   static const char* _rpmFactName;
-
     static const char* _gpsFactGroupName;
     static const char* _gps2FactGroupName;
     static const char* _windFactGroupName;

--- a/src/Vehicle/VehicleRpmFactGroup.cc
+++ b/src/Vehicle/VehicleRpmFactGroup.cc
@@ -1,0 +1,76 @@
+/****************************************************************************
+ *
+ * (c) 2009-2023 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "VehicleSetpointFactGroup.h"
+#include "Vehicle.h"
+
+//const char* VehicleRpmFactGroup::_rpmFactName =      "rpm";
+const char* VehicleRpmFactGroup::_rpm1FactName =      "rpm1";
+const char* VehicleRpmFactGroup::_rpm2FactName =      "rpm2";
+const char* VehicleRpmFactGroup::_rpm3FactName =      "rpm3";
+const char* VehicleRpmFactGroup::_rpm4FactName =      "rpm4";
+
+VehicleRpmFactGroup::VehicleRpmFactGroup(QObject* parent)
+    : FactGroup(1000, ":/json/Vehicle/RpmFact.json", parent)
+  //  , _rpmFact    (0, _rpmFactName,     FactMetaData::valueTypeDouble)
+    , _rpm1Fact    (0, _rpm1FactName,     FactMetaData::valueTypeDouble)
+    , _rpm2Fact    (0, _rpm2FactName,     FactMetaData::valueTypeDouble)
+    , _rpm3Fact    (0, _rpm3FactName,     FactMetaData::valueTypeDouble)
+    , _rpm4Fact    (0, _rpm4FactName,     FactMetaData::valueTypeDouble)
+{
+  //  _addFact(&_rpmFact,       _rpmFactName);
+    _addFact(&_rpm1Fact,       _rpm1FactName);
+    _addFact(&_rpm2Fact,       _rpm2FactName);
+    _addFact(&_rpm3Fact,       _rpm3FactName);
+    _addFact(&_rpm4Fact,       _rpm4FactName);
+
+    // Start out as not available "--.--"
+   // _rpmFact.setRawValue      (qQNaN());
+    _rpm1Fact.setRawValue      (qQNaN());
+    _rpm2Fact.setRawValue      (qQNaN());
+    _rpm3Fact.setRawValue      (qQNaN());
+    _rpm4Fact.setRawValue      (qQNaN());
+}
+
+void VehicleRpmFactGroup::handleMessage(Vehicle* /* vehicle */, mavlink_message_t& message)
+{
+    switch (message.msgid) {
+    case MAVLINK_MSG_ID_RAW_RPM:
+        _handleRawRPM(message);
+        break;
+    default:
+        break;
+    }
+}
+
+void VehicleRpmFactGroup::_handleRawRPM(mavlink_message_t& message)
+{
+    mavlink_raw_rpm_t raw_rpm;
+    mavlink_msg_raw_rpm_decode(&message, &raw_rpm);
+    //rpm()->setRawValue(raw_rpm.frequency);
+    switch (raw_rpm.index) {
+        case 0:
+            rpm1()->setRawValue(raw_rpm.frequency);
+            break;
+        case 1:
+            rpm2()->setRawValue(raw_rpm.frequency);
+            break;
+        case 2: 
+            rpm3()->setRawValue(raw_rpm.frequency);
+            break;
+        case 3: 
+            rpm4()->setRawValue(raw_rpm.frequency);
+            break;
+        default:
+            break;
+
+    }
+    _setTelemetryAvailable(true);
+}
+

--- a/src/Vehicle/VehicleRpmFactGroup.cc
+++ b/src/Vehicle/VehicleRpmFactGroup.cc
@@ -10,7 +10,6 @@
 #include "VehicleSetpointFactGroup.h"
 #include "Vehicle.h"
 
-//const char* VehicleRpmFactGroup::_rpmFactName =      "rpm";
 const char* VehicleRpmFactGroup::_rpm1FactName =      "rpm1";
 const char* VehicleRpmFactGroup::_rpm2FactName =      "rpm2";
 const char* VehicleRpmFactGroup::_rpm3FactName =      "rpm3";
@@ -18,20 +17,17 @@ const char* VehicleRpmFactGroup::_rpm4FactName =      "rpm4";
 
 VehicleRpmFactGroup::VehicleRpmFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/RpmFact.json", parent)
-  //  , _rpmFact    (0, _rpmFactName,     FactMetaData::valueTypeDouble)
     , _rpm1Fact    (0, _rpm1FactName,     FactMetaData::valueTypeDouble)
     , _rpm2Fact    (0, _rpm2FactName,     FactMetaData::valueTypeDouble)
     , _rpm3Fact    (0, _rpm3FactName,     FactMetaData::valueTypeDouble)
     , _rpm4Fact    (0, _rpm4FactName,     FactMetaData::valueTypeDouble)
 {
-  //  _addFact(&_rpmFact,       _rpmFactName);
     _addFact(&_rpm1Fact,       _rpm1FactName);
     _addFact(&_rpm2Fact,       _rpm2FactName);
     _addFact(&_rpm3Fact,       _rpm3FactName);
     _addFact(&_rpm4Fact,       _rpm4FactName);
 
     // Start out as not available "--.--"
-   // _rpmFact.setRawValue      (qQNaN());
     _rpm1Fact.setRawValue      (qQNaN());
     _rpm2Fact.setRawValue      (qQNaN());
     _rpm3Fact.setRawValue      (qQNaN());
@@ -53,7 +49,6 @@ void VehicleRpmFactGroup::_handleRawRPM(mavlink_message_t& message)
 {
     mavlink_raw_rpm_t raw_rpm;
     mavlink_msg_raw_rpm_decode(&message, &raw_rpm);
-    //rpm()->setRawValue(raw_rpm.frequency);
     switch (raw_rpm.index) {
         case 0:
             rpm1()->setRawValue(raw_rpm.frequency);

--- a/src/Vehicle/VehicleRpmFactGroup.h
+++ b/src/Vehicle/VehicleRpmFactGroup.h
@@ -1,0 +1,56 @@
+/****************************************************************************
+ *
+ * (c) 2009-2023 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "FactGroup.h"
+#include "QGCMAVLink.h"
+
+class VehicleRpmFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+public:
+    VehicleRpmFactGroup(QObject* parent = nullptr);
+
+   // Q_PROPERTY(Fact* rpm       READ rpm       CONSTANT)
+    Q_PROPERTY(Fact* rpm1       READ rpm1       CONSTANT)
+    Q_PROPERTY(Fact* rpm2       READ rpm2       CONSTANT)
+    Q_PROPERTY(Fact* rpm3       READ rpm3       CONSTANT)
+    Q_PROPERTY(Fact* rpm4       READ rpm4       CONSTANT)
+
+  //  Fact* rpm () { return &_rpmFact; }
+    Fact* rpm1 () { return &_rpm1Fact; }
+    Fact* rpm2 () { return &_rpm2Fact; }
+    Fact* rpm3 () { return &_rpm3Fact; }
+    Fact* rpm4 () { return &_rpm4Fact; }
+
+    // Overrides from FactGroup
+    void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
+
+//    static const char* _rpmFactName;
+    static const char* _rpm1FactName;
+    static const char* _rpm2FactName;
+    static const char* _rpm3FactName;
+    static const char* _rpm4FactName;
+
+    static const char* _settingsGroup;
+
+    static const double _rpmUnavailable;
+
+private:
+    void _handleRawRPM  (mavlink_message_t& message);
+
+   // Fact            _rpmFact;
+    Fact            _rpm1Fact;
+    Fact            _rpm2Fact;
+    Fact            _rpm3Fact;
+    Fact            _rpm4Fact;
+
+};

--- a/src/Vehicle/VehicleRpmFactGroup.h
+++ b/src/Vehicle/VehicleRpmFactGroup.h
@@ -25,7 +25,6 @@ public:
     Q_PROPERTY(Fact* rpm3       READ rpm3       CONSTANT)
     Q_PROPERTY(Fact* rpm4       READ rpm4       CONSTANT)
 
-  //  Fact* rpm () { return &_rpmFact; }
     Fact* rpm1 () { return &_rpm1Fact; }
     Fact* rpm2 () { return &_rpm2Fact; }
     Fact* rpm3 () { return &_rpm3Fact; }
@@ -34,7 +33,6 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-//    static const char* _rpmFactName;
     static const char* _rpm1FactName;
     static const char* _rpm2FactName;
     static const char* _rpm3FactName;


### PR DESCRIPTION
This pull request adds a new feature to QGroundControl, enabling display value of RPM from MAVLink message on the main application window. With this update, users can now show and monitor up to four RPM values, which proves particularly useful for quadcopters.

To achieve this functionality, a new factView group has been created, allowing users to easily track RPM values in a clear panel within the main QGroundControl interface.

The functionality of the PR and features has been tested both with a custom-built QGC and with PX4 autopilot using TFRPM01 sensors, as well as with the PX4 simulator.
