### PR TITLE
LinkManager: Fix double free on exit

### DIFF
--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -79,6 +79,7 @@ LinkManager::LinkManager(QGCApplication* app, QGCToolbox* toolbox)
 
 LinkManager::~LinkManager()
 {
+    disconnectAll();
 #ifndef __mobile__
 #ifndef NO_SERIAL_LINK
     delete _nmeaPort;
@@ -925,9 +926,9 @@ void LinkManager::_createDynamicForwardLink(const char* linkName, QString hostNa
 {
     UDPConfiguration* udpConfig = new UDPConfiguration(linkName);
     udpConfig->setDynamic(true);
-    
+
     udpConfig->addHost(hostName);
-    
+
     SharedLinkConfigurationPtr config = addConfiguration(udpConfig);
     createConnectedLink(config);
 


### PR DESCRIPTION
This fixes a double free that happens for me when I exit QGC without ever having a vehicle connected.

That's the backtrace I see without this patch:

```
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140322669365376) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140322669365376) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140322669365376, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007f9f687ee476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007f9f687d47f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x00007f9f68835676 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7f9f68987b8c "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#6  0x00007f9f6884ccfc in malloc_printerr (str=str@entry=0x7f9f6898a768 "double free or corruption (fasttop)") at ./malloc/malloc.c:5664
#7  0x00007f9f6884e9ca in _int_free (av=0x7f9f689c5c80 <main_arena>, p=0x55efeb3067b0, have_lock=0) at ./malloc/malloc.c:4539
#8  0x00007f9f68851453 in __GI___libc_free (mem=<optimized out>) at ./malloc/malloc.c:3391
#9  0x000055efe441618d in QList<std::shared_ptr<LinkInterface> >::node_destruct(QList<std::shared_ptr<LinkInterface> >::Node*, QList<std::shared_ptr<LinkInterface> >::Node*) (this=<optimized out>, to=0x55efeaaa73d0, from=0x55efeaaa73d0)
    at /home/julianoes/Qt/5.15.2/gcc_64/include/QtCore/qlist.h:524
#10 QList<std::shared_ptr<LinkInterface> >::dealloc(QListData::Data*) [clone .isra.0] (data=0x55efeaaa73c0, this=<optimized out>)
    at /home/julianoes/Qt/5.15.2/gcc_64/include/QtCore/qlist.h:921
#11 0x000055efe4267fe0 in QList<std::shared_ptr<LinkInterface> >::~QList() (this=<optimized out>, this=<optimized out>)
    at /home/julianoes/Qt/5.15.2/gcc_64/include/QtCore/qlist.h:871
#12 QList<std::shared_ptr<LinkInterface> >::~QList() (this=<optimized out>, this=<optimized out>)
    at /home/julianoes/Qt/5.15.2/gcc_64/include/QtCore/qlist.h:871
#13 LinkManager::~LinkManager() (this=0x55efe879e2f0, this=<optimized out>)
    at /home/julianoes/src/upstream/qgroundcontrol/src/comm/LinkManager.cc:87
#14 0x000055efe426804d in LinkManager::~LinkManager() (this=0x55efe879e2f0, this=<optimized out>)
    at /home/julianoes/src/upstream/qgroundcontrol/src/comm/LinkManager.cc:87
#15 0x00007f9f68ec97c3 in QObjectPrivate::deleteChildren() ()
    at /home/julianoes/src/upstream/qgroundcontrol/build/staging/Qt/libs/libQt5Core.so.5
#16 0x00007f9f68ed3e9e in QObject::~QObject() () at /home/julianoes/src/upstream/qgroundcontrol/build/staging/Qt/libs/libQt5Core.so.5
#17 0x000055efe41b3a27 in QGCToolbox::~QGCToolbox() (this=0x55efe83d8800, this=<optimized out>)
    at /home/julianoes/src/upstream/qgroundcontrol/src/QGCToolbox.h:47
#18 QGCToolbox::~QGCToolbox() (this=0x55efe83d8800, this=<optimized out>) at /home/julianoes/src/upstream/qgroundcontrol/src/QGCToolbox.h:47
#19 0x000055efe40a66b5 in QGCApplication::_shutdown() (this=0x55efe80ee840)
    at /home/julianoes/src/upstream/qgroundcontrol/src/QGCApplication.cc:434
#20 main(int, char**) (argc=<optimized out>, argv=<optimized out>) at /home/julianoes/src/upstream/qgroundcontrol/src/main.cc:424

```