### PR TITLE
Fix typo in Fahrenheit name

### DIFF
--- a/src/Settings/UnitsSettings.cc
+++ b/src/Settings/UnitsSettings.cc
@@ -155,7 +155,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, temperatureUnits)
         // Units settings can't be loaded from json since it creates an infinite loop of meta data loading.
         QStringList     enumStrings;
         QVariantList    enumValues;
-        enumStrings << "Celsius" << "Farenheit";
+        enumStrings << "Celsius" << "Fahrenheit";
         enumValues << QVariant::fromValue(static_cast<uint32_t>(TemperatureUnitsCelsius)) << QVariant::fromValue(static_cast<uint32_t>(TemperatureUnitsFarenheit));
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
         metaData->setName(temperatureUnitsName);


### PR DESCRIPTION
Changes Farenheit to Fahrenheit, only in the string.

Should "farenheit" be replaced to "fahrenheit" in other places throughout the code? I'm worried about backwards compatibility with the method names and such.