### PR TITLE
Telemetry Bar: Fix turning on edit for mobile

### DIFF
--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -92,8 +92,17 @@ Rectangle {
             y:                          telemetryLayout.y
             width:                      telemetryLayout.width
             height:                     telemetryLayout.height
-            hoverEnabled:               true
+            hoverEnabled:               !ScreenTools.isMobile
             propagateComposedEvents:    true
+
+            onClicked: {
+                if (ScreenTools.isMobile && !valueArea.settingsUnlocked) {
+                    valueArea.settingsUnlocked = true
+                    mouse.accepted = true
+                } else {
+                    mouse.accepted = false
+                }
+            }
         }
 
         HorizontalFactValueGrid {


### PR DESCRIPTION
A change was made a while back to the telemetry values bar to use hover instead of click to show the edit tools to unlock it. This works fine if you have a mouse. But on mobile it doesn't really work at all since there is no concept of "hover". I changed the code such that mobile goes back to the way it was before which is a click will enter edit mode. Non-mobile mouse stays with the same hover behavior.