### PR TITLE
[ObstacleDistanceOverlay] Fix 90 degree offset 

### DIFF
--- a/src/FlightDisplay/ObstacleDistanceOverlay.qml
+++ b/src/FlightDisplay/ObstacleDistanceOverlay.qml
@@ -36,7 +36,10 @@ Canvas {
 
     // Converts degrees to index from ranges
     function rangeIdx(deg, increment, offset, len, heading) {
-        const i = (360 - heading + deg - offset) / increment
+        var degrees = deg + offset - heading
+        if (degrees > 360) degrees = degrees - 360
+        if (degrees < 0) degrees = degrees + 360;
+        const i = degrees / increment
         return (len + Math.ceil(i)) % len
     }
 

--- a/src/FlightDisplay/ObstacleDistanceOverlayMap.qml
+++ b/src/FlightDisplay/ObstacleDistanceOverlayMap.qml
@@ -54,10 +54,10 @@ Item {
             const rad =  deg * Math.PI / 180.0
             const m = obstacleDistance._ranges[obstacleDistance._degToRangeIdx(deg, true)] / 100.0
             const pixels = minGradPixels + m * metersToPixels
-            const outerX = centerX + pixels * Math.cos(rad)
-            const outerY = centerY + pixels * Math.sin(rad)
-            const innerX = centerX + (pixels - height) * Math.cos(rad)
-            const innerY = centerY + (pixels - height) * Math.sin(rad)
+            const outerX = centerX + pixels * Math.sin(rad)
+            const outerY = centerY - pixels * Math.cos(rad)
+            const innerX = centerX + (pixels - height) * Math.sin(rad)
+            const innerY = centerY - (pixels - height) * Math.cos(rad)
 
             points.push({'outer_x': outerX, 'outer_y': outerY, 'inner_x': innerX, 'inner_y': innerY, 'range': m})
         }

--- a/src/FlightDisplay/ObstacleDistanceOverlayVideo.qml
+++ b/src/FlightDisplay/ObstacleDistanceOverlayVideo.qml
@@ -18,6 +18,10 @@ Item {
     property var showText: obstacleDistance._showText
 
     function drawSegment(ctx, range, centerX, centerY, lengthFrom, lengthTo, radFrom, radTo, grad) {
+        // Qt expects the angles to be in respect of the X axis, The Incoming Angles are in FRD From Front goind Clockwise
+        // Transform coordinates to Qt XY
+        radFrom -= Math.PI / 2
+        radTo -= Math.PI / 2
         const topSrcX = centerX + lengthFrom * Math.cos(radFrom)
         const topSrcY = centerY + lengthFrom * Math.sin(radFrom)
         const topDstX = centerX + lengthFrom * Math.cos(radTo)


### PR DESCRIPTION
Fixes issue where obstacle distances are displayed with a +90 degree offset. This is due to an error in the coordinate system math along with an error in calculating the degrees for the current distance index. The yaw angle theta is measured CW from North and therefore `r * cos(theta)` is negative Y axis and `r * sin(theta)` is positive X.

**Qt docs**
> The x values increase to the right and the y values increase downwards.
![image](https://github.com/mavlink/qgroundcontrol/assets/37091262/6f48ff18-9173-4f58-b4e7-cdb01b8b1f58)

There's more still that needs to be done. The ObstacleDistanceOverlayVideo.qml probably needs this fix. There's also the VehicleObjectAvoidance class which seems to be entirely unused other than the `distances` array. This feature is currently broken in PX4 and I don't think anyone has used it in years. I want to resurrect the feature and make it all work again.