### PR TITLE
Restore tool inset functionality

### DIFF
--- a/custom-example/qgcresources.qrc
+++ b/custom-example/qgcresources.qrc
@@ -26,11 +26,15 @@
 		<file alias="JoystickBezel.png">../resources/JoystickBezel.png</file>
 		<file alias="JoystickBezelLight.png">../resources/JoystickBezelLight.png</file>
 		<file alias="land.svg">../resources/land.svg</file>
+		<file alias="layout-bottom.svg">../resources/layout-bottom.svg</file>
+		<file alias="layout-right.svg">../resources/layout-right.svg</file>
 		<file alias="LockClosed.svg">../resources/LockClosed.svg</file>
 		<file alias="LockOpen.svg">../resources/LockOpen.svg</file>
 		<file alias="notile.png">../resources/notile.png</file>
+		<file alias="NoVideoBackground.jpg">../resources/NoVideoBackground.jpg</file>
 		<file alias="Pause.svg">../resources/Pause.svg</file>
 		<file alias="pause-mission.svg">../resources/pause-mission.svg</file>
+		<file alias="pencil.svg">../resources/pencil.svg</file>
 		<file alias="Play">../resources/Play.svg</file>
 		<file alias="PowerButton">../resources/PowerButton.svg</file>
 		<file alias="QGCLogoBlack">../resources/QGCLogoBlack.svg</file>
@@ -51,6 +55,9 @@
 		<file alias="XDelete.svg">../resources/XDelete.svg</file>
 		<file alias="XDeleteBlack.svg">../resources/XDeleteBlack.svg</file>
 		<file alias="waypoint.svg">../resources/waypoint.svg</file>
+		<file alias="Gripper.svg">../resources/Gripper.svg</file>
+		<file alias="GripperRelease.svg">../resources/GripperRelease.svg</file>
+		<file alias="GripperGrab.svg">../resources/GripperGrab.svg</file>
 		<file>../resources/icons/qgroundcontrol.ico</file>
 	</qresource>
 	<qresource prefix="/res/firmware">

--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -14,9 +14,11 @@
 		<file alias="ModeIndicator.qml">../src/ui/toolbar/ModeIndicator.qml</file>
 		<file alias="MultiVehicleSelector.qml">../src/ui/toolbar/MultiVehicleSelector.qml</file>
 		<file alias="RCRSSIIndicator.qml">../src/ui/toolbar/RCRSSIIndicator.qml</file>
+		<file alias="RemoteIDIndicator.qml">../src/ui/toolbar/RemoteIDIndicator.qml</file>
 		<file alias="ROIIndicator.qml">../src/ui/toolbar/ROIIndicator.qml</file>
 		<file alias="TelemetryRSSIIndicator.qml">../src/ui/toolbar/TelemetryRSSIIndicator.qml</file>
 		<file alias="VTOLModeIndicator.qml">../src/ui/toolbar/VTOLModeIndicator.qml</file>
+		<file alias="APMSupportForwardingIndicator.qml">../src/ui/toolbar/APMSupportForwardingIndicator.qml</file>
 	</qresource>
 	<qresource prefix="/checklists">
 		<file alias="DefaultChecklist.qml">../src/FlightDisplay/DefaultChecklist.qml</file>
@@ -38,6 +40,7 @@
 		<file alias="BluetoothSettings.qml">../src/ui/preferences/BluetoothSettings.qml</file>
 		<file alias="CorridorScanEditor.qml">../src/PlanView/CorridorScanEditor.qml</file>
 		<file alias="DebugWindow.qml">../src/ui/preferences/DebugWindow.qml</file>
+		<file alias="RemoteIDSettings.qml">../src/ui/preferences/RemoteIDSettings.qml</file>
 		<file alias="ESP8266Component.qml">../src/AutoPilotPlugins/Common/ESP8266Component.qml</file>
 		<file alias="ESP8266ComponentSummary.qml">../src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml</file>
 		<file alias="ExitWithErrorWindow.qml">../src/ui/ExitWithErrorWindow.qml</file>
@@ -66,6 +69,9 @@
 		<file alias="MockLink.qml">../src/ui/preferences/MockLink.qml</file>
 		<file alias="MockLinkSettings.qml">../src/ui/preferences/MockLinkSettings.qml</file>
 		<file alias="MotorComponent.qml">../src/AutoPilotPlugins/Common/MotorComponent.qml</file>
+		<file alias="ActuatorComponent.qml">../src/AutoPilotPlugins/PX4/ActuatorComponent.qml</file>
+		<file alias="ActuatorFact.qml">../src/AutoPilotPlugins/PX4/ActuatorFact.qml</file>
+		<file alias="ActuatorSlider.qml">../src/AutoPilotPlugins/PX4/ActuatorSlider.qml</file>
 		<file alias="OfflineMap.qml">../src/QtLocationPlugin/QMLControl/OfflineMap.qml</file>
 		<file alias="PlanToolBar.qml">../src/PlanView/PlanToolBar.qml</file>
 		<file alias="PlanToolBarIndicators.qml">../src/PlanView/PlanToolBarIndicators.qml</file>
@@ -76,6 +82,7 @@
 		<file alias="QGCInstrumentWidgetAlternate.qml">../src/FlightMap/Widgets/QGCInstrumentWidgetAlternate.qml</file>
 		<file alias="QGroundControl/Controls/AnalyzePage.qml">../src/AnalyzeView/AnalyzePage.qml</file>
 		<file alias="QGroundControl/Controls/AppMessages.qml">../src/QmlControls/AppMessages.qml</file>
+		<file alias="QGroundControl/Controls/AltModeDialog.qml">../src/QmlControls/AltModeDialog.qml</file>
 		<file alias="QGroundControl/Controls/AxisMonitor.qml">../src/QmlControls/AxisMonitor.qml</file>
 		<file alias="QGroundControl/Controls/CameraCalcCamera.qml">../src/PlanView/CameraCalcCamera.qml</file>
 		<file alias="QGroundControl/Controls/CameraCalcGrid.qml">../src/PlanView/CameraCalcGrid.qml</file>
