### PR TITLE
Android supports no serial/bluetooth build and home app

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -113,13 +113,14 @@ linux {
     }
 } else : ios {
     message("iOS build")
-    CONFIG  += iOSBuild MobileBuild app_bundle NoSerialBuild
+    CONFIG  += iOSBuild MobileBuild app_bundle
     CONFIG  -= bitcode
     DEFINES += __ios__
     DEFINES += QGC_NO_GOOGLE_MAPS
     DEFINES += NO_SERIAL_LINK
     DEFINES += QGC_DISABLE_UVC
     DEFINES += QGC_GST_TAISYNC_ENABLED
+    DEFINES += NO_SERIAL_LINK
     QMAKE_IOS_DEPLOYMENT_TARGET = 11.0
     QMAKE_APPLE_TARGETED_DEVICE_FAMILY = 1,2 # Universal
     QMAKE_LFLAGS += -Wl,-no_pie
@@ -141,7 +142,7 @@ linux|macx|ios {
     }
 }
 
-NoSerialBuild {
+contains(DEFINES, NO_SERIAL_LINK) {
     message("Serial port support disabled")
 }
 
@@ -197,6 +198,8 @@ exists ($$PWD/.git) {
 DEFINES += APP_VERSION_STR=\"\\\"$$APP_VERSION_STR\\\"\"
 
 AndroidBuild {
+    QGC_ANDROID_PACKAGE = org.mavlink.qgroundcontrol
+    
     message(VERSION $${VERSION})
     MAJOR_VERSION   = $$section(VERSION, ".", 0, 0)
     MINOR_VERSION   = $$section(VERSION, ".", 1, 1)

--- a/android.pri
+++ b/android.pri
@@ -1,40 +1,67 @@
-include($$PWD/libs/qtandroidserialport/src/qtandroidserialport.pri)
-message("Adding Serial Java Classes")
 QT += androidextras
 
-ANDROID_PACKAGE_SOURCE_DIR = $$PWD/android
+include($$PWD/libs/qtandroidserialport/src/qtandroidserialport.pri)
 
-android_source_dir_target.commands = echo Updating Android Manifest
+ANDROID_PACKAGE_SOURCE_DIR          = $$OUT_PWD/ANDROID_PACKAGE_SOURCE_DIR  # Tells Qt location of package files for build
+ANDROID_PACKAGE_QGC_SOURCE_DIR      = $$PWD/android                         # Original location of QGC package files
+ANDROID_PACKAGE_CUSTOM_SOURCE_DIR   = $$PWD/custom/android                  # Original location for custom build override package files
+
+# We always move the package files to the ANDROID_PACKAGE_SOURCE_DIR build dir so we can modify the manifest as needed
+
+android_source_dir_target.target = $$ANDROID_PACKAGE_QGC_SOURCE_DIR/AndroidManifest.xml
+android_source_dir_target.commands = \
+    $$QMAKE_MKDIR $$ANDROID_PACKAGE_SOURCE_DIR && \
+    $$QMAKE_COPY_DIR $$ANDROID_PACKAGE_QGC_SOURCE_DIR/* $$ANDROID_PACKAGE_SOURCE_DIR
+PRE_TARGETDEPS += $$android_source_dir_target.target
+QMAKE_EXTRA_TARGETS += android_source_dir_target
 android_source_dir_target.depends = FORCE
 
-exists($$PWD/custom/android) {
-    message("Merging $$PWD/custom/android/ -> $$PWD/android/")
+# Custom builds can override android package file
 
-    ANDROID_PACKAGE_SOURCE_DIR = $$OUT_PWD/ANDROID_PACKAGE_SOURCE_DIR
-    android_source_dir_target.target = android_source_dir
-    PRE_TARGETDEPS += $$android_source_dir_target.target
-    QMAKE_EXTRA_TARGETS += android_source_dir_target
+exists($$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR) {
+    message("Merging$$ $$ANDROID_PACKAGE_QGC_SOURCE_DIR and $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR to $$ANDROID_PACKAGE_SOURCE_DIR")
 
+    android_source_dir_target.target = $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/AndroidManifest.xml
     android_source_dir_target.commands = $$android_source_dir_target.commands && \
-            $$QMAKE_MKDIR $$ANDROID_PACKAGE_SOURCE_DIR && \
-            $$QMAKE_COPY_DIR $$PWD/android/* $$OUT_PWD/ANDROID_PACKAGE_SOURCE_DIR && \
-            $$QMAKE_COPY_DIR $$PWD/custom/android/* $$OUT_PWD/ANDROID_PACKAGE_SOURCE_DIR && \
+            $$QMAKE_COPY_DIR $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/* $$ANDROID_PACKAGE_SOURCE_DIR && \
             $$QMAKE_STREAM_EDITOR -i \"s/package=\\\"org.mavlink.qgroundcontrol\\\"/package=\\\"$$QGC_ANDROID_PACKAGE\\\"/\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml
 }
 
-NoSerialBuild {
+# Insert package name into manifest file
+
+android_source_dir_target.commands = $$android_source_dir_target.commands && \
+        $$QMAKE_STREAM_EDITOR -i \"s/%%QGC_INSERT_PACKAGE_NAME%%/$$QGC_ANDROID_PACKAGE/\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml
+
+# Update manifest activity intent filter as needed
+
+QGC_INSERT_ACTIVITY_INTENT_FILTER = ""
+AndroidHomeApp {
+    # QGC is the android home application
+    QGC_INSERT_ACTIVITY_INTENT_FILTER = $$QGC_INSERT_ACTIVITY_INTENT_FILTER "\r\n<category android:name=\\\"android.intent.category.HOME\\\"\\\/>\r\n<category android:name=\\\"android.intent.category.DEFAULT\\\"\\\/>"
+}
+!contains(DEFINES, NO_SERIAL_LINK) {
+    # Add usb device support
+    QGC_INSERT_ACTIVITY_INTENT_FILTER = $$QGC_INSERT_ACTIVITY_INTENT_FILTER "\r\n<action android:name=\\\"android.hardware.usb.action.USB_DEVICE_ATTACHED\\\"\\\/>\r\n<action android:name=\\\"android.hardware.usb.action.USB_DEVICE_DETACHED\\\"\\\/>\r\n<action android:name=\\\"android.hardware.usb.action.USB_ACCESSORY_ATTACHED\\\"\\\/>"
+}
+contains(DEFINES, QGC_ENABLE_BLUETOOTH) {
+    QGC_INSERT_ACTIVITY_INTENT_FILTER = $$QGC_INSERT_ACTIVITY_INTENT_FILTER "\r\n<action android:name=\\\"android.bluetooth.device.action.ACL_CONNECTED\\\"\\\/>\r\n<action android:name=\\\"android.bluetooth.device.action.ACL_DISCONNECTED\\\"\\\/>"
+}
+android_source_dir_target.commands = $$android_source_dir_target.commands && \
+    $$QMAKE_STREAM_EDITOR -i \"s/<!-- %%QGC_INSERT_ACTIVITY_INTENT_FILTER -->/$$QGC_INSERT_ACTIVITY_INTENT_FILTER/\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml
+
+# Update manifest activity meta data as needed
+
+contains(DEFINES, NO_SERIAL_LINK) {
     # No need to add anything to manifest
-    android_source_dir_target.commands = $$android_source_dir_target.commands && \
-        $$QMAKE_STREAM_EDITOR -i \"s/<!-- %%QGC_INSERT_ACTIVITY_INTENT_FILTER -->//\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml
     android_source_dir_target.commands = $$android_source_dir_target.commands && \
         $$QMAKE_STREAM_EDITOR -i \"s/<!-- %%QGC_INSERT_ACTIVITY_META_DATA -->//\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml
 } else {
     # Updates the manifest for usb device support
     android_source_dir_target.commands = $$android_source_dir_target.commands && \
-        $$QMAKE_STREAM_EDITOR -i \"s/<!-- %%QGC_INSERT_ACTIVITY_INTENT_FILTER -->/<action android:name=\\\"android.hardware.usb.action.USB_DEVICE_ATTACHED\\\"\\\/>\r\n<action android:name=\\\"android.hardware.usb.action.USB_DEVICE_DETACHED\\\"\\\/>\r\n<action android:name=\\\"android.hardware.usb.action.USB_ACCESSORY_ATTACHED\\\"\\\/>/\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml
-    android_source_dir_target.commands = $$android_source_dir_target.commands && \
         $$QMAKE_STREAM_EDITOR -i \"s/<!-- %%QGC_INSERT_ACTIVITY_META_DATA -->/<meta-data android:resource=\\\"@xml\\\/device_filter\\\" android:name=\\\"android.hardware.usb.action.USB_DEVICE_ATTACHED\\\"\\\/>\r\n<meta-data android:resource=\\\"@xml\\\/device_filter\\\" android:name=\\\"android.hardware.usb.action.USB_DEVICE_DETACHED\\\"\\\/>\r\n<meta-data android:resource=\\\"@xml\\\/device_filter\\\" android:name=\\\"android.hardware.usb.action.USB_ACCESSORY_ATTACHED\\\"\\\/>/\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml
 }
+
+# OTHER_FILES makes the specified files be visible in Qt Creator for editing
 
 exists($$PWD/custom/android/AndroidManifest.xml) {
     OTHER_FILES += \
@@ -61,7 +88,6 @@ OTHER_FILES += \
     $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAhcCallback.java \
     $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAhsCallback.java \
     $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAmcOnFrameAvailableListener.java
-
 
 DISTFILES += \
     $$PWD/android/gradle/wrapper/gradle-wrapper.jar \

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest package="org.mavlink.qgroundcontrol" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="-- %%INSERT_VERSION_NAME%% --" android:versionCode="-- %%INSERT_VERSION_CODE%% --" android:installLocation="auto">
+<manifest package="%%QGC_INSERT_PACKAGE_NAME%%" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="-- %%INSERT_VERSION_NAME%% --" android:versionCode="-- %%INSERT_VERSION_CODE%% --" android:installLocation="auto">
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.
          Remove the comment if you do not require these default permissions. -->
     <!-- %%INSERT_PERMISSIONS -->
@@ -13,11 +13,7 @@
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density" android:name="org.mavlink.qgroundcontrol.QGCActivity" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="sensorLandscape" android:launchMode="singleTask" android:keepScreenOn="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.HOME"/>
-                <category android:name="android.intent.category.DEFAULT"/>                
                 <category android:name="android.intent.category.LAUNCHER"/>
-                <action android:name="android.bluetooth.device.action.ACL_CONNECTED"/>
-                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED"/>
 
                 <!-- %%QGC_INSERT_ACTIVITY_INTENT_FILTER -->
             </intent-filter>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -796,11 +796,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
     }
 }
 
-contains(DEFINES, NO_SERIAL_LINK) {
-    CONFIG += NoSerialBuild
-}
-
-!NoSerialBuild {
+!contains(DEFINES, NO_SERIAL_LINK) {
 HEADERS += \
     src/comm/QGCSerialPortInfo.h \
     src/comm/SerialLink.h \
@@ -1031,7 +1027,7 @@ SOURCES += \
     src/comm/MockLinkMissionItemHandler.cc \
 }
 
-!NoSerialBuild {
+!contains(DEFINES, NO_SERIAL_LINK) {
 SOURCES += \
     src/comm/QGCSerialPortInfo.cc \
     src/comm/SerialLink.cc \
@@ -1086,7 +1082,7 @@ HEADERS+= \
     src/FirmwarePlugin/FirmwarePluginManager.h \
     src/VehicleSetup/VehicleComponent.h \
 
-!MobileBuild { !NoSerialBuild {
+!MobileBuild { !contains(DEFINES, NO_SERIAL_LINK) {
     HEADERS += \
         src/VehicleSetup/Bootloader.h \
         src/VehicleSetup/FirmwareImage.h \
@@ -1108,7 +1104,7 @@ SOURCES += \
     src/FirmwarePlugin/FirmwarePluginManager.cc \
     src/VehicleSetup/VehicleComponent.cc \
 
-!MobileBuild { !NoSerialBuild {
+!MobileBuild { !contains(DEFINES, NO_SERIAL_LINK) {
     SOURCES += \
         src/VehicleSetup/Bootloader.cc \
         src/VehicleSetup/FirmwareImage.cc \


### PR DESCRIPTION
* DEFINES+=NO_SERIAL_LINK - to turn off serial support
* DEFINES+=QGC_DISABLE_BLUETOOTH - turn off bluetooth support
* CONFIG+=AndroidHomeApp - App is home app. This is new support

Note: NO_SERIAL_LINK and QGC_DISABLE_BLUETOOTH already existed in the build but were not supported (or correctly supported) in android builds.

Although this is generic support, it is drive by getting a clean Herelink custom build out.