### PR TITLE
[Bugfix] Fix Flight Mode Switch settings box not showing

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml
@@ -34,8 +34,8 @@ Item {
             _switchTHList.push("RC_TRANS_TH")
         }
         if (controller.vehicle.fixedWing) {
-            _switchFactList.push("RC_MAP_FLAPS")
-            _switchTHFactList.push("")
+            _switchNameList.push("RC_MAP_FLAPS")
+            _switchTHList.push("")
         }
         switchRepeater.model = _switchNameList
     }


### PR DESCRIPTION
## About
This was introduced in
https://github.com/mavlink/qgroundcontrol/commit/d5dc4f1af17151d7e7f88372847bc12ac499ccb9, and the refactor didn't fix the case for RC_MAP_FLAPS case correctly

Fixes https://github.com/PX4/PX4-Autopilot/issues/21927

## Note
I haven't tested it, but with the built artifact it could be great if you could give it a test @benjinne
