### PR TITLE
Android support for serial/bluetooth disabling

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -141,6 +141,10 @@ linux|macx|ios {
     }
 }
 
+NoSerialBuild {
+    message("Serial port support disabled")
+}
+
 !MacBuild:!AndroidBuild {
     # See QGCPostLinkCommon.pri for details on why MacBuild doesn't use DESTDIR
     DESTDIR = staging

--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -226,9 +226,9 @@ MacBuild {
 # Include Android OpenSSL libs
 AndroidBuild {
     include($$SOURCE_DIR/libs/OpenSSL/android_openssl/openssl.pri)
-    message("ANDROID_EXTRA_LIBS")
-    message($$ANDROID_TARGET_ARCH)
-    message($$ANDROID_EXTRA_LIBS)
+    #message("ANDROID_EXTRA_LIBS")
+    #message($$ANDROID_TARGET_ARCH)
+    #message($$ANDROID_EXTRA_LIBS)
 }
 
 # Pairing

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -13,16 +13,17 @@
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:name="org.mavlink.qgroundcontrol.QGCActivity" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="sensorLandscape" android:launchMode="singleTask" android:keepScreenOn="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.HOME"/>
+                <category android:name="android.intent.category.DEFAULT"/>                
                 <category android:name="android.intent.category.LAUNCHER"/>
-                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
-                <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED"/>
                 <action android:name="android.bluetooth.device.action.ACL_CONNECTED"/>
                 <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED"/>
-                <action android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"/>
+
+                <!-- %%QGC_INSERT_ACTIVITY_INTENT_FILTER -->
             </intent-filter>
-            <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
-            <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_DEVICE_DETACHED"/>
-            <meta-data android:resource="@xml/device_filter" android:name="android.hardware.usb.action.USB_ACCESSORY_ATTACHED"/>
+
+            <!-- %%QGC_INSERT_ACTIVITY_META_DATA -->
+
             <!-- Application arguments -->
             <!-- meta-data android:name="android.app.arguments" android:value="arg1 arg2 arg3"/ -->
             <!-- Application arguments -->

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -182,13 +182,12 @@ contains (CONFIG, QGC_DISABLE_PX4_PLUGIN_FACTORY) {
 
 # Bluetooth
 contains (DEFINES, QGC_DISABLE_BLUETOOTH) {
-    message("Skipping support for Bluetooth (manual override from command line)")
+    message("Bluetooth support disabled (manual override from command line)")
     DEFINES -= QGC_ENABLE_BLUETOOTH
 } else:exists(user_config.pri):infile(user_config.pri, DEFINES, QGC_DISABLE_BLUETOOTH) {
-    message("Skipping support for Bluetooth (manual override from user_config.pri)")
+    message("Bluetooth support disabled (manual override from user_config.pri)")
     DEFINES -= QGC_ENABLE_BLUETOOTH
 } else:exists(user_config.pri):infile(user_config.pri, DEFINES, QGC_ENABLE_BLUETOOTH) {
-    message("Including support for Bluetooth (manual override from user_config.pri)")
     DEFINES += QGC_ENABLE_BLUETOOTH
 }
 


### PR DESCRIPTION
QGC has build settings to disable serial port and bluetooth support. The android build was not correctly supporting these settings which respect to updating the AndroidManifest.xml correctly. This is now fixed.

This change was driven by fixing up upstream qgc for Herelink support in ways which require less upstream changes to get a Herelink build to work. In this specific case Herelink does not support usb (serial) or bluetooth. 