### PR TITLE
Mavlink standard modes protocol

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -724,6 +724,7 @@ HEADERS += \
     src/Vehicle/MultiVehicleManager.h \
     src/Vehicle/RemoteIDManager.h \
     src/Vehicle/StateMachine.h \
+    src/Vehicle/StandardModes.h \
     src/Vehicle/SysStatusSensorInfo.h \
     src/Vehicle/TerrainFactGroup.h \
     src/Vehicle/TerrainProtocolHandler.h \
@@ -979,6 +980,7 @@ SOURCES += \
     src/Vehicle/MultiVehicleManager.cc \
     src/Vehicle/RemoteIDManager.cc \
     src/Vehicle/StateMachine.cc \
+    src/Vehicle/StandardModes.cc \
     src/Vehicle/SysStatusSensorInfo.cc \
     src/Vehicle/TerrainFactGroup.cc \
     src/Vehicle/TerrainProtocolHandler.cc \

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -88,10 +88,6 @@ public:
     /// list available from the firmware. Call will be made again if advanced mode changes.
     virtual QStringList flightModes(Vehicle* /*vehicle*/) { return QStringList(); }
 
-    /// Returns the list of additional flight modes to add to the list for joystick button actions.
-    /// Call will be made again if advanced mode changes.
-    virtual QStringList extraJoystickFlightModes(Vehicle* /*vehicle*/) { return QStringList(); }
-
     /// Returns the name for this flight mode. Flight mode names must be human readable as well as audio speakable.
     ///     @param base_mode Base mode from mavlink HEARTBEAT message
     ///     @param custom_mode Custom mode from mavlink HEARTBEAT message

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -1009,7 +1009,7 @@ void Joystick::_executeButtonAction(const QString& action, bool buttonDown)
         if (buttonDown) emit setVtolInFwdFlight(true);
     } else if (action == _buttonActionVTOLMultiRotor) {
         if (buttonDown) emit setVtolInFwdFlight(false);
-    } else if (_activeVehicle->flightModes().contains(action) || _activeVehicle->extraJoystickFlightModes().contains(action)) {
+    } else if (_activeVehicle->flightModes().contains(action)) {
         if (buttonDown) emit setFlightMode(action);
     } else if(action == _buttonActionContinuousZoomIn || action == _buttonActionContinuousZoomOut) {
         if (buttonDown) {
@@ -1123,10 +1123,6 @@ void Joystick::_buildActionList(Vehicle* activeVehicle)
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionToggleArm));
     if (activeVehicle) {
         QStringList list = activeVehicle->flightModes();
-        foreach(auto mode, list) {
-            _assignableButtonActions.append(new AssignableButtonAction(this, mode));
-        }
-        list = activeVehicle->extraJoystickFlightModes();
         foreach(auto mode, list) {
             _assignableButtonActions.append(new AssignableButtonAction(this, mode));
         }

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -222,6 +222,10 @@ void Joystick::_activeVehicleChanged(Vehicle* activeVehicle)
         setTXMode(mode);
     }
 }
+void Joystick::_flightModesChanged()
+{
+    _buildActionList(_activeVehicle);
+}
 
 void Joystick::_vehicleCountChanged(int count)
 {
@@ -715,6 +719,7 @@ void Joystick::startPolling(Vehicle* vehicle)
             disconnect(this, &Joystick::gimbalControlValue, _activeVehicle, &Vehicle::gimbalControlValue);
             disconnect(this, &Joystick::emergencyStop,      _activeVehicle, &Vehicle::emergencyStop);
             disconnect(this, &Joystick::gripperAction,      _activeVehicle, &Vehicle::setGripperAction);
+            disconnect(_activeVehicle, &Vehicle::flightModesChanged, this, &Joystick::_flightModesChanged);
         }
         // Always set up the new vehicle
         _activeVehicle = vehicle;
@@ -738,6 +743,7 @@ void Joystick::startPolling(Vehicle* vehicle)
             connect(this, &Joystick::gimbalControlValue, _activeVehicle, &Vehicle::gimbalControlValue);
             connect(this, &Joystick::emergencyStop,      _activeVehicle, &Vehicle::emergencyStop);
             connect(this, &Joystick::gripperAction,      _activeVehicle, &Vehicle::setGripperAction);
