### PR TITLE
Fix cmake build after adding APMRemoteSupportComponent

### DIFF
--- a/src/AutoPilotPlugins/APM/CMakeLists.txt
+++ b/src/AutoPilotPlugins/APM/CMakeLists.txt
@@ -14,6 +14,7 @@ SOURCES
     APMPowerComponent.qml
     APMPowerComponentSummary.qml
     APMRadioComponentSummary.qml
+    APMRemoteSupportComponent.qml
     APMSafetyComponent.qml
     APMSafetyComponentCopter.qml
     APMSafetyComponentPlane.qml

--- a/src/AutoPilotPlugins/CMakeLists.txt
+++ b/src/AutoPilotPlugins/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(AutoPilotPlugins
 	APM/APMMotorComponent.cc
 	APM/APMPowerComponent.cc
 	APM/APMRadioComponent.cc
+	APM/APMRemoteSupportComponent.cc
 	APM/APMSafetyComponent.cc
 	APM/APMSensorsComponent.cc
 	APM/APMSensorsComponentController.cc


### PR DESCRIPTION
This update modifies the CMakeLists.txt files in both the AutoPilotPlugins directory and within the APM subdirectory, adding APMRemoteSupportComponent to the list of components included in the project's build. This change is necessary to ensure that the new APMremoteSupportComponent is compiled when the project is built.


