### PR TITLE
Optimize map provider iteration to prevent app crashes. Fixed application crash due to segmentation fault.

### DIFF
--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -156,13 +156,9 @@ quint32 UrlFactory::averageSizeForType(const QString& type) {
 }
 
 QString UrlFactory::getTypeFromId(int id) {
-
-    QHashIterator<QString, MapProvider*> i(_providersTable);
-
-    while (i.hasNext()) {
-        i.next();
-        if ((int)(qHash(i.key())>>1) == id) {
-            return i.key();
+    for (auto it = _providersTable.constBegin(); it != _providersTable.constEnd(); ++it) {
+        if ((int)(qHash(it.key()) >> 1) == id) {
+            return it.key();
         }
     }
     qCDebug(QGCMapUrlEngineLog) << "getTypeFromId : id not found" << id;


### PR DESCRIPTION
Optimize map provider iteration to prevent app crashes. Fixed application crash due to segmentation fault.

Changed from QHashIterator to using a constant iterator for iterating through the map providers in _providersTable. This change prevents application crashes during a map download session caused by the potential modification of an implicitly shared hash.
