### PR TITLE
Add battery voltage in Toolbar's Instrument Panel

### DIFF
--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -98,8 +98,12 @@ add_library(Vehicle
 	VehicleVibrationFactGroup.h
 	VehicleWindFactGroup.cc
 	VehicleWindFactGroup.h
-        VehicleHygrometerFactGroup.cc
-        VehicleHygrometerFactGroup.h
+	VehicleHygrometerFactGroup.cc
+	VehicleHygrometerFactGroup.h
+	VehicleGeneratorFactGroup.cc
+	VehicleGeneratorFactGroup.h
+    VehicleEFIFactGroup.cc
+    VehicleEFIFactGroup.h
 	RemoteIDManager.h
 	RemoteIDManager.cc
 

--- a/src/ui/toolbar/BatteryIndicator.qml
+++ b/src/ui/toolbar/BatteryIndicator.qml
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2023 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
@@ -33,6 +33,7 @@ Item {
         id:             batteryIndicatorRow
         anchors.top:    parent.top
         anchors.bottom: parent.bottom
+        anchors.verticalCenter: parent.verticalCenter
 
         Repeater {
             model: _activeVehicle ? _activeVehicle.batteries : 0
@@ -91,22 +92,48 @@ Item {
                 return ""
             }
 
+            function getBatteryVoltageText() {
+                if (!isNaN(battery.voltage.rawValue)) {
+                    return battery.voltage.valueString + battery.voltage.units
+                } else if (battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED) {
+                    return battery.chargeState.enumStringValue
+                }
+                return "?"
+            }
+
             QGCColoredImage {
+                id:                 battIcon
                 anchors.top:        parent.top
                 anchors.bottom:     parent.bottom
                 width:              height
-                sourceSize.width:   width
+                sourceSize.height:   height
                 source:             "/qmlimages/Battery.svg"
                 fillMode:           Image.PreserveAspectFit
                 color:              getBatteryColor()
             }
+            Column {
+                id:                     batteryInfoColumn
+                anchors.top:            parent.top
+                anchors.bottom:         parent.bottom
+                anchors.leftMargin:     ScreenTools.defaultFontPixelWidth / 2
 
-            QGCLabel {
-                text:                   getBatteryPercentageText()
-                font.pointSize:         ScreenTools.mediumFontPointSize
-                color:                  getBatteryColor()
-                anchors.verticalCenter: parent.verticalCenter
+                QGCLabel {
+                    verticalAlignment:      Text.AlignVCenter
+                    color:                  getBatteryColor()
+                    text:                   getBatteryPercentageText()
+                    font.pointSize:         ScreenTools.defaultFontPointSize
+                }
+
+                QGCLabel {
+                    id:                     voltValue
+                    verticalAlignment:      Text.AlignVCenter
+                    font.pointSize:         ScreenTools.defaultFontPointSize
+                    color:                  getBatteryColor()
+                    text:                   getBatteryVoltageText()
+                }
             }
+
+
         }
     }
 


### PR DESCRIPTION
For most of pilots it's more beneficial to know current voltage. They know their batteries / hardware the best so they know how to react on battery voltage more than on percentage only.

Those are  examples, with two batteries, second one has voltage unavailable, but adds a description instead.
![image](https://github.com/mavlink/qgroundcontrol/assets/440614/20c689f8-902e-4158-8d94-9b303b929f5f)

![image](https://github.com/mavlink/qgroundcontrol/assets/440614/d4cdf7a3-3562-451e-a926-c58e1e27623c)

![image](https://github.com/mavlink/qgroundcontrol/assets/440614/f47332eb-fae9-476d-af5f-77430448d6b7)

![image](https://github.com/mavlink/qgroundcontrol/assets/440614/122c8cf8-5609-4221-a7a5-861657d1d77c)
