### PR TITLE
Fixed exporting tile sets not saving the files with the .qgctiledb extension

### DIFF
--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -15,6 +15,7 @@
 //-- TODO: #include "QGCQFileDialog.h"
 #endif
 
+#include "AppSettings.h"
 #include "QGCMapEngineManager.h"
 #include "QGCApplication.h"
 #include "QGCMapTileSet.h"
@@ -496,6 +497,12 @@ QGCMapEngineManager::exportSets(QString path) {
 #endif
     }
     if(!dir.isEmpty()) {
+
+        // Add tileset file extension if unspecified
+        if (!QFileInfo(path).fileName().contains(".")) {
+            dir += QString(".%1").arg(tilesetFileExtension());
+        }
+
         QVector<QGCCachedTileSet*> sets;
         for(int i = 0; i < _tileSets.count(); i++ ) {
             QGCCachedTileSet* set = qobject_cast<QGCCachedTileSet*>(_tileSets.get(i));
@@ -559,6 +566,11 @@ QGCMapEngineManager::getUniqueName()
         if(!findName(name))
             return name;
     }
+}
+
+QString QGCMapEngineManager::tilesetFileExtension(void) const
+{
+    return AppSettings::tilesetFileExtension;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -37,26 +37,27 @@ public:
     };
     Q_ENUM(ImportAction)
 
-    Q_PROPERTY(quint64              tileCount       READ    tileCount       NOTIFY tileCountChanged)
-    Q_PROPERTY(QString              tileCountStr    READ    tileCountStr    NOTIFY tileCountChanged)
-    Q_PROPERTY(quint64              tileSize        READ    tileSize        NOTIFY tileSizeChanged)
-    Q_PROPERTY(QString              tileSizeStr     READ    tileSizeStr     NOTIFY tileSizeChanged)
-    Q_PROPERTY(QmlObjectListModel*  tileSets        READ    tileSets        NOTIFY tileSetsChanged)
-    Q_PROPERTY(QStringList          mapList         READ    mapList         CONSTANT)
-    Q_PROPERTY(QStringList          mapProviderList READ    mapProviderList CONSTANT)
-    Q_PROPERTY(quint32              maxMemCache     READ    maxMemCache     WRITE   setMaxMemCache  NOTIFY  maxMemCacheChanged)
-    Q_PROPERTY(quint32              maxDiskCache    READ    maxDiskCache    WRITE   setMaxDiskCache NOTIFY  maxDiskCacheChanged)
-    Q_PROPERTY(QString              errorMessage    READ    errorMessage    NOTIFY  errorMessageChanged)
-    Q_PROPERTY(bool                 fetchElevation  READ    fetchElevation  WRITE   setFetchElevation   NOTIFY  fetchElevationChanged)
+    Q_PROPERTY(quint64              tileCount            READ    tileCount            NOTIFY tileCountChanged)
+    Q_PROPERTY(QString              tileCountStr         READ    tileCountStr         NOTIFY tileCountChanged)
+    Q_PROPERTY(quint64              tileSize             READ    tileSize             NOTIFY tileSizeChanged)
+    Q_PROPERTY(QString              tileSizeStr          READ    tileSizeStr          NOTIFY tileSizeChanged)
+    Q_PROPERTY(QmlObjectListModel*  tileSets             READ    tileSets             NOTIFY tileSetsChanged)
+    Q_PROPERTY(QString              tilesetFileExtension READ    tilesetFileExtension CONSTANT)
+    Q_PROPERTY(QStringList          mapList              READ    mapList              CONSTANT)
+    Q_PROPERTY(QStringList          mapProviderList      READ    mapProviderList      CONSTANT)
+    Q_PROPERTY(quint32              maxMemCache          READ    maxMemCache          WRITE   setMaxMemCache  NOTIFY  maxMemCacheChanged)
+    Q_PROPERTY(quint32              maxDiskCache         READ    maxDiskCache         WRITE   setMaxDiskCache NOTIFY  maxDiskCacheChanged)
+    Q_PROPERTY(QString              errorMessage         READ    errorMessage         NOTIFY  errorMessageChanged)
+    Q_PROPERTY(bool                 fetchElevation       READ    fetchElevation       WRITE   setFetchElevation   NOTIFY  fetchElevationChanged)
     //-- Disk Space in MB
