### PR TITLE
Use all mavlink includes instead of ardupilotmega for cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ include_directories(
 	libs/libevents
 
 	libs/mavlink/include/mavlink/v2.0
-	libs/mavlink/include/mavlink/v2.0/ardupilotmega
+	libs/mavlink/include/mavlink/v2.0/all
 	libs/mavlink/include/mavlink/v2.0/common
 
 	libs/shapelib


### PR DESCRIPTION
Switched mavlink include option from 'ardupilotmega' to 'all' in the CMakeLists file. This modification will allow the use of all the functionalities offered by the mavlink library. the range of functionalities that can be utilized from the mavlink library.
@bkueng Please check out this PR because it fixes cmake compilation for StandardModes.
