### PR TITLE
Support joysticks which are buttons only

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -501,7 +501,9 @@ void Joystick::run()
     while (!_exitThread) {
         _update();
         _handleButtons();
-        _handleAxis();
+        if (axisCount() != 0) {
+            _handleAxis();
+        }
         QGC::SLEEP::msleep(qMin(static_cast<int>(1000.0f / _maxAxisFrequencyHz), static_cast<int>(1000.0f / _maxButtonFrequencyHz)) / 2);
     }
     _close();
@@ -719,7 +721,7 @@ void Joystick::startPolling(Vehicle* vehicle)
         // Always set up the new vehicle
         _activeVehicle = vehicle;
         // If joystick is not calibrated, disable it
-        if ( !_calibrated ) {
+        if ( axisCount() != 0 && !_calibrated ) {
             vehicle->setJoystickEnabled(false);
         }
         // Update qml in case of joystick transition

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -175,14 +175,15 @@ QString JoystickManager::activeJoystickName(void)
     return _activeJoystick ? _activeJoystick->name() : QString();
 }
 
-void JoystickManager::setActiveJoystickName(const QString& name)
+bool JoystickManager::setActiveJoystickName(const QString& name)
 {
-    if (!_name2JoystickMap.contains(name)) {
+    if (_name2JoystickMap.contains(name)) {
+        setActiveJoystick(_name2JoystickMap[name]);
+        return true;
+    } else {
         qCWarning(JoystickManagerLog) << "Set active not in map" << name;
-        return;
+        return false;
     }
-
-    setActiveJoystick(_name2JoystickMap[name]);
 }
 
 /*

--- a/src/Joystick/JoystickManager.h
+++ b/src/Joystick/JoystickManager.h
@@ -47,7 +47,7 @@ public:
     void setActiveJoystick(Joystick* joystick);
 
     QString activeJoystickName(void);
-    void setActiveJoystickName(const QString& name);
+    bool setActiveJoystickName(const QString& name);
 
     void restartJoystickCheckTimer(void);
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2156,7 +2156,7 @@ void Vehicle::_captureJoystick()
     Joystick* joystick = _joystickManager->activeJoystick();
 
     if(joystick){
-        qCDebug(JoystickLog) << "Vehicle " << this->id() << " Capture Joystick";
+        qCDebug(JoystickLog) << "Vehicle " << this->id() << " Capture Joystick" << joystick->name();
         joystick->startPolling(this);
     }
 }

--- a/src/VehicleSetup/JoystickConfig.qml
+++ b/src/VehicleSetup/JoystickConfig.qml
@@ -48,7 +48,9 @@ SetupPage {
             height: bar.height + joyLoader.height
 
             readonly property real  labelToMonitorMargin:   ScreenTools.defaultFontPixelWidth * 3
-            property var            _activeJoystick:        joystickManager.activeJoystick
+
+            property var  _activeJoystick:          joystickManager.activeJoystick
+            property bool _allowJoystickSelection:  QGroundControl.corePlugin.options.allowJoystickSelection
 
             function setupPageCompleted() {
                 controller.start()
@@ -62,20 +64,31 @@ SetupPage {
                 id:             bar
                 width:          parent.width
                 Component.onCompleted: {
-                    currentIndex = _activeJoystick && _activeJoystick.calibrated ? 0 : 2
+                    if (_activeJoystick) {
+                        if (_activeJoystick.axisCount == 0) {
+                            currentIndex = _allowJoystickSelection ? 0 : 1
+                        } else {
+                            currentIndex = _activeJoystick.calibrated ? 0 : 2
+                        }
+                    } else {
+                        currentIndex = 0
+                    }
                 }
                 anchors.top:    parent.top
                 QGCTabButton {
                     text:       qsTr("General")
+                    visible:    _allowJoystickSelection
                 }
                 QGCTabButton {
                     text:       qsTr("Button Assigment")
                 }
                 QGCTabButton {
                     text:       qsTr("Calibration")
+                    visible:    _activeJoystick.axisCount != 0
                 }
                 QGCTabButton {
                     text:       qsTr("Advanced")
+                    visible:    _activeJoystick.axisCount != 0
                 }
             }
 

--- a/src/VehicleSetup/JoystickConfigGeneral.qml
+++ b/src/VehicleSetup/JoystickConfigGeneral.qml
@@ -21,9 +21,14 @@ import QGroundControl.FactSystem    1.0
 import QGroundControl.FactControls  1.0
 
 Item {
-    width:                  mainCol.width  + (ScreenTools.defaultFontPixelWidth  * 2)
-    height:                 mainCol.height + (ScreenTools.defaultFontPixelHeight * 2)
+    width:  mainCol.width  + (ScreenTools.defaultFontPixelWidth  * 2)
+    height: mainCol.height + (ScreenTools.defaultFontPixelHeight * 2)
+
     readonly property real axisMonitorWidth: ScreenTools.defaultFontPixelWidth * 32
+
+    property bool _buttonsOnly:         _activeJoystick.axisCount == 0
+    property bool _requiresCalibration: !_activeJoystick.calibrated && !_buttonsOnly
+
     Column {
         id:                 mainCol
         anchors.centerIn:   parent
@@ -35,13 +40,13 @@ Item {
             //---------------------------------------------------------------------
             //-- Enable Joystick
             QGCLabel {
-                text:               _activeJoystick ? _activeJoystick.calibrated ? qsTr("Enable joystick input") : qsTr("Enable not allowed (Calibrate First)") : ""
+                text:               _requiresCalibration ? qsTr("Enable not allowed (Calibrate First)") : qsTr("Enable joystick input")
                 Layout.alignment:   Qt.AlignVCenter
                 Layout.minimumWidth: ScreenTools.defaultFontPixelWidth * 36
             }
             QGCCheckBox {
                 id:             enabledSwitch
-                enabled:        _activeJoystick ? _activeJoystick.calibrated : false
+                enabled:        !_requiresCalibration
                 onClicked:      {
                     globals.activeVehicle.joystickEnabled = checked
                     globals.activeVehicle.saveJoystickSettings()
@@ -99,9 +104,11 @@ Item {
             QGCLabel {
                 text:               qsTr("RC Mode:")
                 Layout.alignment:   Qt.AlignVCenter
+                visible:            !_buttonsOnly
             }
             Row {
                 spacing:            ScreenTools.defaultFontPixelWidth
+                visible:            !_buttonsOnly
                 QGCRadioButton {
                     text:       "1"
                     checked:    controller.transmitterMode === 1
@@ -144,6 +151,7 @@ Item {
                 radius:             ScreenTools.defaultFontPixelWidth * 0.5
                 width:              axisGrid.width  + (ScreenTools.defaultFontPixelWidth  * 2)
                 height:             axisGrid.height + (ScreenTools.defaultFontPixelHeight * 2)
+                visible:            !_buttonsOnly
                 GridLayout {
                     id:                 axisGrid
                     columns:            2

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -260,7 +260,7 @@ Rectangle {
                 id:                 joystickButton
                 imageResource:      "/qmlimages/Joystick.png"
                 setupIndicator:     true
-                setupComplete:      joystickManager.activeJoystick ? joystickManager.activeJoystick.calibrated : false
+                setupComplete:      joystickManager.activeJoystick ? joystickManager.activeJoystick.calibrated || joystickManager.activeJoystick.axisCount == 0 : false
                 exclusiveGroup:     setupButtonGroup
                 visible:            _fullParameterVehicleAvailable && joystickManager.joysticks.length !== 0
                 text:               qsTr("Joystick")

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -80,6 +80,7 @@ public:
     Q_PROPERTY(bool                     showMavlinkLogOptions           READ showMavlinkLogOptions          CONSTANT)
     Q_PROPERTY(bool                     enableSaveMainWindowPosition    READ enableSaveMainWindowPosition   CONSTANT)
     Q_PROPERTY(QStringList              surveyBuiltInPresetNames        READ surveyBuiltInPresetNames       CONSTANT)
+    Q_PROPERTY(bool                     allowJoystickSelection          READ allowJoystickSelection         NOTIFY allowJoystickSelectionChanged)
 
     Q_PROPERTY(QGCFlyViewOptions*       flyView                         READ flyViewOptions                 CONSTANT)
 
@@ -125,6 +126,7 @@ public:
     virtual bool    disableVehicleConnection        () const { return false; }  ///< true: vehicle connection is disabled
     virtual bool    checkFirmwareVersion            () const { return true; }
     virtual bool    showMavlinkLogOptions           () const { return true; }
+    virtual bool    allowJoystickSelection          () const { return true; }   ///< false: custom build has automatically enabled a specific joystick
     /// Desktop builds save the main application size and position on close (and restore it on open)
     virtual bool    enableSaveMainWindowPosition    () const { return true; }
     virtual QStringList surveyBuiltInPresetNames    () const { return QStringList(); } // Built in presets cannot be deleted
@@ -155,6 +157,7 @@ signals:
     void showFirmwareUpgradeChanged             (bool show);
     void missionWaypointsOnlyChanged            (bool missionWaypointsOnly);
     void multiVehicleEnabledChanged             (bool multiVehicleEnabled);
+    void allowJoystickSelectionChanged          (bool allow);
     void showOfflineMapExportChanged            ();
     void showOfflineMapImportChanged            ();
     void showMissionAbsoluteAltitudeChanged     ();


### PR DESCRIPTION
For example the Herelink controller buttons are a joystick with no axes on buttons only. This is a replacement for the previous useButtonsOnly plugin feature which didn't work. It does this:
* Joystick config page hides all tabs but the buttons tab in this case
* Various changes associated with the calibrated flag signalling things which now needs to understand the case where there are no axes as well