### PR TITLE
Fix Richtext message display & html escaping for events

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}
         run: |
-          git fetch --all --tags -f
+          git fetch --all --tags -f --depth 1
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}
         run: |
-          git fetch --all --tags -f
+          git fetch --all --tags -f --depth 1
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}
         run: |
-          git fetch --all --tags -f
+          git fetch --all --tags -f --depth 1
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}
         run: |
-          git fetch --all --tags -f
+          git fetch --all --tags -f --depth 1
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/src/Vehicle/EventHandler.cc
+++ b/src/Vehicle/EventHandler.cc
@@ -45,6 +45,9 @@ EventHandler::EventHandler(QObject* parent, const QString& profile, handle_event
     _parser.formatters().param = [](const std::string& content) {
         return "<a href=\"param://"+content+"\">"+content+"</a>"; };
 
+    _parser.formatters().escape = [](const std::string& str) {
+        return QString::fromStdString(str).toHtmlEscaped().toStdString(); };
+
     events::ReceiveProtocol::Callbacks callbacks{error_cb, _sendRequestCB,
         std::bind(&EventHandler::gotEvent, this, std::placeholders::_1), timeout_cb};
     _protocol = new events::ReceiveProtocol(callbacks, ourSystemId, ourComponentId, systemId, componentId);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -925,7 +925,7 @@ void Vehicle::_chunkedStatusTextCompleted(uint8_t compId)
             qgcApp()->toolbox()->audioOutput()->say(messageText);
         }
     }
-    emit textMessageReceived(id(), compId, severity, messageText);
+    emit textMessageReceived(id(), compId, severity, messageText.toHtmlEscaped(), "");
 }
 
 void Vehicle::_handleStatusText(mavlink_message_t& message)
@@ -1605,24 +1605,19 @@ void Vehicle::_handleEvent(uint8_t comp_id, std::unique_ptr<events::parser::Pars
                 }
             }
             if (!message.empty() && !messageChecks.empty()) {
-                message += "<br/>";
+                message += "\n";
             }
             if (messageChecks.size() == 1) {
                 message += messageChecks[0];
             } else {
                 for (const auto& messageCheck : messageChecks) {
-                    message += "- " + messageCheck + "<br/>";
+                    message += "- " + messageCheck + "\n";
                 }
             }
         }
 
-        if (message.size() > 0) {
-            // TODO: handle this properly in the UI (e.g. with an expand button to display the description, clickable URL's + params)...
-            QString msg = QString::fromStdString(message);
-            if (description.size() > 0) {
-                msg += "<br/><small><small>" + QString::fromStdString(description).replace("\n", "<br/>") + "</small></small>";
-            }
-            emit textMessageReceived(id(), comp_id, severity, msg);
+        if (!message.empty()) {
+            emit textMessageReceived(id(), comp_id, severity, QString::fromStdString(message), QString::fromStdString(description));
         }
     }
 }
@@ -2029,11 +2024,6 @@ void Vehicle::_handleTextMessage(int newCount)
     if(newCount != _messageCount) {
         _messageCount = newCount;
         emit messageCountChanged();
-    }
-    QString errMsg = pMh->getLatestError();
-    if(errMsg != _latestError) {
-        _latestError = errMsg;
-        emit latestErrorChanged();
     }
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -177,7 +177,6 @@ public:
     Q_PROPERTY(int                  newMessageCount             READ newMessageCount                                                NOTIFY newMessageCountChanged)
     Q_PROPERTY(int                  messageCount                READ messageCount                                                   NOTIFY messageCountChanged)
     Q_PROPERTY(QString              formattedMessages           READ formattedMessages                                              NOTIFY formattedMessagesChanged)
-    Q_PROPERTY(QString              latestError                 READ latestError                                                    NOTIFY latestErrorChanged)
     Q_PROPERTY(bool                 joystickEnabled             READ joystickEnabled            WRITE setJoystickEnabled            NOTIFY joystickEnabledChanged)
     Q_PROPERTY(int                  flowImageIndex              READ flowImageIndex                                                 NOTIFY flowImageIndexChanged)
     Q_PROPERTY(int                  rcRSSI                      READ rcRSSI                                                         NOTIFY rcRSSIChanged)
@@ -595,7 +594,6 @@ public:
     int             newMessageCount             () const{ return _currentMessageCount; }
     int             messageCount                () const{ return _messageCount; }
     QString         formattedMessages           ();
-    QString         latestError                 () { return _latestError; }
     float           latitude                    () { return static_cast<float>(_coordinate.latitude()); }
     float           longitude                   () { return static_cast<float>(_coordinate.longitude()); }
     bool            mavPresent                  () { return _mav != nullptr; }
@@ -919,7 +917,7 @@ signals:
     void capabilityBitsChanged          (uint64_t capabilityBits);
     void toolIndicatorsChanged          ();
     void modeIndicatorsChanged          ();
-    void textMessageReceived            (int uasid, int componentid, int severity, QString text);
+    void textMessageReceived            (int uasid, int componentid, int severity, QString text, QString description);
     void calibrationEventReceived       (int uasid, int componentid, int severity, QSharedPointer<events::parser::ParsedEvent> event);
     void checkListStateChanged          ();
     void messagesReceivedChanged        ();
@@ -930,7 +928,6 @@ signals:
     void messageCountChanged            ();
     void formattedMessagesChanged       ();
     void newFormattedMessage            (QString formattedMessage);
-    void latestErrorChanged             ();
     void longitudeChanged               ();
     void currentConfigChanged           ();
     void flowImageIndexChanged          ();
@@ -1129,7 +1126,6 @@ private:
     int             _currentWarningCount = 0;
     int             _currentNormalCount = 0;
     MessageType_t   _currentMessageType = MessageNone;
