### PR TITLE
Fix up support for MAV_RESULT_IN_PROGRESS

### DIFF
--- a/src/Vehicle/Actuators/ActuatorActions.h
+++ b/src/Vehicle/Actuators/ActuatorActions.h
@@ -48,8 +48,7 @@ public:
     Q_INVOKABLE void trigger();
 
 private:
-    static void ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
-            Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
     void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
     void sendMavlinkRequest();
 

--- a/src/Vehicle/Actuators/ActuatorTesting.cc
+++ b/src/Vehicle/Actuators/ActuatorTesting.cc
@@ -120,11 +120,10 @@ void ActuatorTest::setActive(bool active)
     _active = active;
 }
 
-void ActuatorTest::ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
-        Vehicle::MavCmdResultFailureCode_t failureCode)
+void ActuatorTest::ackHandlerEntry(void* resultHandlerData, int /*compId*/, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode)
 {
     ActuatorTest* actuatorTest = (ActuatorTest*)resultHandlerData;
-    actuatorTest->ackHandler(commandResult, failureCode);
+    actuatorTest->ackHandler(static_cast<MAV_RESULT>(ack.result), failureCode);
 }
 
 void ActuatorTest::ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode)
@@ -190,9 +189,12 @@ void ActuatorTest::sendMavlinkRequest(int function, float value, float timeout)
 
     // TODO: consider using a lower command timeout
 