+            connect(_activeVehicle, &Vehicle::flightModesChanged, this, &Joystick::_flightModesChanged);
         }
     }
     if (!isRunning()) {
@@ -758,6 +764,7 @@ void Joystick::stopPolling(void)
             disconnect(this, &Joystick::centerGimbal,       _activeVehicle, &Vehicle::centerGimbal);
             disconnect(this, &Joystick::gimbalControlValue, _activeVehicle, &Vehicle::gimbalControlValue);
             disconnect(this, &Joystick::gripperAction,      _activeVehicle, &Vehicle::setGripperAction);
+            disconnect(_activeVehicle, &Vehicle::flightModesChanged, this, &Joystick::_flightModesChanged);
         }
         _exitThread = true;
     }

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -366,5 +366,5 @@ private:
 private slots:
     void _activeVehicleChanged(Vehicle* activeVehicle);
     void _vehicleCountChanged(int count);
-
+    void _flightModesChanged();
 };

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -56,6 +56,8 @@ add_library(Vehicle
 	MultiVehicleManager.h
 	StateMachine.cc
 	StateMachine.h
+	StandardModes.cc
+	StandardModes.h
 	SysStatusSensorInfo.cc
 	SysStatusSensorInfo.h
 	TerrainFactGroup.cc

--- a/src/Vehicle/InitialConnectStateMachine.h
+++ b/src/Vehicle/InitialConnectStateMachine.h
@@ -37,11 +37,13 @@ signals:
 
 private slots:
     void gotProgressUpdate(float progressValue);
+    void standardModesRequestCompleted();
 
 private:
     static void _stateRequestAutopilotVersion           (StateMachine* stateMachine);
     static void _stateRequestProtocolVersion            (StateMachine* stateMachine);
     static void _stateRequestCompInfo                   (StateMachine* stateMachine);
+    static void _stateRequestStandardModes              (StateMachine* stateMachine);
     static void _stateRequestCompInfoComplete           (void* requestAllCompleteFnData);
     static void _stateRequestParameters                 (StateMachine* stateMachine);
     static void _stateRequestMission                    (StateMachine* stateMachine);

--- a/src/Vehicle/StandardModes.cc
+++ b/src/Vehicle/StandardModes.cc
@@ -1,0 +1,179 @@
+/****************************************************************************
+ *
+ * (c) 2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "Vehicle.h"
+#include "StandardModes.h"
+
+QGC_LOGGING_CATEGORY(StandardModesLog, "StandardModesLog")
+
+
+static void requestMessageResultHandler(void* resultHandlerData, MAV_RESULT result,
+                                        Vehicle::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t &message)
+{
+    StandardModes* standardModes = static_cast<StandardModes*>(resultHandlerData);
+    standardModes->gotMessage(result, message);
+}
+
+StandardModes::StandardModes(QObject *parent, Vehicle *vehicle)
+        : QObject(parent), _vehicle(vehicle)
+{
+}
+
+void StandardModes::gotMessage(MAV_RESULT result, const mavlink_message_t &message)
+{
+    _requestActive = false;
+    if (_wantReset) {
+        _wantReset = false;
+        request();
+        return;
+    }
+
+    if (result == MAV_RESULT_ACCEPTED) {
+        mavlink_available_modes_t availableModes;
+        mavlink_msg_available_modes_decode(&message, &availableModes);
+        bool cannotBeSet = availableModes.properties & MAV_MODE_PROPERTY_NOT_USER_SELECTABLE;
+        bool advanced = availableModes.properties & MAV_MODE_PROPERTY_ADVANCED;
+        availableModes.mode_name[sizeof(availableModes.mode_name)-1] = '\0';
+        QString name = availableModes.mode_name;
+        switch (availableModes.standard_mode) {
+            case MAV_STANDARD_MODE_POSITION_HOLD:
+                name = "Position";
+                break;
+            case MAV_STANDARD_MODE_ORBIT:
+                name = "Orbit";
+                break;
+            case MAV_STANDARD_MODE_CRUISE:
+                name = "Cruise";
+                break;
+            case MAV_STANDARD_MODE_ALTITUDE_HOLD:
+                name = "Altitude";
+                break;
+            case MAV_STANDARD_MODE_RETURN_HOME:
+                name = "Return";
+                break;
+            case MAV_STANDARD_MODE_SAFE_RECOVERY:
+                name = "Safe Recovery";
+                break;
+            case MAV_STANDARD_MODE_MISSION:
+                name = "Mission";
+                break;
+            case MAV_STANDARD_MODE_LAND:
+                name = "Land";
+                break;
+            case MAV_STANDARD_MODE_TAKEOFF:
+                name = "Takeoff";
+                break;
+        }
+
+        if (name == "Takeoff" || name == "VTOL Takeoff" || name == "Orbit" || name == "Land" || name == "Return") { // These are exposed in the UI as separate buttons
+            cannotBeSet = true;
+        }
+
+        qCDebug(StandardModesLog) << "Got mode:" << name << ", idx:" << availableModes.mode_index << ", custom_mode" << availableModes.custom_mode;
+
+        _nextModes[availableModes.custom_mode] = Mode{name, availableModes.standard_mode, advanced, cannotBeSet};
+
+        if (availableModes.mode_index >= availableModes.number_modes) { // We are done
+            qCDebug(StandardModesLog) << "Completed, num modes:" << _nextModes.size();
+            _modes = _nextModes;
+            ensureUniqueModeNames();
+            _hasModes = true;
+            emit modesUpdated();
+            emit requestCompleted();
+
+        } else {
+            requestMode(availableModes.mode_index + 1);
+        }
+
+    } else {
+        qCDebug(StandardModesLog) << "Failed to retrieve available modes" << result;
+        emit requestCompleted();
+    }
+}
+
+void StandardModes::ensureUniqueModeNames()
+{
+    // Ensure mode names are unique. This should generally already be the case, but e.g. during development when
+    // restarting dynamic modes, it might not be.
+    for (auto iter = _modes.begin(); iter != _modes.end(); ++iter) {
+        int duplicateIdx = 0;
+        for (auto iter2 = iter + 1; iter2 != _modes.end(); ++iter2) {
+            if (iter.value().name == iter2.value().name) {
+                iter2.value().name += QStringLiteral(" (%1)").arg(duplicateIdx + 1);
+                ++duplicateIdx;
+            }
+        }
+    }
+}
+
+void StandardModes::request()
+{
+    if (_requestActive) {
+        // If we are in the middle of waiting for a request, wait for the response first
+        _wantReset = true;
+        return;
+    }
+
+    _nextModes.clear();
+
+    qCDebug(StandardModesLog) << "Requesting available modes";
+    // Request one at a time. This could be improved by requesting all, but we can't use Vehicle::requestMessage for that
+    StandardModes::requestMode(1);
+}
+
+void StandardModes::requestMode(int modeIndex)
+{
+    _requestActive = true;
+    _vehicle->requestMessage(
+            requestMessageResultHandler,
+            this,
+            MAV_COMP_ID_AUTOPILOT1,
+            MAVLINK_MSG_ID_AVAILABLE_MODES, modeIndex);
+}
+
+void StandardModes::availableModesMonitorReceived(uint8_t seq)
+{
+    if (_lastSeq != seq) {
+        qCDebug(StandardModesLog) << "Available modes changed, re-requesting";
+        _lastSeq = seq;
+        request();
+    }
+}
+
+QStringList StandardModes::flightModes()
+{
+    QStringList ret;
+    for (const auto& mode : _modes) {
+        if (mode.cannotBeSet) {
+            continue;
+        }
+        ret += mode.name;
+    }
+    return ret;
+}
+
+QString StandardModes::flightMode(uint32_t custom_mode) const
+{
+    auto iter = _modes.find(custom_mode);
+    if (iter != _modes.end()) {
+        return iter->name;
+    }
+    return tr("Unknown %2").arg(custom_mode);
+}
+
+bool StandardModes::setFlightMode(const QString &flightMode, uint32_t *custom_mode)
+{
+    for (auto iter = _modes.constBegin(); iter != _modes.constEnd(); ++iter) {
+        if (iter->name == flightMode) {
+            *custom_mode = iter.key();
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/Vehicle/StandardModes.cc
+++ b/src/Vehicle/StandardModes.cc
@@ -114,6 +114,7 @@ void StandardModes::ensureUniqueModeNames()
 
 void StandardModes::request()
 {
+#ifdef DAILY_BUILD // Disable use of development/WIP MAVLink messages for release builds
     if (_requestActive) {
         // If we are in the middle of waiting for a request, wait for the response first
         _wantReset = true;
@@ -125,6 +126,9 @@ void StandardModes::request()
     qCDebug(StandardModesLog) << "Requesting available modes";
     // Request one at a time. This could be improved by requesting all, but we can't use Vehicle::requestMessage for that
     StandardModes::requestMode(1);
+#else
+    emit requestCompleted();
+#endif // DAILY_BUILD
 }
 
 void StandardModes::requestMode(int modeIndex)

--- a/src/Vehicle/StandardModes.h
+++ b/src/Vehicle/StandardModes.h
@@ -1,0 +1,69 @@
+/****************************************************************************
+ *
+ * (c) 2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGCLoggingCategory.h"
+#include "QGCMAVLink.h"
+#include <QString>
+#include <QMap>
+
+Q_DECLARE_LOGGING_CATEGORY(StandardModesLog)
+
+class Vehicle;
+
+class StandardModes : public QObject
+{
+Q_OBJECT
+
+public:
+    struct Mode {
+        QString name;
+        uint8_t standardMode;
+        bool advanced;
+        bool cannotBeSet;
+    };
+
+    StandardModes(QObject* parent, Vehicle* vehicle);
+
+    void request();
+
+    void availableModesMonitorReceived(uint8_t seq);
+
+    bool supported() const { return _hasModes; }
+
+    QStringList flightModes();
+
+    QString flightMode(uint32_t custom_mode) const;
+
+    bool setFlightMode(const QString& flightMode, uint32_t* custom_mode);
+
+    void gotMessage(MAV_RESULT result, const mavlink_message_t &message);
+signals:
+    void modesUpdated();
+    void requestCompleted();
+
+private:
+
+    void requestMode(int modeIndex);
+    void ensureUniqueModeNames();
+
+    Vehicle*const _vehicle;
+
+    bool _requestActive{false};
+    bool _wantReset{false};
+    QMap<uint32_t, Mode> _nextModes; ///< Modes added by current request
+
+    bool _hasModes{false};
+
+    int _lastSeq{-1};
+
+    QMap<uint32_t, Mode> _modes; ///< key is custom_mode
+};
+

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -765,7 +765,8 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         }
     }
         break;
-    case MAVLINK_MSG_ID_AVAILABLE_MODES_MONITOR:
+#ifdef DAILY_BUILD // Disable use of development/WIP MAVLink messages for release builds
+        case MAVLINK_MSG_ID_AVAILABLE_MODES_MONITOR:
     {
         // Avoid duplicate requests during initial connection setup
         if (!_initialConnectStateMachine || !_initialConnectStateMachine->active()) {
@@ -778,6 +779,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_CURRENT_MODE:
         _handleCurrentMode(message);
         break;
+#endif // DAILY_BUILD
 
         // Following are ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2195,11 +2195,6 @@ QStringList Vehicle::flightModes()
     return _firmwarePlugin->flightModes(this);
 }
 
-QStringList Vehicle::extraJoystickFlightModes()
-{
-    return _firmwarePlugin->extraJoystickFlightModes(this);
-}
-
 QString Vehicle::flightMode() const
 {
     return _firmwarePlugin->flightMode(_base_mode, _custom_mode);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -775,6 +775,9 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         }
         break;
     }
+    case MAVLINK_MSG_ID_CURRENT_MODE:
+        _handleCurrentMode(message);
+        break;
 
         // Following are ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)
@@ -1669,16 +1672,15 @@ EventHandler& Vehicle::_eventHandler(uint8_t compid)
 
         // connect health and arming check updates
         connect(eventHandler.data(), &EventHandler::healthAndArmingChecksUpdated, this, [compid, this]() {
-            // TODO: use user-intended mode instead of currently set mode
             const QSharedPointer<EventHandler>& eventHandler = _events[compid];
             _healthAndArmingCheckReport.update(compid, eventHandler->healthAndArmingCheckResults(),
-                    eventHandler->getModeGroup(_custom_mode));
+                    eventHandler->getModeGroup(_has_custom_mode_user_intention ? _custom_mode_user_intention : _custom_mode));
         });
         connect(this, &Vehicle::flightModeChanged, this, [compid, this]() {
             const QSharedPointer<EventHandler>& eventHandler = _events[compid];
             if (eventHandler->healthAndArmingCheckResultsValid()) {
                 _healthAndArmingCheckReport.update(compid, eventHandler->healthAndArmingCheckResults(),
-                                                   eventHandler->getModeGroup(_custom_mode));
+                                                   eventHandler->getModeGroup(_has_custom_mode_user_intention ? _custom_mode_user_intention : _custom_mode));
             }
         });
     }
@@ -1753,6 +1755,20 @@ void Vehicle::_handleHeartbeat(mavlink_message_t& message)
         _base_mode   = heartbeat.base_mode;
         _custom_mode = heartbeat.custom_mode;
         if (previousFlightMode != flightMode()) {
+            emit flightModeChanged(flightMode());
+        }
+    }
+}
+
+void Vehicle::_handleCurrentMode(mavlink_message_t& message)
+{
+    mavlink_current_mode_t currentMode;
+    mavlink_msg_current_mode_decode(&message, &currentMode);
+    if (currentMode.intended_custom_mode != 0) { // 0 == unknown/not supplied
+        _has_custom_mode_user_intention = true;
+        bool changed = _custom_mode_user_intention != currentMode.intended_custom_mode;
+        _custom_mode_user_intention = currentMode.intended_custom_mode;
+        if (changed) {
             emit flightModeChanged(flightMode());
         }
     }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -48,6 +48,7 @@
 #include "ImageProtocolManager.h"
 #include "HealthAndArmingCheckReport.h"
 #include "TerrainQuery.h"
+#include "StandardModes.h"
 
 class Actuators;
 class EventHandler;
@@ -1089,6 +1090,7 @@ private:
     void _chunkedStatusTextCompleted    (uint8_t compId);
     void _setMessageInterval            (int messageId, int rate);
     EventHandler& _eventHandler         (uint8_t compid);
+    bool setFlightModeCustom            (const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode);
 
     static void _rebootCommandResultHandler(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress, MavCmdResultFailureCode_t failureCode);
 
@@ -1405,6 +1407,7 @@ private:
     InitialConnectStateMachine*     _initialConnectStateMachine = nullptr;
     Actuators*                      _actuators                  = nullptr;
     RemoteIDManager*                _remoteIDManager            = nullptr;
+    StandardModes*                  _standardModes              = nullptr;
 
     static const char* _rollFactName;
     static const char* _pitchFactName;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1039,6 +1039,7 @@ private:
     void _handlePing                    (LinkInterface* link, mavlink_message_t& message);
     void _handleHomePosition            (mavlink_message_t& message);
     void _handleHeartbeat               (mavlink_message_t& message);
+    void _handleCurrentMode             (mavlink_message_t& message);
     void _handleRadioStatus             (mavlink_message_t& message);
     void _handleRCChannels              (mavlink_message_t& message);
     void _handleBatteryStatus           (mavlink_message_t& message);
@@ -1185,6 +1186,8 @@ private:
     bool    _armed = false;         ///< true: vehicle is armed
     uint8_t _base_mode = 0;     ///< base_mode from HEARTBEAT
     uint32_t _custom_mode = 0;  ///< custom_mode from HEARTBEAT
+    uint32_t _custom_mode_user_intention = 0;  ///< custom_mode_user_intention from CURRENT_MODE
+    bool _has_custom_mode_user_intention = false;
 
     /// Used to store a message being sent by sendMessageMultiple
     typedef struct {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -164,7 +164,6 @@ public:
     Q_PROPERTY(bool                 autoDisarm                  READ autoDisarm                                                     NOTIFY autoDisarmChanged)
     Q_PROPERTY(bool                 flightModeSetAvailable      READ flightModeSetAvailable                                         CONSTANT)
     Q_PROPERTY(QStringList          flightModes                 READ flightModes                                                    NOTIFY flightModesChanged)
-    Q_PROPERTY(QStringList          extraJoystickFlightModes    READ extraJoystickFlightModes                                       NOTIFY flightModesChanged)
     Q_PROPERTY(QString              flightMode                  READ flightMode                 WRITE setFlightMode                 NOTIFY flightModeChanged)
     Q_PROPERTY(TrajectoryPoints*    trajectoryPoints            MEMBER _trajectoryPoints                                            CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  cameraTriggerPoints         READ cameraTriggerPoints                                            CONSTANT)
@@ -522,7 +521,6 @@ public:
 
     bool flightModeSetAvailable             ();
     QStringList flightModes                 ();
-    QStringList extraJoystickFlightModes    ();
     QString flightMode                      () const;
     void setFlightMode                      (const QString& flightMode);
 


### PR DESCRIPTION
This brings the MAVLink standard modes protocol from https://github.com/mavlink/mavlink/pull/1750.
It allows the GCS to dynamically request the list of modes.
As the messages are in `development.xml`, they are disabled when doing a release build of QGC.

Implementation on the PX4 side: https://github.com/PX4/PX4-Autopilot/pull/20707

@hamishwillee fyi