### PR TITLE
Add range checking to Mission Item params

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -153,9 +153,7 @@ FactMetaData::FactMetaData(QObject* parent)
     , _rawDefaultValue      (0)
     , _defaultValueAvailable(false)
     , _rawMax               (_maxForType())
-    , _maxIsDefaultForType  (true)
     , _rawMin               (_minForType())
-    , _minIsDefaultForType  (true)
     , _rawTranslator        (_defaultTranslator)
     , _cookedTranslator     (_defaultTranslator)
     , _vehicleRebootRequired(false)
@@ -177,9 +175,7 @@ FactMetaData::FactMetaData(ValueType_t type, QObject* parent)
     , _rawDefaultValue      (0)
     , _defaultValueAvailable(false)
     , _rawMax               (_maxForType())
-    , _maxIsDefaultForType  (true)
     , _rawMin               (_minForType())
-    , _minIsDefaultForType  (true)
     , _rawTranslator        (_defaultTranslator)
     , _cookedTranslator     (_defaultTranslator)
     , _vehicleRebootRequired(false)
@@ -207,9 +203,7 @@ FactMetaData::FactMetaData(ValueType_t type, const QString name, QObject* parent
     , _rawDefaultValue      (0)
     , _defaultValueAvailable(false)
     , _rawMax               (_maxForType())
-    , _maxIsDefaultForType  (true)
     , _rawMin               (_minForType())
-    , _minIsDefaultForType  (true)
     , _name                 (name)
     , _rawTranslator        (_defaultTranslator)
     , _cookedTranslator     (_defaultTranslator)
@@ -238,9 +232,7 @@ const FactMetaData& FactMetaData::operator=(const FactMetaData& other)
     _group                  = other._group;
     _longDescription        = other._longDescription;
     _rawMax                 = other._rawMax;
-    _maxIsDefaultForType    = other._maxIsDefaultForType;
     _rawMin                 = other._rawMin;
-    _minIsDefaultForType    = other._minIsDefaultForType;
     _name                   = other._name;
     _shortDescription       = other._shortDescription;
     _type                   = other._type;
@@ -292,7 +284,6 @@ void FactMetaData::setRawMin(const QVariant& rawMin)
 {
     if (isInRawMinLimit(rawMin)) {
         _rawMin = rawMin;
-        _minIsDefaultForType = false;
     } else {
         qWarning() << "Attempt to set min below allowable value for fact: " << name()
                    << ", value attempted: " << rawMin
@@ -305,9 +296,10 @@ void FactMetaData::setRawMax(const QVariant& rawMax)
 {
     if (isInRawMaxLimit(rawMax)) {
         _rawMax = rawMax;
-        _maxIsDefaultForType = false;
     } else {
-        qWarning() << "Attempt to set max above allowable value";
+        qWarning() << "Attempt to set max above allowable value for fact: " << name()
+                   << ", value attempted: " << rawMax
+                   << ", type: " << type() << ", max for type: " << _maxForType();
         _rawMax = _maxForType();
     }
 }
@@ -372,9 +364,9 @@ bool FactMetaData::isInRawMaxLimit(const QVariant& variantValue) const
     return true;
 }
 
-QVariant FactMetaData::_minForType(void) const
+QVariant FactMetaData::minForType(ValueType_t type)
 {
-    switch (_type) {
+    switch (type) {
     case valueTypeUint8:
         return QVariant(std::numeric_limits<unsigned char>::min());
     case valueTypeInt8:
@@ -409,9 +401,9 @@ QVariant FactMetaData::_minForType(void) const
     return QVariant();
 }
 
-QVariant FactMetaData::_maxForType(void) const
+QVariant FactMetaData::maxForType(ValueType_t type)
 {
-    switch (_type) {
+    switch (type) {
     case valueTypeUint8:
         return QVariant(std::numeric_limits<unsigned char>::max());
     case valueTypeInt8:

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -118,10 +118,10 @@ public:
     QString         longDescription         (void) const { return _longDescription;}
     QVariant        rawMax                  (void) const { return _rawMax; }
     QVariant        cookedMax               (void) const;
-    bool            maxIsDefaultForType     (void) const { return _maxIsDefaultForType; }
+    bool            maxIsDefaultForType     (void) const { return _rawMax == _maxForType(); }
     QVariant        rawMin                  (void) const { return _rawMin; }
     QVariant        cookedMin               (void) const;
-    bool            minIsDefaultForType     (void) const { return _minIsDefaultForType; }
+    bool            minIsDefaultForType     (void) const { return _rawMin == _minForType(); }
     QString         name                    (void) const { return _name; }
     QString         shortDescription        (void) const { return _shortDescription; }
     ValueType_t     type                    (void) const { return _type; }
@@ -206,11 +206,14 @@ public:
     static QString typeToString(ValueType_t type);
     static size_t typeToSize(ValueType_t type);
 
+    static QVariant minForType(ValueType_t type);
+    static QVariant maxForType(ValueType_t type);
+
     static const char* qgcFileType;
 
 private:
-    QVariant _minForType                (void) const;
-    QVariant _maxForType                (void) const;
+    QVariant _minForType                (void) const { return minForType(_type); };
+    QVariant _maxForType                (void) const { return maxForType(_type); };
     void    _setAppSettingsTranslators  (void);
 
     /// Clamp a value to be within cookedMin and cookedMax
@@ -314,9 +317,7 @@ private:
     QString         _group;
     QString         _longDescription;
     QVariant        _rawMax;
-    bool            _maxIsDefaultForType;
     QVariant        _rawMin;
-    bool            _minIsDefaultForType;
     QString         _name;
     QString         _shortDescription;
     QString         _rawUnits;

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -36,13 +36,15 @@
                 "label":            "Hold",
                 "units":            "secs",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "Acceptance",
                 "units":            "m",
                 "default":          0,
-                "decimalPlaces":    2
+                "decimalPlaces":    2,
+                "min":              0
             },
             "param3": {
                 "label":            "Pass Radius",
@@ -93,7 +95,8 @@
             "param1": {
                 "label":            "Turns",
                 "default":          1,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "Leave Loiter",
@@ -129,7 +132,8 @@
                 "label":            "Loiter Time",
                 "units":            "secs",
                 "default":          30,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "Leave Loiter",
@@ -294,7 +298,8 @@
                 "label":            "Hold",
                 "units":            "secs",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             }        
         },
         { "id": 83, "rawName": "MAV_CMD_NAV_ALTITUDE_WAIT", "friendlyName": "Altitude wait" },
@@ -364,27 +369,34 @@
             "id":           93,
             "rawName":      "MAV_CMD_NAV_DELAY",
             "friendlyName": "Delay until",
-            "description":  "Delay unti the specified time is reached.",
+            "description":  "Delay until the specified time is reached.",
             "param1": {
                 "label":            "Hold",
                 "units":            "secs",
                 "default":          30,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              -1
             },
             "param2": {
                 "label":            "Hour (utc)",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              -1,
+                "max":              23
             },
             "param3": {
                 "label":            "Min (utc)",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              -1,
+                "max":              59
             },
             "param4": {
                 "label":            "Sec (utc)",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              -1,
+                "max":              59
             }
         },
         {
@@ -398,7 +410,8 @@
                 "label":            "Delay",
                 "units":            "secs",
                 "default":          30,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             }
         },
         {
@@ -426,7 +439,8 @@
                 "label":            "Distance",
                 "units":            "m",
                 "default":          10,
-                "decimalPlaces":    2
+                "decimalPlaces":    2,
+                "min":              0
             }
         },
         {
@@ -493,12 +507,14 @@
             "param1": {
                 "label":            "Item #",
                 "default":          1,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "Repeat",
                 "default":          10,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             }
         },
         {
@@ -516,12 +532,14 @@
             "param2": {
                 "label":            "Speed",
                 "units":            "m/s",
-                "default":          0
+                "default":          0,
+                "min":              -2
             },
             "param3": {
                 "label":            "Throttle",
                 "units":            "%",
-                "default":          0
+                "default":          0,
+                "min":              -2
             },
             "param4": {
                 "label":            "Offset",
@@ -555,7 +573,8 @@
             "param1": {
                 "label":            "Relay #",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "Value",
@@ -570,19 +589,22 @@
             "param1": {
                 "label":            "Relay #",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "Cycles",
                 "default":          1,
                 "units":            "count",
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              1
             },
             "param3": {
                 "label":            "Time",
                 "default":          10,
                 "units":            "secs",
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             }
         },
         {
@@ -594,12 +616,14 @@
             "param1": {
                 "label":            "Servo",
                 "default":          1,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "PWM",
                 "default":          1500,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             }
         },
         {
@@ -610,24 +634,28 @@
             "param1": {
                 "label":            "Servo",
                 "default":          1,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "PWM",
                 "default":          1000,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param3": {
                 "label":            "Cycles",
                 "default":          1,
                 "units":            "count",
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              1
             },
             "param4": {
                 "label":            "Time",
                 "default":          10,
                 "units":            "secs",
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             }
         },
         {
@@ -755,12 +783,14 @@
             "param2": {
                 "label":            "Mission Index",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param3": {
                 "label":            "ROI Index",
                 "default":          0,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             }
         },
         {
@@ -965,13 +995,15 @@
                 "label":            "Distance",
                 "default":          25,
                 "units":            "m",
-                "decimalPlaces":    2
+                "decimalPlaces":    2,
+                "min":              0
             },
             "param2": {
                 "label":            "Shutter",
                 "default":          0,
                 "units":            "msecs",
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              -1
             },
             "param3": {
                 "label":            "Trigger",
@@ -1076,7 +1108,8 @@
                 "label":            "Timeout",
                 "default":          0,
                 "units":            "secs",
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param2": {
                 "label":            "Min Alt",
@@ -1094,7 +1127,8 @@
                 "label":            "H Limit",
                 "default":          25,
                 "units":            "m",
-                "decimalPlaces":    2
+                "decimalPlaces":    2,
+                "min":              0
             }
         },
         { "id": 241, "rawName": "MAV_CMD_PREFLIGHT_CALIBRATION", "friendlyName": "Calibration" },
@@ -1135,12 +1169,14 @@
                 "label":            "Interval",
                 "default":          0,
                 "units":            "secs",
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             },
             "param3": {
                 "label":            "Photo count",
                 "default":          1,
-                "decimalPlaces":    0
+                "decimalPlaces":    0,
+                "min":              0
             }
         },
         {
@@ -1162,7 +1198,8 @@
                 "label":            "Status Frequency",
                 "default":          0.2,
                 "units":            "Hz",
-                "decimalPlaces":    2
+                "decimalPlaces":    2,
+                "min":              0
             }
         },
         {

--- a/src/MissionManager/MissionCommandUIInfo.h
+++ b/src/MissionManager/MissionCommandUIInfo.h
@@ -55,6 +55,8 @@ public:
     Q_PROPERTY(int          param           READ param          CONSTANT)
     Q_PROPERTY(QString      units           READ units          CONSTANT)
     Q_PROPERTY(bool         nanUnchanged    READ nanUnchanged   CONSTANT)
+    Q_PROPERTY(double       min             READ min            CONSTANT)
+    Q_PROPERTY(double       max             READ max            CONSTANT)
 
     int             decimalPlaces   (void) const { return _decimalPlaces; }
     double          defaultValue    (void) const { return _defaultValue; }
@@ -64,6 +66,8 @@ public:
     int             param           (void) const { return _param; }
     QString         units           (void) const { return _units; }
     bool            nanUnchanged    (void) const { return _nanUnchanged; }
+    double          min             (void) const { return _min; }
+    double          max             (void) const { return _max; }
 
 private:
     int             _decimalPlaces;
@@ -74,6 +78,8 @@ private:
     int             _param;
     QString         _units;
     bool            _nanUnchanged;
+    double          _min;
+    double          _max;
 
     friend class MissionCommandTree;
     friend class MissionCommandUIInfo;
@@ -185,6 +191,8 @@ private:
     static const char* _idJsonKey;
     static const char* _labelJsonKey;
     static const char* _mavCmdInfoJsonKey;
+    static const char* _maxJsonKey;
+    static const char* _minJsonKey;
     static const char* _param1JsonKey;
     static const char* _param2JsonKey;
     static const char* _param3JsonKey;

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -480,6 +480,9 @@ void SimpleMissionItem::_rebuildTextFieldFacts(void)
                     paramFact->_setName(paramInfo->label());
                     paramMetaData->setDecimalPlaces(paramInfo->decimalPlaces());
                     paramMetaData->setRawUnits(paramInfo->units());
+                    paramMetaData->setRawDefaultValue(paramInfo->defaultValue());
+                    paramMetaData->setRawMin(paramInfo->min());
+                    paramMetaData->setRawMax(paramInfo->max());
                     paramFact->setMetaData(paramMetaData);
                     _textFieldFacts.append(paramFact);
                 }
@@ -528,6 +531,9 @@ void SimpleMissionItem::_rebuildNaNFacts(void)
                     paramFact->_setName(paramInfo->label());
                     paramMetaData->setDecimalPlaces(paramInfo->decimalPlaces());
                     paramMetaData->setRawUnits(paramInfo->units());
+                    paramMetaData->setRawDefaultValue(paramInfo->defaultValue());
+                    paramMetaData->setRawMin(paramInfo->min());
+                    paramMetaData->setRawMax(paramInfo->max());
                     paramFact->setMetaData(paramMetaData);
                     _nanFacts.append(paramFact);
                 }
@@ -597,6 +603,9 @@ void SimpleMissionItem::_rebuildComboBoxFacts(void)
                 paramMetaData->setDecimalPlaces(paramInfo->decimalPlaces());
                 paramMetaData->setEnumInfo(paramInfo->enumStrings(), paramInfo->enumValues());
                 paramMetaData->setRawUnits(paramInfo->units());
+                paramMetaData->setRawDefaultValue(paramInfo->defaultValue());
+                paramMetaData->setRawMin(paramInfo->min());
+                paramMetaData->setRawMax(paramInfo->max());
                 paramFact->setMetaData(paramMetaData);
                 _comboboxFacts.append(paramFact);
             }


### PR DESCRIPTION
A number of `MAV_CMD`s have minimum and maximum values for the params. For example, [MAV_CMD_NAV_LOITER_TURNS](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TURNS) has a minimum of 0 for `param1` ("Turns").

This PR adds `"min"` and `"max"` fields to the definitions in `MavCmdInfoCommon.json`, and uses them when setting up the `Fact`s to display when planning a Mission.