@@ -104,6 +111,7 @@
 		<file alias="QGroundControl/Controls/KMLOrSHPFileDialog.qml">../src/QmlControls/KMLOrSHPFileDialog.qml</file>
 		<file alias="QGroundControl/Controls/LogReplayStatusBar.qml">../src/QmlControls/LogReplayStatusBar.qml</file>
 		<file alias="QGroundControl/Controls/MainStatusIndicator.qml">../src/ui/toolbar/MainStatusIndicator.qml</file>
+		<file alias="QGroundControl/Controls/FlightModeMenuIndicator.qml">../src/ui/toolbar/FlightModeMenuIndicator.qml</file>
 		<file alias="QGroundControl/Controls/MainToolBar.qml">../src/ui/toolbar/MainToolBar.qml</file>
 		<file alias="QGroundControl/Controls/MainWindowSavedState.qml">../src/QmlControls/MainWindowSavedState.qml</file>
 		<file alias="QGroundControl/Controls/MAVLinkChart.qml">../src/QmlControls/MAVLinkChart.qml</file>
@@ -125,6 +133,7 @@
 		<file alias="QGroundControl/Controls/PreFlightCheckGroup.qml">../src/QmlControls/PreFlightCheckGroup.qml</file>
 		<file alias="QGroundControl/Controls/PreFlightCheckModel.qml">../src/QmlControls/PreFlightCheckModel.qml</file>
 		<file alias="QGroundControl/Controls/QGCButton.qml">../src/QmlControls/QGCButton.qml</file>
+		<file alias="QGroundControl/Controls/QGCColumnButton.qml">../src/QmlControls/QGCColumnButton.qml</file>
 		<file alias="QGroundControl/Controls/AutotuneUI.qml">../src/QmlControls/AutotuneUI.qml</file>
 		<file alias="QGroundControl/Controls/QGCCheckBox.qml">../src/QmlControls/QGCCheckBox.qml</file>
 		<file alias="QGroundControl/Controls/QGCColoredImage.qml">../src/QmlControls/QGCColoredImage.qml</file>
@@ -147,10 +156,10 @@
 		<file alias="QGroundControl/Controls/QGCMouseArea.qml">../src/QmlControls/QGCMouseArea.qml</file>
 		<file alias="QGroundControl/Controls/QGCMovableItem.qml">../src/QmlControls/QGCMovableItem.qml</file>
 		<file alias="QGroundControl/Controls/QGCPopupDialog.qml">../src/QmlControls/QGCPopupDialog.qml</file>
-		<file alias="QGroundControl/Controls/QGCPopupDialogContainer.qml">../src/QmlControls/QGCPopupDialogContainer.qml</file>
 		<file alias="QGroundControl/Controls/QGCPipOverlay.qml">../src/QmlControls/QGCPipOverlay.qml</file>
 		<file alias="QGroundControl/Controls/QGCPipState.qml">../src/QmlControls/QGCPipState.qml</file>
 		<file alias="QGroundControl/Controls/QGCRadioButton.qml">../src/QmlControls/QGCRadioButton.qml</file>
+		<file alias="QGroundControl/Controls/QGCSimpleMessageDialog.qml">../src/QmlControls/QGCSimpleMessageDialog.qml</file>
 		<file alias="QGroundControl/Controls/QGCSlider.qml">../src/QmlControls/QGCSlider.qml</file>
 		<file alias="QGroundControl/Controls/QGCSwitch.qml">../src/QmlControls/QGCSwitch.qml</file>
 		<file alias="QGroundControl/Controls/QGCTabBar.qml">../src/QmlControls/QGCTabBar.qml</file>
@@ -158,9 +167,6 @@
 		<file alias="QGroundControl/Controls/QGCTextField.qml">../src/QmlControls/QGCTextField.qml</file>
 		<file alias="QGroundControl/Controls/QGCToolBarButton.qml">../src/QmlControls/QGCToolBarButton.qml</file>
 		<file alias="QGroundControl/Controls/QGCToolInsets.qml">../src/QmlControls/QGCToolInsets.qml</file>
-		<file alias="QGroundControl/Controls/QGCViewDialog.qml">../src/QmlControls/QGCViewDialog.qml</file>
-		<file alias="QGroundControl/Controls/QGCViewDialogContainer.qml">../src/QmlControls/QGCViewDialogContainer.qml</file>
-		<file alias="QGroundControl/Controls/QGCViewMessage.qml">../src/QmlControls/QGCViewMessage.qml</file>
 		<file alias="QGroundControl/Controls/qmldir">../src/QmlControls/QGroundControl/Controls/qmldir</file>
 		<file alias="QGroundControl/Controls/RallyPointEditorHeader.qml">../src/PlanView/RallyPointEditorHeader.qml</file>
 		<file alias="QGroundControl/Controls/RallyPointItemEditor.qml">../src/PlanView/RallyPointItemEditor.qml</file>
@@ -180,6 +186,7 @@
 		<file alias="QGroundControl/Controls/TakeoffItemMapVisual.qml">../src/PlanView/TakeoffItemMapVisual.qml</file>
 		<file alias="QGroundControl/Controls/ToolStrip.qml">../src/QmlControls/ToolStrip.qml</file>
 		<file alias="QGroundControl/Controls/ToolStripHoverButton.qml">../src/QmlControls/ToolStripHoverButton.qml</file>
+		<file alias="QGroundControl/Controls/TransectStyleComplexItemEditor.qml">../src/PlanView/TransectStyleComplexItemEditor.qml</file>
 		<file alias="QGroundControl/Controls/TransectStyleComplexItemStats.qml">../src/PlanView/TransectStyleComplexItemStats.qml</file>
 		<file alias="QGroundControl/Controls/TransectStyleComplexItemTabBar.qml">../src/PlanView/TransectStyleComplexItemTabBar.qml</file>
 		<file alias="QGroundControl/Controls/TransectStyleComplexItemTerrainFollow.qml">../src/PlanView/TransectStyleComplexItemTerrainFollow.qml</file>
