### PR TITLE
{Sponsored by Intelliterra} Made "Declare Emergency" button send MAV_CMD to set emergency

### DIFF
--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -414,7 +414,22 @@ void RemoteIDManager::setEmergency(bool declare)
 {
     _emergencyDeclared = declare;
     emit emergencyDeclaredChanged();
-    // Wether we are starting an emergency or cancelling it, we need to enforce sending
+
+    // We send a MAV Command to the vehicle to start or stop the emergency
+    _vehicle->sendMavCommand(
+        _vehicle->compId(),        // Target component
+        MAV_CMD_DO_SET_EMERGENCY,  // MAV_CMD
+        true,                     // ShowError
+        _emergencyDeclared ? 1 : 0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0);
+
+
+    // Whether we are starting an emergency or cancelling it, we need to enforce sending
     // this message. Otherwise, if non optimal connection quality, vehicle RID device
     // could remain in the wrong state. It is clarified to the user in remoteidsettings.qml
     _enforceSendingSelfID = true;


### PR DESCRIPTION
Currently the "Declare Emergency" button does not actually set the OPEN_DRONE_ID_LOCATION status to emergency on PX4. I created a PR into mavlink [here](https://github.com/mavlink/mavlink/pull/2027) which adds a MAV_CMD_DO_SET_EMERGENCY command. My changes on this PR make it so that the Declare Emergency button sends that command.

As a note, I tested the MAVLink changes on QGroundControl by making the changes to the detached head submodule and building that first, since QGC currently is not on the most recent MAVLink build.


**Context**
Link to MAVLink PR: https://github.com/mavlink/mavlink/pull/2027

Link to PX4 PR: https://github.com/PX4/PX4-Autopilot/pull/21959
