### PR TITLE
H.265(HEVC) decoder ranking adjusted for VA-API and libav

### DIFF
--- a/src/VideoReceiver/GStreamer.cc
+++ b/src/VideoReceiver/GStreamer.cc
@@ -136,10 +136,12 @@ GStreamer::blacklist(VideoSettings::VideoDecoderOptions option)
         case VideoSettings::ForceVideoDecoderDefault:
             break;
         case VideoSettings::ForceVideoDecoderSoftware:
-            changeRank("avdec_h264", GST_RANK_PRIMARY + 1);
+            for(auto name : {"avdec_h264", "avdec_h265"}) {
+                changeRank(name, GST_RANK_PRIMARY + 1);
+            }
             break;
         case VideoSettings::ForceVideoDecoderVAAPI:
-            for(auto name : {"vaapimpeg2dec", "vaapimpeg4dec", "vaapih263dec", "vaapih264dec", "vaapivc1dec"}) {
+            for(auto name : {"vaapimpeg2dec", "vaapimpeg4dec", "vaapih263dec", "vaapih264dec", "vaapih265dec", "vaapivc1dec"}) {
                 changeRank(name, GST_RANK_PRIMARY + 1);
             }
             break;


### PR DESCRIPTION
Only gstreamer-vaapi plugin modules addressed as in the original code. Possibly need to have va plugin support too, but on a lower rank.