+    Vehicle::MavCmdAckHandlerInfo_t handlerInfo = {};
+    handlerInfo.resultHandler       = ackHandlerEntry;
+    handlerInfo.resultHandlerData   = this;
+
     _vehicle->sendMavCommandWithHandler(
-            ackHandlerEntry,                  // Ack callback
-            this,                             // Ack callback data
+            &handlerInfo,
             MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
             MAV_CMD_ACTUATOR_TEST,            // the mavlink command
             value,                            // value

--- a/src/Vehicle/Actuators/ActuatorTesting.h
+++ b/src/Vehicle/Actuators/ActuatorTesting.h
@@ -110,8 +110,7 @@ private:
 
     void resetStates();
 
-    static void ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
-            Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
     void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
     void sendMavlinkRequest(int function, float value, float timeout);
 

--- a/src/Vehicle/Actuators/MotorAssignment.h
+++ b/src/Vehicle/Actuators/MotorAssignment.h
@@ -62,8 +62,7 @@ private:
     static constexpr int _spinTimeoutDefaultSec = 1000;
     static constexpr int _spinTimeoutHighSec = 3000; ///< wait a bit longer after assigning motors, so ESCs can initialize
 
-    static void ackHandlerEntry(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress,
-            Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
     void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
     void sendMavlinkRequest(int function, float value);
 

--- a/src/Vehicle/Autotune.cpp
+++ b/src/Vehicle/Autotune.cpp
@@ -41,7 +41,7 @@ void Autotune::autotuneRequest()
 
 
 //-----------------------------------------------------------------------------
-void Autotune::ackHandler(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress, Vehicle::MavCmdResultFailureCode_t failureCode)
+void Autotune::ackHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode)
 {
     Q_UNUSED(compId);
     Q_UNUSED(failureCode);
@@ -49,23 +49,38 @@ void Autotune::ackHandler(void* resultHandlerData, int compId, MAV_RESULT comman
     auto * autotune = static_cast<Autotune *>(resultHandlerData);
 
     if (autotune->_autotuneInProgress) {
-        if ((commandResult == MAV_RESULT_IN_PROGRESS) || (commandResult == MAV_RESULT_ACCEPTED)) {
-            autotune->handleAckStatus(progress);
-        }
-        else if (commandResult == MAV_RESULT_FAILED) {
+        if (failureCode == Vehicle::MavCmdResultCommandResultOnly) {
+            if ((ack.result == MAV_RESULT_IN_PROGRESS) || (ack.result == MAV_RESULT_ACCEPTED)) {
+                autotune->handleAckStatus(ack.progress);
+            }
+            else if (ack.result == MAV_RESULT_FAILED) {
+                autotune->handleAckFailure();
+            }
+            else {
+                autotune->handleAckError(ack.result);
+            }
+        } else {
             autotune->handleAckFailure();
         }
-        else {
-            autotune->handleAckError(commandResult);
-        }
-
         emit autotune->autotuneChanged();
-    }
-    else {
+    } else {
         qWarning() << "Ack received for a command different from MAV_CMD_DO_AUTOTUNE_ENABLE ot wrong UI state.";
     }
 }
 
+void Autotune::progressHandler(void* progressHandlerData, int compId, const mavlink_command_ack_t& ack)
+{
+    Q_UNUSED(compId);
+
+    auto * autotune = static_cast<Autotune *>(progressHandlerData);
+
+    if (autotune->_autotuneInProgress) {
+        autotune->handleAckStatus(ack.progress);
+        emit autotune->autotuneChanged();
+    } else {
+        qWarning() << "Ack received for a command different from MAV_CMD_DO_AUTOTUNE_ENABLE ot wrong UI state.";
+    }
+}
 
 //-----------------------------------------------------------------------------
 bool Autotune::autotuneEnabled()
@@ -162,9 +177,14 @@ void Autotune::stopTimers()
 //-----------------------------------------------------------------------------
 void Autotune::sendMavlinkRequest()
 {
+    Vehicle::MavCmdAckHandlerInfo_t handlerInfo = {};
+    handlerInfo.resultHandler       = ackHandler;
+    handlerInfo.resultHandlerData   = this;
+    handlerInfo.progressHandler     = progressHandler;
+    handlerInfo.progressHandlerData = this;
+
     _vehicle->sendMavCommandWithHandler(
-            ackHandler,                       // Ack callback
-            this,                             // Ack callback data
+            &handlerInfo,
             MAV_COMP_ID_AUTOPILOT1,           // the ID of the autopilot
             MAV_CMD_DO_AUTOTUNE_ENABLE,       // the mavlink command
             1,                                // request autotune

--- a/src/Vehicle/Autotune.h
+++ b/src/Vehicle/Autotune.h
@@ -28,7 +28,8 @@ public:
 
     Q_INVOKABLE void autotuneRequest ();
 
-    static void ackHandler(void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress, Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void ackHandler      (void* resultHandlerData,   int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void progressHandler (void* progressHandlerData, int compId, const mavlink_command_ack_t& ack);
 
     bool      autotuneEnabled    ();
     bool      autotuneInProgress () { return _autotuneInProgress; }

--- a/src/Vehicle/RequestMessageTest.cc
+++ b/src/Vehicle/RequestMessageTest.cc
@@ -38,21 +38,21 @@ void RequestMessageTest::_testCaseWorker(TestCase_t& testCase)
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
 
-    _mockLink->clearSendMavCommandCounts();
+    _mockLink->clearReceivedMavCommandCounts();
     _mockLink->setRequestMessageFailureMode(testCase.failureMode);
 
     vehicle->requestMessage(_requestMessageResultHandler, &testCase, MAV_COMP_ID_AUTOPILOT1, MAVLINK_MSG_ID_DEBUG);
     QVERIFY(QTest::qWaitFor([&]() { return testCase.resultHandlerCalled; }, 10000));
     QCOMPARE(vehicle->_findMavCommandListEntryIndex(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_REQUEST_MESSAGE),   -1);
-    QCOMPARE(_mockLink->sendMavCommandCount(MAV_CMD_REQUEST_MESSAGE),                                   testCase.expectedSendCount);
+    QCOMPARE(_mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_MESSAGE),                                   testCase.expectedSendCount);
 
     // We should be able to do it twice in a row without any duplicate command problems
     testCase.resultHandlerCalled = false;
-    _mockLink->clearSendMavCommandCounts();
+    _mockLink->clearReceivedMavCommandCounts();
     vehicle->requestMessage(_requestMessageResultHandler, &testCase, MAV_COMP_ID_AUTOPILOT1, MAVLINK_MSG_ID_DEBUG);
     QVERIFY(QTest::qWaitFor([&]() { return testCase.resultHandlerCalled; }, 10000));
     QCOMPARE(vehicle->_findMavCommandListEntryIndex(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_REQUEST_MESSAGE),   -1);
-    QCOMPARE(_mockLink->sendMavCommandCount(MAV_CMD_REQUEST_MESSAGE),                                   testCase.expectedSendCount);
+    QCOMPARE(_mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_MESSAGE),                                   testCase.expectedSendCount);
 
     _disconnectMockLink();
 }
@@ -77,19 +77,19 @@ void RequestMessageTest::_duplicateCommand(void)
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
 
-    _mockLink->clearSendMavCommandCounts();
+    _mockLink->clearReceivedMavCommandCounts();
     _mockLink->setRequestMessageFailureMode(testCase.failureMode);
 
     QVERIFY(false == vehicle->isMavCommandPending(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_REQUEST_MESSAGE));
 
     vehicle->requestMessage(_requestMessageResultHandler, &testCase, MAV_COMP_ID_AUTOPILOT1, MAVLINK_MSG_ID_DEBUG);
-    QVERIFY(QTest::qWaitFor([&]() { return _mockLink->sendMavCommandCount(MAV_CMD_REQUEST_MESSAGE) == 1; }, 10));
+    QVERIFY(QTest::qWaitFor([&]() { return _mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_MESSAGE) == 1; }, 10));
     QCOMPARE(testCase.resultHandlerCalled, false);
     vehicle->requestMessage(_requestMessageResultHandler, &testCase, MAV_COMP_ID_AUTOPILOT1, MAVLINK_MSG_ID_DEBUG);
 
     // Duplicate command returns immediately
     QCOMPARE(testCase.resultHandlerCalled,                                                              true);
-    QCOMPARE(_mockLink->sendMavCommandCount(MAV_CMD_REQUEST_MESSAGE),                                   testCase.expectedSendCount);
+    QCOMPARE(_mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_MESSAGE),                                   testCase.expectedSendCount);
     QVERIFY(vehicle->_findMavCommandListEntryIndex(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_REQUEST_MESSAGE) != -1);
     QVERIFY(true == vehicle->isMavCommandPending(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_REQUEST_MESSAGE));
 
@@ -123,13 +123,13 @@ void RequestMessageTest::_compIdAllFailure(void)
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
 
-    _mockLink->clearSendMavCommandCounts();
+    _mockLink->clearReceivedMavCommandCounts();
     _mockLink->setRequestMessageFailureMode(testCase.failureMode);
 
     vehicle->requestMessage(_requestMessageResultHandler, &testCase, MAV_COMP_ID_ALL, MAVLINK_MSG_ID_DEBUG);
     QCOMPARE(testCase.resultHandlerCalled,                                                      true);
     QCOMPARE(vehicle->_findMavCommandListEntryIndex(MAV_COMP_ID_ALL, MAV_CMD_REQUEST_MESSAGE),  -1);
-    QCOMPARE(_mockLink->sendMavCommandCount(MAV_CMD_REQUEST_MESSAGE),                           0);
+    QCOMPARE(_mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_MESSAGE),                           0);
 
     _disconnectMockLink();
 }

