### PR TITLE
Revert "Support custom builds with joysticks which are buttons only"

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -16,8 +16,6 @@
 #include "VideoManager.h"
 #include "QGCCameraManager.h"
 #include "QGCCameraControl.h"
-#include "QGCCorePlugin.h"
-#include "QGCOptions.h"
 
 #include <QSettings>
 
@@ -110,8 +108,6 @@ Joystick::Joystick(const QString& name, int axisCount, int buttonCount, int hatC
     , _totalButtonCount(_buttonCount+_hatButtonCount)
     , _multiVehicleManager(multiVehicleManager)
 {
-    _useButtonsOnly = qgcApp()->toolbox()->corePlugin()->options()->joystickUseButtonsOnly();
-
     qRegisterMetaType<GRIPPER_ACTIONS>();
 
     _rgAxisValues   = new int[static_cast<size_t>(_axisCount)];
@@ -728,9 +724,10 @@ void Joystick::startPolling(Vehicle* vehicle)
         }
         // Update qml in case of joystick transition
         emit calibratedChanged(_calibrated);
+        // Build action list
         _buildActionList(vehicle);
-
-        if (vehicle->joystickEnabled() || _useButtonsOnly) {
+        // Only connect the new vehicle if it wants joystick data
+        if (vehicle->joystickEnabled()) {
             _pollingStartedForCalibration = false;
             connect(this, &Joystick::setArmed,           _activeVehicle, &Vehicle::setArmedShowError);
             connect(this, &Joystick::setVtolInFwdFlight, _activeVehicle, &Vehicle::setVtolInFwdFlight);
@@ -752,7 +749,7 @@ void Joystick::startPolling(Vehicle* vehicle)
 void Joystick::stopPolling(void)
 {
     if (isRunning()) {
-        if (_activeVehicle && (_activeVehicle->joystickEnabled() || _useButtonsOnly)) {
+        if (_activeVehicle && _activeVehicle->joystickEnabled()) {
             disconnect(this, &Joystick::setArmed,           _activeVehicle, &Vehicle::setArmedShowError);
             disconnect(this, &Joystick::setVtolInFwdFlight, _activeVehicle, &Vehicle::setVtolInFwdFlight);
             disconnect(this, &Joystick::setFlightMode,      _activeVehicle, &Vehicle::setFlightMode);
@@ -999,10 +996,9 @@ void Joystick::setCalibrationMode(bool calibrating)
 
 void Joystick::_executeButtonAction(const QString& action, bool buttonDown)
 {
-    if (!_activeVehicle || (!_activeVehicle->joystickEnabled() && !_useButtonsOnly) || action == _buttonActionNone) {
+    if (!_activeVehicle || !_activeVehicle->joystickEnabled() || action == _buttonActionNone) {
         return;
     }
-
     if (action == _buttonActionArm) {
         if (buttonDown) emit setArmed(true);
     } else if (action == _buttonActionDisarm) {

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -94,10 +94,6 @@ public:
     Q_PROPERTY(int      axisCount               READ axisCount              CONSTANT)
     Q_PROPERTY(bool     requiresCalibration     READ requiresCalibration    CONSTANT)
 
-    // This property is used to indicate a joystick setup where the stick axes are ignored and only the
-    // buttons are supported. This type of setup is used by a Herelink controller for example.
-    Q_PROPERTY(bool     useButtonsOnly          MEMBER _useButtonsOnly      CONSTANT)
-
     //-- Actions assigned to buttons
     Q_PROPERTY(QStringList buttonActions        READ buttonActions          NOTIFY buttonActionsChanged)
 
@@ -279,7 +275,6 @@ protected:
 
     std::atomic<bool> _exitThread{false};    ///< true: signal thread to exit
     bool    _calibrationMode        = false;
-    bool    _useButtonsOnly         = false;
     int*    _rgAxisValues           = nullptr;
     Calibration_t* _rgCalibration   = nullptr;
     ThrottleMode_t _throttleMode    = ThrottleModeDownZero;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2088,21 +2088,11 @@ void Vehicle::_loadJoystickSettings()
 {
     QSettings settings;
     settings.beginGroup(QString(_settingsGroup).arg(_id));
-    const bool _useButtonsOnly = qgcApp()->toolbox()->corePlugin()->options()->joystickUseButtonsOnly();
 
-    if (!_useButtonsOnly && _toolbox->joystickManager()->activeJoystick()) {
+    if (_toolbox->joystickManager()->activeJoystick()) {
         qCDebug(JoystickLog) << "Vehicle " << this->id() << " Notified of an active joystick. Loading setting joystickenabled: " << settings.value(_joystickEnabledSettingsKey, false).toBool();
         setJoystickEnabled(settings.value(_joystickEnabledSettingsKey, false).toBool());
-    }
-    else if(_useButtonsOnly)
-    {
-        // in a build with _useButtonsOnly set, joystickenable should always be left false
-        // this prevents the sticks from doing anything
-        qCDebug(JoystickLog) << "Vehicle " << this->id() << " Skipping Load of Joystick Settings because QCC Options useButtonsOnly is set";
-        setJoystickEnabled(false);
-    }
-    else
-    {
+    } else {
         qCDebug(JoystickLog) << "Vehicle " << this->id() << " Notified that there is no active joystick";
         setJoystickEnabled(false);
     }

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -62,30 +62,20 @@ SetupPage {
                 id:             bar
                 width:          parent.width
                 Component.onCompleted: {
-                    currentIndex = 0
-                    if (_activeJoystick) {
-                        if (_activeJoystick.useButtonsOnly) {
-                            currentIndex = 1
-                        } else if (_activeJoystick.calibrated) {
-                            currentIndex = 2
-                        }
-                    }
+                    currentIndex = _activeJoystick && _activeJoystick.calibrated ? 0 : 2
                 }
                 anchors.top:    parent.top
                 QGCTabButton {
                     text:       qsTr("General")
-                    visible:    !_activeJoystick.useButtonsOnly
                 }
                 QGCTabButton {
                     text:       qsTr("Button Assigment")
                 }
                 QGCTabButton {
                     text:       qsTr("Calibration")
-                    visible:    !_activeJoystick.useButtonsOnly
                 }
                 QGCTabButton {
                     text:       qsTr("Advanced")
-                    visible:    !_activeJoystick.useButtonsOnly
                 }
             }
 

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -260,7 +260,7 @@ Rectangle {
                 id:                 joystickButton
                 imageResource:      "/qmlimages/Joystick.png"
                 setupIndicator:     true
-                setupComplete:      joystickManager.activeJoystick ? (joystickManager.activeJoystick.calibrated || joystickManager.activeJoystick.useButtonsOnly) : false
+                setupComplete:      joystickManager.activeJoystick ? joystickManager.activeJoystick.calibrated : false
                 exclusiveGroup:     setupButtonGroup
                 visible:            _fullParameterVehicleAvailable && joystickManager.joysticks.length !== 0
                 text:               qsTr("Joystick")

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -146,10 +146,6 @@ public:
 
     virtual QGCFlyViewOptions* flyViewOptions       ();
 
-    // This is used to indicate a joystick setup where the stick axes are ignored and only the
-    // buttons are supported. This type of setup is used by a Herelink controller for example.
-    virtual bool joystickUseButtonsOnly() const { return false; }
-
 signals:
     void showSensorCalibrationCompassChanged    (bool show);
     void showSensorCalibrationGyroChanged       (bool show);


### PR DESCRIPTION
This reverts commit 48d1441493b3c193bbd2c5fc63c650bf2ae51e48.

This was for Herelink support. Isn't quite what is needed. I will do this a different way.


