### PR TITLE
APM: cope with IN_PROGRESS messages from autopilot

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -524,6 +524,9 @@ void APMSensorsComponentController::_handleCommandAck(mavlink_message_t& message
 
         if (commandAck.command == MAV_CMD_PREFLIGHT_CALIBRATION) {
             switch (commandAck.result) {
+            case MAV_RESULT_IN_PROGRESS:
+                _appendStatusLog(tr("In progress"));
+                break;
             case MAV_RESULT_ACCEPTED:
                 _appendStatusLog(tr("Successfully completed"));
                 _stopCalibration(StopCalibrationSuccessShowLog);


### PR DESCRIPTION
![image](https://github.com/mavlink/qgroundcontrol/assets/7077857/98b3d093-7267-456f-b1ae-6c1623244421)
