### PR TITLE
Vehicle: keep commands in list if in progress

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2738,8 +2738,8 @@ double Vehicle::minimumEquivalentAirspeed()
     return _firmwarePlugin->minimumEquivalentAirspeed(this);
 }
 
-bool Vehicle::hasGripper()  const 
-{ 
+bool Vehicle::hasGripper()  const
+{
     return _firmwarePlugin->hasGripper(this);
 }
 
@@ -3850,7 +3850,7 @@ void Vehicle::_handleRawImuTemp(mavlink_message_t& message)
 {
     // This is used by compass calibration
     emit mavlinkRawImu(message);
-    
+
     mavlink_raw_imu_t imuRaw;
     mavlink_msg_raw_imu_decode(&message, &imuRaw);
 
@@ -4103,8 +4103,8 @@ void Vehicle::doSetHome(const QGeoCoordinate& coord)
             disconnect(_currentDoSetHomeTerrainAtCoordinateQuery, &TerrainAtCoordinateQuery::terrainDataReceived, this, &Vehicle::_doSetHomeTerrainReceived);
             _currentDoSetHomeTerrainAtCoordinateQuery = nullptr;
         }
-        // Save the coord for using when our terrain data arrives. If there was a pending terrain query paired with an older coordinate it is safe to 
-        // Override now, as we just disconnected the signal that would trigger the command sending 
+        // Save the coord for using when our terrain data arrives. If there was a pending terrain query paired with an older coordinate it is safe to
+        // Override now, as we just disconnected the signal that would trigger the command sending
         _doSetHomeCoordinate = coord;
         // Now setup and trigger the new terrain query
         _currentDoSetHomeTerrainAtCoordinateQuery = new TerrainAtCoordinateQuery(true /* autoDelet */);
@@ -4383,16 +4383,16 @@ void Vehicle::setGripperAction(GRIPPER_ACTIONS gripperAction)
 void Vehicle::sendGripperAction(GRIPPER_OPTIONS gripperOption)
 {
     switch(gripperOption) {
-        case Gripper_release: 
+        case Gripper_release:
             setGripperAction(GRIPPER_ACTION_RELEASE);
             break;
-        case Gripper_grab: 
+        case Gripper_grab:
             setGripperAction(GRIPPER_ACTION_GRAB);
             break;
         case Invalid_option:
             qDebug("unknown function");
             break;
-        default: 
+        default:
         break;
     }
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3254,7 +3254,10 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
     int entryIndex = _findMavCommandListEntryIndex(message.compid, static_cast<MAV_CMD>(ack.command));
     bool commandInList = false;
     if (entryIndex != -1) {
-        MavCommandListEntry_t commandEntry = _mavCommandList.takeAt(entryIndex);
+        // We remove the command from the list unless it's still in progress.
+        MavCommandListEntry_t commandEntry =
+            (ack.result == MAV_RESULT_IN_PROGRESS) ? _mavCommandList.at(entryIndex) : _mavCommandList.takeAt(entryIndex);
+
         if (commandEntry.command == ack.command) {
             if (commandEntry.resultHandler) {
                 (*commandEntry.resultHandler)(commandEntry.resultHandlerData, message.compid, static_cast<MAV_RESULT>(ack.result), ack.progress, MavCmdResultCommandResultOnly);


### PR DESCRIPTION
We should not remove commands from the command list when we receive an IN_PROGRESS ack because we should eventually receive a final ack.