### PR TITLE
main: fix Ctrl+C

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -1017,7 +1017,7 @@ bool QGCApplication::compressEvent(QEvent*event, QObject* receiver, QPostEventLi
 bool QGCApplication::event(QEvent *e)
 {
     if (e->type() == QEvent::Quit) {
-        // On OSX if the user selects Quit from the menu (or Command-Q) the ApplicationWindow does not signal closing. Instead you get a Quit even here only.
+        // On OSX if the user selects Quit from the menu (or Command-Q) the ApplicationWindow does not signal closing. Instead you get a Quit event here only.
         // This in turn causes the standard QGC shutdown sequence to not run. So in this case we close the window ourselves such that the
         // signal is sent and the normal shutdown sequence runs.
         bool forceClose = _mainRootWindow->property("_forceClose").toBool();

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,6 +18,7 @@
 #include <QtPlugin>
 #include <QStringListModel>
 #include <QQuickStyle>
+#include <QQuickWindow>
 
 #include "QGC.h"
 #include "QGCApplication.h"
@@ -222,7 +223,9 @@ bool checkAndroidWritePermission() {
 void sigHandler(int s)
 {
     std::signal(s, SIG_DFL);
-    QApplication::instance()->quit();
+    qgcApp()->mainRootWindow()->close();
+    QEvent event{QEvent::Quit};
+    qgcApp()->event(&event);
 }
 
 #endif /* Q_OS_LINUX */


### PR DESCRIPTION
This avoids a segfault on destruction when no vehicle was ever discovered.

This replaces https://github.com/mavlink/qgroundcontrol/pull/10877