### PR TITLE
APMFirmwarePlugin: reposition using MAV_CMD_DO_REPOSITION 

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -137,4 +137,7 @@ public:
 
     QTime lastBatteryStatusTime;
     QTime lastHomePositionTime;
+
+    bool  MAV_CMD_DO_REPOSITION_supported = false;
+    bool  MAV_CMD_DO_REPOSITION_unsupported = false;
 };

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3005,6 +3005,18 @@ void Vehicle::sendMavCommandInt(int compId, MAV_CMD command, MAV_FRAME frame, bo
                           param1, param2, param3, param4, param5, param6, param7);
 }
 
+void Vehicle::sendMavCommandIntWithHandler(MavCmdResultHandler resultHandler, void *resultHandlerData, int compId, MAV_CMD command, MAV_FRAME frame, float param1, float param2, float param3, float param4, double param5, double param6, float param7)
+{
+    _sendMavCommandWorker(true,                   // commandInt
+                          false,                  // showError
+                          resultHandler,
+                          resultHandlerData,
+                          compId,
+                          command,
+                          frame,
+                          param1, param2, param3, param4, param5, param6, param7);
+}
+
 bool Vehicle::isMavCommandPending(int targetCompId, MAV_CMD command)
 {
     return ((-1) < _findMavCommandListEntryIndex(targetCompId, command));

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -774,6 +774,11 @@ public:
     ///     @param resultHandleData Opaque data passed through callback
     void sendMavCommandWithHandler(MavCmdResultHandler resultHandler, void* resultHandlerData, int compId, MAV_CMD command, float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
 
+    /// Sends the command and calls the callback with the result
+    ///     @param resultHandler    Callback for result, nullptr for no callback
+    ///     @param resultHandleData Opaque data passed through callback
+    void sendMavCommandIntWithHandler(MavCmdResultHandler resultHandler, void* resultHandlerData, int compId, MAV_CMD command, MAV_FRAME frame, float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, double param5 = 0.0f, double param6 = 0.0f, float param7 = 0.0f);
+
     typedef enum {
         RequestMessageNoFailure,
         RequestMessageFailureCommandError,


### PR DESCRIPTION
I've tested this in ArduPilot SITL.

The interface used for this testing was click-on-map and select the "Move to" option.

I tested Rover, Copter and Plane which actually implement DO_REPOSITION, and on Sub which doesn't.  All act as expected.