@@ -214,9 +221,11 @@
 		<file alias="QGroundControl/FlightDisplay/GuidedActionLand.qml">../src/FlightDisplay/GuidedActionLand.qml</file>
 		<file alias="QGroundControl/FlightDisplay/GuidedActionList.qml">../src/FlightDisplay/GuidedActionList.qml</file>
 		<file alias="QGroundControl/FlightDisplay/GuidedActionTakeoff.qml">../src/FlightDisplay/GuidedActionTakeoff.qml</file>
+		<file alias="QGroundControl/FlightDisplay/GuidedActionGripper.qml">../src/FlightDisplay/GuidedActionGripper.qml</file>
+		<file alias="QGroundControl/FlightDisplay/GripperMenu.qml">../src/FlightDisplay/GripperMenu.qml</file>
 		<file alias="QGroundControl/FlightDisplay/GuidedActionPause.qml">../src/FlightDisplay/GuidedActionPause.qml</file>
 		<file alias="QGroundControl/FlightDisplay/GuidedActionRTL.qml">../src/FlightDisplay/GuidedActionRTL.qml</file>
-		<file alias="QGroundControl/FlightDisplay/GuidedAltitudeSlider.qml">../src/FlightDisplay/GuidedAltitudeSlider.qml</file>
+		<file alias="QGroundControl/FlightDisplay/GuidedValueSlider.qml">../src/FlightDisplay/GuidedValueSlider.qml</file>
 		<file alias="QGroundControl/FlightDisplay/GuidedToolStripAction.qml">../src/FlightDisplay/GuidedToolStripAction.qml</file>
 		<file alias="QGroundControl/FlightDisplay/MultiVehicleList.qml">../src/FlightDisplay/MultiVehicleList.qml</file>
 		<file alias="QGroundControl/FlightDisplay/PreFlightBatteryCheck.qml">../src/FlightDisplay/PreFlightBatteryCheck.qml</file>
@@ -230,6 +239,9 @@
 		<file alias="QGroundControl/FlightDisplay/TerrainProgress.qml">../src/FlightDisplay/TerrainProgress.qml</file>
 		<file alias="QGroundControl/FlightDisplay/TelemetryValuesBar.qml">../src/FlightDisplay/TelemetryValuesBar.qml</file>
 		<file alias="QGroundControl/FlightDisplay/VehicleWarnings.qml">../src/FlightDisplay/VehicleWarnings.qml</file>
+		<file alias="QGroundControl/FlightDisplay/ObstacleDistanceOverlay.qml">../src/FlightDisplay/ObstacleDistanceOverlay.qml</file>
+		<file alias="QGroundControl/FlightDisplay/ObstacleDistanceOverlayMap.qml">../src/FlightDisplay/ObstacleDistanceOverlayMap.qml</file>
+		<file alias="QGroundControl/FlightDisplay/ObstacleDistanceOverlayVideo.qml">../src/FlightDisplay/ObstacleDistanceOverlayVideo.qml</file>
 		<file alias="QGroundControl/FlightDisplay/qmldir">../src/QmlControls/QGroundControl/FlightDisplay/qmldir</file>
 		<file alias="QGroundControl/FlightMap/CameraTriggerIndicator.qml">../src/FlightMap/MapItems/CameraTriggerIndicator.qml</file>
 		<file alias="QGroundControl/FlightMap/CenterMapDropButton.qml">../src/FlightMap/Widgets/CenterMapDropButton.qml</file>
@@ -274,6 +286,8 @@
 		<file alias="VibrationPage.qml">../src/AnalyzeView/VibrationPage.qml</file>
 		<file alias="VirtualJoystick.qml">../src/FlightDisplay/VirtualJoystick.qml</file>
 		<file alias="VTOLLandingPatternEditor.qml">../src/PlanView/VTOLLandingPatternEditor.qml</file>
+		<file alias="QGroundControl/Controls/MockLinkOptionsDlg.qml">../src/comm/MockLinkOptionsDlg.qml</file>
+		<file alias="QGroundControl/FlightDisplay/FlyViewInsetViewer.qml">../src/FlightDisplay/FlyViewInsetViewer.qml</file>
 	</qresource>
 	<qresource prefix="/FirstRunPromptDialogs">
 		<file alias="UnitsFirstRunPrompt.qml">../src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml</file>
@@ -290,6 +304,7 @@
 		<file alias="CameraSection.FactMetaData.json">../src/MissionManager/CameraSection.FactMetaData.json</file>
 		<file alias="CameraSpec.FactMetaData.json">../src/MissionManager/CameraSpec.FactMetaData.json</file>
 		<file alias="CorridorScan.SettingsGroup.json">../src/MissionManager/CorridorScan.SettingsGroup.json</file>
+		<file alias="RemoteID.SettingsGroup.json">../src/Settings/RemoteID.SettingsGroup.json</file>
 		<file alias="EditPositionDialog.FactMetaData.json">../src/QmlControls/EditPositionDialog.FactMetaData.json</file>
 		<file alias="FirmwareUpgrade.SettingsGroup.json">../src/Settings/FirmwareUpgrade.SettingsGroup.json</file>
 		<file alias="FlightMap.SettingsGroup.json">../src/Settings/FlightMap.SettingsGroup.json</file>
@@ -322,13 +337,15 @@
 		<file alias="Vehicle/GPSFact.json">../src/Vehicle/GPSFact.json</file>
 		<file alias="Vehicle/GPSRTKFact.json">../src/Vehicle/GPSRTKFact.json</file>
 		<file alias="Vehicle/SetpointFact.json">../src/Vehicle/SetpointFact.json</file>
+		<file alias="Vehicle/LocalPositionFact.json">../src/Vehicle/LocalPositionFact.json</file>
+		<file alias="Vehicle/LocalPositionSetpointFact.json">../src/Vehicle/LocalPositionFact.json</file>
 		<file alias="Vehicle/SubmarineFact.json">../src/Vehicle/SubmarineFact.json</file>
 		<file alias="Vehicle/TemperatureFact.json">../src/Vehicle/TemperatureFact.json</file>
 		<file alias="Vehicle/TerrainFactGroup.json">../src/Vehicle/TerrainFactGroup.json</file>
 		<file alias="Vehicle/VehicleFact.json">../src/Vehicle/VehicleFact.json</file>
 		<file alias="Vehicle/VibrationFact.json">../src/Vehicle/VibrationFact.json</file>
 		<file alias="Vehicle/WindFact.json">../src/Vehicle/WindFact.json</file>
