### PR TITLE
PhotoVideoControl.qml: Fix toggleShotting when no mavlink camera

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -101,7 +101,7 @@ Rectangle {
 
     function toggleShooting() {
         console.log("toggleShooting", _anyVideoStreamAvailable)
-        if (_mavlinkCamera && _mavlinkCamera.capturesVideo || _mavlinkCamera.capturesPhotos ) {
+        if (_mavlinkCamera && (_mavlinkCamera.capturesVideo || _mavlinkCamera.capturesPhotos) ) {
             if(_mavlinkCameraInVideoMode) {
                 _mavlinkCamera.toggleVideo()
             } else {


### PR DESCRIPTION
I patched this little time ago in order to allow mavlink cameras that only support photo shooting, but the logic was wrong and it malfunctions for simple cameras. This commit should fix it.