### PR TITLE
Vehicle: update mode when StandardModes::modesUpdated is emitted

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -380,6 +380,7 @@ void Vehicle::_commonInit()
     _vehicleLinkManager             = new VehicleLinkManager            (this);
 
     connect(_standardModes, &StandardModes::modesUpdated, this, &Vehicle::flightModesChanged);
+    connect(_standardModes, &StandardModes::modesUpdated, this, [this](){ Vehicle::flightModeChanged(flightMode()); });
 
     _parameterManager = new ParameterManager(this);
     connect(_parameterManager, &ParameterManager::parametersReadyChanged, this, &Vehicle::_parametersReady);


### PR DESCRIPTION
Required because the label of the currently active mode might change.
E.g. when an external mode gets registered but was already selected.