-                <file alias="Vehicle/HygrometerFact.json">../src/Vehicle/HygrometerFact.json</file>
+		<file alias="Vehicle/HygrometerFact.json">../src/Vehicle/HygrometerFact.json</file>
 		<file alias="Video.SettingsGroup.json">../src/Settings/Video.SettingsGroup.json</file>
 		<file alias="VTOLLandingPattern.FactMetaData.json">../src/MissionManager/VTOLLandingPattern.FactMetaData.json</file>
 	</qresource>
@@ -336,8 +353,9 @@
 		<file alias="APMArduSubMockLink.params">../src/comm/APMArduSubMockLink.params</file>
 		<file alias="PX4MockLink.params">../src/comm/PX4MockLink.params</file>
 		<file alias="General.MetaData.json">../src/comm/MockLink.General.MetaData.json</file>
-		<file alias="General.MetaData.json.xz">src/comm/MockLink.General.MetaData.json.xz</file>
+		<file alias="General.MetaData.json.xz">../src/comm/MockLink.General.MetaData.json.xz</file>
+		<file alias="Parameter.MetaData.json.xz">../src/comm/MockLink.Parameter.MetaData.json.xz</file>
 		<file alias="Parameter.MetaData.json">../src/comm/MockLink.Parameter.MetaData.json</file>
-		<file alias="Parameter.MetaData.json.xz">src/comm/MockLink.Parameter.MetaData.json.xz</file>
+		<file alias="Arduplane.params.ftp.bin">../src/comm/Mocklink.Arduplane.params.ftp.bin</file>
 	</qresource>
 </RCC>

