### PR TITLE
Windows: Look for gstreamer on D drive as well as C

### DIFF
--- a/src/VideoReceiver/VideoReceiver.pri
+++ b/src/VideoReceiver/VideoReceiver.pri
@@ -39,6 +39,11 @@ LinuxBuild {
     #- gstreamer installed by default under c:/gstreamer
     GST_ROOT = c:/gstreamer/1.0/msvc_x86_64
 
+    !exists($$GST_ROOT) {
+        # In GitHub actions windows runner installation is on D drive, so try there as well
+        GST_ROOT = d:/gstreamer/1.0/msvc_x86_64
+    }
+
     exists($$GST_ROOT) {
         CONFIG      += VideoEnabled
 


### PR DESCRIPTION
* Fix for #10861
* Something changed in the github actions windows runner which places everything on the D drive instead of C