--- a/src/Vehicle/SendMavCommandWithHandlerTest.h
+++ b/src/Vehicle/SendMavCommandWithHandlerTest.h
@@ -25,17 +25,19 @@ private:
     typedef struct {
         MAV_CMD                             command;
         MAV_RESULT                          expectedCommandResult;
-        uint8_t                             progress;
+        bool                                expectInProgressResult;
         Vehicle::MavCmdResultFailureCode_t  expectedFailureCode;
         int                                 expectedSendCount;
     } TestCase_t;
 
     void _testCaseWorker(TestCase_t& testCase);
 
-    static void _mavCmdResultHandler            (void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress, Vehicle::MavCmdResultFailureCode_t failureCode);
-    static void _compIdAllMavCmdResultHandler   (void* resultHandlerData, int compId, MAV_RESULT commandResult, uint8_t progress, Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void _mavCmdResultHandler                (void* resultHandlerData,   int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void _mavCmdProgressHandler              (void* progressHandlerData, int compId, const mavlink_command_ack_t& ack);
+    static void _compIdAllFailureMavCmdResultHandler(void* resultHandlerData,   int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
 
-    static bool _handlerCalled;
+    static bool _resultHandlerCalled;
+    static bool _progressHandlerCalled;
 
     static TestCase_t _rgTestCases[];
 };

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -55,6 +55,9 @@ constexpr MAV_CMD MockLink::MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_ACCEPTED;
 constexpr MAV_CMD MockLink::MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_FAILED;
 constexpr MAV_CMD MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE;
 constexpr MAV_CMD MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE_NO_RETRY;
+constexpr MAV_CMD MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_ACCEPTED;
+constexpr MAV_CMD MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_FAILED;
+constexpr MAV_CMD MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_NO_ACK;
 
 // The LinkManager is only forward declared in the header, so a static_assert is here instead to ensure we update if the value changes.
 static_assert(LinkManager::invalidMavlinkChannel() == std::numeric_limits<uint8_t>::max(), "update MockLink::_mavlinkAuxChannel");
@@ -1052,6 +1055,53 @@ void MockLink::_handleFTP(const mavlink_message_t& msg)
     _mockLinkFTP->mavlinkMessageReceived(msg);
 }
 
+void MockLink::_handleInProgressCommandLong(const mavlink_command_long_t& request)
+{
+    uint8_t commandResult = MAV_RESULT_UNSUPPORTED;
+
+    switch (request.command) {
+    case MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_ACCEPTED:
+        // Test command which sends in progress messages and then acceptance ack
+        commandResult = MAV_RESULT_ACCEPTED;
+        break;
+    case MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_FAILED:
+        // Test command which sends in progress messages and then failure ack
+        commandResult = MAV_RESULT_FAILED;
+        break;
+    case MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_NO_ACK:
+        // Test command which sends in progress messages and then never sends final result ack
+        break;
+    }
+
+    mavlink_message_t commandAck;
+
+    mavlink_msg_command_ack_pack_chan(_vehicleSystemId,
+                                      _vehicleComponentId,
+                                      mavlinkChannel(),
+                                      &commandAck,
+                                      request.command,
+                                      MAV_RESULT_IN_PROGRESS,
+                                      1,    // progress
+                                      0,    // result_param2
+                                      0,    // target_system
+                                      0);   // target_component
+    respondWithMavlinkMessage(commandAck);
+
+    if (request.command != MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_NO_ACK) {
+        mavlink_msg_command_ack_pack_chan(_vehicleSystemId,
+                                        _vehicleComponentId,
+                                        mavlinkChannel(),
+                                        &commandAck,
+                                        request.command,
+                                        commandResult,
+                                        0,    // progress
+                                        0,    // result_param2
+                                        0,    // target_system
+                                        0);   // target_component
+        respondWithMavlinkMessage(commandAck);
+    }
+}
+
 void MockLink::_handleCommandLong(const mavlink_message_t& msg)
 {
     static bool firstCmdUser3 = true;
@@ -1063,7 +1113,7 @@ void MockLink::_handleCommandLong(const mavlink_message_t& msg)
 
     mavlink_msg_command_long_decode(&msg, &request);
 
-    _sendMavCommandCountMap[static_cast<MAV_CMD>(request.command)]++;
+    _receivedMavCommandCountMap[static_cast<MAV_CMD>(request.command)]++;
 
     switch (request.command) {
     case MAV_CMD_COMPONENT_ARM_DISARM:
@@ -1111,7 +1161,7 @@ void MockLink::_handleCommandLong(const mavlink_message_t& msg)
         commandResult = MAV_RESULT_FAILED;
         break;
     case MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_ACCEPTED:
-        // Test command which returns MAV_RESULT_ACCEPTED on second attempt
+        // Test command which does not respond to first request and returns MAV_RESULT_ACCEPTED on second attempt
         if (firstCmdUser3) {
             firstCmdUser3 = false;
             return;
@@ -1121,7 +1171,7 @@ void MockLink::_handleCommandLong(const mavlink_message_t& msg)
         }
         break;
     case MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_FAILED:
-        // Test command which returns MAV_RESULT_FAILED on second attempt
+        // Test command which does not respond to first request and returns MAV_RESULT_FAILED on second attempt
         if (firstCmdUser4) {
             firstCmdUser4 = false;
             return;
@@ -1132,7 +1182,12 @@ void MockLink::_handleCommandLong(const mavlink_message_t& msg)
         break;
     case MAV_CMD_MOCKLINK_NO_RESPONSE:
     case MAV_CMD_MOCKLINK_NO_RESPONSE_NO_RETRY:
-        // No response
+        // Test command which never responds
+        return;
+    case MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_ACCEPTED:
+    case MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_FAILED:
+    case MockLink::MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_NO_ACK:
+        _handleInProgressCommandLong(request);
         return;
     }
 

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -162,16 +162,19 @@ public:
     static MockLink* startAPMArduSubMockLink        (bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink* startAPMArduRoverMockLink      (bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
 
-    // Special commands for testing COMMAND_LONG handlers. By default all commands except for MAV_CMD_MOCKLINK_NO_RESPONSE_NO_RETRY should retry.
+    // Special commands for testing Vehicle::sendMavCommandWithHandler
     static constexpr MAV_CMD MAV_CMD_MOCKLINK_ALWAYS_RESULT_ACCEPTED            = MAV_CMD_USER_1;
     static constexpr MAV_CMD MAV_CMD_MOCKLINK_ALWAYS_RESULT_FAILED              = MAV_CMD_USER_2;
     static constexpr MAV_CMD MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_ACCEPTED    = MAV_CMD_USER_3;
     static constexpr MAV_CMD MAV_CMD_MOCKLINK_SECOND_ATTEMPT_RESULT_FAILED      = MAV_CMD_USER_4;
     static constexpr MAV_CMD MAV_CMD_MOCKLINK_NO_RESPONSE                       = MAV_CMD_USER_5;
     static constexpr MAV_CMD MAV_CMD_MOCKLINK_NO_RESPONSE_NO_RETRY              = static_cast<MAV_CMD>(MAV_CMD_USER_5 + 1);
+    static constexpr MAV_CMD MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_ACCEPTED       = static_cast<MAV_CMD>(MAV_CMD_USER_5 + 2);
+    static constexpr MAV_CMD MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_FAILED         = static_cast<MAV_CMD>(MAV_CMD_USER_5 + 3);
+    static constexpr MAV_CMD MAV_CMD_MOCKLINK_RESULT_IN_PROGRESS_NO_ACK         = static_cast<MAV_CMD>(MAV_CMD_USER_5 + 4);
 
-    void clearSendMavCommandCounts(void) { _sendMavCommandCountMap.clear(); }
-    int sendMavCommandCount(MAV_CMD command) { return _sendMavCommandCountMap[command]; }
+    void clearReceivedMavCommandCounts(void) { _receivedMavCommandCountMap.clear(); }
+    int receivedMavCommandCount(MAV_CMD command) { return _receivedMavCommandCountMap[command]; }
 
     typedef enum {
         FailRequestMessageNone,
@@ -220,6 +223,7 @@ private:
     void _handleParamRequestRead        (const mavlink_message_t& msg);
     void _handleFTP                     (const mavlink_message_t& msg);
     void _handleCommandLong             (const mavlink_message_t& msg);
+    void _handleInProgressCommandLong   (const mavlink_command_long_t& request);
     void _handleManualControl           (const mavlink_message_t& msg);
     void _handlePreFlightCalibration    (const mavlink_command_long_t& request);
     void _handleLogRequestList          (const mavlink_message_t& msg);
@@ -310,7 +314,7 @@ private:
 
     RequestMessageFailureMode_t _requestMessageFailureMode = FailRequestMessageNone;
 
-    QMap<MAV_CMD, int>  _sendMavCommandCountMap;
+    QMap<MAV_CMD, int>                          _receivedMavCommandCountMap;
     QMap<int, QMap<QString, QVariant>>          _mapParamName2Value;
     QMap<int, QMap<QString, MAV_PARAM_TYPE>>    _mapParamName2MavParamType;
 


### PR DESCRIPTION
Replacement for #10850.

The current problems with Vehicle::sendMavCommandWithHandler in progress support:
* When a MAV_RESULT_IN_PROGRESS ack is received the Vehicle code does the following incorrect things:
  * The command entry is removed from the entry list. Since this is only a progress indication to command is still in play and we are still waiting for the real ack so it should be left in the list.
  * The timeout for the command ack which is used is left alone. This means that it will fire too early with respect to not getting a completion ack. When an in progress ack is received the timeout should be restarted to give more time for the completion ack to be seen.
  * If the command supports retries and we get an in progress we should not retry the command. The reason being we did hear back from the vehicle with respect to the fact that it got the command. In this case the try count should be reset back to 1 such that no retry happens.
* The other problem relates to the fact that the progress indication comes through the same callback as completion acks. This makes writing the ack callback handlers fragile and complex. Specifically in the case where the command did not initially support MAV_RESULT_IN_PROGRESS. You write some simple checks for command success/fail (like result != MAV_RESULT_ACCEPTED). But then the command suddenly returns MAV_RESULT_IN_PROGRESS in a newer version of firmware which causes your code to think the command failed when it reality it didn't. There currently are multiple examples of this in the existing callback handler implementations.

The changes made to fix all this:
* The Vehicle code was changed to fix all the bugs with handling MAV_RESULT_IN_PROGRESS described above. The changes are all in Vehicle.cc/h.
* I split the handling of in progress acks and completions acks into two separate callback handlers. This way you can implement a simple completion callback handler which won't break if you suddenly start getting progress notications. And you can just ignore the progress information if you like. Or if you want you can implement a separate progress only callback. There are a decent number of changes throughout the code because of the new signature to the Vehicle:: sendMavCommandWithHandler method. But they are mostly mechanical changes in nature as opposed to logic changes.