--- a/custom-example/res/CustomFlyViewOverlay.qml
+++ b/custom-example/res/CustomFlyViewOverlay.qml
@@ -55,8 +55,18 @@ Item {
 
     QGCToolInsets {
         id:                     _totalToolInsets
-        topEdgeCenterInset:     compassArrowIndicator.y + compassArrowIndicator.height
+        leftEdgeTopInset:       parentToolInsets.leftEdgeTopInset
+        leftEdgeCenterInset:    parentToolInsets.leftEdgeCenterInset
+        leftEdgeBottomInset:    parentToolInsets.leftEdgeBottomInset
+        rightEdgeTopInset:      parentToolInsets.rightEdgeTopInset
+        rightEdgeCenterInset:   parentToolInsets.rightEdgeCenterInset
         rightEdgeBottomInset:   parent.width - compassBackground.x
+        topEdgeLeftInset:       parentToolInsets.topEdgeLeftInset
+        topEdgeCenterInset:     compassArrowIndicator.y + compassArrowIndicator.height
+        topEdgeRightInset:      parentToolInsets.topEdgeRightInset
+        bottomEdgeLeftInset:    parentToolInsets.bottomEdgeLeftInset
+        bottomEdgeCenterInset:  parentToolInsets.bottomEdgeCenterInset
+        bottomEdgeRightInset:   parent.height - attitudeIndicator.y
     }
 
     //-------------------------------------------------------------------------
@@ -209,7 +219,7 @@ Item {
 
     Rectangle {
         id:                     attitudeIndicator
-        anchors.bottomMargin:   _toolsMargin
+        anchors.bottomMargin:   _toolsMargin + parentToolInsets.bottomEdgeRightInset
         anchors.rightMargin:    _toolsMargin
         anchors.bottom:         parent.bottom
         anchors.right:          parent.right

--- a/custom-example/res/CustomFlyViewOverlay.qml
+++ b/custom-example/res/CustomFlyViewOverlay.qml
@@ -56,7 +56,7 @@ Item {
     QGCToolInsets {
         id:                     _totalToolInsets
         leftEdgeTopInset:       parentToolInsets.leftEdgeTopInset
-        leftEdgeCenterInset:    parentToolInsets.leftEdgeCenterInset
+        leftEdgeCenterInset:    exampleRectangle.leftEdgeCenterInset
         leftEdgeBottomInset:    parentToolInsets.leftEdgeBottomInset
         rightEdgeTopInset:      parentToolInsets.rightEdgeTopInset
         rightEdgeCenterInset:   parentToolInsets.rightEdgeCenterInset
@@ -67,6 +67,26 @@ Item {
         bottomEdgeLeftInset:    parentToolInsets.bottomEdgeLeftInset
         bottomEdgeCenterInset:  parentToolInsets.bottomEdgeCenterInset
         bottomEdgeRightInset:   parent.height - attitudeIndicator.y
+    }
+
+    // This is an example of how you can use parent tool insets to position an element on the custom fly view layer
+    // - we use parent topEdgeLeftInset to position the widget below the toolstrip
+    // - we use parent bottomEdgeLeftInset to dodge the virtual joystick if enabled
+    // - we use the parent leftEdgeTopInset to size our element to the same width as the ToolStripAction
+    // - we export the width of this element as the leftEdgeCenterInset so that the map will recenter if the vehicle flys behind this element
+    Rectangle {
+        id: exampleRectangle
+        visible: false // to see this example, set this to true. To view insets, enable the insets viewer FlyView.qml
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.topMargin: parentToolInsets.topEdgeLeftInset + _toolsMargin
+        anchors.bottomMargin: parentToolInsets.bottomEdgeLeftInset + _toolsMargin
+        anchors.leftMargin: _toolsMargin
+        width: parentToolInsets.leftEdgeTopInset - _toolsMargin
+        color: 'red'
+
+        property real leftEdgeCenterInset: visible ? x + width : 0
     }
 
     //-------------------------------------------------------------------------

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -185,7 +185,7 @@
         <file alias="QGroundControl/Controls/TerrainStatus.qml">src/PlanView/TerrainStatus.qml</file>
         <file alias="QGroundControl/Controls/TakeoffItemMapVisual.qml">src/PlanView/TakeoffItemMapVisual.qml</file>
         <file alias="QGroundControl/Controls/ToolStrip.qml">src/QmlControls/ToolStrip.qml</file>
-       	<file alias="QGroundControl/Controls/ToolStripHoverButton.qml">src/QmlControls/ToolStripHoverButton.qml</file>
+        <file alias="QGroundControl/Controls/ToolStripHoverButton.qml">src/QmlControls/ToolStripHoverButton.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemEditor.qml">src/PlanView/TransectStyleComplexItemEditor.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemStats.qml">src/PlanView/TransectStyleComplexItemStats.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemTabBar.qml">src/PlanView/TransectStyleComplexItemTabBar.qml</file>
@@ -287,6 +287,8 @@
         <file alias="VibrationPage.qml">src/AnalyzeView/VibrationPage.qml</file>
         <file alias="VirtualJoystick.qml">src/FlightDisplay/VirtualJoystick.qml</file>
         <file alias="VTOLLandingPatternEditor.qml">src/PlanView/VTOLLandingPatternEditor.qml</file>
+        <file alias="QGroundControl/Controls/MockLinkOptionsDlg.qml">src/comm/MockLinkOptionsDlg.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewInsetViewer.qml">src/FlightDisplay/FlyViewInsetViewer.qml</file>
     </qresource>
     <qresource prefix="/FirstRunPromptDialogs">
         <file alias="UnitsFirstRunPrompt.qml">src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml</file>
@@ -356,8 +358,5 @@
         <file alias="Parameter.MetaData.json.xz">src/comm/MockLink.Parameter.MetaData.json.xz</file>
         <file alias="Parameter.MetaData.json">src/comm/MockLink.Parameter.MetaData.json</file>
         <file alias="Arduplane.params.ftp.bin">src/comm/Mocklink.Arduplane.params.ftp.bin</file>
-    </qresource>
-    <qresource prefix="/qml">
-        <file alias="QGroundControl/Controls/MockLinkOptionsDlg.qml">src/comm/MockLinkOptionsDlg.qml</file>
     </qresource>
 </RCC>

--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -85,6 +85,7 @@ Item {
         visible:                !QGroundControl.videoManager.fullScreen
     }
 
+
     FlyViewCustomLayer {
         id:                 customOverlay
         anchors.fill:       widgetLayer
@@ -93,6 +94,20 @@ Item {
         mapControl:         _mapControl
         visible:            !QGroundControl.videoManager.fullScreen
     }
+
+    // Development tool for visualizing the insets for a paticular layer, enable if needed
+    /*
+    FlyViewInsetViewer {
+        id:                     widgetLayerInsetViewer
+        anchors.top:            parent.top
+        anchors.bottom:         parent.bottom
+        anchors.left:           parent.left
+        anchors.right:          guidedValueSlider.visible ? guidedValueSlider.left : parent.right
+
+        z:                      widgetLayer.z + 1
+
+        insetsToView:           customOverlay.totalToolInsets
+    }*/
 
     GuidedActionsController {
         id:                 guidedActionsController

--- a/src/FlightDisplay/FlyViewCustomLayer.qml
+++ b/src/FlightDisplay/FlyViewCustomLayer.qml
@@ -36,19 +36,20 @@ Item {
     property var totalToolInsets:   _toolInsets // These are the insets for your custom overlay additions
     property var mapControl
 
+    // since this file is a placeholder for the custom layer in a standard build, we will just pass through the parent insets
     QGCToolInsets {
-        id:                         _toolInsets
-        leftEdgeCenterInset:    0
-        leftEdgeTopInset:           0
-        leftEdgeBottomInset:        0
-        rightEdgeCenterInset:   0
-        rightEdgeTopInset:          0
-        rightEdgeBottomInset:       0
-        topEdgeCenterInset:       0
-        topEdgeLeftInset:           0
-        topEdgeRightInset:          0
-        bottomEdgeCenterInset:    0
-        bottomEdgeLeftInset:        0
-        bottomEdgeRightInset:       0
+        id:                     _toolInsets
+        leftEdgeTopInset:       parentToolInsets.leftEdgeTopInset
+        leftEdgeCenterInset:    parentToolInsets.leftEdgeCenterInset
+        leftEdgeBottomInset:    parentToolInsets.leftEdgeBottomInset
+        rightEdgeTopInset:      parentToolInsets.rightEdgeTopInset
+        rightEdgeCenterInset:   parentToolInsets.rightEdgeCenterInset
+        rightEdgeBottomInset:   parentToolInsets.rightEdgeBottomInset
+        topEdgeLeftInset:       parentToolInsets.topEdgeLeftInset
+        topEdgeCenterInset:     parentToolInsets.topEdgeCenterInset
+        topEdgeRightInset:      parentToolInsets.topEdgeRightInset
+        bottomEdgeLeftInset:    parentToolInsets.bottomEdgeLeftInset
+        bottomEdgeCenterInset:  parentToolInsets.bottomEdgeCenterInset
+        bottomEdgeRightInset:   parentToolInsets.bottomEdgeRightInset
     }
 }

--- a/src/FlightDisplay/FlyViewInsetViewer.qml
+++ b/src/FlightDisplay/FlyViewInsetViewer.qml
@@ -1,0 +1,194 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick                  2.12
+import QtQuick.Controls         2.4
+import QtQuick.Dialogs          1.3
+import QtQuick.Layouts          1.12
+
+import QtLocation               5.3
+import QtPositioning            5.3
+import QtQuick.Window           2.2
+import QtQml.Models             2.1
+
+import QGroundControl               1.0
+import QGroundControl.Controls      1.0
+import QGroundControl.Controllers   1.0
+import QGroundControl.FlightDisplay 1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.FlightMap     1.0
+
+
+// This is the ui overlay layer for the widgets/tools for Fly View
+Item {
+    id: _root
+    property var insetsToView: QGCToolInsets {}
+    property int _linethickness: 3
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: parent.width/8
+        height: checkboxcolumn.height
+        width: checkboxcolumn.width
+        color: "dimgray"
+
+        ColumnLayout {
+            id: checkboxcolumn
+            QGCCheckBox{
+                checked: true
+                text: "leftEdgeTopInset"
+                onClicked: leftEdgeTopInset.visible = checked
+                textColor: leftEdgeTopInset.color
+                textBold: true
+            }
+            QGCCheckBox{
+                checked: true
+                text: "leftEdgeBottomInset"
+                onClicked: leftEdgeBottomInset.visible = checked
+                textColor: leftEdgeBottomInset.color
+                textBold: true
+            }
+            QGCCheckBox{
+                checked: true
+                text: "rightEdgeTopInset"
+                onClicked: rightEdgeTopInset.visible = checked
+                textColor: rightEdgeTopInset.color
+                textBold: true
+            }
+            QGCCheckBox{
+                checked: true
+                text: "rightEdgeBottomInset"
+                onClicked: rightEdgeBottomInset.visible = checked
+                textColor: rightEdgeBottomInset.color
+                textBold: true
+            }
+            QGCCheckBox{
+                checked: true
+                text: "topEdgeLeftInset"
+                onClicked: topEdgeLeftInset.visible = checked
+                textColor: topEdgeLeftInset.color
+                textBold: true
+            }
+            QGCCheckBox{
+                checked: true
+                text: "topEdgeRightInset"
+                onClicked: topEdgeRightInset.visible = checked
+                textColor: topEdgeRightInset.color
+                textBold: true
+            }
+            QGCCheckBox{
+                checked: true
+                text: "bottomEdgeLeftInset"
+                onClicked: bottomEdgeLeftInset.visible = checked
+                textColor: bottomEdgeLeftInset.color
+                textBold: true
+            }
+            QGCCheckBox{
+                checked: true
+                text: "bottomEdgeRightInset"
+                onClicked: bottomEdgeRightInset.visible = checked
+                textColor: bottomEdgeRightInset.color
+                textBold: true
+            }
+            QGCCheckBox{
+                checked: true
+                text: "centerInsetRect"
+                onClicked: centerInsetRect.visible = checked
+                textColor: centerInsetRect.border.color
+                textBold: true
+            }
+        }
+
+    }
+
+    Rectangle { // leftEdgeTopInset
+        id: leftEdgeTopInset
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.leftMargin: insetsToView.leftEdgeTopInset
+        height: parent.height
+        width: _linethickness
+        color: "coral"
+    }
+    Rectangle { // leftEdgeBottomInset
+        id: leftEdgeBottomInset
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.leftMargin: insetsToView.leftEdgeBottomInset
+        height: parent.height
+        width: _linethickness
+        color: "cornflowerblue"
+    }
+    Rectangle { // rightEdgeTopInset
+        id: rightEdgeTopInset
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.rightMargin: insetsToView.rightEdgeTopInset
+        height: parent.height
+        width: _linethickness
+        color: "darkslateblue"
+    }
+    Rectangle { // rightEdgeBottomInset
+        id: rightEdgeBottomInset
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.rightMargin: insetsToView.rightEdgeBottomInset
+        height: parent.height
+        width: _linethickness
+        color: "firebrick"
+    }
+    Rectangle { // topEdgeLeftInset
+        id: topEdgeLeftInset
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: insetsToView.topEdgeLeftInset
+        height: _linethickness
+        width: parent.width
+        color: "mediumseagreen"
+    }
+    Rectangle { // topEdgeRightInset
+        id: topEdgeRightInset
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: insetsToView.topEdgeRightInset
+        height: _linethickness
+        width: parent.width
+        color: "moccasin"
+    }
+    Rectangle { // bottomEdgeLeftInset
+        id: bottomEdgeLeftInset
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: insetsToView.bottomEdgeLeftInset
+        height: _linethickness
+        width: parent.width
+        color: "salmon"
+    }
+    Rectangle { // bottomEdgeRightInset
+        id: bottomEdgeRightInset
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.bottomMargin: insetsToView.bottomEdgeRightInset
+        height: _linethickness
+        width: parent.width
+        color: "slategrey"
+    }
+    Rectangle {
+        id: centerInsetRect
+        x: insetsToView.leftEdgeCenterInset
+        y: insetsToView.topEdgeCenterInset
+        width: _root.width - insetsToView.leftEdgeCenterInset - insetsToView.rightEdgeCenterInset
+        height: _root.height - insetsToView.topEdgeCenterInset - insetsToView.bottomEdgeCenterInset
+        color: "transparent"
+        border.color: "yellow"
+        border.width: 1
+        radius: 0
+    }
+}

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -51,17 +51,17 @@ Item {
     QGCToolInsets {
         id:                     _totalToolInsets
         leftEdgeTopInset:       toolStrip.leftInset
-        leftEdgeCenterInset:    toolStrip.leftInset
-        leftEdgeBottomInset:    parentToolInsets.leftEdgeBottomInset
-        rightEdgeTopInset:      parentToolInsets.rightEdgeTopInset
-        rightEdgeCenterInset:   parentToolInsets.rightEdgeCenterInset
-        rightEdgeBottomInset:   parentToolInsets.rightEdgeBottomInset
-        topEdgeLeftInset:       parentToolInsets.topEdgeLeftInset
-        topEdgeCenterInset:     parentToolInsets.topEdgeCenterInset
-        topEdgeRightInset:      parentToolInsets.topEdgeRightInset
-        bottomEdgeLeftInset:    parentToolInsets.bottomEdgeLeftInset
-        bottomEdgeCenterInset:  mapScale.centerInset
-        bottomEdgeRightInset:   0
+        leftEdgeCenterInset:    parentToolInsets.leftEdgeCenterInset
+        leftEdgeBottomInset:    virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.leftInset : parentToolInsets.leftEdgeBottomInset
+        rightEdgeTopInset:      instrumentPanel.rightInset
+        rightEdgeCenterInset:   (telemetryPanel.rightInset > photoVideoControl.rightInset) ? telemetryPanel.rightInset : photoVideoControl.rightInset
+        rightEdgeBottomInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.rightInset : parentToolInsets.rightEdgeBottomInset
+        topEdgeLeftInset:       toolStrip.topInset
+        topEdgeCenterInset:     mapScale.topInset
+        topEdgeRightInset:      instrumentPanel.topInset
+        bottomEdgeLeftInset:    virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomInset : parentToolInsets.bottomEdgeLeftInset
+        bottomEdgeCenterInset:  telemetryPanel.bottomInset
+        bottomEdgeRightInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomInset : parentToolInsets.bottomEdgeRightInset
     }
 
     FlyViewMissionCompleteDialog {
@@ -126,6 +126,7 @@ Item {
         availableHeight:            parent.height - y - _toolsMargin
 
         property real rightInset: visible ? parent.width - x : 0
+        property real topInset: visible ? y + height : 0
     }
 
     PhotoVideoControl {
@@ -133,6 +134,9 @@ Item {
         anchors.margins:        _toolsMargin
         anchors.right:          parent.right
         width:                  _rightPanelWidth
+
+        property real rightInset: visible ? parent.width - x : 0
+
         state:                  _verticalCenter ? "verticalCenter" : "topAnchor"
         states: [
             State {
@@ -161,6 +165,9 @@ Item {
         x:                  recalcXPosition()
         anchors.margins:    _toolsMargin
 
+        property real bottomInset: 0
+        property real rightInset: 0
+
         // States for custom layout support
         states: [
             State {
@@ -178,6 +185,8 @@ Item {
                 PropertyChanges {
                     target: telemetryPanel
                     x: recalcXPosition()
+                    bottomInset: visible ? parent.height-y : 0
+                    rightInset: 0
                 }
             },
 
@@ -192,6 +201,11 @@ Item {
                     anchors.right: parent.right
                     anchors.verticalCenter: undefined
                 }
+                PropertyChanges {
+                    target: telemetryPanel
+                    bottomInset: 0
+                    rightInset: visible ? parent.width - x : 0
+                }
             },
 
             State {
@@ -204,6 +218,11 @@ Item {
                     anchors.bottom: undefined
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
+                }
+                PropertyChanges {
+                    target: telemetryPanel
+                    bottomInset: 0
+                    rightInset: visible ? parent.width - x : 0
                 }
             }
         ]
@@ -240,6 +259,12 @@ Item {
         property bool autoCenterThrottle: QGroundControl.settingsManager.appSettings.virtualJoystickAutoCenterThrottle.rawValue
 
         property bool _virtualJoystickEnabled: QGroundControl.settingsManager.appSettings.virtualJoystick.rawValue
+
+        property real bottomInset: parent.height-y
+
+        // Width is difficult to access directly hence this hack which may not work in all circumstances
+        property real leftInset: visible ? bottomInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
+        property real rightInset: visible ? bottomInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
     }
 
     FlyViewToolStrip {
@@ -254,7 +279,9 @@ Item {
 
         onDisplayPreFlightChecklist: preFlightChecklistPopup.createObject(mainWindow).open()
 
-        property real leftInset: x + width
+
+        property real topInset: visible ? y + height : 0
+        property real leftInset: visible ? x + width : 0
     }
 
     GripperMenu {
@@ -275,7 +302,7 @@ Item {
         buttonsOnLeft:      false
         visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && mapControl.pipState.state === mapControl.pipState.fullState
 
-        property real centerInset: visible ? parent.height - y : 0
+        property real topInset: visible ? y + height : 0
     }
 
     Component {

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -50,18 +50,18 @@ Item {
 
     QGCToolInsets {
         id:                     _totalToolInsets
-        leftEdgeTopInset:       toolStrip.leftInset
+        leftEdgeTopInset:       toolStrip.leftEdgeTopInset
         leftEdgeCenterInset:    parentToolInsets.leftEdgeCenterInset
-        leftEdgeBottomInset:    virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.leftInset : parentToolInsets.leftEdgeBottomInset
-        rightEdgeTopInset:      instrumentPanel.rightInset
-        rightEdgeCenterInset:   (telemetryPanel.rightInset > photoVideoControl.rightInset) ? telemetryPanel.rightInset : photoVideoControl.rightInset
-        rightEdgeBottomInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.rightInset : parentToolInsets.rightEdgeBottomInset
-        topEdgeLeftInset:       toolStrip.topInset
-        topEdgeCenterInset:     mapScale.topInset
-        topEdgeRightInset:      instrumentPanel.topInset
-        bottomEdgeLeftInset:    virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomInset : parentToolInsets.bottomEdgeLeftInset
-        bottomEdgeCenterInset:  telemetryPanel.bottomInset
-        bottomEdgeRightInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomInset : parentToolInsets.bottomEdgeRightInset
+        leftEdgeBottomInset:    virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.leftEdgeBottomInset : parentToolInsets.leftEdgeBottomInset
+        rightEdgeTopInset:      instrumentPanel.rightEdgeTopInset
+        rightEdgeCenterInset:   (telemetryPanel.rightEdgeCenterInset > photoVideoControl.rightEdgeCenterInset) ? telemetryPanel.rightEdgeCenterInset : photoVideoControl.rightEdgeCenterInset
+        rightEdgeBottomInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.rightEdgeBottomInset : parentToolInsets.rightEdgeBottomInset
+        topEdgeLeftInset:       toolStrip.topEdgeLeftInset
+        topEdgeCenterInset:     mapScale.topEdgeCenterInset
+        topEdgeRightInset:      instrumentPanel.topEdgeRightInset
+        bottomEdgeLeftInset:    virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomEdgeLeftInset : parentToolInsets.bottomEdgeLeftInset
+        bottomEdgeCenterInset:  telemetryPanel.bottomEdgeCenterInset
+        bottomEdgeRightInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomEdgeRightInset : parentToolInsets.bottomEdgeRightInset
     }
 
     FlyViewMissionCompleteDialog {
@@ -125,8 +125,8 @@ Item {
         visible:                    QGroundControl.corePlugin.options.flyView.showInstrumentPanel && multiVehiclePanelSelector.showSingleVehiclePanel
         availableHeight:            parent.height - y - _toolsMargin
 
-        property real rightInset: visible ? parent.width - x : 0
-        property real topInset: visible ? y + height : 0
+        property real rightEdgeTopInset: visible ? parent.width - x : 0
+        property real topEdgeRightInset: visible ? y + height : 0
     }
 
     PhotoVideoControl {
@@ -135,7 +135,7 @@ Item {
         anchors.right:          parent.right
         width:                  _rightPanelWidth
 
-        property real rightInset: visible ? parent.width - x : 0
+        property real rightEdgeCenterInset: visible ? parent.width - x : 0
 
         state:                  _verticalCenter ? "verticalCenter" : "topAnchor"
         states: [
@@ -165,8 +165,8 @@ Item {
         x:                  recalcXPosition()
         anchors.margins:    _toolsMargin
 
-        property real bottomInset: 0
-        property real rightInset: 0
+        property real bottomEdgeCenterInset: 0
+        property real rightEdgeCenterInset: 0
 
         // States for custom layout support
         states: [
@@ -185,8 +185,8 @@ Item {
                 PropertyChanges {
                     target: telemetryPanel
                     x: recalcXPosition()
-                    bottomInset: visible ? parent.height-y : 0
-                    rightInset: 0
+                    bottomEdgeCenterInset: visible ? parent.height-y : 0
+                    rightEdgeCenterInset: 0
                 }
             },
 
@@ -203,8 +203,8 @@ Item {
                 }
                 PropertyChanges {
                     target: telemetryPanel
-                    bottomInset: 0
-                    rightInset: visible ? parent.width - x : 0
+                    bottomEdgeCenterInset: 0
+                    rightEdgeCenterInset: visible ? parent.width - x : 0
                 }
             },
 
@@ -221,8 +221,8 @@ Item {
                 }
                 PropertyChanges {
                     target: telemetryPanel
-                    bottomInset: 0
-                    rightInset: visible ? parent.width - x : 0
+                    bottomEdgeCenterInset: 0
+                    rightEdgeCenterInset: visible ? parent.width - x : 0
                 }
             }
         ]
@@ -260,11 +260,12 @@ Item {
 
         property bool _virtualJoystickEnabled: QGroundControl.settingsManager.appSettings.virtualJoystick.rawValue
 
-        property real bottomInset: parent.height-y
+        property real bottomEdgeLeftInset: parent.height-y
+        property real bottomEdgeRightInset: parent.height-y
 
         // Width is difficult to access directly hence this hack which may not work in all circumstances
-        property real leftInset: visible ? bottomInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
-        property real rightInset: visible ? bottomInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
+        property real leftEdgeBottomInset: visible ? bottomEdgeLeftInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
+        property real rightEdgeBottomInset: visible ? bottomEdgeRightInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
     }
 
     FlyViewToolStrip {
@@ -280,8 +281,8 @@ Item {
         onDisplayPreFlightChecklist: preFlightChecklistPopup.createObject(mainWindow).open()
 
 
-        property real topInset: visible ? y + height : 0
-        property real leftInset: visible ? x + width : 0
+        property real topEdgeLeftInset: visible ? y + height : 0
+        property real leftEdgeTopInset: visible ? x + width : 0
     }
 
     GripperMenu {
@@ -302,7 +303,7 @@ Item {
         buttonsOnLeft:      false
         visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && mapControl.pipState.state === mapControl.pipState.fullState
 
-        property real topInset: visible ? y + height : 0
+        property real topEdgeCenterInset: visible ? y + height : 0
     }
 
     Component {

--- a/src/QmlControls/QGroundControl/FlightDisplay/qmldir
+++ b/src/QmlControls/QGroundControl/FlightDisplay/qmldir
@@ -11,6 +11,7 @@ FlyViewToolStrip                1.0 FlyViewToolStrip.qml
 FlyViewToolStripActionList      1.0 FlyViewToolStripActionList.qml
 FlyViewVideo                    1.0 FlyViewVideo.qml
 FlyViewWidgetLayer              1.0 FlyViewWidgetLayer.qml
+FlyViewInsetViewer              1.0 FlyViewInsetViewer.qml
 GuidedActionActionList          1.0 GuidedActionActionList.qml
 GuidedActionConfirm             1.0 GuidedActionConfirm.qml
 GuidedActionsController         1.0 GuidedActionsController.qml


### PR DESCRIPTION
When I tried to use insets to position a widget on a custom fly view layer, I discovered that the inset system in master QGC is pretty much non functioning. This PR is my attempt to restore what I think the intended functionality of the system is, and it is a work in progress. There are some elements here which are open to interpretation, so I want some input from others on this.

**The inset system is currently not working because:**
- In the widget layer, very few widgets actually have insets passed out through totalToolInsets
- When the insets are passed through the default FlyViewCustomLayer, all the insets get wiped anyway before they are passed to the map layer
- The FlyViewMap only looks at the center insets to determine whether the vehicle has moved under the UI, this can cause it to not recenter the view if the vehicle has moved under a corner element

**The inset system, as I understand it, is intended to:**

1. Allow widgets in different layers to negotiate space on the flyview. For example, placing a widget on the custom layer that sits below the instrument panel.
2. Allow the map to identify when the vehicle has moved behind a widget, so it can recenter the map

You can verify that current master is not working by flying the aircraft under the instrument panel, you will see that the map view does not recenter (unless you fly off the edge of the screen).

**So on to my solution:**
- I have written a qml component called FlyViewInsetViewer which can be passed a QGCToolInset object and will display it on the screen, this will help in developing and understanding the insets. This is commented out in the flyview, can be enabled while developing when needed, won’t be included as a runtime option.
- I have gone through the widget layer and tried to fill in the correct widgets in each component
- I have corrected the FlyViewCustom layer so it correctly passes through the tool insets unchanged
- I have changed the FlyViewMap to check for the vehicle falling under a corner element

**Still to do:**
- Update the custom-example to correctly set insets
- provide an example in the custom-example of how to use the widget layer insets to position a custom widget
- much more thorough testing
- feedback from others
- consideration of edge cases
- Code tidying, git history cleaning (eg I know I have an unrelated commit in the history, its just for my ease of development on mac, I’ll clean it up before marking this as ready)

**But before I do all the above which is alot of work, I want to ask for feedback**
- Am I on the right track with this?
- Have I misunderstood the inset system?
- Would any or all of these changes be welcome?

Below is a screenshot of the inset viewer showing the total tool insets of a standard build
![Untitled(4)](https://github.com/mavlink/qgroundcontrol/assets/12033706/8f30e66e-ae3d-444b-bc65-b2fc0a2db1f5)