-    QString         _latestError;
     int             _updateCount = 0;
     int             _rcRSSI = 255;
     double          _rcRSSIstore = 255;

--- a/src/uas/UASMessageHandler.cc
+++ b/src/uas/UASMessageHandler.cc
@@ -103,11 +103,17 @@ void UASMessageHandler::_activeVehicleChanged(Vehicle* vehicle)
     }
 }
 
-void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString text)
+void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString text, QString description)
 {
     // Hack to prevent calibration messages from cluttering things up
     if (_activeVehicle->px4Firmware() && text.startsWith(QStringLiteral("[cal] "))) {
         return;
+    }
+
+    text = text.replace("\n", "<br/>");
+    // TODO: handle text + description separately in the UI
+    if (!description.isEmpty()) {
+        text += "<br/><small><small>" + description.replace("\n", "<br/>") + "</small></small>";
     }
 
     // Color the output depending on the message severity. We have 3 distinct cases:
@@ -187,11 +193,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     if (_multiComp) {
         compString = QString(" COMP:%1").arg(compId);
     }
-    message->_setFormatedText(QString("<font style=\"%1\">[%2%3]%4 %5</font><br/>").arg(style).arg(dateString).arg(compString).arg(severityText).arg(text.toHtmlEscaped()));
-
-    if (message->severityIsError()) {
-        _latestError = severityText + " " + text;
-    }
+    message->_setFormatedText(QString("<font style=\"%1\">[%2%3]%4 %5</font><br/>").arg(style).arg(dateString).arg(compString).arg(severityText).arg(text));
 
     _mutex.unlock();
 
@@ -202,7 +204,7 @@ void UASMessageHandler::handleTextMessage(int, int compId, int severity, QString
     emit textMessageCountChanged(count);
 
     if (_showErrorsInToolbar && message->severityIsError()) {
-        _app->showCriticalVehicleMessage(message->getText().toHtmlEscaped());
+        _app->showCriticalVehicleMessage(message->getText());
     }
 }
 

--- a/src/uas/UASMessageHandler.h
+++ b/src/uas/UASMessageHandler.h
@@ -37,7 +37,7 @@ public:
      */
     int getSeverity() const          { return _severity; }
     /**
-     * @brief Get message text (e.g. "[pm] sending list")
+     * @brief Get (html escaped) message text (e.g. "[pm] sending list")
      */
     QString getText()           { return _text; }
     /**
@@ -98,10 +98,6 @@ public:
      * @brief Get normal message count (Resets count once read)
      */
     int getNormalCount();
-    /**
-     * @brief Get latest error message
-     */
-    QString getLatestError()   { return _latestError; }
 
     /// Begin to show message which are errors in the toolbar
     void showErrorsInToolbar(void) { _showErrorsInToolbar = true; }
@@ -115,9 +111,10 @@ public slots:
      * @param uasid UAS Id
      * @param componentid Component Id
      * @param severity Message severity
-     * @param text Message Text
+     * @param text Message Text (html escaped)
+     * @param description Optional detailed description (html escaped)
      */
-    void handleTextMessage(int uasid, int componentid, int severity, QString text);
+    void handleTextMessage(int uasid, int componentid, int severity, QString text, QString description);
 
 signals:
     /**
@@ -144,7 +141,6 @@ private:
     int                     _errorCountTotal;
     int                     _warningCount;
     int                     _normalCount;
-    QString                 _latestError;
     bool                    _showErrorsInToolbar;
     MultiVehicleManager*    _multiVehicleManager;
 };

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -617,6 +617,7 @@ ApplicationWindow {
             anchors.centerIn:   parent
             wrapMode:           Text.WordWrap
             color:              qgcPal.alertText
+            textFormat:         TextEdit.RichText
         }
 
         MouseArea {

--- a/src/ui/toolbar/MessageIndicator.qml
+++ b/src/ui/toolbar/MessageIndicator.qml
@@ -14,6 +14,7 @@ import QtQuick.Layouts  1.2
 
 import QGroundControl                       1.0
 import QGroundControl.Controls              1.0
+import QGroundControl.FactSystem            1.0
 import QGroundControl.MultiVehicleManager   1.0
 import QGroundControl.ScreenTools           1.0
 import QGroundControl.Palette               1.0
@@ -142,6 +143,10 @@ Item {
                 }
             }
 
+            FactPanelController {
+                id: controller
+            }
+
             QGCFlickable {
                 id:                 messageFlick
                 anchors.margins:    ScreenTools.defaultFontPixelHeight
@@ -158,6 +163,27 @@ Item {
                     color:              qgcPal.text
                     selectionColor:     qgcPal.text
                     selectedTextColor:  qgcPal.window
+                    property var fact:  null
+                    onLinkActivated: {
+                        if (link.startsWith('param://')) {
+                            var paramName = link.substr(8);
+                            fact = controller.getParameterFact(-1, paramName, true)
+                            if (fact != null) {
+                                paramEditorDialogComponent.createObject(mainWindow).open()
+                            }
+                        } else {
+                            Qt.openUrlExternally(link);
+                        }
+                    }
+                }
+                Component {
+                    id: paramEditorDialogComponent
+
+                    ParameterEditorDialog {
+                        title:          qsTr("Edit Parameter")
+                        fact:           messageText.fact
+                        destroyOnClose: true
+                    }
                 }
             }
         }


### PR DESCRIPTION
And allows to use URL's & parameters in messages:
![image](https://github.com/mavlink/qgroundcontrol/assets/281593/8ade6086-ed94-4794-9fc5-2ad1eec24c45)

Fixes https://github.com/mavlink/qgroundcontrol/issues/10811