-    Q_PROPERTY(quint32              freeDiskSpace   READ    freeDiskSpace   NOTIFY  freeDiskSpaceChanged)
-    Q_PROPERTY(quint32              diskSpace       READ    diskSpace       CONSTANT)
+    Q_PROPERTY(quint32              freeDiskSpace        READ    freeDiskSpace        NOTIFY  freeDiskSpaceChanged)
+    Q_PROPERTY(quint32              diskSpace            READ    diskSpace            CONSTANT)
     //-- Tile set export
-    Q_PROPERTY(int                  selectedCount   READ    selectedCount   NOTIFY selectedCountChanged)
-    Q_PROPERTY(int                  actionProgress  READ    actionProgress  NOTIFY actionProgressChanged)
-    Q_PROPERTY(ImportAction         importAction    READ    importAction    WRITE  setImportAction   NOTIFY importActionChanged)
+    Q_PROPERTY(int                  selectedCount        READ    selectedCount        NOTIFY selectedCountChanged)
+    Q_PROPERTY(int                  actionProgress       READ    actionProgress       NOTIFY actionProgressChanged)
+    Q_PROPERTY(ImportAction         importAction         READ    importAction         WRITE  setImportAction   NOTIFY importActionChanged)
 
-    Q_PROPERTY(bool                 importReplace   READ    importReplace   WRITE   setImportReplace   NOTIFY importReplaceChanged)
+    Q_PROPERTY(bool                 importReplace        READ    importReplace        WRITE   setImportReplace   NOTIFY importReplaceChanged)
 
     Q_INVOKABLE void                loadTileSets            ();
     Q_INVOKABLE void                updateForCurrentView    (double lon0, double lat0, double lon1, double lat1, int minZoom, int maxZoom, const QString& mapName);
@@ -77,6 +78,7 @@ public:
     QString                         tileCountStr            () const;
     quint64                         tileSize                () const{ return _imageSet.tileSize + _elevationSet.tileSize; }
     QString                         tileSizeStr             () const;
+    QString                         tilesetFileExtension    () const;
     QStringList                     mapList                 ();
     QStringList                     mapProviderList         ();
     Q_INVOKABLE QStringList         mapTypeList             (QString provider);

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -30,6 +30,7 @@ const char* AppSettings::telemetryFileExtension =   "tlog";
 const char* AppSettings::kmlFileExtension =         "kml";
 const char* AppSettings::shpFileExtension =         "shp";
 const char* AppSettings::logFileExtension =         "ulg";
+const char* AppSettings::tilesetFileExtension =     "qgctiledb";
 
 const char* AppSettings::parameterDirectory =       QT_TRANSLATE_NOOP("AppSettings", "Parameters");
 const char* AppSettings::telemetryDirectory =       QT_TRANSLATE_NOOP("AppSettings", "Telemetry");

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -86,6 +86,7 @@ public:
     Q_PROPERTY(QString waypointsFileExtension   MEMBER waypointsFileExtension   CONSTANT)
     Q_PROPERTY(QString parameterFileExtension   MEMBER parameterFileExtension   CONSTANT)
     Q_PROPERTY(QString telemetryFileExtension   MEMBER telemetryFileExtension   CONSTANT)
+    Q_PROPERTY(QString tilesetFileExtension     MEMBER tilesetFileExtension     CONSTANT)
     Q_PROPERTY(QString kmlFileExtension         MEMBER kmlFileExtension         CONSTANT)
     Q_PROPERTY(QString shpFileExtension         MEMBER shpFileExtension         CONSTANT)
     Q_PROPERTY(QString logFileExtension         MEMBER logFileExtension         CONSTANT)
@@ -115,6 +116,7 @@ public:
     static const char* kmlFileExtension;
     static const char* shpFileExtension;
     static const char* logFileExtension;
+    static const char* tilesetFileExtension;
 
     // Child directories of savePath for specific file types
     static const char* parameterDirectory;


### PR DESCRIPTION
Problem mentioned here: https://github.com/mavlink/qgroundcontrol/issues/10591

Exporting tile sets does not save them with any file extension if none are explicitly defined when writing the file name. This patch fixes that problem.