### PR TITLE
fix FirmwarePlugin: increase arming timeout to 1.5s

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -949,8 +949,8 @@ bool FirmwarePlugin::_armVehicleAndValidate(Vehicle* vehicle)
     // Only try arming the vehicle a single time. Doing retries on arming with a delay can lead to safety issues.
     vehicle->setArmed(true, false /* showError */);
 
-    // Wait 1000 msecs for vehicle to arm
-    for (int i=0; i<10; i++) {
+    // Wait 1500 msecs for vehicle to arm (waiting for the next heartbeat)
+    for (int i = 0; i < 15; i++) {
         if (vehicle->armed()) {
             vehicleArmed = true;
             break;


### PR DESCRIPTION
As the arming flag is set from the heartbeat received at 1Hz, we need to wait a bit longer than 1s.

The 1s timeout sometimes led to this error message when trying to start a mission: "Unable to start mission: Vehicle rejected arming."

Fixes https://github.com/PX4/PX4-Autopilot/issues/22042


