### PR TITLE
Display progress for individual mission items

### DIFF
--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -32,6 +32,7 @@ MapQuickItem {
             id:                 _label
             checked:            _isCurrentItem
             label:              missionItem.abbreviation
+            progress:           missionItem.flyView ? missionItem.progress : ""
             index:              missionItem.abbreviation.charAt(0) > 'A' && missionItem.abbreviation.charAt(0) < 'z' ? -1 : missionItem.sequenceNumber
             gimbalYaw:          missionItem.missionGimbalYaw
             vehicleYaw:         missionItem.missionVehicleYaw

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2025,6 +2025,8 @@ void MissionController::_managerVehicleChanged(Vehicle* managerVehicle)
     connect(_managerVehicle, &Vehicle::defaultHoverSpeedChanged,        this, &MissionController::_recalcMissionFlightStatusSignal, Qt::QueuedConnection);
     connect(_managerVehicle, &Vehicle::vehicleTypeChanged,              this, &MissionController::complexMissionItemNamesChanged);
 
+    connect(_missionManager, &MissionManager::currentProgressChanged,   this, &MissionController::_currentProgressChanged);
+
     emit complexMissionItemNamesChanged();
     emit resumeMissionIndexChanged();
 }
@@ -2299,6 +2301,14 @@ void MissionController::_progressPctChanged(double progressPct)
     if (!QGC::fuzzyCompare(progressPct, _progressPct)) {
         _progressPct = progressPct;
         emit progressPctChanged(progressPct);
+    }
+}
+
+void MissionController::_currentProgressChanged(int currentIndex, uint8_t unit, uint8_t percentage, uint16_t remaining)
+{
+    if (currentIndex < _visualItems->count()) {
+        VisualMissionItem* item = _visualItems->value<VisualMissionItem*>(currentIndex);
+        item->setProgress((MISSION_ITEM_PROGRESS_UNITS)unit, percentage, remaining);
     }
 }
 

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -308,6 +308,7 @@ private slots:
     void _recalcMissionFlightStatus             (void);
     void _updateContainsItems                   (void);
     void _progressPctChanged                    (double progressPct);
+    void _currentProgressChanged                (int currentIndex, uint8_t unit, uint8_t percentage, uint16_t remaining);
     void _visualItemsDirtyChanged               (bool dirty);
     void _managerSendComplete                   (bool error);
     void _managerRemoveAllComplete              (bool error);

--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -278,6 +278,13 @@ void MissionManager::_handleMissionCurrent(const mavlink_message_t& message)
     mavlink_mission_current_t missionCurrent;
     mavlink_msg_mission_current_decode(&message, &missionCurrent);
     _updateMissionIndex(missionCurrent.seq);
+
+    emit currentProgressChanged(
+        missionCurrent.seq,
+        missionCurrent.item_progress_units,
+        missionCurrent.item_progress_percentage,
+        missionCurrent.item_progress_remaining
+    );
 }
 
 void MissionManager::_handleHeartbeat(const mavlink_message_t& message)

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -81,6 +81,7 @@ signals:
     void inProgressChanged          (bool inProgress);
     void error                      (int errorCode, const QString& errorMsg);
     void currentIndexChanged        (int currentIndex);
+    void currentProgressChanged     (int currentIndex, uint8_t unit, uint8_t percentage, uint16_t remaining);
     void lastCurrentIndexChanged    (int lastCurrentIndex);
     void progressPct                (double progressPercentPct);
     void removeAllComplete          (bool error);

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -418,10 +418,26 @@ QString SimpleMissionItem::abbreviation() const
     case MAV_CMD_DO_SET_ROI_LOCATION:
         return tr("ROI");
     case MAV_CMD_NAV_LOITER_TIME:
+        return tr("Loiter (time)");
     case MAV_CMD_NAV_LOITER_TURNS:
+        return tr("Loiter (turns)");
     case MAV_CMD_NAV_LOITER_UNLIM:
-    case MAV_CMD_NAV_LOITER_TO_ALT:
         return tr("Loiter");
+    case MAV_CMD_NAV_LOITER_TO_ALT:
+        return tr("Loiter (altitide)");
+    case MAV_CMD_NAV_WAYPOINT:{
+        // This is a little bit magical: MissionItemIndexLabel.qml uses these
+        // strings for both:
+        //     1) the character to use inside the Mission Item icon; and
+        //     2) the label to display next to the Icon.
+        //
+        // If the first character of the label is a letter, then that is used
+        // in the Icon, otherwise the sequence number is used. On Waypoints,
+        // we specifically want the sequence number, so we add a non-printable
+        // character to the start of the string.
+        const auto zero_width_space = QChar(0x200B);
+        return QStringLiteral("%1Waypoint").arg(zero_width_space);
+    }
     default:
         return QString();
     }

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -84,6 +84,8 @@ public:
     Q_PROPERTY(bool             wizardMode                          READ wizardMode                         WRITE setWizardMode             NOTIFY wizardModeChanged)
     Q_PROPERTY(int              previousVTOLMode                    MEMBER _previousVTOLMode                                                NOTIFY previousVTOLModeChanged)                     ///< Current VTOL mode (VehicleClass_t) prior to executing this item
 
+    Q_PROPERTY(QString          progress                            READ progress                                                           NOTIFY progressChanged)
+
     Q_PROPERTY(PlanMasterController*    masterController    READ masterController                                                   CONSTANT)
     Q_PROPERTY(ReadyForSaveState        readyForSaveState   READ readyForSaveState                                                  NOTIFY readyForSaveStateChanged)
     Q_PROPERTY(VisualMissionItem*       parentItem          READ parentItem                        WRITE setParentItem              NOTIFY parentItemChanged)
