### PR TITLE
Two changes relating to text field numeric value input

### DIFF
--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -439,7 +439,7 @@ SetupPage {
                             columns:    2
 
                             QGCLabel { text: qsTr("Measured voltage:") }
-                            QGCTextField { id: measuredVoltage }
+                            QGCTextField { id: measuredVoltage; numericValuesOnly: true }
 
                             QGCLabel { text: qsTr("Vehicle voltage:") }
                             QGCLabel { text: _batteryFactGroup.voltage.valueString }
@@ -497,7 +497,7 @@ SetupPage {
                             columns:    2
 
                             QGCLabel { text: qsTr("Measured current:") }
-                            QGCTextField { id: measuredCurrent }
+                            QGCTextField { id: measuredCurrent; numericValuesOnly: true }
 
                             QGCLabel { text: qsTr("Vehicle current:") }
                             QGCLabel { text: _batteryFactGroup.current.valueString }

--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -11,20 +11,17 @@ import QGroundControl.ScreenTools   1.0
 QGCTextField {
     id: _textField
 
-    text:       fact ? fact.valueString : ""
-    unitsLabel: fact ? fact.units : ""
-    showUnits:  true
-    showHelp:   true
+    text:               fact ? fact.valueString : ""
+    unitsLabel:         fact ? fact.units : ""
+    showUnits:          true
+    showHelp:           true
+    numericValuesOnly:  fact && !fact.typeIsString
 
     signal updated()
 
     property Fact   fact: null
 
     property string _validateString
-
-    inputMethodHints: ((fact && fact.typeIsString) || ScreenTools.isiOS) ?
-                          Qt.ImhNone :                // iOS numeric keyboard has no done button, we can't use it
-                          Qt.ImhFormattedNumbersOnly  // Forces use of virtual numeric keyboard
 
     onEditingFinished: {
         var errorString = fact.validate(text, false /* convertOnly */)

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -12,11 +12,15 @@ TextField {
     implicitHeight:     ScreenTools.implicitTextFieldHeight
     activeFocusOnPress: true
     antialiasing:       true
+    inputMethodHints:   numericValuesOnly && !ScreenTools.isiOS ?
+                          Qt.ImhNone :                // iOS numeric keyboard has no done button, we can't use it.
+                          Qt.ImhFormattedNumbersOnly  // Forces use of virtual numeric keyboard instead of full keyboard
 
     property bool   showUnits:          false
     property bool   showHelp:           false
     property string unitsLabel:         ""
     property string extraUnitsLabel:    ""
+    property bool   numericValuesOnly:  false   // true: Used as hint for mobile devices to show numeric only keyboard
 
     signal helpClicked
 


### PR DESCRIPTION
* QGCTextField has new numericValuesOnly bool property which is used to indicate the input is numeric. This will in turn cause the numeric only keyboard to be used on mobile.
* Updated the voltage/current calculators to use numericValuesOnly so the right virtual keyboard is shown for input