### PR TITLE
QGCTextField: fix forcing the use of virtual numeric keyboard

### DIFF
--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -13,8 +13,8 @@ TextField {
     activeFocusOnPress: true
     antialiasing:       true
     inputMethodHints:   numericValuesOnly && !ScreenTools.isiOS ?
-                          Qt.ImhNone :                // iOS numeric keyboard has no done button, we can't use it.
-                          Qt.ImhFormattedNumbersOnly  // Forces use of virtual numeric keyboard instead of full keyboard
+                          Qt.ImhFormattedNumbersOnly:  // Forces use of virtual numeric keyboard instead of full keyboard
+                          Qt.ImhNone                   // iOS numeric keyboard has no done button, we can't use it.
 
     property bool   showUnits:          false
     property bool   showHelp:           false


### PR DESCRIPTION
**Description:**
This pull request addresses an issue with the input method hints that was causing problems with Android devices, specifically related to the use of the virtual numeric keyboard. The problem arose from an inverted condition, which led to incorrect behavior.

**Changes Made**
Reversed the condition to correctly force the use of the virtual numeric keyboard only when numericValuesOnly is true and the device is not an IOS device.

**Problem**
This condition was causing problems on Android devices by not allowing users to search for parameters or create com link names using alphabetic characters.

![C8AD48CF-62D4-4C4A-B44F-98CE179F3121](https://github.com/mavlink/qgroundcontrol/assets/52117777/e56c5dc0-c624-4a89-8941-abb7a16f2c67)

![7F5A305A-31FB-4299-A1DF-3175BE9278BF](https://github.com/mavlink/qgroundcontrol/assets/52117777/6b4ab1bd-8524-41bb-8485-a33e34119c96)


