### PR TITLE
Master pr/fix custom android build

### DIFF
--- a/android.pri
+++ b/android.pri
@@ -20,7 +20,10 @@ android_source_dir_target.depends = FORCE
 exists($$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR) {
     message("Merging$$ $$ANDROID_PACKAGE_QGC_SOURCE_DIR and $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR to $$ANDROID_PACKAGE_SOURCE_DIR")
 
-    android_source_dir_target.target = $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/AndroidManifest.xml
+    exists($$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/AndroidManifest.xml) {
+        android_source_dir_target.target = $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/AndroidManifest.xml
+    }
+    
     android_source_dir_target.commands = $$android_source_dir_target.commands && \
             $$QMAKE_COPY_DIR $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/* $$ANDROID_PACKAGE_SOURCE_DIR && \
             $$QMAKE_STREAM_EDITOR -i \"s/package=\\\"org.mavlink.qgroundcontrol\\\"/package=\\\"$$QGC_ANDROID_PACKAGE\\\"/\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml

--- a/android.pri
+++ b/android.pri
@@ -12,7 +12,6 @@ android_source_dir_target.target = $$ANDROID_PACKAGE_QGC_SOURCE_DIR/AndroidManif
 android_source_dir_target.commands = \
     $$QMAKE_MKDIR $$ANDROID_PACKAGE_SOURCE_DIR && \
     $$QMAKE_COPY_DIR $$ANDROID_PACKAGE_QGC_SOURCE_DIR/* $$ANDROID_PACKAGE_SOURCE_DIR
-PRE_TARGETDEPS += $$android_source_dir_target.target
 QMAKE_EXTRA_TARGETS += android_source_dir_target
 android_source_dir_target.depends = FORCE
 
@@ -26,6 +25,8 @@ exists($$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR) {
             $$QMAKE_COPY_DIR $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/* $$ANDROID_PACKAGE_SOURCE_DIR && \
             $$QMAKE_STREAM_EDITOR -i \"s/package=\\\"org.mavlink.qgroundcontrol\\\"/package=\\\"$$QGC_ANDROID_PACKAGE\\\"/\" $$ANDROID_PACKAGE_SOURCE_DIR/AndroidManifest.xml
 }
+
+PRE_TARGETDEPS += $$android_source_dir_target.target
 
 # Insert package name into manifest file
 


### PR DESCRIPTION
android.pri was broken when a custom build has a custom android folder. PRE_TARGETDEPS was updated before the custom build evaluation, so if custom build found, the PRE_TARGETDEPS would still be assigned the previous ( QGC standard ) AndroidManifest.xml.

Also, it was needed to handle the case when we have a custom android folder, but no custom AndroidManifest.xml ( in case we are only changing android icons for instance.

@DonLakeFlyer does it look good to you? Thanks!