@@ -99,6 +101,9 @@ public:
     Q_PROPERTY(double azimuth           READ azimuth                WRITE setAzimuth            NOTIFY azimuthChanged)              ///< Azimuth to previous waypoint
     Q_PROPERTY(double distance          READ distance               WRITE setDistance           NOTIFY distanceChanged)             ///< Distance to previous waypoint
     Q_PROPERTY(double distanceFromStart READ distanceFromStart      WRITE setDistanceFromStart  NOTIFY distanceFromStartChanged)    ///< Flight path cumalative horizontal distance from home point to this item
+
+    QString progress            (void) const;
+    void    setProgress         (MISSION_ITEM_PROGRESS_UNITS units, uint8_t percentage, uint16_t remaining);
 
     // Property accesors
     bool    homePosition        (void) const { return _homePositionSpecialCase; }
@@ -247,6 +252,8 @@ signals:
 
     void exitCoordinateSameAsEntryChanged           (bool exitCoordinateSameAsEntry);
 
+    void progressChanged(void);
+
 protected slots:
     void _amslEntryAltChanged(void);    // signals new amslEntryAlt value
     void _amslExitAltChanged(void);     // signals new amslExitAlt value
@@ -291,6 +298,12 @@ private slots:
 
 private:
     void _commonInit(void);
+
+    struct {
+        MISSION_ITEM_PROGRESS_UNITS unit;
+        uint8_t percentage;
+        uint16_t remaining;
+    } _progress;
 
     QTimer                      _updateTerrainTimer;
     TerrainAtCoordinateQuery*   _currentTerrainAtCoordinateQuery = nullptr;

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -13,6 +13,7 @@ Canvas {
     signal clicked
 
     property string label                           ///< Label to show to the side of the index indicator
+    property string progress                        ///< Label to show the progress of the mission item
     property int    index:                  0       ///< Index to show in the indicator, 0 will show single char label instead, -1 first char of label in indicator full label to the side
     property bool   checked:                false
     property bool   small:                  !checked
@@ -77,27 +78,53 @@ Canvas {
 
     Rectangle {
         id:                     labelControl
-        anchors.leftMargin:     -((_labelMargin * 2) + indicator.width)
-        anchors.rightMargin:    -(_labelMargin * 2)
-        anchors.fill:           labelControlLabel
+
+        anchors.left:           indicator.left
+        anchors.top:            indicator.top
+        anchors.leftMargin:     _labelMargin * -1
+        anchors.topMargin:      _labelMargin * -1
+
         color:                  "white"
         opacity:                0.5
         radius:                 _labelRadius
-        visible:                _label.length !== 0 && !small
-    }
 
-    QGCLabel {
-        id:                     labelControlLabel
-        anchors.topMargin:      -_labelMargin
-        anchors.bottomMargin:   -_labelMargin
-        anchors.leftMargin:     _labelMargin
-        anchors.left:           indicator.right
-        anchors.top:            indicator.top
-        anchors.bottom:         indicator.bottom
-        color:                  "black"
-        text:                   _label
-        verticalAlignment:      Text.AlignVCenter
-        visible:                labelControl.visible
+        width:                  childrenRect.width
+        height:                 childrenRect.height
+
+        QGCLabel {
+            id:                     mainLabel
+
+            anchors.left:           labelControl.left
+            anchors.top:            labelControl.top
+            leftPadding:            (_labelMargin * 3) + (_indicatorRadius * 2)
+            rightPadding:           _indicatorRadius
+
+            property real _height:  (_indicatorRadius * 2) + (_labelMargin * 2)
+            height:                 visible ? _height  : 0
+
+            color:                  "black"
+            text:                   _label
+            verticalAlignment:      Text.AlignVCenter
+            visible:                _label.length !== 0 && !small
+        }
+
+        QGCLabel {
+            id:                     progressLabel
+
+            anchors.left:           mainLabel.left
+            anchors.top:            mainLabel.bottom
+            leftPadding:            mainLabel.leftPadding
+            rightPadding:           mainLabel.rightPadding
+            topPadding:             _labelMargin * -4
+
+            property real _height:  _indicatorRadius * 1.5
+            height:                 visible ? _height : 0
+
+            color:                  mainLabel.color
+            text:                   progress
+            verticalAlignment:      Text.AlignVCenter
+            visible:                mainLabel.visible && progress.length > 0 && !small
+        }
     }
 
     Rectangle {


### PR DESCRIPTION
A proposed change in MAVLink adds mission item progress to the `MISSION_CURRENT` message: https://github.com/mavlink/mavlink/pull/2029

This PR adds support for displaying this information on the FlyView map:
![qgc-item-progress-distance](https://github.com/mavlink/qgroundcontrol/assets/48079543/23341605-d13c-45d3-8f19-09a240310705)
![qgc-item-progress-count](https://github.com/mavlink/qgroundcontrol/assets/48079543/26b0ae8e-caba-47a4-90a3-438e8d6469ce)
![qgc-item-progress-time](https://github.com/mavlink/qgroundcontrol/assets/48079543/5bb23254-bb5f-40e3-9616-2700990408a1)

Associated ArduPilot PR: https://github.com/ArduPilot/ardupilot/pull/25249

**NOTE:** This PR won't build as-is, because it doesn't include the changes to the `MISSION_CURRENT` message definition.