### PR TITLE
Handle openssl version mismatch

### DIFF
--- a/src/QGCFileDownload.cc
+++ b/src/QGCFileDownload.cc
@@ -60,6 +60,8 @@ bool QGCFileDownload::download(const QString& remoteFile, const QVector<QPair<QN
         return false;
     }
 
+    setIgnoreSSLErrorsIfNeeded(*networkReply);
+
     connect(networkReply, &QNetworkReply::downloadProgress, this, &QGCFileDownload::downloadProgress);
     connect(networkReply, &QNetworkReply::finished, this, &QGCFileDownload::_downloadFinished);
     connect(networkReply, &QNetworkReply::errorOccurred, this, &QGCFileDownload::_downloadError);
@@ -147,4 +149,20 @@ void QGCFileDownload::_downloadError(QNetworkReply::NetworkError code)
     }
 
     emit downloadComplete(_originalRemoteFile, QString(), errorMsg);
+}
+
+void QGCFileDownload::setIgnoreSSLErrorsIfNeeded(QNetworkReply& networkReply)
+{
+    // Some systems (like Ubuntu 22.04) only ship with OpenSSL 3.x, however Qt 5.15.2 links against OpenSSL 1.x.
+    // This results in unresolved symbols for EVP_PKEY_base_id and SSL_get_peer_certificate.
+    // To still get a connection we have to ignore certificate verification (connection is still encrypted but open to MITM attacks)
+    // See https://bugreports.qt.io/browse/QTBUG-115146
+    const bool sslLibraryBuildIs1x = (QSslSocket::sslLibraryBuildVersionNumber() & 0xf0000000) == 0x10000000;
+    const bool sslLibraryIs3x = (QSslSocket::sslLibraryVersionNumber() & 0xf0000000) == 0x30000000;
+    if (sslLibraryBuildIs1x && sslLibraryIs3x) {
+        qWarning() << "Ignoring ssl certificates due to OpenSSL version mismatch";
+        QList<QSslError> errorsThatCanBeIgnored;
+        errorsThatCanBeIgnored << QSslError(QSslError::NoPeerCertificate);
+        networkReply.ignoreSslErrors(errorsThatCanBeIgnored);
+    }
 }

--- a/src/QGCFileDownload.h
+++ b/src/QGCFileDownload.h
@@ -25,6 +25,8 @@ public:
     /// @return true: Asynchronous download has started, false: Download initialization failed
     bool download(const QString& remoteFile, const QVector<QPair<QNetworkRequest::Attribute, QVariant>>& requestAttributes={}, bool redirect = false);
 
+    static void setIgnoreSSLErrorsIfNeeded(QNetworkReply& networkReply);
+
 signals:
     void downloadProgress(qint64 curr, qint64 total);
     void downloadComplete(QString remoteFile, QString localFile, QString errorMsg);

--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -19,6 +19,7 @@
 #include "QGCMapEngine.h"
 #include "QGCMapTileSet.h"
 #include "QGCMapEngineManager.h"
+#include "QGCFileDownload.h"
 #include "TerrainTile.h"
 
 #include <QSettings>
@@ -249,6 +250,7 @@ void QGCCachedTileSet::_prepareDownload()
 #endif
             QNetworkReply* reply = _networkManager->get(request);
             reply->setParent(0);
+            QGCFileDownload::setIgnoreSSLErrorsIfNeeded(*reply);
             connect(reply, &QNetworkReply::finished, this, &QGCCachedTileSet::_networkReplyFinished);
             connect(reply, &QNetworkReply::errorOccurred, this, &QGCCachedTileSet::_networkReplyError);
             _replies.insert(tile->hash(), reply);

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -10,6 +10,7 @@
 #include "TerrainQuery.h"
 #include "QGCMapEngine.h"
 #include "QGeoMapReplyQGC.h"
+#include "QGCFileDownload.h"
 #include "QGCApplication.h"
 
 #include <QUrl>
@@ -123,7 +124,7 @@ void TerrainAirMapQuery::_sendQuery(const QString& path, const QUrlQuery& urlQue
         _requestFailed();
         return;
     }
-    networkReply->ignoreSslErrors();
+    QGCFileDownload::setIgnoreSSLErrorsIfNeeded(*networkReply);
 
     connect(networkReply, &QNetworkReply::finished, this, &TerrainAirMapQuery::_requestFinished);
     connect(networkReply, &QNetworkReply::sslErrors, this, &TerrainAirMapQuery::_sslErrors);

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -109,8 +109,6 @@ FirmwareUpgradeController::FirmwareUpgradeController(void)
     : _singleFirmwareURL                (qgcApp()->toolbox()->corePlugin()->options()->firmwareUpgradeSingleURL())
     , _singleFirmwareMode               (!_singleFirmwareURL.isEmpty())
     , _downloadingFirmwareList          (false)
-    , _downloadManager                  (nullptr)
-    , _downloadNetworkReply             (nullptr)
     , _statusLog                        (nullptr)
     , _selectedFirmwareBuildType        (StableFirmware)
     , _image                            (nullptr)
@@ -688,7 +686,7 @@ void FirmwareUpgradeController::_downloadArduPilotManifest(void)
 
     QGCFileDownload* downloader = new QGCFileDownload(this);
     connect(downloader, &QGCFileDownload::downloadComplete, this, &FirmwareUpgradeController::_ardupilotManifestDownloadComplete);
-    downloader->download(QStringLiteral("http://firmware.ardupilot.org/manifest.json.gz"));
+    downloader->download(QStringLiteral("https://firmware.ardupilot.org/manifest.json.gz"));
 }
 
 void FirmwareUpgradeController::_ardupilotManifestDownloadComplete(QString remoteFile, QString localFile, QString errorMsg)

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -226,9 +226,6 @@ private:
     
     QString _firmwareFilename;      ///< Image which we are going to flash to the board
     
-    QNetworkAccessManager*  _downloadManager;       ///< Used for firmware file downloading across the internet
-    QNetworkReply*          _downloadNetworkReply;  ///< Used for firmware file downloading across the internet
-    
     /// @brief Thread controller which is used to run bootloader commands on separate thread
     PX4FirmwareUpgradeThreadController* _threadController;
     


### PR DESCRIPTION
Some systems (like Ubuntu 22.04) only ship with OpenSSL 3.x, however Qt 5.15.2 links against OpenSSL 1.x.
This results in unresolved symbols for EVP_PKEY_base_id and SSL_get_peer_certificate.
To still get a connection we have to ignore certificate verification (connection is still encrypted but open to MITM attacks)
See https://bugreports.qt.io/browse/QTBUG-115146

It's not a great solution, but the best one I see given the situation.

Thanks to @julianoes for doing all the investigation & bug reporting.