### PR TITLE
PhotoVideoControl.qml: Fixed TypeError when pressing recording button with no active stream

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -101,7 +101,19 @@ Rectangle {
 
     function toggleShooting() {
         console.log("toggleShooting", _anyVideoStreamAvailable)
-        if (_mavlinkCamera && (_mavlinkCamera.capturesVideo || _mavlinkCamera.capturesPhotos) ) {
+
+        // This whole mavlinkCameraCaptureVideoOrPhotos stuff is to work around some strange qml boolean testing 
+        // behavior which wasn't working correctly. This should work:
+        //    if (_mavlinkCamera && (_mavlinkCamera.capturesVideo || _mavlinkCamera.capturesPhotos) ) {
+        // but it doesn't for some strange reason. Hence all the stuff below...
+        var mavlinkCameraCaptureVideoOrPhotos = false
+        if (_mavlinkCamera) {
+            if (_mavlinkCamera.capturesVideo || _mavlinkCamera.capturesPhotos) {
+                mavlinkCameraCaptureVideoOrPhotos = true
+            }
+        }
+        
+        if (mavlinkCameraCaptureVideoOrPhotos) {
             if(_mavlinkCameraInVideoMode) {
                 _mavlinkCamera.toggleVideo()
             } else {


### PR DESCRIPTION
A minor bug exists where the record button is enabled even before there is an active stream streaming. 

Hitting the record button before there is an active stream will give this error:
`qrc:/qml/QGroundControl/FlightMap/PhotoVideoControl.qml:104: TypeError: Cannot read property 'capturesPhotos' of null`

My change makes the record button disabled until it is possible to record.
