### PR TITLE
CameraIO : Change param type assign method and fixed some compile warning

### DIFF
--- a/src/Camera/QGCCameraIO.h
+++ b/src/Camera/QGCCameraIO.h
@@ -75,7 +75,6 @@ private:
     QTimer              _paramRequestTimer;
     bool                _done;
     bool                _updateOnSet;
-    MAV_PARAM_EXT_TYPE  _mavParamType;
     MAVLinkProtocol*    _pMavlink;
     bool                _forceUIUpdate;
 };


### PR DESCRIPTION
 the param type is only used in _sendParameter method, so don't need store the value in init, So I change the param type and param_value assign together.

Fixed some compile warning in CameraIO using Qt 5.15. 




